### PR TITLE
Fix Shelly NG wizard layout, scrolling, and progress bar

### DIFF
--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -57,7 +57,7 @@
 					<el-button
 						type="primary"
 						class="px-4!"
-						:disabled="!canContinue"
+						:disabled="adoptableDevices.length === 0"
 						@click="activeStep = 'categories'"
 					>
 						{{ t('devicesShellyNgPlugin.buttons.next.title') }}
@@ -339,7 +339,7 @@
 					</el-button>
 					<el-button
 						type="primary"
-						:disabled="!canContinue"
+						:disabled="adoptableDevices.length === 0"
 						@click="activeStep = 'categories'"
 					>
 						{{ t('devicesShellyNgPlugin.buttons.next.title') }}

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -1,263 +1,388 @@
 <template>
-	<section class="flex flex-col gap-4">
-		<el-steps
-			:active="activeStepIndex"
-			finish-status="success"
-			align-center
+	<app-bar-heading
+		v-if="!isMDDevice"
+		teleport
+	>
+		<template #icon>
+			<icon
+				icon="mdi:wizard-hat"
+				class="w[20px] h[20px]"
+			/>
+		</template>
+
+		<template #title>
+			{{ t('devicesShellyNgPlugin.headings.wizard.title') }}
+		</template>
+
+		<template #subtitle>
+			{{ t('devicesShellyNgPlugin.subHeadings.wizard') }}
+		</template>
+	</app-bar-heading>
+
+	<app-bar-button
+		v-if="!isMDDevice"
+		:align="AppBarButtonAlign.LEFT"
+		teleport
+		small
+		@click="handleCancel"
+	>
+		<template #icon>
+			<el-icon :size="24">
+				<icon icon="mdi:chevron-left" />
+			</el-icon>
+		</template>
+	</app-bar-button>
+
+	<app-breadcrumbs :items="breadcrumbs" />
+
+	<view-header
+		:heading="t('devicesShellyNgPlugin.headings.wizard.title')"
+		:sub-heading="t('devicesShellyNgPlugin.subHeadings.wizard')"
+		icon="mdi:wizard-hat"
+	>
+		<template
+			v-if="isMDDevice"
+			#extra
 		>
-			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.discovery')" />
-			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.categories')" />
-			<el-step :title="t('devicesShellyNgPlugin.headings.wizard.results')" />
-		</el-steps>
-
-		<template v-if="activeStep === 'discovery'">
-			<el-alert
-				:title="t('devicesShellyNgPlugin.texts.wizard.discovery')"
-				type="info"
-				:closable="false"
-				show-icon
-			/>
-
-			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-				<div class="flex min-w-0 flex-1 flex-col gap-1">
-					<el-text>
-						{{ t('devicesShellyNgPlugin.texts.wizard.scanStatus', { count: devices.length }) }}
-					</el-text>
-					<el-progress
-						:percentage="scanPercentage"
-						:status="session?.status === 'finished' ? 'success' : undefined"
-					/>
-				</div>
-
+			<div class="flex items-center gap-2">
 				<el-button
-					:loading="formResult === FormResult.WORKING"
-					@click="startDiscovery"
+					link
+					class="px-4!"
+					@click="handleCancel"
 				>
-					<template #icon>
-						<icon icon="mdi:radar" />
-					</template>
-					{{ t('devicesShellyNgPlugin.buttons.wizard.restart.title') }}
+					{{ t('devicesModule.buttons.cancel.title') }}
 				</el-button>
-			</div>
 
-			<el-form
-				:model="manual"
-				label-position="top"
-				class="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
-				@submit.prevent="addManualDevice"
-			>
-				<el-form-item
-					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
-					class="mb-0!"
-				>
-					<el-input
-						v-model="manual.hostname"
-						:placeholder="t('devicesShellyNgPlugin.fields.devices.hostname.placeholder')"
-						name="hostname"
-					/>
-				</el-form-item>
-
-				<el-form-item
-					:label="t('devicesShellyNgPlugin.fields.devices.password.title')"
-					class="mb-0!"
-				>
-					<el-input
-						v-model="manual.password"
-						:placeholder="t('devicesShellyNgPlugin.fields.devices.password.placeholder')"
-						name="password"
-						show-password
-					/>
-				</el-form-item>
-
-				<el-form-item class="mb-0! md:self-end">
+				<template v-if="activeStep === 'discovery'">
 					<el-button
 						type="primary"
-						native-type="submit"
-						:disabled="manual.hostname.trim().length === 0"
-						:loading="formResult === FormResult.WORKING"
+						class="px-4!"
+						:disabled="!canContinue"
+						@click="activeStep = 'categories'"
 					>
-						<template #icon>
-							<icon icon="mdi:plus" />
-						</template>
-						{{ t('devicesShellyNgPlugin.buttons.wizard.addManual.title') }}
+						{{ t('devicesShellyNgPlugin.buttons.next.title') }}
 					</el-button>
-				</el-form-item>
-			</el-form>
-
-			<el-table
-				:data="devices"
-				class="w-full"
-				:empty-text="t('devicesShellyNgPlugin.texts.wizard.noDevices')"
-			>
-				<el-table-column
-					prop="hostname"
-					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
-					min-width="150"
-				/>
-				<el-table-column
-					:label="t('devicesShellyNgPlugin.headings.device.model')"
-					min-width="180"
-				>
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<span>{{ row.displayName || row.model || row.hostname }}</span>
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('devicesShellyNgPlugin.headings.wizard.status')"
-					width="170"
-				>
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<el-tag :type="statusTagType(row.status)">
-							{{ t(`devicesShellyNgPlugin.statuses.wizard.${row.status}`) }}
-						</el-tag>
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
-					min-width="220"
-				>
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<span v-if="row.status !== 'ready'">-</span>
-						<el-select
-							v-else
-							v-model="categoryByHostname[row.hostname]"
-							:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
-							filterable
-						>
-							<el-option
-								v-for="item in categoryOptions(row)"
-								:key="item.value"
-								:label="item.label"
-								:value="item.value"
-							/>
-						</el-select>
-					</template>
-				</el-table-column>
-			</el-table>
-
-			<div class="flex justify-end">
-				<el-button
-					type="primary"
-					:disabled="!canContinue"
-					@click="activeStep = 'categories'"
-				>
-					{{ t('devicesShellyNgPlugin.buttons.next.title') }}
-				</el-button>
-			</div>
-		</template>
-
-		<template v-else-if="activeStep === 'categories'">
-			<el-alert
-				:title="t('devicesShellyNgPlugin.texts.wizard.categories')"
-				type="info"
-				:closable="false"
-				show-icon
-			/>
-
-			<el-table
-				:data="readyDevices"
-				class="w-full"
-			>
-				<el-table-column width="70">
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<el-checkbox v-model="selected[row.hostname]" />
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
-					min-width="220"
-				>
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<el-input v-model="nameByHostname[row.hostname]" />
-					</template>
-				</el-table-column>
-				<el-table-column
-					prop="hostname"
-					:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
-					min-width="150"
-				/>
-				<el-table-column
-					:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
-					min-width="240"
-				>
-					<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-						<el-select
-							v-model="categoryByHostname[row.hostname]"
-							:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
-							filterable
-						>
-							<el-option
-								v-for="item in categoryOptions(row)"
-								:key="item.value"
-								:label="item.label"
-								:value="item.value"
-							/>
-						</el-select>
-					</template>
-				</el-table-column>
-			</el-table>
-
-			<div class="flex justify-between gap-3">
-				<el-button @click="activeStep = 'discovery'">
-					{{ t('devicesModule.buttons.back.title') }}
-				</el-button>
-				<el-button
-					type="primary"
-					:disabled="!canContinue"
-					:loading="formResult === FormResult.WORKING"
-					@click="onAdopt"
-				>
-					<template #icon>
-						<icon icon="mdi:check" />
-					</template>
-					{{ t('devicesShellyNgPlugin.buttons.wizard.adopt.title') }}
-				</el-button>
-			</div>
-		</template>
-
-		<template v-else>
-			<el-result
-				:icon="adoptionResults.some((result) => result.status === 'failed') ? 'warning' : 'success'"
-				:title="t('devicesShellyNgPlugin.headings.wizard.results')"
-			>
-				<template #sub-title>
-					<div class="flex flex-col gap-2">
-						<div
-							v-for="result in adoptionResults"
-							:key="result.hostname"
-							class="flex items-center justify-center gap-2"
-						>
-							<el-tag :type="result.status === 'created' ? 'success' : 'danger'">
-								{{ t(`devicesShellyNgPlugin.statuses.wizard.${result.status}`) }}
-							</el-tag>
-							<span>{{ result.name }} ({{ result.hostname }})</span>
-						</div>
-					</div>
 				</template>
-				<template #extra>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-button
+						class="px-4!"
+						@click="activeStep = 'discovery'"
+					>
+						{{ t('devicesModule.buttons.back.title') }}
+					</el-button>
 					<el-button
 						type="primary"
-						@click="router.push({ name: DevicesRouteNames.DEVICES })"
+						class="px-4!"
+						:disabled="!canContinue"
+						:loading="formResult === FormResult.WORKING"
+						@click="onAdopt"
+					>
+						{{ t('devicesShellyNgPlugin.buttons.wizard.adopt.title') }}
+					</el-button>
+				</template>
+
+				<template v-else>
+					<el-button
+						type="primary"
+						class="px-4!"
+						@click="handleFinish"
 					>
 						{{ t('devicesShellyNgPlugin.buttons.wizard.finish.title') }}
 					</el-button>
 				</template>
-			</el-result>
+			</div>
 		</template>
-	</section>
+	</view-header>
+
+	<div class="grow-1 flex flex-col gap-2 lt-sm:mx-1 sm:mx-2 lt-sm:mb-1 sm:mb-2 overflow-hidden mt-2">
+		<el-card
+			shadow="never"
+			class="max-h-full flex flex-col overflow-hidden box-border"
+			body-class="p-0! max-h-full overflow-hidden flex flex-col"
+		>
+			<template #header>
+				<el-steps
+					:active="activeStepIndex"
+					finish-status="success"
+					align-center
+				>
+					<el-step :title="t('devicesShellyNgPlugin.headings.wizard.discovery')" />
+					<el-step :title="t('devicesShellyNgPlugin.headings.wizard.categories')" />
+					<el-step :title="t('devicesShellyNgPlugin.headings.wizard.results')" />
+				</el-steps>
+			</template>
+
+			<div class="p-4 max-h-full box-border flex flex-col gap-3 overflow-hidden">
+				<template v-if="activeStep === 'discovery'">
+					<el-alert
+						:title="t('devicesShellyNgPlugin.texts.wizard.discovery')"
+						type="info"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between shrink-0">
+						<div class="flex min-w-0 flex-1 flex-col gap-1">
+							<el-text>
+								{{ t('devicesShellyNgPlugin.texts.wizard.scanStatus', { count: devices.length }) }}
+							</el-text>
+							<el-progress
+								:percentage="scanPercentage"
+								:status="session?.status === 'finished' ? 'success' : undefined"
+							/>
+						</div>
+
+						<el-button
+							:loading="formResult === FormResult.WORKING"
+							@click="startDiscovery"
+						>
+							<template #icon>
+								<icon icon="mdi:radar" />
+							</template>
+							{{ t('devicesShellyNgPlugin.buttons.wizard.restart.title') }}
+						</el-button>
+					</div>
+
+					<el-form
+						:model="manual"
+						label-position="top"
+						class="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] shrink-0"
+						@submit.prevent="addManualDevice"
+					>
+						<el-form-item
+							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+							class="mb-0!"
+						>
+							<el-input
+								v-model="manual.hostname"
+								:placeholder="t('devicesShellyNgPlugin.fields.devices.hostname.placeholder')"
+								name="hostname"
+							/>
+						</el-form-item>
+
+						<el-form-item
+							:label="t('devicesShellyNgPlugin.fields.devices.password.title')"
+							class="mb-0!"
+						>
+							<el-input
+								v-model="manual.password"
+								:placeholder="t('devicesShellyNgPlugin.fields.devices.password.placeholder')"
+								name="password"
+								show-password
+							/>
+						</el-form-item>
+
+						<el-form-item class="mb-0! md:self-end">
+							<el-button
+								type="primary"
+								native-type="submit"
+								:disabled="manual.hostname.trim().length === 0"
+								:loading="formResult === FormResult.WORKING"
+							>
+								<template #icon>
+									<icon icon="mdi:plus" />
+								</template>
+								{{ t('devicesShellyNgPlugin.buttons.wizard.addManual.title') }}
+							</el-button>
+						</el-form-item>
+					</el-form>
+
+					<el-table
+						:data="devices"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
+						:empty-text="t('devicesShellyNgPlugin.texts.wizard.noDevices')"
+					>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+							min-width="150"
+						/>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.headings.device.model')"
+							min-width="180"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<span>{{ row.displayName || row.model || row.hostname }}</span>
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.headings.wizard.status')"
+							width="170"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<el-tag :type="statusTagType(row.status)">
+									{{ t(`devicesShellyNgPlugin.statuses.wizard.${row.status}`) }}
+								</el-tag>
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
+							min-width="220"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<span v-if="row.status !== 'ready'">-</span>
+								<el-select
+									v-else
+									v-model="categoryByHostname[row.hostname]"
+									:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
+									filterable
+								>
+									<el-option
+										v-for="item in categoryOptions(row)"
+										:key="item.value"
+										:label="item.label"
+										:value="item.value"
+									/>
+								</el-select>
+							</template>
+						</el-table-column>
+					</el-table>
+				</template>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-alert
+						:title="t('devicesShellyNgPlugin.texts.wizard.categories')"
+						type="info"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<el-table
+						:data="readyDevices"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
+					>
+						<el-table-column width="70">
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<el-checkbox v-model="selected[row.hostname]" />
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
+							min-width="220"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<el-input v-model="nameByHostname[row.hostname]" />
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+							min-width="150"
+						/>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
+							min-width="240"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<el-select
+									v-model="categoryByHostname[row.hostname]"
+									:placeholder="t('devicesShellyNgPlugin.fields.devices.category.placeholder')"
+									filterable
+								>
+									<el-option
+										v-for="item in categoryOptions(row)"
+										:key="item.value"
+										:label="item.label"
+										:value="item.value"
+									/>
+								</el-select>
+							</template>
+						</el-table-column>
+					</el-table>
+				</template>
+
+				<template v-else>
+					<el-result
+						:icon="adoptionResults.some((result) => result.status === 'failed') ? 'warning' : 'success'"
+						:title="t('devicesShellyNgPlugin.headings.wizard.results')"
+						class="flex-grow"
+					>
+						<template #sub-title>
+							<div class="flex flex-col gap-2">
+								<div
+									v-for="result in adoptionResults"
+									:key="result.hostname"
+									class="flex items-center justify-center gap-2"
+								>
+									<el-tag :type="result.status === 'created' ? 'success' : 'danger'">
+										{{ t(`devicesShellyNgPlugin.statuses.wizard.${result.status}`) }}
+									</el-tag>
+									<span>{{ result.name }} ({{ result.hostname }})</span>
+								</div>
+							</div>
+						</template>
+					</el-result>
+				</template>
+			</div>
+
+			<div
+				v-if="!isMDDevice"
+				class="flex justify-between gap-2 p-4 border-t border-t-solid"
+			>
+				<template v-if="activeStep === 'discovery'">
+					<el-button @click="handleCancel">
+						{{ t('devicesModule.buttons.cancel.title') }}
+					</el-button>
+					<el-button
+						type="primary"
+						:disabled="!canContinue"
+						@click="activeStep = 'categories'"
+					>
+						{{ t('devicesShellyNgPlugin.buttons.next.title') }}
+					</el-button>
+				</template>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-button @click="activeStep = 'discovery'">
+						{{ t('devicesModule.buttons.back.title') }}
+					</el-button>
+					<div class="flex gap-2">
+						<el-button @click="handleCancel">
+							{{ t('devicesModule.buttons.cancel.title') }}
+						</el-button>
+						<el-button
+							type="primary"
+							:disabled="!canContinue"
+							:loading="formResult === FormResult.WORKING"
+							@click="onAdopt"
+						>
+							{{ t('devicesShellyNgPlugin.buttons.wizard.adopt.title') }}
+						</el-button>
+					</div>
+				</template>
+
+				<template v-else>
+					<div></div>
+					<el-button
+						type="primary"
+						@click="handleFinish"
+					>
+						{{ t('devicesShellyNgPlugin.buttons.wizard.finish.title') }}
+					</el-button>
+				</template>
+			</div>
+		</el-card>
+	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRouter } from 'vue-router';
+import { type RouteLocationResolvedGeneric, useRouter } from 'vue-router';
 
 import {
 	ElAlert,
 	ElButton,
+	ElCard,
 	ElCheckbox,
 	ElForm,
 	ElFormItem,
+	ElIcon,
 	ElInput,
 	ElOption,
 	ElProgress,
@@ -272,8 +397,10 @@ import {
 } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
+import { useNow } from '@vueuse/core';
 
-import { FormResult, RouteNames as DevicesRouteNames } from '../../../modules/devices';
+import { AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewHeader, useBreakpoints } from '../../../common';
+import { RouteNames as DevicesRouteNames, FormResult } from '../../../modules/devices';
 import { useDevicesWizard } from '../composables/composables';
 import type { IShellyNgDiscoveryDevice } from '../schemas/devices.types';
 
@@ -283,6 +410,8 @@ defineOptions({
 
 const { t } = useI18n();
 const router = useRouter();
+const { isMDDevice, isLGDevice } = useBreakpoints();
+const now = useNow({ interval: 1_000 });
 const {
 	session,
 	devices,
@@ -320,13 +449,31 @@ const scanPercentage = computed<number>(() => {
 		return 0;
 	}
 
+	if (session.value.status !== 'running') {
+		return 100;
+	}
+
 	const startedAt = new Date(session.value.startedAt).getTime();
 	const expiresAt = new Date(session.value.expiresAt).getTime();
 	const total = Math.max(1, expiresAt - startedAt);
-	const remaining = Math.max(0, session.value.remainingSeconds * 1_000);
+	const elapsed = Math.max(0, Math.min(total, now.value.getTime() - startedAt));
 
-	return Math.min(100, Math.max(0, Math.round(((total - remaining) / total) * 100)));
+	return Math.min(100, Math.max(0, Math.round((elapsed / total) * 100)));
 });
+
+const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
+	{
+		label: t('devicesModule.breadcrumbs.devices.list'),
+		route: router.resolve({ name: DevicesRouteNames.DEVICES }),
+	},
+	{
+		label: t('devicesShellyNgPlugin.breadcrumbs.wizard'),
+		route: router.resolve({
+			name: DevicesRouteNames.DEVICES_WIZARD,
+			params: { type: 'devices-shelly-ng-plugin' },
+		}),
+	},
+]);
 
 const statusTagType = (status: IShellyNgDiscoveryDevice['status']): 'success' | 'warning' | 'info' | 'danger' => {
 	if (status === 'ready') {
@@ -342,6 +489,18 @@ const statusTagType = (status: IShellyNgDiscoveryDevice['status']): 'success' | 
 	}
 
 	return 'danger';
+};
+
+const handleCancel = (): void => {
+	if (isLGDevice.value) {
+		router.replace({ name: DevicesRouteNames.DEVICES });
+	} else {
+		router.push({ name: DevicesRouteNames.DEVICES });
+	}
+};
+
+const handleFinish = (): void => {
+	handleCancel();
 };
 
 const onAdopt = async (): Promise<void> => {

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -265,6 +265,7 @@
 						:data="adoptableDevices"
 						class="h-full w-full flex-grow"
 						table-layout="fixed"
+						:default-sort="{ prop: 'name', order: 'ascending' }"
 					>
 						<el-table-column width="60">
 							<template #header>
@@ -280,8 +281,11 @@
 							</template>
 						</el-table-column>
 						<el-table-column
+							prop="name"
 							:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
 							min-width="220"
+							sortable
+							:sort-method="sortByName"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
 								<el-input v-model="nameByHostname[row.hostname]" />
@@ -291,10 +295,15 @@
 							prop="hostname"
 							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
 							min-width="150"
+							sortable
+							:sort-method="sortByHostname"
 						/>
 						<el-table-column
+							prop="status"
 							:label="t('devicesShellyNgPlugin.headings.wizard.status')"
 							width="170"
+							sortable
+							:sort-method="sortByStatus"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
 								<el-tag
@@ -314,8 +323,11 @@
 							</template>
 						</el-table-column>
 						<el-table-column
+							prop="category"
 							:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
 							min-width="240"
+							sortable
+							:sort-method="sortByCategory"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
 								<el-select
@@ -336,26 +348,62 @@
 				</template>
 
 				<template v-else>
-					<el-result
-						:icon="adoptionResults.some((result) => result.status === 'failed') ? 'warning' : 'success'"
-						:title="t('devicesShellyNgPlugin.headings.wizard.results')"
-						class="flex-grow"
+					<el-alert
+						:title="t(`devicesShellyNgPlugin.texts.wizard.results.${adoptionResultSummary}`)"
+						:type="adoptionResultSummary === 'failed' ? 'warning' : 'success'"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<el-table
+						:data="adoptionResults"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
 					>
-						<template #sub-title>
-							<div class="flex flex-col gap-2">
-								<div
-									v-for="result in adoptionResults"
-									:key="result.hostname"
-									class="flex items-center justify-center gap-2"
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.headings.wizard.status')"
+							width="140"
+						>
+							<template #default="{ row }: { row: IShellyNgWizardAdoptionResult }">
+								<el-tag :type="resultTagType(row.status)">
+									{{ t(`devicesShellyNgPlugin.statuses.wizard.${row.status}`) }}
+								</el-tag>
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyNgWizardAdoptionResult }">
+								<span class="font-medium">{{ row.name }}</span>
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
+							min-width="150"
+						/>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.error.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyNgWizardAdoptionResult }">
+								<span
+									v-if="row.error"
+									class="text-red-500"
 								>
