### PR TITLE
fix(backend): Fix simulator scenario property errors and zone space support

### DIFF
--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/large-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/large-house.yaml
@@ -48,12 +48,20 @@ rooms:
   # Outdoor
   - id: front-porch
     name: "Front Porch"
+    type: zone
+    category: outdoor_walkway
   - id: back-patio
     name: "Back Patio"
+    type: zone
+    category: outdoor_terrace
   - id: pool-area
     name: "Pool Area"
+    type: zone
+    category: outdoor_garden
   - id: backyard
     name: "Backyard"
+    type: zone
+    category: outdoor_backyard
 
 devices:
   # ============================================================================

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/large-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/large-house.yaml
@@ -103,6 +103,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: foyer
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -159,6 +160,7 @@ devices:
     room: foyer
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:
@@ -305,6 +307,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -320,6 +323,7 @@ devices:
   - name: "Living Room Sheer Curtains Right"
     category: window_covering
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -336,6 +340,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -406,6 +411,7 @@ devices:
   - name: "Family Room TV"
     category: television
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -425,6 +431,7 @@ devices:
   - name: "Family Room Soundbar"
     category: speaker
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: speaker
         properties:
@@ -459,6 +466,7 @@ devices:
   - name: "Family Room Motorized Blinds"
     category: window_covering
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -476,6 +484,7 @@ devices:
   - name: "Family Room Blackout Shades"
     category: window_covering
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -649,6 +658,7 @@ devices:
   - name: "Kitchen Roman Shades"
     category: window_covering
     room: kitchen
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -700,6 +710,7 @@ devices:
   - name: "Dining Room Curtains"
     category: window_covering
     room: dining-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -795,6 +806,7 @@ devices:
   - name: "Office Roller Shade"
     category: window_covering
     room: office
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -859,6 +871,7 @@ devices:
   - name: "Side Door Lock"
     category: lock
     room: mudroom
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -1093,6 +1106,7 @@ devices:
     room: upper-hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:
@@ -1197,6 +1211,7 @@ devices:
   - name: "Master Bedroom TV"
     category: television
     room: master-suite
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -1235,6 +1250,7 @@ devices:
     category: air_conditioner
     room: master-suite
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: cooler
         properties:
@@ -1255,6 +1271,7 @@ devices:
     category: air_humidifier
     room: master-suite
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: humidifier
         properties:
@@ -1275,6 +1292,7 @@ devices:
     category: window_covering
     room: master-suite
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1290,6 +1308,7 @@ devices:
   - name: "Master Bedroom Sheer Curtains"
     category: window_covering
     room: master-suite
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1516,6 +1535,7 @@ devices:
   - name: "Bedroom 2 Roller Shade"
     category: window_covering
     room: bedroom-2
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1579,6 +1599,7 @@ devices:
   - name: "Bedroom 3 Roller Shade"
     category: window_covering
     room: bedroom-3
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1631,6 +1652,7 @@ devices:
   - name: "Bedroom 4 Roller Shade"
     category: window_covering
     room: bedroom-4
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1759,6 +1781,7 @@ devices:
   - name: "Bonus Room TV"
     category: television
     room: bonus-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -1878,6 +1901,7 @@ devices:
   - name: "Patio Door Lock"
     category: lock
     room: back-patio
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -1904,6 +1928,7 @@ devices:
   - name: "Patio Motorized Awning"
     category: window_covering
     room: back-patio
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/luxury-apartment.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/luxury-apartment.yaml
@@ -23,6 +23,8 @@ rooms:
     name: "Hallway"
   - id: balcony
     name: "Balcony"
+    type: zone
+    category: outdoor_balcony
 
 devices:
   # ============================================================================

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/luxury-apartment.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/luxury-apartment.yaml
@@ -88,6 +88,7 @@ devices:
   - name: "Living Room TV"
     category: television
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -107,6 +108,7 @@ devices:
   - name: "Living Room Soundbar"
     category: speaker
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: speaker
         properties:
@@ -162,6 +164,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -178,6 +181,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -298,6 +302,7 @@ devices:
     category: air_conditioner
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: cooler
         properties:
@@ -324,6 +329,7 @@ devices:
     category: air_humidifier
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: humidifier
         properties:
