### PR TITLE
Fix: Enable GitHub Packages Publishing

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   sync-versions:

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   sync-versions:


### PR DESCRIPTION
### Summary

This PR updates the GitHub Actions workflow permissions to allow publishing packages to the GitHub NPM registry using the default GITHUB_TOKEN.
