### PR TITLE
security(backend): harden auth, headers, and config handling

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -99,6 +99,7 @@
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/swagger": "^11.2.6",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.16",
     "@whiskeysockets/baileys": "7.0.0-rc.9",

--- a/apps/backend/src/app.constants.ts
+++ b/apps/backend/src/app.constants.ts
@@ -7,6 +7,7 @@ export enum RequestResultState {
 	ERROR = 'error',
 }
 
+// INSECURE DEFAULT — only for development
 export const DEFAULT_TOKEN_SECRET = 'g3xHbkELpMD9LRqW4WmJkHL7kz2bdNYAQJyEuFVzR3k=';
 
 export const DEFAULT_TOKEN_EXPIRATION = '1h';

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import { CacheModule } from '@nestjs/cache-manager';
 import { DynamicModule, Module, type Type } from '@nestjs/common';
 import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } from '@nestjs/config';
-import { RouterModule } from '@nestjs/core';
+import { APP_GUARD, RouterModule } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MODULES_PREFIX, PLUGINS_PREFIX } from './app.constants';
@@ -134,7 +135,9 @@ export class AppModule {
 
 		return {
 			module: AppModule,
+			providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 			imports: [
+				ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }]),
 				NestConfigModule.forRoot({
 					envFilePath: [
 						// Monorepo root (../../../ from src/ or dist/)

--- a/apps/backend/src/common/filters/bad-request-exception.filter.ts
+++ b/apps/backend/src/common/filters/bad-request-exception.filter.ts
@@ -1,5 +1,4 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
-import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
@@ -45,7 +44,6 @@ export class BadRequestExceptionFilter implements ExceptionFilter {
 					},
 					metadata: {
 						server_time: new Date().toISOString(),
-						cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 					},
 				});
 		} else if (status === HttpStatus.BAD_REQUEST) {
@@ -67,7 +65,6 @@ export class BadRequestExceptionFilter implements ExceptionFilter {
 					},
 					metadata: {
 						server_time: new Date().toISOString(),
-						cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 					},
 				});
 		}

--- a/apps/backend/src/common/filters/global-error.filter.ts
+++ b/apps/backend/src/common/filters/global-error.filter.ts
@@ -1,5 +1,4 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
-import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
@@ -42,6 +41,8 @@ export class GlobalErrorFilter implements ExceptionFilter {
 			exception instanceof Error ? exception.stack : undefined,
 		);
 
+		const isProduction = process.env.NODE_ENV === 'production';
+
 		const errorResponse = {
 			status: RequestResultState.ERROR,
 			timestamp: new Date().toISOString(),
@@ -52,13 +53,12 @@ export class GlobalErrorFilter implements ExceptionFilter {
 				code: exception instanceof HttpException ? exception.name : 'InternalServerError',
 				message: errorMessage,
 				details:
-					exception instanceof HttpException
+					!isProduction && exception instanceof HttpException
 						? exception.getResponse()
 						: { reason: 'An unexpected server error occurred.' },
 			},
 			metadata: {
 				server_time: new Date().toISOString(),
-				cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 			},
 		};
 

--- a/apps/backend/src/common/filters/internal-server-error-exception.filter.ts
+++ b/apps/backend/src/common/filters/internal-server-error-exception.filter.ts
@@ -1,5 +1,4 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
-import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus, InternalServerErrorException } from '@nestjs/common';
@@ -33,7 +32,6 @@ export class InternalServerErrorExceptionFilter implements ExceptionFilter {
 				},
 				metadata: {
 					server_time: new Date().toISOString(),
-					cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 				},
 			});
 	}

--- a/apps/backend/src/common/filters/not-found-exception.filter.ts
+++ b/apps/backend/src/common/filters/not-found-exception.filter.ts
@@ -1,6 +1,5 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
 import { createReadStream, existsSync } from 'fs';
-import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -66,7 +65,6 @@ export class NotFoundExceptionFilter implements ExceptionFilter {
 				},
 				metadata: {
 					server_time: new Date().toISOString(),
-					cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 				},
 			});
 	}

--- a/apps/backend/src/common/filters/query-failed-exception.filter.ts
+++ b/apps/backend/src/common/filters/query-failed-exception.filter.ts
@@ -1,5 +1,4 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
-import os from 'os';
 import { QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -32,7 +31,6 @@ export class QueryFailedExceptionFilter implements ExceptionFilter {
 				},
 				metadata: {
 					server_time: new Date().toISOString(),
-					cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 				},
 			});
 	}

--- a/apps/backend/src/common/filters/unprocessable-entity-exception.filter.ts
+++ b/apps/backend/src/common/filters/unprocessable-entity-exception.filter.ts
@@ -1,5 +1,4 @@
 import { FastifyRequest as Request, FastifyReply as Response } from 'fastify';
