### PR TITLE
feat(admin): move Devices wizard into plugin registry

### DIFF
--- a/apps/admin/src/modules/devices/composables/types.ts
+++ b/apps/admin/src/modules/devices/composables/types.ts
@@ -278,6 +278,8 @@ export interface IUseDevicesPlugin {
 export interface IUseDevicesPlugins {
 	plugins: ComputedRef<IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas>[]>;
 	options: ComputedRef<{ value: IPluginElement['type']; label: string; disabled: boolean }[]>;
+	wizardOptions: ComputedRef<{ value: IPlugin['type']; label: string; description: string; disabled: boolean }[]>;
+	getByPluginType: (type: IPlugin['type']) => IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;
 	getByName: (type: IPlugin['type']) => IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;
 	getByType: (type: IPluginElement['type']) => IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;
 	getElement: (type: IPluginElement['type']) => IPluginElement<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined;

--- a/apps/admin/src/modules/devices/composables/useDevicesPlugins.spec.ts
+++ b/apps/admin/src/modules/devices/composables/useDevicesPlugins.spec.ts
@@ -32,6 +32,33 @@ const mockPluginList = [
 		modules: [DEVICES_MODULE_NAME],
 	},
 	{
+		type: 'wizard-plugin',
+		source: 'source3',
+		name: 'Wizard Plugin',
+		description: 'Wizard plugin description',
+		links: {
+			documentation: '',
+			devDocumentation: '',
+			bugsTracking: '',
+		},
+		elements: [
+			{
+				type: 'wizard-type',
+				name: 'Wizard Type',
+				components: {
+					deviceWizard: {},
+				},
+			},
+			{
+				type: 'non-wizard-type',
+				name: 'Non Wizard Type',
+				components: {},
+			},
+		],
+		isCore: false,
+		modules: [DEVICES_MODULE_NAME],
+	},
+	{
 		type: 'unrelated-plugin',
 		source: 'source2',
 		name: 'Unrelated Plugin',
@@ -68,7 +95,7 @@ vi.mock('../../config', async (importOriginal) => ({
 describe('useDevicesPlugins', () => {
 	it('returns only plugins related to devices module', () => {
 		const { plugins } = useDevicesPlugins();
-		expect(plugins.value.length).toBe(1);
+		expect(plugins.value.length).toBe(2);
 		expect(plugins.value[0]?.type).toBe('test-plugin');
 	});
 
@@ -105,5 +132,37 @@ describe('useDevicesPlugins', () => {
 		const { getByType } = useDevicesPlugins();
 		const plugin = getByType('nonexistent');
 		expect(plugin).toBeUndefined();
+	});
+
+	it('getByPluginType returns correct plugin', () => {
+		const { getByPluginType } = useDevicesPlugins();
+		const plugin = getByPluginType('wizard-plugin');
+
+		expect(plugin?.name).toBe('Wizard Plugin');
+	});
+
+	it('exposes only wizard-capable devices plugins as wizard options', () => {
+		const { wizardOptions } = useDevicesPlugins();
+
+		expect(wizardOptions.value).toEqual([
+			{
+				value: 'wizard-plugin',
+				label: 'Wizard Plugin',
+				description: 'Wizard plugin description',
+				disabled: false,
+			},
+		]);
+	});
+
+	it('excludes wizard-only elements from regular device type options', () => {
+		const { options } = useDevicesPlugins();
+
+		expect(options.value).toEqual([
+			{
+				value: 'test-type',
+				label: 'Test Plugin',
+				disabled: false,
+			},
+		]);
 	});
 });

--- a/apps/admin/src/modules/devices/composables/useDevicesPlugins.ts
+++ b/apps/admin/src/modules/devices/composables/useDevicesPlugins.ts
@@ -14,7 +14,8 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 
 	const { enabled } = useConfigPlugins();
 
-	const pluginComponents: (keyof IDevicePluginsComponents)[] = ['deviceAddForm', 'deviceEditForm'];
+	const pluginComponents: (keyof IDevicePluginsComponents)[] = ['deviceAddForm', 'deviceEditForm', 'deviceWizard'];
+	const typeOptionComponents: (keyof IDevicePluginsComponents)[] = ['deviceAddForm', 'deviceEditForm'];
 
 	const pluginSchemas: (keyof IDevicePluginsSchemas)[] = [
 		'deviceSchema',
@@ -54,6 +55,12 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 			const flat: { value: IPluginElement['type']; label: string; disabled: boolean }[] = plugins.value.flatMap((plugin) => {
 				return (plugin.elements ?? [])
 					.filter((el) => el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME))
+					.filter((el) => {
+						const hasTypeComponent = !!el.components && typeOptionComponents.some((key) => el.components && key in el.components);
+						const hasTypeSchema = !!el.schemas && pluginSchemas.some((key) => el.schemas && key in el.schemas);
+
+						return hasTypeComponent || hasTypeSchema;
+					})
 					.map((el) => ({
 						value: el.type,
 						label: el.name?.trim() ? el.name : plugin.name,
@@ -65,9 +72,26 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 		}
 	);
 
-	const getByName = (type: IPlugin['type']): IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined => {
+	const wizardOptions = computed<{ value: IPlugin['type']; label: string; description: string; disabled: boolean }[]>(() => {
+		const flat = plugins.value
+			.filter((plugin) =>
+				(plugin.elements ?? []).some((el) => (el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME)) && !!el.components?.deviceWizard)
+			)
+			.map((plugin) => ({
+				value: plugin.type,
+				label: plugin.name,
+				description: plugin.description,
+				disabled: !enabled(plugin.type),
+			}));
+
+		return orderBy(flat, [(o) => o.label], ['asc']);
+	});
+
+	const getByPluginType = (type: IPlugin['type']): IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) => plugin.type === type);
 	};
+
+	const getByName = getByPluginType;
 
 	const getByType = (type: IPluginElement['type']): IPlugin<IDevicePluginsComponents, IDevicePluginsSchemas> | undefined => {
 		return plugins.value.find((plugin) =>
@@ -92,6 +116,8 @@ export const useDevicesPlugins = (): IUseDevicesPlugins => {
 	return {
 		plugins,
 		options,
+		wizardOptions,
+		getByPluginType,
 		getByName,
 		getByType,
 		getElement,

--- a/apps/admin/src/modules/devices/devices.constants.ts
+++ b/apps/admin/src/modules/devices/devices.constants.ts
@@ -36,6 +36,7 @@ export const RouteNames = {
 	DEVICES: 'devices_module-devices',
 	DEVICES_ADD: 'devices_module-devices_add',
 	DEVICES_EDIT: 'devices_module-devices_edit',
+	DEVICES_WIZARD: 'devices_module-devices_wizard',
 	DEVICE: 'devices_module-device',
 	DEVICE_EDIT: 'devices_module-device_edit',
 	DEVICE_CONTROL: 'devices_module-device_control',

--- a/apps/admin/src/modules/devices/devices.types.ts
+++ b/apps/admin/src/modules/devices/devices.types.ts
@@ -23,6 +23,7 @@ import { DeviceCreateReqSchema, DeviceSchema, DeviceUpdateReqSchema } from './st
 export type IDevicePluginsComponents = {
 	deviceAddForm?: DefineComponent<IDeviceAddFormProps, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, typeof deviceAddFormEmits>;
 	deviceEditForm?: DefineComponent<IDeviceEditFormProps, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, typeof deviceEditFormEmits>;
+	deviceWizard?: DefineComponent<{}, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}>;
 };
 
 export type IDevicePluginsSchemas = {

--- a/apps/admin/src/modules/devices/locales/cs-CZ.json
+++ b/apps/admin/src/modules/devices/locales/cs-CZ.json
@@ -74,7 +74,8 @@
       "bulkEnable": "Povolit zařízení?",
       "bulkDisable": "Zakázat zařízení?",
       "adjustFilters": "Filtrovat zařízení",
-      "selectPlugin": "Vyžadován plugin zařízení"
+      "selectPlugin": "Vyžadován plugin zařízení",
+      "selectWizardPlugin": "Vybrat průvodce zařízením"
     },
     "channels": {
       "list": "Kanály",
@@ -214,6 +215,7 @@
         "window_covering": "Zařízení Okenní krytina představuje automatizované okenní prvky, jako jsou žaluzie, rolety nebo záclony."
       },
       "selectPlugin": "Pro vytvoření nového zařízení vyberte prosím kompatibilní plugin ze seznamu. Pluginy poskytují potřebné konfigurační možnosti pro konkrétní typ zařízení.",
+      "noWizardForDevicePlugin": "Plugin zařízení „{type}\" neposkytuje průvodce nastavením.",
       "noChannels": "Toto zařízení zatím nemá žádné kanály. Kanály definují vstupy nebo výstupy zařízení. Vytvořte nový kanál pro zahájení interakce s tímto zařízením.",
       "category": "Kategorie",
       "channelsCount": "Žádné kanály nakonfigurovány | Jeden kanál nakonfigurován | {count} kanálů nakonfigurováno",
@@ -611,6 +613,9 @@
   "buttons": {
     "add": {
       "title": "Přidat"
+    },
+    "wizard": {
+      "title": "Průvodce"
     },
     "edit": {
       "title": "Upravit"

--- a/apps/admin/src/modules/devices/locales/de-DE.json
+++ b/apps/admin/src/modules/devices/locales/de-DE.json
@@ -74,7 +74,8 @@
       "bulkEnable": "Geräte aktivieren?",
       "bulkDisable": "Geräte deaktivieren?",
       "adjustFilters": "Geräte filtern",
-      "selectPlugin": "Geräte-Plugin erforderlich"
+      "selectPlugin": "Geräte-Plugin erforderlich",
+      "selectWizardPlugin": "Geräteassistent auswählen"
     },
     "channels": {
       "list": "Kanäle",
@@ -214,6 +215,7 @@
         "window_covering": "The Window Covering device represents automated window treatments such as blinds, shades, or curtains."
       },
       "selectPlugin": "Um ein neues Gerät zu erstellen, wählen Sie bitte ein kompatibles Plugin aus der Liste. Plugins bieten die notwendigen Konfigurationsoptionen für bestimmte Gerätetypen.",
+      "noWizardForDevicePlugin": "Das Geräte-Plugin „{type}\" stellt keinen Einrichtungsassistenten bereit.",
       "noChannels": "Dieses Gerät hat noch keine Kanäle. Kanäle definieren die Ein- oder Ausgänge eines Geräts. Erstellen Sie einen neuen Kanal, um mit diesem Gerät zu interagieren.",
       "category": "Kategorie",
       "channelsCount": "Keine Kanäle konfiguriert | Ein Kanal konfiguriert | {count} Kanäle konfiguriert",
@@ -611,6 +613,9 @@
   "buttons": {
     "add": {
       "title": "Hinzufügen"
+    },
+    "wizard": {
+      "title": "Assistent"
     },
     "edit": {
       "title": "Bearbeiten"

--- a/apps/admin/src/modules/devices/locales/en-US.json
+++ b/apps/admin/src/modules/devices/locales/en-US.json
@@ -74,7 +74,8 @@
       "bulkEnable": "Enable devices?",
       "bulkDisable": "Disable devices?",
       "adjustFilters": "Filter devices",
-      "selectPlugin": "Device plugin required"
+      "selectPlugin": "Device plugin required",
+      "selectWizardPlugin": "Select a device wizard"
     },
     "channels": {
       "list": "Channels",
@@ -214,6 +215,7 @@
         "window_covering": "The Window Covering device represents automated window treatments such as blinds, shades, or curtains."
       },
       "selectPlugin": "To create a new device, please select a compatible plugin from the list. Plugins provide the necessary configuration options for specific device type.",
+      "noWizardForDevicePlugin": "The \"{type}\" device plugin does not provide a setup wizard.",
       "noChannels": "This device doesn't have any channels yet. Channels define the inputs or outputs of a device. Create a new channel to start interacting with this device.",
       "category": "Category",
       "channelsCount": "No channels configured | One channel configured | {count} channels configured",
@@ -612,6 +614,9 @@
   "buttons": {
     "add": {
       "title": "Add"
+    },
+    "wizard": {
+      "title": "Wizard"
     },
     "edit": {
       "title": "Edit"

--- a/apps/admin/src/modules/devices/locales/es-ES.json
+++ b/apps/admin/src/modules/devices/locales/es-ES.json
@@ -74,7 +74,8 @@
       "bulkEnable": "¿Activar dispositivos?",
       "bulkDisable": "¿Desactivar dispositivos?",
       "adjustFilters": "Filtrar dispositivos",
-      "selectPlugin": "Se requiere plugin de dispositivo"
+      "selectPlugin": "Se requiere plugin de dispositivo",
+      "selectWizardPlugin": "Seleccionar asistente de dispositivo"
     },
     "channels": {
       "list": "Canales",
@@ -214,6 +215,7 @@
         "window_covering": "El dispositivo Cubierta de Ventana representa tratamientos automatizados de ventanas como persianas, estores o cortinas."
       },
       "selectPlugin": "Para crear un nuevo dispositivo, por favor seleccione un plugin compatible de la lista. Los plugins proporcionan las opciones de configuración necesarias para tipos de dispositivo específicos.",
+      "noWizardForDevicePlugin": "El plugin de dispositivo «{type}» no proporciona un asistente de configuración.",
       "noChannels": "Este dispositivo aún no tiene canales. Los canales definen las entradas o salidas de un dispositivo. Cree un nuevo canal para comenzar a interactuar con este dispositivo.",
       "category": "Categoría",
       "channelsCount": "Sin canales configurados | Un canal configurado | {count} canales configurados",
@@ -611,6 +613,9 @@
   "buttons": {
     "add": {
       "title": "Añadir"
+    },
+    "wizard": {
+      "title": "Asistente"
     },
     "edit": {
       "title": "Editar"

--- a/apps/admin/src/modules/devices/locales/pl-PL.json
+++ b/apps/admin/src/modules/devices/locales/pl-PL.json
@@ -74,7 +74,8 @@
 			"bulkEnable": "Włączyć urządzenia?",
 			"bulkDisable": "Wyłączyć urządzenia?",
 			"adjustFilters": "Filtruj urządzenia",
-			"selectPlugin": "Wymagana wtyczka urządzenia"
+			"selectPlugin": "Wymagana wtyczka urządzenia",
+			"selectWizardPlugin": "Wybierz kreator urządzeń"
 		},
 		"channels": {
 			"list": "Kanały",
@@ -214,6 +215,7 @@
 				"window_covering": "The Window Covering device represents automated window treatments such as blinds, shades, or curtains."
 			},
 			"selectPlugin": "Aby utworzyć nowe urządzenie, wybierz kompatybilną wtyczkę z listy. Wtyczki zapewniają niezbędne opcje konfiguracji dla określonego typu urządzenia.",
+			"noWizardForDevicePlugin": "Wtyczka urządzeń „{type}\" nie udostępnia kreatora konfiguracji.",
 			"noChannels": "To urządzenie nie ma jeszcze żadnych kanałów. Kanały definiują wejścia lub wyjścia urządzenia. Utwórz nowy kanał, aby rozpocząć interakcję z tym urządzeniem.",
 			"category": "Kategoria",
 			"channelsCount": "Brak skonfigurowanych kanałów | Jeden skonfigurowany kanał | {count} skonfigurowanych kanałów",
@@ -611,6 +613,9 @@
 	"buttons": {
 		"add": {
 			"title": "Dodaj"
+		},
+		"wizard": {
+			"title": "Kreator"
 		},
 		"edit": {
 			"title": "Edytuj"

--- a/apps/admin/src/modules/devices/locales/sk-SK.json
+++ b/apps/admin/src/modules/devices/locales/sk-SK.json
@@ -74,7 +74,8 @@
 			"bulkEnable": "Povoliť zariadenia?",
 			"bulkDisable": "Zakázať zariadenia?",
 			"adjustFilters": "Filtrovať zariadenia",
-			"selectPlugin": "Vyžaduje sa plugin zariadenia"
+			"selectPlugin": "Vyžaduje sa plugin zariadenia",
+			"selectWizardPlugin": "Vybrať sprievodcu zariadením"
 		},
 		"channels": {
 			"list": "Kanály",
@@ -214,6 +215,7 @@
 				"window_covering": "The Window Covering device represents automated window treatments such as blinds, shades, or curtains."
 			},
 			"selectPlugin": "Na vytvorenie nového zariadenia vyberte kompatibilný plugin zo zoznamu. Pluginy poskytujú potrebné konfiguračné možnosti pre konkrétny typ zariadenia.",
+			"noWizardForDevicePlugin": "Plugin zariadenia „{type}\" neposkytuje sprievodcu nastavením.",
 			"noChannels": "Toto zariadenie zatiaľ nemá žiadne kanály. Kanály definujú vstupy alebo výstupy zariadenia. Vytvorte nový kanál na začatie interakcie s týmto zariadením.",
 			"category": "Kategória",
 			"channelsCount": "Žiadne kanály nakonfigurované | Jeden kanál nakonfigurovaný | {count} kanálov nakonfigurovaných",
@@ -611,6 +613,9 @@
 	"buttons": {
 		"add": {
 			"title": "Pridať"
+		},
+		"wizard": {
+			"title": "Sprievodca"
 		},
 		"edit": {
 			"title": "Upraviť"

--- a/apps/admin/src/modules/devices/router/index.spec.ts
+++ b/apps/admin/src/modules/devices/router/index.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RouteNames } from '../devices.constants';
+
+import { ModuleRoutes } from './index';
+
+vi.mock('../../../locales', () => ({
+	default: {
+		global: {
+			t: (key: string) => key,
+		},
+	},
+}));
+
+vi.mock('../../../openapi.constants', () => ({
+	UsersModuleUserRole: {
+		admin: 'admin',
+		owner: 'owner',
+	},
+}));
+
+vi.mock('../devices.constants', () => ({
+	RouteNames: {
+		DEVICES: 'devices',
+		DEVICES_ADD: 'devices-add',
+		DEVICES_EDIT: 'devices-edit',
+		DEVICES_WIZARD: 'devices-wizard',
+		DEVICE: 'device',
+		DEVICE_EDIT: 'device-edit',
+		DEVICE_CONTROL: 'device-control',
+		DEVICE_ADD_CHANNEL: 'device-add-channel',
+		DEVICE_EDIT_CHANNEL: 'device-edit-channel',
+		DEVICE_CHANNEL_ADD_PROPERTY: 'device-channel-add-property',
+		DEVICE_CHANNEL_EDIT_PROPERTY: 'device-channel-edit-property',
+		CHANNELS: 'channels',
+		CHANNELS_ADD: 'channels-add',
+		CHANNELS_EDIT: 'channels-edit',
+		CHANNEL: 'channel',
+		CHANNEL_EDIT: 'channel-edit',
+		CHANNEL_ADD_PROPERTY: 'channel-add-property',
+		CHANNEL_EDIT_PROPERTY: 'channel-edit-property',
+	},
+}));
+
+describe('devices module routes', () => {
+	it('requires a plugin type for the devices wizard route', () => {
+		const devicesRoute = ModuleRoutes.find((route) => route.name === RouteNames.DEVICES);
+		const wizardRoute = devicesRoute?.children?.find((route) => route.name === RouteNames.DEVICES_WIZARD);
+
+		expect(wizardRoute?.path).toBe('wizard/:type');
+		expect(wizardRoute?.props).toBe(true);
+	});
+
+	it('redirects incomplete wizard paths before the edit route can match them as ids', () => {
+		const devicesRoute = ModuleRoutes.find((route) => route.name === RouteNames.DEVICES);
+		const children = devicesRoute?.children ?? [];
+		const editIndex = children.findIndex((route) => route.name === RouteNames.DEVICES_EDIT);
+		const wizardFallbackIndex = children.findIndex((route) => route.path === 'wizard');
+
+		expect(wizardFallbackIndex).toBeGreaterThanOrEqual(0);
+		expect(wizardFallbackIndex).toBeLessThan(editIndex);
+		expect(children[wizardFallbackIndex]?.redirect).toEqual({ name: RouteNames.DEVICES });
+	});
+});

--- a/apps/admin/src/modules/devices/router/index.ts
+++ b/apps/admin/src/modules/devices/router/index.ts
@@ -35,6 +35,24 @@ export const ModuleRoutes: RouteRecordRaw[] = [
 				},
 			},
 			{
+				path: 'wizard',
+				redirect: { name: RouteNames.DEVICES },
+			},
+			{
+				path: 'wizard/:type',
+				name: RouteNames.DEVICES_WIZARD,
+				component: () => import('../views/view-devices-wizard.vue'),
+				props: true,
+				meta: {
+					guards: {
+						authenticated: true,
+						roles: [UsersModuleUserRole.admin, UsersModuleUserRole.owner],
+					},
+					title: 'Devices Wizard',
+					icon: 'mdi:wizard-hat',
+				},
+			},
+			{
 				path: ':id',
 				name: RouteNames.DEVICES_EDIT,
 				component: () => import('../views/view-device-edit.vue'),

--- a/apps/admin/src/modules/devices/views/view-devices-wizard.spec.ts
+++ b/apps/admin/src/modules/devices/views/view-devices-wizard.spec.ts
@@ -1,0 +1,88 @@
+/* eslint-disable vue/one-component-per-file */
+import { defineComponent } from 'vue';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { mount } from '@vue/test-utils';
+
+import ViewDevicesWizard from './view-devices-wizard.vue';
+
+const OtherWizard = defineComponent({
+	name: 'OtherWizard',
+	template: '<div data-test-id="other-wizard" />',
+});
+
+const DevicesWizard = defineComponent({
+	name: 'DevicesWizard',
+	template: '<div data-test-id="devices-wizard" />',
+});
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const { defineComponent: defineVueComponent } = await import('vue');
+
+	return {
+		EntityNotFound: defineVueComponent({
+			name: 'EntityNotFound',
+			template: '<div data-test-id="entity-not-found" />',
+		}),
+	};
+});
+
+vi.mock('../composables/composables', () => ({
+	useDevicesPlugins: () => ({
+		getByPluginType: (type: string) =>
+			type === 'multi-module-plugin'
+				? {
+						type: 'multi-module-plugin',
+						elements: [
+							{
+								type: 'other-module-wizard',
+								modules: ['other-module'],
+								components: {
+									deviceWizard: OtherWizard,
+								},
+							},
+							{
+								type: 'devices-module-wizard',
+								modules: ['devices-module'],
+								components: {
+									deviceWizard: DevicesWizard,
+								},
+							},
+						],
+					}
+				: undefined,
+	}),
+}));
+
+vi.mock('../devices.constants', () => ({
+	RouteNames: {
+		DEVICES: 'devices',
+	},
+	DEVICES_MODULE_NAME: 'devices-module',
+}));
+
+describe('ViewDevicesWizard', () => {
+	it('renders the devices-scoped wizard element when plugin also has other module wizards', () => {
+		const wrapper = mount(ViewDevicesWizard, {
+			props: {
+				type: 'multi-module-plugin',
+			},
+		});
+
+		expect(wrapper.find('[data-test-id="devices-wizard"]').exists()).toBe(true);
+		expect(wrapper.find('[data-test-id="other-wizard"]').exists()).toBe(false);
+	});
+});

--- a/apps/admin/src/modules/devices/views/view-devices-wizard.vue
+++ b/apps/admin/src/modules/devices/views/view-devices-wizard.vue
@@ -1,0 +1,37 @@
+<template>
+	<component
+		:is="element?.components?.deviceWizard"
+		v-if="element?.components?.deviceWizard"
+	/>
+
+	<entity-not-found
+		v-else
+		icon="mdi:wizard-hat"
+		:message="t('devicesModule.texts.devices.noWizardForDevicePlugin', { type })"
+		:button-label="t('devicesModule.buttons.back.title')"
+		@back="router.push({ name: RouteNames.DEVICES })"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+
+import { EntityNotFound } from '../../../common';
+import { useDevicesPlugins } from '../composables/composables';
+import { DEVICES_MODULE_NAME, RouteNames } from '../devices.constants';
+
+const props = defineProps<{
+	type: string;
+}>();
+
+const { t } = useI18n();
+const router = useRouter();
+const { getByPluginType } = useDevicesPlugins();
+
+const plugin = computed(() => getByPluginType(props.type));
+const element = computed(() =>
+	plugin.value?.elements.find((el) => (el.modules === undefined || el.modules.includes(DEVICES_MODULE_NAME)) && !!el.components?.deviceWizard)
+);
+</script>

--- a/apps/admin/src/modules/devices/views/view-devices.spec.ts
+++ b/apps/admin/src/modules/devices/views/view-devices.spec.ts
@@ -1,0 +1,208 @@
+/* eslint-disable vue/one-component-per-file */
+import { computed, defineComponent, ref } from 'vue';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mount } from '@vue/test-utils';
+
+import ViewDevices from './view-devices.vue';
+
+const mocks = vi.hoisted(() => ({
+	routerPush: vi.fn(),
+	routerReplace: vi.fn(),
+	routerResolve: vi.fn((route) => route),
+	fetchDevices: vi.fn(),
+	fetchValidation: vi.fn(),
+	wizardOptions: [] as { value: string; label: string; description: string; disabled: boolean }[],
+	route: {
+		path: '/devices',
+		name: 'devices',
+		matched: [],
+	},
+}));
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('vue-meta', () => ({
+	useMeta: () => ({
+		meta: {},
+	}),
+}));
+
+vi.mock('vue-router', () => ({
+	useRoute: () => mocks.route,
+	useRouter: () => ({
+		push: mocks.routerPush,
+		replace: mocks.routerReplace,
+		resolve: mocks.routerResolve,
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const { defineComponent: defineVueComponent, h, ref: vueRef } = await import('vue');
+
+	const StubComponent = defineVueComponent({
+		setup(_, { slots }) {
+			return () => h('div', [slots.default?.(), slots.extra?.(), slots.icon?.(), slots.title?.(), slots.subtitle?.()]);
+		},
+	});
+
+	return {
+		AppBar: StubComponent,
+		AppBarButton: StubComponent,
+		AppBarButtonAlign: {
+			LEFT: 'left',
+			RIGHT: 'right',
+		},
+		AppBarHeading: StubComponent,
+		AppBreadcrumbs: StubComponent,
+		ViewError: StubComponent,
+		ViewHeader: StubComponent,
+		useBreakpoints: () => ({
+			isMDDevice: vueRef(true),
+			isLGDevice: vueRef(false),
+		}),
+	};
+});
+
+vi.mock('../components/components', async () => {
+	const { defineComponent: defineVueComponent } = await import('vue');
+
+	return {
+		ListDevices: defineVueComponent({
+			template: '<div />',
+		}),
+		ListDevicesAdjust: defineVueComponent({
+			template: '<div />',
+		}),
+	};
+});
+
+vi.mock('../composables/composables', () => ({
+	useDevicesActions: () => ({
+		remove: vi.fn(),
+		bulkRemove: vi.fn(),
+		bulkEnable: vi.fn(),
+		bulkDisable: vi.fn(),
+	}),
+	useDevicesDataSource: () => ({
+		fetchDevices: mocks.fetchDevices,
+		devices: ref([]),
+		devicesPaginated: ref([]),
+		totalRows: ref(0),
+		filters: ref({ types: [] }),
+		filtersActive: ref(false),
+		sortBy: ref(undefined),
+		sortDir: ref(null),
+		paginateSize: ref(10),
+		paginatePage: ref(1),
+		areLoading: ref(false),
+		resetFilter: vi.fn(),
+	}),
+	useDevicesPlugins: () => ({
+		wizardOptions: computed(() => mocks.wizardOptions),
+	}),
+	useDevicesValidation: () => ({
+		fetchValidation: mocks.fetchValidation,
+	}),
+}));
+
+vi.mock('../devices.constants', () => ({
+	RouteNames: {
+		DEVICES: 'devices',
+		DEVICES_ADD: 'devices-add',
+		DEVICES_EDIT: 'devices-edit',
+		DEVICES_WIZARD: 'devices-wizard',
+	},
+}));
+
+vi.mock('../devices.exceptions', () => ({
+	DevicesException: Error,
+}));
+
+const mountView = () =>
+	mount(ViewDevices, {
+		global: {
+			stubs: {
+				ElButton: defineComponent({
+					template: '<button type="button" @click="$emit(\'click\')"><slot /><slot name="icon" /></button>',
+				}),
+				ElCard: defineComponent({
+					template: '<div @click="$emit(\'click\')"><slot /></div>',
+				}),
+				ElDialog: defineComponent({
+					props: {
+						modelValue: { type: Boolean, default: false },
+					},
+					template: '<div v-if="modelValue"><slot /><slot name="footer" /></div>',
+				}),
+				ElDrawer: true,
+				ElIcon: defineComponent({
+					template: '<span><slot /></span>',
+				}),
+				Icon: true,
+				RouterView: true,
+				Suspense: false,
+				teleport: true,
+			},
+		},
+	});
+
+describe('ViewDevices', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.fetchDevices.mockResolvedValue(undefined);
+		mocks.fetchValidation.mockResolvedValue(undefined);
+		mocks.wizardOptions = [];
+		mocks.route = {
+			path: '/devices',
+			name: 'devices',
+			matched: [],
+		};
+	});
+
+	it('opens the only installed wizard directly without showing the selection dialog', async () => {
+		mocks.wizardOptions = [
+			{
+				value: 'devices-home-assistant-plugin',
+				label: 'Home Assistant',
+				description: 'Wizard',
+				disabled: false,
+			},
+		];
+
+		const wrapper = mountView();
+
+		await wrapper
+			.findAll('button')
+			.find((button) => button.text().includes('devicesModule.buttons.wizard.title'))
+			?.trigger('click');
+
+		expect(mocks.routerPush).toHaveBeenCalledWith({
+			name: 'devices-wizard',
+			params: {
+				type: 'devices-home-assistant-plugin',
+			},
+		});
+		expect(wrapper.text()).not.toContain('Home Assistant');
+	});
+
+	it('hides the wizard button when all wizard-capable plugins are disabled', () => {
+		mocks.wizardOptions = [
+			{
+				value: 'devices-home-assistant-plugin',
+				label: 'Home Assistant',
+				description: 'Wizard',
+				disabled: true,
+			},
+		];
+
+		const wrapper = mountView();
+
+		expect(wrapper.findAll('button').some((button) => button.text().includes('devicesModule.buttons.wizard.title'))).toBe(false);
+	});
+});

--- a/apps/admin/src/modules/devices/views/view-devices.vue
+++ b/apps/admin/src/modules/devices/views/view-devices.vue
@@ -1,8 +1,11 @@
 <template>
-	<app-breadcrumbs :items="breadcrumbs" />
+	<app-breadcrumbs
+		v-if="!isWizardRoute"
+		:items="breadcrumbs"
+	/>
 
 	<app-bar-heading
-		v-if="!isMDDevice && isDevicesListRoute"
+		v-if="!isMDDevice && isDevicesListRoute && !isWizardRoute"
 		teleport
 	>
 		<template #icon>
@@ -22,7 +25,7 @@
 	</app-bar-heading>
 
 	<app-bar-button
-		v-if="!isMDDevice && isDevicesListRoute"
+		v-if="!isMDDevice && isDevicesListRoute && !isWizardRoute"
 		:align="AppBarButtonAlign.LEFT"
 		teleport
 		small
@@ -38,7 +41,7 @@
 	</app-bar-button>
 
 	<app-bar-button
-		v-if="!isMDDevice && isDevicesListRoute"
+		v-if="!isMDDevice && isDevicesListRoute && !isWizardRoute"
 		:align="AppBarButtonAlign.RIGHT"
 		teleport
 		small
@@ -48,12 +51,21 @@
 	</app-bar-button>
 
 	<view-header
+		v-if="!isWizardRoute"
 		:heading="t('devicesModule.headings.devices.list')"
 		:sub-heading="t('devicesModule.subHeadings.devices.list')"
 		icon="mdi:devices"
 	>
 		<template #extra>
 			<div class="flex items-center">
+				<el-button
+					v-if="enabledWizardOptions.length > 0"
+					class="px-4!"
+					@click="onWizard"
+				>
+					<el-icon class="mr-1"><icon icon="mdi:wizard-hat" /></el-icon>
+					{{ t('devicesModule.buttons.wizard.title') }}
+				</el-button>
 				<el-button
 					type="primary"
 					plain
@@ -71,7 +83,7 @@
 	</view-header>
 
 	<div
-		v-if="isDevicesListRoute || isLGDevice"
+		v-if="(isDevicesListRoute || isLGDevice) && !isWizardRoute"
 		class="grow-1 flex flex-col gap-2 lt-sm:mx-1 sm:mx-2 lt-sm:mb-1 sm:mb-2 overflow-hidden mt-2"
 	>
 		<list-devices
@@ -95,7 +107,7 @@
 	</div>
 
 	<router-view
-		v-else
+		v-if="isWizardRoute || (!isDevicesListRoute && !isLGDevice)"
 		:key="props.id"
 		v-slot="{ Component }"
 	>
@@ -158,6 +170,47 @@
 			</template>
 		</div>
 	</el-drawer>
+
+	<el-dialog
+		v-model="wizardPluginDialogVisible"
+		:title="t('devicesModule.headings.devices.selectWizardPlugin')"
+		width="520px"
+	>
+		<div class="flex flex-col gap-2">
+			<el-card
+				v-for="item in wizardOptions"
+				:key="item.value"
+				shadow="hover"
+				class="devices-wizard-plugin-card"
+				:class="{ 'devices-wizard-plugin-card--disabled': item.disabled }"
+				body-class="p-4!"
+				@click="!item.disabled && onStartWizard(item.value)"
+			>
+				<div class="flex items-start gap-3">
+					<div class="devices-wizard-plugin-card__icon">
+						<icon icon="mdi:puzzle-outline" />
+					</div>
+					<div class="flex-1 min-w-0 devices-wizard-plugin-card__content">
+						<h3 class="devices-wizard-plugin-card__title">
+							{{ item.label }}
+						</h3>
+						<p class="devices-wizard-plugin-card__description">
+							{{ item.description || '&nbsp;' }}
+						</p>
+					</div>
+					<div class="devices-wizard-plugin-card__chevron">
+						<icon icon="mdi:chevron-right" />
+					</div>
+				</div>
+			</el-card>
+		</div>
+
+		<template #footer>
+			<el-button @click="wizardPluginDialogVisible = false">
+				{{ t('devicesModule.buttons.cancel.title') }}
+			</el-button>
+		</template>
+	</el-dialog>
 </template>
 
 <script setup lang="ts">
@@ -166,13 +219,13 @@ import { useI18n } from 'vue-i18n';
 import { useMeta } from 'vue-meta';
 import { type RouteLocationResolvedGeneric, useRoute, useRouter } from 'vue-router';
 
-import { ElButton, ElDrawer, ElIcon, ElMessageBox } from 'element-plus';
+import { ElButton, ElCard, ElDialog, ElDrawer, ElIcon, ElMessageBox } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
 
 import { AppBar, AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewError, ViewHeader, useBreakpoints } from '../../../common';
 import { ListDevices, ListDevicesAdjust } from '../components/components';
-import { useDevicesActions, useDevicesDataSource, useDevicesValidation } from '../composables/composables';
+import { useDevicesActions, useDevicesDataSource, useDevicesPlugins, useDevicesValidation } from '../composables/composables';
 import { RouteNames } from '../devices.constants';
 import { DevicesException } from '../devices.exceptions';
 import type { IDevice } from '../store/devices.store.types';
@@ -211,16 +264,23 @@ const {
 } = useDevicesDataSource();
 const deviceActions = useDevicesActions();
 const { fetchValidation } = useDevicesValidation();
+const { wizardOptions } = useDevicesPlugins();
+const enabledWizardOptions = computed(() => wizardOptions.value.filter((item) => !item.disabled));
 
 const mounted = ref<boolean>(false);
 
 const showDrawer = ref<boolean>(false);
 const adjustList = ref<boolean>(false);
+const wizardPluginDialogVisible = ref<boolean>(false);
 
 const remoteFormChanged = ref<boolean>(false);
 
 const isDevicesListRoute = computed<boolean>((): boolean => {
 	return route.name === RouteNames.DEVICES;
+});
+
+const isWizardRoute = computed<boolean>((): boolean => {
+	return route.name === RouteNames.DEVICES_WIZARD;
 });
 
 const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(
@@ -345,6 +405,26 @@ const onAdjustList = (): void => {
 	adjustList.value = true;
 };
 
+const onWizard = (): void => {
+	if (enabledWizardOptions.value.length === 1 && enabledWizardOptions.value[0]) {
+		onStartWizard(enabledWizardOptions.value[0].value);
+		return;
+	}
+
+	wizardPluginDialogVisible.value = true;
+};
+
+const onStartWizard = (type: string): void => {
+	wizardPluginDialogVisible.value = false;
+
+	router.push({
+		name: RouteNames.DEVICES_WIZARD,
+		params: {
+			type,
+		},
+	});
+};
+
 onBeforeMount((): void => {
 	fetchDevices().catch((error: unknown): void => {
 		const err = error as Error;
@@ -373,3 +453,75 @@ watch(
 	}
 );
 </script>
+
+<style scoped lang="scss">
+.devices-wizard-plugin-card {
+	cursor: pointer;
+	transition: all 0.2s ease;
+
+	&:hover {
+		.devices-wizard-plugin-card__chevron {
+			opacity: 1;
+			transform: translateX(2px);
+		}
+	}
+}
+
+.devices-wizard-plugin-card--disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.devices-wizard-plugin-card__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: var(--el-border-radius-base);
+	background-color: var(--el-color-primary-light-9);
+	color: var(--el-color-primary);
+	font-size: 1.25rem;
+	flex-shrink: 0;
+}
+
+.devices-wizard-plugin-card__content {
+	display: flex;
+	flex-direction: column;
+	min-height: 4.5rem;
+}
+
+.devices-wizard-plugin-card__title {
+	margin: 0 0 0.25rem 0;
+	font-size: 0.9375rem;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--el-text-color-primary);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.devices-wizard-plugin-card__description {
+	margin: 0;
+	font-size: 0.8125rem;
+	line-height: 1.4;
+	color: var(--el-text-color-secondary);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.devices-wizard-plugin-card__chevron {
+	display: flex;
+	align-items: center;
+	color: var(--el-text-color-placeholder);
+	font-size: 1.25rem;
+	opacity: 0.5;
+	transition: all 0.2s ease;
+	flex-shrink: 0;
+	align-self: center;
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds plugin-level devices wizard registration via `deviceWizard` and `wizardOptions`.
- Adds the `/devices/wizard/:type` route and dynamic wizard host view.
- Wires the Devices list Wizard button, plugin selection dialog, single-wizard shortcut, fallback copy, and tests mirroring the spaces module pattern.

## Validation

- `pnpm --filter @fastybird/smart-panel-admin exec vitest --run src/modules/devices`
- `pnpm --filter @fastybird/smart-panel-admin exec eslint src/modules/devices/composables/types.ts src/modules/devices/composables/useDevicesPlugins.ts src/modules/devices/composables/useDevicesPlugins.spec.ts src/modules/devices/devices.constants.ts src/modules/devices/devices.types.ts src/modules/devices/router/index.ts src/modules/devices/router/index.spec.ts src/modules/devices/views/view-devices.vue src/modules/devices/views/view-devices.spec.ts src/modules/devices/views/view-devices-wizard.vue src/modules/devices/views/view-devices-wizard.spec.ts`
- `pnpm --filter @fastybird/smart-panel-admin run type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches devices routing and plugin filtering logic, which could change which plugins/types appear in the UI and how `/devices/:id` matching behaves; functionality is UI-only and covered by new tests.
> 
> **Overview**
> Adds a **plugin-registered device setup wizard** capability via a new `deviceWizard` plugin component, exposing `wizardOptions`/`getByPluginType` from `useDevicesPlugins` and ensuring wizard-only elements don’t appear in normal device-type `options`.
> 
> Introduces a new `/devices/wizard/:type` route (with a `wizard` redirect guard to avoid clashing with `:id`) and a `view-devices-wizard` host that renders the devices-scoped wizard component or an *entity-not-found* fallback.
> 
> Updates the devices list view to show a **Wizard** button when any enabled wizard plugins exist, auto-navigating when there’s only one wizard or opening a selection dialog otherwise; adds related i18n strings and new unit tests for plugins, routing, and views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d820821d19b90da10b6d2f163b738bf939e0f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->