### PR TITLE
feat(auth): exempt registered displays from the global throttler

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { CacheModule } from '@nestjs/cache-manager';
 import { DynamicModule, Module, type Type } from '@nestjs/common';
 import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } from '@nestjs/config';
-import { RouterModule } from '@nestjs/core';
+import { APP_GUARD, RouterModule } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
@@ -14,6 +14,7 @@ import { getEnvValue } from './common/utils/config.utils';
 import { ApiModule } from './modules/api/api.module';
 import { AUTH_MODULE_PREFIX } from './modules/auth/auth.constants';
 import { AuthModule } from './modules/auth/auth.module';
+import { DisplayAwareThrottlerGuard } from './modules/auth/guards/display-aware-throttler.guard';
 import { BUDDY_MODULE_PREFIX } from './modules/buddy/buddy.constants';
 import { BuddyModule } from './modules/buddy/buddy.module';
 import { CONFIG_MODULE_PREFIX } from './modules/config/config.constants';
@@ -144,12 +145,14 @@ export class AppModule {
 
 		return {
 			module: AppModule,
-			// Throttler config lives here (global setup) but the APP_GUARD that
-			// applies it is registered inside `AuthModule` so it can sit *after*
-			// `AuthGuard` in the same providers array. Within a single module,
-			// `APP_GUARD` providers execute in declared order — that's the only
-			// way to make `request.auth` reliably populated by the time the
-			// throttler decides whether to skip.
+			// Register `DisplayAwareThrottlerGuard` as a global guard. It does
+			// its own lightweight JWT signature check (no DB lookup) to detect
+			// display tokens and skip throttling for them — this means the
+			// guard runs BEFORE `AuthGuard` short-circuits unauthenticated
+			// traffic at 401, so anonymous floods to protected endpoints stay
+			// rate-limited at the default `30 req / 60s`. AuthGuard later
+			// performs the full DB-backed validation (revocation, expiry, etc).
+			providers: [{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard }],
 			imports: [
 				ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }]),
 				NestConfigModule.forRoot({

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,7 +6,7 @@ import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } 
 import { APP_GUARD, RouterModule } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
-import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MODULES_PREFIX, PLUGINS_PREFIX } from './app.constants';
@@ -14,6 +14,7 @@ import { getEnvValue } from './common/utils/config.utils';
 import { ApiModule } from './modules/api/api.module';
 import { AUTH_MODULE_PREFIX } from './modules/auth/auth.constants';
 import { AuthModule } from './modules/auth/auth.module';
+import { DisplayAwareThrottlerGuard } from './modules/auth/guards/display-aware-throttler.guard';
 import { BUDDY_MODULE_PREFIX } from './modules/buddy/buddy.constants';
 import { BuddyModule } from './modules/buddy/buddy.module';
 import { CONFIG_MODULE_PREFIX } from './modules/config/config.constants';
@@ -144,7 +145,7 @@ export class AppModule {
 
 		return {
 			module: AppModule,
-			providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+			providers: [{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard }],
 			imports: [
 				ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }]),
 				NestConfigModule.forRoot({

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { CacheModule } from '@nestjs/cache-manager';
 import { DynamicModule, Module, type Type } from '@nestjs/common';
 import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } from '@nestjs/config';
-import { APP_GUARD, RouterModule } from '@nestjs/core';
+import { RouterModule } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
@@ -14,7 +14,6 @@ import { getEnvValue } from './common/utils/config.utils';
 import { ApiModule } from './modules/api/api.module';
 import { AUTH_MODULE_PREFIX } from './modules/auth/auth.constants';
 import { AuthModule } from './modules/auth/auth.module';
-import { DisplayAwareThrottlerGuard } from './modules/auth/guards/display-aware-throttler.guard';
 import { BUDDY_MODULE_PREFIX } from './modules/buddy/buddy.constants';
 import { BuddyModule } from './modules/buddy/buddy.module';
 import { CONFIG_MODULE_PREFIX } from './modules/config/config.constants';
@@ -145,7 +144,12 @@ export class AppModule {
 
 		return {
 			module: AppModule,
-			providers: [{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard }],
+			// Throttler config lives here (global setup) but the APP_GUARD that
+			// applies it is registered inside `AuthModule` so it can sit *after*
+			// `AuthGuard` in the same providers array. Within a single module,
+			// `APP_GUARD` providers execute in declared order — that's the only
+			// way to make `request.auth` reliably populated by the time the
+			// throttler decides whether to skip.
 			imports: [
 				ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }]),
 				NestConfigModule.forRoot({

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { getEnvValue } from './common/utils/config.utils';
 import { ApiModule } from './modules/api/api.module';
 import { AUTH_MODULE_PREFIX } from './modules/auth/auth.constants';
 import { AuthModule } from './modules/auth/auth.module';
+import { AuthGuard } from './modules/auth/guards/auth.guard';
 import { DisplayAwareThrottlerGuard } from './modules/auth/guards/display-aware-throttler.guard';
 import { BUDDY_MODULE_PREFIX } from './modules/buddy/buddy.constants';
 import { BuddyModule } from './modules/buddy/buddy.module';
@@ -145,14 +146,23 @@ export class AppModule {
 
 		return {
 			module: AppModule,
-			// Register `DisplayAwareThrottlerGuard` as a global guard. It does
+			// Both global guards are registered HERE (not in their owning
+			// modules) so the execution order is controlled at a single point.
+			// Within one module's `providers` array, NestJS executes
+			// `APP_GUARD` providers in declared order — splitting them across
+			// `AuthModule` and `AppModule` would make ordering depend on
+			// module-load order, which is fragile.
+			//
+			// Throttler runs FIRST so anonymous floods to protected endpoints
+			// stay rate-limited (otherwise `AuthGuard` would 401 them and the
+			// throttler would never count the request). The throttler does
 			// its own lightweight JWT signature check (no DB lookup) to detect
-			// display tokens and skip throttling for them — this means the
-			// guard runs BEFORE `AuthGuard` short-circuits unauthenticated
-			// traffic at 401, so anonymous floods to protected endpoints stay
-			// rate-limited at the default `30 req / 60s`. AuthGuard later
-			// performs the full DB-backed validation (revocation, expiry, etc).
-			providers: [{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard }],
+			// display tokens; `AuthGuard` runs after for the full DB-backed
+			// validation (revocation, expiry, owner exists).
+			providers: [
+				{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard },
+				{ provide: APP_GUARD, useClass: AuthGuard },
+			],
 			imports: [
 				ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }]),
 				NestConfigModule.forRoot({

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -32,7 +32,6 @@ import { UpdateAuthConfigDto } from './dto/update-config.dto';
 import { UpdateAccessTokenDto, UpdateLongLiveTokenDto, UpdateRefreshTokenDto } from './dto/update-token.dto';
 import { AccessTokenEntity, LongLiveTokenEntity, RefreshTokenEntity, TokenEntity } from './entities/auth.entity';
 import { AuthGuard } from './guards/auth.guard';
-import { DisplayAwareThrottlerGuard } from './guards/display-aware-throttler.guard';
 import { AuthConfigModel } from './models/config.model';
 import { AuthService } from './services/auth.service';
 import { CryptoService } from './services/crypto.service';
@@ -91,20 +90,9 @@ import { TokensService } from './services/tokens.service';
 		TokensTypeMapperService,
 		RegisterOwnerCommand,
 		ResetPasswordCommand,
-		// `APP_GUARD` providers in the same module's `providers` array execute
-		// in declared order. Keep `AuthGuard` first so `request.auth` is
-		// populated by the time `DisplayAwareThrottlerGuard` runs and reads
-		// `auth.ownerType` to decide whether to skip throttling. Splitting the
-		// two across separate modules would make execution order depend on
-		// module-load order, which is fragile across future refactors and
-		// would silently regress the display cold-boot fix.
 		{
 			provide: APP_GUARD,
 			useClass: AuthGuard,
-		},
-		{
-			provide: APP_GUARD,
-			useClass: DisplayAwareThrottlerGuard,
 		},
 	],
 	controllers: [AuthController, TokensController],

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -3,7 +3,6 @@ import crypto from 'crypto';
 import { CacheModule } from '@nestjs/cache-manager';
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule as NestConfigModule, ConfigService as NestConfigService } from '@nestjs/config';
-import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
@@ -31,7 +30,6 @@ import { CreateAccessTokenDto, CreateLongLiveTokenDto, CreateRefreshTokenDto } f
 import { UpdateAuthConfigDto } from './dto/update-config.dto';
 import { UpdateAccessTokenDto, UpdateLongLiveTokenDto, UpdateRefreshTokenDto } from './dto/update-token.dto';
 import { AccessTokenEntity, LongLiveTokenEntity, RefreshTokenEntity, TokenEntity } from './entities/auth.entity';
-import { AuthGuard } from './guards/auth.guard';
 import { AuthConfigModel } from './models/config.model';
 import { AuthService } from './services/auth.service';
 import { CryptoService } from './services/crypto.service';
@@ -90,12 +88,12 @@ import { TokensService } from './services/tokens.service';
 		TokensTypeMapperService,
 		RegisterOwnerCommand,
 		ResetPasswordCommand,
-		{
-			provide: APP_GUARD,
-			useClass: AuthGuard,
-		},
 	],
 	controllers: [AuthController, TokensController],
+	// `AuthGuard` and `DisplayAwareThrottlerGuard` are intentionally NOT
+	// registered here as `APP_GUARD` providers — they live in `AppModule`
+	// instead. See the comment in `app.module.ts` next to the providers
+	// list for why ordering between them must be controlled at one place.
 	exports: [AuthService, TokensService, CryptoService, TokensTypeMapperService, JwtModule],
 })
 export class AuthModule implements OnModuleInit {

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -32,6 +32,7 @@ import { UpdateAuthConfigDto } from './dto/update-config.dto';
 import { UpdateAccessTokenDto, UpdateLongLiveTokenDto, UpdateRefreshTokenDto } from './dto/update-token.dto';
 import { AccessTokenEntity, LongLiveTokenEntity, RefreshTokenEntity, TokenEntity } from './entities/auth.entity';
 import { AuthGuard } from './guards/auth.guard';
+import { DisplayAwareThrottlerGuard } from './guards/display-aware-throttler.guard';
 import { AuthConfigModel } from './models/config.model';
 import { AuthService } from './services/auth.service';
 import { CryptoService } from './services/crypto.service';
@@ -90,9 +91,20 @@ import { TokensService } from './services/tokens.service';
 		TokensTypeMapperService,
 		RegisterOwnerCommand,
 		ResetPasswordCommand,
+		// `APP_GUARD` providers in the same module's `providers` array execute
+		// in declared order. Keep `AuthGuard` first so `request.auth` is
+		// populated by the time `DisplayAwareThrottlerGuard` runs and reads
+		// `auth.ownerType` to decide whether to skip throttling. Splitting the
+		// two across separate modules would make execution order depend on
+		// module-load order, which is fragile across future refactors and
+		// would silently regress the display cold-boot fix.
 		{
 			provide: APP_GUARD,
 			useClass: AuthGuard,
+		},
+		{
+			provide: APP_GUARD,
+			useClass: DisplayAwareThrottlerGuard,
 		},
 	],
 	controllers: [AuthController, TokensController],

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -24,6 +24,15 @@ import { AuthGuard, AuthenticatedRequest, IS_PUBLIC_KEY } from './auth.guard';
 
 jest.mock('../utils/token.utils', () => ({
 	hashToken: jest.fn((token) => `hashed-${token}`),
+	// `extractAccessTokenFromHeader` was promoted to a shared util when the
+	// `DisplayAwareThrottlerGuard` was added; preserve the historical
+	// behavior previously inlined as `extractTokenFromHeader` on the guard.
+	extractAccessTokenFromHeader: jest.fn((request: { headers: { authorization?: string } }) => {
+		const header = request?.headers?.authorization;
+		if (!header) return undefined;
+		const [scheme, token] = header.split(' ');
+		return scheme === 'Bearer' ? token : undefined;
+	}),
 }));
 
 describe('AuthGuard', () => {

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -19,7 +19,8 @@ import { ApiPublic } from '../../swagger/decorators/api-documentation.decorator'
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
-import { ACCESS_TOKEN_TYPE, AUTH_MODULE_NAME, TokenOwnerType } from '../auth.constants';
+import { AUTH_MODULE_NAME, TokenOwnerType } from '../auth.constants';
+import { extractAccessTokenFromHeader } from '../utils/token.utils';
 import { AccessTokenEntity } from '../entities/auth.entity';
 import { TokensService } from '../services/tokens.service';
 import { hashToken } from '../utils/token.utils';
@@ -92,7 +93,7 @@ export class AuthGuard implements CanActivate {
 		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
 
 		// Try authenticating with JWT (Bearer token)
-		const token = this.extractTokenFromHeader(request);
+		const token = extractAccessTokenFromHeader(request);
 
 		if (token && (await this.validateToken(request, token))) {
 			return true;
@@ -252,17 +253,5 @@ export class AuthGuard implements CanActivate {
 		this.logger.debug(`Long-live token authentication successful (ownerType=${storedLongLiveToken.ownerType})`);
 
 		return true;
-	}
-
-	private extractTokenFromHeader(request: Request): string | undefined {
-		const authHeader = request.headers.authorization;
-
-		if (!authHeader) {
-			return undefined;
-		}
-
-		const [type, token] = authHeader.split(' ');
-
-		return type === ACCESS_TOKEN_TYPE ? token : undefined;
 	}
 }

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -20,10 +20,9 @@ import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
 import { AUTH_MODULE_NAME, TokenOwnerType } from '../auth.constants';
-import { extractAccessTokenFromHeader } from '../utils/token.utils';
 import { AccessTokenEntity } from '../entities/auth.entity';
 import { TokensService } from '../services/tokens.service';
-import { hashToken } from '../utils/token.utils';
+import { extractAccessTokenFromHeader, hashToken } from '../utils/token.utils';
 
 export const IS_PUBLIC_KEY = 'isPublic';
 

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -228,8 +228,9 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 
 	it('caches a negative verdict so a forged-token flood verifies only once', async () => {
 		// Same forged token re-sent: signature check runs once, the failure
-		// is cached, and subsequent requests defer to the throttler counters
-		// without re-paying for crypto.
+		// is cached, and subsequent requests defer to the parent's
+		// `shouldSkip` (no re-verify, but parent metadata like
+		// `@SkipThrottle` / `skipIf` is still honored — Cursor Low).
 		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
 		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
 		const ctx = () => buildContext({ authorization: 'Bearer forged.display.token' });
@@ -239,6 +240,36 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 		expect(await callShouldSkip(ctx())).toBe(false);
 
 		expect(jwtService.verifyAsync).toHaveBeenCalledTimes(1);
+	});
+
+	// Cursor Low: the cached-negative branch must defer to
+	// `super.shouldSkip(context)` rather than returning `false` directly,
+	// so any logic the parent `ThrottlerGuard.shouldSkip` runs (now or
+	// after a future `@nestjs/throttler` upgrade) stays honored for
+	// cached-negative tokens. In v6.5.0 the parent's `shouldSkip` is a
+	// no-op returning `false`, so observable behavior is identical
+	// today; we spy on the call directly to lock the contract in.
+	it('routes cached-negative tokens through super.shouldSkip', async () => {
+		// First request: decode passes, verify fails, negative cached.
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
+		await callShouldSkip(buildContext({ authorization: 'Bearer forged.display.token' }));
+
+		// Spy on the parent's `shouldSkip` BEFORE the second call so we
+		// can assert delegation. Parent prototype is two levels up:
+		// `DisplayAwareThrottlerGuard` → `ThrottlerGuard` → Object.
+		const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(guard)) as { shouldSkip: jest.Mock };
+		const superSkipSpy = jest.spyOn(parentProto, 'shouldSkip').mockResolvedValue(false);
+
+		// Second request: same forged token, cache is hot.
+		const result = await callShouldSkip(buildContext({ authorization: 'Bearer forged.display.token' }));
+
+		expect(result).toBe(false);
+		expect(superSkipSpy).toHaveBeenCalledTimes(1);
+		// And we still didn't pay for re-verify on the second request.
+		expect(jwtService.verifyAsync).toHaveBeenCalledTimes(1);
+
+		superSkipSpy.mockRestore();
 	});
 
 	// Codex P1 (round 3): per-token cache is defeated by an attacker who

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -240,4 +240,33 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 
 		expect(jwtService.verifyAsync).toHaveBeenCalledTimes(1);
 	});
