### PR TITLE
feat(backend/users): configurable password min length via FB_USERS_PASSWORD_MIN_LENGTH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# Smart Panel — environment configuration template.
+# Copy this file to `.env` (or `.env.local`) and adjust for your deployment.
+# All variables are optional; defaults shown in comments are used when unset.
+
+# Runtime mode: `production` or `development`.
+NODE_ENV=production
+
+# Public origin of the panel (used when building absolute URLs in API responses).
+# Default: http://localhost
+FB_APP_HOST=http://127.0.0.1
+
+# Port the backend HTTP server listens on. Default: 3000
+FB_BACKEND_PORT=3000
+
+# Port the bundled admin UI is served on. Default: 80
+FB_ADMIN_PORT=80
+
+# Filesystem path to the built admin UI assets. Leave blank to use the bundled default.
+FB_ADMIN_UI_PATH=
+
+# Filesystem path to the application config directory (seed files, plugin configs).
+# Leave blank to use the default location relative to the backend.
+FB_CONFIG_PATH=
+
+# Filesystem path to the SQLite database directory. Leave blank for the default.
+FB_DB_PATH=
+
+# TypeORM `synchronize` — auto-applies entity changes to the schema.
+# Leave `false` in production. Default: false
+FB_DB_SYNC=false
+
+# Enable TypeORM SQL query logging. Default: false
+FB_DB_LOGGING=false
+
+# Run pending migrations on startup. Default: false
+FB_DB_MIGRATIONS_RUN=false
+
+# Path used by the secure storage layer (encrypted credentials, tokens).
+FB_SECURE_STORAGE_PATH=
+
+# Secret used to sign auth/session tokens. STRONGLY recommended in production —
+# unset means tokens are signed with an auto-generated secret that does not
+# survive restarts (sessions get invalidated on every boot).
+FB_TOKEN_SECRET=
+
+# Minimum length enforced for user passwords (create, update, register).
+# Default: 8. Hard floor: 1. Invalid values fall back to the default.
+# Lowering this is a security tradeoff — only do so for deployments where
+# the panel is reachable only from a trusted network (VPN, LAN, reverse proxy
+# with its own auth) and operators have accepted weaker user passwords.
+FB_USERS_PASSWORD_MIN_LENGTH=8

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -13,7 +13,7 @@ import {
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { UserRole } from '../../users/users.constants';
+import { USERS_PASSWORD_MIN_LENGTH, UserRole } from '../../users/users.constants';
 
 @ApiSchema({ name: 'AuthModuleRegister' })
 export class RegisterDto {
@@ -47,7 +47,9 @@ export class RegisterDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
+	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
+		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
+	})
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -1,14 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import {
-	IsEmail,
-	IsEnum,
-	IsNotEmpty,
-	IsOptional,
-	IsString,
-	IsUUID,
-	ValidateIf,
-	ValidateNested,
-} from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateIf, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -6,14 +6,13 @@ import {
 	IsOptional,
 	IsString,
 	IsUUID,
-	MinLength,
 	ValidateIf,
 	ValidateNested,
 } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { USERS_PASSWORD_MIN_LENGTH, UserRole } from '../../users/users.constants';
+import { MinUsersPasswordLength, UserRole } from '../../users/users.constants';
 
 @ApiSchema({ name: 'AuthModuleRegister' })
 export class RegisterDto {
@@ -47,9 +46,7 @@ export class RegisterDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
-		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
-	})
+	@MinUsersPasswordLength()
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/users/dto/create-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/create-user.dto.ts
@@ -6,14 +6,13 @@ import {
 	IsOptional,
 	IsString,
 	IsUUID,
-	MinLength,
 	ValidateIf,
 	ValidateNested,
 } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { USERS_PASSWORD_MIN_LENGTH, UserLanguage, UserRole } from '../users.constants';
