### PR TITLE
refactor(admin): remove API response type casts

### DIFF
--- a/apps/admin/src/modules/auth/store/session.store.ts
+++ b/apps/admin/src/modules/auth/store/session.store.ts
@@ -12,7 +12,7 @@ import type {
 	AuthModuleRegisterOperation,
 	UsersModuleUpdateUserOperation,
 } from '../../../openapi.constants';
-import { type IUser, type IUserRes, transformUserResponse, USERS_MODULE_PREFIX } from '../../users';
+import { type IUser, transformUserResponse, USERS_MODULE_PREFIX } from '../../users';
 import { ACCESS_TOKEN_COOKIE_NAME, AUTH_MODULE_PREFIX, AccessTokenType, REFRESH_TOKEN_COOKIE_NAME } from '../auth.constants';
 import { AuthApiException, AuthException } from '../auth.exceptions';
 
@@ -162,7 +162,7 @@ export const useSession = defineStore<'auth_module-session', SessionStoreSetup>(
 				const { data: responseData, error } = await backend.client.GET(`/${MODULES_PREFIX}/${AUTH_MODULE_PREFIX}/auth/profile`);
 
 				if (typeof responseData !== 'undefined') {
-					profile.value = transformUserResponse(responseData.data as IUserRes);
+					profile.value = transformUserResponse(responseData.data);
 
 					return profile.value;
 				}
@@ -279,7 +279,7 @@ export const useSession = defineStore<'auth_module-session', SessionStoreSetup>(
 
 			if (typeof responseData !== 'undefined') {
 				// Update the local profile with the response
-				profile.value = transformUserResponse(responseData.data as IUserRes);
+				profile.value = transformUserResponse(responseData.data);
 
 				return true;
 			}

--- a/apps/admin/src/modules/buddy/composables/useBuddyChat.ts
+++ b/apps/admin/src/modules/buddy/composables/useBuddyChat.ts
@@ -97,7 +97,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 				return;
 			}
 
-			conversations.value = responseData.data as IConversation[];
+			conversations.value = responseData.data;
 		} catch (err: unknown) {
 			flashMessage.error(err instanceof Error ? err.message : t('buddyModule.messages.errors.loadConversations'));
 		} finally {
@@ -122,7 +122,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 				return undefined;
 			}
 
-			const created = responseData.data as IConversation;
+			const created = responseData.data;
 
 			conversations.value.unshift(created);
 			activeConversationId.value = created.id;
@@ -160,7 +160,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 			}
 
 			if (activeConversationId.value === conversationId) {
-				messages.value = responseData.data as IMessage[];
+				messages.value = responseData.data;
 			}
 		} catch (err: unknown) {
 			if (!quiet) {

--- a/apps/admin/src/modules/buddy/composables/useBuddyChat.ts
+++ b/apps/admin/src/modules/buddy/composables/useBuddyChat.ts
@@ -97,7 +97,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 				return;
 			}
 
-			conversations.value = responseData.data;
+			conversations.value = responseData.data as IConversation[];
 		} catch (err: unknown) {
 			flashMessage.error(err instanceof Error ? err.message : t('buddyModule.messages.errors.loadConversations'));
 		} finally {
@@ -122,7 +122,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 				return undefined;
 			}
 
-			const created = responseData.data;
+			const created = responseData.data as IConversation;
 
 			conversations.value.unshift(created);
 			activeConversationId.value = created.id;
