### PR TITLE
fix(spaces): restore admin detail layout

### DIFF
--- a/apps/admin/src/modules/spaces/components/space-detail.spec.ts
+++ b/apps/admin/src/modules/spaces/components/space-detail.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { mount } from '@vue/test-utils';
+
+import { SpaceType } from '../spaces.constants';
+
+import SpaceDetail from './space-detail.vue';
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('./spaces-table-column-plugin.vue', async () => {
+	const { defineComponent } = await import('vue');
+
+	return {
+		default: defineComponent({
+			name: 'SpacesTableColumnPlugin',
+			template: '<span />',
+		}),
+	};
+});
+
+describe('SpaceDetail', () => {
+	it('renders plugin-provided detail rows inside the details list', () => {
+		const wrapper = mount(SpaceDetail, {
+			props: {
+				space: {
+					id: '7a1bafdc-8c7d-4d5a-9e2a-4dfdc3c8253d',
+					name: 'Living room',
+					category: null,
+					description: null,
+					type: SpaceType.ROOM,
+					icon: null,
+					displayOrder: 0,
+					parentId: null,
+					suggestionsEnabled: false,
+					statusWidgets: null,
+					createdAt: new Date(),
+					updatedAt: null,
+					draft: false,
+				},
+			},
+			slots: {
+				default: '<dt data-test-id="plugin-row-label">Floor</dt><dd data-test-id="plugin-row-value">Ground floor</dd>',
+			},
+			global: {
+				stubs: {
+					Icon: true,
+				},
+			},
+		});
+
+		const list = wrapper.find('dl');
+
+		expect(list.find('[data-test-id="plugin-row-label"]').exists()).toBe(true);
+		expect(list.find('[data-test-id="plugin-row-value"]').exists()).toBe(true);
+	});
+});

--- a/apps/admin/src/modules/spaces/components/space-detail.vue
+++ b/apps/admin/src/modules/spaces/components/space-detail.vue
@@ -1,5 +1,6 @@
 <template>
 	<el-card
+		shadow="never"
 		class="mt-2"
 		body-class="p-0!"
 	>
@@ -57,6 +58,8 @@
 					{{ space.icon }}
 				</el-text>
 			</dd>
+
+			<slot />
 		</dl>
 	</el-card>
 </template>

--- a/apps/admin/src/modules/spaces/components/spaces-table.vue
+++ b/apps/admin/src/modules/spaces/components/spaces-table.vue
@@ -142,7 +142,7 @@
 			prop="type"
 			sortable="custom"
 			:sort-orders="['ascending', 'descending']"
-			:width="170"
+			:width="200"
 		>
 			<template #default="scope">
 				<spaces-table-column-plugin

--- a/apps/admin/src/modules/spaces/locales/cs-CZ.json
+++ b/apps/admin/src/modules/spaces/locales/cs-CZ.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Prostory",
 		"spaces": "Prostory",
-		"detail": "Detail prostoru",
+		"detail": "Prostor: {space}",
 		"add": "Přidat prostor",
 		"edit": "Upravit prostor",
 		"removeSpace": "Odebrat prostor",
@@ -48,7 +48,7 @@
 		"list": "Organizujte zařízení a displeje podle místností nebo zón",
 		"adjustFilters": "Upravit nastavení filtrů",
 		"add": "Přidat nový prostor",
-		"detail": "Správa prostoru: {space}",
+		"detail": "Správa prostoru Smart panelu",
 		"onboarding": "Průvodce nastavením prostorů, zařízení a displejů"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/modules/spaces/locales/de-DE.json
+++ b/apps/admin/src/modules/spaces/locales/de-DE.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Bereiche",
 		"spaces": "Bereiche",
-		"detail": "Bereichsdetails",
+		"detail": "Bereich: {space}",
 		"add": "Bereich hinzufügen",
 		"edit": "Bereich bearbeiten",
 		"removeSpace": "Bereich entfernen",
@@ -48,7 +48,7 @@
 		"list": "Geräte und Displays nach Räumen oder Zonen organisieren",
 		"adjustFilters": "Anzeigefilter anpassen",
 		"add": "Neuen Bereich hinzufügen",
