### PR TITLE
Z2M wizard: wrap in standard page layout and fix permit-join UX

### DIFF
--- a/apps/admin/src/common/utils/api-error.utils.ts
+++ b/apps/admin/src/common/utils/api-error.utils.ts
@@ -8,10 +8,11 @@ export const getErrorReason = <T extends Record<string | number, unknown>>(
 	const details = get(error, 'error.details', null);
 
 	if (Array.isArray(details)) {
-		return details
+		const reasons = details
 			.map((row) => ('reason' in row && typeof row['reason'] === 'string' ? row.reason : undefined))
-			.filter((row) => typeof row === 'undefined')
-			.join(', ');
+			.filter((row): row is string => typeof row === 'string');
+
+		return reasons.length > 0 ? reasons.join(', ') : message;
 	} else if (details && typeof details === 'object' && 'reason' in details && typeof details['reason'] === 'string') {
 		return details['reason'];
 	}

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-devices-wizard.vue
@@ -1,87 +1,193 @@
 <template>
-	<div class="z2m-devices-wizard flex flex-col gap-3 h-full overflow-hidden">
-		<el-steps
-			:active="activeStepIndex"
-			finish-status="success"
-			align-center
-			class="shrink-0"
+	<app-bar-heading
+		v-if="!isMDDevice"
+		teleport
+	>
+		<template #icon>
+			<icon
+				icon="mdi:wizard-hat"
+				class="w[20px] h[20px]"
+			/>
+		</template>
+
+		<template #title>
+			{{ t('devicesZigbee2mqttPlugin.wizard.title') }}
+		</template>
+
+		<template #subtitle>
+			{{ t('devicesZigbee2mqttPlugin.wizard.subtitle') }}
+		</template>
+	</app-bar-heading>
+
+	<app-bar-button
+		v-if="!isMDDevice"
+		:align="AppBarButtonAlign.LEFT"
+		teleport
+		small
+		@click="handleCancel"
+	>
+		<template #icon>
+			<el-icon :size="24">
+				<icon icon="mdi:chevron-left" />
+			</el-icon>
+		</template>
+	</app-bar-button>
+
+	<app-breadcrumbs :items="breadcrumbs" />
+
+	<view-header
+		:heading="t('devicesZigbee2mqttPlugin.wizard.title')"
+		:sub-heading="t('devicesZigbee2mqttPlugin.wizard.subtitle')"
+		icon="mdi:wizard-hat"
+	>
+		<template
+			v-if="isMDDevice"
+			#extra
 		>
-			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.discovery.title')" />
-			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.categorize.title')" />
-			<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.results.title')" />
-		</el-steps>
+			<div class="flex items-center gap-2">
+				<el-button
+					v-if="activeStep !== 'results'"
+					link
+					class="px-4!"
+					@click="handleCancel"
+				>
+					{{ t('devicesZigbee2mqttPlugin.wizard.actions.cancel') }}
+				</el-button>
 
-		<div class="flex-grow overflow-hidden">
-			<Zigbee2mqttWizardDiscoveryStep
-				v-if="activeStep === 'discovery'"
-				:devices="devices"
-				:selected="selected"
-				:permit-join="permitJoin"
-				:bridge-online="bridgeOnline"
-				@enable-permit-join="enablePermitJoin"
-				@disable-permit-join="disablePermitJoin"
-				@update:selected="onUpdateSelected"
-			/>
+				<template v-if="activeStep === 'discovery'">
+					<el-button
+						type="primary"
+						class="px-4!"
+						:disabled="selectedDevices.length === 0"
+						@click="goToCategorize"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.next') }}
+					</el-button>
+				</template>
 
-			<Zigbee2mqttWizardCategorizeStep
-				v-else-if="activeStep === 'categorize'"
-				:devices="devices"
-				:selected="selected"
-				:name-by-ieee="nameByIeee"
-				:category-by-ieee="categoryByIeee"
-				:category-options="categoryOptions"
-				@update:name-by-ieee="onUpdateNameByIeee"
-				@update:category-by-ieee="onUpdateCategoryByIeee"
-			/>
+				<template v-else-if="activeStep === 'categorize'">
+					<el-button
+						class="px-4!"
+						@click="goBack"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.back') }}
+					</el-button>
+					<el-button
+						type="primary"
+						class="px-4!"
+						:disabled="!canContinue"
+						:loading="isAdopting"
+						@click="onAdopt"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.adopt') }}
+					</el-button>
+				</template>
+			</div>
+		</template>
+	</view-header>
 
-			<Zigbee2mqttWizardResultsStep
-				v-else
-				:results="adoptionResults"
-				:devices="devices"
-				@done="onDone"
-				@restart="onRestart"
-			/>
-		</div>
+	<div class="grow-1 flex flex-col gap-2 lt-sm:mx-1 sm:mx-2 lt-sm:mb-1 sm:mb-2 overflow-hidden mt-2">
+		<el-card
+			shadow="never"
+			class="max-h-full flex flex-col overflow-hidden box-border"
+			body-class="p-0! max-h-full overflow-hidden flex flex-col"
+		>
+			<template #header>
+				<el-steps
+					:active="activeStepIndex"
+					finish-status="success"
+					align-center
+				>
+					<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.discovery.title')" />
+					<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.categorize.title')" />
+					<el-step :title="t('devicesZigbee2mqttPlugin.wizard.steps.results.title')" />
+				</el-steps>
+			</template>
 
-		<div class="flex justify-between gap-2 shrink-0">
-			<el-button
-				v-if="activeStep === 'categorize'"
-				@click="goBack"
+			<div class="p-4 max-h-full box-border flex flex-col gap-3 overflow-hidden">
+				<Zigbee2mqttWizardDiscoveryStep
+					v-if="activeStep === 'discovery'"
+					:devices="devices"
+					:selected="selected"
+					:permit-join="permitJoin"
+					:bridge-online="bridgeOnline"
+					:session-ready="sessionReady"
+					:permit-join-pending="isPermitJoinPending"
+					@enable-permit-join="onEnablePermitJoin"
+					@disable-permit-join="onDisablePermitJoin"
+					@update:selected="onUpdateSelected"
+				/>
+
+				<Zigbee2mqttWizardCategorizeStep
+					v-else-if="activeStep === 'categorize'"
+					:devices="devices"
+					:selected="selected"
+					:name-by-ieee="nameByIeee"
+					:category-by-ieee="categoryByIeee"
+					:category-options="categoryOptions"
+					@update:name-by-ieee="onUpdateNameByIeee"
+					@update:category-by-ieee="onUpdateCategoryByIeee"
+				/>
+
+				<Zigbee2mqttWizardResultsStep
+					v-else
+					:results="adoptionResults"
+					:devices="devices"
+					@done="onDone"
+					@restart="onRestart"
+				/>
+			</div>
+
+			<div
+				v-if="!isMDDevice && activeStep !== 'results'"
+				class="flex justify-between gap-2 p-4 border-t border-t-solid"
 			>
-				{{ t('devicesZigbee2mqttPlugin.wizard.actions.back') }}
-			</el-button>
-			<div v-else />
+				<template v-if="activeStep === 'discovery'">
+					<el-button @click="handleCancel">
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.cancel') }}
+					</el-button>
+					<el-button
+						type="primary"
+						:disabled="selectedDevices.length === 0"
+						@click="goToCategorize"
+					>
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.next') }}
+					</el-button>
+				</template>
 
-			<el-button
-				v-if="activeStep === 'discovery'"
-				type="primary"
-				:disabled="selectedDevices.length === 0"
-				@click="goToCategorize"
-			>
-				{{ t('devicesZigbee2mqttPlugin.wizard.actions.next') }}
-			</el-button>
-
-			<el-button
-				v-else-if="activeStep === 'categorize'"
-				type="primary"
-				:disabled="!canContinue"
-				:loading="isAdopting"
-				@click="onAdopt"
-			>
-				{{ t('devicesZigbee2mqttPlugin.wizard.actions.adopt') }}
-			</el-button>
-		</div>
+				<template v-else-if="activeStep === 'categorize'">
+					<el-button @click="goBack">
+						{{ t('devicesZigbee2mqttPlugin.wizard.actions.back') }}
+					</el-button>
+					<div class="flex gap-2">
+						<el-button @click="handleCancel">
+							{{ t('devicesZigbee2mqttPlugin.wizard.actions.cancel') }}
+						</el-button>
+						<el-button
+							type="primary"
+							:disabled="!canContinue"
+							:loading="isAdopting"
+							@click="onAdopt"
+						>
+							{{ t('devicesZigbee2mqttPlugin.wizard.actions.adopt') }}
+						</el-button>
+					</div>
+				</template>
+			</div>
+		</el-card>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRouter } from 'vue-router';
+import { type RouteLocationResolvedGeneric, useRouter } from 'vue-router';
 
