### PR TITLE
Fix: Correct Action Reference for Uploading Release Assets

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -175,7 +175,7 @@ jobs:
           name: "flutter-assets"
 
       - name: "Attach Flutter Assets"
-        uses: "AButler/upload-release-assets@v3"
+        uses: "AButler/upload-release-assets@v3.0"
         with:
           files: "smart-panel-display-${{ needs.sync-versions.outputs.version }}.tar.gz;SHASUMS256.txt"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -175,7 +175,7 @@ jobs:
           name: "flutter-assets"
 
       - name: "Attach Flutter Assets"
-        uses: "AButler/upload-release-assets@v3"
+        uses: "AButler/upload-release-assets@v3.0"
         with:
           files: "smart-panel-display-${{ needs.sync-versions.outputs.version }}.tar.gz;SHASUMS256.txt"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📦 What’s Changed

This PR updates the `pre-release-alpha` workflow to fix a failing step caused by an incorrect action reference for uploading release assets.

### ✅ Fixes
- Updated `AButler/upload-release-assets@v3` ➜ `AButler/upload-release-assets@v3.0`
- Resolves `Missing download info` error from GitHub Actions

### 📌 Context
The previous version tag (`@v3`) does not point to a valid immutable release, causing the runner to fail during the job setup. Using `@v3.0` ensures a proper release reference is used.