-		"detail": "Bereich verwalten: {space}",
+		"detail": "Smart Panel Bereich verwalten",
 		"onboarding": "Einrichtungsassistent für Bereiche, Geräte und Displays"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/modules/spaces/locales/en-US.json
+++ b/apps/admin/src/modules/spaces/locales/en-US.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Spaces",
 		"spaces": "Spaces",
-		"detail": "Space detail",
+		"detail": "Space: {space}",
 		"add": "Add space",
 		"edit": "Edit space",
 		"removeSpace": "Remove space",
@@ -48,7 +48,7 @@
 		"list": "Organize devices and displays by rooms or zones",
 		"adjustFilters": "Adjust display filters",
 		"add": "Add new space",
-		"detail": "Manage space: {space}",
+		"detail": "Manage smart panel space",
 		"onboarding": "Setup wizard for spaces, devices and displays"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/modules/spaces/locales/es-ES.json
+++ b/apps/admin/src/modules/spaces/locales/es-ES.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Espacios",
 		"spaces": "Espacios",
-		"detail": "Detalle del espacio",
+		"detail": "Espacio: {space}",
 		"add": "Añadir espacio",
 		"edit": "Editar espacio",
 		"removeSpace": "Eliminar espacio",
@@ -48,7 +48,7 @@
 		"list": "Organiza dispositivos y pantallas por habitaciones o zonas",
 		"adjustFilters": "Ajustar filtros de visualización",
 		"add": "Añadir nuevo espacio",
-		"detail": "Gestionar espacio: {space}",
+		"detail": "Gestionar espacio del panel inteligente",
 		"onboarding": "Asistente de configuración para espacios, dispositivos y pantallas"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/modules/spaces/locales/pl-PL.json
+++ b/apps/admin/src/modules/spaces/locales/pl-PL.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Przestrzenie",
 		"spaces": "Przestrzenie",
-		"detail": "Szczegoly przestrzeni",
+		"detail": "Przestrzen: {space}",
 		"add": "Dodaj przestrzen",
 		"edit": "Edytuj przestrzen",
 		"removeSpace": "Usun przestrzen",
@@ -48,7 +48,7 @@
 		"list": "Organizuj urzadzenia i wyswietlacze wedlug pokoi lub stref",
 		"adjustFilters": "Dostosuj filtry wyswietlania",
 		"add": "Dodaj nowa przestrzen",
-		"detail": "Zarzadzaj przestrzenia: {space}",
+		"detail": "Zarzadzaj przestrzenia smart panelu",
 		"onboarding": "Kreator konfiguracji przestrzeni, urzadzen i wyswietlaczy"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/modules/spaces/locales/sk-SK.json
