### PR TITLE
Fix: Remove unsupported `--yes` flag from `pnpm publish` step

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -55,9 +55,9 @@ runs:
       working-directory: ${{ inputs.package-path }}
       run: |
         if [ -z "${{ inputs.tag }}" ]; then
-          pnpm publish --access public --provenance  --no-git-checks --yes
+          pnpm publish --access public --provenance --no-git-checks
         else
-          pnpm publish --access public --tag=${{ inputs.tag }} --provenance --no-git-checks --yes
+          pnpm publish --access public --tag=${{ inputs.tag }} --provenance --no-git-checks
         fi
       shell: bash
       env:

--- a/.github/actions/send-discord-notification/action.yml
+++ b/.github/actions/send-discord-notification/action.yml
@@ -1,69 +1,69 @@
-name: 'Send Discord Notification'
+name: "Send Discord Notification"
 
-description: 'Sends a message to Discord using sarisia/actions-status-discord'
+description: "Sends a message to Discord using sarisia/actions-status-discord"
 
 inputs:
   status:
-    description: 'Status of the message (Success, Failure, etc.)'
+    description: "Status of the message (Success, Failure, etc.)"
     required: false
-    default: 'Success'
+    default: "Success"
   content:
-    description: 'Main text content of the message'
+    description: "Main text content of the message"
     required: false
-    default: ''
+    default: ""
   title:
-    description: 'Title of the embed message'
+    description: "Title of the embed message"
     required: false
-    default: ''
+    default: ""
   description:
-    description: 'Description of the embed message'
+    description: "Description of the embed message"
     required: false
-    default: ''
+    default: ""
   image:
-    description: 'Image URL to include in the message'
+    description: "Image URL to include in the message"
     required: false
-    default: ''
+    default: ""
   color:
-    description: 'Color of the embed sidebar (hex or decimal)'
+    description: "Color of the embed sidebar (hex or decimal)"
     required: false
-    default: ''
+    default: ""
   url:
-    description: 'URL to link in the title'
+    description: "URL to link in the title"
     required: false
-    default: 'https://smart-panel.fastybird.com'
+    default: "https://smart-panel.fastybird.com"
   username:
-    description: 'Username for the bot'
+    description: "Username for the bot"
     required: false
-    default: 'FastyBird'
+    default: "FastyBird"
   avatar-url:
-    description: 'URL of the bot avatar'
+    description: "URL of the bot avatar"
     required: false
-    default: ''
+    default: ""
   nofail:
-    description: 'Whether to suppress failure on error'
+    description: "Whether to suppress failure on error"
     required: false
-    default: 'true'
+    default: "true"
   noprefix:
     required: false
-    default: 'false'
+    default: "false"
   nodetail:
     required: false
-    default: 'false'
+    default: "false"
   nocontext:
     required: false
-    default: 'false'
+    default: "false"
   notimestamp:
     required: false
-    default: 'false'
+    default: "false"
   webhook:
     description: "Discord notification webhook address"
     required: true
-    default: ''
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: 'Send Discord notification'
+    - name: "Send Discord notification"
       uses: sarisia/actions-status-discord@v1
       with:
         webhook: ${{ inputs.webhook }}

--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "PNPM version"
     default: "9.13.0"
     required: false
+  registry-url:
+    description: "NPM registry"
+    default: "https://registry.npmjs.org"
+    required: false
 
 runs:
   using: "composite"
@@ -21,7 +25,7 @@ runs:
       uses: "actions/setup-node@v4"
       with:
         node-version: ${{ inputs.node-version }}
-        registry-url: 'https://registry.npmjs.org'
+        registry-url: ${{ inputs.registry-url }}
 
     - name: "Install pnpm and export path"
       shell: bash


### PR DESCRIPTION
This PR fixes an issue in the `publish-npm-package` composite action where the `--yes` flag was incorrectly passed to the `pnpm publish` command, causing the workflow to fail.

## ✅ Changes

- Removed `--yes` flag from `pnpm publish` step
- Retained `--no-git-checks` to suppress warnings in CI environments
- Ensured compatibility with `pnpm` CLI in automated release workflows

## 🧪 Why

`pnpm publish` does not support the `--yes` flag. Including it caused the workflow to error out, preventing successful package publication during pre-releases.

## 📦 Context

This is part of ongoing improvements to streamline and stabilize the release automation process using composite GitHub Actions.