@@ -160,7 +160,7 @@ export const useBuddyChat = (): IUseBuddyChat => {
 			}
 
 			if (activeConversationId.value === conversationId) {
-				messages.value = responseData.data;
+				messages.value = responseData.data as IMessage[];
 			}
 		} catch (err: unknown) {
 			if (!quiet) {

--- a/apps/admin/src/modules/buddy/composables/useBuddyMessagingProviders.ts
+++ b/apps/admin/src/modules/buddy/composables/useBuddyMessagingProviders.ts
@@ -41,7 +41,7 @@ export const useBuddyMessagingProviders = (): IUseBuddyMessagingProviders => {
 				return;
 			}
 
-			messagingProviderStatuses.value = responseData.data as IMessagingProviderStatus[];
+			messagingProviderStatuses.value = responseData.data;
 		} catch {
 			messagingProviderFetchFailed.value = true;
 		} finally {

--- a/apps/admin/src/modules/buddy/composables/useBuddyProviders.ts
+++ b/apps/admin/src/modules/buddy/composables/useBuddyProviders.ts
@@ -43,7 +43,7 @@ export const useBuddyProviders = (): IUseBuddyProviders => {
 				return;
 			}
 
-			providerStatuses.value = responseData.data as IProviderStatus[];
+			providerStatuses.value = responseData.data;
 		} catch {
 			providerFetchFailed.value = true;
 		} finally {

--- a/apps/admin/src/modules/buddy/composables/useBuddyVoiceProviders.ts
+++ b/apps/admin/src/modules/buddy/composables/useBuddyVoiceProviders.ts
@@ -56,7 +56,7 @@ export const useBuddyVoiceProviders = (kind: 'stt' | 'tts'): IUseBuddyVoiceProvi
 				return;
 			}
 
-			state.statuses.value = responseData.data as IVoiceProviderStatus[];
+			state.statuses.value = responseData.data;
 		} catch {
 			state.failed.value = true;
 		} finally {

--- a/apps/admin/src/modules/config/store/config-app.store.ts
+++ b/apps/admin/src/modules/config/store/config-app.store.ts
@@ -68,7 +68,7 @@ export const useConfigApp = defineStore<'config-module_config_app', ConfigAppSto
 
 	const onEvent = (payload: IConfigAppOnEventActionPayload): IConfigApp => {
 		return set({
-			data: transformConfigAppResponse(payload.data as unknown as IConfigAppRes),
+			data: transformConfigAppResponse(payload.data as IConfigAppRes),
 		});
 	};
 

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -73,7 +73,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 			const element = getModuleElement(payload.type);
 
 			return set({
-				data: transformConfigModuleResponse(payload.data as unknown as IConfigModuleRes, element?.schemas?.moduleConfigSchema || ConfigModuleSchema),
+				data: transformConfigModuleResponse(payload.data as IConfigModuleRes, element?.schemas?.moduleConfigSchema || ConfigModuleSchema),
 			});
 		};
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -75,7 +75,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 			const element = getPluginElement(payload.type);
 
 			return set({
-				data: transformConfigPluginResponse(payload.data as unknown as IConfigPluginRes, element?.schemas?.pluginConfigSchema || ConfigPluginSchema),
+				data: transformConfigPluginResponse(payload.data as IConfigPluginRes, element?.schemas?.pluginConfigSchema || ConfigPluginSchema),
 			});
 		};
 

--- a/apps/admin/src/modules/dashboard/store/data-sources.store.ts
+++ b/apps/admin/src/modules/dashboard/store/data-sources.store.ts
@@ -104,7 +104,7 @@ export const useDataSources = defineStore<'dashboard_module-data_sources', DataS
 			return set({
 				id: payload.id,
 				parent: payload.parent,
-				data: transformDataSourceResponse(payload.data as unknown as IDataSourceRes, element?.schemas?.dataSourceSchema || DataSourceSchema),
+				data: transformDataSourceResponse(payload.data as IDataSourceRes, element?.schemas?.dataSourceSchema || DataSourceSchema),
 			});
 		};
 

--- a/apps/admin/src/modules/dashboard/store/pages.store.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.ts
@@ -98,7 +98,7 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 
 		return set({
 			id: payload.id,
-			data: transformPageResponse(payload.data as unknown as IPageRes, element?.schemas?.pageSchema || PageSchema),
+			data: transformPageResponse(payload.data as IPageRes, element?.schemas?.pageSchema || PageSchema),
 		});
 	};
 

--- a/apps/admin/src/modules/dashboard/store/tiles.store.ts
+++ b/apps/admin/src/modules/dashboard/store/tiles.store.ts
@@ -110,7 +110,7 @@ export const useTiles = defineStore<'dashboard_module-tiles', TilesStoreSetup>('
 		return set({
 			id: payload.id,
 			parent: payload.parent,
-			data: transformTileResponse(payload.data as unknown as ITileRes, element?.schemas?.tileSchema || TileSchema),
+			data: transformTileResponse(payload.data as ITileRes, element?.schemas?.tileSchema || TileSchema),
 		});
 	};
 