@@ -344,6 +350,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -360,6 +367,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -441,6 +449,7 @@ devices:
   - name: "Guest Bedroom Roller Shade"
     category: window_covering
     room: guest-bedroom
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -708,6 +717,7 @@ devices:
   - name: "Kitchen Roller Blind"
     category: window_covering
     room: kitchen
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -763,6 +773,7 @@ devices:
   - name: "Dining Room Curtains"
     category: window_covering
     room: dining-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -857,6 +868,7 @@ devices:
     category: window_covering
     room: home-office
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -910,6 +922,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: hallway
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -966,6 +979,7 @@ devices:
     room: hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:
@@ -1045,6 +1059,7 @@ devices:
   - name: "Balcony Outdoor Blind"
     category: window_covering
     room: balcony
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/office.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/office.yaml
@@ -48,6 +48,7 @@ devices:
   - name: "Entry Door Lock"
     category: lock
     room: reception
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -82,6 +83,7 @@ devices:
     room: main-office
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:
@@ -140,6 +142,7 @@ devices:
   - name: "Meeting Room Display"
     category: television
     room: meeting-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -188,6 +191,7 @@ devices:
     category: air_conditioner
     room: server-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: cooler
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/penthouse.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/penthouse.yaml
@@ -23,6 +23,8 @@ rooms:
     name: "Hallway"
   - id: terrace
     name: "Terrace"
+    type: zone
+    category: outdoor_terrace
 
 devices:
   # Living Room

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/penthouse.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/penthouse.yaml
@@ -93,6 +93,7 @@ devices:
     category: air_conditioner
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: cooler
         properties:
@@ -110,6 +111,7 @@ devices:
   - name: "Living Room TV"
     category: television
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -130,6 +132,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -183,6 +186,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -432,6 +436,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: hallway
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -462,6 +467,7 @@ devices:
     room: hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-apartment.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-apartment.yaml
@@ -57,6 +57,7 @@ devices:
   - name: "Smart TV"
     category: television
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -157,6 +158,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: hallway
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-house.yaml
@@ -19,6 +19,8 @@ rooms:
     name: "Hallway"
   - id: backyard
     name: "Backyard"
+    type: zone
+    category: outdoor_backyard
 
 devices:
   # Living Room

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/small-house.yaml
@@ -77,6 +77,7 @@ devices:
   - name: "Living Room TV"
     category: television
     room: living-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -306,6 +307,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: hallway
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -336,6 +338,7 @@ devices:
     room: hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max-plus.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max-plus.yaml
@@ -150,6 +150,7 @@ devices:
   category: window_covering
   room: living-room
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -165,6 +166,7 @@ devices:
   category: window_covering
   room: living-room
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -214,6 +216,7 @@ devices:
 - name: Family Room TV
   category: television
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: television
     properties:
@@ -232,6 +235,7 @@ devices:
 - name: Family Room Soundbar
   category: speaker
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -264,6 +268,7 @@ devices:
 - name: Family Room Motorized Blinds
   category: window_covering
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -357,6 +362,7 @@ devices:
   category: air_conditioner
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: cooler
     properties:
@@ -376,6 +382,7 @@ devices:
   category: air_humidifier
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: humidifier
     properties:
@@ -395,6 +402,7 @@ devices:
   category: window_covering
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -409,6 +417,7 @@ devices:
 - name: Master Bedroom Sheer Curtains
   category: window_covering
   room: master-bedroom
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -481,6 +490,7 @@ devices:
 - name: Bedroom 2 Roller Shade
   category: window_covering
   room: bedroom-2
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -527,6 +537,7 @@ devices:
 - name: Bedroom 3 Roller Shade
   category: window_covering
   room: bedroom-3
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -773,6 +784,7 @@ devices:
 - name: Kitchen Roller Blind
   category: window_covering
   room: kitchen
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -818,6 +830,7 @@ devices:
 - name: Dining Room Curtains
   category: window_covering
   room: dining-room
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -887,6 +900,7 @@ devices:
 - name: Office Roller Shade
   category: window_covering
   room: home-office
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -1044,6 +1058,7 @@ devices:
 - name: Front Door Lock
   category: lock
   room: foyer
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1111,6 +1126,7 @@ devices:
   room: hallway
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: temperature
     properties:
@@ -1201,6 +1217,7 @@ devices:
 - name: Patio Door Lock
   category: lock
   room: patio
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1225,6 +1242,7 @@ devices:
 - name: Patio Outdoor Blind
   category: window_covering
   room: patio
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -1350,6 +1368,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: cooler
     properties:
