### PR TITLE
chore: remove monorepo config before installing production dependencies

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -245,11 +245,11 @@ jobs:
 
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add --no-prefer-workspace-packages @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add --no-prefer-workspace-packages @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -243,13 +243,19 @@ jobs:
           cp .env ./build/
           cp -r var ./build/
 
+      - name: "Remove Monorepo Configuration"
+        run: |
+          rm ./package.json
+          rm ./pnpm-lock.yaml
+          rm ./pnpm-workspace.yaml
+
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add --no-prefer-workspace-packages @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add --no-prefer-workspace-packages @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"


### PR DESCRIPTION
## Summary

This PR updates the `build-application` GitHub Action job to ensure the final production package is clean and self-contained.

## Changes Included:

- 🧹 Removed monorepo-related files from the root:
  - `package.json`
  - `pnpm-lock.yaml`
  - `pnpm-workspace.yaml`
- 📦 Ensures that `pnpm add` installs full copies of:
  - `@fastybird/smart-panel-backend`
  - `@fastybird/smart-panel-admin`
- 🔧 Avoids symbolic links in the packaged `node_modules` folder.
- 🎯 Makes the final `smart-panel.tar.gz` package portable and ready for direct deployment on the Raspberry Pi Zero and other environments.

This change resolves symlink issues caused by installing dependencies within the monorepo context.