### PR TITLE
fix: Correct Release Drafter changelog template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -47,4 +47,5 @@ change-template: '- $TITLE @$AUTHOR [#$NUMBER]'
 
 template: |
   ## What's Changed
-  $CATEGORIES
+
+  $CHANGES


### PR DESCRIPTION
## Summary

This PR updates the `.github/release-drafter.yml` to replace the deprecated `$CATEGORIES` placeholder with `$CHANGES` in the changelog template. This ensures that merged PRs are correctly listed in draft releases under the appropriate categories.
