### PR TITLE
Fix: Ensure latest version is used during publish by syncing checkout

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -67,6 +67,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Node Project"
         uses: "./.github/actions/setup-node-project"
@@ -110,6 +115,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Node Project"
         uses: "./.github/actions/setup-node-project"
@@ -150,6 +160,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Flutter"
         uses: "./.github/actions/setup-flutter-project"
@@ -186,6 +201,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Create Pre-Release"
         uses: "viperproject/create-nightly-release@v1"
@@ -230,6 +250,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Send Discord Notification"
         uses: "./.github/actions/send-discord-notification"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -67,6 +67,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Node Project"
         uses: "./.github/actions/setup-node-project"
@@ -110,6 +115,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Node Project"
         uses: "./.github/actions/setup-node-project"
@@ -150,6 +160,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Setup Flutter"
         uses: "./.github/actions/setup-flutter-project"
@@ -186,6 +201,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Create Pre-Release"
         uses: "viperproject/create-nightly-release@v1"
@@ -230,6 +250,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+
+      - name: "Pull Updated Branch"
+        run: git pull origin ${{ github.ref_name }}
 
       - name: "Send Discord Notification"
         uses: "./.github/actions/send-discord-notification"


### PR DESCRIPTION
### Summary

This PR addresses an issue where the publish-* jobs were using outdated versions from the original commit SHA, instead of the versions updated and committed by the sync-versions job.
