### PR TITLE
Add Shelly Gen 1 device wizard

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -353,6 +353,9 @@ export type DevicesShellyNgPluginCreateDiscoveryManualOperation = operations['cr
 // Devices Shelly V1 Plugin Operations
 export type DevicesShellyV1PluginGetSupportedOperation = operations['get-devices-shelly-v1-plugin-supported'];
 export type DevicesShellyV1PluginCreateDeviceInfoOperation = operations['create-devices-shelly-v1-plugin-device-info'];
+export type DevicesShellyV1PluginCreateDiscoveryOperation = operations['create-devices-shelly-v1-plugin-discovery'];
+export type DevicesShellyV1PluginGetDiscoveryOperation = operations['get-devices-shelly-v1-plugin-discovery'];
+export type DevicesShellyV1PluginCreateDiscoveryManualOperation = operations['create-devices-shelly-v1-plugin-discovery-manual'];
 
 // Pages Cards Plugin Operations
 export type PagesCardsPluginGetPageCardOperation = operations['get-pages-cards-plugin-page-card'];

--- a/apps/admin/src/plugins/devices-shelly-v1/components/components.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/components/components.ts
@@ -1,5 +1,6 @@
 export { default as ShellyV1DeviceAddForm } from './shelly-v1-device-add-form.vue';
 export { default as ShellyV1DeviceEditForm } from './shelly-v1-device-edit-form.vue';
+export { default as ShellyV1DevicesWizard } from './shelly-v1-devices-wizard.vue';
 export { default as ShellyV1ConfigForm } from './shelly-v1-config-form.vue';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-shelly-v1/components/shelly-v1-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-shelly-v1/components/shelly-v1-devices-wizard.vue
@@ -1,0 +1,639 @@
+<template>
+	<app-bar-heading
+		v-if="!isMDDevice"
+		teleport
+	>
+		<template #icon>
+			<icon
+				icon="mdi:wizard-hat"
+				class="w[20px] h[20px]"
+			/>
+		</template>
+
+		<template #title>
+			{{ t('devicesShellyV1Plugin.headings.wizard.title') }}
+		</template>
+
+		<template #subtitle>
+			{{ t('devicesShellyV1Plugin.subHeadings.wizard') }}
+		</template>
+	</app-bar-heading>
+
+	<app-bar-button
+		v-if="!isMDDevice"
+		:align="AppBarButtonAlign.LEFT"
+		teleport
+		small
+		@click="handleCancel"
+	>
+		<template #icon>
+			<el-icon :size="24">
+				<icon icon="mdi:chevron-left" />
+			</el-icon>
+		</template>
+	</app-bar-button>
+
+	<app-breadcrumbs :items="breadcrumbs" />
+
+	<view-header
+		:heading="t('devicesShellyV1Plugin.headings.wizard.title')"
+		:sub-heading="t('devicesShellyV1Plugin.subHeadings.wizard')"
+		icon="mdi:wizard-hat"
+	>
+		<template
+			v-if="isMDDevice"
+			#extra
+		>
+			<div class="flex items-center gap-2">
+				<el-button
+					link
+					class="px-4!"
+					@click="handleCancel"
+				>
+					{{ t('devicesModule.buttons.cancel.title') }}
+				</el-button>
+
+				<template v-if="activeStep === 'discovery'">
+					<el-button
+						type="primary"
+						class="px-4!"
+						:disabled="adoptableDevices.length === 0"
+						@click="activeStep = 'categories'"
+					>
+						{{ t('devicesShellyV1Plugin.buttons.next.title') }}
+					</el-button>
+				</template>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-button
+						class="px-4!"
+						@click="activeStep = 'discovery'"
+					>
+						{{ t('devicesModule.buttons.back.title') }}
+					</el-button>
+					<el-button
+						type="primary"
+						class="px-4!"
+						:disabled="!canContinue"
+						:loading="formResult === FormResult.WORKING"
+						@click="onAdopt"
+					>
+						{{ t('devicesShellyV1Plugin.buttons.wizard.adopt.title') }}
+					</el-button>
+				</template>
+
+				<template v-else>
+					<el-button
+						type="primary"
+						class="px-4!"
+						@click="handleFinish"
+					>
+						{{ t('devicesShellyV1Plugin.buttons.wizard.finish.title') }}
+					</el-button>
+				</template>
+			</div>
+		</template>
+	</view-header>
+
+	<div class="grow-1 flex flex-col gap-2 lt-sm:mx-1 sm:mx-2 lt-sm:mb-1 sm:mb-2 overflow-hidden mt-2">
+		<el-card
+			shadow="never"
+			class="max-h-full flex flex-col overflow-hidden box-border"
+			body-class="p-0! max-h-full overflow-hidden flex flex-col"
+		>
+			<template #header>
+				<el-steps
+					:active="activeStepIndex"
+					finish-status="success"
+					align-center
+				>
+					<el-step :title="t('devicesShellyV1Plugin.headings.wizard.discovery')" />
+					<el-step :title="t('devicesShellyV1Plugin.headings.wizard.categories')" />
+					<el-step :title="t('devicesShellyV1Plugin.headings.wizard.results')" />
+				</el-steps>
+			</template>
+
+			<div class="p-4 max-h-full box-border flex flex-col gap-3 overflow-hidden">
+				<template v-if="activeStep === 'discovery'">
+					<el-alert
+						:title="t('devicesShellyV1Plugin.texts.wizard.discovery')"
+						type="info"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between shrink-0">
+						<div class="flex min-w-0 flex-1 flex-col gap-1">
+							<el-text>
+								{{ t('devicesShellyV1Plugin.texts.wizard.scanStatus', { count: devices.length }) }}
+							</el-text>
+							<el-progress
+								:percentage="scanPercentage"
+								:status="session?.status === 'finished' ? 'success' : undefined"
+							/>
+						</div>
+
+						<el-button
+							:loading="formResult === FormResult.WORKING"
+							@click="startDiscovery"
+						>
+							<template #icon>
+								<icon icon="mdi:radar" />
+							</template>
+							{{ t('devicesShellyV1Plugin.buttons.wizard.restart.title') }}
+						</el-button>
+					</div>
+
+					<el-form
+						:model="manual"
+						label-position="top"
+						class="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] shrink-0"
+						@submit.prevent="addManualDevice"
+					>
+						<el-form-item
+							:label="t('devicesShellyV1Plugin.fields.devices.hostname.title')"
+							class="mb-0!"
+						>
+							<el-input
+								v-model="manual.hostname"
+								:placeholder="t('devicesShellyV1Plugin.fields.devices.hostname.placeholder')"
+								name="hostname"
+							/>
+						</el-form-item>
+
+						<el-form-item
+							:label="t('devicesShellyV1Plugin.fields.devices.password.title')"
+							class="mb-0!"
+						>
+							<el-input
+								v-model="manual.password"
+								:placeholder="t('devicesShellyV1Plugin.fields.devices.password.placeholder')"
+								name="password"
+								show-password
+							/>
+						</el-form-item>
+
+						<el-form-item class="mb-0! md:self-end">
+							<el-button
+								type="primary"
+								native-type="submit"
+								:disabled="manual.hostname.trim().length === 0"
+								:loading="formResult === FormResult.WORKING"
+							>
+								<template #icon>
+									<icon icon="mdi:plus" />
+								</template>
+								{{ t('devicesShellyV1Plugin.buttons.wizard.addManual.title') }}
+							</el-button>
+						</el-form-item>
+					</el-form>
+
+					<el-table
+						:data="devices"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
+						:empty-text="t('devicesShellyV1Plugin.texts.wizard.noDevices')"
+					>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.fields.devices.name.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<div class="flex flex-col">
+									<span class="font-medium">
+										{{ row.registeredDeviceName || row.name || row.displayName || row.model || row.hostname }}
+									</span>
+									<span
+										v-if="row.displayName || row.model"
+										class="text-xs text-gray-500"
+									>
+										{{ row.displayName || row.model }}
+									</span>
+								</div>
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyV1Plugin.fields.devices.hostname.title')"
+							min-width="150"
+						/>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.headings.wizard.status')"
+							width="170"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<el-tag :type="statusTagType(row.status)">
+									{{ t(`devicesShellyV1Plugin.statuses.wizard.${row.status}`) }}
+								</el-tag>
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.fields.devices.category.title')"
+							min-width="220"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<span v-if="!isAdoptableStatus(row.status)">-</span>
+								<el-select
+									v-else
+									v-model="categoryByHostname[row.hostname]"
+									:placeholder="t('devicesShellyV1Plugin.fields.devices.category.placeholder')"
+									filterable
+								>
+									<el-option
+										v-for="item in categoryOptions(row)"
+										:key="item.value"
+										:label="item.label"
+										:value="item.value"
+									/>
+								</el-select>
+							</template>
+						</el-table-column>
+					</el-table>
+				</template>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-alert
+						:title="t('devicesShellyV1Plugin.texts.wizard.categories')"
+						type="info"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<el-table
+						:data="adoptableDevices"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
+						:default-sort="{ prop: 'name', order: 'ascending' }"
+					>
+						<el-table-column width="60">
+							<template #header>
+								<el-checkbox
+									:model-value="allAdoptableSelected"
+									:indeterminate="someAdoptableSelected && !allAdoptableSelected"
+									:disabled="adoptableDevices.length === 0"
+									@change="onToggleSelectAll"
+								/>
+							</template>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<el-checkbox v-model="selected[row.hostname]" />
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="name"
+							:label="t('devicesShellyV1Plugin.fields.devices.name.title')"
+							min-width="220"
+							sortable
+							:sort-method="sortByName"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<el-input v-model="nameByHostname[row.hostname]" />
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyV1Plugin.fields.devices.hostname.title')"
+							min-width="150"
+							sortable
+							:sort-method="sortByHostname"
+						/>
+						<el-table-column
+							prop="status"
+							:label="t('devicesShellyV1Plugin.headings.wizard.status')"
+							width="170"
+							sortable
+							:sort-method="sortByStatus"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<el-tag
+									v-if="row.status === 'already_registered'"
+									size="small"
+									type="warning"
+								>
+									{{ t('devicesShellyV1Plugin.statuses.wizard.willUpdate') }}
+								</el-tag>
+								<el-tag
+									v-else
+									size="small"
+									type="success"
+								>
+									{{ t('devicesShellyV1Plugin.statuses.wizard.willCreate') }}
+								</el-tag>
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="category"
+							:label="t('devicesShellyV1Plugin.fields.devices.category.title')"
+							min-width="240"
+							sortable
+							:sort-method="sortByCategory"
+						>
+							<template #default="{ row }: { row: IShellyV1DiscoveryDevice }">
+								<el-select
+									v-model="categoryByHostname[row.hostname]"
+									:placeholder="t('devicesShellyV1Plugin.fields.devices.category.placeholder')"
+									filterable
+								>
+									<el-option
+										v-for="item in categoryOptions(row)"
+										:key="item.value"
+										:label="item.label"
+										:value="item.value"
+									/>
+								</el-select>
+							</template>
+						</el-table-column>
+					</el-table>
+				</template>
+
+				<template v-else>
+					<el-alert
+						:title="t(`devicesShellyV1Plugin.texts.wizard.results.${adoptionResultSummary}`)"
+						:type="adoptionResultSummary === 'failed' ? 'warning' : 'success'"
+						:closable="false"
+						show-icon
+						class="shrink-0"
+					/>
+
+					<el-table
+						:data="adoptionResults"
+						class="h-full w-full flex-grow"
+						table-layout="fixed"
+					>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.headings.wizard.status')"
+							width="140"
+						>
+							<template #default="{ row }: { row: IShellyV1WizardAdoptionResult }">
+								<el-tag :type="resultTagType(row.status)">
+									{{ t(`devicesShellyV1Plugin.statuses.wizard.${row.status}`) }}
+								</el-tag>
+							</template>
+						</el-table-column>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.fields.devices.name.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyV1WizardAdoptionResult }">
+								<span class="font-medium">{{ row.name }}</span>
+							</template>
+						</el-table-column>
+						<el-table-column
+							prop="hostname"
+							:label="t('devicesShellyV1Plugin.fields.devices.hostname.title')"
+							min-width="150"
+						/>
+						<el-table-column
+							:label="t('devicesShellyV1Plugin.fields.devices.error.title')"
+							min-width="200"
+						>
+							<template #default="{ row }: { row: IShellyV1WizardAdoptionResult }">
+								<span
+									v-if="row.error"
+									class="text-red-500"
+								>
+									{{ row.error }}
+								</span>
+								<span
+									v-else
+									class="text-gray-400"
+								>
+									—
+								</span>
+							</template>
+						</el-table-column>
+					</el-table>
+				</template>
+			</div>
+
+			<div
+				v-if="!isMDDevice"
+				class="flex justify-between gap-2 p-4 border-t border-t-solid"
+			>
+				<template v-if="activeStep === 'discovery'">
+					<el-button @click="handleCancel">
+						{{ t('devicesModule.buttons.cancel.title') }}
+					</el-button>
+					<el-button
+						type="primary"
+						:disabled="adoptableDevices.length === 0"
+						@click="activeStep = 'categories'"
+					>
+						{{ t('devicesShellyV1Plugin.buttons.next.title') }}
+					</el-button>
+				</template>
+
+				<template v-else-if="activeStep === 'categories'">
+					<el-button @click="activeStep = 'discovery'">
+						{{ t('devicesModule.buttons.back.title') }}
+					</el-button>
+					<div class="flex gap-2">
+						<el-button @click="handleCancel">
+							{{ t('devicesModule.buttons.cancel.title') }}
+						</el-button>
+						<el-button
+							type="primary"
+							:disabled="!canContinue"
+							:loading="formResult === FormResult.WORKING"
+							@click="onAdopt"
+						>
+							{{ t('devicesShellyV1Plugin.buttons.wizard.adopt.title') }}
+						</el-button>
+					</div>
+				</template>
+
+				<template v-else>
+					<div></div>
+					<el-button
+						type="primary"
+						@click="handleFinish"
+					>
+						{{ t('devicesShellyV1Plugin.buttons.wizard.finish.title') }}
+					</el-button>
+				</template>
+			</div>
+		</el-card>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { type RouteLocationResolvedGeneric, useRouter } from 'vue-router';
+
+import {
+	ElAlert,
+	ElButton,
+	ElCard,
+	ElCheckbox,
+	ElForm,
+	ElFormItem,
+	ElIcon,
+	ElInput,
+	ElOption,
+	ElProgress,
+	ElSelect,
+	ElStep,
+	ElSteps,
+	ElTable,
+	ElTableColumn,
+	ElTag,
+	ElText,
+} from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import { AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewHeader, useBreakpoints } from '../../../common';
+import { RouteNames as DevicesRouteNames, FormResult } from '../../../modules/devices';
+import { useDevicesWizard } from '../composables/composables';
+import { type IShellyV1WizardAdoptionResult, isAdoptableStatus } from '../composables/useDevicesWizard';
+import type { IShellyV1DiscoveryDevice } from '../schemas/devices.types';
+
+defineOptions({
+	name: 'ShellyV1DevicesWizard',
+});
+
+const { t } = useI18n();
+const router = useRouter();
+const { isMDDevice, isLGDevice } = useBreakpoints();
+const {
+	session,
+	devices,
+	manual,
+	selected,
+	categoryByHostname,
+	nameByHostname,
+	adoptionResults,
+	canContinue,
+	formResult,
+	scanPercentage,
+	startDiscovery,
+	addManualDevice,
+	adoptSelected,
+	categoryOptions,
+} = useDevicesWizard();
+
+const activeStep = ref<'discovery' | 'categories' | 'results'>('discovery');
+
+const activeStepIndex = computed<number>(() => {
+	if (activeStep.value === 'categories') {
+		return 1;
+	}
+
+	if (activeStep.value === 'results') {
+		return 2;
+	}
+
+	return 0;
+});
+
+const adoptableDevices = computed<IShellyV1DiscoveryDevice[]>(() => devices.value.filter((device) => isAdoptableStatus(device.status)));
+
+const allAdoptableSelected = computed<boolean>(
+	() => adoptableDevices.value.length > 0 && adoptableDevices.value.every((device) => selected[device.hostname] === true)
+);
+
+const someAdoptableSelected = computed<boolean>(() => adoptableDevices.value.some((device) => selected[device.hostname] === true));
+
+const onToggleSelectAll = (value: boolean | string | number): void => {
+	const next = value === true;
+
+	for (const device of adoptableDevices.value) {
+		selected[device.hostname] = next;
+	}
+};
+
+// Sort comparators for the categories table — `prop`-based sorting can't read our reactive
+// per-hostname maps, so each column gets a custom comparator that reaches into the right
+// source of truth (user-edited name, current category selection, …).
+const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+const sortByName = (a: IShellyV1DiscoveryDevice, b: IShellyV1DiscoveryDevice): number => {
+	const aName = nameByHostname[a.hostname] ?? a.registeredDeviceName ?? a.name ?? a.displayName ?? a.hostname;
+	const bName = nameByHostname[b.hostname] ?? b.registeredDeviceName ?? b.name ?? b.displayName ?? b.hostname;
+	return compareLocale(aName, bName);
+};
+
+const sortByHostname = (a: IShellyV1DiscoveryDevice, b: IShellyV1DiscoveryDevice): number => compareLocale(a.hostname, b.hostname);
+
+// Group "will create" devices before "will update" ones, then by hostname inside each bucket.
+const sortByStatus = (a: IShellyV1DiscoveryDevice, b: IShellyV1DiscoveryDevice): number => {
+	const order = (status: IShellyV1DiscoveryDevice['status']): number => (status === 'already_registered' ? 1 : 0);
+	const diff = order(a.status) - order(b.status);
+	return diff !== 0 ? diff : compareLocale(a.hostname, b.hostname);
+};
+
+const sortByCategory = (a: IShellyV1DiscoveryDevice, b: IShellyV1DiscoveryDevice): number => {
+	const aLabel = categoryByHostname[a.hostname] ? t(`devicesModule.categories.devices.${categoryByHostname[a.hostname]}`) : '';
+	const bLabel = categoryByHostname[b.hostname] ? t(`devicesModule.categories.devices.${categoryByHostname[b.hostname]}`) : '';
+	return compareLocale(aLabel, bLabel);
+};
+
+const adoptionResultSummary = computed<'success' | 'failed'>(() =>
+	adoptionResults.value.some((result) => result.status === 'failed') ? 'failed' : 'success'
+);
+
+const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
+	{
+		label: t('devicesModule.breadcrumbs.devices.list'),
+		route: router.resolve({ name: DevicesRouteNames.DEVICES }),
+	},
+	{
+		label: t('devicesShellyV1Plugin.breadcrumbs.wizard'),
+		route: router.resolve({
+			name: DevicesRouteNames.DEVICES_WIZARD,
+			params: { type: 'devices-shelly-v1-plugin' },
+		}),
+	},
+]);
+
+const statusTagType = (status: IShellyV1DiscoveryDevice['status']): 'success' | 'warning' | 'info' | 'danger' => {
+	if (status === 'ready') {
+		return 'success';
+	}
+
+	if (status === 'checking') {
+		return 'info';
+	}
+
+	if (status === 'needs_password' || status === 'already_registered') {
+		return 'warning';
+	}
+
+	return 'danger';
+};
+
+const resultTagType = (status: IShellyV1WizardAdoptionResult['status']): 'success' | 'warning' | 'danger' => {
+	if (status === 'created') {
+		return 'success';
+	}
+
+	if (status === 'updated') {
+		return 'warning';
+	}
+
+	return 'danger';
+};
+
+const handleCancel = (): void => {
+	if (isLGDevice.value) {
+		router.replace({ name: DevicesRouteNames.DEVICES });
+	} else {
+		router.push({ name: DevicesRouteNames.DEVICES });
+	}
+};
+
+const handleFinish = (): void => {
+	handleCancel();
+};
+
+const onAdopt = async (): Promise<void> => {
+	await adoptSelected();
+	activeStep.value = 'results';
+};
+</script>

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/composables.ts
@@ -1,5 +1,6 @@
 export * from './useDeviceAddForm';
 export * from './useDeviceEditForm';