--- a/apps/admin/src/modules/devices/store/channels.controls.store.ts
+++ b/apps/admin/src/modules/devices/store/channels.controls.store.ts
@@ -75,7 +75,7 @@ export const useChannelsControls = defineStore<'devices_module-channels_controls
 		const onEvent = (payload: IChannelsControlsOnEventActionPayload): IChannelControl => {
 			return set({
 				id: payload.id,
-				data: transformChannelControlResponse(payload.data as unknown as IChannelControlRes),
+				data: transformChannelControlResponse(payload.data as IChannelControlRes),
 			});
 		};
 

--- a/apps/admin/src/modules/devices/store/channels.properties.store.ts
+++ b/apps/admin/src/modules/devices/store/channels.properties.store.ts
@@ -97,7 +97,7 @@ export const useChannelsProperties = defineStore<'devices_module-channels_proper
 			return set({
 				id: payload.id,
 				data: transformChannelPropertyResponse(
-					payload.data as unknown as IChannelPropertyRes,
+					payload.data as IChannelPropertyRes,
 					element?.schemas?.channelPropertySchema || ChannelPropertySchema
 				),
 			});

--- a/apps/admin/src/modules/devices/store/channels.store.ts
+++ b/apps/admin/src/modules/devices/store/channels.store.ts
@@ -108,7 +108,7 @@ export const useChannels = defineStore<'devices_module-channels', ChannelsStoreS
 
 		return set({
 			id: payload.id,
-			data: transformChannelResponse(payload.data as unknown as IChannelRes, element?.schemas?.channelSchema || ChannelSchema),
+			data: transformChannelResponse(payload.data as IChannelRes, element?.schemas?.channelSchema || ChannelSchema),
 		});
 	};
 

--- a/apps/admin/src/modules/devices/store/devices.controls.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.controls.store.ts
@@ -75,7 +75,7 @@ export const useDevicesControls = defineStore<'devices_module-devices_controls',
 		const onEvent = (payload: IDevicesControlsOnEventActionPayload): IDeviceControl => {
 			return set({
 				id: payload.id,
-				data: transformDeviceControlResponse(payload.data as unknown as IDeviceControlRes),
+				data: transformDeviceControlResponse(payload.data as IDeviceControlRes),
 			});
 		};
 

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -100,7 +100,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 
 		return set({
 			id: payload.id,
-			data: transformDeviceResponse(payload.data as unknown as IDeviceRes, element?.schemas?.deviceSchema || DeviceSchema),
+			data: transformDeviceResponse(payload.data as IDeviceRes, element?.schemas?.deviceSchema || DeviceSchema),
 		});
 	};
 

--- a/apps/admin/src/modules/displays/store/displays.store.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.ts
@@ -69,7 +69,7 @@ export const useDisplays = defineStore<'displays_module-displays', DisplaysStore
 	const onEvent = (payload: IDisplaysOnEventActionPayload): IDisplay => {
 		return set({
 			id: payload.id,
-			data: transformDisplayResponse(payload.data as unknown as IDisplayRes),
+			data: transformDisplayResponse(payload.data as IDisplayRes),
 		});
 	};
 

--- a/apps/admin/src/modules/extensions/composables/useActions.ts
+++ b/apps/admin/src/modules/extensions/composables/useActions.ts
@@ -116,7 +116,7 @@ export const useActions = (): IUseActions => {
 			}
 
 			if (responseData?.data) {
-				actions.value = responseData.data as IExtensionActionDescriptor[];
+				actions.value = responseData.data;
 			} else {
 				actions.value = [];
 			}
