### PR TITLE
Feature: Build Before Publish & Prepare Final Backend Package Content

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -25,6 +25,10 @@ inputs:
   npm-auth-token:
     description: "NPM Auth Token"
     required: true
+  npm-registry-url:
+    description: "NPM registry"
+    default: "https://registry.npmjs.org"
+    required: false
 
 outputs:
   NPM_VERSION:
@@ -55,9 +59,9 @@ runs:
       working-directory: ${{ inputs.package-path }}
       run: |
         if [ -z "${{ inputs.tag }}" ]; then
-          pnpm publish --access public --provenance --no-git-checks
+          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --provenance --no-git-checks
         else
-          pnpm publish --access public --tag=${{ inputs.tag }} --provenance --no-git-checks
+          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --tag=${{ inputs.tag }} --provenance --no-git-checks
         fi
       shell: bash
       env:

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -61,6 +61,9 @@ jobs:
         pnpm-version: [ "9.13.0" ]
         operating-system: [ "ubuntu-latest" ]
 
+    outputs:
+      version: ${{ steps.publish-npm.outputs.NPM_VERSION }}
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -71,12 +74,24 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
+      - name: "Build App"
+        run: "pnpm --filter @fastybird/smart-panel-backend build"
+
       - name: "Publish To NPM"
+        id: "publish-npm"
         uses: "./.github/actions/publish-npm-package"
         with:
           package-path: "apps/backend"
           tag: "alpha"
           npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+      - name: "Publish To GitHub NPM"
+        uses: "./.github/actions/publish-npm-package"
+        with:
+          package-path: "apps/backend"
+          tag: "alpha"
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-registry-url: "https://npm.pkg.github.com"
 
   publish-admin:
     needs: "sync-versions"
@@ -89,6 +104,9 @@ jobs:
         pnpm-version: [ "9.13.0" ]
         operating-system: [ "ubuntu-latest" ]
 
+    outputs:
+      version: ${{ steps.publish-npm.outputs.NPM_VERSION }}
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -99,12 +117,24 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
+      - name: "Build App"
+        run: "pnpm --filter @fastybird/smart-panel-admin build"
+
       - name: "Publish To NPM"
+        id: "publish-npm"
         uses: "./.github/actions/publish-npm-package"
         with:
           package-path: "apps/admin"
           tag: "alpha"
           npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+      - name: "Publish To GitHub NPM"
+        uses: "./.github/actions/publish-npm-package"
+        with:
+          package-path: "apps/admin"
+          tag: "alpha"
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-registry-url: "https://npm.pkg.github.com"
 
   build-flutter:
     needs: "sync-versions"
@@ -165,15 +195,15 @@ jobs:
           tag_name: v${{ needs.sync-versions.outputs.version }}
           release_name: v${{ needs.sync-versions.outputs.version }}
           body: |
-            Admin App v${{ needs.publish-admin.outputs.NPM_VERSION }} & Backend App v${{ needs.publish-backend.outputs.NPM_VERSION }} & Display App v${{ needs.sync-versions.outputs.version }}
+            Admin App v${{ needs.publish-admin.outputs.version }} & Backend App v${{ needs.publish-backend.outputs.version }} & Display App v${{ needs.sync-versions.outputs.version }}
           keep_num: 5
           keep_tags: false
 
       - name: "Summary"
         run: |
           echo "### ✅ Alpha Release Created: v${{ needs.sync-versions.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Admin App: v${{ needs.publish-admin.outputs.NPM_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Backend App: v${{ needs.publish-backend.outputs.NPM_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Admin App: v${{ needs.publish-admin.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend App: v${{ needs.publish-backend.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- Display App: v${{ needs.sync-versions.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
       - name: "Download Flutter Assets"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -61,6 +61,9 @@ jobs:
         pnpm-version: [ "9.13.0" ]
         operating-system: [ "ubuntu-latest" ]
 
+    outputs:
+      version: ${{ steps.publish-npm.outputs.NPM_VERSION }}
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -71,12 +74,24 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
+      - name: "Build App"
+        run: "pnpm --filter @fastybird/smart-panel-backend build"
+
       - name: "Publish To NPM"
+        id: "publish-npm"
         uses: "./.github/actions/publish-npm-package"
         with:
           package-path: "apps/backend"
           tag: "beta"
           npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+      - name: "Publish To GitHub NPM"
+        uses: "./.github/actions/publish-npm-package"
+        with:
+          package-path: "apps/backend"
+          tag: "alpha"
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-registry-url: "https://npm.pkg.github.com"
 
   publish-admin:
     needs: "sync-versions"
@@ -89,6 +104,9 @@ jobs:
         pnpm-version: [ "9.13.0" ]
         operating-system: [ "ubuntu-latest" ]
 
+    outputs:
+      version: ${{ steps.publish-npm.outputs.NPM_VERSION }}
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -99,12 +117,24 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
+      - name: "Build App"
+        run: "pnpm --filter @fastybird/smart-panel-admin build"
+
       - name: "Publish To NPM"
+        id: "publish-npm"
         uses: "./.github/actions/publish-npm-package"
         with:
           package-path: "apps/admin"
           tag: "beta"
           npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+      - name: "Publish To GitHub NPM"
+        uses: "./.github/actions/publish-npm-package"
+        with:
+          package-path: "apps/admin"
+          tag: "alpha"
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-registry-url: "https://npm.pkg.github.com"
 
   build-flutter:
     needs: "sync-versions"
@@ -165,15 +195,15 @@ jobs:
           tag_name: v${{ needs.sync-versions.outputs.version }}
           release_name: v${{ needs.sync-versions.outputs.version }}
           body: |
-            Admin App v${{ needs.publish-admin.outputs.NPM_VERSION }} & Backend App v${{ needs.publish-backend.outputs.NPM_VERSION }} & Display App v${{ needs.sync-versions.outputs.version }}
+            Admin App v${{ needs.publish-admin.outputs.version }} & Backend App v${{ needs.publish-backend.outputs.version }} & Display App v${{ needs.sync-versions.outputs.version }}
           keep_num: 5
           keep_tags: false
 
       - name: "Summary"
         run: |
           echo "### ✅ Beta Release Created: v${{ needs.sync-versions.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Admin App: v${{ needs.publish-admin.outputs.NPM_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Backend App: v${{ needs.publish-backend.outputs.NPM_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Admin App: v${{ needs.publish-admin.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend App: v${{ needs.publish-backend.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- Display App: v${{ needs.sync-versions.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
       - name: "Download Flutter Assets"

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -34,6 +34,12 @@
     "type": "git",
     "url": "https://github.com/FastyBird/smart-panel.git"
   },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md",
+    "LICENSE.md"
+  ],
   "scripts": {
     "build": "run-p type-check \"build:no-check {@}\" --",
     "build:no-check": "vite build",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,6 +33,13 @@
     "type": "git",
     "url": "https://github.com/FastyBird/smart-panel.git"
   },
+  "main": "dist/main.js",
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md",
+    "LICENSE.md"
+  ],
   "scripts": {
     "build": "nest build",
     "start": "nest start",


### PR DESCRIPTION
## Summary

This PR updates the `publish-backend` workflow to:

- ✅ Add a `pnpm build` step before publishing the backend package
- 📦 Ensure only the compiled output (`dist/`) and necessary metadata files (`package.json`, `README.md`, `LICENSE.md`) are published
- 🛠 Publish to both NPM and GitHub Package Registry using the appropriate `--registry` flag

These changes ensure that the published package contains production-ready code and follows best practices for NestJS application distribution.