+export * from './useDevicesWizard';
 export * from './useSupportedDevices';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -112,9 +112,16 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	});
 
 	const selectedDevices = computed<IShellyV1DiscoveryDevice[]>(() =>
-		devices.value.filter(
-			(device) => selected[device.hostname] === true && isAdoptableStatus(device.status) && categoryByHostname[device.hostname] !== null
-		)
+		devices.value.filter((device) => {
+			const category = categoryByHostname[device.hostname];
+
+			// Reject `undefined` (no entry yet) AND `null` (entry exists but no category chosen).
+			// `categoryByHostname[hostname]` is typed as `DevicesModuleDeviceCategory | null`, but
+			// indexing a `Record` for a missing key returns `undefined` at runtime — without the
+			// `!= null` guard the filter would let half-initialized rows through and `adoptSelected`
+			// would cast `undefined` to `DevicesModuleDeviceCategory` and send it to the backend.
+			return selected[device.hostname] === true && isAdoptableStatus(device.status) && category != null;
+		})
 	);
 
 	const canContinue = computed<boolean>(() => selectedDevices.value.length > 0);
@@ -124,7 +131,11 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 		pollingTimer = window.setInterval(() => {
 			refreshDiscovery().catch(() => {
-				// User can trigger discovery again if polling fails.
+				// Stop polling on any error — the most likely failure is a 404 after the server
+				// cleaned up the session, and there's no point re-hitting a missing endpoint every
+				// second until the component unmounts. The user can hit "Scan again" to start a
+				// fresh session.
+				stopPolling();
 			});
 		}, 1_000);
 	};

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -1,0 +1,507 @@
+import { type ComputedRef, type Reactive, computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { orderBy } from 'natural-orderby';
+import { v4 as uuid } from 'uuid';
+
+import { tryOnMounted, tryOnUnmounted, useNow } from '@vueuse/core';
+
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { getErrorReason, injectStoresManager, useBackend, useFlashMessage } from '../../../common';
+import { FormResult, type FormResultType, devicesStoreKey } from '../../../modules/devices';
+import {
+	DevicesModuleDeviceCategory,
+	type DevicesShellyV1PluginCreateDiscoveryManualOperation,
+	type DevicesShellyV1PluginCreateDiscoveryOperation,
+	type DevicesShellyV1PluginGetDiscoveryOperation,
+} from '../../../openapi.constants';
+import { DEVICES_SHELLY_V1_PLUGIN_PREFIX, DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+import { DevicesShellyV1ApiException } from '../devices-shelly-v1.exceptions';
+import type { IShellyV1DiscoveryDevice, IShellyV1DiscoverySession } from '../schemas/devices.types';
+import { transformDeviceInfoRequest, transformDiscoverySessionResponse } from '../utils/devices.transformers';
+
+export interface IShellyV1WizardAdoptionResult {
+	hostname: string;
+	name: string;
+	status: 'created' | 'updated' | 'failed';
+	error: string | null;
+}
+
+export const isAdoptableStatus = (status: IShellyV1DiscoveryDevice['status']): boolean =>
+	status === 'ready' || status === 'already_registered';
+
+export interface IUseDevicesWizard {
+	session: ComputedRef<IShellyV1DiscoverySession | null>;
+	devices: ComputedRef<IShellyV1DiscoveryDevice[]>;
+	selectedDevices: ComputedRef<IShellyV1DiscoveryDevice[]>;
+	scanPercentage: ComputedRef<number>;
+	formResult: ComputedRef<FormResultType>;
+	manual: Reactive<{
+		hostname: string;
+		password: string;
+	}>;
+	selected: Reactive<Record<string, boolean>>;
+	categoryByHostname: Reactive<Record<string, DevicesModuleDeviceCategory | null>>;
+	nameByHostname: Reactive<Record<string, string>>;
+	adoptionResults: ComputedRef<IShellyV1WizardAdoptionResult[]>;
+	canContinue: ComputedRef<boolean>;
+	startDiscovery: () => Promise<void>;
+	refreshDiscovery: () => Promise<void>;
+	addManualDevice: () => Promise<void>;
+	adoptSelected: () => Promise<IShellyV1WizardAdoptionResult[]>;
+	categoryOptions: (device: IShellyV1DiscoveryDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+}
+
+export const useDevicesWizard = (): IUseDevicesWizard => {
+	const { t } = useI18n();
+	const backend = useBackend();
+	const storesManager = injectStoresManager();
+	const flashMessage = useFlashMessage();
+	const devicesStore = storesManager.getStore(devicesStoreKey);
+
+	const session = ref<IShellyV1DiscoverySession | null>(null);
+	const formResult = ref<FormResultType>(FormResult.NONE);
+	const adoptionResults = ref<IShellyV1WizardAdoptionResult[]>([]);
+	const selected = reactive<Record<string, boolean>>({});
+	const categoryByHostname = reactive<Record<string, DevicesModuleDeviceCategory | null>>({});
+	const nameByHostname = reactive<Record<string, string>>({});
+	const passwordByHostname = reactive<Record<string, string | null>>({});
+	const manual = reactive({
+		hostname: '',
+		password: '',
+	});
+	const readyHostnames = new Set<string>();
+
+	let pollingTimer: number | null = null;
+
+	// Captured at every applySession so scanPercentage can tick forward independent of any
+	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
+	// on every poll, so any local drift is bounded by the polling interval (~1s).
+	const sessionReceivedAt = ref<number | null>(null);
+	const sessionRemainingMsAtReceipt = ref<number>(0);
+	const sessionDurationMs = ref<number>(0);
+
+	const now = useNow({ interval: 1_000 });
+
+	const devices = computed<IShellyV1DiscoveryDevice[]>(() =>
+		orderBy(
+			session.value?.devices ?? [],
+			[(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.hostname],
+			['asc', 'asc']
+		)
+	);
+
+	const scanPercentage = computed<number>(() => {
+		if (session.value === null) {
+			return 0;
+		}
+
+		if (session.value.status !== 'running') {
+			return 100;
+		}
+
+		if (sessionReceivedAt.value === null || sessionDurationMs.value === 0) {
+			return 0;
+		}
+
+		const elapsedSinceReceipt = Math.max(0, now.value.getTime() - sessionReceivedAt.value);
+		const remainingMs = Math.max(0, sessionRemainingMsAtReceipt.value - elapsedSinceReceipt);
+		const elapsed = sessionDurationMs.value - remainingMs;
+
+		return Math.min(100, Math.max(0, Math.round((elapsed / sessionDurationMs.value) * 100)));
+	});
+
+	const selectedDevices = computed<IShellyV1DiscoveryDevice[]>(() =>
+		devices.value.filter(
+			(device) => selected[device.hostname] === true && isAdoptableStatus(device.status) && categoryByHostname[device.hostname] !== null
+		)
+	);
+
+	const canContinue = computed<boolean>(() => selectedDevices.value.length > 0);
+
+	const startPolling = (): void => {
+		stopPolling();
+
+		pollingTimer = window.setInterval(() => {
+			refreshDiscovery().catch(() => {
+				// User can trigger discovery again if polling fails.
+			});
+		}, 1_000);
+	};
+
+	const stopPolling = (): void => {
+		if (pollingTimer !== null) {
+			window.clearInterval(pollingTimer);
+			pollingTimer = null;
+		}
+	};
+
+	const applySession = (nextSession: IShellyV1DiscoverySession): void => {
+		const previousDevices = session.value?.devices ?? [];
+
+		session.value = nextSession;
+
+		// Snap the client-side progress reference to the moment we received this snapshot.
+		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even
+		// when the client clock is skewed relative to the server's startedAt/expiresAt.
+		sessionReceivedAt.value = Date.now();
+		sessionRemainingMsAtReceipt.value = nextSession.remainingSeconds * 1_000;
+		sessionDurationMs.value = Math.max(1, new Date(nextSession.expiresAt).getTime() - new Date(nextSession.startedAt).getTime());
+
+		for (const device of nextSession.devices) {
+			const previousDevice = previousDevices.find((item) => item.hostname === device.hostname);
+			const becameReady = previousDevice?.status === 'checking' && device.status === 'ready';
+			const becameAdoptable = previousDevice?.status === 'checking' && isAdoptableStatus(device.status);
+			const becameAlreadyRegistered =
+				previousDevice !== undefined && previousDevice.status !== 'already_registered' && device.status === 'already_registered';
+			const wasPreviouslyReady = readyHostnames.has(device.hostname);
+
+			// `ready` devices are pre-selected so the user can adopt new devices in one step.
+			// `already_registered` devices stay deselected — the user must opt in explicitly to override
+			// the category/name the main service auto-adopted them with.
+			//
+			// If a device that was previously `ready` (and possibly user-selected) refreshes to
+			// `already_registered` — typically because the main connector auto-adopted it during the
+			// session — clear the selection so the next Adopt click doesn't silently update an
+			// existing device. `adoptSelected` snapshots the user's selections before its own
+			// refresh, so an in-flight adopt isn't dropped by this rule.
+			if (selected[device.hostname] === undefined || (becameReady && !wasPreviouslyReady)) {
+				selected[device.hostname] = device.status === 'ready';
+			} else if (becameAlreadyRegistered) {
+				selected[device.hostname] = false;
+			}
+
+			// Pre-fill the category dropdown so the wizard never lands on an empty selector for
+			// already-adopted devices: prefer the existing DB category over the descriptor's
+			// suggestion.
+			const initialCategory = device.registeredDeviceCategory ?? device.suggestedCategory;
+
+			if (categoryByHostname[device.hostname] === undefined || (categoryByHostname[device.hostname] === null && initialCategory !== null)) {
+				categoryByHostname[device.hostname] = initialCategory;
+			}
+
+			// Refresh the editable name when the inspect step finishes (checking → ready or
+			// checking → already_registered) and the user hasn't typed anything yet — otherwise
+			// `already_registered` devices would keep the hostname placeholder and overwrite the
+			// existing registered name on update.
+			if (nameByHostname[device.hostname] === undefined || (becameAdoptable && nameByHostname[device.hostname] === device.hostname)) {
+				nameByHostname[device.hostname] = device.registeredDeviceName ?? device.name ?? device.displayName ?? device.hostname;
+			}
+
+			// `readyHostnames` records devices that have been observed in the `ready` state at
+			// least once during the session. Its only consumer is the `becameReady &&
+			// !wasPreviouslyReady` guard above, which prevents re-selecting a device the user
+			// already deselected. We must NOT include `already_registered` here — otherwise a
+			// device that started as `already_registered`, was deleted from the DB mid-session,
+			// then transitioned `checking → ready` would be treated as previously-ready and skip
+			// auto-selection.
+			if (device.status === 'ready') {
+				readyHostnames.add(device.hostname);
+			}
+		}
+
+		if (nextSession.status !== 'running') {
+			stopPolling();
+		}
+	};
+
+	const resetSessionScopedState = (): void => {
+		for (const key of Object.keys(selected)) {
+			delete selected[key];
+		}
+		for (const key of Object.keys(categoryByHostname)) {
+			delete categoryByHostname[key];
+		}
+		for (const key of Object.keys(nameByHostname)) {
+			delete nameByHostname[key];
+		}
+		for (const key of Object.keys(passwordByHostname)) {
+			delete passwordByHostname[key];
+		}
+		readyHostnames.clear();
+	};
+
+	const startDiscovery = async (): Promise<void> => {
+		formResult.value = FormResult.WORKING;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery`);
+
+		if (typeof responseData !== 'undefined') {
+			// Drop any selections / inputs from a previous scan before applying the new snapshot.
+			// Otherwise a device that was `ready` last time and now shows as `already_registered`
+			// would carry over `selected=true` and silently update an existing device on adopt.
+			// Refreshes within the same session keep their state — only `startDiscovery` resets,
+			// so the per-device race fallback in `adoptSelected` still works.
+			resetSessionScopedState();
+			applySession(transformDiscoverySessionResponse(responseData.data));
+			formResult.value = FormResult.NONE;
+			startPolling();
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyV1PluginCreateDiscoveryOperation>(error, t('devicesShellyV1Plugin.messages.wizard.discoveryNotStarted'))
+			: t('devicesShellyV1Plugin.messages.wizard.discoveryNotStarted');
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesShellyV1ApiException(errorReason, response.status);
+	};
+
+	const refreshDiscovery = async (): Promise<void> => {
+		if (session.value === null) {
+			return;
+		}
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.GET(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery/{id}`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformDiscoverySessionResponse(responseData.data));
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyV1PluginGetDiscoveryOperation>(error, t('devicesShellyV1Plugin.messages.wizard.discoveryNotLoaded'))
+			: t('devicesShellyV1Plugin.messages.wizard.discoveryNotLoaded');
+
+		throw new DevicesShellyV1ApiException(errorReason, response.status);
+	};
+
+	const addManualDevice = async (): Promise<void> => {
+		if (session.value === null) {
+			await startDiscovery();
+		}
+
+		if (session.value === null || manual.hostname.trim().length === 0) {
+			return;
+		}
+
+		formResult.value = FormResult.WORKING;
+
+		const hostname = manual.hostname.trim();
+		const password = manual.password.trim() || null;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery/{id}/manual`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+			body: {
+				data: transformDeviceInfoRequest({
+					hostname,
+					password,
+				}),
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			passwordByHostname[hostname] = password;
+			manual.hostname = '';
+			manual.password = '';
+			applySession(transformDiscoverySessionResponse(responseData.data));
+			formResult.value = FormResult.NONE;
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesShellyV1PluginCreateDiscoveryManualOperation>(error, t('devicesShellyV1Plugin.messages.wizard.manualNotAdded'))
+			: t('devicesShellyV1Plugin.messages.wizard.manualNotAdded');
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesShellyV1ApiException(errorReason, response.status);
+	};
+
+	const adoptSelected = async (): Promise<IShellyV1WizardAdoptionResult[]> => {
+		formResult.value = FormResult.WORKING;
+
+		// Snapshot the user's intent BEFORE refreshing. The refresh below can flip a
+		// `ready` device to `already_registered` (because the main connector auto-adopted
+		// it concurrently), and `applySession` deselects on that transition to keep the
+		// opt-in-for-updates contract on subsequent clicks. We still want THIS click to
+		// adopt the device the user chose — as an update, since that's what the new
+		// status means.
+		const userSelections = selectedDevices.value.slice();
+
+		// Refresh once so we see any device the main service auto-adopted between scan and adoption.
+		// Lets us route those through `edit` instead of getting a duplicate-identifier error from `add`.
+		if (session.value !== null) {
+			try {
+				await refreshDiscovery();
+			} catch {
+				// Stale snapshot is fine — the per-device fallback below still handles late races.
+			}
+		}
+
+		const results: IShellyV1WizardAdoptionResult[] = [];
+
+		for (const selection of userSelections) {
+			const device = devices.value.find((item) => item.hostname === selection.hostname) ?? selection;
+			const name = nameByHostname[device.hostname] || device.name || device.displayName || device.hostname;
+			const category = categoryByHostname[device.hostname] as DevicesModuleDeviceCategory;
+			const password = passwordByHostname[device.hostname] ?? null;
+
+			try {
+				if (device.status === 'already_registered' && device.registeredDeviceId !== null) {
+					await updateRegistered(device.registeredDeviceId, { name, category, password });
+
+					results.push({
+						hostname: device.hostname,
+						name,
+						status: 'updated',
+						error: null,
+					});
+
+					continue;
+				}
+
+				const id = uuid().toString();
+
+				try {
+					await devicesStore.add({
+						id,
+						draft: false,
+						data: {
+							id,
+							type: DEVICES_SHELLY_V1_TYPE,
+							category,
+							identifier: device.identifier,
+							name,
+							description: null,
+							enabled: true,
+							password,
+							hostname: device.hostname,
+						},
+					});
+
+					results.push({
+						hostname: device.hostname,
+						name,
+						status: 'created',
+						error: null,
+					});
+				} catch (createError: unknown) {
+					// The device may have been auto-created by the main shelly-v1 service after the discovery
+					// snapshot was taken. Re-poll, and if it now shows as already_registered, fall back to update.
+					try {
+						await refreshDiscovery();
+					} catch {
+						// ignore — handled below
+					}
+
+					const refreshed = devices.value.find((item) => item.hostname === device.hostname);
+
+					if (refreshed?.status === 'already_registered' && refreshed.registeredDeviceId !== null) {
+						await updateRegistered(refreshed.registeredDeviceId, { name, category, password });
+
+						results.push({
+							hostname: device.hostname,
+							name,
+							status: 'updated',
+							error: null,
+						});
+
+						continue;
+					}
+
+					throw createError;
+				}
+			} catch (error: unknown) {
+				results.push({
+					hostname: device.hostname,
+					name,
+					status: 'failed',
+					error: error instanceof Error ? error.message : t('devicesShellyV1Plugin.messages.wizard.adoptionNotCreated'),
+				});
+			}
+		}
+
+		adoptionResults.value = results;
+		formResult.value = results.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
+
+		return results;
+	};
+
+	const updateRegistered = async (
+		id: string,
+		{ name, category, password }: { name: string; category: DevicesModuleDeviceCategory; password: string | null }
+	): Promise<void> => {
+		const data: { type: string; name: string; category: DevicesModuleDeviceCategory; password?: string } = {
+			type: DEVICES_SHELLY_V1_TYPE,
+			name,
+			category,
+		};
+
+		if (password !== null) {
+			data.password = password;
+		}
+
+		// `devicesStore.edit` requires the device to be present in the local store. When the
+		// main connector auto-adopts a device after the wizard's snapshot was taken, the new
+		// row may not be in the admin store yet — pull it in first so the edit can land.
+		if (devicesStore.findById(id) === null) {
+			await devicesStore.get({ id });
+		}
+
+		await devicesStore.edit({ id, data });
+	};
+
+	const categoryOptions = (device: IShellyV1DiscoveryDevice): { value: DevicesModuleDeviceCategory; label: string }[] =>
+		orderBy(device.categories, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map((value) => ({
+			value,
+			label: t(`devicesModule.categories.devices.${value}`),
+		}));
+
+	tryOnMounted(() => {
+		startDiscovery().catch(() => {
+			// The message is already surfaced to the user.
+		});
+	});
+
+	tryOnUnmounted(() => {
+		stopPolling();
+	});
+
+	return {
+		session: computed(() => session.value),
+		devices,
+		selectedDevices,
+		scanPercentage,
+		formResult: computed(() => formResult.value),
+		manual,
+		selected,
+		categoryByHostname,
+		nameByHostname,
+		adoptionResults: computed(() => adoptionResults.value),
+		canContinue,
+		startDiscovery,
+		refreshDiscovery,
+		addManualDevice,
+		adoptSelected,
+		categoryOptions,
+	};
+};

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -317,10 +317,23 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		});
 
 		if (typeof responseData !== 'undefined') {
-			passwordByHostname[hostname] = password;
+			const nextSession = transformDiscoverySessionResponse(responseData.data);
+			const inspected = nextSession.devices.find((item) => item.hostname === hostname);
+
+			// Only persist the entered password when the backend confirms it works (or no auth was
+			// involved). For `already_registered` devices, the DB-hit status takes priority over
+			// `needs_password`, so a wrong password against an existing device still produces
+			// `status: 'already_registered'` with `authentication.valid: false`. Storing it
+			// unconditionally would overwrite the correct on-disk password the next time the user
+			// hits Adopt — `adoptSelected` reads `passwordByHostname[hostname]` and sends it
+			// straight to `updateRegistered`.
+			if (password !== null && inspected?.authentication.valid !== false) {
+				passwordByHostname[hostname] = password;
+			}
+
 			manual.hostname = '';
 			manual.password = '';
-			applySession(transformDiscoverySessionResponse(responseData.data));
+			applySession(nextSession);
 			formResult.value = FormResult.NONE;
 
 			return;

--- a/apps/admin/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
@@ -15,7 +15,7 @@ import {
 	type IDevicePluginsSchemas,
 } from '../../modules/devices';
 
-import { ShellyV1ConfigForm, ShellyV1DeviceAddForm, ShellyV1DeviceEditForm } from './components/components';
+import { ShellyV1ConfigForm, ShellyV1DeviceAddForm, ShellyV1DeviceEditForm, ShellyV1DevicesWizard } from './components/components';
 import { DEVICES_SHELLY_V1_PLUGIN_NAME, DEVICES_SHELLY_V1_TYPE } from './devices-shelly-v1.constants';
 import { locales } from './locales';
 import { ShellyV1ConfigEditFormSchema } from './schemas/config.schemas';
@@ -75,6 +75,7 @@ export default {
 					components: {
 						deviceAddForm: ShellyV1DeviceAddForm,
 						deviceEditForm: ShellyV1DeviceEditForm,
+						deviceWizard: ShellyV1DevicesWizard,
 					},
 					schemas: {
 						deviceSchema: ShellyV1DeviceSchema,

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/cs-CZ.json
@@ -10,7 +10,20 @@
 			"notSupported": "Je nám líto, vaše zařízení není podporováno",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Průvodce vyhledáním Shelly Gen 1",
+			"discovery": "Vyhledávání",
+			"categories": "Kategorie",
+			"results": "Výsledky",
+			"status": "Stav"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Najděte a adoptujte zařízení Shelly Gen 1 ve vaší síti"
+	},
+	"breadcrumbs": {
+		"wizard": "průvodce vyhledáním"
 	},
 	"fields": {
 		"devices": {
@@ -44,6 +57,9 @@
 			"password": {
 				"title": "Heslo administrátora",
 				"placeholder": "Zadejte heslo zařízení, pokud je chráněno"
+			},
+			"error": {
+				"title": "Chyba"
 			},
 			"hostname": {
 				"title": "Název hostitele zařízení",
@@ -101,16 +117,60 @@
 			"edited": "Změny uloženy! Zařízení Shelly Gen 1: {device} bylo aktualizováno.",
 			"notEdited": "Něco se pokazilo. Aktualizace zařízení Shelly Gen 1 nebyla úspěšná.",
 			"failedLoadSupportedDevices": "Něco se pokazilo. Nepodařilo se načíst podporovaná zařízení pluginu."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Něco se pokazilo. Vyhledávání Shelly se nepodařilo spustit.",
+			"discoveryNotLoaded": "Něco se pokazilo. Vyhledávání Shelly se nepodařilo načíst.",
+			"manualNotAdded": "Něco se pokazilo. Ruční vyhledání zařízení Shelly se nepodařilo přidat.",
+			"adoptionNotCreated": "Něco se pokazilo. Zařízení Shelly se nepodařilo adoptovat."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Povolte nebo zakažte integraci zařízení Shelly Gen 1. Pokud je povolena, zařízení Shelly mohou být vyhledána a ovládána prostřednictvím Smart Panelu.",
 		"aboutDiscovery": "Nakonfigurujte, jak plugin vyhledává zařízení Shelly Gen 1 ve vaší lokální síti pomocí Multicast DNS (mDNS). To umožňuje automatickou detekci bez nutnosti ručního zadávání IP adres.",
-		"aboutTimeouts": "Nakonfigurujte nastavení časových limitů pro HTTP komunikaci se zařízeními Shelly Gen 1. Tato nastavení řídí zpracování požadavků a monitorování stavu zařízení."
+		"aboutTimeouts": "Nakonfigurujte nastavení časových limitů pro HTTP komunikaci se zařízeními Shelly Gen 1. Tato nastavení řídí zpracování požadavků a monitorování stavu zařízení.",
+		"wizard": {
+			"discovery": "Průvodce vyhledá zařízení Shelly Gen 1 v lokální síti a přijímá také ručně zadaný hostname nebo IP adresu.",
+			"categories": "Potvrďte, která připravená zařízení mají být adoptována, a vyberte cílovou kategorii pro každé z nich.",
+			"scanStatus": "Nalezeno zařízení: {count}",
+			"noDevices": "Nebyla nalezena žádná zařízení Shelly",
+			"results": {
+				"success": "Všechna zařízení byla úspěšně adoptována.",
+				"failed": "Některá zařízení se nepodařilo adoptovat. Zkontrolujte chyby níže."
+			}
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Další"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Vyhledat znovu"
+			},
+			"addManual": {
+				"title": "Přidat"
+			},
+			"adopt": {
+				"title": "Adoptovat vybrané"
+			},
+			"finish": {
+				"title": "Zpět na zařízení"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Kontrola",
+			"ready": "Připraveno",
+			"needs_password": "Vyžaduje heslo",
+			"already_registered": "Registrováno",
+			"unsupported": "Nepodporováno",
+			"failed": "Selhalo",
+			"created": "Vytvořeno",
+			"updated": "Aktualizováno",
+			"willCreate": "Bude vytvořeno",
+			"willUpdate": "Aktualizuje stávající"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/de-DE.json
@@ -10,7 +10,20 @@
       "notSupported": "Leider wird Ihr Gerät nicht unterstützt",
       "model": "Modell",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "title": "Shelly Gen 1 Discovery-Assistent",
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
+  },
+  "subHeadings": {
+    "wizard": "Finden und übernehmen Sie Shelly Gen 1-Geräte in Ihrem Netzwerk"
+  },
+  "breadcrumbs": {
+    "wizard": "Discovery-Assistent"
   },
   "fields": {
     "devices": {
@@ -44,6 +57,9 @@
       "password": {
         "title": "Admin-Passwort",
         "placeholder": "Gerätepasswort eingeben, falls das Gerät geschützt ist"
+      },
+      "error": {
+        "title": "Fehler"
       },
       "hostname": {
         "title": "Geräte-Hostname",
@@ -101,16 +117,60 @@
       "edited": "Änderungen gespeichert! Das Shelly Gen 1-Gerät: {device} wurde aktualisiert.",
       "notEdited": "Etwas ist schiefgelaufen. Die Aktualisierung des Shelly Gen 1-Geräts war nicht erfolgreich.",
       "failedLoadSupportedDevices": "Etwas ist schiefgelaufen. Die unterstützten Geräte des Plugins konnten nicht geladen werden."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Aktivieren oder deaktivieren Sie die Shelly Gen 1 Geräteintegration. Wenn aktiviert, können Shelly-Geräte über das Smart Panel erkannt und gesteuert werden.",
     "aboutDiscovery": "Konfigurieren Sie, wie das Plugin Shelly Gen 1-Geräte in Ihrem lokalen Netzwerk über Multicast DNS (mDNS) erkennt. Dies ermöglicht die automatische Erkennung ohne manuelle Eingabe von IP-Adressen.",
-    "aboutTimeouts": "Konfigurieren Sie Zeitlimit-Einstellungen für die HTTP-Kommunikation mit Shelly Gen 1-Geräten. Diese Einstellungen steuern die Anfrageverarbeitung und Gerätestatusüberwachung."
+    "aboutTimeouts": "Konfigurieren Sie Zeitlimit-Einstellungen für die HTTP-Kommunikation mit Shelly Gen 1-Geräten. Diese Einstellungen steuern die Anfrageverarbeitung und Gerätestatusüberwachung.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found",
+      "results": {
+        "success": "Alle Geräte wurden erfolgreich übernommen.",
+        "failed": "Einige Geräte konnten nicht übernommen werden. Überprüfen Sie die Fehler unten."
+      }
+    }
   },
   "buttons": {
     "next": {
       "title": "Weiter"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created",
+      "updated": "Aktualisiert",
+      "willCreate": "Wird erstellt",
+      "willUpdate": "Bestehendes wird aktualisiert"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/de-DE.json
@@ -13,9 +13,9 @@
     },
     "wizard": {
       "title": "Shelly Gen 1 Discovery-Assistent",
-      "discovery": "Discovery",
-      "categories": "Categories",
-      "results": "Results",
+      "discovery": "Erkennung",
+      "categories": "Kategorien",
+      "results": "Ergebnisse",
       "status": "Status"
     }
   },
@@ -119,10 +119,10 @@
       "failedLoadSupportedDevices": "Etwas ist schiefgelaufen. Die unterstützten Geräte des Plugins konnten nicht geladen werden."
     },
     "wizard": {
-      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+      "discoveryNotStarted": "Etwas ist schiefgelaufen. Die Shelly-Erkennung konnte nicht gestartet werden.",
+      "discoveryNotLoaded": "Etwas ist schiefgelaufen. Die Shelly-Erkennung konnte nicht geladen werden.",
+      "manualNotAdded": "Etwas ist schiefgelaufen. Die manuelle Shelly-Gerätesuche konnte nicht hinzugefügt werden.",
+      "adoptionNotCreated": "Etwas ist schiefgelaufen. Das Shelly-Gerät konnte nicht übernommen werden."
     }
   },
   "texts": {
@@ -130,10 +130,10 @@
     "aboutDiscovery": "Konfigurieren Sie, wie das Plugin Shelly Gen 1-Geräte in Ihrem lokalen Netzwerk über Multicast DNS (mDNS) erkennt. Dies ermöglicht die automatische Erkennung ohne manuelle Eingabe von IP-Adressen.",
     "aboutTimeouts": "Konfigurieren Sie Zeitlimit-Einstellungen für die HTTP-Kommunikation mit Shelly Gen 1-Geräten. Diese Einstellungen steuern die Anfrageverarbeitung und Gerätestatusüberwachung.",
     "wizard": {
-      "discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
-      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-      "scanStatus": "{count} devices found",
-      "noDevices": "No Shelly devices found",
+      "discovery": "Der Assistent durchsucht das lokale Netzwerk nach Shelly Gen 1-Geräten und akzeptiert auch einen manuell eingegebenen Hostname oder eine IP-Adresse.",
+      "categories": "Bestätigen Sie, welche bereiten Geräte übernommen werden sollen, und wählen Sie für jedes die Zielkategorie aus.",
+      "scanStatus": "{count} Geräte gefunden",
+      "noDevices": "Keine Shelly-Geräte gefunden",
       "results": {
         "success": "Alle Geräte wurden erfolgreich übernommen.",
         "failed": "Einige Geräte konnten nicht übernommen werden. Überprüfen Sie die Fehler unten."
@@ -146,28 +146,28 @@
     },
     "wizard": {
       "restart": {
-        "title": "Scan again"
+        "title": "Erneut scannen"
       },
       "addManual": {
-        "title": "Add"
+        "title": "Hinzufügen"
       },
       "adopt": {
-        "title": "Adopt selected"
+        "title": "Ausgewählte übernehmen"
       },
       "finish": {
-        "title": "Back to devices"
+        "title": "Zurück zu den Geräten"
       }
     }
   },
   "statuses": {
     "wizard": {
-      "checking": "Checking",
-      "ready": "Ready",
-      "needs_password": "Needs password",
-      "already_registered": "Registered",
-      "unsupported": "Unsupported",
-      "failed": "Failed",
-      "created": "Created",
+      "checking": "Wird geprüft",
+      "ready": "Bereit",
+      "needs_password": "Passwort erforderlich",
+      "already_registered": "Registriert",
+      "unsupported": "Nicht unterstützt",
+      "failed": "Fehlgeschlagen",
+      "created": "Erstellt",
       "updated": "Aktualisiert",
       "willCreate": "Wird erstellt",
       "willUpdate": "Bestehendes wird aktualisiert"

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/en-US.json
@@ -10,7 +10,20 @@
       "notSupported": "We are sorry, your device is not supported",
       "model": "Model",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "title": "Shelly Gen 1 discovery wizard",
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
+  },
+  "subHeadings": {
+    "wizard": "Find and adopt Shelly Gen 1 devices on your network"
+  },
+  "breadcrumbs": {
+    "wizard": "discovery wizard"
   },
   "fields": {
     "devices": {
@@ -44,6 +57,9 @@
       "password": {
         "title": "Admin password",
         "placeholder": "Provide device password if device is protected"
+      },
+      "error": {
+        "title": "Error"
       },
       "hostname": {
         "title": "Device hostname",
@@ -101,16 +117,60 @@
       "edited": "Changes saved! The Shelly Gen 1 device: {device} has been updated.",
       "notEdited": "Something went wrong. Shelly Gen 1 device update was not successful.",
       "failedLoadSupportedDevices": "Something went wrong. Plugin supported devices could not be loaded."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Enable or disable the Shelly Gen 1 device integration. When enabled, Shelly devices can be discovered and controlled through the Smart Panel.",
     "aboutDiscovery": "Configure how the plugin discovers Shelly Gen 1 devices on your local network using Multicast DNS (mDNS). This enables automatic detection without needing to manually enter IP addresses.",
-    "aboutTimeouts": "Configure timeout settings for HTTP communication with Shelly Gen 1 devices. These settings control request handling and device state monitoring."
+    "aboutTimeouts": "Configure timeout settings for HTTP communication with Shelly Gen 1 devices. These settings control request handling and device state monitoring.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found",
+      "results": {
+        "success": "All devices were adopted successfully.",
+        "failed": "Some devices could not be adopted. Review the errors below."
+      }
+    }
   },
   "buttons": {
     "next": {
       "title": "Next"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created",
+      "updated": "Updated",
+      "willCreate": "Will create",
+      "willUpdate": "Will update existing"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/es-ES.json
@@ -10,7 +10,20 @@
       "notSupported": "Lo sentimos, su dispositivo no es compatible",
       "model": "Modelo",
       "firmware": "Firmware"
+    },
+    "wizard": {
+      "title": "Asistente de descubrimiento de Shelly Gen 1",
+      "discovery": "Discovery",
+      "categories": "Categories",
+      "results": "Results",
+      "status": "Status"
     }
+  },
+  "subHeadings": {
+    "wizard": "Encuentre y adopte dispositivos Shelly Gen 1 en su red"
+  },
+  "breadcrumbs": {
+    "wizard": "asistente de descubrimiento"
   },
   "fields": {
     "devices": {
@@ -44,6 +57,9 @@
       "password": {
         "title": "Contraseña de administrador",
         "placeholder": "Proporcione la contraseña del dispositivo si está protegido"
+      },
+      "error": {
+        "title": "Error"
       },
       "hostname": {
         "title": "Nombre de host del dispositivo",
@@ -101,16 +117,60 @@
       "edited": "¡Cambios guardados! El dispositivo Shelly Gen 1: {device} ha sido actualizado.",
       "notEdited": "Algo salió mal. La actualización del dispositivo Shelly Gen 1 no fue exitosa.",
       "failedLoadSupportedDevices": "Algo salió mal. No se pudieron cargar los dispositivos compatibles del plugin."
+    },
+    "wizard": {
+      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
     }
   },
   "texts": {
     "aboutPluginStatus": "Habilitar o deshabilitar la integración de dispositivos Shelly Gen 1. Cuando está habilitado, los dispositivos Shelly pueden ser descubiertos y controlados a través del Smart Panel.",
     "aboutDiscovery": "Configure cómo el plugin descubre dispositivos Shelly Gen 1 en su red local usando DNS Multidifusión (mDNS). Esto permite la detección automática sin necesidad de introducir direcciones IP manualmente.",
-    "aboutTimeouts": "Configure los tiempos de espera para la comunicación HTTP con los dispositivos Shelly Gen 1. Estos ajustes controlan el manejo de solicitudes y la monitorización del estado del dispositivo."
+    "aboutTimeouts": "Configure los tiempos de espera para la comunicación HTTP con los dispositivos Shelly Gen 1. Estos ajustes controlan el manejo de solicitudes y la monitorización del estado del dispositivo.",
+    "wizard": {
+      "discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
+      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+      "scanStatus": "{count} devices found",
+      "noDevices": "No Shelly devices found",
+      "results": {
+        "success": "Todos los dispositivos se adoptaron correctamente.",
+        "failed": "Algunos dispositivos no pudieron ser adoptados. Revise los errores a continuación."
+      }
+    }
   },
   "buttons": {
     "next": {
       "title": "Siguiente"
+    },
+    "wizard": {
+      "restart": {
+        "title": "Scan again"
+      },
+      "addManual": {
+        "title": "Add"
+      },
+      "adopt": {
+        "title": "Adopt selected"
+      },
+      "finish": {
+        "title": "Back to devices"
+      }
+    }
+  },
+  "statuses": {
+    "wizard": {
+      "checking": "Checking",
+      "ready": "Ready",
+      "needs_password": "Needs password",
+      "already_registered": "Registered",
+      "unsupported": "Unsupported",
+      "failed": "Failed",
+      "created": "Created",
+      "updated": "Actualizado",
+      "willCreate": "Se creará",
+      "willUpdate": "Actualizará el existente"
     }
   }
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/es-ES.json
@@ -13,10 +13,10 @@
     },
     "wizard": {
       "title": "Asistente de descubrimiento de Shelly Gen 1",
-      "discovery": "Discovery",
-      "categories": "Categories",
-      "results": "Results",
-      "status": "Status"
+      "discovery": "Descubrimiento",
+      "categories": "Categorías",
+      "results": "Resultados",
+      "status": "Estado"
     }
   },
   "subHeadings": {
@@ -119,10 +119,10 @@
       "failedLoadSupportedDevices": "Algo salió mal. No se pudieron cargar los dispositivos compatibles del plugin."
     },
     "wizard": {
-      "discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-      "discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-      "manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-      "adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+      "discoveryNotStarted": "Algo salió mal. No se pudo iniciar el descubrimiento de Shelly.",
+      "discoveryNotLoaded": "Algo salió mal. No se pudo cargar el descubrimiento de Shelly.",
+      "manualNotAdded": "Algo salió mal. No se pudo añadir la búsqueda manual del dispositivo Shelly.",
+      "adoptionNotCreated": "Algo salió mal. No se pudo adoptar el dispositivo Shelly."
     }
   },
   "texts": {
@@ -130,10 +130,10 @@
     "aboutDiscovery": "Configure cómo el plugin descubre dispositivos Shelly Gen 1 en su red local usando DNS Multidifusión (mDNS). Esto permite la detección automática sin necesidad de introducir direcciones IP manualmente.",
     "aboutTimeouts": "Configure los tiempos de espera para la comunicación HTTP con los dispositivos Shelly Gen 1. Estos ajustes controlan el manejo de solicitudes y la monitorización del estado del dispositivo.",
     "wizard": {
-      "discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
-      "categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-      "scanStatus": "{count} devices found",
-      "noDevices": "No Shelly devices found",
+      "discovery": "El asistente escanea la red local en busca de dispositivos Shelly Gen 1 y también acepta un nombre de host o dirección IP introducidos manualmente.",
+      "categories": "Confirme qué dispositivos preparados deben ser adoptados y elija la categoría de destino para cada uno.",
+      "scanStatus": "{count} dispositivos encontrados",
+      "noDevices": "No se encontraron dispositivos Shelly",
       "results": {
         "success": "Todos los dispositivos se adoptaron correctamente.",
         "failed": "Algunos dispositivos no pudieron ser adoptados. Revise los errores a continuación."
@@ -146,28 +146,28 @@
     },
     "wizard": {
       "restart": {
-        "title": "Scan again"
+        "title": "Escanear de nuevo"
       },
       "addManual": {
-        "title": "Add"
+        "title": "Añadir"
       },
       "adopt": {
-        "title": "Adopt selected"
+        "title": "Adoptar seleccionados"
       },
       "finish": {
-        "title": "Back to devices"
+        "title": "Volver a los dispositivos"
       }
     }
   },
   "statuses": {
     "wizard": {
-      "checking": "Checking",
-      "ready": "Ready",
-      "needs_password": "Needs password",
-      "already_registered": "Registered",
-      "unsupported": "Unsupported",
-      "failed": "Failed",
-      "created": "Created",
+      "checking": "Comprobando",
+      "ready": "Listo",
+      "needs_password": "Necesita contraseña",
+      "already_registered": "Registrado",
+      "unsupported": "No compatible",
+      "failed": "Fallido",
+      "created": "Creado",
       "updated": "Actualizado",
       "willCreate": "Se creará",
       "willUpdate": "Actualizará el existente"

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/pl-PL.json
@@ -13,9 +13,9 @@
 		},
 		"wizard": {
 			"title": "Kreator wyszukiwania Shelly Gen 1",
-			"discovery": "Discovery",
-			"categories": "Categories",
-			"results": "Results",
+			"discovery": "Wyszukiwanie",
+			"categories": "Kategorie",
+			"results": "Wyniki",
 			"status": "Status"
 		}
 	},
@@ -119,10 +119,10 @@
 			"failedLoadSupportedDevices": "Cos poszlo nie tak. Obslugiwane urzadzenia wtyczki nie mogly zostac zaladowane."
 		},
 		"wizard": {
-			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
-			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
-			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
-			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
+			"discoveryNotStarted": "Cos poszlo nie tak. Wyszukiwanie Shelly nie moglo zostac uruchomione.",
+			"discoveryNotLoaded": "Cos poszlo nie tak. Wyszukiwanie Shelly nie moglo zostac zaladowane.",
+			"manualNotAdded": "Cos poszlo nie tak. Reczne wyszukanie urzadzenia Shelly nie moglo zostac dodane.",
+			"adoptionNotCreated": "Cos poszlo nie tak. Urzadzenie Shelly nie moglo zostac adoptowane."
 		}
 	},
 	"texts": {
@@ -130,10 +130,10 @@
 		"aboutDiscovery": "Skonfiguruj, jak wtyczka wykrywa urzadzenia Shelly Gen 1 w sieci lokalnej za pomoca Multicast DNS (mDNS).",
 		"aboutTimeouts": "Skonfiguruj ustawienia limitow czasu komunikacji HTTP z urzadzeniami Shelly Gen 1.",
 		"wizard": {
-			"discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
-			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
-			"scanStatus": "{count} devices found",
-			"noDevices": "No Shelly devices found",
+			"discovery": "Kreator skanuje siec lokalna w poszukiwaniu urzadzen Shelly Gen 1 i akceptuje takze recznie wprowadzona nazwe hosta lub adres IP.",
+			"categories": "Potwierdz, ktore gotowe urzadzenia maja zostac adoptowane, i wybierz docelowa kategorie dla kazdego z nich.",
+			"scanStatus": "Znaleziono urzadzen: {count}",
+			"noDevices": "Nie znaleziono zadnych urzadzen Shelly",
 			"results": {
 				"success": "Wszystkie urzadzenia zostaly pomyslnie adoptowane.",
 				"failed": "Niektore urzadzenia nie mogly zostac adoptowane. Sprawdz blody ponizej."
@@ -146,28 +146,28 @@
 		},
 		"wizard": {
 			"restart": {
-				"title": "Scan again"
+				"title": "Skanuj ponownie"
 			},
 			"addManual": {
-				"title": "Add"
+				"title": "Dodaj"
 			},
 			"adopt": {
-				"title": "Adopt selected"
+				"title": "Adoptuj wybrane"
 			},
 			"finish": {
-				"title": "Back to devices"
+				"title": "Powrot do urzadzen"
 			}
 		}
 	},
 	"statuses": {
 		"wizard": {
-			"checking": "Checking",
-			"ready": "Ready",
-			"needs_password": "Needs password",
-			"already_registered": "Registered",
-			"unsupported": "Unsupported",
-			"failed": "Failed",
-			"created": "Created",
+			"checking": "Sprawdzanie",
+			"ready": "Gotowe",
+			"needs_password": "Wymaga hasla",
+			"already_registered": "Zarejestrowane",
+			"unsupported": "Nieobslugiwane",
+			"failed": "Nieudane",
+			"created": "Utworzone",
 			"updated": "Zaktualizowano",
 			"willCreate": "Zostanie utworzone",
 			"willUpdate": "Zaktualizuje istniejace"

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/pl-PL.json
@@ -10,7 +10,20 @@
 			"notSupported": "Przepraszamy, Twoje urzadzenie nie jest obslugiwane",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Kreator wyszukiwania Shelly Gen 1",
+			"discovery": "Discovery",
+			"categories": "Categories",
+			"results": "Results",
+			"status": "Status"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Znajdz i adoptuj urzadzenia Shelly Gen 1 w swojej sieci"
+	},
+	"breadcrumbs": {
+		"wizard": "kreator wyszukiwania"
 	},
 	"fields": {
 		"devices": {
@@ -44,6 +57,9 @@
 			"password": {
 				"title": "Haslo administratora",
 				"placeholder": "Podaj haslo urzadzenia, jesli urzadzenie jest chronione"
+			},
+			"error": {
+				"title": "Blad"
 			},
 			"hostname": {
 				"title": "Nazwa hosta urzadzenia",
@@ -101,16 +117,60 @@
 			"edited": "Zmiany zapisane! Urzadzenie Shelly Gen 1: {device} zostalo zaktualizowane.",
 			"notEdited": "Cos poszlo nie tak. Aktualizacja urzadzenia Shelly Gen 1 nie powiodla sie.",
 			"failedLoadSupportedDevices": "Cos poszlo nie tak. Obslugiwane urzadzenia wtyczki nie mogly zostac zaladowane."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Something went wrong. Shelly discovery could not be started.",
+			"discoveryNotLoaded": "Something went wrong. Shelly discovery could not be loaded.",
+			"manualNotAdded": "Something went wrong. Manual Shelly device lookup could not be added.",
+			"adoptionNotCreated": "Something went wrong. Shelly device could not be adopted."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Wlacz lub wylacz integracje urzadzen Shelly Gen 1. Po wlaczeniu urzadzenia Shelly moga byc wykrywane i sterowane przez Smart Panel.",
 		"aboutDiscovery": "Skonfiguruj, jak wtyczka wykrywa urzadzenia Shelly Gen 1 w sieci lokalnej za pomoca Multicast DNS (mDNS).",
-		"aboutTimeouts": "Skonfiguruj ustawienia limitow czasu komunikacji HTTP z urzadzeniami Shelly Gen 1."
+		"aboutTimeouts": "Skonfiguruj ustawienia limitow czasu komunikacji HTTP z urzadzeniami Shelly Gen 1.",
+		"wizard": {
+			"discovery": "The wizard scans the local network for Shelly Gen 1 devices and also accepts a manually entered hostname or IP address.",
+			"categories": "Confirm which ready devices should be adopted and choose the target category for each one.",
+			"scanStatus": "{count} devices found",
+			"noDevices": "No Shelly devices found",
+			"results": {
+				"success": "Wszystkie urzadzenia zostaly pomyslnie adoptowane.",
+				"failed": "Niektore urzadzenia nie mogly zostac adoptowane. Sprawdz blody ponizej."
+			}
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Dalej"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Scan again"
+			},
+			"addManual": {
+				"title": "Add"
+			},
+			"adopt": {
+				"title": "Adopt selected"
+			},
+			"finish": {
+				"title": "Back to devices"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Checking",
+			"ready": "Ready",
+			"needs_password": "Needs password",
+			"already_registered": "Registered",
+			"unsupported": "Unsupported",
+			"failed": "Failed",
+			"created": "Created",
+			"updated": "Zaktualizowano",
+			"willCreate": "Zostanie utworzone",
+			"willUpdate": "Zaktualizuje istniejace"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-shelly-v1/locales/sk-SK.json
@@ -10,7 +10,20 @@
 			"notSupported": "Ľutujeme, vaše zariadenie nie je podporované",
 			"model": "Model",
 			"firmware": "Firmware"
+		},
+		"wizard": {
+			"title": "Sprievodca vyhľadaním Shelly Gen 1",
+			"discovery": "Vyhľadávanie",
+			"categories": "Kategórie",
+			"results": "Výsledky",
+			"status": "Stav"
 		}
+	},
+	"subHeadings": {
+		"wizard": "Nájdite a adoptujte zariadenia Shelly Gen 1 vo vašej sieti"
+	},
+	"breadcrumbs": {
+		"wizard": "sprievodca vyhľadaním"
 	},
 	"fields": {
 		"devices": {
@@ -44,6 +57,9 @@
 			"password": {
 				"title": "Heslo administrátora",
 				"placeholder": "Zadajte heslo zariadenia, ak je chránené"
+			},
+			"error": {
+				"title": "Chyba"
 			},
 			"hostname": {
 				"title": "Hostname zariadenia",
@@ -101,16 +117,60 @@
 			"edited": "Zmeny uložené! Zariadenie Shelly Gen 1: {device} bolo aktualizované.",
 			"notEdited": "Niečo sa pokazilo. Aktualizácia zariadenia Shelly Gen 1 nebola úspešná.",
 			"failedLoadSupportedDevices": "Niečo sa pokazilo. Podporované zariadenia pluginu sa nepodarilo načítať."
+		},
+		"wizard": {
+			"discoveryNotStarted": "Niečo sa pokazilo. Vyhľadávanie Shelly sa nepodarilo spustiť.",
+			"discoveryNotLoaded": "Niečo sa pokazilo. Vyhľadávanie Shelly sa nepodarilo načítať.",
+			"manualNotAdded": "Niečo sa pokazilo. Manuálne vyhľadanie zariadenia Shelly sa nepodarilo pridať.",
+			"adoptionNotCreated": "Niečo sa pokazilo. Zariadenie Shelly sa nepodarilo adoptovať."
 		}
 	},
 	"texts": {
 		"aboutPluginStatus": "Povoľte alebo zakážte integráciu zariadení Shelly Gen 1. Keď je povolená, zariadenia Shelly môžu byť objavené a ovládané cez Smart Panel.",
 		"aboutDiscovery": "Nakonfigurujte, ako plugin objavuje zariadenia Shelly Gen 1 na vašej lokálnej sieti pomocou Multicast DNS (mDNS). To umožňuje automatickú detekciu bez potreby manuálneho zadávania IP adries.",
-		"aboutTimeouts": "Nakonfigurujte nastavenia časových limitov pre HTTP komunikáciu so zariadeniami Shelly Gen 1. Tieto nastavenia ovládajú spracovanie požiadaviek a monitorovanie stavu zariadení."
+		"aboutTimeouts": "Nakonfigurujte nastavenia časových limitov pre HTTP komunikáciu so zariadeniami Shelly Gen 1. Tieto nastavenia ovládajú spracovanie požiadaviek a monitorovanie stavu zariadení.",
+		"wizard": {
+			"discovery": "Sprievodca vyhľadá zariadenia Shelly Gen 1 v lokálnej sieti a prijíma aj manuálne zadaný hostname alebo IP adresu.",
+			"categories": "Potvrďte, ktoré pripravené zariadenia sa majú adoptovať, a vyberte cieľovú kategóriu pre každé z nich.",
+			"scanStatus": "Nájdené zariadenia: {count}",
+			"noDevices": "Neboli nájdené žiadne zariadenia Shelly",
+			"results": {
+				"success": "Všetky zariadenia boli úspešne adoptované.",
+				"failed": "Niektoré zariadenia nebolo možné adoptovať. Skontrolujte chyby nižšie."
+			}
+		}
 	},
 	"buttons": {
 		"next": {
 			"title": "Ďalej"
+		},
+		"wizard": {
+			"restart": {
+				"title": "Vyhľadať znova"
+			},
+			"addManual": {
+				"title": "Pridať"
+			},
+			"adopt": {
+				"title": "Adoptovať vybrané"
+			},
+			"finish": {
+				"title": "Späť na zariadenia"
+			}
+		}
+	},
+	"statuses": {
+		"wizard": {
+			"checking": "Kontrola",
+			"ready": "Pripravené",
+			"needs_password": "Vyžaduje heslo",
+			"already_registered": "Registrované",
+			"unsupported": "Nepodporované",
+			"failed": "Zlyhalo",
+			"created": "Vytvorené",
+			"updated": "Aktualizované",
+			"willCreate": "Bude vytvorené",
+			"willUpdate": "Aktualizuje existujúce"
 		}
 	}
 }

--- a/apps/admin/src/plugins/devices-shelly-v1/schemas/devices.schemas.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/schemas/devices.schemas.ts
@@ -36,3 +36,34 @@ export const ShellyV1DeviceInfoSchema = z.object({
 	firmware: z.string(),
 	deviceType: z.string(),
 });
+
+export const ShellyV1DiscoveryDeviceSchema = z.object({
+	identifier: z.string().nullable(),
+	hostname: z.string(),
+	name: z.string().nullable(),
+	model: z.string().nullable(),
+	displayName: z.string().nullable(),
+	firmware: z.string().nullable(),
+	status: z.enum(['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed']),
+	source: z.enum(['mdns', 'manual']),
+	categories: z.array(z.nativeEnum(DevicesModuleDeviceCategory)),
+	suggestedCategory: z.nativeEnum(DevicesModuleDeviceCategory).nullable(),
+	authentication: z.object({
+		enabled: z.boolean(),
+		valid: z.boolean().nullable().optional(),
+	}),
+	registeredDeviceId: z.string().nullable(),
+	registeredDeviceName: z.string().nullable(),
+	registeredDeviceCategory: z.nativeEnum(DevicesModuleDeviceCategory).nullable(),
+	error: z.string().nullable(),
+	lastSeenAt: z.string(),
+});
+
+export const ShellyV1DiscoverySessionSchema = z.object({
+	id: z.string(),
+	status: z.enum(['running', 'finished', 'failed']),
+	startedAt: z.string(),
+	expiresAt: z.string(),
+	remainingSeconds: z.number(),
+	devices: z.array(ShellyV1DiscoveryDeviceSchema),
+});

--- a/apps/admin/src/plugins/devices-shelly-v1/schemas/devices.types.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/schemas/devices.types.ts
@@ -5,6 +5,8 @@ import {
 	ShellyV1DeviceEditFormSchema,
 	ShellyV1DeviceInfoRequestSchema,
 	ShellyV1DeviceInfoSchema,
+	ShellyV1DiscoveryDeviceSchema,
+	ShellyV1DiscoverySessionSchema,
 	ShellyV1SupportedDeviceSchema,
 } from './devices.schemas';
 
@@ -17,3 +19,7 @@ export type IShellyV1SupportedDevice = z.infer<typeof ShellyV1SupportedDeviceSch
 export type IShellyV1DeviceInfoRequest = z.infer<typeof ShellyV1DeviceInfoRequestSchema>;
 
 export type IShellyV1DeviceInfo = z.infer<typeof ShellyV1DeviceInfoSchema>;
+
+export type IShellyV1DiscoveryDevice = z.infer<typeof ShellyV1DiscoveryDeviceSchema>;
+
+export type IShellyV1DiscoverySession = z.infer<typeof ShellyV1DiscoverySessionSchema>;

--- a/apps/admin/src/plugins/devices-shelly-v1/utils/devices.transformers.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/utils/devices.transformers.ts
@@ -1,7 +1,17 @@
 import { camelToSnake, logger, snakeToCamel } from '../../../common';
 import { DevicesShellyV1ValidationException } from '../devices-shelly-v1.exceptions';
-import { ShellyV1DeviceInfoRequestSchema, ShellyV1DeviceInfoSchema, ShellyV1SupportedDeviceSchema } from '../schemas/devices.schemas';
-import type { IShellyV1DeviceInfo, IShellyV1DeviceInfoRequest, IShellyV1SupportedDevice } from '../schemas/devices.types';
+import {
+	ShellyV1DeviceInfoRequestSchema,
+	ShellyV1DeviceInfoSchema,
+	ShellyV1DiscoverySessionSchema,
+	ShellyV1SupportedDeviceSchema,
+} from '../schemas/devices.schemas';
+import type {
+	IShellyV1DeviceInfo,
+	IShellyV1DeviceInfoRequest,
+	IShellyV1DiscoverySession,
+	IShellyV1SupportedDevice,
+} from '../schemas/devices.types';
 
 export const transformSupportedDevicesResponse = (response: object[]): IShellyV1SupportedDevice[] => {
 	const devices = [];
@@ -40,6 +50,18 @@ export const transformDeviceInfoRequest = (data: object): IShellyV1DeviceInfoReq
 		logger.error('Schema validation failed with:', parsed.error);
 
 		throw new DevicesShellyV1ValidationException('Failed to validate get device info request.');
+	}
+
+	return parsed.data;
+};
+
+export const transformDiscoverySessionResponse = (response: object): IShellyV1DiscoverySession => {
+	const parsed = ShellyV1DiscoverySessionSchema.safeParse(snakeToCamel(response));
+
+	if (!parsed.success) {
+		logger.error('Schema validation failed with:', parsed.error);
+
+		throw new DevicesShellyV1ValidationException('Failed to validate received discovery session data.');
 	}
 
 	return parsed.data;

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
@@ -10,6 +10,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { DevicesShellyV1Exception } from '../devices-shelly-v1.exceptions';
 import { ShellyV1DeviceInfoModel } from '../models/shelly-v1.model';
+import { ShellyV1DiscoveryService } from '../services/shelly-v1-discovery.service';
 import { ShellyV1ProbeService } from '../services/shelly-v1-probe.service';
 
 import { ShellyV1DevicesController } from './shelly-v1-devices.controller';
@@ -25,9 +26,18 @@ describe('ShellyV1DevicesController', () => {
 			probeDevice: jest.fn(),
 		};
 
+		const discoveryServiceMock: Partial<jest.Mocked<ShellyV1DiscoveryService>> = {
+			start: jest.fn(),
+			get: jest.fn(),
+			manual: jest.fn(),
+		};
+
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [ShellyV1DevicesController],
-			providers: [{ provide: ShellyV1ProbeService, useValue: probeServiceMock }],
+			providers: [
+				{ provide: ShellyV1ProbeService, useValue: probeServiceMock },
+				{ provide: ShellyV1DiscoveryService, useValue: discoveryServiceMock },
+			],
 		}).compile();
 
 		controller = module.get(ShellyV1DevicesController);

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
@@ -54,9 +54,9 @@ export class ShellyV1DevicesController {
 	)
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Post('discovery')
-	async startDiscovery(): Promise<ShellyV1DiscoverySessionResponseModel> {
+	startDiscovery(): ShellyV1DiscoverySessionResponseModel {
 		const response = new ShellyV1DiscoverySessionResponseModel();
-		response.data = await this.discoveryService.start({ duration: 30 });
+		response.data = this.discoveryService.start({ duration: 30 });
 
 		return response;
 	}

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
@@ -24,7 +24,11 @@ import {
 	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 } from '../models/shelly-v1-response.model';
-import { ShellyV1DeviceInfoModel, ShellyV1SupportedDeviceModel } from '../models/shelly-v1.model';
+import {
+	ShellyV1DeviceInfoModel,
+	ShellyV1DiscoverySessionModel,
+	ShellyV1SupportedDeviceModel,
+} from '../models/shelly-v1.model';
 import { ShellyV1DiscoveryService } from '../services/shelly-v1-discovery.service';
 import { ShellyV1ProbeService } from '../services/shelly-v1-probe.service';
 
@@ -56,7 +60,7 @@ export class ShellyV1DevicesController {
 	@Post('discovery')
 	startDiscovery(): ShellyV1DiscoverySessionResponseModel {
 		const response = new ShellyV1DiscoverySessionResponseModel();
-		response.data = this.discoveryService.start({ duration: 30 });
+		response.data = toInstance(ShellyV1DiscoverySessionModel, this.discoveryService.start({ duration: 30 }));
 
 		return response;
 	}
@@ -80,7 +84,7 @@ export class ShellyV1DevicesController {
 		}
 
 		const response = new ShellyV1DiscoverySessionResponseModel();
-		response.data = session;
+		response.data = toInstance(ShellyV1DiscoverySessionModel, session);
 
 		return response;
 	}
@@ -118,7 +122,7 @@ export class ShellyV1DevicesController {
 		}
 
 		const response = new ShellyV1DiscoverySessionResponseModel();
-		response.data = session;
+		response.data = toInstance(ShellyV1DiscoverySessionModel, session);
 
 		return response;
 	}

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
@@ -1,6 +1,6 @@
 import { validate } from 'class-validator';
 
-import { Body, Controller, Get, Post, UnprocessableEntityException } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, Post, UnprocessableEntityException } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
@@ -21,9 +21,11 @@ import { DevicesShellyV1Exception } from '../devices-shelly-v1.exceptions';
 import { DevicesShellyV1PluginReqGetInfo } from '../dto/shelly-v1-probe.dto';
 import {
 	ShellyV1DeviceInfoResponseModel,
+	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 } from '../models/shelly-v1-response.model';
 import { ShellyV1DeviceInfoModel, ShellyV1SupportedDeviceModel } from '../models/shelly-v1.model';
+import { ShellyV1DiscoveryService } from '../services/shelly-v1-discovery.service';
 import { ShellyV1ProbeService } from '../services/shelly-v1-probe.service';
 
 @ApiTags(DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME)
@@ -34,7 +36,92 @@ export class ShellyV1DevicesController {
 		'ShellyV1DevicesController',
 	);
 
-	constructor(private readonly probeService: ShellyV1ProbeService) {}
+	constructor(
+		private readonly probeService: ShellyV1ProbeService,
+		private readonly discoveryService: ShellyV1DiscoveryService,
+	) {}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME],
+		summary: 'Start Shelly V1 discovery wizard scan',
+		description:
+			'Starts a short-lived CoAP/mDNS discovery session for Shelly Generation 1 devices. The session can be polled by the admin wizard and enriched with manual host lookups.',
+		operationId: 'create-devices-shelly-v1-plugin-discovery',
+	})
+	@ApiSuccessResponse(
+		ShellyV1DiscoverySessionResponseModel,
+		'Shelly V1 discovery session was started. The response includes session timing and discovered device candidates.',
+	)
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('discovery')
+	async startDiscovery(): Promise<ShellyV1DiscoverySessionResponseModel> {
+		const response = new ShellyV1DiscoverySessionResponseModel();
+		response.data = await this.discoveryService.start({ duration: 30 });
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME],
+		summary: 'Get Shelly V1 discovery wizard scan',
+		description:
+			'Returns the current state of a Shelly V1 discovery session, including remaining scan time and discovered device candidates.',
+		operationId: 'get-devices-shelly-v1-plugin-discovery',
+	})
+	@ApiSuccessResponse(ShellyV1DiscoverySessionResponseModel, 'Shelly V1 discovery session was successfully retrieved.')
+	@ApiNotFoundResponse('Discovery session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Get('discovery/:id')
+	getDiscovery(@Param('id') id: string): ShellyV1DiscoverySessionResponseModel {
+		const session = this.discoveryService.get(id);
+
+		if (session === null) {
+			throw new NotFoundException('Discovery session could not be found');
+		}
+
+		const response = new ShellyV1DiscoverySessionResponseModel();
+		response.data = session;
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME],
+		summary: 'Add a manual Shelly V1 discovery wizard lookup',
+		description:
+			'Adds a manually entered hostname or IP address to an existing Shelly V1 discovery session. Password-protected devices can be verified by providing their password.',
+		operationId: 'create-devices-shelly-v1-plugin-discovery-manual',
+	})
+	@ApiBody({
+		type: DevicesShellyV1PluginReqGetInfo,
+		description: 'Manual Shelly V1 discovery lookup data',
+	})
+	@ApiSuccessResponse(
+		ShellyV1DiscoverySessionResponseModel,
+		'Manual lookup was added to the Shelly V1 discovery session.',
+	)
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiNotFoundResponse('Discovery session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('discovery/:id/manual')
+	async addManualDiscoveryDevice(
+		@Param('id') id: string,
+		@Body() createDto: DevicesShellyV1PluginReqGetInfo,
+	): Promise<ShellyV1DiscoverySessionResponseModel> {
+		const session = await this.discoveryService.manual(id, {
+			hostname: createDto.data.hostname,
+			password: createDto.data.password,
+		});
+
+		if (session === null) {
+			throw new NotFoundException('Discovery session could not be found');
+		}
+
+		const response = new ShellyV1DiscoverySessionResponseModel();
+		response.data = session;
+
+		return response;
+	}
 
 	@ApiOperation({
 		tags: [DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME],

--- a/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.openapi.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.openapi.ts
@@ -20,9 +20,16 @@ import {
 import { ShellyV1ConfigModel, ShellyV1DiscoveryConfigModel, ShellyV1TimeoutsConfigModel } from './models/config.model';
 import {
 	ShellyV1DeviceInfoResponseModel,
+	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 } from './models/shelly-v1-response.model';
-import { ShellyV1DeviceInfoModel, ShellyV1SupportedDeviceModel } from './models/shelly-v1.model';
+import {
+	ShellyV1DeviceInfoModel,
+	ShellyV1DiscoveryDeviceAuthenticationModel,
+	ShellyV1DiscoveryDeviceModel,
+	ShellyV1DiscoverySessionModel,
+	ShellyV1SupportedDeviceModel,
+} from './models/shelly-v1.model';
 
 export const DEVICES_SHELLY_V1_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	// DTOs
@@ -37,10 +44,14 @@ export const DEVICES_SHELLY_V1_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	ShellyV1UpdatePluginConfigTimeoutsDto,
 	// Response models
 	ShellyV1DeviceInfoResponseModel,
+	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 	// Data models
 	ShellyV1SupportedDeviceModel,
 	ShellyV1DeviceInfoModel,
+	ShellyV1DiscoveryDeviceAuthenticationModel,
+	ShellyV1DiscoveryDeviceModel,
+	ShellyV1DiscoverySessionModel,
 	ShellyV1DiscoveryConfigModel,
 	ShellyV1TimeoutsConfigModel,
 	ShellyV1ConfigModel,

--- a/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
@@ -47,6 +47,7 @@ import { ShellyV1ConfigModel } from './models/config.model';
 import { ShellyV1DevicePlatform } from './platforms/shelly-v1.device.platform';
 import { DeviceMapperService } from './services/device-mapper.service';
 import { ShelliesAdapterService } from './services/shellies-adapter.service';
+import { ShellyV1DiscoveryService } from './services/shelly-v1-discovery.service';
 import { ShellyV1HttpClientService } from './services/shelly-v1-http-client.service';
 import { ShellyV1ProbeService } from './services/shelly-v1-probe.service';
 import { ShellyV1Service } from './services/shelly-v1.service';
@@ -70,6 +71,7 @@ import { DeviceEntitySubscriber } from './subscribers/device-entity.subscriber';
 		DeviceMapperService,
 		ShellyV1HttpClientService,
 		ShellyV1ProbeService,
+		ShellyV1DiscoveryService,
 		ShellyV1DevicePlatform,
 		ShellyV1Service,
 		DeviceEntitySubscriber,

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1-response.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1-response.model.ts
@@ -4,7 +4,11 @@ import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 
-import { ShellyV1DeviceInfoModel, ShellyV1SupportedDeviceModel } from './shelly-v1.model';
+import {
+	ShellyV1DeviceInfoModel,
+	ShellyV1DiscoverySessionModel,
+	ShellyV1SupportedDeviceModel,
+} from './shelly-v1.model';
 
 /**
  * Response wrapper for ShellyV1DeviceInfoModel
@@ -31,4 +35,17 @@ export class ShellyV1SupportedDevicesResponseModel extends BaseSuccessResponseMo
 	})
 	@Expose()
 	declare data: ShellyV1SupportedDeviceModel[];
+}
+
+/**
+ * Response wrapper for ShellyV1DiscoverySessionModel
+ */
+@ApiSchema({ name: 'DevicesShellyV1PluginResDiscoverySession' })
+export class ShellyV1DiscoverySessionResponseModel extends BaseSuccessResponseModel<ShellyV1DiscoverySessionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => ShellyV1DiscoverySessionModel,
+	})
+	@Expose()
+	declare data: ShellyV1DiscoverySessionModel;
 }

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
@@ -201,11 +201,12 @@ export class ShellyV1DiscoveryDeviceModel {
 	model: string | null;
 
 	@ApiPropertyOptional({
+		name: 'display_name',
 		description: 'Friendly supported-device name',
 		nullable: true,
 		example: 'Shelly 1',
 	})
-	@Expose()
+	@Expose({ name: 'display_name' })
 	@IsString()
 	@IsOptional()
 	displayName: string | null;
@@ -250,12 +251,13 @@ export class ShellyV1DiscoveryDeviceModel {
 	categories: DeviceCategory[];
 
 	@ApiPropertyOptional({
+		name: 'suggested_category',
 		description: 'Suggested target device category when the plugin can infer one',
 		nullable: true,
 		enum: DeviceCategory,
 		example: DeviceCategory.SWITCHER,
 	})
-	@Expose()
+	@Expose({ name: 'suggested_category' })
 	@IsString()
 	@IsOptional()
 	suggestedCategory: DeviceCategory | null;
@@ -270,33 +272,36 @@ export class ShellyV1DiscoveryDeviceModel {
 	authentication: ShellyV1DiscoveryDeviceAuthenticationModel;
 
 	@ApiPropertyOptional({
+		name: 'registered_device_id',
 		description: 'Already registered device id',
 		nullable: true,
 		example: null,
 	})
-	@Expose()
+	@Expose({ name: 'registered_device_id' })
 	@IsString()
 	@IsOptional()
 	registeredDeviceId: string | null;
 
 	@ApiPropertyOptional({
+		name: 'registered_device_name',
 		description: 'Already registered device name',
 		nullable: true,
 		example: null,
 	})
-	@Expose()
+	@Expose({ name: 'registered_device_name' })
 	@IsString()
 	@IsOptional()
 	registeredDeviceName: string | null;
 
 	@ApiPropertyOptional({
+		name: 'registered_device_category',
 		description:
 			'Already registered device category — used to pre-fill the wizard so adopted devices keep their existing category by default',
 		enum: DeviceCategory,
 		nullable: true,
 		example: DeviceCategory.SWITCHER,
 	})
-	@Expose()
+	@Expose({ name: 'registered_device_category' })
 	@IsIn(Object.values(DeviceCategory))
 	@IsOptional()
 	registeredDeviceCategory: DeviceCategory | null;
@@ -312,10 +317,11 @@ export class ShellyV1DiscoveryDeviceModel {
 	error: string | null;
 
 	@ApiProperty({
+		name: 'last_seen_at',
 		description: 'Last time this candidate was observed or checked',
 		example: '2026-04-29T12:00:00.000Z',
 	})
-	@Expose()
+	@Expose({ name: 'last_seen_at' })
 	@IsString()
 	lastSeenAt: string;
 }
@@ -340,26 +346,29 @@ export class ShellyV1DiscoverySessionModel {
 	status: string;
 
 	@ApiProperty({
+		name: 'started_at',
 		description: 'Discovery start timestamp',
 		example: '2026-04-29T12:00:00.000Z',
 	})
-	@Expose()
+	@Expose({ name: 'started_at' })
 	@IsString()
 	startedAt: string;
 
 	@ApiProperty({
+		name: 'expires_at',
 		description: 'Discovery expiry timestamp',
 		example: '2026-04-29T12:00:30.000Z',
 	})
-	@Expose()
+	@Expose({ name: 'expires_at' })
 	@IsString()
 	expiresAt: string;
 
 	@ApiProperty({
+		name: 'remaining_seconds',
 		description: 'Remaining discovery time in seconds',
 		example: 30,
 	})
-	@Expose()
+	@Expose({ name: 'remaining_seconds' })
 	@IsInt()
 	remainingSeconds: number;
 

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
@@ -265,7 +265,7 @@ export class ShellyV1DiscoveryDeviceModel {
 		type: () => ShellyV1DiscoveryDeviceAuthenticationModel,
 	})
 	@Expose()
-	@ValidateNested({ each: true })
+	@ValidateNested()
 	@Type(() => ShellyV1DiscoveryDeviceAuthenticationModel)
 	authentication: ShellyV1DiscoveryDeviceAuthenticationModel;
 

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
@@ -1,7 +1,9 @@
-import { Expose } from 'class-transformer';
-import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { Expose, Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
 
-import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
 
 @ApiSchema({ name: 'DevicesShellyV1PluginDataSupportedDevice' })
 export class ShellyV1SupportedDeviceModel {
@@ -135,4 +137,240 @@ export class ShellyV1DeviceInfoModel {
 		example: 'Living room light switch',
 	})
 	description?: string;
+}
+
+@ApiSchema({ name: 'DevicesShellyV1PluginDataDiscoveryDeviceAuthentication' })
+export class ShellyV1DiscoveryDeviceAuthenticationModel {
+	@ApiProperty({
+		description: 'Whether authentication is enabled',
+		example: false,
+	})
+	@Expose()
+	@IsBoolean()
+	enabled: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Whether authentication is valid (only set when a password was supplied)',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsBoolean()
+	@IsOptional()
+	valid: boolean | null;
+}
+
+@ApiSchema({ name: 'DevicesShellyV1PluginDataDiscoveryDevice' })
+export class ShellyV1DiscoveryDeviceModel {
+	@ApiPropertyOptional({
+		description: 'Shelly device identifier',
+		nullable: true,
+		example: 'shelly1-A8032ABE5084',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	identifier: string | null;
+
+	@ApiProperty({
+		description: 'Discovered hostname or IP address',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	@IsString()
+	hostname: string;
+
+	@ApiPropertyOptional({
+		description: 'Device name',
+		nullable: true,
+		example: 'Kitchen relay',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	name: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Device model',
+		nullable: true,
+		example: 'SHSW-1',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	model: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Friendly supported-device name',
+		nullable: true,
+		example: 'Shelly 1',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	displayName: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Firmware version',
+		nullable: true,
+		example: '20230913-001',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	firmware: string | null;
+
+	@ApiProperty({
+		description: 'Discovery candidate status',
+		enum: ['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed'],
+		example: 'ready',
+	})
+	@Expose()
+	@IsIn(['checking', 'ready', 'needs_password', 'already_registered', 'unsupported', 'failed'])
+	status: string;
+
+	@ApiProperty({
+		description: 'How the candidate was found',
+		enum: ['mdns', 'manual'],
+		example: 'mdns',
+	})
+	@Expose()
+	@IsIn(['mdns', 'manual'])
+	source: string;
+
+	@ApiProperty({
+		description: 'Available target device categories',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(DeviceCategory) },
+		example: [DeviceCategory.SWITCHER, DeviceCategory.LIGHTING],
+	})
+	@Expose()
+	@IsArray()
+	@IsString({ each: true })
+	categories: DeviceCategory[];
+
+	@ApiPropertyOptional({
+		description: 'Suggested target device category when the plugin can infer one',
+		nullable: true,
+		enum: DeviceCategory,
+		example: DeviceCategory.SWITCHER,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	suggestedCategory: DeviceCategory | null;
+
+	@ApiProperty({
+		description: 'Authentication configuration',
+		type: () => ShellyV1DiscoveryDeviceAuthenticationModel,
+	})
+	@Expose()
+	@ValidateNested({ each: true })
+	@Type(() => ShellyV1DiscoveryDeviceAuthenticationModel)
+	authentication: ShellyV1DiscoveryDeviceAuthenticationModel;
+
+	@ApiPropertyOptional({
+		description: 'Already registered device id',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceId: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Already registered device name',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceName: string | null;
+
+	@ApiPropertyOptional({
+		description:
+			'Already registered device category — used to pre-fill the wizard so adopted devices keep their existing category by default',
+		enum: DeviceCategory,
+		nullable: true,
+		example: DeviceCategory.SWITCHER,
+	})
+	@Expose()
+	@IsIn(Object.values(DeviceCategory))
+	@IsOptional()
+	registeredDeviceCategory: DeviceCategory | null;
+
+	@ApiPropertyOptional({
+		description: 'Error message from the last lookup attempt',
+		nullable: true,
+		example: null,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	error: string | null;
+
+	@ApiProperty({
+		description: 'Last time this candidate was observed or checked',
+		example: '2026-04-29T12:00:00.000Z',
+	})
+	@Expose()
+	@IsString()
+	lastSeenAt: string;
+}
+
+@ApiSchema({ name: 'DevicesShellyV1PluginDataDiscoverySession' })
+export class ShellyV1DiscoverySessionModel {
+	@ApiProperty({
+		description: 'Discovery session id',
+		example: 'c66808d8-0af1-4b93-bd61-4131cf62f20f',
+	})
+	@Expose()
+	@IsString()
+	id: string;
+
+	@ApiProperty({
+		description: 'Discovery session status',
+		enum: ['running', 'finished', 'failed'],
+		example: 'running',
+	})
+	@Expose()
+	@IsIn(['running', 'finished', 'failed'])
+	status: string;
+
+	@ApiProperty({
+		description: 'Discovery start timestamp',
+		example: '2026-04-29T12:00:00.000Z',
+	})
+	@Expose()
+	@IsString()
+	startedAt: string;
+
+	@ApiProperty({
+		description: 'Discovery expiry timestamp',
+		example: '2026-04-29T12:00:30.000Z',
+	})
+	@Expose()
+	@IsString()
+	expiresAt: string;
+
+	@ApiProperty({
+		description: 'Remaining discovery time in seconds',
+		example: 30,
+	})
+	@Expose()
+	@IsInt()
+	remainingSeconds: number;
+
+	@ApiProperty({
+		description: 'Discovered Shelly V1 device candidates',
+		type: 'array',
+		items: { $ref: getSchemaPath(ShellyV1DiscoveryDeviceModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => ShellyV1DiscoveryDeviceModel)
+	devices: ShellyV1DiscoveryDeviceModel[];
 }

--- a/apps/backend/src/plugins/devices-shelly-v1/platforms/shelly-v1.device.platform.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/platforms/shelly-v1.device.platform.ts
@@ -4,9 +4,9 @@ import { ExtensionLoggerService, createExtensionLogger } from '../../../common/l
 import { coerceBooleanSafe, coerceNumberSafe } from '../../../common/utils/transform.utils';
 import { IDevicePlatform, IDevicePropertyData } from '../../../modules/devices/platforms/device.platform';
 import {
-	DESCRIPTORS,
 	DEVICES_SHELLY_V1_PLUGIN_NAME,
 	DEVICES_SHELLY_V1_TYPE,
+	DeviceDescriptor,
 	PropertyBinding,
 } from '../devices-shelly-v1.constants';
 import { DevicesShellyV1Exception } from '../devices-shelly-v1.exceptions';
@@ -17,6 +17,7 @@ import {
 } from '../entities/devices-shelly-v1.entity';
 import { ShellyColorOptions, ShellyDevice } from '../interfaces/shellies.interface';
 import { ShelliesAdapterService } from '../services/shellies-adapter.service';
+import { findShellyV1Descriptor } from '../utils/descriptor.utils';
 import { ROLLER_COMMAND_VALUE_MAP, validateEnumValue } from '../utils/value-mapping.utils';
 
 export type IShellyV1DevicePropertyData = IDevicePropertyData & {
@@ -141,7 +142,7 @@ export class ShellyV1DevicePlatform implements IDevicePlatform {
 		shellyDevice: ShellyDevice,
 	): Promise<boolean> {
 		// Find the device descriptor
-		const descriptor = this.findDescriptor(shellyDevice.type);
+		const descriptor = findShellyV1Descriptor(shellyDevice.type);
 
 		if (!descriptor) {
 			this.logger.warn(`No descriptor found for device type: ${shellyDevice.type}`, { resource: device.id });
@@ -228,7 +229,7 @@ export class ShellyV1DevicePlatform implements IDevicePlatform {
 		shellyDevice: ShellyDevice,
 		index: number,
 		propertyUpdates: Array<{ property: ShellyV1ChannelPropertyEntity; value: string | number | boolean }>,
-		descriptor: (typeof DESCRIPTORS)[keyof typeof DESCRIPTORS],
+		descriptor: DeviceDescriptor,
 	): Promise<boolean> {
 		// Collect property values
 		const values: {
@@ -494,25 +495,9 @@ export class ShellyV1DevicePlatform implements IDevicePlatform {
 	}
 
 	/**
-	 * Find a descriptor for a device type
-	 */
-	private findDescriptor(deviceType: string): (typeof DESCRIPTORS)[keyof typeof DESCRIPTORS] | null {
-		for (const descriptor of Object.values(DESCRIPTORS)) {
-			if (descriptor.models.some((model) => deviceType.toUpperCase().includes(model))) {
-				return descriptor;
-			}
-		}
-
-		return null;
-	}
-
-	/**
 	 * Get bindings for a device considering mode
 	 */
-	private getBindings(
-		descriptor: (typeof DESCRIPTORS)[keyof typeof DESCRIPTORS],
-		shellyDevice: ShellyDevice,
-	): PropertyBinding[] {
+	private getBindings(descriptor: DeviceDescriptor, shellyDevice: ShellyDevice): PropertyBinding[] {
 		if (descriptor.instance?.modeProperty && descriptor.modes) {
 			const modeValue = shellyDevice[descriptor.instance.modeProperty];
 			const modeProfile = descriptor.modes.find((mode) => mode.modeValue === modeValue);

--- a/apps/backend/src/plugins/devices-shelly-v1/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/device-mapper.service.ts
@@ -21,7 +21,6 @@ import {
 	getRequiredProperties,
 } from '../../../modules/devices/utils/schema.utils';
 import {
-	DESCRIPTORS,
 	DEVICES_SHELLY_V1_PLUGIN_NAME,
 	DEVICES_SHELLY_V1_TYPE,
 	PropertyBinding,
@@ -45,6 +44,7 @@ import {
 import { ShellyDevicePropertyValue } from '../interfaces/shellies.interface';
 import { NormalizedDeviceEvent, ShellyDevice } from '../interfaces/shellies.interface';
 import { ShellyInfoResponse, ShellyStatusResponse } from '../interfaces/shelly-http.interface';
+import { findShellyV1Descriptor } from '../utils/descriptor.utils';
 import { getSyntheticProperties, isSyntheticProperty } from '../utils/synthetic-properties.utils';
 import { VALUE_MAP_REGISTRY, mapValueToCanonical, validateEnumValue } from '../utils/value-mapping.utils';
 
@@ -85,7 +85,7 @@ export class DeviceMapperService {
 		}
 
 		// Find the device descriptor for this device type
-		const descriptor = this.findDescriptor(event.type);
+		const descriptor = findShellyV1Descriptor(event.type);
 
 		if (!descriptor) {
 			this.logger.warn(`No descriptor found for device type: ${event.type}`);
@@ -844,29 +844,6 @@ export class DeviceMapperService {
 			.split('_')
 			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 			.join(' ');
-	}
-
-	/**
-	 * Find the descriptor for a device type
-	 */
-	private findDescriptor(deviceType: string): (typeof DESCRIPTORS)[keyof typeof DESCRIPTORS] | null {
-		// Try to find by exact type match first
-		for (const descriptor of Object.values(DESCRIPTORS)) {
-			if (descriptor.models.some((model) => deviceType.toUpperCase().includes(model))) {
-				return descriptor;
-			}
-		}
-
-		// Fallback: try to match by partial name
-		const typeUpper = deviceType.toUpperCase();
-
-		for (const [key, descriptor] of Object.entries(DESCRIPTORS)) {
-			if (typeUpper.includes(key) || descriptor.name.toUpperCase().includes(typeUpper)) {
-				return descriptor;
-			}
-		}
-
-		return null;
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shellies-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shellies-adapter.service.ts
@@ -38,6 +38,13 @@ export class ShelliesAdapterService {
 	 */
 	private readonly devicesRegistry = new Map<string, RegisteredDevice>();
 
+	/**
+	 * External 'add' subscribers that should receive every device discovered while
+	 * they are subscribed. Kept across stop/start cycles so wizard discovery sessions
+	 * that opened during a connector restart still receive events once the lib is up.
+	 */
+	private readonly addSubscribers = new Set<(device: ShellyDevice) => void>();
+
 	private callbacks: ShelliesAdapterCallbacks = {};
 
 	constructor(
@@ -76,6 +83,13 @@ export class ShelliesAdapterService {
 
 			//this.shellies.on('discover', deviceDiscoveredHandler);
 			this.shellies.on('add', deviceDiscoveredHandler); // Synonym in Gen 1
+
+			// Re-attach external 'add' subscribers (wizard discovery sessions) that registered
+			// while we were stopped/restarting. `subscribeToAddedDevice` keeps them in the set
+			// across connector lifecycles.
+			for (const handler of this.addSubscribers) {
+				this.shellies.on('add', handler);
+			}
 
 			this.logger.log('Shellies library initialized, starting discovery');
 
@@ -168,6 +182,48 @@ export class ShelliesAdapterService {
 	 */
 	getRegisteredDevice(deviceId: string): RegisteredDevice | undefined {
 		return this.devicesRegistry.get(deviceId);
+	}
+
+	/**
+	 * Get all currently-known devices from the underlying shellies library.
+	 * Used by the discovery wizard to seed a new session with devices the lib
+	 * already saw before the wizard opened.
+	 */
+	getKnownDevices(): ShellyDevice[] {
+		const devices: ShellyDevice[] = [];
+
+		if (!this.shellies) {
+			return devices;
+		}
+
+		for (const registered of this.devicesRegistry.values()) {
+			const device = this.shellies.getDevice(registered.type, registered.id);
+
+			if (device) {
+				devices.push(device);
+			}
+		}
+
+		return devices;
+	}
+
+	/**
+	 * Subscribe to new devices the lib discovers for as long as the returned
+	 * unsubscribe is not invoked. Used by the wizard to pick up devices that
+	 * power on during a scan session without needing its own mDNS/CoAP browser.
+	 *
+	 * The handler is also kept across connector stop/start cycles, so a wizard
+	 * scan window that opened during a restart still receives events once the
+	 * lib comes up.
+	 */
+	subscribeToAddedDevice(handler: (device: ShellyDevice) => void): () => void {
+		this.addSubscribers.add(handler);
+		this.shellies?.on('add', handler);
+
+		return () => {
+			this.addSubscribers.delete(handler);
+			this.shellies?.off('add', handler);
+		};
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -89,7 +89,7 @@ export class ShellyV1DiscoveryService {
 		private readonly httpClient: ShellyV1HttpClientService,
 	) {}
 
-	async start({ duration }: { duration: number }): Promise<ShellyV1DiscoverySessionSnapshot> {
+	start({ duration }: { duration: number }): ShellyV1DiscoverySessionSnapshot {
 		const id = randomUUID();
 		const startedAt = new Date();
 		const expiresAt = new Date(startedAt.getTime() + duration * 1_000);
@@ -106,29 +106,31 @@ export class ShellyV1DiscoveryService {
 		// parallel one. The 30s session window is kept for UX so the user can still power on a
 		// new device during the scan and have it picked up.
 		//
-		// Subscribe BEFORE iterating the seed list — `getKnownDevices()` + the awaited DB lookups
-		// inside `handleLibDevice` create a window where the lib could fire `add` for a fresh
-		// device that's not in the seed and there's no listener attached yet. `handleLibDevice` is
-		// keyed on hostname so an overlap between a seed entry and a concurrent `add` event just
+		// Subscribe BEFORE seeding — `getKnownDevices()` + the awaited DB lookups inside
+		// `handleLibDevice` create a window where the lib could fire `add` for a fresh device
+		// that's not in the seed and there's no listener attached yet. `handleLibDevice` is keyed
+		// on hostname so an overlap between a seed entry and a concurrent `add` event just
 		// overwrites the same row rather than duplicating.
 		session.unsubscribeAdded = this.shelliesAdapter.subscribeToAddedDevice((device) => {
 			void this.handleLibDevice(session, device);
 		});
 
-		// Arm the finish timer and register the session BEFORE the seed loop so the wall-clock
-		// session lifetime matches `expiresAt`. Each seed iteration does an HTTP probe + DB lookup
-		// and can take several seconds end-to-end; if the timer were started after the loop the
-		// real expiry would drift by exactly that delay, leaving the frontend's progress bar at
-		// 100% while polling still reports `running`.
+		// Arm the finish timer and register the session BEFORE seeding so the wall-clock session
+		// lifetime matches `expiresAt` regardless of how long enrichment takes.
 		session.timer = setTimeout(() => {
 			void this.finish(id);
 		}, duration * 1_000);
 
 		this.sessions.set(id, session);
 
-		for (const device of this.shelliesAdapter.getKnownDevices()) {
-			await this.handleLibDevice(session, device);
-		}
+		// Seed concurrently and don't await — each `handleLibDevice` does an HTTP probe with a
+		// 3s timeout, so awaiting them sequentially would push the start response past the scan
+		// duration with even a few unreachable devices in the lib's registry. Per-device snapshots
+		// land in `session.devices` as they finish; the frontend's 1Hz polling picks them up
+		// without us blocking the initial response.
+		void Promise.allSettled(
+			this.shelliesAdapter.getKnownDevices().map((device) => this.handleLibDevice(session, device)),
+		);
 
 		return this.toSnapshot(session);
 	}

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -477,6 +477,14 @@ export class ShellyV1DiscoveryService {
 		return mac.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
 	}
 
+	/**
+	 * Mirror the matching strategy used by `device-mapper.service.ts` and the device platform
+	 * — substring match on `descriptor.models`, then partial-name fallback on the descriptor
+	 * key / friendly name. The wizard MUST agree with the main connector here: if a device
+	 * type the connector adopts gets `unsupported` in the wizard, users see a confusing
+	 * inconsistency for variants whose `type` carries an extra suffix beyond the canonical
+	 * model code (e.g. SHSW-1 vs SHSW-1-something).
+	 */
 	private findDescriptor(model: string | null | undefined): DeviceDescriptor | null {
 		if (typeof model !== 'string' || model.length === 0) {
 			return null;
@@ -484,17 +492,19 @@ export class ShellyV1DiscoveryService {
 
 		const normalizedModel = model.toUpperCase();
 
-		// First, try an exact match on a descriptor key (e.g. "SHELLY1")
-		if (normalizedModel in DESCRIPTORS) {
-			return DESCRIPTORS[normalizedModel];
+		for (const descriptor of Object.values(DESCRIPTORS)) {
+			if (descriptor.models.some((descriptorModel) => normalizedModel.includes(descriptorModel.toUpperCase()))) {
+				return descriptor;
+			}
 		}
 
-		// Try to match against the model array of every descriptor
-		return (
-			Object.values(DESCRIPTORS).find((descriptor) =>
-				descriptor.models.some((descriptorModel) => descriptorModel.toUpperCase() === normalizedModel),
-			) ?? null
-		);
+		for (const [key, descriptor] of Object.entries(DESCRIPTORS)) {
+			if (normalizedModel.includes(key) || descriptor.name.toUpperCase().includes(normalizedModel)) {
+				return descriptor;
+			}
+		}
+
+		return null;
 	}
 
 	private toSnapshot(session: ShellyV1DiscoverySession): ShellyV1DiscoverySessionSnapshot {

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -1,0 +1,510 @@
+import { randomUUID } from 'crypto';
+
+import { Injectable } from '@nestjs/common';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import {
+	DESCRIPTORS,
+	DEVICES_SHELLY_V1_PLUGIN_NAME,
+	DEVICES_SHELLY_V1_TYPE,
+	DeviceDescriptor,
+	SHELLY_AUTH_USERNAME,
+} from '../devices-shelly-v1.constants';
+import { ShellyV1DeviceEntity } from '../entities/devices-shelly-v1.entity';
+import { ShellyDevice } from '../interfaces/shellies.interface';
+
+import { ShelliesAdapterService } from './shellies-adapter.service';
+import { ShellyV1HttpClientService } from './shelly-v1-http-client.service';
+
+export type ShellyV1DiscoverySessionStatus = 'running' | 'finished' | 'failed';
+
+export type ShellyV1DiscoveryDeviceStatus =
+	| 'checking'
+	| 'ready'
+	| 'needs_password'
+	| 'already_registered'
+	| 'unsupported'
+	| 'failed';
+
+export type ShellyV1DiscoveryDeviceSource = 'mdns' | 'manual';
+
+export interface ShellyV1DiscoveryDeviceSnapshot {
+	identifier: string | null;
+	hostname: string;
+	name: string | null;
+	model: string | null;
+	displayName: string | null;
+	firmware: string | null;
+	status: ShellyV1DiscoveryDeviceStatus;
+	source: ShellyV1DiscoveryDeviceSource;
+	categories: DeviceCategory[];
+	suggestedCategory: DeviceCategory | null;
+	authentication: {
+		enabled: boolean;
+		valid: boolean | null;
+	};
+	registeredDeviceId: string | null;
+	registeredDeviceName: string | null;
+	registeredDeviceCategory: DeviceCategory | null;
+	error: string | null;
+	lastSeenAt: string;
+}
+
+export interface ShellyV1DiscoverySessionSnapshot {
+	id: string;
+	status: ShellyV1DiscoverySessionStatus;
+	startedAt: string;
+	expiresAt: string;
+	remainingSeconds: number;
+	devices: ShellyV1DiscoveryDeviceSnapshot[];
+}
+
+interface ShellyV1DiscoverySession {
+	id: string;
+	status: ShellyV1DiscoverySessionStatus;
+	startedAt: Date;
+	expiresAt: Date;
+	timer?: NodeJS.Timeout;
+	cleanupTimer?: NodeJS.Timeout;
+	unsubscribeAdded?: () => void;
+	devices: Map<string, ShellyV1DiscoveryDeviceSnapshot>;
+	passwords: Map<string, string>;
+}
+
+@Injectable()
+export class ShellyV1DiscoveryService {
+	private static readonly FINISHED_SESSION_TTL_MS = 5 * 60_000;
+
+	private readonly logger: ExtensionLoggerService = createExtensionLogger(
+		DEVICES_SHELLY_V1_PLUGIN_NAME,
+		'ShellyV1DiscoveryService',
+	);
+
+	private readonly sessions = new Map<string, ShellyV1DiscoverySession>();
+
+	constructor(
+		private readonly shelliesAdapter: ShelliesAdapterService,
+		private readonly devicesService: DevicesService,
+		private readonly httpClient: ShellyV1HttpClientService,
+	) {}
+
+	async start({ duration }: { duration: number }): Promise<ShellyV1DiscoverySessionSnapshot> {
+		const id = randomUUID();
+		const startedAt = new Date();
+		const expiresAt = new Date(startedAt.getTime() + duration * 1_000);
+
+		const session: ShellyV1DiscoverySession = {
+			id,
+			status: 'running',
+			startedAt,
+			expiresAt,
+			devices: new Map(),
+			passwords: new Map(),
+		};
+
+		// Reuse the main connector's already-running CoAP/mDNS browser instead of spinning up a
+		// parallel one. The 30s session window is kept for UX so the user can still power on a
+		// new device during the scan and have it picked up.
+		//
+		// Subscribe BEFORE iterating the seed list — `getKnownDevices()` + the awaited DB lookups
+		// inside `handleLibDevice` create a window where the lib could fire `add` for a fresh
+		// device that's not in the seed and there's no listener attached yet. `handleLibDevice` is
+		// keyed on hostname so an overlap between a seed entry and a concurrent `add` event just
+		// overwrites the same row rather than duplicating.
+		session.unsubscribeAdded = this.shelliesAdapter.subscribeToAddedDevice((device) => {
+			void this.handleLibDevice(session, device);
+		});
+
+		for (const device of this.shelliesAdapter.getKnownDevices()) {
+			await this.handleLibDevice(session, device);
+		}
+
+		session.timer = setTimeout(() => {
+			void this.finish(id);
+		}, duration * 1_000);
+
+		this.sessions.set(id, session);
+
+		return this.toSnapshot(session);
+	}
+
+	get(id: string): ShellyV1DiscoverySessionSnapshot | null {
+		const session = this.sessions.get(id);
+
+		if (session === undefined) {
+			return null;
+		}
+
+		return this.toSnapshot(session);
+	}
+
+	async manual(
+		id: string,
+		{ hostname, password }: { hostname: string; password?: string | null },
+	): Promise<ShellyV1DiscoverySessionSnapshot | null> {
+		const session = this.sessions.get(id);
+
+		if (session === undefined) {
+			return null;
+		}
+
+		const discoveredDevice = await this.inspectDevice(session, hostname, 'manual', password ?? null);
+
+		if (password !== null && typeof password !== 'undefined' && discoveredDevice?.status === 'ready') {
+			this.storePassword(session, discoveredDevice, password);
+		}
+
+		return this.toSnapshot(session);
+	}
+
+	private async finish(id: string): Promise<void> {
+		const session = this.sessions.get(id);
+
+		if (session === undefined || session.status !== 'running') {
+			return;
+		}
+
+		session.status = 'finished';
+
+		this.clearTimer(session);
+		this.unsubscribeFromAdded(session);
+
+		this.scheduleCleanup(session);
+
+		await Promise.resolve();
+	}
+
+	private unsubscribeFromAdded(session: ShellyV1DiscoverySession): void {
+		if (typeof session.unsubscribeAdded === 'function') {
+			try {
+				session.unsubscribeAdded();
+			} catch (error) {
+				const err = error as Error;
+
+				this.logger.warn('Failed to detach Shelly V1 discovery listener', {
+					session: session.id,
+					message: err.message,
+					stack: err.stack,
+				});
+			}
+
+			session.unsubscribeAdded = undefined;
+		}
+	}
+
+	private scheduleCleanup(session: ShellyV1DiscoverySession): void {
+		this.clearCleanupTimer(session);
+
+		session.cleanupTimer = setTimeout(() => {
+			this.sessions.delete(session.id);
+		}, ShellyV1DiscoveryService.FINISHED_SESSION_TTL_MS);
+	}
+
+	private clearTimer(session: ShellyV1DiscoverySession): void {
+		if (session.timer !== undefined) {
+			clearTimeout(session.timer);
+			session.timer = undefined;
+		}
+	}
+
+	private clearCleanupTimer(session: ShellyV1DiscoverySession): void {
+		if (session.cleanupTimer !== undefined) {
+			clearTimeout(session.cleanupTimer);
+			session.cleanupTimer = undefined;
+		}
+	}
+
+	private storePassword(
+		session: ShellyV1DiscoverySession,
+		device: ShellyV1DiscoveryDeviceSnapshot,
+		password: string,
+	): void {
+		session.passwords.set(device.hostname, password);
+
+		if (device.identifier !== null) {
+			session.passwords.set(device.identifier, password);
+		}
+	}
+
+	/**
+	 * Build a discovery snapshot for a device the main connector already knows about.
+	 * Probes the device over HTTP (no auth) to surface model/firmware in the wizard
+	 * — the lib's `device.type` is the model code (e.g. `SHSW-1`) but doesn't expose
+	 * firmware version. Manual entries go through the same `inspectDevice` path because
+	 * they may target devices the main connector hasn't reached and may need a password.
+	 */
+	private async handleLibDevice(session: ShellyV1DiscoverySession, device: ShellyDevice): Promise<void> {
+		const hostname = device.host;
+
+		if (typeof hostname !== 'string' || hostname.length === 0) {
+			return;
+		}
+
+		// Skip if the user already entered this device manually — that path has the password
+		// and a richer snapshot we don't want to overwrite.
+		const existing = session.devices.get(hostname);
+
+		if (existing && existing.source === 'manual') {
+			return;
+		}
+
+		try {
+			const registeredDevice = await this.devicesService.findOneBy<ShellyV1DeviceEntity>(
+				'identifier',
+				device.id,
+				DEVICES_SHELLY_V1_TYPE,
+			);
+
+			const descriptor = this.findDescriptor(device.type);
+			const categories = descriptor?.categories ?? [];
+
+			let status: ShellyV1DiscoveryDeviceStatus;
+
+			if (registeredDevice !== null) {
+				status = 'already_registered';
+			} else if (descriptor === null) {
+				status = 'unsupported';
+			} else {
+				status = 'ready';
+			}
+
+			// Try to enrich with /shelly response (firmware, auth flag) — best effort, the lib
+			// gives us model + host but not firmware version. If the call fails, fall back to
+			// what we have.
+			let firmware: string | null = null;
+			let authEnabled = false;
+
+			try {
+				const shellyInfo = await this.httpClient.getDeviceInfo(hostname, 3_000);
+				firmware = shellyInfo.fw ?? null;
+				authEnabled = Boolean(shellyInfo.auth);
+
+				// If auth is enabled and the device wasn't already registered we can't validate
+				// without a password — surface as needs_password so the user can enter one in the
+				// manual-add form.
+				if (authEnabled && status === 'ready') {
+					status = 'needs_password';
+				}
+			} catch {
+				// /shelly is reachable for most devices, but if it fails we leave the snapshot as-is —
+				// the lib already saw this device, so it's online via CoAP at least.
+			}
+
+			const snapshot: ShellyV1DiscoveryDeviceSnapshot = {
+				identifier: device.id,
+				hostname,
+				name: null,
+				model: device.type,
+				displayName: descriptor?.name ?? device.type,
+				firmware,
+				status,
+				source: 'mdns',
+				categories,
+				// Pre-fill the wizard's category dropdown with the first listed category for the
+				// model so the user can adopt a brand-new device without picking anything. The
+				// descriptor's category list is ordered most-common-first, so this lands on the
+				// typical use; users with edge cases can still flip the dropdown in step 2.
+				suggestedCategory: categories.length > 0 ? categories[0] : null,
+				authentication: { enabled: authEnabled, valid: null },
+				registeredDeviceId: registeredDevice?.id ?? null,
+				registeredDeviceName: registeredDevice?.name ?? null,
+				registeredDeviceCategory: registeredDevice?.category ?? null,
+				error: null,
+				lastSeenAt: new Date().toISOString(),
+			};
+
+			session.devices.set(hostname, snapshot);
+		} catch (error) {
+			// Most likely a transient DB error from `findOneBy`. Surface the device with a
+			// `failed` snapshot so the user can see something happened, but never let the
+			// promise reject — this is invoked from a fire-and-forget `add` listener and
+			// a rejection here would crash the process.
+			const err = error as Error;
+
+			this.logger.warn('Failed to build discovery snapshot for device from main connector', {
+				session: session.id,
+				hostname,
+				message: err.message,
+				stack: err.stack,
+			});
+
+			session.devices.set(hostname, {
+				identifier: device.id,
+				hostname,
+				name: null,
+				model: device.type,
+				displayName: device.type,
+				firmware: null,
+				status: 'failed',
+				source: 'mdns',
+				categories: [],
+				suggestedCategory: null,
+				authentication: { enabled: false, valid: null },
+				registeredDeviceId: null,
+				registeredDeviceName: null,
+				registeredDeviceCategory: null,
+				error: err.message,
+				lastSeenAt: new Date().toISOString(),
+			});
+		}
+	}
+
+	private async inspectDevice(
+		session: ShellyV1DiscoverySession,
+		hostname: string,
+		source: ShellyV1DiscoveryDeviceSource,
+		password: string | null,
+	): Promise<ShellyV1DiscoveryDeviceSnapshot | null> {
+		if (hostname.length === 0) {
+			return null;
+		}
+
+		const existing = session.devices.get(hostname);
+
+		session.devices.set(hostname, {
+			identifier: existing?.identifier ?? null,
+			hostname,
+			name: existing?.name ?? null,
+			model: existing?.model ?? null,
+			displayName: existing?.displayName ?? null,
+			firmware: existing?.firmware ?? null,
+			status: 'checking',
+			source,
+			categories: existing?.categories ?? [],
+			suggestedCategory: existing?.suggestedCategory ?? null,
+			authentication: existing?.authentication ?? { enabled: false, valid: null },
+			registeredDeviceId: existing?.registeredDeviceId ?? null,
+			registeredDeviceName: existing?.registeredDeviceName ?? null,
+			registeredDeviceCategory: existing?.registeredDeviceCategory ?? null,
+			error: null,
+			lastSeenAt: new Date().toISOString(),
+		});
+
+		try {
+			const shellyInfo = await this.httpClient.getDeviceInfo(hostname);
+			const descriptor = this.findDescriptor(shellyInfo.type);
+			// Mirror the shellies library's `device.id` format — uppercase MAC without separators —
+			// so wizard-adopted devices match the identifier the auto-discovery flow uses.
+			const identifier = this.buildIdentifier(shellyInfo.mac);
+			const registeredDevice = identifier
+				? await this.devicesService.findOneBy<ShellyV1DeviceEntity>('identifier', identifier, DEVICES_SHELLY_V1_TYPE)
+				: null;
+			const categories = descriptor?.categories ?? [];
+
+			let authValid: boolean | null = null;
+
+			// Validate password if required + provided
+			if (shellyInfo.auth && password !== null) {
+				try {
+					await this.httpClient.getDeviceStatus(hostname, undefined, SHELLY_AUTH_USERNAME, password);
+					authValid = true;
+				} catch (error) {
+					authValid = false;
+
+					this.logger.warn(
+						`Auth credentials invalid for ${hostname}: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				}
+			}
+
+			let status: ShellyV1DiscoveryDeviceStatus = 'ready';
+
+			if (registeredDevice !== null) {
+				status = 'already_registered';
+			} else if (descriptor === null) {
+				status = 'unsupported';
+			} else if (shellyInfo.auth && (password === null || authValid === false)) {
+				status = 'needs_password';
+			}
+
+			const discoveredDevice: ShellyV1DiscoveryDeviceSnapshot = {
+				identifier,
+				hostname,
+				name: existing?.name ?? null,
+				model: shellyInfo.type,
+				displayName: descriptor?.name ?? shellyInfo.type,
+				firmware: shellyInfo.fw ?? null,
+				status,
+				source,
+				categories,
+				suggestedCategory: categories.length > 0 ? categories[0] : null,
+				authentication: { enabled: Boolean(shellyInfo.auth), valid: authValid },
+				registeredDeviceId: registeredDevice?.id ?? null,
+				registeredDeviceName: registeredDevice?.name ?? null,
+				registeredDeviceCategory: registeredDevice?.category ?? null,
+				error: null,
+				lastSeenAt: new Date().toISOString(),
+			};
+
+			session.devices.set(hostname, discoveredDevice);
+
+			return discoveredDevice;
+		} catch (error) {
+			const err = error as Error;
+			const currentDevice = session.devices.get(hostname);
+
+			if (currentDevice === undefined) {
+				return null;
+			}
+
+			const failedDevice: ShellyV1DiscoveryDeviceSnapshot = {
+				...currentDevice,
+				status: 'failed',
+				source,
+				error: err.message,
+				lastSeenAt: new Date().toISOString(),
+			};
+
+			session.devices.set(hostname, failedDevice);
+
+			return failedDevice;
+		}
+	}
+
+	/**
+	 * Build the canonical device identifier the same way the shellies library does — the
+	 * uppercase MAC address without separators. The auto-discovery path uses this value
+	 * directly (`event.id` from CoAP), so wizard-adopted devices must use the same format
+	 * to be matched on subsequent CoAP frames.
+	 */
+	private buildIdentifier(mac: string | null | undefined): string | null {
+		if (typeof mac !== 'string' || mac.length === 0) {
+			return null;
+		}
+
+		return mac.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+	}
+
+	private findDescriptor(model: string | null | undefined): DeviceDescriptor | null {
+		if (typeof model !== 'string' || model.length === 0) {
+			return null;
+		}
+
+		const normalizedModel = model.toUpperCase();
+
+		// First, try an exact match on a descriptor key (e.g. "SHELLY1")
+		if (normalizedModel in DESCRIPTORS) {
+			return DESCRIPTORS[normalizedModel];
+		}
+
+		// Try to match against the model array of every descriptor
+		return (
+			Object.values(DESCRIPTORS).find((descriptor) =>
+				descriptor.models.some((descriptorModel) => descriptorModel.toUpperCase() === normalizedModel),
+			) ?? null
+		);
+	}
+
+	private toSnapshot(session: ShellyV1DiscoverySession): ShellyV1DiscoverySessionSnapshot {
+		return {
+			id: session.id,
+			status: session.status,
+			startedAt: session.startedAt.toISOString(),
+			expiresAt: session.expiresAt.toISOString(),
+			remainingSeconds: Math.max(0, Math.ceil((session.expiresAt.getTime() - Date.now()) / 1_000)),
+			devices: Array.from(session.devices.values()),
+		};
+	}
+}

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -89,6 +89,17 @@ export class ShellyV1DiscoveryService {
 	) {}
 
 	start({ duration }: { duration: number }): ShellyV1DiscoverySessionSnapshot {
+		// Finish any session still running before this one. A second `start()` (e.g. the user
+		// clicking "Scan again") would otherwise stack a fresh `add` subscription on top of the
+		// previous one, double-probing every device the lib sees and leaving an orphan
+		// finish-timer ticking until it fires. The frontend only tracks the latest session id
+		// anyway, so any in-flight work on the old session is invisible to the user.
+		for (const existing of this.sessions.values()) {
+			if (existing.status === 'running') {
+				void this.finish(existing.id);
+			}
+		}
+
 		const id = randomUUID();
 		const startedAt = new Date();
 		const expiresAt = new Date(startedAt.getTime() + duration * 1_000);

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -70,7 +70,6 @@ interface ShellyV1DiscoverySession {
 	cleanupTimer?: NodeJS.Timeout;
 	unsubscribeAdded?: () => void;
 	devices: Map<string, ShellyV1DiscoveryDeviceSnapshot>;
-	passwords: Map<string, string>;
 }
 
 @Injectable()
@@ -101,7 +100,6 @@ export class ShellyV1DiscoveryService {
 			startedAt,
 			expiresAt,
 			devices: new Map(),
-			passwords: new Map(),
 		};
 
 		// Reuse the main connector's already-running CoAP/mDNS browser instead of spinning up a
@@ -117,15 +115,20 @@ export class ShellyV1DiscoveryService {
 			void this.handleLibDevice(session, device);
 		});
 