@@ -155,7 +155,7 @@ export const useActions = (): IUseActions => {
 			);
 
 			if (responseData?.data) {
-				return responseData.data as IActionResult;
+				return responseData.data;
 			}
 
 			return {
@@ -186,7 +186,7 @@ export const useActions = (): IUseActions => {
 			);
 
 			if (responseData?.data) {
-				return responseData.data as IActionHistoryRecord[];
+				return responseData.data;
 			}
 
 			return [];

--- a/apps/admin/src/modules/extensions/composables/useActions.ts
+++ b/apps/admin/src/modules/extensions/composables/useActions.ts
@@ -186,7 +186,7 @@ export const useActions = (): IUseActions => {
 			);
 
 			if (responseData?.data) {
-				return responseData.data;
+				return responseData.data as IActionHistoryRecord[];
 			}
 
 			return [];

--- a/apps/admin/src/modules/scenes/store/scenes.actions.store.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.actions.store.ts
@@ -82,7 +82,7 @@ export const useScenesActionsStore = defineStore<'scenes_module-scenes_actions',
 		const onEvent = (payload: IScenesActionsOnEventActionPayload): ISceneAction => {
 			return set({
 				id: payload.id,
-				data: transformSceneActionResponse(payload.data as unknown as ISceneActionRes),
+				data: transformSceneActionResponse(payload.data as ISceneActionRes),
 			});
 		};
 

--- a/apps/admin/src/modules/scenes/store/scenes.store.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.store.ts
@@ -83,7 +83,7 @@ export const useScenesStore = defineStore<'scenes_module-scenes', ScenesStoreSet
 	const onEvent = (payload: IScenesOnEventActionPayload): IScene => {
 		return set({
 			id: payload.id,
-			data: transformSceneResponse(payload.data as unknown as ISceneRes, SceneSchema),
+			data: transformSceneResponse(payload.data as ISceneRes, SceneSchema),
 		});
 	};
 

--- a/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpaceMedia.ts
@@ -419,8 +419,8 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error('Failed to fetch media endpoints');
 			}
 
-			const result = (responseData.data ?? {}) as Record<string, unknown>;
-			const rawEndpoints = (result.endpoints ?? []) as Record<string, unknown>[];
+			const result = responseData.data ?? {};
+			const rawEndpoints = ((result as Record<string, unknown>).endpoints ?? []) as Record<string, unknown>[];
 			endpointsData.value = rawEndpoints.map(transformEndpoint);
 		} catch (e: unknown) {
 			endpointsError.value = e instanceof Error ? e.message : 'Unknown error';
@@ -445,8 +445,8 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error('Failed to fetch media bindings');
 			}
 
-			const rawBindings = (responseData.data ?? []) as unknown as Record<string, unknown>[];
-			bindingsData.value = rawBindings.map(transformBinding);
+			const rawBindings = responseData.data ?? [];
+			bindingsData.value = (rawBindings as Record<string, unknown>[]).map(transformBinding);
 		} catch (e: unknown) {
 			bindingsError.value = e instanceof Error ? e.message : 'Unknown error';
 		} finally {
@@ -486,7 +486,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error(message);
 			}
 
-			const updated = transformBinding(responseData.data as unknown as Record<string, unknown>);
+			const updated = transformBinding(responseData.data as Record<string, unknown>);
 
 			// Update local state
 			const idx = bindingsData.value.findIndex((b) => b.id === updated.id);
@@ -541,7 +541,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error(message);
 			}
 
-			const created = transformBinding(responseData.data as unknown as Record<string, unknown>);
+			const created = transformBinding(responseData.data as Record<string, unknown>);
 			bindingsData.value.push(created);
 
 			return created;
@@ -597,8 +597,8 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error('Failed to apply defaults');
 			}
 
-			const rawBindings = (responseData.data ?? []) as unknown as Record<string, unknown>[];
-			bindingsData.value = rawBindings.map(transformBinding);
+			const rawBindings = responseData.data ?? [];
+			bindingsData.value = (rawBindings as Record<string, unknown>[]).map(transformBinding);
 		} catch (e: unknown) {
 			bindingsError.value = e instanceof Error ? e.message : 'Unknown error';
 			throw e;
@@ -624,8 +624,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error('Failed to fetch active state');
 			}
 
-			const raw = responseData.data as Record<string, unknown> | null;
-			activeState.value = raw ? transformActiveEntity(raw) : null;
+			activeState.value = responseData.data ? transformActiveEntity(responseData.data as Record<string, unknown>) : null;
 		} catch (e: unknown) {
 			activationError.value = e instanceof Error ? e.message : 'Unknown error';
 			activationErrorSource.value = 'fetch';
@@ -667,7 +666,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error(message);
 			}
 
