### PR TITLE
chore: Update monorepo config to exclude build/ & fix dependency installation in pre-release

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -251,6 +251,10 @@ jobs:
         working-directory: "./build"
         run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
 
+      - name: "Install Production Dependencies"
+        working-directory: "./build"
+        run: "pnpm install --prod"
+
       - name: "Archive Build"
         run: |
           tar -czvf smart-panel.tar.gz -C ./build .

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -251,6 +251,10 @@ jobs:
         working-directory: "./build"
         run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
 
+      - name: "Install Production Dependencies"
+        working-directory: "./build"
+        run: "pnpm install --prod"
+
       - name: "Archive Build"
         run: |
           tar -czvf smart-panel.tar.gz -C ./build .

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - apps/**
   - docs
+  # Exclude build folder
+  - '!build'
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@parcel/watcher'


### PR DESCRIPTION
## Summary

- Updated root `pnpm-workspace.yaml` to exclude `build/` directory from workspace
- Prevents `pnpm` from creating symlinks when installing packages in the `build/` folder
- Ensures backend and admin apps are installed as proper dependencies for packaging
- Simplifies production tarball by avoiding monorepo development links

This change ensures a reliable, self-contained production build is generated during the pre-release GitHub Actions workflow.