### PR TITLE
fix(devices): handle Shelly NG wizard polling edge cases

### DIFF
--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -80,6 +80,20 @@ const discoverySession: IShellyNgDiscoverySession = {
 	],
 };
 
+const checkingDiscoverySession: IShellyNgDiscoverySession = {
+	...discoverySession,
+	devices: [
+		{
+			...discoverySession.devices[0]!,
+			name: null,
+			displayName: null,
+			status: 'checking',
+			categories: [],
+			suggestedCategory: null,
+		},
+	],
+};
+
 describe('useDevicesWizard', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -153,6 +167,36 @@ describe('useDevicesWizard', () => {
 		});
 		expect(wizard.manual.hostname).toBe('');
 		expect(wizard.devices.value).toHaveLength(1);
+	});
+
+	it('promotes polling placeholders when discovered devices become ready', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: checkingDiscoverySession,
+			},
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		expect(wizard.selected['192.168.1.10']).toBe(false);
+		expect(wizard.categoryByHostname['192.168.1.10']).toBeNull();
+		expect(wizard.nameByHostname['192.168.1.10']).toBe('192.168.1.10');
+
+		await wizard.refreshDiscovery();
+
+		expect(wizard.selected['192.168.1.10']).toBe(true);
+		expect(wizard.categoryByHostname['192.168.1.10']).toBe(DevicesModuleDeviceCategory.lighting);
+		expect(wizard.nameByHostname['192.168.1.10']).toBe('Kitchen relay');
+		expect(wizard.canContinue.value).toBe(true);
 	});
 
 	it('adopts selected ready devices through the devices store', async () => {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -199,6 +199,40 @@ describe('useDevicesWizard', () => {
 		expect(wizard.canContinue.value).toBe(true);
 	});
 
+	it('keeps a user deselection when a ready device is rediscovered', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
+		backendClient.GET
+			.mockResolvedValueOnce({
+				data: {
+					data: checkingDiscoverySession,
+				},
+				response: { status: 200 },
+			})
+			.mockResolvedValueOnce({
+				data: {
+					data: discoverySession,
+				},
+				response: { status: 200 },
+			});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		wizard.selected['192.168.1.10'] = false;
+
+		await wizard.refreshDiscovery();
+		await wizard.refreshDiscovery();
+
+		expect(wizard.selected['192.168.1.10']).toBe(false);
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
 	it('adopts selected ready devices through the devices store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -99,18 +99,26 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	};
 
 	const applySession = (nextSession: IShellyNgDiscoverySession): void => {
+		const previousDevices = session.value?.devices ?? [];
+
 		session.value = nextSession;
 
 		for (const device of nextSession.devices) {
-			if (selected[device.hostname] === undefined) {
+			const previousDevice = previousDevices.find((item) => item.hostname === device.hostname);
+			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
+
+			if (selected[device.hostname] === undefined || becameReady) {
 				selected[device.hostname] = device.status === 'ready';
 			}
 
-			if (categoryByHostname[device.hostname] === undefined) {
+			if (
+				categoryByHostname[device.hostname] === undefined ||
+				(categoryByHostname[device.hostname] === null && device.suggestedCategory !== null)
+			) {
 				categoryByHostname[device.hostname] = device.suggestedCategory;
 			}
 
-			if (nameByHostname[device.hostname] === undefined) {
+			if (nameByHostname[device.hostname] === undefined || (becameReady && nameByHostname[device.hostname] === device.hostname)) {
 				nameByHostname[device.hostname] = device.name ?? device.displayName ?? device.hostname;
 			}
 		}

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -66,6 +66,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		hostname: '',
 		password: '',
 	});
+	const readyHostnames = new Set<string>();
 
 	let pollingTimer: number | null = null;
 
@@ -106,8 +107,9 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		for (const device of nextSession.devices) {
 			const previousDevice = previousDevices.find((item) => item.hostname === device.hostname);
 			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
+			const wasPreviouslyReady = readyHostnames.has(device.hostname);
 
-			if (selected[device.hostname] === undefined || becameReady) {
+			if (selected[device.hostname] === undefined || (becameReady && !wasPreviouslyReady)) {
 				selected[device.hostname] = device.status === 'ready';
 			}
 
@@ -120,6 +122,10 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 			if (nameByHostname[device.hostname] === undefined || (becameReady && nameByHostname[device.hostname] === device.hostname)) {
 				nameByHostname[device.hostname] = device.name ?? device.displayName ?? device.hostname;
+			}
+
+			if (device.status === 'ready') {
+				readyHostnames.add(device.hostname);
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -175,6 +175,49 @@ describe('ShellyNgDiscoveryService', () => {
 		);
 	});
 
+	it('keeps using verified credentials when a protected device is rediscovered', async () => {
+		deviceManager.getDeviceInfo.mockResolvedValue({
+			id: 'shellyht-aabbcc',
+			name: 'Bathroom sensor',
+			mac: 'AABBCC',
+			model: 'SNSN-0013A',
+			fw_id: '2024-05-05-0000',
+			ver: '1.2.3',
+			app: 'HT',
+			profile: 'sensor',
+			auth_en: true,
+			auth_domain: 'shelly',
+			discoverable: true,
+			key: 'key-abc',
+			batch: 'b',
+			fw_sbits: 'bits',
+			components: [{ type: 'temperature', ids: [0] }],
+		});
+		devicesService.findOneBy.mockResolvedValue(null);
+
+		const session = await service.start({ duration: 30 });
+
+		await service.manual(session.id, {
+			hostname: '192.168.1.11',
+			password: 'secret',
+		});
+
+		discoverers[0]?.emit('discover', {
+			deviceId: 'shellyht-aabbcc',
+			hostname: '192.168.1.11',
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['192.168.1.11', 'secret']);
+		expect(service.get(session.id)?.devices[0]).toEqual(
+			expect.objectContaining({
+				status: 'ready',
+			}),
+		);
+	});
+
 	it('finishes and stops the mDNS scan after the requested duration', async () => {
 		const session = await service.start({ duration: 5 });
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -204,12 +204,13 @@ describe('ShellyNgDiscoveryService', () => {
 
 		discoverers[0]?.emit('discover', {
 			deviceId: 'shellyht-aabbcc',
+			hostname: 'shellyht-aabbcc.local',
 		});
 
 		await Promise.resolve();
 		await Promise.resolve();
 
-		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['shellyht-aabbcc', 'secret']);
+		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['shellyht-aabbcc.local', 'secret']);
 		expect(service.get(session.id)?.devices.at(-1)).toEqual(
 			expect.objectContaining({
 				status: 'ready',

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -204,14 +204,13 @@ describe('ShellyNgDiscoveryService', () => {
 
 		discoverers[0]?.emit('discover', {
 			deviceId: 'shellyht-aabbcc',
-			hostname: '192.168.1.11',
 		});
 
 		await Promise.resolve();
 		await Promise.resolve();
 
-		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['192.168.1.11', 'secret']);
-		expect(service.get(session.id)?.devices[0]).toEqual(
+		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['shellyht-aabbcc', 'secret']);
+		expect(service.get(session.id)?.devices.at(-1)).toEqual(
 			expect.objectContaining({
 				status: 'ready',
 			}),

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -104,8 +104,12 @@ export class ShellyNgDiscoveryService {
 
 		discoverer.on('discover', (device: { deviceId?: string; hostname?: string }) => {
 			const hostname = device.hostname ?? device.deviceId ?? '';
+			const password =
+				session.passwords.get(hostname) ??
+				(device.deviceId !== undefined ? session.passwords.get(device.deviceId) : undefined) ??
+				null;
 
-			void this.inspectDevice(session, hostname, 'mdns', session.passwords.get(hostname) ?? null);
+			void this.inspectDevice(session, hostname, 'mdns', password);
 		});
 
 		discoverer.on('error', (error: Error) => {

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -156,7 +156,7 @@ export class ShellyNgDiscoveryService {
 		const discoveredDevice = await this.inspectDevice(session, hostname, 'manual', password ?? null);
 
 		if (password !== null && typeof password !== 'undefined' && discoveredDevice?.status === 'ready') {
-			session.passwords.set(hostname, password);
+			this.storePassword(session, discoveredDevice, password);
 		}
 
 		return this.toSnapshot(session);
@@ -212,6 +212,18 @@ export class ShellyNgDiscoveryService {
 		if (session.cleanupTimer !== undefined) {
 			clearTimeout(session.cleanupTimer);
 			session.cleanupTimer = undefined;
+		}
+	}
+
+	private storePassword(
+		session: ShellyNgDiscoverySession,
+		device: ShellyNgDiscoveryDeviceSnapshot,
+		password: string,
+	): void {
+		session.passwords.set(device.hostname, password);
+
+		if (device.identifier !== null) {
+			session.passwords.set(device.identifier, password);
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -67,6 +67,7 @@ interface ShellyNgDiscoverySession {
 	timer?: NodeJS.Timeout;
 	cleanupTimer?: NodeJS.Timeout;
 	devices: Map<string, ShellyNgDiscoveryDeviceSnapshot>;
+	passwords: Map<string, string>;
 }
 
 @Injectable()
@@ -98,10 +99,13 @@ export class ShellyNgDiscoveryService {
 			expiresAt,
 			discoverer,
 			devices: new Map(),
+			passwords: new Map(),
 		};
 
 		discoverer.on('discover', (device: { deviceId?: string; hostname?: string }) => {
-			void this.inspectDevice(session, device.hostname ?? device.deviceId ?? '', 'mdns', null);
+			const hostname = device.hostname ?? device.deviceId ?? '';
+
+			void this.inspectDevice(session, hostname, 'mdns', session.passwords.get(hostname) ?? null);
 		});
 
 		discoverer.on('error', (error: Error) => {
@@ -149,7 +153,11 @@ export class ShellyNgDiscoveryService {
 			return null;
 		}
 
-		await this.inspectDevice(session, hostname, 'manual', password ?? null);
+		const discoveredDevice = await this.inspectDevice(session, hostname, 'manual', password ?? null);
+
+		if (password !== null && typeof password !== 'undefined' && discoveredDevice?.status === 'ready') {
+			session.passwords.set(hostname, password);
+		}
 
 		return this.toSnapshot(session);
 	}
@@ -212,9 +220,9 @@ export class ShellyNgDiscoveryService {
 		hostname: string,
 		source: ShellyNgDiscoveryDeviceSource,
 		password: string | null,
-	): Promise<void> {
+	): Promise<ShellyNgDiscoveryDeviceSnapshot | null> {
 		if (hostname.length === 0) {
-			return;
+			return null;
 		}
 
 		const existing = session.devices.get(hostname);
@@ -261,7 +269,7 @@ export class ShellyNgDiscoveryService {
 				status = 'needs_password';
 			}
 
-			session.devices.set(hostname, {
+			const discoveredDevice: ShellyNgDiscoveryDeviceSnapshot = {
 				identifier: deviceInfo.id,
 				hostname,
 				name: deviceInfo.name ?? null,
@@ -277,22 +285,30 @@ export class ShellyNgDiscoveryService {
 				registeredDeviceName: registeredDevice?.name ?? null,
 				error: null,
 				lastSeenAt: new Date().toISOString(),
-			});
+			};
+
+			session.devices.set(hostname, discoveredDevice);
+
+			return discoveredDevice;
 		} catch (error) {
 			const err = error as Error;
 			const currentDevice = session.devices.get(hostname);
 
 			if (currentDevice === undefined) {
-				return;
+				return null;
 			}
 
-			session.devices.set(hostname, {
+			const failedDevice: ShellyNgDiscoveryDeviceSnapshot = {
 				...currentDevice,
 				status: 'failed',
 				source,
 				error: err.message,
 				lastSeenAt: new Date().toISOString(),
-			});
+			};
+
+			session.devices.set(hostname, failedDevice);
+
+			return failedDevice;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Preserve manually verified Shelly NG passwords within a discovery session so later mDNS rediscovery does not downgrade protected ready devices back to password-required.
- Promote admin polling placeholders when a discovered device transitions from `checking` to `ready`, restoring default selection, suggested category, and friendly name.
- Add regression tests for both review-reported wizard edge cases.

## Validation

- `pnpm --filter @fastybird/smart-panel-backend exec jest src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts`
- `pnpm --filter @fastybird/smart-panel-admin exec vitest run src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts`
- `pnpm --filter @fastybird/smart-panel-backend run type-check`
- `pnpm --filter @fastybird/smart-panel-admin run type-check`
- `pnpm --filter @fastybird/smart-panel-backend exec eslint src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts`
- `pnpm --filter @fastybird/smart-panel-admin exec eslint src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts`
- `git diff --check`

Follow-up to #599.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches discovery state management and credential reuse within an in-memory session; mistakes could cause incorrect device selection defaults or failure to re-authenticate rediscovered devices.
> 
> **Overview**
> Improves Shelly NG device discovery/wizard resiliency around rediscovery and polling transitions.
> 
> On the **backend**, discovery sessions now persist manually verified passwords (keyed by hostname and device identifier) and reuse them for later mDNS rediscovery so protected devices don’t regress back to `needs_password`; `inspectDevice` now returns the discovered snapshot to enable password caching only when a device is actually `ready`.
> 
> On the **admin wizard**, session application logic now "promotes" placeholder devices that move from `checking` to `ready` by restoring default selection, suggested category, and friendly name *without* overriding explicit user deselection after a device has already been ready once. New unit tests cover these edge cases on both frontend and backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27cf824482cd819cacf1db4198536da8776f96cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->