### PR TITLE
refactor(admin): replace manual extension/service interfaces with generated types (phase 5)

### DIFF
--- a/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MODULES_PREFIX } from '../../../app.constants';
+import { ExtensionsModuleDataExtensionKind } from '../../../openapi';
 import { ExtensionKind, EXTENSIONS_MODULE_PREFIX } from '../extensions.constants';
 import { ExtensionsApiException, ExtensionsValidationException } from '../extensions.exceptions';
 
@@ -11,7 +12,7 @@ import { useExtensions } from './extensions.store';
 
 const mockExtensionRes: IExtensionRes = {
 	type: 'devices-module',
-	kind: 'module',
+	kind: ExtensionsModuleDataExtensionKind.module,
 	name: 'Devices Module',
 	description: 'Manage devices',
 	version: '1.0.0',
@@ -23,7 +24,7 @@ const mockExtensionRes: IExtensionRes = {
 
 const mockPluginRes: IExtensionRes = {
 	type: 'pages-tiles-plugin',
-	kind: 'plugin',
+	kind: ExtensionsModuleDataExtensionKind.plugin,
 	name: 'Pages Tiles Plugin',
 	enabled: true,
 	is_core: true,

--- a/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
@@ -20,6 +20,7 @@ const mockExtensionRes: IExtensionRes = {
 	enabled: true,
 	is_core: true,
 	can_toggle_enabled: false,
+	can_remove: false,
 };
 
 const mockPluginRes: IExtensionRes = {
@@ -29,6 +30,7 @@ const mockPluginRes: IExtensionRes = {
 	enabled: true,
 	is_core: true,
 	can_toggle_enabled: true,
+	can_remove: false,
 };
 
 const backendClient = {

--- a/apps/admin/src/modules/extensions/store/extensions.store.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.ts
@@ -15,7 +15,6 @@ import { ExtensionSchema, ExtensionsUpdateActionPayloadSchema } from './extensio
 import type {
 	ExtensionsStoreSetup,
 	IExtension,
-	IExtensionRes,
 	IExtensionsFetchActionPayload,
 	IExtensionsGetActionPayload,
 	IExtensionsSetActionPayload,
@@ -113,7 +112,7 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 					});
 
 					if (typeof responseData !== 'undefined') {
-						const extension = transformExtensionResponse(responseData.data as unknown as IExtensionRes);
+						const extension = transformExtensionResponse(responseData.data);
 
 						data.value[extension.type] = extension;
 
@@ -170,7 +169,7 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 					}
 
 					if (responseData?.data) {
-						const extensions = responseData.data.map((ext) => transformExtensionResponse(ext as unknown as IExtensionRes));
+						const extensions = responseData.data.map((ext) => transformExtensionResponse(ext));
 
 						// Update store data
 						for (const extension of extensions) {
@@ -235,7 +234,7 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 				});
 
 				if (typeof responseData !== 'undefined') {
-					const extension = transformExtensionResponse(responseData.data as unknown as IExtensionRes);
+					const extension = transformExtensionResponse(responseData.data);
 
 					data.value[extension.type] = extension;
 

--- a/apps/admin/src/modules/extensions/store/extensions.store.types.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.types.ts
@@ -25,26 +25,7 @@ export interface IExtension {
 	links?: IExtensionLinks;
 }
 
-export interface IExtensionRes {
-	type: string;
-	kind: string;
-	name: string;
-	description?: string;
-	version?: string;
-	author?: string;
-	readme?: string;
-	docs?: string;
-	enabled: boolean;
-	is_core: boolean;
-	can_toggle_enabled: boolean;
-	links?: {
-		documentation?: string;
-		dev_documentation?: string;
-		bugs_tracking?: string;
-		repository?: string;
-		homepage?: string;
-	};
-}
+export type { ExtensionsModuleExtensionSchema as IExtensionRes } from '../../../openapi.constants';
 
 export interface IExtensionsStateSemaphore {
 	fetching: {

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
@@ -19,6 +19,7 @@ describe('Extensions Transformers', () => {
 				enabled: true,
 				is_core: true,
 				can_toggle_enabled: false,
+				can_remove: false,
 				links: {
 					documentation: 'https://docs.example.com',
 					dev_documentation: 'https://dev.example.com',
@@ -56,6 +57,7 @@ describe('Extensions Transformers', () => {
 				enabled: true,
 				is_core: true,
 				can_toggle_enabled: true,
+				can_remove: false,
 			};
 
 			const result = transformExtensionResponse(response);
@@ -77,6 +79,7 @@ describe('Extensions Transformers', () => {
 				enabled: false,
 				is_core: false,
 				can_toggle_enabled: true,
+				can_remove: false,
 			};
 
 			const result = transformExtensionResponse(response);

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { ExtensionsModuleDataExtensionKind } from '../../../openapi';
 import { ExtensionKind } from '../extensions.constants';
 
 import type { IExtensionRes } from './extensions.store.types';
@@ -10,7 +11,7 @@ describe('Extensions Transformers', () => {
 		it('should transform module response correctly', () => {
 			const response: IExtensionRes = {
 				type: 'devices-module',
-				kind: 'module',
+				kind: ExtensionsModuleDataExtensionKind.module,
 				name: 'Devices Module',
 				description: 'Manage devices',
 				version: '1.0.0',
@@ -50,7 +51,7 @@ describe('Extensions Transformers', () => {
 		it('should transform plugin response correctly', () => {
 			const response: IExtensionRes = {
 				type: 'pages-tiles-plugin',
-				kind: 'plugin',
+				kind: ExtensionsModuleDataExtensionKind.plugin,
 				name: 'Pages Tiles Plugin',
 				enabled: true,
 				is_core: true,
@@ -71,7 +72,7 @@ describe('Extensions Transformers', () => {
 		it('should handle optional fields', () => {
 			const response: IExtensionRes = {
 				type: 'test-module',
-				kind: 'module',
+				kind: ExtensionsModuleDataExtensionKind.module,
 				name: 'Test Module',
 				enabled: false,
 				is_core: false,
@@ -89,7 +90,7 @@ describe('Extensions Transformers', () => {
 		it('should handle partial links', () => {
 			const response: IExtensionRes = {
 				type: 'test-plugin',
-				kind: 'plugin',
+				kind: ExtensionsModuleDataExtensionKind.plugin,
 				name: 'Test Plugin',
 				enabled: true,
 				is_core: false,

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
@@ -98,6 +98,7 @@ describe('Extensions Transformers', () => {
 				enabled: true,
 				is_core: false,
 				can_toggle_enabled: true,
+				can_remove: true,
 				links: {
 					documentation: 'https://docs.example.com',
 				},

--- a/apps/admin/src/modules/extensions/store/services.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/services.store.spec.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ExtensionsModuleDataServiceStatusState } from '../../../openapi';
 import { ExtensionsModuleServiceState } from '../../../openapi.constants';
 import { ExtensionsApiException, ExtensionsValidationException } from '../extensions.exceptions';
 
@@ -11,7 +12,7 @@ import { useServices } from './services.store';
 const mockServiceRes: IServiceRes = {
 	plugin_name: 'devices-shelly-v1',
 	service_id: 'connector',
-	state: 'started',
+	state: ExtensionsModuleDataServiceStatusState.started,
 	enabled: true,
 	healthy: true,
 	last_started_at: '2025-01-15T10:30:00.000Z',
@@ -22,7 +23,7 @@ const mockServiceRes: IServiceRes = {
 const mockStoppedServiceRes: IServiceRes = {
 	plugin_name: 'devices-home-assistant',
 	service_id: 'connector',
-	state: 'stopped',
+	state: ExtensionsModuleDataServiceStatusState.stopped,
 	enabled: false,
 	start_count: 2,
 };

--- a/apps/admin/src/modules/extensions/store/services.store.ts
+++ b/apps/admin/src/modules/extensions/store/services.store.ts
@@ -15,7 +15,6 @@ import { ExtensionsApiException, ExtensionsValidationException } from '../extens
 import { ServiceSchema } from './services.store.schemas';
 import type {
 	IService,
-	IServiceRes,
 	IServicesGetActionPayload,
 	IServicesRestartActionPayload,
 	IServicesSetActionPayload,
@@ -126,7 +125,7 @@ export const useServices = defineStore<'extensions_module-services', ServicesSto
 					});
 
 					if (typeof responseData !== 'undefined') {
-						const service = transformServiceResponse(responseData.data as unknown as IServiceRes);
+						const service = transformServiceResponse(responseData.data);
 
 						data.value[key] = service;
 
@@ -172,7 +171,7 @@ export const useServices = defineStore<'extensions_module-services', ServicesSto
 					const { data: responseData, error, response } = await backend.client.GET('/modules/extensions/services');
 
 					if (responseData?.data) {
-						const services = responseData.data.map((svc) => transformServiceResponse(svc as unknown as IServiceRes));
+						const services = responseData.data.map((svc) => transformServiceResponse(svc));
 
 						// Update store data
 						for (const service of services) {
@@ -227,7 +226,7 @@ export const useServices = defineStore<'extensions_module-services', ServicesSto
 				});
 
 				if (typeof responseData !== 'undefined') {
-					const service = transformServiceResponse(responseData.data as unknown as IServiceRes);
+					const service = transformServiceResponse(responseData.data);
 
 					data.value[key] = service;
 
@@ -267,7 +266,7 @@ export const useServices = defineStore<'extensions_module-services', ServicesSto
 				});
 
 				if (typeof responseData !== 'undefined') {
-					const service = transformServiceResponse(responseData.data as unknown as IServiceRes);
+					const service = transformServiceResponse(responseData.data);
 
 					data.value[key] = service;
 
@@ -307,7 +306,7 @@ export const useServices = defineStore<'extensions_module-services', ServicesSto
 				});
 
 				if (typeof responseData !== 'undefined') {
-					const service = transformServiceResponse(responseData.data as unknown as IServiceRes);
+					const service = transformServiceResponse(responseData.data);
 
 					data.value[key] = service;
 

--- a/apps/admin/src/modules/extensions/store/services.store.types.ts
+++ b/apps/admin/src/modules/extensions/store/services.store.types.ts
@@ -15,18 +15,7 @@ export interface IService {
 	uptimeMs?: number;
 }
 
-export interface IServiceRes {
-	plugin_name: string;
-	service_id: string;
-	state: string;
-	enabled: boolean;
-	healthy?: boolean;
-	last_started_at?: string;
-	last_stopped_at?: string;
-	last_error?: string;
-	start_count: number;
-	uptime_ms?: number;
-}
+export type { ExtensionsModuleServiceStatusSchema as IServiceRes } from '../../../openapi.constants';
 
 export interface IServicesStateSemaphore {
 	fetching: {


### PR DESCRIPTION
## Summary

Phase 5 of TECH-ADMIN-TS-STRICT-ENUMS — replaces manual `IExtensionRes` and `IServiceRes` interfaces with generated OpenAPI types, now that the backend `@ApiProperty` decorators have been fixed to include snake_case names.

## Changes

- `IExtensionRes` → `ExtensionsModuleExtensionSchema` (from `openapi.constants.ts`)
- `IServiceRes` → `ExtensionsModuleServiceStatusSchema` (from `openapi.constants.ts`)
- Remove 8 `as unknown as IType` casts from extension and service stores
- Extensions module now has **zero type casts**

## Backend prerequisite (already merged to main)
Backend `@ApiProperty` decorators fixed with `name:` for all `@Expose({ name: })` properties across extensions, services, plugins, and websocket modules.

## Progress
| Phase | Casts removed | Total |
|-------|--------------|-------|
| 1-4 | 68 | 68 |
| 5 | 8 | 76 |
| **Starting** | **196** | |
| **Remaining** | | **120** |

## Test plan
- [x] All 1275 admin tests pass
- [x] Backend tests pass (2691 tests)
- [x] Backend lint clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a type-safety refactor in the admin extensions/services stores and tests; runtime behavior is unchanged aside from relying on updated OpenAPI-generated enums/fields (e.g., `can_remove`).
> 
> **Overview**
> Updates the extensions and services Pinia stores to consume OpenAPI-generated response schemas (`IExtensionRes`, `IServiceRes`) instead of locally maintained interfaces, removing the `as unknown as ...` casts when transforming API responses.
> 
> Adjusts unit tests/fixtures to use generated enum values (`ExtensionsModuleDataExtensionKind`, `ExtensionsModuleDataServiceStatusState`) and to include newly required response fields like `can_remove`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ed0a1f492e4f01f54141726674ae617464a601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->