### PR TITLE
refactor(spaces): drop home-control fields from abstract SpaceEntity

### DIFF
--- a/apps/admin/src/modules/spaces/components/list-spaces-adjust.vue
+++ b/apps/admin/src/modules/spaces/components/list-spaces-adjust.vue
@@ -20,31 +20,25 @@
 		<el-scrollbar class="flex-grow">
 			<el-collapse v-model="activeBoxes">
 				<el-collapse-item
-					name="type"
+					name="types"
 					:class="[ns.e('filter-item')]"
 				>
 					<template #title>
 						<el-text class="!px-2">
-							{{ t('spacesModule.filters.type.title') }}
+							{{ t('spacesModule.filters.types.title') }}
 						</el-text>
 					</template>
-
-					<div class="px-2">
-						<el-radio-group v-model="innerFilters.type">
-							<el-radio-button
-								:label="t('spacesModule.misc.types.room')"
-								:value="SpaceType.ROOM"
-							/>
-							<el-radio-button
-								:label="t('spacesModule.misc.types.zone')"
-								:value="SpaceType.ZONE"
-							/>
-							<el-radio-button
-								:label="t('spacesModule.filters.type.all')"
-								value="all"
-							/>
-						</el-radio-group>
-					</div>
+					<el-checkbox-group
+						v-model="innerFilters.types"
+						class="flex flex-col px-4"
+					>
+						<el-checkbox
+							v-for="type of typesOptions"
+							:key="type.value"
+							:label="type.label"
+							:value="type.value"
+						/>
+					</el-checkbox-group>
 				</el-collapse-item>
 			</el-collapse>
 		</el-scrollbar>
@@ -68,13 +62,13 @@
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElButton, ElCollapse, ElCollapseItem, ElRadioButton, ElRadioGroup, ElScrollbar, ElText, useNamespace } from 'element-plus';
+import { ElButton, ElCheckbox, ElCheckboxGroup, ElCollapse, ElCollapseItem, ElScrollbar, ElText, useNamespace } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
 import { useVModel } from '@vueuse/core';
 
 import { AppBarHeading } from '../../../common';