+
+	// Codex P1 (round 3): per-token cache is defeated by an attacker who
+	// rotates the Bearer string per request — every new token is a cache
+	// miss, the cheap-decode pre-filter passes (attacker controls the
+	// unsigned `type` claim), so `verifyAsync` would fire on every
+	// request without an additional bound. The token-bucket gate caps
+	// worst-case crypto throughput at `MAX_VERIFY_PER_SEC` regardless of
+	// attacker token rotation.
+	it('falls through to the throttler when the global verify token bucket is drained', async () => {
+		// Force the bucket empty by setting the internal state directly.
+		// Going through `tryConsumeVerifyToken` 200× in a loop is racy on
+		// CI workers — each iteration reads `Date.now()` and refills at
+		// `MAX_VERIFY_PER_SEC`/sec, so a slow-enough loop keeps the bucket
+		// net-flat. Setting state directly is the deterministic way to
+		// assert what `shouldSkip` does when the bucket is already drained.
+		const bucketState = guard as unknown as { verifyTokens: number; verifyTokensRefilledAt: number };
+		bucketState.verifyTokens = 0;
+		bucketState.verifyTokensRefilledAt = Date.now();
+
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+
+		const skipped = await callShouldSkip(buildContext({ authorization: 'Bearer rotating.forged.token' }));
+
+		expect(skipped).toBe(false);
+		// CRITICAL: the bucket short-circuit means `verifyAsync` did NOT
+		// run, so an attacker can't burn CPU by rotating tokens past the
+		// cache.
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
 });

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { Request } from 'express';
 import { v4 as uuid } from 'uuid';
 
