### PR TITLE
Add registry-based extensibility for space relations and creation

### DIFF
--- a/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
@@ -15,6 +15,8 @@ import { ZoneSpaceEntity } from '../entities/zone-space.entity';
 import { SpaceRoomCategory, SpaceType, SpaceZoneCategory } from '../spaces.constants';
 import { SpacesNotFoundException, SpacesValidationException } from '../spaces.exceptions';
 
+import { SpaceCreateBuilderRegistryService } from './space-create-builder-registry.service';
+import { SpaceRelationsLoaderRegistryService } from './space-relations-loader-registry.service';
 import { SpacesTypeMapperService } from './spaces-type-mapper.service';
 import { SpacesService } from './spaces.service';
 
@@ -123,6 +125,8 @@ describe('SpacesService', () => {
 					},
 				},
 				SpacesTypeMapperService,
+				SpaceRelationsLoaderRegistryService,
+				SpaceCreateBuilderRegistryService,
 			],
 		}).compile();
 

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -60,9 +60,7 @@ export class SpacesService {
 
 		this.logger.debug(`Found ${spaces.length} spaces`);
 
-		for (const space of spaces) {
-			await this.loadRelations(space);
-		}
+		await Promise.all(spaces.map((space) => this.loadRelations(space)));
 
 		return spaces;
 	}
@@ -102,8 +100,14 @@ export class SpacesService {
 	 * Used for deduplication during creation
 	 */
 	async findByCanonicalName(canonicalName: string): Promise<SpaceEntity | null> {
-		const allSpaces = await this.findAll();
-		return allSpaces.find((space) => canonicalizeSpaceName(space.name) === canonicalName) ?? null;
+		// Bypass findAll() here: relation loaders aren't needed for name matching,
+		// and create() hits this for every insert — avoid the N×M loader fan-out.
+		const candidates = await this.repository.find({ select: ['id', 'name'] });
+		const match = candidates.find((space) => canonicalizeSpaceName(space.name) === canonicalName);
+		if (!match) {
+			return null;
+		}
+		return this.findOne(match.id);
 	}
 
 	async create(createDto: CreateSpaceDto): Promise<SpaceEntity> {
@@ -279,8 +283,6 @@ export class SpacesService {
 		}
 
 		await this.repository.save(space);
-
-		await this.loadRelations(space);
 
 		this.logger.debug(`Successfully updated space with id=${space.id}`);
 
@@ -753,8 +755,8 @@ export class SpacesService {
 			throw new SpacesValidationException('A space cannot be its own parent.');
 		}
 
-		// Parent must exist and be a zone
-		const parent = await this.findOne(parentId);
+		// Parent must exist and be a zone — skip relation loaders, we only need the discriminator.
+		const parent = await this.repository.findOne({ where: { id: parentId }, select: ['id', 'type'] });
 
 		if (!parent) {
 			this.logger.error(`Parent space with id=${parentId} not found`);

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -694,6 +694,8 @@ export class SpacesService {
 
 		this.logger.debug(`Found ${children.length} child rooms for zone`);
 
+		await Promise.all(children.map((child) => this.loadRelations(child)));
+
 		return children;
 	}
 
@@ -729,6 +731,8 @@ export class SpacesService {
 		});
 
 		this.logger.debug(`Found ${zones.length} zones`);
+
+		await Promise.all(zones.map((zone) => this.loadRelations(zone)));
 
 		return zones;
 	}

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -284,13 +284,18 @@ export class SpacesService {
 
 		await this.repository.save(space);
 
-		this.logger.debug(`Successfully updated space with id=${space.id}`);
+		// Re-fetch so registered relation loaders reflect post-save entity state
+		// (e.g. loaders keyed on mutable fields like `category`). Matches the
+		// type-change path above and create().
+		const updatedSpace = await this.getOneOrThrow(id);
+
+		this.logger.debug(`Successfully updated space with id=${updatedSpace.id}`);
 
 		if (entityFieldsChanged) {
-			this.eventEmitter.emit(EventType.SPACE_UPDATED, space);
+			this.eventEmitter.emit(EventType.SPACE_UPDATED, updatedSpace);
 		}
 
-		return space;
+		return updatedSpace;
 	}
 
 	async remove(id: string): Promise<void> {

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -764,8 +764,12 @@ export class SpacesService {
 			throw new SpacesValidationException('A space cannot be its own parent.');
 		}
 
-		// Parent must exist and be a zone — skip relation loaders, we only need the discriminator.
-		const parent = await this.repository.findOne({ where: { id: parentId }, select: ['id', 'type'] });
+		// Parent must exist and be a zone. Bypass `findOne()` to skip relation loaders;
+		// also avoid `select: ['id', 'type']` because TableInheritance excludes the
+		// discriminator from column metadata (TypeORM #3261), which would prevent
+		// subtype resolution and trigger the base getter's throw. A full row fetch
+		// by primary key is cheap.
+		const parent = await this.repository.findOne({ where: { id: parentId } });
 
 		if (!parent) {
 			this.logger.error(`Parent space with id=${parentId} not found`);

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -28,6 +28,8 @@ import {
 import { SpacesNotFoundException, SpacesValidationException } from '../spaces.exceptions';
 import { canonicalizeSpaceName } from '../spaces.utils';
 
+import { SpaceCreateBuilderRegistryService } from './space-create-builder-registry.service';
+import { SpaceRelationsLoaderRegistryService } from './space-relations-loader-registry.service';
 import { SpacesTypeMapperService } from './spaces-type-mapper.service';
 
 @Injectable()
@@ -45,6 +47,8 @@ export class SpacesService {
 		private readonly dataSource: DataSource,
 		private readonly eventEmitter: EventEmitter2,
 		private readonly spacesTypeMapper: SpacesTypeMapperService,
+		private readonly relationsRegistry: SpaceRelationsLoaderRegistryService,
+		private readonly createBuilderRegistry: SpaceCreateBuilderRegistryService,
 	) {}
 
 	async findAll(): Promise<SpaceEntity[]> {
@@ -55,6 +59,10 @@ export class SpacesService {
 		});
 
 		this.logger.debug(`Found ${spaces.length} spaces`);
+
+		for (const space of spaces) {
+			await this.loadRelations(space);
+		}
 
 		return spaces;
 	}
@@ -71,6 +79,8 @@ export class SpacesService {
 		}
 
 		this.logger.debug('Successfully fetched space');
+
+		await this.loadRelations(space);
 
 		return space;
 	}
@@ -137,6 +147,12 @@ export class SpacesService {
 				category,
 			}),
 		);
