### PR TITLE
chore: generate & bundle spec files in admin and backend apps

### DIFF
--- a/.github/actions/setup-node-project/README.md
+++ b/.github/actions/setup-node-project/README.md
@@ -8,7 +8,7 @@ This GitHub Action sets up a Node.js project using PNPM, installs dependencies, 
 * Installs a specified PNPM version
 * Caches the PNPM store for faster installs
 * Installs project dependencies
-* Runs `pnpm generate:openapi`
+* Runs `pnpm generate:openapi` and `pnpm generate:spec`
 
 ## ✅ Usage
 
@@ -34,7 +34,7 @@ This GitHub Action sets up a Node.js project using PNPM, installs dependencies, 
 2. Setup PNPM using `pnpm/action-setup`
 3. Cache the PNPM store directory
 4. Install dependencies using `pnpm install`
-5. Run `pnpm generate:openapi`
+5. Run `pnpm generate:openapi` and `pnpm generate:spec`
 
 ## 📁 Project Structure
 

--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -51,4 +51,4 @@ runs:
 
     - name: "Build generated code"
       shell: bash
-      run: pnpm generate:openapi
+      run: pnpm generate:openapi && pnpm generate:spec

--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -26,3 +26,5 @@ coverage
 *.tsbuildinfo
 
 src/openapi.ts
