### PR TITLE
Fix: Publish to GitHub NPM Registry Fix

### DIFF
--- a/.github/actions/publish-npm-package/README.md
+++ b/.github/actions/publish-npm-package/README.md
@@ -2,13 +2,14 @@
 
 This GitHub Action publishes a package to the NPM registry. It supports versioning (manual or automatic), pre-release tags, provenance, and includes the published version as an output.
 
-## 📦 Features
+## ✅ Features
 
-- Publishes any package in the repository to NPM
-- Supports both static and dynamic versioning
-- Supports pre-release identifiers like `alpha`, `beta`
-- Returns published version as output
-- Optionally builds code before publishing
+- ✔️ Publishes any package (e.g., `apps/backend`) to NPM or GitHub Packages
+- 🔄 Supports **manual** or **dynamic versioning**
+- 🏷️ Handles **pre-release tags** like `alpha`, `beta`
+- 🔐 Supports **custom registries** and **authentication**
+- 📤 Outputs the published version for downstream jobs
+- 🧱 Optimized for **monorepos** and **pnpm**
 
 ## ✅ Usage
 
@@ -16,22 +17,23 @@ This GitHub Action publishes a package to the NPM registry. It supports versioni
 - name: Publish to NPM
   uses: ./.github/actions/publish-npm-package
   with:
-    package_path: "apps/backend"
-    tag: "alpha"
-  secrets:
-    npm_auth_token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+    package-path: apps/backend
+    tag: alpha
+    npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
 ```
 
 ## 💡 Inputs
 
-| Name                         | Description                                 | Default | Required |
-|------------------------------|---------------------------------------------|---------|----------|
-| `package-path`               | Path to the package directory               | `-`     | ✅        |
-| `tag`                        | NPM tag name (e.g. latest, alpha, beta)     | `-`     | ❌        |
-| `npm-version-command`        | If set, runs pnpm version <value>           | `-`     | ❌        |
-| `pre-id`                     | Pre-release identifier (e.g. alpha, beta)   | `-`     | ❌        |
-| `dynamically-adjust-version` | Runs script to automatically adjust version | `false` | ❌        |
-| `npm-auth-token`             | NPM token to authenticate publish           | `-`     | ✅        |
+| Name                         | Description                                             | Default                      | Required |
+|------------------------------|---------------------------------------------------------|------------------------------|----------|
+| `package-path`               | Path to the package directory                           | `-`                          | ✅        |
+| `tag`                        | NPM tag name (e.g. latest, alpha, beta)                 | `-`                          | ❌        |
+| `npm-version-command`        | If set, runs pnpm version <value>                       | `-`                          | ❌        |
+| `pre-id`                     | Pre-release identifier (e.g. alpha, beta)               | `-`                          | ❌        |
+| `dynamically-adjust-version` | Runs script to automatically adjust version             | `false`                      | ❌        |
+| `npm-auth-token`             | NPM token to authenticate publish                       | `-`                          | ✅        |
+| `npm-registry-url`           | NPM registry URL (e.g., https://npm.pkg.github.com)     | `https://registry.npmjs.org` | ❌        |
+| `npm-registry`               | Registry hostname for .npmrc (e.g., npm.pkg.github.com) | `npm.pkg.github.com`         | ❌        |
 
 
 ## 🧾 Outputs

--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "NPM registry"
     default: "https://registry.npmjs.org"
     required: false
+  npm-registry:
+    description: "NPM registry (used in .npmrc auth entry)"
+    default: "registry.npmjs.org"
+    required: false
 
 outputs:
   NPM_VERSION:
@@ -37,6 +41,15 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: "Configure .npmrc for GitHub NPM"
+      working-directory: ${{ inputs.package-path }}
+      shell: bash
+      run: |
+        echo "@fastybird:registry=${{ inputs.npm-registry-url }}" >> .npmrc
+        echo "//${{ inputs.npm-registry }}/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+
     - name: "Adjust version dynamically"
       if: ${{ inputs.dynamically-adjust-version == 'true' }}
       working-directory: ${{ inputs.package-path }}

--- a/.github/actions/setup-node-project/README.md
+++ b/.github/actions/setup-node-project/README.md
@@ -22,10 +22,11 @@ This GitHub Action sets up a Node.js project using PNPM, installs dependencies, 
 
 ## 💡 Inputs
 
-| Name            | Description                            | Default  | Required |
-|-----------------|----------------------------------------|----------|----------|
-| `node-version`  | Node.js version to install             | `22`     | ❌        |
-| `pnpm-version`  | PNPM version to install                | `9.13.0` | ❌        |
+| Name               | Description                                         | Default                      | Required |
+|--------------------|-----------------------------------------------------|------------------------------|----------|
+| `node-version`     | Node.js version to install                          | `22`                         | ❌        |
+| `pnpm-version`     | PNPM version to install                             | `9.13.0`                     | ❌        |
+| `npm-registry-url` | NPM registry URL (e.g., https://npm.pkg.github.com) | `https://registry.npmjs.org` | ❌        |
 
 ## 🛠 Included Steps
 

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -97,6 +97,7 @@ jobs:
           tag: "alpha"
           npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
           npm-registry-url: "https://npm.pkg.github.com"
+          npm-registry: "npm.pkg.github.com"
 
   publish-admin:
     needs: "sync-versions"
@@ -145,6 +146,7 @@ jobs:
           tag: "alpha"
           npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
           npm-registry-url: "https://npm.pkg.github.com"
+          npm-registry: "npm.pkg.github.com"
 
   build-flutter:
     needs: "sync-versions"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -97,6 +97,7 @@ jobs:
           tag: "alpha"
           npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
           npm-registry-url: "https://npm.pkg.github.com"
+          npm-registry: "npm.pkg.github.com"
 
   publish-admin:
     needs: "sync-versions"
@@ -145,6 +146,7 @@ jobs:
           tag: "alpha"
           npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
           npm-registry-url: "https://npm.pkg.github.com"
+          npm-registry: "npm.pkg.github.com"
 
   build-flutter:
     needs: "sync-versions"


### PR DESCRIPTION
### Summary

This PR ensures proper authentication and registry configuration for publishing packages to the GitHub NPM registry (npm.pkg.github.com), by:

- Generating a scoped .npmrc file in the composite action
- Using NODE_AUTH_TOKEN to authenticate without requiring setup-node’s registry-url
- Ensuring publishing is skipped if the version already exists
- Publishing the correct scoped package version