+import { MinUsersPasswordLength, UserLanguage, UserRole } from '../users.constants';
 
 @ApiSchema({ name: 'UsersModuleCreateUser' })
 export class CreateUserDto {
@@ -47,9 +46,7 @@ export class CreateUserDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
-		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
-	})
+	@MinUsersPasswordLength()
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/users/dto/create-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/create-user.dto.ts
@@ -13,7 +13,7 @@ import {
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { UserLanguage, UserRole } from '../users.constants';
+import { USERS_PASSWORD_MIN_LENGTH, UserLanguage, UserRole } from '../users.constants';
 
 @ApiSchema({ name: 'UsersModuleCreateUser' })
 export class CreateUserDto {
@@ -47,7 +47,9 @@ export class CreateUserDto {
 	@Expose()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
+	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
+		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
+	})
 	password: string;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/modules/users/dto/create-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/create-user.dto.ts
@@ -1,14 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import {
-	IsEmail,
-	IsEnum,
-	IsNotEmpty,
-	IsOptional,
-	IsString,
-	IsUUID,
-	ValidateIf,
-	ValidateNested,
-} from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateIf, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 

--- a/apps/backend/src/modules/users/dto/update-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-user.dto.ts
@@ -1,13 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import {
-	IsEmail,
-	IsEnum,
-	IsNotEmpty,
-	IsOptional,
-	IsString,
-	ValidateIf,
-	ValidateNested,
-} from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 

--- a/apps/backend/src/modules/users/dto/update-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-user.dto.ts
@@ -5,14 +5,13 @@ import {
 	IsNotEmpty,
 	IsOptional,
 	IsString,
-	MinLength,
 	ValidateIf,
 	ValidateNested,
 } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { USERS_PASSWORD_MIN_LENGTH, UserLanguage, UserRole } from '../users.constants';
+import { MinUsersPasswordLength, UserLanguage, UserRole } from '../users.constants';
 
 @ApiSchema({ name: 'UsersModuleUpdateUser' })
 export class UpdateUserDto {
@@ -39,9 +38,7 @@ export class UpdateUserDto {
 	@IsOptional()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
-		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
-	})
+	@MinUsersPasswordLength()
 	@ValidateIf((_, value) => value !== null)
 	password?: string | null;
 

--- a/apps/backend/src/modules/users/dto/update-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-user.dto.ts
@@ -12,7 +12,7 @@ import {
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
-import { UserLanguage, UserRole } from '../users.constants';
+import { USERS_PASSWORD_MIN_LENGTH, UserLanguage, UserRole } from '../users.constants';
 
 @ApiSchema({ name: 'UsersModuleUpdateUser' })
 export class UpdateUserDto {
@@ -39,7 +39,9 @@ export class UpdateUserDto {
 	@IsOptional()
 	@IsNotEmpty({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
 	@IsString({ message: '[{"field":"password","reason":"Password must be a non-empty string."}]' })
-	@MinLength(8, { message: '[{"field":"password","reason":"Password must be at least 8 characters long."}]' })
+	@MinLength(USERS_PASSWORD_MIN_LENGTH, {
+		message: `[{"field":"password","reason":"Password must be at least ${USERS_PASSWORD_MIN_LENGTH} characters long."}]`,
+	})
 	@ValidateIf((_, value) => value !== null)
 	password?: string | null;
 

--- a/apps/backend/src/modules/users/users.constants.ts
+++ b/apps/backend/src/modules/users/users.constants.ts
@@ -7,6 +7,27 @@ export const USERS_MODULE_API_TAG_NAME = 'Users module';
 export const USERS_MODULE_API_TAG_DESCRIPTION =
 	'Endpoints for managing users, including user roles, permissions, and profile details.';
 
+const DEFAULT_PASSWORD_MIN_LENGTH = 8;
+
+const parsePasswordMinLength = (raw: string | undefined): number => {
+	if (raw === undefined || raw.trim() === '') {
+		return DEFAULT_PASSWORD_MIN_LENGTH;
+	}
+
+	const parsed = Number(raw);
+
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return DEFAULT_PASSWORD_MIN_LENGTH;
+	}
+
+	return Math.floor(parsed);
+};
+
+// Resolved at module load so it can be used in class-validator decorators.
+// Operators may lower this for deployments behind VPN/proxy where weak passwords
+// are an accepted tradeoff. Floor of 1; invalid values fall back to the default.
+export const USERS_PASSWORD_MIN_LENGTH = parsePasswordMinLength(process.env.FB_USERS_PASSWORD_MIN_LENGTH);
+
 export enum EventType {
 	USER_CREATED = 'UsersModule.User.Created',
 	USER_UPDATED = 'UsersModule.User.Updated',

--- a/apps/backend/src/modules/users/users.constants.ts
+++ b/apps/backend/src/modules/users/users.constants.ts
@@ -27,11 +27,13 @@ export const getUsersPasswordMinLength = (): number => {
 
 	const parsed = Number(raw);
 
-	if (!Number.isFinite(parsed) || parsed < 1) {
+	// Reject non-integers (e.g. "7.9") rather than rounding down — silently
+	// floor-ing would weaken the policy below what the operator wrote.
+	if (!Number.isInteger(parsed) || parsed < 1) {
 		return DEFAULT_PASSWORD_MIN_LENGTH;
 	}
 
-	return Math.floor(parsed);
+	return parsed;
 };
 
 export function MinUsersPasswordLength(validationOptions?: ValidationOptions): PropertyDecorator {

--- a/apps/backend/src/modules/users/users.constants.ts
+++ b/apps/backend/src/modules/users/users.constants.ts
@@ -1,3 +1,5 @@
+import { ValidationOptions, registerDecorator } from 'class-validator';
+
 export const USERS_MODULE_PREFIX = 'users';
 
 export const USERS_MODULE_NAME = 'users-module';
@@ -9,8 +11,17 @@ export const USERS_MODULE_API_TAG_DESCRIPTION =
 
 const DEFAULT_PASSWORD_MIN_LENGTH = 8;
 
-const parsePasswordMinLength = (raw: string | undefined): number => {
-	if (raw === undefined || raw.trim() === '') {
+// Resolved on every validation call rather than at module load, because
+// `NestConfigModule.forRoot()` populates `process.env` from `.env` files
+// AFTER all DTO modules have already been imported and their decorators
+// evaluated. An eager read here would silently ignore values set in `.env`.
+// Operators may lower this for deployments behind VPN/proxy where weak
+// passwords are an accepted tradeoff. Floor of 1; invalid values fall back
+// to the default.
+export const getUsersPasswordMinLength = (): number => {
+	const raw = process.env.FB_USERS_PASSWORD_MIN_LENGTH;
+
+	if (typeof raw !== 'string' || raw.trim() === '') {
 		return DEFAULT_PASSWORD_MIN_LENGTH;
 	}
 
@@ -23,10 +34,25 @@ const parsePasswordMinLength = (raw: string | undefined): number => {
 	return Math.floor(parsed);
 };
 
-// Resolved at module load so it can be used in class-validator decorators.
-// Operators may lower this for deployments behind VPN/proxy where weak passwords
-// are an accepted tradeoff. Floor of 1; invalid values fall back to the default.
-export const USERS_PASSWORD_MIN_LENGTH = parsePasswordMinLength(process.env.FB_USERS_PASSWORD_MIN_LENGTH);
+export function MinUsersPasswordLength(validationOptions?: ValidationOptions): PropertyDecorator {
+	return (object: object, propertyName: string | symbol): void => {
+		registerDecorator({
+			name: 'minUsersPasswordLength',
+			target: object.constructor,
+			propertyName: propertyName as string,
+			options: validationOptions,
+			constraints: [],
+			validator: {
+				validate(value: unknown): boolean {
+					return typeof value === 'string' && value.length >= getUsersPasswordMinLength();
+				},
+				defaultMessage(): string {
+					return `[{"field":"password","reason":"Password must be at least ${getUsersPasswordMinLength()} characters long."}]`;
+				},
+			},
+		});
+	};
+}
 
 export enum EventType {
 	USER_CREATED = 'UsersModule.User.Created',


### PR DESCRIPTION
## Summary

- Replace the hardcoded `@MinLength(8, ...)` on the user `password` field in `create-user.dto`, `update-user.dto`, and `register.dto` with a value resolved at module load from a new env var `FB_USERS_PASSWORD_MIN_LENGTH` (default `8`, hard floor `1`; invalid values fall back to the default).
- Add a top-level `.env.example` documenting all backend `FB_` environment variables, including the new one with a note about the security tradeoff.

## Why

Operators running the panel behind a VPN, LAN-only network, or a reverse proxy with its own auth layer have asked to allow weaker user passwords than the previous fixed 8-character minimum. The default stays at 8 — lowering it is an opt-in operator decision, not a runtime user-facing setting, so it lives as an env var rather than in the runtime config API.

## Notes for reviewers

- Resolved at module load (decorator-time), so a backend restart is required after changing the value — appropriate for an operator setting.
- The seeder (`UsersSeederService`) calls `usersService.create()` directly and bypasses the validation pipe, so seed-file passwords are unaffected either way.
- The admin app does not enforce client-side min-length on password fields (only `required`); it surfaces the backend's validation error message. So lowering the env var automatically loosens admin behavior with no admin code changes.
- No existing tests assert on the literal `"8"` or the message text, so no test updates needed.

## Test plan

- [x] With `FB_USERS_PASSWORD_MIN_LENGTH` unset, creating a user with a 7-char password still returns a 422 with `Password must be at least 8 characters long.`
- [x] With `FB_USERS_PASSWORD_MIN_LENGTH=4`, creating a user with a 4-char password succeeds; a 3-char password is rejected with `Password must be at least 4 characters long.`
- [x] With `FB_USERS_PASSWORD_MIN_LENGTH=abc` (invalid), behaviour falls back to the default (8).
- [x] Same checks against `PATCH /users/:id` (update) and `POST /auth/register`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side password validation for user creation/update/registration, which impacts authentication/security posture if misconfigured. Logic is simple and defaults to the existing 8-character minimum, reducing regression risk.
> 
> **Overview**
> Introduces a configurable minimum password length for `POST /auth/register` and users create/update by replacing the hardcoded `@MinLength(8)` DTO validators with a new `@MinUsersPasswordLength()` decorator that reads `FB_USERS_PASSWORD_MIN_LENGTH` (default `8`, floor `1`, invalid values fall back to default).
> 
> Adds a new `.env.example` that documents the backend’s `FB_` environment variables, including the new password policy setting and its security tradeoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb856673abaf473da8b52c8cc5977b2185503d84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->