### PR TITLE
ci: Switch to npm for final application packaging

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: "Prepare Build Folder"
         run: |
-          cp -v ./.env ./build/.env
+          cp .env ./build/
           cp -r var ./build/
 
       - name: "Remove Monorepo Configuration"
@@ -251,19 +251,15 @@ jobs:
 
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
+        run: "npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
-
-      - name: "Install SQLite Dependency"
-        working-directory: "./build"
-        run: "pnpm add sqlite3"
+        run: "npm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"
-        run: "pnpm install --prod"
+        run: "npm install --omit=dev"
 
       - name: "Archive Build"
         run: |

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: "Prepare Build Folder"
         run: |
-          cp -v ./.env ./build/.env
+          cp .env ./build/
           cp -r var ./build/
 
       - name: "Remove Monorepo Configuration"
@@ -251,19 +251,15 @@ jobs:
 
       - name: "Install Backend application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
+        run: "npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}"
 
       - name: "Install Admin application"
         working-directory: "./build"
-        run: "pnpm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
-
-      - name: "Install SQLite Dependency"
-        working-directory: "./build"
-        run: "pnpm add sqlite3"
+        run: "npm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}"
 
       - name: "Install Production Dependencies"
         working-directory: "./build"
-        run: "pnpm install --prod"
+        run: "npm install --omit=dev"
 
       - name: "Archive Build"
         run: |

--- a/build/package.json
+++ b/build/package.json
@@ -15,7 +15,7 @@
     "production",
     "embedded"
   ],
-  "homepage": "https://www.fastybird.com",
+  "homepage": "https://smart-panel.fastybird.com",
   "bugs": "https://github.com/FastyBird/smart-panel/issues",
   "license": "Apache-2.0",
   "author": {
@@ -38,7 +38,7 @@
   },
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10"
+    "npm": ">=11"
   },
-  "packageManager": "pnpm@10.12.0"
+  "packageManager": "npm@11.4.0"
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@fastybird/smart-panel-docs",
   "private": true,
   "version": "1.0.0-dev.1",
-  "homepage": "https://www.fastybird.com",
+  "homepage": "https://smart-panel.fastybird.com",
   "bugs": "https://github.com/FastyBird/smart-panel/issues",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "smart-panel",
     "vue"
   ],
-  "homepage": "https://www.fastybird.com",
+  "homepage": "https://smart-panel.fastybird.com",
   "bugs": "https://github.com/FastyBird/smart-panel/issues",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
## Summary

This pull request updates the GitHub Actions workflow to replace pnpm install --prod with npm install --omit=dev during the final application build step. This ensures that all runtime dependencies are properly installed into the /build/ directory for bundling.

## 📦 Why

pnpm does not install production dependencies correctly outside a workspace context — it resolves packages using symlinks or global store references, which breaks the final tarball. Using npm guarantees compatibility and correctness of the self-contained production build.