-			return transformDryRunPreview(responseData.data as unknown as Record<string, unknown>);
+			return transformDryRunPreview(responseData.data as Record<string, unknown>);
 		} finally {
 			previewing.value = false;
 		}
@@ -702,7 +701,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error(message);
 			}
 
-			const result = transformActivationResult(responseData.data as unknown as Record<string, unknown>);
+			const result = transformActivationResult(responseData.data as Record<string, unknown>);
 			activeState.value = result;
 
 			// Poll for stable state if still activating
@@ -745,7 +744,7 @@ export const useSpaceMedia = (spaceId: Ref<string | undefined>): IUseSpaceMedia 
 				throw new Error(message);
 			}
 
-			const result = transformActivationResult(responseData.data as unknown as Record<string, unknown>);
+			const result = transformActivationResult(responseData.data as Record<string, unknown>);
 			activeState.value = result;
 
 			return result;

--- a/apps/admin/src/modules/spaces/store/spaces.store.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.ts
@@ -251,7 +251,7 @@ export const useSpacesStore = defineStore<'spaces_module-spaces', SpacesStoreSet
 	};
 
 	const onEvent = (payload: { id: ISpace['id']; data: Record<string, unknown> }): void => {
-		const space = transformSpaceResponse(payload.data as unknown as ApiSpace);
+		const space = transformSpaceResponse(payload.data as ApiSpace);
 		data.value[space.id] = space;
 	};
 