+
+		for (const builder of this.createBuilderRegistry.getBuilders()) {
+			if (builder.supports(dtoInstance)) {
+				await builder.build(dtoInstance, space);
+			}
+		}
 
 		await subtypeRepository.save(space);
 
@@ -263,6 +279,8 @@ export class SpacesService {
 		}
 
 		await this.repository.save(space);
+
+		await this.loadRelations(space);
 
 		this.logger.debug(`Successfully updated space with id=${space.id}`);
 
@@ -746,6 +764,14 @@ export class SpacesService {
 		if (parent.type !== SpaceType.ZONE) {
 			this.logger.error(`Parent space ${parentId} is not a zone`);
 			throw new SpacesValidationException('Parent must be a zone. Rooms can only belong to zones.');
+		}
+	}
+
+	private async loadRelations(space: SpaceEntity): Promise<void> {
+		for (const loader of this.relationsRegistry.getLoaders()) {
+			if (loader.supports(space)) {
+				await loader.loadRelations(space);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR introduces a registry-based architecture for loading space relations and building space entities, enabling extensible customization of space creation and relation loading through pluggable services.

## Key Changes
- **New Dependencies**: Injected `SpaceRelationsLoaderRegistryService` and `SpaceCreateBuilderRegistryService` into `SpacesService`
- **Relation Loading**: Added `loadRelations()` private method that iterates through registered loaders and calls `loadRelations()` on those that support the given space entity
  - Called after `findAll()` to load relations for all spaces
  - Called after `findById()` to load relations for a single space
  - Called after `update()` to reload relations after modifications
- **Creation Building**: Added builder invocation in `create()` method that iterates through registered builders and calls `build()` on those that support the given DTO
- **Test Updates**: Updated `SpacesService` test module to provide mock implementations of both registry services

## Implementation Details
- The registry pattern allows multiple loaders/builders to be registered and selectively applied based on `supports()` checks
- Relation loading is applied consistently across all space retrieval operations (findAll, findById, update)
- Builder execution occurs after entity mapping but before persistence, allowing builders to modify the space entity before saving
- Both registries use a consistent interface pattern with `supports()` and async operation methods

https://claude.ai/code/session_01Nfz2XzWawyZvKBkbvmhbha

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `SpacesService` read/write paths to invoke pluggable relation loaders/builders and to re-fetch entities after updates, which could affect performance and downstream event payloads if loaders/builders have side effects or are mis-registered.
> 
> **Overview**
> **Adds registry-driven extensibility to `SpacesService`.** The service now injects `SpaceRelationsLoaderRegistryService` and `SpaceCreateBuilderRegistryService`, loads extra relations via a new `loadRelations()` hook after reads (`findAll`, `findOne`, `findAllZones`, `getChildRooms`), and runs registered builders during `create()` to allow pre-save entity augmentation.
> 
> **Adjusts data-access flow for correctness and efficiency.** `findByCanonicalName()` now avoids `findAll()` (and relation loading) by querying only `id`/`name`, `update()` now re-fetches the saved entity before emitting/returning so relation loaders reflect post-save state, and parent validation bypasses `findOne()` to avoid loader fan-out and TypeORM inheritance edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9d4e58e4bf75b7951ce3e9f36c060db751c6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->