+++ b/apps/admin/src/modules/spaces/locales/sk-SK.json
@@ -7,7 +7,7 @@
 	"headings": {
 		"list": "Priestory",
 		"spaces": "Priestory",
-		"detail": "Detail priestoru",
+		"detail": "Priestor: {space}",
 		"add": "Pridať priestor",
 		"edit": "Upraviť priestor",
 		"removeSpace": "Odstrániť priestor",
@@ -48,7 +48,7 @@
 		"list": "Organizujte zariadenia a displeje podľa miestností alebo zón",
 		"adjustFilters": "Upraviť filtre zobrazenia",
 		"add": "Pridať nový priestor",
-		"detail": "Spravovať priestor: {space}",
+		"detail": "Spravovať priestor smart panelu",
 		"onboarding": "Sprievodca nastavením pre priestory, zariadenia a displeje"
 	},
 	"breadcrumbs": {

--- a/apps/admin/src/plugins/spaces-home-control/components/space-parent-zone-section.spec.ts
+++ b/apps/admin/src/plugins/spaces-home-control/components/space-parent-zone-section.spec.ts
@@ -1,0 +1,109 @@
+import { nextTick } from 'vue';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { shallowMount } from '@vue/test-utils';
+
+import { SpaceType } from '../../../modules/spaces/spaces.constants';
+
+import SpaceParentZoneSection from './space-parent-zone-section.vue';
+
+const mocks = vi.hoisted(() => ({
+	editSpace: vi.fn(),
+	findById: vi.fn(),
+	floorZoneSpaces: { value: [] },
+	flashSuccess: vi.fn(),
+	flashError: vi.fn(),
+}));
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('../../../common', () => ({
+	useFlashMessage: () => ({
+		success: mocks.flashSuccess,
+		error: mocks.flashError,
+	}),
+}));
+
+vi.mock('../../../modules/spaces/composables', () => ({
+	useSpace: () => ({
+		editSpace: mocks.editSpace,
+	}),
+	useSpaces: () => ({
+		floorZoneSpaces: mocks.floorZoneSpaces,
+		findById: mocks.findById,
+	}),
+}));
+
+describe('SpaceParentZoneSection', () => {
+	it('does not add a bottom border to the final detail row', () => {
+		const wrapper = shallowMount(SpaceParentZoneSection, {
+			props: {
+				space: {
+					id: '7a1bafdc-8c7d-4d5a-9e2a-4dfdc3c8253d',
+					name: 'Living room',
+					category: null,
+					description: null,
+					type: SpaceType.ROOM,
+					icon: null,
+					displayOrder: 0,
+					parentId: null,
+					suggestionsEnabled: false,
+					statusWidgets: null,
+					createdAt: new Date(),
+					updatedAt: null,
+					draft: false,
+				},
+			},
+			global: {
+				stubs: {
+					Icon: true,
+				},
+			},
+		});
+
+		expect(wrapper.find('dt').classes()).not.toContain('b-b');
+		expect(wrapper.find('dd').classes()).not.toContain('b-b');
+	});
+
+	it('opens the inline floor selector from the keyboard', async () => {
+		const wrapper = shallowMount(SpaceParentZoneSection, {
+			props: {
+				space: {
+					id: '7a1bafdc-8c7d-4d5a-9e2a-4dfdc3c8253d',
+					name: 'Living room',
+					category: null,
+					description: null,
+					type: SpaceType.ROOM,
+					icon: null,
+					displayOrder: 0,
+					parentId: null,
+					suggestionsEnabled: false,
+					statusWidgets: null,
+					createdAt: new Date(),
+					updatedAt: null,
+					draft: false,
+				},
+			},
+			global: {
+				stubs: {
+					Icon: true,
+				},
+			},
+		});
+
+		const editorTrigger = wrapper.find('[role="button"]');
+
+		expect(editorTrigger.attributes('tabindex')).toBe('0');
+		expect(editorTrigger.attributes('aria-expanded')).toBeUndefined();
+
+		await editorTrigger.trigger('keydown', { key: 'Enter' });
+		await nextTick();
+
+		expect(wrapper.find('el-select-stub').exists()).toBe(true);
+	});
+});

--- a/apps/admin/src/plugins/spaces-home-control/components/space-parent-zone-section.vue
+++ b/apps/admin/src/plugins/spaces-home-control/components/space-parent-zone-section.vue
@@ -1,57 +1,73 @@
 <template>
-	<el-card shadow="never" class="mt-4">
-		<template #header>
-			<span class="font-medium">{{ t('spacesModule.detail.parentZone.title') }}</span>
-		</template>
-
-		<div class="flex items-center gap-4">
-			<div class="flex-1">
-				<el-select
-					v-model="selectedZoneId"
-					:placeholder="t('spacesModule.detail.parentZone.select')"
-					clearable
-					class="w-full"
-					:loading="isSaving"
-					@change="onZoneChange"
-				>
-					<el-option
-						v-for="zone in availableZones"
-						:key="zone.id"
-						:label="zone.name"
-						:value="zone.id"
-					>
-						<div class="flex items-center gap-2">
-							<icon :icon="zone.icon || 'mdi:home-floor-1'" />
-							<span>{{ zone.name }}</span>
-							<el-tag v-if="zone.category" size="small" type="info" class="ml-auto">
-								{{ t(`spacesModule.fields.spaces.category.options.${zone.category}`) }}
-							</el-tag>
-						</div>
-					</el-option>
-				</el-select>
-			</div>
-
-			<template v-if="currentZone">
-				<el-tag type="success" size="large">
-					<div class="flex items-center gap-1">
-						<icon :icon="currentZone.icon || 'mdi:home-floor-1'" />
-						{{ currentZone.name }}
-					</div>
-				</el-tag>
-			</template>
-			<span v-else class="text-gray-400">
+	<dt
+		class="b-r b-r-solid py-3 px-2 flex items-center justify-end"
+		style="background: var(--el-fill-color-light)"
+	>
+		{{ t('spacesModule.detail.parentZone.title') }}
+	</dt>
+	<dd class="col-start-2 m-0 p-2 flex items-center gap-2 min-w-[8rem]">
+		<div
+			v-if="!isEditingFloor"
+			role="button"
+			tabindex="0"
+			:aria-label="t('spacesModule.detail.parentZone.select')"
+			class="flex items-center gap-2 cursor-pointer hover:opacity-70"
+			@click="onFloorTextClick"
+			@keydown.enter.prevent="onFloorTextClick"
+			@keydown.space.prevent="onFloorTextClick"
+		>
+			<el-tag
+				v-if="currentZone"
+				type="success"
+				size="small"
+			>
+				<div class="flex items-center gap-1">
+					<icon :icon="currentZone.icon || 'mdi:home-floor-1'" />
+					{{ currentZone.name }}
+				</div>
+			</el-tag>
+			<span
+				v-else
+				class="text-gray-400 text-sm"
+			>
 				{{ t('spacesModule.detail.parentZone.none') }}
 			</span>
 		</div>
-	</el-card>
+
+		<el-select
+			v-else
+			ref="floorSelectRef"
+			v-model="selectedZoneId"
+			:placeholder="t('spacesModule.detail.parentZone.select')"
+			clearable
+			size="small"
+			class="max-w-[250px]"
+			:loading="isSaving"
+			@change="onZoneChange"
+			@blur="onFloorSelectBlur"
+		>
+			<el-option
+				v-for="zone in availableZones"
+				:key="zone.id"
+				:label="zone.name"
+				:value="zone.id"
+			>
+				<div class="flex items-center gap-2">
+					<icon :icon="zone.icon || 'mdi:home-floor-1'" />
+					<span>{{ zone.name }}</span>
+				</div>
+			</el-option>
+		</el-select>
+	</dd>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElOption, ElSelect, ElTag } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
-import { ElCard, ElOption, ElSelect, ElTag } from 'element-plus';
-import { useI18n } from 'vue-i18n';
 
 import { useFlashMessage } from '../../../common';
 import { useSpace, useSpaces } from '../../../modules/spaces/composables';