-import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus, UnprocessableEntityException } from '@nestjs/common';
@@ -36,7 +35,6 @@ export class UnprocessableEntityExceptionFilter implements ExceptionFilter {
 				},
 				metadata: {
 					server_time: new Date().toISOString(),
-					cpu_usage: parseFloat(os.loadavg()[0].toFixed(2)),
 				},
 			});
 	}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -3,6 +3,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { existsSync } from 'fs';
 import path from 'path';
 
+import helmet from '@fastify/helmet';
 import fastifyMultipart from '@fastify/multipart';
 import fastifyStatic from '@fastify/static';
 import { ValidationPipe, VersioningType } from '@nestjs/common';
@@ -68,6 +69,12 @@ async function bootstrap() {
 			}
 		},
 	);
+
+	// Add security headers via Helmet. CSP is disabled because the admin SPA
+	// needs inline scripts/styles.
+	await app.register(helmet, {
+		contentSecurityPolicy: false,
+	});
 
 	// Register multipart support for file uploads — this adds the content-type
 	// parser that sets req[kMultipart] = true, which req.file() relies on.

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -1,5 +1,7 @@
+import crypto from 'crypto';
+
 import { CacheModule } from '@nestjs/cache-manager';
-import { Module, OnModuleInit } from '@nestjs/common';
+import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
@@ -47,8 +49,30 @@ import { TokensService } from './services/tokens.service';
 			imports: [NestConfigModule],
 			inject: [NestConfigService],
 			useFactory: (configService: NestConfigService) => {
+				const logger = new Logger('AuthModule');
+
+				let secret = getEnvValue<string | undefined>(configService, 'FB_TOKEN_SECRET', DEFAULT_TOKEN_SECRET);
+
+				if (!secret || secret === DEFAULT_TOKEN_SECRET) {
+					const nodeEnv = configService.get<string>('NODE_ENV');
+
+					if (nodeEnv === 'production') {
+						logger.error(
+							'CRITICAL: No FB_TOKEN_SECRET configured in production! ' +
+								'Auto-generating a random secret. Sessions will NOT persist across restarts. ' +
+								'Set the FB_TOKEN_SECRET environment variable to fix this.',
+						);
+					}
+
+					secret = crypto.randomBytes(32).toString('base64');
+
+					logger.warn(
+						'No FB_TOKEN_SECRET configured — using auto-generated secret. Sessions will not persist across restarts.',
+					);
+				}
+
 				return {
-					secret: getEnvValue<string | undefined>(configService, 'FB_TOKEN_SECRET', DEFAULT_TOKEN_SECRET),
+					secret,
 					signOptions: { expiresIn: DEFAULT_TOKEN_EXPIRATION },
 				};
 			},

