### PR TITLE
Zigbee2MQTT: multi-device adoption wizard

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -369,6 +369,12 @@ export type DevicesZigbee2mqttPluginGetDiscoveredDevicesOperation = operations['
 export type DevicesZigbee2mqttPluginGetDiscoveredDeviceOperation = operations['get-devices-zigbee2mqtt-plugin-device'];
 export type DevicesZigbee2mqttPluginPreviewMappingOperation = operations['preview-devices-zigbee2mqtt-plugin-device-mapping'];
 export type DevicesZigbee2mqttPluginAdoptDeviceOperation = operations['adopt-devices-zigbee2mqtt-plugin-device'];
+export type DevicesZigbee2mqttPluginCreateWizardOperation = operations['create-devices-zigbee2mqtt-plugin-wizard'];
+export type DevicesZigbee2mqttPluginGetWizardOperation = operations['get-devices-zigbee2mqtt-plugin-wizard'];
+export type DevicesZigbee2mqttPluginDeleteWizardOperation = operations['delete-devices-zigbee2mqtt-plugin-wizard'];
+export type DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation = operations['enable-devices-zigbee2mqtt-plugin-wizard-permit-join'];
+export type DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation = operations['disable-devices-zigbee2mqtt-plugin-wizard-permit-join'];
+export type DevicesZigbee2mqttPluginAdoptWizardOperation = operations['adopt-devices-zigbee2mqtt-plugin-wizard'];
 
 // Devices Home Assistant Plugin Operations
 export type DevicesHomeAssistantPluginGetDeviceOperation = operations['get-devices-home-assistant-plugin-device'];

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/components.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/components.ts
@@ -2,3 +2,4 @@ export { default as Zigbee2mqttConfigForm } from './zigbee2mqtt-config-form.vue'
 export { default as Zigbee2mqttDeviceAddForm } from './zigbee2mqtt-device-add-form.vue';
 export { default as Zigbee2mqttDeviceAddFormMultiStep } from './zigbee2mqtt-device-add-form-multi-step.vue';
 export { default as Zigbee2mqttDeviceEditForm } from './zigbee2mqtt-device-edit-form.vue';
+export { default as Zigbee2mqttDevicesWizard } from './zigbee2mqtt-devices-wizard.vue';

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
@@ -203,9 +203,13 @@ const onDone = async (): Promise<void> => {
 
 // "Add more" wipes the previous session so the next round of pairings starts from a clean
 // state; the composable's auto-cleanup hook only fires on unmount, not on user-driven resets.
+//
+// Order matters: switching `activeStep` to 'discovery' BEFORE the new session is loaded would
+// briefly render the discovery step with `session.value === null`, which makes `bridgeOnline`
+// compute to false and flashes a misleading "Bridge offline" banner. We finish endSession +
+// startSession first and only then transition the UI, so the discovery step mounts with a
+// real session in place.
 const onRestart = async (): Promise<void> => {
-	activeStep.value = 'discovery';
-
 	try {
 		await endSession();
 	} catch {
@@ -217,5 +221,7 @@ const onRestart = async (): Promise<void> => {
 	} catch {
 		// Errors are surfaced by the composable via flashMessage.
 	}
+
+	activeStep.value = 'discovery';
 };
 </script>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
@@ -77,10 +77,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 import { ElButton, ElStep, ElSteps } from 'element-plus';
 
 import { useFlashMessage } from '../../../common';
+import { RouteNames as DevicesRouteNames } from '../../../modules/devices/devices.constants';
 import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import { useDevicesWizard } from '../composables/useDevicesWizard';
 
@@ -92,11 +94,8 @@ defineOptions({
 	name: 'Zigbee2mqttDevicesWizard',
 });
 
-const emit = defineEmits<{
-	(e: 'done'): void;
-}>();
-
 const { t } = useI18n();
+const router = useRouter();
 const flashMessage = useFlashMessage();
 
 const {
@@ -198,8 +197,8 @@ const onAdopt = async (): Promise<void> => {
 	}
 };
 
-const onDone = (): void => {
-	emit('done');
+const onDone = async (): Promise<void> => {
+	await router.push({ name: DevicesRouteNames.DEVICES });
 };
 
 // "Add more" wipes the previous session so the next round of pairings starts from a clean

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
@@ -1,0 +1,222 @@
+<template>
+	<div class="z2m-devices-wizard flex flex-col gap-3 h-full overflow-hidden">
+		<el-steps
+			:active="activeStepIndex"
+			finish-status="success"
+			align-center
+			class="shrink-0"
+		>
+			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.discovery.title')" />
+			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.categorize.title')" />
+			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.results.title')" />
+		</el-steps>
+
+		<div class="flex-grow overflow-hidden">
+			<Zigbee2mqttWizardDiscoveryStep
+				v-if="activeStep === 'discovery'"
+				:devices="devices"
+				:selected="selected"
+				:permit-join="permitJoin"
+				:bridge-online="bridgeOnline"
+				@enable-permit-join="enablePermitJoin"
+				@disable-permit-join="disablePermitJoin"
+				@update:selected="onUpdateSelected"
+			/>
+
+			<Zigbee2mqttWizardCategorizeStep
+				v-else-if="activeStep === 'categorize'"
+				:devices="devices"
+				:selected="selected"
+				:name-by-ieee="nameByIeee"
+				:category-by-ieee="categoryByIeee"
+				:category-options="categoryOptions"
+				@update:name-by-ieee="onUpdateNameByIeee"
+				@update:category-by-ieee="onUpdateCategoryByIeee"
+			/>
+
+			<Zigbee2mqttWizardResultsStep
+				v-else
+				:results="adoptionResults"
+				:devices="devices"
+				@done="onDone"
+				@restart="onRestart"
+			/>
+		</div>
+
+		<div class="flex justify-between gap-2 shrink-0">
+			<el-button
+				v-if="activeStep === 'categorize'"
+				@click="goBack"
+			>
+				{{ t('devicesZigbee2mqttPlugin.wizard.actions.back') }}
+			</el-button>
+			<div v-else />
+
+			<el-button
+				v-if="activeStep === 'discovery'"
+				type="primary"
+				:disabled="selectedDevices.length === 0"
+				@click="goToCategorize"
+			>
+				{{ t('devicesZigbee2mqttPlugin.wizard.actions.next') }}
+			</el-button>
+
+			<el-button
+				v-else-if="activeStep === 'categorize'"
+				type="primary"
+				:disabled="!canContinue"
+				:loading="isAdopting"
+				@click="onAdopt"
+			>
+				{{ t('devicesZigbee2mqttPlugin.wizard.actions.adopt') }}
+			</el-button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElStep, ElSteps } from 'element-plus';
+
+import { useFlashMessage } from '../../../common';
+import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { useDevicesWizard } from '../composables/useDevicesWizard';
+
+import Zigbee2mqttWizardCategorizeStep from './zigbee2mqtt-wizard-categorize-step.vue';
+import Zigbee2mqttWizardDiscoveryStep from './zigbee2mqtt-wizard-discovery-step.vue';
+import Zigbee2mqttWizardResultsStep from './zigbee2mqtt-wizard-results-step.vue';
+
+defineOptions({
+	name: 'Zigbee2mqttDevicesWizard',
+});
+
+const emit = defineEmits<{
+	(e: 'done'): void;
+}>();
+
+const { t } = useI18n();
+const flashMessage = useFlashMessage();
+
+const {
+	devices,
+	selected,
+	nameByIeee,
+	categoryByIeee,
+	selectedDevices,
+	permitJoin,
+	bridgeOnline,
+	canContinue,
+	adoptionResults,
+	enablePermitJoin,
+	disablePermitJoin,
+	adoptSelected,
+	endSession,
+	startSession,
+	categoryOptions,
+} = useDevicesWizard();
+
+type WizardStep = 'discovery' | 'categorize' | 'results';
+
+const activeStep = ref<WizardStep>('discovery');
+const isAdopting = ref<boolean>(false);
+
+const activeStepIndex = computed<number>(() => {
+	if (activeStep.value === 'categorize') {
+		return 1;
+	}
+
+	if (activeStep.value === 'results') {
+		return 2;
+	}
+
+	return 0;
+});
+
+// The step components emit fresh maps; sync them back into the reactive maps owned by the
+// composable so its derived state (`selectedDevices`, `canContinue`, …) updates immediately.
+const onUpdateSelected = (value: Record<string, boolean>): void => {
+	for (const key of Object.keys(selected)) {
+		if (!(key in value)) {
+			delete selected[key];
+		}
+	}
+
+	Object.assign(selected, value);
+};
+
+const onUpdateNameByIeee = (value: Record<string, string>): void => {
+	for (const key of Object.keys(nameByIeee)) {
+		if (!(key in value)) {
+			delete nameByIeee[key];
+		}
+	}
+
+	Object.assign(nameByIeee, value);
+};
+
+const onUpdateCategoryByIeee = (value: Record<string, DevicesModuleDeviceCategory | null>): void => {
+	for (const key of Object.keys(categoryByIeee)) {
+		if (!(key in value)) {
+			delete categoryByIeee[key];
+		}
+	}
+
+	Object.assign(categoryByIeee, value);
+};
+
+const goToCategorize = async (): Promise<void> => {
+	// Pairing should never be left active once the user moves on — silently turn it off so the
+	// gateway stops accepting new joins while the categorize step is in focus.
+	if (permitJoin.value.active) {
+		try {
+			await disablePermitJoin();
+			flashMessage.info(t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingDisabled'));
+		} catch {
+			// Errors are surfaced by the composable via flashMessage; advancing is still fine.
+		}
+	}
+
+	activeStep.value = 'categorize';
+};
+
+const goBack = (): void => {
+	activeStep.value = 'discovery';
+};
+
+const onAdopt = async (): Promise<void> => {
+	isAdopting.value = true;
+
+	try {
+		await adoptSelected();
+		activeStep.value = 'results';
+	} catch {
+		// Errors are surfaced by the composable via flashMessage; stay on the categorize step.
+	} finally {
+		isAdopting.value = false;
+	}
+};
+
+const onDone = (): void => {
+	emit('done');
+};
+
+// "Add more" wipes the previous session so the next round of pairings starts from a clean
+// state; the composable's auto-cleanup hook only fires on unmount, not on user-driven resets.
+const onRestart = async (): Promise<void> => {
+	activeStep.value = 'discovery';
+
+	try {
+		await endSession();
+	} catch {
+		// Best-effort cleanup; errors are non-fatal because startSession will overwrite anyway.
+	}
+
+	try {
+		await startSession();
+	} catch {
+		// Errors are surfaced by the composable via flashMessage.
+	}
+};
+</script>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
@@ -1,0 +1,229 @@
+<template>
+	<div class="flex flex-col gap-3 h-full overflow-hidden">
+		<el-table
+			:data="selectedDevices"
+			class="h-full w-full flex-grow"
+			table-layout="fixed"
+		>
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.name')"
+				min-width="220"
+				sortable
+				:sort-method="sortByName"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<el-input
+						:model-value="nameByIeee[row.ieeeAddress] ?? ''"
+						@update:model-value="(value: string) => onUpdateName(row.ieeeAddress, value)"
+					/>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				prop="friendlyName"
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.friendlyName')"
+				min-width="180"
+				sortable
+				:sort-method="sortByFriendlyName"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<code class="text-sm">{{ row.friendlyName }}</code>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.manufacturer')"
+				min-width="180"
+				sortable
+				:sort-method="sortByManufacturer"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<small
+						v-if="row.manufacturer || row.model"
+						class="text-gray-500"
+					>
+						{{ [row.manufacturer, row.model].filter(Boolean).join(' · ') }}
+					</small>
+					<small
+						v-else
+						class="text-gray-400"
+					>
+						&mdash;
+					</small>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				prop="status"
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.status')"
+				width="160"
+				sortable
+				:sort-method="sortByStatus"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<el-tag
+						v-if="row.status === 'already_registered'"
+						size="small"
+						type="info"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.categorize.willUpdate') }}
+					</el-tag>
+					<el-tag
+						v-else
+						size="small"
+						type="success"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.categorize.willCreate') }}
+					</el-tag>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.category')"
+				min-width="240"
+				sortable
+				:sort-method="sortByCategory"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<el-select
+						:model-value="categoryByIeee[row.ieeeAddress] ?? null"
+						filterable
+						@update:model-value="(value: DevicesModuleDeviceCategory | null) => onUpdateCategory(row.ieeeAddress, value)"
+					>
+						<el-option
+							v-for="opt in categoryOptions(row)"
+							:key="opt.value"
+							:label="opt.label"
+							:value="opt.value"
+						/>
+					</el-select>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.channels')"
+				width="120"
+				sortable
+				:sort-method="sortByChannels"
+			>
+				<template #default="{ row }: { row: IZ2mWizardDevice }">
+					<el-tooltip
+						v-if="row.previewChannelIdentifiers.length > 0"
+						:content="row.previewChannelIdentifiers.join(', ')"
+						placement="top"
+					>
+						<el-tag
+							size="small"
+							type="info"
+							effect="plain"
+						>
+							{{ t('devicesZigbee2mqttPlugin.wizard.steps.categorize.channels', { count: row.previewChannelCount }) }}
+						</el-tag>
+					</el-tooltip>
+					<el-tag
+						v-else
+						size="small"
+						type="info"
+						effect="plain"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.categorize.channels', { count: row.previewChannelCount }) }}
+					</el-tag>
+				</template>
+			</el-table-column>
+		</el-table>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElInput, ElOption, ElSelect, ElTable, ElTableColumn, ElTag, ElTooltip } from 'element-plus';
+
+import { orderBy } from 'natural-orderby';
+
+import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import type { IZ2mWizardDevice } from '../schemas/wizard.types';
+
+defineOptions({
+	name: 'Zigbee2mqttWizardCategorizeStep',
+});
+
+interface IProps {
+	devices: IZ2mWizardDevice[];
+	selected: Record<string, boolean>;
+	nameByIeee: Record<string, string>;
+	categoryByIeee: Record<string, DevicesModuleDeviceCategory | null>;
+	categoryOptions: (device: IZ2mWizardDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+}
+
+const props = defineProps<IProps>();
+
+const emit = defineEmits<{
+	(e: 'update:nameByIeee', value: Record<string, string>): void;
+	(e: 'update:categoryByIeee', value: Record<string, DevicesModuleDeviceCategory | null>): void;
+}>();
+
+const { t } = useI18n();
+
+const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+// Only show devices the user actively selected on the discovery step. Devices that became
+// `unsupported` or `failed` after selection are also dropped — the wizard composable already
+// strips them from the adoption payload, so showing them here would mislead the user.
+const selectedDevices = computed<IZ2mWizardDevice[]>(() =>
+	orderBy(
+		props.devices.filter((device) => props.selected[device.ieeeAddress] === true),
+		[(device) => device.ieeeAddress],
+		['asc']
+	)
+);
+
+const sortByName = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const aName = props.nameByIeee[a.ieeeAddress] ?? a.friendlyName;
+	const bName = props.nameByIeee[b.ieeeAddress] ?? b.friendlyName;
+	return compareLocale(aName, bName);
+};
+
+const sortByFriendlyName = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => compareLocale(a.friendlyName, b.friendlyName);
+
+const sortByManufacturer = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const aLabel = [a.manufacturer, a.model].filter(Boolean).join(' ');
+	const bLabel = [b.manufacturer, b.model].filter(Boolean).join(' ');
+	return compareLocale(aLabel, bLabel);
+};
+
+// Group "will create" devices ahead of "will update" ones, then by friendlyName inside each
+// bucket so the user can scan the new pairings first.
+const sortByStatus = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const order = (device: IZ2mWizardDevice): number => (device.status === 'already_registered' ? 1 : 0);
+	const diff = order(a) - order(b);
+	return diff !== 0 ? diff : compareLocale(a.friendlyName, b.friendlyName);
+};
+
+const sortByCategory = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const aCategory = props.categoryByIeee[a.ieeeAddress];
+	const bCategory = props.categoryByIeee[b.ieeeAddress];
+	const aLabel = aCategory ? t(`devicesModule.categories.devices.${aCategory}`) : '';
+	const bLabel = bCategory ? t(`devicesModule.categories.devices.${bCategory}`) : '';
+	return compareLocale(aLabel, bLabel);
+};
+
+const sortByChannels = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => a.previewChannelCount - b.previewChannelCount;
+
+const onUpdateName = (ieeeAddress: string, value: string): void => {
+	const next: Record<string, string> = { ...props.nameByIeee, [ieeeAddress]: value };
+
+	emit('update:nameByIeee', next);
+};
+
+const onUpdateCategory = (ieeeAddress: string, value: DevicesModuleDeviceCategory | null): void => {
+	const next: Record<string, DevicesModuleDeviceCategory | null> = { ...props.categoryByIeee, [ieeeAddress]: value };
+
+	emit('update:categoryByIeee', next);
+};
+</script>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
@@ -144,6 +144,7 @@ import { orderBy } from 'natural-orderby';
 
 import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import type { IZ2mWizardDevice } from '../schemas/wizard.types';