--- a/apps/admin/src/modules/stats/store/stats.store.ts
+++ b/apps/admin/src/modules/stats/store/stats.store.ts
@@ -43,7 +43,7 @@ export const useStats = defineStore<'stats_module-stats', StatsStoreSetup>('stat
 
 	const onEvent = (payload: IStatsOnEventActionPayload): IStats => {
 		return set({
-			data: transformStatsResponse(payload.data as unknown as IStatsRes),
+			data: transformStatsResponse(payload.data as IStatsRes),
 		});
 	};
 

--- a/apps/admin/src/modules/system/composables/useUpdateStatus.ts
+++ b/apps/admin/src/modules/system/composables/useUpdateStatus.ts
@@ -151,7 +151,7 @@ export const useUpdateStatus = (): IUseUpdateStatus => {
 				const { data: responseData } = await backend.client.GET(UPDATE_STATUS_PATH);
 
 				if (responseData?.data) {
-					applyInfoResponse(responseData.data as Record<string, unknown>);
+					applyInfoResponse(responseData.data);
 				}
 			} catch {
 				// Silently fail - endpoint may not exist yet
@@ -171,7 +171,7 @@ export const useUpdateStatus = (): IUseUpdateStatus => {
 			const { data: responseData } = await backend.client.POST(UPDATE_CHECK_PATH);
 
 			if (responseData?.data) {
-				applyInfoResponse(responseData.data as Record<string, unknown>);
+				applyInfoResponse(responseData.data);
 			}
 		} catch (err) {
 			error.value = 'systemModule.messages.update.checkFailed';
@@ -242,12 +242,13 @@ export const useUpdateStatus = (): IUseUpdateStatus => {
 				const { data: responseData } = await backend.client.GET(UPDATE_STATUS_PATH);
 
 				if (responseData?.data) {
-					const responseStatus = (responseData.data as Record<string, unknown>).status as string | undefined;
+					const typedData = responseData.data as Record<string, unknown>;
+					const responseStatus = typedData.status as string | undefined;
 
 					// Capture current_version before applyInfoResponse overwrites latestVersion
-					const newVersion = (responseData.data as Record<string, unknown>).current_version as string | undefined;
+					const newVersion = typedData.current_version as string | undefined;
 
-					applyInfoResponse(responseData.data as Record<string, unknown>);
+					applyInfoResponse(typedData);
 					lastSuccessAt = Date.now();
 
 					if (responseStatus === 'complete') {

--- a/apps/admin/src/modules/system/store/logs-entries.store.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.ts
@@ -64,7 +64,7 @@ export const useLogsEntries = defineStore<'system_module-logs', LogsEntriesStore
 	const onEvent = (payload: ILogsEntriesOnEventActionPayload): ILogEntry => {
 		return set({
 			id: payload.id,
-			data: transformLogEntryResponse(payload.data as unknown as ILogEntryRes),
+			data: transformLogEntryResponse(payload.data as ILogEntryRes),
 		});
 	};
 

--- a/apps/admin/src/modules/system/store/system-info.store.ts
+++ b/apps/admin/src/modules/system/store/system-info.store.ts
@@ -43,7 +43,7 @@ export const useSystemInfo = defineStore<'system_module-system_info', SystemInfo
 
 	const onEvent = (payload: ISystemInfoOnEventActionPayload): ISystemInfo => {
 		return set({
-			data: transformSystemInfoResponse(payload.data as unknown as ISystemInfoRes),
+			data: transformSystemInfoResponse(payload.data as ISystemInfoRes),
 		});
 	};
 

--- a/apps/admin/src/modules/system/store/throttle-status.store.ts
+++ b/apps/admin/src/modules/system/store/throttle-status.store.ts
@@ -45,7 +45,7 @@ export const useThrottleStatus = defineStore<'system_module-throttle_status', Th
 
 		const onEvent = (payload: IThrottleStatusOnEventActionPayload): IThrottleStatus => {
 			return set({
-				data: transformThrottleStatusResponse(payload.data as unknown as IThrottleStatusRes),
+				data: transformThrottleStatusResponse(payload.data as IThrottleStatusRes),
 			});
 		};
 

--- a/apps/admin/src/modules/users/store/users.store.ts
+++ b/apps/admin/src/modules/users/store/users.store.ts
@@ -68,7 +68,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 	const onEvent = (payload: IUsersOnEventActionPayload): IUser => {
 		return set({
 			id: payload.id,
-			data: transformUserResponse(payload.data as unknown as IUserRes),
+			data: transformUserResponse(payload.data as IUserRes),
 		});
 	};
 
@@ -127,7 +127,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 			});
 
 			if (typeof responseData !== 'undefined') {
-				const user = transformUserResponse(responseData.data as IUserRes);
+				const user = transformUserResponse(responseData.data);
 
 				data.value[user.id] = user;
 
@@ -159,7 +159,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 			if (typeof responseData !== 'undefined') {
 				data.value = Object.fromEntries(
 					responseData.data.map((user) => {
-						const transformedUser = transformUserResponse(user as IUserRes);
+						const transformedUser = transformUserResponse(user);
 
 						return [transformedUser.id, transformedUser];
 					})
@@ -231,7 +231,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 				});
 
 				if (typeof responseData !== 'undefined' && responseData.data.id === payload.id) {
-					const user = transformUserResponse(responseData.data as IUserRes);
+					const user = transformUserResponse(responseData.data);
 
 					data.value[user.id] = user;
 
@@ -308,7 +308,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 				});
 
 				if (typeof responseData !== 'undefined') {
-					const user = transformUserResponse(responseData.data as IUserRes);
+					const user = transformUserResponse(responseData.data);
 
 					data.value[user.id] = user;
 
@@ -368,7 +368,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 			});
 
 			if (typeof responseData !== 'undefined' && responseData.data.id === payload.id) {
-				const user = transformUserResponse(responseData.data as IUserRes);
+				const user = transformUserResponse(responseData.data);
 
 				data.value[user.id] = user;
 

--- a/apps/admin/src/modules/weather/store/locations.store.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.ts
@@ -85,7 +85,7 @@ export const useWeatherLocations = defineStore<'weather_module-locations', Weath
 		const onEvent = (payload: IWeatherLocationsOnEventActionPayload): IWeatherLocation => {
 			return set({
 				id: payload.id,
-				data: transformLocationResponse(payload.data as unknown as IWeatherLocationRes),
+				data: transformLocationResponse(payload.data as IWeatherLocationRes),
 			});
 		};
 

--- a/apps/admin/src/modules/weather/store/weather-day.store.ts
+++ b/apps/admin/src/modules/weather/store/weather-day.store.ts
@@ -44,7 +44,7 @@ export const useWeatherDay = defineStore<'weather_module-weather-day', WeatherDa
 
 		const onEvent = (payload: IWeatherDayOnEventActionPayload): IWeatherDay => {
 			return set({
-				data: transformWeatherDayResponse(payload.data as unknown as IWeatherDayRes),
+				data: transformWeatherDayResponse(payload.data as IWeatherDayRes),
 			});
 		};
 

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useMappingPreview.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useMappingPreview.ts
@@ -6,7 +6,7 @@ import { PLUGINS_PREFIX } from '../../../app.constants';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX } from '../devices-zigbee2mqtt.constants';
 import { DevicesZigbee2mqttApiException, DevicesZigbee2mqttValidationException } from '../devices-zigbee2mqtt.exceptions';
 import type { IMappingPreviewRequest, IMappingPreviewResponse } from '../schemas/mapping-preview.types';
-import { type ApiMappingPreviewResponse, transformMappingPreviewRequest, transformMappingPreviewResponse } from '../utils/mapping-preview.transformers';
+import { transformMappingPreviewRequest, transformMappingPreviewResponse } from '../utils/mapping-preview.transformers';
 
 export interface IUseMappingPreview {
 	preview: Ref<IMappingPreviewResponse | null>;
@@ -64,7 +64,7 @@ export const useMappingPreview = (): IUseMappingPreview => {
 					throw new DevicesZigbee2mqttApiException('Request was superseded by a newer request.', 0);
 				}
 
-				const transformed = transformMappingPreviewResponse(responseData.data as ApiMappingPreviewResponse);
+				const transformed = transformMappingPreviewResponse(responseData.data);
 
 				preview.value = transformed;
 				isLoading.value = false;

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useMappingPreview.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useMappingPreview.ts
@@ -6,7 +6,7 @@ import { PLUGINS_PREFIX } from '../../../app.constants';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX } from '../devices-zigbee2mqtt.constants';
 import { DevicesZigbee2mqttApiException, DevicesZigbee2mqttValidationException } from '../devices-zigbee2mqtt.exceptions';
 import type { IMappingPreviewRequest, IMappingPreviewResponse } from '../schemas/mapping-preview.types';
-import { transformMappingPreviewRequest, transformMappingPreviewResponse } from '../utils/mapping-preview.transformers';
+import { type ApiMappingPreviewResponse, transformMappingPreviewRequest, transformMappingPreviewResponse } from '../utils/mapping-preview.transformers';
 
 export interface IUseMappingPreview {
 	preview: Ref<IMappingPreviewResponse | null>;
@@ -64,7 +64,7 @@ export const useMappingPreview = (): IUseMappingPreview => {
 					throw new DevicesZigbee2mqttApiException('Request was superseded by a newer request.', 0);
 				}
 
-				const transformed = transformMappingPreviewResponse(responseData.data);
+				const transformed = transformMappingPreviewResponse(responseData.data as ApiMappingPreviewResponse);
 
 				preview.value = transformed;
 				isLoading.value = false;

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
@@ -167,7 +167,7 @@ export const useZigbee2mqttDiscoveredDevices = defineStore<
 				if (typeof responseData !== 'undefined') {
 					data.value = Object.fromEntries(
 						responseData.data.map((device) => {
-							const transformed = transformZigbee2mqttDiscoveredDeviceResponse(device);
+							const transformed = transformZigbee2mqttDiscoveredDeviceResponse(device as ApiDiscoveredDeviceResponse);
 
 							return [transformed.id, transformed];
 						})

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
@@ -18,7 +18,7 @@ import type {
 	IZigbee2mqttDiscoveredDevicesUnsetActionPayload,
 	Zigbee2mqttDiscoveredDevicesStoreSetup,
 } from './zigbee2mqtt-discovered-devices.store.types';
-import { transformZigbee2mqttDiscoveredDeviceResponse } from './zigbee2mqtt-discovered-devices.transformers';
+import { type ApiDiscoveredDeviceResponse, transformZigbee2mqttDiscoveredDeviceResponse } from './zigbee2mqtt-discovered-devices.transformers';
 
 const defaultSemaphore: IZigbee2mqttDiscoveredDevicesStateSemaphore = {
 	fetching: {
@@ -119,7 +119,7 @@ export const useZigbee2mqttDiscoveredDevices = defineStore<
 				);
 
 				if (typeof responseData !== 'undefined') {
-					const transformed = transformZigbee2mqttDiscoveredDeviceResponse(responseData.data);
+					const transformed = transformZigbee2mqttDiscoveredDeviceResponse(responseData.data as ApiDiscoveredDeviceResponse);
 
 					data.value[transformed.id] = transformed;
 

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/store/zigbee2mqtt-discovered-devices.store.ts
@@ -18,7 +18,7 @@ import type {
 	IZigbee2mqttDiscoveredDevicesUnsetActionPayload,
 	Zigbee2mqttDiscoveredDevicesStoreSetup,
 } from './zigbee2mqtt-discovered-devices.store.types';
-import { type ApiDiscoveredDeviceResponse, transformZigbee2mqttDiscoveredDeviceResponse } from './zigbee2mqtt-discovered-devices.transformers';
+import { transformZigbee2mqttDiscoveredDeviceResponse } from './zigbee2mqtt-discovered-devices.transformers';
 
 const defaultSemaphore: IZigbee2mqttDiscoveredDevicesStateSemaphore = {
 	fetching: {
@@ -119,7 +119,7 @@ export const useZigbee2mqttDiscoveredDevices = defineStore<
 				);
 
 				if (typeof responseData !== 'undefined') {
-					const transformed = transformZigbee2mqttDiscoveredDeviceResponse(responseData.data as ApiDiscoveredDeviceResponse);
+					const transformed = transformZigbee2mqttDiscoveredDeviceResponse(responseData.data);
 
 					data.value[transformed.id] = transformed;
 
@@ -167,7 +167,7 @@ export const useZigbee2mqttDiscoveredDevices = defineStore<
 				if (typeof responseData !== 'undefined') {
 					data.value = Object.fromEntries(
 						responseData.data.map((device) => {
-							const transformed = transformZigbee2mqttDiscoveredDeviceResponse(device as ApiDiscoveredDeviceResponse);
+							const transformed = transformZigbee2mqttDiscoveredDeviceResponse(device);
 
 							return [transformed.id, transformed];
 						})

--- a/apps/admin/src/plugins/pages-cards/store/cards.store.ts
+++ b/apps/admin/src/plugins/pages-cards/store/cards.store.ts
@@ -95,7 +95,7 @@ export const useCards = defineStore<'pages_cards_plugin-cards', CardsStoreSetup>
 	const onEvent = (payload: ICardsOnEventActionPayload): ICard => {
 		return set({
 			id: payload.id,
-			data: transformCardResponse(payload.data as unknown as ICardRes),
+			data: transformCardResponse(payload.data as ICardRes),
 		});
 	};
 


### PR DESCRIPTION
## Summary
- Remove ~60 unnecessary type casts from API response handling across 33 files
- Downgrade `as unknown as IXxxRes` double-casts to single `as IXxxRes` in WebSocket onEvent handlers (data is genuinely untyped)
- Remove `as IXxxRes` entirely from API call sites where generated types now match
- Remove unused type imports that were only needed for the casts

### Result
**Zero `as unknown`, `as never`, `as any` casts** remain in non-test admin files.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] All 1275 unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily adjusts TypeScript typing/casts around API and websocket payload handling without changing request/response logic. Main risk is compile-time assumptions about generated client types not matching runtime payload shapes in edge cases.
> 
> **Overview**
> **Refactors admin frontend API response handling** to drop ~60 redundant/unsafe type casts (notably `as unknown as ...` and many `as ...`) across session/auth, buddy providers, config, dashboard, devices, system, spaces/media, stats, users, weather, and cards stores/composables.
> 
> WebSocket `onEvent` handlers now use a single cast where payloads are genuinely untyped, while standard REST call sites consume `responseData.data` directly and remove cast-only imports/aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba7fe1e03303833c70ca3c35856ca760821d39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->