### PR TITLE
docs(backend/extensions): unify and expand extension READMEs

### DIFF
--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -143,38 +143,44 @@ export class AuthModule implements OnModuleInit {
 			name: 'Sign‑in & Security',
 			description: 'Authentication and token management',
 			author: 'FastyBird',
-			readme: `# Authentication Module
+			readme: `# Sign-in & Security
 
-The Authentication module handles user authentication and token management for the Smart Panel.
+> Module · by FastyBird
+
+Handles user authentication, JWT issuing and session management for the Smart Panel backend, admin UI and panel display. Owns the full token lifecycle — login, refresh, logout, profile, password reset and personal access tokens — plus per-display registration credentials issued during pairing.
 
 ## Features
 
-- **JWT Authentication** - Secure token-based authentication
-- **Token Management** - Access tokens, refresh tokens, and long-lived tokens
-- **Session Handling** - Automatic token refresh and session management
-- **Password Security** - Secure password hashing and validation
+- **JWT authentication** — signed access tokens with configurable expiration; rotated automatically on every \`/auth/refresh\`
+- **Refresh tokens** — long-lived tokens stored hashed in the database; used to silently renew access tokens without prompting the user
+- **Long-live (personal) tokens** — non-expiring tokens for automation, scripts and external integrations, individually revocable from the admin UI or the API
+- **Display registration tokens** — short-lived credentials issued during display pairing so a panel can authenticate without a user account
+- **Password security** — bcrypt hashing with per-user salt; passwords never returned in any response
+- **Username / email availability** — public endpoints used by the registration form to validate inputs before submit
+- **Owner bootstrap** — first-run CLI wizard creates the owner account; subsequent owners must be added through the admin UI
+- **Hardening** — guard chain refuses requests when the JWT secret is auto-generated in production and surfaces a critical log line until an explicit \`FB_TOKEN_SECRET\` is provided
 
-## Token Types
+## API Endpoints
 
-### Access Token
-- Short-lived token for API requests
-- Automatically refreshed using refresh token
-- Default expiration: configurable
+- \`POST /api/v1/modules/auth/login\` — exchange username + password for an access / refresh token pair
+- \`POST /api/v1/modules/auth/register\` — register a new user (subject to module configuration)
+- \`POST /api/v1/modules/auth/refresh\` — issue a fresh access token from a refresh token
+- \`POST /api/v1/modules/auth/check/username\` / \`check/email\` — availability lookups for the sign-up form
+- \`GET /api/v1/modules/auth/profile\` — return the authenticated user's profile
+- \`GET|POST|PATCH|DELETE /api/v1/modules/auth/tokens\` — list, create, edit and revoke long-live tokens
+- \`POST /api/v1/modules/auth/tokens/personal\` — quick-create flow for a personal token
 
-### Refresh Token
-- Used to obtain new access tokens
-- Longer lifetime than access tokens
-- Stored securely in the database
+## Configuration
 
-### Long-Live Token
-- For automated systems and integrations
-- Does not expire automatically
-- Can be revoked manually
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`FB_TOKEN_SECRET\` | Secret used to sign JWTs (env var, **set this in production**) | auto-generated random |
+| \`token_expiration\` | Lifetime of access tokens | \`1h\` |
 
 ## CLI Commands
 
-- \`register:owner\` - Create the initial owner account
-- \`reset:password\` - Reset a user's password`,
+- \`pnpm run cli register:owner\` — create the initial owner account
+- \`pnpm run cli reset:password\` — reset a user's password`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -179,8 +179,8 @@ Handles user authentication, JWT issuing and session management for the Smart Pa
 
 ## CLI Commands
 
-- \`pnpm run cli register:owner\` — create the initial owner account
-- \`pnpm run cli reset:password\` — reset a user's password`,
+- \`pnpm run cli auth:onboarding\` — create the initial owner account
+- \`pnpm run cli auth:reset\` — reset the owner password`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/buddy/buddy.module.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.ts
@@ -188,25 +188,39 @@ export class BuddyModule implements OnModuleInit {
 			name: 'Buddy',
 			description: 'AI assistant for proactive suggestions and text chat',
 			author: 'FastyBird',
-			readme: `# Buddy Module
+			readme: `# Buddy
 
-The Buddy module provides an AI assistant for the Smart Panel that observes user actions, learns patterns, and suggests automations.
+> Module · by FastyBird
+
+AI assistant for the Smart Panel. Observes user actions, builds a structured snapshot of the home, surfaces context-aware suggestions and powers a text / voice chat backed by pluggable LLM, TTS, STT and messaging providers. Buddy is the orchestration layer; the actual brains live in companion plugins so you can pick the model and provider that fit your privacy / cost / latency constraints.
+
+## What it gives you
+
+- A grounded assistant: every reply is prepared with a fresh, privacy-respecting snapshot of *your* home (spaces, devices, scenes, weather, energy) — not generic web knowledge
+- A unified tool layer: the LLM can run scenes, control devices and set lighting modes through structured tool calls, without you wiring a new endpoint per intent
+- A pluggable spine: swap LLM provider (Claude / OpenAI / Ollama / VoiceAI), voice (system / ElevenLabs / Whisper) or messaging channel (Discord / Telegram / WhatsApp) without touching this module
+- A safety net: when no AI provider is configured, rule-based suggestions and the action observer keep delivering value offline
 
 ## Features
 
-- **Action Observer** - Tracks completed intents to build a history of user actions
-- **Context Aggregation** - Builds structured snapshots of home state (spaces, devices, scenes, weather, energy)
-- **Text Chat** - Conversational interface powered by pluggable LLM providers
-- **Voice Interface** - Optional STT/TTS for hands-free interaction via pluggable providers
-- **Tool Execution** - LLM can control devices, run scenes, and set lighting modes via extensible tool providers
-- **Suggestions** - Context-aware suggestions based on detected patterns and rules
-- **Offline-First** - Rule-based suggestions work without any AI provider configured
+- **Action observer** — listens to completed intents and builds a rolling, anonymised history of "what happened in the home"; feeds suggestions and chat context
+- **Context aggregator** — produces a structured snapshot of spaces, devices and their roles, recent scenes, current weather, energy stats and security state; the LLM sees this instead of raw rows
+- **Text chat** — conversational REST endpoint backed by an LLM plugin; supports streaming responses, conversation history and per-conversation context overrides
+- **Voice interface** — optional STT (microphone → text) and TTS (text → speaker) so the panel can be operated hands-free; both pluggable
+- **Tool execution** — the LLM can call structured tools (e.g. \`device.control\`, \`scene.run\`, \`lighting.setMode\`); tools come from a registry other modules contribute to
+- **Suggestions engine** — pattern detection, anomaly detection, energy advice and conflict detection running on the action history; results surfaced in the panel "for you" area
+- **Personality file** — a writable markdown file describes how the assistant should behave; users can edit it without touching code
+- **Messaging adapters** — companion plugins can route Buddy chat through Discord, Telegram or WhatsApp so you can talk to your home from anywhere
+- **Offline-first defaults** — without any AI provider configured, the action observer + rule-based suggestions still work
 
-## Plugins
+## Configuration
 
-All LLM, TTS, and STT functionality is provided by separate plugins that register themselves with the buddy module. Install and enable the desired plugins, then set the buddy module \`provider\`, \`tts_plugin\`, and \`stt_plugin\` configs to the corresponding plugin type.
-
-Each plugin declares its capabilities (LLM, TTS, STT) when registering, and the buddy module discovers them dynamically.`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`provider\` | LLM plugin type to use for chat | — |
+| \`tts_plugin\` | TTS plugin for spoken responses | — |
+| \`stt_plugin\` | STT plugin for voice input | — |
+| \`personality_path\` | Path to the personality markdown file (included in backups) | data dir |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/config/config.module.ts
+++ b/apps/backend/src/modules/config/config.module.ts
@@ -94,27 +94,43 @@ export class ConfigModule implements OnModuleInit {
 			name: 'Configuration',
 			description: 'Application and module configuration management',
 			author: 'FastyBird',
-			readme: `# Configuration Module
+			readme: `# Configuration
 
-The Configuration module manages application settings and module configurations for the Smart Panel.
+> Module · by FastyBird
+
+Single source of truth for every setting in the Smart Panel. Modules and plugins register their own config DTOs at startup; this module accepts updates through one API, validates them, persists them to disk, and notifies the registered owner so live reconfiguration is possible without restarts.
+
+## What it gives you
+
+- A common config surface so the admin UI, CLI and Buddy don't need a custom flow per module
+- Strong validation — every section is type-checked against its owning module's DTO at write time, so bad config never reaches the runtime
+- Hot-reload semantics — owners are notified when their slice changes and can react (start polling, swap providers, …) without a backend restart
+- Predictable persistence — settings are JSON files, easy to inspect, version-control, back up and restore
 
 ## Features
 
-- **Centralized Configuration** - Single source of truth for all settings
-- **Module Configuration** - Per-module settings management
-- **Plugin Configuration** - Per-plugin settings management
-- **Factory Reset** - Ability to reset configuration to defaults
-
-## How It Works
-
-The Configuration module provides a unified API for accessing and modifying settings:
-- Application-level settings (language, display, etc.)
-- Module-specific configurations
-- Plugin-specific configurations
+- **Central config store** — every module and plugin reads its settings through this module's typed accessors
+- **Type registry** — modules and plugins register their config DTOs at startup; the registry knows the shape of every section
+- **Validation** — incoming changes are validated against the registered DTOs and rejected with field-level errors when they don't pass
+- **Watcher API** — modules subscribe to "my section changed" notifications and apply updates live
+- **Atomic writes** — changes are written to a temporary file and renamed in place, so a crash mid-write can never corrupt config
+- **Backups** — the config directory is automatically included in system backups; the seed subdir is excluded since those are factory defaults
+- **Factory reset** — restores defaults from the seed directory, preserving the owner's existence
+- **Schema versioning** — sections can declare a version number so future migrations can rewrite them safely
 
 ## Configuration Storage
 
-Settings are stored in a JSON configuration file on the device filesystem.`,
+Settings are stored as JSON files in \`FB_CONFIG_PATH\` (defaults to \`var/data\`).
+
+## API Endpoints
+
+- \`GET /api/v1/modules/config\` — read the global config (owner / admin only)
+- \`GET /api/v1/modules/config/:section\` — read a single section
+- \`PATCH /api/v1/modules/config\` — update one or more module / plugin sections in one transaction
+
+## CLI Commands
+
+- \`pnpm run cli generate:admin-extensions\` — regenerate admin-side extension manifests`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/config/config.module.ts
+++ b/apps/backend/src/modules/config/config.module.ts
@@ -130,7 +130,7 @@ Settings are stored as JSON files in \`FB_CONFIG_PATH\` (defaults to \`var/data\
 
 ## CLI Commands
 
-- \`pnpm run cli generate:admin-extensions\` — regenerate admin-side extension manifests`,
+- \`pnpm run cli config:generate-admin-extensions\` — regenerate the admin-side extensions import map (\`apps/admin/var/config/extensions.ts\`)`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/dashboard/dashboard.module.ts
+++ b/apps/backend/src/modules/dashboard/dashboard.module.ts
@@ -143,32 +143,35 @@ export class DashboardModule implements OnModuleInit {
 			name: 'Dashboards',
 			description: 'Dashboard pages and tiles management',
 			author: 'FastyBird',
-			readme: `# Dashboard Module
+			readme: `# Dashboards
 
-The Dashboard module provides the visual interface framework for the Smart Panel display.
+> Module · by FastyBird
+
+Visual interface framework for the Smart Panel display. Organizes pages, tiles and data sources into a grid-based layout that the Flutter panel renders and operates. This module owns the *what* of the UI; page and tile plugins decide *how* each piece looks and behaves.
+
+## What it gives you
+
+- A page tree that mirrors what the user sees on every panel — swipeable, lockable per space, and editable from the admin UI
+- A grid of tiles per page, each tile owning its own type, configuration and data bindings
+- Data sources that decouple a tile's visuals from its underlying value: the same time-tile can be driven by the system clock or a device property without code changes
 
 ## Features
 
-- **Pages** - Create multiple dashboard pages that can be swiped through on the display
-- **Tiles** - Add various tiles to pages (device controls, weather, time, etc.)
-- **Data Sources** - Connect tiles to device properties or weather data
-- **Layout Grid** - Flexible grid-based tile positioning
+- **Pages** — multiple dashboard pages per space, swipeable on the display, with per-page icon, title and ordering
+- **Tiles** — interactive widgets registered by tile plugins (device controls, weather, time, scenes, info-cards, …); each tile type validates its own config
+- **Data sources** — pluggable adapters that supply live values to tiles (e.g. device channel property, weather location, scene)
+- **Grid layout** — flexible row × column positioning with size hints; the panel re-flows automatically for the configured screen
+- **Plugin registry** — page types, tile types and data-source types are added by plugins; this module enforces correct DTOs and references at the API boundary
+- **Cross-references checked** — tiles that point at devices / channels / properties / scenes are validated through the existence constraints exposed by other modules
+- **Real-time sync** — every change is broadcast over WebSocket so the admin UI and the panel update without polling
+- **Seeding & factory reset** — registers seed data and a reset handler so demo dashboards and full wipes work consistently with the rest of the system
 
-## Tile Types
+## API Endpoints
 
-Tiles are provided by plugins and can display:
-
-- Device property values and controls
-- Weather information
-- Current time and date
-- Custom content
-
-## Data Sources
-
-Data sources connect tiles to live data:
-
-- **Device Channel** - Link to device property values
-- **Weather** - Display weather forecast data`,
+- \`GET|POST|PATCH|DELETE /api/v1/modules/dashboard/pages\` — manage pages
+- \`GET|POST|PATCH|DELETE /api/v1/modules/dashboard/tiles\` — manage tiles
+- \`GET|POST|PATCH|DELETE /api/v1/modules/dashboard/data-sources\` — manage data sources
+- \`GET /api/v1/modules/dashboard/pages/:id/tiles\` — fetch every tile that belongs to a page in one call`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/devices/devices.module.ts
+++ b/apps/backend/src/modules/devices/devices.module.ts
@@ -227,30 +227,38 @@ export class DevicesModule implements OnModuleInit {
 			name: 'Devices',
 			description: 'Central module for device management and interactions',
 			author: 'FastyBird',
-			readme: `# Devices Module
+			readme: `# Devices
 
-The Devices module is the central component for managing all IoT devices connected to the Smart Panel.
+> Module · by FastyBird
+
+Central module for registering, configuring and controlling every IoT device connected to the Smart Panel. Provides a generic device → channel → property data model that integration plugins specialize for their hardware, plus the runtime services that move values between the network, the database, the time-series store and the panel UI.
+
+## What it gives you
+
+- A canonical inventory of every device the panel knows about — regardless of vendor or transport
+- A unified read / write surface so other modules and plugins (dashboards, scenes, Buddy, automations) never need to know how a specific device speaks
+- Live state propagation: property changes received from a plugin are instantly visible on every connected admin and panel client, and asked-for changes are routed back to the right plugin
 
 ## Features
 
-- **Device Management** - Add, configure, and remove devices
-- **Channel Support** - Each device can have multiple channels (e.g., temperature sensor, relay switch)
-- **Property Tracking** - Monitor and control device properties in real-time
-- **Status Monitoring** - Track device connectivity and online status
-- **Time-series Data** - Store historical property values via storage module
+- **Device · Channel · Property model** — three-level shape that fits everything from a single switch to a multi-sensor gateway, with controls (commands), zones and platform metadata on each level
+- **Type registry** — integration plugins register their own device, channel and property subtypes; this module enforces the right DTO / validation per type at the API boundary
+- **Real-time state** — property values are streamed to clients over WebSocket the moment they change, and persisted as time-series for charts and history
+- **Connection tracking** — automatic online / offline state per device with continuous-query history (1-minute rollups for 24h, retained 14 days) used by the stats module and the panel
+- **Provisioning queue** — coordinates device discovery and onboarding across plugins so two integrations can't fight over the same physical device
+- **Connectivity service** — reachability checks, reconnect orchestration and last-seen timestamps surfaced through the API
+- **Tool provider for Buddy** — exposes "list / read / control device" as a structured tool the AI assistant can invoke during chat
+- **Stats provider** — feeds device counts, online ratio and per-platform breakdowns to the system dashboard
+- **Seeders & factory reset** — registers itself with the seed and reset registries so demo data and factory wipes work consistently
+- **Validation constraints** — \`DeviceExists\`, \`ChannelExists\` and \`ChannelPropertyExists\` decorators usable by any other module's DTOs
 
-## Supported Device Types
+## API Endpoints
 
-Devices are managed through platform plugins that provide integration with specific device ecosystems:
-
-- Shelly NG devices
-- Shelly Gen1 devices
-- Home Assistant devices
-- Third-party/manual devices
-
-## Architecture
-
-The module uses a flexible type mapping system that allows plugins to register their own device, channel, and property types while maintaining a unified API.`,
+- \`GET|POST|PATCH|DELETE /api/v1/modules/devices/devices\` — manage devices
+- \`GET|POST|PATCH|DELETE /api/v1/modules/devices/devices/:id/channels\` — manage device channels
+- \`GET|POST|PATCH|DELETE /api/v1/modules/devices/devices/:id/channels/:cid/properties\` — manage channel properties
+- \`GET /api/v1/modules/devices/devices/:id/controls\` — list device controls
+- \`GET /api/v1/modules/devices/channels\` / \`/properties\` — flat aggregated lookups across all devices`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/displays/displays.module.ts
+++ b/apps/backend/src/modules/displays/displays.module.ts
@@ -113,38 +113,36 @@ export class DisplaysModule implements OnModuleInit {
 			name: 'Displays',
 			description: 'Manage connected display panels and their registration',
 			author: 'FastyBird',
-			readme: `# Displays Module
+			readme: `# Displays
 
-The Displays module manages physical display panels connected to the Smart Panel system.
+> Module · by FastyBird
+
+Manages physical display panels (the Flutter touchscreen app) connected to the Smart Panel backend. Owns pairing, per-display configuration, the home-page resolution that decides what each panel shows on boot, and real-time updates that keep every screen in sync without any user-side credentials.
 
 ## Features
 
-- **Display Registration** - Secure pairing of display panels with the backend
-- **Connection Tracking** - Monitor display online/offline status
-- **Multi-Display Support** - Manage multiple display panels from one backend
-- **Status History** - Track connection status over time via storage
+- **Secure pairing (permit-join)** — registration is closed by default; an admin opens a temporary join window from the admin UI, the panel submits its hardware fingerprint, and the admin approves it before any token is issued
+- **Per-display credentials** — once approved, the panel is given a long-lived token tied to its display ID; pulling the display from the admin UI revokes the token immediately
+- **Multi-display** — drive any number of panels from one backend, each with its own primary space, brightness and personalisation
+- **Per-display configuration** — brightness, dark / auto mode, optional PIN lock, idle / screensaver behaviour, primary space and home page; all editable from the admin UI and pushed live to the panel
+- **Home-page resolution** — pluggable resolvers decide which dashboard page a display should land on for a given space; space plugins can register their own logic without touching this module
+- **Space-selection validation** — pluggable validators ensure a display can only be tied to spaces it's actually allowed to render
+- **Connection tracking** — display online / offline state and last-seen timestamps are stored as time-series and exposed to the stats module
+- **WebSocket exchange** — listens to backend events (dashboards, devices, scenes, weather, …) and re-broadcasts only the slices each display needs
+- **Factory reset hook** — registers itself with the system reset pipeline so wiping a panel removes its display record and revokes its token
 
 ## Registration Flow
 
-1. **Permit Join** - Admin enables registration mode in the admin panel
-2. **Display Request** - The display sends a registration request with its details
-3. **Approval** - Admin approves the display in the pending list
-4. **Token Exchange** - Display receives authentication tokens for API access
+1. **Permit join** — an admin enables registration mode in the admin UI for a limited time window
+2. **Display request** — the panel sends its identifier and metadata to the registration endpoint
+3. **Approval** — the admin reviews the pending registration and either approves or rejects it
+4. **Token exchange** — on approval, the panel receives long-lived credentials for API and WebSocket access; permit-join then closes again
 
-## Display Properties
+## API Endpoints
 
-- **Name** - Friendly name for the display
-- **Identifier** - Unique device identifier
-- **Brightness** - Current display brightness level
-- **Dark Mode** - Enable/disable dark theme
-- **Screen Lock** - PIN protection settings
-
-## WebSocket Events
-
-Displays communicate via WebSocket for real-time updates:
-- Configuration changes
-- Dashboard updates
-- Device state changes`,
+- \`GET|PATCH|DELETE /api/v1/modules/displays/displays\` — list, configure and remove displays
+- \`POST /api/v1/modules/displays/registration\` — submit a registration request (panel side)
+- \`PATCH /api/v1/modules/displays/registration/permit\` — toggle permit-join (admin side)`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/energy/energy.module.ts
+++ b/apps/backend/src/modules/energy/energy.module.ts
@@ -88,29 +88,43 @@ export class EnergyModule implements OnModuleInit {
 			name: 'Energy',
 			description: 'Energy consumption and production monitoring with per-space tracking and historical analysis',
 			author: 'FastyBird',
-			readme: `# Energy Module
+			readme: `# Energy
 
-The Energy module tracks energy consumption and production data for the Smart Panel display.
+> Module · by FastyBird
+
+Tracks electrical energy consumption and production across the home. Ingests cumulative kWh readings from any device channel that exposes them, normalises the data into fixed 5-minute buckets and surfaces both per-space breakdowns and a home-wide aggregate.
+
+## What it gives you
+
+- A single source of truth for "how much energy did the house use this week" — independent of how many meters, inverters or smart plugs are involved
+- Per-space accounting so you can see which room is the loudest consumer
+- A simple data model the dashboard energy tile and the assistant can both query without dealing with raw counter values
 
 ## Features
 
-- **Per-Space Tracking** - Monitor energy usage broken down by individual spaces
-- **Home Overview** - Aggregated energy data across all spaces
-- **Historical Analysis** - Query energy data by range (today, yesterday, week, month)
-- **Delta Computation** - Automatic interval-based delta bucketing from cumulative kWh readings
-- **Source Types** - Track consumption import, generation production, grid import, and grid export
+- **Per-space tracking** — energy usage broken down by individual spaces, with multiple sources per space
+- **Home overview** — aggregated consumption, production, grid import and grid export at home level
+- **Delta computation** — cumulative kWh meter readings are turned into 5-minute deltas in the background; counter resets and missing samples are detected and skipped
+- **Historical ranges** — pre-aggregated answers for today, yesterday, this week, this month and any custom range
+- **Cached aggregates** — frequently requested ranges are cached so dashboard tiles render instantly even on big histories
+- **Retention** — old raw records are pruned according to the configured policy; aggregated buckets are kept much longer
+- **Multi-source per space** — a space can mix several sources (e.g. a circuit meter + a solar inverter) and the module deduplicates and signs them correctly
 
-## Endpoints
+## Source Types
 
-- \`GET /api/v1/modules/energy/status\` - Current energy status and configuration
-- \`GET /api/v1/modules/energy/home\` - Aggregated home energy data
-- \`GET /api/v1/modules/energy/spaces/:id\` - Per-space energy breakdown
+| Type | Description |
+|------|-------------|
+| \`consumption\` | Energy imported from a meter or measured at a load |
+| \`production\` | Energy produced (e.g. solar inverter output) |
+| \`grid_import\` | Energy drawn from the utility grid |
+| \`grid_export\` | Energy fed back to the utility grid |
 
-## Architecture
+## API Endpoints
 
-The module ingests cumulative kWh meter readings from device channels and computes
-fixed-interval deltas (5-minute buckets). Results are cached for fast retrieval
-and old records are automatically cleaned up based on configurable retention policy.`,
+- \`GET /api/v1/modules/energy/status\` — current energy status and configuration
+- \`GET /api/v1/modules/energy/home\` — aggregated home energy data
+- \`GET /api/v1/modules/energy/spaces/:id\` — per-space energy breakdown
+- \`GET /api/v1/modules/energy/spaces/:id/sources\` — list / configure per-space sources`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/extensions/extensions.module.ts
+++ b/apps/backend/src/modules/extensions/extensions.module.ts
@@ -92,42 +92,43 @@ export class ExtensionsModule implements OnModuleInit {
 			name: 'Extensions',
 			description: 'Manage application modules and plugins',
 			author: 'FastyBird',
-			readme: `# Extensions Module
+			readme: `# Extensions
 
-The Extensions module provides a unified interface for discovering and managing all modules and plugins in the Smart Panel application.
+> Module · by FastyBird
+
+Provides a unified interface for discovering, enabling, disabling and inspecting every module and plugin registered with the Smart Panel backend. This is what the admin UI's "Extensions" page is built on, and what the rest of the system uses to find out which optional features are actually available.
+
+## What it gives you
+
+- One catalogue of everything plugged into the backend, with consistent metadata (name, description, author, version, README, links)
+- A safe enable / disable surface — toggling a plugin re-validates dependencies (e.g. don't disable the storage backend that's currently in use)
+- A service control plane for plugins that run long-lived workers, so the admin can start / stop / restart them without restarting the whole backend
+- An action audit log so you can see *who* enabled / disabled / restarted what, and when
 
 ## Features
 
-- **Extension Discovery** - Automatically discovers all registered modules and plugins
-- **Metadata Management** - Stores extension information like name, description, author
-- **Enable/Disable** - Toggle plugin functionality on and off
-- **Configuration** - Access extension-specific configuration options
+- **Extension discovery** — enumerates all registered modules and plugins at runtime; the catalogue is built from in-process metadata so it is always exact
+- **Rich metadata** — exposes name, description, author, version, type, default-enabled flag, capabilities, links and the rendered README to the admin UI
+- **Enable / disable** — toggles plugins (and configurable modules) on or off via configuration; the relevant module is notified live so the change takes effect without a restart wherever possible
+- **Dependency awareness** — refuses to disable a plugin that another active component currently depends on (e.g. the selected storage backend) and reports why
+- **Service control** — start, stop and restart long-running plugin services; useful for plugins that connect to external systems where reconnect can fix transient issues
+- **Action audit** — every enable / disable / service action is recorded with the actor and timestamp; available through the API and CLI
+- **Capability registry** — plugins advertise capabilities (\`tts\`, \`stt\`, \`llm\`, \`messaging\`, …) so other modules can pick a provider by capability instead of hard-coded type
 
-## Extension Types
+## API Endpoints
 
-### Modules
-Core functionality providers that cannot be uninstalled:
-- Devices, Dashboard, Users, Weather, Auth, etc.
+- \`GET /api/v1/modules/extensions\` — list all extensions
+- \`GET /api/v1/modules/extensions/:type\` — get a single extension
+- \`PATCH /api/v1/modules/extensions/:type\` — enable or disable an extension
+- \`GET /api/v1/modules/extensions/services\` — list managed plugin services
+- \`POST /api/v1/modules/extensions/services/:type/{start|stop|restart}\` — control a plugin service
 
-### Plugins
-Optional add-ons that extend functionality:
-- Device integrations (Shelly, Home Assistant)
-- Dashboard tiles (time, weather)
-- Data sources for tiles
-- Weather providers
+## CLI Commands
 
-## For Developers
-
-Extensions register their metadata during module initialization using the \`ExtensionsService\`:
-
-\`\`\`typescript
-this.extensionsService.registerModuleMetadata({
-  type: 'my-module',
-  name: 'My Module',
-  description: 'Module description',
-  author: 'Author Name',
-});
-\`\`\``,
+- \`pnpm run cli services:list\` — list managed plugin services
+- \`pnpm run cli services:start <type>\` — start a service
+- \`pnpm run cli services:stop <type>\` — stop a service
+- \`pnpm run cli services:restart <type>\` — restart a service`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/intents/intents.module.ts
+++ b/apps/backend/src/modules/intents/intents.module.ts
@@ -47,42 +47,43 @@ export class IntentsModule {
 			name: 'Intents',
 			description: 'Intent orchestration for UI anti-jitter and optimistic updates',
 			author: 'FastyBird',
-			readme: `# Intents Module
+			readme: `# Intents
 
-The Intents module provides intent orchestration for coordinating UI updates across multiple clients, preventing anti-jitter issues and enabling optimistic updates.
+> Module · by FastyBird
+
+Coordinates UI updates across all connected clients (admin, panel displays, mobile) so optimistic actions stay in sync. An intent represents a user-initiated change with a TTL: clients show the expected value immediately and reconcile when the backend confirms the real outcome or the TTL elapses. This is what makes the panel feel instant even when the underlying device takes a second to respond.
+
+## What it gives you
+
+- A "single source of truth" for in-flight user actions: every client sees the same pending change at the same time
+- Automatic anti-jitter — when two users tap the same switch from two clients, they don't fight each other
+- A short audit trail of recent user actions, queryable by the action observer used in dashboards and Buddy
 
 ## Features
 
-- **Intent Lifecycle Management** - Track intents from creation through completion or expiration
-- **Multi-Target Support** - Single intent can affect multiple devices/properties
-- **Optimistic Updates** - Clients can show expected values before confirmation
-- **Anti-Jitter Protection** - Prevents UI flickering when multiple clients update simultaneously
-- **WebSocket Integration** - Real-time intent status broadcasts to all connected clients
-
-## How It Works
-
-1. **Intent Creation** - When a client initiates an action (e.g., turn on light), an intent is created with a unique ID and TTL
-2. **Broadcasting** - The intent is broadcast to all connected clients via WebSocket
-3. **Target Tracking** - Each target (device/property) within the intent is tracked individually
-4. **Completion** - When backend confirms the change, intent is marked complete
-5. **Expiration** - If TTL expires before confirmation, intent is marked expired
+- **Intent lifecycle** — \`pending → confirmed | failed | expired\`, observable through the API and over WebSocket
+- **Multi-target** — a single intent can carry several device / property writes at once and is committed atomically from the UI's point of view
+- **Optimistic updates** — clients apply the expected value the instant the intent is created and revert if the backend reports failure or the TTL fires
+- **Anti-jitter** — coalesces near-simultaneous intents on the same target so the UI doesn't flicker between competing values
+- **WebSocket broadcast** — every state transition is pushed to every connected client; no polling needed
+- **Time-series log** — completed and failed intents are persisted briefly so dashboards and the assistant can answer "what just happened in this room?"
+- **Pluggable intent types** — modules can register their own intent kinds with their own validation and reconciliation logic
 
 ## Intent Types
 
-- \`light.toggle\` - Toggle light on/off
-- \`light.setBrightness\` - Set light brightness level
-- \`light.setColor\` - Set light RGB color
-- \`light.setColorTemp\` - Set light color temperature
-- \`device.setProperty\` - Generic property value change
-- \`scene.run\` - Execute a scene
+- \`light.toggle\` — toggle a light on/off
+- \`light.setBrightness\` — set light brightness
+- \`light.setColor\` — set light RGB colour
+- \`light.setColorTemp\` — set light colour temperature
+- \`device.setProperty\` — generic property value change
+- \`scene.run\` — execute a scene
 
-## Client Integration
+## Client Flow
 
-Clients should:
-1. Listen for intent events via WebSocket
-2. Apply optimistic updates when intent is created
-3. Revert if intent expires or fails
-4. Confirm when intent completes successfully`,
+1. User triggers an action — a client publishes an intent
+2. The intent is broadcast over WebSocket; every client applies the expected value
+3. The backend confirms the change → intent completes and clients keep the value
+4. If the TTL elapses without confirmation → intent expires and clients revert to the last known good value`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/mdns/mdns.module.ts
+++ b/apps/backend/src/modules/mdns/mdns.module.ts
@@ -49,38 +49,43 @@ export class MdnsModule implements OnModuleInit {
 			name: 'mDNS',
 			description: 'Multicast DNS service advertisement for network discovery',
 			author: 'FastyBird',
-			readme: `# mDNS Module
+			readme: `# mDNS
 
-The mDNS (Multicast DNS) module enables automatic network discovery of the Smart Panel using Bonjour/Avahi protocols.
+> Module · by FastyBird
+
+Advertises the Smart Panel on the local network using Multicast DNS (Bonjour / Avahi) so admin browsers and panel displays can auto-discover the backend without a hard-coded IP address. This is what makes "just plug it in and find it on the LAN" actually work.
+
+## What it gives you
+
+- Newly flashed displays connect to the backend on first boot without any manual IP entry
+- The admin UI bookmarks survive DHCP IP changes — the hostname is what's resolved
+- Multiple Smart Panel installations can coexist on the same network and be told apart by hostname
 
 ## Features
 
-- **Service Advertisement** - Broadcasts Smart Panel presence on the local network
-- **Zero Configuration** - Clients can discover the panel without manual IP configuration
-- **Custom Naming** - Configure a custom hostname for the panel
+- **Zero-conf discovery** — clients find the panel automatically on the LAN by looking up the advertised service name
+- **Custom hostname** — pick the name advertised on the network; defaults to the system hostname
+- **Service metadata** — advertises the API base path, scheme (http/https) and version so clients can build URLs from the discovery record alone
+- **Toggleable** — disable advertisement on networks where mDNS is filtered or undesirable
+- **Live re-broadcast** — when the configuration changes the advertisement is updated without needing a restart
 
-## How It Works
+## Configuration
 
-When enabled, the Smart Panel advertises itself on the local network as:
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`enabled\` | Toggle mDNS advertisement | \`true\` |
+| \`hostname\` | Hostname advertised on the network | system hostname |
+
+## Service Record
 
 \`\`\`
 _smart-panel._tcp.local
 \`\`\`
 
-This allows:
-- Mobile apps to auto-discover the panel
-- Other services to find the panel's IP address
-- Easy setup without manual network configuration
-
-## Configuration
-
-- **Enabled** - Toggle mDNS advertisement on/off
-- **Hostname** - Custom name for network identification
-
 ## Requirements
 
-- The Smart Panel must be on the same network segment as discovering clients
-- mDNS uses UDP port 5353`,
+- Discovering clients must share the same network segment as the panel
+- mDNS uses UDP port \`5353\` — make sure it isn't blocked by host or network firewalls`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/platform/platform.module.ts
+++ b/apps/backend/src/modules/platform/platform.module.ts
@@ -30,30 +30,38 @@ export class PlatformModule implements OnModuleInit {
 			name: 'Platform',
 			description: 'Hardware platform detection, system power actions, and device monitoring',
 			author: 'FastyBird',
-			readme: `# Platform Module
+			readme: `# Platform
 
-The Platform module handles hardware detection and platform-specific system operations.
+> Module · by FastyBird
+
+Auto-detects the underlying hardware / runtime and abstracts platform-specific system operations behind a uniform API. Other modules ask "reboot the device" or "set brightness to 50%" — this module decides whether that means \`systemctl\`, a Docker restart, a sysfs poke or a no-op.
+
+## What it gives you
+
+- A consistent abstraction so the rest of the codebase never branches on "are we on a Pi or in Docker?"
+- Multi-strategy fallback — when the preferred mechanism (systemctl, D-Bus, sudo) is unavailable the module tries the next best option before giving up
+- A safe sandbox for development where destructive actions become harmless equivalents (e.g. process exit instead of OS reboot)
 
 ## Features
 
-- **Platform Detection** - Auto-detects Raspberry Pi (including CM4-based boards like reTerminal), Docker, and generic Linux
-- **System Power** - Reboot and power off with multi-strategy fallback (systemctl, D-Bus, sudo)
-- **Throttle Monitoring** - CPU throttle status on Raspberry Pi (undervoltage, frequency capping, thermal)
-- **System Information** - CPU, memory, storage, network stats, and temperature readings
-- **Display Control** - Screen brightness and resolution management
-- **WiFi Management** - Network scanning and connection
+- **Auto-detection** — Raspberry Pi (incl. CM4 boards like reTerminal), Docker, Home Assistant add-on or generic Linux; a single env override lets you force any platform for testing
+- **Power actions** — reboot and power off with multi-strategy fallback (systemctl, D-Bus, sudo, container restart)
+- **Throttle monitoring** — CPU under-voltage, frequency capping and thermal flags on Raspberry Pi, exposed to the system module so the panel can warn the user
+- **System information** — CPU, memory, storage, network and temperature readings polled in the background and cached
+- **Display control** — screen brightness, screen blanking and resolution management on supported boards
+- **Wi-Fi management** — scan visible networks and connect to a chosen SSID with passphrase
+- **Time / locale** — timezone read and update where supported by the host
 
 ## Supported Platforms
 
-| Platform | Detection | Power Actions | Throttle | Display |
-|----------|-----------|---------------|----------|---------|
-| Raspberry Pi | Auto (device-tree) | Yes | Yes | Yes |
-| reTerminal (CM4) | Auto (device-tree) | Yes | Yes | Yes |
-| Docker | Env var | Container restart | No | No |
-| Home Assistant | Env var | Addon restart | No | No |
-| Generic Linux | Fallback | Limited | No | No |
-| Development | Env var | Process exit | No | No |
-`,
+| Platform | Detection | Power | Throttle | Display | Wi-Fi |
+|----------|-----------|-------|----------|---------|-------|
+| Raspberry Pi | device-tree | yes | yes | yes | yes |
+| reTerminal (CM4) | device-tree | yes | yes | yes | yes |
+| Docker | env var | container restart | no | no | no |
+| Home Assistant | env var | add-on restart | no | no | no |
+| Generic Linux | fallback | limited | no | limited | limited |
+| Development | env var | process exit | no | no | no |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs/plugins/devices-module/reterminal',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/scenes/scenes.module.ts
+++ b/apps/backend/src/modules/scenes/scenes.module.ts
@@ -128,31 +128,31 @@ export class ScenesModule implements OnModuleInit {
 			name: 'Scenes',
 			description: 'Scenes for controlling multiple devices with a single action',
 			author: 'FastyBird',
-			readme: `# Scenes Module
+			readme: `# Scenes
 
-The Scenes module allows you to control multiple devices with a single action, perfect for creating quick shortcuts like "Movie Mode" or "Good Night".
+> Module · by FastyBird
+
+Lets you control many devices at once with a single action — the building block for shortcuts like *Movie Mode*, *Good Night*, *Away* or *Wake-up*. A scene bundles an ordered list of actions; triggering the scene runs every action in sequence and reports per-action status back to the caller.
 
 ## Features
 
-- **Scene Management** - Create, edit, and delete scenes
-- **Action Sequencing** - Define ordered sequences of device commands
-- **Space Assignment** - Associate scenes with rooms or zones
-- **Category Organization** - Categorize scenes (morning, evening, movie, etc.)
-- **Manual Execution** - Execute scenes via API or admin UI
-- **Plugin System** - Extensible action types through plugins
-
-## How It Works
-
-Scenes consist of one or more actions that are executed in sequence when manually triggered. Each action is handled by a registered plugin (e.g., local device control, third-party integrations).
+- **Scene CRUD** — create, edit, reorder and delete scenes through the API or the admin UI
+- **Ordered action lists** — actions execute in declared order; each action returns its own success / failure result so partial failures are visible
+- **Space assignment** — bind a scene to a specific room or zone so the panel can surface it where it's relevant
+- **Categorization & icons** — pick a category (morning, evening, movie, …) and an icon so scenes group nicely on the panel home screen
+- **Multi-trigger** — execute scenes manually from the admin UI, from a panel tile, via REST, from a Buddy chat, or as a step inside another automation
+- **Plugin-based actions** — action *types* are pluggable; the module ships a registry that lets plugins add new action kinds (for example controlling local devices, calling an external service, sending a notification, …)
+- **Validation** — every action references existing devices / channels / properties; the API rejects scenes that point at things that don't exist
+- **Factory reset & seed hooks** — registers itself with the platform reset / seed pipeline so demo scenes and full wipes behave consistently
 
 ## API Endpoints
 
-- \`GET /v1/modules/scenes/scenes\` - List all scenes
-- \`POST /v1/modules/scenes/scenes\` - Create a new scene
-- \`GET /v1/modules/scenes/scenes/{id}\` - Get scene details
-- \`PATCH /v1/modules/scenes/scenes/{id}\` - Update a scene
-- \`DELETE /v1/modules/scenes/scenes/{id}\` - Delete a scene
-- \`POST /v1/modules/scenes/scenes/{id}/trigger\` - Trigger scene execution`,
+- \`GET /api/v1/modules/scenes/scenes\` — list scenes (with their actions)
+- \`POST /api/v1/modules/scenes/scenes\` — create a scene
+- \`GET /api/v1/modules/scenes/scenes/:id\` — read a single scene
+- \`PATCH /api/v1/modules/scenes/scenes/:id\` — update a scene (metadata or actions)
+- \`DELETE /api/v1/modules/scenes/scenes/:id\` — delete a scene
+- \`POST /api/v1/modules/scenes/scenes/:id/trigger\` — execute a scene and receive per-action results`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/security/security.module.ts
+++ b/apps/backend/src/modules/security/security.module.ts
@@ -105,30 +105,35 @@ export class SecurityModule implements OnModuleInit {
 			name: 'Security',
 			description: 'Security status, armed state, and alert management',
 			author: 'FastyBird',
-			readme: `# Security Module
+			readme: `# Security
 
-The Security module provides security status information for the Smart Panel display.
+> Module · by FastyBird
+
+Aggregates the security state of the home (armed mode, alarm state, alerts) into a single API surface. Without any provider plugin installed it returns safe defaults (disarmed, no alerts); integration plugins can register providers to supply real data, and the module merges the results into one consistent view.
+
+## What it gives you
+
+- One canonical answer to "is the alarm on?" no matter how many sensors, sirens or panels are involved
+- A common alert pipe — leaks, smoke, motion, door / window, low battery, integration errors all flow through the same shape
+- A small, predictable surface for dashboards, the panel and Buddy to consume; provider plugins evolve underneath without breaking clients
 
 ## Features
 
-- **Armed State** - Track system armed state (disarmed, armed home, armed away, armed night)
-- **Alarm State** - Monitor alarm state (idle, pending, triggered, silenced)
-- **Alert Severity** - Aggregate alert severity across security devices
-- **Alert Acknowledgement** - Acknowledge alerts with persistent state
-- **Extensible** - Provider-based architecture for future integrations
+- **Armed state** — \`disarmed\`, \`armed_home\`, \`armed_away\`, \`armed_night\` with reason / actor tracking on every transition
+- **Alarm state** — \`idle\`, \`pending\`, \`triggered\`, \`silenced\`; transitions are time-stamped and stored
+- **Alert aggregation** — combines alerts from every registered provider into a unified list, picks the most severe overall level (info / warning / critical), de-duplicates noisy sensors
+- **Alert acknowledgement** — acknowledge individual alerts or wipe every active alert at once; acknowledged alerts stay visible in history
+- **Event timeline** — recent security events (state changes, alert raised / cleared, ack actions) are persisted as time-series for the panel "history" view
+- **Provider architecture** — providers are pluggable: a default safe provider, a future alarm-panel provider, sensor-based providers; the module enforces a stable contract so adding one doesn't change the API
+- **Real-time push** — every state change and alert transition is broadcast over WebSocket so panels and the admin UI react instantly
 
-## Endpoints
+## API Endpoints
 
-- \`GET /api/v1/modules/security/status\` - Current security status
-- \`PATCH /api/v1/modules/security/alerts/:id/ack\` - Acknowledge a single alert
-- \`PATCH /api/v1/modules/security/alerts/ack\` - Acknowledge all active alerts
-- \`GET /api/v1/modules/security/events\` - Recent security event timeline
-
-## Architecture
-
-The module is designed as a state aggregation layer. Security state providers can be registered
-by integration plugins (e.g., Home Assistant, Matter) to supply real device data. Without providers,
-the module returns safe default values (disarmed, no alerts).`,
+- \`GET /api/v1/modules/security/status\` — current armed / alarm state plus active alerts
+- \`GET /api/v1/modules/security/events\` — recent security event timeline
+- \`PATCH /api/v1/modules/security/alerts/:id/ack\` — acknowledge a single alert
+- \`PATCH /api/v1/modules/security/alerts/ack\` — acknowledge every active alert
+- \`PATCH /api/v1/modules/security/arm\` / \`/disarm\` — change armed state (subject to provider rules)`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/spaces/spaces.module.ts
+++ b/apps/backend/src/modules/spaces/spaces.module.ts
@@ -121,27 +121,35 @@ export class SpacesModule implements OnModuleInit {
 			name: 'Spaces',
 			description: 'Manage spaces (rooms/zones) and organize devices and displays',
 			author: 'FastyBird',
-			readme: `# Spaces Module
+			readme: `# Spaces
 
-The Spaces module provides a room-centric organization for your Smart Panel system.
+> Module · by FastyBird
+
+Provides a room-centric organisation layer for the Smart Panel. Devices and displays are grouped into *rooms* and *zones*, which act as the foundation for space-based dashboards, role-based controls (lighting, climate, covers, sensors, media) and the Buddy AI context.
+
+## What it gives you
+
+- A spatial map of your home: every device knows which room it lives in and every display knows which space it primarily serves
+- A *role* layer on top of devices so pages and the assistant can talk about "lights in the living room" instead of "channel \`onoff\` of device \`abc-123\`"
+- A pluggable concept of "what is a space" — synthetic rooms, signage spaces and home-control rooms can all coexist behind the same API
 
 ## Features
 
-- **Space Management** - Create, edit, and delete spaces (rooms/zones)
-- **Device Assignment** - Assign devices to spaces for organized control
-- **Display Assignment** - Link displays to specific spaces
-- **Bulk Operations** - Assign multiple devices/displays at once
+- **Space CRUD** — create, edit and delete rooms and zones with icon, name and ordering
+- **Rooms and zones** — physical rooms (Living Room, Kitchen) and logical groupings (Downstairs, Outdoor); zones can contain rooms and inherit device membership
+- **Device & display assignment** — attach devices and displays to a space individually or in bulk
+- **Role registry** — channels register the role they play within a space (lighting, climate, covers, sensors, media); pages and Buddy use these roles to route commands
+- **Plugin-extensible** — space *types* are pluggable: \`spaces-home-control\`, \`spaces-signage-info-panel\` and the synthetic plugins each register their own space subtype with extra fields and validation
+- **Builder registry** — plugins extend the create / update flow with extra inputs (e.g. signage announcement defaults, home-control role bindings)
+- **Validation** — \`SpaceExists\` and role-binding constraints are exported for use in any other module's DTOs
+- **Stable identifiers** — re-ordering rooms or moving devices between spaces keeps every reference (dashboards, scenes, displays) intact
 
-## Space Types
+## API Endpoints
 
-- **Room** - Physical rooms like Living Room, Bedroom, Kitchen
-- **Zone** - Logical groupings like Downstairs, Outdoor, Entertainment Area
-
-## Benefits
-
-- Simplified device organization
-- Room-centric control experience
-- Foundation for Space Pages and intent-based controls`,
+- \`GET|POST|PATCH|DELETE /api/v1/modules/spaces/spaces\` — manage spaces
+- \`GET|POST|DELETE /api/v1/modules/spaces/spaces/:id/devices\` — attach / detach devices
+- \`GET|POST|DELETE /api/v1/modules/spaces/spaces/:id/displays\` — attach / detach displays
+- \`GET|POST|PATCH|DELETE /api/v1/modules/spaces/spaces/:id/roles\` — manage role bindings inside a space`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/storage/storage.module.ts
+++ b/apps/backend/src/modules/storage/storage.module.ts
@@ -46,14 +46,35 @@ export class StorageModule implements OnModuleInit {
 			name: 'Storage',
 			description: 'Time-series storage with plugin architecture. Supports pluggable storage backends.',
 			author: 'FastyBird',
-			readme: `# Storage Module
+			readme: `# Storage
 
-The Storage module provides time-series data storage for the Smart Panel via a plugin architecture.
+> Module · by FastyBird
+
+Provides time-series data storage for property values, device statuses and other historical metrics. Backends are pluggable — install a storage plugin and select it as the primary (and optional fallback) backend. Other modules don't talk to a database directly: they declare a schema, and the storage module routes writes / queries to the configured backend.
+
+## What it gives you
+
+- A uniform write API across every backend (in-memory, InfluxDB 1.x, InfluxDB 2.x, future ones); module code stays identical when you swap engines
+- Automatic fallback — if the primary backend is down or unreachable, writes go to the fallback so dashboards keep filling out and nothing is lost
+- A central schema registry so modules describe the *shape* of the data they need (tags, fields, retention) and the backend translates that into bucket / measurement / retention-policy on the actual store
+- Optional continuous-query support so backends that can downsample do, and dashboards stay fast on long ranges
+
+## Features
+
+- **Pluggable backends** — any storage plugin can register; selection is at runtime via configuration so you can swap engines without changing module code
+- **Primary + fallback** — every write is attempted on the primary, and routed to the fallback on failure; reads prefer the primary but fall through automatically
+- **Schema registry** — modules declare the time-series schemas they need (measurement name, tags, fields, retention); applied to every registered backend at startup
+- **Continuous queries** — backends that support it (InfluxDB) get automatic downsampling so 1-minute / 1-hour rollups exist without a cron
+- **Connection health** — health checks per backend; the system module surfaces a warning when the primary is degraded
+- **Typed query helpers** — query builders for time-bucketed values, last-known reading and aggregate counts
+- **Factory-reset hook** — clears every registered backend in one go when a factory reset is performed
 
 ## Configuration
 
-- **primaryStorage** — Plugin to use as primary storage
-- **fallbackStorage** — Plugin to use when primary is unavailable`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`primary_storage\` | Plugin used as the primary storage backend | — |
+| \`fallback_storage\` | Plugin used when the primary backend is unavailable | — |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/system/system.module.ts
+++ b/apps/backend/src/modules/system/system.module.ts
@@ -201,41 +201,49 @@ export class SystemModule implements OnModuleInit, OnApplicationBootstrap {
 			name: 'System',
 			description: 'System management, logs, and platform operations',
 			author: 'FastyBird',
-			readme: `# System Module
+			readme: `# System
 
-The System module provides core system management functionality for the Smart Panel.
+> Module · by FastyBird
+
+Core platform management for the Smart Panel. Owns everything that is *about the box itself* rather than the things plugged into it: status reporting, structured logging, software updates, backups, statistics aggregation and the dangerous platform-level commands (reboot, power off, factory reset).
+
+## What it gives you
+
+- A single place to see how the appliance is doing (CPU, memory, disk, network, uptime, version) — surfaced both in the admin UI and on the panel
+- A pluggable update channel that can pull a new backend, a new panel build, or both, and roll them out together
+- A backup pipeline that collects contributions from every module and plugin into one archive, and can restore the whole appliance from it
+- A central reset / seed coordinator so a "factory reset" actually wipes everything in the right order
+- A structured logs API so the admin UI can show recent log entries, filter by level or module, and trigger downloads
 
 ## Features
 
-- **System Information** - View system status, uptime, and resource usage
-- **Logging** - Centralized application logging with configurable levels
-- **System Commands** - Reboot, power off, and factory reset operations
-- **Statistics** - System-wide statistics collection and reporting
+- **System info** — uptime, CPU, memory, storage, network, version and platform stats refreshed in the background
+- **Centralised structured logs** — every module emits through the same logger; entries are persisted with module / level / context and exposed through the API
+- **Power actions** — reboot, power off and full factory reset, all owner-only and audited
+- **Display actions** — remotely reboot, power off or factory-reset a connected panel display
+- **Backups** — orchestrates a backup registry: every module / plugin contributes the files and rows it owns into one downloadable archive; restore replays them in the same order
+- **Updates** — check for available backend / panel updates, install them, and report progress; updates are pluggable so different deployment targets (Docker, embedded, dev) can each register their own runner
+- **Statistics aggregator** — runs the stats registry: every module exposes its own metrics provider, the system module merges them into one snapshot for the admin UI and the API
+- **Factory-reset registry** — orchestrated, prioritised wipe across all modules / plugins; safe order, error reporting per step
+- **Settings & ownership** — owns the system-level config (locale, time-zone, log levels, update channel, …)
 
-## System Commands
+## API Endpoints
 
-### Reboot
-Safely restarts the Smart Panel application and optionally the host system.
+- \`GET /api/v1/modules/system/status\` — system status and stats
+- \`GET /api/v1/modules/system/logs\` — recent log entries (filterable by module / level)
+- \`POST /api/v1/modules/system/power/{reboot|shutdown|factory-reset}\` — power actions
+- \`POST /api/v1/modules/system/backup\` / \`/restore\` — create or restore a backup archive
+- \`POST /api/v1/modules/system/update/{check|install}\` — update operations
 
-### Power Off
-Performs a clean shutdown of the Smart Panel.
+## CLI Commands
 
-### Factory Reset
-Resets all settings and data to initial state:
-- Removes all configured devices
-- Clears dashboard pages and tiles
-- Resets user accounts (except owner)
-- Restores default configuration
+- \`pnpm run cli system:update:check\` — check for available updates
+- \`pnpm run cli system:update:server\` — update the backend
+- \`pnpm run cli system:update:panel\` — update the panel display
 
-## Logging
+## Logging Levels
 
-Supports multiple log levels:
-- **Error** - Critical errors requiring attention
-- **Warning** - Potential issues
-- **Info** - General operational messages
-- **Debug** - Detailed debugging information
-
-Logs are stored in memory and can be viewed through the admin interface.`,
+\`error\` · \`warn\` · \`info\` · \`debug\` — configurable via the \`logLevels\` setting.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/users/users.module.ts
+++ b/apps/backend/src/modules/users/users.module.ts
@@ -91,28 +91,44 @@ export class UsersModule implements OnModuleInit {
 			name: 'Users',
 			description: 'User accounts and roles management',
 			author: 'FastyBird',
-			readme: `# Users Module
+			readme: `# Users
 
-The Users module handles user account management and access control for the Smart Panel.
+> Module · by FastyBird
+
+Manages user accounts and role-based access control for the Smart Panel. The auth module verifies who you are; this module decides what you're allowed to do and stores the human-facing details (display name, email, language, avatar).
+
+## What it gives you
+
+- A clear role hierarchy — \`owner\` ➜ \`admin\` ➜ \`user\` — that every module can rely on through standard guards / decorators
+- A bootstrapping safeguard: there is always exactly one owner; deleting or demoting it is refused
+- Per-user preferences (language, theme, time-zone, dashboard layout overrides) so the same backend can serve mixed households
 
 ## Features
 
-- **User Management** - Create, update, and delete user accounts
-- **Role-Based Access** - Support for admin and regular user roles
-- **Profile Management** - Users can update their profile information
-- **Factory Reset** - User data can be cleared during factory reset
+- **Account management** — create, update and delete user accounts; password changes are routed through the auth module's hashing logic
+- **Role-based access** — \`@Roles()\` decorator and a registered guard enforce role checks across every other module without each module reinventing it
+- **Profile management** — users can edit their own display name, email, password and preferences; admins can edit anyone except the owner
+- **Bootstrapping** — first run promotes a single account to \`owner\` via the auth CLI; this module guarantees that role always exists
+- **Factory reset** — user data (except the owner) is cleared on factory reset; the owner's password is preserved unless explicitly reset
+- **Validation** — \`UserExists\` constraint exported for any module that wants to bind data to a user (favourites, preferences, audit trails)
 
 ## User Roles
 
-- **Owner** - Full system access, can manage all users and settings
-- **Admin** - Can manage devices, displays, and dashboard configuration
-- **User** - Basic access to view and control devices
+| Role | Description |
+|------|-------------|
+| \`owner\` | Full system access; can manage every setting and other users; the only role that can perform factory reset / power actions |
+| \`admin\` | Can manage devices, displays, dashboards and most configuration; cannot remove or demote the owner |
+| \`user\` | Can view dashboards and operate devices they have access to; cannot change configuration |
 
-## Security
+## API Endpoints
 
-- Passwords are securely hashed using bcrypt
-- User sessions are managed through JWT tokens
-- Role-based guards protect sensitive endpoints`,
+- \`GET|POST|PATCH|DELETE /api/v1/modules/users/users\` — manage users
+- \`GET /api/v1/modules/users/users/me\` — the current user's profile
+- \`PATCH /api/v1/modules/users/users/me\` — update your own profile
+
+## CLI Commands
+
+- \`pnpm run cli users:list\` — print the configured users to the console`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/weather/weather.module.ts
+++ b/apps/backend/src/modules/weather/weather.module.ts
@@ -102,32 +102,34 @@ export class WeatherModule implements OnModuleInit {
 			name: 'Weather',
 			description: 'Weather forecasts and geolocation services',
 			author: 'FastyBird',
-			readme: `# Weather Module
+			readme: `# Weather
 
-The Weather module provides weather forecast data and location management for the Smart Panel display.
+> Module · by FastyBird
+
+Aggregates weather data for the Smart Panel. Manages a list of named locations, delegates the actual data fetching to provider plugins, normalises the result into a single shape, and pushes updates to the panel and dashboards in real time.
+
+## What it gives you
+
+- One canonical weather model regardless of which provider you use, so tiles, pages and the assistant don't care whether the bytes came from Open-Meteo or OpenWeather
+- A long-running scheduler that keeps every location fresh in the background, with automatic retry / back-off on provider errors
+- Time-series storage of past observations so dashboards can show trends, not just snapshots
 
 ## Features
 
-- **Weather Forecasts** - Current conditions and multi-day forecasts
-- **Location Management** - Configure weather locations by coordinates or city name
-- **Provider System** - Pluggable weather data providers
-- **Historical Data** - Store and retrieve past weather data via storage
-- **Multiple Locations** - Support for multiple weather locations
+- **Multiple locations** — keep as many locations as you need (home, weekend cabin, parents' place, …) each with its own provider configuration
+- **Provider plugins** — pluggable data sources; pick a provider per location at creation time, swap providers without losing the location's history
+- **Background polling** — the module schedules refreshes for every location and re-tries failures with exponential back-off; the panel never has to call the provider directly
+- **Forecasts** — current conditions plus a multi-day outlook (resolution depends on the chosen provider)
+- **Rich, normalised data** — temperature (current / min / max), humidity, pressure, wind speed and direction, condition code and label, sunrise / sunset, UV index, precipitation
+- **Historical data** — every observation is written to the storage module as time-series, exposed through the \`/history\` endpoint
+- **Real-time push** — fresh observations are broadcast over WebSocket so panel weather tiles update without polling
+- **Validation** — location DTOs are validated by the active provider plugin so an invalid coordinate / city / API key fails fast at the API layer
 
-## Weather Providers
+## API Endpoints
 
-Weather data is fetched through provider plugins:
-
-- **OpenWeatherMap** - Current weather and daily forecasts
-- **OpenWeatherMap One Call** - Detailed hourly and daily forecasts
-
-## Data Available
-
-- Temperature (current, min, max)
-- Weather conditions and descriptions
-- Humidity, pressure, wind speed
-- Sunrise and sunset times
-- Multi-day forecasts`,
+- \`GET|POST|PATCH|DELETE /api/v1/modules/weather/locations\` — manage locations
+- \`GET /api/v1/modules/weather/locations/:id\` — current weather for a location
+- \`GET /api/v1/modules/weather/locations/:id/history\` — historical observations`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-claude-setup-token/buddy-claude-setup-token.plugin.ts
+++ b/apps/backend/src/plugins/buddy-claude-setup-token/buddy-claude-setup-token.plugin.ts
@@ -60,26 +60,36 @@ export class BuddyClaudeSetupTokenPlugin implements OnModuleInit {
 			name: 'Claude Setup Token',
 			description: 'LLM provider for Buddy module using Anthropic Claude with setup-token authentication',
 			author: 'FastyBird',
-			readme: `# Buddy Claude Setup Token Provider
+			readme: `# Claude (Setup Token)
 
-LLM provider plugin for the Buddy module using the Anthropic Claude API with setup-token authentication.
+> Plugin · by FastyBird · capability: LLM
 
-## Features
+Alternative Claude provider that authenticates with a setup token issued by your Claude subscription instead of an API key — useful when you have access to Claude through Claude Code rather than the API console, and don't want to pay for a separate Anthropic API key.
 
-- **Claude Models** - Access to Claude Sonnet, Opus, and Haiku models
-- **Setup Token** - Uses a setup-token from your Claude subscription for API access
+## What you get
+
+- Use a Claude *subscription* you already have for Buddy chat, no Anthropic API key required
+- Same streaming and tool-calling behaviour as the regular Claude plugin — switching between the two is config-only
+- Automatic credential refresh — the plugin keeps the setup token valid in the background
+
+## Capabilities
+
+- **LLM (chat)** — streaming completions; native tool calling for device / scene control
+- **Drop-in alternative** — interchangeable with the regular \`buddy-claude\` plugin from Buddy's point of view
 
 ## Setup
 
-1. Run \`claude setup-token\` in your terminal (requires Claude Code CLI)
-2. Copy the generated token
-3. Paste the token in plugin configuration
-4. Set the buddy module \`provider\` to \`${BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME}\`
+1. Install the [Claude Code CLI](https://docs.claude.com/claude-code) and sign in
+2. Run \`claude setup-token\` and copy the generated token
+3. Paste the token into this plugin's configuration
+4. Set the Buddy module's \`provider\` to \`${BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **Setup Token** - The token obtained from \`claude setup-token\` (required)
-- **Model** - Model name to use (default: claude-sonnet-4-20250514)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`setup_token\` | Token from \`claude setup-token\` (required) | — |
+| \`model\` | Claude model to use | \`claude-sonnet-4-20250514\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-claude/buddy-claude.plugin.ts
+++ b/apps/backend/src/plugins/buddy-claude/buddy-claude.plugin.ts
@@ -58,26 +58,39 @@ export class BuddyClaudePlugin implements OnModuleInit {
 			name: 'Claude',
 			description: 'LLM provider for Buddy module using Anthropic Claude API',
 			author: 'FastyBird',
-			readme: `# Buddy Claude Provider
+			readme: `# Claude
 
-LLM provider plugin for the Buddy module using the Anthropic Claude API.
+> Plugin · by FastyBird · capability: LLM
 
-## Features
+Anthropic Claude as an LLM provider for the Buddy module. Powers chat conversations with Claude Sonnet, Opus or Haiku — picking the model is a single config change.
 
-- **Claude Models** - Access to Claude Sonnet, Opus, and Haiku models
-- **Chat Conversations** - Powers Buddy text chat with Claude intelligence
+## What you get
+
+- Streaming chat replies grounded on your home's real context (spaces, devices, weather, energy)
+- Native tool calling so Claude can run scenes, control devices and adjust lighting modes through the registered Buddy tools
+- A predictable, low-noise assistant — Claude tends to refuse confidently rather than make things up
+- A simple privacy posture: requests are only sent when the user actually talks to Buddy; no background telemetry from this plugin
+
+## Capabilities
+
+- **Streaming responses** — answers stream token-by-token to the panel and admin chat
+- **Tool calls** — uses Claude's native tool API; every device / scene action is a structured call, not parsed from prose
+- **Configurable model** — pick any Claude model your account has access to (Sonnet for balance, Opus for hardest tasks, Haiku for fastest / cheapest)
+- **Long context** — the full home snapshot fits comfortably in the prompt, so the assistant always has the latest state
 
 ## Setup
 
-1. Create an account at [Anthropic](https://console.anthropic.com)
-2. Generate an API key from your account dashboard
-3. Enter the API key in plugin configuration
-4. Set the buddy module \`provider\` to \`${BUDDY_CLAUDE_PLUGIN_NAME}\`
+1. Create an account at [Anthropic Console](https://console.anthropic.com)
+2. Generate an API key in your dashboard
+3. Enter the API key in this plugin's configuration
+4. Set the Buddy module's \`provider\` to \`${BUDDY_CLAUDE_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **API Key** - Your Anthropic API key (required)
-- **Model** - Model name to use (default: claude-sonnet-4-20250514)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | Anthropic API key (required) | — |
+| \`model\` | Claude model to use | \`claude-sonnet-4-20250514\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-discord/buddy-discord.plugin.ts
+++ b/apps/backend/src/plugins/buddy-discord/buddy-discord.plugin.ts
@@ -58,32 +58,44 @@ export class BuddyDiscordPlugin implements OnModuleInit {
 			description: 'Discord bot adapter for Buddy module with multi-channel space mapping',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.MESSAGING],
-			readme: `# Buddy Discord Plugin
+			readme: `# Discord
 
-Discord bot adapter plugin for the Buddy module. Enables remote conversations and alert forwarding via Discord with multi-channel space mapping.
+> Plugin · by FastyBird · capability: messaging
+
+Discord bot adapter for the Buddy module. Forwards alerts and supports remote conversations from any Discord client, with optional per-space channel mapping so messages in your "kitchen" channel are answered with the kitchen's context.
+
+## What you get
+
+- Talk to your home from anywhere Discord works — desktop, web, mobile
+- A dedicated channel per room so conversations stay tidy and context-aware (the assistant scopes the home snapshot to whichever space the channel maps to)
+- Alerts and suggestions are routed to the right channel automatically — leak in the bathroom? You'll see it in #bathroom, not #general
+- Granular access control: restrict the bot to a specific Discord role so only authorised users can issue commands
 
 ## Features
 
-- **Multi-Channel Support** - Map Discord channels to smart home spaces for context-aware conversations
-- **Remote Chat** - Interact with your smart home buddy from anywhere via Discord
-- **Alert Routing** - Receive suggestion notifications in the relevant space channel
-- **Role-Based Access** - Restrict bot interaction to users with a specific Discord role
+- **Multi-channel mapping** — map Discord channels to smart-home spaces for context-aware conversations
+- **Remote chat** — talk to Buddy from anywhere Discord runs
+- **Alert routing** — suggestion notifications land in the relevant space's channel
+- **Role-based access** — restrict who can interact via a Discord role
+- **Markdown-friendly replies** — Buddy's answers render cleanly in Discord (lists, code blocks, links)
+- **Thread-aware** — keeps replies in the originating thread when the message starts in one
 
 ## Setup
 
-1. Create a bot application at the [Discord Developer Portal](https://discord.com/developers/applications)
-2. Enable the "Message Content Intent" under Bot settings
-3. Copy the bot token
-4. Add the bot to your server with required permissions (Send Messages, Read Messages, Add Reactions)
-5. Enable the plugin and configure the bot token, guild ID, and channel mappings
+1. Create a bot at the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Enable the **Message Content Intent** under Bot settings and copy the bot token
+3. Invite the bot to your server with the *Send Messages*, *Read Messages* and *Add Reactions* permissions
+4. Enable the plugin and fill in the configuration
 
 ## Configuration
 
-- **Bot Token** - Discord bot token from the Developer Portal (required)
-- **Guild ID** - Discord server ID (required)
-- **General Channel ID** - Default channel for cross-space queries (required)
-- **Space-Channel Mappings** - JSON mapping of space IDs to Discord channel IDs
-- **Allowed Role ID** - Discord role required to interact (empty = allow all server members)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`bot_token\` | Discord bot token (required) | — |
+| \`guild_id\` | Discord server ID (required) | — |
+| \`general_channel_id\` | Default channel for cross-space queries (required) | — |
+| \`space_channel_mappings\` | JSON map of space IDs → Discord channel IDs | \`{}\` |
+| \`allowed_role_id\` | Discord role required to interact | unrestricted |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-elevenlabs/buddy-elevenlabs.plugin.ts
+++ b/apps/backend/src/plugins/buddy-elevenlabs/buddy-elevenlabs.plugin.ts
@@ -65,27 +65,38 @@ export class BuddyElevenlabsPlugin implements OnModuleInit {
 			description: 'STT and TTS provider for Buddy module using ElevenLabs API',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.STT, BuddyCapability.TTS],
-			readme: `# Buddy ElevenLabs Provider
+			readme: `# ElevenLabs
 
-STT and TTS provider plugin for the Buddy module using the ElevenLabs API.
+> Plugin · by FastyBird · capabilities: STT, TTS
 
-## Features
+ElevenLabs as both a speech-to-text and text-to-speech provider for the Buddy module. Uses the Scribe v2 model for transcription across 99 languages and ElevenLabs' high-quality neural voices for synthesis — easily the most realistic voice option in the bundle.
 
-- **Speech-to-Text** - Accurate transcription using the Scribe v2 model across 99 languages
-- **High-Quality Voices** - Natural-sounding text-to-speech
-- **Multiple Voices** - Choose from various voice profiles
+## What you get
+
+- Best-in-class voice quality for the assistant's spoken replies
+- Multilingual transcription with Scribe v2 (99 languages) so the panel works for non-English households out of the box
+- Configurable voice — pick any ElevenLabs voice (default, premade or cloned) by pasting its voice ID
+- Fully cloud-hosted: no on-device GPU required for high-quality voice
+
+## Capabilities
+
+- **TTS** — neural synthesis with the chosen voice; streaming where supported
+- **STT** — Scribe v2 transcription with automatic language detection
+- **Pair freely** — combine with any LLM provider (Claude, OpenAI, Ollama) for the chat brain
 
 ## Setup
 
 1. Create an account at [ElevenLabs](https://elevenlabs.io)
-2. Generate an API key from your account dashboard
-3. Enter the API key in plugin configuration
-4. Set the buddy module \`stt_plugin\` and/or \`tts_plugin\` to \`${BUDDY_ELEVENLABS_PLUGIN_NAME}\`
+2. Generate an API key from your dashboard
+3. Enter the API key in this plugin's configuration
+4. Set Buddy's \`stt_plugin\` and/or \`tts_plugin\` to \`${BUDDY_ELEVENLABS_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **API Key** - Your ElevenLabs API key (required)
-- **Voice ID** - ElevenLabs voice ID for TTS (auto-detected if not set)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | ElevenLabs API key (required) | — |
+| \`voice_id\` | Voice ID used for TTS | auto-detected |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-ollama/buddy-ollama.plugin.ts
+++ b/apps/backend/src/plugins/buddy-ollama/buddy-ollama.plugin.ts
@@ -58,27 +58,43 @@ export class BuddyOllamaPlugin implements OnModuleInit {
 			name: 'Ollama',
 			description: 'LLM provider for Buddy module using local Ollama inference',
 			author: 'FastyBird',
-			readme: `# Buddy Ollama Provider
+			readme: `# Ollama
 
-LLM provider plugin for the Buddy module using local Ollama inference.
+> Plugin · by FastyBird · capability: LLM
 
-## Features
+Run an LLM provider locally via [Ollama](https://ollama.ai). Supports Llama, Mistral, CodeLlama and any other model Ollama can serve. No API key, no per-request fee, and — most importantly — no data leaves your network.
 
-- **Local LLM** - Run AI models locally without cloud APIs
-- **Multiple Models** - Support for Llama, Mistral, CodeLlama, and more
-- **No API Key Required** - Completely offline operation
+## What you get
+
+- A 100% local assistant: prompts, your home snapshot and replies all stay on the host running Ollama
+- Zero recurring cost — the only resource is your CPU / GPU
+- Free choice of model: pull whichever Ollama-compatible model fits your hardware (\`llama3\`, \`llama3.1\`, \`mistral\`, \`qwen\`, \`phi\`, …) and switch by changing one config value
+- Works with a remote Ollama server too — point \`base_url\` at any reachable host and Buddy talks to it transparently
+
+## Capabilities
+
+- **LLM (chat)** — streaming completions backed by Ollama
+- **Tool calling** — uses Ollama's tool-call protocol where the chosen model supports it; falls back gracefully when it doesn't
+- **No outbound traffic** — when Ollama runs on the same host, Buddy never reaches the public internet
+
+## Tradeoffs
+
+- Quality and speed depend entirely on the model and the host's hardware; small machines should pick small models
+- Tool-calling fidelity varies between models; if scenes / device control aren't dispatched cleanly, try a larger / instruction-tuned model
 
 ## Setup
 
-1. Install [Ollama](https://ollama.ai) on your system
-2. Pull a model: \`ollama pull llama3\`
-3. Enable this plugin in configuration
-4. Set the buddy module \`provider\` to \`${BUDDY_OLLAMA_PLUGIN_NAME}\`
+1. Install Ollama on the host running the backend (or any reachable machine)
+2. Pull at least one model — for example \`ollama pull llama3\`
+3. Enable this plugin
+4. Set Buddy's \`provider\` to \`${BUDDY_OLLAMA_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **Model** - Model name to use (default: llama3)
-- **Base URL** - Ollama API endpoint (default: http://localhost:11434)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`model\` | Ollama model name | \`llama3\` |
+| \`base_url\` | Ollama HTTP endpoint | \`http://localhost:11434\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-openai-codex/buddy-openai-codex.plugin.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/buddy-openai-codex.plugin.ts
@@ -60,31 +60,42 @@ export class BuddyOpenaiCodexPlugin implements OnModuleInit {
 			name: 'OpenAI Codex',
 			description: 'LLM provider for Buddy module using OpenAI Codex with OAuth authentication',
 			author: 'FastyBird',
-			readme: `# Buddy OpenAI Codex Provider
+			readme: `# OpenAI Codex
 
-LLM provider plugin for the Buddy module using the OpenAI Codex API with OAuth authentication.
+> Plugin · by FastyBird · capability: LLM
 
-## Features
+OpenAI Codex as an LLM provider for the Buddy module, authenticated with OAuth2 — so an existing Codex subscription can power the assistant without provisioning a separate API key. Access tokens are refreshed automatically; the user logs in once and the plugin keeps its own credentials fresh in the background.
 
-- **Codex Models** - Access to codex-mini and other OpenAI Codex models
-- **OAuth Authentication** - Uses OAuth2 client credentials for secure API access
-- **Token Refresh** - Automatic access token refresh using refresh tokens
+## What you get
+
+- Use a Codex subscription you already pay for instead of a separate API key
+- Automatic OAuth token refresh — the plugin renews access tokens before they expire and never blocks a chat on auth
+- Native tool calling backed by Codex models, so Buddy can drive devices and scenes through structured calls
+- Streaming chat with the same shape as the regular OpenAI plugin — switching providers requires no code change in Buddy
+
+## Capabilities
+
+- **LLM (chat)** — streaming completions
+- **Tool calls** — structured device / scene control
+- **OAuth login** — credentials are stored encrypted in config and refreshed automatically
 
 ## Setup
 
 1. Register an OAuth application at [OpenAI](https://platform.openai.com)
-2. Obtain client ID and client secret
-3. Complete the OAuth flow to get access and refresh tokens
-4. Enter the credentials in plugin configuration
-5. Set the buddy module \`provider\` to \`${BUDDY_OPENAI_CODEX_PLUGIN_NAME}\`
+2. Note the client ID (and client secret, if your app uses one)
+3. Complete the OAuth flow to obtain access and refresh tokens
+4. Enter the credentials in this plugin's configuration
+5. Set Buddy's \`provider\` to \`${BUDDY_OPENAI_CODEX_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **Client ID** - OAuth client ID (required)
-- **Client Secret** - OAuth client secret (optional)
-- **Access Token** - OAuth access token
-- **Refresh Token** - OAuth refresh token for automatic renewal
-- **Model** - Model name to use (default: codex-mini)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`client_id\` | OAuth client ID (required) | — |
+| \`client_secret\` | OAuth client secret | — |
+| \`access_token\` | Current OAuth access token | — |
+| \`refresh_token\` | OAuth refresh token used for automatic renewal | — |
+| \`model\` | Codex model to use | \`codex-mini\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-openai/buddy-openai.plugin.ts
+++ b/apps/backend/src/plugins/buddy-openai/buddy-openai.plugin.ts
@@ -70,30 +70,39 @@ export class BuddyOpenaiPlugin implements OnModuleInit {
 			description: 'LLM, STT, and TTS provider for Buddy module using OpenAI API',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.LLM, BuddyCapability.STT, BuddyCapability.TTS],
-			readme: `# Buddy OpenAI Provider
+			readme: `# OpenAI
 
-LLM and TTS provider plugin for the Buddy module using the OpenAI API.
+> Plugin · by FastyBird · capabilities: LLM, STT, TTS
 
-## Features
+OpenAI as an all-in-one provider for the Buddy module — chat completions via GPT, transcription via Whisper, and synthesis via the TTS API (\`alloy\`, \`echo\`, \`fable\`, \`onyx\`, \`nova\`, \`shimmer\`). One API key unlocks the whole assistant experience.
 
-- **GPT Models** - Access to GPT-4o, GPT-4o-mini, and other OpenAI models
-- **Chat Completions** - Powers Buddy text chat conversations
-- **Speech-to-Text** - OpenAI Whisper API for voice input transcription
-- **Text-to-Speech** - OpenAI TTS API for voice output (alloy, echo, fable, onyx, nova, shimmer voices)
+## What you get
+
+- A single key that powers chat, voice input and voice output, so Buddy is a complete experience without juggling three providers
+- High-quality streaming chat with native tool calling — the model can drive your devices and scenes through structured calls
+- Server-side speech recognition with Whisper for hands-free interaction on the panel
+- A choice of six TTS voices to match the personality you want for your home
+
+## Capabilities
+
+- **LLM (chat)** — streaming completions; native tool calls for device / scene control
+- **STT (speech-to-text)** — Whisper transcription of microphone audio captured on the panel
+- **TTS (text-to-speech)** — six voices, configurable per deployment
+- **Per-capability fan-out** — you can use OpenAI for any subset (just LLM, just TTS, …) and pair it with other providers for the rest
 
 ## Setup
 
-1. Create an account at [OpenAI](https://platform.openai.com)
-2. Generate an API key from your account dashboard
-3. Enter the API key in plugin configuration
-4. Set the buddy module \`provider\` to \`${BUDDY_OPENAI_PLUGIN_NAME}\` for chat
-5. Set the buddy module \`stt_plugin\` to \`${BUDDY_OPENAI_PLUGIN_NAME}\` for STT
-6. Set the buddy module \`tts_plugin\` to \`${BUDDY_OPENAI_PLUGIN_NAME}\` for TTS
+1. Create an account at [OpenAI Platform](https://platform.openai.com)
+2. Generate an API key in your dashboard
+3. Enter the API key in this plugin's configuration
+4. Set Buddy's \`provider\`, \`stt_plugin\` and/or \`tts_plugin\` to \`${BUDDY_OPENAI_PLUGIN_NAME}\` for the capabilities you want to use
 
 ## Configuration
 
-- **API Key** - Your OpenAI API key (required)
-- **Model** - Model name to use (default: gpt-4o)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | OpenAI API key (required) | — |
+| \`model\` | Model used for chat completions | \`gpt-4o\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-stt-whisper-local/buddy-stt-whisper-local.plugin.ts
+++ b/apps/backend/src/plugins/buddy-stt-whisper-local/buddy-stt-whisper-local.plugin.ts
@@ -59,24 +59,38 @@ export class BuddySttWhisperLocalPlugin implements OnModuleInit {
 			description: 'STT provider for Buddy module using locally installed Whisper',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.STT],
-			readme: `# Buddy Local Whisper STT Provider
+			readme: `# Whisper Local
 
-Speech-to-text provider plugin for the Buddy module using a locally installed Whisper CLI.
+> Plugin · by FastyBird · capability: STT
 
-## Prerequisites
+Speech-to-text provider that runs OpenAI's Whisper locally via the \`whisper\` CLI. No API key, no network calls — the audio captured on the panel never leaves your network.
 
-Install whisper on your system. The \`whisper\` command must be available in PATH.
+## What you get
+
+- A privacy-respecting STT path: voice queries are transcribed on the host running the backend
+- Free choice of model size — \`tiny\` for low-spec hardware, \`large\` for top accuracy
+- Auto language detection or a fixed language hint when you know everyone in the household speaks the same one
+- Drop-in replacement for cloud STT providers — pair with any LLM / TTS combination
+
+## Capabilities
+
+- **STT only** — pair with any LLM and any TTS provider
+- **Configurable accuracy / speed** — pick the Whisper model that fits your CPU
+- **Language hint** — optional, otherwise Whisper detects automatically
+- **No outbound traffic** — every transcription stays on the host
 
 ## Setup
 
-1. Install whisper on the system
-2. Enable the plugin
-3. Set the buddy module \`stt_plugin\` to \`${BUDDY_STT_WHISPER_LOCAL_PLUGIN_NAME}\`
+1. Install Whisper so that the \`whisper\` command is available on \`PATH\`
+2. Enable this plugin
+3. Set Buddy's \`stt_plugin\` to \`${BUDDY_STT_WHISPER_LOCAL_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **Model** - Whisper model size (default: base). Options: tiny, base, small, medium, large
-- **Language** - ISO 639-1 language hint (optional, e.g. en, cs)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`model\` | Whisper model size — \`tiny\`, \`base\`, \`small\`, \`medium\`, \`large\` | \`base\` |
+| \`language\` | ISO 639-1 language hint (e.g. \`en\`, \`cs\`) | auto-detect |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-system-tts/buddy-system-tts.plugin.ts
+++ b/apps/backend/src/plugins/buddy-system-tts/buddy-system-tts.plugin.ts
@@ -59,26 +59,37 @@ export class BuddySystemTtsPlugin implements OnModuleInit {
 			description: 'Local TTS provider using piper or espeak',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.TTS],
-			readme: `# Buddy System TTS Provider
+			readme: `# System TTS
 
-Local TTS provider plugin for the Buddy module using system-installed speech synthesizers.
+> Plugin · by FastyBird · capability: TTS
 
-## Features
+Local text-to-speech provider that delegates synthesis to a system-installed engine — Piper for natural neural voices, eSpeak as a lightweight fallback. No API key, no network calls, no per-request fee.
 
-- **Piper** - High-quality neural TTS (preferred when available)
-- **eSpeak** - Lightweight fallback TTS
-- **No API Key Required** - Runs entirely locally
+## What you get
+
+- 100% offline voice for the assistant — useful when you want full local control or on networks without outbound internet
+- Free choice of voice quality vs. resource cost: Piper sounds great but needs more CPU; eSpeak is tiny and works on the most modest hardware
+- Multilingual support — both engines ship voices for many languages; pick one once and the assistant uses it everywhere
+- Auto-detection of which engine is actually installed, so the same configuration works across hosts that have only one of the two
+
+## Capabilities
+
+- **TTS only** — pair with any LLM and any STT provider
+- **Multiple engines** — Piper (preferred for quality) and eSpeak (fallback for low-power hosts)
+- **Streaming output** — audio is piped to the panel as soon as the engine emits it
 
 ## Setup
 
-1. Install piper or espeak on your system
+1. Install \`piper\` and/or \`espeak\` on the host
 2. Enable this plugin
-3. Set the buddy module \`tts_plugin\` to \`${BUDDY_SYSTEM_TTS_PLUGIN_NAME}\`
+3. Set Buddy's \`tts_plugin\` to \`${BUDDY_SYSTEM_TTS_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **Engine** - Preferred engine: piper or espeak (auto-detected if not set)
-- **Voice** - Voice identifier (piper model name or espeak voice code)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`engine\` | Preferred engine (\`piper\` or \`espeak\`) | auto-detected |
+| \`voice\` | Voice identifier (Piper model or eSpeak voice code) | engine default |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-telegram/buddy-telegram.plugin.ts
+++ b/apps/backend/src/plugins/buddy-telegram/buddy-telegram.plugin.ts
@@ -58,27 +58,38 @@ export class BuddyTelegramPlugin implements OnModuleInit {
 			description: 'Telegram bot adapter for Buddy module remote conversations and alerts',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.MESSAGING],
-			readme: `# Buddy Telegram Plugin
+			readme: `# Telegram
 
-Telegram bot adapter plugin for the Buddy module. Enables remote conversations and alert forwarding via Telegram.
+> Plugin · by FastyBird · capability: messaging
+
+Telegram bot adapter for the Buddy module. Forwards alerts (with inline accept / dismiss buttons) and lets you have full Buddy conversations from any Telegram client.
+
+## What you get
+
+- Talk to your home from a Telegram chat — same brain as the panel, available worldwide
+- Inline buttons on suggestions / alerts so you can act with one tap (acknowledge a leak alarm, run a scene, dismiss a suggestion)
+- Tight access control — limit who can chat with the bot to a list of explicit Telegram user IDs
+- Zero infrastructure to host: Telegram's bot API does the heavy lifting, you only need a bot token
 
 ## Features
 
-- **Remote Chat** - Interact with your smart home buddy from anywhere via Telegram
-- **Alert Forwarding** - Receive suggestion notifications with accept/dismiss buttons
-- **User Whitelist** - Restrict access to specific Telegram user IDs
+- **Remote chat** — text Buddy from any Telegram device with the same context as the panel
+- **Inline alert buttons** — every alert / suggestion ships with quick-action buttons
+- **Allow-list** — restrict access to a comma-separated list of user IDs; everyone else is silently ignored
+- **Markdown formatting** — replies render cleanly in Telegram with lists and code blocks where useful
 
 ## Setup
 
-1. Create a bot via [@BotFather](https://t.me/BotFather) on Telegram
-2. Copy the bot token
-3. Enable the plugin and enter the bot token in configuration
-4. Optionally set allowed user IDs to restrict access
+1. Create a bot via [@BotFather](https://t.me/BotFather) and copy the token
+2. Enable the plugin and paste the token into configuration
+3. Optionally restrict access by listing allowed user IDs
 
 ## Configuration
 
-- **Bot Token** - Telegram Bot API token from @BotFather (required)
-- **Allowed User IDs** - Comma-separated Telegram user IDs (empty = allow all)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`bot_token\` | Telegram Bot API token (required) | — |
+| \`allowed_user_ids\` | Comma-separated Telegram user IDs allowed to chat | unrestricted |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-voiceai/buddy-voiceai.plugin.ts
+++ b/apps/backend/src/plugins/buddy-voiceai/buddy-voiceai.plugin.ts
@@ -60,28 +60,38 @@ export class BuddyVoiceaiPlugin implements OnModuleInit {
 			description: 'TTS provider for Buddy module using Voice.ai API',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.TTS],
-			readme: `# Buddy Voice.ai Provider
+			readme: `# Voice.ai
 
-TTS provider plugin for the Buddy module using the Voice.ai API.
+> Plugin · by FastyBird · capability: TTS
 
-## Features
+Voice.ai as a text-to-speech provider for the Buddy module. Synthesises Buddy's spoken replies with a natural-sounding voice — including custom cloned voices if you have set them up in your Voice.ai account.
 
-- **AI Voice Cloning** - Create custom voices from audio samples
-- **High-Quality TTS** - Natural-sounding text-to-speech synthesis
-- **Multiple Output Formats** - MP3, WAV, and PCM audio support
+## What you get
+
+- Studio-grade synthesis that turns Buddy from text-only into a real voice on the panel speaker
+- Voice cloning support — train a voice on Voice.ai once, then point this plugin at the resulting voice ID
+- Multiple audio formats so the plugin can hand the panel exactly what it can play without a server-side re-encode
+- A clean handoff with Buddy's chat / tool layer: the assistant generates the reply, this plugin turns it into audio
+
+## Capabilities
+
+- **TTS only** — pair with any LLM provider (Claude, OpenAI, Ollama, …) and any STT provider
+- **Per-deployment voice** — pick the voice ID once; every panel using this backend uses the same voice
+- **Streaming** where supported by the chosen voice / format, so playback can start before synthesis completes
 
 ## Setup
 
 1. Create an account at [Voice.ai](https://voice.ai)
-2. Generate an API key from your dashboard
-3. Enter the API key in plugin configuration
-4. Set a voice ID (use the Voice.ai API to list available voices)
-5. Set the buddy module \`tts_plugin\` to \`${BUDDY_VOICEAI_PLUGIN_NAME}\`
+2. Generate an API key in your dashboard
+3. Enter the API key and a voice ID in this plugin's configuration (use the Voice.ai API to list available voices)
+4. Set Buddy's \`tts_plugin\` to \`${BUDDY_VOICEAI_PLUGIN_NAME}\`
 
 ## Configuration
 
-- **API Key** - Your Voice.ai API key (required)
-- **Voice ID** - Voice.ai voice ID (required)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | Voice.ai API key (required) | — |
+| \`voice_id\` | Voice.ai voice ID (required) | — |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/buddy-whatsapp/buddy-whatsapp.plugin.ts
+++ b/apps/backend/src/plugins/buddy-whatsapp/buddy-whatsapp.plugin.ts
@@ -59,28 +59,40 @@ export class BuddyWhatsappPlugin implements OnModuleInit {
 			description: 'WhatsApp adapter plugin for Buddy module remote conversations and alerts',
 			author: 'FastyBird',
 			capabilities: [BuddyCapability.MESSAGING],
-			readme: `# Buddy WhatsApp Plugin
+			readme: `# WhatsApp
 
-WhatsApp adapter plugin for the Buddy module. Connects via WhatsApp Web protocol (QR code scan).
+> Plugin · by FastyBird · capability: messaging
+
+WhatsApp adapter for the Buddy module that connects through the WhatsApp Web protocol — no Meta Business account, no cloud middleman, just a phone running WhatsApp paired as a "linked device".
+
+## What you get
+
+- Talk to Buddy from any WhatsApp client — desktop, web, Android, iOS — the same way you'd message a friend
+- Use a number you already own; no business verification, no new SIM, no Meta API onboarding
+- Persistent session: pair once, the plugin remembers the auth state across restarts and reconnects automatically when the phone goes online again
+- Granular access control via a phone-number allow-list, so the bot only answers people you trust
 
 ## Features
 
-- **QR Code Pairing** - Scan a QR code with your phone to connect (no Meta Business account needed)
-- **Remote Chat** - Interact with your smart home buddy from anywhere via WhatsApp
-- **Alert Forwarding** - Receive suggestion notifications
-- **Phone Whitelist** - Restrict access to specific phone numbers
-- **Persistent Session** - Authentication persists across restarts
+- **QR-code pairing** — link a phone via *Settings → Linked Devices*
+- **Remote chat** — interact with Buddy from anywhere
+- **Alert forwarding** — receive suggestion notifications as regular WhatsApp messages
+- **Phone whitelist** — restrict access to a comma-separated list of E.164 numbers
+- **Persistent session** — authentication survives restarts; you don't re-scan the QR every time
+- **Auto reconnect** — the plugin handles WhatsApp Web disconnects and re-establishes the session in the background
 
 ## Setup
 
-1. Enable the plugin in configuration
-2. Open the status endpoint or check the terminal for the QR code
-3. Scan the QR code with WhatsApp on your phone (Linked Devices)
-4. Start chatting with the bot
+1. Enable the plugin
+2. Read the QR code from the status endpoint or backend logs
+3. Scan it with WhatsApp on your phone (*Settings → Linked Devices*)
+4. Start chatting with Buddy
 
 ## Configuration
 
-- **Allowed Phone Numbers** - Comma-separated E.164 phone numbers (empty = allow all)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`allowed_phone_numbers\` | Comma-separated E.164 numbers permitted to chat | unrestricted |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/data-sources-device-channel/data-sources-device-channel.plugin.ts
+++ b/apps/backend/src/plugins/data-sources-device-channel/data-sources-device-channel.plugin.ts
@@ -105,45 +105,31 @@ export class DataSourcesDeviceChannelPlugin {
 			name: 'Device Channel Property Data Source',
 			description: 'Data sources for connecting tiles to device channel properties',
 			author: 'FastyBird',
-			readme: `# Device Channel Data Sources Plugin
+			readme: `# Device Channel Data Source
 
-Data source type for connecting dashboard tiles to device properties.
+> Plugin · by FastyBird · platform: dashboard data sources
+
+Data source that binds a dashboard tile to a single device-channel property. Reads stream live to the tile; tiles that support writing can push values back through the property's platform handler — so the same data source powers both a sensor display and an interactive switch.
+
+## What you get
+
+- A no-code way to wire any dashboard tile to any device property without ever leaving the admin UI
+- The same optimistic-UI guarantees the rest of the panel uses: feedback is instant, the value reconciles with the device when the backend confirms
+- Strict validation: a tile that points at a missing or deleted property is refused at save time
+- Type-aware rendering: the tile knows whether the underlying property is a boolean, number, string or enum and renders the right control / unit / formatter
 
 ## Features
 
-- **Property Binding** - Link tiles to specific device properties
-- **Real-time Updates** - Receive live property value changes
-- **Bidirectional** - Support for both reading and writing values
-- **Validation** - Ensures referenced device/channel/property exists
-
-## How It Works
-
-Data sources act as a bridge between:
-- **Tiles** - Visual elements on dashboard pages
-- **Device Properties** - Values from connected devices
-
-When a property value changes, connected tiles update automatically.
-
-## Configuration
-
-Each data source specifies:
-- Target device ID
-- Channel ID within the device
-- Property ID to bind to
-
-## Usage
-
-1. Add a tile that supports data sources
-2. Create a device channel data source
-3. Select device → channel → property
-4. The tile will display the property value
+- **Property binding** — link a tile to \`device → channel → property\` with one config object
+- **Real-time updates** — values stream over WebSocket; tiles re-render only when the value changes
+- **Bidirectional** — read and (optionally) write; whether writes are allowed is derived from the property's permissions, never overridden by the tile
+- **Validation** — referenced device, channel and property must exist; the data source survives device renames but breaks loudly if the property is deleted
 
 ## Supported Property Types
 
-- Boolean (on/off states)
-- Numeric (temperature, humidity, etc.)
-- String (text values)
-- Enum (predefined value lists)`,
+Boolean (on / off states), numeric (temperature, humidity, …), string and enum.
+
+Each data source picks its target \`device_id\`, \`channel_id\` and \`property_id\` when it is created — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/data-sources-weather/data-sources-weather.plugin.ts
+++ b/apps/backend/src/plugins/data-sources-weather/data-sources-weather.plugin.ts
@@ -140,45 +140,33 @@ export class DataSourcesWeatherPlugin {
 			name: 'Weather Data Source',
 			description: 'Data sources for connecting tiles to weather information',
 			author: 'FastyBird',
-			readme: `# Weather Data Sources Plugin
+			readme: `# Weather Data Source
 
-Data source types for connecting dashboard tiles to weather data.
+> Plugin · by FastyBird · platform: dashboard data sources
 
-## Features
+Data sources that bind dashboard tiles to weather information served by the Weather module — the bridge between the module's normalised location data and the weather tiles drawn on the panel.
 
-- **Current Weather** - Bind to current weather conditions
-- **Forecast Data** - Access multi-day weather forecasts
-- **Location Selection** - Choose which weather location to display
-- **Auto-refresh** - Weather data updates automatically
+## What you get
+
+- Drop-in weather data for any tile that wants it, without any tile needing direct knowledge of the Weather module's API
+- Two sharply-defined shapes: "current conditions for this location" and "forecast for this location, N days from today"
+- Provider-agnostic: the data source picks the location, not the provider, so you can swap providers without recreating the data source
+- The same real-time push the rest of the panel benefits from — the tile updates as soon as the weather module receives a fresh observation
 
 ## Data Source Types
 
-### Current Weather Data Source
-Provides:
-- Current temperature
-- Weather conditions
-- Humidity and wind
-- Last update time
+- **Current weather** — temperature, condition code & label, humidity, wind speed / direction, pressure, last update time, sunrise / sunset
+- **Forecast day** — high / low temperature, condition, precipitation probability for a given day offset (\`0\` = today, \`1\` = tomorrow, …)
 
-### Forecast Day Data Source
-Provides:
-- Daily high/low temperatures
-- Weather conditions per day
-- Day index selection (0 = today, 1 = tomorrow, etc.)
+## Behaviour
+
+- **Live updates** — re-emits whenever the weather module receives a new observation
+- **Unit-aware** — values are emitted in the location's configured units (°C / °F, m·s⁻¹ / mph, …)
+- **Graceful empty state** — when the location has not yet received its first observation the data source emits a clearly-marked empty value rather than zeros
 
 ## Requirements
 
-- Weather module must be configured
-- At least one weather location defined
-- A weather provider plugin enabled (e.g., OpenWeatherMap)
-
-## Usage
-
-1. Add a weather tile to a dashboard page
-2. Create a weather data source
-3. Select the location
-4. For forecasts, select the day offset
-5. The tile displays the weather data`,
+The Weather module must be configured with at least one location and an enabled weather provider plugin (e.g. OpenWeatherMap). Each data source selects its weather location (and day offset for forecasts) when it is created.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
@@ -275,129 +275,83 @@ export class DevicesHomeAssistantPlugin {
 			name: 'Home Assistant',
 			description: 'Integration with Home Assistant for device management',
 			author: 'FastyBird',
-			readme: `# Home Assistant Devices Plugin
+			readme: `# Home Assistant
 
-Integration plugin for connecting Smart Panel to Home Assistant.
+> Plugin · by FastyBird · platform: devices
+
+Imports devices from a Home Assistant instance and keeps them in sync over its WebSocket API. Entities are mapped to Smart Panel channels and properties via configurable YAML rules, so any HA-supported integration becomes available to dashboards, scenes and Buddy with no extra code.
+
+## What you get
+
+- A bridge to anything Home Assistant already knows about — Z-Wave, Zigbee, ESPHome, BLE, Matter, Hue, Sonos, you name it — without re-pairing devices
+- Bidirectional control: changes on the panel reach HA and vice-versa, with consistent state on both sides
+- Predictable, type-safe data: HA entities are normalised into Smart Panel's device → channel → property model so downstream code doesn't need HA-specific knowledge
+- Automatic reconnection — short blips and full HA restarts heal themselves; the plugin re-subscribes and reconciles state
+- Total control over how HA looks inside Smart Panel via the YAML mapping system (default mappings cover the common cases)
 
 ## Features
 
-- **Device Import** - Import devices from Home Assistant into Smart Panel
-- **Real-time Sync** - WebSocket connection for instant state updates
-- **Bidirectional Control** - Control Home Assistant devices from Smart Panel
-- **Entity Mapping** - Automatic mapping of HA entities to Smart Panel channels
-- **YAML Configuration** - Customizable entity mappings and virtual properties
-
-## Supported Entity Types
-
-- **Switches** - On/off controls
-- **Lights** - Brightness, color temperature, RGB, RGBW
-- **Sensors** - Temperature, humidity, power, energy, illuminance, etc.
-- **Binary Sensors** - Motion, door/window, occupancy, smoke, gas, leak
-- **Climate** - HVAC controls and thermostats
-- **Covers** - Blinds, curtains, garage doors, gates
-- **Fans** - Speed, direction, oscillation
-- **Locks** - Lock/unlock controls
-- **Media Players** - TV, speakers, generic players
-- **And more** - Valves, vacuums, cameras, alarms, water heaters
+- **Device import** — pull devices and entities from Home Assistant into Smart Panel via the discovery feed
+- **Real-time sync** — WebSocket subscription with automatic reconnection and back-off
+- **Bidirectional control** — drive HA entities from Smart Panel; commands are translated to the right HA service / parameter shape
+- **Declarative entity mapping** — YAML rules map HA domains and device classes to Smart Panel channels and property roles
+- **Virtual properties** — derive computed values or expose command-only properties (e.g. cover open / close / stop) when HA's native model doesn't match cleanly
+- **Transformers** — built-in scale / map / format helpers so 0–255 brightness becomes 0–100% without custom code
+- **Override-friendly** — built-in mappings can be overridden per-installation by dropping YAML files in the data directory
 
 ## Setup
 
-1. Generate a Long-Lived Access Token in Home Assistant
-2. Configure the Home Assistant URL and token in plugin settings
-3. Browse discovered devices and import them to Smart Panel
+1. Generate a Long-Lived Access Token in Home Assistant (*Profile → Long-Lived Access Tokens*)
+2. Enter the hostname/IP and token in this plugin's configuration
+3. Open the discovery view and adopt the devices you want to use
 
-## Communication
+## Configuration
 
-- **WebSocket API** - Real-time event subscription
-- **REST API** - State queries and service calls
-- **Auto-reconnect** - Automatic reconnection on connection loss
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`hostname\` | Home Assistant host or IP (e.g. \`homeassistant.local\`) | — |
+| \`api_key\` | Long-Lived Access Token (required) | — |
 
-## YAML Configuration
+## Supported Entity Types
 
-The plugin uses YAML files to define how Home Assistant entities are mapped to Smart Panel channels and properties.
+Switches, lights (brightness / color temperature / RGB / RGBW), sensors, binary sensors, climate, covers, fans, locks, media players, valves, vacuums, cameras, alarms and water heaters.
 
-### Configuration Files
+## YAML Mapping
 
-Built-in mappings are located in:
-- \`mappings/definitions/entity-mappings.yaml\` - Entity to channel mappings
-- \`mappings/definitions/virtual-properties.yaml\` - Virtual property definitions
+Entity-to-channel mappings live in YAML files. Built-in defaults ship in \`mappings/definitions/\`; user overrides are loaded from \`var/data/plugin.devices-home-assistant.*.yaml\` (or \`HA_MAPPINGS_PATH\`) and take precedence.
 
-User overrides can be placed in \`var/data/\` using the prefix \`plugin.devices-home-assistant.\`:
-- \`var/data/plugin.devices-home-assistant.entity-mappings.yaml\`
-- \`var/data/plugin.devices-home-assistant.virtual-properties.yaml\`
-
-Alternatively, set \`HA_MAPPINGS_PATH\` env variable to a custom directory.
-
-User overrides are merged with built-in mappings and take precedence.
-
-### Entity Mappings Structure
+### Entity mapping example
 
 \`\`\`yaml
 version: "1.0"
 
-# Value transformers for converting between HA and Smart Panel formats
 transformers:
   brightness_to_percent:
     type: scale
     input_range: [0, 255]
     output_range: [0, 100]
 
-# Domain role classification
-domain_roles:
-  primary: [light, switch, climate, cover]    # Main controllable entities
-  standalone: [sensor, binary_sensor]          # Independent sensors
-  secondary: [button, number, select]          # Helper entities
-
-# Entity mapping rules
 mappings:
   - name: light_default
-    description: "Standard light entity"
     domain: light
-    device_class: null           # null = fallback for any device_class
-    priority: 50                 # Higher priority = matched first
+    priority: 50
     channel:
       category: LIGHT
     device_category: LIGHTING
     property_bindings:
-      - ha_attribute: fb.main_state    # Special: maps entity state
+      - ha_attribute: fb.main_state
         property_category: ON
       - ha_attribute: brightness
         property_category: BRIGHTNESS
         transformer: brightness_to_percent
-      - ha_attribute: color_temp_kelvin
-        property_category: COLOR_TEMPERATURE
 \`\`\`
 
-### Virtual Properties Structure
-
-Virtual properties are calculated values or commands not directly from HA attributes:
+### Virtual property example
 
 \`\`\`yaml
 version: "1.0"
 
-# Reusable derivation rules
-derivations:
-  battery_status_from_percentage:
-    description: "Derive battery status from percentage"
-    rule:
-      type: threshold
-      source_property: PERCENTAGE
-      thresholds:
-        - max: 20
-          value: "low"
-        - value: "ok"
-      default_value: "ok"
-
-# Virtual properties by channel category
 virtual_properties:
-  BATTERY:
-    - property_category: STATUS
-      virtual_type: derived
-      data_type: ENUM
-      permissions: [read_only]
-      format: ["ok", "low"]
-      derivation: battery_status_from_percentage
-
   WINDOW_COVERING:
     - property_category: COMMAND
       virtual_type: command
@@ -412,62 +366,7 @@ virtual_properties:
           stop: stop_cover
 \`\`\`
 
-### Custom Mapping Example
-
-To add custom mappings, create a file at \`var/data/plugin.devices-home-assistant.entity-mappings.yaml\`:
-
-\`\`\`yaml
-version: "1.0"
-
-# Custom transformer for Zigbee2MQTT brightness (0-254)
-transformers:
-  z2m_brightness_to_percent:
-    type: scale
-    input_range: [0, 254]
-    output_range: [0, 100]
-
-# Custom mappings
-mappings:
-  # Map Zigbee2MQTT air quality sensor
-  - name: sensor_air_quality_z2m
-    description: "Zigbee2MQTT air quality sensor"
-    domain: sensor
-    device_class: null
-    priority: 30                          # Higher than default sensor (20)
-    entity_id_contains: air_quality       # Match by entity_id pattern
-    channel:
-      category: AIR_PARTICULATE
-    device_category: SENSOR
-    property_bindings:
-      - ha_attribute: fb.main_state
-        property_category: DENSITY
-
-  # Custom smart plug with energy monitoring
-  - name: switch_energy_plug
-    description: "Smart plug with energy monitoring"
-    domain: switch
-    device_class: outlet
-    priority: 70                          # Higher than default outlet (60)
-    channel:
-      category: OUTLET
-    device_category: OUTLET
-    property_bindings:
-      - ha_attribute: fb.main_state
-        property_category: ON
-      - ha_attribute: current_power_w
-        property_category: POWER
-      - ha_attribute: today_energy_kwh
-        property_category: CONSUMPTION
-\`\`\`
-
-### Key Concepts
-
-- **priority** - Higher values are matched first; use >50 to override defaults
-- **device_class** - Match specific HA device classes, or \`null\` for fallback
-- **entity_id_contains** - Pattern matching on entity ID for flexible matching
-- **fb.main_state** - Special attribute that maps the entity's main state
-- **transformer** - Reference to a transformer for value conversion
-- **array_index** - Extract specific index from array attributes (e.g., RGB colors)`,
+Key concepts: \`priority\` (higher matches first), \`device_class\` (or \`null\` as fallback), \`entity_id_contains\` (pattern matching), \`fb.main_state\` (maps the entity's main state), \`transformer\` (value conversion).`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-reterminal/devices-reterminal.plugin.ts
+++ b/apps/backend/src/plugins/devices-reterminal/devices-reterminal.plugin.ts
@@ -203,31 +203,34 @@ export class DevicesReTerminalPlugin {
 			name: 'reTerminal',
 			description: 'Support for SeeedStudio reTerminal hardware peripherals',
 			author: 'FastyBird',
-			readme: `# reTerminal Devices Plugin
+			readme: `# reTerminal
 
-Host device integration plugin for SeeedStudio reTerminal hardware.
+> Plugin · by FastyBird · platform: devices
 
-## Supported Hardware
+Host-device platform that exposes the on-board peripherals of a SeeedStudio reTerminal (the panel running Smart Panel itself) — buttons, LEDs, buzzer and built-in sensors — as regular Smart Panel channels.
 
-- **reTerminal CM4** (5" touchscreen) - Buttons (F1, F2, F3, O), USR LED, STA LED (red/green), buzzer, light sensor, accelerometer
-- **reTerminal DM** (10.1" industrial) - Status LED, digital inputs/outputs, CPU temperature
+## What you get
+
+- The reTerminal becomes a fully-fledged smart device of your own home: its buttons can trigger scenes, its LEDs can signal alerts, its buzzer can wake the household
+- Built-in environmental data: ambient light sensor, accelerometer-derived orientation, and CPU temperature available to dashboards and Buddy
+- Zero configuration — the plugin auto-detects which reTerminal model you have and exposes only the peripherals that are actually present
 
 ## Features
 
-- **Auto-Detection** - Automatically detects reTerminal hardware variant
-- **Button Events** - Press, long press, and double press detection via evdev
-- **LED Control** - On/off, brightness, and color control via sysfs
-- **Buzzer Control** - Audible alert output
-- **Sensor Polling** - Light sensor, accelerometer, and CPU temperature monitoring
-- **Orientation Detection** - Computed from accelerometer data
+- **Auto-detection** — recognises the reTerminal hardware variant on first start
+- **Button events** — press, long press and double press via Linux evdev; usable as scene triggers from the scenes module
+- **LED control** — on / off, brightness and colour via sysfs; the panel can paint status (e.g. red while a leak alert is active)
+- **Buzzer control** — audible alert output for critical events
+- **Sensor polling** — light sensor, accelerometer, CPU temperature at a sensible default rate
+- **Orientation** — landscape / portrait derived from accelerometer data; useful for kiosks that get rotated on the wall
+- **No outbound traffic** — every read and write goes to the local kernel; nothing leaves the box
 
-## Communication
+## Supported Hardware
 
-Uses Linux sysfs and evdev interfaces:
-- \`/sys/class/leds/\` for LED and buzzer control
-- \`/dev/input/\` for button event monitoring
-- \`/sys/bus/iio/devices/\` for sensor data
-- \`/sys/class/thermal/\` for CPU temperature`,
+- **reTerminal CM4** (5" touchscreen) — F1 / F2 / F3 / O buttons, USR LED, STA LED (red / green), buzzer, light sensor, accelerometer
+- **reTerminal DM** (10.1" industrial) — status LED, digital inputs / outputs, CPU temperature
+
+The plugin auto-detects the hardware and talks to Linux sysfs (\`/sys/class/leds/\`, \`/sys/bus/iio/devices/\`, \`/sys/class/thermal/\`) and evdev (\`/dev/input/\`) directly — no configuration is required.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
@@ -259,35 +259,44 @@ export class DevicesShellyNgPlugin {
 			name: 'Shelly Next Generation',
 			description: 'Support for Shelly next-generation devices',
 			author: 'FastyBird',
-			readme: `# Shelly NG Devices Plugin
+			readme: `# Shelly Next Generation
 
-Integration plugin for Shelly next-generation (Gen2+) devices.
+> Plugin · by FastyBird · platform: devices
+
+Integration for Shelly next-generation (Gen2+) devices using Shelly's RPC API. Devices are discovered via mDNS, controlled over HTTP, and stream live state over an outbound WebSocket — even battery-powered, sleeping devices push status to the backend the moment they wake.
+
+## What you get
+
+- Plug-and-play onboarding: power up a new Shelly Plus / Pro device on the same network and the panel sees it within seconds
+- Real device telemetry, not poll snapshots: temperature, power, energy and switch state arrive at the backend as soon as the device sees a change
+- Stable, locally controlled devices — no Shelly cloud account required, all RPC traffic stays on your LAN
+- Per-device configuration is read on first connect (channels, ranges, units) so the panel always reflects the device's actual capabilities
 
 ## Features
 
-- **Auto-Discovery** - Automatically discovers Shelly NG devices on the local network
-- **Real-time Updates** - WebSocket-based state synchronization
-- **Device Control** - Control relays, lights, and other outputs
-- **Sensor Monitoring** - Read temperature, humidity, power consumption, etc.
+- **mDNS auto-discovery** — finds Gen2+ devices on the LAN automatically; new devices show up in the discovery feed for one-click adoption
+- **Outbound WebSocket** — devices initiate the WebSocket back to the backend, so battery / sleeping devices push state on wake without the backend having to poll them
+- **HTTP RPC fallback** — when WebSocket isn't available the plugin falls back to plain HTTP RPC; reconnection is automatic with configurable back-off
+- **Device control** — relays, dimmers, RGBW lights, covers / shutters and other outputs through one unified \`device.control\` surface
+- **Sensor monitoring** — temperature, humidity, power, energy, current, voltage; mapped onto standard channel property roles so dashboards and Buddy can read them generically
+- **Optional polling** — a low-rate status poll catches missed events and surfaces a clear warning when a device stops talking
+- **Resilient reconnect** — back-off ladder so a noisy network doesn't hammer either side
+- **Local-IP auto-detection** — works out which interface is on the device's subnet so the WebSocket URL is always reachable
 
 ## Supported Devices
 
-- Shelly Plus series (Plus 1, Plus 2PM, Plus Plug, etc.)
-- Shelly Pro series (Pro 1, Pro 2, Pro 4PM, etc.)
-- Shelly Mini series
-- Other Gen2+ devices with RPC API
-
-## Communication
-
-Uses Shelly's RPC (Remote Procedure Call) API over:
-- HTTP for device configuration and control
-- WebSocket for real-time state updates
-- mDNS for device discovery
+Shelly Plus (Plus 1, Plus 2PM, Plus Plug, …), Shelly Pro (Pro 1, Pro 2, Pro 4PM, …), Shelly Mini and any other Gen2+ device exposing the Shelly RPC API.
 
 ## Configuration
 
-- **Polling Interval** - How often to refresh device states
-- **Discovery** - Enable/disable automatic device discovery`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`status_poll_interval\` | Status poll interval in seconds (\`0\` disables polling) | \`60\` |
+| \`mdns.enabled\` | Run mDNS discovery for Shelly NG devices | \`true\` |
+| \`mdns.interface\` | Network interface to bind discovery to | system default |
+| \`websockets.request_timeout\` | RPC request timeout (s) | \`10\` |
+| \`websockets.ping_interval\` | WebSocket ping interval (s) | \`30\` |
+| \`websockets.reconnect_interval\` | Reconnect back-off in seconds | \`[5, 10, 15, 30, 60]\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
@@ -198,39 +198,41 @@ export class DevicesShellyV1Plugin {
 			name: 'Shelly Gen 1',
 			description: 'Support for Shelly first-generation devices',
 			author: 'FastyBird',
-			readme: `# Shelly V1 Devices Plugin
+			readme: `# Shelly Gen 1
 
-Integration plugin for Shelly first-generation (Gen1) devices.
+> Plugin · by FastyBird · platform: devices
+
+Integration for Shelly first-generation (Gen1) devices. Discovers devices over mDNS, controls them via the HTTP API and listens to real-time state updates over CoAP — completely local, no Shelly cloud account required.
+
+## What you get
+
+- A drop-in path to use existing Shelly 1 / 2 / Dimmer / RGBW2 / Plug etc. as native Smart Panel devices, with no firmware changes
+- Real-time state via CoAP push — updates arrive immediately, even on devices that don't expose the newer WebSocket protocol
+- Automatic stale detection: when a device stops talking the plugin marks it offline and the panel reflects that within seconds
+- A unified device shape regardless of whether the underlying hardware is a single relay or a multi-channel power meter
 
 ## Features
 
-- **Auto-Discovery** - Discovers Shelly Gen1 devices via mDNS/CoAP
-- **Device Control** - Control relays, dimmers, and roller shutters
-- **Status Monitoring** - Monitor power consumption, temperature, inputs
-- **CoAP Protocol** - Efficient real-time updates via CoAP
+- **mDNS auto-discovery** — finds Shelly Gen1 devices on the local network and surfaces them in the discovery feed
+- **CoAP push updates** — listens on UDP 5683 for the multicast status frames the devices send on every change
+- **HTTP control** — relays, dimmers, roller-shutters, lights driven through Gen1's classic HTTP endpoints
+- **Status monitoring** — power, temperature, inputs and metering mapped to standard property roles
+- **Stale detection** — devices that go silent are marked offline; the panel and Buddy see the change immediately
+- **Auto-recovery** — when a stale device starts talking again it is brought back online without manual intervention
+- **Configurable timeouts** — tune request and stale thresholds for noisy networks
 
 ## Supported Devices
 
-- Shelly 1 / 1PM
-- Shelly 2 / 2.5
-- Shelly Dimmer / Dimmer 2
-- Shelly EM / 3EM
-- Shelly Plug / Plug S
-- Shelly RGBW2
-- Shelly Bulb / Duo
-- And other Gen1 devices
-
-## Communication
-
-- **CoAP** - Real-time state updates (UDP port 5683)
-- **HTTP API** - Device control and configuration
-- **mDNS** - Device discovery
+Shelly 1 / 1PM, Shelly 2 / 2.5, Shelly Dimmer / Dimmer 2, Shelly EM / 3EM, Shelly Plug / Plug S, Shelly RGBW2, Shelly Bulb / Duo and other Gen1 hardware.
 
 ## Configuration
 
-- Enable/disable automatic device discovery
-- Configure polling intervals
-- Set authentication credentials for protected devices`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`discovery.enabled\` | Run mDNS discovery for Shelly devices | \`true\` |
+| \`discovery.interface\` | Network interface to bind discovery to | system default |
+| \`timeouts.request_timeout\` | HTTP request timeout (ms) | \`5000\` |
+| \`timeouts.stale_timeout\` | Mark a device stale after no updates for (ms) | \`30000\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-third-party/devices-third-party.plugin.ts
+++ b/apps/backend/src/plugins/devices-third-party/devices-third-party.plugin.ts
@@ -185,37 +185,33 @@ export class DevicesThirdPartyPlugin {
 			name: 'Third Party',
 			description: 'Support for integrating third-party devices via custom protocols',
 			author: 'FastyBird',
-			readme: `# Third Party Devices Plugin
+			readme: `# Third Party
 
-Plugin for manually adding and managing custom devices.
+> Plugin · by FastyBird · platform: devices
+
+Generic platform for manually-defined devices that don't have a dedicated integration. Lets you build custom channels and properties and drive them through the REST API or WebSocket — perfect for one-off hardware, custom firmware, scripts pushing values from somewhere else, and testing.
+
+## What you get
+
+- A way to make *anything* show up as a Smart Panel device — even gear that has no native integration yet
+- The same dashboard / scene / Buddy experience for your DIY hardware as for first-class devices
+- A predictable API contract: define the channels and properties once, then push values whenever you have new ones
+- A safe sandbox for prototyping new integrations before turning them into a proper plugin
 
 ## Features
 
-- **Manual Device Creation** - Add devices that aren't auto-discovered
-- **Custom Channels** - Define custom channels and properties
-- **API Integration** - Devices can be controlled via the REST API
-- **Flexible Schema** - Support for various property types and formats
+- **Manual device creation** — define devices that aren't auto-discovered, with a custom name and category
+- **Custom channels & properties** — booleans, numbers, strings or enums; readable, writable or both
+- **REST + WebSocket control** — push current values from any external system; receive write requests when the panel asks for a change
+- **Validation** — property writes are validated against the declared schema, so a script can't push a string into a numeric property
+- **Flexible schema** — model anything Smart Panel's data model can describe; useful for sensors, switches, virtual devices and more
 
 ## Use Cases
 
-- Devices without native integration plugins
-- Custom hardware projects
-- Testing and development
-- External systems pushing data via API
-
-## Device Structure
-
-Each third-party device can have:
-- Multiple **channels** (e.g., relay, sensor, button)
-- Multiple **properties** per channel (e.g., state, value, unit)
-- Custom property types (boolean, number, string, enum)
-
-## API Control
-
-Third-party device states can be updated via:
-- REST API endpoints
-- WebSocket events
-- Direct database updates (for advanced use)`,
+- Hardware without a native plugin yet
+- DIY / custom firmware projects publishing over HTTP or WebSocket
+- Pushing values from external services or scripts (e.g. a cron job that posts your car's battery level)
+- Testing and development of dashboards / scenes without touching real devices`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
@@ -197,36 +197,46 @@ export class DevicesWledPlugin {
 			name: 'WLED',
 			description: 'Support for WLED addressable LED controllers',
 			author: 'FastyBird',
-			readme: `# WLED Devices Plugin
+			readme: `# WLED
 
-Integration plugin for WLED addressable LED controllers.
+> Plugin · by FastyBird · platform: devices
+
+Integration for [WLED](https://kno.wled.ge) addressable-LED controllers running on ESP8266 / ESP32. Exposes brightness, colour, effects, segments, presets and palettes through WLED's JSON API and keeps panel state in sync via WLED's WebSocket.
+
+## What you get
+
+- Full creative control over WLED strips from the panel and dashboards — colour, effect, palette, segment, preset, all without leaving the room
+- Real-time state: open WLED's own UI on a phone and changes show on the panel instantly (and vice versa)
+- Per-segment control so a single physical strip can act as several independent lights on the panel
+- A graceful fallback: if WebSocket is unavailable the plugin polls the JSON API at a configurable interval, so the integration keeps working
 
 ## Features
 
-- **Auto-Discovery** - Automatically discovers WLED devices via mDNS
-- **Real-time Updates** - WebSocket-based state synchronization
-- **Device Control** - Control brightness, colors, effects, and segments
-- **Presets & Palettes** - Access WLED presets and color palettes
-- **Nightlight Mode** - Configure automatic dimming
-- **UDP Sync** - Enable/disable sync between WLED devices
+- **mDNS auto-discovery** — finds WLED devices on the LAN; new strips appear in the discovery feed and can be auto-adopted
+- **WebSocket sync** — live, push-based state updates with automatic reconnection
+- **HTTP / JSON fallback** — when WebSocket is off or unavailable, the plugin polls JSON state at a configurable interval
+- **Full effect / palette / preset access** — all the visual richness of WLED, addressable through the standard Smart Panel light channel
+- **Segments** — every WLED segment is exposed as its own channel so they can be controlled independently from dashboards or scenes
+- **Nightlight & UDP sync** — drive WLED's automatic dimming and inter-device sync from the panel
+- **Command debouncing** — fast slider drags don't flood the device; commands are coalesced before being sent
+- **Per-device tunables** — connection / debounce / poll intervals can be tuned for slow or chatty networks
 
 ## Supported Devices
 
-- All WLED-compatible ESP8266/ESP32 controllers
-- Any device running WLED firmware 0.13+
-
-## Communication
-
-Uses WLED's JSON API over:
-- HTTP for device configuration and control
-- WebSocket for real-time state updates
-- mDNS for device discovery
+Any ESP8266 / ESP32 controller running WLED firmware **0.13** or later.
 
 ## Configuration
 
-- **Polling Interval** - How often to refresh device states
-- **Discovery** - Enable/disable mDNS auto-discovery
-- **WebSocket** - Enable/disable real-time updates`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`mdns.enabled\` | Run mDNS discovery for WLED devices | \`true\` |
+| \`mdns.interface\` | Network interface to bind discovery to | all |
+| \`mdns.auto_add\` | Auto-add discovered devices | \`true\` |
+| \`websocket.enabled\` | Use WebSocket for real-time updates | \`true\` |
+| \`websocket.reconnect_interval\` | WebSocket reconnect interval (ms, min 1000) | \`5000\` |
+| \`polling.interval\` | State polling interval (ms, min 5000) | \`30000\` |
+| \`timeouts.connection_timeout\` | HTTP connection timeout (ms, min 1000) | plugin default |
+| \`timeouts.command_debounce\` | Command debounce delay (ms) | plugin default |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
@@ -225,42 +225,57 @@ export class DevicesZigbee2mqttPlugin {
 			name: 'Zigbee2MQTT',
 			description: 'Integration plugin for Zigbee devices via Zigbee2MQTT',
 			author: 'FastyBird',
-			readme: `# Zigbee2MQTT Plugin
+			readme: `# Zigbee2MQTT
 
-Integration plugin for Zigbee devices through Zigbee2MQTT bridge.
+> Plugin · by FastyBird · platform: devices
+
+Integration for Zigbee devices via a [Zigbee2MQTT](https://www.zigbee2mqtt.io) bridge. Connects either through an MQTT broker or directly to the Zigbee2MQTT frontend over WebSocket, then automatically maps Z2M *exposes* to Smart Panel channels and properties so a freshly-paired bulb appears on your dashboard with no manual mapping.
+
+## What you get
+
+- A path to use any Zigbee device that Zigbee2MQTT supports — thousands of models across hundreds of vendors
+- Two transport options so the plugin fits both setups: a shared MQTT broker (typical Z2M install) or a direct WebSocket to the Z2M frontend (no broker needed)
+- Auto-mapping: most devices come up correctly out of the box because the plugin reads Z2M's *exposes* and maps them to standard Smart Panel property roles
+- A safety net: when a device exposes something unusual you can add a YAML override without touching code
 
 ## Features
 
-- **Dual Connection Mode** - Connect via MQTT broker or directly via WebSocket to Zigbee2MQTT
-- **Automatic Device Discovery** - Discovers and maps devices from Zigbee2MQTT bridge
-- **Dynamic Capability Mapping** - Automatically maps Z2M exposes to Smart Panel properties
-- **Real-time State Updates** - Receives state changes via MQTT subscriptions
-- **Bidirectional Control** - Send commands to devices via MQTT
-- **User-Extensible Mappings** - Define custom device mappings via YAML configuration
+- **Dual transport** — MQTT broker or direct WebSocket to Zigbee2MQTT
+- **Automatic discovery** — devices and their capabilities are pulled from the bridge on connect; new devices show up in the discovery feed in real time
+- **Dynamic mapping** — Z2M exposes are mapped to Smart Panel properties using a default rule set that covers lights, switches, sensors, climate, covers, locks
+- **Real-time updates** — state changes are streamed via MQTT or WS as they happen, no polling
+- **Bidirectional control** — commands from Smart Panel are translated back to Z2M's expected payload (turning a switch, setting brightness / colour / temperature, …)
+- **Custom YAML mappings** — drop a YAML file in the data dir to override defaults, add transformers, or model exotic devices
+- **Configurable auto-adopt** — choose whether newly-discovered devices appear adopted automatically or wait for explicit confirmation
 
 ## Supported Devices
 
-Supports all Zigbee devices compatible with Zigbee2MQTT, including:
-- Smart lights (dimmable, color, color temperature)
-- Switches and relays
-- Sensors (temperature, humidity, motion, door/window, etc.)
-- Thermostats and climate controls
-- Covers and blinds
-- Locks
+Any device supported by Zigbee2MQTT — smart lights (dimmable, CCT, RGB), switches and relays, sensors (temperature, humidity, motion, contact, …), thermostats, covers and locks.
 
-## Custom Device Mappings
+## Configuration
 
-Place custom YAML files in \`var/data/\` using the prefix \`plugin.devices-zigbee2mqtt.\` (e.g. \`plugin.devices-zigbee2mqtt.my-sensors.yaml\`), or set \`ZIGBEE_MAPPINGS_PATH\` env variable to a custom directory.
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`connection_type\` | \`mqtt\` (via broker) or \`ws\` (direct WebSocket) | \`mqtt\` |
+| \`mqtt.host\` | MQTT broker host (MQTT mode) | — |
+| \`mqtt.port\` | MQTT broker port (MQTT mode) | \`1883\` |
+| \`mqtt.tls\` | TLS / SSL options (MQTT mode) | disabled |
+| \`websocket.host\` | Zigbee2MQTT frontend host (WS mode) | — |
+| \`websocket.port\` | Zigbee2MQTT frontend port (WS mode) | \`8080\` |
+| \`base_topic\` | Zigbee2MQTT base topic | \`zigbee2mqtt\` |
+| \`discovery.auto_add\` | Auto-adopt newly discovered devices | \`true\` |
 
-### Example: Custom Sensor Property
+## Custom Mappings
+
+Drop YAML files into \`var/data/\` with the prefix \`plugin.devices-zigbee2mqtt.\` (e.g. \`plugin.devices-zigbee2mqtt.my-sensors.yaml\`) or set \`ZIGBEE_MAPPINGS_PATH\` to a custom directory.
+
+### Example — sensor property
 
 \`\`\`yaml
-# var/data/plugin.devices-zigbee2mqtt.my-sensors.yaml
 version: "1.0"
 
 mappings:
   - name: cpu_temperature_sensor
-    description: "Device internal temperature"
     priority: 100
     match:
       expose_type: numeric
@@ -280,13 +295,12 @@ mappings:
               settable: false
 \`\`\`
 
-### Example: Custom Transformer
+### Example — custom transformer
 
 \`\`\`yaml
 version: "1.0"
 
 transformers:
-  # Custom brightness scale (0-1000 instead of 0-254)
   brightness_1000:
     type: scale
     input_range: [0, 1000]
@@ -297,7 +311,7 @@ mappings:
     priority: 200
     match:
       expose_type: light
-      any_property: [custom_feature]  # Match specific device
+      any_property: [custom_feature]
     device_category: LIGHTING
     channels:
       - identifier: light
@@ -311,37 +325,9 @@ mappings:
             transformer: brightness_1000
 \`\`\`
 
-### Match Conditions
+**Match keys:** \`expose_type\` (\`light\`/\`switch\`/\`numeric\`/\`binary\`/\`enum\`/\`climate\`/\`cover\`/\`fan\`/\`lock\`), \`property\`, \`has_features\`, \`any_property\`, \`is_list\`.
 
-- \`expose_type\` - Z2M type: light, switch, numeric, binary, enum, climate, cover, fan, lock
-- \`property\` - Property name for generic exposes (temperature, humidity, etc.)
-- \`has_features\` - Required features: [state, brightness]
-- \`any_property\` - Match if device has any of these properties
-- \`is_list\` - True for multi-endpoint devices
-
-### Transformer Types
-
-- \`scale\` - Linear scaling: input_range, output_range
-- \`map\` - Value mapping: read, write, or bidirectional
-- \`boolean\` - Boolean conversion: true_value, false_value, invert
-- \`formula\` - Custom JS expression: read, write
-
-## Requirements
-
-- Running Zigbee2MQTT instance
-- For MQTT mode: MQTT broker (Mosquitto, etc.) and network connectivity
-- For WebSocket mode: Network connectivity to Zigbee2MQTT frontend
-
-## Configuration
-
-- **Connection Type** - "mqtt" (via MQTT broker) or "ws" (direct WebSocket to Zigbee2MQTT)
-- **MQTT Host** - MQTT broker hostname or IP (MQTT mode)
-- **MQTT Port** - MQTT broker port, default: 1883 (MQTT mode)
-- **WebSocket Host** - Zigbee2MQTT frontend hostname or IP (WebSocket mode)
-- **WebSocket Port** - Zigbee2MQTT frontend port, default: 8080 (WebSocket mode)
-- **Base Topic** - Zigbee2MQTT base topic (default: zigbee2mqtt)
-- **TLS** - Optional TLS/SSL configuration (MQTT mode)
-- **Discovery** - Auto-add devices and sync on startup options`,
+**Transformer types:** \`scale\`, \`map\`, \`boolean\`, \`formula\`.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/influx-v1/influx-v1.plugin.ts
+++ b/apps/backend/src/plugins/influx-v1/influx-v1.plugin.ts
@@ -41,15 +41,49 @@ export class InfluxV1Plugin implements OnModuleInit {
 			name: 'InfluxDB v1',
 			description: 'InfluxDB 1.x time-series storage backend with retention policies and continuous queries.',
 			author: 'FastyBird',
-			readme: `# InfluxDB v1 Plugin
+			readme: `# InfluxDB v1
 
-Connects to an InfluxDB 1.x server and provides full time-series storage with retention policies, continuous queries, and all native InfluxDB features.
+> Plugin · by FastyBird · platform: storage
+
+Time-series storage backend that connects Smart Panel to an InfluxDB 1.x server. Persists historical property values, device statuses and energy buckets with full InfluxDB features — retention policies, continuous queries and the native HTTP query API.
+
+## What you get
+
+- Production-grade history: long-term retention with InfluxDB's continuous queries doing the downsampling so dashboards stay fast on year-long ranges
+- A backend that scales beyond what an embedded store can handle, including multi-tenant or multi-installation scenarios
+- A familiar query language for ops: data is in standard InfluxDB measurements / fields / tags, queryable with InfluxQL from any tool you already use
+- Smart fallback partner — pair it with \`memory-storage\` as the fallback so a network blip never loses data
+
+## Capabilities
+
+- **Bulk writes** — buffered batched writes to keep load on the DB low
+- **Retention policies** — automatically created from each module's schema (e.g. raw 24h, 1-minute / 14d, 1-hour / 1y)
+- **Continuous queries** — automatic downsampling so dashboards have fast roll-ups
+- **Time-bucketed reads** — the storage module's query helpers translate to optimal InfluxQL
+- **Health checks** — surface degraded connectivity to the system module so the admin UI can warn the user
+
+## Setup
+
+1. Run an InfluxDB 1.x server reachable from the backend
+2. Create a database (defaults to \`fastybird\`)
+3. Enable this plugin and fill in the configuration
+4. Pick this plugin as the primary storage backend in the storage module configuration
+
+## Setup
+
+1. Run an InfluxDB 1.x server reachable from the backend
+2. Create a database (defaults to \`fastybird\`)
+3. Enable this plugin and fill in the configuration
+4. The Storage module will start writing time-series data through this plugin
 
 ## Configuration
 
-- **host** — InfluxDB server address (default: 127.0.0.1)
-- **database** — InfluxDB database name (default: fastybird)
-- **username/password** — Optional authentication credentials`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`host\` | InfluxDB server host or IP | \`127.0.0.1\` |
+| \`database\` | InfluxDB database name | \`fastybird\` |
+| \`username\` | Optional username for authentication | — |
+| \`password\` | Optional password for authentication | — |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/influx-v2/influx-v2.plugin.ts
+++ b/apps/backend/src/plugins/influx-v2/influx-v2.plugin.ts
@@ -42,16 +42,49 @@ export class InfluxV2Plugin implements OnModuleInit {
 			description:
 				'InfluxDB 2.x time-series storage backend with Flux query language, token-based auth, and bucket management.',
 			author: 'FastyBird',
-			readme: `# InfluxDB v2 Plugin
+			readme: `# InfluxDB v2
 
-Connects to an InfluxDB 2.x server and provides time-series storage using the Flux query language, buckets, organizations, and token-based authentication.
+> Plugin · by FastyBird · platform: storage
+
+Time-series storage backend that writes property history, device statuses and energy buckets to an InfluxDB 2.x server. Uses the Flux query language with token-based authentication and bucket / organisation scoping — the modern InfluxDB option for new installs.
+
+## What you get
+
+- The current generation of InfluxDB: token authentication, organisations, buckets and the Flux query language out of the box
+- Production-grade scaling for installations that retain a lot of history or run many devices
+- Clean operational separation: a dedicated bucket / org so Smart Panel data doesn't mix with anything else you store in Influx
+- Familiar tooling for ops: query the same data with the InfluxDB UI, Grafana or your own scripts
+
+## Capabilities
+
+- **Token authentication** — fine-grained access control via Influx tokens; no plaintext password
+- **Bucket / organisation scoping** — tidy multi-tenant deployments
+- **Flux queries** — modern query language with grouping, joining and pivoting baked in
+- **Buffered writes** — batched writes minimise HTTP overhead and keep the DB happy under sustained load
+- **Health checks** — surface degraded connectivity to the system module so the admin UI can warn the user
+
+## Setup
+
+1. Run an InfluxDB 2.x server reachable from the backend
+2. Create an organisation, bucket and an API token with write access to the bucket
+3. Enable this plugin and fill in the configuration
+4. Pick this plugin as the primary storage backend in the storage module configuration
+
+## Setup
+
+1. Run an InfluxDB 2.x server reachable from the backend
+2. Create an organization, bucket and an API token with write access to the bucket
+3. Enable this plugin and fill in the configuration
+4. The Storage module will start writing time-series data through this plugin
 
 ## Configuration
 
-- **url** — InfluxDB v2 server URL (default: http://127.0.0.1:8086)
-- **token** — API token for authentication
-- **org** — Organization name (default: fastybird)
-- **bucket** — Bucket name (default: fastybird)`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`url\` | InfluxDB v2 server URL | \`http://127.0.0.1:8086\` |
+| \`token\` | API token with read/write access | — |
+| \`org\` | Organization name | \`fastybird\` |
+| \`bucket\` | Bucket name | \`fastybird\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/logger-rotating-file/logger-rotating-file.plugin.ts
+++ b/apps/backend/src/plugins/logger-rotating-file/logger-rotating-file.plugin.ts
@@ -46,44 +46,35 @@ export class LoggerRotatingFilePlugin {
 			name: 'Rotating File Logger',
 			description: 'File-based logging with automatic log rotation',
 			author: 'FastyBird',
-			readme: `# Rotating File Logger Plugin
+			readme: `# Rotating File Logger
 
-File-based logging with automatic rotation and retention management.
+> Plugin · by FastyBird · platform: logging
+
+Persists application logs to disk in a configurable directory. Files are rotated daily and old logs are cleaned up on a cron schedule based on the configured retention window — the simplest way to keep a forensic trail without external log shippers.
+
+## What you get
+
+- A reliable, self-managing on-disk log archive: write speed isn't bottlenecked, files are rotated automatically, and you don't have to remember to clean them up
+- A direct, plain-text format that any tool can consume (\`grep\`, \`tail -f\`, log shippers, viewers in the admin UI)
+- Bounded disk usage thanks to the retention policy — a verbose deployment cannot fill the disk silently
+- Plays nicely with the system module: the same structured log entries the API exposes are mirrored to disk
 
 ## Features
 
-- **File Logging** - Persist logs to disk for later analysis
-- **Automatic Rotation** - Create new log files based on size or time
-- **Retention Policy** - Automatically delete old log files
-- **Configurable Format** - Customize log output format
-
-## How It Works
-
-The plugin writes application logs to files in a configured directory. When logs reach a certain size or age, they are rotated:
-
-1. Current log file is renamed with timestamp
-2. New log file is created
-3. Old rotated files are deleted based on retention settings
+- **Daily rotation** — one file per day, timestamped (e.g. \`smart-panel-2026-04-27.log\`)
+- **Retention policy** — files older than \`retention_days\` are deleted automatically
+- **Cron-driven cleanup** — schedule the eviction job with a standard cron expression so it runs at a quiet hour
+- **Custom prefix & directory** — pick the file name and storage location to match your deployment layout
+- **Atomic-safe writes** — log writes are flushed in line with the application's structured logger so a crash doesn't truncate a half-written entry
 
 ## Configuration
 
-- **Enabled** - Toggle file logging on/off
-- **Log Directory** - Where to store log files
-- **Max File Size** - Rotate when file reaches this size
-- **Max Files** - Number of rotated files to keep
-- **Log Level** - Minimum level to log (debug, info, warn, error)
-
-## Log Location
-
-By default, logs are stored in:
-\`\`\`
-./logs/smart-panel.log
-\`\`\`
-
-Rotated files are named:
-\`\`\`
-smart-panel-2024-01-15.log
-\`\`\``,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`dir\` | Directory where log files are written | system default (\`./logs\`) |
+| \`file_prefix\` | Prefix for rotated files (\`[A-Za-z0-9._-]+\`) | \`smart-panel\` |
+| \`retention_days\` | Days to retain rotated files (≥ 1) | \`7\` |
+| \`cleanup_cron\` | Cron expression for the cleanup job | \`0 3 * * *\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/memory-storage/memory-storage.plugin.ts
+++ b/apps/backend/src/plugins/memory-storage/memory-storage.plugin.ts
@@ -42,16 +42,32 @@ export class MemoryStoragePlugin implements OnModuleInit {
 			description:
 				'In-memory ring-buffer storage. Data is lost on restart. Used as default fallback when no external database is available.',
 			author: 'FastyBird',
-			readme: `# In-Memory Storage Plugin
+			readme: `# In-Memory Storage
 
-Stores time-series data in process memory with automatic eviction. Always available — used as the default fallback when the primary storage is unreachable.
+> Plugin · by FastyBird · platform: storage
+
+Process-local ring-buffer time-series storage. Always available and used as the default fallback when no external database (InfluxDB, …) is configured or reachable. The "no-config, just works" backend that keeps the panel functional out of the box.
+
+## What you get
+
+- Zero-setup history: the panel starts up and dashboards have data immediately, no Influx instance required
+- A safety net for production setups: pair it with an external backend as the fallback so a network blip never loses recent data
+- Fast: every read / write is a memory operation, there is no network in the path
+- Predictable footprint — the ring buffer is hard-capped, so a misbehaving sensor can't fill the host's RAM
+
+## Use cases
+
+- **Out-of-the-box experience** — the panel works the moment it is installed, dashboards show real data within minutes
+- **Development and tests** — no Docker container or external service needed to exercise the time-series path
+- **Fallback for the primary backend** — keep the last 24 h locally so a temporary Influx outage doesn't black out the dashboards
+- **Tiny installations** — homes with few devices and short histories can run entirely on this backend
 
 ## Limitations
 
-- Data does NOT persist across process restarts
-- Limited to 10,000 points per measurement
-- Points older than 24 hours are automatically evicted
-- No continuous query support`,
+- Data does **not** persist across process restarts
+- Capped at 10 000 points per measurement
+- Points older than 24 hours are evicted automatically
+- No continuous-query support — downsampling is provided in a best-effort, on-the-fly manner`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/pages-cards/pages-cards.plugin.ts
+++ b/apps/backend/src/plugins/pages-cards/pages-cards.plugin.ts
@@ -111,39 +111,28 @@ export class PagesCardsPlugin {
 			name: 'Cards Page',
 			description: 'Dashboard page type for displaying information cards',
 			author: 'FastyBird',
-			readme: `# Cards Page Plugin
+			readme: `# Cards Page
 
-Dashboard page type for displaying scrollable information cards.
+> Plugin · by FastyBird · platform: dashboard pages
+
+Dashboard page type that lays out scrollable information cards — useful for status summaries, navigation menus, quick actions and "everything that doesn't fit a grid". Picks up where the tile grid stops: lists of items where each item is a small standalone card.
+
+## What you get
+
+- A flexible page surface for items that aren't tile-sized but still want a rich, tappable presentation
+- A common shape for navigation hubs (e.g. a "rooms" page that lists every space with its key state)
+- Logical grouping so pages stay legible even with many cards
+- Tap actions that integrate with the rest of the system: trigger scenes, run scripts, navigate to other pages, or drop a user into a detail view
 
 ## Features
 
-- **Card Layout** - Vertical scrolling card list
-- **Rich Content** - Cards support text, icons, and actions
-- **Action Buttons** - Configurable tap actions per card
-- **Grouping** - Organize cards into logical groups
+- **Card layout** — vertical scrolling list of cards, each with an icon, title, optional secondary line and tap action
+- **Rich content** — text, icons, badges and accent colours per card
+- **Quick actions** — fire scenes, send device commands or navigate to other dashboard pages
+- **Section grouping** — organise cards into logical sections with optional headings
+- **Live data** — cards bound to data sources update in real time without re-rendering the whole page
 
-## Card Types
-
-Cards can display:
-- Static information
-- Quick action buttons
-- Navigation links
-- Status summaries
-
-## Page Structure
-
-- Header with page title
-- Scrollable card container
-- Cards stack vertically
-- Each card has title, content, and optional actions
-
-## Usage
-
-1. Create a new cards page
-2. Add cards with titles and content
-3. Configure actions for each card
-4. Order cards as needed
-5. View on the panel display`,
+Each page defines its own cards (title, content, icon, action) when created — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/pages-device-detail/pages-device-detail.plugin.ts
+++ b/apps/backend/src/plugins/pages-device-detail/pages-device-detail.plugin.ts
@@ -93,38 +93,29 @@ export class PagesDeviceDetailPlugin {
 			name: 'Device Detail Page',
 			description: 'Dashboard page for detailed device information and controls',
 			author: 'FastyBird',
-			readme: `# Device Detail Page Plugin
+			readme: `# Device Detail Page
 
-Dashboard page type for displaying detailed device information.
+> Plugin · by FastyBird · platform: dashboard pages
+
+Full-screen dashboard page that surfaces every channel and property of a single device, with controls for writable properties and live updates for the rest. The "deep dive" view a tile points to when the user wants more than a glance.
+
+## What you get
+
+- A complete picture of one device — every channel, every property, every sensor reading and every control on a single page
+- Automatic UI per property: switches for booleans, sliders for ranged numbers, dropdowns for enums, read-only labels for sensors
+- Real-time refresh so the page reflects external changes (someone flipping the physical switch, a sensor changing) without polling
+- A great fallback for devices that don't yet have a custom dashboard: drop a Device Detail page and you immediately have full control
 
 ## Features
 
-- **Full Device View** - Comprehensive device information display
-- **Channel List** - View all device channels and their properties
-- **Property Controls** - Interact with all controllable properties
-- **Real-time Updates** - Live property value updates
+- **Full device view** — name, category, icon, connection status, last-seen timestamp
+- **Channel list** — every channel grouped with its properties; collapsed by default for devices with many channels
+- **Property controls** — automatic UI for writable properties (switch, slider, picker, …) using the same components the rest of the panel uses
+- **Read-only sensors** — non-writable properties render as live values with their unit and label
+- **Real-time updates** — values stream in over WebSocket; controls feed back through the optimistic intent layer for instant feel
+- **Range / enum awareness** — sliders respect the property's declared min / max / step; pickers honour the enum format
 
-## Page Content
-
-### Device Information
-- Device name and type
-- Connection status
-- Device icon
-
-### Channels Section
-- List of all device channels
-- Each channel shows its properties
-- Controls for settable properties
-
-## Usage
-
-Create a device detail page and select a device. When displayed on the panel, users can view all device information and control any writable properties.
-
-## Navigation
-
-Device detail pages can be accessed:
-- From device preview tiles (tap to open)
-- From the pages carousel (swipe to navigate)`,
+Each page selects its target device when created — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/pages-tiles/pages-tiles.plugin.ts
+++ b/apps/backend/src/plugins/pages-tiles/pages-tiles.plugin.ts
@@ -98,39 +98,28 @@ export class PagesTilesPlugin {
 			name: 'Tiles Page',
 			description: 'Dashboard page type for displaying tiles with widgets',
 			author: 'FastyBird',
-			readme: `# Tiles Page Plugin
+			readme: `# Tiles Page
 
-Dashboard page type for displaying a grid of configurable tiles.
+> Plugin · by FastyBird · platform: dashboard pages
+
+Dashboard page type that lays out configurable tiles in a flexible grid. The default page used for "the main view of a room" or any custom layout — works with every registered tile plugin (clock, weather, device preview, scenes, …) and lets them mix freely on the same page.
+
+## What you get
+
+- A free-form, room-style canvas: drop a clock here, two switches there, a temperature graph beside them
+- Variable tile sizes so big-impact tiles (a temperature gauge) can sit next to small ones (a quick switch)
+- Live data everywhere — every tile reflects the underlying device / weather / scene state in real time
+- Responsiveness by default — the same page renders on a phone-sized panel and a 10" panel without per-device tweaks
 
 ## Features
 
-- **Grid Layout** - Arrange tiles in a flexible grid system
-- **Multiple Tile Types** - Support for various tile plugins
-- **Responsive Design** - Adapts to display size
-- **Tile Data Sources** - Connect tiles to live data
+- **Grid layout** — configurable rows × columns; tiles can span multiple cells horizontally and vertically
+- **Mixed tiles** — combine any registered tile plugins on the same page
+- **Drag-and-drop editing** in the admin UI; positions and sizes are validated against the configured grid
+- **Live data** — tiles bound to data-source plugins update automatically as values change
+- **Empty-state hint** — a freshly created page guides the user into adding the first tile rather than showing a blank screen
 
-## Page Layout
-
-Tiles pages display widgets in a grid:
-- Configurable grid dimensions
-- Tiles can span multiple cells
-- Automatic layout optimization
-
-## Supported Tiles
-
-Works with any registered tile type:
-- Time tiles
-- Weather tiles
-- Device preview tiles
-- Custom tile plugins
-
-## Usage
-
-1. Create a new tiles page
-2. Configure grid size
-3. Add tiles and position them
-4. Connect data sources to tiles
-5. Save and view on the panel display`,
+Grid size and tile placement are configured per page — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/scenes-local/scenes-local.plugin.ts
+++ b/apps/backend/src/plugins/scenes-local/scenes-local.plugin.ts
@@ -97,39 +97,38 @@ export class ScenesLocalPlugin implements OnModuleInit {
 			name: 'Local Scenes',
 			description: 'Execute scenes locally by controlling device properties',
 			author: 'FastyBird',
-			readme: `# Local Scenes Plugin
+			readme: `# Local Scenes
 
-Plugin for executing scenes that control local device properties.
+> Plugin · by FastyBird · platform: scenes
 
-## Features
+Scene-action provider that drives local device properties — when a scene is triggered, each action sets a property on a target device managed by this Smart Panel installation. Validates device / channel / property existence, write permissions and value-type compatibility before issuing any commands.
 
-- **Device Control** - Set device property values when scene triggers
-- **Action Validation** - Validates device, channel, and property exist
-- **Permission Checking** - Ensures properties are writable before execution
-- **Value Type Validation** - Checks value matches property data type
+## What you get
 
-## How It Works
-
-When a local scene is triggered:
-1. Each action is validated for device/channel/property availability
-2. Property write permissions are verified
-3. Value type compatibility is checked
-4. Commands are sent to devices through their platform handlers
+- A first-class way to bundle multiple local device changes into one scene with full validation — the scene either references real, writable things or it never gets saved
+- Predictable execution: every action returns its own success / failure result so partial failures are visible to the caller (panel, admin UI or Buddy)
+- Type safety: a scene that tries to push a string into a numeric switch is rejected at create / update time, not at run time
+- Channel auto-detection so you don't need to memorise channel IDs when a device only has one matching channel
 
 ## Action Structure
 
 Each local scene action specifies:
-- **deviceId** - Target device identifier
-- **channelId** - Optional channel (auto-detected if omitted)
-- **propertyId** - Property to modify
-- **value** - New value (boolean, number, or string)
+
+- \`device_id\` — target device
+- \`channel_id\` — optional channel (auto-detected when the device has a single matching channel)
+- \`property_id\` — property to modify
+- \`value\` — new value (boolean, number, string or enum)
+
+## Behaviour
+
+- **Validation up front** — the action is checked at scene save time, not at trigger time, so broken scenes are caught early
+- **Permission-aware** — read-only properties are rejected with a clear error
+- **Sequential execution** — actions run in declared order; later actions still run even if an earlier one fails, but the overall scene reports a partial-failure status
+- **Optimistic feedback** — uses the standard intent layer so panel UIs reflect the change instantly
 
 ## Supported Value Types
 
-- Boolean (bool, boolean)
-- Numbers (int, uint, float, short, ushort, char, uchar)
-- Strings
-- Enums (validated against allowed format values)`,
+Boolean (\`bool\`, \`boolean\`), numbers (\`int\`, \`uint\`, \`float\`, \`short\`, \`ushort\`, \`char\`, \`uchar\`), strings, and enums (validated against allowed format values).`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/simulator/simulator.plugin.ts
+++ b/apps/backend/src/plugins/simulator/simulator.plugin.ts
@@ -234,90 +234,81 @@ export class SimulatorPlugin {
 			name: 'Simulator',
 			description: 'Plugin for creating simulated devices, spaces, and scenes for testing and development',
 			author: 'FastyBird',
-			readme: `# Simulator Plugin
+			readme: `# Simulator
 
-Plugin for creating virtual devices, spaces, and scenes for testing purposes without requiring physical hardware.
+> Plugin · by FastyBird · platform: devices
+
+Creates virtual devices, channels and properties for testing and development — and for showing the panel off without any physical hardware. Supports loading entire homes from YAML scenarios, generating individual devices, realistic time- and location-aware behaviour, and toggling connection state on demand.
+
+## What you get
+
+- A complete, believable home in seconds: pick a scenario (small apartment, penthouse, office) and the simulator seeds devices, channels and properties that look exactly like real ones to the rest of the system
+- A way to develop dashboards, scenes and Buddy logic without touching real hardware — values change realistically over time, daylight follows your latitude, AC and heaters react to setpoints
+- A reproducible test bed for QA: fixed scenarios with known expected behaviour mean dashboards and scenes can be tested end-to-end
+- A live demo mode: pair with auto-simulation and the panel becomes a self-driving showroom
+- Granular control: simulate a single property, the entire device, or the whole home; flip connection states to exercise offline / reconnect handling
 
 ## Features
 
-- **Load Scenarios** - Load predefined device sets from YAML files (small apartment, penthouse, office, etc.)
-- **Generate Devices** - Create simulated devices of any category with proper channels and properties
-- **Realistic Simulation** - Time-based and environmental simulation for realistic device behavior
-- **Smart Simulators** - Dedicated simulators for sensors, lighting, AC, heaters, thermostats, and more
-- **Connection Testing** - Simulate connection state changes (online/offline)
-- **Auto-Simulation** - Enable automatic value updates at configurable intervals
-- **Location-Aware** - Latitude-based simulation for accurate daylight and temperature patterns
+- **Scenarios** — load predefined device sets from YAML (small apartment, penthouse, office, …) or your own custom files
+- **Device generation** — synthesise devices of any supported category with sensible defaults for channels and properties
+- **Realistic simulators** — time-based and environmental simulation for sensors, lighting, AC, heaters, thermostats, outlets, fans, locks and window coverings
+- **Connection testing** — flip devices between connected / lost states to exercise reconnect logic in scenes, dashboards and Buddy
+- **Auto-simulation** — periodic value updates at a configurable interval, optionally with smooth transitions for realism
+- **Location-aware** — latitude-based daylight and temperature curves so the simulated home behaves differently in summer vs. winter, day vs. night
+- **Smooth transitions** — values gradually move toward the next target rather than snapping, so dashboards look alive
 
-## Supported Device Categories with Realistic Simulators
+## Supported Categories
 
-- **Sensors** - Temperature, humidity, motion, illuminance, pressure, contact, leak, smoke, CO, CO2, air quality
-- **Lighting** - Time-based on/off, brightness, color temperature, RGB colors
-- **Air Conditioners** - Cooling/heating modes, fan control, temperature regulation
-- **Heating Units** - Temperature control, power consumption
-- **Thermostats** - Scheduled temperature control with hysteresis
-- **Outlets** - Power monitoring, energy consumption tracking
-- **Fans** - Temperature-based speed control
-- **Locks** - Time-based lock/unlock patterns
-- **Window Coverings** - Position based on time of day and season
+Sensors (temperature, humidity, motion, illuminance, pressure, contact, leak, smoke, CO, CO₂, air quality), lighting (on / off, brightness, CCT, RGB), air conditioners, heating units, thermostats, outlets (with power & energy), fans, locks and window coverings.
 
-## Configuration Options
+## Configuration
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| \`update_on_start\` | Simulate values when service starts | \`false\` |
-| \`simulation_interval\` | Auto-simulation interval (ms), 0 = disabled | \`0\` |
-| \`latitude\` | Location for daylight/temperature calculations | \`50.0\` |
+| \`update_on_start\` | Simulate values immediately on service start | \`false\` |
+| \`simulation_interval\` | Auto-simulation interval in ms (\`0\` = disabled) | \`0\` |
+| \`latitude\` | Latitude used for daylight / temperature patterns | \`50.0\` |
 | \`smooth_transitions\` | Gradual value changes for realism | \`true\` |
+
+## API Endpoints
+
+- \`GET /api/v1/plugins/simulator/categories\` — list device categories
+- \`POST /api/v1/plugins/simulator/generate\` — generate a simulated device
+- \`POST /api/v1/plugins/simulator/{device_id}/simulate-value\` — set a property value
+- \`POST /api/v1/plugins/simulator/{device_id}/simulate-connection\` — change connection state
+- \`POST /api/v1/plugins/simulator/{device_id}/simulate-all\` — randomise all properties
 
 ## CLI Commands
 
-### Realistic Simulation (New!)
 \`\`\`bash
-pnpm run cli simulator:simulate --list              # List devices with simulator info
-pnpm run cli simulator:simulate --all               # Simulate all devices once
-pnpm run cli simulator:simulate --device <id>       # Simulate specific device
-pnpm run cli simulator:simulate --config            # Show configuration
-pnpm run cli simulator:simulate --start --interval 5000  # Start auto-simulation
-pnpm run cli simulator:simulate --stop              # Stop auto-simulation
-pnpm run cli simulator:simulate                     # Interactive mode
-\`\`\`
+# Realistic simulation
+pnpm run cli simulator:simulate --list
+pnpm run cli simulator:simulate --all
+pnpm run cli simulator:simulate --device <id>
+pnpm run cli simulator:simulate --start --interval 5000
+pnpm run cli simulator:simulate --stop
 
-### Load Scenarios (New!)
-\`\`\`bash
-pnpm run cli simulator:scenario --list              # List available scenarios
-pnpm run cli simulator:scenario -s small-apartment  # Load a scenario
-pnpm run cli simulator:scenario --truncate -s office # Clear devices first
-pnpm run cli simulator:scenario -f /path/to/custom.yaml  # Load custom YAML
-pnpm run cli simulator:scenario --dry-run -s penthouse   # Preview only
-pnpm run cli simulator:scenario                     # Interactive mode
-\`\`\`
+# Scenarios
+pnpm run cli simulator:scenario --list
+pnpm run cli simulator:scenario -s small-apartment
+pnpm run cli simulator:scenario --truncate -s office
+pnpm run cli simulator:scenario -f /path/to/custom.yaml
+pnpm run cli simulator:scenario --dry-run -s penthouse
 
-### Generate Devices
-\`\`\`bash
+# Device generation
 pnpm run cli simulator:generate --list
 pnpm run cli simulator:generate --category sensor --name "Living Room Sensor"
 pnpm run cli simulator:generate --category thermostat --count 3
-\`\`\`
 
-### Random Values (Legacy)
-\`\`\`bash
+# Random values (legacy)
 pnpm run cli simulator:populate --all
 pnpm run cli simulator:populate --device <id>
-\`\`\`
 
-### Connection State
-\`\`\`bash
+# Connection state
 pnpm run cli simulator:connection --all --state connected
 pnpm run cli simulator:connection --device <id> --state lost
-\`\`\`
-
-## REST API Endpoints
-
-- \`GET /simulator/categories\` - List available device categories
-- \`POST /simulator/generate\` - Generate a new simulated device
-- \`POST /simulator/{deviceId}/simulate-value\` - Set a property value
-- \`POST /simulator/{deviceId}/simulate-connection\` - Change connection state
-- \`POST /simulator/{deviceId}/simulate-all\` - Generate random values`,
+\`\`\``,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/spaces-home-control/spaces-home-control.plugin.ts
+++ b/apps/backend/src/plugins/spaces-home-control/spaces-home-control.plugin.ts
@@ -362,27 +362,30 @@ export class SpacesHomeControlPlugin implements OnModuleInit {
 			description:
 				'Provides the built-in Room and Zone space types along with lighting, climate, covers, sensor, and media role domains, intent catalog, suggestions, and undo history.',
 			author: 'FastyBird',
-			readme: `# Spaces Home Control Plugin
+			readme: `# Home Control Spaces
 
-Contributes the home-control space types (Room and Zone) that turn the
-Smart Panel into an interactive surface for controlling devices.
+> Plugin · by FastyBird · platform: spaces
+
+Contributes the **Room** and **Zone** space types — the home-control surface that turns the Smart Panel into an interactive room / zone controller. Owns the lighting, climate, covers, sensor and media role domains, the intent catalog, the suggestions engine and the undo history. This is the plugin that makes "the living room lights" a thing instead of "channel \`onoff\` of device \`abc\`".
+
+## What you get
+
+- A real room-centric model: every room becomes a switchable, dimmable, climate-controllable space without per-device wiring
+- A semantic layer: lights, blinds, thermostats and sensors are bound by their *role* in the room, so swapping a bulb doesn't break a scene
+- Intents that compose: "turn off the lights" / "set living room to 22°C" / "close all blinds" map to validated, reversible operations
+- Suggestions and undo: the panel can propose smart actions and let you walk them back if they overshoot
 
 ## Features
 
-- **Room and Zone space types** — organize physical rooms and logical groupings.
-- **Lighting domain** — discover light targets, assign roles, execute lighting intents (on/off, brightness, color, temperature).
-- **Climate domain** — HVAC and setpoint roles, climate intents.
-- **Covers domain** — blinds, shades, and cover roles and intents.
-- **Sensor domain** — sensor roles and aggregated state.
-- **Media domain** — media activity bindings and orchestrated playback.
-- **Intent catalog** — YAML-driven intent definitions for voice/text assistants.
-- **Suggestions and undo history** — space-scoped automation hints and reversible intents.
-
-## Uninstall behavior
-
-Uninstalling this plugin disables Room and Zone creation and strips the
-domain endpoints listed above. Synthetic and signage space-type plugins
-continue to work independently.`,
+- **Room & Zone space types** — physical rooms and logical zone groupings; zones can contain rooms and inherit device membership
+- **Lighting domain** — main / accent / decorative light targets; roles for on / off, brightness, colour temperature, RGB; lighting modes (reading, movie, dim, off, …)
+- **Climate domain** — HVAC and setpoint roles with climate intents (set mode, set temperature, set humidity); merges multiple climate devices in the same room into a single coherent surface
+- **Covers domain** — blinds, shades and curtains with open / close / set-position intents; honours per-cover position limits
+- **Sensor domain** — sensor roles and aggregated readings (temperature, humidity, CO₂, motion, contact); the room exposes a single best value when several sensors are present
+- **Media domain** — media activity bindings and orchestrated playback (play / pause / volume / source) across the room's media-capable devices
+- **Intent catalog** — YAML-driven intent definitions used by the Buddy assistant and any other text / voice client
+- **Suggestions** — pattern-based automation hints scoped to the room; the user can accept or dismiss
+- **Undo history** — every space-scoped intent is recorded with an inverse so a user can revert recent actions in one tap`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/spaces-signage-info-panel/spaces-signage-info-panel.plugin.ts
+++ b/apps/backend/src/plugins/spaces-signage-info-panel/spaces-signage-info-panel.plugin.ts
@@ -134,23 +134,35 @@ export class SpacesSignageInfoPanelPlugin implements OnModuleInit {
 			description:
 				'Contributes the information-panel signage space type — a read-only, full-screen surface with configurable sections (clock, weather, announcements, optional feed) and nested announcement CRUD.',
 			author: 'FastyBird',
-			readme: `# Spaces Signage Info Panel Plugin
+			readme: `# Information Panel
 
-Contributes the **Information Panel** signage space type — a read-only,
-full-screen surface for hallway / lobby info displays.
+> Plugin · by FastyBird · platform: spaces
+
+Contributes the **Information Panel** signage space type — a read-only, full-screen surface designed for hallway, lobby and reception displays. Lays out a configurable mix of clock, weather, scrollable announcements and an optional external feed, and skips the regular dashboard navigation entirely.
+
+## What you get
+
+- A purpose-built signage mode that turns any panel into a low-touch info display without writing a custom UI
+- Announcement management from the admin UI: type a message, set its priority and visibility window, and it shows up on the panel within seconds
+- Reuse of everything else you already have: the same Weather module, the same clock, the same time-zone settings — no separate stack
+- A safe surface for public spaces — the panel does not expose any controls, just information
 
 ## Features
 
-- **Configurable sections** — clock, weather, announcements, optional external feed.
-- **Announcements** — nested CRUD with priority, sort order, and optional active-window scheduling.
-- **Per-space weather location** — the weather section reuses the existing weather plugin pipeline.
-- **No dashboard chrome** — the panel renders the info view directly, bypassing pages and navigation.
+- **Configurable sections** — clock, weather, announcements and an optional external feed (RSS / URL); each section can be toggled per-space
+- **Announcements** — full CRUD with priority, sort order and optional active-window scheduling (start / end timestamps); the panel auto-cycles through active items
+- **Per-space weather** — reuses the existing Weather module pipeline; pick the location once
+- **No dashboard chrome** — the panel renders the info view directly, bypassing pages, tabs and navigation
+- **Reorder API** — drag-and-drop in the admin UI persists through a dedicated reorder endpoint
+- **Time-window aware** — announcements outside their start / end window are quietly hidden without manual cleanup
 
-## Uninstall behavior
+## API Endpoints
 
-Uninstalling leaves signage space rows orphaned in the spaces table; displays
-pointing at them will no longer resolve to a rendered view until the plugin
-is reinstalled. Factory reset re-seeds via the reset handler.`,
+- \`GET /api/v1/plugins/spaces-signage-info-panel/announcements\` — list announcements
+- \`POST /api/v1/plugins/spaces-signage-info-panel/announcements\` — create
+- \`PATCH /api/v1/plugins/spaces-signage-info-panel/announcements/:id\` — update
+- \`DELETE /api/v1/plugins/spaces-signage-info-panel/announcements/:id\` — delete
+- \`POST /api/v1/plugins/spaces-signage-info-panel/announcements/reorder\` — reorder`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/spaces-synthetic-entry/spaces-synthetic-entry.plugin.ts
+++ b/apps/backend/src/plugins/spaces-synthetic-entry/spaces-synthetic-entry.plugin.ts
@@ -99,25 +99,24 @@ export class SpacesSyntheticEntryPlugin implements OnModuleInit {
 			name: 'Spaces Synthetic Entry',
 			description: 'Contributes the singleton Entry synthetic space for security / front-door surfaces.',
 			author: 'FastyBird',
-			readme: `# Spaces Synthetic Entry Plugin
+			readme: `# Entry Space
 
-Contributes the **Entry** space type — a singleton synthetic space that represents
-the security / front-door surface. Unlike Room and Zone spaces, the entry space has
-no physical-room semantics and no parent/child hierarchy.
+> Plugin · by FastyBird · platform: spaces
+
+Contributes the singleton **Entry** synthetic space — a security / front-door surface with no physical-room semantics. Used as the binding for entry-focused displays (intercom, alarm status, lock state, recent doorbell events).
+
+## What you get
+
+- A dedicated anchor for the front-door / entry experience, separate from any specific room
+- A clean target for displays placed near the entrance where the panel should show alarm and access information instead of a generic dashboard
+- Tight integration with the rest of the system: the security module's armed / alarm state feeds straight into pages bound to this space
 
 ## Features
 
-- **Singleton** — at most one entry space per installation. The singleton guard in the
-  spaces service rejects attempts to create a second one.
-- **User-owned** — the row is created, edited, and removed through the standard spaces
-  API. This plugin does not seed or restore the entry space automatically.
-- **Display target** — displays configured for security / entry surfaces point at this space.
-
-## Uninstall behavior
-
-Uninstalling this plugin leaves the entry row orphaned in the spaces table;
-displays pointing at it will no longer resolve to a rendered view until the
-plugin is reinstalled.`,
+- **Singleton** — only one entry space per installation; the spaces service rejects attempts to create a second one
+- **User-owned** — created, edited and removed through the standard spaces API (this plugin never auto-seeds it)
+- **Display target** — used as the binding for security / front-door displays
+- **Plays nicely with security & devices** — pages built on top can show alarm state, latest doorbell ring, lock state and recent intrusion alerts without bespoke wiring`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/spaces-synthetic-master/spaces-synthetic-master.plugin.ts
+++ b/apps/backend/src/plugins/spaces-synthetic-master/spaces-synthetic-master.plugin.ts
@@ -99,25 +99,24 @@ export class SpacesSyntheticMasterPlugin implements OnModuleInit {
 			name: 'Spaces Synthetic Master',
 			description: 'Contributes the singleton Master synthetic space for whole-house overview surfaces.',
 			author: 'FastyBird',
-			readme: `# Spaces Synthetic Master Plugin
+			readme: `# Master Space
 
-Contributes the **Master** space type — a singleton synthetic space that represents
-the whole-house overview surface. Unlike Room and Zone spaces, the master space has
-no physical-room semantics and no parent/child hierarchy.
+> Plugin · by FastyBird · platform: spaces
+
+Contributes the singleton **Master** synthetic space — a whole-house overview surface with no physical-room semantics and no parent / child hierarchy. Displays configured for the overall view of the home are bound to this space.
+
+## What you get
+
+- A natural anchor for "the home" itself when a panel needs a top-level overview that isn't tied to any specific room
+- Cleanly separates "this is the whole house" from regular rooms / zones, so the panel can render a different layout without special-casing
+- Plays nicely with the rest of the spaces module: the same APIs, validations and home-page resolution apply
 
 ## Features
 
-- **Singleton** — at most one master space per installation. The singleton guard in the
-  spaces service rejects attempts to create a second one.
-- **User-owned** — the row is created, edited, and removed through the standard spaces
-  API. This plugin does not seed or restore the master space automatically.
-- **Display target** — displays configured for whole-house overview point at this space.
-
-## Uninstall behavior
-
-Uninstalling this plugin leaves the master row orphaned in the spaces table;
-displays pointing at it will no longer resolve to a rendered view until the
-plugin is reinstalled.`,
+- **Singleton** — only one master space per installation; the spaces service rejects attempts to create a second one
+- **User-owned** — created, edited and removed through the standard spaces API (this plugin never auto-seeds it)
+- **Display target** — used as the binding for whole-house overview displays
+- **Same plumbing as rooms / zones** — dashboards, scenes and Buddy treat the master space exactly like any other space, just with a different shape`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/tiles-device-preview/tiles-device-preview.plugin.ts
+++ b/apps/backend/src/plugins/tiles-device-preview/tiles-device-preview.plugin.ts
@@ -93,35 +93,29 @@ export class TilesDevicePreviewPlugin {
 			name: 'Device Preview Tile',
 			description: 'Dashboard tiles for displaying device status preview',
 			author: 'FastyBird',
-			readme: `# Device Preview Tiles Plugin
+			readme: `# Device Preview Tile
 
-Dashboard tiles for displaying device status and quick controls.
+> Plugin · by FastyBird · platform: dashboard tiles
+
+Compact dashboard tile that surfaces the live status of a device with optional one-tap control — the workhorse tile of any dashboard, suitable for everything from a single switch to a temperature sensor.
+
+## What you get
+
+- A standardised, glanceable view of any device's most relevant value with the panel's optimistic-UI guarantees baked in
+- Per-tile choice of *primary* property so the tile shows what matters for that device (a switch's on / off, a sensor's temperature, a power meter's current draw)
+- Optional *secondary* properties so a single tile can convey "is the AC running, what's the room temperature, what's the set-point" at one glance
+- One-tap control on writable primary properties without dropping the user into a detail page
 
 ## Features
 
-- **Device Status** - Show real-time device status on dashboard
-- **Quick Controls** - Toggle devices directly from the tile
-- **Status Icons** - Visual indicators for device state
-- **Multi-Property Display** - Show multiple device properties
+- **Live status** — real-time updates of the selected primary property over WebSocket
+- **Quick control** — toggle controllable devices directly from the tile; the optimistic UI means feedback is instant
+- **Status icon** — connection / state indicator turns the tile into a connectivity dashboard at a glance
+- **Multi-property** — render additional secondary properties under the primary value
+- **Unit-aware** — values are rendered with the unit declared by the device's property
+- **Tap-through** — tapping the tile body opens the device detail page when present, the property dialog otherwise
 
-## Tile Types
-
-### Device Preview Tile
-Compact device status display:
-- Device icon and name
-- Primary property value (e.g., on/off state)
-- Quick action button for controllable devices
-- Connection status indicator
-
-## Usage
-
-Add device preview tiles to dashboard pages for at-a-glance monitoring of your most important devices. Tap tiles to toggle state or view details.
-
-## Configuration
-
-- Select the device to display
-- Choose which property to show as primary
-- Enable/disable quick control button`,
+Each tile selects its target device and primary property when placed on a dashboard — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/tiles-scene/tiles-scene.plugin.ts
+++ b/apps/backend/src/plugins/tiles-scene/tiles-scene.plugin.ts
@@ -94,34 +94,28 @@ export class TilesScenePlugin {
 			name: 'Scene Tile',
 			description: 'Dashboard tiles for displaying scene status and triggering scenes',
 			author: 'FastyBird',
-			readme: `# Scene Tiles Plugin
+			readme: `# Scene Tile
 
-Dashboard tiles for displaying scene status and quick triggering.
+> Plugin · by FastyBird · platform: dashboard tiles
+
+Dashboard tile that surfaces a scene — shows its status and category and lets the user trigger it with a single tap. The fastest way to put your most-used routines (Movie, Goodnight, Away) one finger-press away.
+
+## What you get
+
+- One-tap access to any scene right from the dashboard, no menu diving
+- Optimistic feedback — the tile shows the press happening immediately and updates with the real result the moment the backend confirms
+- Visual grouping by category (morning, evening, …) so a single page can host a coherent "scenes" layout
+- Last-run timestamp so it's clear when something actually fired
 
 ## Features
 
-- **Scene Status** - Show scene information on dashboard
-- **Quick Trigger** - Trigger scenes directly from the tile
-- **Status Icons** - Visual indicators for scene category
-- **Last Triggered** - Show when the scene was last executed
+- **Scene status** — name, icon and category indicator
+- **Quick trigger** — execute the bound scene directly from the tile, with progress / success / failure feedback
+- **Custom icon** — override the scene's default icon per-tile when placed on a dashboard
+- **Last triggered** — timestamp of the last execution, refreshed in real time
+- **Per-action result** — when a scene's action partially fails, the tile surfaces a warning so the user knows to look
 
-## Tile Types
-
-### Scene Tile
-Compact scene display:
-- Scene icon and name
-- Category indicator
-- Quick trigger button for triggerable scenes
-- Last triggered timestamp
-
-## Usage
-
-Add scene tiles to dashboard pages for quick access to your most used scenes. Tap tiles to trigger the scene execution.
-
-## Configuration
-
-- Select the scene to display
-- Choose a custom icon (optional)`,
+Each tile selects the scene to display and (optionally) a custom icon when placed on a dashboard — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/tiles-time/tiles-time.plugin.ts
+++ b/apps/backend/src/plugins/tiles-time/tiles-time.plugin.ts
@@ -78,32 +78,26 @@ export class TilesTimePlugin {
 			name: 'Clock Tile',
 			description: 'Dashboard tiles for displaying time and date',
 			author: 'FastyBird',
-			readme: `# Time Tiles Plugin
+			readme: `# Clock Tile
 
-Dashboard tiles for displaying current time and date.
+> Plugin · by FastyBird · platform: dashboard tiles
+
+Dashboard tile that displays the current time and date with live updates — the simplest way to turn a panel into a glanceable clock without dedicating a whole page to it.
+
+## What you get
+
+- A clean, always-correct clock on any dashboard page
+- Per-tile timezone — drop two clock tiles on the same page to show home time and a remote office time at once
+- Live updates without polling — the panel renders the next minute as soon as it ticks
 
 ## Features
 
-- **Digital Clock** - Display current time in various formats
-- **Date Display** - Show current date with customizable formatting
-- **Timezone Support** - Display time for different timezones
-- **Auto-Update** - Real-time clock updates
+- **Digital clock** — 12 or 24-hour format, optional seconds, optional AM / PM marker
+- **Date display** — customisable date format (full, short, weekday-only, …)
+- **Timezone aware** — render time for any IANA timezone independently of the host's clock
+- **Auto-update** — re-renders without reloading the page; respects the panel's reduced-motion settings
 
-## Tile Types
-
-### Time Tile
-Displays the current time with configurable:
-- 12/24 hour format
-- Show/hide seconds
-- Custom time format strings
-
-## Usage
-
-Add a time tile to any dashboard page to display the current time. The tile updates automatically without requiring page refresh.
-
-## Styling
-
-The time display adapts to the tile size and supports both light and dark themes.`,
+Appearance and timezone are configured per tile when placed on a dashboard — there is no global plugin configuration.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/tiles-weather/tiles-weather.plugin.ts
+++ b/apps/backend/src/plugins/tiles-weather/tiles-weather.plugin.ts
@@ -121,35 +121,32 @@ export class TilesWeatherPlugin {
 			name: 'Weather Tiles',
 			description: 'Dashboard tiles for displaying current weather and forecasts',
 			author: 'FastyBird',
-			readme: `# Weather Tiles Plugin
+			readme: `# Weather Tiles
 
-Dashboard tiles for displaying weather information.
+> Plugin · by FastyBird · platform: dashboard tiles
 
-## Features
+Dashboard tiles that surface data from the Weather module — turn a configured location into an at-a-glance card on any page.
 
-- **Current Weather** - Display current conditions for a location
-- **Weather Forecast** - Show multi-day weather forecast
-- **Weather Icons** - Visual weather condition indicators
-- **Temperature Display** - Current, min, and max temperatures
+## What you get
+
+- Glanceable, real-time weather without writing any code or hitting any provider API yourself
+- A pluggable look-and-feel: the same data behind a compact "now" tile or an expanded multi-day forecast
+- Automatic units — the panel honours the unit chosen on the underlying weather location, so °C / °F / m·s⁻¹ / mph all behave correctly
 
 ## Tile Types
 
-### Day Weather Tile
-Shows current weather conditions:
-- Current temperature
-- Weather condition icon
-- Location name
-- Humidity and wind info
+- **Day weather** — current temperature, condition icon, location label, feels-like, humidity and wind
+- **Forecast** — multi-day high / low temperatures, condition icons, precipitation probability and short condition labels
 
-### Forecast Weather Tile
-Displays multi-day forecast:
-- Daily high/low temperatures
-- Weather icons for each day
-- Precipitation probability
+## Behaviour
+
+- **Live updates** — the tile re-renders as soon as the weather module pushes a new observation, so values are never more than one polling cycle stale
+- **Provider-agnostic** — works with any weather provider plugin you have installed
+- **Sensible defaults** — when a value isn't available from the chosen provider (e.g. UV index on Open-Meteo's current endpoint) the tile gracefully omits it rather than showing zero
 
 ## Requirements
 
-Requires the Weather module to be configured with at least one location and a weather provider plugin (e.g., OpenWeatherMap).`,
+The Weather module must be configured with at least one location and a weather provider plugin (e.g. OpenWeatherMap). Each tile is configured individually when placed on a dashboard.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/weather-open-meteo/weather-open-meteo.plugin.ts
+++ b/apps/backend/src/plugins/weather-open-meteo/weather-open-meteo.plugin.ts
@@ -116,38 +116,49 @@ export class WeatherOpenMeteoPlugin implements OnModuleInit {
 			name: 'Open-Meteo',
 			description: 'Free weather data provider using Open-Meteo API. No API key required.',
 			author: 'FastyBird',
-			readme: `# Open-Meteo Weather Provider
+			readme: `# Open-Meteo
 
-Free weather data provider using the Open-Meteo API.
+> Plugin · by FastyBird · platform: weather
 
-## Features
+Free, no-registration weather provider backed by the [Open-Meteo](https://open-meteo.com) API. Aggregates data from ECMWF, NOAA / GFS, DWD and other national weather services. Current conditions plus a 7-day daily forecast — weather alerts are not exposed by this provider.
 
-- **No API Key Required** - Works out of the box with no registration
-- **Current Weather** - Real-time temperature, humidity, wind, and conditions
-- **7-Day Forecast** - Daily weather predictions
-- **Global Coverage** - Weather data for any location worldwide
-- **Multiple Weather Models** - Data from ECMWF, GFS, and other national weather services
+## What you get
+
+- Real meteorological data with no API key, no account, no rate limit anxiety
+- An ensemble of national weather services under the hood, so accuracy is generally on par with paid providers in covered regions
+- A coordinate-based geolocation helper so users can pick a location by city name in the admin UI without copying lat / lon themselves
+- A safe default: enabling this plugin and adding a location is all you need to power the weather tiles
+
+## Capabilities
+
+- **Current conditions** — temperature with "feels like", humidity, pressure, wind speed / direction / gusts, cloud cover, precipitation
+- **Daily forecast** — 7 days with high / low temperature, condition, precipitation probability, sunrise / sunset
+- **Geolocation lookup** — name-based search returns coordinates ready to feed back into a location create call
+- **Configurable units** — Celsius or Fahrenheit per deployment
+
+## Setup
+
+1. Enable the plugin (no account or API key required)
+2. Add a weather location — use the geolocation endpoint to look up coordinates
+3. Set the location's provider to \`${WEATHER_OPEN_METEO_PLUGIN_NAME}\`
+
+## API Endpoints
+
+- \`GET /api/v1/plugins/weather-open-meteo/geolocation?query=…\` — search coordinates by city name
 
 ## Data Provided
 
-- Current conditions with "feels like" temperature
-- Daily forecasts for 7 days
-- Wind speed, direction, and gusts
-- Cloud coverage
-- Precipitation (rain and snow)
-- Sunrise and sunset times
-- Atmospheric pressure and humidity
+Current conditions with "feels like" temperature, 7-day daily forecast, wind speed/direction/gusts, cloud coverage, precipitation (rain and snow), sunrise / sunset, atmospheric pressure and humidity.
 
 ## Configuration
 
-- **Units** - Temperature units (metric/imperial)
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`unit\` | Temperature unit (\`celsius\` or \`fahrenheit\`) | \`celsius\` |
 
-## Notes
+## Usage Limits
 
-- Free for non-commercial use (up to 10,000 API calls/day)
-- No registration or API key needed
-- Weather alerts are not supported by this provider
-- Data sourced from top national weather services (ECMWF, NOAA, DWD, and more)`,
+Free for non-commercial use, up to 10 000 API calls per day.`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.plugin.ts
+++ b/apps/backend/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.plugin.ts
@@ -122,41 +122,45 @@ export class WeatherOpenweathermapOnecallPlugin implements OnModuleInit {
 			name: 'OpenWeatherMap OneCall 3.0',
 			description: 'Weather data provider using OpenWeatherMap One Call API',
 			author: 'FastyBird',
-			readme: `# OpenWeatherMap One Call Weather Provider
+			readme: `# OpenWeatherMap One Call
 
-Weather data provider using the OpenWeatherMap One Call 3.0 API.
+> Plugin · by FastyBird · platform: weather
 
-## Features
+Weather provider backed by the OpenWeatherMap **One Call API 3.0** — current conditions, 48-hour hourly forecast, 8-day daily forecast, UV index, precipitation probability and government weather alerts in a single request. Includes a built-in geolocation lookup to convert city names into coordinates so users can pick a location by name in the admin UI.
 
-- **Comprehensive Data** - Current, hourly, and daily forecasts in one call
-- **8-Day Forecast** - Extended daily weather predictions
-- **48-Hour Hourly** - Detailed hourly forecast
-- **Weather Alerts** - Government weather warnings (where available)
-- **Geolocation** - Search locations by city name
+## What you get
+
+- The richest forecast available from OpenWeatherMap: hourly resolution out to 48 hours, daily for 8 days, plus official severe-weather alerts
+- One-call efficiency: a single HTTP request hydrates everything the panel needs, so the polling rate stays well within the free tier
+- A coordinate lookup endpoint so users never need to copy / paste lat / lon by hand
+- Drop-in compatibility with the weather tiles and data sources — pick this plugin per-location for a power-user setup, leave others on the simpler current-weather plugin
+
+## Capabilities
+
+- **Current conditions** — full set including UV index, dew point and visibility
+- **Hourly forecast** — next 48 hours with temperature, precipitation probability and condition
+- **Daily forecast** — next 8 days with high / low, condition, sunrise / sunset and precipitation
+- **Weather alerts** — government / national-service severe-weather alerts (when available)
+- **Geolocation lookup** — name-based search returns coordinates ready to feed back into a location create call
+- **Configurable unit** — Celsius or Fahrenheit per deployment
 
 ## Setup
 
 1. Create an account at [OpenWeatherMap](https://openweathermap.org)
-2. Subscribe to One Call API 3.0 (has free tier with 1000 calls/day)
-3. Enter your API key in plugin configuration
+2. Subscribe to **One Call API 3.0** (free tier: 1 000 calls/day)
+3. Enter the API key in this plugin's configuration
+4. Add a weather location (use the geolocation endpoint to look up coordinates) and set its provider to \`${WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME}\`
 
-## Data Provided
+## API Endpoints
 
-- Current conditions with "feels like" temperature
-- Hourly forecasts for 48 hours
-- Daily forecasts for 8 days
-- UV index
-- Precipitation probability
-- Weather alerts
+- \`GET /api/v1/plugins/weather-openweathermap-onecall/geolocation?query=…\` — search coordinates by city name
 
 ## Configuration
 
-- **API Key** - Your OpenWeatherMap API key (required)
-- **Units** - Temperature units (metric/imperial)
-
-## Geolocation
-
-This plugin includes a location search feature to find coordinates by city name, making it easy to set up weather locations.`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | OpenWeatherMap API key (required) | — |
+| \`unit\` | Temperature unit (\`celsius\` or \`fahrenheit\`) | \`celsius\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/plugins/weather-openweathermap/weather-openweathermap.plugin.ts
+++ b/apps/backend/src/plugins/weather-openweathermap/weather-openweathermap.plugin.ts
@@ -114,42 +114,41 @@ export class WeatherOpenweathermapPlugin implements OnModuleInit {
 			name: 'OpenWeatherMap',
 			description: 'Weather data provider using OpenWeatherMap API',
 			author: 'FastyBird',
-			readme: `# OpenWeatherMap Weather Provider
+			readme: `# OpenWeatherMap
 
-Weather data provider using the OpenWeatherMap Current Weather API.
+> Plugin · by FastyBird · platform: weather
 
-## Features
+Weather provider backed by the [OpenWeatherMap](https://openweathermap.org) Current Weather API. Works with the free tier (1 000 calls / day, 60 calls / min) and provides current conditions plus a basic daily forecast — a friendly default if you already have an OpenWeatherMap key.
 
-- **Current Weather** - Real-time weather conditions
-- **Basic Forecast** - Daily weather forecasts
-- **Global Coverage** - Weather data for locations worldwide
-- **Free Tier** - Works with OpenWeatherMap free API plan
+## What you get
+
+- A familiar provider with worldwide coverage and a generous free tier
+- Reliable current-conditions data with the standard suite of values dashboards and Buddy expect (temperature, condition, humidity, wind, pressure, sunrise / sunset)
+- Drop-in compatible with all weather tiles and the weather data source — pick this plugin per-location, swap to another later without touching the location
+
+## Capabilities
+
+- **Current conditions** — temperature, condition (clear / cloudy / rain / …), humidity, pressure, wind speed and direction, sunrise / sunset
+- **Basic daily forecast** — high / low and condition for the next few days (resolution depends on OpenWeatherMap's free tier)
+- **Configurable unit** — Celsius or Fahrenheit per deployment
 
 ## Setup
 
 1. Create a free account at [OpenWeatherMap](https://openweathermap.org)
-2. Generate an API key from your account dashboard
-3. Enter the API key in plugin configuration
+2. Generate an API key in your dashboard
+3. Enter the API key in this plugin's configuration
+4. Add a weather location (Weather module) and set its provider to \`${WEATHER_OPENWEATHERMAP_PLUGIN_NAME}\`
 
 ## Data Provided
 
-- Current temperature
-- Weather conditions (clear, cloudy, rain, etc.)
-- Humidity and pressure
-- Wind speed and direction
-- Sunrise and sunset times
+Current temperature, condition (clear / cloudy / rain / …), humidity and pressure, wind speed and direction, sunrise and sunset times.
 
 ## Configuration
 
-- **API Key** - Your OpenWeatherMap API key (required)
-- **Units** - Temperature units (metric/imperial)
-- **Update Interval** - How often to refresh data
-
-## API Limits
-
-Free tier allows:
-- 1,000 API calls per day
-- 60 calls per minute`,
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`api_key\` | OpenWeatherMap API key (required) | — |
+| \`unit\` | Temperature unit (\`celsius\` or \`fahrenheit\`) | \`celsius\` |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',


### PR DESCRIPTION
## Summary

- Standardises the `readme` field on every backend module and plugin (59 extensions in total) so the admin Extensions page renders a consistent layout: display-name heading, `Kind · by Author` byline, intro, "what you get" rationale, expanded features list, and — where applicable — API endpoints, CLI commands and a configuration table.
- Expands the descriptive content for every extension: each README now explains concrete capabilities, behaviour, validation, real-time / fallback paths and integration points instead of a one-line label, so users browsing the catalog can actually tell what an extension does and when to enable it.
- Drops sections that don't apply to core extensions: removes `## Uninstall` from the bundled `spaces-*` plugins (they ship with the panel and can't be uninstalled), removes empty `## Configuration` blocks that only said "no configurable options", and folds the remaining "configured per item" notes into prose.
- Removes hard-coded plugin lists from module READMEs (`devices`, `dashboard`, `scenes`, `spaces`, `weather`, `storage`, `buddy`) — modules don't lock to a specific backend, so they now talk in terms of "provider plugins" / "pluggable backends" instead of naming specific instances.
- Configuration options are now rendered as a Markdown `Option · Description · Default` table, sourced from each plugin's `UpdatePluginConfigDto`, so the admin UI can present them uniformly.
- No runtime / API surface changes — only the metadata strings registered through `extensionsService.registerModuleMetadata` / `registerPluginMetadata`.

## Test plan

- [x] `pnpm --filter @fastybird/smart-panel-backend run build` passes
- [x] `pnpm run lint:js` passes for the touched files
- [x] Open the admin Extensions page and visually verify a sample of modules and plugins render correctly:
  - [x] A module without configuration (e.g. `devices`)
  - [x] A module with configuration (e.g. `auth`, `buddy`)
  - [x] A plugin with configuration table (e.g. `devices-shelly-ng`, `weather-openweathermap`)
  - [x] A plugin without configuration (e.g. `memory-storage`, `devices-third-party`)
  - [x] A `spaces-*` plugin (verify no Uninstall section)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only updates to extension metadata READMEs; no runtime behavior, API logic, or configuration handling changes beyond documentation text.
> 
> **Overview**
> Updates backend modules and plugins to use a consistent, richer Markdown `readme` in `registerModuleMetadata`/`registerPluginMetadata`, including a standard heading/byline plus clearer descriptions and expanded feature lists.
> 
> Where applicable, the READMEs now include standardized **API endpoint**, **CLI command**, and **configuration option** tables, and remove/avoid irrelevant sections (e.g. “no config” boilerplate), improving how the admin Extensions catalog renders and reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d83006fbdf3447700e3922d085b6f30d887caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->