@@ -1436,6 +1455,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: television
     properties:
@@ -1922,6 +1942,7 @@ devices:
 - name: Garage Side Door Lock
   category: lock
   room: garage
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1936,6 +1957,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -1952,6 +1974,7 @@ devices:
 - name: Kitchen Smart Speaker
   category: speaker
   room: kitchen
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -1968,6 +1991,7 @@ devices:
 - name: Patio Speaker
   category: speaker
   room: patio
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max-plus.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max-plus.yaml
@@ -36,8 +36,12 @@ rooms:
   name: Hallway
 - id: patio
   name: Patio
+  type: zone
+  category: outdoor_terrace
 - id: backyard
   name: Backyard
+  type: zone
+  category: outdoor_backyard
 devices:
 - name: Living Room Ceiling Light
   category: lighting
@@ -1437,8 +1441,10 @@ devices:
     properties:
     - category: 'on'
       value: true
+  - category: media_input
+    properties:
     - category: source
-      value: hdmi_1
+      value: hdmi1
   - category: speaker
     properties:
     - category: active

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max.yaml
@@ -34,8 +34,12 @@ rooms:
     name: Hallway
   - id: patio
     name: Patio
+    type: zone
+    category: outdoor_terrace
   - id: backyard
     name: Backyard
+    type: zone
+    category: outdoor_backyard
 devices:
   - name: Living Room Ceiling Light
     category: lighting
@@ -876,8 +880,10 @@ devices:
       properties:
       - category: "on"
         value: false
+    - category: media_input
+      properties:
       - category: source
-        value: hdmi_1
+        value: hdmi1
     - category: speaker
       properties:
       - category: active
@@ -2276,8 +2282,10 @@ devices:
       properties:
       - category: "on"
         value: true
+    - category: media_input
+      properties:
       - category: source
-        value: hdmi_1
+        value: hdmi1
     - category: speaker
       properties:
       - category: active

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-max.yaml
@@ -148,6 +148,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -163,6 +164,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -311,6 +313,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -325,6 +328,7 @@ devices:
   - name: Living Room Venetian Blinds
     category: window_covering
     room: living-room
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -341,6 +345,7 @@ devices:
   - name: Living Room Patio Door Shade
     category: window_covering
     room: living-room
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -358,6 +363,7 @@ devices:
     category: speaker
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: speaker
       properties:
@@ -372,6 +378,7 @@ devices:
   - name: Living Room Subwoofer
     category: speaker
     room: living-room
+    behavior_mode: realistic
     channels:
     - category: speaker
       properties:
@@ -481,6 +488,7 @@ devices:
   - name: Family Room TV
     category: television
     room: family-room
+    behavior_mode: realistic
     channels:
     - category: television
       properties:
@@ -499,6 +507,7 @@ devices:
   - name: Family Room Soundbar
     category: speaker
     room: family-room
+    behavior_mode: realistic
     channels:
     - category: speaker
       properties:
@@ -531,6 +540,7 @@ devices:
   - name: Family Room Motorized Blinds
     category: window_covering
     room: family-room
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -624,6 +634,7 @@ devices:
     category: air_conditioner
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: cooler
       properties:
@@ -643,6 +654,7 @@ devices:
     category: air_humidifier
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: humidifier
       properties:
@@ -662,6 +674,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -676,6 +689,7 @@ devices:
   - name: Master Bedroom Sheer Curtains
     category: window_covering
     room: master-bedroom
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -827,6 +841,7 @@ devices:
   - name: Master Bedroom Venetian Blinds
     category: window_covering
     room: master-bedroom
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -843,6 +858,7 @@ devices:
   - name: Master Bedroom Awning
     category: window_covering
     room: master-bedroom
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -858,6 +874,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -875,6 +892,7 @@ devices:
     category: television
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: television
       properties:
@@ -898,6 +916,7 @@ devices:
     category: speaker
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: speaker
       properties:
