### PR TITLE
# feature: Enable/disable plugins

### DIFF
--- a/apps/admin/src/modules/config/composables/composables.ts
+++ b/apps/admin/src/modules/config/composables/composables.ts
@@ -6,6 +6,8 @@ export * from './useConfigLanguage';
 export * from './useConfigLanguageEditForm';
 export * from './useConfigWeather';
 export * from './useConfigWeatherEditForm';
+export * from './useConfigPlugin';
+export * from './useConfigPlugins';
 export * from './useConfigPluginEditForm';
 export * from './usePlugin';
 export * from './usePlugins';

--- a/apps/admin/src/modules/config/composables/types.ts
+++ b/apps/admin/src/modules/config/composables/types.ts
@@ -135,6 +135,14 @@ export interface IUseConfigPlugin {
 	fetchConfigPlugin: () => Promise<void>;
 }
 
+export interface IUseConfigPlugins {
+	configPlugins: ComputedRef<IConfigPlugin[]>;
+	areLoading: ComputedRef<boolean>;
+	loaded: ComputedRef<boolean>;
+	enabled: (type: IConfigPlugin['type']) => boolean;
+	fetchConfigPlugins: () => Promise<void>;
+}
+
 export interface IUseConfigPluginEditForm<TForm extends IConfigPluginEditForm = IConfigPluginEditForm> {
 	model: Reactive<TForm>;
 	formEl: Ref<FormInstance | undefined>;

--- a/apps/admin/src/modules/config/composables/useConfigPlugin.spec.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPlugin.spec.ts
@@ -11,6 +11,7 @@ import { useConfigPlugin } from './useConfigPlugin';
 
 const mockPlugin: IConfigPlugin = {
 	type: 'custom-plugin',
+	enabled: true,
 };
 
 vi.mock('../../../common', async () => {
@@ -24,9 +25,11 @@ vi.mock('../../../common', async () => {
 
 describe('useConfigPlugin', () => {
 	let get: Mock;
+	let findByType: Mock;
 
 	let mockStore: {
 		get: Mock;
+		findByType: Mock;
 		$id: string;
 		data: Ref;
 		semaphore: Ref;
@@ -36,13 +39,15 @@ describe('useConfigPlugin', () => {
 		setActivePinia(createPinia());
 
 		get = vi.fn();
+		findByType = vi.fn().mockReturnValue(mockPlugin);
 
 		mockStore = {
 			get,
+			findByType,
 			$id: 'configPlugin',
 			data: ref({}),
 			semaphore: ref({
-				getting: [],
+				fetching: { items: false, item: [] },
 			}),
 		};
 
@@ -60,7 +65,7 @@ describe('useConfigPlugin', () => {
 	});
 
 	it('returns isLoading true if data is null and getting is true', () => {
-		mockStore.semaphore.value.getting.push(mockPlugin.type);
+		mockStore.semaphore.value.fetching.item.push(mockPlugin.type);
 
 		const { isLoading } = useConfigPlugin({ type: 'custom-plugin' });
 

--- a/apps/admin/src/modules/config/composables/useConfigPlugin.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPlugin.ts
@@ -20,7 +20,7 @@ export const useConfigPlugin = ({ type }: IUseConfigPluginProps): IUseConfigPlug
 	const { data, semaphore } = storeToRefs(configPluginStore);
 
 	const configPlugin = computed<IConfigPlugin | null>((): IConfigPlugin | null => {
-		return type in data.value ? data.value[type] : null;
+		return configPluginStore.findByType(type);
 	});
 
 	const fetchConfigPlugin = async (): Promise<void> => {
@@ -32,7 +32,7 @@ export const useConfigPlugin = ({ type }: IUseConfigPluginProps): IUseConfigPlug
 			return false;
 		}
 
-		return semaphore.value.getting.includes(type);
+		return semaphore.value.fetching.item.includes(type);
 	});
 
 	return {

--- a/apps/admin/src/modules/config/composables/useConfigPlugins.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPlugins.ts
@@ -1,0 +1,55 @@
+import { computed } from 'vue';
+
+import { storeToRefs } from 'pinia';
+
+import { injectStoresManager } from '../../../common';
+import type { IConfigPlugin } from '../store/config-plugins.store.types';
+import { configPluginsStoreKey } from '../store/keys';
+
+import type { IUseConfigPlugins } from './types';
+
+export const useConfigPlugins = (): IUseConfigPlugins => {
+	const storesManager = injectStoresManager();
+
+	const configPluginStore = storesManager.getStore(configPluginsStoreKey);
+
+	const { firstLoad, semaphore } = storeToRefs(configPluginStore);
+
+	const configPlugins = computed<IConfigPlugin[]>((): IConfigPlugin[] => {
+		return configPluginStore.findAll();
+	});
+
+	const fetchConfigPlugins = async (): Promise<void> => {
+		await configPluginStore.fetch();
+	};
+
+	const areLoading = computed<boolean>((): boolean => {
+		if (semaphore.value.fetching.items) {
+			return true;
+		}
+
+		if (firstLoad.value) {
+			return false;
+		}
+
+		return semaphore.value.fetching.items;
+	});
+
+	const loaded = computed<boolean>((): boolean => {
+		return firstLoad.value;
+	});
+
+	const enabled = (type: IConfigPlugin['type']): boolean => {
+		const plugin = configPluginStore.findByType(type);
+
+		return plugin?.enabled ?? false;
+	};
+
+	return {
+		configPlugins,
+		areLoading,
+		loaded,
+		enabled,
+		fetchConfigPlugins,
+	};
+};

--- a/apps/admin/src/modules/config/schemas/plugins.schemas.ts
+++ b/apps/admin/src/modules/config/schemas/plugins.schemas.ts
@@ -2,4 +2,5 @@ import { z } from 'zod';
 
 export const ConfigPluginEditFormSchema = z.object({
 	type: z.string().trim().nonempty(),
+	enabled: z.boolean().default(false),
 });

--- a/apps/admin/src/modules/config/store/config-plugins.store.schemas.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.schemas.ts
@@ -1,6 +1,7 @@
 import { type ZodType, z } from 'zod';
 
 import { type components } from '../../../openapi';
+import { ItemIdSchema } from '../../devices';
 
 type ApiConfigPlugin = components['schemas']['ConfigModulePlugin'];
 type ApiConfigUpdatePlugin = components['schemas']['ConfigModuleUpdatePlugin'];
@@ -10,10 +11,14 @@ type ApiConfigUpdatePlugin = components['schemas']['ConfigModuleUpdatePlugin'];
 
 export const ConfigPluginSchema = z.object({
 	type: z.string(),
+	enabled: z.boolean().default(false),
 });
 
 export const ConfigPluginsStateSemaphoreSchema = z.object({
-	getting: z.array(z.string()),
+	fetching: z.object({
+		items: z.boolean().default(false),
+		item: z.array(ItemIdSchema),
+	}),
 	updating: z.array(z.string()),
 });
 
@@ -46,8 +51,10 @@ export const ConfigPluginsEditActionPayloadSchema = z.object({
 
 export const ConfigPluginUpdateReqSchema: ZodType<ApiConfigUpdatePlugin> = z.object({
 	type: z.string(),
+	enabled: z.boolean().optional(),
 });
 
 export const ConfigPluginResSchema: ZodType<ApiConfigPlugin> = z.object({
 	type: z.string(),
+	enabled: z.boolean(),
 });

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -26,11 +26,13 @@ const CustomPluginConfigUpdateReqSchema = ConfigPluginUpdateReqSchema.and(
 
 const mockPluginRes = {
 	type: 'custom-plugin',
+	enabled: true,
 	mockValue: 'default value',
 };
 
 const mockPlugin = {
 	type: 'custom-plugin',
+	enabled: true,
 	mockValue: 'default value',
 };
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.types.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.types.ts
@@ -39,16 +39,22 @@ export type IConfigPluginsEditActionPayload = z.infer<typeof ConfigPluginsEditAc
 export interface IConfigPluginsStoreState {
 	data: Ref<{ [key: string]: IConfigPlugin }>;
 	semaphore: Ref<IConfigPluginsStateSemaphore>;
+	firstLoad: Ref<boolean>;
 }
 
 export interface IConfigPluginsStoreActions {
 	// Getters
+	firstLoadFinished: () => boolean;
+	findByType: (id: IConfigPlugin['type']) => IConfigPlugin | null;
+	findAll: () => IConfigPlugin[];
 	getting: (plugin: IConfigPlugin['type']) => boolean;
+	fetching: () => boolean;
 	updating: (plugin: IConfigPlugin['type']) => boolean;
 	// Actions
 	onEvent: (payload: IConfigPluginsOnEventActionPayload) => IConfigPlugin;
 	set: (payload: IConfigPluginsSetActionPayload) => IConfigPlugin;
 	get: (payload: IConfigPluginsGetActionPayload) => Promise<IConfigPlugin>;
+	fetch: () => Promise<IConfigPlugin[]>;
 	edit: (payload: IConfigPluginsEditActionPayload) => Promise<IConfigPlugin>;
 }
 

--- a/apps/admin/src/modules/config/store/config-plugins.transformers.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.transformers.spec.ts
@@ -19,11 +19,13 @@ const CustomPluginConfigUpdateReqSchema = ConfigPluginUpdateReqSchema.and(
 
 const validConfigPluginResponse: IConfigPluginRes = {
 	type: 'custom-plugin',
+	enabled: true,
 	mock_value: 'Default value',
 } as IConfigPluginRes;
 
 const validConfigPluginUpdatePayload: IConfigPluginsEditActionPayload['data'] = {
 	type: 'custom-plugin',
+	enabled: true,
 	mockValue: 'Default value',
 } as IConfigPluginsEditActionPayload['data'];
 
@@ -34,6 +36,7 @@ describe('Config Plugin Transformers', (): void => {
 
 			expect(result).toEqual({
 				type: 'custom-plugin',
+				enabled: true,
 				mockValue: 'Default value',
 			});
 		});
@@ -51,6 +54,7 @@ describe('Config Plugin Transformers', (): void => {
 
 			expect(result).toEqual({
 				type: 'custom-plugin',
+				enabled: true,
 				mock_value: 'Default value',
 			});
 		});

--- a/apps/admin/src/modules/dashboard/components/data-sources/select-data-source-plugin.vue
+++ b/apps/admin/src/modules/dashboard/components/data-sources/select-data-source-plugin.vue
@@ -14,6 +14,7 @@
 				:key="item.value"
 				:label="item.label"
 				:value="item.value"
+				:disabled="item.disabled"
 			/>
 		</el-select>
 	</el-form-item>

--- a/apps/admin/src/modules/dashboard/components/pages/select-page-plugin.vue
+++ b/apps/admin/src/modules/dashboard/components/pages/select-page-plugin.vue
@@ -14,6 +14,7 @@
 				:key="item.value"
 				:label="item.label"
 				:value="item.value"
+				:disabled="item.disabled"
 			/>
 		</el-select>
 	</el-form-item>

--- a/apps/admin/src/modules/dashboard/components/tiles/select-tile-plugin.vue
+++ b/apps/admin/src/modules/dashboard/components/tiles/select-tile-plugin.vue
@@ -14,6 +14,7 @@
 				:key="item.value"
 				:label="item.label"
 				:value="item.value"
+				:disabled="item.disabled"
 			/>
 		</el-select>
 	</el-form-item>

--- a/apps/admin/src/modules/dashboard/composables/types.ts
+++ b/apps/admin/src/modules/dashboard/composables/types.ts
@@ -98,7 +98,7 @@ export interface IUsePagesPlugin {
 
 export interface IUsePagesPlugins {
 	plugins: ComputedRef<IPlugin<IPagePluginsComponents, IPagePluginsSchemas, IPagePluginRoutes>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<IPagePluginsComponents, IPagePluginsSchemas, IPagePluginRoutes> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IPagePluginsComponents, IPagePluginsSchemas, IPagePluginRoutes> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IPagePluginsComponents, IPagePluginsSchemas> | undefined;
@@ -162,7 +162,7 @@ export interface IUseTilesPlugin {
 
 export interface IUseTilesPlugins {
 	plugins: ComputedRef<IPlugin<ITilePluginsComponents, ITilePluginsSchemas>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<ITilePluginsComponents, ITilePluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<ITilePluginsComponents, ITilePluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<ITilePluginsComponents, ITilePluginsSchemas> | undefined;
@@ -226,7 +226,7 @@ export interface IUseDataSourcesPlugin {
 
 export interface IUseDataSourcesPlugins {
 	plugins: ComputedRef<IPlugin<IDataSourcePluginsComponents, IDataSourcePluginsSchemas>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<IDataSourcePluginsComponents, IDataSourcePluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IDataSourcePluginsComponents, IDataSourcePluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IDataSourcePluginsComponents, IDataSourcePluginsSchemas> | undefined;

--- a/apps/admin/src/modules/dashboard/composables/useTilesPlugins.ts
+++ b/apps/admin/src/modules/dashboard/composables/useTilesPlugins.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { orderBy } from 'natural-orderby';
 
 import { type IPlugin, type IPluginElement, injectPluginsManager } from '../../../common';
+import { useConfigPlugins } from '../../config';
 import { DASHBOARD_MODULE_NAME } from '../dashboard.constants';
 import type { ITilePluginsComponents, ITilePluginsSchemas } from '../dashboard.types';
 
@@ -10,6 +11,8 @@ import type { IUseTilesPlugins } from './types';
 
 export const useTilesPlugins = (): IUseTilesPlugins => {
 	const pluginsManager = injectPluginsManager();
+
+	const { enabled, fetchConfigPlugins, loaded } = useConfigPlugins();
 
 	const pluginComponents: (keyof ITilePluginsComponents)[] = ['tileAddForm', 'tileEditForm'];
 
@@ -46,18 +49,21 @@ export const useTilesPlugins = (): IUseTilesPlugins => {
 		});
 	});
 
-	const options = computed<{ value: IPluginElement['type']; label: string }[]>((): { value: IPluginElement['type']; label: string }[] => {
-		const flat: { value: IPluginElement['type']; label: string }[] = plugins.value.flatMap((plugin) => {
-			return (plugin.elements ?? [])
-				.filter((el) => el.modules === undefined || el.modules.includes(DASHBOARD_MODULE_NAME))
-				.map((el) => ({
-					value: el.type,
-					label: el.name?.trim() ? el.name : plugin.name,
-				}));
-		});
+	const options = computed<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>(
+		(): { value: IPluginElement['type']; label: string; disabled: boolean }[] => {
+			const flat: { value: IPluginElement['type']; label: string; disabled: boolean }[] = plugins.value.flatMap((plugin) => {
+				return (plugin.elements ?? [])
+					.filter((el) => el.modules === undefined || el.modules.includes(DASHBOARD_MODULE_NAME))
+					.map((el) => ({
+						value: el.type,
+						label: el.name?.trim() ? el.name : plugin.name,
+						disabled: !enabled(plugin.type),
+					}));
+			});
 
-		return orderBy(flat, [(o) => o.label], ['asc']);
-	});
+			return orderBy(flat, [(o) => o.label], ['asc']);
+		}
+	);
 
 	const getByName = (type: IPlugin['type']): IPlugin<ITilePluginsComponents, ITilePluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) => plugin.type === type);
@@ -82,6 +88,12 @@ export const useTilesPlugins = (): IUseTilesPlugins => {
 
 		return undefined;
 	};
+
+	if (!loaded.value) {
+		fetchConfigPlugins().catch((): void => {
+			// Something went wrong
+		});
+	}
 
 	return {
 		plugins,

--- a/apps/admin/src/modules/devices/components/channels/select-channel-plugin.vue
+++ b/apps/admin/src/modules/devices/components/channels/select-channel-plugin.vue
@@ -14,6 +14,7 @@
 				:key="item.value"
 				:label="item.label"
 				:value="item.value"
+				:disabled="item.disabled"
 			/>
 		</el-select>
 	</el-form-item>

--- a/apps/admin/src/modules/devices/components/devices/select-device-plugin.vue
+++ b/apps/admin/src/modules/devices/components/devices/select-device-plugin.vue
@@ -14,6 +14,7 @@
 				:key="item.value"
 				:label="item.label"
 				:value="item.value"
+				:disabled="item.disabled"
 			/>
 		</el-select>
 	</el-form-item>

--- a/apps/admin/src/modules/devices/composables/types.ts
+++ b/apps/admin/src/modules/devices/composables/types.ts
@@ -121,7 +121,7 @@ export interface IUseChannelsPlugin {
 
 export interface IUseChannelsPlugins {
 	plugins: ComputedRef<IPlugin<IChannelPluginsComponents, IChannelPluginsSchemas>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<IChannelPluginsComponents, IChannelPluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IChannelPluginsComponents, IChannelPluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IChannelPluginsComponents, IChannelPluginsSchemas> | undefined;
@@ -205,7 +205,7 @@ export interface IUseChannelsPropertiesPlugin {
 
 export interface IUseChannelsPropertiesPlugins {
 	plugins: ComputedRef<IPlugin<IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas> | undefined;
@@ -285,7 +285,7 @@ export interface IUseDevicesPlugin {
 
 export interface IUseDevicesPlugins {
 	plugins: ComputedRef<IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas>[]>;
-	options: ComputedRef<{ value: IPluginElement['type']; label: string }[]>;
+	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
 	getByName: (type: IPlugin['type']) => IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;

--- a/apps/admin/src/modules/devices/composables/useChannelsPlugins.ts
+++ b/apps/admin/src/modules/devices/composables/useChannelsPlugins.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { orderBy } from 'natural-orderby';
 
 import { type IPlugin, type IPluginElement, injectPluginsManager } from '../../../common';
+import { useConfigPlugins } from '../../config';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
 import type { IChannelPluginsComponents, IChannelPluginsSchemas } from '../devices.types';
 
@@ -10,6 +11,8 @@ import type { IUseChannelsPlugins } from './types';
 
 export const useChannelsPlugins = (): IUseChannelsPlugins => {
 	const pluginsManager = injectPluginsManager();
+
+	const { enabled, fetchConfigPlugins, loaded } = useConfigPlugins();
 
 	const pluginComponents: (keyof IChannelPluginsComponents)[] = ['channelAddForm', 'channelEditForm'];
 
@@ -46,18 +49,21 @@ export const useChannelsPlugins = (): IUseChannelsPlugins => {
 		});
 	});
 
-	const options = computed<{ value: IPluginElement['type']; label: string }[]>((): { value: IPluginElement['type']; label: string }[] => {
-		const flat: { value: IPluginElement['type']; label: string }[] = plugins.value.flatMap((plugin) => {
-			return (plugin.elements ?? [])
-				.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
-				.map((el) => ({
-					value: el.type,
-					label: el.name?.trim() ? el.name : plugin.name,
-				}));
-		});
+	const options = computed<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>(
+		(): { value: IPluginElement['type']; label: string; disabled: boolean }[] => {
+			const flat: { value: IPluginElement['type']; label: string; disabled: boolean }[] = plugins.value.flatMap((plugin) => {
+				return (plugin.elements ?? [])
+					.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
+					.map((el) => ({
+						value: el.type,
+						label: el.name?.trim() ? el.name : plugin.name,
+						disabled: !enabled(plugin.type),
+					}));
+			});
 
-		return orderBy(flat, [(o) => o.label], ['asc']);
-	});
+			return orderBy(flat, [(o) => o.label], ['asc']);
+		}
+	);
 
 	const getByName = (type: IPlugin['type']): IPlugin<IChannelPluginsComponents, IChannelPluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) => plugin.type === type);
@@ -82,6 +88,12 @@ export const useChannelsPlugins = (): IUseChannelsPlugins => {
 
 		return undefined;
 	};
+
+	if (!loaded.value) {
+		fetchConfigPlugins().catch((): void => {
+			// Something went wrong
+		});
+	}
 
 	return {
 		plugins,

--- a/apps/admin/src/modules/devices/composables/useChannelsPropertiesPlugins.ts
+++ b/apps/admin/src/modules/devices/composables/useChannelsPropertiesPlugins.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { orderBy } from 'natural-orderby';
 
 import { type IPlugin, type IPluginElement, injectPluginsManager } from '../../../common';
+import { useConfigPlugins } from '../../config';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
 import type { IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas } from '../devices.types';
 
@@ -10,6 +11,8 @@ import type { IUseChannelsPropertiesPlugins } from './types';
 
 export const useChannelsPropertiesPlugins = (): IUseChannelsPropertiesPlugins => {
 	const pluginsManager = injectPluginsManager();
+
+	const { enabled, fetchConfigPlugins, loaded } = useConfigPlugins();
 
 	const pluginComponents: (keyof IChannelPropertyPluginsComponents)[] = ['channelPropertyAddForm', 'channelPropertyEditForm'];
 
@@ -46,18 +49,21 @@ export const useChannelsPropertiesPlugins = (): IUseChannelsPropertiesPlugins =>
 		});
 	});
 
-	const options = computed<{ value: IPluginElement['type']; label: string }[]>((): { value: IPluginElement['type']; label: string }[] => {
-		const flat: { value: IPluginElement['type']; label: string }[] = plugins.value.flatMap((plugin) => {
-			return (plugin.elements ?? [])
-				.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
-				.map((el) => ({
-					value: el.type,
-					label: el.name?.trim() ? el.name : plugin.name,
-				}));
-		});
+	const options = computed<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>(
+		(): { value: IPluginElement['type']; label: string; disabled: boolean }[] => {
+			const flat: { value: IPluginElement['type']; label: string; disabled: boolean }[] = plugins.value.flatMap((plugin) => {
+				return (plugin.elements ?? [])
+					.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
+					.map((el) => ({
+						value: el.type,
+						label: el.name?.trim() ? el.name : plugin.name,
+						disabled: !enabled(plugin.type),
+					}));
+			});
 
-		return orderBy(flat, [(o) => o.label], ['asc']);
-	});
+			return orderBy(flat, [(o) => o.label], ['asc']);
+		}
+	);
 
 	const getByName = (type: IPlugin['type']): IPlugin<IChannelPropertyPluginsComponents, IChannelPropertyPluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) => plugin.type === type);
@@ -84,6 +90,12 @@ export const useChannelsPropertiesPlugins = (): IUseChannelsPropertiesPlugins =>
 
 		return undefined;
 	};
+
+	if (!loaded.value) {
+		fetchConfigPlugins().catch((): void => {
+			// Something went wrong
+		});
+	}
 
 	return {
 		plugins,

--- a/apps/admin/src/modules/devices/composables/useDevicesPlugins.ts
+++ b/apps/admin/src/modules/devices/composables/useDevicesPlugins.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { orderBy } from 'natural-orderby';
 
 import { type IPlugin, type IPluginElement, injectPluginsManager } from '../../../common';
+import { useConfigPlugins } from '../../config';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
 import type { IDevicePluginsComponents, IDevicePluginsSchemas } from '../devices.types';
 
@@ -10,6 +11,8 @@ import type { IUseDevicesPlugins } from './types';
 
 export const useDevicesPlugins = (): IUseDevicesPlugins => {
 	const pluginsManager = injectPluginsManager();
+
+	const { enabled, fetchConfigPlugins, loaded } = useConfigPlugins();
 
 	const pluginComponents: (keyof IDevicePluginsComponents)[] = ['deviceAddForm', 'deviceEditForm'];
 
@@ -46,18 +49,21 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 		});
 	});
 
-	const options = computed<{ value: IPluginElement['type']; label: string }[]>((): { value: IPluginElement['type']; label: string }[] => {
-		const flat: { value: IPluginElement['type']; label: string }[] = plugins.value.flatMap((plugin) => {
-			return (plugin.elements ?? [])
-				.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
-				.map((el) => ({
-					value: el.type,
-					label: el.name?.trim() ? el.name : plugin.name,
-				}));
-		});
+	const options = computed<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>(
+		(): { value: IPluginElement['type']; label: string; disabled: boolean }[] => {
+			const flat: { value: IPluginElement['type']; label: string; disabled: boolean }[] = plugins.value.flatMap((plugin) => {
+				return (plugin.elements ?? [])
+					.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
+					.map((el) => ({
+						value: el.type,
+						label: el.name?.trim() ? el.name : plugin.name,
+						disabled: !enabled(plugin.type),
+					}));
+			});
 
-		return orderBy(flat, [(o) => o.label], ['asc']);
-	});
+			return orderBy(flat, [(o) => o.label], ['asc']);
+		}
+	);
 
 	const getByName = (type: IPlugin['type']): IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) => plugin.type === type);
@@ -82,6 +88,12 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 
 		return undefined;
 	};
+
+	if (!loaded.value) {
+		fetchConfigPlugins().catch((): void => {
+			// Something went wrong
+		});
+	}
 
 	return {
 		plugins,

--- a/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.types.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.types.ts
@@ -1,4 +1,4 @@
-import type { FormResultType } from '../../../modules/config';
+import type { FormResultType, LayoutType } from '../../../modules/config';
 import type { IConfigPlugin } from '../../../modules/config/store/config-plugins.store.types';
 
 export interface IHomeAssistantConfigFormProps {
@@ -7,4 +7,5 @@ export interface IHomeAssistantConfigFormProps {
 	remoteFormResult?: FormResultType;
 	remoteFormReset?: boolean;
 	remoteFormChanged?: boolean;
+	layout?: LayoutType;
 }

--- a/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.vue
+++ b/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.vue
@@ -3,9 +3,22 @@
 		ref="formEl"
 		:model="model"
 		:rules="rules"
-		label-position="top"
+		:label-position="props.layout === Layout.PHONE ? 'top' : 'right'"
+		:label-width="180"
 		status-icon
 	>
+		<el-form-item
+			:label="t('devicesHomeAssistantPlugin.fields.config.enabled.title')"
+			prop="enabled"
+		>
+			<el-switch
+				v-model="model.enabled"
+				name="enabled"
+				:active-text="t('devicesHomeAssistantPlugin.fields.config.enabled.values.enabled').toLowerCase()"
+				:inactive-text="t('devicesHomeAssistantPlugin.fields.config.enabled.values.disabled').toLowerCase()"
+			/>
+		</el-form-item>
+
 		<el-form-item
 			:label="t('devicesHomeAssistantPlugin.fields.config.apiKey.title')"
 			:prop="['apiKey']"
@@ -38,9 +51,9 @@
 import { reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElForm, ElFormItem, ElInput, type FormRules } from 'element-plus';
+import { ElForm, ElFormItem, ElInput, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, useConfigPluginEditForm } from '../../../modules/config';
+import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IHomeAssistantConfigEditForm } from '../schemas/config.types';
 
 import type { IHomeAssistantConfigFormProps } from './home-assistant-config-form.types';
@@ -53,6 +66,7 @@ const props = withDefaults(defineProps<IHomeAssistantConfigFormProps>(), {
 	remoteFormResult: FormResult.NONE,
 	remoteFormReset: false,
 	remoteFormChanged: false,
+	layout: Layout.DEFAULT,
 });
 
 const emit = defineEmits<{

--- a/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
@@ -110,6 +110,13 @@
       }
     },
     "config": {
+      "enabled": {
+        "title": "Enabled",
+        "values": {
+          "enabled": "Allow to communicate with Home Assistant",
+          "disabled": "Disallow to communicate with Home Assistant"
+        }
+      },
       "apiKey": {
         "title": "API key",
         "placeholder": "Enter your Home Assistant long-lived access token",

--- a/apps/backend/src/modules/config/dto/config.dto.ts
+++ b/apps/backend/src/modules/config/dto/config.dto.ts
@@ -311,6 +311,11 @@ export class UpdatePluginConfigDto implements UpdatePlugin {
 	@Expose()
 	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
 	type: string;
+
+	@Expose()
+	@IsOptional()
+	@IsBoolean({ message: '[{"field":"enabled","reason":"Enabled must be a boolean value."}]' })
+	enabled?: boolean;
 }
 
 export class ReqUpdatePluginDto implements ReqUpdatePlugin {

--- a/apps/backend/src/modules/config/models/config.model.ts
+++ b/apps/backend/src/modules/config/models/config.model.ts
@@ -188,6 +188,10 @@ export abstract class PluginConfigModel {
 	@Expose({ groups: ['api'] })
 	@IsString()
 	type: string;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = false;
 }
 
 export class AppConfigModel {

--- a/apps/backend/src/modules/config/services/config.service.spec.ts
+++ b/apps/backend/src/modules/config/services/config.service.spec.ts
@@ -70,6 +70,12 @@ describe('ConfigService', () => {
 			microphone: false,
 			microphone_volume: 30,
 		},
+		plugins: {
+			mock: {
+				enabled: true,
+				mockValue: 'default value',
+			},
+		},
 	};
 
 	const mockConfig: Partial<AppConfigModel> = {
@@ -105,6 +111,7 @@ describe('ConfigService', () => {
 		plugins: [
 			{
 				type: 'mock',
+				enabled: true,
 				mockValue: 'default value',
 			} as PluginConfigModel,
 		],
@@ -342,11 +349,11 @@ describe('ConfigService', () => {
 				type: 'mock',
 				mock_value: 'Updated value',
 			};
-			const mergedConfig = { ...mockConfig.plugins[0], ...{ mockValue: 'Updated value' } };
+			const mergedConfig = { ...mockConfig.plugins[0], ...{ enabled: true, mockValue: 'Updated value' } };
 
 			const updatedRawConfig = {
 				...mockRawConfig,
-				...{ plugins: { mock: { mock_value: 'Updated value' } } },
+				...{ plugins: { mock: { enabled: true, mock_value: 'Updated value' } } },
 			};
 
 			jest.spyOn(fs, 'existsSync').mockReturnValue(true);

--- a/apps/backend/src/plugins/data-sources-device-channel/data-sources-device-channel.plugin.ts
+++ b/apps/backend/src/plugins/data-sources-device-channel/data-sources-device-channel.plugin.ts
@@ -1,22 +1,26 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { DataSourceRelationsLoaderRegistryService } from '../../modules/dashboard/services/data-source-relations-loader-registry.service';
 import { DataSourcesTypeMapperService } from '../../modules/dashboard/services/data-source-type-mapper.service';
 import { DevicesModule } from '../../modules/devices/devices.module';
 
-import { DATA_SOURCES_DEVICE_TYPE } from './data-sources-device-channel.constants';
+import { DATA_SOURCES_DEVICE_PLUGIN_NAME, DATA_SOURCES_DEVICE_TYPE } from './data-sources-device-channel.constants';
 import { CreateDeviceChannelDataSourceDto } from './dto/create-data-source.dto';
+import { DeviceChannelUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateDeviceChannelDataSourceDto } from './dto/update-data-source.dto';
 import { DeviceChannelDataSourceEntity } from './entities/data-sources-device-channel.entity';
+import { DeviceChannelConfigModel } from './models/config.model';
 import { DataSourceRelationsLoaderService } from './services/data-source-relations-loader.service';
 import { ChannelPropertyExistsConstraintValidator } from './validators/channel-property-exists-constraint.validator';
 import { DeviceChannelExistsConstraintValidator } from './validators/device-channel-exists-constraint.validator';
 import { DeviceExistsConstraintValidator } from './validators/device-exists-constraint.validator';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([DeviceChannelDataSourceEntity]), DashboardModule, DevicesModule],
+	imports: [TypeOrmModule.forFeature([DeviceChannelDataSourceEntity]), DashboardModule, DevicesModule, ConfigModule],
 	providers: [
 		DeviceExistsConstraintValidator,
 		DeviceChannelExistsConstraintValidator,
@@ -26,13 +30,20 @@ import { DeviceExistsConstraintValidator } from './validators/device-exists-cons
 })
 export class DataSourcesDeviceChannelPlugin {
 	constructor(
-		private readonly mapper: DataSourcesTypeMapperService,
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly dataSourcesMapper: DataSourcesTypeMapperService,
 		private readonly dataSourceRelationsLoaderRegistryService: DataSourceRelationsLoaderRegistryService,
 		private readonly dataSourceRelationsLoaderService: DataSourceRelationsLoaderService,
 	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<
+		this.configMapper.registerMapping<DeviceChannelConfigModel, DeviceChannelUpdatePluginConfigDto>({
+			type: DATA_SOURCES_DEVICE_PLUGIN_NAME,
+			class: DeviceChannelConfigModel,
+			configDto: DeviceChannelUpdatePluginConfigDto,
+		});
+
+		this.dataSourcesMapper.registerMapping<
 			DeviceChannelDataSourceEntity,
 			CreateDeviceChannelDataSourceDto,
 			UpdateDeviceChannelDataSourceDto

--- a/apps/backend/src/plugins/data-sources-device-channel/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/data-sources-device-channel/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { DATA_SOURCES_DEVICE_PLUGIN_NAME } from '../data-sources-device-channel.constants';
+
+export class DeviceChannelUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof DATA_SOURCES_DEVICE_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/data-sources-device-channel/models/config.model.ts
+++ b/apps/backend/src/plugins/data-sources-device-channel/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { DATA_SOURCES_DEVICE_PLUGIN_NAME } from '../data-sources-device-channel.constants';
+
+export class DeviceChannelConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = DATA_SOURCES_DEVICE_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/devices-home-assistant/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/dto/update-config.dto.ts
@@ -2,12 +2,12 @@ import { Expose } from 'class-transformer';
 import { IsOptional, IsString } from 'class-validator';
 
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
-import { DEVICES_HOME_ASSISTANT_TYPE } from '../devices-home-assistant.constants';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME } from '../devices-home-assistant.constants';
 
 export class HomeAssistantUpdatePluginConfigDto extends UpdatePluginConfigDto {
 	@Expose()
 	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
-	type: typeof DEVICES_HOME_ASSISTANT_TYPE;
+	type: typeof DEVICES_HOME_ASSISTANT_PLUGIN_NAME;
 
 	@Expose()
 	@IsOptional()

--- a/apps/backend/src/plugins/devices-home-assistant/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/models/config.model.ts
@@ -2,12 +2,12 @@ import { Expose } from 'class-transformer';
 import { IsOptional, IsString } from 'class-validator';
 
 import { PluginConfigModel } from '../../../modules/config/models/config.model';
-import { DEVICES_HOME_ASSISTANT_TYPE } from '../devices-home-assistant.constants';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME } from '../devices-home-assistant.constants';
 
 export class HomeAssistantConfigModel extends PluginConfigModel {
 	@Expose({ groups: ['api'] })
 	@IsString()
-	type: string = DEVICES_HOME_ASSISTANT_TYPE;
+	type: string = DEVICES_HOME_ASSISTANT_PLUGIN_NAME;
 
 	@Expose({ name: 'api_key' })
 	@IsOptional()

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.ws.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.ws.service.ts
@@ -7,7 +7,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { toInstance } from '../../../common/utils/transform.utils';
 import { EventType as ConfigModuleEventType } from '../../../modules/config/config.constants';
 import { ConfigService } from '../../../modules/config/services/config.service';
-import { DEVICES_HOME_ASSISTANT_TYPE } from '../devices-home-assistant.constants';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME, DEVICES_HOME_ASSISTANT_TYPE } from '../devices-home-assistant.constants';
 import {
 	DevicesHomeAssistantException,
 	DevicesHomeAssistantNotFoundException,
@@ -67,6 +67,12 @@ export class HomeAssistantWsService {
 	}
 
 	connect() {
+		if (this.configService.getPluginConfig(DEVICES_HOME_ASSISTANT_PLUGIN_NAME).enabled === false) {
+			this.logger.debug('[HOME ASSISTANT][WS] Home Assistant plugin is disabled.');
+
+			return;
+		}
+
 		if (this.apiKey === null) {
 			this.logger.warn('[HOME ASSISTANT][WS] Missing API key for Home Assistant WS service');
 

--- a/apps/backend/src/plugins/devices-third-party/devices-third-party.plugin.ts
+++ b/apps/backend/src/plugins/devices-third-party/devices-third-party.plugin.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DevicesModule } from '../../modules/devices/devices.module';
 import { ChannelsTypeMapperService } from '../../modules/devices/services/channels-type-mapper.service';
 import { ChannelsPropertiesTypeMapperService } from '../../modules/devices/services/channels.properties-type-mapper.service';
@@ -8,27 +10,30 @@ import { DevicesTypeMapperService } from '../../modules/devices/services/devices
 import { PlatformRegistryService } from '../../modules/devices/services/platform.registry.service';
 
 import { ThirdPartyDemoController } from './controllers/third-party-demo.controller';
-import { DEVICES_THIRD_PARTY_TYPE } from './devices-third-party.constants';
+import { DEVICES_THIRD_PARTY_PLUGIN_NAME, DEVICES_THIRD_PARTY_TYPE } from './devices-third-party.constants';
 import { CreateThirdPartyChannelPropertyDto } from './dto/create-channel-property.dto';
 import { CreateThirdPartyChannelDto } from './dto/create-channel.dto';
 import { CreateThirdPartyDeviceDto } from './dto/create-device.dto';
 import { UpdateThirdPartyChannelPropertyDto } from './dto/update-channel-property.dto';
 import { UpdateThirdPartyChannelDto } from './dto/update-channel.dto';
+import { ThirdPartyUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateThirdPartyDeviceDto } from './dto/update-device.dto';
 import {
 	ThirdPartyChannelEntity,
 	ThirdPartyChannelPropertyEntity,
 	ThirdPartyDeviceEntity,
 } from './entities/devices-third-party.entity';
+import { ThirdPartyConfigModel } from './models/config.model';
 import { ThirdPartyDevicePlatform } from './platforms/third-party-device.platform';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([ThirdPartyDeviceEntity]), DevicesModule],
+	imports: [TypeOrmModule.forFeature([ThirdPartyDeviceEntity]), DevicesModule, ConfigModule],
 	providers: [ThirdPartyDevicePlatform],
 	controllers: [ThirdPartyDemoController],
 })
 export class DevicesThirdPartyPlugin {
 	constructor(
+		private readonly configMapper: PluginsTypeMapperService,
 		private readonly devicesMapper: DevicesTypeMapperService,
 		private readonly channelsMapper: ChannelsTypeMapperService,
 		private readonly channelsPropertiesMapper: ChannelsPropertiesTypeMapperService,
@@ -37,6 +42,12 @@ export class DevicesThirdPartyPlugin {
 	) {}
 
 	onModuleInit() {
+		this.configMapper.registerMapping<ThirdPartyConfigModel, ThirdPartyUpdatePluginConfigDto>({
+			type: DEVICES_THIRD_PARTY_PLUGIN_NAME,
+			class: ThirdPartyConfigModel,
+			configDto: ThirdPartyUpdatePluginConfigDto,
+		});
+
 		this.devicesMapper.registerMapping<ThirdPartyDeviceEntity, CreateThirdPartyDeviceDto, UpdateThirdPartyDeviceDto>({
 			type: DEVICES_THIRD_PARTY_TYPE,
 			class: ThirdPartyDeviceEntity,

--- a/apps/backend/src/plugins/devices-third-party/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-third-party/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { DEVICES_THIRD_PARTY_PLUGIN_NAME } from '../devices-third-party.constants';
+
+export class ThirdPartyUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof DEVICES_THIRD_PARTY_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/devices-third-party/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-third-party/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { DEVICES_THIRD_PARTY_PLUGIN_NAME } from '../devices-third-party.constants';
+
+export class ThirdPartyConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = DEVICES_THIRD_PARTY_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/pages-cards/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/pages-cards/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { PAGES_CARDS_PLUGIN_NAME } from '../pages-cards.constants';
+
+export class CardsUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof PAGES_CARDS_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/pages-cards/models/config.model.ts
+++ b/apps/backend/src/plugins/pages-cards/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { PAGES_CARDS_PLUGIN_NAME } from '../pages-cards.constants';
+
+export class CardsConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = PAGES_CARDS_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/pages-cards/pages-cards.plugin.ts
+++ b/apps/backend/src/plugins/pages-cards/pages-cards.plugin.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { PageCreateBuilderRegistryService } from '../../modules/dashboard/services/page-create-builder-registry.service';
 import { PagesTypeMapperService } from '../../modules/dashboard/services/pages-type-mapper.service';
@@ -9,22 +11,25 @@ import { SystemModule } from '../../modules/system/system.module';
 
 import { CardsController } from './controllers/cards.controller';
 import { CreateCardsPageDto } from './dto/create-page.dto';
+import { CardsUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateCardsPageDto } from './dto/update-page.dto';
 import { CardEntity, CardsPageEntity } from './entities/pages-cards.entity';
-import { PAGES_CARDS_TYPE } from './pages-cards.constants';
+import { CardsConfigModel } from './models/config.model';
+import { PAGES_CARDS_PLUGIN_NAME, PAGES_CARDS_TYPE } from './pages-cards.constants';
 import { CardsService } from './services/cards.service';
 import { CardsPageNestedBuilderService } from './services/page-create-nested-builder.service';
 import { PluginResetService } from './services/plugin-reset.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([CardsPageEntity, CardEntity]), DashboardModule, SystemModule],
+	imports: [TypeOrmModule.forFeature([CardsPageEntity, CardEntity]), DashboardModule, ConfigModule, SystemModule],
 	providers: [CardsService, CardsPageNestedBuilderService, PluginResetService],
 	controllers: [CardsController],
 	exports: [CardsService],
 })
 export class PagesCardsPlugin {
 	constructor(
-		private readonly mapper: PagesTypeMapperService,
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly pagesMapper: PagesTypeMapperService,
 		private readonly pageCreateBuilderRegistryService: PageCreateBuilderRegistryService,
 		private readonly cardsPageNestedBuilderService: CardsPageNestedBuilderService,
 		private readonly pluginReset: PluginResetService,
@@ -32,7 +37,13 @@ export class PagesCardsPlugin {
 	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<CardsPageEntity, CreateCardsPageDto, UpdateCardsPageDto>({
+		this.configMapper.registerMapping<CardsConfigModel, CardsUpdatePluginConfigDto>({
+			type: PAGES_CARDS_PLUGIN_NAME,
+			class: CardsConfigModel,
+			configDto: CardsUpdatePluginConfigDto,
+		});
+
+		this.pagesMapper.registerMapping<CardsPageEntity, CreateCardsPageDto, UpdateCardsPageDto>({
 			type: PAGES_CARDS_TYPE,
 			class: CardsPageEntity,
 			createDto: CreateCardsPageDto,

--- a/apps/backend/src/plugins/pages-device-detail/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/pages-device-detail/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { PAGES_DEVICE_DETAIL_PLUGIN_NAME } from '../pages-device-detail.constants';
+
+export class DeviceDetailUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof PAGES_DEVICE_DETAIL_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/pages-device-detail/models/config.model.ts
+++ b/apps/backend/src/plugins/pages-device-detail/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { PAGES_DEVICE_DETAIL_PLUGIN_NAME } from '../pages-device-detail.constants';
+
+export class DeviceDetailConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = PAGES_DEVICE_DETAIL_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/pages-device-detail/pages-device-detail.plugin.ts
+++ b/apps/backend/src/plugins/pages-device-detail/pages-device-detail.plugin.ts
@@ -1,30 +1,41 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { PageRelationsLoaderRegistryService } from '../../modules/dashboard/services/page-relations-loader-registry.service';
 import { PagesTypeMapperService } from '../../modules/dashboard/services/pages-type-mapper.service';
 import { DevicesModule } from '../../modules/devices/devices.module';
 
 import { CreateDeviceDetailPageDto } from './dto/create-page.dto';
+import { DeviceDetailUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateDeviceDetailPageDto } from './dto/update-page.dto';
 import { DeviceDetailPageEntity } from './entities/pages-device-detail.entity';
-import { PAGES_DEVICE_DETAIL_TYPE } from './pages-device-detail.constants';
+import { DeviceDetailConfigModel } from './models/config.model';
+import { PAGES_DEVICE_DETAIL_PLUGIN_NAME, PAGES_DEVICE_DETAIL_TYPE } from './pages-device-detail.constants';
 import { PageRelationsLoaderService } from './services/page-relations-loader.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([DeviceDetailPageEntity]), DashboardModule, DevicesModule],
+	imports: [TypeOrmModule.forFeature([DeviceDetailPageEntity]), DashboardModule, DevicesModule, ConfigModule],
 	providers: [PageRelationsLoaderService],
 })
 export class PagesDeviceDetailPlugin {
 	constructor(
-		private readonly mapper: PagesTypeMapperService,
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly pagesMapper: PagesTypeMapperService,
 		private readonly pageRelationsLoaderRegistryService: PageRelationsLoaderRegistryService,
 		private readonly pageRelationsLoaderService: PageRelationsLoaderService,
 	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<DeviceDetailPageEntity, CreateDeviceDetailPageDto, UpdateDeviceDetailPageDto>({
+		this.configMapper.registerMapping<DeviceDetailConfigModel, DeviceDetailUpdatePluginConfigDto>({
+			type: PAGES_DEVICE_DETAIL_PLUGIN_NAME,
+			class: DeviceDetailConfigModel,
+			configDto: DeviceDetailUpdatePluginConfigDto,
+		});
+
+		this.pagesMapper.registerMapping<DeviceDetailPageEntity, CreateDeviceDetailPageDto, UpdateDeviceDetailPageDto>({
 			type: PAGES_DEVICE_DETAIL_TYPE,
 			class: DeviceDetailPageEntity,
 			createDto: CreateDeviceDetailPageDto,

--- a/apps/backend/src/plugins/pages-tiles/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/pages-tiles/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { PAGES_TILES_PLUGIN_NAME } from '../pages-tiles.constants';
+
+export class TilesUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof PAGES_TILES_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/pages-tiles/models/config.model.ts
+++ b/apps/backend/src/plugins/pages-tiles/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { PAGES_TILES_PLUGIN_NAME } from '../pages-tiles.constants';
+
+export class TilesConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = PAGES_TILES_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/pages-tiles/pages-tiles.plugin.ts
+++ b/apps/backend/src/plugins/pages-tiles/pages-tiles.plugin.ts
@@ -1,25 +1,30 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { PageCreateBuilderRegistryService } from '../../modules/dashboard/services/page-create-builder-registry.service';
 import { PageRelationsLoaderRegistryService } from '../../modules/dashboard/services/page-relations-loader-registry.service';
 import { PagesTypeMapperService } from '../../modules/dashboard/services/pages-type-mapper.service';
 
 import { CreateTilesPageDto } from './dto/create-page.dto';
+import { TilesUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateTilesPageDto } from './dto/update-page.dto';
 import { TilesPageEntity } from './entities/pages-tiles.entity';
-import { PAGES_TILES_TYPE } from './pages-tiles.constants';
+import { TilesConfigModel } from './models/config.model';
+import { PAGES_TILES_PLUGIN_NAME, PAGES_TILES_TYPE } from './pages-tiles.constants';
 import { TilesPageNestedBuilderService } from './services/page-create-nested-builder.service';
 import { PageRelationsLoaderService } from './services/page-relations-loader.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([TilesPageEntity]), DashboardModule],
+	imports: [TypeOrmModule.forFeature([TilesPageEntity]), DashboardModule, ConfigModule],
 	providers: [PageRelationsLoaderService, TilesPageNestedBuilderService, TilesPageNestedBuilderService],
 })
 export class PagesTilesPlugin {
 	constructor(
-		private readonly mapper: PagesTypeMapperService,
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly pagesMapper: PagesTypeMapperService,
 		private readonly pageRelationsLoaderRegistryService: PageRelationsLoaderRegistryService,
 		private readonly pageRelationsLoaderService: PageRelationsLoaderService,
 		private readonly pageCreateBuilderRegistryService: PageCreateBuilderRegistryService,
@@ -27,7 +32,13 @@ export class PagesTilesPlugin {
 	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<TilesPageEntity, CreateTilesPageDto, UpdateTilesPageDto>({
+		this.configMapper.registerMapping<TilesConfigModel, TilesUpdatePluginConfigDto>({
+			type: PAGES_TILES_PLUGIN_NAME,
+			class: TilesConfigModel,
+			configDto: TilesUpdatePluginConfigDto,
+		});
+
+		this.pagesMapper.registerMapping<TilesPageEntity, CreateTilesPageDto, UpdateTilesPageDto>({
 			type: PAGES_TILES_TYPE,
 			class: TilesPageEntity,
 			createDto: CreateTilesPageDto,

--- a/apps/backend/src/plugins/tiles-device-preview/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/tiles-device-preview/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { TILES_DEVICE_PREVIEW_PLUGIN_NAME } from '../tiles-device-preview.constants';
+
+export class DevicePreviewUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof TILES_DEVICE_PREVIEW_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/tiles-device-preview/models/config.model.ts
+++ b/apps/backend/src/plugins/tiles-device-preview/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { TILES_DEVICE_PREVIEW_PLUGIN_NAME } from '../tiles-device-preview.constants';
+
+export class DevicePreviewConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = TILES_DEVICE_PREVIEW_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/tiles-device-preview/tiles-device-preview.plugin.ts
+++ b/apps/backend/src/plugins/tiles-device-preview/tiles-device-preview.plugin.ts
@@ -1,30 +1,41 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { TileRelationsLoaderRegistryService } from '../../modules/dashboard/services/tile-relations-loader-registry.service';
 import { TilesTypeMapperService } from '../../modules/dashboard/services/tiles-type-mapper.service';
 import { DevicesModule } from '../../modules/devices/devices.module';
 
 import { CreateDevicePreviewTileDto } from './dto/create-tile.dto';
+import { DevicePreviewUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateDevicePreviewTileDto } from './dto/update-tile.dto';
 import { DevicePreviewTileEntity } from './entities/tiles-device-preview.entity';
+import { DevicePreviewConfigModel } from './models/config.model';
 import { TileRelationsLoaderService } from './services/tile-relations-loader.service';
-import { TILES_DEVICE_PREVIEW_TYPE } from './tiles-device-preview.constants';
+import { TILES_DEVICE_PREVIEW_PLUGIN_NAME, TILES_DEVICE_PREVIEW_TYPE } from './tiles-device-preview.constants';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([DevicePreviewTileEntity]), DashboardModule, DevicesModule],
+	imports: [TypeOrmModule.forFeature([DevicePreviewTileEntity]), DashboardModule, DevicesModule, ConfigModule],
 	providers: [TileRelationsLoaderService],
 })
 export class TilesDevicePreviewPlugin {
 	constructor(
-		private readonly mapper: TilesTypeMapperService,
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly tilesMapper: TilesTypeMapperService,
 		private readonly tileRelationsLoaderRegistryService: TileRelationsLoaderRegistryService,
 		private readonly tileRelationsLoaderService: TileRelationsLoaderService,
 	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<DevicePreviewTileEntity, CreateDevicePreviewTileDto, UpdateDevicePreviewTileDto>({
+		this.configMapper.registerMapping<DevicePreviewConfigModel, DevicePreviewUpdatePluginConfigDto>({
+			type: TILES_DEVICE_PREVIEW_PLUGIN_NAME,
+			class: DevicePreviewConfigModel,
+			configDto: DevicePreviewUpdatePluginConfigDto,
+		});
+
+		this.tilesMapper.registerMapping<DevicePreviewTileEntity, CreateDevicePreviewTileDto, UpdateDevicePreviewTileDto>({
 			type: TILES_DEVICE_PREVIEW_TYPE,
 			class: DevicePreviewTileEntity,
 			createDto: CreateDevicePreviewTileDto,

--- a/apps/backend/src/plugins/tiles-time/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/tiles-time/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { TILES_TIME_PLUGIN_NAME } from '../tiles-time.constants';
+
+export class TimeUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof TILES_TIME_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/tiles-time/models/config.model.ts
+++ b/apps/backend/src/plugins/tiles-time/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { TILES_TIME_PLUGIN_NAME } from '../tiles-time.constants';
+
+export class TimeConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = TILES_TIME_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/tiles-time/tiles-time.plugin.ts
+++ b/apps/backend/src/plugins/tiles-time/tiles-time.plugin.ts
@@ -1,22 +1,35 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { TilesTypeMapperService } from '../../modules/dashboard/services/tiles-type-mapper.service';
 
 import { CreateTimeTileDto } from './dto/create-tile.dto';
+import { TimeUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateTimeTileDto } from './dto/update-tile.dto';
 import { TimeTileEntity } from './entities/tiles-time.entity';
-import { TILES_TIME_TYPE } from './tiles-time.constants';
+import { TimeConfigModel } from './models/config.model';
+import { TILES_TIME_PLUGIN_NAME, TILES_TIME_TYPE } from './tiles-time.constants';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([TimeTileEntity]), DashboardModule],
+	imports: [TypeOrmModule.forFeature([TimeTileEntity]), DashboardModule, ConfigModule],
 })
 export class TilesTimePlugin {
-	constructor(private readonly mapper: TilesTypeMapperService) {}
+	constructor(
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly tilesMapper: TilesTypeMapperService,
+	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<TimeTileEntity, CreateTimeTileDto, UpdateTimeTileDto>({
+		this.configMapper.registerMapping<TimeConfigModel, TimeUpdatePluginConfigDto>({
+			type: TILES_TIME_PLUGIN_NAME,
+			class: TimeConfigModel,
+			configDto: TimeUpdatePluginConfigDto,
+		});
+
+		this.tilesMapper.registerMapping<TimeTileEntity, CreateTimeTileDto, UpdateTimeTileDto>({
 			type: TILES_TIME_TYPE,
 			class: TimeTileEntity,
 			createDto: CreateTimeTileDto,

--- a/apps/backend/src/plugins/tiles-weather/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/tiles-weather/dto/update-config.dto.ts
@@ -1,0 +1,11 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import { TILES_WEATHER_PLUGIN_NAME } from '../tiles-weather.constants';
+
+export class WeatherUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof TILES_WEATHER_PLUGIN_NAME;
+}

--- a/apps/backend/src/plugins/tiles-weather/models/config.model.ts
+++ b/apps/backend/src/plugins/tiles-weather/models/config.model.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import { TILES_WEATHER_PLUGIN_NAME } from '../tiles-weather.constants';
+
+export class WeatherConfigModel extends PluginConfigModel {
+	@Expose({ groups: ['api'] })
+	@IsString()
+	type: string = TILES_WEATHER_PLUGIN_NAME;
+
+	@Expose()
+	@IsBoolean()
+	enabled: boolean = true;
+}

--- a/apps/backend/src/plugins/tiles-weather/tiles-weather.plugin.ts
+++ b/apps/backend/src/plugins/tiles-weather/tiles-weather.plugin.ts
@@ -1,29 +1,50 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { DashboardModule } from '../../modules/dashboard/dashboard.module';
 import { TilesTypeMapperService } from '../../modules/dashboard/services/tiles-type-mapper.service';
 
 import { CreateDayWeatherTileDto, CreateForecastWeatherTileDto } from './dto/create-tile.dto';
+import { WeatherUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateDayWeatherTileDto, UpdateForecastWeatherTileDto } from './dto/update-tile.dto';
 import { DayWeatherTileEntity, ForecastWeatherTileEntity } from './entities/tiles-weather.entity';
-import { TILES_WEATHER_DAY_TYPE, TILES_WEATHER_FORECAST_TYPE } from './tiles-weather.constants';
+import { WeatherConfigModel } from './models/config.model';
+import {
+	TILES_WEATHER_DAY_TYPE,
+	TILES_WEATHER_FORECAST_TYPE,
+	TILES_WEATHER_PLUGIN_NAME,
+} from './tiles-weather.constants';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([DayWeatherTileEntity, ForecastWeatherTileEntity]), DashboardModule],
+	imports: [TypeOrmModule.forFeature([DayWeatherTileEntity, ForecastWeatherTileEntity]), DashboardModule, ConfigModule],
 })
 export class TilesWeatherPlugin {
-	constructor(private readonly mapper: TilesTypeMapperService) {}
+	constructor(
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly tilesMapper: TilesTypeMapperService,
+	) {}
 
 	onModuleInit() {
-		this.mapper.registerMapping<DayWeatherTileEntity, CreateDayWeatherTileDto, UpdateDayWeatherTileDto>({
+		this.configMapper.registerMapping<WeatherConfigModel, WeatherUpdatePluginConfigDto>({
+			type: TILES_WEATHER_PLUGIN_NAME,
+			class: WeatherConfigModel,
+			configDto: WeatherUpdatePluginConfigDto,
+		});
+
+		this.tilesMapper.registerMapping<DayWeatherTileEntity, CreateDayWeatherTileDto, UpdateDayWeatherTileDto>({
 			type: TILES_WEATHER_DAY_TYPE,
 			class: DayWeatherTileEntity,
 			createDto: CreateDayWeatherTileDto,
 			updateDto: UpdateDayWeatherTileDto,
 		});
 
-		this.mapper.registerMapping<ForecastWeatherTileEntity, CreateForecastWeatherTileDto, UpdateForecastWeatherTileDto>({
+		this.tilesMapper.registerMapping<
+			ForecastWeatherTileEntity,
+			CreateForecastWeatherTileDto,
+			UpdateForecastWeatherTileDto
+		>({
 			type: TILES_WEATHER_FORECAST_TYPE,
 			class: ForecastWeatherTileEntity,
 			createDto: CreateForecastWeatherTileDto,

--- a/spec/api/v1/openapi.json
+++ b/spec/api/v1/openapi.json
@@ -5650,7 +5650,8 @@
                       "path": "/api/v1/config-module/plugin/custom-plugin",
                       "method": "GET",
                       "data": {
-                        "type": "custom-plugin"
+                        "type": "custom-plugin",
+                        "enabled": true
                       },
                       "metadata": {
                         "request_duration_ms": 57,
@@ -5737,7 +5738,8 @@
                       "path": "/api/v1/config-module/plugin/custom-plugin",
                       "method": "PATCH",
                       "data": {
-                        "type": "custom-plugin"
+                        "type": "custom-plugin",
+                        "enabled": true
                       },
                       "metadata": {
                         "request_duration_ms": 57,
@@ -9559,18 +9561,26 @@
         "description": "Schema for plugin configuration.",
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "enabled"
         ],
         "properties": {
           "type": {
             "type": "string",
             "description": "Configuration plugin type",
             "default": "custom-plugin"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enables or disables the plugin.",
+            "example": true
           }
         },
         "examples": [
           {
-            "type": "custom-plugin"
+            "type": "custom-plugin",
+            "enabled": true
           }
         ]
       },
@@ -10074,11 +10084,18 @@
           "type": {
             "type": "string",
             "description": "Configuration plugin type"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enables or disables the plugin.",
+            "example": true
           }
         },
         "examples": [
           {
-            "type": "custom-plugin"
+            "type": "custom-plugin",
+            "enabled": false
           }
         ]
       },


### PR DESCRIPTION
## Summary  

This PR introduces the ability to **enable or disable plugins** directly from the Admin App.  
Users can now decide which plugins should be active without editing configuration files manually.  

## ⚙️ Admin App Plugin Controls  
- Added a new **toggle control** in the plugin configuration view.  
- Disabled plugins are ignored by the system until re-enabled.  
- Improves flexibility — unused plugins can be turned off without uninstalling them.  

## 📦 Backend & API Updates  
- Extended plugin configuration schema with a new `enabled` property.  
- API updated to persist plugin enable/disable state.  
- Ensures disabled plugins are excluded from execution, UI elements, and background processes.  

## 🖥️ User Experience  
- Clear visual indication of plugin state (enabled/disabled) in the Admin App.  
- State is fully synchronized between backend configuration and the Admin UI.  

This feature provides **greater control over plugin lifecycle** and makes it easier to manage Smart Panel extensions in dynamic environments.  