### PR TITLE
Fix: Correct script path for version sync in release workflow

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Sync Versions"
         id: "set-version"
-        run: "node scripts/monorepo-version-sync.js ${{ github.ref }} alpha"
+        run: "node .github/scripts/monorepo-version-sync.js ${{ github.ref }} alpha"
 
       - name: "Commit Version Changes"
         run: |

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Sync Versions"
         id: "set-version"
-        run: "node scripts/monorepo-version-sync.js ${{ github.ref }} beta"
+        run: "node .github/scripts/monorepo-version-sync.js ${{ github.ref }} beta"
 
       - name: "Commit Version Changes"
         run: |


### PR DESCRIPTION
This PR fixes a path issue in the `alpha-release.yml` and `beta-release.yml` workflows where the `monorepo-version-sync.js` script was referenced with an incorrect relative path.

## ✅ Changes
- Updated `run: node scripts/monorepo-version-sync.js` to `node .github/scripts/monorepo-version-sync.js` to reflect its actual location.
- Ensures proper version synchronization during release workflows.

This fix allows the release workflows to execute the version sync step without failure.