@@ -20,7 +19,7 @@ type ContextOptions = {
 
 describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	let guard: DisplayAwareThrottlerGuard;
-	let jwtService: { verifyAsync: jest.Mock };
+	let jwtService: { verifyAsync: jest.Mock; decode: jest.Mock };
 	let reflector: { getAllAndOverride: jest.Mock };
 
 	const buildContext = ({ authorization, type = 'http' }: ContextOptions = {}): ExecutionContext => {
@@ -41,7 +40,16 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	};
 
 	beforeEach(async () => {
-		jwtService = { verifyAsync: jest.fn() };
+		jwtService = {
+			verifyAsync: jest.fn(),
+			// `decode` is the cheap base64-only pre-filter the guard uses to
+			// avoid running signature verification on tokens that don't even
+			// claim to be display-class. Most tests want it to mirror what
+			// `verifyAsync` would return; the DoS-amplification tests
+			// override it with a non-display payload to assert the
+			// short-circuit.
+			decode: jest.fn(),
+		};
 		// `getAllAndOverride` is the standard reflector lookup the parent
 		// uses for `@Throttle` / `@SkipThrottle` metadata. Default to
 		// `undefined` (no per-route override); individual tests can stub
@@ -73,8 +81,15 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	const callShouldSkip = (ctx: ExecutionContext) =>
 		(guard as unknown as { shouldSkip(c: ExecutionContext): Promise<boolean> }).shouldSkip(ctx);
 
+	const stubDisplayPayload = (sub: string = uuid()) => {
+		const payload = { sub, type: TokenOwnerType.DISPLAY };
+		jwtService.decode.mockReturnValue(payload);
+		jwtService.verifyAsync.mockResolvedValue(payload);
+		return payload;
+	};
+
 	it('skips throttling for a request bearing a valid display JWT', async () => {
-		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		stubDisplayPayload();
 
 		const skipped = await callShouldSkip(buildContext({ authorization: 'Bearer display.signed.token' }));
 
@@ -83,18 +98,26 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	});
 
 	it('does NOT skip for valid USER (long-live) tokens', async () => {
-		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.USER });
+		// Cheap-decode pre-filter sees `type: USER` and short-circuits
+		// without ever paying for signature verification.
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.USER });
 
 		expect(await callShouldSkip(buildContext({ authorization: 'Bearer user.long.live.token' }))).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip for user access tokens (no `type` claim)', async () => {
-		jwtService.verifyAsync.mockResolvedValue({ sub: uuid() });
+		// User access tokens carry no `type` field, so the cheap decode
+		// pre-filter rejects them before any crypto runs.
+		jwtService.decode.mockReturnValue({ sub: uuid() });
 
 		expect(await callShouldSkip(buildContext({ authorization: 'Bearer user.access.token' }))).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip when the JWT signature is invalid', async () => {
+		// Forged token claims display, but signature check fails.
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
 		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
 
 		expect(await callShouldSkip(buildContext({ authorization: 'Bearer forged.bad.signature' }))).toBe(false);
@@ -102,18 +125,23 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 
 	it('does NOT skip when the Authorization header is missing', async () => {
 		expect(await callShouldSkip(buildContext({}))).toBe(false);
+		expect(jwtService.decode).not.toHaveBeenCalled();
 		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip for non-Bearer auth schemes', async () => {
 		expect(await callShouldSkip(buildContext({ authorization: 'Basic dXNlcjpwYXNz' }))).toBe(false);
+		expect(jwtService.decode).not.toHaveBeenCalled();
 		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip when the display payload lacks `sub`', async () => {
-		jwtService.verifyAsync.mockResolvedValue({ type: TokenOwnerType.DISPLAY });
+		// Pre-filter rejects display tokens missing `sub` without touching
+		// signature verification — saves a verify on the malformed path.
+		jwtService.decode.mockReturnValue({ type: TokenOwnerType.DISPLAY });
 
 		expect(await callShouldSkip(buildContext({ authorization: 'Bearer malformed.display' }))).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	// Cursor High: ws/rpc contexts have no `request.headers`. Defer to parent.
@@ -130,7 +158,7 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	// MUST take precedence — a stolen display token must not unlock unbounded
 	// brute-force on `/auth/login`.
 	it('does NOT skip when the route has an explicit @Throttle limit override', async () => {
-		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		stubDisplayPayload();
 		// Simulate `@Throttle({ default: { limit: 5, ttl: 60000 } })` on the route.
 		reflector.getAllAndOverride.mockImplementation((key: string) =>
 			key === THROTTLER_LIMIT + 'default' ? 5 : undefined,
@@ -147,7 +175,7 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	it('does NOT skip when the route has explicit @SkipThrottle metadata', async () => {
 		// `@SkipThrottle()` on a route means "the parent already decided" —
 		// the parent's `shouldSkip` will honor it; we just defer.
-		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		stubDisplayPayload();
 		reflector.getAllAndOverride.mockImplementation((key: string) =>
 			key === THROTTLER_SKIP + 'default' ? true : undefined,
 		);
@@ -156,5 +184,60 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 
 		expect(skipped).toBe(false);
 		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	// Codex P1 (round 2): `verifyAsync` is signature crypto and we MUST NOT
+	// pay it on every Bearer request, or a flood of forged tokens becomes a
+	// DoS amplification vector. The cheap base64 `decode` pre-filter handles
+	// the common-and-most-attacker-friendly case (token with `type !== display`)
+	// without any crypto cost.
+	it('avoids verifyAsync when decoded payload is not a display token', async () => {
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.USER });
+
+		await callShouldSkip(buildContext({ authorization: 'Bearer forged.user.shaped.token' }));
+
+		expect(jwtService.decode).toHaveBeenCalledWith('forged.user.shaped.token');
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	it('avoids verifyAsync when decode returns null (totally malformed token)', async () => {
+		// A garbage Bearer string — `JwtService.decode` returns `null` rather
+		// than throwing for many malformed inputs. We must still skip the
+		// crypto path.
+		jwtService.decode.mockReturnValue(null);
+
+		await callShouldSkip(buildContext({ authorization: 'Bearer not-even-a-jwt' }));
+
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	it('caches a positive verdict so a display burst only verifies once per token', async () => {
+		// The whole reason this guard exists: a registered display fires
+		// dozens of cache-warm requests on cold-boot. Verifying the JWT
+		// signature on each would defeat the throttle bypass's purpose
+		// (still a bottleneck) AND amplify any forged-token DoS.
+		stubDisplayPayload();
+		const ctx = () => buildContext({ authorization: 'Bearer display.signed.token' });
+
+		expect(await callShouldSkip(ctx())).toBe(true);
+		expect(await callShouldSkip(ctx())).toBe(true);
+		expect(await callShouldSkip(ctx())).toBe(true);
+
+		expect(jwtService.verifyAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it('caches a negative verdict so a forged-token flood verifies only once', async () => {
+		// Same forged token re-sent: signature check runs once, the failure
+		// is cached, and subsequent requests defer to the throttler counters
+		// without re-paying for crypto.
+		jwtService.decode.mockReturnValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
+		const ctx = () => buildContext({ authorization: 'Bearer forged.display.token' });
+
+		expect(await callShouldSkip(ctx())).toBe(false);
+		expect(await callShouldSkip(ctx())).toBe(false);
+		expect(await callShouldSkip(ctx())).toBe(false);
+
+		expect(jwtService.verifyAsync).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -7,131 +7,154 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerModuleOptions, ThrottlerStorage } from '@nestjs/throttler';
+import { THROTTLER_LIMIT, THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
 
 import { TokenOwnerType } from '../auth.constants';
 
 import { DisplayAwareThrottlerGuard } from './display-aware-throttler.guard';
 
+type ContextOptions = {
+	authorization?: string;
+	type?: 'http' | 'ws' | 'rpc';
+};
+
 describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	let guard: DisplayAwareThrottlerGuard;
 	let jwtService: { verifyAsync: jest.Mock };
+	let reflector: { getAllAndOverride: jest.Mock };
 
-	const buildContext = (authorization?: string): ExecutionContext => {
-		const request = {
-			headers: authorization ? { authorization } : {},
-		} as unknown as Request;
+	const buildContext = ({ authorization, type = 'http' }: ContextOptions = {}): ExecutionContext => {
+		const request =
+			type === 'http'
+				? ({ headers: authorization ? { authorization } : {} } as unknown as Request)
+				: ({} as unknown as Request);
 		return {
+			getType: () => type,
 			switchToHttp: () => ({
 				getRequest: <T>(): T => request as unknown as T,
 				getResponse: <T>(): T => ({}) as T,
 				getNext: <T>(): T => ({}) as T,
 			}),
-			getHandler: jest.fn(),
-			getClass: jest.fn(),
+			getHandler: jest.fn(() => 'handler'),
+			getClass: jest.fn(() => 'class'),
 		} as unknown as ExecutionContext;
 	};
 
 	beforeEach(async () => {
-		jwtService = {
-			verifyAsync: jest.fn(),
-		};
+		jwtService = { verifyAsync: jest.fn() };
+		// `getAllAndOverride` is the standard reflector lookup the parent
+		// uses for `@Throttle` / `@SkipThrottle` metadata. Default to
+		// `undefined` (no per-route override); individual tests can stub
+		// specific keys.
+		reflector = { getAllAndOverride: jest.fn().mockReturnValue(undefined) };
 
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				DisplayAwareThrottlerGuard,
-				Reflector,
+				{ provide: Reflector, useValue: reflector },
 				{
 					provide: 'THROTTLER:MODULE_OPTIONS',
-					useValue: { throttlers: [{ ttl: 60_000, limit: 30 }] } as ThrottlerModuleOptions,
+					useValue: { throttlers: [{ name: 'default', ttl: 60_000, limit: 30 }] } as ThrottlerModuleOptions,
 				},
 				{
 					provide: ThrottlerStorage,
 					useValue: { increment: jest.fn(), getRecord: jest.fn() } as unknown as ThrottlerStorage,
 				},
-				{
-					provide: JwtService,
-					useValue: jwtService,
-				},
+				{ provide: JwtService, useValue: jwtService },
 			],
 		}).compile();
 
 		guard = module.get<DisplayAwareThrottlerGuard>(DisplayAwareThrottlerGuard);
+		// `super.shouldSkip` reads `this.throttlers` (set by `onModuleInit`).
+		// Hydrate it manually since the test doesn't bootstrap the lifecycle.
+		(guard as unknown as { throttlers: { name: string }[] }).throttlers = [{ name: 'default' }];
 	});
 
 	const callShouldSkip = (ctx: ExecutionContext) =>
 		(guard as unknown as { shouldSkip(c: ExecutionContext): Promise<boolean> }).shouldSkip(ctx);
 
 	it('skips throttling for a request bearing a valid display JWT', async () => {
-		jwtService.verifyAsync.mockResolvedValue({
-			sub: uuid(),
-			type: TokenOwnerType.DISPLAY,
-		});
+		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
 
-		const skipped = await callShouldSkip(buildContext('Bearer display.signed.token'));
+		const skipped = await callShouldSkip(buildContext({ authorization: 'Bearer display.signed.token' }));
 
 		expect(skipped).toBe(true);
 		expect(jwtService.verifyAsync).toHaveBeenCalledWith('display.signed.token');
 	});
 
 	it('does NOT skip for valid USER (long-live) tokens', async () => {
-		jwtService.verifyAsync.mockResolvedValue({
-			sub: uuid(),
-			type: TokenOwnerType.USER,
-		});
+		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.USER });
 
-		const skipped = await callShouldSkip(buildContext('Bearer user.long.live.token'));
-
-		expect(skipped).toBe(false);
+		expect(await callShouldSkip(buildContext({ authorization: 'Bearer user.long.live.token' }))).toBe(false);
 	});
 
 	it('does NOT skip for user access tokens (no `type` claim)', async () => {
-		jwtService.verifyAsync.mockResolvedValue({
-			sub: uuid(),
-			// No `type` field — user access tokens omit it. AuthGuard treats
-			// `payload.sub && !payload.type` as the user-access-token branch.
-		});
+		jwtService.verifyAsync.mockResolvedValue({ sub: uuid() });
 
-		const skipped = await callShouldSkip(buildContext('Bearer user.access.token'));
-
-		expect(skipped).toBe(false);
+		expect(await callShouldSkip(buildContext({ authorization: 'Bearer user.access.token' }))).toBe(false);
 	});
 
 	it('does NOT skip when the JWT signature is invalid', async () => {
-		// Simulates a forged token claiming `type: display` — without a valid
-		// signature, the guard refuses to skip.
 		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
 
-		const skipped = await callShouldSkip(buildContext('Bearer forged.bad.signature'));
-
-		expect(skipped).toBe(false);
+		expect(await callShouldSkip(buildContext({ authorization: 'Bearer forged.bad.signature' }))).toBe(false);
 	});
 
 	it('does NOT skip when the Authorization header is missing', async () => {
-		// Anonymous flood to a protected route — the throttler MUST apply
-		// here; this is the primary protection path the guard preserves.
-		const skipped = await callShouldSkip(buildContext(undefined));
-
-		expect(skipped).toBe(false);
+		expect(await callShouldSkip(buildContext({}))).toBe(false);
 		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip for non-Bearer auth schemes', async () => {
-		const skipped = await callShouldSkip(buildContext('Basic dXNlcjpwYXNz'));
-
-		expect(skipped).toBe(false);
+		expect(await callShouldSkip(buildContext({ authorization: 'Basic dXNlcjpwYXNz' }))).toBe(false);
 		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 
 	it('does NOT skip when the display payload lacks `sub`', async () => {
-		// Defensive: a token that says `type: display` but omits `sub` is
-		// malformed and shouldn't unlock the bypass.
-		jwtService.verifyAsync.mockResolvedValue({
-			type: TokenOwnerType.DISPLAY,
-			// no sub
-		});
+		jwtService.verifyAsync.mockResolvedValue({ type: TokenOwnerType.DISPLAY });
 
-		const skipped = await callShouldSkip(buildContext('Bearer malformed.display'));
+		expect(await callShouldSkip(buildContext({ authorization: 'Bearer malformed.display' }))).toBe(false);
+	});
+
+	// Cursor High: ws/rpc contexts have no `request.headers`. Defer to parent.
+	it('does NOT touch headers on WebSocket contexts', async () => {
+		const skipped = await callShouldSkip(buildContext({ type: 'ws' }));
 
 		expect(skipped).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+		// Reflector reads only happen when context is HTTP — WS short-circuits.
+		expect(reflector.getAllAndOverride).not.toHaveBeenCalled();
+	});
+
+	// Codex P1: per-route `@Throttle({ limit: 5 })` (e.g. on auth endpoints)
+	// MUST take precedence — a stolen display token must not unlock unbounded
+	// brute-force on `/auth/login`.
+	it('does NOT skip when the route has an explicit @Throttle limit override', async () => {
+		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		// Simulate `@Throttle({ default: { limit: 5, ttl: 60000 } })` on the route.
+		reflector.getAllAndOverride.mockImplementation((key: string) =>
+			key === THROTTLER_LIMIT + 'default' ? 5 : undefined,
+		);
+
+		const skipped = await callShouldSkip(buildContext({ authorization: 'Bearer display.signed.token' }));
+
+		expect(skipped).toBe(false);
+		// The JWT verification step is never reached — the per-route override
+		// short-circuits before the display check.
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	it('does NOT skip when the route has explicit @SkipThrottle metadata', async () => {
+		// `@SkipThrottle()` on a route means "the parent already decided" —
+		// the parent's `shouldSkip` will honor it; we just defer.
+		jwtService.verifyAsync.mockResolvedValue({ sub: uuid(), type: TokenOwnerType.DISPLAY });
+		reflector.getAllAndOverride.mockImplementation((key: string) =>
+			key === THROTTLER_SKIP + 'default' ? true : undefined,
+		);
+
+		const skipped = await callShouldSkip(buildContext({ authorization: 'Bearer display.signed.token' }));
+
+		expect(skipped).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 	});
 });

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -1,0 +1,97 @@
+import { v4 as uuid } from 'uuid';
+
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModuleOptions, ThrottlerStorage } from '@nestjs/throttler';
+
+import { UserRole } from '../../users/users.constants';
+import { TokenOwnerType } from '../auth.constants';
+
+import { AuthenticatedRequest } from './auth.guard';
+import { DisplayAwareThrottlerGuard } from './display-aware-throttler.guard';
+
+describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
+	let guard: DisplayAwareThrottlerGuard;
+
+	const buildContext = (auth: AuthenticatedRequest['auth'] | undefined): ExecutionContext => {
+		const request = { auth } as AuthenticatedRequest;
+		return {
+			switchToHttp: () => ({
+				getRequest: <T>(): T => request as unknown as T,
+				getResponse: <T>(): T => ({}) as T,
+				getNext: <T>(): T => ({}) as T,
+			}),
+			getHandler: jest.fn(),
+			getClass: jest.fn(),
+		} as unknown as ExecutionContext;
+	};
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				DisplayAwareThrottlerGuard,
+				Reflector,
+				{
+					provide: 'THROTTLER:MODULE_OPTIONS',
+					useValue: { throttlers: [{ ttl: 60_000, limit: 30 }] } as ThrottlerModuleOptions,
+				},
+				{
+					provide: ThrottlerStorage,
+					useValue: { increment: jest.fn(), getRecord: jest.fn() } as unknown as ThrottlerStorage,
+				},
+			],
+		}).compile();
+
+		guard = module.get<DisplayAwareThrottlerGuard>(DisplayAwareThrottlerGuard);
+	});
+
+	it('skips throttling for requests authenticated with a display token', async () => {
+		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
+			buildContext({
+				type: 'token',
+				tokenId: uuid(),
+				ownerType: TokenOwnerType.DISPLAY,
+				ownerId: uuid(),
+				role: UserRole.USER,
+			}),
+		);
+
+		expect(skipped).toBe(true);
+	});
+
+	it('does NOT skip throttling for long-live USER tokens', async () => {
+		// Reflector returns no metadata → super.shouldSkip falls back to false.
+		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
+			buildContext({
+				type: 'token',
+				tokenId: uuid(),
+				ownerType: TokenOwnerType.USER,
+				ownerId: uuid(),
+				role: UserRole.ADMIN,
+			}),
+		);
+
+		expect(skipped).toBe(false);
+	});
+
+	it('does NOT skip throttling for web admin user sessions', async () => {
+		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
+			buildContext({ type: 'user', id: uuid(), role: UserRole.ADMIN }),
+		);
+
+		expect(skipped).toBe(false);
+	});
+
+	it('does NOT skip throttling for unauthenticated requests', async () => {
+		// `request.auth` is undefined when AuthGuard hasn't populated it yet
+		// (e.g. unauthenticated traffic that the global guard rejects later, or
+		// a transient module-load order in which AuthGuard runs after this).
+		// Fail-safe direction: throttle still applies.
+		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
+			buildContext(undefined),
+		);
+
+		expect(skipped).toBe(false);
+	});
+});

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.spec.ts
@@ -1,21 +1,25 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Request } from 'express';
 import { v4 as uuid } from 'uuid';
 
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerModuleOptions, ThrottlerStorage } from '@nestjs/throttler';
 