--- a/apps/backend/src/modules/auth/controllers/auth.controller.ts
+++ b/apps/backend/src/modules/auth/controllers/auth.controller.ts
@@ -117,6 +117,7 @@ export class AuthController {
 	@ApiBadRequestResponse('Invalid refresh token data')
 	@ApiNotFoundResponse('Refresh token not found')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Throttle({ default: { limit: 5, ttl: 60000 } })
 	@Public()
 	@Post('refresh')
 	async refreshAccessToken(@Body() body: ReqRefreshDto): Promise<RefreshResponseModel> {

--- a/apps/backend/src/modules/auth/controllers/auth.controller.ts
+++ b/apps/backend/src/modules/auth/controllers/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, ForbiddenException, Get, HttpCode, NotFoundException, Post, Req } from '@nestjs/common';
 import { ApiBody, ApiNoContentResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 import { createExtensionLogger } from '../../../common/logger';
 import {
@@ -50,6 +51,7 @@ export class AuthController {
 	@ApiBadRequestResponse('Invalid login credentials')
 	@ApiNotFoundResponse('User not found')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Throttle({ default: { limit: 5, ttl: 60000 } })
 	@Public()
 	@Post('login')
 	async login(@Body() body: ReqLoginDto): Promise<LoginResponseModel> {
@@ -84,6 +86,7 @@ export class AuthController {
 	@ApiBadRequestResponse('Invalid input data')
 	@ApiForbiddenResponse('Owner already exists')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Throttle({ default: { limit: 5, ttl: 60000 } })
 	@Public()
 	@HttpCode(204)
 	@Post('register')
@@ -145,6 +148,7 @@ export class AuthController {
 	@ApiSuccessResponse(CheckUsernameResponseModel, 'Username availability result')
 	@ApiBadRequestResponse('Invalid username')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Throttle({ default: { limit: 5, ttl: 60000 } })
 	@Public()
 	@Post('check/username')
 	async checkUsername(@Body() body: ReqCheckUsernameDto): Promise<CheckUsernameResponseModel> {
@@ -170,6 +174,7 @@ export class AuthController {
 	@ApiSuccessResponse(CheckEmailResponseModel, 'Email availability result')
 	@ApiBadRequestResponse('Invalid email')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Throttle({ default: { limit: 5, ttl: 60000 } })
 	@Public()
 	@Post('check/email')
 	async checkEmail(@Body() body: ReqCheckEmailDto): Promise<CheckEmailResponseModel> {

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -1,6 +1,7 @@
 import { Expose, Transform, Type } from 'class-transformer';
 import {
 	IsEmail,
+	IsEnum,
 	IsNotEmpty,
 	IsOptional,
 	IsString,
@@ -11,6 +12,8 @@ import {
 } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { UserRole } from '../../users/users.constants';
 
 @ApiSchema({ name: 'AuthModuleRegister' })
 export class RegisterDto {
@@ -85,6 +88,19 @@ export class RegisterDto {
 	@IsString({ message: '[{"field":"last_name","reason":"Last name must be a non-empty string."}]' })
 	@ValidateIf((_, value) => value !== null)
 	last_name?: string | null;
+
+	// Role field kept in DTO for OpenAPI enum generation but ignored by the service —
+	// the service always computes role server-side (OWNER for first user, USER for subsequent).
+	@ApiPropertyOptional({
+		description: 'User role (ignored — computed server-side)',
+		enum: UserRole,
+		default: UserRole.USER,
+	})
+	@Expose()
+	@Transform(({ value }: { value: unknown }) => (value === null ? undefined : value))
+	@IsOptional()
+	@IsEnum(UserRole, { message: '[{"field":"role","reason":"Role must be one of the valid roles."}]' })
+	role?: UserRole;
 }
 
 @ApiSchema({ name: 'AuthModuleReqRegister' })

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -1,9 +1,16 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateIf, ValidateNested } from 'class-validator';
+import {
+	IsEmail,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	IsUUID,
+	MinLength,
+	ValidateIf,
+	ValidateNested,
+} from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
-
-import { UserRole } from '../../users/users.constants';
 
 @ApiSchema({ name: 'AuthModuleRegister' })
 export class RegisterDto {
@@ -28,16 +35,6 @@ export class RegisterDto {
 	@IsString({ message: '[{"field":"username","reason":"Username must be a non-empty string."}]' })
 	username: string;
 
-	@ApiPropertyOptional({
-		description: 'User role',
-		enum: UserRole,
-	})
-	@Expose()
-	@Transform(({ value }: { value: unknown }) => (value === null ? undefined : value))
-	@IsOptional()
-	@IsEnum(UserRole, { message: '[{"field":"role","reason":"Role must be one of the valid roles."}]' })
-	role?: UserRole;
-
 	@ApiProperty({
 		description: "User's password.",
 		type: 'string',
@@ -47,6 +44,7 @@ export class RegisterDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
+	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/auth/services/auth.service.ts
+++ b/apps/backend/src/modules/auth/services/auth.service.ts
@@ -164,7 +164,7 @@ export class AuthService {
 		const user = await this.usersService.create({
 			...dtoInstance,
 			password,
-			role: dtoInstance.role ?? (ownerExists ? UserRole.USER : UserRole.OWNER),
+			role: ownerExists ? UserRole.USER : UserRole.OWNER,
 		});
 
 		this.logger.debug(`Successfully registered user id=${user.id}`);

--- a/apps/backend/src/modules/config/services/config.service.ts
+++ b/apps/backend/src/modules/config/services/config.service.ts
@@ -163,7 +163,7 @@ export class ConfigService {
 		this.normalizeEmptyStrings(plainAppConfig);
 
 		const yamlContent = yaml.stringify(plainAppConfig);
-		fs.writeFileSync(path.resolve(this.configPath, this.filename), yamlContent, 'utf8');
+		fs.writeFileSync(path.resolve(this.configPath, this.filename), yamlContent, { encoding: 'utf8', mode: 0o600 });
 
 		this.config = null;
 

--- a/apps/backend/src/modules/stats/controllers/prometheus.controller.ts
+++ b/apps/backend/src/modules/stats/controllers/prometheus.controller.ts
@@ -2,12 +2,10 @@ import { Controller, Get, Header } from '@nestjs/common';
 import { ApiOperation, ApiProduces, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RawRoute } from '../../api/decorators/raw-route.decorator';
-import { Public } from '../../auth/guards/auth.guard';
 import { PrometheusExporterService } from '../services/stats.prometheus.service';
 import { STATS_MODULE_API_TAG_NAME } from '../stats.constants';
 
 @ApiTags(STATS_MODULE_API_TAG_NAME)
-@Public()
 @Controller('/metrics')
 export class PrometheusController {
 	constructor(private readonly exporter: PrometheusExporterService) {}

--- a/apps/backend/src/modules/users/dto/create-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/create-user.dto.ts
@@ -1,5 +1,15 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateIf, ValidateNested } from 'class-validator';
+import {
+	IsEmail,
+	IsEnum,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	IsUUID,
+	MinLength,
+	ValidateIf,
+	ValidateNested,
+} from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -37,6 +47,7 @@ export class CreateUserDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
+	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/users/dto/update-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-user.dto.ts
@@ -1,5 +1,14 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
+import {
+	IsEmail,
+	IsEnum,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	MinLength,
+	ValidateIf,
+	ValidateNested,
+} from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -30,6 +39,7 @@ export class UpdateUserDto {
 	@IsOptional()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
+	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
 	@ValidateIf((_, value) => value !== null)
 	password?: string | null;
 

--- a/apps/backend/src/modules/users/services/users.service.ts
+++ b/apps/backend/src/modules/users/services/users.service.ts
@@ -66,7 +66,7 @@ export class UsersService {
 		const dtoInstance = await this.validateDto<CreateUserDto>(CreateUserDto, createDto);
 
 		// Hash password before storing it
-		const hashedPassword = await bcrypt.hash(dtoInstance.password, 10);
+		const hashedPassword = await bcrypt.hash(dtoInstance.password, 12);
 
 		const user = this.repository.create(
 			toInstance(
@@ -111,7 +111,7 @@ export class UsersService {
 		const dtoInstance = await this.validateDto<UpdateUserDto>(UpdateUserDto, updateDto);
 
 		// Hash password before storing it
-		const hashedPassword = dtoInstance.password ? await bcrypt.hash(dtoInstance.password, 10) : undefined;
+		const hashedPassword = dtoInstance.password ? await bcrypt.hash(dtoInstance.password, 12) : undefined;
 
 		// Get the fields to update from DTO (excluding undefined values)
 		const updateFields = omitBy(

--- a/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
+++ b/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
@@ -3,6 +3,7 @@ import { isArray } from 'class-validator';
 import { Server, Socket } from 'socket.io';
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SkipThrottle } from '@nestjs/throttler';
 import {
 	ConnectedSocket,
 	MessageBody,
@@ -37,6 +38,7 @@ interface ClientData {
 	user?: ClientUserDto;
 }
 
+@SkipThrottle()
 @WebSocketGateway({
 	cors: {
 		origin: '*',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^11.2.6
         version: 11.2.6(@fastify/static@9.0.0)(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(babel-plugin-macros@3.1.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@5.9.3)))
@@ -2747,6 +2750,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@nestjs/typeorm@11.0.0':
     resolution: {integrity: sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==}
@@ -13876,6 +13886,12 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)
 
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(@nestjs/websockets@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+
   '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(babel-plugin-macros@3.1.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.16(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -22142,7 +22158,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
       long: 4.0.0
 
   protobufjs@7.5.4:


### PR DESCRIPTION
## Summary

Security hardening covering 9 findings from the security audit.

### CRITICAL
- **C1**: Auto-generate JWT secret when `FB_TOKEN_SECRET` not set (prevents using hardcoded default)
- **C2**: Rate limiting via `@nestjs/throttler` — 30 req/min global, 5 req/min on auth endpoints

### HIGH
- **H1**: `@MinLength(8)` on all password fields
- **H3**: `@fastify/helmet` for security headers
- **H5**: Prometheus metrics requires authentication

### MEDIUM
- **M2**: Remove `role` from registration DTO (server computes)
- **M4**: Remove CPU usage from error responses, hide details in production

### LOW
- **L1**: bcrypt salt rounds 10 → 12
- **L5**: Config file permissions set to 0600

## Test plan
- [x] All 210 backend test suites pass (2747 tests)
- [x] All 201 admin test suites pass (1275 tests)
- [x] Lint clean (0 errors)
- [x] Manual: verify login rate limiting works
- [x] Manual: verify security headers present in response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/token configuration and introduces global/per-route throttling, which can change login/session behavior and reject high-traffic clients if misconfigured. Also tightens error/metrics exposure and file permissions, which is safer but may impact debugging and operational workflows.
> 
> **Overview**
> Adds **request throttling** via `@nestjs/throttler` (global 30 req/min guard) with stricter 5 req/min limits on public auth endpoints, while explicitly skipping throttling for the WebSocket gateway.
> 
> Hardens **auth and secrets** by auto-generating a random JWT secret when `FB_TOKEN_SECRET` is missing/left at the insecure default (with production logging), enforcing `@MinLength(8)` on password DTOs, and ensuring registration roles are computed server-side (ignoring client-provided `role`).
> 
> Improves **security posture** by enabling `@fastify/helmet`, requiring auth for `/metrics` (removes `@Public()`), writing config files with `0600` permissions, and removing CPU usage + hiding HTTP exception details in production error responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a648929283659861995d0d7e7b1db36091eb848f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->