### PR TITLE
chore: switch ARM build job to Pi Zero 2-compatible image

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -244,7 +244,9 @@ jobs:
       - name: "Run Build in ARM Environment"
         uses: "pguyot/arm-runner-action@v2"
         with:
-          base_image: "raspios_lite:latest"
+          base_image: "dietpi:rpi_armv7_bookworm"
+          cpu: "cortex-a7"
+          cpu_info: "cpuinfo/raspberrypi_zero2_w"
           image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -244,7 +244,9 @@ jobs:
       - name: "Run Build in ARM Environment"
         uses: "pguyot/arm-runner-action@v2"
         with:
-          base_image: "raspios_lite:latest"
+          base_image: "dietpi:rpi_armv7_bookworm"
+          cpu: "cortex-a7"
+          cpu_info: "cpuinfo/raspberrypi_zero2_w"
           image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
           copy_artifact_path: "/opt/smart-panel/build/smart-panel.tar.gz;/opt/build/smart-panel/SHASUMS256.txt"


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions workflow to use a DietPi image specifically targeting Raspberry Pi Zero 2 (armv7), resolving runtime crashes caused by incompatible instruction sets.

## ✅ Changes
- Updated `base_image` to `dietpi:rpi_armv7_bookworm` in `arm-runner-action`
- Added `cpu: cortex-a7` and `cpu_info: cpuinfo/raspberrypi_zero2_w`
- Ensures compatibility with ARMv7-A architecture (used by Raspberry Pi Zero 2 W)
- Prevents `Illegal instruction (core dumped)` errors during `npm add` step

## 📦 Why
Previous builds were failing due to architecture mismatch:
Illegal instruction (core dumped)

Using the correct image and CPU configuration ensures node modules are built with compatible instructions for the Pi Zero 2.

#### 🎯 Outcome
The resulting `smart-panel.tar.gz` is now fully executable on target devices without needing additional runtime compilation.