@@ -75,6 +91,10 @@ const { editSpace } = useSpace(spaceId);
 
 const selectedZoneId = ref<string | null>(props.space.parentId);
 const isSaving = ref(false);
+const isEditingFloor = ref(false);
+const floorSelectRef = ref<InstanceType<typeof ElSelect> | null>(null);
+const originalZoneId = ref<string | null>(props.space.parentId);
+const justChanged = ref(false);
 
 // Get the current parent zone
 const currentZone = computed<ISpace | null>(() => {
@@ -87,17 +107,55 @@ const availableZones = computed(() => {
 	return floorZoneSpaces.value.filter((space) => space.id !== props.space.id);
 });
 
+const onFloorTextClick = (): void => {
+	isEditingFloor.value = true;
+	originalZoneId.value = props.space.parentId;
+	selectedZoneId.value = props.space.parentId;
+	justChanged.value = false;
+
+	nextTick(() => {
+		floorSelectRef.value?.focus?.();
+	});
+};
+
+const onFloorSelectBlur = (): void => {
+	setTimeout(() => {
+		if (!justChanged.value && !isSaving.value && isEditingFloor.value) {
+			isEditingFloor.value = false;
+		}
+
+		justChanged.value = false;
+	}, 200);
+};
+
+const handleEscapeKey = (event: KeyboardEvent): void => {
+	if (isEditingFloor.value && event.key === 'Escape') {
+		selectedZoneId.value = originalZoneId.value;
+		isEditingFloor.value = false;
+		justChanged.value = false;
+	}
+};
+
 // Watch for external changes to parent zone
 watch(
 	() => props.space.parentId,
 	(newParentId) => {
-		selectedZoneId.value = newParentId;
-	}
+		if (!isEditingFloor.value) {
+			selectedZoneId.value = newParentId;
+			originalZoneId.value = newParentId;
+		}
+	},
+	{ immediate: true }
 );
 
 const onZoneChange = async (newZoneId: string | null): Promise<void> => {
-	if (newZoneId === props.space.parentId) return;
+	if (newZoneId === props.space.parentId) {
+		isEditingFloor.value = false;
+		justChanged.value = false;
+		return;
+	}
 
+	justChanged.value = true;
 	isSaving.value = true;
 
 	try {
@@ -107,12 +165,24 @@ const onZoneChange = async (newZoneId: string | null): Promise<void> => {
 		});
 
 		flashMessage.success(t('spacesModule.messages.edited', { space: props.space.name }));
+		isEditingFloor.value = false;
+		justChanged.value = false;
 	} catch {
 		// Revert selection on error
-		selectedZoneId.value = props.space.parentId;
+		selectedZoneId.value = originalZoneId.value;
 		flashMessage.error(t('spacesModule.messages.saveError'));
+		isEditingFloor.value = false;
+		justChanged.value = false;
 	} finally {
 		isSaving.value = false;
 	}
 };