-		for (const device of this.shelliesAdapter.getKnownDevices()) {
-			await this.handleLibDevice(session, device);
-		}
-
+		// Arm the finish timer and register the session BEFORE the seed loop so the wall-clock
+		// session lifetime matches `expiresAt`. Each seed iteration does an HTTP probe + DB lookup
+		// and can take several seconds end-to-end; if the timer were started after the loop the
+		// real expiry would drift by exactly that delay, leaving the frontend's progress bar at
+		// 100% while polling still reports `running`.
 		session.timer = setTimeout(() => {
 			void this.finish(id);
 		}, duration * 1_000);
 
 		this.sessions.set(id, session);
+
+		for (const device of this.shelliesAdapter.getKnownDevices()) {
+			await this.handleLibDevice(session, device);
+		}
 
 		return this.toSnapshot(session);
 	}
@@ -150,11 +153,7 @@ export class ShellyV1DiscoveryService {
 			return null;
 		}
 
-		const discoveredDevice = await this.inspectDevice(session, hostname, 'manual', password ?? null);
-
-		if (password !== null && typeof password !== 'undefined' && discoveredDevice?.status === 'ready') {
-			this.storePassword(session, discoveredDevice, password);
-		}
+		await this.inspectDevice(session, hostname, 'manual', password ?? null);
 
 		return this.toSnapshot(session);
 	}
