### PR TITLE
ci: fix missing Node setup in production build step

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -204,7 +204,7 @@ jobs:
 
   build-application:
     needs: [ "build-display", "publish-admin", "publish-backend" ]
-    name: "Build Nest Backend App"
+    name: "Pre-Build Application"
     runs-on: "${{ matrix.operating-system }}"
 
     strategy:
@@ -221,6 +221,12 @@ jobs:
 
       - name: "Pull Updated Branch"
         run: git pull origin ${{ github.ref_name }}
+
+      - name: "Setup Node Project"
+        uses: "./.github/actions/setup-node-project"
+        with:
+          node-version: "${{ matrix.node-version }}"
+          pnpm-version: "${{ matrix.pnpm-version }}"
 
       - name: "Download Application Assets"
         uses: "actions/download-artifact@v4"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -204,7 +204,7 @@ jobs:
 
   build-application:
     needs: [ "build-display", "publish-admin", "publish-backend" ]
-    name: "Build Nest Backend App"
+    name: "Pre-Build Application"
     runs-on: "${{ matrix.operating-system }}"
 
     strategy:
@@ -221,6 +221,12 @@ jobs:
 
       - name: "Pull Updated Branch"
         run: git pull origin ${{ github.ref_name }}
+
+      - name: "Setup Node Project"
+        uses: "./.github/actions/setup-node-project"
+        with:
+          node-version: "${{ matrix.node-version }}"
+          pnpm-version: "${{ matrix.pnpm-version }}"
 
       - name: "Download Application Assets"
         uses: "actions/download-artifact@v4"


### PR DESCRIPTION
## Summary

This PR fixes a missing setup step in the `build-backend` job of the **Alpha Release** GitHub Actions workflow.

## What Was Missing?

The Node.js and pnpm environment were not initialized before attempting to install the backend and admin packages inside the `/build` directory. This caused the `pnpm add` commands to fail due to missing context.

## Fix Applied

- ✅ Added `Setup Node Project` step using the shared `.github/actions/setup-node-project` action before the `pnpm add` commands.