-									<el-tag :type="resultTagType(result.status)">
-										{{ t(`devicesShellyNgPlugin.statuses.wizard.${result.status}`) }}
-									</el-tag>
-									<span>{{ result.name }} ({{ result.hostname }})</span>
-								</div>
-							</div>
-						</template>
-					</el-result>
+									{{ row.error }}
+								</span>
+								<span
+									v-else
+									class="text-gray-400"
+								>
+									—
+								</span>
+							</template>
+						</el-table-column>
+					</el-table>
 				</template>
 			</div>
 
@@ -425,7 +473,6 @@ import {
 	ElInput,
 	ElOption,
 	ElProgress,
-	ElResult,
 	ElSelect,
 	ElStep,
 	ElSteps,
@@ -496,6 +543,40 @@ const onToggleSelectAll = (value: boolean | string | number): void => {
 		selected[device.hostname] = next;
 	}
 };
+
+// Sort comparators for the categories table — `prop`-based sorting can't read our reactive
+// per-hostname maps, so each column gets a custom comparator that reaches into the right
+// source of truth (user-edited name, current category selection, …).
+const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+const sortByName = (a: IShellyNgDiscoveryDevice, b: IShellyNgDiscoveryDevice): number => {
+	const aName = nameByHostname[a.hostname] ?? a.registeredDeviceName ?? a.name ?? a.displayName ?? a.hostname;
+	const bName = nameByHostname[b.hostname] ?? b.registeredDeviceName ?? b.name ?? b.displayName ?? b.hostname;
+	return compareLocale(aName, bName);
+};
+
+const sortByHostname = (a: IShellyNgDiscoveryDevice, b: IShellyNgDiscoveryDevice): number => compareLocale(a.hostname, b.hostname);
+
+// Group "will create" devices before "will update" ones, then by hostname inside each bucket.
+const sortByStatus = (a: IShellyNgDiscoveryDevice, b: IShellyNgDiscoveryDevice): number => {
+	const order = (status: IShellyNgDiscoveryDevice['status']): number => (status === 'already_registered' ? 1 : 0);
+	const diff = order(a.status) - order(b.status);
+	return diff !== 0 ? diff : compareLocale(a.hostname, b.hostname);
+};
+
+const sortByCategory = (a: IShellyNgDiscoveryDevice, b: IShellyNgDiscoveryDevice): number => {
+	const aLabel = categoryByHostname[a.hostname] ? t(`devicesModule.categories.devices.${categoryByHostname[a.hostname]}`) : '';
+	const bLabel = categoryByHostname[b.hostname] ? t(`devicesModule.categories.devices.${categoryByHostname[b.hostname]}`) : '';
+	return compareLocale(aLabel, bLabel);
+};
+
+const adoptionResultSummary = computed<'success' | 'failed'>(() =>
+	adoptionResults.value.some((result) => result.status === 'failed') ? 'failed' : 'success'
+);
 
 const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
 	{

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -223,7 +223,7 @@
 							min-width="220"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-								<span v-if="row.status !== 'ready'">-</span>
+								<span v-if="!isAdoptableStatus(row.status)">-</span>
 								<el-select
 									v-else
 									v-model="categoryByHostname[row.hostname]"
@@ -252,7 +252,7 @@
 					/>
 
 					<el-table
-						:data="readyDevices"
+						:data="adoptableDevices"
 						class="h-full w-full flex-grow"
 						table-layout="fixed"
 					>
@@ -266,7 +266,16 @@
 							min-width="220"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-								<el-input v-model="nameByHostname[row.hostname]" />
+								<div class="flex flex-col gap-1">
+									<el-input v-model="nameByHostname[row.hostname]" />
+									<el-tag
+										v-if="row.status === 'already_registered'"
+										size="small"
+										type="warning"
+									>
+										{{ t('devicesShellyNgPlugin.statuses.wizard.willUpdate') }}
+									</el-tag>
+								</div>
 							</template>
 						</el-table-column>
 						<el-table-column
@@ -309,7 +318,7 @@
 									:key="result.hostname"
 									class="flex items-center justify-center gap-2"
 								>
-									<el-tag :type="result.status === 'created' ? 'success' : 'danger'">
+									<el-tag :type="resultTagType(result.status)">
 										{{ t(`devicesShellyNgPlugin.statuses.wizard.${result.status}`) }}
 									</el-tag>
 									<span>{{ result.name }} ({{ result.hostname }})</span>
@@ -402,6 +411,7 @@ import { useNow } from '@vueuse/core';
 import { AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewHeader, useBreakpoints } from '../../../common';
 import { RouteNames as DevicesRouteNames, FormResult } from '../../../modules/devices';
 import { useDevicesWizard } from '../composables/composables';
+import type { IShellyNgWizardAdoptionResult } from '../composables/useDevicesWizard';
 import type { IShellyNgDiscoveryDevice } from '../schemas/devices.types';
 
 defineOptions({
@@ -442,7 +452,9 @@ const activeStepIndex = computed<number>(() => {
 	return 0;
 });
 
-const readyDevices = computed<IShellyNgDiscoveryDevice[]>(() => devices.value.filter((device) => device.status === 'ready'));
+const isAdoptableStatus = (status: IShellyNgDiscoveryDevice['status']): boolean => status === 'ready' || status === 'already_registered';
+
+const adoptableDevices = computed<IShellyNgDiscoveryDevice[]>(() => devices.value.filter((device) => isAdoptableStatus(device.status)));
 
 const scanPercentage = computed<number>(() => {
 	if (session.value === null) {
@@ -485,6 +497,18 @@ const statusTagType = (status: IShellyNgDiscoveryDevice['status']): 'success' | 
 	}
 
 	if (status === 'needs_password' || status === 'already_registered') {
+		return 'warning';
+	}
+
+	return 'danger';
+};
+
+const resultTagType = (status: IShellyNgWizardAdoptionResult['status']): 'success' | 'warning' | 'danger' => {
+	if (status === 'created') {
+		return 'success';
+	}
+
+	if (status === 'updated') {
 		return 'warning';
 	}
 

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -256,7 +256,15 @@
 						class="h-full w-full flex-grow"
 						table-layout="fixed"
 					>
-						<el-table-column width="70">
+						<el-table-column width="60">
+							<template #header>
+								<el-checkbox
+									:model-value="allAdoptableSelected"
+									:indeterminate="someAdoptableSelected && !allAdoptableSelected"
+									:disabled="adoptableDevices.length === 0"
+									@change="onToggleSelectAll"
+								/>
+							</template>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
 								<el-checkbox v-model="selected[row.hostname]" />
 							</template>
@@ -266,16 +274,7 @@
 							min-width="220"
 						>
 							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-								<div class="flex flex-col gap-1">
-									<el-input v-model="nameByHostname[row.hostname]" />
-									<el-tag
-										v-if="row.status === 'already_registered'"
-										size="small"
-										type="warning"
-									>
-										{{ t('devicesShellyNgPlugin.statuses.wizard.willUpdate') }}
-									</el-tag>
-								</div>
+								<el-input v-model="nameByHostname[row.hostname]" />
 							</template>
 						</el-table-column>
 						<el-table-column
@@ -283,6 +282,27 @@
 							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
 							min-width="150"
 						/>
+						<el-table-column
+							:label="t('devicesShellyNgPlugin.headings.wizard.status')"
+							width="170"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<el-tag
+									v-if="row.status === 'already_registered'"
+									size="small"
+									type="warning"
+								>
+									{{ t('devicesShellyNgPlugin.statuses.wizard.willUpdate') }}
+								</el-tag>
+								<el-tag
+									v-else
+									size="small"
+									type="success"
+								>
+									{{ t('devicesShellyNgPlugin.statuses.wizard.willCreate') }}
+								</el-tag>
+							</template>
+						</el-table-column>
 						<el-table-column
 							:label="t('devicesShellyNgPlugin.fields.devices.category.title')"
 							min-width="240"
@@ -452,6 +472,20 @@ const activeStepIndex = computed<number>(() => {
 });
 
 const adoptableDevices = computed<IShellyNgDiscoveryDevice[]>(() => devices.value.filter((device) => isAdoptableStatus(device.status)));
+
+const allAdoptableSelected = computed<boolean>(
+	() => adoptableDevices.value.length > 0 && adoptableDevices.value.every((device) => selected[device.hostname] === true)
+);
+
+const someAdoptableSelected = computed<boolean>(() => adoptableDevices.value.some((device) => selected[device.hostname] === true));
+
+const onToggleSelectAll = (value: boolean | string | number): void => {
+	const next = value === true;
+
+	for (const device of adoptableDevices.value) {
+		selected[device.hostname] = next;
+	}
+};
 
 const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
 	{

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -196,18 +196,28 @@
 						:empty-text="t('devicesShellyNgPlugin.texts.wizard.noDevices')"
 					>
 						<el-table-column
+							:label="t('devicesShellyNgPlugin.fields.devices.name.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
+								<div class="flex flex-col">
+									<span class="font-medium">
+										{{ row.registeredDeviceName || row.name || row.displayName || row.model || row.hostname }}
+									</span>
+									<span
+										v-if="row.displayName || row.model"
+										class="text-xs text-gray-500"
+									>
+										{{ row.displayName || row.model }}
+									</span>
+								</div>
+							</template>
+						</el-table-column>
+						<el-table-column
 							prop="hostname"
 							:label="t('devicesShellyNgPlugin.fields.devices.hostname.title')"
 							min-width="150"
 						/>
-						<el-table-column
-							:label="t('devicesShellyNgPlugin.headings.device.model')"
-							min-width="180"
-						>
-							<template #default="{ row }: { row: IShellyNgDiscoveryDevice }">
-								<span>{{ row.displayName || row.model || row.hostname }}</span>
-							</template>
-						</el-table-column>
 						<el-table-column
 							:label="t('devicesShellyNgPlugin.headings.wizard.status')"
 							width="170"

--- a/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue
@@ -406,12 +406,11 @@ import {
 } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
-import { useNow } from '@vueuse/core';
 
 import { AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewHeader, useBreakpoints } from '../../../common';
 import { RouteNames as DevicesRouteNames, FormResult } from '../../../modules/devices';
 import { useDevicesWizard } from '../composables/composables';
-import type { IShellyNgWizardAdoptionResult } from '../composables/useDevicesWizard';
+import { type IShellyNgWizardAdoptionResult, isAdoptableStatus } from '../composables/useDevicesWizard';
 import type { IShellyNgDiscoveryDevice } from '../schemas/devices.types';
 
 defineOptions({
@@ -421,7 +420,6 @@ defineOptions({
 const { t } = useI18n();
 const router = useRouter();
 const { isMDDevice, isLGDevice } = useBreakpoints();
-const now = useNow({ interval: 1_000 });
 const {
 	session,
 	devices,
@@ -432,6 +430,7 @@ const {
 	adoptionResults,
 	canContinue,
 	formResult,
+	scanPercentage,
 	startDiscovery,
 	addManualDevice,
 	adoptSelected,
@@ -452,26 +451,7 @@ const activeStepIndex = computed<number>(() => {
 	return 0;
 });
 
-const isAdoptableStatus = (status: IShellyNgDiscoveryDevice['status']): boolean => status === 'ready' || status === 'already_registered';
-
 const adoptableDevices = computed<IShellyNgDiscoveryDevice[]>(() => devices.value.filter((device) => isAdoptableStatus(device.status)));
-
-const scanPercentage = computed<number>(() => {
-	if (session.value === null) {
-		return 0;
-	}
-
-	if (session.value.status !== 'running') {
-		return 100;
-	}
-
-	const startedAt = new Date(session.value.startedAt).getTime();
-	const expiresAt = new Date(session.value.expiresAt).getTime();
-	const total = Math.max(1, expiresAt - startedAt);
-	const elapsed = Math.max(0, Math.min(total, now.value.getTime() - startedAt));
-
-	return Math.min(100, Math.max(0, Math.round((elapsed / total) * 100)));
-});
 
 const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
 	{

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -368,4 +368,80 @@ describe('useDevicesWizard', () => {
 			}),
 		]);
 	});
+
+	it('refreshes the editable name when a device transitions from checking to already_registered', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-3',
+					registeredDeviceName: 'Auto-adopted by main service',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: checkingDiscoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		// Placeholder during checking — no registered name available yet.
+		expect(wizard.nameByHostname['192.168.1.10']).toBe('192.168.1.10');
+
+		await wizard.refreshDiscovery();
+
+		// On checking → already_registered, the name field picks up registeredDeviceName so
+		// opting in to update doesn't accidentally overwrite the existing name with the hostname.
+		expect(wizard.nameByHostname['192.168.1.10']).toBe('Auto-adopted by main service');
+	});
+
+	it('starts scan progress at 0 even when the client clock is skewed from server timestamps', async () => {
+		// The discoverySession says scan started at 2026-04-29T12:00:00Z. The client clock is
+		// in 2030 — a previous client-clock-based implementation would have read elapsed as years
+		// and stayed at 100% (or 0% if behind). Receipt-anchored logic returns 0% on receipt.
+		vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+		await wizard.startDiscovery();
+
+		expect(wizard.scanPercentage.value).toBe(0);
+	});
+
+	it('jumps scan progress to 100 when the session finishes', async () => {
+		const finishedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			status: 'finished',
+			remainingSeconds: 0,
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: finishedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+		await wizard.startDiscovery();
+		await wizard.refreshDiscovery();
+
+		expect(wizard.scanPercentage.value).toBe(100);
+	});
 });

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -7,6 +7,7 @@ import type { IShellyNgDiscoverySession } from '../schemas/devices.types';
 import { useDevicesWizard } from './useDevicesWizard';
 
 const mockAdd = vi.fn();
+const mockEdit = vi.fn();
 
 const backendClient = {
 	GET: vi.fn(),
@@ -38,6 +39,7 @@ vi.mock('../../../common', async () => {
 		injectStoresManager: () => ({
 			getStore: () => ({
 				add: mockAdd,
+				edit: mockEdit,
 			}),
 		}),
 		useBackend: () => ({
@@ -99,6 +101,7 @@ describe('useDevicesWizard', () => {
 		vi.useFakeTimers();
 		vi.clearAllMocks();
 		mockAdd.mockResolvedValue(undefined);
+		mockEdit.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -126,22 +129,20 @@ describe('useDevicesWizard', () => {
 	});
 
 	it('adds a manual lookup to an existing discovery session', async () => {
-		backendClient.POST
-			.mockResolvedValueOnce({
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
 				data: {
-					data: {
-						...discoverySession,
-						devices: [],
-					},
+					...discoverySession,
+					devices: [],
 				},
-				response: { status: 200 },
-			})
-			.mockResolvedValueOnce({
-				data: {
-					data: discoverySession,
-				},
-				response: { status: 200 },
-			});
+			},
+			response: { status: 200 },
+		}).mockResolvedValueOnce({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
 
 		const wizard = useDevicesWizard();
 
@@ -206,19 +207,17 @@ describe('useDevicesWizard', () => {
 			},
 			response: { status: 200 },
 		});
-		backendClient.GET
-			.mockResolvedValueOnce({
-				data: {
-					data: checkingDiscoverySession,
-				},
-				response: { status: 200 },
-			})
-			.mockResolvedValueOnce({
-				data: {
-					data: discoverySession,
-				},
-				response: { status: 200 },
-			});
+		backendClient.GET.mockResolvedValueOnce({
+			data: {
+				data: checkingDiscoverySession,
+			},
+			response: { status: 200 },
+		}).mockResolvedValueOnce({
+			data: {
+				data: discoverySession,
+			},
+			response: { status: 200 },
+		});
 
 		const wizard = useDevicesWizard();
 
@@ -263,6 +262,109 @@ describe('useDevicesWizard', () => {
 				hostname: '192.168.1.10',
 				name: 'Kitchen relay',
 				status: 'created',
+			}),
+		]);
+	});
+
+	it('updates already_registered devices via edit when the user opts in', async () => {
+		const alreadyRegisteredSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-1',
+					registeredDeviceName: 'Existing kitchen relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: alreadyRegisteredSession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: alreadyRegisteredSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		// already_registered devices start unselected — user must opt in to override
+		expect(wizard.selected['192.168.1.10']).toBe(false);
+		expect(wizard.nameByHostname['192.168.1.10']).toBe('Existing kitchen relay');
+
+		wizard.selected['192.168.1.10'] = true;
+		wizard.categoryByHostname['192.168.1.10'] = DevicesModuleDeviceCategory.switcher;
+
+		await wizard.adoptSelected();
+
+		expect(mockEdit).toHaveBeenCalledWith({
+			id: 'device-uuid-1',
+			data: expect.objectContaining({
+				type: DEVICES_SHELLY_NG_TYPE,
+				category: DevicesModuleDeviceCategory.switcher,
+				name: 'Existing kitchen relay',
+			}),
+		});
+		expect(mockAdd).not.toHaveBeenCalled();
+		expect(wizard.adoptionResults.value).toEqual([
+			expect.objectContaining({
+				hostname: '192.168.1.10',
+				status: 'updated',
+			}),
+		]);
+	});
+
+	it('falls back to update when create fails because the main service auto-adopted the device', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-2',
+					registeredDeviceName: 'Auto-adopted relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		// First refresh in adoptSelected: still shows the snapshot's `ready` status.
+		// Second refresh (after add fails): shows the device now exists.
+		backendClient.GET.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		}).mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		mockAdd.mockRejectedValueOnce(new Error('Duplicate identifier'));
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+		await wizard.adoptSelected();
+
+		expect(mockAdd).toHaveBeenCalledTimes(1);
+		expect(mockEdit).toHaveBeenCalledWith({
+			id: 'device-uuid-2',
+			data: expect.objectContaining({
+				type: DEVICES_SHELLY_NG_TYPE,
+				category: DevicesModuleDeviceCategory.lighting,
+				name: 'Kitchen relay',
+			}),
+		});
+		expect(wizard.adoptionResults.value).toEqual([
+			expect.objectContaining({
+				hostname: '192.168.1.10',
+				status: 'updated',
 			}),
 		]);
 	});

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -80,6 +80,7 @@ const discoverySession: IShellyNgDiscoverySession = {
 			},
 			registeredDeviceId: null,
 			registeredDeviceName: null,
+			registeredDeviceCategory: null,
 			error: null,
 			lastSeenAt: '2026-04-29T12:00:01.000Z',
 		},
@@ -272,6 +273,35 @@ describe('useDevicesWizard', () => {
 		]);
 	});
 
+	it('pre-fills the category dropdown from registeredDeviceCategory for already_registered devices', async () => {
+		// Plus 1 supports both `lighting` and `switcher`, so `suggestedCategory` is null. Without
+		// `registeredDeviceCategory` the user would land on step 2 with an empty selector even
+		// though we already chose a category when the device was first adopted.
+		const alreadyRegisteredSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					suggestedCategory: null,
+					registeredDeviceId: 'device-uuid-1',
+					registeredDeviceName: 'Existing kitchen relay',
+					registeredDeviceCategory: DevicesModuleDeviceCategory.switcher,
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: alreadyRegisteredSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+		await wizard.startDiscovery();
+
+		expect(wizard.categoryByHostname['192.168.1.10']).toBe(DevicesModuleDeviceCategory.switcher);
+	});
+
 	it('updates already_registered devices via edit when the user opts in', async () => {
 		const alreadyRegisteredSession: IShellyNgDiscoverySession = {
 			...discoverySession,
@@ -281,6 +311,7 @@ describe('useDevicesWizard', () => {
 					status: 'already_registered',
 					registeredDeviceId: 'device-uuid-1',
 					registeredDeviceName: 'Existing kitchen relay',
+					registeredDeviceCategory: DevicesModuleDeviceCategory.lighting,
 				},
 			],
 		};

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -296,6 +296,12 @@ describe('useDevicesWizard', () => {
 		expect(wizard.selected['192.168.1.10']).toBe(false);
 		expect(wizard.nameByHostname['192.168.1.10']).toBe('Existing kitchen relay');
 
+		// Even though nothing is selected (so canContinue is false), the device list still has
+		// adoptable entries — the wizard's Next button must gate on that, not on canContinue,
+		// or a scan returning only already_registered devices would trap the user on step 1.
+		expect(wizard.canContinue.value).toBe(false);
+		expect(wizard.devices.value.some((d) => d.status === 'already_registered')).toBe(true);
+
 		wizard.selected['192.168.1.10'] = true;
 		wizard.categoryByHostname['192.168.1.10'] = DevicesModuleDeviceCategory.switcher;
 

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -430,6 +430,90 @@ describe('useDevicesWizard', () => {
 		]);
 	});
 
+	it('deselects a previously ready device when polling reports it as already_registered', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-mid-session',
+					registeredDeviceName: 'Auto-adopted relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		// Device started ready and was auto-selected.
+		expect(wizard.selected['192.168.1.10']).toBe(true);
+
+		// Polling refresh: device transitions to already_registered (e.g., main connector
+		// auto-adopted it). Selection must clear so the next Adopt click doesn't silently
+		// update the existing device — the user has to explicitly opt in for updates.
+		await wizard.refreshDiscovery();
+
+		expect(wizard.selected['192.168.1.10']).toBe(false);
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
+	it('still adopts a device the user selected if the refresh inside adoptSelected flips it to already_registered', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-in-flight',
+					registeredDeviceName: 'Auto-adopted relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		// First refresh (inside adoptSelected) reports the status flip.
+		backendClient.GET.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+		// User explicitly selected the device when it was still `ready`.
+		expect(wizard.selected['192.168.1.10']).toBe(true);
+
+		await wizard.adoptSelected();
+
+		// Snapshot-before-refresh keeps the device in scope for adoption even though
+		// the refresh deselects it in live state.
+		expect(mockEdit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'device-uuid-in-flight',
+			})
+		);
+		expect(wizard.adoptionResults.value).toEqual([
+			expect.objectContaining({
+				hostname: '192.168.1.10',
+				status: 'updated',
+			}),
+		]);
+	});
+
 	it('refreshes the editable name when a device transitions from checking to already_registered', async () => {
 		const racedSession: IShellyNgDiscoverySession = {
 			...discoverySession,

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -8,6 +8,8 @@ import { useDevicesWizard } from './useDevicesWizard';
 
 const mockAdd = vi.fn();
 const mockEdit = vi.fn();
+const mockGet = vi.fn();
+const mockFindById = vi.fn();
 
 const backendClient = {
 	GET: vi.fn(),
@@ -40,6 +42,8 @@ vi.mock('../../../common', async () => {
 			getStore: () => ({
 				add: mockAdd,
 				edit: mockEdit,
+				get: mockGet,
+				findById: mockFindById,
 			}),
 		}),
 		useBackend: () => ({
@@ -102,6 +106,8 @@ describe('useDevicesWizard', () => {
 		vi.clearAllMocks();
 		mockAdd.mockResolvedValue(undefined);
 		mockEdit.mockResolvedValue(undefined);
+		mockGet.mockResolvedValue(undefined);
+		mockFindById.mockReturnValue({ id: 'placeholder' });
 	});
 
 	afterEach(() => {
@@ -367,6 +373,55 @@ describe('useDevicesWizard', () => {
 				name: 'Kitchen relay',
 			}),
 		});
+		expect(wizard.adoptionResults.value).toEqual([
+			expect.objectContaining({
+				hostname: '192.168.1.10',
+				status: 'updated',
+			}),
+		]);
+	});
+
+	it('loads the device into the local store before editing if it was just auto-adopted', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-fresh',
+					registeredDeviceName: 'Auto-adopted relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		// Device exists in the backend (already_registered) but not yet in the admin store —
+		// `devicesStore.edit` would otherwise reject the id.
+		mockFindById.mockReturnValue(null);
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startDiscovery();
+
+		wizard.selected['192.168.1.10'] = true;
+		wizard.categoryByHostname['192.168.1.10'] = DevicesModuleDeviceCategory.switcher;
+
+		await wizard.adoptSelected();
+
+		expect(mockGet).toHaveBeenCalledWith({ id: 'device-uuid-fresh' });
+		expect(mockEdit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'device-uuid-fresh',
+			})
+		);
 		expect(wizard.adoptionResults.value).toEqual([
 			expect.objectContaining({
 				hostname: '192.168.1.10',

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -422,6 +422,43 @@ describe('useDevicesWizard', () => {
 		expect(wizard.scanPercentage.value).toBe(0);
 	});
 
+	it('clears stale selections from a previous scan when the user clicks Scan again', async () => {
+		const racedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			id: 'session-2',
+			devices: [
+				{
+					...discoverySession.devices[0]!,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-existing',
+					registeredDeviceName: 'Auto-adopted relay',
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		}).mockResolvedValueOnce({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		// First scan: device is ready, gets pre-selected.
+		await wizard.startDiscovery();
+		expect(wizard.selected['192.168.1.10']).toBe(true);
+
+		// User clicks Scan again. The same device now shows as already_registered (the main
+		// service auto-adopted it in the meantime). The previous selection must NOT persist —
+		// otherwise the next adopt would silently update an existing device.
+		await wizard.startDiscovery();
+
+		expect(wizard.selected['192.168.1.10']).toBe(false);
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
 	it('jumps scan progress to 100 when the session finishes', async () => {
 		const finishedSession: IShellyNgDiscoverySession = {
 			...discoverySession,

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { orderBy } from 'natural-orderby';
 import { v4 as uuid } from 'uuid';
 
-import { tryOnMounted, tryOnUnmounted } from '@vueuse/core';
+import { tryOnMounted, tryOnUnmounted, useNow } from '@vueuse/core';
 
 import { PLUGINS_PREFIX } from '../../../app.constants';
 import { getErrorReason, injectStoresManager, useBackend, useFlashMessage } from '../../../common';
@@ -27,10 +27,13 @@ export interface IShellyNgWizardAdoptionResult {
 	error: string | null;
 }
 
+export const isAdoptableStatus = (status: IShellyNgDiscoveryDevice['status']): boolean => status === 'ready' || status === 'already_registered';
+
 export interface IUseDevicesWizard {
 	session: ComputedRef<IShellyNgDiscoverySession | null>;
 	devices: ComputedRef<IShellyNgDiscoveryDevice[]>;
 	selectedDevices: ComputedRef<IShellyNgDiscoveryDevice[]>;
+	scanPercentage: ComputedRef<number>;
 	formResult: ComputedRef<FormResultType>;
 	manual: Reactive<{
 		hostname: string;
@@ -70,11 +73,38 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 	let pollingTimer: number | null = null;
 
-	const isAdoptableStatus = (status: IShellyNgDiscoveryDevice['status']): boolean => status === 'ready' || status === 'already_registered';
+	// Captured at every applySession so scanPercentage can tick forward independent of any
+	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
+	// on every poll, so any local drift is bounded by the polling interval (~1s).
+	const sessionReceivedAt = ref<number | null>(null);
+	const sessionRemainingMsAtReceipt = ref<number>(0);
+	const sessionDurationMs = ref<number>(0);
+
+	const now = useNow({ interval: 1_000 });
 
 	const devices = computed<IShellyNgDiscoveryDevice[]>(() =>
 		orderBy(session.value?.devices ?? [], [(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.hostname], ['asc', 'asc'])
 	);
+
+	const scanPercentage = computed<number>(() => {
+		if (session.value === null) {
+			return 0;
+		}
+
+		if (session.value.status !== 'running') {
+			return 100;
+		}
+
+		if (sessionReceivedAt.value === null || sessionDurationMs.value === 0) {
+			return 0;
+		}
+
+		const elapsedSinceReceipt = Math.max(0, now.value.getTime() - sessionReceivedAt.value);
+		const remainingMs = Math.max(0, sessionRemainingMsAtReceipt.value - elapsedSinceReceipt);
+		const elapsed = sessionDurationMs.value - remainingMs;
+
+		return Math.min(100, Math.max(0, Math.round((elapsed / sessionDurationMs.value) * 100)));
+	});
 
 	const selectedDevices = computed<IShellyNgDiscoveryDevice[]>(() =>
 		devices.value.filter(
@@ -106,9 +136,17 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 		session.value = nextSession;
 
+		// Snap the client-side progress reference to the moment we received this snapshot.
+		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even
+		// when the client clock is skewed relative to the server's startedAt/expiresAt.
+		sessionReceivedAt.value = Date.now();
+		sessionRemainingMsAtReceipt.value = nextSession.remainingSeconds * 1_000;
+		sessionDurationMs.value = Math.max(1, new Date(nextSession.expiresAt).getTime() - new Date(nextSession.startedAt).getTime());
+
 		for (const device of nextSession.devices) {
 			const previousDevice = previousDevices.find((item) => item.hostname === device.hostname);
 			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
+			const becameAdoptable = previousDevice?.status === 'checking' && isAdoptableStatus(device.status);
 			const wasPreviouslyReady = readyHostnames.has(device.hostname);
 
 			// `ready` devices are pre-selected so the user can adopt new devices in one step.
@@ -122,7 +160,11 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				categoryByHostname[device.hostname] = device.suggestedCategory;
 			}
 
-			if (nameByHostname[device.hostname] === undefined || (becameReady && nameByHostname[device.hostname] === device.hostname)) {
+			// Refresh the editable name when the inspect step finishes (checking → ready or
+			// checking → already_registered) and the user hasn't typed anything yet — otherwise
+			// `already_registered` devices would keep the hostname placeholder and overwrite the
+			// existing registered name on update.
+			if (nameByHostname[device.hostname] === undefined || (becameAdoptable && nameByHostname[device.hostname] === device.hostname)) {
 				nameByHostname[device.hostname] = device.registeredDeviceName ?? device.name ?? device.displayName ?? device.hostname;
 			}
 
@@ -384,6 +426,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		session: computed(() => session.value),
 		devices,
 		selectedDevices,
+		scanPercentage,
 		formResult: computed(() => formResult.value),
 		manual,
 		selected,

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -185,7 +185,14 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				nameByHostname[device.hostname] = device.registeredDeviceName ?? device.name ?? device.displayName ?? device.hostname;
 			}
 
-			if (isAdoptableStatus(device.status)) {
+			// `readyHostnames` records devices that have been observed in the `ready` state at
+			// least once during the session. Its only consumer is the `becameReady &&
+			// !wasPreviouslyReady` guard above, which prevents re-selecting a device the user
+			// already deselected. We must NOT include `already_registered` here — otherwise a
+			// device that started as `already_registered`, was deleted from the DB mid-session,
+			// then transitioned `checking → ready` would be treated as previously-ready and skip
+			// auto-selection.
+			if (device.status === 'ready') {
 				readyHostnames.add(device.hostname);
 			}
 		}

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -166,8 +166,15 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				selected[device.hostname] = false;
 			}
 
-			if (categoryByHostname[device.hostname] === undefined || (categoryByHostname[device.hostname] === null && device.suggestedCategory !== null)) {
-				categoryByHostname[device.hostname] = device.suggestedCategory;
+			// Pre-fill the category dropdown so the wizard never lands on an empty selector for
+			// already-adopted devices: prefer the existing DB category over the descriptor's
+			// suggestion (the descriptor's `suggestedCategory` is only set when the model maps
+			// to a single category, so a Plus 1 — which supports both `lighting` and `switcher` —
+			// would otherwise show as blank even though we already picked one when adopting).
+			const initialCategory = device.registeredDeviceCategory ?? device.suggestedCategory;
+
+			if (categoryByHostname[device.hostname] === undefined || (categoryByHostname[device.hostname] === null && initialCategory !== null)) {
+				categoryByHostname[device.hostname] = initialCategory;
 			}
 
 			// Refresh the editable name when the inspect step finishes (checking → ready or

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -425,6 +425,13 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			data.password = password;
 		}
 
+		// `devicesStore.edit` requires the device to be present in the local store. When the
+		// main connector auto-adopts a device after the wizard's snapshot was taken, the new
+		// row may not be in the admin store yet — pull it in first so the edit can land.
+		if (devicesStore.findById(id) === null) {
+			await devicesStore.get({ id });
+		}
+
 		await devicesStore.edit({ id, data });
 	};
 

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -147,13 +147,23 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			const previousDevice = previousDevices.find((item) => item.hostname === device.hostname);
 			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
 			const becameAdoptable = previousDevice?.status === 'checking' && isAdoptableStatus(device.status);
+			const becameAlreadyRegistered =
+				previousDevice !== undefined && previousDevice.status !== 'already_registered' && device.status === 'already_registered';
 			const wasPreviouslyReady = readyHostnames.has(device.hostname);
 
 			// `ready` devices are pre-selected so the user can adopt new devices in one step.
 			// `already_registered` devices stay deselected — the user must opt in explicitly to override
 			// the category/name the main service auto-adopted them with.
+			//
+			// If a device that was previously `ready` (and possibly user-selected) refreshes to
+			// `already_registered` — typically because the main connector auto-adopted it during the
+			// session — clear the selection so the next Adopt click doesn't silently update an
+			// existing device. `adoptSelected` snapshots the user's selections before its own
+			// refresh, so an in-flight adopt isn't dropped by this rule.
 			if (selected[device.hostname] === undefined || (becameReady && !wasPreviouslyReady)) {
 				selected[device.hostname] = device.status === 'ready';
+			} else if (becameAlreadyRegistered) {
+				selected[device.hostname] = false;
 			}
 
 			if (categoryByHostname[device.hostname] === undefined || (categoryByHostname[device.hostname] === null && device.suggestedCategory !== null)) {
@@ -312,6 +322,14 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	const adoptSelected = async (): Promise<IShellyNgWizardAdoptionResult[]> => {
 		formResult.value = FormResult.WORKING;
 
+		// Snapshot the user's intent BEFORE refreshing. The refresh below can flip a
+		// `ready` device to `already_registered` (because the main connector auto-adopted
+		// it concurrently), and `applySession` deselects on that transition to keep the
+		// opt-in-for-updates contract on subsequent clicks. We still want THIS click to
+		// adopt the device the user chose — as an update, since that's what the new
+		// status means.
+		const userSelections = selectedDevices.value.slice();
+
 		// Refresh once so we see any device the main service auto-adopted between scan and adoption.
 		// Lets us route those through `edit` instead of getting a duplicate-identifier error from `add`.
 		if (session.value !== null) {
@@ -324,7 +342,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 		const results: IShellyNgWizardAdoptionResult[] = [];
 
-		for (const selection of selectedDevices.value) {
+		for (const selection of userSelections) {
 			const device = devices.value.find((item) => item.hostname === selection.hostname) ?? selection;
 			const name = nameByHostname[device.hostname] || device.name || device.displayName || device.hostname;
 			const category = categoryByHostname[device.hostname] as DevicesModuleDeviceCategory;

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -178,6 +178,22 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		}
 	};
 
+	const resetSessionScopedState = (): void => {
+		for (const key of Object.keys(selected)) {
+			delete selected[key];
+		}
+		for (const key of Object.keys(categoryByHostname)) {
+			delete categoryByHostname[key];
+		}
+		for (const key of Object.keys(nameByHostname)) {
+			delete nameByHostname[key];
+		}
+		for (const key of Object.keys(passwordByHostname)) {
+			delete passwordByHostname[key];
+		}
+		readyHostnames.clear();
+	};
+
 	const startDiscovery = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 
@@ -188,6 +204,12 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
 
 		if (typeof responseData !== 'undefined') {
+			// Drop any selections / inputs from a previous scan before applying the new snapshot.
+			// Otherwise a device that was `ready` last time and now shows as `already_registered`
+			// would carry over `selected=true` and silently update an existing device on adopt.
+			// Refreshes within the same session keep their state — only `startDiscovery` resets,
+			// so the per-device race fallback in `adoptSelected` still works.
+			resetSessionScopedState();
 			applySession(transformDiscoverySessionResponse(responseData.data));
 			formResult.value = FormResult.NONE;
 			startPolling();

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -6,8 +6,8 @@ import { v4 as uuid } from 'uuid';
 
 import { tryOnMounted, tryOnUnmounted } from '@vueuse/core';
 
-import { getErrorReason, injectStoresManager, useBackend, useFlashMessage } from '../../../common';
 import { PLUGINS_PREFIX } from '../../../app.constants';
+import { getErrorReason, injectStoresManager, useBackend, useFlashMessage } from '../../../common';
 import { FormResult, type FormResultType, devicesStoreKey } from '../../../modules/devices';
 import {
 	DevicesModuleDeviceCategory,
@@ -23,7 +23,7 @@ import { transformDeviceInfoRequest, transformDiscoverySessionResponse } from '.
 export interface IShellyNgWizardAdoptionResult {
 	hostname: string;
 	name: string;
-	status: 'created' | 'failed';
+	status: 'created' | 'updated' | 'failed';
 	error: string | null;
 }
 
@@ -70,13 +70,15 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 	let pollingTimer: number | null = null;
 
+	const isAdoptableStatus = (status: IShellyNgDiscoveryDevice['status']): boolean => status === 'ready' || status === 'already_registered';
+
 	const devices = computed<IShellyNgDiscoveryDevice[]>(() =>
-		orderBy(session.value?.devices ?? [], [(device) => device.status === 'ready' ? 0 : 1, (device) => device.hostname], ['asc', 'asc'])
+		orderBy(session.value?.devices ?? [], [(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.hostname], ['asc', 'asc'])
 	);
 
 	const selectedDevices = computed<IShellyNgDiscoveryDevice[]>(() =>
 		devices.value.filter(
-			(device) => selected[device.hostname] === true && device.status === 'ready' && categoryByHostname[device.hostname] !== null
+			(device) => selected[device.hostname] === true && isAdoptableStatus(device.status) && categoryByHostname[device.hostname] !== null
 		)
 	);
 
@@ -109,22 +111,22 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
 			const wasPreviouslyReady = readyHostnames.has(device.hostname);
 
+			// `ready` devices are pre-selected so the user can adopt new devices in one step.
+			// `already_registered` devices stay deselected — the user must opt in explicitly to override
+			// the category/name the main service auto-adopted them with.
 			if (selected[device.hostname] === undefined || (becameReady && !wasPreviouslyReady)) {
 				selected[device.hostname] = device.status === 'ready';
 			}
 
-			if (
-				categoryByHostname[device.hostname] === undefined ||
-				(categoryByHostname[device.hostname] === null && device.suggestedCategory !== null)
-			) {
+			if (categoryByHostname[device.hostname] === undefined || (categoryByHostname[device.hostname] === null && device.suggestedCategory !== null)) {
 				categoryByHostname[device.hostname] = device.suggestedCategory;
 			}
 
 			if (nameByHostname[device.hostname] === undefined || (becameReady && nameByHostname[device.hostname] === device.hostname)) {
-				nameByHostname[device.hostname] = device.name ?? device.displayName ?? device.hostname;
+				nameByHostname[device.hostname] = device.registeredDeviceName ?? device.name ?? device.displayName ?? device.hostname;
 			}
 
-			if (device.status === 'ready') {
+			if (isAdoptableStatus(device.status)) {
 				readyHostnames.add(device.hostname);
 			}
 		}
@@ -234,10 +236,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		}
 
 		const errorReason = error
-			? getErrorReason<DevicesShellyNgPluginCreateDiscoveryManualOperation>(
-					error,
-					t('devicesShellyNgPlugin.messages.wizard.manualNotAdded')
-				)
+			? getErrorReason<DevicesShellyNgPluginCreateDiscoveryManualOperation>(error, t('devicesShellyNgPlugin.messages.wizard.manualNotAdded'))
 			: t('devicesShellyNgPlugin.messages.wizard.manualNotAdded');
 
 		formResult.value = FormResult.ERROR;
@@ -249,35 +248,89 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	const adoptSelected = async (): Promise<IShellyNgWizardAdoptionResult[]> => {
 		formResult.value = FormResult.WORKING;
 
+		// Refresh once so we see any device the main service auto-adopted between scan and adoption.
+		// Lets us route those through `edit` instead of getting a duplicate-identifier error from `add`.
+		if (session.value !== null) {
+			try {
+				await refreshDiscovery();
+			} catch {
+				// Stale snapshot is fine — the per-device fallback below still handles late races.
+			}
+		}
+
 		const results: IShellyNgWizardAdoptionResult[] = [];
 
-		for (const device of selectedDevices.value) {
-			const id = uuid().toString();
+		for (const selection of selectedDevices.value) {
+			const device = devices.value.find((item) => item.hostname === selection.hostname) ?? selection;
 			const name = nameByHostname[device.hostname] || device.name || device.displayName || device.hostname;
+			const category = categoryByHostname[device.hostname] as DevicesModuleDeviceCategory;
+			const password = passwordByHostname[device.hostname] ?? null;
 
 			try {
-				await devicesStore.add({
-					id,
-					draft: false,
-					data: {
-						id,
-						type: DEVICES_SHELLY_NG_TYPE,
-						category: categoryByHostname[device.hostname] as DevicesModuleDeviceCategory,
-						identifier: device.identifier,
-						name,
-						description: null,
-						enabled: true,
-						password: passwordByHostname[device.hostname] ?? null,
-						wifiAddress: device.hostname,
-					},
-				});
+				if (device.status === 'already_registered' && device.registeredDeviceId !== null) {
+					await updateRegistered(device.registeredDeviceId, { name, category, password });
 
-				results.push({
-					hostname: device.hostname,
-					name,
-					status: 'created',
-					error: null,
-				});
+					results.push({
+						hostname: device.hostname,
+						name,
+						status: 'updated',
+						error: null,
+					});
+
+					continue;
+				}
+
+				const id = uuid().toString();
+
+				try {
+					await devicesStore.add({
+						id,
+						draft: false,
+						data: {
+							id,
+							type: DEVICES_SHELLY_NG_TYPE,
+							category,
+							identifier: device.identifier,
+							name,
+							description: null,
+							enabled: true,
+							password,
+							wifiAddress: device.hostname,
+						},
+					});
+
+					results.push({
+						hostname: device.hostname,
+						name,
+						status: 'created',
+						error: null,
+					});
+				} catch (createError: unknown) {
+					// The device may have been auto-created by the main shelly-ng service after the discovery
+					// snapshot was taken. Re-poll, and if it now shows as already_registered, fall back to update.
+					try {
+						await refreshDiscovery();
+					} catch {
+						// ignore — handled below
+					}
+
+					const refreshed = devices.value.find((item) => item.hostname === device.hostname);
+
+					if (refreshed?.status === 'already_registered' && refreshed.registeredDeviceId !== null) {
+						await updateRegistered(refreshed.registeredDeviceId, { name, category, password });
+
+						results.push({
+							hostname: device.hostname,
+							name,
+							status: 'updated',
+							error: null,
+						});
+
+						continue;
+					}
+
+					throw createError;
+				}
 			} catch (error: unknown) {
 				results.push({
 					hostname: device.hostname,
@@ -292,6 +345,23 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		formResult.value = results.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
 
 		return results;
+	};
+
+	const updateRegistered = async (
+		id: string,
+		{ name, category, password }: { name: string; category: DevicesModuleDeviceCategory; password: string | null }
+	): Promise<void> => {
+		const data: { type: string; name: string; category: DevicesModuleDeviceCategory; password?: string } = {
+			type: DEVICES_SHELLY_NG_TYPE,
+			name,
+			category,
+		};
+
+		if (password !== null) {
+			data.password = password;
+		}
+
+		await devicesStore.edit({ id, data });
 	};
 
 	const categoryOptions = (device: IShellyNgDiscoveryDevice): { value: DevicesModuleDeviceCategory; label: string }[] =>

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
@@ -167,7 +167,9 @@
 			"already_registered": "Registrováno",
 			"unsupported": "Nepodporováno",
 			"failed": "Selhalo",
-			"created": "Vytvořeno"
+			"created": "Vytvořeno",
+			"updated": "Aktualizováno",
+			"willUpdate": "Aktualizuje stávající"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
@@ -169,6 +169,7 @@
 			"failed": "Selhalo",
 			"created": "Vytvořeno",
 			"updated": "Aktualizováno",
+			"willCreate": "Bude vytvořeno",
 			"willUpdate": "Aktualizuje stávající"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
@@ -58,6 +58,9 @@
 				"title": "Heslo administrátora",
 				"placeholder": "Zadejte heslo zařízení, pokud je chráněno"
 			},
+			"error": {
+				"title": "Chyba"
+			},
 			"hostname": {
 				"title": "Název hostitele zařízení",
 				"placeholder": "Síťový název nebo IP adresa zařízení",
@@ -137,7 +140,11 @@
 			"discovery": "Průvodce vyhledá zařízení Shelly NG v lokální síti a přijímá také ručně zadaný hostname nebo IP adresu.",
 			"categories": "Potvrďte, která připravená zařízení mají být adoptována, a vyberte cílovou kategorii pro každé z nich.",
 			"scanStatus": "Nalezeno zařízení: {count}",
-			"noDevices": "Nebyla nalezena žádná zařízení Shelly"
+			"noDevices": "Nebyla nalezena žádná zařízení Shelly",
+			"results": {
+				"success": "Všechna zařízení byla úspěšně adoptována.",
+				"failed": "Některá zařízení se nepodařilo adoptovat. Zkontrolujte chyby níže."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/cs-CZ.json
@@ -12,11 +12,18 @@
 			"firmware": "Firmware"
 		},
 		"wizard": {
+			"title": "Průvodce vyhledáním Shelly NG",
 			"discovery": "Vyhledávání",
 			"categories": "Kategorie",
 			"results": "Výsledky",
 			"status": "Stav"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Najděte a adoptujte zařízení Shelly NG ve vaší síti"
+	},
+	"breadcrumbs": {
+		"wizard": "průvodce vyhledáním"
 	},
 	"fields": {
 		"devices": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
@@ -167,7 +167,9 @@
 			"already_registered": "Registered",
 			"unsupported": "Unsupported",
 			"failed": "Failed",
-			"created": "Created"
+			"created": "Created",
+			"updated": "Aktualisiert",
+			"willUpdate": "Bestehendes wird aktualisiert"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
@@ -58,6 +58,9 @@
 				"title": "Admin-Passwort",
 				"placeholder": "Gerätepasswort eingeben, falls das Gerät geschützt ist"
 			},
+			"error": {
+				"title": "Fehler"
+			},
 			"hostname": {
 				"title": "Geräte-Hostname",
 				"placeholder": "Netzwerkname oder IP-Adresse des Geräts",
@@ -137,7 +140,11 @@
 			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
 			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
 			"scanStatus": "{count} devices found",
-			"noDevices": "No Shelly devices found"
+			"noDevices": "No Shelly devices found",
+			"results": {
+				"success": "Alle Geräte wurden erfolgreich übernommen.",
+				"failed": "Einige Geräte konnten nicht übernommen werden. Überprüfen Sie die Fehler unten."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
@@ -1,166 +1,173 @@
 {
-  "headings": {
-    "aboutPluginStatus": "Plugin-Status",
-    "aboutMdns": "MDNS-Einstellungen",
-    "aboutWebsockets": "WebSocket-Einstellungen",
-    "device": {
-      "deviceConnection": "Geräteverbindung",
-      "information": "Geräteinformationen",
-      "supported": "Glückwunsch! Gerät wird unterstützt",
-      "notSupported": "Leider wird Ihr Gerät nicht unterstützt",
-      "model": "Modell",
-      "firmware": "Firmware"
-    },
-    "wizard": {
-      "discovery": "Discovery",
-      "categories": "Categories",
-      "results": "Results",
-      "status": "Status"
-    }
-  },
-  "fields": {
-    "devices": {
-      "id": {
-        "title": "Interner Bezeichner",
-        "placeholder": "Geräte-ID"
-      },
-      "category": {
-        "title": "Kategorie",
-        "placeholder": "Gerätekategorie",
-        "description": "Über Kategorie",
-        "validation": {
-          "required": "Bitte wählen Sie eine Gerätekategorie"
-        }
-      },
-      "name": {
-        "title": "Name",
-        "placeholder": "Gerätename",
-        "validation": {
-          "required": "Bitte geben Sie den Gerätenamen ein"
-        }
-      },
-      "description": {
-        "title": "Beschreibung",
-        "placeholder": "Gerätebeschreibung"
-      },
-      "enabled": {
-        "title": "Aktiviert",
-        "placeholder": "Gerät aktivieren oder deaktivieren"
-      },
-      "password": {
-        "title": "Admin-Passwort",
-        "placeholder": "Gerätepasswort eingeben, falls das Gerät geschützt ist"
-      },
-      "hostname": {
-        "title": "Geräte-Hostname",
-        "placeholder": "Netzwerkname oder IP-Adresse des Geräts",
-        "validation": {
-          "required": "Bitte geben Sie den Geräte-Hostname oder die IP-Adresse ein"
-        }
-      }
-    },
-    "config": {
-      "enabled": {
-        "title": "Aktiviert"
-      },
-      "mdns": {
-        "enabled": {
-          "title": "Erkennung aktiviert"
-        },
-        "interface": {
-          "title": "Schnittstelle",
-          "placeholder": "Die zu verwendende Netzwerkschnittstelle. Wenn keine angegeben ist, werden alle verfügbaren Schnittstellen verwendet."
-        }
-      },
-      "websockets": {
-        "requestTimeout": {
-          "title": "Anfragezeitlimit",
-          "placeholder": "Die Zeit in Sekunden, die auf eine Antwort gewartet wird, bevor eine Anfrage abgebrochen wird.",
-          "validation": {
-            "required": "Bitte geben Sie das Anfragezeitlimit ein",
-            "number": "Anfragezeitlimit muss eine Zahl sein"
-          }
-        },
-        "pingInterval": {
-          "title": "Ping-Intervall",
-          "placeholder": "Das Intervall in Sekunden, in dem Ping-Anfragen gesendet werden, um zu überprüfen, ob die Verbindung offen ist. Auf 0 setzen zum Deaktivieren.",
-          "validation": {
-            "required": "Bitte geben Sie das Ping-Intervall ein",
-            "number": "Ping-Intervall muss eine Zahl sein"
-          }
-        },
-        "reconnectInterval": {
-          "title": "Wiederverbindungsintervall",
-          "placeholder": "Das Intervall in Sekunden, in dem ein Verbindungsversuch nach dem Schließen eines Sockets unternommen wird.",
-          "validation": {
-            "required": "Bitte geben Sie das Wiederverbindungsintervall ein",
-            "number": "Wiederverbindungsintervall muss eine Zahl sein",
-            "array": "Wiederverbindungsintervall muss ein Array von Zahlen sein"
-          }
-        }
-      }
-    }
-  },
-  "messages": {
-    "config": {
-      "edited": "Änderungen gespeichert! Die Shelly Next Generation Plugin-Konfiguration wurde aktualisiert.",
-      "notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung der Shelly Next Generation Plugin-Konfiguration war nicht erfolgreich."
-    },
-    "devices": {
-      "exists": "Ein Gerät mit diesem Hostname und Passwort ist bereits im System registriert.",
-      "created": "Neues Shelly Next-Generation-Gerät erfolgreich hinzugefügt.",
-      "notCreated": "Etwas ist schiefgelaufen. Das Shelly Next-Generation-Gerät konnte nicht erstellt werden.",
-      "notChecked": "Etwas ist schiefgelaufen. Geräteinformationen konnten nicht geladen werden. Überprüfen Sie den Geräte-Hostname oder das Passwort.",
-      "edited": "Änderungen gespeichert! Das Shelly Next-Generation-Gerät: {device} wurde aktualisiert.",
-      "notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung des Shelly Next-Generation-Geräts war nicht erfolgreich.",
-      "failedLoadSupportedDevices": "Etwas ist schiefgelaufen. Die unterstützten Geräte des Plugins konnten nicht geladen werden."
-    },
-    "wizard": {
-      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
-    }
-  },
-  "texts": {
-    "aboutPluginStatus": "Aktivieren oder deaktivieren Sie die Shelly Next Generation Geräteintegration. Wenn aktiviert, können Shelly-Geräte über das Smart Panel erkannt und gesteuert werden.",
-    "aboutMdns": "Konfigurieren Sie, wie das Plugin Shelly-Geräte in Ihrem lokalen Netzwerk über Multicast DNS (mDNS) erkennt. Dies ermöglicht die automatische Erkennung ohne manuelle Eingabe von IP-Adressen.",
-    "aboutWebsockets": "Verwalten Sie WebSocket-Verbindungsparameter für Shelly-Geräte. Diese Einstellungen steuern Kommunikationsstabilität, Anfrageverarbeitung und Wiederverbindungsverhalten.",
-    "wizard": {
-      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
-      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-      "scanStatus": "{count} devices found",
-      "noDevices": "No Shelly devices found"
-    }
-  },
-  "buttons": {
-    "next": {
-      "title": "Weiter"
-    },
-    "wizard": {
-      "restart": {
-        "title": "Scan again"
-      },
-      "addManual": {
-        "title": "Add"
-      },
-      "adopt": {
-        "title": "Adopt selected"
-      },
-      "finish": {
-        "title": "Back to devices"
-      }
-    }
-  },
-  "statuses": {
-    "wizard": {
-      "checking": "Checking",
-      "ready": "Ready",
-      "needs_password": "Needs password",
-      "already_registered": "Registered",
-      "unsupported": "Unsupported",
-      "failed": "Failed",
-      "created": "Created"
-    }
-  }
+	"headings": {
+		"aboutPluginStatus": "Plugin-Status",
+		"aboutMdns": "MDNS-Einstellungen",
+		"aboutWebsockets": "WebSocket-Einstellungen",
+		"device": {
+			"deviceConnection": "Geräteverbindung",
+			"information": "Geräteinformationen",
+			"supported": "Glückwunsch! Gerät wird unterstützt",
+			"notSupported": "Leider wird Ihr Gerät nicht unterstützt",
+			"model": "Modell",
+			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Shelly NG Discovery-Assistent",
+			"discovery": "Discovery",
+			"categories": "Categories",
+			"results": "Results",
+			"status": "Status"
+		}
+	},
+	"subHeadings": {
+		"wizard": "Finden und übernehmen Sie Shelly NG-Geräte in Ihrem Netzwerk"
+	},
+	"breadcrumbs": {
+		"wizard": "Discovery-Assistent"
+	},
+	"fields": {
+		"devices": {
+			"id": {
+				"title": "Interner Bezeichner",
+				"placeholder": "Geräte-ID"
+			},
+			"category": {
+				"title": "Kategorie",
+				"placeholder": "Gerätekategorie",
+				"description": "Über Kategorie",
+				"validation": {
+					"required": "Bitte wählen Sie eine Gerätekategorie"
+				}
+			},
+			"name": {
+				"title": "Name",
+				"placeholder": "Gerätename",
+				"validation": {
+					"required": "Bitte geben Sie den Gerätenamen ein"
+				}
+			},
+			"description": {
+				"title": "Beschreibung",
+				"placeholder": "Gerätebeschreibung"
+			},
+			"enabled": {
+				"title": "Aktiviert",
+				"placeholder": "Gerät aktivieren oder deaktivieren"
+			},
+			"password": {
+				"title": "Admin-Passwort",
+				"placeholder": "Gerätepasswort eingeben, falls das Gerät geschützt ist"
+			},
+			"hostname": {
+				"title": "Geräte-Hostname",
+				"placeholder": "Netzwerkname oder IP-Adresse des Geräts",
+				"validation": {
+					"required": "Bitte geben Sie den Geräte-Hostname oder die IP-Adresse ein"
+				}
+			}
+		},
+		"config": {
+			"enabled": {
+				"title": "Aktiviert"
+			},
+			"mdns": {
+				"enabled": {
+					"title": "Erkennung aktiviert"
+				},
+				"interface": {
+					"title": "Schnittstelle",
+					"placeholder": "Die zu verwendende Netzwerkschnittstelle. Wenn keine angegeben ist, werden alle verfügbaren Schnittstellen verwendet."
+				}
+			},
+			"websockets": {
+				"requestTimeout": {
+					"title": "Anfragezeitlimit",
+					"placeholder": "Die Zeit in Sekunden, die auf eine Antwort gewartet wird, bevor eine Anfrage abgebrochen wird.",
+					"validation": {
+						"required": "Bitte geben Sie das Anfragezeitlimit ein",
+						"number": "Anfragezeitlimit muss eine Zahl sein"
+					}
+				},
+				"pingInterval": {
+					"title": "Ping-Intervall",
+					"placeholder": "Das Intervall in Sekunden, in dem Ping-Anfragen gesendet werden, um zu überprüfen, ob die Verbindung offen ist. Auf 0 setzen zum Deaktivieren.",
+					"validation": {
+						"required": "Bitte geben Sie das Ping-Intervall ein",
+						"number": "Ping-Intervall muss eine Zahl sein"
+					}
+				},
+				"reconnectInterval": {
+					"title": "Wiederverbindungsintervall",
+					"placeholder": "Das Intervall in Sekunden, in dem ein Verbindungsversuch nach dem Schließen eines Sockets unternommen wird.",
+					"validation": {
+						"required": "Bitte geben Sie das Wiederverbindungsintervall ein",
+						"number": "Wiederverbindungsintervall muss eine Zahl sein",
+						"array": "Wiederverbindungsintervall muss ein Array von Zahlen sein"
+					}
+				}
+			}
+		}
+	},
+	"messages": {
+		"config": {
+			"edited": "Änderungen gespeichert! Die Shelly Next Generation Plugin-Konfiguration wurde aktualisiert.",
+			"notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung der Shelly Next Generation Plugin-Konfiguration war nicht erfolgreich."
+		},
+		"devices": {
+			"exists": "Ein Gerät mit diesem Hostname und Passwort ist bereits im System registriert.",
+			"created": "Neues Shelly Next-Generation-Gerät erfolgreich hinzugefügt.",
+			"notCreated": "Etwas ist schiefgelaufen. Das Shelly Next-Generation-Gerät konnte nicht erstellt werden.",
+			"notChecked": "Etwas ist schiefgelaufen. Geräteinformationen konnten nicht geladen werden. Überprüfen Sie den Geräte-Hostname oder das Passwort.",
+			"edited": "Änderungen gespeichert! Das Shelly Next-Generation-Gerät: {device} wurde aktualisiert.",
+			"notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung des Shelly Next-Generation-Geräts war nicht erfolgreich.",
+			"failedLoadSupportedDevices": "Etwas ist schiefgelaufen. Die unterstützten Geräte des Plugins konnten nicht geladen werden."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+		}
+	},
+	"texts": {
+		"aboutPluginStatus": "Aktivieren oder deaktivieren Sie die Shelly Next Generation Geräteintegration. Wenn aktiviert, können Shelly-Geräte über das Smart Panel erkannt und gesteuert werden.",
+		"aboutMdns": "Konfigurieren Sie, wie das Plugin Shelly-Geräte in Ihrem lokalen Netzwerk über Multicast DNS (mDNS) erkennt. Dies ermöglicht die automatische Erkennung ohne manuelle Eingabe von IP-Adressen.",
+		"aboutWebsockets": "Verwalten Sie WebSocket-Verbindungsparameter für Shelly-Geräte. Diese Einstellungen steuern Kommunikationsstabilität, Anfrageverarbeitung und Wiederverbindungsverhalten.",
+		"wizard": {
+			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+			"scanStatus": "{count} devices found",
+			"noDevices": "No Shelly devices found"
+		}
+	},
+	"buttons": {
+		"next": {
+			"title": "Weiter"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Scan again"
+			},
+			"addManual": {
+				"title": "Add"
+			},
+			"adopt": {
+				"title": "Adopt selected"
+			},
+			"finish": {
+				"title": "Back to devices"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Checking",
+			"ready": "Ready",
+			"needs_password": "Needs password",
+			"already_registered": "Registered",
+			"unsupported": "Unsupported",
+			"failed": "Failed",
+			"created": "Created"
+		}
+	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/de-DE.json
@@ -169,6 +169,7 @@
 			"failed": "Failed",
 			"created": "Created",
 			"updated": "Aktualisiert",
+			"willCreate": "Wird erstellt",
 			"willUpdate": "Bestehendes wird aktualisiert"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
@@ -1,174 +1,181 @@
 {
-  "headings": {
-    "aboutPluginStatus": "Plugin Status",
-    "aboutMdns": "MDNS settings",
-    "aboutWebsockets": "Websockets settings",
-    "device": {
-      "deviceConnection": "Device connection",
-      "information": "Device information",
-      "supported": "Congrats! Device is supported",
-      "notSupported": "We are sorry, you device is not supported",
-      "model": "Model",
-      "firmware": "Firmware"
-    },
-    "wizard": {
-      "discovery": "Discovery",
-      "categories": "Categories",
-      "results": "Results",
-      "status": "Status"
-    }
-  },
-  "fields": {
-    "devices": {
-      "id": {
-        "title": "Internal identifier",
-        "placeholder": "Device id"
-      },
-      "category": {
-        "title": "Category",
-        "placeholder": "Device category",
-        "description": "About category",
-        "validation": {
-          "required": "Please select device category"
-        }
-      },
-      "name": {
-        "title": "Name",
-        "placeholder": "Device name",
-        "validation": {
-          "required": "Please fill in device name"
-        }
-      },
-      "description": {
-        "title": "Description",
-        "placeholder": "Device description"
-      },
-      "enabled": {
-        "title": "Enabled",
-        "placeholder": "Enable or disable device"
-      },
-      "password": {
-        "title": "Admin password",
-        "placeholder": "Provide device password if device is protected"
-      },
-      "hostname": {
-        "title": "Device hostname",
-        "placeholder": "Device network name or IP address",
-        "validation": {
-          "required": "Please fill in device hostname or IP address"
-        }
-      },
-      "ethernetAddress": {
-        "title": "Ethernet address",
-        "placeholder": "Ethernet IP address (e.g. 192.168.1.100)"
-      },
-      "wifiAddress": {
-        "title": "WiFi address",
-        "placeholder": "WiFi IP address (e.g. 192.168.1.101)"
-      }
-    },
-    "config": {
-      "enabled": {
-        "title": "Enabled"
-      },
-      "mdns": {
-        "enabled": {
-          "title": "Discovery enabled"
-        },
-        "interface": {
-          "title": "Interface",
-          "placeholder": "The network interface to use. If none is specified, all available interfaces will be used."
-        }
-      },
-      "websockets": {
-        "requestTimeout": {
-          "title": "Request timeout",
-          "placeholder": "The time, in seconds, to wait for a response before a request is aborted.",
-          "validation": {
-            "required": "Please fill in request timeout",
-            "number": "Request timeout must be a number"
-          }
-        },
-        "pingInterval": {
-          "title": "Ping interval",
-          "placeholder": "The interval, in seconds, at which ping requests should be made to verify that the connection is open. Set to 0 to disable.",
-          "validation": {
-            "required": "Please fill in ping interval",
-            "number": "Ping interval must be a number"
-          }
-        },
-        "reconnectInterval": {
-          "title": "Reconnect interval",
-          "placeholder": "The interval, in seconds, at which a connection attempt should be made after a socket has been closed.",
-          "validation": {
-            "required": "Please fill in reconnect interval",
-            "number": "Reconnect interval must be a number",
-            "array": "Reconnect interval must be an array of numbers"
-          }
-        }
-      }
-    }
-  },
-  "messages": {
-    "config": {
-      "edited": "Changes saved! The Shelly Next Generation plugin config has been updated.",
-      "notEdited": "Something went wrong. Shelly Next Generation plugin config update was not successful."
-    },
-    "devices": {
-      "exists": "Device with provided hostname and password is already registered in system.",
-      "created": "New Shelly Next-Generation device added successfully.",
-      "notCreated": "Something went wrong. Unable to create the Shelly Next-Generation device.",
-      "notChecked": "Something went wrong. Device information could not be loaded. Check the device hostname or password.",
-      "edited": "Changes saved! The Shelly Next-Generation device: {device} has been updated.",
-      "notEdited": "Something went wrong. Shelly Next-Generation device update was not successful.",
-      "failedLoadSupportedDevices": "Something went wrong. Plugin supported devices could not be loaded."
-    },
-    "wizard": {
-      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
-    }
-  },
-  "texts": {
-    "aboutPluginStatus": "Enable or disable the Shelly Next Generation device integration. When enabled, Shelly devices can be discovered and controlled through the Smart Panel.",
-    "aboutMdns": "Configure how the plugin discovers Shelly devices on your local network using Multicast DNS (mDNS). This enables automatic detection without needing to manually enter IP addresses.",
-    "aboutWebsockets": "Manage WebSocket connection parameters for Shelly devices. These settings control communication stability, request handling, and reconnection behavior.",
-    "wizard": {
-      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
-      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-      "scanStatus": "{count} devices found",
-      "noDevices": "No Shelly devices found"
-    }
-  },
-  "buttons": {
-    "next": {
-      "title": "Next"
-    },
-    "wizard": {
-      "restart": {
-        "title": "Scan again"
-      },
-      "addManual": {
-        "title": "Add"
-      },
-      "adopt": {
-        "title": "Adopt selected"
-      },
-      "finish": {
-        "title": "Back to devices"
-      }
-    }
-  },
-  "statuses": {
-    "wizard": {
-      "checking": "Checking",
-      "ready": "Ready",
-      "needs_password": "Needs password",
-      "already_registered": "Registered",
-      "unsupported": "Unsupported",
-      "failed": "Failed",
-      "created": "Created"
-    }
-  }
+	"headings": {
+		"aboutPluginStatus": "Plugin Status",
+		"aboutMdns": "MDNS settings",
+		"aboutWebsockets": "Websockets settings",
+		"device": {
+			"deviceConnection": "Device connection",
+			"information": "Device information",
+			"supported": "Congrats! Device is supported",
+			"notSupported": "We are sorry, you device is not supported",
+			"model": "Model",
+			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Shelly NG discovery wizard",
+			"discovery": "Discovery",
+			"categories": "Categories",
+			"results": "Results",
+			"status": "Status"
+		}
+	},
+	"subHeadings": {
+		"wizard": "Find and adopt Shelly NG devices on your network"
+	},
+	"breadcrumbs": {
+		"wizard": "discovery wizard"
+	},
+	"fields": {
+		"devices": {
+			"id": {
+				"title": "Internal identifier",
+				"placeholder": "Device id"
+			},
+			"category": {
+				"title": "Category",
+				"placeholder": "Device category",
+				"description": "About category",
+				"validation": {
+					"required": "Please select device category"
+				}
+			},
+			"name": {
+				"title": "Name",
+				"placeholder": "Device name",
+				"validation": {
+					"required": "Please fill in device name"
+				}
+			},
+			"description": {
+				"title": "Description",
+				"placeholder": "Device description"
+			},
+			"enabled": {
+				"title": "Enabled",
+				"placeholder": "Enable or disable device"
+			},
+			"password": {
+				"title": "Admin password",
+				"placeholder": "Provide device password if device is protected"
+			},
+			"hostname": {
+				"title": "Device hostname",
+				"placeholder": "Device network name or IP address",
+				"validation": {
+					"required": "Please fill in device hostname or IP address"
+				}
+			},
+			"ethernetAddress": {
+				"title": "Ethernet address",
+				"placeholder": "Ethernet IP address (e.g. 192.168.1.100)"
+			},
+			"wifiAddress": {
+				"title": "WiFi address",
+				"placeholder": "WiFi IP address (e.g. 192.168.1.101)"
+			}
+		},
+		"config": {
+			"enabled": {
+				"title": "Enabled"
+			},
+			"mdns": {
+				"enabled": {
+					"title": "Discovery enabled"
+				},
+				"interface": {
+					"title": "Interface",
+					"placeholder": "The network interface to use. If none is specified, all available interfaces will be used."
+				}
+			},
+			"websockets": {
+				"requestTimeout": {
+					"title": "Request timeout",
+					"placeholder": "The time, in seconds, to wait for a response before a request is aborted.",
+					"validation": {
+						"required": "Please fill in request timeout",
+						"number": "Request timeout must be a number"
+					}
+				},
+				"pingInterval": {
+					"title": "Ping interval",
+					"placeholder": "The interval, in seconds, at which ping requests should be made to verify that the connection is open. Set to 0 to disable.",
+					"validation": {
+						"required": "Please fill in ping interval",
+						"number": "Ping interval must be a number"
+					}
+				},
+				"reconnectInterval": {
+					"title": "Reconnect interval",
+					"placeholder": "The interval, in seconds, at which a connection attempt should be made after a socket has been closed.",
+					"validation": {
+						"required": "Please fill in reconnect interval",
+						"number": "Reconnect interval must be a number",
+						"array": "Reconnect interval must be an array of numbers"
+					}
+				}
+			}
+		}
+	},
+	"messages": {
+		"config": {
+			"edited": "Changes saved! The Shelly Next Generation plugin config has been updated.",
+			"notEdited": "Something went wrong. Shelly Next Generation plugin config update was not successful."
+		},
+		"devices": {
+			"exists": "Device with provided hostname and password is already registered in system.",
+			"created": "New Shelly Next-Generation device added successfully.",
+			"notCreated": "Something went wrong. Unable to create the Shelly Next-Generation device.",
+			"notChecked": "Something went wrong. Device information could not be loaded. Check the device hostname or password.",
+			"edited": "Changes saved! The Shelly Next-Generation device: {device} has been updated.",
+			"notEdited": "Something went wrong. Shelly Next-Generation device update was not successful.",
+			"failedLoadSupportedDevices": "Something went wrong. Plugin supported devices could not be loaded."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+		}
+	},
+	"texts": {
+		"aboutPluginStatus": "Enable or disable the Shelly Next Generation device integration. When enabled, Shelly devices can be discovered and controlled through the Smart Panel.",
+		"aboutMdns": "Configure how the plugin discovers Shelly devices on your local network using Multicast DNS (mDNS). This enables automatic detection without needing to manually enter IP addresses.",
+		"aboutWebsockets": "Manage WebSocket connection parameters for Shelly devices. These settings control communication stability, request handling, and reconnection behavior.",
+		"wizard": {
+			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+			"scanStatus": "{count} devices found",
+			"noDevices": "No Shelly devices found"
+		}
+	},
+	"buttons": {
+		"next": {
+			"title": "Next"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Scan again"
+			},
+			"addManual": {
+				"title": "Add"
+			},
+			"adopt": {
+				"title": "Adopt selected"
+			},
+			"finish": {
+				"title": "Back to devices"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Checking",
+			"ready": "Ready",
+			"needs_password": "Needs password",
+			"already_registered": "Registered",
+			"unsupported": "Unsupported",
+			"failed": "Failed",
+			"created": "Created"
+		}
+	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
@@ -58,6 +58,9 @@
 				"title": "Admin password",
 				"placeholder": "Provide device password if device is protected"
 			},
+			"error": {
+				"title": "Error"
+			},
 			"hostname": {
 				"title": "Device hostname",
 				"placeholder": "Device network name or IP address",
@@ -145,7 +148,11 @@
 			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
 			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
 			"scanStatus": "{count} devices found",
-			"noDevices": "No Shelly devices found"
+			"noDevices": "No Shelly devices found",
+			"results": {
+				"success": "All devices were adopted successfully.",
+				"failed": "Some devices could not be adopted. Review the errors below."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
@@ -177,6 +177,7 @@
 			"failed": "Failed",
 			"created": "Created",
 			"updated": "Updated",
+			"willCreate": "Will create",
 			"willUpdate": "Will update existing"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json
@@ -175,7 +175,9 @@
 			"already_registered": "Registered",
 			"unsupported": "Unsupported",
 			"failed": "Failed",
-			"created": "Created"
+			"created": "Created",
+			"updated": "Updated",
+			"willUpdate": "Will update existing"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
@@ -58,6 +58,9 @@
 				"title": "Contraseña de administrador",
 				"placeholder": "Proporcione la contraseña del dispositivo si está protegido"
 			},
+			"error": {
+				"title": "Error"
+			},
 			"hostname": {
 				"title": "Nombre de host del dispositivo",
 				"placeholder": "Nombre de red o dirección IP del dispositivo",
@@ -137,7 +140,11 @@
 			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
 			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
 			"scanStatus": "{count} devices found",
-			"noDevices": "No Shelly devices found"
+			"noDevices": "No Shelly devices found",
+			"results": {
+				"success": "Todos los dispositivos se adoptaron correctamente.",
+				"failed": "Algunos dispositivos no pudieron ser adoptados. Revise los errores a continuación."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
@@ -169,6 +169,7 @@
 			"failed": "Failed",
 			"created": "Created",
 			"updated": "Actualizado",
+			"willCreate": "Se creará",
 			"willUpdate": "Actualizará el existente"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
@@ -1,166 +1,173 @@
 {
-  "headings": {
-    "aboutPluginStatus": "Estado del plugin",
-    "aboutMdns": "Configuración de mDNS",
-    "aboutWebsockets": "Configuración de WebSockets",
-    "device": {
-      "deviceConnection": "Conexión del dispositivo",
-      "information": "Información del dispositivo",
-      "supported": "¡Felicidades! El dispositivo es compatible",
-      "notSupported": "Lo sentimos, su dispositivo no es compatible",
-      "model": "Modelo",
-      "firmware": "Firmware"
-    },
-    "wizard": {
-      "discovery": "Discovery",
-      "categories": "Categories",
-      "results": "Results",
-      "status": "Status"
-    }
-  },
-  "fields": {
-    "devices": {
-      "id": {
-        "title": "Identificador interno",
-        "placeholder": "ID del dispositivo"
-      },
-      "category": {
-        "title": "Categoría",
-        "placeholder": "Categoría del dispositivo",
-        "description": "Acerca de la categoría",
-        "validation": {
-          "required": "Por favor, seleccione la categoría del dispositivo"
-        }
-      },
-      "name": {
-        "title": "Nombre",
-        "placeholder": "Nombre del dispositivo",
-        "validation": {
-          "required": "Por favor, introduzca el nombre del dispositivo"
-        }
-      },
-      "description": {
-        "title": "Descripción",
-        "placeholder": "Descripción del dispositivo"
-      },
-      "enabled": {
-        "title": "Habilitado",
-        "placeholder": "Habilitar o deshabilitar el dispositivo"
-      },
-      "password": {
-        "title": "Contraseña de administrador",
-        "placeholder": "Proporcione la contraseña del dispositivo si está protegido"
-      },
-      "hostname": {
-        "title": "Nombre de host del dispositivo",
-        "placeholder": "Nombre de red o dirección IP del dispositivo",
-        "validation": {
-          "required": "Por favor, introduzca el nombre de host o la dirección IP del dispositivo"
-        }
-      }
-    },
-    "config": {
-      "enabled": {
-        "title": "Habilitado"
-      },
-      "mdns": {
-        "enabled": {
-          "title": "Descubrimiento habilitado"
-        },
-        "interface": {
-          "title": "Interfaz",
-          "placeholder": "La interfaz de red a utilizar. Si no se especifica ninguna, se utilizarán todas las interfaces disponibles."
-        }
-      },
-      "websockets": {
-        "requestTimeout": {
-          "title": "Tiempo de espera de solicitud",
-          "placeholder": "El tiempo, en segundos, de espera para una respuesta antes de abortar la solicitud.",
-          "validation": {
-            "required": "Por favor, introduzca el tiempo de espera de solicitud",
-            "number": "El tiempo de espera de solicitud debe ser un número"
-          }
-        },
-        "pingInterval": {
-          "title": "Intervalo de ping",
-          "placeholder": "El intervalo, en segundos, para realizar solicitudes de ping y verificar que la conexión está abierta. Establezca en 0 para deshabilitar.",
-          "validation": {
-            "required": "Por favor, introduzca el intervalo de ping",
-            "number": "El intervalo de ping debe ser un número"
-          }
-        },
-        "reconnectInterval": {
-          "title": "Intervalo de reconexión",
-          "placeholder": "El intervalo, en segundos, para intentar reconectar después de que un socket se haya cerrado.",
-          "validation": {
-            "required": "Por favor, introduzca el intervalo de reconexión",
-            "number": "El intervalo de reconexión debe ser un número",
-            "array": "El intervalo de reconexión debe ser un arreglo de números"
-          }
-        }
-      }
-    }
-  },
-  "messages": {
-    "config": {
-      "edited": "¡Cambios guardados! La configuración del plugin Shelly Next Generation ha sido actualizada.",
-      "notEdited": "Algo salió mal. La actualización de la configuración del plugin Shelly Next Generation no fue exitosa."
-    },
-    "devices": {
-      "exists": "El dispositivo con el nombre de host y la contraseña proporcionados ya está registrado en el sistema.",
-      "created": "Nuevo dispositivo Shelly Next-Generation agregado correctamente.",
-      "notCreated": "Algo salió mal. No se pudo crear el dispositivo Shelly Next-Generation.",
-      "notChecked": "Algo salió mal. No se pudo cargar la información del dispositivo. Verifique el nombre de host o la contraseña del dispositivo.",
-      "edited": "¡Cambios guardados! El dispositivo Shelly Next-Generation: {device} ha sido actualizado.",
-      "notEdited": "Algo salió mal. La actualización del dispositivo Shelly Next-Generation no fue exitosa.",
-      "failedLoadSupportedDevices": "Algo salió mal. No se pudieron cargar los dispositivos compatibles del plugin."
-    },
-    "wizard": {
-      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
-    }
-  },
-  "texts": {
-    "aboutPluginStatus": "Habilitar o deshabilitar la integración de dispositivos Shelly Next Generation. Cuando está habilitado, los dispositivos Shelly pueden ser descubiertos y controlados a través del Smart Panel.",
-    "aboutMdns": "Configure cómo el plugin descubre dispositivos Shelly en su red local usando DNS Multidifusión (mDNS). Esto permite la detección automática sin necesidad de introducir direcciones IP manualmente.",
-    "aboutWebsockets": "Gestione los parámetros de conexión WebSocket para los dispositivos Shelly. Estos ajustes controlan la estabilidad de la comunicación, el manejo de solicitudes y el comportamiento de reconexión.",
-    "wizard": {
-      "discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
-      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-      "scanStatus": "{count} devices found",
-      "noDevices": "No Shelly devices found"
-    }
-  },
-  "buttons": {
-    "next": {
-      "title": "Siguiente"
-    },
-    "wizard": {
-      "restart": {
-        "title": "Scan again"
-      },
-      "addManual": {
-        "title": "Add"
-      },
-      "adopt": {
-        "title": "Adopt selected"
-      },
-      "finish": {
-        "title": "Back to devices"
-      }
-    }
-  },
-  "statuses": {
-    "wizard": {
-      "checking": "Checking",
-      "ready": "Ready",
-      "needs_password": "Needs password",
-      "already_registered": "Registered",
-      "unsupported": "Unsupported",
-      "failed": "Failed",
-      "created": "Created"
-    }
-  }
+	"headings": {
+		"aboutPluginStatus": "Estado del plugin",
+		"aboutMdns": "Configuración de mDNS",
+		"aboutWebsockets": "Configuración de WebSockets",
+		"device": {
+			"deviceConnection": "Conexión del dispositivo",
+			"information": "Información del dispositivo",
+			"supported": "¡Felicidades! El dispositivo es compatible",
+			"notSupported": "Lo sentimos, su dispositivo no es compatible",
+			"model": "Modelo",
+			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Asistente de descubrimiento de Shelly NG",
+			"discovery": "Discovery",
+			"categories": "Categories",
+			"results": "Results",
+			"status": "Status"
+		}
+	},
+	"subHeadings": {
+		"wizard": "Encuentre y adopte dispositivos Shelly NG en su red"
+	},
+	"breadcrumbs": {
+		"wizard": "asistente de descubrimiento"
+	},
+	"fields": {
+		"devices": {
+			"id": {
+				"title": "Identificador interno",
+				"placeholder": "ID del dispositivo"
+			},
+			"category": {
+				"title": "Categoría",
+				"placeholder": "Categoría del dispositivo",
+				"description": "Acerca de la categoría",
+				"validation": {
+					"required": "Por favor, seleccione la categoría del dispositivo"
+				}
+			},
+			"name": {
+				"title": "Nombre",
+				"placeholder": "Nombre del dispositivo",
+				"validation": {
+					"required": "Por favor, introduzca el nombre del dispositivo"
+				}
+			},
+			"description": {
+				"title": "Descripción",
+				"placeholder": "Descripción del dispositivo"
+			},
+			"enabled": {
+				"title": "Habilitado",
+				"placeholder": "Habilitar o deshabilitar el dispositivo"
+			},
+			"password": {
+				"title": "Contraseña de administrador",
+				"placeholder": "Proporcione la contraseña del dispositivo si está protegido"
+			},
+			"hostname": {
+				"title": "Nombre de host del dispositivo",
+				"placeholder": "Nombre de red o dirección IP del dispositivo",
+				"validation": {
+					"required": "Por favor, introduzca el nombre de host o la dirección IP del dispositivo"
+				}
+			}
+		},
+		"config": {
+			"enabled": {
+				"title": "Habilitado"
+			},
+			"mdns": {
+				"enabled": {
+					"title": "Descubrimiento habilitado"
+				},
+				"interface": {
+					"title": "Interfaz",
+					"placeholder": "La interfaz de red a utilizar. Si no se especifica ninguna, se utilizarán todas las interfaces disponibles."
+				}
+			},
+			"websockets": {
+				"requestTimeout": {
+					"title": "Tiempo de espera de solicitud",
+					"placeholder": "El tiempo, en segundos, de espera para una respuesta antes de abortar la solicitud.",
+					"validation": {
+						"required": "Por favor, introduzca el tiempo de espera de solicitud",
+						"number": "El tiempo de espera de solicitud debe ser un número"
+					}
+				},
+				"pingInterval": {
+					"title": "Intervalo de ping",
+					"placeholder": "El intervalo, en segundos, para realizar solicitudes de ping y verificar que la conexión está abierta. Establezca en 0 para deshabilitar.",
+					"validation": {
+						"required": "Por favor, introduzca el intervalo de ping",
+						"number": "El intervalo de ping debe ser un número"
+					}
+				},
+				"reconnectInterval": {
+					"title": "Intervalo de reconexión",
+					"placeholder": "El intervalo, en segundos, para intentar reconectar después de que un socket se haya cerrado.",
+					"validation": {
+						"required": "Por favor, introduzca el intervalo de reconexión",
+						"number": "El intervalo de reconexión debe ser un número",
+						"array": "El intervalo de reconexión debe ser un arreglo de números"
+					}
+				}
+			}
+		}
+	},
+	"messages": {
+		"config": {
+			"edited": "¡Cambios guardados! La configuración del plugin Shelly Next Generation ha sido actualizada.",
+			"notEdited": "Algo salió mal. La actualización de la configuración del plugin Shelly Next Generation no fue exitosa."
+		},
+		"devices": {
+			"exists": "El dispositivo con el nombre de host y la contraseña proporcionados ya está registrado en el sistema.",
+			"created": "Nuevo dispositivo Shelly Next-Generation agregado correctamente.",
+			"notCreated": "Algo salió mal. No se pudo crear el dispositivo Shelly Next-Generation.",
+			"notChecked": "Algo salió mal. No se pudo cargar la información del dispositivo. Verifique el nombre de host o la contraseña del dispositivo.",
+			"edited": "¡Cambios guardados! El dispositivo Shelly Next-Generation: {device} ha sido actualizado.",
+			"notEdited": "Algo salió mal. La actualización del dispositivo Shelly Next-Generation no fue exitosa.",
+			"failedLoadSupportedDevices": "Algo salió mal. No se pudieron cargar los dispositivos compatibles del plugin."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+		}
+	},
+	"texts": {
+		"aboutPluginStatus": "Habilitar o deshabilitar la integración de dispositivos Shelly Next Generation. Cuando está habilitado, los dispositivos Shelly pueden ser descubiertos y controlados a través del Smart Panel.",
+		"aboutMdns": "Configure cómo el plugin descubre dispositivos Shelly en su red local usando DNS Multidifusión (mDNS). Esto permite la detección automática sin necesidad de introducir direcciones IP manualmente.",
+		"aboutWebsockets": "Gestione los parámetros de conexión WebSocket para los dispositivos Shelly. Estos ajustes controlan la estabilidad de la comunicación, el manejo de solicitudes y el comportamiento de reconexión.",
+		"wizard": {
+			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
+			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+			"scanStatus": "{count} devices found",
+			"noDevices": "No Shelly devices found"
+		}
+	},
+	"buttons": {
+		"next": {
+			"title": "Siguiente"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Scan again"
+			},
+			"addManual": {
+				"title": "Add"
+			},
+			"adopt": {
+				"title": "Adopt selected"
+			},
+			"finish": {
+				"title": "Back to devices"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Checking",
+			"ready": "Ready",
+			"needs_password": "Needs password",
+			"already_registered": "Registered",
+			"unsupported": "Unsupported",
+			"failed": "Failed",
+			"created": "Created"
+		}
+	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/es-ES.json
@@ -167,7 +167,9 @@
 			"already_registered": "Registered",
 			"unsupported": "Unsupported",
 			"failed": "Failed",
-			"created": "Created"
+			"created": "Created",
+			"updated": "Actualizado",
+			"willUpdate": "Actualizará el existente"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
@@ -58,6 +58,9 @@
 				"title": "Haslo administratora",
 				"placeholder": "Podaj haslo urzadzenia, jesli urzadzenie jest chronione"
 			},
+			"error": {
+				"title": "Blad"
+			},
 			"hostname": {
 				"title": "Nazwa hosta urzadzenia",
 				"placeholder": "Nazwa sieciowa lub adres IP urzadzenia",
@@ -137,7 +140,11 @@
 			"discovery": "The wizard scans the local network for Shelly NG devices and also accepts a manually entered hostname or IP address.",
 			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
 			"scanStatus": "{count} devices found",
-			"noDevices": "No Shelly devices found"
+			"noDevices": "No Shelly devices found",
+			"results": {
+				"success": "Wszystkie urzadzenia zostaly pomyslnie adoptowane.",
+				"failed": "Niektore urzadzenia nie mogly zostac adoptowane. Sprawdz blody ponizej."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
@@ -169,6 +169,7 @@
 			"failed": "Failed",
 			"created": "Created",
 			"updated": "Zaktualizowano",
+			"willCreate": "Zostanie utworzone",
 			"willUpdate": "Zaktualizuje istniejace"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
@@ -12,11 +12,18 @@
 			"firmware": "Firmware"
 		},
 		"wizard": {
+			"title": "Kreator wyszukiwania Shelly NG",
 			"discovery": "Discovery",
 			"categories": "Categories",
 			"results": "Results",
 			"status": "Status"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Znajdz i adoptuj urzadzenia Shelly NG w swojej sieci"
+	},
+	"breadcrumbs": {
+		"wizard": "kreator wyszukiwania"
 	},
 	"fields": {
 		"devices": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/pl-PL.json
@@ -167,7 +167,9 @@
 			"already_registered": "Registered",
 			"unsupported": "Unsupported",
 			"failed": "Failed",
-			"created": "Created"
+			"created": "Created",
+			"updated": "Zaktualizowano",
+			"willUpdate": "Zaktualizuje istniejace"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
@@ -169,6 +169,7 @@
 			"failed": "Zlyhalo",
 			"created": "Vytvorené",
 			"updated": "Aktualizované",
+			"willCreate": "Bude vytvorené",
 			"willUpdate": "Aktualizuje existujúce"
 		}
 	}

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
@@ -167,7 +167,9 @@
 			"already_registered": "Registrované",
 			"unsupported": "Nepodporované",
 			"failed": "Zlyhalo",
-			"created": "Vytvorené"
+			"created": "Vytvorené",
+			"updated": "Aktualizované",
+			"willUpdate": "Aktualizuje existujúce"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
@@ -12,11 +12,18 @@
 			"firmware": "Firmware"
 		},
 		"wizard": {
+			"title": "Sprievodca vyhľadaním Shelly NG",
 			"discovery": "Vyhľadávanie",
 			"categories": "Kategórie",
 			"results": "Výsledky",
 			"status": "Stav"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Nájdite a adoptujte zariadenia Shelly NG vo vašej sieti"
+	},
+	"breadcrumbs": {
+		"wizard": "sprievodca vyhľadaním"
 	},
 	"fields": {
 		"devices": {

--- a/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-ng/locales/sk-SK.json
@@ -58,6 +58,9 @@
 				"title": "Heslo administrátora",
 				"placeholder": "Zadajte heslo zariadenia, ak je chránené"
 			},
+			"error": {
+				"title": "Chyba"
+			},
 			"hostname": {
 				"title": "Hostname zariadenia",
 				"placeholder": "Sieťový názov alebo IP adresa zariadenia",
@@ -137,7 +140,11 @@
 			"discovery": "Sprievodca vyhľadá zariadenia Shelly NG v lokálnej sieti a prijíma aj manuálne zadaný hostname alebo IP adresu.",
 			"categories": "Potvrďte, ktoré pripravené zariadenia sa majú adoptovať, a vyberte cieľovú kategóriu pre každé z nich.",
 			"scanStatus": "Nájdené zariadenia: {count}",
-			"noDevices": "Neboli nájdené žiadne zariadenia Shelly"
+			"noDevices": "Neboli nájdené žiadne zariadenia Shelly",
+			"results": {
+				"success": "Všetky zariadenia boli úspešne adoptované.",
+				"failed": "Niektoré zariadenia nebolo možné adoptovať. Skontrolujte chyby nižšie."
+			}
 		}
 	},
 	"buttons": {

--- a/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/schemas/devices.schemas.ts
@@ -30,7 +30,7 @@ export const ShellyNgDeviceEditFormSchema = DeviceEditFormSchema.extend({
 	{
 		message: 'At least one network address (WiFi or Ethernet) is required',
 		path: ['wifiAddress'],
-	},
+	}
 );
 
 export const ShellyNgSupportedDeviceSchema = z.object({
@@ -94,6 +94,7 @@ export const ShellyNgDiscoveryDeviceSchema = z.object({
 	}),
 	registeredDeviceId: z.string().nullable(),
 	registeredDeviceName: z.string().nullable(),
+	registeredDeviceCategory: z.nativeEnum(DevicesModuleDeviceCategory).nullable(),
 	error: z.string().nullable(),
 	lastSeenAt: z.string(),
 });

--- a/apps/backend/src/plugins/devices-shelly-ng/delegates/delegates-manager.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/delegates/delegates-manager.service.ts
@@ -2112,6 +2112,16 @@ export class DelegatesManagerService {
 	}
 
 	private determineCategory(delegate: ShellyDeviceDelegate): DeviceCategory {
+		// Prefer the descriptor's canonical first category. The component-based heuristic
+		// below misclassified some sensor-only devices (e.g. Shelly PM Mini Gen3, whose
+		// only relevant component is `pm1:1`) as GENERIC when the lib didn't expose the
+		// expected component shape — descriptor-first is the source of truth.
+		if (delegate.descriptor && delegate.descriptor.categories.length > 0) {
+			return delegate.descriptor.categories[0];
+		}
+
+		// Fallback for the rare case a delegate is built without a matched descriptor
+		// (the constructor throws in that case today, but keep the heuristic for safety).
 		if (delegate.covers.size > 0) {
 			return DeviceCategory.WINDOW_COVERING;
 		} else if (delegate.lights.size > 0 || delegate.rgb.size > 0 || delegate.rgbw.size > 0 || delegate.cct.size > 0) {

--- a/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.ts
@@ -22,6 +22,7 @@ import {
 	ComponentType,
 	DESCRIPTORS,
 	DEVICES_SHELLY_NG_PLUGIN_NAME,
+	DeviceDescriptor,
 	DeviceProfile,
 } from '../devices-shelly-ng.constants';
 import { DevicesShellyNgException } from '../devices-shelly-ng.exceptions';
@@ -72,16 +73,27 @@ export class ShellyDeviceDelegate extends EventEmitter2 {
 
 	public pm1: Map<number, Pm1> = new Map();
 
+	/**
+	 * The descriptor that matched this device's model. Stored on construction so callers
+	 * (e.g. `DelegatesManagerService.determineCategory`) can read the canonical category
+	 * list directly instead of inferring from which component maps the lib happened to
+	 * populate — for sensor-only devices like the PM Mini Gen3, the lib may not expose a
+	 * component the heuristic checks against, falling through to `GENERIC`.
+	 */
+	public readonly descriptor: DeviceDescriptor | null;
+
 	private changeHandlers: Map<string, (char: string, val: CharacteristicValue) => void> = new Map();
 
 	constructor(private shelly: Device) {
 		super();
 
 		let isKnown = false;
+		let matchedDescriptor: DeviceDescriptor | null = null;
 
 		Object.values(DESCRIPTORS).forEach((DESCRIPTOR): void => {
 			if (DESCRIPTOR.models.includes(this.shelly.model.toUpperCase())) {
 				isKnown = true;
+				matchedDescriptor = DESCRIPTOR;
 
 				this.connected = this.shelly.rpcHandler.connected;
 
@@ -193,6 +205,8 @@ export class ShellyDeviceDelegate extends EventEmitter2 {
 		if (!isKnown) {
 			throw new DevicesShellyNgException('Device is not supported.');
 		}
+
+		this.descriptor = matchedDescriptor;
 	}
 
 	public get id(): string {

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
@@ -387,6 +387,18 @@ export class ShellyNgDiscoveryDeviceModel {
 	registeredDeviceName: string | null;
 
 	@ApiPropertyOptional({
+		description:
+			'Already registered device category — used to pre-fill the wizard so adopted devices keep their existing category by default',
+		enum: DeviceCategory,
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsIn(Object.values(DeviceCategory))
+	@IsOptional()
+	registeredDeviceCategory: DeviceCategory | null;
+
+	@ApiPropertyOptional({
 		description: 'Error message from the last lookup attempt',
 		nullable: true,
 		example: null,

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
@@ -391,7 +391,7 @@ export class ShellyNgDiscoveryDeviceModel {
 			'Already registered device category — used to pre-fill the wizard so adopted devices keep their existing category by default',
 		enum: DeviceCategory,
 		nullable: true,
-		example: null,
+		example: DeviceCategory.LIGHTING,
 	})
 	@Expose()
 	@IsIn(Object.values(DeviceCategory))

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -4,22 +4,7 @@ import { DevicesService } from '../../../modules/devices/services/devices.servic
 
 import { DeviceManagerService } from './device-manager.service';
 import { ShellyNgDiscoveryService } from './shelly-ng-discovery.service';
-
-const startMock = jest.fn();
-const stopMock = jest.fn();
-const discoverers: EventEmitter[] = [];
-
-jest.mock('shellies-ds9', () => ({
-	MdnsDeviceDiscoverer: class MockMdnsDeviceDiscoverer extends EventEmitter {
-		constructor() {
-			super();
-			discoverers.push(this);
-		}
-
-		start = startMock;
-		stop = stopMock;
-	},
-}));
+import { ShellyNgService } from './shelly-ng.service';
 
 jest.mock('../devices-shelly-ng.constants', () => ({
 	DEVICES_SHELLY_NG_PLUGIN_NAME: 'devices-shelly-ng-plugin',
@@ -46,18 +31,36 @@ jest.mock('../devices-shelly-ng.constants', () => ({
 	},
 }));
 
+interface FakeLibDevice {
+	id: string;
+	model: string;
+	modelName: string;
+	firmware: { version?: string };
+	wifi?: { sta_ip?: string };
+	ethernet?: { ip?: string };
+	system?: { config?: { device?: { name?: string | null } } };
+}
+
+const buildLibDevice = (overrides: Partial<FakeLibDevice> = {}): FakeLibDevice => ({
+	id: 'shellyplus1-aabbcc',
+	model: 'SNSW-001X16EU',
+	modelName: 'Shelly Plus 1',
+	firmware: { version: '1.2.3' },
+	wifi: { sta_ip: '192.168.1.10' },
+	system: { config: { device: { name: 'Kitchen relay' } } },
+	...overrides,
+});
+
 describe('ShellyNgDiscoveryService', () => {
 	let service: ShellyNgDiscoveryService;
 	let deviceManager: jest.Mocked<DeviceManagerService>;
 	let devicesService: jest.Mocked<DevicesService>;
+	let shellyNgService: jest.Mocked<ShellyNgService>;
+	let addedEmitter: EventEmitter;
 
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.clearAllMocks();
-		discoverers.length = 0;
-
-		startMock.mockResolvedValue(undefined);
-		stopMock.mockResolvedValue(undefined);
 
 		deviceManager = {
 			getDeviceInfo: jest.fn(),
@@ -66,17 +69,130 @@ describe('ShellyNgDiscoveryService', () => {
 			findOneBy: jest.fn(),
 		} as unknown as jest.Mocked<DevicesService>;
 
-		service = new ShellyNgDiscoveryService(deviceManager, devicesService);
+		addedEmitter = new EventEmitter();
+		shellyNgService = {
+			getKnownDevices: jest.fn().mockReturnValue([]),
+			subscribeToAddedDevice: jest.fn((handler: (device: unknown) => void) => {
+				addedEmitter.on('add', handler);
+				return () => addedEmitter.off('add', handler);
+			}),
+		} as unknown as jest.Mocked<ShellyNgService>;
+
+		service = new ShellyNgDiscoveryService(deviceManager, devicesService, shellyNgService);
 	});
 
 	afterEach(() => {
 		jest.useRealTimers();
 	});
 
-	it('starts an mDNS scan and enriches discovered unprotected devices', async () => {
+	it('seeds the session from devices the main connector already knows', async () => {
+		const libDevice = buildLibDevice();
+		shellyNgService.getKnownDevices.mockReturnValue([libDevice as unknown as never]);
+		devicesService.findOneBy.mockResolvedValue(null);
+
+		const session = await service.start({ duration: 30 });
+
+		expect(deviceManager.getDeviceInfo.mock.calls).toHaveLength(0);
+		expect(session.devices).toEqual([
+			expect.objectContaining({
+				identifier: 'shellyplus1-aabbcc',
+				hostname: '192.168.1.10',
+				name: 'Kitchen relay',
+				model: 'SNSW-001X16EU',
+				displayName: 'Shelly Plus 1',
+				status: 'ready',
+				source: 'mdns',
+				categories: ['lighting', 'switcher'],
+			}),
+		]);
+	});
+
+	it('marks devices already in the database as already_registered without RPC', async () => {
+		const libDevice = buildLibDevice();
+		shellyNgService.getKnownDevices.mockReturnValue([libDevice as unknown as never]);
+		devicesService.findOneBy.mockResolvedValue({
+			id: 'existing-uuid',
+			name: 'Adopted relay',
+		} as never);
+
+		const session = await service.start({ duration: 30 });
+
+		expect(deviceManager.getDeviceInfo.mock.calls).toHaveLength(0);
+		expect(session.devices[0]).toEqual(
+			expect.objectContaining({
+				status: 'already_registered',
+				registeredDeviceId: 'existing-uuid',
+				registeredDeviceName: 'Adopted relay',
+			}),
+		);
+	});
+
+	it('picks up new devices the main connector reports during the scan window', async () => {
+		shellyNgService.getKnownDevices.mockReturnValue([]);
+		devicesService.findOneBy.mockResolvedValue(null);
+
+		const session = await service.start({ duration: 30 });
+
+		expect(session.devices).toEqual([]);
+
+		addedEmitter.emit('add', buildLibDevice());
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(service.get(session.id)?.devices).toEqual([
+			expect.objectContaining({
+				identifier: 'shellyplus1-aabbcc',
+				status: 'ready',
+				source: 'mdns',
+			}),
+		]);
+	});
+
+	it('inspects manually entered hostnames over RPC and stores their password', async () => {
+		shellyNgService.getKnownDevices.mockReturnValue([]);
+		devicesService.findOneBy.mockResolvedValue(null);
+		deviceManager.getDeviceInfo.mockResolvedValue({
+			id: 'shellyht-aabbcc',
+			name: 'Bathroom sensor',
+			mac: 'AABBCC',
+			model: 'SNSN-0013A',
+			fw_id: '2024-05-05-0000',
+			ver: '1.2.3',
+			app: 'HT',
+			profile: 'sensor',
+			auth_en: true,
+			auth_domain: 'shelly',
+			discoverable: true,
+			key: 'key-abc',
+			batch: 'b',
+			fw_sbits: 'bits',
+			components: [{ type: 'temperature', ids: [0] }],
+		});
+
+		const session = await service.start({ duration: 30 });
+
+		await service.manual(session.id, {
+			hostname: '192.168.1.11',
+			password: 'secret',
+		});
+
+		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['192.168.1.11', 'secret']);
+		expect(service.get(session.id)?.devices.at(-1)).toEqual(
+			expect.objectContaining({
+				identifier: 'shellyht-aabbcc',
+				status: 'ready',
+				source: 'manual',
+			}),
+		);
+	});
+
+	it('does not overwrite a manually-entered snapshot when the same hostname comes through the lib', async () => {
+		shellyNgService.getKnownDevices.mockReturnValue([]);
+		devicesService.findOneBy.mockResolvedValue(null);
 		deviceManager.getDeviceInfo.mockResolvedValue({
 			id: 'shellyplus1-aabbcc',
-			name: 'Kitchen relay',
+			name: 'Manual entry name',
 			mac: 'AABBCC',
 			model: 'SNSW-001X16EU',
 			fw_id: '2024-05-05-0000',
@@ -91,143 +207,40 @@ describe('ShellyNgDiscoveryService', () => {
 			fw_sbits: 'bits',
 			components: [{ type: 'switch', ids: [0] }],
 		});
-		devicesService.findOneBy.mockResolvedValue(null);
 
 		const session = await service.start({ duration: 30 });
 
-		expect(startMock).toHaveBeenCalledTimes(1);
-		expect(session.status).toBe('running');
-		expect(session.devices).toEqual([]);
-
-		discoverers[0]?.emit('discover', {
-			deviceId: 'shellyplus1-aabbcc',
+		await service.manual(session.id, {
 			hostname: '192.168.1.10',
+			password: null,
 		});
 
-		await Promise.resolve();
-		await Promise.resolve();
-
-		const updated = service.get(session.id);
-
-		expect(deviceManager.getDeviceInfo.mock.calls).toContainEqual(['192.168.1.10', null]);
-		expect(updated?.devices).toEqual([
-			expect.objectContaining({
-				identifier: 'shellyplus1-aabbcc',
-				hostname: '192.168.1.10',
-				name: 'Kitchen relay',
-				model: 'SNSW-001X16EU',
-				displayName: 'Shelly Plus 1',
-				status: 'ready',
-				categories: ['lighting', 'switcher'],
-				suggestedCategory: null,
-			}),
-		]);
-	});
-
-	it('marks protected devices as needing a password until manually verified', async () => {
-		deviceManager.getDeviceInfo.mockResolvedValue({
-			id: 'shellyht-aabbcc',
-			name: 'Bathroom sensor',
-			mac: 'AABBCC',
-			model: 'SNSN-0013A',
-			fw_id: '2024-05-05-0000',
-			ver: '1.2.3',
-			app: 'HT',
-			profile: 'sensor',
-			auth_en: true,
-			auth_domain: 'shelly',
-			discoverable: true,
-			key: 'key-abc',
-			batch: 'b',
-			fw_sbits: 'bits',
-			components: [{ type: 'temperature', ids: [0] }],
-		});
-		devicesService.findOneBy.mockResolvedValue(null);
-
-		const session = await service.start({ duration: 30 });
-
-		discoverers[0]?.emit('discover', {
-			deviceId: 'shellyht-aabbcc',
-			hostname: '192.168.1.11',
-		});
+		// Lib reports the same hostname after the user already entered it manually.
+		addedEmitter.emit('add', buildLibDevice());
 
 		await Promise.resolve();
 		await Promise.resolve();
 
+		// Manual entry wins — it has the user's password and is the canonical snapshot.
 		expect(service.get(session.id)?.devices[0]).toEqual(
 			expect.objectContaining({
-				status: 'needs_password',
-				suggestedCategory: 'sensor',
-			}),
-		);
-
-		await service.manual(session.id, {
-			hostname: '192.168.1.11',
-			password: 'secret',
-		});
-
-		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['192.168.1.11', 'secret']);
-		expect(service.get(session.id)?.devices[0]).toEqual(
-			expect.objectContaining({
-				status: 'ready',
 				source: 'manual',
+				name: 'Manual entry name',
 			}),
 		);
 	});
 
-	it('keeps using verified credentials when a protected device is rediscovered', async () => {
-		deviceManager.getDeviceInfo.mockResolvedValue({
-			id: 'shellyht-aabbcc',
-			name: 'Bathroom sensor',
-			mac: 'AABBCC',
-			model: 'SNSN-0013A',
-			fw_id: '2024-05-05-0000',
-			ver: '1.2.3',
-			app: 'HT',
-			profile: 'sensor',
-			auth_en: true,
-			auth_domain: 'shelly',
-			discoverable: true,
-			key: 'key-abc',
-			batch: 'b',
-			fw_sbits: 'bits',
-			components: [{ type: 'temperature', ids: [0] }],
-		});
-		devicesService.findOneBy.mockResolvedValue(null);
+	it('finishes after the requested duration and detaches the listener', async () => {
+		const unsubscribe = jest.fn();
+		shellyNgService.subscribeToAddedDevice.mockReturnValue(unsubscribe);
 
-		const session = await service.start({ duration: 30 });
-
-		await service.manual(session.id, {
-			hostname: '192.168.1.11',
-			password: 'secret',
-		});
-
-		discoverers[0]?.emit('discover', {
-			deviceId: 'shellyht-aabbcc',
-			hostname: 'shellyht-aabbcc.local',
-		});
-
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(deviceManager.getDeviceInfo.mock.calls.at(-1)).toEqual(['shellyht-aabbcc.local', 'secret']);
-		expect(service.get(session.id)?.devices.at(-1)).toEqual(
-			expect.objectContaining({
-				status: 'ready',
-			}),
-		);
-	});
-
-	it('finishes and stops the mDNS scan after the requested duration', async () => {
 		const session = await service.start({ duration: 5 });
 
 		jest.advanceTimersByTime(5_000);
 		await Promise.resolve();
 
-		const updated = service.get(session.id);
-
-		expect(stopMock).toHaveBeenCalledTimes(1);
-		expect(updated?.status).toBe('finished');
+		expect(service.get(session.id)?.status).toBe('finished');
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
 	});
 
 	it('removes finished sessions after the cleanup delay', async () => {
@@ -241,14 +254,5 @@ describe('ShellyNgDiscoveryService', () => {
 		jest.advanceTimersByTime(5 * 60_000);
 
 		expect(service.get(session.id)).toBeNull();
-	});
-
-	it('does not retain a session when mDNS startup fails', async () => {
-		startMock.mockRejectedValueOnce(new Error('bind failed'));
-
-		await expect(service.start({ duration: 5 })).rejects.toThrow('bind failed');
-
-		expect((service as unknown as { sessions: Map<string, unknown> }).sessions.size).toBe(0);
-		expect(jest.getTimerCount()).toBe(0);
 	});
 });

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.spec.ts
@@ -103,6 +103,9 @@ describe('ShellyNgDiscoveryService', () => {
 				status: 'ready',
 				source: 'mdns',
 				categories: ['lighting', 'switcher'],
+				// Multi-category models pre-fill with the descriptor's first category so the
+				// user can adopt without picking — Plus 1's primary use is lighting.
+				suggestedCategory: 'lighting',
 			}),
 		]);
 	});

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -285,7 +285,10 @@ export class ShellyNgDiscoveryService {
 			categories,
 			suggestedCategory: categories.length === 1 ? categories[0] : null,
 			// Devices in `shellies.values()` have already authenticated successfully
-			// (the main connector wouldn't expose them otherwise).
+			// (the main connector wouldn't expose them otherwise). Password-protected
+			// devices the connector can't reach never appear here — they have to be
+			// adopted via the wizard's manual-entry path, which still inspects over
+			// HTTP and surfaces `needs_password` correctly.
 			authentication: { enabled: false, domain: null },
 			registeredDeviceId: registeredDevice?.id ?? null,
 			registeredDeviceName: registeredDevice?.name ?? null,

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -52,6 +52,7 @@ export interface ShellyNgDiscoveryDeviceSnapshot {
 	};
 	registeredDeviceId: string | null;
 	registeredDeviceName: string | null;
+	registeredDeviceCategory: DeviceCategory | null;
 	error: string | null;
 	lastSeenAt: string;
 }
@@ -299,6 +300,7 @@ export class ShellyNgDiscoveryService {
 				authentication: { enabled: false, domain: null },
 				registeredDeviceId: registeredDevice?.id ?? null,
 				registeredDeviceName: registeredDevice?.name ?? null,
+				registeredDeviceCategory: registeredDevice?.category ?? null,
 				error: null,
 				lastSeenAt: new Date().toISOString(),
 			};
@@ -332,6 +334,7 @@ export class ShellyNgDiscoveryService {
 				authentication: { enabled: false, domain: null },
 				registeredDeviceId: null,
 				registeredDeviceName: null,
+				registeredDeviceCategory: null,
 				error: err.message,
 				lastSeenAt: new Date().toISOString(),
 			});
@@ -364,6 +367,7 @@ export class ShellyNgDiscoveryService {
 			authentication: existing?.authentication ?? { enabled: false, domain: null },
 			registeredDeviceId: existing?.registeredDeviceId ?? null,
 			registeredDeviceName: existing?.registeredDeviceName ?? null,
+			registeredDeviceCategory: existing?.registeredDeviceCategory ?? null,
 			error: null,
 			lastSeenAt: new Date().toISOString(),
 		});
@@ -406,6 +410,7 @@ export class ShellyNgDiscoveryService {
 				authentication,
 				registeredDeviceId: registeredDevice?.id ?? null,
 				registeredDeviceName: registeredDevice?.name ?? null,
+				registeredDeviceCategory: registeredDevice?.category ?? null,
 				error: null,
 				lastSeenAt: new Date().toISOString(),
 			};

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -112,13 +112,19 @@ export class ShellyNgDiscoveryService {
 		// a parallel one. Two browsers + two RPC inspect loops were causing relay glitches
 		// on some Plus/Pro firmware. The 30s session window is kept for UX so the user can
 		// still power on a new device during the scan and have it picked up.
-		for (const device of this.shellyNgService.getKnownDevices()) {
-			await this.handleLibDevice(session, device as LibDevice);
-		}
-
+		//
+		// Subscribe BEFORE iterating the seed list — `getKnownDevices()` + the awaited DB
+		// lookups inside `handleLibDevice` create a window where the lib could fire `add`
+		// for a fresh device that's not in the seed and there's no listener attached yet.
+		// `handleLibDevice` is keyed on hostname so an overlap between a seed entry and
+		// a concurrent `add` event just overwrites the same row rather than duplicating.
 		session.unsubscribeAdded = this.shellyNgService.subscribeToAddedDevice((device) => {
 			void this.handleLibDevice(session, device as LibDevice);
 		});
+
+		for (const device of this.shellyNgService.getKnownDevices()) {
+			await this.handleLibDevice(session, device as LibDevice);
+		}
 
 		session.timer = setTimeout(() => {
 			void this.finish(id);
@@ -254,49 +260,82 @@ export class ShellyNgDiscoveryService {
 			return;
 		}
 
-		const registeredDevice = await this.devicesService.findOneBy<ShellyNgDeviceEntity>(
-			'identifier',
-			device.id,
-			DEVICES_SHELLY_NG_TYPE,
-		);
+		try {
+			const registeredDevice = await this.devicesService.findOneBy<ShellyNgDeviceEntity>(
+				'identifier',
+				device.id,
+				DEVICES_SHELLY_NG_TYPE,
+			);
 
-		const descriptor = this.findDescriptor(device.model);
-		const categories = descriptor?.categories ?? [];
+			const descriptor = this.findDescriptor(device.model);
+			const categories = descriptor?.categories ?? [];
 
-		let status: ShellyNgDiscoveryDeviceStatus;
+			let status: ShellyNgDiscoveryDeviceStatus;
 
-		if (registeredDevice !== null) {
-			status = 'already_registered';
-		} else if (descriptor === null) {
-			status = 'unsupported';
-		} else {
-			status = 'ready';
+			if (registeredDevice !== null) {
+				status = 'already_registered';
+			} else if (descriptor === null) {
+				status = 'unsupported';
+			} else {
+				status = 'ready';
+			}
+
+			const snapshot: ShellyNgDiscoveryDeviceSnapshot = {
+				identifier: device.id,
+				hostname,
+				name: device.system?.config?.device?.name ?? null,
+				model: device.model,
+				displayName: descriptor?.name ?? device.modelName ?? device.model,
+				firmware: device.firmware?.version ?? null,
+				status,
+				source: 'mdns',
+				categories,
+				suggestedCategory: categories.length === 1 ? categories[0] : null,
+				// Devices in `shellies.values()` have already authenticated successfully
+				// (the main connector wouldn't expose them otherwise). Password-protected
+				// devices the connector can't reach never appear here — they have to be
+				// adopted via the wizard's manual-entry path, which still inspects over
+				// HTTP and surfaces `needs_password` correctly.
+				authentication: { enabled: false, domain: null },
+				registeredDeviceId: registeredDevice?.id ?? null,
+				registeredDeviceName: registeredDevice?.name ?? null,
+				error: null,
+				lastSeenAt: new Date().toISOString(),
+			};
+
+			session.devices.set(hostname, snapshot);
+		} catch (error) {
+			// Most likely a transient DB error from `findOneBy`. Surface the device with a
+			// `failed` snapshot so the user can see something happened, but never let the
+			// promise reject — this is invoked from a fire-and-forget `add` listener and
+			// a rejection here would crash the process.
+			const err = error as Error;
+
+			this.logger.warn('Failed to build discovery snapshot for device from main connector', {
+				session: session.id,
+				hostname,
+				message: err.message,
+				stack: err.stack,
+			});
+
+			session.devices.set(hostname, {
+				identifier: device.id,
+				hostname,
+				name: device.system?.config?.device?.name ?? null,
+				model: device.model,
+				displayName: device.modelName ?? device.model,
+				firmware: device.firmware?.version ?? null,
+				status: 'failed',
+				source: 'mdns',
+				categories: [],
+				suggestedCategory: null,
+				authentication: { enabled: false, domain: null },
+				registeredDeviceId: null,
+				registeredDeviceName: null,
+				error: err.message,
+				lastSeenAt: new Date().toISOString(),
+			});
 		}
-
-		const snapshot: ShellyNgDiscoveryDeviceSnapshot = {
-			identifier: device.id,
-			hostname,
-			name: device.system?.config?.device?.name ?? null,
-			model: device.model,
-			displayName: descriptor?.name ?? device.modelName ?? device.model,
-			firmware: device.firmware?.version ?? null,
-			status,
-			source: 'mdns',
-			categories,
-			suggestedCategory: categories.length === 1 ? categories[0] : null,
-			// Devices in `shellies.values()` have already authenticated successfully
-			// (the main connector wouldn't expose them otherwise). Password-protected
-			// devices the connector can't reach never appear here — they have to be
-			// adopted via the wizard's manual-entry path, which still inspects over
-			// HTTP and surfaces `needs_password` correctly.
-			authentication: { enabled: false, domain: null },
-			registeredDeviceId: registeredDevice?.id ?? null,
-			registeredDeviceName: registeredDevice?.name ?? null,
-			error: null,
-			lastSeenAt: new Date().toISOString(),
-		};
-
-		session.devices.set(hostname, snapshot);
 	}
 
 	private async inspectDevice(

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -291,7 +291,12 @@ export class ShellyNgDiscoveryService {
 				status,
 				source: 'mdns',
 				categories,
-				suggestedCategory: categories.length === 1 ? categories[0] : null,
+				// Pre-fill the wizard's category dropdown with the first listed category for the
+				// model so the user can adopt a brand-new device without picking anything. The
+				// descriptor's category list is ordered most-common-first (e.g. Plus 1 → lighting,
+				// switcher), so this lands on the typical use; users with edge cases can still
+				// flip the dropdown in step 2.
+				suggestedCategory: categories.length > 0 ? categories[0] : null,
 				// Devices in `shellies.values()` have already authenticated successfully
 				// (the main connector wouldn't expose them otherwise). Password-protected
 				// devices the connector can't reach never appear here — they have to be
@@ -406,7 +411,12 @@ export class ShellyNgDiscoveryService {
 				status,
 				source,
 				categories,
-				suggestedCategory: categories.length === 1 ? categories[0] : null,
+				// Pre-fill the wizard's category dropdown with the first listed category for the
+				// model so the user can adopt a brand-new device without picking anything. The
+				// descriptor's category list is ordered most-common-first (e.g. Plus 1 → lighting,
+				// switcher), so this lands on the typical use; users with edge cases can still
+				// flip the dropdown in step 2.
+				suggestedCategory: categories.length > 0 ? categories[0] : null,
 				authentication,
 				registeredDeviceId: registeredDevice?.id ?? null,
 				registeredDeviceName: registeredDevice?.name ?? null,

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { MdnsDeviceDiscoverer } from 'shellies-ds9';
+import { Device, Ethernet, WiFi } from 'shellies-ds9';
 
 import { Injectable } from '@nestjs/common';
 
@@ -15,6 +15,13 @@ import {
 import { ShellyNgDeviceEntity } from '../entities/devices-shelly-ng.entity';
 
 import { DeviceManagerService } from './device-manager.service';
+import { ShellyNgService } from './shelly-ng.service';
+
+type LibDevice = Device & {
+	wifi?: WiFi & { sta_ip?: string | null };
+	ethernet?: Ethernet & { ip?: string | null };
+	system?: { config?: { device?: { name?: string | null } } };
+};
 
 export type ShellyNgDiscoverySessionStatus = 'running' | 'finished' | 'failed';
 
@@ -63,9 +70,9 @@ interface ShellyNgDiscoverySession {
 	status: ShellyNgDiscoverySessionStatus;
 	startedAt: Date;
 	expiresAt: Date;
-	discoverer: MdnsDeviceDiscoverer;
 	timer?: NodeJS.Timeout;
 	cleanupTimer?: NodeJS.Timeout;
+	unsubscribeAdded?: () => void;
 	devices: Map<string, ShellyNgDiscoveryDeviceSnapshot>;
 	passwords: Map<string, string>;
 }
@@ -84,49 +91,34 @@ export class ShellyNgDiscoveryService {
 	constructor(
 		private readonly deviceManagerService: DeviceManagerService,
 		private readonly devicesService: DevicesService,
+		private readonly shellyNgService: ShellyNgService,
 	) {}
 
 	async start({ duration }: { duration: number }): Promise<ShellyNgDiscoverySessionSnapshot> {
 		const id = randomUUID();
 		const startedAt = new Date();
 		const expiresAt = new Date(startedAt.getTime() + duration * 1_000);
-		const discoverer = new MdnsDeviceDiscoverer();
 
 		const session: ShellyNgDiscoverySession = {
 			id,
 			status: 'running',
 			startedAt,
 			expiresAt,
-			discoverer,
 			devices: new Map(),
 			passwords: new Map(),
 		};
 
-		discoverer.on('discover', (device: { deviceId?: string; hostname?: string }) => {
-			const hostname = device.hostname ?? device.deviceId ?? '';
-			const password =
-				session.passwords.get(hostname) ??
-				(device.deviceId !== undefined ? session.passwords.get(device.deviceId) : undefined) ??
-				null;
-
-			void this.inspectDevice(session, hostname, 'mdns', password);
-		});
-
-		discoverer.on('error', (error: Error) => {
-			this.logger.warn('mDNS discovery emitted an error', {
-				session: id,
-				message: error.message,
-				stack: error.stack,
-			});
-		});
-
-		try {
-			await discoverer.start();
-		} catch (error) {
-			this.clearTimers(session);
-
-			throw error;
+		// Reuse the main connector's already-running mDNS browser instead of spinning up
+		// a parallel one. Two browsers + two RPC inspect loops were causing relay glitches
+		// on some Plus/Pro firmware. The 30s session window is kept for UX so the user can
+		// still power on a new device during the scan and have it picked up.
+		for (const device of this.shellyNgService.getKnownDevices()) {
+			await this.handleLibDevice(session, device as LibDevice);
 		}
+
+		session.unsubscribeAdded = this.shellyNgService.subscribeToAddedDevice((device) => {
+			void this.handleLibDevice(session, device as LibDevice);
+		});
 
 		session.timer = setTimeout(() => {
 			void this.finish(id);
@@ -176,20 +168,29 @@ export class ShellyNgDiscoveryService {
 		session.status = 'finished';
 
 		this.clearTimer(session);
-
-		try {
-			await session.discoverer.stop();
-		} catch (error) {
-			const err = error as Error;
-
-			this.logger.warn('Failed to stop Shelly NG mDNS discovery session', {
-				session: id,
-				message: err.message,
-				stack: err.stack,
-			});
-		}
+		this.unsubscribeFromAdded(session);
 
 		this.scheduleCleanup(session);
+
+		await Promise.resolve();
+	}
+
+	private unsubscribeFromAdded(session: ShellyNgDiscoverySession): void {
+		if (typeof session.unsubscribeAdded === 'function') {
+			try {
+				session.unsubscribeAdded();
+			} catch (error) {
+				const err = error as Error;
+
+				this.logger.warn('Failed to detach Shelly NG discovery listener', {
+					session: session.id,
+					message: err.message,
+					stack: err.stack,
+				});
+			}
+
+			session.unsubscribeAdded = undefined;
+		}
 	}
 
 	private scheduleCleanup(session: ShellyNgDiscoverySession): void {
@@ -203,6 +204,7 @@ export class ShellyNgDiscoveryService {
 	private clearTimers(session: ShellyNgDiscoverySession): void {
 		this.clearTimer(session);
 		this.clearCleanupTimer(session);
+		this.unsubscribeFromAdded(session);
 	}
 
 	private clearTimer(session: ShellyNgDiscoverySession): void {
@@ -229,6 +231,69 @@ export class ShellyNgDiscoveryService {
 		if (device.identifier !== null) {
 			session.passwords.set(device.identifier, password);
 		}
+	}
+
+	/**
+	 * Build a discovery snapshot for a device the main connector's mDNS browser already
+	 * knows about. No HTTP RPC is sent to the device — everything comes from the lib's
+	 * cached info plus a DB lookup. Manual entries still go through `inspectDevice`
+	 * because they may target devices the main connector hasn't reached.
+	 */
+	private async handleLibDevice(session: ShellyNgDiscoverySession, device: LibDevice): Promise<void> {
+		const hostname = device.wifi?.sta_ip ?? device.ethernet?.ip ?? null;
+
+		if (typeof hostname !== 'string' || hostname.length === 0) {
+			return;
+		}
+
+		// Skip if the user already entered this device manually — that path has the password
+		// and a richer (RPC-fetched) snapshot we don't want to overwrite.
+		const existing = session.devices.get(hostname);
+
+		if (existing && existing.source === 'manual') {
+			return;
+		}
+
+		const registeredDevice = await this.devicesService.findOneBy<ShellyNgDeviceEntity>(
+			'identifier',
+			device.id,
+			DEVICES_SHELLY_NG_TYPE,
+		);
+
+		const descriptor = this.findDescriptor(device.model);
+		const categories = descriptor?.categories ?? [];
+
+		let status: ShellyNgDiscoveryDeviceStatus;
+
+		if (registeredDevice !== null) {
+			status = 'already_registered';
+		} else if (descriptor === null) {
+			status = 'unsupported';
+		} else {
+			status = 'ready';
+		}
+
+		const snapshot: ShellyNgDiscoveryDeviceSnapshot = {
+			identifier: device.id,
+			hostname,
+			name: device.system?.config?.device?.name ?? null,
+			model: device.model,
+			displayName: descriptor?.name ?? device.modelName ?? device.model,
+			firmware: device.firmware?.version ?? null,
+			status,
+			source: 'mdns',
+			categories,
+			suggestedCategory: categories.length === 1 ? categories[0] : null,
+			// Devices in `shellies.values()` have already authenticated successfully
+			// (the main connector wouldn't expose them otherwise).
+			authentication: { enabled: false, domain: null },
+			registeredDeviceId: registeredDevice?.id ?? null,
+			registeredDeviceName: registeredDevice?.name ?? null,
+			error: null,
+			lastSeenAt: new Date().toISOString(),
+		};
+
+		session.devices.set(hostname, snapshot);
 	}
 
 	private async inspectDevice(

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
@@ -526,6 +526,43 @@ export class ShellyNgService extends BaseManagedPluginService {
 		});
 	};
 
+	/**
+	 * Snapshot of every device the main mDNS/lib has currently discovered.
+	 *
+	 * Used by `ShellyNgDiscoveryService` so the wizard can read the existing
+	 * known-device list instead of running a parallel `MdnsDeviceDiscoverer`.
+	 * Running two browsers + two RPC inspect loops on the same LAN was causing
+	 * relay glitches on some Plus/Pro firmware.
+	 */
+	getKnownDevices(): Device[] {
+		if (typeof this.shellies === 'undefined') {
+			return [];
+		}
+
+		return Array.from(this.shellies.values());
+	}
+
+	/**
+	 * Subscribe to new devices the lib discovers for as long as the returned
+	 * unsubscribe is not invoked. Used by the wizard to pick up devices that
+	 * power on during a scan session without needing its own mDNS browser.
+	 */
+	subscribeToAddedDevice(handler: (device: Device) => void): () => void {
+		if (typeof this.shellies === 'undefined') {
+			return () => {
+				/* noop — service not running */
+			};
+		}
+
+		const shellies = this.shellies;
+
+		shellies.on('add', handler);
+
+		return () => {
+			shellies.off('add', handler);
+		};
+	}
+
 	private async initialize(): Promise<void> {
 		const devices = await this.devicesService.findAll<ShellyNgDeviceEntity>(DEVICES_SHELLY_NG_TYPE);
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
@@ -264,6 +264,13 @@ export class ShellyNgService extends BaseManagedPluginService {
 				.on('unknown', this.handleUnknownDevice)
 				.on('error', this.handleError);
 
+			// Re-attach external 'add' subscribers (wizard discovery sessions) that registered
+			// while we were stopped/restarting. `subscribeToAddedDevice` keeps them in the set
+			// across connector lifecycles.
+			for (const handler of this.addSubscribers) {
+				this.shellies.on('add', handler);
+			}
+
 			this.shellies.registerDiscoverer(this.databaseDiscovererService);
 
 			await this.databaseDiscovererService.run();
@@ -527,6 +534,15 @@ export class ShellyNgService extends BaseManagedPluginService {
 	};
 
 	/**
+	 * External subscribers (currently the wizard) that want to be notified when the
+	 * main lib discovers new devices. Tracked here separately from the connector's
+	 * own internal handlers so they can be re-attached automatically across
+	 * stop/start cycles — a wizard scan opened while the connector is restarting
+	 * will pick up events as soon as the new `shellies` instance comes up.
+	 */
+	private readonly addSubscribers: Set<(device: Device) => void> = new Set();
+
+	/**
 	 * Snapshot of every device the main mDNS/lib has currently discovered.
 	 *
 	 * Used by `ShellyNgDiscoveryService` so the wizard can read the existing
@@ -546,20 +562,18 @@ export class ShellyNgService extends BaseManagedPluginService {
 	 * Subscribe to new devices the lib discovers for as long as the returned
 	 * unsubscribe is not invoked. Used by the wizard to pick up devices that
 	 * power on during a scan session without needing its own mDNS browser.
+	 *
+	 * The handler is also kept across connector stop/start cycles, so a wizard
+	 * scan window that opened during a restart still receives events once the
+	 * lib comes up.
 	 */
 	subscribeToAddedDevice(handler: (device: Device) => void): () => void {
-		if (typeof this.shellies === 'undefined') {
-			return () => {
-				/* noop — service not running */
-			};
-		}
-
-		const shellies = this.shellies;
-
-		shellies.on('add', handler);
+		this.addSubscribers.add(handler);
+		this.shellies?.on('add', handler);
 
 		return () => {
-			shellies.off('add', handler);
+			this.addSubscribers.delete(handler);
+			this.shellies?.off('add', handler);
 		};
 	}
 


### PR DESCRIPTION
## Summary

- Wraps the Shelly NG wizard in the standard page layout (app-bar, breadcrumbs, view-header with action buttons, scrollable card with steps) to match the spaces wizard pattern.
- Moves action buttons (Cancel / Next / Back / Adopt / Finish) into the view-header `extra` slot on desktop and a fixed footer on mobile, so the device tables scroll inside the card body while the buttons stay visible.
- Drives the discovery progress bar from a client-side `useNow({ interval: 1000 })` tick instead of `session.remainingSeconds`. The polling-based value got stuck at 0% on rescan and jumped straight to 100%; the new computation is independent of polling latency or rescan races.
- Adds wizard heading, sub-heading, and breadcrumb locale keys across all six locales.

## Test plan

- [x] `pnpm --filter ./apps/admin run lint:js` — clean
- [x] `pnpm --filter ./apps/admin run type-check` — clean
- [x] `pnpm --filter ./apps/admin exec prettier --check` — clean
- [x] `pnpm --filter ./apps/admin run test:unit -- --run` — 1320/1320 pass
- [x] Manual: open wizard with the Shelly NG plugin enabled, confirm layout matches spaces wizard, tables scroll while Next stays visible, progress bar advances during the scan and after pressing "Scan again"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify the Shelly NG discovery/adoption flow on both admin and backend (including switching discovery to reuse the main connector and adding update-on-adopt behavior), which could affect device onboarding and existing device updates if edge cases are missed.
> 
> **Overview**
> Refactors the Shelly NG devices wizard UI to use the standard admin page layout (app bar, breadcrumbs, `ViewHeader`, scrollable `ElCard`), keeping action buttons visible while tables scroll and adding clearer results/error presentation.
> 
> Updates wizard behavior to treat `already_registered` devices as *adoptable* (opt-in), including select-all support, table sorting helpers, and result statuses (`created` vs `updated`). The wizard now pre-fills categories from a new `registeredDeviceCategory` field and avoids stale selections by resetting per-scan state.
> 
> Improves discovery progress accuracy by computing `scanPercentage` from a receipt-anchored client tick (`useNow`) rather than relying on polling timing.
> 
> Backend discovery is reworked to reuse the main Shelly connector’s mDNS/lib device stream (`getKnownDevices` + `subscribeToAddedDevice`) instead of starting a separate `MdnsDeviceDiscoverer`, and device category selection prefers descriptor categories to avoid heuristic misclassification. Locales and schemas are extended with new wizard title/subheading/breadcrumb and result/status strings, plus the new `registeredDeviceCategory` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e748f3b69351bdf4307706bdc46b3d5c31794d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->