### PR TITLE
feat(devices): add Shelly NG discovery wizard

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -152,6 +152,8 @@ export type DevicesShellyNgPluginConfigSchema = components['schemas']['DevicesSh
 export type DevicesShellyNgPluginCreateDeviceSchema = components['schemas']['DevicesShellyNgPluginCreateDevice'];
 export type DevicesShellyNgPluginUpdateDeviceSchema = components['schemas']['DevicesShellyNgPluginUpdateDevice'];
 export type DevicesShellyNgPluginDeviceSchema = components['schemas']['DevicesShellyNgPluginDataDevice'];
+export type DevicesShellyNgPluginDiscoveryDeviceSchema = components['schemas']['DevicesShellyNgPluginDataDiscoveryDevice'];
+export type DevicesShellyNgPluginDiscoverySessionSchema = components['schemas']['DevicesShellyNgPluginDataDiscoverySession'];
 export type DevicesShellyNgPluginCreateChannelSchema = components['schemas']['DevicesShellyNgPluginCreateChannel'];
 export type DevicesShellyNgPluginUpdateChannelSchema = components['schemas']['DevicesShellyNgPluginUpdateChannel'];
 export type DevicesShellyNgPluginChannelSchema = components['schemas']['DevicesShellyNgPluginDataChannel'];
@@ -344,6 +346,9 @@ export type StatsModuleGetStatsOperation = operations['get-stats-module-stats'];
 // Devices Shelly NG Plugin Operations
 export type DevicesShellyNgPluginGetSupportedOperation = operations['get-devices-shelly-ng-plugin-supported'];
 export type DevicesShellyNgPluginCreateDeviceInfoOperation = operations['create-devices-shelly-ng-plugin-device-info'];
+export type DevicesShellyNgPluginCreateDiscoveryOperation = operations['create-devices-shelly-ng-plugin-discovery'];
+export type DevicesShellyNgPluginGetDiscoveryOperation = operations['get-devices-shelly-ng-plugin-discovery'];
+export type DevicesShellyNgPluginCreateDiscoveryManualOperation = operations['create-devices-shelly-ng-plugin-discovery-manual'];
 
 // Devices Shelly V1 Plugin Operations
 export type DevicesShellyV1PluginGetSupportedOperation = operations['get-devices-shelly-v1-plugin-supported'];

--- a/apps/admin/src/plugins/devices-shelly-ng/components/components.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/components.ts
@@ -1,5 +1,6 @@
 export { default as ShellyNgDeviceAddForm } from './shelly-ng-device-add-form.vue';
 export { default as ShellyNgDeviceEditForm } from './shelly-ng-device-edit-form.vue';
+export { default as ShellyNgDevicesWizard } from './shelly-ng-devices-wizard.vue';
 export { default as ShellyNgConfigForm } from './shelly-ng-config-form.vue';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -1,0 +1,351 @@
+<template>
+	<section class="flex flex-col gap-4">
+		<el-steps
+			:active="activeStepIndex"
+			finish-status="success"
+			align-center
+		>
+			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.discovery')" />
+			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.categories')" />
+			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.results')" />
+		</el-steps>
+
+		<template v-if="activeStep === 'discovery'">
+			<el-alert
+				:title="t('devicesShellyNgPlugin.texts.wizard.discovery')"
+				type="info"
+				:closable="false"
+				show-icon
+			/>
+
+			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+				<div class="flex min-w-0 flex-1 flex-col gap-1">
+					<el-text>
+						{{ t('devicesShellyNgPlugin.texts.wizard.scanStatus', { count: devices.length }) }}
+					</el-text>
+					<el-progress
+						:percentage="scanPercentage"
+						:status="session?.status === 'finished' ? 'success' : undefined"
+					/>
+				</div>
+
+				<el-button
+					:loading="formResult === FormResult.WORKING"
+					@click="startDiscovery"
+				>
+					<template #icon>
+						<icon icon="mdi:radar" />
+					</template>
+					{{ t('devicesShellyNgPlugin.buttons.wizard.restart.title') }}
+				</el-button>
+			</div>
+
+			<el-form
+				:model="manual"
+				label-position="top"
+				class="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+				@submit.prevent="addManualDevice"
+			>
+				<el-form-item
+					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+					class="mb-0!"
+				>
+					<el-input
+						v-model="manual.hostname"
+						:placeholder="t('devicesShellyNgPlugin.fields.devices.hostname.placeholder')"
+						name="hostname"
+					/>
+				</el-form-item>
+
+				<el-form-item
+					:label="t('devicesShellyNgPlugin.fields.devices.password.title')"
+					class="mb-0!"
+				>
+					<el-input
+						v-model="manual.password"
+						:placeholder="t('devicesShellyNgPlugin.fields.devices.password.placeholder')"
+						name="password"
+						show-password
+					/>
+				</el-form-item>
+
+				<el-form-item class="mb-0! md:self-end">
+					<el-button
+						type="primary"
+						native-type="submit"
+						:disabled="manual.hostname.trim().length === 0"
+						:loading="formResult === FormResult.WORKING"
+					>
+						<template #icon>
+							<icon icon="mdi:plus" />
+						</template>
+						{{ t('devicesShellyNgPlugin.buttons.wizard.addManual.title') }}
+					</el-button>
+				</el-form-item>
+			</el-form>
+
+			<el-table
+				:data="devices"
+				class="w-full"
+				:empty-text="t('devicesShellyNgPlugin.texts.wizard.noDevices')"
+			>
+				<el-table-column
+					prop="hostname"
+					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+					min-width="150"
+				/>
+				<el-table-column
+					:label="t('devicesShellyNgPlugin.headings.device.model')"
+					min-width="180"
+				>
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<span>{{ row.displayName || row.model || row.hostname }}</span>
+					</template>
+				</el-table-column>
+				<el-table-column
+					:label="t('devicesShellyNgPlugin.headings.wizard.status')"
+					width="170"
+				>
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<el-tag :type="statusTagType(row.status)">
+							{{ t(`devicesShellyNgPlugin.statuses.wizard.${row.status}`) }}
+						</el-tag>
+					</template>
+				</el-table-column>
+				<el-table-column
+					:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
+					min-width="220"
+				>
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<span v-if="row.status !== 'ready'">-</span>
+						<el-select
+							v-else
+							v-model="categoryByHostname[row.hostname]"
+							:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
+							filterable
+						>
+							<el-option
+								v-for="item in categoryOptions(row)"
+								:key="item.value"
+								:label="item.label"
+								:value="item.value"
+							/>
+						</el-select>
+					</template>
+				</el-table-column>
+			</el-table>
+
+			<div class="flex justify-end">
+				<el-button
+					type="primary"
+					:disabled="!canContinue"
+					@click="activeStep = 'categories'"
+				>
+					{{ t('devicesShellyNgPlugin.buttons.next.title') }}
+				</el-button>
+			</div>
+		</template>
+
+		<template v-else-if="activeStep === 'categories'">
+			<el-alert
+				:title="t('devicesShellyNgPlugin.texts.wizard.categories')"
+				type="info"
+				:closable="false"
+				show-icon
+			/>
+
+			<el-table
+				:data="readyDevices"
+				class="w-full"
+			>
+				<el-table-column width="70">
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<el-checkbox v-model="selected[row.hostname]" />
+					</template>
+				</el-table-column>
+				<el-table-column
+					:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
+					min-width="220"
+				>
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<el-input v-model="nameByHostname[row.hostname]" />
+					</template>
+				</el-table-column>
+				<el-table-column
+					prop="hostname"
+					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+					min-width="150"
+				/>
+				<el-table-column
+					:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
+					min-width="240"
+				>
+					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+						<el-select
+							v-model="categoryByHostname[row.hostname]"
+							:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
+							filterable
+						>
+							<el-option
+								v-for="item in categoryOptions(row)"
+								:key="item.value"
+								:label="item.label"
+								:value="item.value"
+							/>
+						</el-select>
+					</template>
+				</el-table-column>
+			</el-table>
+
+			<div class="flex justify-between gap-3">
+				<el-button @click="activeStep = 'discovery'">
+					{{ t('devicesModule.buttons.back.title') }}
+				</el-button>
+				<el-button
+					type="primary"
+					:disabled="!canContinue"
+					:loading="formResult === FormResult.WORKING"
+					@click="onAdopt"
+				>
+					<template #icon>
+						<icon icon="mdi:check" />
+					</template>
+					{{ t('devicesShellyNgPlugin.buttons.wizard.adopt.title') }}
+				</el-button>
+			</div>
+		</template>
+
+		<template v-else>
+			<el-result
+				:icon="adoptionResults.some((result) => result.status === 'failed') ? 'warning' : 'success'"
+				:title="t('devicesShellyNgPlugin.headings.wizard.results')"
+			>
+				<template #sub-title>
+					<div class="flex flex-col gap-2">
+						<div
+							v-for="result in adoptionResults"
+							:key="result.hostname"
+							class="flex items-center justify-center gap-2"
+						>
+							<el-tag :type="result.status === 'created' ? 'success' : 'danger'">
+								{{ t(`devicesShellyNgPlugin.statuses.wizard.${result.status}`) }}
+							</el-tag>
+							<span>{{ result.name }} ({{ result.hostname }})</span>
+						</div>
+					</div>
+				</template>
+				<template #extra>
+					<el-button
+						type="primary"
+						@click="router.push({ name: DevicesRouteNames.DEVICES })"
+					>
+						{{ t('devicesShellyNgPlugin.buttons.wizard.finish.title') }}
+					</el-button>
+				</template>
+			</el-result>
+		</template>
+	</section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+
+import {
+	ElAlert,
+	ElButton,
+	ElCheckbox,
+	ElForm,
+	ElFormItem,
+	ElInput,
+	ElOption,
+	ElProgress,
+	ElResult,
+	ElSelect,
+	ElStep,
+	ElSteps,
+	ElTable,
+	ElTableColumn,
+	ElTag,
+	ElText,
+} from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import { FormResult, RouteNames as DevicesRouteNames } from '../../../modules/devices';
+import { useDevicesWizard } from '../composables/composables';
+import type { IShellyNgDiscoveryDevice } from '../schemas/devices.types';
+
+defineOptions({
+	name: 'ShellyNgDevicesWizard',
+});
+
+const { t } = useI18n();
+const router = useRouter();
+const {
+	session,
+	devices,
+	manual,
+	selected,
+	categoryByHostname,
+	nameByHostname,
+	adoptionResults,
+	canContinue,
+	formResult,
+	startDiscovery,
+	addManualDevice,
+	adoptSelected,
+	categoryOptions,
+} = useDevicesWizard();
+
+const activeStep = ref<'discovery' | 'categories' | 'results'>('discovery');
+
+const activeStepIndex = computed<number>(() => {
+	if (activeStep.value === 'categories') {
+		return 1;
+	}
+
+	if (activeStep.value === 'results') {
+		return 2;
+	}
+
+	return 0;
+});
+
+const readyDevices = computed<IShellyNgDiscoveryDevice[]>(() => devices.value.filter((device) => device.status === 'ready'));
+
+const scanPercentage = computed<number>(() => {
+	if (session.value === null) {
+		return 0;
+	}
+
+	const startedAt = new Date(session.value.startedAt).getTime();
+	const expiresAt = new Date(session.value.expiresAt).getTime();
+	const total = Math.max(1, expiresAt - startedAt);
+	const remaining = Math.max(0, session.value.remainingSeconds * 1_000);
+
+	return Math.min(100, Math.max(0, Math.round(((total - remaining) / total) * 100)));
+});
+
+const statusTagType = (status: IShellyNgDiscoveryDevice['status']): 'success' | 'warning' | 'info' | 'danger' => {
+	if (status === 'ready') {
+		return 'success';
+	}
+
+	if (status === 'checking') {
+		return 'info';
+	}
+
+	if (status === 'needs_password' || status === 'already_registered') {
+		return 'warning';
+	}
+
+	return 'danger';
+};
+
+const onAdopt = async (): Promise<void> => {
+	await adoptSelected();
+	activeStep.value = 'results';
+};
+</script>

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/composables.ts
@@ -1,5 +1,6 @@
 export * from './useDeviceAddForm';
 export * from './useDeviceEditForm';
+export * from './useDevicesWizard';
 export * from './useSupportedDevices';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { DEVICES_SHELLY_NG_PLUGIN_PREFIX, DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import type { IShellyNgDiscoverySession } from '../schemas/devices.types';
+
+import { useDevicesWizard } from './useDevicesWizard';
+
+const mockAdd = vi.fn();
+
+const backendClient = {
+	GET: vi.fn(),
+	POST: vi.fn(),
+};
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual('@vueuse/core');
+
+	return {
+		...actual,
+		tryOnMounted: vi.fn(),
+		tryOnUnmounted: vi.fn(),
+	};
+});
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({ global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => {} } }),
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		injectStoresManager: () => ({
+			getStore: () => ({
+				add: mockAdd,
+			}),
+		}),
+		useBackend: () => ({
+			client: backendClient,
+		}),
+		useFlashMessage: () => ({
+			error: vi.fn(),
+			success: vi.fn(),
+		}),
+	};
+});
+
+const discoverySession: IShellyNgDiscoverySession = {
+	id: 'session-1',
+	status: 'running',
+	startedAt: '2026-04-29T12:00:00.000Z',
+	expiresAt: '2026-04-29T12:00:30.000Z',
+	remainingSeconds: 30,
+	devices: [
+		{
+			identifier: 'shellyplus1-aabbcc',
+			hostname: '192.168.1.10',
+			name: 'Kitchen relay',
+			model: 'SNSW-001X16EU',
+			displayName: 'Shelly Plus 1',
+			firmware: '1.2.3',
+			status: 'ready',
+			source: 'mdns',
+			categories: [DevicesModuleDeviceCategory.lighting, DevicesModuleDeviceCategory.switcher],
+			suggestedCategory: DevicesModuleDeviceCategory.lighting,
+			authentication: {
+				enabled: false,
+				domain: null,
+			},
+			registeredDeviceId: null,
+			registeredDeviceName: null,
+			error: null,
+			lastSeenAt: '2026-04-29T12:00:01.000Z',
+		},
+	],
+};
+
+describe('useDevicesWizard', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		mockAdd.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('starts discovery and prepares ready devices for adoption', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
+		expect(wizard.session.value?.id).toBe('session-1');
+		expect(wizard.selected['192.168.1.10']).toBe(true);
+		expect(wizard.categoryByHostname['192.168.1.10']).toBe(DevicesModuleDeviceCategory.lighting);
+		expect(wizard.canContinue.value).toBe(true);
+	});
+
+	it('adds a manual lookup to an existing discovery session', async () => {
+		backendClient.POST
+			.mockResolvedValueOnce({
+				data: {
+					data: {
+						...discoverySession,
+						devices: [],
+					},
+				},
+				response: { status: 200 },
+			})
+			.mockResolvedValueOnce({
+				data: {
+					data: discoverySession,
+				},
+				response: { status: 200 },
+			});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		wizard.manual.hostname = '192.168.1.10';
+		wizard.manual.password = 'secret';
+
+		await wizard.addManualDevice();
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(`/plugins/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery/{id}/manual`, {
+			params: {
+				path: {
+					id: 'session-1',
+				},
+			},
+			body: {
+				data: {
+					hostname: '192.168.1.10',
+					password: 'secret',
+				},
+			},
+		});
+		expect(wizard.manual.hostname).toBe('');
+		expect(wizard.devices.value).toHaveLength(1);
+	});
+
+	it('adopts selected ready devices through the devices store', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+		await wizard.adoptSelected();
+
+		expect(mockAdd).toHaveBeenCalledWith({
+			id: expect.any(String),
+			draft: false,
+			data: expect.objectContaining({
+				type: DEVICES_SHELLY_NG_TYPE,
+				category: DevicesModuleDeviceCategory.lighting,
+				identifier: 'shellyplus1-aabbcc',
+				name: 'Kitchen relay',
+				password: null,
+				wifiAddress: '192.168.1.10',
+			}),
+		});
+		expect(wizard.adoptionResults.value).toEqual([
+			expect.objectContaining({
+				hostname: '192.168.1.10',
+				name: 'Kitchen relay',
+				status: 'created',
+			}),
+		]);
+	});
+});

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -1,0 +1,316 @@
+import { type ComputedRef, type Reactive, computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { orderBy } from 'natural-orderby';
+import { v4 as uuid } from 'uuid';
+
+import { tryOnMounted, tryOnUnmounted } from '@vueuse/core';
+
+import { getErrorReason, injectStoresManager, useBackend, useFlashMessage } from '../../../common';
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { FormResult, type FormResultType, devicesStoreKey } from '../../../modules/devices';
+import {
+	DevicesModuleDeviceCategory,
+	type DevicesShellyNgPluginCreateDiscoveryManualOperation,
+	type DevicesShellyNgPluginCreateDiscoveryOperation,
+	type DevicesShellyNgPluginGetDiscoveryOperation,
+} from '../../../openapi.constants';
+import { DEVICES_SHELLY_NG_PLUGIN_PREFIX, DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import { DevicesShellyNgApiException } from '../devices-shelly-ng.exceptions';
+import type { IShellyNgDiscoveryDevice, IShellyNgDiscoverySession } from '../schemas/devices.types';
+import { transformDeviceInfoRequest, transformDiscoverySessionResponse } from '../utils/devices.transformers';
+
+export interface IShellyNgWizardAdoptionResult {
+	hostname: string;
+	name: string;
+	status: 'created' | 'failed';
+	error: string | null;
+}
+
+export interface IUseDevicesWizard {
+	session: ComputedRef<IShellyNgDiscoverySession | null>;
+	devices: ComputedRef<IShellyNgDiscoveryDevice[]>;
+	selectedDevices: ComputedRef<IShellyNgDiscoveryDevice[]>;
+	formResult: ComputedRef<FormResultType>;
+	manual: Reactive<{
+		hostname: string;
+		password: string;
+	}>;
+	selected: Reactive<Record<string, boolean>>;
+	categoryByHostname: Reactive<Record<string, DevicesModuleDeviceCategory | null>>;
+	nameByHostname: Reactive<Record<string, string>>;
+	adoptionResults: ComputedRef<IShellyNgWizardAdoptionResult[]>;
+	canContinue: ComputedRef<boolean>;
+	startDiscovery: () => Promise<void>;
+	refreshDiscovery: () => Promise<void>;
+	addManualDevice: () => Promise<void>;
+	adoptSelected: () => Promise<IShellyNgWizardAdoptionResult[]>;
+	categoryOptions: (device: IShellyNgDiscoveryDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+}
+
+export const useDevicesWizard = (): IUseDevicesWizard => {
+	const { t } = useI18n();
+	const backend = useBackend();
+	const storesManager = injectStoresManager();
+	const flashMessage = useFlashMessage();
+	const devicesStore = storesManager.getStore(devicesStoreKey);
+
+	const session = ref<IShellyNgDiscoverySession | null>(null);
+	const formResult = ref<FormResultType>(FormResult.NONE);
+	const adoptionResults = ref<IShellyNgWizardAdoptionResult[]>([]);
+	const selected = reactive<Record<string, boolean>>({});
+	const categoryByHostname = reactive<Record<string, DevicesModuleDeviceCategory | null>>({});
+	const nameByHostname = reactive<Record<string, string>>({});
+	const passwordByHostname = reactive<Record<string, string | null>>({});
+	const manual = reactive({
+		hostname: '',
+		password: '',
+	});
+
+	let pollingTimer: number | null = null;
+
+	const devices = computed<IShellyNgDiscoveryDevice[]>(() =>
+		orderBy(session.value?.devices ?? [], [(device) => device.status === 'ready' ? 0 : 1, (device) => device.hostname], ['asc', 'asc'])
+	);
+
+	const selectedDevices = computed<IShellyNgDiscoveryDevice[]>(() =>
+		devices.value.filter(
+			(device) => selected[device.hostname] === true && device.status === 'ready' && categoryByHostname[device.hostname] !== null
+		)
+	);
+
+	const canContinue = computed<boolean>(() => selectedDevices.value.length > 0);
+
+	const startPolling = (): void => {
+		stopPolling();
+
+		pollingTimer = window.setInterval(() => {
+			refreshDiscovery().catch(() => {
+				// User can trigger discovery again if polling fails.
+			});
+		}, 1_000);
+	};
+
+	const stopPolling = (): void => {
+		if (pollingTimer !== null) {
+			window.clearInterval(pollingTimer);
+			pollingTimer = null;
+		}
+	};
+
+	const applySession = (nextSession: IShellyNgDiscoverySession): void => {
+		session.value = nextSession;
+
+		for (const device of nextSession.devices) {
+			if (selected[device.hostname] === undefined) {
+				selected[device.hostname] = device.status === 'ready';
+			}
+
+			if (categoryByHostname[device.hostname] === undefined) {
+				categoryByHostname[device.hostname] = device.suggestedCategory;
+			}
+
+			if (nameByHostname[device.hostname] === undefined) {
+				nameByHostname[device.hostname] = device.name ?? device.displayName ?? device.hostname;
+			}
+		}
+
+		if (nextSession.status !== 'running') {
+			stopPolling();
+		}
+	};
+
+	const startDiscovery = async (): Promise<void> => {
+		formResult.value = FormResult.WORKING;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformDiscoverySessionResponse(responseData.data));
+			formResult.value = FormResult.NONE;
+			startPolling();
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyNgPluginCreateDiscoveryOperation>(error, t('devicesShellyNgPlugin.messages.wizard.discoveryNotStarted'))
+			: t('devicesShellyNgPlugin.messages.wizard.discoveryNotStarted');
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesShellyNgApiException(errorReason, response.status);
+	};
+
+	const refreshDiscovery = async (): Promise<void> => {
+		if (session.value === null) {
+			return;
+		}
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.GET(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery/{id}`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformDiscoverySessionResponse(responseData.data));
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyNgPluginGetDiscoveryOperation>(error, t('devicesShellyNgPlugin.messages.wizard.discoveryNotLoaded'))
+			: t('devicesShellyNgPlugin.messages.wizard.discoveryNotLoaded');
+
+		throw new DevicesShellyNgApiException(errorReason, response.status);
+	};
+
+	const addManualDevice = async (): Promise<void> => {
+		if (session.value === null) {
+			await startDiscovery();
+		}
+
+		if (session.value === null || manual.hostname.trim().length === 0) {
+			return;
+		}
+
+		formResult.value = FormResult.WORKING;
+
+		const hostname = manual.hostname.trim();
+		const password = manual.password.trim() || null;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery/{id}/manual`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+			body: {
+				data: transformDeviceInfoRequest({
+					hostname,
+					password,
+				}),
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			passwordByHostname[hostname] = password;
+			manual.hostname = '';
+			manual.password = '';
+			applySession(transformDiscoverySessionResponse(responseData.data));
+			formResult.value = FormResult.NONE;
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyNgPluginCreateDiscoveryManualOperation>(
+					error,
+					t('devicesShellyNgPlugin.messages.wizard.manualNotAdded')
+				)
+			: t('devicesShellyNgPlugin.messages.wizard.manualNotAdded');
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesShellyNgApiException(errorReason, response.status);
+	};
+
+	const adoptSelected = async (): Promise<IShellyNgWizardAdoptionResult[]> => {
+		formResult.value = FormResult.WORKING;
+
+		const results: IShellyNgWizardAdoptionResult[] = [];
+
+		for (const device of selectedDevices.value) {
+			const id = uuid().toString();
+			const name = nameByHostname[device.hostname] || device.name || device.displayName || device.hostname;
+
+			try {
+				await devicesStore.add({
+					id,
+					draft: false,
+					data: {
+						id,
+						type: DEVICES_SHELLY_NG_TYPE,
+						category: categoryByHostname[device.hostname] as DevicesModuleDeviceCategory,
+						identifier: device.identifier,
+						name,
+						description: null,
+						enabled: true,
+						password: passwordByHostname[device.hostname] ?? null,
+						wifiAddress: device.hostname,
+					},
+				});
+
+				results.push({
+					hostname: device.hostname,
+					name,
+					status: 'created',
+					error: null,
+				});
+			} catch (error: unknown) {
+				results.push({
+					hostname: device.hostname,
+					name,
+					status: 'failed',
+					error: error instanceof Error ? error.message : t('devicesShellyNgPlugin.messages.wizard.adoptionNotCreated'),
+				});
+			}
+		}
+
+		adoptionResults.value = results;
+		formResult.value = results.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
+
+		return results;
+	};
+
+	const categoryOptions = (device: IShellyNgDiscoveryDevice): { value: DevicesModuleDeviceCategory; label: string }[] =>
+		orderBy(device.categories, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map((value) => ({
+			value,
+			label: t(`devicesModule.categories.devices.${value}`),
+		}));
+
+	tryOnMounted(() => {
+		startDiscovery().catch(() => {
+			// The message is already surfaced to the user.
+		});
+	});
+
+	tryOnUnmounted(() => {
+		stopPolling();
+	});
+
+	return {
+		session: computed(() => session.value),
+		devices,
+		selectedDevices,
+		formResult: computed(() => formResult.value),
+		manual,
+		selected,
+		categoryByHostname,
+		nameByHostname,
+		adoptionResults: computed(() => adoptionResults.value),
+		canContinue,
+		startDiscovery,
+		refreshDiscovery,
+		addManualDevice,
+		adoptSelected,
+		categoryOptions,
+	};
+};

--- a/apps/admin/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
@@ -15,7 +15,7 @@ import {
 	type IDevicePluginsSchemas,
 } from '../../modules/devices';
 
-import { ShellyNgConfigForm, ShellyNgDeviceAddForm, ShellyNgDeviceEditForm } from './components/components';
+import { ShellyNgConfigForm, ShellyNgDeviceAddForm, ShellyNgDeviceEditForm, ShellyNgDevicesWizard } from './components/components';
 import { DEVICES_SHELLY_NG_PLUGIN_NAME, DEVICES_SHELLY_NG_TYPE } from './devices-shelly-ng.constants';
 import { locales } from './locales';
 import { ShellyNgConfigEditFormSchema } from './schemas/config.schemas';
@@ -75,6 +75,7 @@ export default {
 					components: {
 						deviceAddForm: ShellyNgDeviceAddForm,
 						deviceEditForm: ShellyNgDeviceEditForm,
+						deviceWizard: ShellyNgDevicesWizard,
 					},
 					schemas: {
 						deviceSchema: ShellyNgDeviceSchema,

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
@@ -10,6 +10,12 @@
 			"notSupported": "Je nám líto, vaše zařízení není podporováno",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"discovery": "Vyhledávání",
+			"categories": "Kategorie",
+			"results": "Výsledky",
+			"status": "Stav"
 		}
 	},
 	"fields": {
@@ -108,16 +114,53 @@
 			"edited": "Změny uloženy! Zařízení Shelly Next-Generation: {device} bylo aktualizováno.",
 			"notEdited": "Něco se pokazilo. Aktualizace zařízení Shelly Next-Generation nebyla úspěšná.",
 			"failedLoadSupportedDevices": "Něco se pokazilo. Nepodařilo se načíst podporovaná zařízení pluginu."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Něco se pokazilo. Vyhledávání Shelly se nepodařilo spustit.",
+			"discoveryNotLoaded": "Něco se pokazilo. Vyhledávání Shelly se nepodařilo načíst.",
+			"manualNotAdded": "Něco se pokazilo. Ruční vyhledání zařízení Shelly se nepodařilo přidat.",
+			"adoptionNotCreated": "Něco se pokazilo. Zařízení Shelly se nepodařilo adoptovat."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Povolte nebo zakažte integraci zařízení Shelly Next Generation. Pokud je povolena, zařízení Shelly mohou být vyhledána a ovládána prostřednictvím Smart Panelu.",
 		"aboutMdns": "Nakonfigurujte, jak plugin vyhledává zařízení Shelly ve vaší lokální síti pomocí Multicast DNS (mDNS). To umožňuje automatickou detekci bez nutnosti ručního zadávání IP adres.",
-		"aboutWebsockets": "Spravujte parametry WebSocket připojení pro zařízení Shelly. Tato nastavení řídí stabilitu komunikace, zpracování požadavků a chování opětovného připojení."
+		"aboutWebsockets": "Spravujte parametry WebSocket připojení pro zařízení Shelly. Tato nastavení řídí stabilitu komunikace, zpracování požadavků a chování opětovného připojení.",
+		"wizard": {
+			"discovery": "Průvodce vyhledá zařízení Shelly NG v lokální síti a přijímá také ručně zadaný hostname nebo IP adresu.",
+			"categories": "Potvrďte, která připravená zařízení mají být adoptována, a vyberte cílovou kategorii pro každé z nich.",
+			"scanStatus": "Nalezeno zařízení: {count}",
+			"noDevices": "Nebyla nalezena žádná zařízení Shelly"
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Další"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Vyhledat znovu"
+			},
+			"addManual": {
+				"title": "Přidat"
+			},
+			"adopt": {
+				"title": "Adoptovat vybrané"
+			},
+			"finish": {
+				"title": "Zpět na zařízení"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Kontrola",
+			"ready": "Připraveno",
+			"needs_password": "Vyžaduje heslo",
+			"already_registered": "Registrováno",
+			"unsupported": "Nepodporováno",
+			"failed": "Selhalo",
+			"created": "Vytvořeno"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
@@ -10,6 +10,12 @@
       "notSupported": "Leider wird Ihr Gerät nicht unterstützt",
       "model": "Modell",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
   },
   "fields": {
@@ -108,16 +114,53 @@
       "edited": "Änderungen gespeichert! Das Shelly Next-Generation-Gerät: {device} wurde aktualisiert.",
       "notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung des Shelly Next-Generation-Geräts war nicht erfolgreich.",
       "failedLoadSupportedDevices": "Etwas ist schiefgelaufen. Die unterstützten Geräte des Plugins konnten nicht geladen werden."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Aktivieren oder deaktivieren Sie die Shelly Next Generation Geräteintegration. Wenn aktiviert, können Shelly-Geräte über das Smart Panel erkannt und gesteuert werden.",
     "aboutMdns": "Konfigurieren Sie, wie das Plugin Shelly-Geräte in Ihrem lokalen Netzwerk über Multicast DNS (mDNS) erkennt. Dies ermöglicht die automatische Erkennung ohne manuelle Eingabe von IP-Adressen.",
-    "aboutWebsockets": "Verwalten Sie WebSocket-Verbindungsparameter für Shelly-Geräte. Diese Einstellungen steuern Kommunikationsstabilität, Anfrageverarbeitung und Wiederverbindungsverhalten."
+    "aboutWebsockets": "Verwalten Sie WebSocket-Verbindungsparameter für Shelly-Geräte. Diese Einstellungen steuern Kommunikationsstabilität, Anfrageverarbeitung und Wiederverbindungsverhalten.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found"
+    }
   },
   "buttons": {
     "next": {
       "title": "Weiter"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
@@ -10,6 +10,12 @@
       "notSupported": "We are sorry, you device is not supported",
       "model": "Model",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
   },
   "fields": {
@@ -116,16 +122,53 @@
       "edited": "Changes saved! The Shelly Next-Generation device: {device} has been updated.",
       "notEdited": "Something went wrong. Shelly Next-Generation device update was not successful.",
       "failedLoadSupportedDevices": "Something went wrong. Plugin supported devices could not be loaded."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Enable or disable the Shelly Next Generation device integration. When enabled, Shelly devices can be discovered and controlled through the Smart Panel.",
     "aboutMdns": "Configure how the plugin discovers Shelly devices on your local network using Multicast DNS (mDNS). This enables automatic detection without needing to manually enter IP addresses.",
-    "aboutWebsockets": "Manage WebSocket connection parameters for Shelly devices. These settings control communication stability, request handling, and reconnection behavior."
+    "aboutWebsockets": "Manage WebSocket connection parameters for Shelly devices. These settings control communication stability, request handling, and reconnection behavior.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found"
+    }
   },
   "buttons": {
     "next": {
       "title": "Next"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
@@ -10,6 +10,12 @@
       "notSupported": "Lo sentimos, su dispositivo no es compatible",
       "model": "Modelo",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
   },
   "fields": {
@@ -108,16 +114,53 @@
       "edited": "¡Cambios guardados! El dispositivo Shelly Next-Generation: {device} ha sido actualizado.",
       "notEdited": "Algo salió mal. La actualización del dispositivo Shelly Next-Generation no fue exitosa.",
       "failedLoadSupportedDevices": "Algo salió mal. No se pudieron cargar los dispositivos compatibles del plugin."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Habilitar o deshabilitar la integración de dispositivos Shelly Next Generation. Cuando está habilitado, los dispositivos Shelly pueden ser descubiertos y controlados a través del Smart Panel.",
     "aboutMdns": "Configure cómo el plugin descubre dispositivos Shelly en su red local usando DNS Multidifusión (mDNS). Esto permite la detección automática sin necesidad de introducir direcciones IP manualmente.",
-    "aboutWebsockets": "Gestione los parámetros de conexión WebSocket para los dispositivos Shelly. Estos ajustes controlan la estabilidad de la comunicación, el manejo de solicitudes y el comportamiento de reconexión."
+    "aboutWebsockets": "Gestione los parámetros de conexión WebSocket para los dispositivos Shelly. Estos ajustes controlan la estabilidad de la comunicación, el manejo de solicitudes y el comportamiento de reconexión.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found"
+    }
   },
   "buttons": {
     "next": {
       "title": "Siguiente"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
@@ -10,6 +10,12 @@
 			"notSupported": "Przepraszamy, Twoje urzadzenie nie jest obslugiwane",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"discovery": "Discovery",
+			"categories": "Categories",
+			"results": "Results",
+			"status": "Status"
 		}
 	},
 	"fields": {
@@ -108,16 +114,53 @@
 			"edited": "Zmiany zapisane! Urzadzenie Shelly Next-Generation: {device} zostalo zaktualizowane.",
 			"notEdited": "Cos poszlo nie tak. Aktualizacja urzadzenia Shelly Next-Generation nie powiodla sie.",
 			"failedLoadSupportedDevices": "Cos poszlo nie tak. Obslugiwane urzadzenia wtyczki nie mogly zostac zaladowane."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Wlacz lub wylacz integracje urzadzen Shelly Next Generation. Po wlaczeniu urzadzenia Shelly moga byc wykrywane i sterowane przez Smart Panel.",
 		"aboutMdns": "Skonfiguruj, jak wtyczka wykrywa urzadzenia Shelly w sieci lokalnej za pomoca Multicast DNS (mDNS). Umozliwia to automatyczne wykrywanie bez koniecznosci recznego wprowadzania adresow IP.",
-		"aboutWebsockets": "Zarzadzaj parametrami polaczenia WebSocket dla urzadzen Shelly. Te ustawienia kontroluja stabilnosc komunikacji, obsluge zadan i zachowanie ponownego polaczenia."
+		"aboutWebsockets": "Zarzadzaj parametrami polaczenia WebSocket dla urzadzen Shelly. Te ustawienia kontroluja stabilnosc komunikacji, obsluge zadan i zachowanie ponownego polaczenia.",
+		"wizard": {
+			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+			"scanStatus": "{count} devices found",
+			"noDevices": "No Shelly devices found"
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Dalej"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Scan again"
+			},
+			"addManual": {
+				"title": "Add"
+			},
+			"adopt": {
+				"title": "Adopt selected"
+			},
+			"finish": {
+				"title": "Back to devices"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Checking",
+			"ready": "Ready",
+			"needs_password": "Needs password",
+			"already_registered": "Registered",
+			"unsupported": "Unsupported",
+			"failed": "Failed",
+			"created": "Created"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
@@ -10,6 +10,12 @@
 			"notSupported": "Ľutujeme, vaše zariadenie nie je podporované",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"discovery": "Vyhľadávanie",
+			"categories": "Kategórie",
+			"results": "Výsledky",
+			"status": "Stav"
 		}
 	},
 	"fields": {
@@ -108,16 +114,53 @@
 			"edited": "Zmeny uložené! Zariadenie Shelly Next-Generation: {device} bolo aktualizované.",
 			"notEdited": "Niečo sa pokazilo. Aktualizácia zariadenia Shelly Next-Generation nebola úspešná.",
 			"failedLoadSupportedDevices": "Niečo sa pokazilo. Podporované zariadenia pluginu sa nepodarilo načítať."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Niečo sa pokazilo. Vyhľadávanie Shelly sa nepodarilo spustiť.",
+			"discoveryNotLoaded": "Niečo sa pokazilo. Vyhľadávanie Shelly sa nepodarilo načítať.",
+			"manualNotAdded": "Niečo sa pokazilo. Manuálne vyhľadanie zariadenia Shelly sa nepodarilo pridať.",
+			"adoptionNotCreated": "Niečo sa pokazilo. Zariadenie Shelly sa nepodarilo adoptovať."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Povoľte alebo zakážte integráciu zariadení Shelly Next Generation. Keď je povolená, zariadenia Shelly môžu byť objavené a ovládané cez Smart Panel.",
 		"aboutMdns": "Nakonfigurujte, ako plugin objavuje zariadenia Shelly na vašej lokálnej sieti pomocou Multicast DNS (mDNS). To umožňuje automatickú detekciu bez potreby manuálneho zadávania IP adries.",
-		"aboutWebsockets": "Spravujte parametre WebSocket pripojenia pre zariadenia Shelly. Tieto nastavenia ovládajú stabilitu komunikácie, spracovanie požiadaviek a správanie pri opätovnom pripojení."
+		"aboutWebsockets": "Spravujte parametre WebSocket pripojenia pre zariadenia Shelly. Tieto nastavenia ovládajú stabilitu komunikácie, spracovanie požiadaviek a správanie pri opätovnom pripojení.",
+		"wizard": {
+			"discovery": "Sprievodca vyhľadá zariadenia Shelly NG v lokálnej sieti a prijíma aj manuálne zadaný hostname alebo IP adresu.",
+			"categories": "Potvrďte, ktoré pripravené zariadenia sa majú adoptovať, a vyberte cieľovú kategóriu pre každé z nich.",
+			"scanStatus": "Nájdené zariadenia: {count}",
+			"noDevices": "Neboli nájdené žiadne zariadenia Shelly"
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Ďalej"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Vyhľadať znova"
+			},
+			"addManual": {
+				"title": "Pridať"
+			},
+			"adopt": {
+				"title": "Adoptovať vybrané"
+			},
+			"finish": {
+				"title": "Späť na zariadenia"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Kontrola",
+			"ready": "Pripravené",
+			"needs_password": "Vyžaduje heslo",
+			"already_registered": "Registrované",
+			"unsupported": "Nepodporované",
+			"failed": "Zlyhalo",
+			"created": "Vytvorené"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.schemas.ts
@@ -76,3 +76,33 @@ export const ShellyNgDeviceInfoSchema = z.object({
 		})
 	),
 });
+
+export const ShellyNgDiscoveryDeviceSchema = z.object({
+	identifier: z.string().nullable(),
+	hostname: z.string(),
+	name: z.string().nullable(),
+	model: z.string().nullable(),
+	displayName: z.string().nullable(),
+	firmware: z.string().nullable(),
+	status: z.enum(['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed']),
+	source: z.enum(['mdns', 'manual']),
+	categories: z.array(z.nativeEnum(DevicesModuleDeviceCategory)),
+	suggestedCategory: z.nativeEnum(DevicesModuleDeviceCategory).nullable(),
+	authentication: z.object({
+		enabled: z.boolean(),
+		domain: z.string().nullable().optional(),
+	}),
+	registeredDeviceId: z.string().nullable(),
+	registeredDeviceName: z.string().nullable(),
+	error: z.string().nullable(),
+	lastSeenAt: z.string(),
+});
+
+export const ShellyNgDiscoverySessionSchema = z.object({
+	id: z.string(),
+	status: z.enum(['running', 'finished', 'failed']),
+	startedAt: z.string(),
+	expiresAt: z.string(),
+	remainingSeconds: z.number(),
+	devices: z.array(ShellyNgDiscoveryDeviceSchema),
+});

--- a/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.types.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.types.ts
@@ -5,6 +5,8 @@ import {
 	ShellyNgDeviceEditFormSchema,
 	ShellyNgDeviceInfoRequestSchema,
 	ShellyNgDeviceInfoSchema,
+	ShellyNgDiscoveryDeviceSchema,
+	ShellyNgDiscoverySessionSchema,
 	ShellyNgSupportedDeviceSchema,
 } from './devices.schemas';
 
@@ -17,3 +19,7 @@ export type IShellyNgSupportedDevice = z.infer<typeof ShellyNgSupportedDeviceSch
 export type IShellyNgDeviceInfoRequest = z.infer<typeof ShellyNgDeviceInfoRequestSchema>;
 
 export type IShellyNgDeviceInfo = z.infer<typeof ShellyNgDeviceInfoSchema>;
+
+export type IShellyNgDiscoveryDevice = z.infer<typeof ShellyNgDiscoveryDeviceSchema>;
+
+export type IShellyNgDiscoverySession = z.infer<typeof ShellyNgDiscoverySessionSchema>;

--- a/apps/admin/src/plugins/devices-shelly-ng/utils/devices.transformers.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/utils/devices.transformers.ts
@@ -1,7 +1,17 @@
 import { camelToSnake, logger, snakeToCamel } from '../../../common';
 import { DevicesShellyNgValidationException } from '../devices-shelly-ng.exceptions';
-import { ShellyNgDeviceInfoRequestSchema, ShellyNgDeviceInfoSchema, ShellyNgSupportedDeviceSchema } from '../schemas/devices.schemas';
-import type { IShellyNgDeviceInfo, IShellyNgDeviceInfoRequest, IShellyNgSupportedDevice } from '../schemas/devices.types';
+import {
+	ShellyNgDeviceInfoRequestSchema,
+	ShellyNgDeviceInfoSchema,
+	ShellyNgDiscoverySessionSchema,
+	ShellyNgSupportedDeviceSchema,
+} from '../schemas/devices.schemas';
+import type {
+	IShellyNgDeviceInfo,
+	IShellyNgDeviceInfoRequest,
+	IShellyNgDiscoverySession,
+	IShellyNgSupportedDevice,
+} from '../schemas/devices.types';
 
 export const transformSupportedDevicesResponse = (response: object[]): IShellyNgSupportedDevice[] => {
 	const devices = [];
@@ -40,6 +50,18 @@ export const transformDeviceInfoRequest = (data: object): IShellyNgDeviceInfoReq
 		logger.error('Schema validation failed with:', parsed.error);
 
 		throw new DevicesShellyNgValidationException('Failed to validate get device info request.');
+	}
+
+	return parsed.data;
+};
+
+export const transformDiscoverySessionResponse = (response: object): IShellyNgDiscoverySession => {
+	const parsed = ShellyNgDiscoverySessionSchema.safeParse(snakeToCamel(response));
+
+	if (!parsed.success) {
+		logger.error('Schema validation failed with:', parsed.error);
+
+		throw new DevicesShellyNgValidationException('Failed to validate received discovery session data.');
 	}
 
 	return parsed.data;

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
@@ -12,6 +12,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { MappingLoaderService } from '../mappings';
 import { DeviceManagerService } from '../services/device-manager.service';
+import { ShellyNgDiscoveryService } from '../services/shelly-ng-discovery.service';
 
 import { ShellyNgDevicesController } from './shelly-ng-devices.controller';
 
@@ -47,6 +48,7 @@ jest.mock('../devices-shelly-ng.constants', () => ({
 describe('ShellyNgDevicesController', () => {
 	let controller: ShellyNgDevicesController;
 	let deviceManager: jest.Mocked<DeviceManagerService>;
+	let discoveryService: jest.Mocked<ShellyNgDiscoveryService>;
 
 	beforeAll(() => {});
 
@@ -54,11 +56,17 @@ describe('ShellyNgDevicesController', () => {
 		const deviceManagerMock: Partial<jest.Mocked<DeviceManagerService>> = {
 			getDeviceInfo: jest.fn(),
 		};
+		const discoveryServiceMock: Partial<jest.Mocked<ShellyNgDiscoveryService>> = {
+			start: jest.fn(),
+			get: jest.fn(),
+			manual: jest.fn(),
+		};
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [ShellyNgDevicesController],
 			providers: [
 				{ provide: DeviceManagerService, useValue: deviceManagerMock },
+				{ provide: ShellyNgDiscoveryService, useValue: discoveryServiceMock },
 				{
 					provide: MappingLoaderService,
 					useValue: {
@@ -71,6 +79,59 @@ describe('ShellyNgDevicesController', () => {
 
 		controller = module.get(ShellyNgDevicesController);
 		deviceManager = module.get(DeviceManagerService) as jest.Mocked<DeviceManagerService>;
+		discoveryService = module.get(ShellyNgDiscoveryService) as jest.Mocked<ShellyNgDiscoveryService>;
+	});
+
+	describe('Shelly NG discovery endpoints', () => {
+		const discoverySession = {
+			id: 'session-1',
+			status: 'running' as const,
+			startedAt: '2026-04-29T12:00:00.000Z',
+			expiresAt: '2026-04-29T12:00:30.000Z',
+			remainingSeconds: 30,
+			devices: [],
+		};
+
+		it('starts a discovery session', async () => {
+			discoveryService.start.mockResolvedValue(discoverySession);
+
+			const result = await controller.startDiscovery();
+
+			expect(discoveryService.start).toHaveBeenCalledWith({ duration: 30 });
+			expect(result.data).toEqual(discoverySession);
+		});
+
+		it('returns an existing discovery session', () => {
+			discoveryService.get.mockReturnValue(discoverySession);
+
+			const result = controller.getDiscovery('session-1');
+
+			expect(discoveryService.get).toHaveBeenCalledWith('session-1');
+			expect(result.data).toEqual(discoverySession);
+		});
+
+		it('throws NotFoundException when discovery session does not exist', () => {
+			discoveryService.get.mockReturnValue(null);
+
+			expect(() => controller.getDiscovery('missing')).toThrow(NotFoundException);
+		});
+
+		it('adds manual device lookup to a discovery session', async () => {
+			discoveryService.manual.mockResolvedValue(discoverySession);
+
+			const result = await controller.addManualDiscoveryDevice('session-1', {
+				data: {
+					hostname: '192.168.1.12',
+					password: 'secret',
+				},
+			});
+
+			expect(discoveryService.manual).toHaveBeenCalledWith('session-1', {
+				hostname: '192.168.1.12',
+				password: 'secret',
+			});
+			expect(result.data).toEqual(discoverySession);
+		});
 	});
 
 	afterEach(() => {

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
@@ -1,6 +1,6 @@
 import { validate } from 'class-validator';
 
-import { Body, Controller, Get, NotFoundException, Post, UnprocessableEntityException } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, Post, UnprocessableEntityException } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
@@ -22,11 +22,13 @@ import { DevicesShellyNgPluginReqGetInfo } from '../dto/shelly-ng-get-info.dto';
 import { MappingLoaderService } from '../mappings';
 import {
 	ShellyNgDeviceInfoResponseModel,
+	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
 	ShellyNgSupportedDevicesResponseModel,
 } from '../models/shelly-ng-response.model';
 import { ShellyNgDeviceInfoModel, ShellyNgSupportedDeviceModel } from '../models/shelly-ng.model';
 import { DeviceManagerService } from '../services/device-manager.service';
+import { ShellyNgDiscoveryService } from '../services/shelly-ng-discovery.service';
 
 @ApiTags(DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME)
 @Controller('devices')
@@ -39,7 +41,90 @@ export class ShellyNgDevicesController {
 	constructor(
 		private readonly deviceManagerService: DeviceManagerService,
 		private readonly mappingLoaderService: MappingLoaderService,
+		private readonly discoveryService: ShellyNgDiscoveryService,
 	) {}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME],
+		summary: 'Start Shelly NG discovery wizard scan',
+		description:
+			'Starts a short-lived mDNS discovery session for Shelly Next-Generation devices. The session can be polled by the admin wizard and enriched with manual host lookups.',
+		operationId: 'create-devices-shelly-ng-plugin-discovery',
+	})
+	@ApiSuccessResponse(
+		ShellyNgDiscoverySessionResponseModel,
+		'Shelly NG discovery session was started. The response includes session timing and discovered device candidates.',
+	)
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('discovery')
+	async startDiscovery(): Promise<ShellyNgDiscoverySessionResponseModel> {
+		const response = new ShellyNgDiscoverySessionResponseModel();
+		response.data = await this.discoveryService.start({ duration: 30 });
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME],
+		summary: 'Get Shelly NG discovery wizard scan',
+		description:
+			'Returns the current state of a Shelly NG discovery session, including remaining scan time and discovered device candidates.',
+		operationId: 'get-devices-shelly-ng-plugin-discovery',
+	})
+	@ApiSuccessResponse(ShellyNgDiscoverySessionResponseModel, 'Shelly NG discovery session was successfully retrieved.')
+	@ApiNotFoundResponse('Discovery session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Get('discovery/:id')
+	getDiscovery(@Param('id') id: string): ShellyNgDiscoverySessionResponseModel {
+		const session = this.discoveryService.get(id);
+
+		if (session === null) {
+			throw new NotFoundException('Discovery session could not be found');
+		}
+
+		const response = new ShellyNgDiscoverySessionResponseModel();
+		response.data = session;
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME],
+		summary: 'Add a manual Shelly NG discovery wizard lookup',
+		description:
+			'Adds a manually entered hostname or IP address to an existing Shelly NG discovery session. Password-protected devices can be verified by providing their password.',
+		operationId: 'create-devices-shelly-ng-plugin-discovery-manual',
+	})
+	@ApiBody({
+		type: DevicesShellyNgPluginReqGetInfo,
+		description: 'Manual Shelly NG discovery lookup data',
+	})
+	@ApiSuccessResponse(
+		ShellyNgDiscoverySessionResponseModel,
+		'Manual lookup was added to the Shelly NG discovery session.',
+	)
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiNotFoundResponse('Discovery session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('discovery/:id/manual')
+	async addManualDiscoveryDevice(
+		@Param('id') id: string,
+		@Body() createDto: DevicesShellyNgPluginReqGetInfo,
+	): Promise<ShellyNgDiscoverySessionResponseModel> {
+		const session = await this.discoveryService.manual(id, {
+			hostname: createDto.data.hostname,
+			password: createDto.data.password,
+		});
+
+		if (session === null) {
+			throw new NotFoundException('Discovery session could not be found');
+		}
+
+		const response = new ShellyNgDiscoverySessionResponseModel();
+		response.data = session;
+
+		return response;
+	}
 
 	@ApiOperation({
 		tags: [DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME],

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.openapi.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.openapi.ts
@@ -20,6 +20,7 @@ import {
 import { ShellyNgConfigModel, ShellyNgMdnsConfigModel, ShellyNgWebsocketsConfigModel } from './models/config.model';
 import {
 	ShellyNgDeviceInfoResponseModel,
+	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
 	ShellyNgSupportedDevicesResponseModel,
 } from './models/shelly-ng-response.model';
@@ -27,6 +28,9 @@ import {
 	ShellyNgDeviceInfoAuthenticationModel,
 	ShellyNgDeviceInfoComponentModel,
 	ShellyNgDeviceInfoModel,
+	ShellyNgDiscoveryDeviceAuthenticationModel,
+	ShellyNgDiscoveryDeviceModel,
+	ShellyNgDiscoverySessionModel,
 	ShellyNgMappingReloadCacheStatsModel,
 	ShellyNgMappingReloadModel,
 	ShellyNgSupportedDeviceComponentModel,
@@ -47,9 +51,13 @@ export const DEVICES_SHELLY_NG_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	ShellyNgUpdatePluginConfigWebsocketsDto,
 	// Response models
 	ShellyNgDeviceInfoResponseModel,
+	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
 	ShellyNgSupportedDevicesResponseModel,
 	// Data models
+	ShellyNgDiscoveryDeviceAuthenticationModel,
+	ShellyNgDiscoveryDeviceModel,
+	ShellyNgDiscoverySessionModel,
 	ShellyNgMappingReloadCacheStatsModel,
 	ShellyNgMappingReloadModel,
 	ShellyNgSupportedDeviceComponentModel,

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
@@ -57,6 +57,7 @@ import { ShellyNgDevicePlatform } from './platforms/shelly-ng.device.platform';
 import { DatabaseDiscovererService } from './services/database-discoverer.service';
 import { DeviceAddressService } from './services/device-address.service';
 import { DeviceManagerService } from './services/device-manager.service';
+import { ShellyNgDiscoveryService } from './services/shelly-ng-discovery.service';
 import { ShellyNgService } from './services/shelly-ng.service';
 import { ShellyRpcClientService } from './services/shelly-rpc-client.service';
 import { ShellyWsServerService } from './services/shelly-ws-server.service';
@@ -90,6 +91,7 @@ import { DeviceEntitySubscriber } from './subscribers/device-entity.subscriber';
 		DatabaseDiscovererService,
 		DelegatesManagerService,
 		DeviceManagerService,
+		ShellyNgDiscoveryService,
 		ShellyNgService,
 		ShellyWsServerService,
 		ShellyNgDevicePlatform,

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng-response.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng-response.model.ts
@@ -4,7 +4,12 @@ import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 
-import { ShellyNgDeviceInfoModel, ShellyNgMappingReloadModel, ShellyNgSupportedDeviceModel } from './shelly-ng.model';
+import {
+	ShellyNgDeviceInfoModel,
+	ShellyNgDiscoverySessionModel,
+	ShellyNgMappingReloadModel,
+	ShellyNgSupportedDeviceModel,
+} from './shelly-ng.model';
 
 /**
  * Response wrapper for ShellyNgDeviceInfoModel
@@ -31,6 +36,19 @@ export class ShellyNgSupportedDevicesResponseModel extends BaseSuccessResponseMo
 	})
 	@Expose()
 	declare data: ShellyNgSupportedDeviceModel[];
+}
+
+/**
+ * Response wrapper for ShellyNgDiscoverySessionModel
+ */
+@ApiSchema({ name: 'DevicesShellyNgPluginResDiscoverySession' })
+export class ShellyNgDiscoverySessionResponseModel extends BaseSuccessResponseModel<ShellyNgDiscoverySessionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => ShellyNgDiscoverySessionModel,
+	})
+	@Expose()
+	declare data: ShellyNgDiscoverySessionModel;
 }
 
 /**

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
@@ -234,6 +234,230 @@ export class ShellyNgDeviceInfoModel {
 	@ValidateNested({ each: true })
 	@Type(() => ShellyNgDeviceInfoComponentModel)
 	components: ShellyNgDeviceInfoComponentModel[];
+}
+
+@ApiSchema({ name: 'DevicesShellyNgPluginDataDiscoveryDeviceAuthentication' })
+export class ShellyNgDiscoveryDeviceAuthenticationModel {
+	@ApiProperty({
+		description: 'Whether authentication is enabled',
+		example: false,
+	})
+	@Expose()
+	@IsBoolean()
+	enabled: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Authentication domain',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	domain: string | null;
+}
+
+@ApiSchema({ name: 'DevicesShellyNgPluginDataDiscoveryDevice' })
+export class ShellyNgDiscoveryDeviceModel {
+	@ApiPropertyOptional({
+		description: 'Shelly device identifier',
+		nullable: true,
+		example: 'shellyplus1-a8032abe5084',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	identifier: string | null;
+
+	@ApiProperty({
+		description: 'Discovered hostname or IP address',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	@IsString()
+	hostname: string;
+
+	@ApiPropertyOptional({
+		description: 'Device name',
+		nullable: true,
+		example: 'Kitchen relay',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	name: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Device model',
+		nullable: true,
+		example: 'SNSW-001P16EU',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	model: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Friendly supported-device name',
+		nullable: true,
+		example: 'Shelly Plus 1',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	displayName: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Firmware version',
+		nullable: true,
+		example: '1.0.0',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	firmware: string | null;
+
+	@ApiProperty({
+		description: 'Discovery candidate status',
+		enum: ['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed'],
+		example: 'ready',
+	})
+	@Expose()
+	@IsIn(['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed'])
+	status: string;
+
+	@ApiProperty({
+		description: 'How the candidate was found',
+		enum: ['mdns', 'manual'],
+		example: 'mdns',
+	})
+	@Expose()
+	@IsIn(['mdns', 'manual'])
+	source: string;
+
+	@ApiProperty({
+		description: 'Available target device categories',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(DeviceCategory) },
+		example: [DeviceCategory.LIGHTING, DeviceCategory.SWITCHER],
+	})
+	@Expose()
+	@IsArray()
+	@IsString({ each: true })
+	categories: DeviceCategory[];
+
+	@ApiPropertyOptional({
+		description: 'Suggested target device category when the plugin can infer one',
+		nullable: true,
+		enum: DeviceCategory,
+		example: DeviceCategory.LIGHTING,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	suggestedCategory: DeviceCategory | null;
+
+	@ApiProperty({
+		description: 'Authentication configuration',
+		type: () => ShellyNgDiscoveryDeviceAuthenticationModel,
+	})
+	@Expose()
+	@ValidateNested({ each: true })
+	@Type(() => ShellyNgDiscoveryDeviceAuthenticationModel)
+	authentication: ShellyNgDiscoveryDeviceAuthenticationModel;
+
+	@ApiPropertyOptional({
+		description: 'Already registered device id',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceId: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Already registered device name',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceName: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Error message from the last lookup attempt',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	error: string | null;
+
+	@ApiProperty({
+		description: 'Last time this candidate was observed or checked',
+		example: '2026-04-29T12:00:00.000Z',
+	})
+	@Expose()
+	@IsString()
+	lastSeenAt: string;
+}
+
+@ApiSchema({ name: 'DevicesShellyNgPluginDataDiscoverySession' })
+export class ShellyNgDiscoverySessionModel {
+	@ApiProperty({
+		description: 'Discovery session id',
+		example: 'c66808d8-0af1-4b93-bd61-4131cf62f20f',
+	})
+	@Expose()
+	@IsString()
+	id: string;
+
+	@ApiProperty({
+		description: 'Discovery session status',
+		enum: ['running', 'finished', 'failed'],
+		example: 'running',
+	})
+	@Expose()
+	@IsIn(['running', 'finished', 'failed'])
+	status: string;
+
+	@ApiProperty({
+		description: 'Discovery start timestamp',
+		example: '2026-04-29T12:00:00.000Z',
+	})
+	@Expose()
+	@IsString()
+	startedAt: string;
+
+	@ApiProperty({
+		description: 'Discovery expiry timestamp',
+		example: '2026-04-29T12:00:30.000Z',
+	})
+	@Expose()
+	@IsString()
+	expiresAt: string;
+
+	@ApiProperty({
+		description: 'Remaining discovery time in seconds',
+		example: 30,
+	})
+	@Expose()
+	@IsInt()
+	remainingSeconds: number;
+
+	@ApiProperty({
+		description: 'Discovered Shelly NG device candidates',
+		type: 'array',
+		items: { $ref: getSchemaPath(ShellyNgDiscoveryDeviceModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => ShellyNgDiscoveryDeviceModel)
+	devices: ShellyNgDiscoveryDeviceModel[];
 }
 
 @ApiSchema({ name: 'DevicesShellyNgPluginDataMappingReloadCacheStats' })

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -186,4 +186,26 @@ describe('ShellyNgDiscoveryService', () => {
 		expect(stopMock).toHaveBeenCalledTimes(1);
 		expect(updated?.status).toBe('finished');
 	});
+
+	it('removes finished sessions after the cleanup delay', async () => {
+		const session = await service.start({ duration: 5 });
+
+		jest.advanceTimersByTime(5_000);
+		await Promise.resolve();
+
+		expect(service.get(session.id)?.status).toBe('finished');
+
+		jest.advanceTimersByTime(5 * 60_000);
+
+		expect(service.get(session.id)).toBeNull();
+	});
+
+	it('does not retain a session when mDNS startup fails', async () => {
+		startMock.mockRejectedValueOnce(new Error('bind failed'));
+
+		await expect(service.start({ duration: 5 })).rejects.toThrow('bind failed');
+
+		expect((service as unknown as { sessions: Map<string, unknown> }).sessions.size).toBe(0);
+		expect(jest.getTimerCount()).toBe(0);
+	});
 });

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'events';
+
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+
+import { DeviceManagerService } from './device-manager.service';
+import { ShellyNgDiscoveryService } from './shelly-ng-discovery.service';
+
+const startMock = jest.fn();
+const stopMock = jest.fn();
+const discoverers: EventEmitter[] = [];
+
+jest.mock('shellies-ds9', () => ({
+	MdnsDeviceDiscoverer: class MockMdnsDeviceDiscoverer extends EventEmitter {
+		constructor() {
+			super();
+			discoverers.push(this);
+		}
+
+		start = startMock;
+		stop = stopMock;
+	},
+}));
+
+jest.mock('../devices-shelly-ng.constants', () => ({
+	DEVICES_SHELLY_NG_PLUGIN_NAME: 'devices-shelly-ng-plugin',
+	DEVICES_SHELLY_NG_TYPE: 'shelly-ng',
+	AddressType: {
+		ETHERNET: 'ethernet',
+		WIFI: 'wifi',
+	},
+	DESCRIPTORS: {
+		SWITCH: {
+			name: 'Shelly Plus 1',
+			models: ['SNSW-001X16EU'],
+			categories: ['lighting', 'switcher'],
+			components: [{ type: 'switch', ids: [0] }],
+			system: [{ type: 'wifi' }],
+		},
+		SENSOR: {
+			name: 'Shelly H&T',
+			models: ['SNSN-0013A'],
+			categories: ['sensor'],
+			components: [{ type: 'temperature', ids: [0] }],
+			system: [{ type: 'wifi' }],
+		},
+	},
+}));
+
+describe('ShellyNgDiscoveryService', () => {
+	let service: ShellyNgDiscoveryService;
+	let deviceManager: jest.Mocked<DeviceManagerService>;
+	let devicesService: jest.Mocked<DevicesService>;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		discoverers.length = 0;
+
+		startMock.mockResolvedValue(undefined);
+		stopMock.mockResolvedValue(undefined);
+
+		deviceManager = {
+			getDeviceInfo: jest.fn(),
+		} as unknown as jest.Mocked<DeviceManagerService>;
+		devicesService = {
+			findOneBy: jest.fn(),
+		} as unknown as jest.Mocked<DevicesService>;
+
+		service = new ShellyNgDiscoveryService(deviceManager, devicesService);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('starts an mDNS scan and enriches discovered unprotected devices', async () => {
+		deviceManager.getDeviceInfo.mockResolvedValue({
+			id: 'shellyplus1-aabbcc',
+			name: 'Kitchen relay',
+			mac: 'AABBCC',
+			model: 'SNSW-001X16EU',
+			fw_id: '2024-05-05-0000',
+			ver: '1.2.3',
+			app: 'Plus1',
+			profile: 'switch',
+			auth_en: false,
+			auth_domain: null,
+			discoverable: true,
+			key: 'key-abc',
+			batch: 'b',
+			fw_sbits: 'bits',
+			components: [{ type: 'switch', ids: [0] }],
+		});
+		devicesService.findOneBy.mockResolvedValue(null);
+
+		const session = await service.start({ duration: 30 });
+
+		expect(startMock).toHaveBeenCalledTimes(1);
+		expect(session.status).toBe('running');
+		expect(session.devices).toEqual([]);
+
+		discoverers[0]?.emit('discover', {
+			deviceId: 'shellyplus1-aabbcc',
+			hostname: '192.168.1.10',
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const updated = service.get(session.id);
+
+		expect(deviceManager.getDeviceInfo.mock.calls).toContainEqual(['192.168.1.10', null]);
+		expect(updated?.devices).toEqual([
+			expect.objectContaining({
+				identifier: 'shellyplus1-aabbcc',
+				hostname: '192.168.1.10',
+				name: 'Kitchen relay',
+				model: 'SNSW-001X16EU',
+				displayName: 'Shelly Plus 1',
+				status: 'ready',
+				categories: ['lighting', 'switcher'],
+				suggestedCategory: null,
+			}),
+		]);
+	});
+
+	it('marks protected devices as needing a password until manually verified', async () => {
+		deviceManager.getDeviceInfo.mockResolvedValue({
+			id: 'shellyht-aabbcc',
+			name: 'Bathroom sensor',
+			mac: 'AABBCC',
+			model: 'SNSN-0013A',
+			fw_id: '2024-05-05-0000',
+			ver: '1.2.3',
+			app: 'HT',
+			profile: 'sensor',
+			auth_en: true,
+			auth_domain: 'shelly',
+			discoverable: true,
+			key: 'key-abc',
+			batch: 'b',
+			fw_sbits: 'bits',
+			components: [{ type: 'temperature', ids: [0] }],
+		});
+		devicesService.findOneBy.mockResolvedValue(null);
+
+		const session = await service.start({ duration: 30 });
+
+		discoverers[0]?.emit('discover', {
+			deviceId: 'shellyht-aabbcc',
+			hostname: '192.168.1.11',
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(service.get(session.id)?.devices[0]).toEqual(
+			expect.objectContaining({
+				status: 'needs_password',
+				suggestedCategory: 'sensor',
+			}),
+		);
+
+		await service.manual(session.id, {
+			hostname: '192.168.1.11',
+			password: 'secret',
+		});
+
+		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['192.168.1.11', 'secret']);
+		expect(service.get(session.id)?.devices[0]).toEqual(
+			expect.objectContaining({
+				status: 'ready',
+				source: 'manual',
+			}),
+		);
+	});
+
+	it('finishes and stops the mDNS scan after the requested duration', async () => {
+		const session = await service.start({ duration: 5 });
+
+		jest.advanceTimersByTime(5_000);
+		await Promise.resolve();
+
+		const updated = service.get(session.id);
+
+		expect(stopMock).toHaveBeenCalledTimes(1);
+		expect(updated?.status).toBe('finished');
+	});
+});

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -64,12 +64,15 @@ interface ShellyNgDiscoverySession {
 	startedAt: Date;
 	expiresAt: Date;
 	discoverer: MdnsDeviceDiscoverer;
-	timer: NodeJS.Timeout;
+	timer?: NodeJS.Timeout;
+	cleanupTimer?: NodeJS.Timeout;
 	devices: Map<string, ShellyNgDiscoveryDeviceSnapshot>;
 }
 
 @Injectable()
 export class ShellyNgDiscoveryService {
+	private static readonly FINISHED_SESSION_TTL_MS = 5 * 60_000;
+
 	private readonly logger: ExtensionLoggerService = createExtensionLogger(
 		DEVICES_SHELLY_NG_PLUGIN_NAME,
 		'ShellyNgDiscoveryService',
@@ -94,13 +97,8 @@ export class ShellyNgDiscoveryService {
 			startedAt,
 			expiresAt,
 			discoverer,
-			timer: setTimeout(() => {
-				void this.finish(id);
-			}, duration * 1_000),
 			devices: new Map(),
 		};
-
-		this.sessions.set(id, session);
 
 		discoverer.on('discover', (device: { deviceId?: string; hostname?: string }) => {
 			void this.inspectDevice(session, device.hostname ?? device.deviceId ?? '', 'mdns', null);
@@ -114,7 +112,19 @@ export class ShellyNgDiscoveryService {
 			});
 		});
 
-		await discoverer.start();
+		try {
+			await discoverer.start();
+		} catch (error) {
+			this.clearTimers(session);
+
+			throw error;
+		}
+
+		session.timer = setTimeout(() => {
+			void this.finish(id);
+		}, duration * 1_000);
+
+		this.sessions.set(id, session);
 
 		return this.toSnapshot(session);
 	}
@@ -153,6 +163,8 @@ export class ShellyNgDiscoveryService {
 
 		session.status = 'finished';
 
+		this.clearTimer(session);
+
 		try {
 			await session.discoverer.stop();
 		} catch (error) {
@@ -163,6 +175,35 @@ export class ShellyNgDiscoveryService {
 				message: err.message,
 				stack: err.stack,
 			});
+		}
+
+		this.scheduleCleanup(session);
+	}
+
+	private scheduleCleanup(session: ShellyNgDiscoverySession): void {
+		this.clearCleanupTimer(session);
+
+		session.cleanupTimer = setTimeout(() => {
+			this.sessions.delete(session.id);
+		}, ShellyNgDiscoveryService.FINISHED_SESSION_TTL_MS);
+	}
+
+	private clearTimers(session: ShellyNgDiscoverySession): void {
+		this.clearTimer(session);
+		this.clearCleanupTimer(session);
+	}
+
+	private clearTimer(session: ShellyNgDiscoverySession): void {
+		if (session.timer !== undefined) {
+			clearTimeout(session.timer);
+			session.timer = undefined;
+		}
+	}
+
+	private clearCleanupTimer(session: ShellyNgDiscoverySession): void {
+		if (session.cleanupTimer !== undefined) {
+			clearTimeout(session.cleanupTimer);
+			session.cleanupTimer = undefined;
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from 'crypto';
+import { MdnsDeviceDiscoverer } from 'shellies-ds9';
+
+import { Injectable } from '@nestjs/common';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import {
+	DESCRIPTORS,
+	DEVICES_SHELLY_NG_PLUGIN_NAME,
+	DEVICES_SHELLY_NG_TYPE,
+	DeviceDescriptor,
+} from '../devices-shelly-ng.constants';
+import { ShellyNgDeviceEntity } from '../entities/devices-shelly-ng.entity';
+
+import { DeviceManagerService } from './device-manager.service';
+
+export type ShellyNgDiscoverySessionStatus = 'running' | 'finished' | 'failed';
+
+export type ShellyNgDiscoveryDeviceStatus =
+	| 'checking'
+	| 'ready'
+	| 'needs_password'
+	| 'already_registered'
+	| 'unsupported'
+	| 'failed';
+
+export type ShellyNgDiscoveryDeviceSource = 'mdns' | 'manual';
+
+export interface ShellyNgDiscoveryDeviceSnapshot {
+	identifier: string | null;
+	hostname: string;
+	name: string | null;
+	model: string | null;
+	displayName: string | null;
+	firmware: string | null;
+	status: ShellyNgDiscoveryDeviceStatus;
+	source: ShellyNgDiscoveryDeviceSource;
+	categories: DeviceCategory[];
+	suggestedCategory: DeviceCategory | null;
+	authentication: {
+		enabled: boolean;
+		domain: string | null;
+	};
+	registeredDeviceId: string | null;
+	registeredDeviceName: string | null;
+	error: string | null;
+	lastSeenAt: string;
+}
+
+export interface ShellyNgDiscoverySessionSnapshot {
+	id: string;
+	status: ShellyNgDiscoverySessionStatus;
+	startedAt: string;
+	expiresAt: string;
+	remainingSeconds: number;
+	devices: ShellyNgDiscoveryDeviceSnapshot[];
+}
+
+interface ShellyNgDiscoverySession {
+	id: string;
+	status: ShellyNgDiscoverySessionStatus;
+	startedAt: Date;
+	expiresAt: Date;
+	discoverer: MdnsDeviceDiscoverer;
+	timer: NodeJS.Timeout;
+	devices: Map<string, ShellyNgDiscoveryDeviceSnapshot>;
+}
+
+@Injectable()
+export class ShellyNgDiscoveryService {
+	private readonly logger: ExtensionLoggerService = createExtensionLogger(
+		DEVICES_SHELLY_NG_PLUGIN_NAME,
+		'ShellyNgDiscoveryService',
+	);
+
+	private readonly sessions = new Map<string, ShellyNgDiscoverySession>();
+
+	constructor(
+		private readonly deviceManagerService: DeviceManagerService,
+		private readonly devicesService: DevicesService,
+	) {}
+
+	async start({ duration }: { duration: number }): Promise<ShellyNgDiscoverySessionSnapshot> {
+		const id = randomUUID();
+		const startedAt = new Date();
+		const expiresAt = new Date(startedAt.getTime() + duration * 1_000);
+		const discoverer = new MdnsDeviceDiscoverer();
+
+		const session: ShellyNgDiscoverySession = {
+			id,
+			status: 'running',
+			startedAt,
+			expiresAt,
+			discoverer,
+			timer: setTimeout(() => {
+				void this.finish(id);
+			}, duration * 1_000),
+			devices: new Map(),
+		};
+
+		this.sessions.set(id, session);
+
+		discoverer.on('discover', (device: { deviceId?: string; hostname?: string }) => {
+			void this.inspectDevice(session, device.hostname ?? device.deviceId ?? '', 'mdns', null);
+		});
+
+		discoverer.on('error', (error: Error) => {
+			this.logger.warn('mDNS discovery emitted an error', {
+				session: id,
+				message: error.message,
+				stack: error.stack,
+			});
+		});
+
+		await discoverer.start();
+
+		return this.toSnapshot(session);
+	}
+
+	get(id: string): ShellyNgDiscoverySessionSnapshot | null {
+		const session = this.sessions.get(id);
+
+		if (session === undefined) {
+			return null;
+		}
+
+		return this.toSnapshot(session);
+	}
+
+	async manual(
+		id: string,
+		{ hostname, password }: { hostname: string; password?: string | null },
+	): Promise<ShellyNgDiscoverySessionSnapshot | null> {
+		const session = this.sessions.get(id);
+
+		if (session === undefined) {
+			return null;
+		}
+
+		await this.inspectDevice(session, hostname, 'manual', password ?? null);
+
+		return this.toSnapshot(session);
+	}
+
+	private async finish(id: string): Promise<void> {
+		const session = this.sessions.get(id);
+
+		if (session === undefined || session.status !== 'running') {
+			return;
+		}
+
+		session.status = 'finished';
+
+		try {
+			await session.discoverer.stop();
+		} catch (error) {
+			const err = error as Error;
+
+			this.logger.warn('Failed to stop Shelly NG mDNS discovery session', {
+				session: id,
+				message: err.message,
+				stack: err.stack,
+			});
+		}
+	}
+
+	private async inspectDevice(
+		session: ShellyNgDiscoverySession,
+		hostname: string,
+		source: ShellyNgDiscoveryDeviceSource,
+		password: string | null,
+	): Promise<void> {
+		if (hostname.length === 0) {
+			return;
+		}
+
+		const existing = session.devices.get(hostname);
+
+		session.devices.set(hostname, {
+			identifier: existing?.identifier ?? null,
+			hostname,
+			name: existing?.name ?? null,
+			model: existing?.model ?? null,
+			displayName: existing?.displayName ?? null,
+			firmware: existing?.firmware ?? null,
+			status: 'checking',
+			source,
+			categories: existing?.categories ?? [],
+			suggestedCategory: existing?.suggestedCategory ?? null,
+			authentication: existing?.authentication ?? { enabled: false, domain: null },
+			registeredDeviceId: existing?.registeredDeviceId ?? null,
+			registeredDeviceName: existing?.registeredDeviceName ?? null,
+			error: null,
+			lastSeenAt: new Date().toISOString(),
+		});
+
+		try {
+			const deviceInfo = await this.deviceManagerService.getDeviceInfo(hostname, password);
+			const descriptor = this.findDescriptor(deviceInfo.model);
+			const registeredDevice = await this.devicesService.findOneBy<ShellyNgDeviceEntity>(
+				'identifier',
+				deviceInfo.id,
+				DEVICES_SHELLY_NG_TYPE,
+			);
+			const categories = descriptor?.categories ?? [];
+			const authentication = {
+				enabled: deviceInfo.auth_en,
+				domain: deviceInfo.auth_domain,
+			};
+
+			let status: ShellyNgDiscoveryDeviceStatus = 'ready';
+
+			if (registeredDevice !== null) {
+				status = 'already_registered';
+			} else if (descriptor === null) {
+				status = 'unsupported';
+			} else if (deviceInfo.auth_en && password === null) {
+				status = 'needs_password';
+			}
+
+			session.devices.set(hostname, {
+				identifier: deviceInfo.id,
+				hostname,
+				name: deviceInfo.name ?? null,
+				model: deviceInfo.model,
+				displayName: descriptor?.name ?? deviceInfo.model,
+				firmware: deviceInfo.ver,
+				status,
+				source,
+				categories,
+				suggestedCategory: categories.length === 1 ? categories[0] : null,
+				authentication,
+				registeredDeviceId: registeredDevice?.id ?? null,
+				registeredDeviceName: registeredDevice?.name ?? null,
+				error: null,
+				lastSeenAt: new Date().toISOString(),
+			});
+		} catch (error) {
+			const err = error as Error;
+			const currentDevice = session.devices.get(hostname);
+
+			if (currentDevice === undefined) {
+				return;
+			}
+
+			session.devices.set(hostname, {
+				...currentDevice,
+				status: 'failed',
+				source,
+				error: err.message,
+				lastSeenAt: new Date().toISOString(),
+			});
+		}
+	}
+
+	private findDescriptor(model: string): DeviceDescriptor | null {
+		const normalizedModel = model.toUpperCase();
+
+		return (
+			Object.values(DESCRIPTORS).find((descriptor) =>
+				descriptor.models.some((descriptorModel) => descriptorModel.toUpperCase() === normalizedModel),
+			) ?? null
+		);
+	}
+
+	private toSnapshot(session: ShellyNgDiscoverySession): ShellyNgDiscoverySessionSnapshot {
+		return {
+			id: session.id,
+			status: session.status,
+			startedAt: session.startedAt.toISOString(),
+			expiresAt: session.expiresAt.toISOString(),
+			remainingSeconds: Math.max(0, Math.ceil((session.expiresAt.getTime() - Date.now()) / 1_000)),
+			devices: Array.from(session.devices.values()),
+		};
+	}
+}


### PR DESCRIPTION
## Summary

- Adds short-lived Shelly NG discovery sessions backed by mDNS, with polling, manual hostname/password lookup, candidate status enrichment, supported category suggestions, and existing-device detection.
- Registers the Shelly NG plugin as the first Devices wizard and adds a three-step admin flow: discovery/manual entry, category confirmation, and adoption results.
- Adds admin/backend schemas, response models, OpenAPI constants, locale strings, and focused coverage for the discovery service, controller endpoints, and wizard composable.

## Validation

- `pnpm run generate:openapi`
- `pnpm --filter @fastybird/smart-panel-backend exec jest src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts`
- `pnpm --filter @fastybird/smart-panel-admin exec vitest run src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts`
- `pnpm --filter @fastybird/smart-panel-admin run test:unit -- --run src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts` (ran the full admin suite: 216 files / 1318 tests)
- `pnpm --filter @fastybird/smart-panel-admin run type-check`
- `pnpm --filter @fastybird/smart-panel-backend run type-check`
- `pnpm run lint:js` (passes; reports two existing backend warnings in `buddy-discord` and `buddy-telegram` providers)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new network-discovery endpoints and a stateful polling flow (timers/session lifecycle), which can impact backend resource usage and UX if edge cases aren’t handled.
> 
> **Overview**
> Adds a **Shelly NG discovery/adoption wizard** to the admin app (3-step flow: scan + manual hostname/password entry, category/name confirmation, results) and wires it into the Shelly NG plugin via the new `deviceWizard` component.
> 
> Introduces new backend **discovery session APIs** (`POST /devices/discovery`, `GET /devices/discovery/:id`, `POST /devices/discovery/:id/manual`) backed by `ShellyNgDiscoveryService`, which runs short-lived mDNS scans, enriches candidates with status/category suggestions, and flags already-registered/unsupported/password-protected devices.
> 
> Extends OpenAPI/admin schemas and transformers for discovery session/device payloads, adds i18n strings for wizard UI/statuses, and adds focused unit tests for the backend controller/service and the admin `useDevicesWizard` composable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1092f85372e2c9739ddab6605542903f1df7ba94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->