### PR TITLE
chore: Use latest Node.js in ARM runner environment

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -251,7 +251,9 @@ jobs:
           copy_artifact_dest: "."
           commands: |
             apt-get update
-            apt-get install -y curl git nodejs npm
+            apt-get install -y curl git
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+            apt-get install -y nodejs
             cd /opt/smart-panel/build
             npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}
             npm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -251,7 +251,9 @@ jobs:
           copy_artifact_dest: "."
           commands: |
             apt-get update
-            apt-get install -y curl git nodejs npm
+            apt-get install -y curl git
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+            apt-get install -y nodejs
             cd /opt/smart-panel/build
             npm add @fastybird/smart-panel-backend@${{ needs.publish-backend.outputs.version }}
             npm add @fastybird/smart-panel-admin@${{ needs.publish-admin.outputs.version }}


### PR DESCRIPTION
## Summary

This PR updates the `build-application` job to explicitly install the latest LTS version of Node.js within the `arm-runner-action` environment to avoid using the outdated default (Node.js 18).

## ✅ Changes

- Installs latest Node.js LTS via the NodeSource setup script inside the emulated ARM job.
- Adds `curl` and `git` as prerequisites for NodeSource setup.
- Ensures the correct Node.js version is used during dependency installation and packaging.

## 🐛 Why

By default, the `raspios_lite:latest` image comes with Node.js 18, which is not aligned with the version required by the Smart Panel project (Node.js 20+). This change ensures version compatibility and prevents runtime or build-time issues due to version mismatch.