+
+onMounted(() => {
+	document.addEventListener('keydown', handleEscapeKey);
+});
+
+onBeforeUnmount(() => {
+	document.removeEventListener('keydown', handleEscapeKey);
+});
 </script>

--- a/apps/admin/src/plugins/spaces-home-control/views/view-space-configure.spec.ts
+++ b/apps/admin/src/plugins/spaces-home-control/views/view-space-configure.spec.ts
@@ -117,28 +117,30 @@ vi.mock('../../../modules/spaces', async () => {
 vi.mock('../components/components', async () => {
 	const { defineComponent, h } = await import('vue');
 
-	const StubComponent = defineComponent({
-		props: {
-			space: { type: Object, required: false, default: null },
-			spaceId: { type: String, required: false, default: null },
-			spaceType: { type: String, required: false, default: null },
-			visible: { type: Boolean, required: false },
-		},
-		setup(_, { slots }) {
-			return () => h('div', slots.default?.());
-		},
-	});
+	const StubComponent = (name: string) =>
+		defineComponent({
+			name,
+			props: {
+				space: { type: Object, required: false, default: null },
+				spaceId: { type: String, required: false, default: null },
+				spaceType: { type: String, required: false, default: null },
+				visible: { type: Boolean, required: false },
+			},
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		});
 
 	return {
-		SpaceAddDeviceDialog: StubComponent,
-		SpaceAddDisplayDialog: StubComponent,
-		SpaceAddSceneDialog: StubComponent,
-		SpaceDetail: StubComponent,
-		SpaceDevicesSection: StubComponent,
-		SpaceDisplaysSection: StubComponent,
-		SpaceDomainsSection: StubComponent,
-		SpaceParentZoneSection: StubComponent,
-		SpaceScenesSection: StubComponent,
+		SpaceAddDeviceDialog: StubComponent('SpaceAddDeviceDialog'),
+		SpaceAddDisplayDialog: StubComponent('SpaceAddDisplayDialog'),
+		SpaceAddSceneDialog: StubComponent('SpaceAddSceneDialog'),
+		SpaceDetail: StubComponent('SpaceDetail'),
+		SpaceDevicesSection: StubComponent('SpaceDevicesSection'),
+		SpaceDisplaysSection: StubComponent('SpaceDisplaysSection'),
+		SpaceDomainsSection: StubComponent('SpaceDomainsSection'),
+		SpaceParentZoneSection: StubComponent('SpaceParentZoneSection'),
+		SpaceScenesSection: StubComponent('SpaceScenesSection'),
 	};
 });
 
@@ -174,6 +176,7 @@ describe('ViewSpaceConfigure', () => {
 				},
 			},
 			global: {
+				renderStubDefaultSlot: true,
 				stubs: {
 					RouterView: true,
 					teleport: true,
@@ -204,6 +207,7 @@ describe('ViewSpaceConfigure', () => {
 				},
 			},
 			global: {
+				renderStubDefaultSlot: true,
 				stubs: {
 					RouterView: true,
 					teleport: true,
@@ -253,5 +257,38 @@ describe('ViewSpaceConfigure', () => {
 		});
 
 		expect(wrapper.find('[data-test-id="space-configure-edit-route"]').exists()).toBe(true);
+	});
+
+	it('renders the room floor selector inside the space detail rows', () => {
+		const wrapper = shallowMount(ViewSpaceConfigure, {
+			props: {
+				space: {
+					id: '7a1bafdc-8c7d-4d5a-9e2a-4dfdc3c8253d',
+					name: 'Living room',
+					category: null,
+					description: null,
+					type: SpaceType.ROOM,
+					icon: null,
+					displayOrder: 0,
+					parentId: null,
+					suggestionsEnabled: false,
+					statusWidgets: null,
+					createdAt: new Date(),
+					updatedAt: null,
+					draft: false,
+				},
+			},
+			global: {
+				renderStubDefaultSlot: true,
+				stubs: {
+					RouterView: true,
+					teleport: true,
+				},
+			},
+		});
+
+		const detail = wrapper.findComponent({ name: 'SpaceDetail' });
+
+		expect(detail.findComponent({ name: 'SpaceParentZoneSection' }).exists()).toBe(true);
 	});
 });

--- a/apps/admin/src/plugins/spaces-home-control/views/view-space-configure.vue
+++ b/apps/admin/src/plugins/spaces-home-control/views/view-space-configure.vue
@@ -58,12 +58,12 @@
 		v-if="!isSpaceEditRoute || isLGDevice"
 		class="flex flex-col h-full min-h-0"
 	>
-		<space-detail :space="props.space" />
-
-		<space-parent-zone-section
-			v-if="props.space.type === SpaceType.ROOM"
-			:space="props.space"
-		/>
+		<space-detail :space="props.space">
+			<space-parent-zone-section
+				v-if="props.space.type === SpaceType.ROOM"
+				:space="props.space"
+			/>
+		</space-detail>
 
 		<el-tabs
 			v-model="activeTab"


### PR DESCRIPTION
## Summary

- Restore the home-control floor selector to the inline space detail list while keeping the selector implementation in the plugin.
- Add a detail-row slot to the core spaces detail card so plugin-specific rows can render in the same list layout.
- Keep the inline floor selector keyboard reachable without changing its visual layout.
- Align spaces detail heading/subheading text with the dashboard module pattern and widen the spaces list type column.
- Add regression coverage for plugin detail rows, inline floor selector placement, and keyboard access.

## Root Cause

The spaces admin refactor moved the room floor selector out of the core `SpaceDetail` list into a separate plugin card. That kept the logic plugin-owned, but changed the UI from the previous inline detail-row behavior. The inline editor also initially opened only from a mouse click on a non-focusable element, which made it unreachable for keyboard users.

## Validation

- `pnpm --filter ./apps/admin exec vitest run src/plugins/spaces-home-control/components/space-parent-zone-section.spec.ts src/plugins/spaces-home-control/views/view-space-configure.spec.ts src/modules/spaces/components/space-detail.spec.ts`
- `pnpm --filter ./apps/admin exec eslint src/plugins/spaces-home-control/components/space-parent-zone-section.vue src/plugins/spaces-home-control/components/space-parent-zone-section.spec.ts`
- `pnpm --filter ./apps/admin run type-check`
- `pnpm --filter ./apps/admin exec prettier src/plugins/spaces-home-control/components/space-parent-zone-section.vue src/plugins/spaces-home-control/components/space-parent-zone-section.spec.ts --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/layout and accessibility changes with localized string updates; primary risk is minor regressions in the inline floor selector’s open/close behavior and focus handling.
> 
> **Overview**
> Restores the inline space-detail layout by adding a default slot to `SpaceDetail` so plugins can inject additional `<dt>/<dd>` rows directly into the core details `<dl>`.
> 
> Moves the home-control room “floor/parent zone” selector back into the `SpaceDetail` row list (instead of a separate card) and updates the selector to be keyboard-accessible (focusable trigger, Enter/Space to open, Escape/blur to close/revert).
> 
> Tweaks spaces UI text and layout: updates localized detail heading/subheading strings and widens the spaces table “type” column. Adds regression tests covering plugin detail-row rendering, floor selector placement, and keyboard interaction; updates stubs to render default slots in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8a013fd6710ab4ec06188df23cdb3728fe20a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->