@@ -213,18 +212,6 @@ export class ShellyV1DiscoveryService {
 		if (session.cleanupTimer !== undefined) {
 			clearTimeout(session.cleanupTimer);
 			session.cleanupTimer = undefined;
-		}
-	}
-
-	private storePassword(
-		session: ShellyV1DiscoverySession,
-		device: ShellyV1DiscoveryDeviceSnapshot,
-		password: string,
-	): void {
-		session.passwords.set(device.hostname, password);
-
-		if (device.identifier !== null) {
-			session.passwords.set(device.identifier, password);
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-discovery.service.ts
@@ -6,14 +6,13 @@ import { ExtensionLoggerService, createExtensionLogger } from '../../../common/l
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import {
-	DESCRIPTORS,
 	DEVICES_SHELLY_V1_PLUGIN_NAME,
 	DEVICES_SHELLY_V1_TYPE,
-	DeviceDescriptor,
 	SHELLY_AUTH_USERNAME,
 } from '../devices-shelly-v1.constants';
 import { ShellyV1DeviceEntity } from '../entities/devices-shelly-v1.entity';
 import { ShellyDevice } from '../interfaces/shellies.interface';
+import { findShellyV1Descriptor } from '../utils/descriptor.utils';
 
 import { ShelliesAdapterService } from './shellies-adapter.service';
 import { ShellyV1HttpClientService } from './shelly-v1-http-client.service';
@@ -246,7 +245,7 @@ export class ShellyV1DiscoveryService {
 				DEVICES_SHELLY_V1_TYPE,
 			);
 
-			const descriptor = this.findDescriptor(device.type);
+			const descriptor = findShellyV1Descriptor(device.type);
 			const categories = descriptor?.categories ?? [];
 
 			let status: ShellyV1DiscoveryDeviceStatus;
@@ -373,7 +372,7 @@ export class ShellyV1DiscoveryService {
 
 		try {
 			const shellyInfo = await this.httpClient.getDeviceInfo(hostname);
-			const descriptor = this.findDescriptor(shellyInfo.type);
+			const descriptor = findShellyV1Descriptor(shellyInfo.type);
 			// Mirror the shellies library's `device.id` format — uppercase MAC without separators —
 			// so wizard-adopted devices match the identifier the auto-discovery flow uses.
 			const identifier = this.buildIdentifier(shellyInfo.mac);
@@ -464,36 +463,6 @@ export class ShellyV1DiscoveryService {
 		}
 
 		return mac.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
-	}
-
-	/**
-	 * Mirror the matching strategy used by `device-mapper.service.ts` and the device platform
-	 * — substring match on `descriptor.models`, then partial-name fallback on the descriptor
-	 * key / friendly name. The wizard MUST agree with the main connector here: if a device
-	 * type the connector adopts gets `unsupported` in the wizard, users see a confusing
-	 * inconsistency for variants whose `type` carries an extra suffix beyond the canonical
-	 * model code (e.g. SHSW-1 vs SHSW-1-something).
-	 */
-	private findDescriptor(model: string | null | undefined): DeviceDescriptor | null {
-		if (typeof model !== 'string' || model.length === 0) {
-			return null;
-		}
-
-		const normalizedModel = model.toUpperCase();
-
-		for (const descriptor of Object.values(DESCRIPTORS)) {
-			if (descriptor.models.some((descriptorModel) => normalizedModel.includes(descriptorModel.toUpperCase()))) {
-				return descriptor;
-			}
-		}
-
-		for (const [key, descriptor] of Object.entries(DESCRIPTORS)) {
-			if (normalizedModel.includes(key) || descriptor.name.toUpperCase().includes(normalizedModel)) {
-				return descriptor;
-			}
-		}
-
-		return null;
 	}
 
 	private toSnapshot(session: ShellyV1DiscoverySession): ShellyV1DiscoverySessionSnapshot {

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1.service.ts
@@ -17,9 +17,9 @@ import {
 	ServiceState,
 } from '../../../modules/extensions/services/managed-plugin-service.interface';
 import {
-	DESCRIPTORS,
 	DEVICES_SHELLY_V1_PLUGIN_NAME,
 	DEVICES_SHELLY_V1_TYPE,
+	DeviceDescriptor,
 	PropertyBinding,
 	SHELLY_AUTH_USERNAME,
 	SHELLY_V1_CHANNEL_IDENTIFIERS,
@@ -33,6 +33,7 @@ import {
 } from '../entities/devices-shelly-v1.entity';
 import { NormalizedDeviceChangeEvent, NormalizedDeviceEvent } from '../interfaces/shellies.interface';
 import { ShellyV1ConfigModel } from '../models/config.model';
+import { findShellyV1Descriptor } from '../utils/descriptor.utils';
 
 import { DeviceMapperService } from './device-mapper.service';
 import { ShelliesAdapterService } from './shellies-adapter.service';
@@ -510,9 +511,7 @@ export class ShellyV1Service extends BaseManagedPluginService {
 	/**
 	 * Find the descriptor for a device entity by querying the model from a device_information channel
 	 */
-	private async findDescriptor(
-		device: ShellyV1DeviceEntity,
-	): Promise<(typeof DESCRIPTORS)[keyof typeof DESCRIPTORS] | null> {
+	private async findDescriptor(device: ShellyV1DeviceEntity): Promise<DeviceDescriptor | null> {
 		// Get the device_information channel
 		const deviceInfoChannel = await this.channelsService.findOneBy<ShellyV1ChannelEntity>(
 			'identifier',
@@ -541,31 +540,14 @@ export class ShellyV1Service extends BaseManagedPluginService {
 			return null;
 		}
 
-		const deviceModel = String(modelProperty.value.value).toUpperCase();
+		const deviceModel = String(modelProperty.value.value);
+		const descriptor = findShellyV1Descriptor(deviceModel);
 
-		// Try to find by exact device model match first
-		for (const descriptor of Object.values(DESCRIPTORS)) {
-			if (descriptor.models.some((model) => deviceModel === model)) {
-				return descriptor;
-			}
-		}
-		// Fallback: try to find by partial device model match
-		for (const descriptor of Object.values(DESCRIPTORS)) {
-			if (descriptor.models.some((model) => deviceModel.includes(model))) {
-				return descriptor;
-			}
+		if (!descriptor) {
+			this.logger.warn(`No descriptor found for device model: ${deviceModel.toUpperCase()}`);
 		}
 
-		// Fallback: try to match by partial name
-		for (const [key, descriptor] of Object.entries(DESCRIPTORS)) {
-			if (deviceModel.includes(key) || descriptor.name.toUpperCase().includes(deviceModel)) {
-				return descriptor;
-			}
-		}
-
-		this.logger.warn(`No descriptor found for device model: ${deviceModel}`);
-
-		return null;
+		return descriptor;
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-shelly-v1/utils/descriptor.utils.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/utils/descriptor.utils.ts
@@ -1,0 +1,41 @@
+import { DESCRIPTORS, DeviceDescriptor } from '../devices-shelly-v1.constants';
+
+/**
+ * Resolve the descriptor for a Shelly Gen 1 device's reported type. Used by every
+ * caller that needs to map a device-reported model code (e.g. `SHSW-1`) onto a
+ * descriptor in `DESCRIPTORS`: discovery wizard, device mapper, device platform,
+ * and any future caller. Keeping this in one place is critical — divergent matching
+ * strategies cause user-visible inconsistencies (e.g. the wizard reporting
+ * `unsupported` for a device the main connector adopts cleanly).
+ *
+ * Matching is two-pass and case-insensitive:
+ * 1. **Model substring match.** Each descriptor lists canonical model codes
+ *    (`SHSW-1`, `SHSW-PM`, …). A device whose `type` *contains* one of those codes
+ *    matches that descriptor — covers Shelly's habit of suffixing variants
+ *    (`SHSW-1-extra`).
+ * 2. **Key / friendly-name fallback.** If no model matches, look for the
+ *    descriptor key (`SHELLY1`, `SHELLY1PM`, …) inside the type, or the friendly
+ *    name (`Shelly 1`) inside the type. This recovers devices that report a name
+ *    rather than a model code.
+ */
+export const findShellyV1Descriptor = (deviceType: string | null | undefined): DeviceDescriptor | null => {
+	if (typeof deviceType !== 'string' || deviceType.length === 0) {
+		return null;
+	}
+
+	const normalizedType = deviceType.toUpperCase();
+
+	for (const descriptor of Object.values(DESCRIPTORS)) {
+		if (descriptor.models.some((model) => normalizedType.includes(model.toUpperCase()))) {
+			return descriptor;
+		}
+	}
+
+	for (const [key, descriptor] of Object.entries(DESCRIPTORS)) {
+		if (normalizedType.includes(key) || descriptor.name.toUpperCase().includes(normalizedType)) {
+			return descriptor;
+		}
+	}
+
+	return null;
+};


### PR DESCRIPTION
## Summary

- Adds a discovery wizard to the **shelly-v1** plugin, mirroring the existing shelly-ng wizard so Gen 1 devices can be adopted through the same three-step flow (Discovery → Categories → Results)
- Reuses the main connector's already-running CoAP/mDNS browser via a new `subscribeToAddedDevice()` / `getKnownDevices()` pair on `ShelliesAdapterService` — no parallel network listeners
- Supports manual hostname + password entry for protected devices, with HTTP Basic auth validation against `/status`

## Implementation notes

**Backend** (`apps/backend/src/plugins/devices-shelly-v1/`)
- `services/shelly-v1-discovery.service.ts` — session lifecycle (30s scan window, 5min finished-TTL), seed from `getKnownDevices()` + live subscription, manual lookup probes `/shelly` then validates auth via `/status`
- `services/shellies-adapter.service.ts` — added `getKnownDevices()` and `subscribeToAddedDevice()` with cross-restart subscriber retention
- `controllers/shelly-v1-devices.controller.ts` — new endpoints: `POST /discovery`, `GET /discovery/{id}`, `POST /discovery/{id}/manual`
- `models/shelly-v1.model.ts` + `models/shelly-v1-response.model.ts` — discovery device / session models and response wrapper, registered in `devices-shelly-v1.openapi.ts`
- Identifier built as uppercase MAC without separators to match the `shellies` library's `device.id` format used by auto-discovery

**Admin** (`apps/admin/src/plugins/devices-shelly-v1/`)
- `composables/useDevicesWizard.ts` — session polling (1s), client-side scan-progress ticking that's resilient to clock skew, race-resilient adopt with create→update fallback, opt-in updates for already-registered devices
- `components/shelly-v1-devices-wizard.vue` — three-step wizard with sortable categories table, select-all checkbox, and table-format results step
- Schemas / types / transformers extended for the new discovery payloads
- Locales updated for en-US, cs-CZ, de-DE, es-ES, pl-PL, sk-SK

## Test plan

- [ ] Backend: `pnpm --filter ./apps/backend exec jest src/plugins/devices-shelly-v1` — 105/105 pass locally
- [ ] Admin: `pnpm --filter ./apps/admin run test:unit` — 1330/1330 pass locally
- [ ] Lint + type-check clean for both apps
- [ ] Manual: open `Devices → wizard/devices-shelly-v1-plugin` with a Gen 1 device on the LAN and confirm it appears via mDNS, can be adopted with category, and shows up in the devices list
- [ ] Manual: enter a password-protected device manually with wrong password (expect `needs_password`), then with the right password (expect `ready`)
- [ ] Manual: re-run wizard with an already-adopted device (expect `already_registered` with opt-in update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new backend discovery-session APIs and a new in-memory discovery service wired into the Shelly V1 connector, plus a new admin wizard flow that can create or update devices; mistakes could affect device adoption/update behavior but changes are scoped to the Shelly V1 plugin.
> 
> **Overview**
> Adds a **Shelly Gen 1 (V1) discovery/adoption wizard** in the admin UI (Discovery → Categories → Results), including polling scan progress, manual hostname/password lookups, per-device selection/category/name editing, and a results table.
> 
> Introduces new backend support for the wizard via `POST /devices/discovery`, `GET /devices/discovery/:id`, and `POST /devices/discovery/:id/manual`, backed by a short-lived discovery session service that reuses the existing Shellies connector event stream (new `getKnownDevices()`/`subscribeToAddedDevice()`), probes devices over HTTP for enrichment/auth validation, and exposes typed OpenAPI models.
> 
> Refactors Shelly V1 descriptor matching into shared `findShellyV1Descriptor()` and updates the platform/mapper/service to use it, and extends admin schemas/transformers/openapi aliases and i18n strings to support the new discovery payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b4a62b17922bf185f1b96bc12380a5c81b945b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->