@@ -1034,6 +1053,7 @@ devices:
   - name: Bedroom 2 Roller Shade
     category: window_covering
     room: bedroom-2
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1080,6 +1100,7 @@ devices:
   - name: Bedroom 3 Roller Shade
     category: window_covering
     room: bedroom-3
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1326,6 +1347,7 @@ devices:
   - name: Kitchen Roller Blind
     category: window_covering
     room: kitchen
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1371,6 +1393,7 @@ devices:
   - name: Dining Room Curtains
     category: window_covering
     room: dining-room
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1440,6 +1463,7 @@ devices:
   - name: Office Roller Shade
     category: window_covering
     room: home-office
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1561,6 +1585,7 @@ devices:
     category: window_covering
     room: home-office
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1575,6 +1600,7 @@ devices:
   - name: Office Sheer Curtain
     category: window_covering
     room: home-office
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1589,6 +1615,7 @@ devices:
   - name: Office Venetian Blinds
     category: window_covering
     room: home-office
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -1608,6 +1635,7 @@ devices:
     category: speaker
     room: home-office
     auto_simulate: true
+    behavior_mode: realistic
     channels:
     - category: speaker
       properties:
@@ -1882,6 +1910,7 @@ devices:
   - name: Front Door Lock
     category: lock
     room: foyer
+    behavior_mode: realistic
     channels:
     - category: lock
       properties:
@@ -1949,6 +1978,7 @@ devices:
     room: hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
     - category: temperature
       properties:
@@ -2039,6 +2069,7 @@ devices:
   - name: Patio Door Lock
     category: lock
     room: patio
+    behavior_mode: realistic
     channels:
     - category: lock
       properties:
@@ -2063,6 +2094,7 @@ devices:
   - name: Patio Outdoor Blind
     category: window_covering
     room: patio
+    behavior_mode: realistic
     channels:
     - category: window_covering
       properties:
@@ -2189,6 +2221,7 @@ devices:
     room: living-room
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
     - category: cooler
       properties:
@@ -2277,6 +2310,7 @@ devices:
     room: living-room
     auto_simulate: true
     simulate_interval: 20000
+    behavior_mode: realistic
     channels:
     - category: television
       properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-stress.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-stress.yaml
@@ -35,8 +35,12 @@ rooms:
   name: Hallway
 - id: patio
   name: Patio
+  type: zone
+  category: outdoor_terrace
 - id: backyard
   name: Backyard
+  type: zone
+  category: outdoor_backyard
 devices:
 - name: Living Room Ceiling Light
   category: lighting
@@ -1436,8 +1440,10 @@ devices:
     properties:
     - category: 'on'
       value: true
+  - category: media_input
+    properties:
     - category: source
-      value: hdmi_1
+      value: hdmi1
   - category: speaker
     properties:
     - category: active

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-stress.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house-stress.yaml
@@ -149,6 +149,7 @@ devices:
   category: window_covering
   room: living-room
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -164,6 +165,7 @@ devices:
   category: window_covering
   room: living-room
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -213,6 +215,7 @@ devices:
 - name: Family Room TV
   category: television
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: television
     properties:
@@ -231,6 +234,7 @@ devices:
 - name: Family Room Soundbar
   category: speaker
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -263,6 +267,7 @@ devices:
 - name: Family Room Motorized Blinds
   category: window_covering
   room: family-room
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -356,6 +361,7 @@ devices:
   category: air_conditioner
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: cooler
     properties:
@@ -375,6 +381,7 @@ devices:
   category: air_humidifier
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: humidifier
     properties:
@@ -394,6 +401,7 @@ devices:
   category: window_covering
   room: master-bedroom
   auto_simulate: true
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -408,6 +416,7 @@ devices:
 - name: Master Bedroom Sheer Curtains
   category: window_covering
   room: master-bedroom
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -480,6 +489,7 @@ devices:
 - name: Bedroom 2 Roller Shade
   category: window_covering
   room: bedroom-2
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -526,6 +536,7 @@ devices:
 - name: Bedroom 3 Roller Shade
   category: window_covering
   room: bedroom-3
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -772,6 +783,7 @@ devices:
 - name: Kitchen Roller Blind
   category: window_covering
   room: kitchen
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -817,6 +829,7 @@ devices:
 - name: Dining Room Curtains
   category: window_covering
   room: dining-room
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -886,6 +899,7 @@ devices:
 - name: Office Roller Shade
   category: window_covering
   room: home-office
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -1043,6 +1057,7 @@ devices:
 - name: Front Door Lock
   category: lock
   room: foyer
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1110,6 +1125,7 @@ devices:
   room: hallway
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: temperature
     properties:
