### PR TITLE
chore: remove monorepo config before installing production dependencies

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -203,7 +203,7 @@ jobs:
             SHASUMS256.txt
 
   build-application:
-    needs: [ "build-display", "publish-admin", "publish-backend" ]
+    needs: ["sync-versions", "build-display", "publish-admin", "publish-backend" ]
     name: "Pre-Build Application"
     runs-on: "${{ matrix.operating-system }}"
 
@@ -228,7 +228,7 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
-      - name: "Download Application Assets"
+      - name: "Download Display Assets"
         uses: "actions/download-artifact@v4"
         with:
           name: "flutter-assets"
@@ -242,6 +242,12 @@ jobs:
         run: |
           cp .env ./build/
           cp -r var ./build/
+
+      - name: "Remove Monorepo Configuration"
+        run: |
+          rm ./package.json
+          rm ./pnpm-lock.yaml
+          rm ./pnpm-workspace.yaml
 
       - name: "Install Backend application"
         working-directory: "./build"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -203,7 +203,7 @@ jobs:
             SHASUMS256.txt
 
   build-application:
-    needs: [ "build-display", "publish-admin", "publish-backend" ]
+    needs: ["sync-versions", "build-display", "publish-admin", "publish-backend" ]
     name: "Pre-Build Application"
     runs-on: "${{ matrix.operating-system }}"
 
@@ -228,7 +228,7 @@ jobs:
           node-version: "${{ matrix.node-version }}"
           pnpm-version: "${{ matrix.pnpm-version }}"
 
-      - name: "Download Application Assets"
+      - name: "Download Display Assets"
         uses: "actions/download-artifact@v4"
         with:
           name: "flutter-assets"


### PR DESCRIPTION
## Summary

This PR updates the `build-application` GitHub Action job to ensure the final production package is clean and self-contained.

## Changes Included:

- 🧹 Removed monorepo-related files from the root:
  - `package.json`
  - `pnpm-lock.yaml`
  - `pnpm-workspace.yaml`
- 📦 Ensures that `pnpm add` installs full copies of:
  - `@fastybird/smart-panel-backend`
  - `@fastybird/smart-panel-admin`
- 🔧 Avoids symbolic links in the packaged `node_modules` folder.
- 🎯 Makes the final `smart-panel.tar.gz` package portable and ready for direct deployment on the Raspberry Pi Zero and other environments.

This change resolves symlink issues caused by installing dependencies within the monorepo context.