### PR TITLE
chore: skip already published versions during npm publish

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -58,10 +58,17 @@ runs:
     - name: "Publish to NPM"
       working-directory: ${{ inputs.package-path }}
       run: |
-        if [ -z "${{ inputs.tag }}" ]; then
-          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --provenance --no-git-checks --allow-same-version
+        VERSION=$(jq -r .version package.json)
+        PACKAGE_NAME=$(jq -r .name package.json)
+        
+        if npm view $PACKAGE_NAME@$VERSION --registry=${{ inputs.npm-registry-url }} > /dev/null 2>&1; then
+          echo "🔁 Skipping: $PACKAGE_NAME@$VERSION already exists on registry"
         else
-          pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --tag=${{ inputs.tag }} --provenance --no-git-checks --allow-same-version
+          if [ -z "${{ inputs.tag }}" ]; then
+            pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --provenance --no-git-checks
+          else
+            pnpm publish --registry=${{ inputs.npm-registry-url }} --access public --tag=${{ inputs.tag }} --provenance --no-git-checks
+          fi
         fi
       shell: bash
       env:


### PR DESCRIPTION
## Summary

This update enhances the `publish-npm-package` composite action by adding logic to check if the current version is already published on the target npm registry. If the version exists, the publish step will be skipped to prevent errors.

## ✅ Changes

- Replaced unsupported `--allow-same-version` flag with a manual check using `npm view`
- If the version is already published, the publish step is skipped gracefully
- Maintains normal publish behavior for new versions

## 💡 Why?

To support development flows (especially pre-releases like alpha/beta) where the same version might be reused or reattempted. This avoids unnecessary CI failures due to already-published versions on npm or GitHub registries.