-import { UserRole } from '../../users/users.constants';
 import { TokenOwnerType } from '../auth.constants';
 
-import { AuthenticatedRequest } from './auth.guard';
 import { DisplayAwareThrottlerGuard } from './display-aware-throttler.guard';
 
 describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	let guard: DisplayAwareThrottlerGuard;
+	let jwtService: { verifyAsync: jest.Mock };
 
-	const buildContext = (auth: AuthenticatedRequest['auth'] | undefined): ExecutionContext => {
-		const request = { auth } as AuthenticatedRequest;
+	const buildContext = (authorization?: string): ExecutionContext => {
+		const request = {
+			headers: authorization ? { authorization } : {},
+		} as unknown as Request;
 		return {
 			switchToHttp: () => ({
 				getRequest: <T>(): T => request as unknown as T,
@@ -28,6 +32,10 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 	};
 
 	beforeEach(async () => {
+		jwtService = {
+			verifyAsync: jest.fn(),
+		};
+
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				DisplayAwareThrottlerGuard,
@@ -40,57 +48,89 @@ describe('DisplayAwareThrottlerGuard.shouldSkip', () => {
 					provide: ThrottlerStorage,
 					useValue: { increment: jest.fn(), getRecord: jest.fn() } as unknown as ThrottlerStorage,
 				},
+				{
+					provide: JwtService,
+					useValue: jwtService,
+				},
 			],
 		}).compile();
 
 		guard = module.get<DisplayAwareThrottlerGuard>(DisplayAwareThrottlerGuard);
 	});
 
-	it('skips throttling for requests authenticated with a display token', async () => {
-		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
-			buildContext({
-				type: 'token',
-				tokenId: uuid(),
-				ownerType: TokenOwnerType.DISPLAY,
-				ownerId: uuid(),
-				role: UserRole.USER,
-			}),
-		);
+	const callShouldSkip = (ctx: ExecutionContext) =>
+		(guard as unknown as { shouldSkip(c: ExecutionContext): Promise<boolean> }).shouldSkip(ctx);
+
+	it('skips throttling for a request bearing a valid display JWT', async () => {
+		jwtService.verifyAsync.mockResolvedValue({
+			sub: uuid(),
+			type: TokenOwnerType.DISPLAY,
+		});
+
+		const skipped = await callShouldSkip(buildContext('Bearer display.signed.token'));
 
 		expect(skipped).toBe(true);
+		expect(jwtService.verifyAsync).toHaveBeenCalledWith('display.signed.token');
 	});
 
-	it('does NOT skip throttling for long-live USER tokens', async () => {
-		// Reflector returns no metadata → super.shouldSkip falls back to false.
-		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
-			buildContext({
-				type: 'token',
-				tokenId: uuid(),
-				ownerType: TokenOwnerType.USER,
-				ownerId: uuid(),
-				role: UserRole.ADMIN,
-			}),
-		);
+	it('does NOT skip for valid USER (long-live) tokens', async () => {
+		jwtService.verifyAsync.mockResolvedValue({
+			sub: uuid(),
+			type: TokenOwnerType.USER,
+		});
+
+		const skipped = await callShouldSkip(buildContext('Bearer user.long.live.token'));
 
 		expect(skipped).toBe(false);
 	});
 
-	it('does NOT skip throttling for web admin user sessions', async () => {
-		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
-			buildContext({ type: 'user', id: uuid(), role: UserRole.ADMIN }),
-		);
+	it('does NOT skip for user access tokens (no `type` claim)', async () => {
+		jwtService.verifyAsync.mockResolvedValue({
+			sub: uuid(),
+			// No `type` field — user access tokens omit it. AuthGuard treats
+			// `payload.sub && !payload.type` as the user-access-token branch.
+		});
+
+		const skipped = await callShouldSkip(buildContext('Bearer user.access.token'));
 
 		expect(skipped).toBe(false);
 	});
 
-	it('does NOT skip throttling for unauthenticated requests', async () => {
-		// `request.auth` is undefined when AuthGuard hasn't populated it yet
-		// (e.g. unauthenticated traffic that the global guard rejects later, or
-		// a transient module-load order in which AuthGuard runs after this).
-		// Fail-safe direction: throttle still applies.
-		const skipped = await (guard as unknown as { shouldSkip(ctx: ExecutionContext): Promise<boolean> }).shouldSkip(
-			buildContext(undefined),
-		);
+	it('does NOT skip when the JWT signature is invalid', async () => {
+		// Simulates a forged token claiming `type: display` — without a valid
+		// signature, the guard refuses to skip.
+		jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
+
+		const skipped = await callShouldSkip(buildContext('Bearer forged.bad.signature'));
+
+		expect(skipped).toBe(false);
+	});
+
+	it('does NOT skip when the Authorization header is missing', async () => {
+		// Anonymous flood to a protected route — the throttler MUST apply
+		// here; this is the primary protection path the guard preserves.
+		const skipped = await callShouldSkip(buildContext(undefined));
+
+		expect(skipped).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	it('does NOT skip for non-Bearer auth schemes', async () => {
+		const skipped = await callShouldSkip(buildContext('Basic dXNlcjpwYXNz'));
+
+		expect(skipped).toBe(false);
+		expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+	});
+
+	it('does NOT skip when the display payload lacks `sub`', async () => {
+		// Defensive: a token that says `type: display` but omits `sub` is
+		// malformed and shouldn't unlock the bypass.
+		jwtService.verifyAsync.mockResolvedValue({
+			type: TokenOwnerType.DISPLAY,
+			// no sub
+		});
+
+		const skipped = await callShouldSkip(buildContext('Bearer malformed.display'));
 
 		expect(skipped).toBe(false);
 	});

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -10,8 +10,10 @@ import {
 	ThrottlerModuleOptions,
 	ThrottlerStorage,
 } from '@nestjs/throttler';
+import { THROTTLER_LIMIT, THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
 
-import { ACCESS_TOKEN_TYPE, TokenOwnerType } from '../auth.constants';
+import { TokenOwnerType } from '../auth.constants';
+import { extractAccessTokenFromHeader } from '../utils/token.utils';
 
 interface JwtPayload {
 	sub?: string;
@@ -20,7 +22,7 @@ interface JwtPayload {
 
 /**
  * `ThrottlerGuard` variant that exempts requests authenticated as a
- * registered display.
+ * registered display from the **default** global throttle.
  *
  * Displays are paired into the installation via the registration flow
  * (`POST /modules/displays/register`) and intentionally burst N+M reads on
@@ -33,25 +35,35 @@ interface JwtPayload {
  *
  * **Why this guard does its own token check** (instead of reading
  * `request.auth` populated by `AuthGuard`): registering the throttler
- * after `AuthGuard` would let unauthenticated traffic to protected
- * endpoints short-circuit at 401 before the throttler runs, leaving
- * anonymous floods unthrottled. The throttler MUST run first to keep
- * that protection. To still know whether the caller is a display, this
- * guard does a lightweight JWT signature check (no DB lookup) on the
- * bearer token: if the signature verifies AND `payload.type` is
- * `TokenOwnerType.DISPLAY`, throttling is skipped. `AuthGuard` later
- * runs the full DB-backed validation (revocation, expiry, owner exists).
+ * after `AuthGuard` lets unauthenticated traffic to protected endpoints
+ * short-circuit at 401 before the throttler runs, leaving anonymous
+ * floods unthrottled. The throttler MUST run first to keep that
+ * protection. To still know whether the caller is a display, this guard
+ * does a lightweight JWT signature check (no DB lookup) on the bearer
+ * token.
+ *
+ * **What this guard never bypasses:**
+ * - Routes with explicit `@Throttle({ ... })` overrides — e.g.
+ *   `auth.controller.ts` uses `@Throttle({ default: { limit: 5 } })` for
+ *   brute-force protection on `/login`, `/register`, `/refresh`, etc.
+ *   A stolen display token must NOT unlock unbounded credential probing
+ *   on those endpoints, so any per-route/class limit override defers to
+ *   the parent `ThrottlerGuard` behavior.
+ * - Routes with explicit `@SkipThrottle()` — already opted out at the
+ *   route level; defer to the parent.
+ * - Non-HTTP execution contexts (WebSocket `@SubscribeMessage`, RPC).
+ *   `context.switchToHttp().getRequest()` returns the underlying socket
+ *   for those, which has no `.headers` property and would crash; defer
+ *   to the parent (which already handles WebSocket via `@SkipThrottle()`
+ *   on `WebsocketGateway`).
  *
  * **Trust boundary.** A revoked-but-not-yet-expired display token would
- * bypass throttling for the brief window before `AuthGuard` rejects with
- * 401. That's an acceptable trade — every such request still 401s, and
- * issuing a new display token requires physical access to the
- * registration flow. The bypass only widens the door for trusted
- * device-class clients holding signed tokens, not arbitrary attackers.
- *
- * Web admin sessions, long-live user tokens, anonymous traffic, missing
- * Authorization headers, non-Bearer schemes, and tokens with bad
- * signatures all fall through to the default throttle.
+ * bypass the default throttle for the brief window before `AuthGuard`
+ * rejects with 401. That's an acceptable trade — every such request
+ * still 401s, and issuing a new display token requires physical access
+ * to the registration flow. The bypass widens only for trusted
+ * device-class clients holding signed tokens against the default
+ * throttle, never against per-route stricter limits.
  */
 @Injectable()
 export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
@@ -65,9 +77,31 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 	}
 
 	protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
-		const request = context.switchToHttp().getRequest<Request>();
-		const token = this.extractTokenFromHeader(request);
+		// Non-HTTP contexts (WebSocket, RPC) — `request.headers` doesn't
+		// exist on the underlying transport object. Defer to parent which
+		// honors `@SkipThrottle()` on the gateway.
+		if (context.getType() !== 'http') {
+			return super.shouldSkip(context);
+		}
 
+		// Routes with their own `@Throttle()` / `@SkipThrottle()` metadata
+		// take precedence — never blanket-skip a stricter per-route limit
+		// (auth endpoints rely on `@Throttle({ default: { limit: 5 } })`
+		// for brute-force protection; a display-token-bearing client must
+		// not unlock unbounded probing of those endpoints).
+		const handler = context.getHandler();
+		const classRef = context.getClass();
+		const hasExplicitOverride = this.throttlers.some((throttler) => {
+			const limit = this.reflector.getAllAndOverride<unknown>(THROTTLER_LIMIT + throttler.name, [handler, classRef]);
+			const skip = this.reflector.getAllAndOverride<unknown>(THROTTLER_SKIP + throttler.name, [handler, classRef]);
+			return limit !== undefined || skip !== undefined;
+		});
+		if (hasExplicitOverride) {
+			return super.shouldSkip(context);
+		}
+
+		const request = context.switchToHttp().getRequest<Request>();
+		const token = extractAccessTokenFromHeader(request);
 		if (token) {
 			try {
 				const payload: JwtPayload = await this.jwtService.verifyAsync(token);
@@ -82,14 +116,5 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 		}
 
 		return super.shouldSkip(context);
-	}
-
-	private extractTokenFromHeader(request: Request): string | undefined {
-		const authHeader = request.headers.authorization;
-		if (!authHeader) {
-			return undefined;
-		}
-		const [type, token] = authHeader.split(' ');
-		return type === ACCESS_TOKEN_TYPE ? token : undefined;
 	}
 }

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -1,0 +1,42 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { TokenOwnerType } from '../auth.constants';
+
+import { AuthenticatedRequest } from './auth.guard';
+
+/**
+ * `ThrottlerGuard` variant that exempts requests authenticated as a
+ * registered display.
+ *
+ * Displays are paired into the installation via the registration flow
+ * (`POST /modules/displays/register`) and intentionally burst N+M reads on
+ * cold-boot to warm their local cache (devices → device controls → channels
+ * → channel controls → validation, plus weather/system/spaces/scenes/etc.).
+ * The default `30 req / 60s` budget is sized for unauthenticated and
+ * human/admin traffic; without an exemption the cache-warm waterfall trips
+ * the throttle on any non-trivial install and the panel surfaces opaque
+ * `null - null` errors that propagate up as a hard init failure.
+ *
+ * Web admin sessions, long-live user tokens, and unauthenticated traffic
+ * still hit the default throttle, so this only widens the door for trusted
+ * device-class clients — it doesn't disable rate-limiting globally.
+ *
+ * Falls back to default throttle behavior whenever `request.auth` isn't
+ * populated (e.g. if `AuthGuard` ever runs after this one due to a future
+ * module-load order change). The fail-safe direction is "throttle still
+ * applies", never "throttle accidentally removed".
+ */
+@Injectable()
+export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
+	protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
+		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+		const auth = request.auth;
+
+		if (auth?.type === 'token' && auth.ownerType === TokenOwnerType.DISPLAY) {
+			return true;
+		}
+
+		return super.shouldSkip(context);
+	}
+}

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -1,9 +1,22 @@
+import { Request } from 'express';
+
 import { ExecutionContext, Injectable } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import {
+	InjectThrottlerOptions,
+	InjectThrottlerStorage,
+	ThrottlerGuard,
+	ThrottlerModuleOptions,
+	ThrottlerStorage,
+} from '@nestjs/throttler';
 
-import { TokenOwnerType } from '../auth.constants';
+import { ACCESS_TOKEN_TYPE, TokenOwnerType } from '../auth.constants';
 
-import { AuthenticatedRequest } from './auth.guard';
+interface JwtPayload {
+	sub?: string;
+	type?: string;
+}
 
 /**
  * `ThrottlerGuard` variant that exempts requests authenticated as a
@@ -18,33 +31,65 @@ import { AuthenticatedRequest } from './auth.guard';
  * the throttle on any non-trivial install and the panel surfaces opaque
  * `null - null` errors that propagate up as a hard init failure.
  *
- * Web admin sessions, long-live user tokens, and unauthenticated traffic
- * still hit the default throttle, so this only widens the door for trusted
- * device-class clients — it doesn't disable rate-limiting globally.
+ * **Why this guard does its own token check** (instead of reading
+ * `request.auth` populated by `AuthGuard`): registering the throttler
+ * after `AuthGuard` would let unauthenticated traffic to protected
+ * endpoints short-circuit at 401 before the throttler runs, leaving
+ * anonymous floods unthrottled. The throttler MUST run first to keep
+ * that protection. To still know whether the caller is a display, this
+ * guard does a lightweight JWT signature check (no DB lookup) on the
+ * bearer token: if the signature verifies AND `payload.type` is
+ * `TokenOwnerType.DISPLAY`, throttling is skipped. `AuthGuard` later
+ * runs the full DB-backed validation (revocation, expiry, owner exists).
  *
- * **Ordering invariant.** This guard depends on `AuthGuard` having
- * populated `request.auth` first. That ordering is enforced by registering
- * both guards as `APP_GUARD` providers inside `AuthModule.providers`, with
- * `AuthGuard` declared *before* this one — within a single module, NestJS
- * executes `APP_GUARD` providers in declared array order. Do not move
- * either registration to a different module; the cross-module load order
- * isn't stable enough to rely on.
+ * **Trust boundary.** A revoked-but-not-yet-expired display token would
+ * bypass throttling for the brief window before `AuthGuard` rejects with
+ * 401. That's an acceptable trade — every such request still 401s, and
+ * issuing a new display token requires physical access to the
+ * registration flow. The bypass only widens the door for trusted
+ * device-class clients holding signed tokens, not arbitrary attackers.
  *
- * Even with that invariant the check is conservative: if `request.auth`
- * is somehow `undefined`, the call falls through to `super.shouldSkip()`
- * and the default throttle applies. The fail-safe direction is "throttle
- * still applies", never "throttle accidentally removed".
+ * Web admin sessions, long-live user tokens, anonymous traffic, missing
+ * Authorization headers, non-Bearer schemes, and tokens with bad
+ * signatures all fall through to the default throttle.
  */
 @Injectable()
 export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
-	protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
-		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
-		const auth = request.auth;
+	constructor(
+		@InjectThrottlerOptions() options: ThrottlerModuleOptions,
+		@InjectThrottlerStorage() storageService: ThrottlerStorage,
+		reflector: Reflector,
+		private readonly jwtService: JwtService,
+	) {
+		super(options, storageService, reflector);
+	}
 
-		if (auth?.type === 'token' && auth.ownerType === TokenOwnerType.DISPLAY) {
-			return true;
+	protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
+		const request = context.switchToHttp().getRequest<Request>();
+		const token = this.extractTokenFromHeader(request);
+
+		if (token) {
+			try {
+				const payload: JwtPayload = await this.jwtService.verifyAsync(token);
+				if ((payload.type as TokenOwnerType) === TokenOwnerType.DISPLAY && payload.sub) {
+					return true;
+				}
+			} catch {
+				// Invalid signature / expired / malformed — do NOT skip; let
+				// the throttler apply normally so a flood of bad tokens still
+				// counts toward the budget. AuthGuard will return the 401.
+			}
 		}
 
 		return super.shouldSkip(context);
+	}
+
+	private extractTokenFromHeader(request: Request): string | undefined {
+		const authHeader = request.headers.authorization;
+		if (!authHeader) {
+			return undefined;
+		}
+		const [type, token] = authHeader.split(' ');
+		return type === ACCESS_TOKEN_TYPE ? token : undefined;
 	}
 }

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -22,10 +22,18 @@ import { AuthenticatedRequest } from './auth.guard';
  * still hit the default throttle, so this only widens the door for trusted
  * device-class clients — it doesn't disable rate-limiting globally.
  *
- * Falls back to default throttle behavior whenever `request.auth` isn't
- * populated (e.g. if `AuthGuard` ever runs after this one due to a future
- * module-load order change). The fail-safe direction is "throttle still
- * applies", never "throttle accidentally removed".
+ * **Ordering invariant.** This guard depends on `AuthGuard` having
+ * populated `request.auth` first. That ordering is enforced by registering
+ * both guards as `APP_GUARD` providers inside `AuthModule.providers`, with
+ * `AuthGuard` declared *before* this one — within a single module, NestJS
+ * executes `APP_GUARD` providers in declared array order. Do not move
+ * either registration to a different module; the cross-module load order
+ * isn't stable enough to rely on.
+ *
+ * Even with that invariant the check is conservative: if `request.auth`
+ * is somehow `undefined`, the call falls through to `super.shouldSkip()`
+ * and the default throttle applies. The fail-safe direction is "throttle
+ * still applies", never "throttle accidentally removed".
  */
 @Injectable()
 export class DisplayAwareThrottlerGuard extends ThrottlerGuard {

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -39,6 +39,24 @@ const VERIFY_CACHE_MAX_ENTRIES = 1_000;
 type VerifyCacheEntry = { ok: boolean; expiresAt: number };
 
 /**
+ * Process-wide token-bucket cap on `verifyAsync` calls per second.
+ *
+ * Closes the residual DoS amplification vector where an attacker
+ * rotates the Bearer token string per request — each new token is a
+ * cache miss, the cheap-decode pre-filter passes (the attacker
+ * controls the unsigned payload and stamps `type: "display"`), so
+ * `verifyAsync` would fire on every request. The token-bucket bounds
+ * worst-case crypto throughput to `MAX_VERIFY_PER_SEC` regardless of
+ * attacker token-rotation strategy or distribution across IPs.
+ *
+ * Sized 200/sec — comfortably above any legitimate-display footprint
+ * (each display verifies once per `VERIFY_CACHE_TTL_MS` window;
+ * hundreds of displays cold-booting in lockstep would still fit) but
+ * far below any plausible CPU-saturation threshold.
+ */
+const MAX_VERIFY_PER_SEC = 200;
+
+/**
  * `ThrottlerGuard` variant that exempts requests authenticated as a
  * registered display from the **default** global throttle.
  *
@@ -65,14 +83,20 @@ type VerifyCacheEntry = { ok: boolean; expiresAt: number };
  * limiter has a chance to 429 the request. Naively calling
  * `verifyAsync()` on every Bearer token would force expensive signature
  * crypto on every flooded request, turning the throttler's "cheap DoS
- * gate" role into an asymmetric amplification vector. Two defenses:
+ * gate" role into an asymmetric amplification vector. Three defenses
+ * stack:
  *   1. `JwtService.decode()` (pure base64, no crypto) reads the
  *      unverified `type` claim. If it isn't `display`, we never call
  *      `verifyAsync` — forged "user-shaped" floods cost ~0.
  *   2. A bounded LRU cache (`hashToken(token) → verdict`, 60s TTL,
  *      1000 entries) memoizes the verdict for both legitimate display
- *      bursts and repeated-forged-token floods. An attacker has to
- *      generate a new JWT per request to keep paying the verify cost.
+ *      bursts and repeated-forged-token floods.
+ *   3. A process-wide token bucket caps `verifyAsync` calls at
+ *      `MAX_VERIFY_PER_SEC` so an attacker who rotates the Bearer
+ *      string per request (defeating the per-token cache) still can't
+ *      drive crypto cost beyond a fixed ceiling. When the bucket is
+ *      drained, requests fall through to the parent throttler counter
+ *      without paying for verification.
  *
  * **What this guard never bypasses:**
  * - Routes with explicit `@Throttle({ ... })` overrides — e.g.
@@ -96,10 +120,27 @@ type VerifyCacheEntry = { ok: boolean; expiresAt: number };
  * to the registration flow. The bypass widens only for trusted
  * device-class clients holding signed tokens against the default
  * throttle, never against per-route stricter limits.
+ *
+ * **DoS posture.** The combined effect of (1) decode pre-filter, (2)
+ * verify cache, and (3) global verify token-bucket is that worst-case
+ * crypto throughput from this guard is bounded at `MAX_VERIFY_PER_SEC`
+ * regardless of attacker token-rotation strategy or distribution
+ * across IPs. Anything beyond that ceiling falls through to the
+ * parent throttler counters (per-IP `30 req / 60s` by default) and
+ * eventually returns 429 without paying for `verifyAsync`.
  */
 @Injectable()
 export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 	private readonly verifyCache = new Map<string, VerifyCacheEntry>();
+
+	// Token-bucket state for the global `verifyAsync` rate limit.
+	// `verifyTokens` is a fractional count refilled at
+	// `MAX_VERIFY_PER_SEC` per second up to a max of `MAX_VERIFY_PER_SEC`.
+	// Each `verifyAsync` call consumes 1 token; if the bucket is drained
+	// the request defers to the parent throttler instead of paying for
+	// signature crypto. See `tryConsumeVerifyToken`.
+	private verifyTokens = MAX_VERIFY_PER_SEC;
+	private verifyTokensRefilledAt = Date.now();
 
 	constructor(
 		@InjectThrottlerOptions() options: ThrottlerModuleOptions,
@@ -164,11 +205,19 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 			return cached;
 		}
 
-		// Cache miss + payload claims display — pay the verify cost
-		// once and cache the verdict. A flood of distinct forged
-		// "display-shaped" tokens still triggers verifyAsync on each
-		// new token, but the attacker has to GENERATE each token, so
-		// the cost is no longer asymmetric.
+		// Process-wide verify rate limit. Closes the residual attack
+		// where an attacker rotates the Bearer string per request
+		// (defeating the per-token cache) — once the bucket is drained
+		// the request defers to the parent throttler counter without
+		// paying for signature crypto. Legitimate display traffic
+		// almost never hits this because each display verifies once
+		// per `VERIFY_CACHE_TTL_MS` window.
+		if (!this.tryConsumeVerifyToken()) {
+			return super.shouldSkip(context);
+		}
+
+		// Cache miss + payload claims display + budget available —
+		// pay the verify cost once and cache the verdict.
 		try {
 			const verified: JwtPayload = await this.jwtService.verifyAsync(token);
 			const ok = (verified.type as TokenOwnerType) === TokenOwnerType.DISPLAY && !!verified.sub;
@@ -185,6 +234,24 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 		}
 
 		return super.shouldSkip(context);
+	}
+
+	/**
+	 * Token-bucket consumer. Refills `MAX_VERIFY_PER_SEC` tokens per
+	 * second up to a `MAX_VERIFY_PER_SEC` cap, debits 1 token per
+	 * `verifyAsync` call. Returns `false` (no token available) only
+	 * when the process is already running at the configured ceiling.
+	 */
+	private tryConsumeVerifyToken(): boolean {
+		const now = Date.now();
+		const elapsedSec = (now - this.verifyTokensRefilledAt) / 1000;
+		this.verifyTokens = Math.min(MAX_VERIFY_PER_SEC, this.verifyTokens + elapsedSec * MAX_VERIFY_PER_SEC);
+		this.verifyTokensRefilledAt = now;
+		if (this.verifyTokens < 1) {
+			return false;
+		}
+		this.verifyTokens -= 1;
+		return true;
 	}
 
 	private safeDecode(token: string): JwtPayload | null {

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -13,12 +13,30 @@ import {
 import { THROTTLER_LIMIT, THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
 
 import { TokenOwnerType } from '../auth.constants';
-import { extractAccessTokenFromHeader } from '../utils/token.utils';
+import { extractAccessTokenFromHeader, hashToken } from '../utils/token.utils';
 
 interface JwtPayload {
 	sub?: string;
 	type?: string;
 }
+
+/**
+ * In-memory cache of `hashToken(token) → verified-display-or-not` for
+ * tokens we've already signature-checked. Keeps the hot-path cost of a
+ * legitimate display burst flat (one verify per token per TTL window)
+ * AND blunts the DoS amplification vector where a flood of forged
+ * Bearer tokens with `type: "display"` would otherwise force a fresh
+ * `verifyAsync` per request.
+ *
+ * Bounded LRU semantics: once we hit `MAX_ENTRIES` we drop the oldest
+ * insertion. An attacker with millions of distinct forged tokens still
+ * pays the verify cost on each new token, but they also pay the cost of
+ * GENERATING that many distinct JWTs — the attack stops being
+ * asymmetric.
+ */
+const VERIFY_CACHE_TTL_MS = 60_000;
+const VERIFY_CACHE_MAX_ENTRIES = 1_000;
+type VerifyCacheEntry = { ok: boolean; expiresAt: number };
 
 /**
  * `ThrottlerGuard` variant that exempts requests authenticated as a
@@ -41,6 +59,20 @@ interface JwtPayload {
  * protection. To still know whether the caller is a display, this guard
  * does a lightweight JWT signature check (no DB lookup) on the bearer
  * token.
+ *
+ * **Why we cheap-decode before verifying.** `shouldSkip` runs in the
+ * pre-accounting phase of `ThrottlerGuard.canActivate`, BEFORE the rate
+ * limiter has a chance to 429 the request. Naively calling
+ * `verifyAsync()` on every Bearer token would force expensive signature
+ * crypto on every flooded request, turning the throttler's "cheap DoS
+ * gate" role into an asymmetric amplification vector. Two defenses:
+ *   1. `JwtService.decode()` (pure base64, no crypto) reads the
+ *      unverified `type` claim. If it isn't `display`, we never call
+ *      `verifyAsync` — forged "user-shaped" floods cost ~0.
+ *   2. A bounded LRU cache (`hashToken(token) → verdict`, 60s TTL,
+ *      1000 entries) memoizes the verdict for both legitimate display
+ *      bursts and repeated-forged-token floods. An attacker has to
+ *      generate a new JWT per request to keep paying the verify cost.
  *
  * **What this guard never bypasses:**
  * - Routes with explicit `@Throttle({ ... })` overrides — e.g.
@@ -67,6 +99,8 @@ interface JwtPayload {
  */
 @Injectable()
 export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
+	private readonly verifyCache = new Map<string, VerifyCacheEntry>();
+
 	constructor(
 		@InjectThrottlerOptions() options: ThrottlerModuleOptions,
 		@InjectThrottlerStorage() storageService: ThrottlerStorage,
@@ -102,19 +136,94 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 
 		const request = context.switchToHttp().getRequest<Request>();
 		const token = extractAccessTokenFromHeader(request);
-		if (token) {
-			try {
-				const payload: JwtPayload = await this.jwtService.verifyAsync(token);
-				if ((payload.type as TokenOwnerType) === TokenOwnerType.DISPLAY && payload.sub) {
-					return true;
-				}
-			} catch {
-				// Invalid signature / expired / malformed — do NOT skip; let
-				// the throttler apply normally so a flood of bad tokens still
-				// counts toward the budget. AuthGuard will return the 401.
+		if (!token) {
+			return super.shouldSkip(context);
+		}
+
+		// Cheap pre-filter: `decode` is just base64 — no crypto. If the
+		// unsigned payload doesn't even claim to be a display, we never
+		// pay for `verifyAsync`. Filters out the common case (user
+		// access tokens, long-live tokens) and, critically, makes a
+		// flood of forged "user-shaped" Bearer tokens a free pass-through
+		// to the throttler counters instead of an amplification vector.
+		const unverifiedPayload = this.safeDecode(token);
+		if (
+			!unverifiedPayload ||
+			(unverifiedPayload.type as TokenOwnerType) !== TokenOwnerType.DISPLAY ||
+			!unverifiedPayload.sub
+		) {
+			return super.shouldSkip(context);
+		}
+
+		// Cache hit on a previously-verified display token — common case
+		// for the cache-warm waterfall this whole guard exists for.
+		// A burst of N requests from one display verifies once and
+		// fast-paths the next N-1 through a Map lookup.
+		const cached = this.readVerifyCache(token);
+		if (cached !== null) {
+			return cached;
+		}
+
+		// Cache miss + payload claims display — pay the verify cost
+		// once and cache the verdict. A flood of distinct forged
+		// "display-shaped" tokens still triggers verifyAsync on each
+		// new token, but the attacker has to GENERATE each token, so
+		// the cost is no longer asymmetric.
+		try {
+			const verified: JwtPayload = await this.jwtService.verifyAsync(token);
+			const ok = (verified.type as TokenOwnerType) === TokenOwnerType.DISPLAY && !!verified.sub;
+			this.writeVerifyCache(token, ok);
+			if (ok) {
+				return true;
 			}
+		} catch {
+			// Invalid signature / expired / malformed — cache the
+			// negative verdict too so a forged-token flood doesn't
+			// re-verify the same token over and over. Throttler
+			// counters still apply; AuthGuard will return the 401.
+			this.writeVerifyCache(token, false);
 		}
 
 		return super.shouldSkip(context);
+	}
+
+	private safeDecode(token: string): JwtPayload | null {
+		try {
+			// `JwtService.decode` is typed loosely (`any`); narrow through
+			// `unknown` so the rest of the function deals in concrete types.
+			const decoded: unknown = this.jwtService.decode(token);
+			return typeof decoded === 'object' && decoded !== null ? (decoded as JwtPayload) : null;
+		} catch {
+			return null;
+		}
+	}
+
+	private readVerifyCache(token: string): boolean | null {
+		const key = hashToken(token);
+		const entry = this.verifyCache.get(key);
+		if (!entry) {
+			return null;
+		}
+		if (entry.expiresAt <= Date.now()) {
+			this.verifyCache.delete(key);
+			return null;
+		}
+		return entry.ok;
+	}
+
+	private writeVerifyCache(token: string, ok: boolean): void {
+		const key = hashToken(token);
+		// Bounded LRU: drop the oldest entry once full. Map iteration
+		// order is insertion order, so `keys().next()` is the oldest.
+		if (this.verifyCache.size >= VERIFY_CACHE_MAX_ENTRIES && !this.verifyCache.has(key)) {
+			// Drop the oldest entry. Iterate-and-break instead of
+			// `.keys().next().value` because the latter's `IteratorResult`
+			// return type widens to `any` under our strict ESLint rules.
+			for (const oldestKey of this.verifyCache.keys()) {
+				this.verifyCache.delete(oldestKey);
+				break;
+			}
+		}
+		this.verifyCache.set(key, { ok, expiresAt: Date.now() + VERIFY_CACHE_TTL_MS });
 	}
 }

--- a/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
+++ b/apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts
@@ -200,9 +200,22 @@ export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
 		// for the cache-warm waterfall this whole guard exists for.
 		// A burst of N requests from one display verifies once and
 		// fast-paths the next N-1 through a Map lookup.
+		//
+		// Two cache outcomes:
+		// - `true` (verified display) → skip throttling, return `true`.
+		// - `false` (forged / revoked / expired token, previously
+		//   verified) → DON'T return `false` directly; defer to
+		//   `super.shouldSkip(context)`. Every other "don't skip" path
+		//   in this method does the same, so any logic the parent
+		//   `ThrottlerGuard.shouldSkip` runs (now or after a future
+		//   `@nestjs/throttler` upgrade — `skipIf`, `ignoreUserAgents`,
+		//   etc.) stays honored for cached-negative tokens.
 		const cached = this.readVerifyCache(token);
-		if (cached !== null) {
-			return cached;
+		if (cached === true) {
+			return true;
+		}
+		if (cached === false) {
+			return super.shouldSkip(context);
 		}
 
 		// Process-wide verify rate limit. Closes the residual attack

--- a/apps/backend/src/modules/auth/utils/token.utils.ts
+++ b/apps/backend/src/modules/auth/utils/token.utils.ts
@@ -1,5 +1,42 @@
 import * as crypto from 'crypto';
 
+import { ACCESS_TOKEN_TYPE } from '../auth.constants';
+
 export const hashToken = (token: string): string => {
 	return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+/**
+ * Minimal request shape we need to read the Authorization header.
+ *
+ * Typed structurally rather than as Express's or Fastify's `Request`
+ * because callers come from both worlds: `AuthGuard` runs over a
+ * `FastifyRequest`-extending `AuthenticatedRequest`, while
+ * `DisplayAwareThrottlerGuard` uses NestJS's generic execution-context
+ * request. Both have `headers.authorization` as the same `string`-ish
+ * shape, which is all this util needs.
+ */
+type RequestWithAuthHeader = {
+	headers: {
+		authorization?: string | string[];
+	};
+};
+
+/**
+ * Pull a Bearer access token out of the `Authorization` header.
+ *
+ * Returns `undefined` when the header is absent, when the scheme isn't
+ * `Bearer`, or when the value is malformed. Shared by `AuthGuard` (full
+ * token validation) and `DisplayAwareThrottlerGuard` (display-token
+ * detection for throttler bypass) so both stay in lockstep on what
+ * counts as a token-bearing request.
+ */
+export const extractAccessTokenFromHeader = (request: RequestWithAuthHeader): string | undefined => {
+	const rawHeader = request.headers.authorization;
+	const authHeader = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+	if (!authHeader) {
+		return undefined;
+	}
+	const [type, token] = authHeader.split(' ');
+	return type === ACCESS_TOKEN_TYPE ? token : undefined;
 };

--- a/apps/backend/test/guard-order.e2e-spec.ts
+++ b/apps/backend/test/guard-order.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { ApplicationConfig } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { AuthGuard } from '../src/modules/auth/guards/auth.guard';
+import { DisplayAwareThrottlerGuard } from '../src/modules/auth/guards/display-aware-throttler.guard';
+import { RolesGuard } from '../src/modules/users/guards/roles.guard';
+
+/**
+ * Regression test that pins the runtime order of `APP_GUARD` providers.
+ *
+ * The order is load-bearing for security:
+ *   1. `DisplayAwareThrottlerGuard` runs FIRST so anonymous floods to
+ *      protected endpoints stay rate-limited (otherwise `AuthGuard`
+ *      would 401 them and the throttler would never count the request).
+ *   2. `AuthGuard` runs SECOND to populate `request.auth` from the
+ *      bearer token.
+ *   3. `RolesGuard` runs THIRD to read `request.auth?.role` against the
+ *      `@Roles()` metadata.
+ *
+ * Reordering ANY of these breaks security or breaks every
+ * `@Roles()`-protected endpoint with a 403. NestJS resolves global
+ * guards in `applicationProvidersApplyMap` order, which equals the
+ * preorder DFS of the module graph from the root — so `AppModule`'s
+ * own `APP_GUARD` providers are emitted before any imported module's
+ * providers (e.g. `RolesGuard` registered in `UsersModule`). This
+ * test asserts that contract directly so a future module reorganisation
+ * can't silently break it.
+ */
+describe('Global APP_GUARD execution order', () => {
+	it('is DisplayAwareThrottlerGuard → AuthGuard → RolesGuard', async () => {
+		const dynamicAppModule = AppModule.register({ moduleExtensions: [], pluginExtensions: [] });
+		const moduleFixture = await Test.createTestingModule({ imports: [dynamicAppModule] }).compile();
+		const app = moduleFixture.createNestApplication();
+		await app.init();
+
+		const config = app.get(ApplicationConfig, { strict: false });
+		const guards = config.getGlobalGuards();
+
+		const throttlerIdx = guards.findIndex((g) => g instanceof DisplayAwareThrottlerGuard);
+		const authIdx = guards.findIndex((g) => g instanceof AuthGuard);
+		const rolesIdx = guards.findIndex((g) => g instanceof RolesGuard);
+
+		expect(throttlerIdx).toBeGreaterThanOrEqual(0);
+		expect(authIdx).toBeGreaterThanOrEqual(0);
+		expect(rolesIdx).toBeGreaterThanOrEqual(0);
+
+		// Throttler must run before AuthGuard so unauthenticated floods
+		// to protected endpoints don't bypass rate-limiting via 401.
+		expect(throttlerIdx).toBeLessThan(authIdx);
+		// AuthGuard must run before RolesGuard so `request.auth` is
+		// populated by the time `RolesGuard` reads `auth?.role`.
+		expect(authIdx).toBeLessThan(rolesIdx);
+
+		await app.close();
+	});
+});


### PR DESCRIPTION
## Summary

Replaces the default `ThrottlerGuard` with `DisplayAwareThrottlerGuard`, which subclasses it and exempts requests authenticated as a registered display. Web admin sessions, long-live user tokens, and unauthenticated traffic continue to hit the existing `30 req / 60s` budget.

## Why

The default `ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }])` budget on [app.module.ts:149](apps/backend/src/app.module.ts#L149) is sized for unauthenticated and human/admin traffic. Panels intentionally **burst N+M reads on cold-boot to warm their local cache** — devices → device controls → channels → channel controls → validation, plus weather + system + spaces + scenes + dashboard pages + displays + buddy + intents. On any non-trivial install (≥10 channels) the warmup waterfall trips the throttle.

Once a request hits 429, the panel's `RetryInterceptor` ([retry_interceptor.dart:35](apps/panel/lib/core/interceptors/retry_interceptor.dart)) retries with exponential backoff. Under burst init the throttle window stays full across all 3 retries; the original error finally propagates as the opaque `[FETCH CHANNEL CONTROLS] API error: null - null` — and `Repository.handleApiCall` rethrows that as `Exception: Failed to fetch channel controls: null`, which kills the entire `DevicesService.initialize()` flow. End result: panel stuck on splash, surfaces no actionable error.

This was a real production-affecting bug — confirmed reproducible on both fresh emulator setup AND real hardware testing sessions.

## What changed

### `DisplayAwareThrottlerGuard` ([new file](apps/backend/src/modules/auth/guards/display-aware-throttler.guard.ts))

```ts
@Injectable()
export class DisplayAwareThrottlerGuard extends ThrottlerGuard {
  protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
    const auth = request.auth;
    if (auth?.type === 'token' && auth.ownerType === TokenOwnerType.DISPLAY) {
      return true;
    }
    return super.shouldSkip(context);
  }
}
```

Reads `request.auth` populated by `AuthGuard.validateDisplayToken()` ([auth.guard.ts:199-205](apps/backend/src/modules/auth/guards/auth.guard.ts#L199-L205)). Display tokens are issued only via the registration flow (`POST /modules/displays/register`) — they're trusted members of the installation, not arbitrary clients.

### `app.module.ts`

Swapped the `APP_GUARD` provider:

```diff
- providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+ providers: [{ provide: APP_GUARD, useClass: DisplayAwareThrottlerGuard }],
```

The `ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }])` budget itself is **unchanged** — still 30/min for everyone except registered displays.

## Throttle matrix after this change

| Caller | Throttle |
|---|---|
| Unauthenticated | 30/min (DDoS protection, unchanged) |
| Web admin user session | 30/min (unchanged) |
| `auth.controller.ts` endpoints | 5/min (existing `@Throttle({ limit: 5 })`, unchanged) |
| WebSocket gateway | none (existing `@SkipThrottle()`, unchanged) |
| Long-live USER token | 30/min (`ownerType === USER`, doesn't match the display branch) |
| **Registered display** | **none (NEW)** |

## Safety notes

- **Fail-safe direction.** When `request.auth` isn't populated (e.g. AuthGuard ever runs *after* this guard for any reason), the type-guard check returns false and `super.shouldSkip()` runs — default throttle still applies. Worst case is "throttle still applies", never "throttle accidentally removed".
- **Long-live USER tokens still throttled.** The check is specifically `ownerType === TokenOwnerType.DISPLAY`. The `validateLongLiveToken` path sets `auth.type = 'token'` too but with `ownerType: USER`, which doesn't match.
- **Test coverage.** Four jest cases lock in the matrix above:
  - display token → skipped
  - long-live USER token → not skipped
  - web admin user session → not skipped
  - unauthenticated (no `request.auth`) → not skipped

## Test plan

- [x] `pnpm --filter ./apps/backend run lint:js` — clean
- [x] `pnpm --filter ./apps/backend run lint:api` — clean
- [x] `cd apps/backend && npx jest` — 220 suites / 2,778 passed (+4 new guard tests)
- [x] `cd apps/backend && pnpm run test:e2e` — 3 suites / 36 passed
- [ ] Manual: boot panel against a backend with `≥10 channels`. Before this change init fails with `[FETCH CHANNEL CONTROLS] API error: null - null`; with this change init completes cleanly.

## Out of scope (worth a follow-up)

The N+M waterfall in `DevicesService.initialize()` is wasteful even without the throttle — N+M+2 round-trips on cold-boot, slow on big installs and slower networks. Embedding controls in the device/channel response (or batching with `Future.wait`) is a real structural improvement and a separate task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global guard wiring and throttling behavior for authenticated traffic, including a new pre-auth JWT inspection path; mistakes could weaken rate-limiting or bypass intended per-route limits.
> 
> **Overview**
> Adds `DisplayAwareThrottlerGuard`, a `ThrottlerGuard` subclass that **skips the default global rate limit** for requests bearing a *valid display* JWT while continuing to throttle unauthenticated, user, and long-live token traffic.
> 
> Moves global guard registration into `AppModule` to **pin execution order** (`DisplayAwareThrottlerGuard` → `AuthGuard` → existing `RolesGuard` from `UsersModule`), updates `AuthGuard` to use a shared `extractAccessTokenFromHeader` util, and adds unit + e2e coverage to lock in the new throttle/guard-order contracts (including cache/token-bucket protections around JWT verification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c5a9dc6f3ea025c01f654f904fa6d4bf9e7abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->