+src/spec
+src/spec/*

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -59,7 +59,8 @@
     "test:cov:watch": "vitest --watch --coverage",
     "test:e2e": "playwright test",
     "type-check": "vue-tsc --build",
-    "generate:openapi": "openapi-typescript ../../spec/api/v1/openapi.json -o ./src/openapi.ts --enum --dedupe-enums --root-types --default-non-nullable=false"
+    "generate:openapi": "openapi-typescript ../../spec/api/v1/openapi.json -o ./src/openapi.ts --enum --dedupe-enums --root-types --default-non-nullable=false",
+    "generate:spec": "node ./tools/build_devices_spec.mjs && node ./tools/build_channel_spec.mjs"
   },
   "dependencies": {
     "@iconify/json": "^2.2",

--- a/apps/admin/src/modules/devices/devices.mapping.ts
+++ b/apps/admin/src/modules/devices/devices.mapping.ts
@@ -1,5 +1,3 @@
-import channelsMappingSchema from '../../../../../spec/devices/channels.json';
-import devicesMappingSchema from '../../../../../spec/devices/devices.json';
 import {
 	DevicesModuleChannelCategory,
 	DevicesModuleChannelPropertyCategory,
@@ -7,6 +5,8 @@ import {
 	DevicesModuleChannelPropertyPermissions,
 	DevicesModuleDeviceCategory,
 } from '../../openapi';
+import { channelsSchema } from '../../spec/channels.ts';
+import { devicesSchema } from '../../spec/devices.ts';
 
 export type ChannelPropertySpec = {
 	category: DevicesModuleChannelPropertyCategory;
@@ -259,28 +259,26 @@ const deviceChannelsSortingSpecification: Record<DevicesModuleDeviceCategory, De
 };
 
 export const deviceChannelsSpecificationOrder: Record<string, DevicesModuleChannelCategory[]> = Object.fromEntries(
-	Object.entries<DeviceSpec>(devicesMappingSchema as unknown as Record<DevicesModuleDeviceCategory, DeviceSpec>).map(
-		([deviceCategory, deviceSpec]) => {
-			const unsortedChannels = Object.values<DeviceChannelSpec>(deviceSpec.channels).map((ch) => ch.category);
+	Object.entries<DeviceSpec>(devicesSchema as unknown as Record<DevicesModuleDeviceCategory, DeviceSpec>).map(([deviceCategory, deviceSpec]) => {
+		const unsortedChannels = Object.values<DeviceChannelSpec>(deviceSpec.channels).map((ch) => ch.category);
 
-			const customOrder = deviceChannelsSortingSpecification[deviceCategory as DevicesModuleDeviceCategory];
+		const customOrder = deviceChannelsSortingSpecification[deviceCategory as DevicesModuleDeviceCategory];
 
-			const sortedChannels = customOrder
-				? [...unsortedChannels].sort((a, b) => {
-						const ai = customOrder.indexOf(a);
-						const bi = customOrder.indexOf(b);
+		const sortedChannels = customOrder
+			? [...unsortedChannels].sort((a, b) => {
+					const ai = customOrder.indexOf(a);
+					const bi = customOrder.indexOf(b);
 
-						if (ai === -1 && bi === -1) return 0; // both not found: keep relative
-						if (ai === -1) return 1; // a not found, b found: b first
-						if (bi === -1) return -1; // b not found, a found: a first
+					if (ai === -1 && bi === -1) return 0; // both not found: keep relative
+					if (ai === -1) return 1; // a not found, b found: b first
+					if (bi === -1) return -1; // b not found, a found: a first
 
-						return ai - bi; // both found: sort by index
-					})
-				: unsortedChannels;
+					return ai - bi; // both found: sort by index
+				})
+			: unsortedChannels;
 
-			return [deviceCategory, sortedChannels];
-		}
-	)
+		return [deviceCategory, sortedChannels];
+	})
 );
 
 export const deviceChannelsSpecificationMappers: Record<
@@ -291,30 +289,28 @@ export const deviceChannelsSpecificationMappers: Record<
 		multiple: DevicesModuleChannelCategory[];
 	}
 > = Object.fromEntries(
-	Object.entries<DeviceSpec>(devicesMappingSchema as unknown as Record<DevicesModuleDeviceCategory, DeviceSpec>).map(
-		([deviceCategory, deviceSpec]) => {
-			const required = Object.values<DeviceChannelSpec>(deviceSpec.channels)
-				.filter((channelSpec) => channelSpec.required)
-				.map((channelSpec) => channelSpec.category);
+	Object.entries<DeviceSpec>(devicesSchema as unknown as Record<DevicesModuleDeviceCategory, DeviceSpec>).map(([deviceCategory, deviceSpec]) => {
+		const required = Object.values<DeviceChannelSpec>(deviceSpec.channels)
+			.filter((channelSpec) => channelSpec.required)
+			.map((channelSpec) => channelSpec.category);
 
-			const optional = Object.values<DeviceChannelSpec>(deviceSpec.channels)
-				.filter((channelSpec) => !channelSpec.required)
-				.map((channelSpec) => channelSpec.category);
+		const optional = Object.values<DeviceChannelSpec>(deviceSpec.channels)
+			.filter((channelSpec) => !channelSpec.required)
+			.map((channelSpec) => channelSpec.category);
 
-			const multiple = Object.values<DeviceChannelSpec>(deviceSpec.channels)
-				.filter((channelSpec) => channelSpec.multiple)
-				.map((channelSpec) => channelSpec.category);
+		const multiple = Object.values<DeviceChannelSpec>(deviceSpec.channels)
+			.filter((channelSpec) => channelSpec.multiple)
+			.map((channelSpec) => channelSpec.category);
 
-			return [
-				deviceCategory,
-				{
-					required,
-					optional,
-					multiple,
-				},
-			];
-		}
-	)
+		return [
+			deviceCategory,
+			{
+				required,
+				optional,
+				multiple,
+			},
+		];
+	})
 );
 
 export const channelChannelsPropertiesSpecificationMappers: Record<
@@ -324,7 +320,7 @@ export const channelChannelsPropertiesSpecificationMappers: Record<
 		optional: DevicesModuleChannelPropertyCategory[];
 	}
 > = Object.fromEntries(
-	Object.entries<ChannelSpec>(channelsMappingSchema as unknown as Record<DevicesModuleChannelCategory, ChannelSpec>).map(
+	Object.entries<ChannelSpec>(channelsSchema as unknown as Record<DevicesModuleChannelCategory, ChannelSpec>).map(
 		([channelCategory, channelSpec]) => {
 			const required = Object.values<ChannelPropertySpec>(channelSpec.properties)
 				.filter((prop) => prop.required)
@@ -343,7 +339,7 @@ export const getChannelPropertySpecification = (
 	channelCategory: DevicesModuleChannelCategory,
 	propertyCategory: DevicesModuleChannelPropertyCategory
 ): ChannelPropertySpec | undefined => {
-	const channelSpec = (channelsMappingSchema as unknown as Record<DevicesModuleChannelCategory, ChannelSpec>)[channelCategory];
+	const channelSpec = (channelsSchema as unknown as Record<DevicesModuleChannelCategory, ChannelSpec>)[channelCategory];
 
 	if (!channelSpec) {
 		return undefined;

--- a/apps/admin/src/modules/devices/devices.mapping.ts
+++ b/apps/admin/src/modules/devices/devices.mapping.ts
@@ -5,8 +5,8 @@ import {
 	DevicesModuleChannelPropertyPermissions,
 	DevicesModuleDeviceCategory,
 } from '../../openapi';
-import { channelsSchema } from '../../spec/channels.ts';
-import { devicesSchema } from '../../spec/devices.ts';
+import { channelsSchema } from '../../spec/channels';
+import { devicesSchema } from '../../spec/devices';
 
 export type ChannelPropertySpec = {
 	category: DevicesModuleChannelPropertyCategory;

--- a/apps/admin/tools/build_channel_spec.mjs
+++ b/apps/admin/tools/build_channel_spec.mjs
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const inputPath = path.join(__dirname, '../../../spec/devices/channels.json');
+const outputPath = path.join(__dirname, '../src/spec/channels.ts');
+
+const raw = fs.readFileSync(inputPath, 'utf-8');
+const json = JSON.parse(raw);
+
+const output = `
+// This file is generated from channels.json
+// Do not edit manually!
+
+export const channelsSchema = ${JSON.stringify(json, null, 2)} as const;
+
+export type ChannelCategory = keyof typeof channelsSchema;
+export type ChannelDefinition = typeof channelsSchema[ChannelCategory];
+`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, output, 'utf-8');
+
+console.log('✅ Generated channels.ts');

--- a/apps/admin/tools/build_devices_spec.mjs
+++ b/apps/admin/tools/build_devices_spec.mjs
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const inputPath = path.join(__dirname, '../../../spec/devices/devices.json');
+const outputPath = path.join(__dirname, '../src/spec/devices.ts');
+
+const raw = fs.readFileSync(inputPath, 'utf-8');
+const json = JSON.parse(raw);
+
+const output = `
+// This file is generated from devices.json
+// Do not edit manually!
+
+export const devicesSchema = ${JSON.stringify(json, null, 2)} as const;
+
+export type DeviceCategory = keyof typeof devicesSchema;
+export type DeviceDefinition = typeof devicesSchema[DeviceCategory];
+`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, output, 'utf-8');
+
+console.log('✅ Generated devices.ts');

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -400,3 +400,5 @@ dist
 .serverless/**/*.zip
 
 src/openapi.d.ts
