### PR TITLE
chore: remove monorepo config before installing production dependencies

### DIFF
--- a/.github/scripts/monorepo-version-sync.js
+++ b/.github/scripts/monorepo-version-sync.js
@@ -11,6 +11,7 @@ const PACKAGES = [
 ];
 
 const ROOT_PKG_PATH = "package.json";
+const BUILD_PKG_PATH = "build/package.json";
 const PUBSPEC_PATH = "apps/panel/pubspec.yaml";
 
 const ref = process.argv[2];
@@ -124,6 +125,20 @@ const updateRootPackageJson = (newVersion) => {
 	console.log(`✅ Updated root package.json`);
 };
 
+const updateBuildPackageJson = (newVersion) => {
+	if (!fs.existsSync(BUILD_PKG_PATH)) {
+		throw new Error(`Missing build package.json at: ${BUILD_PKG_PATH}`);
+	}
+
+	const pkg = JSON.parse(fs.readFileSync(BUILD_PKG_PATH, "utf8"));
+
+	pkg.version = newVersion;
+
+	fs.writeFileSync(BUILD_PKG_PATH, JSON.stringify(pkg, null, 2));
+
+	console.log(`✅ Updated build package.json`);
+};
+
 const updatePubspecYaml = (filePath, baseVersion, tag, buildNumber) => {
 	if (!fs.existsSync(filePath)) {
 		throw new Error(`Missing pubspec.yaml at: ${filePath}`);
@@ -159,6 +174,7 @@ const updatePubspecYaml = (filePath, baseVersion, tag, buildNumber) => {
 	}
 
 	updateRootPackageJson(fullVersion);
+	updateBuildPackageJson(fullVersion);
 	updatePubspecYaml(PUBSPEC_PATH, baseVersion, tag, buildNumber);
 
 	console.log(`📦 Published Version: ${fullVersion}`);

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -251,11 +251,11 @@ jobs:
 
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -251,11 +251,11 @@ jobs:
 
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.sync-versions.outputs.version }}"
+        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"

--- a/build/package.json
+++ b/build/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fastybird/smart-panel",
+  "name": "@fastybird/smart-panel-build",
   "private": true,
   "type": "module",
   "version": "1.0.0-dev.1",
@@ -40,5 +40,5 @@
     "node": ">=20",
     "pnpm": ">=10"
   },
-  "packageManager": "pnpm@10.13.0"
+  "packageManager": "pnpm@10.12.0"
 }


### PR DESCRIPTION
## Summary

This PR updates the `build-application` GitHub Action job to ensure the final production package is clean and self-contained.

## Changes Included:

- 🧹 Removed monorepo-related files from the root:
  - `package.json`
  - `pnpm-lock.yaml`
  - `pnpm-workspace.yaml`
- 📦 Ensures that `pnpm add` installs full copies of:
  - `@fastybird/smart-panel-backend`
  - `@fastybird/smart-panel-admin`
- 🔧 Avoids symbolic links in the packaged `node_modules` folder.
- 🎯 Makes the final `smart-panel.tar.gz` package portable and ready for direct deployment on the Raspberry Pi Zero and other environments.

This change resolves symlink issues caused by installing dependencies within the monorepo context.