### PR TITLE
chore: Fix missing sqlite3 dependency in production build

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -257,6 +257,10 @@ jobs:
         working-directory: "./build"
         run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
+      - name: "Install SQLite Dependency"
+        working-directory: "./build"
+        run: "pnpm add sqlite3"
+
       - name: "Install Production Dependencies"
         working-directory: "./build"
         run: "pnpm install --prod"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -257,6 +257,10 @@ jobs:
         working-directory: "./build"
         run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
+      - name: "Install SQLite Dependency"
+        working-directory: "./build"
+        run: "pnpm add sqlite3"
+
       - name: "Install Production Dependencies"
         working-directory: "./build"
         run: "pnpm install --prod"


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions workflow to ensure the `sqlite3` Node.js package is properly installed in the pre-built application bundle.

## Changes

- ✅ Added `pnpm add sqlite3` to the `build-application` job in the alpha release workflow
- 🐛 Prevents runtime `DriverPackageNotInstalledError` in production
- 🧱 Ensures the backend can initialize SQLite connections out-of-the-box

## Notes

- The system-wide SQLite binary is not sufficient for TypeORM usage in Node.js
- This fix guarantees a complete and portable deployment tarball

---

Closes part of the packaging issues encountered on Raspberry Pi Zero.