+import { compareLocale } from '../utils/wizard.sort';
 
 defineOptions({
 	name: 'Zigbee2mqttWizardCategorizeStep',
@@ -165,12 +166,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
-	const left = (a ?? '').toString();
-	const right = (b ?? '').toString();
-	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
-};
 
 // Only show devices the user actively selected on the discovery step. Devices that became
 // `unsupported` or `failed` after selection are also dropped — the wizard composable already

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
@@ -143,6 +143,7 @@ import { ElInput, ElOption, ElSelect, ElTable, ElTableColumn, ElTag, ElTooltip }
 import { orderBy } from 'natural-orderby';
 
 import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { isAdoptableStatus } from '../composables/useDevicesWizard';
 import type { IZ2mWizardDevice } from '../schemas/wizard.types';
 import { compareLocale } from '../utils/wizard.sort';
 
@@ -169,10 +170,12 @@ const { t } = useI18n();
 
 // Only show devices the user actively selected on the discovery step. Devices that became
 // `unsupported` or `failed` after selection are also dropped — the wizard composable already
-// strips them from the adoption payload, so showing them here would mislead the user.
+// strips them from the adoption payload, so showing them here would mislead the user. The
+// `isAdoptableStatus` filter here MUST match the composable's `selectedDevices` filter so the
+// table matches what `adoptSelected` will actually send.
 const selectedDevices = computed<IZ2mWizardDevice[]>(() =>
 	orderBy(
-		props.devices.filter((device) => props.selected[device.ieeeAddress] === true),
+		props.devices.filter((device) => props.selected[device.ieeeAddress] === true && isAdoptableStatus(device.status)),
 		[(device) => device.ieeeAddress],
 		['asc']
 	)

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue
@@ -91,7 +91,7 @@
 						@update:model-value="(value: DevicesModuleDeviceCategory | null) => onUpdateCategory(row.ieeeAddress, value)"
 					>
 						<el-option
-							v-for="opt in categoryOptions(row)"
+							v-for="opt in categoryOptions()"
 							:key="opt.value"
 							:label="opt.label"
 							:value="opt.value"
@@ -156,7 +156,7 @@ interface IProps {
 	selected: Record<string, boolean>;
 	nameByIeee: Record<string, string>;
 	categoryByIeee: Record<string, DevicesModuleDeviceCategory | null>;
-	categoryOptions: (device: IZ2mWizardDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+	categoryOptions: () => { value: DevicesModuleDeviceCategory; label: string }[];
 }
 
 const props = defineProps<IProps>();

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -1,0 +1,284 @@
+<template>
+	<div class="flex flex-col gap-3 h-full overflow-hidden">
+		<el-alert
+			v-if="!bridgeOnline"
+			type="warning"
+			:closable="false"
+			show-icon
+			class="shrink-0"
+		>
+			<template #title>
+				{{ t('devicesZigbee2mqttPlugin.wizard.bridge.offline.title') }}
+			</template>
+			<template #default>
+				<div class="flex flex-col gap-2">
+					<el-text>
+						{{ t('devicesZigbee2mqttPlugin.wizard.bridge.offline.message') }}
+					</el-text>
+					<router-link
+						:to="{ name: ConfigRouteNames.CONFIG_PLUGIN_EDIT, params: { plugin: DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } }"
+						class="text-primary"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.bridge.offline.openConfig') }}
+					</router-link>
+				</div>
+			</template>
+		</el-alert>
+
+		<template v-else>
+			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between shrink-0">
+				<div class="flex min-w-0 flex-1 flex-col gap-1">
+					<template v-if="permitJoin.active">
+						<el-text>
+							{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingActive', { remaining: permitJoin.remainingSeconds }) }}
+						</el-text>
+						<el-progress
+							:percentage="permitJoinPercentage"
+							:status="permitJoinPercentage <= 25 ? 'warning' : undefined"
+						/>
+					</template>
+				</div>
+
+				<div class="flex flex-wrap gap-2">
+					<el-button
+						v-if="!permitJoin.active"
+						type="primary"
+						:disabled="!bridgeOnline"
+						@click="emit('enable-permit-join')"
+					>
+						<template #icon>
+							<icon icon="mdi:plus-circle-outline" />
+						</template>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.permitJoin') }}
+					</el-button>
+
+					<el-button
+						v-else
+						type="warning"
+						@click="emit('disable-permit-join')"
+					>
+						<template #icon>
+							<icon icon="mdi:close-circle-outline" />
+						</template>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.cancelPairing') }}
+					</el-button>
+
+					<el-button
+						:disabled="adoptableDevices.length === 0"
+						@click="onAutoPickAll"
+					>
+						<template #icon>
+							<icon icon="mdi:checkbox-multiple-marked-outline" />
+						</template>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.autoPickAll') }}
+					</el-button>
+
+					<el-button
+						:disabled="!hasAnySelected"
+						@click="onClearSelection"
+					>
+						<template #icon>
+							<icon icon="mdi:checkbox-multiple-blank-outline" />
+						</template>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.clearSelection') }}
+					</el-button>
+				</div>
+			</div>
+
+			<el-table
+				:data="sortedDevices"
+				class="h-full w-full flex-grow"
+				table-layout="fixed"
+				:empty-text="t('devicesZigbee2mqttPlugin.wizard.steps.discovery.empty')"
+			>
+				<el-table-column width="60">
+					<template #default="{ row }: { row: IZ2mWizardDevice }">
+						<el-checkbox
+							:model-value="selected[row.ieeeAddress] === true"
+							:disabled="!isAdoptableStatus(row.status)"
+							@change="(value: boolean | string | number) => onToggleRow(row.ieeeAddress, value === true)"
+						/>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					prop="friendlyName"
+					:label="t('devicesZigbee2mqttPlugin.wizard.columns.friendlyName')"
+					min-width="200"
+					sortable
+					:sort-method="sortByFriendlyName"
+				>
+					<template #default="{ row }: { row: IZ2mWizardDevice }">
+						<code class="text-sm">{{ row.friendlyName }}</code>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					:label="t('devicesZigbee2mqttPlugin.wizard.columns.manufacturer')"
+					min-width="180"
+					sortable
+					:sort-method="sortByManufacturer"
+				>
+					<template #default="{ row }: { row: IZ2mWizardDevice }">
+						<small
+							v-if="row.manufacturer || row.model"
+							class="text-gray-500"
+						>
+							{{ [row.manufacturer, row.model].filter(Boolean).join(' · ') }}
+						</small>
+						<small
+							v-else
+							class="text-gray-400"
+						>
+							&mdash;
+						</small>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					prop="status"
+					:label="t('devicesZigbee2mqttPlugin.wizard.columns.status')"
+					width="180"
+					sortable
+					:sort-method="sortByStatus"
+				>
+					<template #default="{ row }: { row: IZ2mWizardDevice }">
+						<el-tag :type="statusTagType(row.status)">
+							{{ t(`devicesZigbee2mqttPlugin.wizard.status.${statusI18nKey(row.status)}`) }}
+						</el-tag>
+					</template>
+				</el-table-column>
+			</el-table>
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElAlert, ElButton, ElCheckbox, ElProgress, ElTable, ElTableColumn, ElTag, ElText } from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import { orderBy } from 'natural-orderby';
+
+import { RouteNames as ConfigRouteNames } from '../../../modules/config';
+import { isAdoptableStatus } from '../composables/useDevicesWizard';
+import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+import type { IZ2mWizardDevice, IZ2mWizardDeviceStatus, IZ2mWizardPermitJoin } from '../schemas/wizard.types';
+
+defineOptions({
+	name: 'Zigbee2mqttWizardDiscoveryStep',
+});
+
+interface IProps {
+	devices: IZ2mWizardDevice[];
+	selected: Record<string, boolean>;
+	permitJoin: IZ2mWizardPermitJoin;
+	bridgeOnline: boolean;
+}
+
+const props = defineProps<IProps>();
+
+const emit = defineEmits<{
+	(e: 'enable-permit-join'): void;
+	(e: 'disable-permit-join'): void;
+	(e: 'update:selected', value: Record<string, boolean>): void;
+}>();
+
+const { t } = useI18n();
+
+const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+// Group adoptable devices first, then by ieeeAddress — matches the wizard composable's
+// default ordering so the table opens with new pairings on top.
+const sortedDevices = computed<IZ2mWizardDevice[]>(() =>
+	orderBy(props.devices, [(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.ieeeAddress], ['asc', 'asc'])
+);
+
+const adoptableDevices = computed<IZ2mWizardDevice[]>(() => props.devices.filter((device) => isAdoptableStatus(device.status)));
+
+const hasAnySelected = computed<boolean>(() => Object.values(props.selected).some((value) => value === true));
+
+const permitJoinPercentage = computed<number>(() => {
+	if (!props.permitJoin.active) {
+		return 0;
+	}
+
+	// 254 seconds is the typical Zigbee permit-join window — clamp the bar so it always fits.
+	const total = Math.max(props.permitJoin.remainingSeconds, 1);
+
+	return Math.min(100, Math.round((total / 254) * 100));
+});
+
+const sortByFriendlyName = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => compareLocale(a.friendlyName, b.friendlyName);
+
+const sortByManufacturer = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const aLabel = [a.manufacturer, a.model].filter(Boolean).join(' ');
+	const bLabel = [b.manufacturer, b.model].filter(Boolean).join(' ');
+	return compareLocale(aLabel, bLabel);
+};
+
+// Group adoptable devices ahead of unsupported/failed ones, then by friendlyName inside each
+// bucket — matches the discovery composable's default ordering.
+const sortByStatus = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => {
+	const order = (status: IZ2mWizardDeviceStatus): number => (isAdoptableStatus(status) ? 0 : 1);
+	const diff = order(a.status) - order(b.status);
+	return diff !== 0 ? diff : compareLocale(a.friendlyName, b.friendlyName);
+};
+
+const statusTagType = (status: IZ2mWizardDeviceStatus): 'success' | 'warning' | 'info' | 'danger' => {
+	if (status === 'ready') {
+		return 'success';
+	}
+
+	if (status === 'already_registered') {
+		return 'info';
+	}
+
+	if (status === 'unsupported') {
+		return 'warning';
+	}
+
+	return 'danger';
+};
+
+const statusI18nKey = (status: IZ2mWizardDeviceStatus): string => {
+	if (status === 'already_registered') {
+		return 'alreadyRegistered';
+	}
+
+	return status;
+};
+
+const onToggleRow = (ieeeAddress: string, value: boolean): void => {
+	const next: Record<string, boolean> = { ...props.selected, [ieeeAddress]: value };
+
+	emit('update:selected', next);
+};
+
+const onAutoPickAll = (): void => {
+	const next: Record<string, boolean> = { ...props.selected };
+
+	for (const device of adoptableDevices.value) {
+		next[device.ieeeAddress] = true;
+	}
+
+	emit('update:selected', next);
+};
+
+const onClearSelection = (): void => {
+	const next: Record<string, boolean> = {};
+
+	for (const key of Object.keys(props.selected)) {
+		next[key] = false;
+	}
+
+	emit('update:selected', next);
+};
+</script>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -167,6 +167,7 @@ import { RouteNames as ConfigRouteNames } from '../../../modules/config';
 import { isAdoptableStatus } from '../composables/useDevicesWizard';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
 import type { IZ2mWizardDevice, IZ2mWizardDeviceStatus, IZ2mWizardPermitJoin } from '../schemas/wizard.types';
+import { compareLocale } from '../utils/wizard.sort';
 
 defineOptions({
 	name: 'Zigbee2mqttWizardDiscoveryStep',
@@ -188,12 +189,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
-	const left = (a ?? '').toString();
-	const right = (b ?? '').toString();
-	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
-};
 
 // Group adoptable devices first, then by ieeeAddress — matches the wizard composable's
 // default ordering so the table opens with new pairings on top.

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -210,10 +210,12 @@ const permitJoinPercentage = computed<number>(() => {
 		return 0;
 	}
 
-	// 254 seconds is the typical Zigbee permit-join window — clamp the bar so it always fits.
-	const total = Math.max(props.permitJoin.remainingSeconds, 1);
+	// `el-progress` shows "how much is complete", so we render elapsed time (filling up
+	// toward the deadline) rather than remaining time. 254 s is the typical Zigbee
+	// permit-join window; clamp to [0, 100] in case remainingSeconds briefly exceeds it.
+	const elapsedSeconds = Math.max(0, 254 - props.permitJoin.remainingSeconds);
 
-	return Math.min(100, Math.round((total / 254) * 100));
+	return Math.min(100, Math.round((elapsedSeconds / 254) * 100));
 });
 
 const sortByFriendlyName = (a: IZ2mWizardDevice, b: IZ2mWizardDevice): number => compareLocale(a.friendlyName, b.friendlyName);

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -34,7 +34,7 @@
 						</el-text>
 						<el-progress
 							:percentage="permitJoinPercentage"
-							:status="permitJoinPercentage <= 25 ? 'warning' : undefined"
+							:status="permitJoinPercentage >= 75 ? 'warning' : undefined"
 						/>
 					</template>
 				</div>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -30,7 +30,7 @@
 				<div class="flex min-w-0 flex-1 flex-col gap-1">
 					<template v-if="permitJoin.active">
 						<el-text>
-							{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingActive', { remaining: permitJoin.remainingSeconds }) }}
+							{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingActive', { remaining: smoothRemainingSeconds }) }}
 						</el-text>
 						<el-progress
 							:percentage="permitJoinPercentage"
@@ -157,6 +157,8 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import { useNow } from '@vueuse/core';
+
 import { ElAlert, ElButton, ElCheckbox, ElProgress, ElTable, ElTableColumn, ElTag, ElText } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
@@ -190,6 +192,32 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
+// Tick the countdown locally between backend polls so the progress bar and "Xs remaining"
+// text update smoothly instead of freezing for a full second between server responses.
+// Resolution of 250 ms gives a perceptibly fluid bar without overdrawing.
+const now = useNow({ interval: 250 });
+
+// Smoothed remaining seconds derived from the server-supplied `expiresAt`. Falls back to
+// the server's `remainingSeconds` if `expiresAt` isn't available yet (e.g. a transient null
+// during the first poll), so the UI still shows something sensible.
+const smoothRemainingSeconds = computed<number>(() => {
+	if (!props.permitJoin.active) {
+		return 0;
+	}
+
+	if (props.permitJoin.expiresAt === null) {
+		return props.permitJoin.remainingSeconds;
+	}
+
+	const expiresAtMs = new Date(props.permitJoin.expiresAt).getTime();
+
+	if (Number.isNaN(expiresAtMs)) {
+		return props.permitJoin.remainingSeconds;
+	}
+
+	return Math.max(0, Math.ceil((expiresAtMs - now.value.getTime()) / 1_000));
+});
+
 // Group adoptable devices first, then by ieeeAddress — matches the wizard composable's
 // default ordering so the table opens with new pairings on top.
 const sortedDevices = computed<IZ2mWizardDevice[]>(() =>
@@ -208,7 +236,8 @@ const permitJoinPercentage = computed<number>(() => {
 	// `el-progress` shows "how much is complete", so we render elapsed time (filling up
 	// toward the deadline) rather than remaining time. 254 s is the typical Zigbee
 	// permit-join window; clamp to [0, 100] in case remainingSeconds briefly exceeds it.
-	const elapsedSeconds = Math.max(0, 254 - props.permitJoin.remainingSeconds);
+	// Drives off the smoothed countdown so the bar advances visibly between polls.
+	const elapsedSeconds = Math.max(0, 254 - smoothRemainingSeconds.value);
 
 	return Math.min(100, Math.round((elapsedSeconds / 254) * 100));
 });

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue
@@ -1,0 +1,192 @@
+<template>
+	<div class="flex flex-col gap-3 h-full overflow-hidden">
+		<el-table
+			:data="rows"
+			class="h-full w-full flex-grow"
+			table-layout="fixed"
+		>
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.status')"
+				width="160"
+				sortable
+				:sort-method="sortByStatus"
+			>
+				<template #default="{ row }: { row: IResultRow }">
+					<el-tag :type="resultTagType(row.result.status)">
+						{{ t(`devicesZigbee2mqttPlugin.wizard.steps.results.${row.result.status}`) }}
+					</el-tag>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.name')"
+				min-width="200"
+				sortable
+				:sort-method="sortByName"
+			>
+				<template #default="{ row }: { row: IResultRow }">
+					<span class="font-medium">{{ row.result.name }}</span>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.friendlyName')"
+				min-width="180"
+				sortable
+				:sort-method="sortByFriendlyName"
+			>
+				<template #default="{ row }: { row: IResultRow }">
+					<code class="text-sm">{{ row.device?.friendlyName ?? row.result.ieeeAddress }}</code>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.manufacturer')"
+				min-width="180"
+				sortable
+				:sort-method="sortByManufacturer"
+			>
+				<template #default="{ row }: { row: IResultRow }">
+					<small
+						v-if="row.device && (row.device.manufacturer || row.device.model)"
+						class="text-gray-500"
+					>
+						{{ [row.device.manufacturer, row.device.model].filter(Boolean).join(' · ') }}
+					</small>
+					<small
+						v-else
+						class="text-gray-400"
+					>
+						&mdash;
+					</small>
+				</template>
+			</el-table-column>
+
+			<el-table-column
+				:label="t('devicesZigbee2mqttPlugin.wizard.columns.error')"
+				min-width="220"
+			>
+				<template #default="{ row }: { row: IResultRow }">
+					<span
+						v-if="row.result.error"
+						class="text-red-500"
+					>
+						{{ row.result.error }}
+					</span>
+					<span
+						v-else
+						class="text-gray-400"
+					>
+						&mdash;
+					</span>
+				</template>
+			</el-table-column>
+		</el-table>
+
+		<div class="flex justify-end gap-2 shrink-0">
+			<el-button @click="emit('restart')">
+				<template #icon>
+					<icon icon="mdi:plus" />
+				</template>
+				{{ t('devicesZigbee2mqttPlugin.wizard.steps.results.addMore') }}
+			</el-button>
+			<el-button
+				type="primary"
+				@click="emit('done')"
+			>
+				{{ t('devicesZigbee2mqttPlugin.wizard.steps.results.done') }}
+			</el-button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElTable, ElTableColumn, ElTag } from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import type { IZ2mWizardAdoptionResult, IZ2mWizardDevice } from '../schemas/wizard.types';
+
+defineOptions({
+	name: 'Zigbee2mqttWizardResultsStep',
+});
+
+interface IProps {
+	results: IZ2mWizardAdoptionResult[];
+	devices: IZ2mWizardDevice[];
+}
+
+const props = defineProps<IProps>();
+
+const emit = defineEmits<{
+	(e: 'done'): void;
+	(e: 'restart'): void;
+}>();
+
+const { t } = useI18n();
+
+interface IResultRow {
+	result: IZ2mWizardAdoptionResult;
+	device: IZ2mWizardDevice | null;
+}
+
+const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};
+
+// Pre-join each result with its source device so the table cells don't have to repeat the
+// O(n) lookup, and so sort comparators can index into the device fields cleanly.
+const rows = computed<IResultRow[]>(() =>
+	props.results.map((result) => ({
+		result,
+		device: props.devices.find((device) => device.ieeeAddress === result.ieeeAddress) ?? null,
+	}))
+);
+
+// Failures rise to the top so the user immediately sees which devices need attention; created
+// devices come next, then updates, finally falling back to alphabetical name within ties.
+const sortByStatus = (a: IResultRow, b: IResultRow): number => {
+	const order = (status: IZ2mWizardAdoptionResult['status']): number => {
+		if (status === 'failed') {
+			return 0;
+		}
+
+		if (status === 'created') {
+			return 1;
+		}
+
+		return 2;
+	};
+
+	const diff = order(a.result.status) - order(b.result.status);
+	return diff !== 0 ? diff : compareLocale(a.result.name, b.result.name);
+};
+
+const sortByName = (a: IResultRow, b: IResultRow): number => compareLocale(a.result.name, b.result.name);
+
+const sortByFriendlyName = (a: IResultRow, b: IResultRow): number =>
+	compareLocale(a.device?.friendlyName ?? a.result.ieeeAddress, b.device?.friendlyName ?? b.result.ieeeAddress);
+
+const sortByManufacturer = (a: IResultRow, b: IResultRow): number => {
+	const aLabel = [a.device?.manufacturer, a.device?.model].filter(Boolean).join(' ');
+	const bLabel = [b.device?.manufacturer, b.device?.model].filter(Boolean).join(' ');
+	return compareLocale(aLabel, bLabel);
+};
+
+const resultTagType = (status: IZ2mWizardAdoptionResult['status']): 'success' | 'info' | 'danger' => {
+	if (status === 'created') {
+		return 'success';
+	}
+
+	if (status === 'updated') {
+		return 'info';
+	}
+
+	return 'danger';
+};
+</script>

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue
@@ -109,6 +109,7 @@ import { ElButton, ElTable, ElTableColumn, ElTag } from 'element-plus';
 import { Icon } from '@iconify/vue';
 
 import type { IZ2mWizardAdoptionResult, IZ2mWizardDevice } from '../schemas/wizard.types';
+import { compareLocale } from '../utils/wizard.sort';
 
 defineOptions({
 	name: 'Zigbee2mqttWizardResultsStep',
@@ -132,12 +133,6 @@ interface IResultRow {
 	result: IZ2mWizardAdoptionResult;
 	device: IZ2mWizardDevice | null;
 }
-
-const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
-	const left = (a ?? '').toString();
-	const right = (b ?? '').toString();
-	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
-};
 
 // Pre-join each result with its source device so the table cells don't have to repeat the
 // O(n) lookup, and so sort comparators can index into the device fields cleanly.

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/composables.ts
@@ -2,6 +2,7 @@ export * from './useDeviceAddForm';
 export * from './useDeviceAddFormMultiStep';
 export * from './useDeviceAdoption';
 export * from './useDeviceEditForm';
+export * from './useDevicesWizard';
 export * from './useDiscoveredDevices';
 export * from './useDiscoveredDevicesOptions';
 export * from './useFriendlyNameHumanizer';

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/composables.ts
@@ -4,6 +4,7 @@ export * from './useDeviceAdoption';
 export * from './useDeviceEditForm';
 export * from './useDiscoveredDevices';
 export * from './useDiscoveredDevicesOptions';
+export * from './useFriendlyNameHumanizer';
 export * from './useMappingPreview';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX } from '../devices-zigbee2mqtt.constants';
+import type { ApiWizardSession } from '../utils/wizard.transformers';
+
+import { useDevicesWizard } from './useDevicesWizard';
+
+const backendClient = {
+	GET: vi.fn(),
+	POST: vi.fn(),
+	DELETE: vi.fn(),
+};
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual('@vueuse/core');
+
+	return {
+		...actual,
+		tryOnMounted: vi.fn(),
+		tryOnUnmounted: vi.fn(),
+	};
+});
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({ global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => {} } }),
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: () => ({
+			client: backendClient,
+		}),
+		useFlashMessage: () => ({
+			error: vi.fn(),
+			success: vi.fn(),
+		}),
+		useLogger: () => ({
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		}),
+	};
+});
+
+const baseDevice = {
+	ieeeAddress: '0x00158d0001a2b3c4',
+	friendlyName: 'kitchen_motion_sensor',
+	manufacturer: 'Aqara',
+	model: 'RTCGQ11LM',
+	description: 'Aqara human body sensor',
+	status: 'ready' as const,
+	categories: [DevicesModuleDeviceCategory.sensor],
+	suggestedCategory: DevicesModuleDeviceCategory.sensor,
+	previewChannelCount: 2,
+	previewChannelIdentifiers: ['occupancy', 'illuminance'],
+	registeredDeviceId: null,
+	registeredDeviceName: null,
+	registeredDeviceCategory: null,
+	error: null,
+	lastSeenAt: '2026-04-29T12:00:01.000Z',
+};
+
+const wizardSession: ApiWizardSession = {
+	id: 'session-1',
+	bridgeOnline: true,
+	startedAt: '2026-04-29T12:00:00.000Z',
+	permitJoin: {
+		active: false,
+		expiresAt: null,
+		remainingSeconds: 0,
+	},
+	devices: [baseDevice],
+};
+
+describe('useDevicesWizard', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('starts session and pre-fills humanized names plus suggested categories for ready devices', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startSession();
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard`);
+		expect(wizard.session.value?.id).toBe('session-1');
+		expect(wizard.bridgeOnline.value).toBe(true);
+		// Humanized name: snake_case -> Title Case.
+		expect(wizard.nameByIeee['0x00158d0001a2b3c4']).toBe('Kitchen Motion Sensor');
+		expect(wizard.categoryByIeee['0x00158d0001a2b3c4']).toBe(DevicesModuleDeviceCategory.sensor);
+		expect(wizard.selected['0x00158d0001a2b3c4']).toBe(true);
+		expect(wizard.canContinue.value).toBe(true);
+	});
+
+	it('deselects a previously ready device when polling reports it as already_registered', async () => {
+		const racedSession: ApiWizardSession = {
+			...wizardSession,
+			devices: [
+				{
+					...baseDevice,
+					status: 'already_registered',
+					registeredDeviceId: 'device-uuid-mid-session',
+					registeredDeviceName: 'Auto-adopted relay',
+					registeredDeviceCategory: DevicesModuleDeviceCategory.sensor,
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValue({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: racedSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startSession();
+		expect(wizard.selected['0x00158d0001a2b3c4']).toBe(true);
+
+		await wizard.refreshSession();
+
+		expect(wizard.selected['0x00158d0001a2b3c4']).toBe(false);
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
+	it('canContinue is false when any selected device has an empty name', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startSession();
+
+		expect(wizard.canContinue.value).toBe(true);
+
+		wizard.nameByIeee['0x00158d0001a2b3c4'] = '   ';
+
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
+	it('canContinue is false when any selected device has a null category', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startSession();
+
+		expect(wizard.canContinue.value).toBe(true);
+
+		wizard.categoryByIeee['0x00158d0001a2b3c4'] = null;
+
+		expect(wizard.canContinue.value).toBe(false);
+	});
+
+	it('adoptSelected POSTs the right body and returns the results array', async () => {
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+
+		const adoptionResponse = {
+			results: [
+				{
+					ieeeAddress: '0x00158d0001a2b3c4',
+					name: 'Kitchen Motion Sensor',
+					status: 'created',
+					error: null,
+				},
+			],
+		};
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: adoptionResponse },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+
+		await wizard.startSession();
+
+		const results = await wizard.adoptSelected();
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(`/plugins/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
+			params: {
+				path: {
+					id: 'session-1',
+				},
+			},
+			body: {
+				data: {
+					devices: [
+						{
+							ieeeAddress: '0x00158d0001a2b3c4',
+							name: 'Kitchen Motion Sensor',
+							category: DevicesModuleDeviceCategory.sensor,
+						},
+					],
+				},
+			},
+		});
+
+		expect(results).toEqual([
+			expect.objectContaining({
+				ieeeAddress: '0x00158d0001a2b3c4',
+				name: 'Kitchen Motion Sensor',
+				status: 'created',
+			}),
+		]);
+		expect(wizard.adoptionResults.value).toEqual(results);
+	});
+
+	it('enablePermitJoin POSTs and updates permitJoin from the response', async () => {
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+
+		const permitJoinSession: ApiWizardSession = {
+			...wizardSession,
+			permitJoin: {
+				active: true,
+				expiresAt: '2026-04-29T12:04:14.000Z',
+				remainingSeconds: 254,
+			},
+		};
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: permitJoinSession },
+			response: { status: 200 },
+		});
+
+		const wizard = useDevicesWizard();
+		await wizard.startSession();
+
+		expect(wizard.permitJoin.value.active).toBe(false);
+
+		await wizard.enablePermitJoin();
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(`/plugins/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}/permit-join`, {
+			params: {
+				path: {
+					id: 'session-1',
+				},
+			},
+		});
+		expect(wizard.permitJoin.value.active).toBe(true);
+		expect(wizard.permitJoin.value.remainingSeconds).toBe(254);
+	});
+
+	it('endSession DELETEs the session and clears reactive state', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: wizardSession },
+			response: { status: 200 },
+		});
+		backendClient.DELETE.mockResolvedValue({
+			data: undefined,
+			response: { status: 204 },
+		});
+
+		const wizard = useDevicesWizard();
+		await wizard.startSession();
+
+		expect(wizard.session.value).not.toBeNull();
+		expect(Object.keys(wizard.selected).length).toBe(1);
+
+		await wizard.endSession();
+
+		expect(backendClient.DELETE).toHaveBeenCalledWith(`/plugins/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}`, {
+			params: {
+				path: {
+					id: 'session-1',
+				},
+			},
+		});
+		expect(wizard.session.value).toBeNull();
+		expect(Object.keys(wizard.selected).length).toBe(0);
+		expect(Object.keys(wizard.nameByIeee).length).toBe(0);
+		expect(Object.keys(wizard.categoryByIeee).length).toBe(0);
+	});
+});

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts
@@ -57,7 +57,6 @@ const baseDevice = {
 	model: 'RTCGQ11LM',
 	description: 'Aqara human body sensor',
 	status: 'ready' as const,
-	categories: [DevicesModuleDeviceCategory.sensor],
 	suggestedCategory: DevicesModuleDeviceCategory.sensor,
 	previewChannelCount: 2,
 	previewChannelIdentifiers: ['occupancy', 'illuminance'],

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -1,0 +1,452 @@
+import { type ComputedRef, type Reactive, computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { orderBy } from 'natural-orderby';
+
+import { tryOnMounted, tryOnUnmounted } from '@vueuse/core';
+
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { getErrorReason, useBackend, useFlashMessage, useLogger } from '../../../common';
+import { FormResult, type FormResultType } from '../../../modules/devices';
+import {
+	DevicesModuleDeviceCategory,
+	type DevicesZigbee2mqttPluginAdoptWizardOperation,
+	type DevicesZigbee2mqttPluginCreateWizardOperation,
+	type DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation,
+	type DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation,
+	type DevicesZigbee2mqttPluginGetWizardOperation,
+} from '../../../openapi.constants';
+import { DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX } from '../devices-zigbee2mqtt.constants';
+import { DevicesZigbee2mqttApiException } from '../devices-zigbee2mqtt.exceptions';
+import type { IZ2mWizardAdoptionResult, IZ2mWizardDevice, IZ2mWizardSession } from '../schemas/wizard.types';
+import {
+	type ApiWizardAdoption,
+	type ApiWizardSession,
+	transformWizardAdoptRequest,
+	transformWizardAdoptionResponse,
+	transformWizardSessionResponse,
+} from '../utils/wizard.transformers';
+
+import { useFriendlyNameHumanizer } from './useFriendlyNameHumanizer';
+
+export const isAdoptableStatus = (status: IZ2mWizardDevice['status']): boolean =>
+	status === 'ready' || status === 'already_registered';
+
+export interface IUseDevicesWizard {
+	session: ComputedRef<IZ2mWizardSession | null>;
+	devices: ComputedRef<IZ2mWizardDevice[]>;
+	selectedDevices: ComputedRef<IZ2mWizardDevice[]>;
+	permitJoin: ComputedRef<IZ2mWizardSession['permitJoin']>;
+	bridgeOnline: ComputedRef<boolean>;
+	formResult: ComputedRef<FormResultType>;
+	selected: Reactive<Record<string, boolean>>;
+	categoryByIeee: Reactive<Record<string, DevicesModuleDeviceCategory | null>>;
+	nameByIeee: Reactive<Record<string, string>>;
+	adoptionResults: ComputedRef<IZ2mWizardAdoptionResult[]>;
+	canContinue: ComputedRef<boolean>;
+	startSession: () => Promise<void>;
+	refreshSession: () => Promise<void>;
+	endSession: () => Promise<void>;
+	enablePermitJoin: () => Promise<void>;
+	disablePermitJoin: () => Promise<void>;
+	adoptSelected: () => Promise<IZ2mWizardAdoptionResult[]>;
+	categoryOptions: (device: IZ2mWizardDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+}
+
+const DEFAULT_PERMIT_JOIN: IZ2mWizardSession['permitJoin'] = {
+	active: false,
+	expiresAt: null,
+	remainingSeconds: 0,
+};
+
+export const useDevicesWizard = (): IUseDevicesWizard => {
+	const { t } = useI18n();
+	const backend = useBackend();
+	const logger = useLogger();
+	const flashMessage = useFlashMessage();
+	const { humanize } = useFriendlyNameHumanizer();
+
+	const session = ref<IZ2mWizardSession | null>(null);
+	const formResult = ref<FormResultType>(FormResult.NONE);
+	const adoptionResults = ref<IZ2mWizardAdoptionResult[]>([]);
+	const selected = reactive<Record<string, boolean>>({});
+	const categoryByIeee = reactive<Record<string, DevicesModuleDeviceCategory | null>>({});
+	const nameByIeee = reactive<Record<string, string>>({});
+	const readyAddresses = new Set<string>();
+
+	let pollingTimer: number | null = null;
+
+	const devices = computed<IZ2mWizardDevice[]>(() =>
+		orderBy(
+			session.value?.devices ?? [],
+			[(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.ieeeAddress],
+			['asc', 'asc']
+		)
+	);
+
+	const selectedDevices = computed<IZ2mWizardDevice[]>(() =>
+		devices.value.filter((device) => selected[device.ieeeAddress] === true && isAdoptableStatus(device.status))
+	);
+
+	const canContinue = computed<boolean>(() => {
+		if (selectedDevices.value.length === 0) {
+			return false;
+		}
+
+		return selectedDevices.value.every((device) => {
+			const name = nameByIeee[device.ieeeAddress];
+			const category = categoryByIeee[device.ieeeAddress];
+
+			return typeof name === 'string' && name.trim().length > 0 && category !== null && category !== undefined;
+		});
+	});
+
+	const permitJoin = computed<IZ2mWizardSession['permitJoin']>(() => session.value?.permitJoin ?? DEFAULT_PERMIT_JOIN);
+
+	const bridgeOnline = computed<boolean>(() => session.value?.bridgeOnline ?? false);
+
+	const stopPolling = (): void => {
+		if (pollingTimer !== null) {
+			window.clearTimeout(pollingTimer);
+			pollingTimer = null;
+		}
+	};
+
+	const schedulePoll = (): void => {
+		stopPolling();
+
+		pollingTimer = window.setTimeout(async () => {
+			pollingTimer = null;
+
+			try {
+				await refreshSession();
+			} catch {
+				// Polling failures are non-fatal — keep trying so transient hiccups recover automatically.
+			} finally {
+				if (session.value !== null) {
+					schedulePoll();
+				}
+			}
+		}, 1_000);
+	};
+
+	const applySession = (nextSession: IZ2mWizardSession): void => {
+		const previousDevices = session.value?.devices ?? [];
+
+		session.value = nextSession;
+
+		for (const device of nextSession.devices) {
+			const previousDevice = previousDevices.find((item) => item.ieeeAddress === device.ieeeAddress);
+			const becameAlreadyRegistered =
+				previousDevice !== undefined && previousDevice.status !== 'already_registered' && device.status === 'already_registered';
+			const wasPreviouslyReady = readyAddresses.has(device.ieeeAddress);
+
+			// `ready` devices are pre-selected so the user can adopt new pairings in a single step.
+			// `already_registered` devices stay deselected — the user must opt in explicitly to override
+			// the category/name the main service auto-adopted them with.
+			if (selected[device.ieeeAddress] === undefined) {
+				selected[device.ieeeAddress] = device.status === 'ready';
+			} else if (becameAlreadyRegistered) {
+				selected[device.ieeeAddress] = false;
+			} else if (device.status === 'ready' && !wasPreviouslyReady && previousDevice === undefined) {
+				selected[device.ieeeAddress] = true;
+			}
+
+			// Pre-fill the category dropdown so the wizard never lands on an empty selector for
+			// already-adopted devices: prefer the existing DB category over the descriptor's
+			// suggestion.
+			const initialCategory = device.registeredDeviceCategory ?? device.suggestedCategory;
+
+			if (categoryByIeee[device.ieeeAddress] === undefined || (categoryByIeee[device.ieeeAddress] === null && initialCategory !== null)) {
+				categoryByIeee[device.ieeeAddress] = initialCategory;
+			}
+
+			// Pre-fill an editable name from the existing registration, otherwise humanize the
+			// zigbee2mqtt friendlyName so the user sees a sensible default instead of a slug.
+			if (nameByIeee[device.ieeeAddress] === undefined) {
+				nameByIeee[device.ieeeAddress] = device.registeredDeviceName ?? humanize(device.friendlyName);
+			}
+
+			if (device.status === 'ready') {
+				readyAddresses.add(device.ieeeAddress);
+			}
+		}
+	};
+
+	const resetSessionScopedState = (): void => {
+		for (const key of Object.keys(selected)) {
+			delete selected[key];
+		}
+		for (const key of Object.keys(categoryByIeee)) {
+			delete categoryByIeee[key];
+		}
+		for (const key of Object.keys(nameByIeee)) {
+			delete nameByIeee[key];
+		}
+		readyAddresses.clear();
+		adoptionResults.value = [];
+	};
+
+	const startSession = async (): Promise<void> => {
+		formResult.value = FormResult.WORKING;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard`);
+
+		if (typeof responseData !== 'undefined') {
+			resetSessionScopedState();
+			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
+			formResult.value = FormResult.OK;
+			schedulePoll();
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesZigbee2mqttPluginCreateWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
+			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+		logger.error('Failed to start z2m wizard session');
+
+		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
+	};
+
+	const refreshSession = async (): Promise<void> => {
+		if (session.value === null) {
+			return;
+		}
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.GET(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesZigbee2mqttPluginGetWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
+			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+
+		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
+	};
+
+	const endSession = async (): Promise<void> => {
+		stopPolling();
+
+		const currentSession = session.value;
+
+		if (currentSession === null) {
+			resetSessionScopedState();
+
+			return;
+		}
+
+		try {
+			await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}`, {
+				params: {
+					path: {
+						id: currentSession.id,
+					},
+				},
+			});
+		} catch (error: unknown) {
+			logger.warn('Failed to cleanly end z2m wizard session', error);
+		} finally {
+			session.value = null;
+			resetSessionScopedState();
+		}
+	};
+
+	const enablePermitJoin = async (): Promise<void> => {
+		if (session.value === null) {
+			return;
+		}
+
+		formResult.value = FormResult.WORKING;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}/permit-join`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
+			formResult.value = FormResult.OK;
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
+			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
+	};
+
+	const disablePermitJoin = async (): Promise<void> => {
+		if (session.value === null) {
+			return;
+		}
+
+		formResult.value = FormResult.WORKING;
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}/permit-join`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+		});
+
+		if (typeof responseData !== 'undefined') {
+			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
+			formResult.value = FormResult.OK;
+
+			return;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
+			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
+	};
+
+	const adoptSelected = async (): Promise<IZ2mWizardAdoptionResult[]> => {
+		if (session.value === null) {
+			return [];
+		}
+
+		formResult.value = FormResult.WORKING;
+
+		const userSelections = selectedDevices.value.slice();
+
+		const adoptDevices = userSelections.map((device) => ({
+			ieeeAddress: device.ieeeAddress,
+			name: (nameByIeee[device.ieeeAddress] || humanize(device.friendlyName) || device.ieeeAddress).trim(),
+			category: (categoryByIeee[device.ieeeAddress] ?? DevicesModuleDeviceCategory.generic) as DevicesModuleDeviceCategory,
+		}));
+
+		const {
+			data: responseData,
+			error,
+			response,
+		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
+			params: {
+				path: {
+					id: session.value.id,
+				},
+			},
+			body: transformWizardAdoptRequest(adoptDevices) as never,
+		});
+
+		if (typeof responseData !== 'undefined') {
+			const results = transformWizardAdoptionResponse((responseData as { data: ApiWizardAdoption }).data);
+
+			adoptionResults.value = results;
+			formResult.value = results.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
+
+			return results;
+		}
+
+		const errorReason = error
+			? getErrorReason<DevicesZigbee2mqttPluginAdoptWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
+			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(errorReason);
+
+		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
+	};
+
+	const categoryOptions = (device: IZ2mWizardDevice): { value: DevicesModuleDeviceCategory; label: string }[] => {
+		const categorySet = new Set<DevicesModuleDeviceCategory>(device.categories);
+
+		// Always include the device's existing registered category, even if the descriptor no
+		// longer reports it — otherwise the dropdown would render an empty value for an existing
+		// device and silently lose the user's previous choice on save.
+		if (device.registeredDeviceCategory !== null) {
+			categorySet.add(device.registeredDeviceCategory);
+		}
+
+		// When a descriptor exposes no categories at all, fall back to the full enum so the user
+		// can still pick something for a generic device.
+		const candidates: DevicesModuleDeviceCategory[] =
+			categorySet.size > 0 ? Array.from(categorySet) : (Object.values(DevicesModuleDeviceCategory) as DevicesModuleDeviceCategory[]);
+
+		return orderBy(candidates, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map((value) => ({
+			value,
+			label: t(`devicesModule.categories.devices.${value}`),
+		}));
+	};
+
+	tryOnMounted(() => {
+		startSession().catch(() => {
+			// The error is already surfaced via flashMessage / formResult.
+		});
+	});
+
+	tryOnUnmounted(() => {
+		stopPolling();
+
+		if (session.value !== null) {
+			endSession().catch(() => {
+				// Best-effort cleanup — backend will time the session out anyway.
+			});
+		}
+	});
+
+	return {
+		session: computed(() => session.value),
+		devices,
+		selectedDevices,
+		permitJoin,
+		bridgeOnline,
+		formResult: computed(() => formResult.value),
+		selected,
+		categoryByIeee,
+		nameByIeee,
+		adoptionResults: computed(() => adoptionResults.value),
+		canContinue,
+		startSession,
+		refreshSession,
+		endSession,
+		enablePermitJoin,
+		disablePermitJoin,
+		adoptSelected,
+		categoryOptions,
+	};
+};

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -320,6 +320,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		}
 
 		formResult.value = FormResult.WORKING;
+		const requestGeneration = sessionGeneration;
 
 		const {
 			data: responseData,
@@ -332,6 +333,12 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				},
 			},
 		});
+
+		// Drop the response if endSession (or onRestart) ran during the await — otherwise
+		// applySession would resurrect the deleted session and trigger a 404 polling loop.
+		if (sessionGeneration !== requestGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
@@ -356,6 +363,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		}
 
 		formResult.value = FormResult.WORKING;
+		const requestGeneration = sessionGeneration;
 
 		const {
 			data: responseData,
@@ -368,6 +376,12 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				},
 			},
 		});
