### PR TITLE
chore: Build Smart Panel App in ARM Environment

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -245,11 +245,12 @@ jobs:
         uses: "pguyot/arm-runner-action@v2"
         with:
           base_image: "raspios_lite:latest"
-          image_additional_mb: "2048"
+          image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"
           copy_artifact_dest: "."
           commands: |
+            apt-get update
             apt-get install -y curl git nodejs npm
             cd /opt/smart-panel/build
             npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -245,11 +245,12 @@ jobs:
         uses: "pguyot/arm-runner-action@v2"
         with:
           base_image: "raspios_lite:latest"
-          image_additional_mb: "2048"
+          image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"
           copy_artifact_dest: "."
           commands: |
+            apt-get update
             apt-get install -y curl git nodejs npm
             cd /opt/smart-panel/build
             npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}


### PR DESCRIPTION
## Summary

This PR increases the disk space allocated to the `arm-runner-action` used in the `build-application` job for building the Smart Panel app in an emulated ARM environment.


## ✅ Changes

- Adds `image_additional_mb: 4096` to the `arm-runner-action` step.
- Resolves `E: You don't have enough free space in /var/cache/apt/archives/` error encountered during APT package installation.

## 🔧 Why

The default image size was insufficient to complete installation of system dependencies required for building backend and admin apps. Increasing the space ensures the build process completes reliably in the ARM emulation environment.