### PR TITLE
Fix: Provenance Publishing Error in Alpha Release Workflow

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -7,6 +7,10 @@ on:
       - "alpha"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   sync-versions:
     name: "Sync packages versions"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,6 +7,10 @@ on:
       - "beta"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   sync-versions:
     name: "Sync packages versions"


### PR DESCRIPTION
## ✨ Summary

This PR fixes the issue with `pnpm publish --provenance` failing due to missing permissions in GitHub Actions. The `id-token: write` permission is now added to the `alpha-release.yml` workflow to enable provenance support.

## ✅ Changes

- Added `permissions` block to `alpha-release.yml`:
  ```yaml
  permissions:
    contents: write
    id-token: write