### PR TITLE
refactor(admin): add ZodType annotations to all remaining response schemas

### DIFF
--- a/apps/admin/src/modules/displays/store/displays.store.schemas.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.schemas.ts
@@ -1,10 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { type ZodType, z } from 'zod';
-
-import type { DisplaysModuleDisplaySchema, DisplaysModuleLongLiveTokenSchema } from '../../../openapi.constants';
-
-type ApiDisplay = DisplaysModuleDisplaySchema;
-type ApiDisplayToken = DisplaysModuleLongLiveTokenSchema;
+import { z } from 'zod';
 
 export const DisplayIdSchema = z.string().uuid();
 
@@ -254,7 +249,7 @@ export const DisplayUpdateReqSchema = z.object({
 	weather_location_id: z.string().uuid().nullable().optional(),
 });
 
-export const DisplayResSchema: ZodType<ApiDisplay> = z.object({
+export const DisplayResSchema = z.object({
 	id: z.string().uuid(),
 	mac_address: z.string().trim().nonempty(),
 	name: z.string().nullable().optional().default(null),
@@ -304,7 +299,7 @@ export const DisplayResSchema: ZodType<ApiDisplay> = z.object({
 });
 
 // Token response schema
-export const DisplayTokenResSchema: ZodType<ApiDisplayToken> = z.object({
+export const DisplayTokenResSchema = z.object({
 	id: z.string().uuid(),
 	owner_type: z.string(),
 	owner_id: z.string().uuid().nullable(),

--- a/apps/admin/src/modules/displays/store/displays.store.schemas.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.schemas.ts
@@ -1,5 +1,10 @@
 import { v4 as uuid } from 'uuid';
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { DisplaysModuleDisplaySchema, DisplaysModuleLongLiveTokenSchema } from '../../../openapi.constants';
+
+type ApiDisplay = DisplaysModuleDisplaySchema;
+type ApiDisplayToken = DisplaysModuleLongLiveTokenSchema;
 
 export const DisplayIdSchema = z.string().uuid();
 
@@ -249,7 +254,7 @@ export const DisplayUpdateReqSchema = z.object({
 	weather_location_id: z.string().uuid().nullable().optional(),
 });
 
-export const DisplayResSchema = z.object({
+export const DisplayResSchema: ZodType<ApiDisplay> = z.object({
 	id: z.string().uuid(),
 	mac_address: z.string().trim().nonempty(),
 	name: z.string().nullable().optional().default(null),
@@ -299,7 +304,7 @@ export const DisplayResSchema = z.object({
 });
 
 // Token response schema
-export const DisplayTokenResSchema = z.object({
+export const DisplayTokenResSchema: ZodType<ApiDisplayToken> = z.object({
 	id: z.string().uuid(),
 	owner_type: z.string(),
 	owner_id: z.string().uuid().nullable(),

--- a/apps/admin/src/modules/extensions/store/discovered-extensions.store.schemas.ts
+++ b/apps/admin/src/modules/extensions/store/discovered-extensions.store.schemas.ts
@@ -1,9 +1,4 @@
-import { type ZodType, z } from 'zod';
-
-import type { ExtensionsModuleDiscoveredExtensionAdminSchema, ExtensionsModuleDiscoveredExtensionBackendSchema } from '../../../openapi.constants';
-
-type ApiDiscoveredAdmin = ExtensionsModuleDiscoveredExtensionAdminSchema;
-type ApiDiscoveredBackend = ExtensionsModuleDiscoveredExtensionBackendSchema;
+import { z } from 'zod';
 
 import { ExtensionKind, ExtensionSource, ExtensionSurface } from '../extensions.constants';
 
@@ -52,7 +47,7 @@ export const DiscoveredExtensionsGetActionPayloadSchema = z.object({
 // BACKEND API
 // ===========
 
-export const DiscoveredExtensionAdminResSchema: ZodType<ApiDiscoveredAdmin> = z.object({
+export const DiscoveredExtensionAdminResSchema = z.object({
 	name: z.string(),
 	kind: z.nativeEnum(ExtensionKind),
 	surface: z.nativeEnum(ExtensionSurface),
@@ -64,7 +59,7 @@ export const DiscoveredExtensionAdminResSchema: ZodType<ApiDiscoveredAdmin> = z.
 	type: z.literal('admin'),
 });
 
-export const DiscoveredExtensionBackendResSchema: ZodType<ApiDiscoveredBackend> = z.object({
+export const DiscoveredExtensionBackendResSchema = z.object({
 	name: z.string(),
 	kind: z.nativeEnum(ExtensionKind),
 	surface: z.nativeEnum(ExtensionSurface),

--- a/apps/admin/src/modules/extensions/store/discovered-extensions.store.schemas.ts
+++ b/apps/admin/src/modules/extensions/store/discovered-extensions.store.schemas.ts
@@ -1,4 +1,9 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { ExtensionsModuleDiscoveredExtensionAdminSchema, ExtensionsModuleDiscoveredExtensionBackendSchema } from '../../../openapi.constants';
+
+type ApiDiscoveredAdmin = ExtensionsModuleDiscoveredExtensionAdminSchema;
+type ApiDiscoveredBackend = ExtensionsModuleDiscoveredExtensionBackendSchema;
 
 import { ExtensionKind, ExtensionSource, ExtensionSurface } from '../extensions.constants';
 
@@ -47,7 +52,7 @@ export const DiscoveredExtensionsGetActionPayloadSchema = z.object({
 // BACKEND API
 // ===========
 
-export const DiscoveredExtensionAdminResSchema = z.object({
+export const DiscoveredExtensionAdminResSchema: ZodType<ApiDiscoveredAdmin> = z.object({
 	name: z.string(),
 	kind: z.nativeEnum(ExtensionKind),
 	surface: z.nativeEnum(ExtensionSurface),
@@ -59,7 +64,7 @@ export const DiscoveredExtensionAdminResSchema = z.object({
 	type: z.literal('admin'),
 });
 
-export const DiscoveredExtensionBackendResSchema = z.object({
+export const DiscoveredExtensionBackendResSchema: ZodType<ApiDiscoveredBackend> = z.object({
 	name: z.string(),
 	kind: z.nativeEnum(ExtensionKind),
 	surface: z.nativeEnum(ExtensionSurface),

--- a/apps/admin/src/modules/scenes/store/scenes.actions.store.schemas.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.actions.store.schemas.ts
@@ -3,9 +3,9 @@ import { type ZodType, z } from 'zod';
 
 import type { ScenesModuleSceneActionSchema } from '../../../openapi.constants';
 
-type ApiSceneAction = ScenesModuleSceneActionSchema;
-
 import { ItemIdSchema } from './types';
+
+type ApiSceneAction = ScenesModuleSceneActionSchema;
 
 // STORE STATE
 // ===========

--- a/apps/admin/src/modules/scenes/store/scenes.actions.store.schemas.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.actions.store.schemas.ts
@@ -1,5 +1,9 @@
 import { v4 as uuid } from 'uuid';
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { ScenesModuleSceneActionSchema } from '../../../openapi.constants';
+
+type ApiSceneAction = ScenesModuleSceneActionSchema;
 
 import { ItemIdSchema } from './types';
 
@@ -134,7 +138,7 @@ export const SceneActionUpdateReqSchema = z
 	})
 	.catchall(z.unknown());
 
-export const SceneActionResSchema = z
+export const SceneActionResSchema: ZodType<ApiSceneAction> = z
 	.object({
 		id: z.string().uuid(),
 		type: z.string(),

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -214,6 +214,7 @@ export type DevicesThirdPartyPluginChannelPropertySchema = components['schemas']
 export type SimulatorPluginDeviceSchema = components['schemas']['SimulatorPluginDataDevice'];
 export type SimulatorPluginChannelSchema = components['schemas']['SimulatorPluginDataChannel'];
 export type SimulatorPluginChannelPropertySchema = components['schemas']['SimulatorPluginDataChannelProperty'];
+export { SimulatorPluginGenerateDeviceBehavior_mode as SimulatorPluginBehaviorMode } from './openapi';
 
 // Pages Cards Plugin Schemas
 export type PagesCardsPluginCreateCardsPageSchema = components['schemas']['PagesCardsPluginCreateCardsPage'];
@@ -455,11 +456,13 @@ export type BuddySystemTtsPluginConfigSchema = components['schemas']['BuddySyste
 // =============================
 export type WeatherOpenweathermapPluginConfigSchema = components['schemas']['WeatherOpenweathermapPluginDataConfig'];
 export type WeatherOpenweathermapOnecallPluginConfigSchema = components['schemas']['WeatherOpenweathermapOnecallPluginDataConfig'];
+export { DisplaysModuleUpdateDisplayTemperature_unit as WeatherTemperatureUnit } from './openapi';
 
 // Data Sources Weather Plugin Schemas
 // ====================================
 export type DataSourcesWeatherPluginCurrentWeatherDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataCurrentWeatherDataSource'];
 export type DataSourcesWeatherPluginForecastDayDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataForecastDayDataSource'];
+export { DataSourcesWeatherPluginDataCurrentWeatherDataSourceField as WeatherDataSourceField } from './openapi';
 
 // Spaces Module Role Enums
 // ========================

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -140,6 +140,12 @@ export type DataSourcesDeviceChannelPluginCreateDeviceChannelDataSourceSchema = 
 export type DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSourceSchema = components['schemas']['DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSource'];
 export type DataSourcesDeviceChannelPluginDeviceChannelDataSourceSchema = components['schemas']['DataSourcesDeviceChannelPluginDataDeviceChannelDataSource'];
 
+// Devices Shelly V1 Plugin Schemas
+export type DevicesShellyV1PluginDeviceSchema = components['schemas']['DevicesShellyV1PluginDataDevice'];
+export type DevicesShellyV1PluginChannelSchema = components['schemas']['DevicesShellyV1PluginDataChannel'];
+export type DevicesShellyV1PluginChannelPropertySchema = components['schemas']['DevicesShellyV1PluginDataChannelProperty'];
+export type DevicesShellyV1PluginConfigSchema = components['schemas']['DevicesShellyV1PluginDataConfig'];
+
 // Devices Shelly NG Plugin Schemas
 export type DevicesShellyNgPluginUpdateConfigSchema = components['schemas']['DevicesShellyNgPluginUpdateConfig'];
 export type DevicesShellyNgPluginConfigSchema = components['schemas']['DevicesShellyNgPluginDataShellyNgConfig'];
@@ -203,6 +209,11 @@ export type DevicesThirdPartyPluginChannelSchema = components['schemas']['Device
 export type DevicesThirdPartyPluginCreateChannelPropertySchema = components['schemas']['DevicesThirdPartyPluginCreateChannelProperty'];
 export type DevicesThirdPartyPluginUpdateChannelPropertySchema = components['schemas']['DevicesThirdPartyPluginUpdateChannelProperty'];
 export type DevicesThirdPartyPluginChannelPropertySchema = components['schemas']['DevicesThirdPartyPluginDataChannelProperty'];
+
+// Simulator Plugin Schemas
+export type SimulatorPluginDeviceSchema = components['schemas']['SimulatorPluginDataDevice'];
+export type SimulatorPluginChannelSchema = components['schemas']['SimulatorPluginDataChannel'];
+export type SimulatorPluginChannelPropertySchema = components['schemas']['SimulatorPluginDataChannelProperty'];
 
 // Pages Cards Plugin Schemas
 export type PagesCardsPluginCreateCardsPageSchema = components['schemas']['PagesCardsPluginCreateCardsPage'];
@@ -427,6 +438,28 @@ export type WeatherModuleUpdateLocationSchema = components['schemas']['WeatherMo
 // Extensions Module Service State Enum
 // =====================================
 export { ExtensionsModuleDataServiceStatusState as ExtensionsModuleServiceState } from './openapi';
+
+// Buddy Plugin Config Schemas
+// ===========================
+export type BuddyClaudePluginConfigSchema = components['schemas']['BuddyClaudePluginDataConfig'];
+export type BuddyClaudeSetupTokenPluginConfigSchema = components['schemas']['BuddyClaudeSetupTokenPluginDataConfig'];
+export type BuddyOllamaPluginConfigSchema = components['schemas']['BuddyOllamaPluginDataConfig'];
+export type BuddyOpenaiPluginConfigSchema = components['schemas']['BuddyOpenaiPluginDataConfig'];
+export type BuddyOpenaiCodexPluginConfigSchema = components['schemas']['BuddyOpenaiCodexPluginDataConfig'];
+export type BuddyElevenlabsPluginConfigSchema = components['schemas']['BuddyElevenlabsPluginDataConfig'];
+export type BuddyVoiceaiPluginConfigSchema = components['schemas']['BuddyVoiceaiPluginDataConfig'];
+export type BuddySttWhisperLocalPluginConfigSchema = components['schemas']['BuddySttWhisperLocalPluginDataConfig'];
+export type BuddySystemTtsPluginConfigSchema = components['schemas']['BuddySystemTtsPluginDataConfig'];
+
+// Weather Plugin Config Schemas
+// =============================
+export type WeatherOpenweathermapPluginConfigSchema = components['schemas']['WeatherOpenweathermapPluginDataConfig'];
+export type WeatherOpenweathermapOnecallPluginConfigSchema = components['schemas']['WeatherOpenweathermapOnecallPluginDataConfig'];
+
+// Data Sources Weather Plugin Schemas
+// ====================================
+export type DataSourcesWeatherPluginCurrentWeatherDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataCurrentWeatherDataSource'];
+export type DataSourcesWeatherPluginForecastDayDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataForecastDayDataSource'];
 
 // Spaces Module Role Enums
 // ========================

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -456,13 +456,13 @@ export type BuddySystemTtsPluginConfigSchema = components['schemas']['BuddySyste
 // =============================
 export type WeatherOpenweathermapPluginConfigSchema = components['schemas']['WeatherOpenweathermapPluginDataConfig'];
 export type WeatherOpenweathermapOnecallPluginConfigSchema = components['schemas']['WeatherOpenweathermapOnecallPluginDataConfig'];
-export { DisplaysModuleUpdateDisplayTemperature_unit as WeatherTemperatureUnit } from './openapi';
+export { DisplaysModuleUpdateDisplayTemperature_unit as TemperatureUnit } from './openapi';
 
 // Data Sources Weather Plugin Schemas
 // ====================================
 export type DataSourcesWeatherPluginCurrentWeatherDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataCurrentWeatherDataSource'];
 export type DataSourcesWeatherPluginForecastDayDataSourceSchema = components['schemas']['DataSourcesWeatherPluginDataForecastDayDataSource'];
-export { DataSourcesWeatherPluginDataCurrentWeatherDataSourceField as WeatherDataSourceField } from './openapi';
+export { DataSourcesWeatherPluginDataCurrentWeatherDataSourceField as WeatherDataField } from './openapi';
 
 // Spaces Module Role Enums
 // ========================

--- a/apps/admin/src/plugins/buddy-claude-setup-token/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude-setup-token/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyClaudeSetupTokenPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME } from '../buddy-claude-setup-token.constants';
+
+type ApiConfig = BuddyClaudeSetupTokenPluginConfigSchema;
 
 export const ClaudeSetupTokenConfigSchema = ConfigPluginSchema.extend({
 	accessToken: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const ClaudeSetupTokenConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.
 	})
 );
 
-export const ClaudeSetupTokenConfigResSchema= ConfigPluginResSchema.and(
+export const ClaudeSetupTokenConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME),
 		access_token: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-claude/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyClaudePluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_CLAUDE_PLUGIN_NAME } from '../buddy-claude.constants';
+
+type ApiConfig = BuddyClaudePluginConfigSchema;
 
 export const ClaudeConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const ClaudeConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const ClaudeConfigResSchema= ConfigPluginResSchema.and(
+export const ClaudeConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_CLAUDE_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-elevenlabs/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-elevenlabs/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyElevenlabsPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_ELEVENLABS_PLUGIN_NAME } from '../buddy-elevenlabs.constants';
+
+type ApiConfig = BuddyElevenlabsPluginConfigSchema;
 
 export const ElevenlabsConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const ElevenlabsConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const ElevenlabsConfigResSchema= ConfigPluginResSchema.and(
+export const ElevenlabsConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_ELEVENLABS_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-ollama/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-ollama/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyOllamaPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_OLLAMA_PLUGIN_NAME } from '../buddy-ollama.constants';
+
+type ApiConfig = BuddyOllamaPluginConfigSchema;
 
 export const OllamaConfigSchema = ConfigPluginSchema.extend({
 	model: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const OllamaConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const OllamaConfigResSchema= ConfigPluginResSchema.and(
+export const OllamaConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_OLLAMA_PLUGIN_NAME),
 		model: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-openai-codex/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai-codex/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyOpenaiCodexPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_OPENAI_CODEX_PLUGIN_NAME } from '../buddy-openai-codex.constants';
+
+type ApiConfig = BuddyOpenaiCodexPluginConfigSchema;
 
 export const OpenAiCodexConfigSchema = ConfigPluginSchema.extend({
 	clientId: z.string().trim().nullable(),
@@ -25,7 +28,7 @@ export const OpenAiCodexConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const OpenAiCodexConfigResSchema= ConfigPluginResSchema.and(
+export const OpenAiCodexConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_OPENAI_CODEX_PLUGIN_NAME),
 		client_id: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-openai/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyOpenaiPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_OPENAI_PLUGIN_NAME } from '../buddy-openai.constants';
+
+type ApiConfig = BuddyOpenaiPluginConfigSchema;
 
 export const OpenAiConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const OpenAiConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const OpenAiConfigResSchema= ConfigPluginResSchema.and(
+export const OpenAiConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_OPENAI_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-stt-whisper-local/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-stt-whisper-local/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddySttWhisperLocalPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_STT_WHISPER_LOCAL_PLUGIN_NAME } from '../buddy-stt-whisper-local.constants';
+
+type ApiConfig = BuddySttWhisperLocalPluginConfigSchema;
 
 export const SttWhisperLocalConfigSchema = ConfigPluginSchema.extend({
 	model: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const SttWhisperLocalConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.a
 	})
 );
 
-export const SttWhisperLocalConfigResSchema= ConfigPluginResSchema.and(
+export const SttWhisperLocalConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_STT_WHISPER_LOCAL_PLUGIN_NAME),
 		model: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-system-tts/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-system-tts/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddySystemTtsPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_SYSTEM_TTS_PLUGIN_NAME } from '../buddy-system-tts.constants';
+
+type ApiConfig = BuddySystemTtsPluginConfigSchema;
 
 export const SystemTtsConfigSchema = ConfigPluginSchema.extend({
 	engine: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const SystemTtsConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const SystemTtsConfigResSchema= ConfigPluginResSchema.and(
+export const SystemTtsConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_SYSTEM_TTS_PLUGIN_NAME),
 		engine: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/buddy-voiceai/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-voiceai/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import { type BuddyVoiceaiPluginConfigSchema } from '../../../openapi.constants';
 import { BUDDY_VOICEAI_PLUGIN_NAME } from '../buddy-voiceai.constants';
+
+type ApiConfig = BuddyVoiceaiPluginConfigSchema;
 
 export const VoiceaiConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const VoiceaiConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const VoiceaiConfigResSchema= ConfigPluginResSchema.and(
+export const VoiceaiConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_VOICEAI_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/data-sources-weather/data-sources-weather.constants.ts
+++ b/apps/admin/src/plugins/data-sources-weather/data-sources-weather.constants.ts
@@ -4,15 +4,6 @@ export const DATA_SOURCES_WEATHER_CURRENT_TYPE = 'data-source-weather-current';
 
 export const DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE = 'data-source-weather-forecast-day';
 
-export enum WeatherDataField {
-	TEMPERATURE = 'temperature',
-	TEMPERATURE_MIN = 'temperature_min',
-	TEMPERATURE_MAX = 'temperature_max',
-	FEELS_LIKE = 'feels_like',
-	HUMIDITY = 'humidity',
-	PRESSURE = 'pressure',
-	WEATHER_ICON = 'weather_icon',
-	WEATHER_MAIN = 'weather_main',
-	WEATHER_DESCRIPTION = 'weather_description',
-	WIND_SPEED = 'wind_speed',
-}
+import { WeatherDataField } from '../../openapi.constants';
+
+export { WeatherDataField };

--- a/apps/admin/src/plugins/data-sources-weather/data-sources-weather.constants.ts
+++ b/apps/admin/src/plugins/data-sources-weather/data-sources-weather.constants.ts
@@ -1,9 +1,9 @@
+import { WeatherDataField } from '../../openapi.constants';
+
+export { WeatherDataField };
+
 export const DATA_SOURCES_WEATHER_PLUGIN_NAME = 'data-sources-weather-plugin';
 
 export const DATA_SOURCES_WEATHER_CURRENT_TYPE = 'data-source-weather-current';
 
 export const DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE = 'data-source-weather-forecast-day';
-
-import { WeatherDataField } from '../../openapi.constants';
-
-export { WeatherDataField };

--- a/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
+++ b/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import {
 	DataSourceCreateReqSchema,
@@ -6,11 +6,19 @@ import {
 	DataSourceSchema,
 	DataSourceUpdateReqSchema,
 } from '../../../modules/dashboard';
+import type {
+	DataSourcesWeatherPluginCurrentWeatherDataSourceSchema,
+	DataSourcesWeatherPluginForecastDayDataSourceSchema,
+} from '../../../openapi.constants';
+import { WeatherDataSourceField } from '../../../openapi.constants';
 import {
 	DATA_SOURCES_WEATHER_CURRENT_TYPE,
 	DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE,
 	WeatherDataField,
 } from '../data-sources-weather.constants';
+
+type ApiCurrentWeatherDataSource = DataSourcesWeatherPluginCurrentWeatherDataSourceSchema;
+type ApiForecastDayDataSource = DataSourcesWeatherPluginForecastDayDataSourceSchema;
 
 // STORE STATE
 // ===========
@@ -93,11 +101,11 @@ export const CurrentWeatherDataSourceUpdateReqSchema = DataSourceUpdateReqSchema
 	})
 );
 
-export const CurrentWeatherDataSourceResSchema = DataSourceResSchema.and(
+export const CurrentWeatherDataSourceResSchema: ZodType<ApiCurrentWeatherDataSource> = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_CURRENT_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
-		field: z.nativeEnum(WeatherDataField),
+		field: z.nativeEnum(WeatherDataSourceField),
 		icon: z.string().nullable(),
 		unit: z.string().nullable(),
 	})
@@ -145,12 +153,12 @@ export const ForecastDayDataSourceUpdateReqSchema = DataSourceUpdateReqSchema.an
 	})
 );
 
-export const ForecastDayDataSourceResSchema = DataSourceResSchema.and(
+export const ForecastDayDataSourceResSchema: ZodType<ApiForecastDayDataSource> = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
 		day_offset: z.number().min(0).max(7),
-		field: z.nativeEnum(WeatherDataField),
+		field: z.nativeEnum(WeatherDataSourceField),
 		icon: z.string().nullable(),
 		unit: z.string().nullable(),
 	})

--- a/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
+++ b/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import {
 	DataSourceCreateReqSchema,
@@ -6,11 +6,18 @@ import {
 	DataSourceSchema,
 	DataSourceUpdateReqSchema,
 } from '../../../modules/dashboard';
+import type {
+	DataSourcesWeatherPluginCurrentWeatherDataSourceSchema,
+	DataSourcesWeatherPluginForecastDayDataSourceSchema,
+} from '../../../openapi.constants';
 import {
 	DATA_SOURCES_WEATHER_CURRENT_TYPE,
 	DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE,
 	WeatherDataField,
 } from '../data-sources-weather.constants';
+
+type ApiCurrentWeatherDataSource = DataSourcesWeatherPluginCurrentWeatherDataSourceSchema;
+type ApiForecastDayDataSource = DataSourcesWeatherPluginForecastDayDataSourceSchema;
 
 // STORE STATE
 // ===========
@@ -93,7 +100,7 @@ export const CurrentWeatherDataSourceUpdateReqSchema = DataSourceUpdateReqSchema
 	})
 );
 
-export const CurrentWeatherDataSourceResSchema = DataSourceResSchema.and(
+export const CurrentWeatherDataSourceResSchema: ZodType<ApiCurrentWeatherDataSource> = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_CURRENT_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
@@ -145,7 +152,7 @@ export const ForecastDayDataSourceUpdateReqSchema = DataSourceUpdateReqSchema.an
 	})
 );
 
-export const ForecastDayDataSourceResSchema = DataSourceResSchema.and(
+export const ForecastDayDataSourceResSchema: ZodType<ApiForecastDayDataSource> = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE),
 		location_id: z.string().uuid().optional().nullable(),

--- a/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
+++ b/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
@@ -1,4 +1,4 @@
-import { type ZodType, z } from 'zod';
+import { z } from 'zod';
 
 import {
 	DataSourceCreateReqSchema,
@@ -6,18 +6,11 @@ import {
 	DataSourceSchema,
 	DataSourceUpdateReqSchema,
 } from '../../../modules/dashboard';
-import type {
-	DataSourcesWeatherPluginCurrentWeatherDataSourceSchema,
-	DataSourcesWeatherPluginForecastDayDataSourceSchema,
-} from '../../../openapi.constants';
 import {
 	DATA_SOURCES_WEATHER_CURRENT_TYPE,
 	DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE,
 	WeatherDataField,
 } from '../data-sources-weather.constants';
-
-type ApiCurrentWeatherDataSource = DataSourcesWeatherPluginCurrentWeatherDataSourceSchema;
-type ApiForecastDayDataSource = DataSourcesWeatherPluginForecastDayDataSourceSchema;
 
 // STORE STATE
 // ===========
@@ -100,7 +93,7 @@ export const CurrentWeatherDataSourceUpdateReqSchema = DataSourceUpdateReqSchema
 	})
 );
 
-export const CurrentWeatherDataSourceResSchema: ZodType<ApiCurrentWeatherDataSource> = DataSourceResSchema.and(
+export const CurrentWeatherDataSourceResSchema = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_CURRENT_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
@@ -152,7 +145,7 @@ export const ForecastDayDataSourceUpdateReqSchema = DataSourceUpdateReqSchema.an
 	})
 );
 
-export const ForecastDayDataSourceResSchema: ZodType<ApiForecastDayDataSource> = DataSourceResSchema.and(
+export const ForecastDayDataSourceResSchema = DataSourceResSchema.and(
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE),
 		location_id: z.string().uuid().optional().nullable(),

--- a/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
+++ b/apps/admin/src/plugins/data-sources-weather/store/data-sources.store.schemas.ts
@@ -10,7 +10,6 @@ import type {
 	DataSourcesWeatherPluginCurrentWeatherDataSourceSchema,
 	DataSourcesWeatherPluginForecastDayDataSourceSchema,
 } from '../../../openapi.constants';
-import { WeatherDataSourceField } from '../../../openapi.constants';
 import {
 	DATA_SOURCES_WEATHER_CURRENT_TYPE,
 	DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE,
@@ -25,7 +24,7 @@ type ApiForecastDayDataSource = DataSourcesWeatherPluginForecastDayDataSourceSch
 
 export const CurrentWeatherDataSourceSchema = DataSourceSchema.extend({
 	locationId: z.string().uuid().optional().nullable().default(null),
-	field: z.nativeEnum(WeatherDataField).default(WeatherDataField.TEMPERATURE),
+	field: z.nativeEnum(WeatherDataField).default(WeatherDataField.temperature),
 	icon: z
 		.string()
 		.trim()
@@ -43,7 +42,7 @@ export const CurrentWeatherDataSourceSchema = DataSourceSchema.extend({
 export const ForecastDayDataSourceSchema = DataSourceSchema.extend({
 	locationId: z.string().uuid().optional().nullable().default(null),
 	dayOffset: z.number().min(0).max(7).default(1),
-	field: z.nativeEnum(WeatherDataField).default(WeatherDataField.TEMPERATURE_MAX),
+	field: z.nativeEnum(WeatherDataField).default(WeatherDataField.temperature_max),
 	icon: z
 		.string()
 		.trim()
@@ -105,7 +104,7 @@ export const CurrentWeatherDataSourceResSchema: ZodType<ApiCurrentWeatherDataSou
 	z.object({
 		type: z.literal(DATA_SOURCES_WEATHER_CURRENT_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
-		field: z.nativeEnum(WeatherDataSourceField),
+		field: z.nativeEnum(WeatherDataField),
 		icon: z.string().nullable(),
 		unit: z.string().nullable(),
 	})
@@ -158,7 +157,7 @@ export const ForecastDayDataSourceResSchema: ZodType<ApiForecastDayDataSource> =
 		type: z.literal(DATA_SOURCES_WEATHER_FORECAST_DAY_TYPE),
 		location_id: z.string().uuid().optional().nullable(),
 		day_offset: z.number().min(0).max(7),
-		field: z.nativeEnum(WeatherDataSourceField),
+		field: z.nativeEnum(WeatherDataField),
 		icon: z.string().nullable(),
 		unit: z.string().nullable(),
 	})

--- a/apps/admin/src/plugins/devices-home-assistant/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/store/config.store.schemas.ts
@@ -1,9 +1,10 @@
 import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
-import type { DevicesHomeAssistantPluginUpdateConfigSchema } from '../../../openapi.constants';
+import type { DevicesHomeAssistantPluginConfigSchema, DevicesHomeAssistantPluginUpdateConfigSchema } from '../../../openapi.constants';
 import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME } from '../devices-home-assistant.constants';
 
+type ApiConfig = DevicesHomeAssistantPluginConfigSchema;
 type ApiUpdateConfig = DevicesHomeAssistantPluginUpdateConfigSchema;
 
 export const HomeAssistantConfigSchema = ConfigPluginSchema.extend({
@@ -23,7 +24,7 @@ export const HomeAssistantConfigUpdateReqSchema: ZodType<ApiUpdateConfig> = Conf
 	})
 );
 
-export const HomeAssistantConfigResSchema = ConfigPluginResSchema.and(
+export const HomeAssistantConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_HOME_ASSISTANT_PLUGIN_NAME),
 		api_key: z.string().trim().nonempty().nullable(),

--- a/apps/admin/src/plugins/devices-shelly-v1/store/channels.properties.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/store/channels.properties.store.schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import {
 	ChannelPropertyCreateReqSchema,
@@ -6,7 +6,10 @@ import {
 	ChannelPropertySchema,
 	ChannelPropertyUpdateReqSchema,
 } from '../../../modules/devices';
+import type { DevicesShellyV1PluginChannelPropertySchema } from '../../../openapi.constants';
 import { DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+
+type ApiChannelProperty = DevicesShellyV1PluginChannelPropertySchema;
 
 export const ShellyV1ChannelPropertySchema = ChannelPropertySchema;
 
@@ -25,7 +28,7 @@ export const ShellyV1ChannelPropertyUpdateReqSchema = ChannelPropertyUpdateReqSc
 	})
 );
 
-export const ShellyV1ChannelPropertyResSchema = ChannelPropertyResSchema.and(
+export const ShellyV1ChannelPropertyResSchema: ZodType<ApiChannelProperty> = ChannelPropertyResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_SHELLY_V1_TYPE),
 	})

--- a/apps/admin/src/plugins/devices-shelly-v1/store/channels.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/store/channels.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ChannelCreateReqSchema, ChannelResSchema, ChannelSchema, ChannelUpdateReqSchema } from '../../../modules/devices';
+import type { DevicesShellyV1PluginChannelSchema } from '../../../openapi.constants';
 import { DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+
+type ApiChannel = DevicesShellyV1PluginChannelSchema;
 
 export const ShellyV1ChannelSchema = ChannelSchema;
 
@@ -20,7 +23,7 @@ export const ShellyV1ChannelUpdateReqSchema = ChannelUpdateReqSchema.and(
 	})
 );
 
-export const ShellyV1ChannelResSchema = ChannelResSchema.and(
+export const ShellyV1ChannelResSchema: ZodType<ApiChannel> = ChannelResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_SHELLY_V1_TYPE),
 	})

--- a/apps/admin/src/plugins/devices-shelly-v1/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import type { DevicesShellyV1PluginConfigSchema } from '../../../openapi.constants';
 import { DEVICES_SHELLY_V1_PLUGIN_NAME } from '../devices-shelly-v1.constants';
+
+type ApiConfig = DevicesShellyV1PluginConfigSchema;
 
 export const ShellyV1ConfigSchema = ConfigPluginSchema.extend({
 	discovery: z.object({
@@ -35,7 +38,7 @@ export const ShellyV1ConfigUpdateReqSchema = ConfigPluginUpdateReqSchema.and(
 	})
 );
 
-export const ShellyV1ConfigResSchema = ConfigPluginResSchema.and(
+export const ShellyV1ConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_SHELLY_V1_PLUGIN_NAME),
 		discovery: z.object({

--- a/apps/admin/src/plugins/devices-shelly-v1/store/devices.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/store/devices.store.schemas.ts
@@ -1,8 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { DeviceCreateReqSchema, DeviceResSchema, DeviceSchema, DeviceUpdateReqSchema } from '../../../modules/devices';
+import type { DevicesShellyV1PluginDeviceSchema } from '../../../openapi.constants';
 import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import { DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+
+type ApiDevice = DevicesShellyV1PluginDeviceSchema;
 
 export const ShellyV1DeviceSchema = DeviceSchema.extend({
 	password: z.string().nullable(),
@@ -29,7 +32,7 @@ export const ShellyV1DeviceUpdateReqSchema = DeviceUpdateReqSchema.and(
 	})
 );
 
-export const ShellyV1DeviceResSchema = DeviceResSchema.and(
+export const ShellyV1DeviceResSchema: ZodType<ApiDevice> = DeviceResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_SHELLY_V1_TYPE),
 		password: z.string().nullable(),

--- a/apps/admin/src/plugins/simulator/store/channels.properties.store.schemas.ts
+++ b/apps/admin/src/plugins/simulator/store/channels.properties.store.schemas.ts
@@ -1,4 +1,6 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { SimulatorPluginChannelPropertySchema } from '../../../openapi.constants';
 
 import {
 	ChannelPropertyCreateReqSchema,
@@ -7,6 +9,8 @@ import {
 	ChannelPropertyUpdateReqSchema,
 } from '../../../modules/devices';
 import { SIMULATOR_TYPE } from '../simulator.constants';
+
+type ApiChannelProperty = SimulatorPluginChannelPropertySchema;
 
 export const SimulatorChannelPropertySchema = ChannelPropertySchema;
 
@@ -25,7 +29,7 @@ export const SimulatorChannelPropertyUpdateReqSchema= ChannelPropertyUpdateReqSc
 	})
 );
 
-export const SimulatorChannelPropertyResSchema= ChannelPropertyResSchema.and(
+export const SimulatorChannelPropertyResSchema: ZodType<ApiChannelProperty> = ChannelPropertyResSchema.and(
 	z.object({
 		type: z.literal(SIMULATOR_TYPE),
 	})

--- a/apps/admin/src/plugins/simulator/store/channels.store.schemas.ts
+++ b/apps/admin/src/plugins/simulator/store/channels.store.schemas.ts
@@ -1,7 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { SimulatorPluginChannelSchema } from '../../../openapi.constants';
 
 import { ChannelCreateReqSchema, ChannelResSchema, ChannelSchema, ChannelUpdateReqSchema } from '../../../modules/devices';
 import { SIMULATOR_TYPE } from '../simulator.constants';
+
+type ApiChannel = SimulatorPluginChannelSchema;
 
 export const SimulatorChannelSchema = ChannelSchema;
 
@@ -20,7 +24,7 @@ export const SimulatorChannelUpdateReqSchema= ChannelUpdateReqSchema.and(
 	})
 );
 
-export const SimulatorChannelResSchema= ChannelResSchema.and(
+export const SimulatorChannelResSchema: ZodType<ApiChannel> = ChannelResSchema.and(
 	z.object({
 		type: z.literal(SIMULATOR_TYPE),
 	})

--- a/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
+++ b/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
@@ -1,11 +1,7 @@
-import { type ZodType, z } from 'zod';
-
-import type { SimulatorPluginDeviceSchema } from '../../../openapi.constants';
+import { z } from 'zod';
 
 import { DeviceCreateReqSchema, DeviceResSchema, DeviceSchema, DeviceUpdateReqSchema } from '../../../modules/devices';
 import { SIMULATOR_TYPE } from '../simulator.constants';
-
-type ApiDevice = SimulatorPluginDeviceSchema;
 
 export const SimulatorDeviceSchema = DeviceSchema;
 
@@ -24,7 +20,7 @@ export const SimulatorDeviceUpdateReqSchema= DeviceUpdateReqSchema.and(
 	})
 );
 
-export const SimulatorDeviceResSchema: ZodType<ApiDevice> = DeviceResSchema.and(
+export const SimulatorDeviceResSchema = DeviceResSchema.and(
 	z.object({
 		type: z.literal(SIMULATOR_TYPE),
 	})

--- a/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
+++ b/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
@@ -1,7 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { DeviceCreateReqSchema, DeviceResSchema, DeviceSchema, DeviceUpdateReqSchema } from '../../../modules/devices';
+import type { SimulatorPluginDeviceSchema } from '../../../openapi.constants';
+import { SimulatorPluginBehaviorMode } from '../../../openapi.constants';
 import { SIMULATOR_TYPE } from '../simulator.constants';
+
+type ApiDevice = SimulatorPluginDeviceSchema;
 
 export const SimulatorDeviceSchema = DeviceSchema;
 
@@ -20,8 +24,11 @@ export const SimulatorDeviceUpdateReqSchema= DeviceUpdateReqSchema.and(
 	})
 );
 
-export const SimulatorDeviceResSchema = DeviceResSchema.and(
+export const SimulatorDeviceResSchema: ZodType<ApiDevice> = DeviceResSchema.and(
 	z.object({
 		type: z.literal(SIMULATOR_TYPE),
+		auto_simulate: z.boolean(),
+		simulate_interval: z.number(),
+		behavior_mode: z.nativeEnum(SimulatorPluginBehaviorMode),
 	})
 );

--- a/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
+++ b/apps/admin/src/plugins/simulator/store/devices.store.schemas.ts
@@ -1,7 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
+
+import type { SimulatorPluginDeviceSchema } from '../../../openapi.constants';
 
 import { DeviceCreateReqSchema, DeviceResSchema, DeviceSchema, DeviceUpdateReqSchema } from '../../../modules/devices';
 import { SIMULATOR_TYPE } from '../simulator.constants';
+
+type ApiDevice = SimulatorPluginDeviceSchema;
 
 export const SimulatorDeviceSchema = DeviceSchema;
 
@@ -20,7 +24,7 @@ export const SimulatorDeviceUpdateReqSchema= DeviceUpdateReqSchema.and(
 	})
 );
 
-export const SimulatorDeviceResSchema= DeviceResSchema.and(
+export const SimulatorDeviceResSchema: ZodType<ApiDevice> = DeviceResSchema.and(
 	z.object({
 		type: z.literal(SIMULATOR_TYPE),
 	})

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/components/openweathermap-onecall-config-form.vue
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/components/openweathermap-onecall-config-form.vue
@@ -106,11 +106,11 @@ const { formEl, model, formChanged, submit, formResult } = useConfigPluginEditFo
 
 const unitOptions = computed(() => [
 	{
-		value: TemperatureUnit.CELSIUS,
+		value: TemperatureUnit.celsius,
 		label: t('weatherOpenweathermapOnecallPlugin.fields.config.unit.values.celsius'),
 	},
 	{
-		value: TemperatureUnit.FAHRENHEIT,
+		value: TemperatureUnit.fahrenheit,
 		label: t('weatherOpenweathermapOnecallPlugin.fields.config.unit.values.fahrenheit'),
 	},
 ]);

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
@@ -1,10 +1,7 @@
-import { type ZodType, z } from 'zod';
+import { z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
-import type { WeatherOpenweathermapOnecallPluginConfigSchema } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../weather-openweathermap-onecall.constants';
-
-type ApiConfig = WeatherOpenweathermapOnecallPluginConfigSchema;
 
 export const OpenWeatherMapOneCallConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -22,7 +19,7 @@ export const OpenWeatherMapOneCallConfigUpdateReqSchema= ConfigPluginUpdateReqSc
 	})
 );
 
-export const OpenWeatherMapOneCallConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
+export const OpenWeatherMapOneCallConfigResSchema = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
@@ -1,7 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import type { WeatherOpenweathermapOnecallPluginConfigSchema } from '../../../openapi.constants';
+import { WeatherTemperatureUnit } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../weather-openweathermap-onecall.constants';
+
+type ApiConfig = WeatherOpenweathermapOnecallPluginConfigSchema;
 
 export const OpenWeatherMapOneCallConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,10 +23,10 @@ export const OpenWeatherMapOneCallConfigUpdateReqSchema= ConfigPluginUpdateReqSc
 	})
 );
 
-export const OpenWeatherMapOneCallConfigResSchema = ConfigPluginResSchema.and(
+export const OpenWeatherMapOneCallConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),
-		unit: z.nativeEnum(TemperatureUnit),
+		unit: z.nativeEnum(WeatherTemperatureUnit),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import type { WeatherOpenweathermapOnecallPluginConfigSchema } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../weather-openweathermap-onecall.constants';
+
+type ApiConfig = WeatherOpenweathermapOnecallPluginConfigSchema;
 
 export const OpenWeatherMapOneCallConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const OpenWeatherMapOneCallConfigUpdateReqSchema= ConfigPluginUpdateReqSc
 	})
 );
 
-export const OpenWeatherMapOneCallConfigResSchema= ConfigPluginResSchema.and(
+export const OpenWeatherMapOneCallConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
@@ -2,14 +2,13 @@ import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
 import type { WeatherOpenweathermapOnecallPluginConfigSchema } from '../../../openapi.constants';
-import { WeatherTemperatureUnit } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../weather-openweathermap-onecall.constants';
 
 type ApiConfig = WeatherOpenweathermapOnecallPluginConfigSchema;
 
 export const OpenWeatherMapOneCallConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
-	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.CELSIUS),
+	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.celsius),
 });
 
 // BACKEND API
@@ -27,6 +26,6 @@ export const OpenWeatherMapOneCallConfigResSchema: ZodType<ApiConfig> = ConfigPl
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),
-		unit: z.nativeEnum(WeatherTemperatureUnit),
+		unit: z.nativeEnum(TemperatureUnit),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.constants.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.constants.ts
@@ -4,7 +4,6 @@ export const WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME = 'weather-openweatherma
 
 export const WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_TYPE = 'weather-openweathermap-onecall';
 
-export enum TemperatureUnit {
-	CELSIUS = 'celsius',
-	FAHRENHEIT = 'fahrenheit',
-}
+import { TemperatureUnit } from '../../openapi.constants';
+
+export { TemperatureUnit };

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.constants.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.constants.ts
@@ -1,9 +1,9 @@
+import { TemperatureUnit } from '../../openapi.constants';
+
+export { TemperatureUnit };
+
 export const WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_PREFIX = 'weather-openweathermap-onecall';
 
 export const WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME = 'weather-openweathermap-onecall-plugin';
 
 export const WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_TYPE = 'weather-openweathermap-onecall';
-
-import { TemperatureUnit } from '../../openapi.constants';
-
-export { TemperatureUnit };

--- a/apps/admin/src/plugins/weather-openweathermap/components/openweathermap-config-form.vue
+++ b/apps/admin/src/plugins/weather-openweathermap/components/openweathermap-config-form.vue
@@ -103,11 +103,11 @@ const { formEl, model, formChanged, submit, formResult } = useConfigPluginEditFo
 
 const unitOptions = computed(() => [
 	{
-		value: TemperatureUnit.CELSIUS,
+		value: TemperatureUnit.celsius,
 		label: t('weatherOpenweathermapPlugin.fields.config.unit.values.celsius'),
 	},
 	{
-		value: TemperatureUnit.FAHRENHEIT,
+		value: TemperatureUnit.fahrenheit,
 		label: t('weatherOpenweathermapPlugin.fields.config.unit.values.fahrenheit'),
 	},
 ]);

--- a/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
@@ -2,14 +2,13 @@ import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
 import type { WeatherOpenweathermapPluginConfigSchema } from '../../../openapi.constants';
-import { WeatherTemperatureUnit } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-openweathermap.constants';
 
 type ApiConfig = WeatherOpenweathermapPluginConfigSchema;
 
 export const OpenWeatherMapConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
-	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.CELSIUS),
+	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.celsius),
 });
 
 // BACKEND API
@@ -27,6 +26,6 @@ export const OpenWeatherMapConfigResSchema: ZodType<ApiConfig> = ConfigPluginRes
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),
-		unit: z.nativeEnum(WeatherTemperatureUnit),
+		unit: z.nativeEnum(TemperatureUnit),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import type { WeatherOpenweathermapPluginConfigSchema } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-openweathermap.constants';
+
+type ApiConfig = WeatherOpenweathermapPluginConfigSchema;
 
 export const OpenWeatherMapConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,7 +22,7 @@ export const OpenWeatherMapConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.an
 	})
 );
 
-export const OpenWeatherMapConfigResSchema= ConfigPluginResSchema.and(
+export const OpenWeatherMapConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
@@ -1,10 +1,7 @@
-import { type ZodType, z } from 'zod';
+import { z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
-import type { WeatherOpenweathermapPluginConfigSchema } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-openweathermap.constants';
-
-type ApiConfig = WeatherOpenweathermapPluginConfigSchema;
 
 export const OpenWeatherMapConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -22,7 +19,7 @@ export const OpenWeatherMapConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.an
 	})
 );
 
-export const OpenWeatherMapConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
+export const OpenWeatherMapConfigResSchema = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),

--- a/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
@@ -1,7 +1,11 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
+import type { WeatherOpenweathermapPluginConfigSchema } from '../../../openapi.constants';
+import { WeatherTemperatureUnit } from '../../../openapi.constants';
 import { TemperatureUnit, WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-openweathermap.constants';
+
+type ApiConfig = WeatherOpenweathermapPluginConfigSchema;
 
 export const OpenWeatherMapConfigSchema = ConfigPluginSchema.extend({
 	apiKey: z.string().trim().nullable(),
@@ -19,10 +23,10 @@ export const OpenWeatherMapConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.an
 	})
 );
 
-export const OpenWeatherMapConfigResSchema = ConfigPluginResSchema.and(
+export const OpenWeatherMapConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_NAME),
 		api_key: z.string().trim().nullable(),
-		unit: z.nativeEnum(TemperatureUnit),
+		unit: z.nativeEnum(WeatherTemperatureUnit),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
@@ -1,14 +1,14 @@
 import { WeatherOpenweathermapPluginDataLocationLocation_type } from '../../openapi';
 
+import { TemperatureUnit } from '../../openapi.constants';
+
+export { TemperatureUnit };
+
 export const WEATHER_OPENWEATHERMAP_PLUGIN_PREFIX = 'weather-openweathermap';
 
 export const WEATHER_OPENWEATHERMAP_PLUGIN_NAME = 'weather-openweathermap-plugin';
 
 export const WEATHER_OPENWEATHERMAP_PLUGIN_TYPE = 'weather-openweathermap';
-
-import { TemperatureUnit } from '../../openapi.constants';
-
-export { TemperatureUnit };
 
 // Re-export the OpenAPI enum for convenience
 export const OpenWeatherMapLocationType = WeatherOpenweathermapPluginDataLocationLocation_type;

--- a/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
@@ -6,10 +6,9 @@ export const WEATHER_OPENWEATHERMAP_PLUGIN_NAME = 'weather-openweathermap-plugin
 
 export const WEATHER_OPENWEATHERMAP_PLUGIN_TYPE = 'weather-openweathermap';
 
-export enum TemperatureUnit {
-	CELSIUS = 'celsius',
-	FAHRENHEIT = 'fahrenheit',
-}
+import { TemperatureUnit } from '../../openapi.constants';
+
+export { TemperatureUnit };
 
 // Re-export the OpenAPI enum for convenience
 export const OpenWeatherMapLocationType = WeatherOpenweathermapPluginDataLocationLocation_type;

--- a/tasks/technical/TECH-ADMIN-TS-STRICT-ENUMS.md
+++ b/tasks/technical/TECH-ADMIN-TS-STRICT-ENUMS.md
@@ -4,7 +4,7 @@ Type: technical
 Scope: admin
 Size: large
 Parent: (none)
-Status: planned
+Status: done
 
 ## 1. Business goal
 
@@ -63,15 +63,15 @@ I want the admin app to use strict TypeScript types from the generated OpenAPI s
 
 ## 4. Acceptance criteria
 
-- [ ] Zero `as unknown` casts in non-test admin files (currently 239)
-- [ ] Zero `as never` casts in non-test admin files
-- [ ] Zero `as any` casts in non-test admin files (except documented exceptions)
-- [ ] All enum imports go through `openapi.constants.ts`, not directly from `openapi.ts`
-- [ ] String literals replaced with enum values where a generated enum exists
-- [ ] `pnpm --filter ./apps/admin run test:unit` passes
-- [ ] `pnpm --filter @fastybird/smart-panel-admin lint:js` passes
-- [ ] `pnpm --filter @fastybird/smart-panel-admin type-check` passes
-- [ ] No functional regressions
+- [x] Zero `as unknown` casts in non-test admin files (currently 239) — **Done: 0 remaining**
+- [x] Zero `as never` casts in non-test admin files — **Done: 0 remaining**
+- [x] Zero `as any` casts in non-test admin files (except documented exceptions) — **Done: 0 remaining**
+- [x] All enum imports go through `openapi.constants.ts`, not directly from `openapi.ts` — **Done**
+- [x] String literals replaced with enum values where a generated enum exists — **Done**
+- [x] `pnpm --filter ./apps/admin run test:unit` passes — **Done: 1275/1275 pass**
+- [x] `pnpm --filter @fastybird/smart-panel-admin lint:js` passes — **Done**
+- [x] `pnpm --filter @fastybird/smart-panel-admin type-check` passes — **Done**
+- [x] No functional regressions — **Done**
 
 ## 5. Technical constraints
 


### PR DESCRIPTION
## Summary
- Annotate all 27 remaining response Zod schemas with `ZodType<ApiType>` for compile-time alignment with generated OpenAPI types
- Add type exports to `openapi.constants.ts` for Shelly V1, Simulator, buddy plugins, weather plugins, and weather data sources
- Mark `TECH-ADMIN-TS-STRICT-ENUMS` task as **done** — all acceptance criteria met

### Schemas annotated
| Group | Schemas |
|-------|---------|
| Scenes | `SceneActionResSchema` |
| Displays | `DisplayResSchema`, `DisplayTokenResSchema` |
| Extensions | `DiscoveredExtensionAdminResSchema`, `DiscoveredExtensionBackendResSchema` |
| Shelly V1 | Device, Channel, ChannelProperty, Config |
| Simulator | Device, Channel, ChannelProperty |
| Buddy plugins | Claude, Claude Setup Token, Ollama, OpenAI, OpenAI Codex, Elevenlabs, VoiceAI, STT Whisper Local, System TTS |
| Weather plugins | OpenWeatherMap, OpenWeatherMap OneCall |
| Weather data sources | CurrentWeather, ForecastDay |
| Home Assistant | Config |

### Task completion status
- 0 `as unknown`/`as never`/`as any` casts in non-test admin files
- 0 direct imports from `openapi.ts` (all go through `openapi.constants.ts`)
- 101/101 response schemas have `ZodType` annotations
- 1275/1275 tests pass
- Type-check clean

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 1275 unit tests pass
- [x] Zero unsafe casts confirmed via grep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly type-safety refactors, but it changes enum sources/defaults and tightens response validation (including new required simulator device fields), which could surface runtime parse failures if backend payloads differ.
> 
> **Overview**
> **Type-safety alignment:** Annotates remaining response validators (e.g. `*ResSchema`) with `ZodType<...>` bound to generated OpenAPI types, so Zod parsing and TypeScript stay in sync.
> 
> **Enum/source cleanup:** Expands `openapi.constants.ts` with additional plugin/data-source type exports and switches weather-related enums (`TemperatureUnit`, `WeatherDataField`) to be re-exported from OpenAPI (updating defaults/usages to match generated enum members).
> 
> **Schema shape updates:** Updates the simulator device response schema to validate additional fields (`auto_simulate`, `simulate_interval`, `behavior_mode`) and marks `TECH-ADMIN-TS-STRICT-ENUMS` as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2da3a8fda6110fb439a6d6e147aaee6a94448b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->