### PR TITLE
fix(admin): redirect test file enum imports to openapi.constants.ts

### DIFF
--- a/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.spec.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MODULES_PREFIX } from '../../../app.constants';
-import { ExtensionsModuleDataExtensionKind } from '../../../openapi';
 import { ExtensionKind, EXTENSIONS_MODULE_PREFIX } from '../extensions.constants';
 import { ExtensionsApiException, ExtensionsValidationException } from '../extensions.exceptions';
 
@@ -12,7 +11,7 @@ import { useExtensions } from './extensions.store';
 
 const mockExtensionRes: IExtensionRes = {
 	type: 'devices-module',
-	kind: ExtensionsModuleDataExtensionKind.module,
+	kind: ExtensionKind.module,
 	name: 'Devices Module',
 	description: 'Manage devices',
 	version: '1.0.0',
@@ -25,7 +24,7 @@ const mockExtensionRes: IExtensionRes = {
 
 const mockPluginRes: IExtensionRes = {
 	type: 'pages-tiles-plugin',
-	kind: ExtensionsModuleDataExtensionKind.plugin,
+	kind: ExtensionKind.plugin,
 	name: 'Pages Tiles Plugin',
 	enabled: true,
 	is_core: true,

--- a/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.transformers.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { ExtensionsModuleDataExtensionKind } from '../../../openapi';
 import { ExtensionKind } from '../extensions.constants';
 
 import type { IExtensionRes } from './extensions.store.types';
@@ -11,7 +10,7 @@ describe('Extensions Transformers', () => {
 		it('should transform module response correctly', () => {
 			const response: IExtensionRes = {
 				type: 'devices-module',
-				kind: ExtensionsModuleDataExtensionKind.module,
+				kind: ExtensionKind.module,
 				name: 'Devices Module',
 				description: 'Manage devices',
 				version: '1.0.0',
@@ -52,7 +51,7 @@ describe('Extensions Transformers', () => {
 		it('should transform plugin response correctly', () => {
 			const response: IExtensionRes = {
 				type: 'pages-tiles-plugin',
-				kind: ExtensionsModuleDataExtensionKind.plugin,
+				kind: ExtensionKind.plugin,
 				name: 'Pages Tiles Plugin',
 				enabled: true,
 				is_core: true,
@@ -74,7 +73,7 @@ describe('Extensions Transformers', () => {
 		it('should handle optional fields', () => {
 			const response: IExtensionRes = {
 				type: 'test-module',
-				kind: ExtensionsModuleDataExtensionKind.module,
+				kind: ExtensionKind.module,
 				name: 'Test Module',
 				enabled: false,
 				is_core: false,
@@ -93,7 +92,7 @@ describe('Extensions Transformers', () => {
 		it('should handle partial links', () => {
 			const response: IExtensionRes = {
 				type: 'test-plugin',
-				kind: ExtensionsModuleDataExtensionKind.plugin,
+				kind: ExtensionKind.plugin,
 				name: 'Test Plugin',
 				enabled: true,
 				is_core: false,

--- a/apps/admin/src/modules/extensions/store/services.store.spec.ts
+++ b/apps/admin/src/modules/extensions/store/services.store.spec.ts
@@ -2,7 +2,6 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ExtensionsModuleDataServiceStatusState } from '../../../openapi';
 import { ExtensionsModuleServiceState } from '../../../openapi.constants';
 import { ExtensionsApiException, ExtensionsValidationException } from '../extensions.exceptions';
 
@@ -12,7 +11,7 @@ import { useServices } from './services.store';
 const mockServiceRes: IServiceRes = {
 	plugin_name: 'devices-shelly-v1',
 	service_id: 'connector',
-	state: ExtensionsModuleDataServiceStatusState.started,
+	state: ExtensionsModuleServiceState.started,
 	enabled: true,
 	healthy: true,
 	last_started_at: '2025-01-15T10:30:00.000Z',
@@ -23,7 +22,7 @@ const mockServiceRes: IServiceRes = {
 const mockStoppedServiceRes: IServiceRes = {
 	plugin_name: 'devices-home-assistant',
 	service_id: 'connector',
-	state: ExtensionsModuleDataServiceStatusState.stopped,
+	state: ExtensionsModuleServiceState.stopped,
 	enabled: false,
 	start_count: 2,
 };

--- a/apps/admin/src/modules/spaces/store/spaces.transformers.spec.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.transformers.spec.ts
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
 	SpacesModuleCreateSpaceCategory,
-	SpacesModuleCreateSpaceStatus_widgetsSettingsRange,
 	SpacesModuleCreateSpaceType,
-} from '../../../openapi';
+	SpacesModuleEnergyWidgetRange,
+} from '../../../openapi.constants';
 import {
 	ENERGY_WIDGET_DEFAULTS,
 	EnergyWidgetRange,
@@ -317,7 +317,7 @@ describe('Spaces Transformers', (): void => {
 						type: 'energy',
 						order: 0,
 						settings: {
-							range: SpacesModuleCreateSpaceStatus_widgetsSettingsRange.today,
+							range: SpacesModuleEnergyWidgetRange.today,
 							show_production: true,
 						},
 					},
@@ -363,7 +363,7 @@ describe('Spaces Transformers', (): void => {
 						type: 'energy',
 						order: 0,
 						settings: {
-							range: SpacesModuleCreateSpaceStatus_widgetsSettingsRange.week,
+							range: SpacesModuleEnergyWidgetRange.week,
 							show_production: false,
 						},
 					},
@@ -500,7 +500,7 @@ describe('Spaces Transformers', (): void => {
 						type: 'energy',
 						order: 0,
 						settings: {
-							range: SpacesModuleCreateSpaceStatus_widgetsSettingsRange.today,
+							range: SpacesModuleEnergyWidgetRange.today,
 							show_production: true,
 						},
 					},

--- a/apps/admin/src/modules/system/composables/useSystemInfo.spec.ts
+++ b/apps/admin/src/modules/system/composables/useSystemInfo.spec.ts
@@ -5,14 +5,13 @@ import { createPinia, setActivePinia } from 'pinia';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { injectStoresManager } from '../../../common';
-import { SystemModuleNetworkMode } from '../../../openapi.constants';
-import { SystemModuleDataSystemInfoPlatform } from '../../../openapi';
+import { SystemModuleNetworkMode, SystemModulePlatform } from '../../../openapi.constants';
 import type { ISystemInfo } from '../store/system-info.store.types';
 
 import { useSystemInfo } from './useSystemInfo';
 
 const mockAudio: ISystemInfo = {
-	platform: SystemModuleDataSystemInfoPlatform.generic,
+	platform: SystemModulePlatform.generic,
 	networkMode: SystemModuleNetworkMode.online,
 	cpuLoad: 15.3,
 	memory: {

--- a/apps/admin/src/modules/system/store/system-info.store.spec.ts
+++ b/apps/admin/src/modules/system/store/system-info.store.spec.ts
@@ -2,15 +2,14 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { SystemModuleNetworkMode } from '../../../openapi.constants';
-import { SystemModuleDataSystemInfoPlatform } from '../../../openapi';
+import { SystemModuleNetworkMode, SystemModulePlatform } from '../../../openapi.constants';
 import { SystemApiException, SystemValidationException } from '../system.exceptions';
 
 import { useSystemInfo } from './system-info.store';
 import type { ISystemInfoSetActionPayload } from './system-info.store.types';
 
 const mockSystemInfoRes = {
-	platform: SystemModuleDataSystemInfoPlatform.generic,
+	platform: SystemModulePlatform.generic,
 	network_mode: SystemModuleNetworkMode.online,
 	cpu_load: 15.3,
 	memory: {
@@ -72,7 +71,7 @@ const mockSystemInfoRes = {
 };
 
 const mockSystemInfo = {
-	platform: SystemModuleDataSystemInfoPlatform.generic,
+	platform: SystemModulePlatform.generic,
 	networkMode: SystemModuleNetworkMode.online,
 	cpuLoad: 15.3,
 	memory: {

--- a/apps/admin/src/modules/system/store/system-info.transformers.spec.ts
+++ b/apps/admin/src/modules/system/store/system-info.transformers.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { SystemModuleNetworkMode } from '../../../openapi.constants';
-import { SystemModuleDataSystemInfoPlatform } from '../../../openapi';
+import { SystemModuleNetworkMode, SystemModulePlatform } from '../../../openapi.constants';
 import { SystemValidationException } from '../system.exceptions';
 
 import type { ISystemInfoRes } from './system-info.store.types';
@@ -22,7 +21,7 @@ vi.mock('../../../common', async () => {
 });
 
 const validSystemInfoResponse: ISystemInfoRes = {
-	platform: SystemModuleDataSystemInfoPlatform.generic,
+	platform: SystemModulePlatform.generic,
 	network_mode: SystemModuleNetworkMode.online as ISystemInfoRes['network_mode'],
 	cpu_load: 15.3,
 	memory: {
@@ -88,7 +87,7 @@ describe('System Info Transformers', (): void => {
 			const result = transformSystemInfoResponse(validSystemInfoResponse);
 
 			expect(result).toEqual({
-				platform: SystemModuleDataSystemInfoPlatform.generic,
+				platform: SystemModulePlatform.generic,
 				networkMode: SystemModuleNetworkMode.online,
 				cpuLoad: 15.3,
 				memory: {

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -486,6 +486,7 @@ export { SpacesModuleClimateIntentType } from './openapi';
 export { SpacesModuleClimateIntentMode } from './openapi';
 export { SpacesModuleDataLightingStateDetected_mode as SpacesModuleLightingDetectedMode } from './openapi';
 export { SpacesModuleSuggestionFeedbackSuggestion_type as SpacesModuleSuggestionType } from './openapi';
+export { SpacesModuleCreateSpaceStatus_widgetsSettingsRange as SpacesModuleEnergyWidgetRange } from './openapi';
 
 // Spaces Module Type Schemas
 // ==========================


### PR DESCRIPTION
## Summary
- Redirect 7 test files from direct `openapi.ts` enum imports to stable aliases in `openapi.constants.ts`
- Add `SpacesModuleEnergyWidgetRange` re-export to `openapi.constants.ts`
- **Zero remaining direct `openapi.ts` imports** across all files (production + tests)

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 1275 unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates are limited to unit tests and a single enum re-export, with no runtime logic changes.
> 
> **Overview**
> Switches several admin unit tests (extensions, services, spaces, system info) from direct generated `openapi` enum imports to the stable aliases in `openapi.constants.ts` (e.g., `SystemModulePlatform`, `ExtensionsModuleServiceState`, `SpacesModuleEnergyWidgetRange`).
> 
> Adds a new `SpacesModuleEnergyWidgetRange` re-export in `openapi.constants.ts` to support the spaces status-widget transformer tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5cea7810ad225b7eb0fe3b45b163e8c6c03647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->