### PR TITLE
Fix: Allow Publishing Same Version with Suffix

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -46,22 +46,22 @@ runs:
     - name: "Run npm version (with git commit)"
       if: ${{ inputs.npm-version-command != '' && inputs.dynamically-adjust-version == 'false' }}
       working-directory: ${{ inputs.package-path }}
-      run: "pnpm version ${{ inputs.npm-version-command }} --preid=${{ inputs.pre-id }}"
+      run: "pnpm version ${{ inputs.npm-version-command }} --preid=${{ inputs.pre-id }} --allow-same-version"
       shell: bash
 
     - name: "Run npm version (no git commit)"
       if: ${{ inputs.npm-version-command != '' && inputs.dynamically-adjust-version == 'true' }}
       working-directory: ${{ inputs.package-path }}
-      run: "pnpm version ${{ inputs.npm-version-command }} --preid=${{ inputs.pre-id }} --no-git-tag-version"
+      run: "pnpm version ${{ inputs.npm-version-command }} --preid=${{ inputs.pre-id }} --no-git-tag-version --allow-same-version"
       shell: bash
 
     - name: "Publish to NPM"
       working-directory: ${{ inputs.package-path }}
       run: |
         if [ -z "${{ inputs.tag }}" ]; then
-          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --provenance --no-git-checks
+          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --provenance --no-git-checks --allow-same-version
         else
-          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --tag=${{ inputs.tag }} --provenance --no-git-checks
+          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --tag=${{ inputs.tag }} --provenance --no-git-checks --allow-same-version
         fi
       shell: bash
       env:


### PR DESCRIPTION
### Summary
- Added `--allow-same-version` flag to the `pnpm publish` command in the `publish-npm-package` composite action.
- Enables republishing the same version (e.g. `1.0.0-alpha.1`) to different registries.

### 🔍 Why

During pre-release workflows, we might publish the same version to both npmjs and GitHub registries.  
Without this flag, `pnpm` throws an error if the version already exists.

### ✅ Example

```bash
pnpm publish --registry=https://npm.pkg.github.com --tag=alpha --allow-same-version