@@ -1200,6 +1216,7 @@ devices:
 - name: Patio Door Lock
   category: lock
   room: patio
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1224,6 +1241,7 @@ devices:
 - name: Patio Outdoor Blind
   category: window_covering
   room: patio
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -1349,6 +1367,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: cooler
     properties:
@@ -1435,6 +1454,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: television
     properties:
@@ -1921,6 +1941,7 @@ devices:
 - name: Garage Side Door Lock
   category: lock
   room: garage
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -1935,6 +1956,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -1951,6 +1973,7 @@ devices:
 - name: Kitchen Smart Speaker
   category: speaker
   room: kitchen
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -1967,6 +1990,7 @@ devices:
 - name: Patio Speaker
   category: speaker
   room: patio
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -5967,6 +5991,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -5985,6 +6010,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6003,6 +6029,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6019,6 +6046,7 @@ devices:
   room: living-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6223,6 +6251,7 @@ devices:
   room: family-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6241,6 +6270,7 @@ devices:
   room: family-room
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6259,6 +6289,7 @@ devices:
   room: family-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6277,6 +6308,7 @@ devices:
   room: family-room
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6483,6 +6515,7 @@ devices:
   room: kitchen
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6501,6 +6534,7 @@ devices:
   room: kitchen
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6519,6 +6553,7 @@ devices:
   room: kitchen
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6535,6 +6570,7 @@ devices:
   room: kitchen
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6739,6 +6775,7 @@ devices:
   room: home-office
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6757,6 +6794,7 @@ devices:
   room: home-office
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -6775,6 +6813,7 @@ devices:
   room: home-office
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6791,6 +6830,7 @@ devices:
   room: home-office
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -6991,6 +7031,7 @@ devices:
   room: master-bedroom
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -7009,6 +7050,7 @@ devices:
   room: master-bedroom
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -7027,6 +7069,7 @@ devices:
   room: master-bedroom
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -7045,6 +7088,7 @@ devices:
   room: master-bedroom
   auto_simulate: true
   simulate_interval: 60000
+  behavior_mode: realistic
   channels:
   - category: window_covering
     properties:
@@ -7621,6 +7665,7 @@ devices:
   room: patio
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -7639,6 +7684,7 @@ devices:
   room: patio
   auto_simulate: true
   simulate_interval: 20000
+  behavior_mode: realistic
   channels:
   - category: speaker
     properties:
@@ -8187,6 +8233,7 @@ devices:
 - name: Patio Secondary Door Lock
   category: lock
   room: patio
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -8199,6 +8246,7 @@ devices:
 - name: Garage Internal Door Lock
   category: lock
   room: garage
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:
@@ -8211,6 +8259,7 @@ devices:
 - name: Front Door Lock (Backup)
   category: lock
   room: foyer
+  behavior_mode: realistic
   channels:
   - category: lock
     properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house.yaml
@@ -157,6 +157,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -173,6 +174,7 @@ devices:
     category: window_covering
     room: living-room
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -228,6 +230,7 @@ devices:
   - name: "Family Room TV"
     category: television
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: television
         properties:
@@ -247,6 +250,7 @@ devices:
   - name: "Family Room Soundbar"
     category: speaker
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: speaker
         properties:
@@ -281,6 +285,7 @@ devices:
   - name: "Family Room Motorized Blinds"
     category: window_covering
     room: family-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -383,6 +388,7 @@ devices:
     category: air_conditioner
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: cooler
         properties:
@@ -403,6 +409,7 @@ devices:
     category: air_humidifier
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: humidifier
         properties:
@@ -423,6 +430,7 @@ devices:
     category: window_covering
     room: master-bedroom
     auto_simulate: true
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -438,6 +446,7 @@ devices:
   - name: "Master Bedroom Sheer Curtains"
     category: window_covering
     room: master-bedroom
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -518,6 +527,7 @@ devices:
   - name: "Bedroom 2 Roller Shade"
     category: window_covering
     room: bedroom-2
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -570,6 +580,7 @@ devices:
   - name: "Bedroom 3 Roller Shade"
     category: window_covering
     room: bedroom-3
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -842,6 +853,7 @@ devices:
   - name: "Kitchen Roller Blind"
     category: window_covering
     room: kitchen
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -893,6 +905,7 @@ devices:
   - name: "Dining Room Curtains"
     category: window_covering
     room: dining-room
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -969,6 +982,7 @@ devices:
   - name: "Office Roller Shade"
     category: window_covering
     room: home-office
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:
@@ -1146,6 +1160,7 @@ devices:
   - name: "Front Door Lock"
     category: lock
     room: foyer
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -1221,6 +1236,7 @@ devices:
     room: hallway
     auto_simulate: true
     simulate_interval: 60000