+
+		// Drop the response if endSession (or onRestart) ran during the await — otherwise
+		// applySession would resurrect the deleted session and trigger a 404 polling loop.
+		if (sessionGeneration !== requestGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -51,7 +51,7 @@ export interface IUseDevicesWizard {
 	enablePermitJoin: () => Promise<void>;
 	disablePermitJoin: () => Promise<void>;
 	adoptSelected: () => Promise<IZ2mWizardAdoptionResult[]>;
-	categoryOptions: (device: IZ2mWizardDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+	categoryOptions: () => { value: DevicesModuleDeviceCategory; label: string }[];
 }
 
 const DEFAULT_PERMIT_JOIN: IZ2mWizardSession['permitJoin'] = {
@@ -447,22 +447,15 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
 	};
 
-	const categoryOptions = (device: IZ2mWizardDevice): { value: DevicesModuleDeviceCategory; label: string }[] => {
-		const categorySet = new Set<DevicesModuleDeviceCategory>(device.categories);
-
-		// Always include the device's existing registered category, even if the descriptor no
-		// longer reports it — otherwise the dropdown would render an empty value for an existing
-		// device and silently lose the user's previous choice on save.
-		if (device.registeredDeviceCategory !== null) {
-			categorySet.add(device.registeredDeviceCategory);
-		}
-
-		// When a descriptor exposes no categories at all, fall back to the full enum so the user
-		// can still pick something for a generic device.
-		const candidates: DevicesModuleDeviceCategory[] =
-			categorySet.size > 0 ? Array.from(categorySet) : (Object.values(DevicesModuleDeviceCategory) as DevicesModuleDeviceCategory[]);
-
-		return orderBy(candidates, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map((value) => ({
+	const categoryOptions = (): { value: DevicesModuleDeviceCategory; label: string }[] => {
+		// The wizard always lets users pick any DeviceCategory — `suggestedCategory` and
+		// `registeredDeviceCategory` are pre-fill defaults, not constraints. Render the
+		// full enum sorted by translated label for stable, predictable ordering.
+		return orderBy(
+			Object.values(DevicesModuleDeviceCategory) as DevicesModuleDeviceCategory[],
+			[(category: string) => t(`devicesModule.categories.devices.${category}`)],
+			['asc']
+		).map((value) => ({
 			value,
 			label: t(`devicesModule.categories.devices.${value}`),
 		}));

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -12,6 +12,7 @@ import {
 	DevicesModuleDeviceCategory,
 	type DevicesZigbee2mqttPluginAdoptWizardOperation,
 	type DevicesZigbee2mqttPluginCreateWizardOperation,
+	type DevicesZigbee2mqttPluginDeleteWizardOperation,
 	type DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation,
 	type DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation,
 	type DevicesZigbee2mqttPluginGetWizardOperation,
@@ -290,13 +291,21 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		}
 
 		try {
-			await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}`, {
+			const { error } = await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard/{id}`, {
 				params: {
 					path: {
 						id: currentSession.id,
 					},
 				},
 			});
+
+			if (error) {
+				// Best-effort cleanup — DELETE failures are logged but don't surface to the user,
+				// who has already moved on. The typed reason gives a clearer log line than the
+				// raw API envelope.
+				const reason = getErrorReason<DevicesZigbee2mqttPluginDeleteWizardOperation>(error, 'Failed to cleanly end z2m wizard session');
+				logger.warn(reason);
+			}
 		} catch (error: unknown) {
 			logger.warn('Failed to cleanly end z2m wizard session', error);
 		} finally {

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -76,6 +76,13 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 	let pollingTimer: number | null = null;
 
+	// Generation counter — incremented on every session boundary (start / end). Polling
+	// captures the generation at schedule time; if the generation changed by the time the
+	// awaited refresh resolves, the response is dropped instead of resurrecting the session.
+	// This prevents an in-flight `refreshSession` started before `endSession` from writing
+	// back to `session.value` after deletion and looping on 404s.
+	let sessionGeneration = 0;
+
 	const devices = computed<IZ2mWizardDevice[]>(() =>
 		orderBy(
 			session.value?.devices ?? [],
@@ -115,6 +122,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	const schedulePoll = (): void => {
 		stopPolling();
 
+		const scheduledGeneration = sessionGeneration;
+
 		pollingTimer = window.setTimeout(async () => {
 			pollingTimer = null;
 
@@ -123,7 +132,10 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			} catch {
 				// Polling failures are non-fatal — keep trying so transient hiccups recover automatically.
 			} finally {
-				if (session.value !== null) {
+				// If endSession or startSession ran during the awaited refresh, the generation
+				// has bumped and rescheduling here would either resurrect a deleted session or
+				// race with the new one. Bail out and let the new session manage its own polls.
+				if (sessionGeneration === scheduledGeneration && session.value !== null) {
 					schedulePoll();
 				}
 			}
@@ -189,12 +201,20 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 	const startSession = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
+		sessionGeneration += 1;
+		const startGeneration = sessionGeneration;
 
 		const {
 			data: responseData,
 			error,
 			response,
 		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard`);
+
+		// If endSession (or another startSession) raced ahead while POST was in-flight,
+		// drop this response so we don't resurrect a session the caller has already torn down.
+		if (sessionGeneration !== startGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			resetSessionScopedState();
@@ -221,6 +241,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return;
 		}
 
+		const refreshGeneration = sessionGeneration;
+
 		const {
 			data: responseData,
 			error,
@@ -232,6 +254,13 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 				},
 			},
 		});
+
+		// Discard the response if endSession ran during the await — otherwise applySession
+		// would write the stale snapshot back into session.value, resurrecting a deleted
+		// session and triggering a 404 loop the next time polling fires.
+		if (sessionGeneration !== refreshGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			applySession(transformWizardSessionResponse((responseData as { data: ApiWizardSession }).data));
@@ -247,6 +276,9 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	};
 
 	const endSession = async (): Promise<void> => {
+		// Bump the generation BEFORE awaiting anything so any in-flight refreshSession
+		// (or its scheduling tail) sees the change and bails out instead of writing back.
+		sessionGeneration += 1;
 		stopPolling();
 
 		const currentSession = session.value;

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.spec.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { useFriendlyNameHumanizer } from './useFriendlyNameHumanizer';
+
+describe('useFriendlyNameHumanizer', () => {
+	const { humanize } = useFriendlyNameHumanizer();
+
+	it('humanizes snake_case', () => {
+		expect(humanize('living_room_lamp')).toBe('Living Room Lamp');
+	});
+
+	it('humanizes kebab-case', () => {
+		expect(humanize('kitchen-light-1')).toBe('Kitchen Light 1');
+	});
+
+	it('humanizes camelCase', () => {
+		expect(humanize('frontDoorSensor')).toBe('Front Door Sensor');
+	});
+
+	it('humanizes single word', () => {
+		expect(humanize('thermostat')).toBe('Thermostat');
+	});
+
+	it('preserves trailing numbers as separate tokens', () => {
+		expect(humanize('sensor_3')).toBe('Sensor 3');
+	});
+
+	it('handles already-humanized names', () => {
+		expect(humanize('Living Room Lamp')).toBe('Living Room Lamp');
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(humanize('')).toBe('');
+	});
+});

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.ts
@@ -1,0 +1,28 @@
+export interface IUseFriendlyNameHumanizer {
+	humanize: (input: string) => string;
+}
+
+export const useFriendlyNameHumanizer = (): IUseFriendlyNameHumanizer => {
+	const humanize = (input: string): string => {
+		if (!input) return '';
+
+		return (
+			input
+				// camelCase boundary: insert space before each uppercase letter
+				.replace(/([a-z])([A-Z])/g, '$1 $2')
+				// letter→digit boundary: "sensor3" → "sensor 3"
+				.replace(/([a-zA-Z])(\d)/g, '$1 $2')
+				// delimiters
+				.replace(/[_-]+/g, ' ')
+				// collapse whitespace
+				.replace(/\s+/g, ' ')
+				.trim()
+				// Title-case each word
+				.split(' ')
+				.map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1).toLowerCase() : ''))
+				.join(' ')
+		);
+	};
+
+	return { humanize };
+};

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
@@ -15,7 +15,12 @@ import {
 	type IDevicePluginsSchemas,
 } from '../../modules/devices';
 
-import { Zigbee2mqttConfigForm, Zigbee2mqttDeviceAddFormMultiStep, Zigbee2mqttDeviceEditForm } from './components/components';
+import {
+	Zigbee2mqttConfigForm,
+	Zigbee2mqttDeviceAddFormMultiStep,
+	Zigbee2mqttDeviceEditForm,
+	Zigbee2mqttDevicesWizard,
+} from './components/components';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from './devices-zigbee2mqtt.constants';
 import { locales } from './locales';
 import { Zigbee2mqttConfigEditFormSchema } from './schemas/config.schemas';
@@ -84,6 +89,7 @@ export default {
 					components: {
 						deviceAddForm: Zigbee2mqttDeviceAddFormMultiStep,
 						deviceEditForm: Zigbee2mqttDeviceEditForm,
+						deviceWizard: Zigbee2mqttDevicesWizard,
 					},
 					schemas: {
 						deviceSchema: Zigbee2mqttDeviceSchema,

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/cs-CZ.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Adoptovat zařízení",
 		"refresh": "Obnovit",
 		"use": "Použít"
+	},
+	"wizard": {
+		"title": "Přidat zařízení Zigbee",
+		"subtitle": "Objevte a hromadně přidejte vaše Zigbee zařízení",
+		"bridge": {
+			"offline": {
+				"title": "Bridge offline",
+				"message": "Zigbee2MQTT bridge je momentálně offline. Pro pokračování nakonfigurujte připojení.",
+				"openConfig": "Otevřít konfiguraci"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Vyhledávání",
+				"permitJoin": "Spárovat nové zařízení",
+				"cancelPairing": "Zrušit párování",
+				"pairingActive": "Režim párování aktivní — zbývá {remaining}s",
+				"pairingDisabled": "Režim párování deaktivován",
+				"autoPickAll": "Vybrat vše",
+				"clearSelection": "Zrušit výběr",
+				"empty": "Nebyla objevena žádná Zigbee zařízení. Klepněte na \"Spárovat nové zařízení\" pro přepnutí bridge do režimu párování."
+			},
+			"categorize": {
+				"title": "Kategorizace",
+				"willCreate": "Bude vytvořeno",
+				"willUpdate": "Bude aktualizováno",
+				"channels": "{count} kanál | {count} kanály | {count} kanálů"
+			},
+			"results": {
+				"title": "Výsledky",
+				"created": "Vytvořeno",
+				"updated": "Aktualizováno",
+				"failed": "Selhalo",
+				"done": "Hotovo",
+				"addMore": "Přidat další"
+			}
+		},
+		"columns": {
+			"name": "Název",
+			"friendlyName": "Přátelské jméno",
+			"manufacturer": "Výrobce",
+			"model": "Model",
+			"status": "Stav",
+			"category": "Kategorie",
+			"channels": "Kanály",
+			"error": "Chyba"
+		},
+		"status": {
+			"ready": "Připraveno",
+			"unsupported": "Nepodporováno",
+			"alreadyRegistered": "Již přidáno",
+			"failed": "Selhalo"
+		},
+		"actions": {
+			"next": "Další",
+			"back": "Zpět",
+			"adopt": "Přidat vybrané",
+			"cancel": "Zrušit"
+		},
+		"validation": {
+			"nameRequired": "Název je povinný",
+			"categoryRequired": "Kategorie je povinná"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/de-DE.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Gerät übernehmen",
 		"refresh": "Aktualisieren",
 		"use": "Verwenden"
+	},
+	"wizard": {
+		"title": "Zigbee-Geräte übernehmen",
+		"subtitle": "Entdecken und übernehmen Sie Ihre Zigbee-Geräte in großen Mengen",
+		"bridge": {
+			"offline": {
+				"title": "Bridge offline",
+				"message": "Die Zigbee2MQTT-Bridge ist derzeit offline. Konfigurieren Sie die Verbindung, um fortzufahren.",
+				"openConfig": "Konfiguration öffnen"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Suche",
+				"permitJoin": "Neues Gerät koppeln",
+				"cancelPairing": "Kopplung abbrechen",
+				"pairingActive": "Kopplungsmodus aktiv — {remaining}s verbleibend",
+				"pairingDisabled": "Kopplungsmodus deaktiviert",
+				"autoPickAll": "Alle auswählen",
+				"clearSelection": "Auswahl aufheben",
+				"empty": "Keine Zigbee-Geräte gefunden. Klicken Sie auf \"Neues Gerät koppeln\", um die Bridge in den Kopplungsmodus zu versetzen."
+			},
+			"categorize": {
+				"title": "Kategorisieren",
+				"willCreate": "Wird erstellt",
+				"willUpdate": "Wird aktualisiert",
+				"channels": "{count} Kanal | {count} Kanäle"
+			},
+			"results": {
+				"title": "Ergebnisse",
+				"created": "Erstellt",
+				"updated": "Aktualisiert",
+				"failed": "Fehlgeschlagen",
+				"done": "Fertig",
+				"addMore": "Mehr hinzufügen"
+			}
+		},
+		"columns": {
+			"name": "Name",
+			"friendlyName": "Anzeigename",
+			"manufacturer": "Hersteller",
+			"model": "Modell",
+			"status": "Status",
+			"category": "Kategorie",
+			"channels": "Kanäle",
+			"error": "Fehler"
+		},
+		"status": {
+			"ready": "Bereit",
+			"unsupported": "Nicht unterstützt",
+			"alreadyRegistered": "Bereits übernommen",
+			"failed": "Fehlgeschlagen"
+		},
+		"actions": {
+			"next": "Weiter",
+			"back": "Zurück",
+			"adopt": "Ausgewählte übernehmen",
+			"cancel": "Abbrechen"
+		},
+		"validation": {
+			"nameRequired": "Name ist erforderlich",
+			"categoryRequired": "Kategorie ist erforderlich"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/en-US.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Adopt device",
 		"refresh": "Refresh",
 		"use": "Use"
+	},
+	"wizard": {
+		"title": "Adopt Zigbee devices",
+		"subtitle": "Discover and adopt your Zigbee devices in bulk",
+		"bridge": {
+			"offline": {
+				"title": "Bridge offline",
+				"message": "The Zigbee2MQTT bridge is currently offline. Configure the connection to continue.",
+				"openConfig": "Open configuration"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Discovery",
+				"permitJoin": "Pair new device",
+				"cancelPairing": "Cancel pairing",
+				"pairingActive": "Pairing mode active — {remaining}s remaining",
+				"pairingDisabled": "Pairing mode disabled",
+				"autoPickAll": "Select all",
+				"clearSelection": "Clear selection",
+				"empty": "No Zigbee devices discovered. Click \"Pair new device\" to put the bridge into pairing mode."
+			},
+			"categorize": {
+				"title": "Categorize",
+				"willCreate": "Will create",
+				"willUpdate": "Will update",
+				"channels": "{count} channel | {count} channels"
+			},
+			"results": {
+				"title": "Results",
+				"created": "Created",
+				"updated": "Updated",
+				"failed": "Failed",
+				"done": "Done",
+				"addMore": "Add more"
+			}
+		},
+		"columns": {
+			"name": "Name",
+			"friendlyName": "Friendly name",
+			"manufacturer": "Manufacturer",
+			"model": "Model",
+			"status": "Status",
+			"category": "Category",
+			"channels": "Channels",
+			"error": "Error"
+		},
+		"status": {
+			"ready": "Ready",
+			"unsupported": "Unsupported",
+			"alreadyRegistered": "Already adopted",
+			"failed": "Failed"
+		},
+		"actions": {
+			"next": "Next",
+			"back": "Back",
+			"adopt": "Adopt selected",
+			"cancel": "Cancel"
+		},
+		"validation": {
+			"nameRequired": "Name is required",
+			"categoryRequired": "Category is required"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/es-ES.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Adoptar dispositivo",
 		"refresh": "Actualizar",
 		"use": "Usar"
+	},
+	"wizard": {
+		"title": "Adoptar dispositivos Zigbee",
+		"subtitle": "Descubra y adopte sus dispositivos Zigbee en bloque",
+		"bridge": {
+			"offline": {
+				"title": "Bridge sin conexión",
+				"message": "El bridge de Zigbee2MQTT está actualmente sin conexión. Configure la conexión para continuar.",
+				"openConfig": "Abrir configuración"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Descubrimiento",
+				"permitJoin": "Emparejar nuevo dispositivo",
+				"cancelPairing": "Cancelar emparejamiento",
+				"pairingActive": "Modo de emparejamiento activo — {remaining}s restantes",
+				"pairingDisabled": "Modo de emparejamiento desactivado",
+				"autoPickAll": "Seleccionar todo",
+				"clearSelection": "Borrar selección",
+				"empty": "No se han descubierto dispositivos Zigbee. Haga clic en \"Emparejar nuevo dispositivo\" para poner el bridge en modo de emparejamiento."
+			},
+			"categorize": {
+				"title": "Categorizar",
+				"willCreate": "Se creará",
+				"willUpdate": "Se actualizará",
+				"channels": "{count} canal | {count} canales"
+			},
+			"results": {
+				"title": "Resultados",
+				"created": "Creado",
+				"updated": "Actualizado",
+				"failed": "Fallido",
+				"done": "Hecho",
+				"addMore": "Agregar más"
+			}
+		},
+		"columns": {
+			"name": "Nombre",
+			"friendlyName": "Nombre amigable",
+			"manufacturer": "Fabricante",
+			"model": "Modelo",
+			"status": "Estado",
+			"category": "Categoría",
+			"channels": "Canales",
+			"error": "Error"
+		},
+		"status": {
+			"ready": "Listo",
+			"unsupported": "No compatible",
+			"alreadyRegistered": "Ya adoptado",
+			"failed": "Fallido"
+		},
+		"actions": {
+			"next": "Siguiente",
+			"back": "Atrás",
+			"adopt": "Adoptar seleccionados",
+			"cancel": "Cancelar"
+		},
+		"validation": {
+			"nameRequired": "El nombre es obligatorio",
+			"categoryRequired": "La categoría es obligatoria"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/pl-PL.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Adoptuj urządzenie",
 		"refresh": "Odśwież",
 		"use": "Użyj"
+	},
+	"wizard": {
+		"title": "Adoptuj urządzenia Zigbee",
+		"subtitle": "Odkryj i adoptuj swoje urządzenia Zigbee zbiorczo",
+		"bridge": {
+			"offline": {
+				"title": "Bridge offline",
+				"message": "Bridge Zigbee2MQTT jest obecnie offline. Skonfiguruj połączenie, aby kontynuować.",
+				"openConfig": "Otwórz konfigurację"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Wykrywanie",
+				"permitJoin": "Sparuj nowe urządzenie",
+				"cancelPairing": "Anuluj parowanie",
+				"pairingActive": "Tryb parowania aktywny — pozostało {remaining}s",
+				"pairingDisabled": "Tryb parowania wyłączony",
+				"autoPickAll": "Zaznacz wszystkie",
+				"clearSelection": "Wyczyść wybór",
+				"empty": "Nie wykryto żadnych urządzeń Zigbee. Kliknij \"Sparuj nowe urządzenie\", aby przełączyć bridge w tryb parowania."
+			},
+			"categorize": {
+				"title": "Kategoryzuj",
+				"willCreate": "Zostanie utworzone",
+				"willUpdate": "Zostanie zaktualizowane",
+				"channels": "{count} kanał | {count} kanały | {count} kanałów"
+			},
+			"results": {
+				"title": "Wyniki",
+				"created": "Utworzono",
+				"updated": "Zaktualizowano",
+				"failed": "Nie powiodło się",
+				"done": "Gotowe",
+				"addMore": "Dodaj więcej"
+			}
+		},
+		"columns": {
+			"name": "Nazwa",
+			"friendlyName": "Przyjazna nazwa",
+			"manufacturer": "Producent",
+			"model": "Model",
+			"status": "Status",
+			"category": "Kategoria",
+			"channels": "Kanały",
+			"error": "Błąd"
+		},
+		"status": {
+			"ready": "Gotowe",
+			"unsupported": "Nieobsługiwane",
+			"alreadyRegistered": "Już adoptowane",
+			"failed": "Nie powiodło się"
+		},
+		"actions": {
+			"next": "Dalej",
+			"back": "Wstecz",
+			"adopt": "Adoptuj wybrane",
+			"cancel": "Anuluj"
+		},
+		"validation": {
+			"nameRequired": "Nazwa jest wymagana",
+			"categoryRequired": "Kategoria jest wymagana"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/sk-SK.json
@@ -297,5 +297,68 @@
 		"adoptDevice": "Prijať zariadenie",
 		"refresh": "Obnoviť",
 		"use": "Použiť"
+	},
+	"wizard": {
+		"title": "Pridať zariadenia Zigbee",
+		"subtitle": "Objavte a hromadne pridajte vaše Zigbee zariadenia",
+		"bridge": {
+			"offline": {
+				"title": "Bridge offline",
+				"message": "Zigbee2MQTT bridge je momentálne offline. Pre pokračovanie nakonfigurujte pripojenie.",
+				"openConfig": "Otvoriť konfiguráciu"
+			}
+		},
+		"steps": {
+			"discovery": {
+				"title": "Vyhľadávanie",
+				"permitJoin": "Spárovať nové zariadenie",
+				"cancelPairing": "Zrušiť párovanie",
+				"pairingActive": "Režim párovania aktívny — zostáva {remaining}s",
+				"pairingDisabled": "Režim párovania deaktivovaný",
+				"autoPickAll": "Vybrať všetko",
+				"clearSelection": "Zrušiť výber",
+				"empty": "Neboli objavené žiadne Zigbee zariadenia. Kliknite na \"Spárovať nové zariadenie\" pre prepnutie bridge do režimu párovania."
+			},
+			"categorize": {
+				"title": "Kategorizácia",
+				"willCreate": "Bude vytvorené",
+				"willUpdate": "Bude aktualizované",
+				"channels": "{count} kanál | {count} kanály | {count} kanálov"
+			},
+			"results": {
+				"title": "Výsledky",
+				"created": "Vytvorené",
+				"updated": "Aktualizované",
+				"failed": "Zlyhalo",
+				"done": "Hotovo",
+				"addMore": "Pridať ďalšie"
+			}
+		},
+		"columns": {
+			"name": "Názov",
+			"friendlyName": "Priateľské meno",
+			"manufacturer": "Výrobca",
+			"model": "Model",
+			"status": "Stav",
+			"category": "Kategória",
+			"channels": "Kanály",
+			"error": "Chyba"
+		},
+		"status": {
+			"ready": "Pripravené",
+			"unsupported": "Nepodporované",
+			"alreadyRegistered": "Už pridané",
+			"failed": "Zlyhalo"
+		},
+		"actions": {
+			"next": "Ďalej",
+			"back": "Späť",
+			"adopt": "Pridať vybrané",
+			"cancel": "Zrušiť"
+		},
+		"validation": {
+			"nameRequired": "Názov je povinný",
+			"categoryRequired": "Kategória je povinná"
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/schemas.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/schemas.ts
@@ -1,3 +1,4 @@
 export * from './config.schemas';
 export * from './devices.schemas';
 export * from './types';
+export * from './wizard.types';

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/wizard.types.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/wizard.types.ts
@@ -1,0 +1,48 @@
+import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+
+export type IZ2mWizardDeviceStatus = 'ready' | 'unsupported' | 'already_registered' | 'failed';
+
+export interface IZ2mWizardPermitJoin {
+	active: boolean;
+	expiresAt: string | null;
+	remainingSeconds: number;
+}
+
+export interface IZ2mWizardDevice {
+	ieeeAddress: string;
+	friendlyName: string;
+	manufacturer: string | null;
+	model: string | null;
+	description: string | null;
+	status: IZ2mWizardDeviceStatus;
+	categories: DevicesModuleDeviceCategory[];
+	suggestedCategory: DevicesModuleDeviceCategory | null;
+	previewChannelCount: number;
+	previewChannelIdentifiers: string[];
+	registeredDeviceId: string | null;
+	registeredDeviceName: string | null;
+	registeredDeviceCategory: DevicesModuleDeviceCategory | null;
+	error: string | null;
+	lastSeenAt: string;
+}
+
+export interface IZ2mWizardSession {
+	id: string;
+	bridgeOnline: boolean;
+	startedAt: string;
+	permitJoin: IZ2mWizardPermitJoin;
+	devices: IZ2mWizardDevice[];
+}
+
+export interface IZ2mWizardAdoptionResult {
+	ieeeAddress: string;
+	name: string;
+	status: 'created' | 'updated' | 'failed';
+	error: string | null;
+}
+
+export interface IZ2mWizardAdoptDevice {
+	ieeeAddress: string;
+	name: string;
+	category: DevicesModuleDeviceCategory;
+}

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/wizard.types.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/wizard.types.ts
@@ -15,7 +15,6 @@ export interface IZ2mWizardDevice {
 	model: string | null;
 	description: string | null;
 	status: IZ2mWizardDeviceStatus;
-	categories: DevicesModuleDeviceCategory[];
 	suggestedCategory: DevicesModuleDeviceCategory | null;
 	previewChannelCount: number;
 	previewChannelIdentifiers: string[];

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.sort.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.sort.ts
@@ -1,0 +1,10 @@
+/**
+ * Locale-aware comparator used by the wizard step tables. Treats null/undefined as empty
+ * strings, sorts numbers naturally (so `device 2` sorts before `device 10`), and ignores
+ * case differences.
+ */
+export const compareLocale = (a: string | null | undefined, b: string | null | undefined): number => {
+	const left = (a ?? '').toString();
+	const right = (b ?? '').toString();
+	return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+};

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.transformers.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.transformers.ts
@@ -24,7 +24,6 @@ interface ApiWizardDevice {
 	model?: string | null;
 	description?: string | null;
 	status: string;
-	categories?: string[];
 	suggestedCategory?: string | null;
 	previewChannelCount: number;
 	previewChannelIdentifiers?: string[];
@@ -65,7 +64,6 @@ const transformWizardDevice = (device: ApiWizardDevice): IZ2mWizardDevice => ({
 	model: device.model ?? null,
 	description: device.description ?? null,
 	status: device.status as IZ2mWizardDeviceStatus,
-	categories: (device.categories ?? []) as DevicesModuleDeviceCategory[],
 	suggestedCategory: (device.suggestedCategory ?? null) as DevicesModuleDeviceCategory | null,
 	previewChannelCount: device.previewChannelCount,
 	previewChannelIdentifiers: device.previewChannelIdentifiers ?? [],

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.transformers.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/utils/wizard.transformers.ts
@@ -1,0 +1,123 @@
+import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import type {
+	IZ2mWizardAdoptDevice,
+	IZ2mWizardAdoptionResult,
+	IZ2mWizardDevice,
+	IZ2mWizardDeviceStatus,
+	IZ2mWizardSession,
+} from '../schemas/wizard.types';
+
+// ============================================================================
+// API Response Shapes
+// ============================================================================
+
+interface ApiWizardPermitJoin {
+	active: boolean;
+	expiresAt?: string | null;
+	remainingSeconds: number;
+}
+
+interface ApiWizardDevice {
+	ieeeAddress: string;
+	friendlyName: string;
+	manufacturer?: string | null;
+	model?: string | null;
+	description?: string | null;
+	status: string;
+	categories?: string[];
+	suggestedCategory?: string | null;
+	previewChannelCount: number;
+	previewChannelIdentifiers?: string[];
+	registeredDeviceId?: string | null;
+	registeredDeviceName?: string | null;
+	registeredDeviceCategory?: string | null;
+	error?: string | null;
+	lastSeenAt: string;
+}
+
+export interface ApiWizardSession {
+	id: string;
+	bridgeOnline: boolean;
+	startedAt: string;
+	permitJoin: ApiWizardPermitJoin;
+	devices: ApiWizardDevice[];
+}
+
+interface ApiWizardAdoptionResult {
+	ieeeAddress: string;
+	name: string;
+	status: string;
+	error?: string | null;
+}
+
+export interface ApiWizardAdoption {
+	results: ApiWizardAdoptionResult[];
+}
+
+// ============================================================================
+// Response Transformers
+// ============================================================================
+
+const transformWizardDevice = (device: ApiWizardDevice): IZ2mWizardDevice => ({
+	ieeeAddress: device.ieeeAddress,
+	friendlyName: device.friendlyName,
+	manufacturer: device.manufacturer ?? null,
+	model: device.model ?? null,
+	description: device.description ?? null,
+	status: device.status as IZ2mWizardDeviceStatus,
+	categories: (device.categories ?? []) as DevicesModuleDeviceCategory[],
+	suggestedCategory: (device.suggestedCategory ?? null) as DevicesModuleDeviceCategory | null,
+	previewChannelCount: device.previewChannelCount,
+	previewChannelIdentifiers: device.previewChannelIdentifiers ?? [],
+	registeredDeviceId: device.registeredDeviceId ?? null,
+	registeredDeviceName: device.registeredDeviceName ?? null,
+	registeredDeviceCategory: (device.registeredDeviceCategory ?? null) as DevicesModuleDeviceCategory | null,
+	error: device.error ?? null,
+	lastSeenAt: device.lastSeenAt,
+});
+
+export const transformWizardSessionResponse = (raw: ApiWizardSession): IZ2mWizardSession => ({
+	id: raw.id,
+	bridgeOnline: raw.bridgeOnline,
+	startedAt: raw.startedAt,
+	permitJoin: {
+		active: raw.permitJoin.active,
+		expiresAt: raw.permitJoin.expiresAt ?? null,
+		remainingSeconds: raw.permitJoin.remainingSeconds,
+	},
+	devices: raw.devices.map(transformWizardDevice),
+});
+
+export const transformWizardAdoptionResponse = (raw: ApiWizardAdoption): IZ2mWizardAdoptionResult[] =>
+	raw.results.map((result) => ({
+		ieeeAddress: result.ieeeAddress,
+		name: result.name,
+		status: result.status as IZ2mWizardAdoptionResult['status'],
+		error: result.error ?? null,
+	}));
+
+// ============================================================================
+// Request Transformers
+// ============================================================================
+
+interface ApiWizardAdoptRequestData {
+	devices: Array<{
+		ieeeAddress: string;
+		name: string;
+		category: string;
+	}>;
+}
+
+export interface ApiWizardAdoptRequest {
+	data: ApiWizardAdoptRequestData;
+}
+
+export const transformWizardAdoptRequest = (devices: IZ2mWizardAdoptDevice[]): ApiWizardAdoptRequest => ({
+	data: {
+		devices: devices.map((device) => ({
+			ieeeAddress: device.ieeeAddress,
+			name: device.name,
+			category: device.category,
+		})),
+	},
+});

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
@@ -101,4 +101,13 @@ describe('Zigbee2mqttWizardController', () => {
 		expect(res.data.results).toHaveLength(1);
 		expect(res.data.results[0]?.status).toBe('created');
 	});
+
+	it('POST /wizard/:id/adopt throws 404 when service returns null (unknown session)', async () => {
+		wizardService.adopt.mockResolvedValueOnce(null);
+		await expect(
+			controller.adopt('nope', {
+				data: { devices: [{ ieeeAddress: 'x', name: 'X', category: 'lighting' as any }] },
+			} as any)
+		).rejects.toBeInstanceOf(NotFoundException);
+	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
@@ -107,7 +107,7 @@ describe('Zigbee2mqttWizardController', () => {
 		await expect(
 			controller.adopt('nope', {
 				data: { devices: [{ ieeeAddress: 'x', name: 'X', category: 'lighting' as any }] },
-			} as any)
+			} as any),
 		).rejects.toBeInstanceOf(NotFoundException);
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
@@ -1,0 +1,104 @@
+/*
+eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method,
+@typescript-eslint/no-unsafe-argument
+*/
+/*
+Reason: The mocking and test setup requires dynamic assignment and
+handling of Jest mocks, which ESLint rules flag unnecessarily.
+*/
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Z2mWizardService } from '../services/wizard.service';
+
+import { Zigbee2mqttWizardController } from './zigbee2mqtt-wizard.controller';
+
+describe('Zigbee2mqttWizardController', () => {
+	let controller: Zigbee2mqttWizardController;
+	let wizardService: jest.Mocked<Z2mWizardService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [Zigbee2mqttWizardController],
+			providers: [
+				{
+					provide: Z2mWizardService,
+					useValue: {
+						start: jest.fn(),
+						get: jest.fn(),
+						end: jest.fn(),
+						enablePermitJoin: jest.fn(),
+						disablePermitJoin: jest.fn(),
+						adopt: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+		controller = module.get(Zigbee2mqttWizardController);
+		wizardService = module.get(Z2mWizardService);
+	});
+
+	it('POST /wizard returns the new session', async () => {
+		const session = {
+			id: 'a',
+			bridgeOnline: true,
+			startedAt: 't',
+			permitJoin: { active: false, expiresAt: null, remainingSeconds: 0 },
+			devices: [],
+		};
+		wizardService.start.mockResolvedValueOnce(session as any);
+		const res = await controller.startSession();
+		expect(res.data).toEqual(session);
+	});
+
+	it('GET /wizard/:id throws 404 for unknown id', () => {
+		wizardService.get.mockReturnValue(null);
+		expect(() => controller.getSession('nope')).toThrow(NotFoundException);
+	});
+
+	it('DELETE /wizard/:id calls service.end()', async () => {
+		wizardService.end.mockResolvedValueOnce(undefined);
+		await controller.endSession('a');
+		expect(wizardService.end).toHaveBeenCalledWith('a');
+	});
+
+	it('POST /wizard/:id/permit-join returns updated session', async () => {
+		const updated = {
+			id: 'a',
+			bridgeOnline: true,
+			startedAt: 't',
+			permitJoin: { active: true, expiresAt: 'x', remainingSeconds: 254 },
+			devices: [],
+		};
+		wizardService.enablePermitJoin.mockResolvedValueOnce(updated as any);
+		const res = await controller.enablePermitJoin('a');
+		expect(res.data).toEqual(updated);
+	});
+
+	it('POST /wizard/:id/permit-join throws 404 when service returns null', async () => {
+		wizardService.enablePermitJoin.mockResolvedValueOnce(null);
+		await expect(controller.enablePermitJoin('nope')).rejects.toBeInstanceOf(NotFoundException);
+	});
+
+	it('DELETE /wizard/:id/permit-join returns updated session', async () => {
+		const updated = {
+			id: 'a',
+			bridgeOnline: true,
+			startedAt: 't',
+			permitJoin: { active: false, expiresAt: null, remainingSeconds: 0 },
+			devices: [],
+		};
+		wizardService.disablePermitJoin.mockResolvedValueOnce(updated as any);
+		const res = await controller.disablePermitJoin('a');
+		expect(res.data).toEqual(updated);
+	});
+
+	it('POST /wizard/:id/adopt returns adoption results', async () => {
+		wizardService.adopt.mockResolvedValueOnce([{ ieeeAddress: 'x', name: 'X', status: 'created', error: null }]);
+		const res = await controller.adopt('a', {
+			data: { devices: [{ ieeeAddress: 'x', name: 'X', category: 'lighting' as any }] },
+		} as any);
+		expect(res.data.results).toHaveLength(1);
+		expect(res.data.results[0]?.status).toBe('created');
+	});
+});

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
@@ -148,6 +148,10 @@ export class Zigbee2mqttWizardController {
 
 		const results = await this.wizardService.adopt(id, body.data.devices);
 
+		if (results === null) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
 		const response = new Z2mWizardAdoptionResponseModel();
 		response.data = { results } as never;
 		return response;

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
@@ -1,0 +1,153 @@
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import {
+	ApiBadRequestResponse,
+	ApiCreatedSuccessResponse,
+	ApiInternalServerErrorResponse,
+	ApiNotFoundResponse,
+	ApiSuccessResponse,
+} from '../../../modules/swagger/decorators/api-documentation.decorator';
+import { DEVICES_ZIGBEE2MQTT_API_TAG_NAME, DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+import { ReqZ2mWizardAdoptDto } from '../dto/wizard-adopt.dto';
+import { Z2mWizardAdoptionResponseModel, Z2mWizardSessionResponseModel } from '../models/zigbee2mqtt-response.model';
+import { Z2mWizardService } from '../services/wizard.service';
+
+@ApiTags(DEVICES_ZIGBEE2MQTT_API_TAG_NAME)
+@Controller('wizard')
+export class Zigbee2mqttWizardController {
+	private readonly logger: ExtensionLoggerService = createExtensionLogger(
+		DEVICES_ZIGBEE2MQTT_PLUGIN_NAME,
+		'WizardController',
+	);
+
+	constructor(private readonly wizardService: Z2mWizardService) {}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'Start Zigbee2MQTT adoption wizard session',
+		description:
+			'Creates a wizard session, returning the list of currently unadopted Zigbee devices with mapping previews.',
+		operationId: 'create-devices-zigbee2mqtt-plugin-wizard',
+	})
+	@ApiCreatedSuccessResponse(Z2mWizardSessionResponseModel, 'Wizard session was started successfully')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post()
+	async startSession(): Promise<Z2mWizardSessionResponseModel> {
+		this.logger.debug('Starting Zigbee2MQTT wizard session');
+
+		const response = new Z2mWizardSessionResponseModel();
+		response.data = await this.wizardService.start();
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'Get Zigbee2MQTT wizard session state',
+		description:
+			'Returns the current state of the wizard session, including any newly-paired devices that arrived since the last poll and remaining permit_join time.',
+		operationId: 'get-devices-zigbee2mqtt-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Wizard session was successfully retrieved.')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Get(':id')
+	getSession(@Param('id') id: string): Z2mWizardSessionResponseModel {
+		const session = this.wizardService.get(id);
+
+		if (!session) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
+		const response = new Z2mWizardSessionResponseModel();
+		response.data = session;
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'End Zigbee2MQTT wizard session',
+		description: 'Terminates the wizard session. If permit_join is active for this session it is disabled.',
+		operationId: 'delete-devices-zigbee2mqtt-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Delete(':id')
+	async endSession(@Param('id') id: string): Promise<void> {
+		this.logger.debug(`Ending Zigbee2MQTT wizard session id=${id}`);
+
+		await this.wizardService.end(id);
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'Enable Zigbee2MQTT pairing mode (permit_join)',
+		description: 'Enables permit_join on the bridge for 254 seconds, scoped to this wizard session.',
+		operationId: 'enable-devices-zigbee2mqtt-plugin-wizard-permit-join',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Pairing mode enabled')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post(':id/permit-join')
+	async enablePermitJoin(@Param('id') id: string): Promise<Z2mWizardSessionResponseModel> {
+		const session = await this.wizardService.enablePermitJoin(id);
+
+		if (!session) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
+		const response = new Z2mWizardSessionResponseModel();
+		response.data = session;
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'Disable Zigbee2MQTT pairing mode (permit_join)',
+		description: 'Disables permit_join on the bridge.',
+		operationId: 'disable-devices-zigbee2mqtt-plugin-wizard-permit-join',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Pairing mode disabled')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Delete(':id/permit-join')
+	async disablePermitJoin(@Param('id') id: string): Promise<Z2mWizardSessionResponseModel> {
+		const session = await this.wizardService.disablePermitJoin(id);
+
+		if (!session) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
+		const response = new Z2mWizardSessionResponseModel();
+		response.data = session;
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+		summary: 'Adopt selected devices from wizard',
+		description:
+			'Adopts each requested device with the supplied display name and category. Devices already adopted in another flow are updated instead of created.',
+		operationId: 'adopt-devices-zigbee2mqtt-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiBody({ type: ReqZ2mWizardAdoptDto })
+	@ApiSuccessResponse(Z2mWizardAdoptionResponseModel, 'Adoption results returned')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post(':id/adopt')
+	async adopt(@Param('id') id: string, @Body() body: ReqZ2mWizardAdoptDto): Promise<Z2mWizardAdoptionResponseModel> {
+		this.logger.debug(`Adopting Zigbee2MQTT wizard devices session=${id} count=${body.data.devices.length}`);
+
+		const results = await this.wizardService.adopt(id, body.data.devices);
+
+		const response = new Z2mWizardAdoptionResponseModel();
+		response.data = { results } as never;
+		return response;
+	}
+}

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Post } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, HttpCode, NotFoundException, Param, Post } from '@nestjs/common';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
 import {
@@ -73,8 +73,10 @@ export class Zigbee2mqttWizardController {
 		operationId: 'delete-devices-zigbee2mqtt-plugin-wizard',
 	})
 	@ApiParam({ name: 'id', type: 'string' })
+	@ApiNoContentResponse({ description: 'Wizard session ended' })
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Delete(':id')
+	@HttpCode(204)
 	async endSession(@Param('id') id: string): Promise<void> {
 		this.logger.debug(`Ending Zigbee2MQTT wizard session id=${id}`);
 

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.openapi.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.openapi.ts
@@ -21,6 +21,7 @@ import {
 	Zigbee2mqttUpdatePluginConfigDto,
 } from './dto/update-config.dto';
 import { UpdateZigbee2mqttDeviceDto } from './dto/update-device.dto';
+import { ReqZ2mWizardAdoptDto, Z2mWizardAdoptDeviceDto, Z2mWizardAdoptDto } from './dto/wizard-adopt.dto';
 import {
 	Zigbee2mqttChannelEntity,
 	Zigbee2mqttChannelPropertyEntity,
@@ -34,6 +35,13 @@ import {
 	Zigbee2mqttConfigModel,
 } from './models/config.model';
 import {
+	Z2mWizardAdoptionModel,
+	Z2mWizardAdoptionResultModel,
+	Z2mWizardDeviceSnapshotModel,
+	Z2mWizardPermitJoinModel,
+	Z2mWizardSessionModel,
+} from './models/wizard.model';
+import {
 	Z2mDeviceInfoModel,
 	Z2mExposeInfoModel,
 	Z2mExposeMappingPreviewModel,
@@ -43,6 +51,8 @@ import {
 	Z2mPropertyMappingPreviewModel,
 	Z2mSuggestedChannelModel,
 	Z2mSuggestedDeviceModel,
+	Z2mWizardAdoptionResponseModel,
+	Z2mWizardSessionResponseModel,
 	Zigbee2mqttDiscoveredDeviceModel,
 	Zigbee2mqttDiscoveredDeviceResponseModel,
 	Zigbee2mqttDiscoveredDevicesResponseModel,
@@ -67,6 +77,10 @@ export const DEVICES_ZIGBEE2MQTT_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	AdoptDeviceRequestDto,
 	AdoptChannelDefinitionDto,
 	AdoptPropertyDefinitionDto,
+	// Wizard DTOs
+	Z2mWizardAdoptDeviceDto,
+	Z2mWizardAdoptDto,
+	ReqZ2mWizardAdoptDto,
 	// Config models
 	Zigbee2mqttConfigModel,
 	Z2mMqttConfigModel,
@@ -86,6 +100,14 @@ export const DEVICES_ZIGBEE2MQTT_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	Z2mSuggestedChannelModel,
 	Z2mPropertyMappingPreviewModel,
 	Z2mMappingWarningModel,
+	// Wizard models
+	Z2mWizardPermitJoinModel,
+	Z2mWizardDeviceSnapshotModel,
+	Z2mWizardSessionModel,
+	Z2mWizardAdoptionResultModel,
+	Z2mWizardAdoptionModel,
+	Z2mWizardSessionResponseModel,
+	Z2mWizardAdoptionResponseModel,
 	// Entities
 	Zigbee2mqttDeviceEntity,
 	Zigbee2mqttChannelEntity,

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
@@ -24,6 +24,7 @@ import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swa
 import { SwaggerModule } from '../../modules/swagger/swagger.module';
 
 import { Zigbee2mqttDiscoveredDevicesController } from './controllers/zigbee2mqtt-discovered-devices.controller';
+import { Zigbee2mqttWizardController } from './controllers/zigbee2mqtt-wizard.controller';
 import {
 	DEVICES_ZIGBEE2MQTT_API_TAG_DESCRIPTION,
 	DEVICES_ZIGBEE2MQTT_API_TAG_NAME,
@@ -54,6 +55,7 @@ import { Z2mExposesMapperService } from './services/exposes-mapper.service';
 import { Z2mMappingPreviewService } from './services/mapping-preview.service';
 import { Z2mMqttClientAdapterService } from './services/mqtt-client-adapter.service';
 import { Z2mVirtualPropertyService } from './services/virtual-property.service';
+import { Z2mWizardService } from './services/wizard.service';
 import { Z2mWsClientAdapterService } from './services/ws-client-adapter.service';
 import { Zigbee2mqttConfigValidatorService } from './services/zigbee2mqtt-config-validator.service';
 import { Zigbee2mqttService } from './services/zigbee2mqtt.service';
@@ -85,10 +87,11 @@ import { Zigbee2mqttService } from './services/zigbee2mqtt.service';
 		Z2mVirtualPropertyService,
 		Z2mMappingPreviewService,
 		Z2mDeviceAdoptionService,
+		Z2mWizardService,
 		Zigbee2mqttDevicePlatform,
 		Zigbee2mqttService,
 	],
-	controllers: [Zigbee2mqttDiscoveredDevicesController],
+	controllers: [Zigbee2mqttDiscoveredDevicesController, Zigbee2mqttWizardController],
 })
 export class DevicesZigbee2mqttPlugin {
 	constructor(

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/dto/wizard-adopt.dto.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/dto/wizard-adopt.dto.ts
@@ -1,0 +1,48 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsEnum, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdoptDevice' })
+export class Z2mWizardAdoptDeviceDto {
+	@ApiProperty({ description: 'Device IEEE address from the wizard session', example: '0x00158d0001a1b2c3' })
+	@Expose()
+	@IsString()
+	ieeeAddress: string;
+
+	@ApiProperty({ description: 'Display name override', example: 'Living Room Lamp' })
+	@Expose()
+	@IsString()
+	name: string;
+
+	@ApiProperty({ description: 'Target device category', enum: DeviceCategory, example: DeviceCategory.LIGHTING })
+	@Expose()
+	@IsEnum(DeviceCategory)
+	category: DeviceCategory;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdopt' })
+export class Z2mWizardAdoptDto {
+	@ApiProperty({
+		description: 'Devices to adopt with display name and category overrides',
+		type: 'array',
+		items: { $ref: getSchemaPath(Z2mWizardAdoptDeviceDto) },
+	})
+	@Expose()
+	@IsArray()
+	@ArrayNotEmpty()
+	@ValidateNested({ each: true })
+	@Type(() => Z2mWizardAdoptDeviceDto)
+	devices: Z2mWizardAdoptDeviceDto[];
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdoptWrap' })
+export class ReqZ2mWizardAdoptDto {
+	@ApiProperty({ description: 'Wizard adoption payload', type: () => Z2mWizardAdoptDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => Z2mWizardAdoptDto)
+	data: Z2mWizardAdoptDto;
+}

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
@@ -1,0 +1,218 @@
+import { Expose, Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardPermitJoin' })
+export class Z2mWizardPermitJoinModel {
+	@ApiProperty({ description: 'Whether bridge is currently in pairing mode', example: false })
+	@Expose()
+	@IsBoolean()
+	active: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Permit_join expiry timestamp',
+		nullable: true,
+		example: '2026-04-30T12:04:14.000Z',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	expiresAt: string | null;
+
+	@ApiProperty({ description: 'Remaining permit_join seconds (0 when inactive)', example: 0 })
+	@Expose()
+	@IsInt()
+	remainingSeconds: number;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardDevice' })
+export class Z2mWizardDeviceSnapshotModel {
+	@ApiProperty({ description: 'Device IEEE address (unique key)', example: '0x00158d0001a1b2c3' })
+	@Expose()
+	@IsString()
+	ieeeAddress: string;
+
+	@ApiProperty({ description: 'Z2M friendly name (raw, as configured in zigbee2mqtt)', example: 'living_room_lamp' })
+	@Expose()
+	@IsString()
+	friendlyName: string;
+
+	@ApiPropertyOptional({ description: 'Manufacturer (vendor)', nullable: true, example: 'Philips' })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	manufacturer: string | null;
+
+	@ApiPropertyOptional({ description: 'Model identifier', nullable: true, example: 'LCT001' })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	model: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Human-readable model description',
+		nullable: true,
+		example: 'Hue White and Color Ambiance E27',
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	description: string | null;
+
+	@ApiProperty({
+		description: 'Wizard candidate status',
+		enum: ['ready', 'unsupported', 'already_registered', 'failed'],
+		example: 'ready',
+	})
+	@Expose()
+	@IsIn(['ready', 'unsupported', 'already_registered', 'failed'])
+	status: string;
+
+	@ApiProperty({
+		description: 'Available target device categories',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(DeviceCategory) },
+		example: [DeviceCategory.LIGHTING],
+	})
+	@Expose()
+	@IsArray()
+	@IsString({ each: true })
+	categories: DeviceCategory[];
+
+	@ApiPropertyOptional({
+		description: 'Suggested target device category from descriptor',
+		nullable: true,
+		enum: DeviceCategory,
+		example: DeviceCategory.LIGHTING,
+	})
+	@Expose()
+	@IsString()
+	@IsOptional()
+	suggestedCategory: DeviceCategory | null;
+
+	@ApiProperty({ description: 'Channel count predicted by the mapping preview', example: 4 })
+	@Expose()
+	@IsInt()
+	previewChannelCount: number;
+
+	@ApiProperty({
+		description: 'Identifiers of channels that would be created (for tooltip)',
+		type: 'array',
+		items: { type: 'string' },
+		example: ['light', 'illuminance', 'battery'],
+	})
+	@Expose()
+	@IsArray()
+	@IsString({ each: true })
+	previewChannelIdentifiers: string[];
+
+	@ApiPropertyOptional({ description: 'Already registered device id', nullable: true, example: null })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceId: string | null;
+
+	@ApiPropertyOptional({ description: 'Already registered device name', nullable: true, example: null })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	registeredDeviceName: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Already registered device category',
+		nullable: true,
+		enum: DeviceCategory,
+		example: null,
+	})
+	@Expose()
+	@IsIn(Object.values(DeviceCategory))
+	@IsOptional()
+	registeredDeviceCategory: DeviceCategory | null;
+
+	@ApiPropertyOptional({ description: 'Last lookup error message', nullable: true, example: null })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	error: string | null;
+
+	@ApiProperty({ description: 'Last time this candidate was observed', example: '2026-04-30T12:00:00.000Z' })
+	@Expose()
+	@IsString()
+	lastSeenAt: string;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardSession' })
+export class Z2mWizardSessionModel {
+	@ApiProperty({ description: 'Wizard session id', example: 'c66808d8-0af1-4b93-bd61-4131cf62f20f' })
+	@Expose()
+	@IsString()
+	id: string;
+
+	@ApiProperty({ description: 'Whether bridge is currently online', example: true })
+	@Expose()
+	@IsBoolean()
+	bridgeOnline: boolean;
+
+	@ApiProperty({ description: 'Wizard session start timestamp', example: '2026-04-30T12:00:00.000Z' })
+	@Expose()
+	@IsString()
+	startedAt: string;
+
+	@ApiProperty({ description: 'Permit_join state', type: () => Z2mWizardPermitJoinModel })
+	@Expose()
+	@ValidateNested()
+	@Type(() => Z2mWizardPermitJoinModel)
+	permitJoin: Z2mWizardPermitJoinModel;
+
+	@ApiProperty({
+		description: 'Discovered Zigbee device candidates',
+		type: 'array',
+		items: { $ref: getSchemaPath(Z2mWizardDeviceSnapshotModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => Z2mWizardDeviceSnapshotModel)
+	devices: Z2mWizardDeviceSnapshotModel[];
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardAdoptionResult' })
+export class Z2mWizardAdoptionResultModel {
+	@ApiProperty({ description: 'Device IEEE address', example: '0x00158d0001a1b2c3' })
+	@Expose()
+	@IsString()
+	ieeeAddress: string;
+
+	@ApiProperty({ description: 'Resolved Smart Panel device name', example: 'Living Room Lamp' })
+	@Expose()
+	@IsString()
+	name: string;
+
+	@ApiProperty({ description: 'Adoption outcome', enum: ['created', 'updated', 'failed'], example: 'created' })
+	@Expose()
+	@IsIn(['created', 'updated', 'failed'])
+	status: string;
+
+	@ApiPropertyOptional({ description: 'Failure message', nullable: true, example: null })
+	@Expose()
+	@IsString()
+	@IsOptional()
+	error: string | null;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardAdoption' })
+export class Z2mWizardAdoptionModel {
+	@ApiProperty({
+		description: 'Per-device adoption results',
+		type: 'array',
+		items: { $ref: getSchemaPath(Z2mWizardAdoptionResultModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => Z2mWizardAdoptionResultModel)
+	results: Z2mWizardAdoptionResultModel[];
+}

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
@@ -71,17 +71,6 @@ export class Z2mWizardDeviceSnapshotModel {
 	@IsIn(['ready', 'unsupported', 'already_registered', 'failed'])
 	status: 'ready' | 'unsupported' | 'already_registered' | 'failed';
 
-	@ApiProperty({
-		description: 'Available target device categories',
-		type: 'array',
-		items: { type: 'string', enum: Object.values(DeviceCategory) },
-		example: [DeviceCategory.LIGHTING],
-	})
-	@Expose()
-	@IsArray()
-	@IsEnum(DeviceCategory, { each: true })
-	categories: DeviceCategory[];
-
 	@ApiPropertyOptional({
 		description: 'Suggested target device category from descriptor',
 		nullable: true,

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
@@ -69,7 +69,7 @@ export class Z2mWizardDeviceSnapshotModel {
 	})
 	@Expose()
 	@IsIn(['ready', 'unsupported', 'already_registered', 'failed'])
-	status: string;
+	status: 'ready' | 'unsupported' | 'already_registered' | 'failed';
 
 	@ApiProperty({
 		description: 'Available target device categories',
@@ -79,7 +79,7 @@ export class Z2mWizardDeviceSnapshotModel {
 	})
 	@Expose()
 	@IsArray()
-	@IsString({ each: true })
+	@IsEnum(DeviceCategory, { each: true })
 	categories: DeviceCategory[];
 
 	@ApiPropertyOptional({
@@ -89,7 +89,7 @@ export class Z2mWizardDeviceSnapshotModel {
 		example: DeviceCategory.LIGHTING,
 	})
 	@Expose()
-	@IsString()
+	@IsEnum(DeviceCategory)
 	@IsOptional()
 	suggestedCategory: DeviceCategory | null;
 
@@ -128,7 +128,7 @@ export class Z2mWizardDeviceSnapshotModel {
 		example: null,
 	})
 	@Expose()
-	@IsIn(Object.values(DeviceCategory))
+	@IsEnum(DeviceCategory)
 	@IsOptional()
 	registeredDeviceCategory: DeviceCategory | null;
 
@@ -194,7 +194,7 @@ export class Z2mWizardAdoptionResultModel {
 	@ApiProperty({ description: 'Adoption outcome', enum: ['created', 'updated', 'failed'], example: 'created' })
 	@Expose()
 	@IsIn(['created', 'updated', 'failed'])
-	status: string;
+	status: 'created' | 'updated' | 'failed';
 
 	@ApiPropertyOptional({ description: 'Failure message', nullable: true, example: null })
 	@Expose()

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts
@@ -125,7 +125,6 @@ export class Z2mWizardDeviceSnapshotModel {
 		description: 'Already registered device category',
 		nullable: true,
 		enum: DeviceCategory,
-		example: null,
 	})
 	@Expose()
 	@IsEnum(DeviceCategory)

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/zigbee2mqtt-response.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/zigbee2mqtt-response.model.ts
@@ -12,6 +12,8 @@ import {
 	PropertyCategory,
 } from '../../../modules/devices/devices.constants';
 
+import { Z2mWizardAdoptionModel, Z2mWizardSessionModel } from './wizard.model';
+
 // ============================================================================
 // Discovered Device Model
 // ============================================================================
@@ -639,4 +641,28 @@ export class Z2mMappingPreviewResponseModel extends BaseSuccessResponseModel<Z2m
 	})
 	@Expose()
 	declare data: Z2mMappingPreviewModel;
+}
+
+// ============================================================================
+// Wizard Response Models
+// ============================================================================
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginResWizardSession' })
+export class Z2mWizardSessionResponseModel extends BaseSuccessResponseModel<Z2mWizardSessionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => Z2mWizardSessionModel,
+	})
+	@Expose()
+	declare data: Z2mWizardSessionModel;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginResWizardAdoption' })
+export class Z2mWizardAdoptionResponseModel extends BaseSuccessResponseModel<Z2mWizardAdoptionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => Z2mWizardAdoptionModel,
+	})
+	@Expose()
+	declare data: Z2mWizardAdoptionModel;
 }

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/base-client-adapter.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/base-client-adapter.ts
@@ -129,6 +129,13 @@ export abstract class Z2mBaseClientAdapter {
 	 */
 	abstract requestState(friendlyName: string, properties?: string[]): Promise<boolean>;
 
+	/**
+	 * Toggle the bridge's permit_join state for a bounded number of seconds.
+	 * Returns true on successful publish/send, false otherwise.
+	 * Pass 0 to disable pairing immediately.
+	 */
+	abstract setPermitJoin(seconds: number): Promise<boolean>;
+
 	// =========================================================================
 	// Shared message handling logic
 	// =========================================================================

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/mqtt-client-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/mqtt-client-adapter.service.ts
@@ -171,6 +171,37 @@ export class Z2mMqttClientAdapterService extends Z2mBaseClientAdapter {
 	}
 
 	/**
+	 * Toggle the bridge's permit_join state for a bounded number of seconds.
+	 * Returns true on successful publish, false otherwise.
+	 * Pass 0 to disable pairing immediately.
+	 */
+	async setPermitJoin(seconds: number): Promise<boolean> {
+		if (!this.client?.connected) {
+			this.logger.warn('Cannot toggle permit_join: not connected to MQTT broker');
+			return false;
+		}
+
+		const topic = `${this.baseTopic}/bridge/request/permit_join`;
+		const value = seconds > 0;
+		const message = JSON.stringify({ value, time: seconds });
+
+		this.logger.debug(`Publishing permit_join to ${topic}: ${message}`);
+
+		return new Promise<boolean>((resolve) => {
+			this.client?.publish(topic, message, { qos: 1 }, (error) => {
+				if (error) {
+					this.logger.error(`Failed to publish permit_join to ${topic}`, {
+						message: error.message,
+					});
+					resolve(false);
+					return;
+				}
+				resolve(true);
+			});
+		});
+	}
+
+	/**
 	 * Request current state from a device
 	 */
 	async requestState(friendlyName: string, properties: string[] = []): Promise<boolean> {

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -1,3 +1,10 @@
+/*
+eslint-disable @typescript-eslint/unbound-method
+*/
+/*
+Reason: The mocking and test setup requires dynamic assignment and
+handling of Jest mocks, which ESLint rules flag unnecessarily.
+*/
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { DevicesService } from '../../../modules/devices/services/devices.service';
@@ -74,6 +81,7 @@ describe('Z2mWizardService', () => {
 		const started = await service.start();
 		await service.end(started.id);
 		expect(service.get(started.id)).toBeNull();
-		expect(zigbee2mqttService).toBeDefined();
+		// permit_join was never enabled in this session, so end() should NOT have called setPermitJoin
+		expect(zigbee2mqttService.setPermitJoin).not.toHaveBeenCalled();
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -162,4 +162,28 @@ describe('Z2mWizardService', () => {
 			expect(snapshot.devices[0]?.status).toBe('unsupported');
 		});
 	});
+
+	describe('permit_join', () => {
+		it('enablePermitJoin() sets active=true and remainingSeconds≈254', async () => {
+			const started = await service.start();
+			const updated = await service.enablePermitJoin(started.id);
+			expect(updated?.permitJoin.active).toBe(true);
+			expect(updated?.permitJoin.remainingSeconds).toBeGreaterThan(250);
+			expect(zigbee2mqttService.setPermitJoin).toHaveBeenCalledWith(254);
+		});
+
+		it('disablePermitJoin() sets active=false and remainingSeconds=0', async () => {
+			const started = await service.start();
+			await service.enablePermitJoin(started.id);
+			const updated = await service.disablePermitJoin(started.id);
+			expect(updated?.permitJoin.active).toBe(false);
+			expect(updated?.permitJoin.remainingSeconds).toBe(0);
+			expect(zigbee2mqttService.setPermitJoin).toHaveBeenLastCalledWith(0);
+		});
+
+		it('returns null for unknown session id', async () => {
+			expect(await service.enablePermitJoin('nope')).toBeNull();
+			expect(await service.disablePermitJoin('nope')).toBeNull();
+		});
+	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -196,6 +196,12 @@ describe('Z2mWizardService', () => {
 			expect(await service.enablePermitJoin('nope')).toBeNull();
 			expect(await service.disablePermitJoin('nope')).toBeNull();
 		});
+
+		it('throws when bridge fails to activate permit_join', async () => {
+			const started = await service.start();
+			zigbee2mqttService.setPermitJoin.mockResolvedValueOnce(false);
+			await expect(service.enablePermitJoin(started.id)).rejects.toThrow();
+		});
 	});
 
 	describe('adopt', () => {

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+
+import { Z2mDeviceAdoptionService } from './device-adoption.service';
+import { Z2mMappingPreviewService } from './mapping-preview.service';
+import { Z2mWizardService } from './wizard.service';
+import { Zigbee2mqttService } from './zigbee2mqtt.service';
+
+describe('Z2mWizardService', () => {
+	let service: Z2mWizardService;
+	let zigbee2mqttService: jest.Mocked<Zigbee2mqttService>;
+
+	beforeEach(async () => {
+		jest.useFakeTimers();
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				Z2mWizardService,
+				{
+					provide: Zigbee2mqttService,
+					useValue: {
+						isBridgeOnline: jest.fn().mockReturnValue(true),
+						getRegisteredDevices: jest.fn().mockReturnValue([]),
+						setPermitJoin: jest.fn().mockResolvedValue(true),
+						subscribeToDeviceJoined: jest.fn().mockReturnValue(() => {}),
+					},
+				},
+				{ provide: Z2mDeviceAdoptionService, useValue: { adoptDevice: jest.fn() } },
+				{
+					provide: Z2mMappingPreviewService,
+					useValue: {
+						generatePreview: jest.fn().mockResolvedValue({
+							suggestedCategory: 'LIGHTING',
+							channels: [{ identifier: 'light', name: 'Light', properties: [] }],
+							warnings: [],
+							readyToAdopt: true,
+							exposes: [],
+						}),
+					},
+				},
+				{ provide: DevicesService, useValue: { findAll: jest.fn().mockResolvedValue([]) } },
+			],
+		}).compile();
+
+		service = module.get(Z2mWizardService);
+		zigbee2mqttService = module.get(Zigbee2mqttService);
+	});
+
+	afterEach(async () => {
+		await service.onModuleDestroy();
+		jest.useRealTimers();
+	});
+
+	it('start() returns a session with bridgeOnline=true and an id', async () => {
+		const snapshot = await service.start();
+		expect(snapshot.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(snapshot.bridgeOnline).toBe(true);
+		expect(snapshot.permitJoin.active).toBe(false);
+		expect(snapshot.devices).toEqual([]);
+	});
+
+	it('get() returns null for unknown id', () => {
+		expect(service.get('does-not-exist')).toBeNull();
+	});
+
+	it('get() returns the same snapshot after start()', async () => {
+		const started = await service.start();
+		const fetched = service.get(started.id);
+		expect(fetched?.id).toBe(started.id);
+	});
+
+	it('end() removes the session and disables permit_join', async () => {
+		const started = await service.start();
+		await service.end(started.id);
+		expect(service.get(started.id)).toBeNull();
+		expect(zigbee2mqttService).toBeDefined();
+	});
+});

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -262,9 +262,9 @@ describe('Z2mWizardService', () => {
 			expect(out[0]?.error).toBe('boom');
 		});
 
-		it('returns empty array for unknown session id', async () => {
+		it('returns null for unknown session id (so the controller can 404)', async () => {
 			const out = await service.adopt('nope', []);
-			expect(out).toEqual([]);
+			expect(out).toBeNull();
 		});
 
 		it('returns failed when device not in session', async () => {
@@ -272,8 +272,8 @@ describe('Z2mWizardService', () => {
 			const out = await service.adopt(started.id, [
 				{ ieeeAddress: '0xnotinsession', name: 'X', category: 'lighting' as any },
 			]);
-			expect(out[0]?.status).toBe('failed');
-			expect(out[0]?.error).toContain('not in session');
+			expect(out?.[0]?.status).toBe('failed');
+			expect(out?.[0]?.error).toContain('not in session');
 		});
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -56,7 +56,18 @@ describe('Z2mWizardService', () => {
 									exposeType: 'light',
 									status: 'mapped',
 									suggestedChannel: { category: 'light', name: 'Light', confidence: 'high' },
-									suggestedProperties: [],
+									suggestedProperties: [
+										{
+											category: 'on',
+											name: 'On',
+											z2mProperty: 'state',
+											dataType: 'bool',
+											permissions: ['rw'],
+											format: null,
+											required: true,
+											currentValue: null,
+										},
+									],
 									missingRequiredProperties: [],
 								},
 							],
@@ -184,6 +195,79 @@ describe('Z2mWizardService', () => {
 		it('returns null for unknown session id', async () => {
 			expect(await service.enablePermitJoin('nope')).toBeNull();
 			expect(await service.disablePermitJoin('nope')).toBeNull();
+		});
+	});
+
+	describe('adopt', () => {
+		const ieee = '0x00158d0001a1b2c3';
+		const sampleZ2mDevice = {
+			ieeeAddress: ieee,
+			friendlyName: 'living_room_lamp',
+			type: 'Router',
+			modelId: 'LCT001',
+			supported: true,
+			available: true,
+			definition: { vendor: 'Philips', model: 'LCT001', description: 'Hue', exposes: [{ type: 'light' }] },
+		};
+
+		beforeEach(() => {
+			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+		});
+
+		it('returns created result on successful adoption', async () => {
+			const adoptionService = (service as any).deviceAdoptionService;
+			adoptionService.adoptDevice.mockResolvedValueOnce({ id: 'd1', name: 'Living Room Lamp' });
+			const started = await service.start();
+			const out = await service.adopt(started.id, [
+				{ ieeeAddress: ieee, name: 'Living Room Lamp', category: 'lighting' as any },
+			]);
+			expect(out).toEqual([{ ieeeAddress: ieee, name: 'Living Room Lamp', status: 'created', error: null }]);
+			expect(adoptionService.adoptDevice).toHaveBeenCalledWith(
+				expect.objectContaining({
+					ieeeAddress: ieee,
+					name: 'Living Room Lamp',
+					category: 'lighting',
+					channels: expect.arrayContaining([expect.objectContaining({ category: 'light' })]),
+				}),
+			);
+		});
+
+		it('returns updated result when device was already adopted (race fallback)', async () => {
+			const started = await service.start();
+			const session = (service as any).sessions.get(started.id);
+			session.devices.get(ieee).status = 'already_registered';
+			session.devices.get(ieee).registeredDeviceId = 'd1';
+			const devicesService = (service as any).devicesService;
+			devicesService.update = jest.fn().mockResolvedValue({ id: 'd1' });
+			const out = await service.adopt(started.id, [{ ieeeAddress: ieee, name: 'X', category: 'lighting' as any }]);
+			expect(out[0]?.status).toBe('updated');
+			expect(devicesService.update).toHaveBeenCalledWith(
+				'd1',
+				expect.objectContaining({ name: 'X', category: 'lighting' }),
+			);
+		});
+
+		it('returns failed result when adoption throws', async () => {
+			const adoptionService = (service as any).deviceAdoptionService;
+			adoptionService.adoptDevice.mockRejectedValueOnce(new Error('boom'));
+			const started = await service.start();
+			const out = await service.adopt(started.id, [{ ieeeAddress: ieee, name: 'X', category: 'lighting' as any }]);
+			expect(out[0]?.status).toBe('failed');
+			expect(out[0]?.error).toBe('boom');
+		});
+
+		it('returns empty array for unknown session id', async () => {
+			const out = await service.adopt('nope', []);
+			expect(out).toEqual([]);
+		});
+
+		it('returns failed when device not in session', async () => {
+			const started = await service.start();
+			const out = await service.adopt(started.id, [
+				{ ieeeAddress: '0xnotinsession', name: 'X', category: 'lighting' as any },
+			]);
+			expect(out[0]?.status).toBe('failed');
+			expect(out[0]?.error).toContain('not in session');
 		});
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -1,5 +1,9 @@
 /*
-eslint-disable @typescript-eslint/unbound-method
+eslint-disable @typescript-eslint/unbound-method,
+@typescript-eslint/no-unsafe-assignment,
+@typescript-eslint/no-unsafe-member-access,
+@typescript-eslint/no-unsafe-call,
+@typescript-eslint/no-unsafe-argument
 */
 /*
 Reason: The mocking and test setup requires dynamic assignment and
@@ -83,5 +87,57 @@ describe('Z2mWizardService', () => {
 		expect(service.get(started.id)).toBeNull();
 		// permit_join was never enabled in this session, so end() should NOT have called setPermitJoin
 		expect(zigbee2mqttService.setPermitJoin).not.toHaveBeenCalled();
+	});
+
+	describe('device snapshots', () => {
+		const sampleZ2mDevice = {
+			ieeeAddress: '0x00158d0001a1b2c3',
+			friendlyName: 'living_room_lamp',
+			type: 'Router',
+			modelId: 'LCT001',
+			powerSource: 'Mains',
+			supported: true,
+			available: true,
+			definition: {
+				vendor: 'Philips',
+				model: 'LCT001',
+				description: 'Hue White and Color Ambiance E27',
+				exposes: [{ type: 'light', name: 'light', features: [], property: undefined, label: undefined, access: 7 }],
+			},
+		};
+
+		it('marks ready when device has descriptor and is unadopted', async () => {
+			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+			const snapshot = await service.start();
+			expect(snapshot.devices).toHaveLength(1);
+			expect(snapshot.devices[0]?.status).toBe('ready');
+			expect(snapshot.devices[0]?.suggestedCategory).toBe('LIGHTING');
+			expect(snapshot.devices[0]?.previewChannelCount).toBe(1);
+		});
+
+		it('marks already_registered when device has matching adopted record', async () => {
+			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+			const findAll = (service as any).devicesService.findAll;
+			findAll.mockResolvedValueOnce([
+				{ id: 'adopted-1', identifier: 'living_room_lamp', name: 'Existing Lamp', category: 'LIGHTING' },
+			]);
+			const snapshot = await service.start();
+			expect(snapshot.devices[0]?.status).toBe('already_registered');
+			expect(snapshot.devices[0]?.registeredDeviceId).toBe('adopted-1');
+		});
+
+		it('marks unsupported when mapping preview returns no channels', async () => {
+			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+			const previewService = (service as any).mappingPreviewService;
+			previewService.generatePreview.mockResolvedValueOnce({
+				suggestedCategory: null,
+				channels: [],
+				warnings: [],
+				readyToAdopt: false,
+				exposes: [],
+			});
+			const snapshot = await service.start();
+			expect(snapshot.devices[0]?.status).toBe('unsupported');
+		});
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
@@ -42,11 +42,26 @@ describe('Z2mWizardService', () => {
 					provide: Z2mMappingPreviewService,
 					useValue: {
 						generatePreview: jest.fn().mockResolvedValue({
-							suggestedCategory: 'LIGHTING',
-							channels: [{ identifier: 'light', name: 'Light', properties: [] }],
+							z2mDevice: {
+								ieeeAddress: '0x00158d0001a1b2c3',
+								friendlyName: 'living_room_lamp',
+								manufacturer: 'Philips',
+								model: 'LCT001',
+								description: null,
+							},
+							suggestedDevice: { category: 'lighting', name: 'Light', confidence: 'high' },
+							exposes: [
+								{
+									exposeName: 'light',
+									exposeType: 'light',
+									status: 'mapped',
+									suggestedChannel: { category: 'light', name: 'Light', confidence: 'high' },
+									suggestedProperties: [],
+									missingRequiredProperties: [],
+								},
+							],
 							warnings: [],
 							readyToAdopt: true,
-							exposes: [],
 						}),
 					},
 				},
@@ -111,15 +126,16 @@ describe('Z2mWizardService', () => {
 			const snapshot = await service.start();
 			expect(snapshot.devices).toHaveLength(1);
 			expect(snapshot.devices[0]?.status).toBe('ready');
-			expect(snapshot.devices[0]?.suggestedCategory).toBe('LIGHTING');
+			expect(snapshot.devices[0]?.suggestedCategory).toBe('lighting');
 			expect(snapshot.devices[0]?.previewChannelCount).toBe(1);
+			expect(snapshot.devices[0]?.previewChannelIdentifiers).toContain('light');
 		});
 
 		it('marks already_registered when device has matching adopted record', async () => {
 			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
 			const findAll = (service as any).devicesService.findAll;
 			findAll.mockResolvedValueOnce([
-				{ id: 'adopted-1', identifier: 'living_room_lamp', name: 'Existing Lamp', category: 'LIGHTING' },
+				{ id: 'adopted-1', identifier: 'living_room_lamp', name: 'Existing Lamp', category: 'lighting' },
 			]);
 			const snapshot = await service.start();
 			expect(snapshot.devices[0]?.status).toBe('already_registered');
@@ -130,11 +146,17 @@ describe('Z2mWizardService', () => {
 			zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
 			const previewService = (service as any).mappingPreviewService;
 			previewService.generatePreview.mockResolvedValueOnce({
-				suggestedCategory: null,
-				channels: [],
+				z2mDevice: {
+					ieeeAddress: '0x00158d0001a1b2c3',
+					friendlyName: 'living_room_lamp',
+					manufacturer: null,
+					model: null,
+					description: null,
+				},
+				suggestedDevice: { category: 'generic', name: 'Generic', confidence: 'low' },
+				exposes: [],
 				warnings: [],
 				readyToAdopt: false,
-				exposes: [],
 			});
 			const snapshot = await service.start();
 			expect(snapshot.devices[0]?.status).toBe('unsupported');

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -6,6 +6,7 @@ import { ExtensionLoggerService, createExtensionLogger } from '../../../common/l
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
+import { Zigbee2mqttBridgeOfflineException } from '../devices-zigbee2mqtt.exceptions';
 import { AdoptChannelDefinitionDto, AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
 import { Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
@@ -151,7 +152,9 @@ export class Z2mWizardService implements OnModuleDestroy {
 		if (!ok) {
 			this.logger.warn('Failed to enable permit_join', { session: id });
 
-			return this.toSnapshot(session);
+			// Surface the failure so the frontend can show an error instead of silently
+			// rendering a "still off" snapshot (which the user reads as "click had no effect").
+			throw new Zigbee2mqttBridgeOfflineException();
 		}
 
 		if (session.permitJoin.timer) {

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -6,6 +6,7 @@ import { ExtensionLoggerService, createExtensionLogger } from '../../../common/l
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
+import { AdoptChannelDefinitionDto, AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
 import { Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
 import { Z2mMappingPreviewModel } from '../models/zigbee2mqtt-response.model';
@@ -15,6 +16,13 @@ import { Z2mMappingPreviewService } from './mapping-preview.service';
 import { Zigbee2mqttService } from './zigbee2mqtt.service';
 
 export type Z2mWizardDeviceStatus = 'ready' | 'unsupported' | 'already_registered' | 'failed';
+
+export interface Z2mWizardAdoptionResult {
+	ieeeAddress: string;
+	name: string;
+	status: 'created' | 'updated' | 'failed';
+	error: string | null;
+}
 
 export interface Z2mWizardDeviceSnapshot {
 	ieeeAddress: string;
@@ -312,5 +320,157 @@ export class Z2mWizardService implements OnModuleDestroy {
 		};
 	}
 
-	// adopt — implemented in Task 8
+	async adopt(
+		id: string,
+		requests: { ieeeAddress: string; name: string; category: DeviceCategory }[],
+	): Promise<Z2mWizardAdoptionResult[]> {
+		const session = this.sessions.get(id);
+		if (!session) return [];
+		this.refreshIdleTimer(session);
+
+		// Refresh-before-adopt: rebuild snapshots so we see current registered status.
+		const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+		for (const z2mDevice of this.zigbee2mqttService.getRegisteredDevices()) {
+			const refreshed = await this.computeSnapshot(z2mDevice, adopted);
+			const existing = session.devices.get(refreshed.ieeeAddress);
+			// Preserve already_registered status set by a previous successful adopt() call
+			// in this session, even if the underlying findAll didn't pick the record up
+			// for some reason. The race-fallback path needs the registeredDeviceId.
+			if (existing?.status === 'already_registered' && existing.registeredDeviceId) {
+				session.devices.set(refreshed.ieeeAddress, {
+					...refreshed,
+					status: 'already_registered',
+					registeredDeviceId: existing.registeredDeviceId,
+					registeredDeviceName: existing.registeredDeviceName,
+					registeredDeviceCategory: existing.registeredDeviceCategory,
+				});
+			} else {
+				session.devices.set(refreshed.ieeeAddress, refreshed);
+			}
+		}
+
+		const results: Z2mWizardAdoptionResult[] = [];
+
+		for (const req of requests) {
+			const current = session.devices.get(req.ieeeAddress);
+
+			if (!current) {
+				results.push({
+					ieeeAddress: req.ieeeAddress,
+					name: req.name,
+					status: 'failed',
+					error: 'Device not in session',
+				});
+				continue;
+			}
+
+			try {
+				// Race fallback: device already adopted (either before session start or
+				// by an auto-adopt path mid-session). Update name/category instead of creating.
+				if (current.status === 'already_registered' && current.registeredDeviceId) {
+					await this.devicesService.update(current.registeredDeviceId, {
+						type: DEVICES_ZIGBEE2MQTT_TYPE,
+						name: req.name,
+						category: req.category,
+					} as never);
+
+					session.devices.set(req.ieeeAddress, {
+						...current,
+						registeredDeviceName: req.name,
+						registeredDeviceCategory: req.category,
+					});
+
+					results.push({
+						ieeeAddress: req.ieeeAddress,
+						name: req.name,
+						status: 'updated',
+						error: null,
+					});
+					continue;
+				}
+
+				// Build the AdoptDeviceRequestDto from the device's mapping preview.
+				const adoptRequest = await this.buildAdoptRequest(req.ieeeAddress, req.name, req.category);
+				const created = await this.deviceAdoptionService.adoptDevice(adoptRequest);
+
+				session.devices.set(req.ieeeAddress, {
+					...current,
+					status: 'already_registered',
+					registeredDeviceId: created.id,
+					registeredDeviceName: req.name,
+					registeredDeviceCategory: req.category,
+				});
+
+				results.push({
+					ieeeAddress: req.ieeeAddress,
+					name: req.name,
+					status: 'created',
+					error: null,
+				});
+			} catch (e) {
+				results.push({
+					ieeeAddress: req.ieeeAddress,
+					name: req.name,
+					status: 'failed',
+					error: (e as Error).message,
+				});
+			}
+		}
+
+		return results;
+	}
+
+	/**
+	 * Convert a device's mapping preview into a fully-populated AdoptDeviceRequestDto.
+	 * Mirrors the conversion logic in the admin's useDeviceAddFormMultiStep composable
+	 * (single-device form). Groups exposes by suggested channel category, skips
+	 * 'skipped'/'unmapped' exposes and 'generic' channels, dedupes properties by category
+	 * (NOT z2mProperty since multiple props can share one Z2M property like color hue/saturation).
+	 */
+	private async buildAdoptRequest(
+		ieeeAddress: string,
+		name: string,
+		category: DeviceCategory,
+	): Promise<AdoptDeviceRequestDto> {
+		const preview = await this.mappingPreviewService.generatePreview(ieeeAddress);
+
+		const channelMap = new Map<string, AdoptChannelDefinitionDto>();
+		for (const expose of preview.exposes) {
+			if (expose.status === 'skipped' || expose.status === 'unmapped') continue;
+			if (!expose.suggestedChannel) continue;
+			const channelCategory = expose.suggestedChannel.category;
+			// Skip generic channels (admin form does the same — it's a placeholder category)
+			if ((channelCategory as string) === 'generic') continue;
+			if (!expose.suggestedProperties || expose.suggestedProperties.length === 0) continue;
+
+			let channel = channelMap.get(channelCategory);
+			if (!channel) {
+				channel = {
+					category: channelCategory,
+					name: expose.suggestedChannel.name || channelCategory,
+					identifier: channelCategory,
+					properties: [],
+				};
+				channelMap.set(channelCategory, channel);
+			}
+
+			for (const prop of expose.suggestedProperties) {
+				if (channel.properties.find((p) => p.category === prop.category)) continue;
+				channel.properties.push({
+					category: prop.category,
+					z2mProperty: prop.z2mProperty,
+					dataType: prop.dataType,
+					permissions: prop.permissions,
+					format: (prop.format ?? null) as string[] | number[] | null,
+				});
+			}
+		}
+
+		const request = new AdoptDeviceRequestDto();
+		request.ieeeAddress = ieeeAddress;
+		request.name = name;
+		request.category = category;
+		request.channels = Array.from(channelMap.values());
+		return request;
+	}
 }

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -32,7 +32,6 @@ export interface Z2mWizardDeviceSnapshot {
 	model: string | null;
 	description: string | null;
 	status: Z2mWizardDeviceStatus;
-	categories: DeviceCategory[];
 	suggestedCategory: DeviceCategory | null;
 	previewChannelCount: number;
 	previewChannelIdentifiers: string[];
@@ -280,11 +279,11 @@ export class Z2mWizardService implements OnModuleDestroy {
 			previewError = (e as Error).message;
 		}
 
+		// `suggestedCategory` is the descriptor's best guess used as the dropdown's pre-fill.
+		// The wizard always lets the user pick any DeviceCategory, so we deliberately don't
+		// publish a per-device "available categories" list — the frontend renders the full
+		// enum directly.
 		const suggestedCategory = preview?.suggestedDevice?.category ?? null;
-		// Always offer the full enum so users can override the suggested category. The
-		// suggestion is exposed separately via `suggestedCategory` so the frontend can
-		// pre-select it. If no suggestion was produced the user still gets the full picker.
-		const categories: DeviceCategory[] = Object.values(DeviceCategory) as DeviceCategory[];
 
 		// Distinct channel categories from exposes that would actually be adopted. Filter
 		// rules MUST match buildAdoptRequest exactly — otherwise a device whose only mapped
@@ -319,7 +318,6 @@ export class Z2mWizardService implements OnModuleDestroy {
 			model: z2mDevice.definition?.model ?? null,
 			description: z2mDevice.definition?.description ?? null,
 			status,
-			categories,
 			suggestedCategory,
 			previewChannelCount,
 			previewChannelIdentifiers,

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -6,6 +6,7 @@ import { ExtensionLoggerService, createExtensionLogger } from '../../../common/l
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+import { Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
 
 import { Z2mDeviceAdoptionService } from './device-adoption.service';
 import { Z2mMappingPreviewService } from './mapping-preview.service';
@@ -79,11 +80,17 @@ export class Z2mWizardService implements OnModuleDestroy {
 		this.sessions.set(id, session);
 		this.refreshIdleTimer(session);
 
-		await this.populateInitialDevices(session);
-
+		// Subscribe BEFORE populating the seed list — `populateInitialDevices` will perform
+		// awaited DB lookups (Task 6) that create a window where the bridge could fire
+		// `device_joined` for a fresh device that's not in the seed and there's no listener
+		// attached yet. `handleDeviceJoined` is keyed on `ieeeAddress` so an overlap between
+		// a seed entry and a concurrent `device_joined` event just overwrites the same row
+		// rather than duplicating.
 		session.unsubscribeJoined = this.zigbee2mqttService.subscribeToDeviceJoined((device) => {
 			void this.handleDeviceJoined(session, device);
 		});
+
+		await this.populateInitialDevices(session);
 
 		return this.toSnapshot(session);
 	}
@@ -107,6 +114,20 @@ export class Z2mWizardService implements OnModuleDestroy {
 			return;
 		}
 
+		await this.cleanupSession(session);
+
+		this.sessions.delete(id);
+	}
+
+	async onModuleDestroy(): Promise<void> {
+		for (const session of this.sessions.values()) {
+			await this.cleanupSession(session);
+		}
+
+		this.sessions.clear();
+	}
+
+	private async cleanupSession(session: Z2mWizardSession): Promise<void> {
 		await this.disablePermitJoinInternal(session);
 
 		session.unsubscribeJoined?.();
@@ -114,22 +135,6 @@ export class Z2mWizardService implements OnModuleDestroy {
 		if (session.idleTimer) {
 			clearTimeout(session.idleTimer);
 		}
-
-		this.sessions.delete(id);
-	}
-
-	async onModuleDestroy(): Promise<void> {
-		for (const session of this.sessions.values()) {
-			await this.disablePermitJoinInternal(session);
-
-			session.unsubscribeJoined?.();
-
-			if (session.idleTimer) {
-				clearTimeout(session.idleTimer);
-			}
-		}
-
-		this.sessions.clear();
 	}
 
 	private toSnapshot(session: Z2mWizardSession): Z2mWizardSessionSnapshot {
@@ -182,7 +187,7 @@ export class Z2mWizardService implements OnModuleDestroy {
 		await Promise.resolve();
 	}
 
-	private async handleDeviceJoined(_session: Z2mWizardSession, _device: unknown): Promise<void> {
+	private async handleDeviceJoined(_session: Z2mWizardSession, _device: Z2mRegisteredDevice): Promise<void> {
 		// Implemented in Task 6
 		await Promise.resolve();
 	}

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -283,12 +283,17 @@ export class Z2mWizardService implements OnModuleDestroy {
 		// pre-select it. If no suggestion was produced the user still gets the full picker.
 		const categories: DeviceCategory[] = Object.values(DeviceCategory) as DeviceCategory[];
 
-		// Distinct channel categories from exposes that have a real suggested channel mapping.
+		// Distinct channel categories from exposes that would actually be adopted. Filter
+		// rules MUST match buildAdoptRequest exactly — otherwise a device whose only mapped
+		// exposes produce 'generic' channels would be marked 'ready' here but produce an
+		// empty-channel device when adopted.
 		const channelCategories = new Set<string>();
 		for (const expose of preview?.exposes ?? []) {
-			if (expose.suggestedChannel && (expose.status === 'mapped' || expose.status === 'partial')) {
-				channelCategories.add(expose.suggestedChannel.category);
-			}
+			if (expose.status === 'skipped' || expose.status === 'unmapped') continue;
+			if (!expose.suggestedChannel) continue;
+			if ((expose.suggestedChannel.category as string) === 'generic') continue;
+			if (!expose.suggestedProperties || expose.suggestedProperties.length === 0) continue;
+			channelCategories.add(expose.suggestedChannel.category);
 		}
 		const previewChannelIdentifiers = Array.from(channelCategories);
 		const previewChannelCount = previewChannelIdentifiers.length;

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -129,6 +129,52 @@ export class Z2mWizardService implements OnModuleDestroy {
 		this.sessions.clear();
 	}
 
+	async enablePermitJoin(id: string): Promise<Z2mWizardSessionSnapshot | null> {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return null;
+		}
+
+		this.refreshIdleTimer(session);
+
+		const ok = await this.zigbee2mqttService.setPermitJoin(Z2mWizardService.PERMIT_JOIN_DURATION_S);
+
+		if (!ok) {
+			this.logger.warn('Failed to enable permit_join', { session: id });
+
+			return this.toSnapshot(session);
+		}
+
+		if (session.permitJoin.timer) {
+			clearTimeout(session.permitJoin.timer);
+		}
+
+		session.permitJoin = {
+			active: true,
+			expiresAt: new Date(Date.now() + Z2mWizardService.PERMIT_JOIN_DURATION_S * 1_000),
+			timer: setTimeout(() => {
+				session.permitJoin = { active: false, expiresAt: null };
+			}, Z2mWizardService.PERMIT_JOIN_DURATION_S * 1_000),
+		};
+
+		return this.toSnapshot(session);
+	}
+
+	async disablePermitJoin(id: string): Promise<Z2mWizardSessionSnapshot | null> {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return null;
+		}
+
+		this.refreshIdleTimer(session);
+
+		await this.disablePermitJoinInternal(session);
+
+		return this.toSnapshot(session);
+	}
+
 	private async cleanupSession(session: Z2mWizardSession): Promise<void> {
 		await this.disablePermitJoinInternal(session);
 
@@ -266,6 +312,5 @@ export class Z2mWizardService implements OnModuleDestroy {
 		};
 	}
 
-	// enablePermitJoin, disablePermitJoin — implemented in Task 7
 	// adopt — implemented in Task 8
 }

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from 'crypto';
+
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+
+import { Z2mDeviceAdoptionService } from './device-adoption.service';
+import { Z2mMappingPreviewService } from './mapping-preview.service';
+import { Zigbee2mqttService } from './zigbee2mqtt.service';
+
+export type Z2mWizardDeviceStatus = 'ready' | 'unsupported' | 'already_registered' | 'failed';
+
+export interface Z2mWizardDeviceSnapshot {
+	ieeeAddress: string;
+	friendlyName: string;
+	manufacturer: string | null;
+	model: string | null;
+	description: string | null;
+	status: Z2mWizardDeviceStatus;
+	categories: DeviceCategory[];
+	suggestedCategory: DeviceCategory | null;
+	previewChannelCount: number;
+	previewChannelIdentifiers: string[];
+	registeredDeviceId: string | null;
+	registeredDeviceName: string | null;
+	registeredDeviceCategory: DeviceCategory | null;
+	error: string | null;
+	lastSeenAt: string;
+}
+
+export interface Z2mWizardSessionSnapshot {
+	id: string;
+	bridgeOnline: boolean;
+	startedAt: string;
+	permitJoin: { active: boolean; expiresAt: string | null; remainingSeconds: number };
+	devices: Z2mWizardDeviceSnapshot[];
+}
+
+interface Z2mWizardSession {
+	id: string;
+	startedAt: Date;
+	permitJoin: { active: boolean; expiresAt: Date | null; timer?: NodeJS.Timeout };
+	devices: Map<string, Z2mWizardDeviceSnapshot>;
+	unsubscribeJoined?: () => void;
+	idleTimer?: NodeJS.Timeout;
+}
+
+@Injectable()
+export class Z2mWizardService implements OnModuleDestroy {
+	private static readonly IDLE_TTL_MS = 10 * 60_000;
+	private static readonly PERMIT_JOIN_DURATION_S = 254;
+
+	private readonly logger: ExtensionLoggerService = createExtensionLogger(
+		DEVICES_ZIGBEE2MQTT_PLUGIN_NAME,
+		'Z2mWizardService',
+	);
+
+	private readonly sessions = new Map<string, Z2mWizardSession>();
+
+	constructor(
+		private readonly zigbee2mqttService: Zigbee2mqttService,
+		private readonly deviceAdoptionService: Z2mDeviceAdoptionService,
+		private readonly mappingPreviewService: Z2mMappingPreviewService,
+		private readonly devicesService: DevicesService,
+	) {}
+
+	async start(): Promise<Z2mWizardSessionSnapshot> {
+		const id = randomUUID();
+		const session: Z2mWizardSession = {
+			id,
+			startedAt: new Date(),
+			permitJoin: { active: false, expiresAt: null },
+			devices: new Map(),
+		};
+
+		this.sessions.set(id, session);
+		this.refreshIdleTimer(session);
+
+		await this.populateInitialDevices(session);
+
+		session.unsubscribeJoined = this.zigbee2mqttService.subscribeToDeviceJoined((device) => {
+			void this.handleDeviceJoined(session, device);
+		});
+
+		return this.toSnapshot(session);
+	}
+
+	get(id: string): Z2mWizardSessionSnapshot | null {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return null;
+		}
+
+		this.refreshIdleTimer(session);
+
+		return this.toSnapshot(session);
+	}
+
+	async end(id: string): Promise<void> {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return;
+		}
+
+		await this.disablePermitJoinInternal(session);
+
+		session.unsubscribeJoined?.();
+
+		if (session.idleTimer) {
+			clearTimeout(session.idleTimer);
+		}
+
+		this.sessions.delete(id);
+	}
+
+	async onModuleDestroy(): Promise<void> {
+		for (const session of this.sessions.values()) {
+			await this.disablePermitJoinInternal(session);
+
+			session.unsubscribeJoined?.();
+
+			if (session.idleTimer) {
+				clearTimeout(session.idleTimer);
+			}
+		}
+
+		this.sessions.clear();
+	}
+
+	private toSnapshot(session: Z2mWizardSession): Z2mWizardSessionSnapshot {
+		return {
+			id: session.id,
+			bridgeOnline: this.zigbee2mqttService.isBridgeOnline(),
+			startedAt: session.startedAt.toISOString(),
+			permitJoin: {
+				active: session.permitJoin.active,
+				expiresAt: session.permitJoin.expiresAt?.toISOString() ?? null,
+				remainingSeconds: session.permitJoin.expiresAt
+					? Math.max(0, Math.ceil((session.permitJoin.expiresAt.getTime() - Date.now()) / 1_000))
+					: 0,
+			},
+			devices: Array.from(session.devices.values()),
+		};
+	}
+
+	private refreshIdleTimer(session: Z2mWizardSession): void {
+		if (session.idleTimer) {
+			clearTimeout(session.idleTimer);
+		}
+
+		session.idleTimer = setTimeout(() => {
+			void this.end(session.id);
+		}, Z2mWizardService.IDLE_TTL_MS);
+	}
+
+	private async disablePermitJoinInternal(session: Z2mWizardSession): Promise<void> {
+		if (!session.permitJoin.active) {
+			return;
+		}
+
+		if (session.permitJoin.timer) {
+			clearTimeout(session.permitJoin.timer);
+		}
+
+		try {
+			await this.zigbee2mqttService.setPermitJoin(0);
+		} catch (e) {
+			this.logger.warn('Failed to disable permit_join during cleanup', { message: (e as Error).message });
+		}
+
+		session.permitJoin = { active: false, expiresAt: null };
+	}
+
+	// populateInitialDevices, handleDeviceJoined — implemented in Task 6
+	private async populateInitialDevices(_session: Z2mWizardSession): Promise<void> {
+		// Implemented in Task 6
+		await Promise.resolve();
+	}
+
+	private async handleDeviceJoined(_session: Z2mWizardSession, _device: unknown): Promise<void> {
+		// Implemented in Task 6
+		await Promise.resolve();
+	}
+
+	// enablePermitJoin, disablePermitJoin — implemented in Task 7
+	// adopt — implemented in Task 8
+}

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -334,9 +334,11 @@ export class Z2mWizardService implements OnModuleDestroy {
 	async adopt(
 		id: string,
 		requests: { ieeeAddress: string; name: string; category: DeviceCategory }[],
-	): Promise<Z2mWizardAdoptionResult[]> {
+	): Promise<Z2mWizardAdoptionResult[] | null> {
 		const session = this.sessions.get(id);
-		if (!session) return [];
+		// Returning null lets the controller distinguish "unknown session" (404) from
+		// "session exists but no devices were requested" (200 with empty array).
+		if (!session) return null;
 		this.refreshIdleTimer(session);
 
 		// Refresh-before-adopt: rebuild snapshots so we see current registered status.

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -5,7 +5,8 @@ import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
-import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
+import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
 import { Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
 
 import { Z2mDeviceAdoptionService } from './device-adoption.service';
@@ -181,15 +182,90 @@ export class Z2mWizardService implements OnModuleDestroy {
 		session.permitJoin = { active: false, expiresAt: null };
 	}
 
-	// populateInitialDevices, handleDeviceJoined — implemented in Task 6
-	private async populateInitialDevices(_session: Z2mWizardSession): Promise<void> {
-		// Implemented in Task 6
-		await Promise.resolve();
+	private async populateInitialDevices(session: Z2mWizardSession): Promise<void> {
+		if (!this.zigbee2mqttService.isBridgeOnline()) return;
+
+		const z2mDevices = this.zigbee2mqttService.getRegisteredDevices();
+		const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+
+		for (const z2mDevice of z2mDevices) {
+			const snapshot = await this.computeSnapshot(z2mDevice, adopted);
+			session.devices.set(snapshot.ieeeAddress, snapshot);
+		}
 	}
 
-	private async handleDeviceJoined(_session: Z2mWizardSession, _device: Z2mRegisteredDevice): Promise<void> {
-		// Implemented in Task 6
-		await Promise.resolve();
+	private async handleDeviceJoined(session: Z2mWizardSession, z2mDevice: Z2mRegisteredDevice): Promise<void> {
+		try {
+			const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+			const snapshot = await this.computeSnapshot(z2mDevice, adopted);
+			session.devices.set(snapshot.ieeeAddress, snapshot);
+		} catch (e) {
+			this.logger.warn('Failed to handle device-joined event', {
+				session: session.id,
+				ieeeAddress: z2mDevice?.ieeeAddress,
+				message: (e as Error).message,
+			});
+		}
+	}
+
+	private async computeSnapshot(
+		z2mDevice: Z2mRegisteredDevice,
+		adopted: Zigbee2mqttDeviceEntity[],
+	): Promise<Z2mWizardDeviceSnapshot> {
+		const adoptedRecord = adopted.find((d) => d.identifier === z2mDevice.friendlyName) ?? null;
+
+		// The wizard treats the preview output as `{ suggestedCategory, channels }` — a flatter
+		// shape than `Z2mMappingPreviewService['generatePreview']` returns. The cast lets us read
+		// the wizard contract without coupling tests to the full Z2mMappingPreviewModel.
+		type WizardPreviewShape = {
+			suggestedCategory?: DeviceCategory | null;
+			channels?: Array<{ identifier?: string; name?: string }>;
+		};
+		let preview: WizardPreviewShape | null = null;
+		let previewError: string | null = null;
+		try {
+			preview = (await this.mappingPreviewService.generatePreview(
+				z2mDevice.ieeeAddress,
+			)) as unknown as WizardPreviewShape;
+		} catch (e) {
+			previewError = (e as Error).message;
+		}
+
+		const previewChannels = preview?.channels ?? [];
+
+		let status: Z2mWizardDeviceStatus;
+		if (previewError) {
+			status = 'failed';
+		} else if (adoptedRecord) {
+			status = 'already_registered';
+		} else if (!preview || previewChannels.length === 0) {
+			status = 'unsupported';
+		} else {
+			status = 'ready';
+		}
+
+		const suggestedCategory = preview?.suggestedCategory ?? null;
+		const categories: DeviceCategory[] = suggestedCategory ? [suggestedCategory] : [];
+		const previewChannelCount = previewChannels.length;
+		const previewChannelIdentifiers = previewChannels.map((c) => c.identifier ?? c.name ?? '');
+
+		return {
+			ieeeAddress: z2mDevice.ieeeAddress,
+			friendlyName: z2mDevice.friendlyName,
+			manufacturer: z2mDevice.definition?.vendor ?? null,
+			model: z2mDevice.definition?.model ?? null,
+			description: z2mDevice.definition?.description ?? null,
+			status,
+			categories,
+			suggestedCategory,
+			previewChannelCount,
+			previewChannelIdentifiers,
+			registeredDeviceId: adoptedRecord?.id ?? null,
+			registeredDeviceName: adoptedRecord?.name ?? null,
+			registeredDeviceCategory: adoptedRecord?.category ?? null,
+			error: previewError,
+			lastSeenAt: new Date().toISOString(),
+		};
 	}
 
 	// enablePermitJoin, disablePermitJoin — implemented in Task 7

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -278,7 +278,10 @@ export class Z2mWizardService implements OnModuleDestroy {
 		}
 
 		const suggestedCategory = preview?.suggestedDevice?.category ?? null;
-		const categories: DeviceCategory[] = suggestedCategory ? [suggestedCategory] : [];
+		// Always offer the full enum so users can override the suggested category. The
+		// suggestion is exposed separately via `suggestedCategory` so the frontend can
+		// pre-select it. If no suggestion was produced the user still gets the full picker.
+		const categories: DeviceCategory[] = Object.values(DeviceCategory) as DeviceCategory[];
 
 		// Distinct channel categories from exposes that have a real suggested channel mapping.
 		const channelCategories = new Set<string>();

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts
@@ -8,6 +8,7 @@ import { DevicesService } from '../../../modules/devices/services/devices.servic
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
 import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
 import { Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
+import { Z2mMappingPreviewModel } from '../models/zigbee2mqtt-response.model';
 
 import { Z2mDeviceAdoptionService } from './device-adoption.service';
 import { Z2mMappingPreviewService } from './mapping-preview.service';
@@ -214,40 +215,37 @@ export class Z2mWizardService implements OnModuleDestroy {
 	): Promise<Z2mWizardDeviceSnapshot> {
 		const adoptedRecord = adopted.find((d) => d.identifier === z2mDevice.friendlyName) ?? null;
 
-		// The wizard treats the preview output as `{ suggestedCategory, channels }` — a flatter
-		// shape than `Z2mMappingPreviewService['generatePreview']` returns. The cast lets us read
-		// the wizard contract without coupling tests to the full Z2mMappingPreviewModel.
-		type WizardPreviewShape = {
-			suggestedCategory?: DeviceCategory | null;
-			channels?: Array<{ identifier?: string; name?: string }>;
-		};
-		let preview: WizardPreviewShape | null = null;
+		let preview: Z2mMappingPreviewModel | null = null;
 		let previewError: string | null = null;
 		try {
-			preview = (await this.mappingPreviewService.generatePreview(
-				z2mDevice.ieeeAddress,
-			)) as unknown as WizardPreviewShape;
+			preview = await this.mappingPreviewService.generatePreview(z2mDevice.ieeeAddress);
 		} catch (e) {
 			previewError = (e as Error).message;
 		}
 
-		const previewChannels = preview?.channels ?? [];
+		const suggestedCategory = preview?.suggestedDevice?.category ?? null;
+		const categories: DeviceCategory[] = suggestedCategory ? [suggestedCategory] : [];
+
+		// Distinct channel categories from exposes that have a real suggested channel mapping.
+		const channelCategories = new Set<string>();
+		for (const expose of preview?.exposes ?? []) {
+			if (expose.suggestedChannel && (expose.status === 'mapped' || expose.status === 'partial')) {
+				channelCategories.add(expose.suggestedChannel.category);
+			}
+		}
+		const previewChannelIdentifiers = Array.from(channelCategories);
+		const previewChannelCount = previewChannelIdentifiers.length;
 
 		let status: Z2mWizardDeviceStatus;
 		if (previewError) {
 			status = 'failed';
 		} else if (adoptedRecord) {
 			status = 'already_registered';
-		} else if (!preview || previewChannels.length === 0) {
+		} else if (previewChannelCount === 0) {
 			status = 'unsupported';
 		} else {
 			status = 'ready';
 		}
-
-		const suggestedCategory = preview?.suggestedCategory ?? null;
-		const categories: DeviceCategory[] = suggestedCategory ? [suggestedCategory] : [];
-		const previewChannelCount = previewChannels.length;
-		const previewChannelIdentifiers = previewChannels.map((c) => c.identifier ?? c.name ?? '');
 
 		return {
 			ieeeAddress: z2mDevice.ieeeAddress,

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/ws-client-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/ws-client-adapter.service.ts
@@ -215,6 +215,40 @@ export class Z2mWsClientAdapterService extends Z2mBaseClientAdapter {
 	}
 
 	/**
+	 * Toggle the bridge's permit_join state for a bounded number of seconds.
+	 * Returns true on successful send, false otherwise.
+	 * Pass 0 to disable pairing immediately.
+	 *
+	 * Note: Topics are sent without the baseTopic prefix (see publishCommand).
+	 */
+	async setPermitJoin(seconds: number): Promise<boolean> {
+		if (!this.ws || !this.connected) {
+			this.logger.warn('Cannot toggle permit_join: not connected to Zigbee2MQTT WebSocket');
+			return false;
+		}
+
+		const topic = 'bridge/request/permit_join';
+		const value = seconds > 0;
+		const payload = { value, time: seconds };
+		const message: Z2mWsMessage = { topic, payload };
+
+		this.logger.debug(`Sending WS permit_join to ${topic}: ${JSON.stringify(payload)}`);
+
+		return new Promise<boolean>((resolve) => {
+			this.ws?.send(JSON.stringify(message), (error) => {
+				if (error) {
+					this.logger.error(`Failed to send WS permit_join to ${topic}`, {
+						message: error.message,
+					});
+					resolve(false);
+					return;
+				}
+				resolve(true);
+			});
+		});
+	}
+
+	/**
 	 * Request current state from a device via WebSocket
 	 *
 	 * Note: Topics are sent without the baseTopic prefix (see publishCommand).

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.spec.ts
@@ -14,7 +14,7 @@ import { DevicesService } from '../../../modules/devices/services/devices.servic
 import { PluginServiceManagerService } from '../../../modules/extensions/services/plugin-service-manager.service';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
 import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
-import { Z2mAdapterCallbacks, Z2mDevice } from '../interfaces/zigbee2mqtt.interface';
+import { Z2mAdapterCallbacks, Z2mDevice, Z2mRegisteredDevice } from '../interfaces/zigbee2mqtt.interface';
 import { Zigbee2mqttConfigModel } from '../models/config.model';
 
 import { Z2mDeviceMapperService } from './device-mapper.service';
@@ -498,6 +498,151 @@ describe('Zigbee2mqttService', () => {
 	describe('getActiveAdapter', () => {
 		it('should return MQTT adapter by default', () => {
 			expect(service.getActiveAdapter()).toBe(mqttAdapter);
+		});
+	});
+
+	describe('setPermitJoin', () => {
+		it('should return false when bridge is offline', async () => {
+			mqttAdapter.isBridgeOnline.mockReturnValue(false);
+
+			const result = await service.setPermitJoin(120);
+
+			expect(result).toBe(false);
+			expect(mqttAdapter.setPermitJoin).not.toHaveBeenCalled();
+		});
+
+		it('should return false when no active adapter', async () => {
+			// Bypass the bridge-online guard, then null out the adapter to hit
+			// the defensive `!this.activeAdapter` branch.
+			jest.spyOn(service, 'isBridgeOnline').mockReturnValue(true);
+			(service as unknown as { activeAdapter: unknown }).activeAdapter = null;
+
+			const result = await service.setPermitJoin(120);
+
+			expect(result).toBe(false);
+		});
+
+		it('should proxy through to the active adapter when bridge is online', async () => {
+			mqttAdapter.isBridgeOnline.mockReturnValue(true);
+			mqttAdapter.setPermitJoin.mockResolvedValue(true);
+
+			const result = await service.setPermitJoin(120);
+
+			expect(result).toBe(true);
+			expect(mqttAdapter.setPermitJoin).toHaveBeenCalledWith(120);
+		});
+
+		it('should return the value the adapter returns', async () => {
+			mqttAdapter.isBridgeOnline.mockReturnValue(true);
+			mqttAdapter.setPermitJoin.mockResolvedValue(false);
+
+			const result = await service.setPermitJoin(0);
+
+			expect(result).toBe(false);
+			expect(mqttAdapter.setPermitJoin).toHaveBeenCalledWith(0);
+		});
+	});
+
+	describe('subscribeToDeviceJoined', () => {
+		const buildRegistered = (friendlyName: string): Z2mRegisteredDevice => ({
+			ieeeAddress: `0x${friendlyName}`,
+			friendlyName,
+			type: 'Router',
+			supported: true,
+			disabled: false,
+			available: true,
+			currentState: {},
+		});
+
+		it('should fire when a device joins and is included in the next bridge/devices payload', async () => {
+			const subscriber = jest.fn();
+			service.subscribeToDeviceJoined(subscriber);
+
+			// Bridge online and registry initially populated only with a pre-existing device
+			const existing = buildRegistered('existing_device');
+			const newDevice = buildRegistered('new_device');
+
+			mqttAdapter.getRegisteredDevices.mockReturnValue([existing]);
+			await capturedCallbacks.onBridgeOnline?.();
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			// Initial fetch must NOT fire any subscriber
+			expect(subscriber).not.toHaveBeenCalled();
+
+			// Now a real device_joined event arrives
+			await capturedCallbacks.onDeviceJoined?.(newDevice.ieeeAddress, newDevice.friendlyName);
+
+			// Bridge republishes devices including the newly-joined device
+			mqttAdapter.getRegisteredDevices.mockReturnValue([existing, newDevice]);
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			expect(subscriber).toHaveBeenCalledTimes(1);
+			expect(subscriber).toHaveBeenCalledWith(newDevice);
+		});
+
+		it('should NOT fire on a periodic bridge/devices republish containing only already-paired devices', async () => {
+			const subscriber = jest.fn();
+			service.subscribeToDeviceJoined(subscriber);
+
+			const existingA = buildRegistered('existing_a');
+			const existingB = buildRegistered('existing_b');
+
+			mqttAdapter.getRegisteredDevices.mockReturnValue([existingA, existingB]);
+			await capturedCallbacks.onBridgeOnline?.();
+
+			// Initial fetch
+			await capturedCallbacks.onDevicesReceived?.([]);
+			expect(subscriber).not.toHaveBeenCalled();
+
+			// Subsequent periodic republishes — same devices, no device_joined in between
+			await capturedCallbacks.onDevicesReceived?.([]);
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			expect(subscriber).not.toHaveBeenCalled();
+		});
+
+		it('should stop firing after unsubscribe', async () => {
+			const subscriber = jest.fn();
+			const unsubscribe = service.subscribeToDeviceJoined(subscriber);
+
+			const existing = buildRegistered('existing');
+			const newDevice = buildRegistered('new');
+
+			mqttAdapter.getRegisteredDevices.mockReturnValue([existing]);
+			await capturedCallbacks.onBridgeOnline?.();
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			unsubscribe();
+
+			// Real device_joined + republish; should not fire because we unsubscribed
+			await capturedCallbacks.onDeviceJoined?.(newDevice.ieeeAddress, newDevice.friendlyName);
+			mqttAdapter.getRegisteredDevices.mockReturnValue([existing, newDevice]);
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			expect(subscriber).not.toHaveBeenCalled();
+		});
+
+		it('should not let a throwing subscriber prevent other subscribers from firing', async () => {
+			const throwing = jest.fn(() => {
+				throw new Error('boom');
+			});
+			const good = jest.fn();
+			service.subscribeToDeviceJoined(throwing);
+			service.subscribeToDeviceJoined(good);
+
+			const newDevice = buildRegistered('new');
+
+			mqttAdapter.getRegisteredDevices.mockReturnValue([]);
+			await capturedCallbacks.onBridgeOnline?.();
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			await capturedCallbacks.onDeviceJoined?.(newDevice.ieeeAddress, newDevice.friendlyName);
+			mqttAdapter.getRegisteredDevices.mockReturnValue([newDevice]);
+			await capturedCallbacks.onDevicesReceived?.([]);
+
+			expect(throwing).toHaveBeenCalledTimes(1);
+			expect(good).toHaveBeenCalledTimes(1);
+			expect(good).toHaveBeenCalledWith(newDevice);
 		});
 	});
 });

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.spec.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.spec.ts
@@ -107,6 +107,7 @@ describe('Zigbee2mqttService', () => {
 		getCachedState: jest.fn().mockReturnValue({}),
 		publishCommand: jest.fn().mockResolvedValue(true),
 		requestState: jest.fn().mockResolvedValue(true),
+		setPermitJoin: jest.fn().mockResolvedValue(true),
 		getDevice: jest.fn(),
 		getDeviceByIeeeAddress: jest.fn(),
 		setCallbacks: jest.fn().mockImplementation((callbacks: Z2mAdapterCallbacks) => {

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
@@ -58,7 +58,11 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 	// per truly new device. This avoids the initial-fetch problem where every
 	// already-paired device would otherwise look "new" to a freshly-started
 	// service.
-	private readonly pendingJoinedFriendlyNames = new Set<string>();
+	// Keyed by IEEE address (immutable) rather than friendly name, because Z2M
+	// can rename a device between the `device_joined` event and the subsequent
+	// `bridge/devices` republish (auto-rename on collision, user rename via Z2M
+	// UI mid-interview). Looking up by IEEE address keeps the drain robust.
+	private readonly pendingJoinedIeeeAddresses = new Set<string>();
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -474,7 +478,7 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		this.pendingDevices = null;
 		this.isSyncing = false;
 		this.transformersRestored = false;
-		this.pendingJoinedFriendlyNames.clear();
+		this.pendingJoinedIeeeAddresses.clear();
 
 		// Set all devices to unknown state
 		try {
@@ -512,19 +516,20 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		await this.deviceMapper.restoreTransformersForExistingDevices(registeredDevices);
 		this.transformersRestored = true;
 
-		// Drain pending joined friendly names. The bridge fires a real
+		// Drain pending joined IEEE addresses. The bridge fires a real
 		// `device_joined` / `device_announce` event for new devices, then
 		// republishes `bridge/devices` once the interview completes. Here we
 		// look up each pending join in the now-populated registry and notify
 		// subscribers — exactly once per truly new device. Already-paired
 		// devices in this republish are NOT notified, which avoids the
-		// initial-fetch problem.
-		if (this.pendingJoinedFriendlyNames.size > 0) {
-			const registryByName = new Map(registeredDevices.map((d) => [d.friendlyName, d]));
-			for (const friendlyName of [...this.pendingJoinedFriendlyNames]) {
-				const registered = registryByName.get(friendlyName);
+		// initial-fetch problem. Keyed by IEEE address (immutable) so a Z2M
+		// auto-rename or user rename mid-interview doesn't lose the device.
+		if (this.pendingJoinedIeeeAddresses.size > 0) {
+			const registryByIeee = new Map(registeredDevices.map((d) => [d.ieeeAddress, d]));
+			for (const ieeeAddress of [...this.pendingJoinedIeeeAddresses]) {
+				const registered = registryByIeee.get(ieeeAddress);
 				if (registered) {
-					this.pendingJoinedFriendlyNames.delete(friendlyName);
+					this.pendingJoinedIeeeAddresses.delete(ieeeAddress);
 					this.notifyDeviceJoined(registered);
 				}
 				// If not yet in registry (interview still pending), leave it in
@@ -622,13 +627,13 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 	 * The bridge sends this for actual `device_joined` / `device_announce`
 	 * events — the authoritative signal that a NEW device is pairing. The
 	 * bridge then republishes `bridge/devices` once the interview completes
-	 * (which is what populates the registry). We record the friendly name
+	 * (which is what populates the registry). We record the IEEE address
 	 * here and let `handleDevicesReceived` drain the pending set once the
 	 * full `Z2mRegisteredDevice` is available.
 	 */
-	private handleDeviceJoined(_ieeeAddress: string, friendlyName: string): void {
-		this.logger.log(`Device joined: ${friendlyName}`);
-		this.pendingJoinedFriendlyNames.add(friendlyName);
+	private handleDeviceJoined(ieeeAddress: string, friendlyName: string): void {
+		this.logger.log(`Device joined: ${friendlyName} (${ieeeAddress})`);
+		this.pendingJoinedIeeeAddresses.add(ieeeAddress);
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
@@ -13,7 +13,7 @@ import {
 import { PluginServiceManagerService } from '../../../modules/extensions/services/plugin-service-manager.service';
 import { DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, DEVICES_ZIGBEE2MQTT_TYPE } from '../devices-zigbee2mqtt.constants';
 import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
-import { Z2mDevice, Z2mMqttConfig, Z2mWsConfig } from '../interfaces/zigbee2mqtt.interface';
+import { Z2mDevice, Z2mMqttConfig, Z2mRegisteredDevice, Z2mWsConfig } from '../interfaces/zigbee2mqtt.interface';
 import { Zigbee2mqttConfigModel } from '../models/config.model';
 
 import { Z2mBaseClientAdapter } from './base-client-adapter';
@@ -46,6 +46,15 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 
 	// The active adapter is selected based on connection_type config
 	private activeAdapter: Z2mBaseClientAdapter;
+
+	// Subscribers notified when a brand-new Z2M device appears in the registry.
+	// Used by the wizard service to react to devices joined during a pairing session.
+	private readonly deviceJoinedSubscribers = new Set<(device: Z2mRegisteredDevice) => void>();
+
+	// Friendly names already known to this service. Used to detect truly new
+	// devices in handleDevicesReceived so we only notify subscribers once per
+	// new device — never on subsequent re-publishes of the device list.
+	private readonly knownFriendlyNames = new Set<string>();
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -219,6 +228,59 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 	 */
 	async requestDeviceState(friendlyName: string): Promise<boolean> {
 		return this.activeAdapter.requestState(friendlyName);
+	}
+
+	/**
+	 * Toggle the bridge's permit_join state for a bounded number of seconds.
+	 * Returns true on successful publish/send, false otherwise.
+	 * Pass 0 to disable pairing immediately.
+	 *
+	 * Returns false if the bridge is offline or no adapter is active.
+	 */
+	async setPermitJoin(seconds: number): Promise<boolean> {
+		if (!this.isBridgeOnline()) {
+			return false;
+		}
+
+		if (!this.activeAdapter) {
+			return false;
+		}
+
+		return this.activeAdapter.setPermitJoin(seconds);
+	}
+
+	/**
+	 * Subscribe to "device joined" notifications.
+	 *
+	 * The callback is invoked with the new Z2mRegisteredDevice each time a
+	 * previously-unknown device is added to the internal registry. It is NOT
+	 * invoked for updates to already-registered devices.
+	 *
+	 * Returns an unsubscribe function.
+	 */
+	subscribeToDeviceJoined(cb: (device: Z2mRegisteredDevice) => void): () => void {
+		this.deviceJoinedSubscribers.add(cb);
+
+		return () => {
+			this.deviceJoinedSubscribers.delete(cb);
+		};
+	}
+
+	/**
+	 * Notify all device-joined subscribers of a new device.
+	 * Subscriber exceptions are caught and logged so a faulty subscriber
+	 * cannot break the others (or the calling sync logic).
+	 */
+	private notifyDeviceJoined(device: Z2mRegisteredDevice): void {
+		for (const cb of this.deviceJoinedSubscribers) {
+			try {
+				cb(device);
+			} catch (e) {
+				this.logger.warn('Device-joined subscriber threw', {
+					message: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}
 	}
 
 	/**
@@ -408,6 +470,7 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		this.pendingDevices = null;
 		this.isSyncing = false;
 		this.transformersRestored = false;
+		this.knownFriendlyNames.clear();
 
 		// Set all devices to unknown state
 		try {
@@ -444,6 +507,25 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		const registeredDevices = this.activeAdapter.getRegisteredDevices();
 		await this.deviceMapper.restoreTransformersForExistingDevices(registeredDevices);
 		this.transformersRestored = true;
+
+		// Notify subscribers about devices that are new to this service since the
+		// last bridge/devices message. We compare against knownFriendlyNames so we
+		// fire exactly once per device — not on every refresh that includes it.
+		for (const registered of registeredDevices) {
+			if (!this.knownFriendlyNames.has(registered.friendlyName)) {
+				this.knownFriendlyNames.add(registered.friendlyName);
+				this.notifyDeviceJoined(registered);
+			}
+		}
+
+		// Drop friendly names that are no longer present so a future re-pairing of
+		// the same friendly_name (e.g. after device_leave) is treated as new again.
+		const currentNames = new Set(registeredDevices.map((d) => d.friendlyName));
+		for (const name of this.knownFriendlyNames) {
+			if (!currentNames.has(name)) {
+				this.knownFriendlyNames.delete(name);
+			}
+		}
 
 		// Process cached state for all existing devices
 		const existingDevices = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
@@ -51,10 +51,14 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 	// Used by the wizard service to react to devices joined during a pairing session.
 	private readonly deviceJoinedSubscribers = new Set<(device: Z2mRegisteredDevice) => void>();
 
-	// Friendly names already known to this service. Used to detect truly new
-	// devices in handleDevicesReceived so we only notify subscribers once per
-	// new device — never on subsequent re-publishes of the device list.
-	private readonly knownFriendlyNames = new Set<string>();
+	// Friendly names captured from real `device_joined` / `device_announce`
+	// bridge events. The bridge follows up with a `bridge/devices` republish
+	// once interview completes — at that point we drain this set, look up the
+	// full `Z2mRegisteredDevice`, and fire `notifyDeviceJoined` exactly once
+	// per truly new device. This avoids the initial-fetch problem where every
+	// already-paired device would otherwise look "new" to a freshly-started
+	// service.
+	private readonly pendingJoinedFriendlyNames = new Set<string>();
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -470,7 +474,7 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		this.pendingDevices = null;
 		this.isSyncing = false;
 		this.transformersRestored = false;
-		this.knownFriendlyNames.clear();
+		this.pendingJoinedFriendlyNames.clear();
 
 		// Set all devices to unknown state
 		try {
@@ -508,22 +512,23 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 		await this.deviceMapper.restoreTransformersForExistingDevices(registeredDevices);
 		this.transformersRestored = true;
 
-		// Notify subscribers about devices that are new to this service since the
-		// last bridge/devices message. We compare against knownFriendlyNames so we
-		// fire exactly once per device — not on every refresh that includes it.
-		for (const registered of registeredDevices) {
-			if (!this.knownFriendlyNames.has(registered.friendlyName)) {
-				this.knownFriendlyNames.add(registered.friendlyName);
-				this.notifyDeviceJoined(registered);
-			}
-		}
-
-		// Drop friendly names that are no longer present so a future re-pairing of
-		// the same friendly_name (e.g. after device_leave) is treated as new again.
-		const currentNames = new Set(registeredDevices.map((d) => d.friendlyName));
-		for (const name of this.knownFriendlyNames) {
-			if (!currentNames.has(name)) {
-				this.knownFriendlyNames.delete(name);
+		// Drain pending joined friendly names. The bridge fires a real
+		// `device_joined` / `device_announce` event for new devices, then
+		// republishes `bridge/devices` once the interview completes. Here we
+		// look up each pending join in the now-populated registry and notify
+		// subscribers — exactly once per truly new device. Already-paired
+		// devices in this republish are NOT notified, which avoids the
+		// initial-fetch problem.
+		if (this.pendingJoinedFriendlyNames.size > 0) {
+			const registryByName = new Map(registeredDevices.map((d) => [d.friendlyName, d]));
+			for (const friendlyName of [...this.pendingJoinedFriendlyNames]) {
+				const registered = registryByName.get(friendlyName);
+				if (registered) {
+					this.pendingJoinedFriendlyNames.delete(friendlyName);
+					this.notifyDeviceJoined(registered);
+				}
+				// If not yet in registry (interview still pending), leave it in
+				// the set; the next `bridge/devices` republish will pick it up.
 			}
 		}
 
@@ -612,10 +617,18 @@ export class Zigbee2mqttService extends BaseManagedPluginService {
 	}
 
 	/**
-	 * Handle device joined event
+	 * Handle device joined event.
+	 *
+	 * The bridge sends this for actual `device_joined` / `device_announce`
+	 * events — the authoritative signal that a NEW device is pairing. The
+	 * bridge then republishes `bridge/devices` once the interview completes
+	 * (which is what populates the registry). We record the friendly name
+	 * here and let `handleDevicesReceived` drain the pending set once the
+	 * full `Z2mRegisteredDevice` is available.
 	 */
 	private handleDeviceJoined(_ieeeAddress: string, friendlyName: string): void {
 		this.logger.log(`Device joined: ${friendlyName}`);
+		this.pendingJoinedFriendlyNames.add(friendlyName);
 	}
 
 	/**

--- a/docs/superpowers/plans/2026-04-30-zigbee2mqtt-device-wizard.md
+++ b/docs/superpowers/plans/2026-04-30-zigbee2mqtt-device-wizard.md
@@ -1,0 +1,2063 @@
+# Zigbee2MQTT Device Adoption Wizard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a multi-device adoption wizard to the `devices-zigbee2mqtt` plugin, modeled on shelly-ng's wizard, with two-mode discovery (existing-unadopted + permit_join), auto-mapping, humanized friendly_names, and category overrides.
+
+**Architecture:** Backend `Z2mWizardService` keeps in-memory wizard sessions, subscribes to existing z2m events, exposes 6 REST endpoints, and reuses `Z2mDeviceAdoptionService` / `Z2mMappingPreviewService`. Admin adds 4 Vue components (top-level + 3 step components), 2 composables, and i18n keys, registered as the plugin's `deviceWizard` slot. Existing single-device add form stays unchanged.
+
+**Tech Stack:** NestJS + class-validator + Swagger decorators (backend), Vue 3 Composition API + Element Plus + natural-orderby + Vitest (admin), Jest (backend tests), pnpm workspaces.
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-zigbee2mqtt-device-wizard-design.md`](../specs/2026-04-30-zigbee2mqtt-device-wizard-design.md)
+
+**Conventions:**
+- Backend file path prefix: `apps/backend/src/plugins/devices-zigbee2mqtt/`
+- Admin file path prefix: `apps/admin/src/plugins/devices-zigbee2mqtt/`
+- Schema name prefix: `DevicesZigbee2mqttPluginRes*`, `DevicesZigbee2mqttPluginReq*`, `DevicesZigbee2mqttPluginData*`
+- Backend logger: `createExtensionLogger(DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, '<ClassName>')`
+- Run lint with `pnpm run lint:js` and tests with `pnpm run test:unit` (backend) / `pnpm --filter ./apps/admin run test:unit` (admin)
+
+**Reference files** (read before starting, do not modify):
+- Backend wizard reference: [`apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts`](../../../apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-discovery.service.ts), [`controllers/shelly-ng-devices.controller.ts`](../../../apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts), [`models/shelly-ng.model.ts`](../../../apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts)
+- Admin wizard reference: [`apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue`](../../../apps/admin/src/plugins/devices-shelly-ng/components/shelly-ng-devices-wizard.vue), [`composables/useDevicesWizard.ts`](../../../apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts)
+- Existing zigbee2mqtt service & adapter: [`apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts`](../../../apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts), [`base-client-adapter.ts`](../../../apps/backend/src/plugins/devices-zigbee2mqtt/services/base-client-adapter.ts), [`mqtt-client-adapter.service.ts`](../../../apps/backend/src/plugins/devices-zigbee2mqtt/services/mqtt-client-adapter.service.ts), [`ws-client-adapter.service.ts`](../../../apps/backend/src/plugins/devices-zigbee2mqtt/services/ws-client-adapter.service.ts)
+
+---
+
+## File Inventory
+
+### Backend — new files
+
+| Path | Responsibility |
+|---|---|
+| `services/wizard.service.ts` | Wizard session lifecycle, permit_join control, batch adoption, z2m event subscription |
+| `services/wizard.service.spec.ts` | Unit tests for wizard service |
+| `controllers/zigbee2mqtt-wizard.controller.ts` | Six REST endpoints under `/wizard` |
+| `controllers/zigbee2mqtt-wizard.controller.spec.ts` | Unit tests for wizard controller |
+| `models/wizard.model.ts` | Data models: `Z2mWizardDeviceSnapshotModel`, `Z2mWizardSessionModel`, `Z2mWizardAdoptionResultModel`, `Z2mWizardPermitJoinModel` |
+| `dto/wizard-adopt.dto.ts` | `Z2mWizardAdoptDeviceDto`, `Z2mWizardAdoptDto`, `ReqZ2mWizardAdoptDto` |
+
+### Backend — modified files
+
+| Path | Change |
+|---|---|
+| `services/base-client-adapter.ts` | Add abstract `setPermitJoin(seconds: number): Promise<boolean>` method |
+| `services/mqtt-client-adapter.service.ts` | Implement `setPermitJoin` — publish `<baseTopic>/bridge/request/permit_join` with `{value, time}` |
+| `services/ws-client-adapter.service.ts` | Implement `setPermitJoin` — send websocket `bridge/request/permit_join` event |
+| `services/zigbee2mqtt.service.ts` | Add `setPermitJoin(seconds)` proxy + `subscribeToDeviceJoined(cb): () => void` event subscription |
+| `models/zigbee2mqtt-response.model.ts` | Add four response wrappers for wizard models |
+| `devices-zigbee2mqtt.plugin.ts` | Register `Zigbee2mqttWizardController` and `Z2mWizardService` |
+| `devices-zigbee2mqtt.openapi.ts` | Register new schemas in OpenAPI registry |
+
+### Admin — new files
+
+| Path | Responsibility |
+|---|---|
+| `components/zigbee2mqtt-devices-wizard.vue` | Top-level wizard, step orchestrator, registered as `deviceWizard` |
+| `components/zigbee2mqtt-wizard-discovery-step.vue` | Step 1: list of devices + permit_join button + countdown |
+| `components/zigbee2mqtt-wizard-categorize-step.vue` | Step 2: sortable table with editable name/category + channel badge |
+| `components/zigbee2mqtt-wizard-results-step.vue` | Step 3: read-only adoption outcomes |
+| `composables/useDevicesWizard.ts` | Wizard state (session, selection, overrides), polling, adopt action |
+| `composables/useDevicesWizard.spec.ts` | Unit tests for `useDevicesWizard` |
+| `composables/useFriendlyNameHumanizer.ts` | snake/kebab/camel → Title Case |
+| `composables/useFriendlyNameHumanizer.spec.ts` | Unit tests for humanizer |
+
+### Admin — modified files
+
+| Path | Change |
+|---|---|
+| `components/components.ts` | Export new wizard component |
+| `composables/composables.ts` | Export new composables |
+| `schemas/devices.types.ts` | Add `IZ2mWizardSession`, `IZ2mWizardDevice`, `IZ2mWizardPermitJoin`, `IZ2mWizardAdoptionResult` types |
+| `utils/devices.transformers.ts` | Add `transformWizardSessionResponse()` |
+| `devices-zigbee2mqtt.plugin.ts` | Register `deviceWizard: Zigbee2mqttDevicesWizard` |
+| `locales/en-US.json` (and other locales matching shelly's locale set) | Add `plugins.devices-zigbee2mqtt.wizard.*` keys |
+
+### Generated files (DO NOT edit; regenerated by `pnpm run generate:openapi`)
+
+- `spec/api/v1/openapi.json`
+- `apps/admin/src/openapi.ts`
+
+---
+
+## Task 1: Add `setPermitJoin` to base adapter and implementations
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/base-client-adapter.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/mqtt-client-adapter.service.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/ws-client-adapter.service.ts`
+
+- [ ] **Step 1: Add abstract method to base adapter**
+
+In `base-client-adapter.ts`, add the abstract method next to the other abstracts:
+
+```ts
+/**
+ * Toggle the bridge's permit_join state for a bounded number of seconds.
+ * Returns true on successful publish/send, false otherwise.
+ * Pass 0 to disable pairing immediately.
+ */
+abstract setPermitJoin(seconds: number): Promise<boolean>;
+```
+
+- [ ] **Step 2: Implement `setPermitJoin` in MQTT adapter**
+
+In `mqtt-client-adapter.service.ts`, add (after `requestState` or wherever `publishCommand` lives):
+
+```ts
+async setPermitJoin(seconds: number): Promise<boolean> {
+    if (!this.client?.connected) {
+        this.logger.warn('Cannot toggle permit_join: not connected to MQTT broker');
+        return false;
+    }
+
+    const topic = `${this.baseTopic}/bridge/request/permit_join`;
+    const value = seconds > 0;
+    const message = JSON.stringify({ value, time: seconds });
+
+    this.logger.debug(`Publishing permit_join to ${topic}: ${message}`);
+
+    return new Promise<boolean>((resolve) => {
+        this.client?.publish(topic, message, { qos: 1 }, (error) => {
+            if (error) {
+                this.logger.error(`Failed to publish permit_join to ${topic}`, {
+                    message: error.message,
+                });
+                resolve(false);
+                return;
+            }
+            resolve(true);
+        });
+    });
+}
+```
+
+- [ ] **Step 3: Implement `setPermitJoin` in WS adapter**
+
+In `ws-client-adapter.service.ts`, add an analogous method that sends the same payload over the websocket connection. The shape is the same — `bridge/request/permit_join` topic with `{value, time}` body. Reuse the websocket `send` mechanism already used by `publishCommand` in this file.
+
+- [ ] **Step 4: Run typecheck to confirm no compile errors**
+
+Run: `pnpm run lint:js`
+Expected: PASS (no new errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/base-client-adapter.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/mqtt-client-adapter.service.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/ws-client-adapter.service.ts
+git commit -m "Z2M wizard: add setPermitJoin to bridge adapters"
+```
+
+---
+
+## Task 2: Expose `setPermitJoin` and `subscribeToDeviceJoined` on `Zigbee2mqttService`
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts`
+
+- [ ] **Step 1: Locate the active adapter accessor**
+
+Read `zigbee2mqtt.service.ts` to find how it accesses the active adapter (likely a private field set during `start()` based on config.connectionType). The new methods must proxy through this.
+
+- [ ] **Step 2: Add `setPermitJoin` proxy method**
+
+Add the public method on `Zigbee2mqttService`:
+
+```ts
+async setPermitJoin(seconds: number): Promise<boolean> {
+    if (!this.isBridgeOnline()) {
+        return false;
+    }
+
+    if (!this.activeAdapter) {
+        return false;
+    }
+
+    return this.activeAdapter.setPermitJoin(seconds);
+}
+```
+
+(Replace `this.activeAdapter` with the actual private field name.)
+
+- [ ] **Step 3: Add `subscribeToDeviceJoined` event subscription**
+
+Identify how device-joined events are currently raised inside `Zigbee2mqttService` (look for `emit`, `EventEmitter`, or callback registries). Expose an `(cb: (device: Z2mRegisteredDevice) => void) => () => void` subscription that fires whenever a new device appears. If the service already has an internal event emitter, just add the public method that wraps it; if not, add a small subscriber set:
+
+```ts
+private readonly deviceJoinedSubscribers = new Set<(d: Z2mRegisteredDevice) => void>();
+
+subscribeToDeviceJoined(cb: (d: Z2mRegisteredDevice) => void): () => void {
+    this.deviceJoinedSubscribers.add(cb);
+    return () => this.deviceJoinedSubscribers.delete(cb);
+}
+
+private notifyDeviceJoined(device: Z2mRegisteredDevice): void {
+    for (const cb of this.deviceJoinedSubscribers) {
+        try { cb(device); } catch (e) {
+            this.logger.warn('Device-joined subscriber threw', { message: (e as Error).message });
+        }
+    }
+}
+```
+
+Then call `notifyDeviceJoined(device)` wherever the service currently registers a newly joined Z2M device.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm run lint:js`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/zigbee2mqtt.service.ts
+git commit -m "Z2M wizard: expose setPermitJoin and device-joined subscription"
+```
+
+---
+
+## Task 3: Backend wizard data models
+
+**Files:**
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/models/zigbee2mqtt-response.model.ts`
+
+- [ ] **Step 1: Create `wizard.model.ts` with all wizard data classes**
+
+Create `apps/backend/src/plugins/devices-zigbee2mqtt/models/wizard.model.ts`. Use shelly-ng `models/shelly-ng.model.ts` as the structural template (class-validator + class-transformer + Swagger decorators with `@ApiSchema({ name: 'DevicesZigbee2mqttPluginData<Name>' })`).
+
+Required classes:
+
+```ts
+import { Expose, Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardPermitJoin' })
+export class Z2mWizardPermitJoinModel {
+    @ApiProperty({ description: 'Whether bridge is currently in pairing mode', example: false })
+    @Expose()
+    @IsBoolean()
+    active: boolean;
+
+    @ApiPropertyOptional({ description: 'Permit_join expiry timestamp', nullable: true, example: '2026-04-30T12:04:14.000Z' })
+    @Expose()
+    @IsString()
+    @IsOptional()
+    expiresAt: string | null;
+
+    @ApiProperty({ description: 'Remaining permit_join seconds (0 when inactive)', example: 0 })
+    @Expose()
+    @IsInt()
+    remainingSeconds: number;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardDevice' })
+export class Z2mWizardDeviceSnapshotModel {
+    @ApiProperty({ description: 'Device IEEE address (unique key)', example: '0x00158d0001a1b2c3' })
+    @Expose()
+    @IsString()
+    ieeeAddress: string;
+
+    @ApiProperty({ description: 'Z2M friendly name (raw, as configured in zigbee2mqtt)', example: 'living_room_lamp' })
+    @Expose()
+    @IsString()
+    friendlyName: string;
+
+    @ApiPropertyOptional({ description: 'Manufacturer (vendor)', nullable: true, example: 'Philips' })
+    @Expose()
+    @IsString()
+    @IsOptional()
+    manufacturer: string | null;
+
+    @ApiPropertyOptional({ description: 'Model identifier', nullable: true, example: 'LCT001' })
+    @Expose()
+    @IsString()
+    @IsOptional()
+    model: string | null;
+
+    @ApiPropertyOptional({ description: 'Human-readable model description', nullable: true, example: 'Hue White and Color Ambiance E27' })
+    @Expose()
+    @IsString()
+    @IsOptional()
+    description: string | null;
+
+    @ApiProperty({
+        description: 'Wizard candidate status',
+        enum: ['ready', 'unsupported', 'already_registered', 'failed'],
+        example: 'ready',
+    })
+    @Expose()
+    @IsIn(['ready', 'unsupported', 'already_registered', 'failed'])
+    status: string;
+
+    @ApiProperty({
+        description: 'Available target device categories',
+        type: 'array',
+        items: { type: 'string', enum: Object.values(DeviceCategory) },
+        example: [DeviceCategory.LIGHTING],
+    })
+    @Expose()
+    @IsArray()
+    @IsString({ each: true })
+    categories: DeviceCategory[];
+
+    @ApiPropertyOptional({
+        description: 'Suggested target device category from descriptor',
+        nullable: true,
+        enum: DeviceCategory,
+        example: DeviceCategory.LIGHTING,
+    })
+    @Expose()
+    @IsString()
+    @IsOptional()
+    suggestedCategory: DeviceCategory | null;
+
+    @ApiProperty({ description: 'Channel count predicted by the mapping preview', example: 4 })
+    @Expose()
+    @IsInt()
+    previewChannelCount: number;
+
+    @ApiProperty({
+        description: 'Identifiers of channels that would be created (for tooltip)',
+        type: 'array',
+        items: { type: 'string' },
+        example: ['light', 'illuminance', 'battery'],
+    })
+    @Expose()
+    @IsArray()
+    @IsString({ each: true })
+    previewChannelIdentifiers: string[];
+
+    @ApiPropertyOptional({ description: 'Already registered device id', nullable: true, example: null })
+    @Expose() @IsString() @IsOptional()
+    registeredDeviceId: string | null;
+
+    @ApiPropertyOptional({ description: 'Already registered device name', nullable: true, example: null })
+    @Expose() @IsString() @IsOptional()
+    registeredDeviceName: string | null;
+
+    @ApiPropertyOptional({ description: 'Already registered device category', nullable: true, enum: DeviceCategory, example: null })
+    @Expose() @IsIn(Object.values(DeviceCategory)) @IsOptional()
+    registeredDeviceCategory: DeviceCategory | null;
+
+    @ApiPropertyOptional({ description: 'Last lookup error message', nullable: true, example: null })
+    @Expose() @IsString() @IsOptional()
+    error: string | null;
+
+    @ApiProperty({ description: 'Last time this candidate was observed', example: '2026-04-30T12:00:00.000Z' })
+    @Expose() @IsString()
+    lastSeenAt: string;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardSession' })
+export class Z2mWizardSessionModel {
+    @ApiProperty({ description: 'Wizard session id', example: 'c66808d8-0af1-4b93-bd61-4131cf62f20f' })
+    @Expose() @IsString() id: string;
+
+    @ApiProperty({ description: 'Whether bridge is currently online', example: true })
+    @Expose() @IsBoolean() bridgeOnline: boolean;
+
+    @ApiProperty({ description: 'Wizard session start timestamp', example: '2026-04-30T12:00:00.000Z' })
+    @Expose() @IsString() startedAt: string;
+
+    @ApiProperty({ description: 'Permit_join state', type: () => Z2mWizardPermitJoinModel })
+    @Expose() @ValidateNested() @Type(() => Z2mWizardPermitJoinModel)
+    permitJoin: Z2mWizardPermitJoinModel;
+
+    @ApiProperty({
+        description: 'Discovered Zigbee device candidates',
+        type: 'array',
+        items: { $ref: getSchemaPath(Z2mWizardDeviceSnapshotModel) },
+    })
+    @Expose()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => Z2mWizardDeviceSnapshotModel)
+    devices: Z2mWizardDeviceSnapshotModel[];
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardAdoptionResult' })
+export class Z2mWizardAdoptionResultModel {
+    @ApiProperty({ description: 'Device IEEE address', example: '0x00158d0001a1b2c3' })
+    @Expose() @IsString() ieeeAddress: string;
+
+    @ApiProperty({ description: 'Resolved Smart Panel device name', example: 'Living Room Lamp' })
+    @Expose() @IsString() name: string;
+
+    @ApiProperty({ description: 'Adoption outcome', enum: ['created', 'updated', 'failed'], example: 'created' })
+    @Expose() @IsIn(['created', 'updated', 'failed']) status: string;
+
+    @ApiPropertyOptional({ description: 'Failure message', nullable: true, example: null })
+    @Expose() @IsString() @IsOptional() error: string | null;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginDataWizardAdoption' })
+export class Z2mWizardAdoptionModel {
+    @ApiProperty({
+        description: 'Per-device adoption results',
+        type: 'array',
+        items: { $ref: getSchemaPath(Z2mWizardAdoptionResultModel) },
+    })
+    @Expose() @IsArray() @ValidateNested({ each: true })
+    @Type(() => Z2mWizardAdoptionResultModel)
+    results: Z2mWizardAdoptionResultModel[];
+}
+```
+
+- [ ] **Step 2: Add response wrappers in `zigbee2mqtt-response.model.ts`**
+
+Append to `models/zigbee2mqtt-response.model.ts`:
+
+```ts
+import {
+    Z2mWizardSessionModel,
+    Z2mWizardAdoptionModel,
+} from './wizard.model';
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginResWizardSession' })
+export class Z2mWizardSessionResponseModel extends BaseSuccessResponseModel<Z2mWizardSessionModel> {
+    @ApiProperty({ description: 'The actual data payload returned by the API', type: () => Z2mWizardSessionModel })
+    @Expose()
+    declare data: Z2mWizardSessionModel;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginResWizardAdoption' })
+export class Z2mWizardAdoptionResponseModel extends BaseSuccessResponseModel<Z2mWizardAdoptionModel> {
+    @ApiProperty({ description: 'The actual data payload returned by the API', type: () => Z2mWizardAdoptionModel })
+    @Expose()
+    declare data: Z2mWizardAdoptionModel;
+}
+```
+
+(Match the existing import style in this file. If `BaseSuccessResponseModel` and `Expose` are already imported, do not duplicate.)
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm run lint:js`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/models/
+git commit -m "Z2M wizard: backend response models"
+```
+
+---
+
+## Task 4: Backend wizard adopt DTO
+
+**Files:**
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/dto/wizard-adopt.dto.ts`
+
+- [ ] **Step 1: Create the DTO**
+
+Use `dto/mapping-preview.dto.ts` (`ReqAdoptDeviceDto`) as the structural reference for the request envelope shape (`{ data: ... }` pattern).
+
+```ts
+import { Expose, Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsIn, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdoptDevice' })
+export class Z2mWizardAdoptDeviceDto {
+    @ApiProperty({ description: 'Device IEEE address from the wizard session', example: '0x00158d0001a1b2c3' })
+    @Expose() @IsString() ieeeAddress: string;
+
+    @ApiProperty({ description: 'Display name override', example: 'Living Room Lamp' })
+    @Expose() @IsString() name: string;
+
+    @ApiProperty({ description: 'Target device category', enum: DeviceCategory, example: DeviceCategory.LIGHTING })
+    @Expose() @IsIn(Object.values(DeviceCategory)) category: DeviceCategory;
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdopt' })
+export class Z2mWizardAdoptDto {
+    @ApiProperty({
+        description: 'Devices to adopt with display name and category overrides',
+        type: 'array',
+        items: { $ref: getSchemaPath(Z2mWizardAdoptDeviceDto) },
+    })
+    @Expose() @IsArray() @ArrayNotEmpty() @ValidateNested({ each: true })
+    @Type(() => Z2mWizardAdoptDeviceDto)
+    devices: Z2mWizardAdoptDeviceDto[];
+}
+
+@ApiSchema({ name: 'DevicesZigbee2mqttPluginReqWizardAdoptWrap' })
+export class ReqZ2mWizardAdoptDto {
+    @ApiProperty({ description: 'Wizard adoption payload', type: () => Z2mWizardAdoptDto })
+    @Expose() @ValidateNested() @Type(() => Z2mWizardAdoptDto)
+    data: Z2mWizardAdoptDto;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm run lint:js`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/dto/wizard-adopt.dto.ts
+git commit -m "Z2M wizard: adopt request DTO"
+```
+
+---
+
+## Task 5: Backend wizard service — session lifecycle (write tests first)
+
+**Files:**
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts`
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts`
+
+- [ ] **Step 1: Write the failing test for `start()` returning a session snapshot**
+
+Use shelly-ng `services/shelly-ng-discovery.service.spec.ts` as the testing-style template (NestJS `Test.createTestingModule` with mocked dependencies).
+
+Create `wizard.service.spec.ts` with:
+
+```ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { Z2mWizardService } from './wizard.service';
+import { Zigbee2mqttService } from './zigbee2mqtt.service';
+import { Z2mDeviceAdoptionService } from './device-adoption.service';
+import { Z2mMappingPreviewService } from './mapping-preview.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+
+describe('Z2mWizardService', () => {
+    let service: Z2mWizardService;
+    let zigbee2mqttService: jest.Mocked<Zigbee2mqttService>;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                Z2mWizardService,
+                { provide: Zigbee2mqttService, useValue: {
+                    isBridgeOnline: jest.fn().mockReturnValue(true),
+                    getRegisteredDevices: jest.fn().mockReturnValue([]),
+                    setPermitJoin: jest.fn().mockResolvedValue(true),
+                    subscribeToDeviceJoined: jest.fn().mockReturnValue(() => {}),
+                }},
+                { provide: Z2mDeviceAdoptionService, useValue: { adoptDevice: jest.fn() } },
+                { provide: Z2mMappingPreviewService, useValue: {
+                    generatePreview: jest.fn().mockResolvedValue({
+                        suggestedCategory: 'LIGHTING',
+                        channels: [{ identifier: 'light', name: 'Light', properties: [] }],
+                        warnings: [],
+                        readyToAdopt: true,
+                        exposes: [],
+                    }),
+                }},
+                { provide: DevicesService, useValue: { findAll: jest.fn().mockResolvedValue([]) } },
+            ],
+        }).compile();
+
+        service = module.get(Z2mWizardService);
+        zigbee2mqttService = module.get(Zigbee2mqttService);
+    });
+
+    it('start() returns a session with bridgeOnline=true and an id', async () => {
+        const snapshot = await service.start();
+        expect(snapshot.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(snapshot.bridgeOnline).toBe(true);
+        expect(snapshot.permitJoin.active).toBe(false);
+        expect(snapshot.devices).toEqual([]);
+    });
+
+    it('get() returns null for unknown id', () => {
+        expect(service.get('does-not-exist')).toBeNull();
+    });
+
+    it('get() returns the same snapshot after start()', async () => {
+        const started = await service.start();
+        const fetched = service.get(started.id);
+        expect(fetched?.id).toBe(started.id);
+    });
+
+    it('end() removes the session and disables permit_join', async () => {
+        const started = await service.start();
+        await service.end(started.id);
+        expect(service.get(started.id)).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: FAIL with "Cannot find module './wizard.service'"
+
+- [ ] **Step 3: Implement minimal `Z2mWizardService` to pass the lifecycle tests**
+
+Create `wizard.service.ts` with the session map, randomUUID-based id, in-memory storage, and `start`/`get`/`end` methods. Reference shelly's `ShellyNgDiscoveryService` for the session shape pattern. Skeleton:
+
+```ts
+import { randomUUID } from 'crypto';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import {
+    DEVICES_ZIGBEE2MQTT_PLUGIN_NAME,
+    DEVICES_ZIGBEE2MQTT_TYPE,
+} from '../devices-zigbee2mqtt.constants';
+import { Zigbee2mqttDeviceEntity } from '../entities/devices-zigbee2mqtt.entity';
+import { Z2mDeviceAdoptionService } from './device-adoption.service';
+import { Z2mMappingPreviewService } from './mapping-preview.service';
+import { Zigbee2mqttService } from './zigbee2mqtt.service';
+
+export type Z2mWizardDeviceStatus = 'ready' | 'unsupported' | 'already_registered' | 'failed';
+
+export interface Z2mWizardDeviceSnapshot {
+    ieeeAddress: string;
+    friendlyName: string;
+    manufacturer: string | null;
+    model: string | null;
+    description: string | null;
+    status: Z2mWizardDeviceStatus;
+    categories: DeviceCategory[];
+    suggestedCategory: DeviceCategory | null;
+    previewChannelCount: number;
+    previewChannelIdentifiers: string[];
+    registeredDeviceId: string | null;
+    registeredDeviceName: string | null;
+    registeredDeviceCategory: DeviceCategory | null;
+    error: string | null;
+    lastSeenAt: string;
+}
+
+export interface Z2mWizardSessionSnapshot {
+    id: string;
+    bridgeOnline: boolean;
+    startedAt: string;
+    permitJoin: { active: boolean; expiresAt: string | null; remainingSeconds: number };
+    devices: Z2mWizardDeviceSnapshot[];
+}
+
+interface Z2mWizardSession {
+    id: string;
+    startedAt: Date;
+    permitJoin: { active: boolean; expiresAt: Date | null; timer?: NodeJS.Timeout };
+    devices: Map<string, Z2mWizardDeviceSnapshot>;
+    unsubscribeJoined?: () => void;
+    idleTimer?: NodeJS.Timeout;
+}
+
+@Injectable()
+export class Z2mWizardService implements OnModuleDestroy {
+    private static readonly IDLE_TTL_MS = 10 * 60_000;
+    private static readonly PERMIT_JOIN_DURATION_S = 254;
+
+    private readonly logger: ExtensionLoggerService = createExtensionLogger(
+        DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, 'Z2mWizardService',
+    );
+    private readonly sessions = new Map<string, Z2mWizardSession>();
+
+    constructor(
+        private readonly zigbee2mqttService: Zigbee2mqttService,
+        private readonly deviceAdoptionService: Z2mDeviceAdoptionService,
+        private readonly mappingPreviewService: Z2mMappingPreviewService,
+        private readonly devicesService: DevicesService,
+    ) {}
+
+    async start(): Promise<Z2mWizardSessionSnapshot> {
+        const id = randomUUID();
+        const session: Z2mWizardSession = {
+            id,
+            startedAt: new Date(),
+            permitJoin: { active: false, expiresAt: null },
+            devices: new Map(),
+        };
+
+        this.sessions.set(id, session);
+        this.refreshIdleTimer(session);
+
+        await this.populateInitialDevices(session);
+
+        session.unsubscribeJoined = this.zigbee2mqttService.subscribeToDeviceJoined((device) => {
+            void this.handleDeviceJoined(session, device);
+        });
+
+        return this.toSnapshot(session);
+    }
+
+    get(id: string): Z2mWizardSessionSnapshot | null {
+        const session = this.sessions.get(id);
+        if (!session) return null;
+        this.refreshIdleTimer(session);
+        return this.toSnapshot(session);
+    }
+
+    async end(id: string): Promise<void> {
+        const session = this.sessions.get(id);
+        if (!session) return;
+        await this.disablePermitJoinInternal(session);
+        session.unsubscribeJoined?.();
+        if (session.idleTimer) clearTimeout(session.idleTimer);
+        this.sessions.delete(id);
+    }
+
+    async onModuleDestroy(): Promise<void> {
+        for (const session of this.sessions.values()) {
+            await this.disablePermitJoinInternal(session);
+            session.unsubscribeJoined?.();
+            if (session.idleTimer) clearTimeout(session.idleTimer);
+        }
+        this.sessions.clear();
+    }
+
+    // populateInitialDevices, handleDeviceJoined, computeSnapshot, refreshIdleTimer,
+    // disablePermitJoinInternal — added in later tasks
+
+    private toSnapshot(session: Z2mWizardSession): Z2mWizardSessionSnapshot {
+        return {
+            id: session.id,
+            bridgeOnline: this.zigbee2mqttService.isBridgeOnline(),
+            startedAt: session.startedAt.toISOString(),
+            permitJoin: {
+                active: session.permitJoin.active,
+                expiresAt: session.permitJoin.expiresAt?.toISOString() ?? null,
+                remainingSeconds: session.permitJoin.expiresAt
+                    ? Math.max(0, Math.ceil((session.permitJoin.expiresAt.getTime() - Date.now()) / 1_000))
+                    : 0,
+            },
+            devices: Array.from(session.devices.values()),
+        };
+    }
+
+    private refreshIdleTimer(session: Z2mWizardSession): void {
+        if (session.idleTimer) clearTimeout(session.idleTimer);
+        session.idleTimer = setTimeout(() => { void this.end(session.id); }, Z2mWizardService.IDLE_TTL_MS);
+    }
+
+    private async disablePermitJoinInternal(session: Z2mWizardSession): Promise<void> {
+        if (!session.permitJoin.active) return;
+        if (session.permitJoin.timer) clearTimeout(session.permitJoin.timer);
+        try {
+            await this.zigbee2mqttService.setPermitJoin(0);
+        } catch (e) {
+            this.logger.warn('Failed to disable permit_join during cleanup', { message: (e as Error).message });
+        }
+        session.permitJoin = { active: false, expiresAt: null };
+    }
+
+    private async populateInitialDevices(_session: Z2mWizardSession): Promise<void> {
+        // Implemented in Task 6
+    }
+
+    private async handleDeviceJoined(_session: Z2mWizardSession, _device: unknown): Promise<void> {
+        // Implemented in Task 6
+    }
+}
+```
+
+- [ ] **Step 4: Run the lifecycle tests to verify they pass**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+git commit -m "Z2M wizard: service skeleton with session lifecycle"
+```
+
+---
+
+## Task 6: Wizard service — device snapshot building
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts`
+
+- [ ] **Step 1: Add a failing test for snapshot building**
+
+Append to the spec:
+
+```ts
+describe('device snapshots', () => {
+    const sampleZ2mDevice = {
+        ieeeAddress: '0x00158d0001a1b2c3',
+        friendlyName: 'living_room_lamp',
+        type: 'Router',
+        modelId: 'LCT001',
+        powerSource: 'Mains',
+        supported: true,
+        available: true,
+        definition: {
+            vendor: 'Philips',
+            model: 'LCT001',
+            description: 'Hue White and Color Ambiance E27',
+            exposes: [
+                { type: 'light', name: 'light', features: [], property: undefined, label: undefined, access: 7 },
+            ],
+        },
+    };
+
+    it('marks ready when device has descriptor and is unadopted', async () => {
+        zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+        const snapshot = await service.start();
+        expect(snapshot.devices).toHaveLength(1);
+        expect(snapshot.devices[0]?.status).toBe('ready');
+        expect(snapshot.devices[0]?.suggestedCategory).toBe('LIGHTING');
+        expect(snapshot.devices[0]?.previewChannelCount).toBe(1);
+    });
+
+    it('marks already_registered when device has matching adopted record', async () => {
+        zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+        const devicesService = { findAll: jest.fn().mockResolvedValue([
+            { id: 'adopted-1', identifier: 'living_room_lamp', name: 'Existing Lamp', category: 'LIGHTING' },
+        ]) };
+        // Re-create module with this devicesService...
+        // OR override the existing mock:
+        const findAll = (service as any).devicesService.findAll;
+        findAll.mockResolvedValueOnce([
+            { id: 'adopted-1', identifier: 'living_room_lamp', name: 'Existing Lamp', category: 'LIGHTING' },
+        ]);
+        const snapshot = await service.start();
+        expect(snapshot.devices[0]?.status).toBe('already_registered');
+        expect(snapshot.devices[0]?.registeredDeviceId).toBe('adopted-1');
+    });
+
+    it('marks unsupported when mapping preview returns no channels', async () => {
+        zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+        const previewService = (service as any).mappingPreviewService;
+        previewService.generatePreview.mockResolvedValueOnce({
+            suggestedCategory: null, channels: [], warnings: [], readyToAdopt: false, exposes: [],
+        });
+        const snapshot = await service.start();
+        expect(snapshot.devices[0]?.status).toBe('unsupported');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: FAIL — `expect(received).toHaveLength(1)` (still 0 because populateInitialDevices is empty)
+
+- [ ] **Step 3: Implement `populateInitialDevices` and `handleDeviceJoined`**
+
+Replace the placeholders in `wizard.service.ts`:
+
+```ts
+private async populateInitialDevices(session: Z2mWizardSession): Promise<void> {
+    if (!this.zigbee2mqttService.isBridgeOnline()) return;
+
+    const z2mDevices = this.zigbee2mqttService.getRegisteredDevices();
+    const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+
+    for (const z2mDevice of z2mDevices) {
+        const snapshot = await this.computeSnapshot(z2mDevice, adopted);
+        session.devices.set(snapshot.ieeeAddress, snapshot);
+    }
+}
+
+private async handleDeviceJoined(session: Z2mWizardSession, z2mDevice: any): Promise<void> {
+    try {
+        const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+        const snapshot = await this.computeSnapshot(z2mDevice, adopted);
+        session.devices.set(snapshot.ieeeAddress, snapshot);
+    } catch (e) {
+        this.logger.warn('Failed to handle device-joined event', {
+            session: session.id,
+            ieeeAddress: z2mDevice?.ieeeAddress,
+            message: (e as Error).message,
+        });
+    }
+}
+
+private async computeSnapshot(
+    z2mDevice: any,
+    adopted: Zigbee2mqttDeviceEntity[],
+): Promise<Z2mWizardDeviceSnapshot> {
+    const adoptedRecord = adopted.find((d) => d.identifier === z2mDevice.friendlyName) ?? null;
+
+    let preview: Awaited<ReturnType<Z2mMappingPreviewService['generatePreview']>> | null = null;
+    let previewError: string | null = null;
+    try {
+        preview = await this.mappingPreviewService.generatePreview(z2mDevice.ieeeAddress);
+    } catch (e) {
+        previewError = (e as Error).message;
+    }
+
+    let status: Z2mWizardDeviceStatus;
+    if (previewError) {
+        status = 'failed';
+    } else if (adoptedRecord) {
+        status = 'already_registered';
+    } else if (!preview || preview.channels.length === 0) {
+        status = 'unsupported';
+    } else {
+        status = 'ready';
+    }
+
+    const suggestedCategory = (preview?.suggestedCategory ?? null) as DeviceCategory | null;
+    const categories: DeviceCategory[] = suggestedCategory ? [suggestedCategory] : [];
+    const previewChannelCount = preview?.channels.length ?? 0;
+    const previewChannelIdentifiers = preview?.channels.map((c: any) => c.identifier) ?? [];
+
+    return {
+        ieeeAddress: z2mDevice.ieeeAddress,
+        friendlyName: z2mDevice.friendlyName,
+        manufacturer: z2mDevice.definition?.vendor ?? null,
+        model: z2mDevice.definition?.model ?? null,
+        description: z2mDevice.definition?.description ?? null,
+        status,
+        categories,
+        suggestedCategory,
+        previewChannelCount,
+        previewChannelIdentifiers,
+        registeredDeviceId: adoptedRecord?.id ?? null,
+        registeredDeviceName: adoptedRecord?.name ?? null,
+        registeredDeviceCategory: adoptedRecord?.category ?? null,
+        error: previewError,
+        lastSeenAt: new Date().toISOString(),
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: PASS (all tests in this file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+git commit -m "Z2M wizard: device snapshot building"
+```
+
+---
+
+## Task 7: Wizard service — permit_join lifecycle
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts`
+
+- [ ] **Step 1: Write failing tests for permit_join enable/disable**
+
+Append:
+
+```ts
+describe('permit_join', () => {
+    it('enablePermitJoin() sets active=true and remainingSeconds≈254', async () => {
+        const started = await service.start();
+        const updated = await service.enablePermitJoin(started.id);
+        expect(updated?.permitJoin.active).toBe(true);
+        expect(updated?.permitJoin.remainingSeconds).toBeGreaterThan(250);
+        expect(zigbee2mqttService.setPermitJoin).toHaveBeenCalledWith(254);
+    });
+
+    it('disablePermitJoin() sets active=false and remainingSeconds=0', async () => {
+        const started = await service.start();
+        await service.enablePermitJoin(started.id);
+        const updated = await service.disablePermitJoin(started.id);
+        expect(updated?.permitJoin.active).toBe(false);
+        expect(updated?.permitJoin.remainingSeconds).toBe(0);
+        expect(zigbee2mqttService.setPermitJoin).toHaveBeenLastCalledWith(0);
+    });
+
+    it('returns null for unknown session id', async () => {
+        expect(await service.enablePermitJoin('nope')).toBeNull();
+        expect(await service.disablePermitJoin('nope')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: FAIL with "service.enablePermitJoin is not a function"
+
+- [ ] **Step 3: Implement permit_join methods**
+
+Add to `Z2mWizardService`:
+
+```ts
+async enablePermitJoin(id: string): Promise<Z2mWizardSessionSnapshot | null> {
+    const session = this.sessions.get(id);
+    if (!session) return null;
+    this.refreshIdleTimer(session);
+
+    const ok = await this.zigbee2mqttService.setPermitJoin(Z2mWizardService.PERMIT_JOIN_DURATION_S);
+    if (!ok) {
+        this.logger.warn('Failed to enable permit_join', { session: id });
+        return this.toSnapshot(session);
+    }
+
+    if (session.permitJoin.timer) clearTimeout(session.permitJoin.timer);
+
+    session.permitJoin = {
+        active: true,
+        expiresAt: new Date(Date.now() + Z2mWizardService.PERMIT_JOIN_DURATION_S * 1_000),
+        timer: setTimeout(() => {
+            session.permitJoin = { active: false, expiresAt: null };
+        }, Z2mWizardService.PERMIT_JOIN_DURATION_S * 1_000),
+    };
+
+    return this.toSnapshot(session);
+}
+
+async disablePermitJoin(id: string): Promise<Z2mWizardSessionSnapshot | null> {
+    const session = this.sessions.get(id);
+    if (!session) return null;
+    this.refreshIdleTimer(session);
+    await this.disablePermitJoinInternal(session);
+    return this.toSnapshot(session);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+git commit -m "Z2M wizard: permit_join lifecycle"
+```
+
+---
+
+## Task 8: Wizard service — batch adoption with race fallback
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts`
+
+- [ ] **Step 1: Write failing tests for adopt**
+
+Read the existing `Z2mDeviceAdoptionService.adoptDevice()` signature in `services/device-adoption.service.ts` first to know what arguments to pass and what it returns. The DTO it accepts is `AdoptDeviceRequestDto` (from `dto/mapping-preview.dto.ts`) and it returns a `DeviceEntity`. The existing service may also throw `DevicesZigbee2mqttValidationException` for already-adopted cases — use that as the signal for the race fallback.
+
+Append:
+
+```ts
+describe('adopt', () => {
+    const ieee = '0x00158d0001a1b2c3';
+    const sampleZ2mDevice = {
+        ieeeAddress: ieee,
+        friendlyName: 'living_room_lamp',
+        type: 'Router',
+        modelId: 'LCT001',
+        supported: true,
+        available: true,
+        definition: { vendor: 'Philips', model: 'LCT001', description: 'Hue', exposes: [{ type: 'light' }] },
+    };
+
+    beforeEach(() => {
+        zigbee2mqttService.getRegisteredDevices.mockReturnValue([sampleZ2mDevice as any]);
+    });
+
+    it('returns created result on successful adoption', async () => {
+        (service as any).deviceAdoptionService.adoptDevice.mockResolvedValueOnce({ id: 'd1', name: 'Living Room Lamp' });
+        const started = await service.start();
+        const out = await service.adopt(started.id, [{ ieeeAddress: ieee, name: 'Living Room Lamp', category: 'LIGHTING' as any }]);
+        expect(out).toEqual([{ ieeeAddress: ieee, name: 'Living Room Lamp', status: 'created', error: null }]);
+    });
+
+    it('returns updated result when device was already adopted (race fallback)', async () => {
+        const started = await service.start();
+        // Force the wizard to see it as already_registered after the snapshot was built:
+        const session = (service as any).sessions.get(started.id);
+        session.devices.get(ieee).status = 'already_registered';
+        session.devices.get(ieee).registeredDeviceId = 'd1';
+        const out = await service.adopt(started.id, [{ ieeeAddress: ieee, name: 'X', category: 'LIGHTING' as any }]);
+        expect(out[0]?.status).toBe('updated');
+    });
+
+    it('returns failed result when adoption throws', async () => {
+        (service as any).deviceAdoptionService.adoptDevice.mockRejectedValueOnce(new Error('boom'));
+        const started = await service.start();
+        const out = await service.adopt(started.id, [{ ieeeAddress: ieee, name: 'X', category: 'LIGHTING' as any }]);
+        expect(out[0]?.status).toBe('failed');
+        expect(out[0]?.error).toBe('boom');
+    });
+
+    it('returns empty array for unknown session id', async () => {
+        const out = await service.adopt('nope', []);
+        expect(out).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: FAIL — `service.adopt is not a function`
+
+- [ ] **Step 3: Implement `adopt`**
+
+Look at `Z2mDeviceAdoptionService.adoptDevice` signature first — read `services/device-adoption.service.ts`. It expects an `AdoptDeviceRequestDto` shape with `ieeeAddress`, `name`, `category`, etc. Adapt the call:
+
+```ts
+async adopt(
+    id: string,
+    requests: { ieeeAddress: string; name: string; category: DeviceCategory }[],
+): Promise<{ ieeeAddress: string; name: string; status: 'created' | 'updated' | 'failed'; error: string | null }[]> {
+    const session = this.sessions.get(id);
+    if (!session) return [];
+    this.refreshIdleTimer(session);
+
+    // Refresh-before-adopt: rebuild snapshots so we have current registered status
+    const adopted = await this.devicesService.findAll<Zigbee2mqttDeviceEntity>(DEVICES_ZIGBEE2MQTT_TYPE);
+    for (const z2mDevice of this.zigbee2mqttService.getRegisteredDevices()) {
+        const snapshot = await this.computeSnapshot(z2mDevice, adopted);
+        session.devices.set(snapshot.ieeeAddress, snapshot);
+    }
+
+    const results: { ieeeAddress: string; name: string; status: 'created' | 'updated' | 'failed'; error: string | null }[] = [];
+
+    for (const req of requests) {
+        const current = session.devices.get(req.ieeeAddress);
+
+        if (!current) {
+            results.push({ ieeeAddress: req.ieeeAddress, name: req.name, status: 'failed', error: 'Device not in session' });
+            continue;
+        }
+
+        try {
+            if (current.status === 'already_registered' && current.registeredDeviceId) {
+                // Race fallback: device was adopted between session start and adopt call.
+                // Update name/category via DevicesService instead of creating.
+                await this.devicesService.update(current.registeredDeviceId, {
+                    name: req.name,
+                    category: req.category,
+                } as any);
+
+                // Refresh snapshot so the response reflects the updated state.
+                session.devices.set(req.ieeeAddress, {
+                    ...current,
+                    registeredDeviceName: req.name,
+                    registeredDeviceCategory: req.category,
+                });
+
+                results.push({ ieeeAddress: req.ieeeAddress, name: req.name, status: 'updated', error: null });
+                continue;
+            }
+
+            const created = await this.deviceAdoptionService.adoptDevice({
+                ieeeAddress: req.ieeeAddress,
+                name: req.name,
+                category: req.category,
+            } as any);
+
+            // Refresh the snapshot to reflect the adoption.
+            session.devices.set(req.ieeeAddress, {
+                ...current,
+                status: 'already_registered',
+                registeredDeviceId: created.id,
+                registeredDeviceName: req.name,
+                registeredDeviceCategory: req.category,
+            });
+
+            results.push({ ieeeAddress: req.ieeeAddress, name: req.name, status: 'created', error: null });
+        } catch (e) {
+            results.push({ ieeeAddress: req.ieeeAddress, name: req.name, status: 'failed', error: (e as Error).message });
+        }
+    }
+
+    return results;
+}
+```
+
+> Note for the implementer: the exact `adoptDevice()` argument shape and `devicesService.update()` signature must match what's actually in the codebase. Read those files and adjust the call sites — do NOT invent fields.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm run test:unit -- --testPathPattern wizard.service`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.ts apps/backend/src/plugins/devices-zigbee2mqtt/services/wizard.service.spec.ts
+git commit -m "Z2M wizard: batch adoption with race fallback"
+```
+
+---
+
+## Task 9: Wizard controller (with tests)
+
+**Files:**
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts`
+- Create: `apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts`
+
+- [ ] **Step 1: Write failing controller tests**
+
+Reference shelly-ng's `controllers/shelly-ng-devices.controller.spec.ts` for the testing pattern — it constructs the controller with mocked services and asserts response shape + 404 behavior.
+
+```ts
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Zigbee2mqttWizardController } from './zigbee2mqtt-wizard.controller';
+import { Z2mWizardService } from '../services/wizard.service';
+
+describe('Zigbee2mqttWizardController', () => {
+    let controller: Zigbee2mqttWizardController;
+    let wizardService: jest.Mocked<Z2mWizardService>;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [Zigbee2mqttWizardController],
+            providers: [{
+                provide: Z2mWizardService,
+                useValue: {
+                    start: jest.fn(),
+                    get: jest.fn(),
+                    end: jest.fn(),
+                    enablePermitJoin: jest.fn(),
+                    disablePermitJoin: jest.fn(),
+                    adopt: jest.fn(),
+                },
+            }],
+        }).compile();
+        controller = module.get(Zigbee2mqttWizardController);
+        wizardService = module.get(Z2mWizardService);
+    });
+
+    it('POST /wizard returns the new session', async () => {
+        const session = { id: 'a', bridgeOnline: true, startedAt: 't', permitJoin: { active: false, expiresAt: null, remainingSeconds: 0 }, devices: [] };
+        wizardService.start.mockResolvedValueOnce(session as any);
+        const res = await controller.startSession();
+        expect(res.data).toEqual(session);
+    });
+
+    it('GET /wizard/:id throws 404 for unknown id', () => {
+        wizardService.get.mockReturnValue(null);
+        expect(() => controller.getSession('nope')).toThrow(NotFoundException);
+    });
+
+    it('DELETE /wizard/:id calls service.end()', async () => {
+        wizardService.end.mockResolvedValueOnce(undefined);
+        await controller.endSession('a');
+        expect(wizardService.end).toHaveBeenCalledWith('a');
+    });
+
+    it('POST /wizard/:id/permit-join returns updated session', async () => {
+        const updated = { id: 'a', bridgeOnline: true, startedAt: 't', permitJoin: { active: true, expiresAt: 'x', remainingSeconds: 254 }, devices: [] };
+        wizardService.enablePermitJoin.mockResolvedValueOnce(updated as any);
+        const res = await controller.enablePermitJoin('a');
+        expect(res.data).toEqual(updated);
+    });
+
+    it('POST /wizard/:id/permit-join throws 404 when service returns null', async () => {
+        wizardService.enablePermitJoin.mockResolvedValueOnce(null);
+        await expect(controller.enablePermitJoin('nope')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('POST /wizard/:id/adopt returns adoption results', async () => {
+        wizardService.adopt.mockResolvedValueOnce([
+            { ieeeAddress: 'x', name: 'X', status: 'created', error: null },
+        ]);
+        const res = await controller.adopt('a', { data: { devices: [{ ieeeAddress: 'x', name: 'X', category: 'LIGHTING' as any }] } } as any);
+        expect(res.data.results).toHaveLength(1);
+        expect(res.data.results[0]?.status).toBe('created');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm run test:unit -- --testPathPattern zigbee2mqtt-wizard.controller`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implement the controller**
+
+Reference: `apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts`. Use the same Swagger decorator pattern (`@ApiOperation`, `@ApiSuccessResponse`, etc.) and the same `@ApiTags(DEVICES_ZIGBEE2MQTT_API_TAG_NAME)`.
+
+```ts
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import {
+    ApiBadRequestResponse, ApiCreatedSuccessResponse, ApiInternalServerErrorResponse,
+    ApiNotFoundResponse, ApiSuccessResponse,
+} from '../../../modules/swagger/decorators/api-documentation.decorator';
+import { DEVICES_ZIGBEE2MQTT_API_TAG_NAME, DEVICES_ZIGBEE2MQTT_PLUGIN_NAME } from '../devices-zigbee2mqtt.constants';
+import { ReqZ2mWizardAdoptDto } from '../dto/wizard-adopt.dto';
+import {
+    Z2mWizardAdoptionResponseModel, Z2mWizardSessionResponseModel,
+} from '../models/zigbee2mqtt-response.model';
+import { Z2mWizardService } from '../services/wizard.service';
+
+@ApiTags(DEVICES_ZIGBEE2MQTT_API_TAG_NAME)
+@Controller('wizard')
+export class Zigbee2mqttWizardController {
+    private readonly logger: ExtensionLoggerService = createExtensionLogger(
+        DEVICES_ZIGBEE2MQTT_PLUGIN_NAME, 'WizardController',
+    );
+
+    constructor(private readonly wizardService: Z2mWizardService) {}
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'Start Zigbee2MQTT adoption wizard session',
+        description: 'Creates a wizard session, returning the list of currently unadopted Zigbee devices with mapping previews.',
+        operationId: 'create-devices-zigbee2mqtt-plugin-wizard',
+    })
+    @ApiCreatedSuccessResponse(Z2mWizardSessionResponseModel, 'Wizard session was started successfully')
+    @ApiInternalServerErrorResponse('Internal server error')
+    @Post()
+    async startSession(): Promise<Z2mWizardSessionResponseModel> {
+        const response = new Z2mWizardSessionResponseModel();
+        response.data = await this.wizardService.start();
+        return response;
+    }
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'Get Zigbee2MQTT wizard session state',
+        description: 'Returns the current state of the wizard session, including any newly-paired devices that arrived since the last poll and remaining permit_join time.',
+        operationId: 'get-devices-zigbee2mqtt-plugin-wizard',
+    })
+    @ApiParam({ name: 'id', type: 'string' })
+    @ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Wizard session was successfully retrieved.')
+    @ApiNotFoundResponse('Wizard session could not be found')
+    @ApiInternalServerErrorResponse('Internal server error')
+    @Get(':id')
+    getSession(@Param('id') id: string): Z2mWizardSessionResponseModel {
+        const session = this.wizardService.get(id);
+        if (!session) throw new NotFoundException('Wizard session could not be found');
+        const response = new Z2mWizardSessionResponseModel();
+        response.data = session;
+        return response;
+    }
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'End Zigbee2MQTT wizard session',
+        description: 'Terminates the wizard session. If permit_join is active for this session it is disabled.',
+        operationId: 'delete-devices-zigbee2mqtt-plugin-wizard',
+    })
+    @ApiParam({ name: 'id', type: 'string' })
+    @ApiInternalServerErrorResponse('Internal server error')
+    @Delete(':id')
+    async endSession(@Param('id') id: string): Promise<void> {
+        await this.wizardService.end(id);
+    }
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'Enable Zigbee2MQTT pairing mode (permit_join)',
+        description: 'Enables permit_join on the bridge for 254 seconds, scoped to this wizard session.',
+        operationId: 'enable-devices-zigbee2mqtt-plugin-wizard-permit-join',
+    })
+    @ApiParam({ name: 'id', type: 'string' })
+    @ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Pairing mode enabled')
+    @ApiNotFoundResponse('Wizard session could not be found')
+    @Post(':id/permit-join')
+    async enablePermitJoin(@Param('id') id: string): Promise<Z2mWizardSessionResponseModel> {
+        const session = await this.wizardService.enablePermitJoin(id);
+        if (!session) throw new NotFoundException('Wizard session could not be found');
+        const response = new Z2mWizardSessionResponseModel();
+        response.data = session;
+        return response;
+    }
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'Disable Zigbee2MQTT pairing mode (permit_join)',
+        description: 'Disables permit_join on the bridge.',
+        operationId: 'disable-devices-zigbee2mqtt-plugin-wizard-permit-join',
+    })
+    @ApiParam({ name: 'id', type: 'string' })
+    @ApiSuccessResponse(Z2mWizardSessionResponseModel, 'Pairing mode disabled')
+    @ApiNotFoundResponse('Wizard session could not be found')
+    @Delete(':id/permit-join')
+    async disablePermitJoin(@Param('id') id: string): Promise<Z2mWizardSessionResponseModel> {
+        const session = await this.wizardService.disablePermitJoin(id);
+        if (!session) throw new NotFoundException('Wizard session could not be found');
+        const response = new Z2mWizardSessionResponseModel();
+        response.data = session;
+        return response;
+    }
+
+    @ApiOperation({
+        tags: [DEVICES_ZIGBEE2MQTT_API_TAG_NAME],
+        summary: 'Adopt selected devices from wizard',
+        description: 'Adopts each requested device with the supplied display name and category. Devices already adopted in another flow are updated instead of created.',
+        operationId: 'adopt-devices-zigbee2mqtt-plugin-wizard',
+    })
+    @ApiParam({ name: 'id', type: 'string' })
+    @ApiBody({ type: ReqZ2mWizardAdoptDto })
+    @ApiSuccessResponse(Z2mWizardAdoptionResponseModel, 'Adoption results returned')
+    @ApiBadRequestResponse('Invalid request data')
+    @ApiNotFoundResponse('Wizard session could not be found')
+    @Post(':id/adopt')
+    async adopt(@Param('id') id: string, @Body() body: ReqZ2mWizardAdoptDto): Promise<Z2mWizardAdoptionResponseModel> {
+        const results = await this.wizardService.adopt(id, body.data.devices);
+        const response = new Z2mWizardAdoptionResponseModel();
+        response.data = { results } as any;
+        return response;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm run test:unit -- --testPathPattern zigbee2mqtt-wizard.controller`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.ts apps/backend/src/plugins/devices-zigbee2mqtt/controllers/zigbee2mqtt-wizard.controller.spec.ts
+git commit -m "Z2M wizard: REST controller"
+```
+
+---
+
+## Task 10: Wire wizard into plugin module + OpenAPI registry
+
+**Files:**
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts`
+- Modify: `apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.openapi.ts`
+
+- [ ] **Step 1: Read both files to find where existing controllers/services/models are registered**
+
+Run: `cat apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts`
+Run: `cat apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.openapi.ts`
+
+- [ ] **Step 2: Register `Zigbee2mqttWizardController` and `Z2mWizardService` in the plugin module**
+
+In `devices-zigbee2mqtt.plugin.ts`, add the controller to the `controllers` array of the `@Module` decorator (or wherever the existing `Zigbee2mqttDiscoveredDevicesController` is registered) and `Z2mWizardService` to `providers`. Also export `Z2mWizardService` if other modules import services from this plugin (mirror the pattern of `Z2mDeviceAdoptionService`).
+
+- [ ] **Step 3: Register new schemas in OpenAPI registry**
+
+In `devices-zigbee2mqtt.openapi.ts`, add the new model classes to the schema registration list. Look at how `Zigbee2mqttDiscoveredDeviceModel` is registered and follow the exact same pattern for:
+- `Z2mWizardPermitJoinModel`
+- `Z2mWizardDeviceSnapshotModel`
+- `Z2mWizardSessionModel`
+- `Z2mWizardAdoptionResultModel`
+- `Z2mWizardAdoptionModel`
+- `Z2mWizardSessionResponseModel`
+- `Z2mWizardAdoptionResponseModel`
+- `Z2mWizardAdoptDeviceDto`
+- `Z2mWizardAdoptDto`
+- `ReqZ2mWizardAdoptDto`
+
+- [ ] **Step 4: Run typecheck and existing test suite to confirm nothing regressed**
+
+Run: `pnpm run lint:js && pnpm run test:unit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.openapi.ts
+git commit -m "Z2M wizard: wire controller and service into plugin module"
+```
+
+---
+
+## Task 11: Regenerate OpenAPI spec & admin types
+
+**Files:**
+- Modify (auto-generated): `spec/api/v1/openapi.json`
+- Modify (auto-generated): `apps/admin/src/openapi.ts`
+
+- [ ] **Step 1: Run the generator**
+
+Run: `pnpm run generate:openapi`
+Expected: Completes without errors. Diff shows new wizard schemas/operations.
+
+- [ ] **Step 2: Spot-check the spec**
+
+Run: `grep -c 'devices-zigbee2mqtt-plugin-wizard' spec/api/v1/openapi.json`
+Expected: Output ≥ 6 (the operationIds we registered).
+
+- [ ] **Step 3: Confirm admin types regenerated**
+
+Run: `grep -c 'DevicesZigbee2mqttPluginCreate.*Wizard' apps/admin/src/openapi.ts`
+Expected: Output ≥ 1.
+
+- [ ] **Step 4: Commit generated files**
+
+```bash
+git add spec/api/v1/openapi.json apps/admin/src/openapi.ts apps/admin/src/openapi.constants.ts apps/panel/lib/api/ apps/panel/lib/spec/ 2>/dev/null
+git commit -m "Z2M wizard: regenerate OpenAPI spec and clients"
+```
+
+(If the generator does not modify panel files, drop those paths from the `git add`.)
+
+---
+
+## Task 12: Admin types and transformers
+
+**Files:**
+- Modify: `apps/admin/src/plugins/devices-zigbee2mqtt/schemas/devices.types.ts` (or whichever schemas file the plugin uses — check first)
+- Modify: `apps/admin/src/plugins/devices-zigbee2mqtt/utils/devices.transformers.ts` (or the analogous transformer file)
+
+- [ ] **Step 1: Locate existing schema and transformer files**
+
+Run: `ls apps/admin/src/plugins/devices-zigbee2mqtt/schemas/ apps/admin/src/plugins/devices-zigbee2mqtt/utils/`
+
+Adjust target paths in steps 2-3 if the plugin uses a different layout.
+
+- [ ] **Step 2: Add wizard types**
+
+Append to the schemas types file:
+
+```ts
+import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+
+export type IZ2mWizardDeviceStatus = 'ready' | 'unsupported' | 'already_registered' | 'failed';
+
+export interface IZ2mWizardPermitJoin {
+    active: boolean;
+    expiresAt: string | null;
+    remainingSeconds: number;
+}
+
+export interface IZ2mWizardDevice {
+    ieeeAddress: string;
+    friendlyName: string;
+    manufacturer: string | null;
+    model: string | null;
+    description: string | null;
+    status: IZ2mWizardDeviceStatus;
+    categories: DevicesModuleDeviceCategory[];
+    suggestedCategory: DevicesModuleDeviceCategory | null;
+    previewChannelCount: number;
+    previewChannelIdentifiers: string[];
+    registeredDeviceId: string | null;
+    registeredDeviceName: string | null;
+    registeredDeviceCategory: DevicesModuleDeviceCategory | null;
+    error: string | null;
+    lastSeenAt: string;
+}
+
+export interface IZ2mWizardSession {
+    id: string;
+    bridgeOnline: boolean;
+    startedAt: string;
+    permitJoin: IZ2mWizardPermitJoin;
+    devices: IZ2mWizardDevice[];
+}
+
+export interface IZ2mWizardAdoptionResult {
+    ieeeAddress: string;
+    name: string;
+    status: 'created' | 'updated' | 'failed';
+    error: string | null;
+}
+```
+
+- [ ] **Step 3: Add a response transformer**
+
+Append to the transformers file:
+
+```ts
+import type { components } from '../../../openapi';
+import type { IZ2mWizardSession } from '../schemas/devices.types';
+
+type WizardSessionResponse = components['schemas']['DevicesZigbee2mqttPluginDataWizardSession'];
+
+export const transformWizardSessionResponse = (raw: WizardSessionResponse): IZ2mWizardSession => ({
+    id: raw.id,
+    bridgeOnline: raw.bridgeOnline,
+    startedAt: raw.startedAt,
+    permitJoin: {
+        active: raw.permitJoin.active,
+        expiresAt: raw.permitJoin.expiresAt ?? null,
+        remainingSeconds: raw.permitJoin.remainingSeconds,
+    },
+    devices: raw.devices.map((d) => ({
+        ieeeAddress: d.ieeeAddress,
+        friendlyName: d.friendlyName,
+        manufacturer: d.manufacturer ?? null,
+        model: d.model ?? null,
+        description: d.description ?? null,
+        status: d.status as IZ2mWizardSession['devices'][number]['status'],
+        categories: d.categories ?? [],
+        suggestedCategory: d.suggestedCategory ?? null,
+        previewChannelCount: d.previewChannelCount,
+        previewChannelIdentifiers: d.previewChannelIdentifiers ?? [],
+        registeredDeviceId: d.registeredDeviceId ?? null,
+        registeredDeviceName: d.registeredDeviceName ?? null,
+        registeredDeviceCategory: d.registeredDeviceCategory ?? null,
+        error: d.error ?? null,
+        lastSeenAt: d.lastSeenAt,
+    })),
+});
+```
+
+(If `components['schemas']` typing isn't how this codebase imports OpenAPI types, follow the existing pattern in `devices.transformers.ts`.)
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter ./apps/admin run lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/schemas/devices.types.ts apps/admin/src/plugins/devices-zigbee2mqtt/utils/devices.transformers.ts
+git commit -m "Z2M wizard: admin types and response transformer"
+```
+
+---
+
+## Task 13: `useFriendlyNameHumanizer` composable (TDD)
+
+**Files:**
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.ts`
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `useFriendlyNameHumanizer.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { useFriendlyNameHumanizer } from './useFriendlyNameHumanizer';
+
+describe('useFriendlyNameHumanizer', () => {
+    const { humanize } = useFriendlyNameHumanizer();
+
+    it('humanizes snake_case', () => {
+        expect(humanize('living_room_lamp')).toBe('Living Room Lamp');
+    });
+
+    it('humanizes kebab-case', () => {
+        expect(humanize('kitchen-light-1')).toBe('Kitchen Light 1');
+    });
+
+    it('humanizes camelCase', () => {
+        expect(humanize('frontDoorSensor')).toBe('Front Door Sensor');
+    });
+
+    it('humanizes single word', () => {
+        expect(humanize('thermostat')).toBe('Thermostat');
+    });
+
+    it('preserves trailing numbers as separate tokens', () => {
+        expect(humanize('sensor_3')).toBe('Sensor 3');
+    });
+
+    it('handles already-humanized names', () => {
+        expect(humanize('Living Room Lamp')).toBe('Living Room Lamp');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(humanize('')).toBe('');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter ./apps/admin run test:unit -- useFriendlyNameHumanizer`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the composable**
+
+Create `useFriendlyNameHumanizer.ts`:
+
+```ts
+export interface IUseFriendlyNameHumanizer {
+    humanize: (input: string) => string;
+}
+
+export const useFriendlyNameHumanizer = (): IUseFriendlyNameHumanizer => {
+    const humanize = (input: string): string => {
+        if (!input) return '';
+
+        return input
+            // camelCase boundary: insert space before each uppercase letter
+            .replace(/([a-z])([A-Z])/g, '$1 $2')
+            // letter→digit boundary: "sensor3" → "sensor 3"
+            .replace(/([a-zA-Z])(\d)/g, '$1 $2')
+            // delimiters
+            .replace(/[_\-]+/g, ' ')
+            // collapse whitespace
+            .replace(/\s+/g, ' ')
+            .trim()
+            // Title-case each word
+            .split(' ')
+            .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1).toLowerCase() : ''))
+            .join(' ');
+    };
+
+    return { humanize };
+};
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter ./apps/admin run test:unit -- useFriendlyNameHumanizer`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.ts apps/admin/src/plugins/devices-zigbee2mqtt/composables/useFriendlyNameHumanizer.spec.ts
+git commit -m "Z2M wizard: friendly name humanizer composable"
+```
+
+---
+
+## Task 14: `useDevicesWizard` composable
+
+**Files:**
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts`
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts`
+
+The shape mirrors shelly-ng's `useDevicesWizard` ([reference](../../../apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts)) with these substitutions:
+- `hostname` key → `ieeeAddress` key everywhere
+- No `manual` entry, no scan-progress percentage, no password fields
+- New: `permitJoin` reactive state + `enablePermitJoin()` / `disablePermitJoin()` methods
+- New: name pre-fill uses `humanize(friendlyName)`
+- Polling interval: 1s; only running when a session exists
+
+- [ ] **Step 1: Write failing tests for the composable**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useDevicesWizard } from './useDevicesWizard';
+
+// Mock backend HTTP. Replicate the pattern used in
+// apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts —
+// look up `useBackend()` mocks there and reuse the same shape.
+
+describe('useDevicesWizard', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('startSession() populates session and pre-fills humanized names', async () => {
+        // ... mock POST /wizard to return a session with one device named 'living_room_lamp'
+        // expect nameByIeee[ieee] === 'Living Room Lamp'
+    });
+
+    it('auto-selects ready devices and pre-fills suggestedCategory', async () => {
+        // ... session with one ready device, suggestedCategory=LIGHTING
+        // expect selected[ieee] === true
+        // expect categoryByIeee[ieee] === 'LIGHTING'
+    });
+
+    it('deselects when status transitions ready → already_registered', async () => {
+        // start with ready, poll updates to already_registered
+        // expect selected[ieee] === false
+    });
+
+    it('canContinue is false when any selected device has empty name', async () => {
+        // selected, but nameByIeee[ieee] = ''
+        // expect canContinue === false
+    });
+
+    it('adoptSelected returns adoption results from the API', async () => {
+        // mock POST /wizard/:id/adopt
+        // expect adoptionResults to contain {status: 'created', ...}
+    });
+});
+```
+
+> Use the spec at `apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts` as a literal template for the mock setup (`useBackend`, `useFlashMessage`, devices store) — only the URL paths and key names differ.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter ./apps/admin run test:unit -- useDevicesWizard.spec`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the composable**
+
+Create `useDevicesWizard.ts`. Use shelly-ng's composable as the base; substitute `hostname → ieeeAddress`, drop `manual`/`scanPercentage`/`passwordByHostname`/`addManualDevice`, and add `permitJoin` / `enablePermitJoin` / `disablePermitJoin`.
+
+Public surface (interface):
+
+```ts
+import type { ComputedRef, Reactive, Ref } from 'vue';
+import type { FormResultType } from '../../../modules/devices';
+import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import type { IZ2mWizardSession, IZ2mWizardDevice, IZ2mWizardAdoptionResult } from '../schemas/devices.types';
+
+export interface IUseDevicesWizard {
+    session: ComputedRef<IZ2mWizardSession | null>;
+    devices: ComputedRef<IZ2mWizardDevice[]>;
+    selectedDevices: ComputedRef<IZ2mWizardDevice[]>;
+    permitJoin: ComputedRef<IZ2mWizardSession['permitJoin']>;
+    bridgeOnline: ComputedRef<boolean>;
+    formResult: ComputedRef<FormResultType>;
+    selected: Reactive<Record<string, boolean>>;
+    categoryByIeee: Reactive<Record<string, DevicesModuleDeviceCategory | null>>;
+    nameByIeee: Reactive<Record<string, string>>;
+    adoptionResults: ComputedRef<IZ2mWizardAdoptionResult[]>;
+    canContinue: ComputedRef<boolean>;
+    startSession: () => Promise<void>;
+    refreshSession: () => Promise<void>;
+    endSession: () => Promise<void>;
+    enablePermitJoin: () => Promise<void>;
+    disablePermitJoin: () => Promise<void>;
+    adoptSelected: () => Promise<IZ2mWizardAdoptionResult[]>;
+    categoryOptions: (device: IZ2mWizardDevice) => { value: DevicesModuleDeviceCategory; label: string }[];
+}
+
+export const isAdoptableStatus = (s: IZ2mWizardDevice['status']): boolean =>
+    s === 'ready' || s === 'already_registered';
+
+export const useDevicesWizard = (): IUseDevicesWizard => {
+    // 1. Construct reactive state (session, selected, categoryByIeee, nameByIeee, etc.)
+    // 2. Wire up backend calls to the wizard endpoints — paths:
+    //    POST   ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard         → start
+    //    GET    ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard/:id     → refresh
+    //    DELETE ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard/:id     → end
+    //    POST   ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard/:id/permit-join   → enable
+    //    DELETE ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard/:id/permit-join   → disable
+    //    POST   ${PLUGINS_PREFIX}/devices-zigbee2mqtt/wizard/:id/adopt         → adopt
+    // 3. Pre-fill nameByIeee from humanize(friendlyName), categoryByIeee from suggestedCategory
+    // 4. 1s polling tick while session exists; refresh devices/permitJoin
+    // 5. `selected` watcher: deselect when status transitions ready → already_registered
+    // 6. `canContinue`: every selected has non-empty name + non-null category
+    // 7. adoptSelected: snapshot selections, refresh, then call /adopt
+    //
+    // Refer to apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts for
+    // the polling/lifecycle/cleanup pattern (tryOnMounted/tryOnUnmounted, setTimeout chain).
+};
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter ./apps/admin run test:unit -- useDevicesWizard.spec`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.spec.ts
+git commit -m "Z2M wizard: useDevicesWizard composable"
+```
+
+---
+
+## Task 15: Wizard step components
+
+**Files:**
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue`
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue`
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue`
+
+Each step is a presentational component that receives wizard state as props and emits events back to the parent. The parent owns the composable; steps stay focused. Reference: shelly-ng's monolithic `shelly-ng-devices-wizard.vue` — split its three step blocks into three files.
+
+- [ ] **Step 1: Discovery step**
+
+`zigbee2mqtt-wizard-discovery-step.vue`. Responsibilities:
+- Show `bridgeOnline=false` banner with link to plugin config (use existing route helper used by `zigbee2mqtt-config-form.vue`)
+- Show "Pair new device" button (disabled when bridge offline). Click → emit `enable-permit-join`
+- When `permitJoin.active === true`: show countdown bar (`remainingSeconds / 254`), "Cancel pairing" button → emit `disable-permit-join`
+- Sortable table of devices (use `natural-orderby` with the same comparator pattern as shelly's wizard). Columns: checkbox, Name (display only — friendlyName), Manufacturer/Model, Status (tag with color matching shelly's: success for ready, info for already_registered, warning for unsupported, danger for failed). Adoptable rows have a checkbox bound to `selected` map.
+- Header actions: "Auto-pick all" / "Clear selection"
+
+Props: `devices: IZ2mWizardDevice[]`, `selected: Record<string, boolean>`, `permitJoin: IZ2mWizardPermitJoin`, `bridgeOnline: boolean`.
+Emits: `(e: 'enable-permit-join'): void`, `(e: 'disable-permit-join'): void`.
+
+- [ ] **Step 2: Categorize step**
+
+`zigbee2mqtt-wizard-categorize-step.vue`. Responsibilities:
+- Sortable table — natural-orderby with reactive maps. Columns: checkbox, Name (`<el-input>` bound to `nameByIeee[ieee]`), Friendly name (read-only monospace), Manufacturer/Model (secondary text), Status (tag: "will create" for ready, "will update" for already_registered), Category (`<el-select>` bound to `categoryByIeee[ieee]`, options from `categoryOptions(device)`), Channels (badge `{{ device.previewChannelCount }}` with `<el-tooltip>` listing `previewChannelIdentifiers.join(', ')`)
+- Sort comparators same shape as shelly-ng's categorize step (look at the existing wizard for the natural-orderby `getValue` lambdas)
+
+Props: `devices: IZ2mWizardDevice[]`, `selected: Record<string, boolean>`, `nameByIeee: Record<string, string>`, `categoryByIeee: Record<string, DevicesModuleDeviceCategory | null>`, `categoryOptions: (d) => Option[]`.
+
+- [ ] **Step 3: Results step**
+
+`zigbee2mqtt-wizard-results-step.vue`. Responsibilities:
+- Sortable read-only table. Columns: Status (tag: success for created, info for updated, danger for failed), Name, Friendly name, Manufacturer/Model, Error message
+- "Done" button → emit `done`. "Add more" button → emit `restart`
+
+Props: `results: IZ2mWizardAdoptionResult[]`, `devices: IZ2mWizardDevice[]` (for joining results back to friendlyName/manufacturer).
+Emits: `(e: 'done'): void`, `(e: 'restart'): void`.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter ./apps/admin run lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-categorize-step.vue apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-results-step.vue
+git commit -m "Z2M wizard: step components (discovery, categorize, results)"
+```
+
+---
+
+## Task 16: Top-level wizard component
+
+**Files:**
+- Create: `apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue`
+- Modify: `apps/admin/src/plugins/devices-zigbee2mqtt/components/components.ts`
+
+- [ ] **Step 1: Implement the orchestrator component**
+
+`zigbee2mqtt-devices-wizard.vue`. Responsibilities:
+- Use `useDevicesWizard()` to get all wizard state
+- Use `useFriendlyNameHumanizer()` for the pre-fill on session start (the composable should already do this internally, but the wizard wires the hook into name fields)
+- Use `<el-steps>` (or whatever the existing shelly wizard uses) with three steps: Discovery / Categorize / Results
+- Step navigation:
+  - Step 1 → Step 2: enabled when `selectedDevices.length > 0`
+  - Step 2 → Step 3 (Adopt): enabled when `canContinue === true`. Click invokes `adoptSelected()` and advances on resolution
+  - Step 3 → Done: emits `done` → close dialog (parent listens)
+  - Step 3 → Add more: clears state and resets to Step 1
+- On step transition out of Step 1: if `permitJoin.active`, prompt before disabling — or just call `disablePermitJoin()` silently (decide based on what feels least surprising; recommend silent disable + a brief toast)
+- On unmount/dialog close: call `endSession()` to clean up server-side
+
+- [ ] **Step 2: Export from `components.ts`**
+
+Add `export { default as Zigbee2mqttDevicesWizard } from './zigbee2mqtt-devices-wizard.vue';` (match existing export style in this file).
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm --filter ./apps/admin run lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue apps/admin/src/plugins/devices-zigbee2mqtt/components/components.ts
+git commit -m "Z2M wizard: top-level wizard component"
+```
+
+---
+
+## Task 17: Plugin registration
+
+**Files:**
+- Modify: `apps/admin/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts`
+
+- [ ] **Step 1: Register the wizard component**
+
+In the existing `registerComponents` block (where `deviceAddForm: Zigbee2mqttDeviceAddFormMultiStep` lives), add:
+
+```ts
+deviceWizard: Zigbee2mqttDevicesWizard,
+```
+
+Import it from `./components` (or `./components/components`). Match the existing import style.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm --filter ./apps/admin run lint`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
+git commit -m "Z2M wizard: register deviceWizard component"
+```
+
+---
+
+## Task 18: i18n keys
+
+**Files:**
+- Modify: `apps/admin/src/plugins/devices-zigbee2mqtt/locales/en-US.json` (and other locales matching shelly's locale set)
+
+- [ ] **Step 1: Identify which locales the plugin uses**
+
+Run: `ls apps/admin/src/plugins/devices-zigbee2mqtt/locales/`
+
+- [ ] **Step 2: Look up shelly's wizard i18n keys to mirror them**
+
+Run: `grep -A 200 '"wizard"' apps/admin/src/plugins/devices-shelly-ng/locales/en-US.json | head -200`
+
+- [ ] **Step 3: Add a `wizard` block under `plugins.devices-zigbee2mqtt`**
+
+Required keys (add to every locale, English values shown — translate to other locales):
+- `title`, `subtitle`
+- `bridge.offline.title`, `bridge.offline.message`, `bridge.offline.openConfig`
+- `steps.discovery.title`, `steps.discovery.permitJoin`, `steps.discovery.cancelPairing`, `steps.discovery.pairingActive` (with `{remaining}` slot), `steps.discovery.autoPickAll`, `steps.discovery.clearSelection`, `steps.discovery.empty`
+- `steps.categorize.title`, `steps.categorize.willCreate`, `steps.categorize.willUpdate`, `steps.categorize.channels` (with `{count}` slot)
+- `steps.results.title`, `steps.results.created`, `steps.results.updated`, `steps.results.failed`, `steps.results.done`, `steps.results.addMore`
+- `columns.name`, `columns.friendlyName`, `columns.manufacturer`, `columns.model`, `columns.status`, `columns.category`, `columns.channels`, `columns.error`
+- `status.ready`, `status.unsupported`, `status.alreadyRegistered`, `status.failed`
+- `actions.next`, `actions.back`, `actions.adopt`, `actions.cancel`
+- `validation.nameRequired`, `validation.categoryRequired`
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter ./apps/admin run lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/admin/src/plugins/devices-zigbee2mqtt/locales/
+git commit -m "Z2M wizard: i18n keys"
+```
+
+---
+
+## Task 19: Final verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run full lint suite**
+
+Run: `pnpm run lint:js`
+Expected: PASS
+
+- [ ] **Step 2: Run full backend test suite**
+
+Run: `pnpm run test:unit`
+Expected: PASS (no regressions; new wizard tests included)
+
+- [ ] **Step 3: Run admin test suite**
+
+Run: `pnpm --filter ./apps/admin run test:unit`
+Expected: PASS
+
+- [ ] **Step 4: Manual smoke test**
+
+Start backend (`pnpm run start:dev`), open admin, navigate to Devices → Add via wizard → choose Zigbee2MQTT plugin. Walk through:
+1. Step 1 — verify bridge status shows correctly; click "Pair new device" if a real coordinator is available, watch countdown, optionally cancel
+2. Step 2 — verify name pre-fill is humanized, category pre-fill matches descriptor, channel badge tooltip lists identifiers
+3. Step 3 — verify results table shows correct outcome; click "Add more" → returns to Step 1 with a fresh session
+
+Document any deviations in a follow-up task; do not silently fix issues outside the plan's scope.
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin claude/friendly-elion-e3c803
+gh pr create --title "Z2M wizard: multi-device adoption flow" --body "$(cat <<'EOF'
+## Summary
+- Adds a multi-device adoption wizard to the zigbee2mqtt plugin, modeled on the shelly-ng wizard
+- Two-mode discovery: lists already-paired-but-unadopted devices and exposes a permit_join button for new pairings
+- Auto-mapping with humanized friendly_names, suggested categories editable in Step 2
+- Existing single-device add form is unchanged
+
+## Test plan
+- [ ] Backend unit tests: `pnpm run test:unit -- --testPathPattern wizard`
+- [ ] Admin unit tests: `pnpm --filter ./apps/admin run test:unit -- wizard`
+- [ ] Lint: `pnpm run lint:js`
+- [ ] Manual smoke test against a real Zigbee bridge
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes on parallelism
+
+The tasks are largely sequential because each builds on the last. However, these pairs can be parallelized once their predecessors land:
+
+- Task 13 (`useFriendlyNameHumanizer`) is independent of Tasks 12 / 14 — can land in parallel with Task 12.
+- Task 18 (i18n) only requires knowing the key names; it can be drafted in parallel with Tasks 15-17.
+
+If running with subagent-driven-development, dispatch sequentially through Task 11 (the OpenAPI regen gate), then Tasks 12 and 13 in parallel, then 14, then 15-18 in parallel, then 19.

--- a/docs/superpowers/specs/2026-04-30-zigbee2mqtt-device-wizard-design.md
+++ b/docs/superpowers/specs/2026-04-30-zigbee2mqtt-device-wizard-design.md
@@ -1,0 +1,255 @@
+# Zigbee2MQTT Device Adoption Wizard — Design
+
+**Status:** Approved
+**Date:** 2026-04-30
+**Author:** Adam Kadlec
+**Related:** shelly-ng wizard implementation (reference), `tasks/`
+
+## Goal
+
+Add a multi-device adoption wizard to the `devices-zigbee2mqtt` plugin, modeled on the existing shelly-ng wizard. The wizard makes it easy to adopt many Zigbee devices at once with minimal user input. Auto-mapping, auto-suggested categories, and humanized device names produce sensible defaults; the user only confirms category and (optionally) renames.
+
+## Non-Goals
+
+- The existing single-device add form (`zigbee2mqtt-device-add-form-multi-step.vue`) is **kept unchanged** and remains the path for fine-grained per-device control (mapping preview / mapping customization).
+- No Panel (Flutter) wizard UI — adopted devices appear in the panel through normal sync.
+- No bulk re-mapping after adoption.
+- No removal/repairing of devices in z2m from inside the wizard.
+- No new device descriptors / spec generators — the wizard reuses existing mapping infrastructure.
+
+## User Story
+
+> As a user with N Zigbee devices already paired in zigbee2mqtt but not yet adopted in Smart Panel, I open the wizard, see all unadopted devices listed, optionally enable pairing mode for fresh hardware, adjust categories that were auto-detected wrongly, and click "Adopt" to bring them all into Smart Panel in one action.
+
+## High-Level Flow
+
+Three steps, mirroring shelly-ng's UX:
+
+```
+Step 1: Discovery        Step 2: Categorize       Step 3: Results
+─────────────────       ─────────────────       ─────────────────
+Bridge online status    Sortable table:           Sortable table:
+                        - Name (editable, pre-    - Status tag
+List unadopted devices    filled humanized)         (created/updated/
+- realtime via WS       - Friendly name             failed)
+- sortable                (read-only)             - Name
+- multi-select          - Manufacturer/model      - Friendly name
+                          (read-only)             - Manufacturer/model
+[Pair new device]       - Status (will create/    - Error message
+button:                   will update)
+  → permit_join 254s    - Category (dropdown,
+  → live countdown        editable)
+  → cancel button       - "N channels" badge
+                          (tooltip lists ids)
+```
+
+### Step 1 — Discovery
+
+- **Bridge offline:** banner with link to Zigbee2MQTT plugin config; table disabled.
+- **Bridge online:** table lists devices that are paired in zigbee2mqtt but not yet adopted in Smart Panel.
+- Real-time updates via existing `Z2mWsClientAdapterService` events (no client polling needed beyond reading session state).
+- "Pair new device" button toggles `permit_join: 254s` on the bridge; live countdown bar; "Cancel pairing" stops it early. Auto-disables on wizard close, step exit, or session expiry.
+- Newly-pairing devices appear with a brief highlight animation.
+- Auto-selects all devices with `status=ready`.
+- Devices with no matching descriptor → status `unsupported`, not selectable.
+
+### Step 2 — Categorize
+
+- Editable name, pre-filled with **humanized** friendly_name (`living_room_lamp` → `Living Room Lamp`). Original z2m identifier kept internally.
+- Pre-filled category from descriptor's suggested category (or first matching one if multiple categories apply).
+- "N channels" badge with tooltip listing channel identifiers.
+- Sortable columns (natural-orderby + reactive maps, same as shelly).
+- Validation: cannot proceed if any selected row has empty name or no category.
+
+### Step 3 — Results
+
+- Sortable read-only table.
+- Per-device outcome: `created` / `updated` / `failed` + error message.
+- "Done" closes the wizard. "Add more" creates a **new** session (`POST /wizard`), discarding the current one's state and returning the user to Step 1.
+
+## Backend Design
+
+**Location:** `apps/backend/src/plugins/devices-zigbee2mqtt/`
+
+### New files
+
+```
+controllers/
+  zigbee2mqtt-wizard.controller.ts       # REST endpoints
+services/
+  z2m-wizard.service.ts                  # Session lifecycle, permit_join, batch adoption
+models/
+  z2m-wizard-session.model.ts            # Response model
+  z2m-wizard-device-snapshot.model.ts    # Device row in session
+  z2m-wizard-adoption-result.model.ts    # Per-device adoption outcome
+dto/
+  z2m-wizard-adopt.dto.ts                # POST body: array of {ieeeAddress, name, category}
+```
+
+### REST endpoints
+
+Mounted under the plugin's existing route prefix (`/plugins/devices-zigbee2mqtt`).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/wizard` | Start session; returns initial device list + bridge status |
+| `GET` | `/wizard/:id` | Poll session state (devices, permit_join remaining, bridge status) |
+| `POST` | `/wizard/:id/permit-join` | Enable `permit_join` for 254s, return updated session |
+| `DELETE` | `/wizard/:id/permit-join` | Disable `permit_join` early |
+| `POST` | `/wizard/:id/adopt` | Batch adopt selected devices with name+category overrides |
+| `DELETE` | `/wizard/:id` | End session, cleanup permit_join if active |
+
+### `Z2mWizardService`
+
+Responsibilities:
+
+- In-memory session map (10-min idle TTL).
+- Subscribe to existing z2m events (`device-joined`, `device-announced`, `bridge-state-changed`) and update session snapshots.
+- Compute device snapshot per device:
+  - `friendlyName`, `manufacturer`, `model`, `ieeeAddress`
+  - `status`: `ready` | `unsupported` | `already_registered` | `failed`
+  - `suggestedCategory`, `availableCategories`
+  - `previewChannelCount`, `previewChannelIdentifiers[]`
+  - `registeredDeviceId`, `registeredDeviceName`, `registeredDeviceCategory` (when already adopted)
+- `permitJoin: { active, expiresAt, remainingSeconds }` block in session.
+- `adopt(sessionId, devices[])`:
+  - Refresh-before-adopt (re-check current status to avoid stale reads).
+  - Per device: call existing `Z2mDeviceAdoptionService.adoptDevice()` with name + category overrides.
+  - Race fallback: if the device is now `already_registered`, route to update path.
+  - Returns `Z2mWizardAdoptionResult[]`.
+- Session cleanup: on session expire/delete, disable `permit_join` if still active.
+- `onModuleDestroy()`: disable any active permit_join sessions before app shutdown.
+
+### Reused infrastructure (no duplication)
+
+- `Z2mDeviceAdoptionService` — adoption call.
+- `Z2mMappingPreviewService` — channel preview / count.
+- `Z2mExposesMapperService` — mapping resolution.
+- `Z2mWsClientAdapterService` / `Z2mMqttClientAdapterService` — events + permit_join command.
+- `Zigbee2mqttService.isBridgeOnline()` — bridge status.
+
+### Key delta from shelly-ng
+
+- **No 30s scan timer** — z2m maintains the device list. Sessions are long-lived.
+- Only `permit_join` is timed (managed inside the session).
+
+## Admin (Vue) Design
+
+**Location:** `apps/admin/src/plugins/devices-zigbee2mqtt/`
+
+### New files
+
+```
+components/
+  zigbee2mqtt-devices-wizard.vue           # Top-level wizard
+  zigbee2mqtt-wizard-discovery-step.vue    # Step 1
+  zigbee2mqtt-wizard-categorize-step.vue   # Step 2
+  zigbee2mqtt-wizard-results-step.vue      # Step 3
+composables/
+  useDevicesWizard.ts                      # Wizard state mgmt (mirrors shelly's composable)
+  useFriendlyNameHumanizer.ts              # snake/kebab/camel → Title Case
+types/
+  wizard.ts                                # IZ2mWizardSession, IZ2mWizardDevice,
+                                           # IZ2mWizardAdoptionResult
+```
+
+### Plugin registration
+
+In `devices-zigbee2mqtt.plugin.ts`:
+
+```typescript
+registerComponents({
+  deviceWizard: Zigbee2mqttDevicesWizard,
+  // existing: deviceAddForm, deviceEditForm, configForm
+})
+```
+
+This integrates with the Devices module's plugin component registry exactly like shelly-ng (`DEVICES_SHELLY_NG_TYPE` → `DEVICES_ZIGBEE2MQTT_TYPE`), so the wizard appears in the same place.
+
+### `useDevicesWizard` composable state
+
+- `session`, `devices[]`, `selected: Set<ieeeAddress>`
+- `nameByIeee: Record<string, string>` (user overrides)
+- `categoryByIeee: Record<string, DeviceCategory>` (user overrides)
+- `permitJoin: { active, remainingSeconds, expiresAt }`
+- `bridgeOnline: boolean`
+- 1s polling of `GET /wizard/:id` to refresh `permitJoin.remainingSeconds` and pick up devices that the backend pushed into the session via z2m events. (No client-side WebSocket subscription; the backend service is the single subscriber to z2m events and materializes them into the session snapshot.)
+
+### Auto-population
+
+- On session start: every device with `status=ready` is auto-selected; name pre-filled (humanized from friendly_name); category pre-filled from `suggestedCategory`.
+- On `ready → already_registered` transition (e.g., backend auto-adopt happens mid-wizard): deselect; row switches to "will update".
+
+### Step 1 UX
+
+- Bridge offline: banner with config link, table disabled.
+- Bridge online: sortable table with status tags (`ready` / `unsupported` / `already_registered`).
+- "Pair new device" button (disabled when bridge offline) starts permit_join with countdown bar; "Cancel pairing" stops early.
+- Newly-paired devices get a brief highlight animation.
+
+### Step 2 UX (Categorize)
+
+- Sortable table — same comparator pattern as shelly (natural-orderby + reactive maps).
+- Columns: checkbox, Name (editable), Friendly name (read-only, monospace), Manufacturer/Model (read-only, secondary), Status, Category (select), Channels (badge with tooltip).
+- Header actions: "Auto-pick all" / "Clear selection".
+- Cannot proceed if any selected row has empty name or unset category.
+
+### Step 3 UX (Results)
+
+- Sortable read-only table.
+- Columns: Status, Name, Friendly name, Manufacturer/Model, Error.
+- "Done" / "Add more" actions.
+
+### Error handling
+
+- Bridge offline mid-wizard → toast + table greys out; wizard remains open for retry.
+- Per-device adoption failure → row marked `failed` in step 3; other devices still adopted (partial success, not all-or-nothing).
+- Session expires (10min idle) → banner "Wizard session expired, please reopen".
+
+### i18n
+
+New keys under `plugins.devices-zigbee2mqtt.wizard.*` in admin locales (en, cs, etc., matching the keys shelly added).
+
+## Types & Spec Generation
+
+- Backend response models annotated with `@ApiProperty` Swagger decorators → flow into OpenAPI spec via `pnpm run generate:openapi`.
+- Admin types regenerated automatically into `apps/admin/src/openapi.ts`.
+- Schema names follow project convention:
+  - `Zigbee2mqttPluginResWizard*`
+  - `Zigbee2mqttPluginReqWizard*`
+  - `Zigbee2mqttPluginDataWizard*`
+- No new spec generators (`apps/backend/src/spec/` unchanged — wizard isn't a device descriptor).
+- No DB migrations — sessions are in-memory.
+
+## Testing
+
+### Backend (Jest)
+
+- `z2m-wizard.service.spec.ts` — session lifecycle, permit_join enable/disable, adoption with overrides, race fallback (`already_registered`), session expiry cleanup, `onModuleDestroy` cleanup.
+- `zigbee2mqtt-wizard.controller.spec.ts` — endpoint contracts, DTO validation, response envelope shape.
+- E2E `test/zigbee2mqtt-wizard.e2e-spec.ts` — full flow against in-memory sqlite + mocked z2m adapter.
+
+### Admin (Vitest)
+
+- `useDevicesWizard.spec.ts` — auto-select logic, ready→already_registered transition, name/category override map, permit_join countdown.
+- `useFriendlyNameHumanizer.spec.ts` — snake/kebab/camel → Title Case (edge cases: numbers, abbreviations, single words).
+
+## Lifecycle / Cleanup Edge Cases
+
+- **App shutdown with active permit_join** → `Z2mWizardService.onModuleDestroy()` disables permit_join on every active session.
+- **Wizard closed mid-pairing** → frontend calls `DELETE /wizard/:id`, which disables permit_join.
+- **Session idle 10min** → expiry sweep (60s interval) closes session and disables permit_join.
+- **Bridge disconnect mid-pairing** → adapter raises event; service marks session `permitJoin.active=false`; user sees banner.
+- **Concurrent auto-adoption** by background sync → wizard refresh-before-adopt detects updated status; adopts via update path; row reflects "updated" outcome.
+
+## Open Questions
+
+None — all design points resolved during brainstorming.
+
+## Out of Scope
+
+- Panel (Flutter) wizard UI.
+- Mapping preview / customization in the wizard (existing single-device form covers this).
+- Bulk re-mapping after adoption.
+- Removing/unpairing devices from z2m through the wizard.
+- New device descriptors or spec changes.


### PR DESCRIPTION
## Summary

Adds a multi-device adoption wizard to the `devices-zigbee2mqtt` plugin, modeled on the shelly-ng wizard.

- **Two-mode discovery** — lists already-paired-but-unadopted devices AND exposes a "Pair new device" button that toggles `permit_join` for new pairings (254s window with countdown)
- **Three steps** — Discovery → Categorize → Results
- **Auto-mapping** — channel definitions auto-derived from the existing `Z2mMappingPreviewService`; the wizard's UI just shows a channel-count badge with tooltip
- **Humanized friendly names** — `living_room_lamp` → `Living Room Lamp` for the editable name field
- **Suggested categories** — pre-filled from the descriptor; user can override per device
- **Race fallback** — if a device gets adopted between session-start and adopt-call, the wizard updates name/category instead of failing

The existing single-device add form is **unchanged** and remains the path for fine-grained per-device control (mapping preview / mapping customization).

## Architecture

**Backend** (`apps/backend/src/plugins/devices-zigbee2mqtt/`):
- New `Z2mWizardService` — in-memory sessions, 10-min idle TTL, permit_join lifecycle, batch adoption with race fallback
- New `Zigbee2mqttWizardController` — 6 REST endpoints under `/wizard`
- `setPermitJoin` primitive added to bridge adapters (MQTT + WS)
- `subscribeToDeviceJoined` event subscription on `Zigbee2mqttService` (drives real-time wizard updates)
- Reuses existing `Z2mDeviceAdoptionService`, `Z2mMappingPreviewService`, `Z2mExposesMapperService`

**Admin** (`apps/admin/src/plugins/devices-zigbee2mqtt/`):
- New `useDevicesWizard` composable — state, polling, adopt action
- New `useFriendlyNameHumanizer` composable — snake/kebab/camel → Title Case
- 4 new Vue components: top-level orchestrator + 3 step components
- Registered as plugin's `deviceWizard` slot
- All 6 locales translated (en, cs, de, es, pl, sk)

## Test plan

- [x] Backend wizard tests: 7 suites, 120 passing (`pnpm run test:unit -- --testPathPattern 'wizard|zigbee2mqtt'`)
- [x] Admin tests: 218 files, 1344 passing (`pnpm --filter ./apps/admin run test:unit`)
- [x] Lint: 0 errors (`pnpm run lint:js`)
- [ ] Manual smoke test against a real Zigbee2MQTT bridge:
  - Bridge offline state shows banner + config link
  - Bridge online: list of unadopted devices appears
  - "Pair new device" puts bridge into permit_join mode (254s countdown)
  - Step 2 pre-fills humanized names + suggested categories; channel count badge correct
  - Step 3 shows created/updated/failed outcomes
  - "Add more" creates a fresh session and returns to Step 1

## Spec & plan

- Design spec: [docs/superpowers/specs/2026-04-30-zigbee2mqtt-device-wizard-design.md](docs/superpowers/specs/2026-04-30-zigbee2mqtt-device-wizard-design.md)
- Implementation plan: [docs/superpowers/plans/2026-04-30-zigbee2mqtt-device-wizard.md](docs/superpowers/plans/2026-04-30-zigbee2mqtt-device-wizard.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new backend endpoints and in-memory session state to control `permit_join` and bulk-adopt devices, plus new admin wizard UI and polling logic; issues could affect pairing mode toggling and device adoption correctness.
> 
> **Overview**
> Adds a **multi-device Zigbee2MQTT adoption wizard** to the admin app (Discovery → Categorize → Results), including bulk selection, name/category editing with friendly-name humanization, and a results view for created/updated/failed outcomes.
> 
> Introduces a new backend `wizard` API (start/get/end session, enable/disable `permit_join`, and bulk adopt) backed by an in-memory `Z2mWizardService` with polling-friendly snapshots, idle TTL cleanup, and a race-safe “update if already adopted” fallback.
> 
> Extends Zigbee2MQTT transport adapters and service to support `setPermitJoin()` and a `subscribeToDeviceJoined` notification flow so wizard sessions can react to newly paired devices; updates OpenAPI/admin types and adds i18n strings and unit tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94a5f20db7a7ea39a0c57e9ae97706d527cb791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->