### PR TITLE
refactor(admin): replace local enums with generated OpenAPI enums

### DIFF
--- a/apps/admin/src/modules/extensions/components/extension-card.vue
+++ b/apps/admin/src/modules/extensions/components/extension-card.vue
@@ -17,10 +17,10 @@
 					<h3 class="extension-card__title">{{ extension.name }}</h3>
 					<div class="extension-card__tags">
 						<el-tag
-							:type="extension.kind === ExtensionKind.MODULE ? 'primary' : 'success'"
+							:type="extension.kind === ExtensionKind.module ? 'primary' : 'success'"
 							size="small"
 						>
-							{{ extension.kind === ExtensionKind.MODULE ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
+							{{ extension.kind === ExtensionKind.module ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
 						</el-tag>
 						<el-tag
 							v-if="extension.isCore"
@@ -199,14 +199,14 @@ const emit = defineEmits<IExtensionCardEmits>();
 const { t } = useI18n();
 
 const extensionIcon = computed<string>(() => {
-	if (props.extension.kind === ExtensionKind.MODULE) {
+	if (props.extension.kind === ExtensionKind.module) {
 		return 'mdi:package-variant';
 	}
 	return 'mdi:toy-brick';
 });
 
 const toggleDisabledReason = computed<string>(() => {
-	if (props.extension.isCore && props.extension.kind === ExtensionKind.MODULE) {
+	if (props.extension.isCore && props.extension.kind === ExtensionKind.module) {
 		return t('extensionsModule.tooltips.coreModuleCannotBeDisabled');
 	}
 	return t('extensionsModule.tooltips.cannotToggleEnabled');

--- a/apps/admin/src/modules/extensions/components/extensions-table.vue
+++ b/apps/admin/src/modules/extensions/components/extensions-table.vue
@@ -109,7 +109,7 @@
 			<template #default="scope">
 				<el-avatar :size="32">
 					<icon
-						:icon="scope.row.kind === ExtensionKind.MODULE ? 'mdi:package-variant' : 'mdi:toy-brick'"
+						:icon="scope.row.kind === ExtensionKind.module ? 'mdi:package-variant' : 'mdi:toy-brick'"
 						class="w[20px] h[20px]"
 					/>
 				</el-avatar>
@@ -175,10 +175,10 @@
 		>
 			<template #default="scope">
 				<el-tag
-					:type="scope.row.kind === ExtensionKind.MODULE ? 'primary' : 'success'"
+					:type="scope.row.kind === ExtensionKind.module ? 'primary' : 'success'"
 					size="small"
 				>
-					{{ scope.row.kind === ExtensionKind.MODULE ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
+					{{ scope.row.kind === ExtensionKind.module ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
 				</el-tag>
 			</template>
 		</el-table-column>

--- a/apps/admin/src/modules/extensions/composables/schemas.ts
+++ b/apps/admin/src/modules/extensions/composables/schemas.ts
@@ -4,7 +4,7 @@ import { ExtensionKind } from '../extensions.constants';
 
 export const ExtensionsFilterSchema = z.object({
 	search: z.string().optional(),
-	kind: z.enum(['all', ExtensionKind.MODULE, ExtensionKind.PLUGIN]).default('all'),
+	kind: z.enum(['all', ExtensionKind.module, ExtensionKind.plugin]).default('all'),
 	enabled: z.enum(['all', 'enabled', 'disabled']).default('all'),
 	isCore: z.enum(['all', 'core', 'addon']).default('all'),
 });

--- a/apps/admin/src/modules/extensions/composables/useExtensions.spec.ts
+++ b/apps/admin/src/modules/extensions/composables/useExtensions.spec.ts
@@ -10,7 +10,7 @@ import { useExtensions } from './useExtensions';
 const mockExtensions: IExtension[] = [
 	{
 		type: 'devices-module',
-		kind: ExtensionKind.MODULE,
+		kind: ExtensionKind.module,
 		name: 'Devices Module',
 		enabled: true,
 		isCore: true,
@@ -18,7 +18,7 @@ const mockExtensions: IExtension[] = [
 	},
 	{
 		type: 'auth-module',
-		kind: ExtensionKind.MODULE,
+		kind: ExtensionKind.module,
 		name: 'Auth Module',
 		enabled: true,
 		isCore: true,
@@ -26,7 +26,7 @@ const mockExtensions: IExtension[] = [
 	},
 	{
 		type: 'pages-tiles-plugin',
-		kind: ExtensionKind.PLUGIN,
+		kind: ExtensionKind.plugin,
 		name: 'Pages Tiles Plugin',
 		enabled: true,
 		isCore: true,
@@ -63,14 +63,14 @@ describe('useExtensions', () => {
 		const { modules } = useExtensions();
 
 		expect(modules.value).toHaveLength(2);
-		expect(modules.value.every((m) => m.kind === ExtensionKind.MODULE)).toBe(true);
+		expect(modules.value.every((m) => m.kind === ExtensionKind.module)).toBe(true);
 	});
 
 	it('should return only plugins', () => {
 		const { plugins } = useExtensions();
 
 		expect(plugins.value).toHaveLength(1);
-		expect(plugins.value[0]?.kind).toBe(ExtensionKind.PLUGIN);
+		expect(plugins.value[0]?.kind).toBe(ExtensionKind.plugin);
 	});
 
 	it('should indicate loading state', () => {

--- a/apps/admin/src/modules/extensions/composables/useExtensions.ts
+++ b/apps/admin/src/modules/extensions/composables/useExtensions.ts
@@ -27,11 +27,11 @@ export const useExtensions = (): IUseExtensions => {
 	});
 
 	const modules = computed<IExtension[]>(() => {
-		return Object.values(data.value).filter((ext) => ext.kind === ExtensionKind.MODULE);
+		return Object.values(data.value).filter((ext) => ext.kind === ExtensionKind.module);
 	});
 
 	const plugins = computed<IExtension[]>(() => {
-		return Object.values(data.value).filter((ext) => ext.kind === ExtensionKind.PLUGIN);
+		return Object.values(data.value).filter((ext) => ext.kind === ExtensionKind.plugin);
 	});
 
 	const areLoading = computed<boolean>(() => {

--- a/apps/admin/src/modules/extensions/composables/useExtensionsDataSource.spec.ts
+++ b/apps/admin/src/modules/extensions/composables/useExtensionsDataSource.spec.ts
@@ -10,7 +10,7 @@ import { defaultExtensionsFilter, defaultExtensionsSort, useExtensionsDataSource
 const mockExtensions: IExtension[] = [
 	{
 		type: 'devices-module',
-		kind: ExtensionKind.MODULE,
+		kind: ExtensionKind.module,
 		name: 'Devices Module',
 		description: 'Device management',
 		enabled: true,
@@ -19,7 +19,7 @@ const mockExtensions: IExtension[] = [
 	},
 	{
 		type: 'auth-module',
-		kind: ExtensionKind.MODULE,
+		kind: ExtensionKind.module,
 		name: 'Auth Module',
 		description: 'Authentication',
 		enabled: false,
@@ -28,7 +28,7 @@ const mockExtensions: IExtension[] = [
 	},
 	{
 		type: 'pages-tiles-plugin',
-		kind: ExtensionKind.PLUGIN,
+		kind: ExtensionKind.plugin,
 		name: 'Pages Tiles Plugin',
 		description: 'Dashboard tiles',
 		enabled: true,
@@ -37,7 +37,7 @@ const mockExtensions: IExtension[] = [
 	},
 	{
 		type: 'external-plugin',
-		kind: ExtensionKind.PLUGIN,
+		kind: ExtensionKind.plugin,
 		name: 'External Plugin',
 		description: 'Third party addon',
 		enabled: true,
@@ -94,21 +94,21 @@ describe('useExtensionsDataSource', () => {
 		});
 
 		it('should return only modules when filtered by MODULE kind', () => {
-			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.MODULE };
+			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.module };
 
 			const { modules } = useExtensionsDataSource();
 
 			expect(modules.value).toHaveLength(2);
-			expect(modules.value.every((m) => m.kind === ExtensionKind.MODULE)).toBe(true);
+			expect(modules.value.every((m) => m.kind === ExtensionKind.module)).toBe(true);
 		});
 
 		it('should return only plugins when filtered by PLUGIN kind', () => {
-			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.PLUGIN };
+			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.plugin };
 
 			const { plugins } = useExtensionsDataSource();
 
 			expect(plugins.value).toHaveLength(2);
-			expect(plugins.value.every((p) => p.kind === ExtensionKind.PLUGIN)).toBe(true);
+			expect(plugins.value.every((p) => p.kind === ExtensionKind.plugin)).toBe(true);
 		});
 	});
 
@@ -193,7 +193,7 @@ describe('useExtensionsDataSource', () => {
 		it('should apply multiple filters together', () => {
 			mockFilters.value = {
 				search: undefined,
-				kind: ExtensionKind.PLUGIN,
+				kind: ExtensionKind.plugin,
 				enabled: 'enabled',
 				isCore: 'core',
 			};
@@ -221,7 +221,7 @@ describe('useExtensionsDataSource', () => {
 		});
 
 		it('should be true when kind filter is changed', () => {
-			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.MODULE };
+			mockFilters.value = { ...defaultExtensionsFilter, kind: ExtensionKind.module };
 
 			const { filtersActive } = useExtensionsDataSource();
 

--- a/apps/admin/src/modules/extensions/composables/useExtensionsDataSource.ts
+++ b/apps/admin/src/modules/extensions/composables/useExtensionsDataSource.ts
@@ -131,11 +131,11 @@ export const useExtensionsDataSource = (): IUseExtensionsDataSource => {
 	});
 
 	const modules = computed<IExtension[]>((): IExtension[] => {
-		return filteredExtensions.value.filter((ext) => ext.kind === ExtensionKind.MODULE);
+		return filteredExtensions.value.filter((ext) => ext.kind === ExtensionKind.module);
 	});
 
 	const plugins = computed<IExtension[]>((): IExtension[] => {
-		return filteredExtensions.value.filter((ext) => ext.kind === ExtensionKind.PLUGIN);
+		return filteredExtensions.value.filter((ext) => ext.kind === ExtensionKind.plugin);
 	});
 
 	const fetchExtensions = async (): Promise<void> => {

--- a/apps/admin/src/modules/extensions/extensions.constants.ts
+++ b/apps/admin/src/modules/extensions/extensions.constants.ts
@@ -1,23 +1,12 @@
+import { ExtensionKind, ExtensionSource, ExtensionSurface } from '../../openapi.constants';
+
+export { ExtensionKind, ExtensionSource, ExtensionSurface };
+
 export const EXTENSIONS_MODULE_PREFIX = 'extensions';
 
 export const EXTENSIONS_MODULE_NAME = 'extensions-module';
 
 export const EXTENSIONS_MODULE_EVENT_PREFIX = 'ExtensionsModule.';
-
-export enum ExtensionKind {
-	MODULE = 'module',
-	PLUGIN = 'plugin',
-}
-
-export enum ExtensionSurface {
-	ADMIN = 'admin',
-	BACKEND = 'backend',
-}
-
-export enum ExtensionSource {
-	BUNDLED = 'bundled',
-	RUNTIME = 'runtime',
-}
 
 export enum FormResult {
 	NONE = 'none',

--- a/apps/admin/src/modules/extensions/loaders/remote-extensions.loader.ts
+++ b/apps/admin/src/modules/extensions/loaders/remote-extensions.loader.ts
@@ -5,7 +5,7 @@ import type { Client } from 'openapi-fetch';
 
 import type { IExtensionOptions } from '../../../app.types';
 import type { OpenApiPaths } from '../../../openapi.constants';
-import { PathsModulesExtensionsDiscoveredGetParametersQuerySurface } from '../../../openapi';
+import { ExtensionsDiscoverySurface } from '../../../openapi.constants';
 
 type PluginInstallFn<TOptions> = (app: App, options?: TOptions) => void;
 
@@ -50,7 +50,7 @@ export const installRemoteExtensions = async (
 	} = await backendClient.GET('/modules/extensions/discovered', {
 		params: {
 			query: {
-				surface: PathsModulesExtensionsDiscoveredGetParametersQuerySurface.admin,
+				surface: ExtensionsDiscoverySurface.admin,
 			},
 		},
 	});

--- a/apps/admin/src/modules/extensions/store/discovered-extensions.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/discovered-extensions.store.spec.ts
@@ -11,24 +11,24 @@ import { useDiscoveredExtensions } from './discovered-extensions.store';
 
 const mockAdminExtensionRes: IDiscoveredExtensionRes = {
 	name: 'test-module',
-	kind: ExtensionKind.MODULE,
-	surface: ExtensionSurface.ADMIN,
+	kind: ExtensionKind.module,
+	surface: ExtensionSurface.admin,
 	display_name: 'Test Module',
 	description: 'A test module',
 	version: '1.0.0',
-	source: ExtensionSource.BUNDLED,
+	source: ExtensionSource.bundled,
 	remote_url: 'http://localhost:3000',
 	type: 'admin',
 };
 
 const mockBackendExtensionRes: IDiscoveredExtensionRes = {
 	name: 'test-module',
-	kind: ExtensionKind.MODULE,
-	surface: ExtensionSurface.BACKEND,
+	kind: ExtensionKind.module,
+	surface: ExtensionSurface.backend,
 	display_name: 'Test Module',
 	description: 'A test module',
 	version: '1.0.0',
-	source: ExtensionSource.BUNDLED,
+	source: ExtensionSource.bundled,
 	route_prefix: '/api/v1/test-module',
 	type: 'backend',
 };

--- a/apps/admin/src/modules/extensions/store/discovered-extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/discovered-extensions.transformers.spec.ts
@@ -11,12 +11,12 @@ describe('Discovered Extensions Transformers', () => {
 		it('should transform admin extension response correctly', () => {
 			const response: IDiscoveredExtensionRes = {
 				name: 'test-module',
-				kind: ExtensionKind.MODULE,
-				surface: ExtensionSurface.ADMIN,
+				kind: ExtensionKind.module,
+				surface: ExtensionSurface.admin,
 				display_name: 'Test Module',
 				description: 'A test module',
 				version: '1.0.0',
-				source: ExtensionSource.BUNDLED,
+				source: ExtensionSource.bundled,
 				remote_url: 'http://localhost:3000',
 				type: 'admin',
 			};
@@ -24,24 +24,24 @@ describe('Discovered Extensions Transformers', () => {
 			const result = transformDiscoveredExtensionResponse(response);
 
 			expect(result.name).toBe('test-module');
-			expect(result.kind).toBe(ExtensionKind.MODULE);
-			expect(result.surface).toBe(ExtensionSurface.ADMIN);
+			expect(result.kind).toBe(ExtensionKind.module);
+			expect(result.surface).toBe(ExtensionSurface.admin);
 			expect(result.displayName).toBe('Test Module');
 			expect(result.description).toBe('A test module');
 			expect(result.version).toBe('1.0.0');
-			expect(result.source).toBe(ExtensionSource.BUNDLED);
+			expect(result.source).toBe(ExtensionSource.bundled);
 			expect((result as { remoteUrl: string }).remoteUrl).toBe('http://localhost:3000');
 		});
 
 		it('should transform backend extension response correctly', () => {
 			const response: IDiscoveredExtensionRes = {
 				name: 'test-plugin',
-				kind: ExtensionKind.PLUGIN,
-				surface: ExtensionSurface.BACKEND,
+				kind: ExtensionKind.plugin,
+				surface: ExtensionSurface.backend,
 				display_name: 'Test Plugin',
 				description: 'A test plugin',
 				version: '2.0.0',
-				source: ExtensionSource.RUNTIME,
+				source: ExtensionSource.runtime,
 				route_prefix: '/api/v1/test-plugin',
 				type: 'backend',
 			};
@@ -49,24 +49,24 @@ describe('Discovered Extensions Transformers', () => {
 			const result = transformDiscoveredExtensionResponse(response);
 
 			expect(result.name).toBe('test-plugin');
-			expect(result.kind).toBe(ExtensionKind.PLUGIN);
-			expect(result.surface).toBe(ExtensionSurface.BACKEND);
+			expect(result.kind).toBe(ExtensionKind.plugin);
+			expect(result.surface).toBe(ExtensionSurface.backend);
 			expect(result.displayName).toBe('Test Plugin');
 			expect(result.description).toBe('A test plugin');
 			expect(result.version).toBe('2.0.0');
-			expect(result.source).toBe(ExtensionSource.RUNTIME);
+			expect(result.source).toBe(ExtensionSource.runtime);
 			expect((result as { routePrefix: string }).routePrefix).toBe('/api/v1/test-plugin');
 		});
 
 		it('should handle null description', () => {
 			const response: IDiscoveredExtensionRes = {
 				name: 'test-module',
-				kind: ExtensionKind.MODULE,
-				surface: ExtensionSurface.ADMIN,
+				kind: ExtensionKind.module,
+				surface: ExtensionSurface.admin,
 				display_name: 'Test Module',
 				description: null,
 				version: null,
-				source: ExtensionSource.BUNDLED,
+				source: ExtensionSource.bundled,
 				remote_url: 'http://localhost:3000',
 				type: 'admin',
 			};

--- a/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
@@ -80,7 +80,7 @@ describe('Extensions Store', () => {
 		it('should set extension data successfully', () => {
 			const extension = {
 				type: 'test-module',
-				kind: ExtensionKind.MODULE,
+				kind: ExtensionKind.module,
 				name: 'Test Module',
 				enabled: true,
 				isCore: false,
@@ -96,7 +96,7 @@ describe('Extensions Store', () => {
 		it('should update existing extension', () => {
 			const extension = {
 				type: 'test-module',
-				kind: ExtensionKind.MODULE,
+				kind: ExtensionKind.module,
 				name: 'Test Module',
 				enabled: true,
 				isCore: false,
@@ -130,7 +130,7 @@ describe('Extensions Store', () => {
 				type: 'module-1',
 				data: {
 					type: 'module-1',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Module 1',
 					enabled: true,
 					isCore: false,
@@ -142,7 +142,7 @@ describe('Extensions Store', () => {
 				type: 'plugin-1',
 				data: {
 					type: 'plugin-1',
-					kind: ExtensionKind.PLUGIN,
+					kind: ExtensionKind.plugin,
 					name: 'Plugin 1',
 					enabled: true,
 					isCore: false,
@@ -162,7 +162,7 @@ describe('Extensions Store', () => {
 				type: 'module-1',
 				data: {
 					type: 'module-1',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Module 1',
 					enabled: true,
 					isCore: false,
@@ -174,7 +174,7 @@ describe('Extensions Store', () => {
 				type: 'plugin-1',
 				data: {
 					type: 'plugin-1',
-					kind: ExtensionKind.PLUGIN,
+					kind: ExtensionKind.plugin,
 					name: 'Plugin 1',
 					enabled: true,
 					isCore: false,
@@ -182,7 +182,7 @@ describe('Extensions Store', () => {
 				},
 			});
 
-			const modules = store.findByKind(ExtensionKind.MODULE);
+			const modules = store.findByKind(ExtensionKind.module);
 
 			expect(modules).toHaveLength(1);
 			expect(modules[0]?.type).toBe('module-1');
@@ -193,7 +193,7 @@ describe('Extensions Store', () => {
 				type: 'module-1',
 				data: {
 					type: 'module-1',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Module 1',
 					enabled: true,
 					isCore: false,
@@ -205,7 +205,7 @@ describe('Extensions Store', () => {
 				type: 'plugin-1',
 				data: {
 					type: 'plugin-1',
-					kind: ExtensionKind.PLUGIN,
+					kind: ExtensionKind.plugin,
 					name: 'Plugin 1',
 					enabled: true,
 					isCore: false,
@@ -213,7 +213,7 @@ describe('Extensions Store', () => {
 				},
 			});
 
-			const plugins = store.findByKind(ExtensionKind.PLUGIN);
+			const plugins = store.findByKind(ExtensionKind.plugin);
 
 			expect(plugins).toHaveLength(1);
 			expect(plugins[0]?.type).toBe('plugin-1');
@@ -226,7 +226,7 @@ describe('Extensions Store', () => {
 				type: 'test-module',
 				data: {
 					type: 'test-module',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Test Module',
 					enabled: true,
 					isCore: false,
@@ -258,7 +258,7 @@ describe('Extensions Store', () => {
 			const result = await store.get({ type: 'devices-module' });
 
 			expect(result.type).toBe('devices-module');
-			expect(result.kind).toBe(ExtensionKind.MODULE);
+			expect(result.kind).toBe(ExtensionKind.module);
 			expect(store.data['devices-module']).toBeDefined();
 			expect(backendClient.GET).toHaveBeenCalledWith(`/${MODULES_PREFIX}/${EXTENSIONS_MODULE_PREFIX}/extensions/{type}`, {
 				params: { path: { type: 'devices-module' } },
@@ -314,7 +314,7 @@ describe('Extensions Store', () => {
 				response: { status: 200 },
 			});
 
-			await store.fetch({ kind: ExtensionKind.MODULE });
+			await store.fetch({ kind: ExtensionKind.module });
 
 			expect(backendClient.GET).toHaveBeenCalledWith(`/${MODULES_PREFIX}/${EXTENSIONS_MODULE_PREFIX}/extensions/modules`);
 		});
@@ -326,7 +326,7 @@ describe('Extensions Store', () => {
 				response: { status: 200 },
 			});
 
-			await store.fetch({ kind: ExtensionKind.PLUGIN });
+			await store.fetch({ kind: ExtensionKind.plugin });
 
 			expect(backendClient.GET).toHaveBeenCalledWith(`/${MODULES_PREFIX}/${EXTENSIONS_MODULE_PREFIX}/extensions/plugins`);
 		});
@@ -364,7 +364,7 @@ describe('Extensions Store', () => {
 				type: 'devices-module',
 				data: {
 					type: 'devices-module',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Devices Module',
 					enabled: true,
 					isCore: false,
@@ -401,7 +401,7 @@ describe('Extensions Store', () => {
 				type: 'devices-module',
 				data: {
 					type: 'devices-module',
-					kind: ExtensionKind.MODULE,
+					kind: ExtensionKind.module,
 					name: 'Devices Module',
 					enabled: true,
 					isCore: false,

--- a/apps/admin/src/modules/extensions/store/extensions.store.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.ts
@@ -160,9 +160,9 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 					let error;
 					let response;
 
-					if (payload?.kind === ExtensionKind.MODULE) {
+					if (payload?.kind === ExtensionKind.module) {
 						({ data: responseData, error, response } = await backend.client.GET('/modules/extensions/extensions/modules'));
-					} else if (payload?.kind === ExtensionKind.PLUGIN) {
+					} else if (payload?.kind === ExtensionKind.plugin) {
 						({ data: responseData, error, response } = await backend.client.GET('/modules/extensions/extensions/plugins'));
 					} else {
 						({ data: responseData, error, response } = await backend.client.GET('/modules/extensions/extensions'));

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
@@ -32,7 +32,7 @@ describe('Extensions Transformers', () => {
 			const result = transformExtensionResponse(response);
 
 			expect(result.type).toBe('devices-module');
-			expect(result.kind).toBe(ExtensionKind.MODULE);
+			expect(result.kind).toBe(ExtensionKind.module);
 			expect(result.name).toBe('Devices Module');
 			expect(result.description).toBe('Manage devices');
 			expect(result.version).toBe('1.0.0');
@@ -63,7 +63,7 @@ describe('Extensions Transformers', () => {
 			const result = transformExtensionResponse(response);
 
 			expect(result.type).toBe('pages-tiles-plugin');
-			expect(result.kind).toBe(ExtensionKind.PLUGIN);
+			expect(result.kind).toBe(ExtensionKind.plugin);
 			expect(result.name).toBe('Pages Tiles Plugin');
 			expect(result.enabled).toBe(true);
 			expect(result.isCore).toBe(true);

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.ts
@@ -8,7 +8,7 @@ export const transformExtensionResponse = (response: IExtensionRes): IExtension 
 
 	return {
 		type: response.type,
-		kind: response.kind === 'module' ? ExtensionKind.MODULE : ExtensionKind.PLUGIN,
+		kind: response.kind === 'module' ? ExtensionKind.module : ExtensionKind.plugin,
 		name: response.name,
 		description: response.description,
 		version,

--- a/apps/admin/src/modules/extensions/views/view-extension-detail.vue
+++ b/apps/admin/src/modules/extensions/views/view-extension-detail.vue
@@ -159,10 +159,10 @@
 					</dt>
 					<dd class="b-b b-b-solid m-0 p-2 flex items-center min-w-[8rem]">
 						<el-tag
-							:type="extension.kind === ExtensionKind.MODULE ? 'primary' : 'success'"
+							:type="extension.kind === ExtensionKind.module ? 'primary' : 'success'"
 							size="small"
 						>
-							{{ extension.kind === ExtensionKind.MODULE ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
+							{{ extension.kind === ExtensionKind.module ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
 						</el-tag>
 					</dd>
 
@@ -368,10 +368,10 @@
 					</dt>
 					<dd class="b-b b-b-solid m-0 p-2 flex items-center min-w-[8rem]">
 						<el-tag
-							:type="extension.kind === ExtensionKind.MODULE ? 'primary' : 'success'"
+							:type="extension.kind === ExtensionKind.module ? 'primary' : 'success'"
 							size="small"
 						>
-							{{ extension.kind === ExtensionKind.MODULE ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
+							{{ extension.kind === ExtensionKind.module ? t('extensionsModule.labels.module') : t('extensionsModule.labels.plugin') }}
 						</el-tag>
 					</dd>
 
@@ -603,7 +603,7 @@ watch(
 );
 
 const extensionIcon = computed<string>(() => {
-	if (extension.value?.kind === ExtensionKind.MODULE) {
+	if (extension.value?.kind === ExtensionKind.module) {
 		return 'mdi:cube-outline';
 	}
 	return 'mdi:puzzle';
@@ -612,7 +612,7 @@ const extensionIcon = computed<string>(() => {
 const hasConfiguration = computed<boolean>(() => {
 	if (!extension.value) return false;
 
-	if (extension.value.kind === ExtensionKind.MODULE) {
+	if (extension.value.kind === ExtensionKind.module) {
 		return configurableModules.value.some((m) => m.type === props.type);
 	}
 	return configurablePlugins.value.some((p) => p.type === props.type);
@@ -644,7 +644,7 @@ const onToggleEnabled = async (): Promise<void> => {
 };
 
 const onOpenConfiguration = (): void => {
-	if (extension.value?.kind === ExtensionKind.MODULE) {
+	if (extension.value?.kind === ExtensionKind.module) {
 		router.push({
 			name: 'config_module-config_module_edit',
 			params: { module: props.type },

--- a/apps/admin/src/modules/onboarding/components/step-complete.vue
+++ b/apps/admin/src/modules/onboarding/components/step-complete.vue
@@ -171,6 +171,6 @@ const assignedDevicesCount = computed(() => {
 
 const integrationsCount = computed(() => {
 	return Object.values(extensionsStore.data)
-		.filter((ext) => ext.kind === ExtensionKind.PLUGIN && ext.type.startsWith('devices-') && ext.enabled).length;
+		.filter((ext) => ext.kind === ExtensionKind.plugin && ext.type.startsWith('devices-') && ext.enabled).length;
 });
 </script>

--- a/apps/admin/src/modules/onboarding/components/step-integrations.vue
+++ b/apps/admin/src/modules/onboarding/components/step-integrations.vue
@@ -268,7 +268,7 @@ const getPluginIcon = (type: string): string => {
 
 const devicePlugins = computed(() => {
 	return Object.values(extensionsStore.data)
-		.filter((ext) => ext.kind === ExtensionKind.PLUGIN && (ext.type.startsWith('devices-') || ext.type === 'simulator-plugin'))
+		.filter((ext) => ext.kind === ExtensionKind.plugin && (ext.type.startsWith('devices-') || ext.type === 'simulator-plugin'))
 		.sort((a, b) => a.name.localeCompare(b.name));
 });
 

--- a/apps/admin/src/modules/spaces/composables/useSpaceClimateState.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceClimateState.ts
@@ -5,9 +5,9 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import type { components } from '../../../openapi';
+import type { SpacesModuleClimateStateSchema } from '../../../openapi.constants';
 
-type ClimateStateData = components['schemas']['SpacesModuleDataClimateState'];
+type ClimateStateData = SpacesModuleClimateStateSchema;
 
 /**
  * Climate state for a space, including temperature, humidity, and HVAC mode.

--- a/apps/admin/src/modules/spaces/composables/useSpaceCoversState.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceCoversState.ts
@@ -5,9 +5,9 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import type { components } from '../../../openapi';
+import type { SpacesModuleCoversStateSchema } from '../../../openapi.constants';
 
-type CoversStateData = components['schemas']['SpacesModuleDataCoversState'];
+type CoversStateData = SpacesModuleCoversStateSchema;
 
 /**
  * Covers state for a space, including position and role breakdown.

--- a/apps/admin/src/modules/spaces/composables/useSpaceIntents.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceIntents.ts
@@ -5,28 +5,28 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import type { components } from '../../../openapi';
+import type { SpacesModuleLightingIntentSchema, SpacesModuleClimateIntentSchema } from '../../../openapi.constants';
 import {
 	SpacesModuleLightingIntentType,
-	SpacesModuleDataLightingStateDetected_mode,
+	SpacesModuleLightingDetectedMode,
 	SpacesModuleLightingIntentDelta,
-	SpacesModuleDataRoleAggregatedStateRole,
+	SpacesModuleLightingRole,
 	SpacesModuleClimateIntentType,
 	SpacesModuleClimateIntentMode,
-} from '../../../openapi';
+} from '../../../openapi.constants';
 
-type LightingIntentBody = components['schemas']['SpacesModuleLightingIntent'];
-type ClimateIntentBody = components['schemas']['SpacesModuleClimateIntent'];
+type LightingIntentBody = SpacesModuleLightingIntentSchema;
+type ClimateIntentBody = SpacesModuleClimateIntentSchema;
 
 // ============================================
 // LIGHTING INTENT TYPES
 // ============================================
 
 export type LightingIntentType = `${SpacesModuleLightingIntentType}`;
-export type LightingMode = `${SpacesModuleDataLightingStateDetected_mode}`;
+export type LightingMode = `${SpacesModuleLightingDetectedMode}`;
 export type BrightnessDelta = `${SpacesModuleLightingIntentDelta}`;
 // Note: LightingRole is also exported from spaces.constants.ts - use type alias here to avoid conflict
-type LightingRole = `${SpacesModuleDataRoleAggregatedStateRole}`;
+type LightingRole = `${SpacesModuleLightingRole}`;
 
 /**
  * Request parameters for a lighting intent.
@@ -200,10 +200,10 @@ export const useSpaceIntents = (spaceId: Ref<ISpace['id'] | undefined>): IUseSpa
 		try {
 			const body = {
 				type: request.type as SpacesModuleLightingIntentType,
-				mode: request.mode as SpacesModuleDataLightingStateDetected_mode | undefined,
+				mode: request.mode as SpacesModuleLightingDetectedMode | undefined,
 				delta: request.delta as SpacesModuleLightingIntentDelta | undefined,
 				increase: request.increase,
-				role: request.role as SpacesModuleDataRoleAggregatedStateRole | undefined,
+				role: request.role as SpacesModuleLightingRole | undefined,
 				on: request.on,
 				brightness: request.brightness,
 				color: request.color,

--- a/apps/admin/src/modules/spaces/composables/useSpaceLightingState.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceLightingState.ts
@@ -5,10 +5,10 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import type { components } from '../../../openapi';
+import type { SpacesModuleLightingStateSchema, SpacesModuleRoleAggregatedStateSchema } from '../../../openapi.constants';
 
-type LightingStateData = components['schemas']['SpacesModuleDataLightingState'];
-type RoleAggregatedState = components['schemas']['SpacesModuleDataRoleAggregatedState'];
+type LightingStateData = SpacesModuleLightingStateSchema;
+type RoleAggregatedState = SpacesModuleRoleAggregatedStateSchema;
 
 /**
  * Lighting state for a space, including mode detection and per-role breakdown.

--- a/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
@@ -1,16 +1,15 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue';
 
 import {
-	PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
-	SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
-} from '../../../openapi';
-import type { SpacesModuleMediaEndpointType } from '../../../openapi.constants';
+	type SpacesModuleMediaEndpointType,
+	SpacesModuleMediaActivityKey,
+} from '../../../openapi.constants';
 import { useBackend } from '../../../common';
 import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 
-export { SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types as MediaEndpointType } from '../../../openapi';
-export { PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey as MediaActivityKey } from '../../../openapi';
+export { SpacesModuleMediaEndpointType as MediaEndpointType } from '../../../openapi.constants';
+export { SpacesModuleMediaActivityKey as MediaActivityKey } from '../../../openapi.constants';
 
 export interface IDerivedMediaCapabilities {
 	power: boolean;
@@ -46,7 +45,7 @@ export interface IDerivedMediaEndpoint {
 export interface IMediaActivityBinding {
 	id: string;
 	spaceId: string;
-	activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey;
+	activityKey: SpacesModuleMediaActivityKey;
 	displayEndpointId: string | null;
 	audioEndpointId: string | null;
 	sourceEndpointId: string | null;
@@ -103,7 +102,7 @@ export interface IMediaResolvedDevices {
 export type MediaActivationState = 'activating' | 'active' | 'failed' | 'deactivated';
 
 export interface IMediaActiveState {
-	activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey | null;
+	activityKey: SpacesModuleMediaActivityKey | null;
 	state: MediaActivationState;
 	resolved?: IMediaResolvedDevices;
 	summary?: IMediaActivationSummary;
@@ -156,15 +155,15 @@ export interface IUseSpaceMedia {
 	fetchActiveState: () => Promise<void>;
 	previewing: Ref<boolean>;
 	activate: (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	) => Promise<IMediaActiveState>;
 	preview: (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	) => Promise<IMediaDryRunPreview>;
 	deactivate: () => Promise<IMediaActiveState>;
 	saveBinding: (bindingId: string, payload: IBindingSavePayload) => Promise<IMediaActivityBinding>;
 	createBinding: (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 		payload: IBindingSavePayload,
 	) => Promise<IMediaActivityBinding>;
 	deleteBinding: (bindingId: string) => Promise<void>;
@@ -173,7 +172,7 @@ export interface IUseSpaceMedia {
 		type: SpacesModuleMediaEndpointType,
 	) => ComputedRef<IDerivedMediaEndpoint[]>;
 	findBindingByActivity: (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	) => IMediaActivityBinding | undefined;
 }
 
@@ -219,7 +218,7 @@ const transformBinding = (raw: Record<string, unknown>): IMediaActivityBinding =
 		id: raw.id as string,
 		spaceId: raw.space_id as string,
 		activityKey:
-			raw.activity_key as PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+			raw.activity_key as SpacesModuleMediaActivityKey,
 		displayEndpointId: (raw.display_endpoint_id as string) ?? null,
 		audioEndpointId: (raw.audio_endpoint_id as string) ?? null,
 		sourceEndpointId: (raw.source_endpoint_id as string) ?? null,
@@ -307,7 +306,7 @@ const transformActivationResult = (raw: Record<string, unknown>): IMediaActiveSt
 
 	return {
 		activityKey:
-			(raw.activity_key as PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey) ??
+			(raw.activity_key as SpacesModuleMediaActivityKey) ??
 			null,
 		state: (raw.state as MediaActivationState) ?? 'deactivated',
 		resolved: resolved ? transformResolvedDevices(resolved) : undefined,
@@ -340,7 +339,7 @@ const transformActiveEntity = (raw: Record<string, unknown>): IMediaActiveState 
 
 	return {
 		activityKey:
-			(raw.activity_key as PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey) ??
+			(raw.activity_key as SpacesModuleMediaActivityKey) ??
 			null,
 		state: (raw.state as MediaActivationState) ?? 'deactivated',
 		resolved,
@@ -505,7 +504,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 	};
 
 	const createBinding = async (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 		payload: IBindingSavePayload,
 	): Promise<IMediaActivityBinding> => {
 		if (!spaceId.value) throw new Error('Space ID is required');
@@ -646,7 +645,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 	};
 
 	const preview = async (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	): Promise<IMediaDryRunPreview> => {
 		if (!spaceId.value) throw new Error('Space ID is required');
 
@@ -675,7 +674,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 	};
 
 	const activate = async (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	): Promise<IMediaActiveState> => {
 		if (!spaceId.value) throw new Error('Space ID is required');
 
@@ -766,7 +765,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 	};
 
 	const findBindingByActivity = (
-		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+		activityKey: SpacesModuleMediaActivityKey,
 	): IMediaActivityBinding | undefined => {
 		return bindingsData.value.find((b) => b.activityKey === activityKey);
 	};

--- a/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
@@ -1,9 +1,10 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue';
 
 import {
-	type PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
-	type SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
+	PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
+	SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
 } from '../../../openapi';
+import type { SpacesModuleMediaEndpointType } from '../../../openapi.constants';
 import { useBackend } from '../../../common';
 import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
@@ -36,7 +37,7 @@ export interface IDerivedMediaEndpoint {
 	endpointId: string;
 	spaceId: string;
 	deviceId: string;
-	type: SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types;
+	type: SpacesModuleMediaEndpointType;
 	name: string;
 	capabilities: IDerivedMediaCapabilities;
 	links?: IDerivedMediaLinks;
@@ -169,7 +170,7 @@ export interface IUseSpaceMedia {
 	deleteBinding: (bindingId: string) => Promise<void>;
 	applyDefaults: () => Promise<void>;
 	endpointsByType: (
-		type: SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
+		type: SpacesModuleMediaEndpointType,
 	) => ComputedRef<IDerivedMediaEndpoint[]>;
 	findBindingByActivity: (
 		activityKey: PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey,
@@ -198,7 +199,7 @@ const transformEndpoint = (raw: Record<string, unknown>): IDerivedMediaEndpoint 
 		endpointId: raw.endpoint_id as string,
 		spaceId: raw.space_id as string,
 		deviceId: raw.device_id as string,
-		type: raw.type as SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
+		type: raw.type as SpacesModuleMediaEndpointType,
 		name: raw.name as string,
 		capabilities: {
 			power: caps.power ?? false,
@@ -759,7 +760,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 	};
 
 	const endpointsByType = (
-		type: SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types,
+		type: SpacesModuleMediaEndpointType,
 	): ComputedRef<IDerivedMediaEndpoint[]> => {
 		return computed(() => endpointsData.value.filter((ep) => ep.type === type));
 	};

--- a/apps/admin/src/modules/spaces/composables/useSpaceSensorState.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceSensorState.ts
@@ -5,13 +5,19 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import type { components } from '../../../openapi';
+import type {
+	SpacesModuleSensorStateSchema,
+	SpacesModuleSensorReadingSchema,
+	SpacesModuleSensorRoleReadingsSchema,
+	SpacesModuleEnvironmentSummarySchema,
+	SpacesModuleSafetyAlertSchema,
+} from '../../../openapi.constants';
 
-type SensorStateData = components['schemas']['SpacesModuleDataSensorState'];
-type SensorReadingData = components['schemas']['SpacesModuleDataSensorReading'];
-type SensorRoleReadingsData = components['schemas']['SpacesModuleDataSensorRoleReadings'];
-type EnvironmentSummaryData = components['schemas']['SpacesModuleDataEnvironmentSummary'];
-type SafetyAlertData = components['schemas']['SpacesModuleDataSafetyAlert'];
+type SensorStateData = SpacesModuleSensorStateSchema;
+type SensorReadingData = SpacesModuleSensorReadingSchema;
+type SensorRoleReadingsData = SpacesModuleSensorRoleReadingsSchema;
+type EnvironmentSummaryData = SpacesModuleEnvironmentSummarySchema;
+type SafetyAlertData = SpacesModuleSafetyAlertSchema;
 
 /**
  * Individual sensor reading

--- a/apps/admin/src/modules/spaces/composables/useSpaceSuggestion.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceSuggestion.ts
@@ -5,10 +5,8 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 import type { ISpace } from '../store';
 
-import {
-	type SchemaSpacesModuleSuggestionFeedback,
-	SpacesModuleSuggestionFeedbackSuggestion_type,
-} from '../../../openapi';
+import type { SpacesModuleSuggestionFeedbackSchema } from '../../../openapi.constants';
+import { SpacesModuleSuggestionType } from '../../../openapi.constants';
 
 
 
@@ -17,9 +15,9 @@ import {
 // ============================================
 
 /** Type of suggestion provided by the backend */
-export type SuggestionType = `${SpacesModuleSuggestionFeedbackSuggestion_type}`;
+export type SuggestionType = `${SpacesModuleSuggestionType}`;
 /** User feedback on a suggestion */
-export type SuggestionFeedback = `${SchemaSpacesModuleSuggestionFeedback['feedback']}`;
+export type SuggestionFeedback = `${SpacesModuleSuggestionFeedbackSchema['feedback']}`;
 
 /**
  * A smart suggestion for the space based on context (time, occupancy, etc.).
@@ -183,8 +181,8 @@ export const useSpaceSuggestion = (spaceId: Ref<ISpace['id'] | undefined>): IUse
 					body: {
 						data: {
 							suggestion_type:
-								suggestionData.value.type as SpacesModuleSuggestionFeedbackSuggestion_type,
-							feedback: feedback as SchemaSpacesModuleSuggestionFeedback['feedback'],
+								suggestionData.value.type as SpacesModuleSuggestionType,
+							feedback: feedback as SpacesModuleSuggestionFeedbackSchema['feedback'],
 						},
 					},
 				}

--- a/apps/admin/src/modules/spaces/composables/useSpacesOnboarding.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpacesOnboarding.ts
@@ -4,7 +4,7 @@ import { injectBackendClient, useUuid } from '../../../common';
 import {
 	SpacesModuleCreateSpaceCategory,
 	SpacesModuleCreateSpaceType,
-} from '../../../openapi';
+} from '../../../openapi.constants';
 import {
 	ASSIGNABLE_ZONE_CATEGORIES,
 	SPACE_ALL_CATEGORY_TEMPLATES,

--- a/apps/admin/src/modules/spaces/store/spaces.transformers.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.transformers.ts
@@ -2,7 +2,7 @@ import type { operations } from '../../../openapi';
 import {
 	SpacesModuleCreateSpaceCategory,
 	SpacesModuleCreateSpaceType,
-} from '../../../openapi';
+} from '../../../openapi.constants';
 
 import { type IStatusWidget, type SpaceRoomCategory, SpaceType, type SpaceZoneCategory } from '../spaces.constants';
 

--- a/apps/admin/src/modules/system/store/system-info.store.schemas.ts
+++ b/apps/admin/src/modules/system/store/system-info.store.schemas.ts
@@ -1,7 +1,6 @@
 import { type ZodType, z } from 'zod';
 
-import { SystemModuleNetworkMode, type SystemModuleSystemInfoSchema } from '../../../openapi.constants';
-import { SystemModuleDataSystemInfoPlatform } from '../../../openapi';
+import { SystemModuleNetworkMode, SystemModulePlatform, type SystemModuleSystemInfoSchema } from '../../../openapi.constants';
 
 type ApiSystemInfo = SystemModuleSystemInfoSchema;
 
@@ -9,7 +8,7 @@ type ApiSystemInfo = SystemModuleSystemInfoSchema;
 // ===========
 
 export const SystemInfoSchema = z.object({
-	platform: z.nativeEnum(SystemModuleDataSystemInfoPlatform),
+	platform: z.nativeEnum(SystemModulePlatform),
 	networkMode: z.nativeEnum(SystemModuleNetworkMode).optional().default(SystemModuleNetworkMode.online),
 	cpuLoad: z.number(),
 	memory: z.object({
@@ -83,7 +82,7 @@ export const SystemInfoOnEventActionPayloadSchema = z.object({
 
 export const SystemInfoSetActionPayloadSchema = z.object({
 	data: z.object({
-		platform: z.nativeEnum(SystemModuleDataSystemInfoPlatform),
+		platform: z.nativeEnum(SystemModulePlatform),
 		networkMode: z.nativeEnum(SystemModuleNetworkMode).optional().default(SystemModuleNetworkMode.online),
 		cpuLoad: z.number(),
 		memory: z.object({
@@ -149,7 +148,7 @@ export const SystemInfoSetActionPayloadSchema = z.object({
 // ===========
 
 export const SystemInfoResSchema: ZodType<ApiSystemInfo> = z.object({
-	platform: z.nativeEnum(SystemModuleDataSystemInfoPlatform),
+	platform: z.nativeEnum(SystemModulePlatform),
 	network_mode: z.nativeEnum(SystemModuleNetworkMode),
 	cpu_load: z.number(),
 	memory: z.object({

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -436,9 +436,13 @@ export type WeatherModuleLocationSchema = components['schemas']['WeatherModuleDa
 export type WeatherModuleCreateLocationSchema = components['schemas']['WeatherModuleCreateLocation'];
 export type WeatherModuleUpdateLocationSchema = components['schemas']['WeatherModuleUpdateLocation'];
 
-// Extensions Module Service State Enum
-// =====================================
+// Extensions Module Enums
+// =======================
 export { ExtensionsModuleDataServiceStatusState as ExtensionsModuleServiceState } from './openapi';
+export { ExtensionsModuleDataExtensionKind as ExtensionKind } from './openapi';
+export { ExtensionsModuleDataDiscoveredExtensionBaseSurface as ExtensionSurface } from './openapi';
+export { ExtensionsModuleDataDiscoveredExtensionBaseSource as ExtensionSource } from './openapi';
+export { PathsModulesExtensionsDiscoveredGetParametersQuerySurface as ExtensionsDiscoverySurface } from './openapi';
 
 // Buddy Plugin Config Schemas
 // ===========================
@@ -472,5 +476,41 @@ export { SpacesModuleSetClimateRoleRole as SpacesModuleClimateRole } from './ope
 
 export { SpacesModuleCoversIntentRole as SpacesModuleCoversRole } from './openapi';
 
-// Note: Media domain now uses routing-based architecture (V2)
-// Old role-based types have been removed
+// Spaces Module Enums
+// ===================
+export { SpacesModuleCreateSpaceCategory } from './openapi';
+export { SpacesModuleCreateSpaceType } from './openapi';
+export { SpacesModuleLightingIntentType } from './openapi';
+export { SpacesModuleLightingIntentDelta } from './openapi';
+export { SpacesModuleClimateIntentType } from './openapi';
+export { SpacesModuleClimateIntentMode } from './openapi';
+export { SpacesModuleDataLightingStateDetected_mode as SpacesModuleLightingDetectedMode } from './openapi';
+export { SpacesModuleSuggestionFeedbackSuggestion_type as SpacesModuleSuggestionType } from './openapi';
+
+// Spaces Module Type Schemas
+// ==========================
+export type SpacesModuleLightingStateSchema = components['schemas']['SpacesModuleDataLightingState'];
+export type SpacesModuleRoleAggregatedStateSchema = components['schemas']['SpacesModuleDataRoleAggregatedState'];
+export type SpacesModuleCoversStateSchema = components['schemas']['SpacesModuleDataCoversState'];
+export type SpacesModuleClimateStateSchema = components['schemas']['SpacesModuleDataClimateState'];
+export type SpacesModuleLightingIntentSchema = components['schemas']['SpacesModuleLightingIntent'];
+export type SpacesModuleClimateIntentSchema = components['schemas']['SpacesModuleClimateIntent'];
+export type SpacesModuleSensorStateSchema = components['schemas']['SpacesModuleDataSensorState'];
+export type SpacesModuleSensorReadingSchema = components['schemas']['SpacesModuleDataSensorReading'];
+export type SpacesModuleSensorRoleReadingsSchema = components['schemas']['SpacesModuleDataSensorRoleReadings'];
+export type SpacesModuleEnvironmentSummarySchema = components['schemas']['SpacesModuleDataEnvironmentSummary'];
+export type SpacesModuleSafetyAlertSchema = components['schemas']['SpacesModuleDataSafetyAlert'];
+export type SpacesModuleSuggestionFeedbackSchema = components['schemas']['SpacesModuleSuggestionFeedback'];
+export type SpacesModuleMediaEndpointType = components['schemas']['SpacesModuleDataMediaCapabilitySummary']['suggested_endpoint_types'];
+
+// Weather Plugin Enums
+// ====================
+export { WeatherOpenweathermapPluginDataLocationLocation_type as WeatherLocationType } from './openapi';
+
+// Zigbee2MQTT Plugin Enums
+// ========================
+export { DevicesZigbee2mqttPluginUpdateConfigConnection_type as Zigbee2mqttConnectionType } from './openapi';
+
+// System Module Enums (additional)
+// ================================
+export { SystemModuleDataSystemInfoPlatform as SystemModulePlatform } from './openapi';

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -501,7 +501,8 @@ export type SpacesModuleSensorRoleReadingsSchema = components['schemas']['Spaces
 export type SpacesModuleEnvironmentSummarySchema = components['schemas']['SpacesModuleDataEnvironmentSummary'];
 export type SpacesModuleSafetyAlertSchema = components['schemas']['SpacesModuleDataSafetyAlert'];
 export type SpacesModuleSuggestionFeedbackSchema = components['schemas']['SpacesModuleSuggestionFeedback'];
-export type SpacesModuleMediaEndpointType = components['schemas']['SpacesModuleDataMediaCapabilitySummary']['suggested_endpoint_types'];
+export { SpacesModuleDataMediaCapabilitySummarySuggested_endpoint_types as SpacesModuleMediaEndpointType } from './openapi';
+export { PathsModulesSpacesSpacesIdMediaActivitiesActivityKeyPreviewPostParametersPathActivityKey as SpacesModuleMediaActivityKey } from './openapi';
 
 // Weather Plugin Enums
 // ====================

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/store/config.store.schemas.ts
@@ -1,8 +1,7 @@
 import { type ZodType, z } from 'zod';
 
 import { ConfigPluginResSchema, ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../modules/config/store/config-plugins.store.schemas';
-import { DevicesZigbee2mqttPluginUpdateConfigConnection_type } from '../../../openapi';
-import type { DevicesZigbee2mqttPluginUpdateConfigSchema, DevicesZigbee2mqttPluginConfigSchema } from '../../../openapi.constants';
+import { Zigbee2mqttConnectionType, type DevicesZigbee2mqttPluginUpdateConfigSchema, type DevicesZigbee2mqttPluginConfigSchema } from '../../../openapi.constants';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
 
 type ApiUpdateConfig = DevicesZigbee2mqttPluginUpdateConfigSchema;
@@ -49,7 +48,7 @@ export const Zigbee2mqttConfigSchema = ConfigPluginSchema.extend({
 export const Zigbee2mqttConfigUpdateReqSchema: ZodType<ApiUpdateConfig> = ConfigPluginUpdateReqSchema.and(
 	z.object({
 		type: z.literal(DEVICES_ZIGBEE2MQTT_PLUGIN_NAME),
-		connection_type: z.nativeEnum(DevicesZigbee2mqttPluginUpdateConfigConnection_type).optional(),
+		connection_type: z.nativeEnum(Zigbee2mqttConnectionType).optional(),
 		mqtt: z
 			.object({
 				host: z.string().optional(),
@@ -95,7 +94,7 @@ export const Zigbee2mqttConfigUpdateReqSchema: ZodType<ApiUpdateConfig> = Config
 export const Zigbee2mqttConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_ZIGBEE2MQTT_PLUGIN_NAME),
-		connection_type: z.nativeEnum(DevicesZigbee2mqttPluginUpdateConfigConnection_type),
+		connection_type: z.nativeEnum(Zigbee2mqttConnectionType),
 		mqtt: z.object({
 			host: z.string(),
 			port: z.number(),

--- a/apps/admin/src/plugins/weather-open-meteo/components/open-meteo-config-form.vue
+++ b/apps/admin/src/plugins/weather-open-meteo/components/open-meteo-config-form.vue
@@ -90,11 +90,11 @@ const { formEl, model, formChanged, submit, formResult } = useConfigPluginEditFo
 
 const unitOptions = computed(() => [
 	{
-		value: TemperatureUnit.CELSIUS,
+		value: TemperatureUnit.celsius,
 		label: t('weatherOpenMeteoPlugin.fields.config.unit.values.celsius'),
 	},
 	{
-		value: TemperatureUnit.FAHRENHEIT,
+		value: TemperatureUnit.fahrenheit,
 		label: t('weatherOpenMeteoPlugin.fields.config.unit.values.fahrenheit'),
 	},
 ]);

--- a/apps/admin/src/plugins/weather-open-meteo/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-open-meteo/store/config.store.schemas.ts
@@ -4,7 +4,7 @@ import { ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../module
 import { TemperatureUnit, WEATHER_OPEN_METEO_PLUGIN_NAME } from '../weather-open-meteo.constants';
 
 export const OpenMeteoConfigSchema = ConfigPluginSchema.extend({
-	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.CELSIUS),
+	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.celsius),
 });
 
 // BACKEND API

--- a/apps/admin/src/plugins/weather-open-meteo/weather-open-meteo.constants.ts
+++ b/apps/admin/src/plugins/weather-open-meteo/weather-open-meteo.constants.ts
@@ -1,10 +1,9 @@
+import { TemperatureUnit } from '../../openapi.constants';
+
+export { TemperatureUnit };
+
 export const WEATHER_OPEN_METEO_PLUGIN_PREFIX = 'weather-open-meteo';
 
 export const WEATHER_OPEN_METEO_PLUGIN_NAME = 'weather-open-meteo-plugin';
 
 export const WEATHER_OPEN_METEO_PLUGIN_TYPE = 'weather-open-meteo';
-
-export enum TemperatureUnit {
-	CELSIUS = 'celsius',
-	FAHRENHEIT = 'fahrenheit',
-}

--- a/apps/admin/src/plugins/weather-openweathermap/schemas/locations.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/schemas/locations.schemas.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
 import { LocationAddFormSchema, LocationEditFormSchema } from '../../../modules/weather';
-import { WeatherOpenweathermapPluginDataLocationLocation_type } from '../../../openapi';
+import { WeatherLocationType } from '../../../openapi.constants';
 
 export const OpenWeatherMapLocationAddFormSchema = LocationAddFormSchema.extend({
-	locationType: z.nativeEnum(WeatherOpenweathermapPluginDataLocationLocation_type),
+	locationType: z.nativeEnum(WeatherLocationType),
 	latitude: z.number().min(-90).max(90).nullable().optional(),
 	longitude: z.number().min(-180).max(180).nullable().optional(),
 	cityName: z.string().nullable().optional(),
@@ -14,7 +14,7 @@ export const OpenWeatherMapLocationAddFormSchema = LocationAddFormSchema.extend(
 });
 
 export const OpenWeatherMapLocationEditFormSchema = LocationEditFormSchema.extend({
-	locationType: z.nativeEnum(WeatherOpenweathermapPluginDataLocationLocation_type).optional(),
+	locationType: z.nativeEnum(WeatherLocationType).optional(),
 	latitude: z.number().min(-90).max(90).nullable().optional(),
 	longitude: z.number().min(-180).max(180).nullable().optional(),
 	cityName: z.string().nullable().optional(),

--- a/apps/admin/src/plugins/weather-openweathermap/store/locations.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/locations.store.schemas.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
 import { LocationCreateReqSchema, LocationSchema, LocationUpdateReqSchema } from '../../../modules/weather';
-import { WeatherOpenweathermapPluginDataLocationLocation_type } from '../../../openapi';
+import { WeatherLocationType } from '../../../openapi.constants';
 import { WEATHER_OPENWEATHERMAP_PLUGIN_TYPE } from '../weather-openweathermap.constants';
 
 export const OpenWeatherMapLocationSchema = LocationSchema.extend({
-	locationType: z.nativeEnum(WeatherOpenweathermapPluginDataLocationLocation_type),
+	locationType: z.nativeEnum(WeatherLocationType),
 	latitude: z.number().nullable().optional(),
 	longitude: z.number().nullable().optional(),
 	cityName: z.string().nullable().optional(),
@@ -20,7 +20,7 @@ export const OpenWeatherMapLocationSchema = LocationSchema.extend({
 export const OpenWeatherMapLocationCreateReqSchema = LocationCreateReqSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_TYPE),
-		location_type: z.nativeEnum(WeatherOpenweathermapPluginDataLocationLocation_type),
+		location_type: z.nativeEnum(WeatherLocationType),
 		latitude: z.number().optional(),
 		longitude: z.number().optional(),
 		city_name: z.string().optional(),
@@ -33,7 +33,7 @@ export const OpenWeatherMapLocationCreateReqSchema = LocationCreateReqSchema.and
 export const OpenWeatherMapLocationUpdateReqSchema = LocationUpdateReqSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_TYPE),
-		location_type: z.nativeEnum(WeatherOpenweathermapPluginDataLocationLocation_type).optional(),
+		location_type: z.nativeEnum(WeatherLocationType).optional(),
 		latitude: z.number().optional(),
 		longitude: z.number().optional(),
 		city_name: z.string().optional(),

--- a/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/weather-openweathermap.constants.ts
@@ -1,6 +1,4 @@
-import { WeatherOpenweathermapPluginDataLocationLocation_type } from '../../openapi';
-
-import { TemperatureUnit } from '../../openapi.constants';
+import { TemperatureUnit, WeatherLocationType } from '../../openapi.constants';
 
 export { TemperatureUnit };
 
@@ -11,4 +9,4 @@ export const WEATHER_OPENWEATHERMAP_PLUGIN_NAME = 'weather-openweathermap-plugin
 export const WEATHER_OPENWEATHERMAP_PLUGIN_TYPE = 'weather-openweathermap';
 
 // Re-export the OpenAPI enum for convenience
-export const OpenWeatherMapLocationType = WeatherOpenweathermapPluginDataLocationLocation_type;
+export const OpenWeatherMapLocationType = WeatherLocationType;


### PR DESCRIPTION
## Summary
- Replace 4 local enum definitions with re-exports of generated OpenAPI enums (`ExtensionKind`, `ExtensionSurface`, `ExtensionSource`, `TemperatureUnit` in open-meteo)
- Redirect all 15 direct `openapi.ts` imports to go through `openapi.constants.ts`
- Add 30+ new re-exports to `openapi.constants.ts` (enums + type schemas for spaces, weather, zigbee2mqtt, system, extensions)
- Migrate all enum key usages from UPPERCASE to lowercase across 36 files

### Why
Direct imports from `openapi.ts` bypass the stable re-export layer, so name changes in the generator would break consumers. Local enums duplicate generated ones and can drift out of sync.

### Zero remaining violations
- 0 direct `openapi.ts` imports in non-generated files (including tests)
- 0 local enum definitions duplicating generated enums

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 1275 unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across UI, stores, and composables to swap enum sources and enum member names; risk is mainly mismatched enum values/keys causing filtering, icons, or API query params to break at runtime despite being type-safe.
> 
> **Overview**
> **Replaces local/admin-defined enums with OpenAPI-generated ones.** The extensions module now re-exports `ExtensionKind`/`ExtensionSurface`/`ExtensionSource` from `openapi.constants`, and all usages are updated from `UPPERCASE` members (e.g. `MODULE`) to the generated lowercase members (e.g. `module`) across UI components, stores, composables, and tests.
> 
> **Centralizes OpenAPI usage behind `openapi.constants.ts`.** Adds many new enum and schema/type re-exports (extensions, spaces, weather, zigbee2mqtt, system) and migrates multiple modules (e.g. spaces state/intents/media composables, system info and plugin config schemas) away from direct `openapi` imports to these stable re-exports, including updating request parameter enums like `ExtensionsDiscoverySurface`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e707958c0101902f124fba5f57ec92d2c62d523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->