-import { ElButton, ElStep, ElSteps } from 'element-plus';
+import { ElButton, ElCard, ElIcon, ElStep, ElSteps } from 'element-plus';
 
-import { useFlashMessage } from '../../../common';
+import { Icon } from '@iconify/vue';
+
+import { AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewHeader, useBreakpoints, useFlashMessage } from '../../../common';
 import { RouteNames as DevicesRouteNames } from '../../../modules/devices/devices.constants';
 import { type DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import { useDevicesWizard } from '../composables/useDevicesWizard';
@@ -97,6 +203,7 @@ defineOptions({
 const { t } = useI18n();
 const router = useRouter();
 const flashMessage = useFlashMessage();
+const { isMDDevice, isLGDevice } = useBreakpoints();
 
 const {
 	devices,
@@ -106,6 +213,7 @@ const {
 	selectedDevices,
 	permitJoin,
 	bridgeOnline,
+	sessionReady,
 	canContinue,
 	adoptionResults,
 	enablePermitJoin,
@@ -120,6 +228,7 @@ type WizardStep = 'discovery' | 'categorize' | 'results';
 
 const activeStep = ref<WizardStep>('discovery');
 const isAdopting = ref<boolean>(false);
+const isPermitJoinPending = ref<boolean>(false);
 
 const activeStepIndex = computed<number>(() => {
 	if (activeStep.value === 'categorize') {
@@ -132,6 +241,20 @@ const activeStepIndex = computed<number>(() => {
 
 	return 0;
 });
+
+const breadcrumbs = computed<{ label: string; route: RouteLocationResolvedGeneric }[]>(() => [
+	{
+		label: t('devicesModule.breadcrumbs.devices.list'),
+		route: router.resolve({ name: DevicesRouteNames.DEVICES }),
+	},
+	{
+		label: t('devicesZigbee2mqttPlugin.wizard.breadcrumb'),
+		route: router.resolve({
+			name: DevicesRouteNames.DEVICES_WIZARD,
+			params: { type: 'devices-zigbee2mqtt-plugin' },
+		}),
+	},
+]);
 
 // The step components emit fresh maps; sync them back into the reactive maps owned by the
 // composable so its derived state (`selectedDevices`, `canContinue`, …) updates immediately.
@@ -165,6 +288,33 @@ const onUpdateCategoryByIeee = (value: Record<string, DevicesModuleDeviceCategor
 	Object.assign(categoryByIeee, value);
 };
 
+// Track in-flight permit_join toggles separately so the discovery step can disable / show
+// loading on the pair / cancel buttons during the round-trip. Errors are already surfaced by
+// the composable via flashMessage; we just need to release the pending flag either way.
+const onEnablePermitJoin = async (): Promise<void> => {
+	isPermitJoinPending.value = true;
+
+	try {
+		await enablePermitJoin();
+	} catch {
+		// Error already surfaced by the composable.
+	} finally {
+		isPermitJoinPending.value = false;
+	}
+};
+
+const onDisablePermitJoin = async (): Promise<void> => {
+	isPermitJoinPending.value = true;
+
+	try {
+		await disablePermitJoin();
+	} catch {
+		// Error already surfaced by the composable.
+	} finally {
+		isPermitJoinPending.value = false;
+	}
+};
+
 const goToCategorize = async (): Promise<void> => {
 	// Pairing should never be left active once the user moves on — silently turn it off so the
 	// gateway stops accepting new joins while the categorize step is in focus.
@@ -194,6 +344,14 @@ const onAdopt = async (): Promise<void> => {
 		// Errors are surfaced by the composable via flashMessage; stay on the categorize step.
 	} finally {
 		isAdopting.value = false;
+	}
+};
+
+const handleCancel = (): void => {
+	if (isLGDevice.value) {
+		router.replace({ name: DevicesRouteNames.DEVICES });
+	} else {
+		router.push({ name: DevicesRouteNames.DEVICES });
 	}
 };
 

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-wizard-discovery-step.vue
@@ -1,7 +1,12 @@
 <template>
-	<div class="flex flex-col gap-3 h-full overflow-hidden">
+	<div
+		v-loading="!sessionReady"
+		:element-loading-text="t('devicesZigbee2mqttPlugin.wizard.steps.discovery.loading')"
+		element-loading-background="var(--el-bg-color-overlay)"
+		class="flex flex-col gap-3 h-full overflow-hidden min-h-[200px]"
+	>
 		<el-alert
-			v-if="!bridgeOnline"
+			v-if="sessionReady && !bridgeOnline"
 			type="warning"
 			:closable="false"
 			show-icon
@@ -25,25 +30,28 @@
 			</template>
 		</el-alert>
 
-		<template v-else>
+		<template v-else-if="sessionReady && bridgeOnline">
 			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between shrink-0">
-				<div class="flex min-w-0 flex-1 flex-col gap-1">
-					<template v-if="permitJoin.active">
-						<el-text>
-							{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingActive', { remaining: smoothRemainingSeconds }) }}
-						</el-text>
-						<el-progress
-							:percentage="permitJoinPercentage"
-							:status="permitJoinPercentage >= 75 ? 'warning' : undefined"
-						/>
-					</template>
+				<div
+					class="flex min-w-0 flex-1 flex-col gap-1"
+					:class="{ invisible: !permitJoin.active }"
+					aria-live="polite"
+				>
+					<el-text>
+						{{ t('devicesZigbee2mqttPlugin.wizard.steps.discovery.pairingActive', { remaining: smoothRemainingSeconds }) }}
+					</el-text>
+					<el-progress
+						:percentage="permitJoinPercentage"
+						:status="permitJoinPercentage >= 75 ? 'warning' : undefined"
+					/>
 				</div>
 
 				<div class="flex flex-wrap gap-2">
 					<el-button
 						v-if="!permitJoin.active"
 						type="primary"
-						:disabled="!bridgeOnline"
+						:disabled="!bridgeOnline || permitJoinPending"
+						:loading="permitJoinPending"
 						@click="emit('enable-permit-join')"
 					>
 						<template #icon>
@@ -55,6 +63,8 @@
 					<el-button
 						v-else
 						type="warning"
+						:disabled="permitJoinPending"
+						:loading="permitJoinPending"
 						@click="emit('disable-permit-join')"
 					>
 						<template #icon>
@@ -157,13 +167,11 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { useNow } from '@vueuse/core';
-
-import { ElAlert, ElButton, ElCheckbox, ElProgress, ElTable, ElTableColumn, ElTag, ElText } from 'element-plus';
+import { ElAlert, ElButton, ElCheckbox, ElProgress, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
+import { orderBy } from 'natural-orderby';
 
 import { Icon } from '@iconify/vue';
-
-import { orderBy } from 'natural-orderby';
+import { useNow } from '@vueuse/core';
 
 import { RouteNames as ConfigRouteNames } from '../../../modules/config';
 import { isAdoptableStatus } from '../composables/useDevicesWizard';
@@ -180,6 +188,8 @@ interface IProps {
 	selected: Record<string, boolean>;
 	permitJoin: IZ2mWizardPermitJoin;
 	bridgeOnline: boolean;
+	sessionReady: boolean;
+	permitJoinPending: boolean;
 }
 
 const props = defineProps<IProps>();

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/composables/useDevicesWizard.ts
@@ -30,11 +30,11 @@ import {
 
 import { useFriendlyNameHumanizer } from './useFriendlyNameHumanizer';
 
-export const isAdoptableStatus = (status: IZ2mWizardDevice['status']): boolean =>
-	status === 'ready' || status === 'already_registered';
+export const isAdoptableStatus = (status: IZ2mWizardDevice['status']): boolean => status === 'ready' || status === 'already_registered';
 
 export interface IUseDevicesWizard {
 	session: ComputedRef<IZ2mWizardSession | null>;
+	sessionReady: ComputedRef<boolean>;
 	devices: ComputedRef<IZ2mWizardDevice[]>;
 	selectedDevices: ComputedRef<IZ2mWizardDevice[]>;
 	permitJoin: ComputedRef<IZ2mWizardSession['permitJoin']>;
@@ -85,11 +85,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	let sessionGeneration = 0;
 
 	const devices = computed<IZ2mWizardDevice[]>(() =>
-		orderBy(
-			session.value?.devices ?? [],
-			[(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.ieeeAddress],
-			['asc', 'asc']
-		)
+		orderBy(session.value?.devices ?? [], [(device) => (isAdoptableStatus(device.status) ? 0 : 1), (device) => device.ieeeAddress], ['asc', 'asc'])
 	);
 
 	const selectedDevices = computed<IZ2mWizardDevice[]>(() =>
@@ -112,6 +108,12 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 	const permitJoin = computed<IZ2mWizardSession['permitJoin']>(() => session.value?.permitJoin ?? DEFAULT_PERMIT_JOIN);
 
 	const bridgeOnline = computed<boolean>(() => session.value?.bridgeOnline ?? false);
+
+	// `bridgeOnline` defaults to false while the session is still loading, which would otherwise
+	// flash a misleading "Bridge offline / Configure the connection" alert on initial mount even
+	// for healthy bridges. `sessionReady` lets consumers gate that alert until we have a real
+	// answer from the backend.
+	const sessionReady = computed<boolean>(() => session.value !== null);
 
 	const stopPolling = (): void => {
 		if (pollingTimer !== null) {
@@ -205,11 +207,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 		sessionGeneration += 1;
 		const startGeneration = sessionGeneration;
 
-		const {
-			data: responseData,
-			error,
-			response,
-		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard`);
+		const { data: responseData, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_ZIGBEE2MQTT_PLUGIN_PREFIX}/wizard`);
 
 		// If endSession (or another startSession) raced ahead while POST was in-flight,
 		// drop this response so we don't resurrect a session the caller has already torn down.
@@ -226,9 +224,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return;
 		}
 
-		const errorReason = error
-			? getErrorReason<DevicesZigbee2mqttPluginCreateWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
-			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+		const fallback = t('devicesZigbee2mqttPlugin.messages.wizard.sessionNotStarted');
+		const errorReason = error ? getErrorReason<DevicesZigbee2mqttPluginCreateWizardOperation>(error, fallback) : fallback;
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
@@ -269,9 +266,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return;
 		}
 
-		const errorReason = error
-			? getErrorReason<DevicesZigbee2mqttPluginGetWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
-			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+		const fallback = t('devicesZigbee2mqttPlugin.messages.wizard.sessionNotLoaded');
+		const errorReason = error ? getErrorReason<DevicesZigbee2mqttPluginGetWizardOperation>(error, fallback) : fallback;
 
 		throw new DevicesZigbee2mqttApiException(errorReason, response.status);
 	};
@@ -347,9 +343,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return;
 		}
 
-		const errorReason = error
-			? getErrorReason<DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
-			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+		const fallback = t('devicesZigbee2mqttPlugin.messages.wizard.permitJoinNotEnabled');
+		const errorReason = error ? getErrorReason<DevicesZigbee2mqttPluginEnableWizardPermitJoinOperation>(error, fallback) : fallback;
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
@@ -390,9 +385,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return;
 		}
 
-		const errorReason = error
-			? getErrorReason<DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
-			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+		const fallback = t('devicesZigbee2mqttPlugin.messages.wizard.permitJoinNotDisabled');
+		const errorReason = error ? getErrorReason<DevicesZigbee2mqttPluginDisableWizardPermitJoinOperation>(error, fallback) : fallback;
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
@@ -437,9 +431,8 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 			return results;
 		}
 
-		const errorReason = error
-			? getErrorReason<DevicesZigbee2mqttPluginAdoptWizardOperation>(error, t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' }))
-			: t('devicesZigbee2mqttPlugin.messages.devices.notAdopted', { device: '' });
+		const fallback = t('devicesZigbee2mqttPlugin.messages.wizard.adoptionFailed');
+		const errorReason = error ? getErrorReason<DevicesZigbee2mqttPluginAdoptWizardOperation>(error, fallback) : fallback;
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
@@ -479,6 +472,7 @@ export const useDevicesWizard = (): IUseDevicesWizard => {
 
 	return {
 		session: computed(() => session.value),
+		sessionReady,
 		devices,
 		selectedDevices,
 		permitJoin,

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/cs-CZ.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Nepodařilo se načíst nalezená zařízení",
 			"mappingPreviewFailed": "Nepodařilo se načíst náhled mapování"
 		},
+		"wizard": {
+			"sessionNotStarted": "Nepodařilo se spustit průvodce přidáním",
+			"sessionNotLoaded": "Nepodařilo se obnovit průvodce přidáním",
+			"permitJoinNotEnabled": "Nepodařilo se zapnout režim párování",
+			"permitJoinNotDisabled": "Nepodařilo se vypnout režim párování",
+			"adoptionFailed": "Nepodařilo se přidat vybraná zařízení"
+		},
 		"mapping": {
 			"previewError": "Nepodařilo se načíst náhled mapování",
 			"previewLoading": "Načítání náhledu mapování...",
@@ -299,8 +306,9 @@
 		"use": "Použít"
 	},
 	"wizard": {
-		"title": "Přidat zařízení Zigbee",
-		"subtitle": "Objevte a hromadně přidejte vaše Zigbee zařízení",
+		"title": "Průvodce přidáním Zigbee2MQTT",
+		"subtitle": "Najděte a přidejte Zigbee zařízení přes Zigbee2MQTT bridge",
+		"breadcrumb": "průvodce přidáním",
 		"bridge": {
 			"offline": {
 				"title": "Bridge offline",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Vyhledávání",
+				"loading": "Načítání objevených zařízení...",
 				"permitJoin": "Spárovat nové zařízení",
 				"cancelPairing": "Zrušit párování",
 				"pairingActive": "Režim párování aktivní — zbývá {remaining}s",

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/de-DE.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Erkannte Geräte konnten nicht geladen werden",
 			"mappingPreviewFailed": "Zuordnungsvorschau konnte nicht geladen werden"
 		},
+		"wizard": {
+			"sessionNotStarted": "Erkennungsassistent konnte nicht gestartet werden",
+			"sessionNotLoaded": "Erkennungsassistent konnte nicht aktualisiert werden",
+			"permitJoinNotEnabled": "Kopplungsmodus konnte nicht aktiviert werden",
+			"permitJoinNotDisabled": "Kopplungsmodus konnte nicht deaktiviert werden",
+			"adoptionFailed": "Ausgewählte Geräte konnten nicht übernommen werden"
+		},
 		"mapping": {
 			"previewError": "Zuordnungsvorschau konnte nicht geladen werden",
 			"previewLoading": "Zuordnungsvorschau wird geladen...",
@@ -299,8 +306,9 @@
 		"use": "Verwenden"
 	},
 	"wizard": {
-		"title": "Zigbee-Geräte übernehmen",
-		"subtitle": "Entdecken und übernehmen Sie Ihre Zigbee-Geräte in großen Mengen",
+		"title": "Zigbee2MQTT-Erkennungsassistent",
+		"subtitle": "Zigbee-Geräte über die Zigbee2MQTT-Bridge finden und übernehmen",
+		"breadcrumb": "Erkennungsassistent",
 		"bridge": {
 			"offline": {
 				"title": "Bridge offline",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Suche",
+				"loading": "Erkannte Geräte werden geladen...",
 				"permitJoin": "Neues Gerät koppeln",
 				"cancelPairing": "Kopplung abbrechen",
 				"pairingActive": "Kopplungsmodus aktiv — {remaining}s verbleibend",

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/en-US.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Failed to load discovered devices",
 			"mappingPreviewFailed": "Failed to load mapping preview"
 		},
+		"wizard": {
+			"sessionNotStarted": "Failed to start the adoption wizard",
+			"sessionNotLoaded": "Failed to refresh the adoption wizard",
+			"permitJoinNotEnabled": "Failed to enable pairing mode",
+			"permitJoinNotDisabled": "Failed to disable pairing mode",
+			"adoptionFailed": "Failed to adopt the selected devices"
+		},
 		"mapping": {
 			"previewError": "Failed to load mapping preview",
 			"previewLoading": "Loading mapping preview...",
@@ -299,8 +306,9 @@
 		"use": "Use"
 	},
 	"wizard": {
-		"title": "Adopt Zigbee devices",
-		"subtitle": "Discover and adopt your Zigbee devices in bulk",
+		"title": "Zigbee2MQTT discovery wizard",
+		"subtitle": "Find and adopt Zigbee devices via the Zigbee2MQTT bridge",
+		"breadcrumb": "discovery wizard",
 		"bridge": {
 			"offline": {
 				"title": "Bridge offline",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Discovery",
+				"loading": "Loading discovered devices...",
 				"permitJoin": "Pair new device",
 				"cancelPairing": "Cancel pairing",
 				"pairingActive": "Pairing mode active — {remaining}s remaining",

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/es-ES.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Error al cargar los dispositivos descubiertos",
 			"mappingPreviewFailed": "Error al cargar la vista previa del mapeo"
 		},
+		"wizard": {
+			"sessionNotStarted": "Error al iniciar el asistente de descubrimiento",
+			"sessionNotLoaded": "Error al actualizar el asistente de descubrimiento",
+			"permitJoinNotEnabled": "Error al activar el modo de emparejamiento",
+			"permitJoinNotDisabled": "Error al desactivar el modo de emparejamiento",
+			"adoptionFailed": "Error al adoptar los dispositivos seleccionados"
+		},
 		"mapping": {
 			"previewError": "Error al cargar la vista previa del mapeo",
 			"previewLoading": "Cargando vista previa del mapeo...",
@@ -299,8 +306,9 @@
 		"use": "Usar"
 	},
 	"wizard": {
-		"title": "Adoptar dispositivos Zigbee",
-		"subtitle": "Descubra y adopte sus dispositivos Zigbee en bloque",
+		"title": "Asistente de descubrimiento de Zigbee2MQTT",
+		"subtitle": "Encuentre y adopte dispositivos Zigbee a través del bridge Zigbee2MQTT",
+		"breadcrumb": "asistente de descubrimiento",
 		"bridge": {
 			"offline": {
 				"title": "Bridge sin conexión",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Descubrimiento",
+				"loading": "Cargando dispositivos descubiertos...",
 				"permitJoin": "Emparejar nuevo dispositivo",
 				"cancelPairing": "Cancelar emparejamiento",
 				"pairingActive": "Modo de emparejamiento activo — {remaining}s restantes",

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/pl-PL.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Nie udało się załadować wykrytych urządzeń",
 			"mappingPreviewFailed": "Nie udało się załadować podglądu mapowania"
 		},
+		"wizard": {
+			"sessionNotStarted": "Nie udało się uruchomić kreatora wykrywania",
+			"sessionNotLoaded": "Nie udało się odświeżyć kreatora wykrywania",
+			"permitJoinNotEnabled": "Nie udało się włączyć trybu parowania",
+			"permitJoinNotDisabled": "Nie udało się wyłączyć trybu parowania",
+			"adoptionFailed": "Nie udało się adoptować wybranych urządzeń"
+		},
 		"mapping": {
 			"previewError": "Nie udało się załadować podglądu mapowania",
 			"previewLoading": "Ładowanie podglądu mapowania...",
@@ -299,8 +306,9 @@
 		"use": "Użyj"
 	},
 	"wizard": {
-		"title": "Adoptuj urządzenia Zigbee",
-		"subtitle": "Odkryj i adoptuj swoje urządzenia Zigbee zbiorczo",
+		"title": "Kreator wykrywania Zigbee2MQTT",
+		"subtitle": "Znajdź i adoptuj urządzenia Zigbee przez bridge Zigbee2MQTT",
+		"breadcrumb": "kreator wykrywania",
 		"bridge": {
 			"offline": {
 				"title": "Bridge offline",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Wykrywanie",
+				"loading": "Ładowanie wykrytych urządzeń...",
 				"permitJoin": "Sparuj nowe urządzenie",
 				"cancelPairing": "Anuluj parowanie",
 				"pairingActive": "Tryb parowania aktywny — pozostało {remaining}s",

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/locales/sk-SK.json
@@ -274,6 +274,13 @@
 			"loadFailed": "Nepodarilo sa načítať objavené zariadenia",
 			"mappingPreviewFailed": "Nepodarilo sa načítať náhľad mapovania"
 		},
+		"wizard": {
+			"sessionNotStarted": "Nepodarilo sa spustiť sprievodcu pridávaním",
+			"sessionNotLoaded": "Nepodarilo sa obnoviť sprievodcu pridávaním",
+			"permitJoinNotEnabled": "Nepodarilo sa zapnúť režim párovania",
+			"permitJoinNotDisabled": "Nepodarilo sa vypnúť režim párovania",
+			"adoptionFailed": "Nepodarilo sa pridať vybrané zariadenia"
+		},
 		"mapping": {
 			"previewError": "Nepodarilo sa načítať náhľad mapovania",
 			"previewLoading": "Načítavanie náhľadu mapovania...",
@@ -299,8 +306,9 @@
 		"use": "Použiť"
 	},
 	"wizard": {
-		"title": "Pridať zariadenia Zigbee",
-		"subtitle": "Objavte a hromadne pridajte vaše Zigbee zariadenia",
+		"title": "Sprievodca pridávaním Zigbee2MQTT",
+		"subtitle": "Nájdite a pridajte Zigbee zariadenia cez Zigbee2MQTT bridge",
+		"breadcrumb": "sprievodca pridávaním",
 		"bridge": {
 			"offline": {
 				"title": "Bridge offline",
@@ -311,6 +319,7 @@
 		"steps": {
 			"discovery": {
 				"title": "Vyhľadávanie",
+				"loading": "Načítavanie objavených zariadení...",
 				"permitJoin": "Spárovať nové zariadenie",
 				"cancelPairing": "Zrušiť párovanie",
 				"pairingActive": "Režim párovania aktívny — zostáva {remaining}s",

--- a/apps/backend/src/modules/api/interceptors/open-api-response.interceptor.ts
+++ b/apps/backend/src/modules/api/interceptors/open-api-response.interceptor.ts
@@ -33,7 +33,10 @@ export class OpenApiResponseInterceptor<T> implements NestInterceptor<T, any> {
 		return next.handle().pipe(
 			map((data) => {
 				const responseTime = Date.now() - startTime;
-				if (request.method === 'DELETE') {
+				// Only force 204 for DELETE handlers that returned nothing. DELETE handlers that
+				// return a payload (e.g. wizard permit-join toggle returning the updated session)
+				// must keep their body so the client can apply the new state.
+				if (request.method === 'DELETE' && (data === null || data === undefined)) {
 					response.status(HttpStatus.NO_CONTENT);
 
 					return null;


### PR DESCRIPTION
## Summary

- Wrap the Zigbee2MQTT discovery wizard in the same page layout the Shelly wizards use (app bar / breadcrumbs / view header / card) and align the heading with the `{Plugin} discovery wizard` pattern.
- Fix permit-join UX: loading mask on initial session start, `:loading` on the pair / cancel buttons during the round-trip, and a height-stable status row so toggling pairing no longer shifts the device table.
- Stop the global response interceptor from stripping every DELETE body — the wizard's permit-join toggle is a DELETE that returns the updated session, and the strip-the-body shortcut was the actual reason "stop pairing" looked broken on the client even though the bridge did stop.
- Replace the misleading `messages.devices.notAdopted` fallback with per-operation messages under `messages.wizard.*` (translated to all six locales), and fix `getErrorReason`'s inverted filter that was silently discarding every valid backend `reason`.

## Test plan

- [x] `pnpm run type-check` (admin)
- [x] `pnpm run lint:js` (admin + backend)
- [x] `pnpm run test:unit` (admin: 1344 passing)
- [x] `pnpm jest --testPathPatterns=devices-zigbee2mqtt` (backend: 122 passing)
- [ ] Manually open the wizard with z2m configured: heading + breadcrumbs match Shelly, loading mask shows during start, no false "Bridge offline" flash
- [ ] Click "Pair new device": button shows spinner, table doesn't jump when status row appears, countdown bar advances
- [ ] Click "Cancel pairing": button shows spinner, pairing actually stops on the bridge, no error toast
- [ ] Click into one of the other DELETE-driven flows (e.g. delete a token, delete a card) to verify the interceptor change still returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes global API response behavior for all `DELETE` requests and refactors a complex wizard UI flow; regressions could affect unrelated DELETE endpoints or wizard state updates.
> 
> **Overview**
> Updates the Zigbee2MQTT devices wizard to use the standard admin page layout (app bar, breadcrumbs, header, card) and adds responsive navigation/cancel behavior.
> 
> Improves the discovery step UX by gating the offline banner behind a new `sessionReady` state, adding an initial loading mask, keeping the pairing status row height-stable, and showing disabled/loading states while `permitJoin` enable/disable requests are in-flight.
> 
> Fixes error handling by correcting `getErrorReason` so array `details` reasons are no longer dropped, and by switching wizard API fallbacks to new `messages.wizard.*` strings (added/translated across locales).
> 
> Adjusts the backend `OpenApiResponseInterceptor` to only force `204 No Content` for `DELETE` handlers that return no payload, preserving bodies for DELETE endpoints that return updated state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7193614ed9670b2830e30b82572b5820ccea16ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->