### PR TITLE
chore: Use ARM emulation to preinstall dependencies into RPi-compatible tarball

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -249,7 +249,7 @@ jobs:
           cpu_info: "cpuinfo/raspberrypi_zero2_w"
           image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
-          copy_artifact_path: "/opt/smart-panel/smart-panel.tar.gz;/opt/smart-panel/SHASUMS256.txt"
+          copy_artifact_path: "smart-panel.tar.gz;SHASUMS256.txt"
           copy_artifact_dest: "."
           commands: |
             apt-get update

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -249,7 +249,7 @@ jobs:
           cpu_info: "cpuinfo/raspberrypi_zero2_w"
           image_additional_mb: "4096"
           copy_repository_path: "/opt/smart-panel"
-          copy_artifact_path: "/opt/smart-panel/smart-panel.tar.gz;/opt/smart-panel/SHASUMS256.txt"
+          copy_artifact_path: "smart-panel.tar.gz;SHASUMS256.txt"
           copy_artifact_dest: "."
           commands: |
             apt-get update


### PR DESCRIPTION
## Summary

This PR enhances the `build-application` job in the GitHub Actions workflow by:

- 🛠️ Switching to [`pguyot/arm-runner-action`](https://github.com/pguyot/arm-runner-action) to emulate a Raspberry Pi Zero 2 environment
- 🧠 Using:
  - `raspios_lite:latest` as the base image
  - `cpu: cortex-a7` with matching `cpu_info: raspberrypi_zero2_w`
- 📦 Installing `@fastybird/smart-panel-backend` and `@fastybird/smart-panel-admin` inside the `/build` folder
- ✅ Ensuring dependencies are fully installed and native to the target architecture
- 🗃️ Archiving the `/build` folder from the project root (outside the build context) to avoid errors when tarballing
- 🔐 Generating and attaching a SHA256 checksum

## Why?

This approach solves:

- ❌ `Illegal instruction` errors when running on RPi Zero 2
- ❌ Incomplete `node_modules` when bundling with `pnpm`
- ❌ Slow post-install time on underpowered hardware like the Zero

It prepares a ready-to-use production package (`smart-panel.tar.gz`) that can be unpacked and run immediately on the target device.