-import { SpaceType } from '../spaces.constants';
+import { useSpacesPlugins } from '../composables/useSpacesPlugins';
 import type { ISpacesFilter } from '../composables/types';
 
 interface IListSpacesAdjustProps {
@@ -96,7 +90,9 @@ const emit = defineEmits<{
 const ns = useNamespace('list-spaces-adjust');
 const { t } = useI18n();
 
-const activeBoxes = ref<string[]>(['type']);
+const { options: typesOptions } = useSpacesPlugins();
+
+const activeBoxes = ref<string[]>(['types']);
 
 const innerFilters = useVModel(props, 'filters', emit);
 </script>

--- a/apps/admin/src/modules/spaces/components/spaces-table-column-plugin.types.ts
+++ b/apps/admin/src/modules/spaces/components/spaces-table-column-plugin.types.ts
@@ -1,5 +1,7 @@
+import type { ISpacesFilter } from '../composables/types';
 import type { ISpace } from '../store/spaces.store.types';
 
 export interface ISpacesTableColumnPluginProps {
 	space: ISpace;
+	filters?: ISpacesFilter;
 }

--- a/apps/admin/src/modules/spaces/components/spaces-table-column-plugin.vue
+++ b/apps/admin/src/modules/spaces/components/spaces-table-column-plugin.vue
@@ -1,15 +1,43 @@
 <template>
 	<el-text
+		v-if="!props.filters"
 		truncated
 		class="font-400!"
 	>
 		{{ plugin?.name || props.space.type }}
 	</el-text>
+	<el-text
+		v-else
+		truncated
+	>
+		<el-link
+			:type="props.filters.types.includes(props.space.type) ? 'danger' : undefined"
+			underline="never"
+			class="font-400!"
+			@click.stop="emit('filter-by', props.space.type, !props.filters.types.includes(props.space.type))"
+		>
+			<el-icon class="el-icon--left">
+				<icon
+					v-if="props.filters.types.includes(props.space.type)"
+					icon="mdi:filter-minus"
+				/>
+				<icon
+					v-else
+					icon="mdi:filter-plus"
+				/>
+			</el-icon>
+
+			{{ plugin?.name || props.space.type }}
+		</el-link>
+	</el-text>
 </template>
 
 <script setup lang="ts">
-import { ElText } from 'element-plus';
+import { ElIcon, ElLink, ElText } from 'element-plus';
 
+import { Icon } from '@iconify/vue';
+
+import type { IPluginElement } from '../../../common';
 import { useSpacesPlugin } from '../composables';
 
 import type { ISpacesTableColumnPluginProps } from './spaces-table-column-plugin.types';
@@ -19,6 +47,10 @@ defineOptions({
 });
 
 const props = defineProps<ISpacesTableColumnPluginProps>();
+
+const emit = defineEmits<{
+	(e: 'filter-by', value: IPluginElement['type'], add: boolean): void;
+}>();
 
 const { plugin } = useSpacesPlugin({ type: (): typeof props.space.type => props.space.type });
 </script>

--- a/apps/admin/src/modules/spaces/components/spaces-table.vue
+++ b/apps/admin/src/modules/spaces/components/spaces-table.vue
@@ -146,29 +146,11 @@
 			:width="170"
 		>
 			<template #default="scope">
-				<spaces-table-column-plugin :space="scope.row" />
-			</template>
-		</el-table-column>
-
-		<el-table-column
-			:label="t('spacesModule.table.columns.category')"
-			prop="category"
-			:width="150"
-		>
-			<template #default="scope">
-				<el-text
-					v-if="scope.row.category"
-					size="small"
-				>
-					{{ t(`spacesModule.fields.spaces.category.options.${scope.row.category}`) }}
-				</el-text>
-				<el-text
-					v-else
-					size="small"
-					type="info"
-				>
-					—
-				</el-text>
+				<spaces-table-column-plugin
+					:space="scope.row"
+					:filters="innerFilters"
+					@filter-by="(value: IPluginElement['type'], add: boolean) => onFilterBy(value, add)"
+				/>
 			</template>
 		</el-table-column>
 
@@ -239,8 +221,10 @@ import { useI18n } from 'vue-i18n';
 import { ElAvatar, ElButton, ElResult, ElTable, ElTableColumn, ElText, vLoading } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
+import { useVModel } from '@vueuse/core';
 
-import { IconWithChild, useBreakpoints } from '../../../common';
+import { IconWithChild, type IPluginElement, useBreakpoints } from '../../../common';
+import type { ISpacesFilter } from '../composables/types';
 import { SpaceType } from '../spaces.constants';
 import type { ISpace } from '../store/spaces.store.types';
 
@@ -259,6 +243,7 @@ const emit = defineEmits<{
 	(e: 'remove', id: ISpace['id']): void;
 	(e: 'add'): void;
 	(e: 'reset-filters'): void;
+	(e: 'update:filters', filters: ISpacesFilter): void;
 	(e: 'update:sort-by', by: 'name' | 'type' | 'displayOrder' | undefined): void;
 	(e: 'update:sort-dir', dir: 'asc' | 'desc' | null): void;
 	(e: 'selected-changes', items: ISpace[]): void;
@@ -267,6 +252,8 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const { isMDDevice } = useBreakpoints();
+
+const innerFilters = useVModel(props, 'filters', emit);
 
 const noResults = computed<boolean>((): boolean => props.totalRows === 0);
 
@@ -289,5 +276,13 @@ const onRowClick = (row: ISpace): void => {
 
 const onSelectionChange = (selected: ISpace[]): void => {
 	emit('selected-changes', selected);
+};
+
+const onFilterBy = (value: IPluginElement['type'], add: boolean): void => {
+	const filteredTypes = add
+		? [...innerFilters.value.types, value]
+		: innerFilters.value.types.filter((item) => item !== value);
+
+	innerFilters.value.types = Array.from(new Set(filteredTypes));
 };
 </script>

--- a/apps/admin/src/modules/spaces/composables/schemas.ts
+++ b/apps/admin/src/modules/spaces/composables/schemas.ts
@@ -5,7 +5,7 @@ import { StatusWidgetSchema } from '../store/spaces.store.schemas';
 
 export const SpacesFilterSchema = z.object({
 	search: z.string().optional(),
-	type: z.union([z.nativeEnum(SpaceType), z.literal('all')]).default('all'),
+	types: z.array(z.string()),
 });
 
 export type SpacesFilterSchemaType = z.infer<typeof SpacesFilterSchema>;

--- a/apps/admin/src/modules/spaces/composables/types.ts
+++ b/apps/admin/src/modules/spaces/composables/types.ts
@@ -3,7 +3,7 @@ import type { ComputedRef, Reactive, Ref } from 'vue';
 import type { FormInstance } from 'element-plus';
 
 import type { IPlugin, IPluginElement } from '../../../common';
-import type { FormResultType, SpaceType } from '../spaces.constants';
+import type { FormResultType } from '../spaces.constants';
 import type { ISpacePluginRoutes, ISpacePluginsComponents, ISpacePluginsSchemas } from '../spaces.types';
 import type { ISpace, ISpaceEditData } from '../store/spaces.store.types';
 
@@ -11,7 +11,7 @@ import type { SpaceAddFormSchemaType, SpaceEditFormSchemaType } from './schemas'
 
 export interface ISpacesFilter {
 	search?: string | undefined;
-	type: SpaceType | 'all';
+	types: string[];
 }
 
 export interface IUseSpacesDataSource {

--- a/apps/admin/src/modules/spaces/composables/useSpacesDataSource.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpacesDataSource.ts
@@ -6,7 +6,7 @@ import { isEqual } from 'lodash';
 import { orderBy } from 'natural-orderby';
 
 import { type ISortEntry, injectStoresManager, useListQuery } from '../../../common';
-import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, SPACES_MODULE_NAME, SpaceType } from '../spaces.constants';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, SPACES_MODULE_NAME } from '../spaces.constants';
 import type { ISpace } from '../store/spaces.store.types';
 import { spacesStoreKey } from '../store/keys';
 
@@ -15,7 +15,7 @@ import type { ISpacesFilter, IUseSpacesDataSource } from './types';
 
 export const defaultSpacesFilter: ISpacesFilter = {
 	search: undefined,
-	type: 'all',
+	types: [],
 };
 
 export const defaultSpacesSort: ISortEntry = {
@@ -57,7 +57,7 @@ export const useSpacesDataSource = (): IUseSpacesDataSource => {
 	const filtersActive = computed<boolean>((): boolean => {
 		return (
 			filters.value.search !== defaultSpacesFilter.search ||
-			!isEqual(filters.value.type, defaultSpacesFilter.type)
+			!isEqual(filters.value.types, defaultSpacesFilter.types)
 		);
 	});
 
@@ -82,9 +82,7 @@ export const useSpacesDataSource = (): IUseSpacesDataSource => {
 							space.id.toLowerCase().includes(filters.value.search.toLowerCase()) ||
 							space.name?.toLowerCase().includes(filters.value.search.toLowerCase()) ||
 							space.description?.toLowerCase().includes(filters.value.search.toLowerCase())) &&
-						(filters.value.type === 'all' ||
-							(filters.value.type === SpaceType.ROOM && space.type === SpaceType.ROOM) ||
-							(filters.value.type === SpaceType.ZONE && space.type === SpaceType.ZONE))
+						(filters.value.types.length === 0 || filters.value.types.includes(space.type))
 				),
 			[
 				(space: ISpace) => {

--- a/apps/admin/src/modules/spaces/composables/useSpacesDataSource.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpacesDataSource.ts
@@ -51,7 +51,12 @@ export const useSpacesDataSource = (): IUseSpacesDataSource => {
 			},
 		},
 		syncQuery: true,
-		version: 1,
+		// Bumped from 1 → 2: the filter schema's `type: SpaceType | 'all'` was
+		// replaced with `types: string[]`. Without bumping the version, existing
+		// users with cached `spaces:list` state would rehydrate the old shape
+		// (no `types` key) and crash on first render with "Cannot read properties
+		// of undefined (reading 'length')" when the spaces filter is evaluated.
+		version: 2,
 	});
 
 	const filtersActive = computed<boolean>((): boolean => {

--- a/apps/admin/src/modules/spaces/locales/cs-CZ.json
+++ b/apps/admin/src/modules/spaces/locales/cs-CZ.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Typ",
-			"all": "Vše"
+		"types": {
+			"title": "Typ"
 		}
 	},
 	"texts": {

--- a/apps/admin/src/modules/spaces/locales/de-DE.json
+++ b/apps/admin/src/modules/spaces/locales/de-DE.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Typ",
-			"all": "Alle"
+		"types": {
+			"title": "Typ"
 		}
 	},
 	"texts": {

--- a/apps/admin/src/modules/spaces/locales/en-US.json
+++ b/apps/admin/src/modules/spaces/locales/en-US.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Type",
-			"all": "All"
+		"types": {
+			"title": "Type"
 		}
 	},
 	"texts": {

--- a/apps/admin/src/modules/spaces/locales/es-ES.json
+++ b/apps/admin/src/modules/spaces/locales/es-ES.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Tipo",
-			"all": "Todos"
+		"types": {
+			"title": "Tipo"
 		}
 	},
 	"texts": {

--- a/apps/admin/src/modules/spaces/locales/pl-PL.json
+++ b/apps/admin/src/modules/spaces/locales/pl-PL.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Typ",
-			"all": "Wszystkie"
+		"types": {
+			"title": "Typ"
 		}
 	},
 	"texts": {

--- a/apps/admin/src/modules/spaces/locales/sk-SK.json
+++ b/apps/admin/src/modules/spaces/locales/sk-SK.json
@@ -214,9 +214,8 @@
 		}
 	},
 	"filters": {
-		"type": {
-			"title": "Typ",
-			"all": "Všetky"
+		"types": {
+			"title": "Typ"
 		}
 	},
 	"texts": {

--- a/apps/backend/src/modules/buddy/services/buddy-context.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-context.service.ts
@@ -215,10 +215,11 @@ export class BuddyContextService {
 					{
 						id: space.id,
 						name: space.name,
-						// `category` is home-control-specific; it's undefined on master /
-						// entry / signage spaces. Collapse undefined to null so the
-						// downstream snapshot keeps its existing "string | null" shape.
-						category: space.category ?? null,
+						// `category` lives on home-control's RoomSpaceEntity / ZoneSpaceEntity,
+						// not the abstract SpaceEntity. Read it via an indexed-property cast
+						// so non-home-control spaces (master / entry / signage) collapse to null
+						// and the snapshot keeps its existing "string | null" shape.
+						category: (space as { category?: string | null }).category ?? null,
 						deviceCount: spaceDevices.length,
 					},
 				];
@@ -243,7 +244,7 @@ export class BuddyContextService {
 						id: space.id,
 						name: space.name,
 						// See note above — home-control-only field; normalize to null.
-						category: space.category ?? null,
+						category: (space as { category?: string | null }).category ?? null,
 						deviceCount,
 					};
 				}),

--- a/apps/backend/src/modules/buddy/services/heartbeat.service.ts
+++ b/apps/backend/src/modules/buddy/services/heartbeat.service.ts
@@ -89,7 +89,10 @@ export class HeartbeatService implements OnApplicationBootstrap, OnModuleDestroy
 
 		try {
 			const spaces = await this.spacesService.findAll();
-			const enabledSpaces = spaces.filter((s) => s.suggestionsEnabled);
+			// `suggestionsEnabled` lives on home-control's RoomSpaceEntity / ZoneSpaceEntity,
+			// not the abstract SpaceEntity. Read it via an indexed-property cast so non-home-control
+			// spaces (master / entry / signage) — where the field is undefined — are excluded.
+			const enabledSpaces = spaces.filter((s) => (s as { suggestionsEnabled?: boolean }).suggestionsEnabled === true);
 
 			if (enabledSpaces.length === 0) {
 				return;

--- a/apps/backend/src/modules/devices/services/device-zones.service.ts
+++ b/apps/backend/src/modules/devices/services/device-zones.service.ts
@@ -88,8 +88,9 @@ export class DeviceZonesService {
 			throw new DevicesValidationException('Can only add device to a zone, not a room');
 		}
 
-		// Validate that it's not a floor zone
-		if (isFloorZoneCategory(zone.category)) {
+		// Validate that it's not a floor zone. `category` lives on home-control's
+		// ZoneSpaceEntity, not the abstract SpaceEntity, so read it via an indexed-property cast.
+		if (isFloorZoneCategory((zone as { category?: string | null }).category ?? null)) {
 			this.logger.error(`Cannot explicitly assign device to floor zone ${zoneId}`);
 			throw new DevicesValidationException(
 				'Cannot explicitly assign device to a floor zone. Floor membership is derived from room→zone hierarchy.',
@@ -169,7 +170,7 @@ export class DeviceZonesService {
 				throw new DevicesValidationException(`${zone.name} is not a zone`);
 			}
 
-			if (isFloorZoneCategory(zone.category)) {
+			if (isFloorZoneCategory((zone as { category?: string | null }).category ?? null)) {
 				this.logger.error(`Cannot explicitly assign device to floor zone ${zoneId}`);
 				throw new DevicesValidationException(
 					`Cannot assign to floor zone "${zone.name}". Floor membership is derived from room hierarchy.`,

--- a/apps/backend/src/modules/spaces/entities/space.entity.ts
+++ b/apps/backend/src/modules/spaces/entities/space.entity.ts
@@ -5,7 +5,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, TableInheritan
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
 import { BaseEntity } from '../../../common/entities/base.entity';
-import { SpaceRoomCategory, SpaceType, SpaceZoneCategory } from '../spaces.constants';
+import { SpaceType } from '../spaces.constants';
 
 @ApiSchema({ name: 'SpacesModuleDataSpace' })
 @Entity('spaces_module_spaces')
@@ -32,13 +32,6 @@ export abstract class SpaceEntity extends BaseEntity {
 	@IsString()
 	@Column({ nullable: true, default: null })
 	description: string | null;
-
-	// `category` is a home-control-specific concept (Room/Zone taxonomy). The
-	// @Column + @ApiProperty decorations live on RoomSpaceEntity / ZoneSpaceEntity
-	// so the generated OpenAPI schemas only surface it on those subtypes.
-	// Declared as optional here so the abstract base's TS type remains readable
-	// by cross-module consumers that don't (or can't) narrow to a subtype.
-	category?: SpaceRoomCategory | SpaceZoneCategory | null;
 
 	@ApiPropertyOptional({
 		name: 'parent_id',
@@ -105,14 +98,6 @@ export abstract class SpaceEntity extends BaseEntity {
 	)
 	@Column({ type: 'int', default: 0 })
 	displayOrder: number;
-
-	// `suggestionsEnabled` + `statusWidgets` are home-control-specific. Their
-	// @Column + @ApiProperty decorations live on RoomSpaceEntity / ZoneSpaceEntity.
-	// Declared optional here so cross-module consumers (e.g. Buddy) can still
-	// read them off the abstract base without narrowing to a subtype.
-	suggestionsEnabled?: boolean;
-
-	statusWidgets?: Record<string, unknown>[] | null;
 
 	@ApiPropertyOptional({
 		name: 'last_activity_at',

--- a/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
@@ -382,7 +382,9 @@ describe('SpacesService', () => {
 			const result = await service.create(createDto);
 
 			expect(result.type).toBe(SpaceType.ROOM);
-			expect(result.category).toBe(SpaceRoomCategory.LIVING_ROOM);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceRoomCategory.LIVING_ROOM,
+			);
 		});
 
 		it('should accept ZONE with zone category', async () => {
@@ -406,7 +408,9 @@ describe('SpacesService', () => {
 			const result = await service.create(createDto);
 
 			expect(result.type).toBe(SpaceType.ZONE);
-			expect(result.category).toBe(SpaceZoneCategory.FLOOR_GROUND);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceZoneCategory.FLOOR_GROUND,
+			);
 		});
 
 		it('should accept null category for both types', async () => {
@@ -429,7 +433,7 @@ describe('SpacesService', () => {
 
 			const result = await service.create(createDto);
 
-			expect(result.category).toBeNull();
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBeNull();
 		});
 
 		it('should reject ROOM with zone category', async () => {
@@ -527,7 +531,9 @@ describe('SpacesService', () => {
 			const result = await service.update(existingRoomSpace.id, updateDto);
 
 			expect(result.type).toBe(SpaceType.ROOM);
-			expect(result.category).toBe(SpaceRoomCategory.BEDROOM);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceRoomCategory.BEDROOM,
+			);
 		});
 
 		it('should accept updating ZONE category to another zone category', async () => {
@@ -547,7 +553,9 @@ describe('SpacesService', () => {
 			const result = await service.update(existingZoneSpace.id, updateDto);
 
 			expect(result.type).toBe(SpaceType.ZONE);
-			expect(result.category).toBe(SpaceZoneCategory.FLOOR_FIRST);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceZoneCategory.FLOOR_FIRST,
+			);
 		});
 
 		it('should reject updating ROOM category to a zone category', async () => {
@@ -655,7 +663,9 @@ describe('SpacesService', () => {
 			const result = await service.update(spaceWithNullCategory.id, updateDto);
 
 			expect(result.type).toBe(SpaceType.ZONE);
-			expect(result.category).toBe(SpaceZoneCategory.FLOOR_GROUND);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceZoneCategory.FLOOR_GROUND,
+			);
 			// The raw UPDATE path for type changes must emit the discriminator column.
 			// We assert the payload handed to TypeORM's QueryBuilder.set() — TypeORM then
 			// resolves `type` via @TableInheritance's entityMetadata to the discriminator
@@ -689,7 +699,9 @@ describe('SpacesService', () => {
 			const result = await service.update(existingRoomSpace.id, updateDto);
 
 			expect(result.type).toBe(SpaceType.ZONE);
-			expect(result.category).toBe(SpaceZoneCategory.FLOOR_GROUND);
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBe(
+				SpaceZoneCategory.FLOOR_GROUND,
+			);
 			// Same assertion as above — verify the raw UPDATE SET payload includes the
 			// new discriminator alongside the other DTO-sourced fields, and is keyed by id.
 			expect(mockQueryBuilder.set).toHaveBeenCalledWith(
@@ -723,7 +735,7 @@ describe('SpacesService', () => {
 
 			const result = await service.update(roomSpace.id, updateDto);
 
-			expect(result.category).toBeNull();
+			expect((result as { category?: SpaceRoomCategory | SpaceZoneCategory | null }).category).toBeNull();
 		});
 
 		it('should reject setting category to null for a ZONE', async () => {

--- a/apps/backend/src/plugins/spaces-home-control/listeners/space-activity.listener.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/listeners/space-activity.listener.spec.ts
@@ -8,6 +8,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../modules/devices/entities/devices.entity';
 import { SpaceEntity } from '../../../modules/spaces/entities/space.entity';
 import { SpaceType } from '../../../modules/spaces/spaces.constants';
+import { RoomSpaceEntity } from '../entities/room-space.entity';
 
 import { SpaceActivityListener } from './space-activity.listener';
 
@@ -16,7 +17,7 @@ describe('SpaceActivityListener', () => {
 	let spaceRepository: jest.Mocked<Repository<SpaceEntity>>;
 	let channelRepository: jest.Mocked<Repository<ChannelEntity>>;
 
-	const mockSpace: SpaceEntity = {
+	const mockSpace: RoomSpaceEntity = {
 		id: uuid(),
 		name: 'Living Room',
 		description: 'Main living area',

--- a/apps/backend/src/plugins/spaces-home-control/services/space-context-snapshot.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-context-snapshot.service.spec.ts
@@ -6,9 +6,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelCategory, DeviceCategory, PropertyCategory } from '../../../modules/devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../modules/devices/entities/devices.entity';
 import { PropertyValueState } from '../../../modules/devices/models/property-value-state.model';
-import { SpaceEntity } from '../../../modules/spaces/entities/space.entity';
 import { SpacesService } from '../../../modules/spaces/services/spaces.service';
 import { SpaceType } from '../../../modules/spaces/spaces.constants';
+import { RoomSpaceEntity } from '../entities/room-space.entity';
 import { SpaceLightingRoleEntity } from '../entities/space-lighting-role.entity';
 import { ClimateMode, LightingRole } from '../spaces-home-control.constants';
 
@@ -26,7 +26,7 @@ describe('SpaceContextSnapshotService', () => {
 	let coversRoleService: jest.Mocked<SpaceCoversRoleService>;
 	let climateStateService: jest.Mocked<SpaceClimateStateService>;
 
-	const createSpace = (id: string, name: string): SpaceEntity => ({
+	const createSpace = (id: string, name: string): RoomSpaceEntity => ({
 		id,
 		name,
 		description: null,

--- a/apps/backend/src/plugins/spaces-home-control/services/space-suggestion-heartbeat.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-suggestion-heartbeat.service.ts
@@ -86,7 +86,11 @@ export class SpaceSuggestionHeartbeatService implements OnApplicationBootstrap, 
 
 		try {
 			const spaces = await this.spacesService.findAll();
-			const enabledSpaces = spaces.filter((s) => s.suggestionsEnabled);
+			// `suggestionsEnabled` lives on RoomSpaceEntity / ZoneSpaceEntity (this plugin's
+			// subtypes) and not the abstract SpaceEntity. Cross-plugin space types (master /
+			// entry / signage) don't expose it, so an indexed-property cast collapses their
+			// undefined to a falsy value and excludes them from the suggestion cycle.
+			const enabledSpaces = spaces.filter((s) => (s as { suggestionsEnabled?: boolean }).suggestionsEnabled === true);
 
 			if (enabledSpaces.length === 0) {
 				return;

--- a/apps/backend/src/plugins/spaces-home-control/services/space-suggestion.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-suggestion.service.spec.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 
-import { SpaceEntity } from '../../../modules/spaces/entities/space.entity';
 import { SpaceType } from '../../../modules/spaces/spaces.constants';
+import { RoomSpaceEntity } from '../entities/room-space.entity';
 import { SuggestionType } from '../spaces-home-control.constants';
 import { ResolvedSuggestionRule } from '../spec/intent-spec.types';
 
@@ -156,7 +156,7 @@ describe('SpaceSuggestionService - Pure Functions', () => {
 	});
 
 	describe('evaluateSuggestionRules', () => {
-		const createSpace = (name: string): SpaceEntity => ({
+		const createSpace = (name: string): RoomSpaceEntity => ({
 			id: uuid(),
 			name,
 			description: null,

--- a/apps/backend/src/plugins/spaces-home-control/services/space-suggestion.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-suggestion.service.ts
@@ -142,8 +142,11 @@ export class SpaceSuggestionService {
 		// Get space - throws if not found
 		const space = await this.spacesService.getOneOrThrow(spaceId);
 
-		// Check if suggestions are enabled
-		if (!space.suggestionsEnabled) {
+		// `suggestionsEnabled` lives on RoomSpaceEntity / ZoneSpaceEntity (this plugin's
+		// subtypes) and not the abstract SpaceEntity. Read it via an indexed-property cast
+		// so cross-plugin types (master / entry / signage) — where the field is undefined —
+		// are treated as suggestion-disabled instead of triggering a TS error.
+		if ((space as { suggestionsEnabled?: boolean }).suggestionsEnabled !== true) {
 			return null;
 		}
 


### PR DESCRIPTION
## Summary

Continues the spaces module refactor by removing home-control–specific fields (`category`, `suggestionsEnabled`, `statusWidgets`) from the abstract `SpaceEntity` and replacing the admin's room/zone/all type radio filter with a plugin-type checkbox filter (mirrors the devices module). Also drops the now plugin-specific `category` column from the admin spaces list table.

## What changed

### Backend
- **`SpaceEntity`** — removed the three abstract escape-hatch property declarations. They live on home-control's `RoomSpaceEntity` / `ZoneSpaceEntity` only.
- **Cross-module consumers** updated to read those fields via indexed-property casts so non-home-control space types (master / entry / signage) collapse to safe defaults instead of producing TS errors:
  - `buddy-context.service` and `heartbeat.service` (buddy module)
  - `space-suggestion.service` and `space-suggestion-heartbeat.service` (home-control plugin)
  - `device-zones.service` (floor-zone check)
- Test mock factories in home-control specs switched from `SpaceEntity` to `RoomSpaceEntity` where the home-control fields are needed.

### Admin
- **Spaces list table** — removed the `category` column.
- **Spaces filter** — replaced the room/zone/all radio with a multi-checkbox plugin-type filter, matching the devices module pattern:
  - `SpacesFilterSchema` switches from `type: SpaceType | 'all'` to `types: string[]`.
  - `useSpacesDataSource` filters by `types`.
  - `list-spaces-adjust` renders a checkbox group fed by `useSpacesPlugins().options`.
  - `spaces-table-column-plugin` becomes click-to-filter when given filter context, falls back to plain text in detail/list views (no breaking change to those callers).
- Locale files (en/cs/de/es/pl/sk) renamed `filters.type.{title,all}` → `filters.types.title`.

## Why

The abstract `SpaceEntity` was leaking plugin-specific concepts into the core type so that buddy and home-control services could read them off the base. With this refactor, the abstract base only carries the truly cross-cutting fields, plugin-specific fields stay on plugin entities, and consumers narrow explicitly. The admin filter and table changes finish aligning the spaces UI with how plugins now own their own type taxonomy (the same pattern devices already uses).

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] Backend Jest: 889/889 pass across `spaces`, `buddy`, `device-zones`, and `spaces-home-control`
- [x] Admin `vue-tsc --build` clean for spaces files (remaining repo-wide errors are pre-existing in unrelated modules)
- [x] Admin Vitest spaces suite: 61/61 pass
- [x] `pnpm run lint:js:fix` produces 0 errors
- [ ] Manual smoke in admin: open spaces list, toggle plugin-type filter via the adjust panel and via the table column click, verify category column is gone
- [ ] Manual smoke for buddy heartbeat / home-control suggestion cycle still picks up only home-control rooms/zones with `suggestionsEnabled === true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to API/entity typing changes and updated space filtering UI/state shape, which could affect downstream consumers and cached list state if any code path still assumes the old fields/filter schema.
> 
> **Overview**
> **Backend:** Removes home-control-specific fields (`category`, `suggestionsEnabled`, `statusWidgets`) from the abstract `SpaceEntity`, and updates Buddy/devices/home-control plugin code (and related tests) to access those fields via safe indexed-property casts or concrete `RoomSpaceEntity` mocks.
> 
> **Admin:** Replaces the single `type` (room/zone/all) radio filter with a multi-select `types: string[]` checkbox filter driven by plugin types, updates filtering logic/schema (including list-query `version` bump to avoid cached-state crashes), enables click-to-filter toggling from the Type column, and removes the `category` column from the spaces list table. Locales are updated from `filters.type` to `filters.types`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61feb46765c5a2e6a3ff2e48207c2ac632f85e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->