### PR TITLE
feature: Add system health endpoint & improve display startup behavior

### DIFF
--- a/apps/backend/src/modules/system/controllers/system.controller.ts
+++ b/apps/backend/src/modules/system/controllers/system.controller.ts
@@ -28,11 +28,13 @@ export class SystemController {
 
 	@Public()
 	@Get('health')
-	async getSystemHealth(): Promise<SystemHealthModel> {
+	getSystemHealth(): SystemHealthModel {
 		this.logger.debug('[LOOKUP] Health check');
 
 		try {
-			const pkgJson = JSON.parse(readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8'));
+			const pkgJson: { version: string } | undefined = JSON.parse(
+				readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8'),
+			);
 
 			return plainToInstance(
 				SystemHealthModel,

--- a/apps/backend/src/modules/system/controllers/system.controller.ts
+++ b/apps/backend/src/modules/system/controllers/system.controller.ts
@@ -32,9 +32,9 @@ export class SystemController {
 		this.logger.debug('[LOOKUP] Health check');
 
 		try {
-			const pkgJson: { version: string } | undefined = JSON.parse(
-				readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8'),
-			);
+			const pkgJson = JSON.parse(readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8')) as
+				| { version: string }
+				| undefined;
 
 			return plainToInstance(
 				SystemHealthModel,

--- a/apps/backend/src/modules/system/models/system.model.spec.ts
+++ b/apps/backend/src/modules/system/models/system.model.spec.ts
@@ -10,6 +10,7 @@ import {
 	NetworkStatsModel,
 	OperatingSystemInfoModel,
 	StorageInfoModel,
+	SystemHealthModel,
 	SystemInfoModel,
 	TemperatureInfoModel,
 	ThrottleStatusModel,
@@ -21,6 +22,7 @@ type TemperatureInfo = components['schemas']['SystemModuleTemperatureInfo'];
 type OperatingSystemInfo = components['schemas']['SystemModuleOperatingSystemInfo'];
 type DisplayInfo = components['schemas']['SystemModuleDisplayInfo'];
 type NetworkStats = components['schemas']['SystemModuleNetworkStats'];
+type SystemHealth = components['schemas']['SystemModuleSystemHealth'];
 type SystemInfo = components['schemas']['SystemModuleSystemInfo'];
 type ThrottleStatus = components['schemas']['SystemModuleThrottleStatus'];
 
@@ -47,7 +49,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		});
 	};
 
-	test('MemoryInfoModel matches SystemMemoryInfo', () => {
+	test('MemoryInfoModel matches MemoryInfo', () => {
 		const openApiModel: MemoryInfo = {
 			total: 8388608000,
 			used: 4200000000,
@@ -68,7 +70,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('StorageInfoModel matches SystemStorageInfo', () => {
+	test('StorageInfoModel matches StorageInfo', () => {
 		const openApiModel: StorageInfo = {
 			fs: '/dev/mmcblk0p1',
 			used: 15000000000,
@@ -90,7 +92,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('TemperatureInfoModel matches SystemTemperatureInfo', () => {
+	test('TemperatureInfoModel matches TemperatureInfo', () => {
 		const openApiModel: TemperatureInfo = {
 			cpu: 55,
 			gpu: 60,
@@ -110,7 +112,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('OperatingSystemInfoModel matches SystemOperatingSystemInfo', () => {
+	test('OperatingSystemInfoModel matches OperatingSystemInfo', () => {
 		const openApiModel: OperatingSystemInfo = {
 			platform: 'linux',
 			distro: 'Debian',
@@ -132,7 +134,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('DisplayInfoModel matches SystemDisplayInfo', () => {
+	test('DisplayInfoModel matches DisplayInfo', () => {
 		const openApiModel: DisplayInfo = {
 			resolution_x: 1920,
 			resolution_y: 1080,
@@ -154,7 +156,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('NetworkStatsModel matches SystemNetworkStats', () => {
+	test('NetworkStatsModel matches NetworkStats', () => {
 		const openApiModel: NetworkStats = {
 			interface: 'eth0',
 			rx_bytes: 123456789,
@@ -175,7 +177,7 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('SystemInfoModel matches SystemSystemInfo', () => {
+	test('SystemInfoModel matches SystemInfo', () => {
 		const openApiModel: SystemInfo = {
 			cpu_load: 15.3,
 			memory: {
@@ -236,7 +238,27 @@ describe('System module model and OpenAPI component synchronization', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	test('ThrottleStatusModel matches SystemThrottleStatus', () => {
+	test('SystemHealthModel matches SystemHealth', () => {
+		const openApiModel: SystemHealth = {
+			status: 'ok',
+			version: '1.0.0',
+		};
+
+		const modelInstance = plainToInstance(SystemHealthModel, openApiModel, {
+			excludeExtraneousValues: true,
+			enableImplicitConversion: true,
+		});
+
+		validateModelAgainstComponent(modelInstance, openApiModel);
+
+		const errors = validateSync(modelInstance, {
+			whitelist: true,
+			forbidNonWhitelisted: true,
+		});
+		expect(errors).toHaveLength(0);
+	});
+
+	test('ThrottleStatusModel matches ThrottleStatus', () => {
 		const openApiModel: ThrottleStatus = {
 			undervoltage: false,
 			frequency_capping: false,

--- a/apps/backend/src/modules/system/models/system.model.ts
+++ b/apps/backend/src/modules/system/models/system.model.ts
@@ -113,6 +113,16 @@ export class DefaultNetworkModel {
 	mac: string;
 }
 
+export class SystemHealthModel {
+	@Expose()
+	@IsString()
+	status: string;
+
+	@Expose()
+	@IsString()
+	version: string;
+}
+
 export class SystemInfoModel {
 	@Expose({ name: 'cpu_load' })
 	@IsNumber()

--- a/docs/app/docs/get-started/installation/page.mdx
+++ b/docs/app/docs/get-started/installation/page.mdx
@@ -312,6 +312,7 @@ Now that your Raspberry Pi is set up, it’s time to install the software that p
 	[Unit]
 	Description=Smart Panel Display App
 	After=network.target
+	Requires=smart-panel-backend.service
 
 	[Service]
 	User=pi

--- a/spec/api/v1/openapi.json
+++ b/spec/api/v1/openapi.json
@@ -5127,6 +5127,51 @@
         ]
       }
     },
+    "/system-module/system/health": {
+      "get": {
+        "tags": [
+          "System module"
+        ],
+        "summary": "Check backend health status",
+        "description": "Returns a summary of the backend system health, including status and version.",
+        "operationId": "get-system-module-system-health",
+        "responses": {
+          "200": {
+            "description": "Backend is healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemModuleResSystemHealth"
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "status": "success",
+                      "timestamp": "2025-01-18T12:00:00Z",
+                      "request_id": "b27b7c58-76f6-407a-bc78-4068e4cfd082",
+                      "path": "/api/v1/system-module/system/health",
+                      "method": "GET",
+                      "data": {
+                        "status": "ok",
+                        "version": "1.0.0"
+                      },
+                      "metadata": {
+                        "request_duration_ms": 57,
+                        "server_time": "2025-01-18T12:00:00Z",
+                        "cpu_usage": 25.28
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Backend is not ready"
+          }
+        }
+      }
+    },
     "/system-module/system/info": {
       "get": {
         "tags": [
@@ -11955,6 +12000,35 @@
           }
         }
       },
+      "SystemModuleSystemHealth": {
+        "title": "System Health",
+        "description": "Schema representing basic health information about the system, including backend availability and version.",
+        "type": "object",
+        "required": [
+          "status",
+          "version"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Current backend status. Expected value is 'ok'.",
+            "example": "ok",
+            "readOnly": true
+          },
+          "version": {
+            "type": "string",
+            "description": "Semantic version of the backend service.",
+            "example": "1.0.0",
+            "readOnly": true
+          }
+        },
+        "examples": [
+          {
+            "status": "ok",
+            "version": "1.0.0"
+          }
+        ]
+      },
       "SystemModuleSystemInfo": {
         "title": "System Info",
         "description": "Schema for a detailed information about the system, including CPU load, memory, storage, temperature, operating system, network, and display.",
@@ -12100,6 +12174,86 @@
             "frequency_capping": false,
             "throttling": false,
             "soft_temp_limit": false
+          }
+        ]
+      },
+      "SystemModuleResSystemHealth": {
+        "title": "System Health Response",
+        "description": "Standard response wrapper for system health status.",
+        "type": "object",
+        "required": [
+          "status",
+          "timestamp",
+          "request_id",
+          "path",
+          "method",
+          "data",
+          "metadata"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Indicates whether the API request was successful (`success`) or encountered an error (`error`).",
+            "example": "success",
+            "readOnly": true
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the response was generated, in ISO 8601 format (`YYYY-MM-DDTHH:mm:ssZ`).",
+            "example": "2025-01-18T12:00:00Z",
+            "readOnly": true
+          },
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "A unique identifier assigned to this API request. Useful for debugging and tracking API calls.",
+            "example": "b27b7c58-76f6-407a-bc78-4068e4cfd082",
+            "readOnly": true
+          },
+          "path": {
+            "type": "string",
+            "description": "The API endpoint that was requested, including any dynamic parameters.",
+            "example": "/api/v1/system-module/system/health",
+            "readOnly": true
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "PATCH",
+              "DELETE"
+            ],
+            "description": "The HTTP method used for the request (`GET`, `POST`, `PATCH`, `DELETE`).",
+            "example": "GET",
+            "readOnly": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/SystemModuleSystemHealth",
+            "description": "The actual data payload returned by the API. The structure depends on the specific endpoint response."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/CommonResMetadata",
+            "description": "Additional metadata about the request and server performance metrics."
+          }
+        },
+        "examples": [
+          {
+            "status": "success",
+            "timestamp": "2025-01-18T12:00:00Z",
+            "request_id": "b27b7c58-76f6-407a-bc78-4068e4cfd082",
+            "path": "/api/v1/system-module/system/health",
+            "method": "GET",
+            "data": {
+              "status": "ok",
+              "version": "1.0.0"
+            },
+            "metadata": {
+              "request_duration_ms": 57,
+              "server_time": "2025-01-18T12:00:00Z",
+              "cpu_usage": 25.28
+            }
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Added `/system-module/system/health` endpoint under the System module in the OpenAPI spec.
- Implemented backend controller to expose system health status, including version and runtime checks.
- Introduced schema `SystemModuleSystemHealth` and response wrapper `SystemModuleResSystemHealth`.
- Integrated health check call in the display startup flow before attempting API registration or connection.
- Display app now shows loading state and gracefully handles backend unavailability at boot.

## 🛠 Improvements

- Added logic to read backend version from `APP_VERSION` env var with fallback to `"unknown"`.

## 📚 Documentation

- OpenAPI spec updated with system health route, schemas, and example response.

---

This improves robustness of the display on boot, especially when the backend takes longer to start (e.g. on Raspberry Pi Zero 2).