+    behavior_mode: realistic
     channels:
       - category: temperature
         properties:
@@ -1320,6 +1336,7 @@ devices:
   - name: "Patio Door Lock"
     category: lock
     room: patio
+    behavior_mode: realistic
     channels:
       - category: lock
         properties:
@@ -1346,6 +1363,7 @@ devices:
   - name: "Patio Outdoor Blind"
     category: window_covering
     room: patio
+    behavior_mode: realistic
     channels:
       - category: window_covering
         properties:

--- a/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house.yaml
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/definitions/smart-house.yaml
@@ -33,8 +33,12 @@ rooms:
     name: "Hallway"
   - id: patio
     name: "Patio"
+    type: zone
+    category: outdoor_terrace
   - id: backyard
     name: "Backyard"
+    type: zone
+    category: outdoor_backyard
 
 devices:
   # ============================================================================

--- a/apps/backend/src/plugins/devices-simulator/scenarios/scenario.types.ts
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/scenario.types.ts
@@ -59,6 +59,10 @@ export interface ScenarioRoomDefinition {
 	id: string;
 	/** Display name for the room */
 	name: string;
+	/** Space type: 'room' or 'zone' (defaults to 'room') */
+	type?: 'room' | 'zone';
+	/** Space category matching the type (e.g., 'living_room', 'outdoor_backyard') */
+	category?: string;
 }
 
 /**

--- a/apps/backend/src/plugins/devices-simulator/scenarios/schema/scenario-schema.json
+++ b/apps/backend/src/plugins/devices-simulator/scenarios/schema/scenario-schema.json
@@ -57,6 +57,16 @@
 					"minLength": 1,
 					"maxLength": 100,
 					"description": "Room display name"
+				},
+				"type": {
+					"type": "string",
+					"enum": ["room", "zone"],
+					"default": "room",
+					"description": "Space type: 'room' for physical rooms, 'zone' for outdoor areas or logical groupings"
+				},
+				"category": {
+					"type": "string",
+					"description": "Space category matching the type (e.g., living_room for rooms, outdoor_backyard for zones)"
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
- **Fix `source` property error**: Moved misplaced `source` property from `television` channel to `media_input` channel across 3 scenario files (4 occurrences). Fixed `hdmi_1` → `hdmi1` to match spec enum values.
- **Support zone spaces in scenarios**: Added optional `type` and `category` fields to scenario room definitions so outdoor areas (backyard, patio, terrace, balcony, pool area, front porch) are created as `zone` instead of `room`. Updated 8 scenario files (15 outdoor spaces).
- **Schema & executor updates**: Extended JSON schema, TypeScript types, and executor service to read `type`/`category` from YAML definitions, defaulting to `room` for backward compatibility.

## Test plan
- [ ] Run `pnpm run cli -- simulator:scenario` and load `smart-house-max-plus` — should no longer fail on `source` property error
- [ ] Verify created spaces: outdoor areas (backyard, patio) should have type `zone` with correct category
- [ ] Load an older/unmodified scenario (e.g., `small-apartment`) to confirm backward compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scenario execution and space/device assignment logic; mistakes could create incorrect spaces or mis-assign devices to `room_id` vs `zone_ids`, but scope is limited to simulator scenario loading.
> 
> **Overview**
> Simulator scenarios now support creating *zones* in addition to rooms: scenario room definitions accept optional `type: zone` and `category`, the JSON schema/TS types are extended accordingly, and `ScenarioExecutorService` creates `SpaceType.ZONE` spaces and assigns devices targeting zones via `zone_ids` instead of `room_id`.
> 
> Multiple built-in scenario YAMLs are updated to mark outdoor areas (e.g., patio/backyard/balcony/terrace/pool/front porch) as zones with outdoor categories, and many devices in these scenarios now use `behavior_mode: realistic`. The smart-house scenarios also fix an invalid TV `source` property by moving it under a `media_input` channel and normalizing `hdmi_1` to `hdmi1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b12d232c94552c8bc8405f13b305d1e223aa461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->