### PR TITLE
chore: Build Smart Panel App in ARM Environment

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -245,7 +245,7 @@ jobs:
         uses: "pguyot/arm-runner-action@v2"
         with:
           base_image: "raspios_lite:latest"
-          image_additional_mb: "512"
+          image_additional_mb: "1024"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"
           copy_artifact_dest: "."

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -245,7 +245,7 @@ jobs:
         uses: "pguyot/arm-runner-action@v2"
         with:
           base_image: "raspios_lite:latest"
-          image_additional_mb: "512"
+          image_additional_mb: "1024"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"
           copy_artifact_dest: "."


### PR DESCRIPTION
## Summary

This PR increases the disk space allocated to the `arm-runner-action` used in the `build-application` job for building the Smart Panel app in an emulated ARM environment.


## ✅ Changes

- Adds `image_additional_mb: 512` to the `arm-runner-action` step.
- Resolves `E: You don't have enough free space in /var/cache/apt/archives/` error encountered during APT package installation.

## 🔧 Why

The default image size was insufficient to complete installation of system dependencies required for building backend and admin apps. Increasing the space ensures the build process completes reliably in the ARM emulation environment.