+src/spec
+src/spec/*

--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -7,7 +7,7 @@ import eslint from '@eslint/js';
 
 export default tseslint.config(
 	{
-		ignores: ['eslint.config.mjs', 'src/openapi.d.ts', 'src/migrations/*'],
+		ignores: ['eslint.config.mjs', 'src/openapi.d.ts', 'src/migrations/*', 'src/spec/*'],
 	},
 	eslint.configs.recommended,
 	...tseslint.configs.recommendedTypeChecked,

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -64,6 +64,7 @@
     "typeorm:migration:revert": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:revert -d ./src/dataSource.ts",
     "typeorm:migration:run:prod": "node ./node_modules/typeorm/cli.js migration:run -d ./dist/dataSource.js",
     "generate:openapi": "openapi-typescript ../../spec/api/v1/openapi.json -o ./src/openapi.d.ts --root-types --default-non-nullable=false --path-params-as-types=true",
+    "generate:spec": "ts-node ./tools/build_devices_spec.ts && ts-node ./tools/build_channel_spec.ts",
     "cli": "nestjs-command",
     "cli:prod": "node dist/cli"
   },

--- a/apps/backend/src/plugins/devices-home-assistant/subscribers/devices-service.subscriber.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/subscribers/devices-service.subscriber.ts
@@ -3,11 +3,11 @@ import { validate } from 'class-validator';
 
 import { Injectable, Logger } from '@nestjs/common';
 
-import * as channelsSchema from '../../../../../../spec/devices/channels.json';
 import { ChannelCategory, ConnectionState, PropertyCategory } from '../../../modules/devices/devices.constants';
 import { ChannelSpecModel } from '../../../modules/devices/models/devices.model';
 import { ChannelsService } from '../../../modules/devices/services/channels.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { channelsSchema } from '../../../spec/channels';
 import { DEVICES_HOME_ASSISTANT_TYPE } from '../devices-home-assistant.constants';
 import { CreateHomeAssistantChannelDto } from '../dto/create-channel.dto';
 import { HomeAssistantDeviceEntity } from '../entities/devices-home-assistant.entity';

--- a/apps/backend/tools/build_channel_spec.ts
+++ b/apps/backend/tools/build_channel_spec.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+const inputPath = path.join(__dirname, '../../../spec/devices/channels.json');
+const outputPath = path.join(__dirname, '../src/spec/channels.ts');
+
+const raw = fs.readFileSync(inputPath, 'utf-8');
+const json = JSON.parse(raw);
+
+const output = `
+// This file is generated from channels.json
+// Do not edit manually!
+
+export const channelsSchema = ${JSON.stringify(json, null, 2)} as const;
+
+export type ChannelCategory = keyof typeof channelsSchema;
+export type ChannelDefinition = typeof channelsSchema[ChannelCategory];
+`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, output, 'utf-8');
+
+console.log('✅ Generated channels.ts');

--- a/apps/backend/tools/build_devices_spec.ts
+++ b/apps/backend/tools/build_devices_spec.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+const inputPath = path.join(__dirname, '../../../spec/devices/devices.json');
+const outputPath = path.join(__dirname, '../src/spec/devices.ts');
+
+const raw = fs.readFileSync(inputPath, 'utf-8');
+const json = JSON.parse(raw);
+
+const output = `
+// This file is generated from devices.json
+// Do not edit manually!
+
+export const devicesSchema = ${JSON.stringify(json, null, 2)} as const;
+
+export type DeviceCategory = keyof typeof devicesSchema;
+export type DeviceDefinition = typeof devicesSchema[DeviceCategory];
+`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, output, 'utf-8');
+
+console.log('✅ Generated devices.ts');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:debug": "pnpm run -r test:debug",
     "test:e2e": "pnpm run -r test:e2e",
     "generate:openapi": "pnpm run -r generate:openapi",
-    "bootstrap": "pnpm install && pnpm run generate:openapi && pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run && pnpm --filter @fastybird/smart-panel-backend run build && pnpm --filter @fastybird/smart-panel-admin run build",
+    "generate:spec": "pnpm run -r generate:spec",
+    "bootstrap": "pnpm install && pnpm run generate:openapi && run generate:spec && pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run && pnpm --filter @fastybird/smart-panel-backend run build && pnpm --filter @fastybird/smart-panel-admin run build",
     "onboard": "pnpm --filter @fastybird/smart-panel-backend run cli:prod auth:onboarding"
   },
   "engines": {


### PR DESCRIPTION
## Summary

This PR introduces tools and build process changes to support generating and bundling static spec files for both the **backend** and **admin** applications.

## ✨ What's Included

- ✅ Added `tools/` to generate TypeScript spec definitions from JSON source files (`/spec/`) for:
  - Device types
  - Channel types
- ✅ Introduced `generate:spec` command in both backend and admin packages
- ✅ Updated build process to:
  - Run `generate:spec` prior to compilation
  - Include generated `.ts` spec files in the published packages
- ✅ Resolved ES module compatibility issues:
  - Replaced `__dirname` with `import.meta.url`-based resolution
  - Aligned file extensions and `"type": "module"` support


## 📦 Benefits

- Removes the need to manually copy JSON spec files
- Makes spec definitions directly importable from published packages
- Enables strong typing and IDE support across apps using shared specs
