### PR TITLE
chore: add Superset workspace setup, run and teardown scripts

### DIFF
--- a/.superset/.gitignore
+++ b/.superset/.gitignore
@@ -1,0 +1,2 @@
+# Written by run.sh while a dev server is up (the port the backend actually got)
+.run-state/

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,5 @@
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Superset run command — FastyBird Smart Panel dev servers.
+#
+# Usage: ./.superset/run.sh [backend|admin|website|testing|all]
+#        (default: backend + admin)
+#
+# Ports are picked automatically starting from the project defaults, so several
+# workspaces (and the root checkout) can run side by side. Pin them by exporting
+# FB_BACKEND_PORT / FB_ADMIN_PORT / FB_WEBSITE_PORT before starting.
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TARGET="${1:-default}"
+
+# First free TCP port at or above $1.
+free_port() {
+	node -e '
+		const net = require("net");
+		let port = Number(process.argv[1]);
+		const probe = () => {
+			const server = net.createServer();
+			server.once("error", () => { port += 1; probe(); });
+			server.once("listening", () => server.close(() => console.log(port)));
+			server.listen(port, "0.0.0.0");
+		};
+		probe();
+	' "$1"
+}
+
+# The backend reads these from process.env before .env/.env.local, and the admin
+# vite config exposes any FB_APP_/FB_BACKEND_/FB_ADMIN_ prefixed process.env var
+# with priority over the root .env files — so exporting them here wins.
+export NODE_ENV="${NODE_ENV:-development}"
+export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
+export FB_BACKEND_PORT="${FB_BACKEND_PORT:-$(free_port 3000)}"
+export FB_ADMIN_PORT="${FB_ADMIN_PORT:-$(free_port 3003)}"
+FB_WEBSITE_PORT="${FB_WEBSITE_PORT:-$(free_port 3006)}"
+
+pids=""
+
+# The servers run three processes deep (pnpm → nest/vite → the app itself) and
+# the leaf process is the one holding the port, so signalling just the pnpm
+# parent orphans a listening server. Print every descendant of $1, depth first.
+descendants() {
+	local child
+	for child in $(pgrep -P "$1" 2>/dev/null || true); do
+		printf '%s ' "$child"
+		descendants "$child"
+	done
+}
+
+cleanup() {
+	trap - INT TERM EXIT
+
+	# Snapshot the trees while they are still intact — once a parent dies its
+	# children are reparented and can no longer be found through it.
+	local targets="" pid
+	for pid in $pids; do
+		targets="$targets $pid $(descendants "$pid")"
+	done
+
+	# Parents first, so watch mode cannot respawn what we just killed.
+	for pid in $targets; do
+		kill -TERM "$pid" 2>/dev/null || true
+	done
+
+	sleep 2
+
+	for pid in $targets; do
+		kill -KILL "$pid" 2>/dev/null || true
+	done
+
+	wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+start() {
+	local label="$1"
+	shift
+	printf '\033[1;36m▸ starting %s\033[0m\n' "$label"
+	"$@" &
+	pids="$pids $!"
+}
+
+printf '\n\033[1mFastyBird Smart Panel — %s\033[0m\n' "${SUPERSET_WORKSPACE_NAME:-workspace}"
+
+case "$TARGET" in
+default | backend | all)
+	printf '  backend   %s:%s  (docs at /api/docs)\n' "$FB_APP_HOST" "$FB_BACKEND_PORT"
+	;;
+esac
+
+case "$TARGET" in
+default | admin | all)
+	printf '  admin     http://localhost:%s\n' "$FB_ADMIN_PORT"
+	;;
+esac
+
+case "$TARGET" in
+website | all)
+	printf '  website   http://localhost:%s\n' "$FB_WEBSITE_PORT"
+	;;
+esac
+
+case "$TARGET" in
+testing)
+	printf '  testing app — vite prints its URL below\n'
+	;;
+esac
+
+printf '\n'
+
+case "$TARGET" in
+default | backend | all)
+	start "backend (nest --watch)" pnpm --filter @fastybird/smart-panel-backend run start:dev
+	;;
+esac
+
+case "$TARGET" in
+default | admin | all)
+	start "admin (vite)" pnpm --filter @fastybird/smart-panel-admin run start:dev
+	;;
+esac
+
+case "$TARGET" in
+website | all)
+	start "website (next)" pnpm --filter @fastybird/smart-panel-website exec next dev -p "$FB_WEBSITE_PORT"
+	;;
+esac
+
+case "$TARGET" in
+testing)
+	start "testing app (vite)" pnpm --filter @fastybird/smart-panel-testing run start:dev
+	;;
+esac
+
+if [ -z "$pids" ]; then
+	echo "Unknown target '$TARGET' — use: backend | admin | website | testing | all" >&2
+	exit 1
+fi
+
+wait

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -116,8 +116,45 @@ env_value() { # env_value <KEY> <fallback> [env file...]
 		const path = require("path");
 		const [key, fallback, ...files] = process.argv.slice(1);
 		const searched = files.length > 0 ? files : [".env.local", ".env"];
-		const DOUBLE_QUOTE = 34;
-		const SINGLE_QUOTE = 39;
+
+		// Parse with the very library the backend and Vite use, so this script
+		// cannot disagree with them about what a line means — an inline comment in
+		// `FB_DB_PATH=/tmp/db # local` is part of the value to a naive parser and
+		// stripped by dotenv, and exporting our reading would override theirs.
+		const loadDotenvParse = () => {
+			try {
+				return require(
+					require.resolve("dotenv", { paths: [path.join(process.cwd(), "apps/backend"), process.cwd()] }),
+				).parse;
+			} catch (error) {
+				return null;
+			}
+		};
+
+		// Only reached before dependencies are installed. Mirrors dotenv closely:
+		// quoted values are literal, unquoted ones end at the first #.
+		const parseFallback = (content) => {
+			const values = {};
+
+			for (const line of content.split(/\r?\n/)) {
+				const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+				if (!match) continue;
+
+				let value = match[2].trim();
+				const quote = value[0];
+				if (value.length > 1 && (quote === String.fromCharCode(34) || quote === String.fromCharCode(39)) && value.endsWith(quote)) {
+					value = value.slice(1, -1);
+				} else {
+					value = value.split("#")[0].trim();
+				}
+
+				values[match[1]] = value;
+			}
+
+			return values;
+		};
+
+		const parse = loadDotenvParse() || parseFallback;
 
 		const resolveValue = () => {
 			if (process.env[key]) return process.env[key];
@@ -126,22 +163,8 @@ env_value() { # env_value <KEY> <fallback> [env file...]
 				const full = path.join(process.cwd(), file);
 				if (!fs.existsSync(full)) continue;
 
-				for (const line of fs.readFileSync(full, "utf8").split(/\r?\n/)) {
-					const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-					if (!match || match[1] !== key) continue;
-
-					let value = match[2].trim();
-					const first = value.charCodeAt(0);
-					if (
-						value.length > 1 &&
-						(first === DOUBLE_QUOTE || first === SINGLE_QUOTE) &&
-						value.charCodeAt(value.length - 1) === first
-					) {
-						value = value.slice(1, -1);
-					}
-
-					if (value) return value;
-				}
+				const value = parse(fs.readFileSync(full, "utf8"))[key];
+				if (value) return value;
 			}
 
 			return fallback;

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -209,19 +209,27 @@ clamp_state_path() { # clamp_state_path <KEY> <workspace default>
 	local workspace_default="$2"
 	local current
 
-	current="$(env_value "$key" "$workspace_default")"
-	case "$current" in
-	/*) ;;
-	*) current="$ROOT_DIR/$current" ;;
-	esac
+	# Resolve before comparing: string-prefixing the worktree onto the raw value
+	# lets `var/../../shared` look contained while the backend's path.resolve
+	# lands outside it. Resolving against the worktree also matches how setup.sh
+	# read the same value — the backend would otherwise resolve a relative path
+	# against apps/backend and miss the state setup prepared.
+	current="$(node -e 'console.log(require("path").resolve(process.argv[1], process.argv[2]))' \
+		"$ROOT_DIR" "$(env_value "$key" "$workspace_default")")"
 
-	if inside_workspace "$current" || [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
+	if [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
 		return 0
 	fi
 
-	state_notes="$state_notes  note      $key pointed outside the workspace ($current); using $workspace_default
+	if ! inside_workspace "$current"; then
+		state_notes="$state_notes  note      $key pointed outside the workspace ($current); using $workspace_default
 "
-	export "$key=$workspace_default"
+		current="$workspace_default"
+	fi
+
+	# Always hand over the resolved path, so every process this script starts
+	# agrees with setup.sh regardless of its own working directory.
+	export "$key=$current"
 }
 
 if [ "$starts_backend" = yes ]; then
@@ -229,8 +237,40 @@ if [ "$starts_backend" = yes ]; then
 	clamp_state_path FB_DB_PATH "$ROOT_DIR/var/db"
 fi
 
+# A backend pane records the port it actually got, so an admin pane started
+# later proxies to this workspace instead of whatever the env files name — with
+# the configured port taken, the allocator moves on and .env alone would send
+# /api to the root checkout's backend.
+run_state_dir="$ROOT_DIR/.superset/.run-state"
+backend_port_file="$run_state_dir/backend-port"
+recorded_backend=""
+
+port_is_live() {
+	node -e '
+		const net = require("net");
+		const socket = net.connect(Number(process.argv[1]), "127.0.0.1");
+		const done = (code) => { socket.destroy(); process.exit(code); };
+		socket.setTimeout(500);
+		socket.once("connect", () => done(0));
+		socket.once("timeout", () => done(1));
+		socket.once("error", () => done(1));
+	' "$1"
+}
+
 app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
 overridden_host=""
+
+if [ "$starts_admin" = yes ] && [ "$starts_backend" = no ] && [ -f "$backend_port_file" ]; then
+	# Only trust the record while something is answering on it: a pane that died
+	# without cleanup would otherwise point the proxy at a closed port.
+	candidate="$(cat "$backend_port_file")"
+	if [ -n "$candidate" ] && port_is_live "$candidate"; then
+		recorded_backend="$candidate"
+		app_host="http://127.0.0.1"
+		export FB_APP_HOST="$app_host"
+		export FB_BACKEND_PORT="$recorded_backend"
+	fi
+fi
 
 if [ "$starts_backend" = yes ] && [ "$starts_admin" = yes ]; then
 	# Vite builds its proxy target by pairing FB_APP_HOST with FB_BACKEND_PORT,
@@ -276,6 +316,10 @@ descendants() {
 
 cleanup() {
 	trap - INT TERM EXIT
+
+	if [ "$starts_backend" = yes ]; then
+		rm -f "$backend_port_file"
+	fi
 
 	# Snapshot the trees while they are still intact — once a parent dies its
 	# children are reparented and can no longer be found through it.
@@ -326,10 +370,19 @@ fi
 if [ "$starts_admin" = yes ]; then
 	printf '  admin     http://localhost:%s\n' "$FB_ADMIN_PORT"
 
-	# An admin-only run proxies /api at whatever the env files configure, which
-	# is the point — say so, since nothing on screen would otherwise reveal it.
+	# An admin-only run proxies /api somewhere it did not start — say where,
+	# since nothing else on screen would reveal it.
 	if [ "$starts_backend" = no ]; then
-		printf '  api proxy %s:%s (from .env/.env.local)\n' "$app_host" "$(env_value FB_BACKEND_PORT 3000)"
+		if [ -n "$recorded_backend" ]; then
+			printf '  api proxy %s:%s (backend started by this workspace)\n' "$app_host" "$recorded_backend"
+		else
+			proxy_port="$(env_value FB_BACKEND_PORT 3000)"
+			printf '  api proxy %s:%s (from .env/.env.local)\n' "$app_host" "$proxy_port"
+
+			if ! port_is_live "$proxy_port"; then
+				printf '            nothing is listening there yet\n'
+			fi
+		fi
 	fi
 fi
 
@@ -344,6 +397,9 @@ fi
 printf '\n'
 
 if [ "$starts_backend" = yes ]; then
+	mkdir -p "$run_state_dir"
+	printf '%s' "$FB_BACKEND_PORT" > "$backend_port_file"
+
 	start "backend (nest --watch)" pnpm --filter @fastybird/smart-panel-backend run start:dev
 fi
 

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -217,18 +217,16 @@ clamp_state_path() { # clamp_state_path <KEY> <workspace default>
 	current="$(node -e 'console.log(require("path").resolve(process.argv[1], process.argv[2]))' \
 		"$ROOT_DIR" "$(env_value "$key" "$workspace_default")")"
 
-	if [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
-		return 0
-	fi
-
-	if ! inside_workspace "$current"; then
+	if [ -z "${SUPERSET_ALLOW_SHARED_STATE:-}" ] && ! inside_workspace "$current"; then
 		state_notes="$state_notes  note      $key pointed outside the workspace ($current); using $workspace_default
 "
 		current="$workspace_default"
 	fi
 
-	# Always hand over the resolved path, so every process this script starts
-	# agrees with setup.sh regardless of its own working directory.
+	# Always hand over the resolved path — including when shared state is allowed,
+	# where the point is to reach the very directory setup used. The backend
+	# resolves a relative value against apps/backend, so passing the raw string
+	# through would land it somewhere setup never prepared.
 	export "$key=$current"
 }
 
@@ -261,14 +259,20 @@ app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
 overridden_host=""
 
 if [ "$starts_admin" = yes ] && [ "$starts_backend" = no ] && [ -f "$backend_port_file" ]; then
-	# Only trust the record while something is answering on it: a pane that died
-	# without cleanup would otherwise point the proxy at a closed port.
-	candidate="$(cat "$backend_port_file")"
-	if [ -n "$candidate" ] && port_is_live "$candidate"; then
-		recorded_backend="$candidate"
-		app_host="http://127.0.0.1"
-		export FB_APP_HOST="$app_host"
-		export FB_BACKEND_PORT="$recorded_backend"
+	# The record is "<pid of the backend pane> <port>". Trust it while that pane
+	# is alive — Nest takes tens of seconds to bind, and an admin pane started in
+	# the meantime would otherwise reject a perfectly good allocation and spend
+	# its whole life proxying to the fallback. A port that answers is trusted too,
+	# for a backend that outlived its pane; anything else is stale.
+	read -r recorded_pid candidate < "$backend_port_file" || true
+
+	if [ -n "${candidate:-}" ]; then
+		if kill -0 "$recorded_pid" 2>/dev/null || port_is_live "$candidate"; then
+			recorded_backend="$candidate"
+			app_host="http://127.0.0.1"
+			export FB_APP_HOST="$app_host"
+			export FB_BACKEND_PORT="$recorded_backend"
+		fi
 	fi
 fi
 
@@ -398,7 +402,7 @@ printf '\n'
 
 if [ "$starts_backend" = yes ]; then
 	mkdir -p "$run_state_dir"
-	printf '%s' "$FB_BACKEND_PORT" > "$backend_port_file"
+	printf '%s %s\n' "$$" "$FB_BACKEND_PORT" > "$backend_port_file"
 
 	start "backend (nest --watch)" pnpm --filter @fastybird/smart-panel-backend run start:dev
 fi

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -93,22 +93,23 @@ for port in "${FB_BACKEND_PORT:-}" "${FB_ADMIN_PORT:-}" "${FB_WEBSITE_PORT:-}"; 
 done
 
 # What the apps themselves will resolve for a variable: an exported one wins,
-# then .env.local, then .env, then the fallback. Anything this script only needs
-# to know (rather than change) goes through here — exporting a "default" would
-# override a configured value, since both the backend and Vite give the process
-# environment priority over the env files.
-env_value() { # env_value <KEY> <fallback>
+# then the given env files (.env.local then .env by default), then the fallback.
+# Anything this script only needs to know (rather than change) goes through here
+# — exporting a "default" would override a configured value, since both the
+# backend and Vite give the process environment priority over the env files.
+env_value() { # env_value <KEY> <fallback> [env file...]
 	node -e '
 		const fs = require("fs");
 		const path = require("path");
-		const [key, fallback] = process.argv.slice(1);
+		const [key, fallback, ...files] = process.argv.slice(1);
+		const searched = files.length > 0 ? files : [".env.local", ".env"];
 		const DOUBLE_QUOTE = 34;
 		const SINGLE_QUOTE = 39;
 
 		const resolveValue = () => {
 			if (process.env[key]) return process.env[key];
 
-			for (const file of [".env.local", ".env"]) {
+			for (const file of searched) {
 				const full = path.join(process.cwd(), file);
 				if (!fs.existsSync(full)) continue;
 
@@ -134,7 +135,7 @@ env_value() { # env_value <KEY> <fallback>
 		};
 
 		console.log(resolveValue());
-	' "$1" "$2"
+	' "$@"
 }
 
 # Start the backend scan at the configured port so a separate admin-only pane,
@@ -177,16 +178,25 @@ if [ "$starts_website" = yes ] && [ -z "${FB_WEBSITE_PORT:-}" ]; then
 	shift
 fi
 
-# Only default NODE_ENV when nothing configures it — .env.local saying
-# production is a deliberate choice, not something a dev runner should undo.
-if [ -z "$(env_value NODE_ENV '')" ]; then
+# .env ships NODE_ENV=production for deployments, so treating it as configured
+# would leave this dev runner in production mode — global-error.filter.ts then
+# replaces exception details with "An unexpected server error occurred.". Only
+# an ambient value or .env.local counts as a deliberate choice here.
+if [ -z "$(env_value NODE_ENV '' .env.local)" ]; then
 	export NODE_ENV=development
 fi
 
-# FB_APP_HOST is never exported: .env.local may point the admin at a backend on
-# another host, and exporting a loopback default would silently redirect the
-# proxy there. Resolve it for display instead.
-app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
+if [ "$starts_backend" = yes ]; then
+	# This invocation starts the backend, so it listens locally on the port just
+	# allocated. The host has to match: pairing a configured remote FB_APP_HOST
+	# with a local port would aim the admin proxy at neither backend.
+	export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
+	app_host="$FB_APP_HOST"
+else
+	# Nothing local to point at — keep whatever endpoint is configured, which is
+	# the whole point of an admin-only run, and only read it for the banner.
+	app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
+fi
 
 # The ports are different — these are ports this script picked, so the servers
 # and the proxy have to be told about them.

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -9,6 +9,9 @@
 # workspaces (and the root checkout) can run side by side. Pin them by exporting
 # FB_BACKEND_PORT / FB_ADMIN_PORT / FB_WEBSITE_PORT before starting.
 #
+# FB_CONFIG_PATH / FB_DB_PATH are kept inside the worktree so a workspace cannot
+# write another checkout's state; export SUPERSET_ALLOW_SHARED_STATE=1 to opt out.
+#
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -186,6 +189,46 @@ if [ -z "$(env_value NODE_ENV '' .env.local)" ]; then
 	export NODE_ENV=development
 fi
 
+# Superset runs setup and this script as separate processes, so the paths setup
+# exported do not reach here — an ambient FB_DB_PATH/FB_CONFIG_PATH pointing
+# outside the worktree would have this backend open, migrate and write another
+# checkout's state while the copies setup prepared sit unused. Writing them into
+# .env.local would not help either: @nestjs/config skips keys already present in
+# process.env. So clamp them again, here, for the processes we start.
+state_notes=""
+
+inside_workspace() {
+	case "$1/" in
+	"$ROOT_DIR"/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+clamp_state_path() { # clamp_state_path <KEY> <workspace default>
+	local key="$1"
+	local workspace_default="$2"
+	local current
+
+	current="$(env_value "$key" "$workspace_default")"
+	case "$current" in
+	/*) ;;
+	*) current="$ROOT_DIR/$current" ;;
+	esac
+
+	if inside_workspace "$current" || [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
+		return 0
+	fi
+
+	state_notes="$state_notes  note      $key pointed outside the workspace ($current); using $workspace_default
+"
+	export "$key=$workspace_default"
+}
+
+if [ "$starts_backend" = yes ]; then
+	clamp_state_path FB_CONFIG_PATH "$ROOT_DIR/var/data"
+	clamp_state_path FB_DB_PATH "$ROOT_DIR/var/db"
+fi
+
 app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
 overridden_host=""
 
@@ -272,6 +315,11 @@ if [ "$starts_backend" = yes ]; then
 	if [ -n "$overridden_host" ]; then
 		printf '  note      FB_APP_HOST %s ignored: the admin proxy has to reach the backend started here\n' "$overridden_host"
 		printf '            run the backend on its own to keep it as the public origin\n'
+	fi
+
+	if [ -n "$state_notes" ]; then
+		printf '%s' "$state_notes"
+		printf '            set SUPERSET_ALLOW_SHARED_STATE=1 to use the shared location instead\n'
 	fi
 fi
 

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -92,9 +92,63 @@ for port in "${FB_BACKEND_PORT:-}" "${FB_ADMIN_PORT:-}" "${FB_WEBSITE_PORT:-}"; 
 	fi
 done
 
+# What the apps themselves will resolve for a variable: an exported one wins,
+# then .env.local, then .env, then the fallback. Anything this script only needs
+# to know (rather than change) goes through here — exporting a "default" would
+# override a configured value, since both the backend and Vite give the process
+# environment priority over the env files.
+env_value() { # env_value <KEY> <fallback>
+	node -e '
+		const fs = require("fs");
+		const path = require("path");
+		const [key, fallback] = process.argv.slice(1);
+		const DOUBLE_QUOTE = 34;
+		const SINGLE_QUOTE = 39;
+
+		const resolveValue = () => {
+			if (process.env[key]) return process.env[key];
+
+			for (const file of [".env.local", ".env"]) {
+				const full = path.join(process.cwd(), file);
+				if (!fs.existsSync(full)) continue;
+
+				for (const line of fs.readFileSync(full, "utf8").split(/\r?\n/)) {
+					const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+					if (!match || match[1] !== key) continue;
+
+					let value = match[2].trim();
+					const first = value.charCodeAt(0);
+					if (
+						value.length > 1 &&
+						(first === DOUBLE_QUOTE || first === SINGLE_QUOTE) &&
+						value.charCodeAt(value.length - 1) === first
+					) {
+						value = value.slice(1, -1);
+					}
+
+					if (value) return value;
+				}
+			}
+
+			return fallback;
+		};
+
+		console.log(resolveValue());
+	' "$1" "$2"
+}
+
+# Start the backend scan at the configured port so a separate admin-only pane,
+# which proxies to whatever the env files say, agrees with it. FB_ADMIN_PORT is
+# not treated the same way: .env sets it to 80 for the bundled production admin,
+# which the Vite dev server cannot bind.
+backend_base="$(env_value FB_BACKEND_PORT 3000)"
+case "$backend_base" in
+'' | *[!0-9]*) backend_base=3000 ;;
+esac
+
 bases=""
 if [ "$starts_backend" = yes ] && [ -z "${FB_BACKEND_PORT:-}" ]; then
-	bases="$bases 3000"
+	bases="$bases $backend_base"
 fi
 if [ "$starts_admin" = yes ] && [ -z "${FB_ADMIN_PORT:-}" ]; then
 	bases="$bases 3003"
@@ -123,11 +177,19 @@ if [ "$starts_website" = yes ] && [ -z "${FB_WEBSITE_PORT:-}" ]; then
 	shift
 fi
 
-# The backend reads these from process.env before .env/.env.local, and the admin
-# vite config exposes any FB_APP_/FB_BACKEND_/FB_ADMIN_ prefixed process.env var
-# with priority over the root .env files — so exporting them here wins.
-export NODE_ENV="${NODE_ENV:-development}"
-export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
+# Only default NODE_ENV when nothing configures it — .env.local saying
+# production is a deliberate choice, not something a dev runner should undo.
+if [ -z "$(env_value NODE_ENV '')" ]; then
+	export NODE_ENV=development
+fi
+
+# FB_APP_HOST is never exported: .env.local may point the admin at a backend on
+# another host, and exporting a loopback default would silently redirect the
+# proxy there. Resolve it for display instead.
+app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
+
+# The ports are different — these are ports this script picked, so the servers
+# and the proxy have to be told about them.
 if [ -n "${FB_BACKEND_PORT:-}" ]; then
 	export FB_BACKEND_PORT
 fi
@@ -184,18 +246,16 @@ start() {
 printf '\n\033[1mFastyBird Smart Panel — %s\033[0m\n' "${SUPERSET_WORKSPACE_NAME:-workspace}"
 
 if [ "$starts_backend" = yes ]; then
-	printf '  backend   %s:%s  (docs at /api/docs)\n' "$FB_APP_HOST" "$FB_BACKEND_PORT"
+	printf '  backend   %s:%s  (docs at /api/docs)\n' "$app_host" "$FB_BACKEND_PORT"
 fi
 
 if [ "$starts_admin" = yes ]; then
 	printf '  admin     http://localhost:%s\n' "$FB_ADMIN_PORT"
 
+	# An admin-only run proxies /api at whatever the env files configure, which
+	# is the point — say so, since nothing on screen would otherwise reveal it.
 	if [ "$starts_backend" = no ]; then
-		if [ -n "${FB_BACKEND_PORT:-}" ]; then
-			printf '  api proxy %s:%s\n' "$FB_APP_HOST" "$FB_BACKEND_PORT"
-		else
-			printf '  api proxy → FB_BACKEND_PORT from .env/.env.local (export it to point elsewhere)\n'
-		fi
+		printf '  api proxy %s:%s (from .env/.env.local)\n' "$app_host" "$(env_value FB_BACKEND_PORT 3000)"
 	fi
 fi
 

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -16,29 +16,63 @@ cd "$ROOT_DIR"
 
 TARGET="${1:-default}"
 
-# First free TCP port at or above $1.
-free_port() {
+# Pick one free port per base, all in a single pass: every probe socket stays
+# bound until the last port is chosen, and ports already claimed by the caller
+# are excluded. Probing each base independently would hand two services the same
+# port whenever their scan ranges meet — with 3000-3004 busy, a scan from 3000
+# and a scan from 3003 both land on 3005.
+# Usage: alloc_ports "<comma separated ports to avoid>" <base> [base...]
+alloc_ports() {
 	node -e '
 		const net = require("net");
-		let port = Number(process.argv[1]);
-		const probe = () => {
+		const taken = new Set(String(process.argv[1]).split(",").filter(Boolean).map(Number));
+		const bases = process.argv.slice(2).map(Number);
+		const held = [];
+		const chosen = [];
+
+		const claim = (port, done) => {
+			if (taken.has(port)) return claim(port + 1, done);
+
 			const server = net.createServer();
-			server.once("error", () => { port += 1; probe(); });
-			server.once("listening", () => server.close(() => console.log(port)));
+			server.once("error", () => claim(port + 1, done));
+			server.once("listening", () => {
+				held.push(server);
+				taken.add(port);
+				done(port);
+			});
 			server.listen(port, "0.0.0.0");
 		};
-		probe();
-	' "$1"
+
+		const report = () => {
+			let pending = held.length;
+			if (pending === 0) return console.log(chosen.join(" "));
+			held.forEach((server) => server.close(() => { if (--pending === 0) console.log(chosen.join(" ")); }));
+		};
+
+		const next = (index) => {
+			if (index === bases.length) return report();
+			claim(bases[index], (port) => { chosen.push(port); next(index + 1); });
+		};
+
+		next(0);
+	' "$@"
 }
+
+pinned=""
+for port in "${FB_BACKEND_PORT:-}" "${FB_ADMIN_PORT:-}" "${FB_WEBSITE_PORT:-}"; do
+	[ -n "$port" ] && pinned="$pinned,$port"
+done
+
+read -r auto_backend auto_admin auto_website <<<"$(alloc_ports "$pinned" 3000 3003 3006)"
 
 # The backend reads these from process.env before .env/.env.local, and the admin
 # vite config exposes any FB_APP_/FB_BACKEND_/FB_ADMIN_ prefixed process.env var
 # with priority over the root .env files — so exporting them here wins.
 export NODE_ENV="${NODE_ENV:-development}"
 export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
-export FB_BACKEND_PORT="${FB_BACKEND_PORT:-$(free_port 3000)}"
-export FB_ADMIN_PORT="${FB_ADMIN_PORT:-$(free_port 3003)}"
-FB_WEBSITE_PORT="${FB_WEBSITE_PORT:-$(free_port 3006)}"
+export FB_BACKEND_PORT="${FB_BACKEND_PORT:-$auto_backend}"
+export FB_ADMIN_PORT="${FB_ADMIN_PORT:-$auto_admin}"
+FB_WEBSITE_PORT="${FB_WEBSITE_PORT:-$auto_website}"
 
 pids=""
 

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -19,6 +19,16 @@ cd "$ROOT_DIR"
 
 TARGET="${1:-default}"
 
+# Knobs are read through this, so SUPERSET_ALLOW_SHARED_STATE=0 turns sharing
+# off rather than on — a bare non-empty test would have read "0" and "false" as
+# "enabled", which is the opposite of what anyone typing them means.
+flag_enabled() {
+	case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+	'' | 0 | false | no | off) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
 # Pick one free port per base, all in a single pass: every probe socket stays
 # bound until the last port is chosen, and ports already claimed by the caller
 # are excluded. Probing each base independently would hand two services the same
@@ -217,7 +227,7 @@ clamp_state_path() { # clamp_state_path <KEY> <workspace default>
 	current="$(node -e 'console.log(require("path").resolve(process.argv[1], process.argv[2]))' \
 		"$ROOT_DIR" "$(env_value "$key" "$workspace_default")")"
 
-	if [ -z "${SUPERSET_ALLOW_SHARED_STATE:-}" ] && ! inside_workspace "$current"; then
+	if ! flag_enabled "${SUPERSET_ALLOW_SHARED_STATE:-}" && ! inside_workspace "$current"; then
 		state_notes="$state_notes  note      $key pointed outside the workspace ($current); using $workspace_default
 "
 		current="$workspace_default"

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -58,21 +58,82 @@ alloc_ports() {
 	' "$@"
 }
 
+starts_backend=no
+starts_admin=no
+starts_website=no
+starts_testing=no
+
+case "$TARGET" in
+default | backend | all) starts_backend=yes ;;
+esac
+case "$TARGET" in
+default | admin | all) starts_admin=yes ;;
+esac
+case "$TARGET" in
+website | all) starts_website=yes ;;
+esac
+case "$TARGET" in
+testing) starts_testing=yes ;;
+esac
+
+if [ "$starts_backend$starts_admin$starts_website$starts_testing" = "nononono" ]; then
+	echo "Unknown target '$TARGET' — use: backend | admin | website | testing | all" >&2
+	exit 1
+fi
+
+# Only allocate a port for a server this invocation actually starts. Allocating
+# FB_BACKEND_PORT for an admin-only run would export a port that is free by
+# construction, pointing the admin's /api proxy at nothing — an admin-only run
+# has to keep whatever backend endpoint .env/.env.local already configures.
 pinned=""
 for port in "${FB_BACKEND_PORT:-}" "${FB_ADMIN_PORT:-}" "${FB_WEBSITE_PORT:-}"; do
-	[ -n "$port" ] && pinned="$pinned,$port"
+	if [ -n "$port" ]; then
+		pinned="$pinned,$port"
+	fi
 done
 
-read -r auto_backend auto_admin auto_website <<<"$(alloc_ports "$pinned" 3000 3003 3006)"
+bases=""
+if [ "$starts_backend" = yes ] && [ -z "${FB_BACKEND_PORT:-}" ]; then
+	bases="$bases 3000"
+fi
+if [ "$starts_admin" = yes ] && [ -z "${FB_ADMIN_PORT:-}" ]; then
+	bases="$bases 3003"
+fi
+if [ "$starts_website" = yes ] && [ -z "${FB_WEBSITE_PORT:-}" ]; then
+	bases="$bases 3006"
+fi
+
+allocated=""
+if [ -n "$bases" ]; then
+	allocated="$(alloc_ports "$pinned" $bases)"
+fi
+
+# Consume the allocations in the same order the bases were queued.
+set -- $allocated
+if [ "$starts_backend" = yes ] && [ -z "${FB_BACKEND_PORT:-}" ]; then
+	FB_BACKEND_PORT="$1"
+	shift
+fi
+if [ "$starts_admin" = yes ] && [ -z "${FB_ADMIN_PORT:-}" ]; then
+	FB_ADMIN_PORT="$1"
+	shift
+fi
+if [ "$starts_website" = yes ] && [ -z "${FB_WEBSITE_PORT:-}" ]; then
+	FB_WEBSITE_PORT="$1"
+	shift
+fi
 
 # The backend reads these from process.env before .env/.env.local, and the admin
 # vite config exposes any FB_APP_/FB_BACKEND_/FB_ADMIN_ prefixed process.env var
 # with priority over the root .env files — so exporting them here wins.
 export NODE_ENV="${NODE_ENV:-development}"
 export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
-export FB_BACKEND_PORT="${FB_BACKEND_PORT:-$auto_backend}"
-export FB_ADMIN_PORT="${FB_ADMIN_PORT:-$auto_admin}"
-FB_WEBSITE_PORT="${FB_WEBSITE_PORT:-$auto_website}"
+if [ -n "${FB_BACKEND_PORT:-}" ]; then
+	export FB_BACKEND_PORT
+fi
+if [ -n "${FB_ADMIN_PORT:-}" ]; then
+	export FB_ADMIN_PORT
+fi
 
 pids=""
 
@@ -122,59 +183,46 @@ start() {
 
 printf '\n\033[1mFastyBird Smart Panel — %s\033[0m\n' "${SUPERSET_WORKSPACE_NAME:-workspace}"
 
-case "$TARGET" in
-default | backend | all)
+if [ "$starts_backend" = yes ]; then
 	printf '  backend   %s:%s  (docs at /api/docs)\n' "$FB_APP_HOST" "$FB_BACKEND_PORT"
-	;;
-esac
+fi
 
-case "$TARGET" in
-default | admin | all)
+if [ "$starts_admin" = yes ]; then
 	printf '  admin     http://localhost:%s\n' "$FB_ADMIN_PORT"
-	;;
-esac
 
-case "$TARGET" in
-website | all)
+	if [ "$starts_backend" = no ]; then
+		if [ -n "${FB_BACKEND_PORT:-}" ]; then
+			printf '  api proxy %s:%s\n' "$FB_APP_HOST" "$FB_BACKEND_PORT"
+		else
+			printf '  api proxy → FB_BACKEND_PORT from .env/.env.local (export it to point elsewhere)\n'
+		fi
+	fi
+fi
+
+if [ "$starts_website" = yes ]; then
 	printf '  website   http://localhost:%s\n' "$FB_WEBSITE_PORT"
-	;;
-esac
+fi
 
-case "$TARGET" in
-testing)
+if [ "$starts_testing" = yes ]; then
 	printf '  testing app — vite prints its URL below\n'
-	;;
-esac
+fi
 
 printf '\n'
 
-case "$TARGET" in
-default | backend | all)
+if [ "$starts_backend" = yes ]; then
 	start "backend (nest --watch)" pnpm --filter @fastybird/smart-panel-backend run start:dev
-	;;
-esac
+fi
 
-case "$TARGET" in
-default | admin | all)
+if [ "$starts_admin" = yes ]; then
 	start "admin (vite)" pnpm --filter @fastybird/smart-panel-admin run start:dev
-	;;
-esac
+fi
 
-case "$TARGET" in
-website | all)
+if [ "$starts_website" = yes ]; then
 	start "website (next)" pnpm --filter @fastybird/smart-panel-website exec next dev -p "$FB_WEBSITE_PORT"
-	;;
-esac
+fi
 
-case "$TARGET" in
-testing)
+if [ "$starts_testing" = yes ]; then
 	start "testing app (vite)" pnpm --filter @fastybird/smart-panel-testing run start:dev
-	;;
-esac
-
-if [ -z "$pids" ]; then
-	echo "Unknown target '$TARGET' — use: backend | admin | website | testing | all" >&2
-	exit 1
 fi
 
 wait

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -186,17 +186,28 @@ if [ -z "$(env_value NODE_ENV '' .env.local)" ]; then
 	export NODE_ENV=development
 fi
 
-if [ "$starts_backend" = yes ]; then
-	# This invocation starts the backend, so it listens locally on the port just
-	# allocated. The host has to match: pairing a configured remote FB_APP_HOST
-	# with a local port would aim the admin proxy at neither backend.
-	export FB_APP_HOST="${FB_APP_HOST:-http://127.0.0.1}"
-	app_host="$FB_APP_HOST"
-else
-	# Nothing local to point at — keep whatever endpoint is configured, which is
-	# the whole point of an admin-only run, and only read it for the banner.
-	app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
+app_host="$(env_value FB_APP_HOST http://127.0.0.1)"
+overridden_host=""
+
+if [ "$starts_backend" = yes ] && [ "$starts_admin" = yes ]; then
+	# Vite builds its proxy target by pairing FB_APP_HOST with FB_BACKEND_PORT,
+	# and the port is the local one allocated above — so any host but loopback
+	# sends /api to a machine that is not running this backend. This wins over an
+	# exported value too: it is the one combination that cannot be correct.
+	if [ "$app_host" != "http://127.0.0.1" ]; then
+		overridden_host="$app_host"
+	fi
+
+	app_host="http://127.0.0.1"
+	export FB_APP_HOST="$app_host"
+elif [ "$starts_backend" = yes ]; then
+	# No admin proxy in this invocation, so nothing pairs the host with our port.
+	# Keep the configured public origin — it is what the backend puts in absolute
+	# URLs, and it stays reachable because the backend binds 0.0.0.0.
+	export FB_APP_HOST="$app_host"
 fi
+# An admin-only run exports nothing: keeping the configured endpoint is the
+# entire point, and app_host above is only used for the banner.
 
 # The ports are different — these are ports this script picked, so the servers
 # and the proxy have to be told about them.
@@ -257,6 +268,11 @@ printf '\n\033[1mFastyBird Smart Panel — %s\033[0m\n' "${SUPERSET_WORKSPACE_NA
 
 if [ "$starts_backend" = yes ]; then
 	printf '  backend   %s:%s  (docs at /api/docs)\n' "$app_host" "$FB_BACKEND_PORT"
+
+	if [ -n "$overridden_host" ]; then
+		printf '  note      FB_APP_HOST %s ignored: the admin proxy has to reach the backend started here\n' "$overridden_host"
+		printf '            run the backend on its own to keep it as the public origin\n'
+	fi
 fi
 
 if [ "$starts_admin" = yes ]; then

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -30,6 +30,16 @@ cd "$ROOT_DIR"
 log() { printf '\n\033[1;36m▸ %s\033[0m\n' "$*"; }
 warn() { printf '\033[1;33m! %s\033[0m\n' "$*"; }
 
+# Knobs are read through this, so SUPERSET_ALLOW_SHARED_STATE=0 turns sharing
+# off rather than on — a bare non-empty test would have read "0" and "false" as
+# "enabled", which is the opposite of what anyone typing them means.
+flag_enabled() {
+	case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+	'' | 0 | false | no | off) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
 # --- toolchain ---------------------------------------------------------------
 
 if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
@@ -195,7 +205,7 @@ inside_workspace() {
 	esac
 }
 
-if [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
+if flag_enabled "${SUPERSET_ALLOW_SHARED_STATE:-}"; then
 	if ! inside_workspace "$config_dir" || ! inside_workspace "$db_dir"; then
 		warn "SUPERSET_ALLOW_SHARED_STATE is set — using state outside this workspace as-is"
 		warn "Migrations from this branch will be applied to whatever else runs on it"
@@ -239,7 +249,7 @@ if [ -n "$root_config_dir" ]; then
 		' "$config_dir/config.yaml"
 	fi
 
-	if [ -z "${SUPERSET_SKIP_DB_COPY:-}" ] && [ -f "$root_db_dir/database.sqlite" ] && [ ! -f "$db_dir/database.sqlite" ]; then
+	if ! flag_enabled "${SUPERSET_SKIP_DB_COPY:-}" && [ -f "$root_db_dir/database.sqlite" ] && [ ! -f "$db_dir/database.sqlite" ]; then
 		log "Copying the SQLite database from the root checkout"
 		# Always go through the SQLite backup API. A plain cp of a database the
 		# root backend is writing to can miss committed data still sitting in the
@@ -292,7 +302,7 @@ pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
 # apps/panel/lib/api and apps/panel/lib/spec are generated and untracked, so the
 # panel does not compile in a fresh worktree until they are rebuilt.
 
-if [ -z "${SUPERSET_SKIP_FLUTTER:-}" ] && command -v flutter >/dev/null 2>&1; then
+if ! flag_enabled "${SUPERSET_SKIP_FLUTTER:-}" && command -v flutter >/dev/null 2>&1; then
 	log "Fetching Flutter packages for apps/panel"
 	if ! (cd apps/panel && flutter pub get); then
 		warn "flutter pub get failed — run it manually before working on the panel app"

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Superset workspace setup — FastyBird Smart Panel
+#
+# Runs once when a new workspace (git worktree) is created. It installs the pnpm
+# workspace dependencies, generates the code that the apps import at build time
+# (device/channel specs, OpenAPI clients), seeds the workspace with the local dev
+# state from the root checkout, and applies the database migrations.
+#
+# It intentionally skips the production builds that `pnpm run bootstrap` does
+# (backend `nest build`, admin `vue-tsc` + `vite build`) — the dev servers
+# started by `.superset/run.sh` compile on the fly, and those builds are the
+# slowest part of bootstrap.
+#
+# Knobs:
+#   SUPERSET_SKIP_DB_COPY=1   start from an empty database instead of copying
+#                             the root checkout's SQLite database
+#   SUPERSET_SKIP_FLUTTER=1   skip `flutter pub get` for apps/panel
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log() { printf '\n\033[1;36m▸ %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m! %s\033[0m\n' "$*"; }
+
+# --- toolchain ---------------------------------------------------------------
+
+if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+	log "Enabling pnpm through corepack"
+	corepack enable >/dev/null 2>&1 || true
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+	echo "pnpm not found. Install Node.js >= 24 and run 'corepack enable'." >&2
+	exit 1
+fi
+
+# --- dependencies ------------------------------------------------------------
+
+log "Installing workspace dependencies"
+if ! pnpm install --frozen-lockfile; then
+	warn "Frozen install failed (lockfile out of sync?) — retrying without --frozen-lockfile"
+	pnpm install
+fi
+
+# --- runtime directories -----------------------------------------------------
+
+log "Creating runtime directories"
+node init.js
+
+# --- local dev state from the root checkout ----------------------------------
+#
+# .env.local, var/data/config.yaml and var/db/database.sqlite are gitignored, so
+# a fresh worktree has none of them. Copying them over means the workspace boots
+# with the same configuration and user account as the root checkout instead of
+# needing `pnpm run onboard` first. Existing files are never overwritten.
+
+if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPERSET_ROOT_PATH" != "$ROOT_DIR" ]; then
+	if [ -f "$SUPERSET_ROOT_PATH/.env.local" ] && [ ! -f .env.local ]; then
+		log "Copying .env.local from the root checkout"
+		cp "$SUPERSET_ROOT_PATH/.env.local" .env.local
+	fi
+
+	if [ -f "$SUPERSET_ROOT_PATH/var/data/config.yaml" ] && [ ! -f var/data/config.yaml ]; then
+		log "Copying var/data/config.yaml from the root checkout"
+		cp "$SUPERSET_ROOT_PATH/var/data/config.yaml" var/data/config.yaml
+		chmod 600 var/data/config.yaml
+		# ConfigService stores its own absolute location in the file — repoint it
+		# at this workspace so the copied value is not misleading.
+		node -e '
+			const fs = require("fs");
+			const file = "var/data/config.yaml";
+			const target = `${process.cwd()}/${file}`;
+			const content = fs.readFileSync(file, "utf8");
+			if (/^path: .*$/m.test(content)) {
+				fs.writeFileSync(file, content.replace(/^path: .*$/m, `path: ${target}`));
+			}
+		'
+	fi
+
+	if [ -z "${SUPERSET_SKIP_DB_COPY:-}" ] && [ -f "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ] && [ ! -f var/db/database.sqlite ]; then
+		log "Copying the SQLite database from the root checkout"
+		if command -v sqlite3 >/dev/null 2>&1; then
+			# .backup takes a consistent snapshot even if the root backend is running.
+			sqlite3 "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ".backup '$ROOT_DIR/var/db/database.sqlite'"
+		else
+			cp "$SUPERSET_ROOT_PATH/var/db/database.sqlite" var/db/database.sqlite
+		fi
+	fi
+fi
+
+# --- generated code ----------------------------------------------------------
+#
+# spec/api/v1/openapi.json, apps/admin/src/openapi.ts and apps/backend/src/spec
+# are generated, not committed — the apps do not compile without them.
+
+log "Generating device & channel specs"
+pnpm run generate:spec
+
+log "Building the extension SDK"
+pnpm --filter @fastybird/smart-panel-extension-sdk run build
+
+log "Generating the OpenAPI spec and typed API clients"
+pnpm run generate:openapi
+
+log "Applying database migrations"
+pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
+
+# --- Flutter panel (optional) ------------------------------------------------
+
+if [ -z "${SUPERSET_SKIP_FLUTTER:-}" ] && command -v flutter >/dev/null 2>&1; then
+	log "Fetching Flutter packages for apps/panel"
+	(cd apps/panel && flutter pub get) || warn "flutter pub get failed — run it manually before working on the panel app"
+fi
+
+printf '\n\033[1;32m✓ Workspace ready\033[0m\n'
+printf '  Start the dev servers with the Run button (or ./.superset/run.sh).\n'
+printf '  No user account yet? Run: pnpm run onboard\n\n'

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -60,7 +60,55 @@ node init.js
 if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPERSET_ROOT_PATH" != "$ROOT_DIR" ]; then
 	if [ -f "$SUPERSET_ROOT_PATH/.env.local" ] && [ ! -f .env.local ]; then
 		log "Copying .env.local from the root checkout"
-		cp "$SUPERSET_ROOT_PATH/.env.local" .env.local
+		# FB_CONFIG_PATH, FB_DB_PATH and FB_ADMIN_UI_PATH are read from the repo
+		# root .env.local by the running backend. Copied verbatim they would point
+		# this workspace at the root checkout's config and database — so anything
+		# resolving inside the root checkout is repointed at the workspace copy.
+		node -e '
+			const fs = require("fs");
+			const [src, dst, rootPath, workspacePath] = process.argv.slice(1);
+			const DOUBLE_QUOTE = 34;
+			const SINGLE_QUOTE = 39;
+			const shared = [];
+
+			const rewritten = fs
+				.readFileSync(src, "utf8")
+				.split(/\r?\n/)
+				.map((line) => {
+					const match = line.match(/^(\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*)(.*)$/);
+					if (!match) return line;
+
+					const [, assignment, key, rawValue] = match;
+					if (!/_PATH$/.test(key)) return line;
+
+					const trimmed = rawValue.trim();
+					const first = trimmed.charCodeAt(0);
+					const quoted =
+						trimmed.length > 1 &&
+						(first === DOUBLE_QUOTE || first === SINGLE_QUOTE) &&
+						trimmed.charCodeAt(trimmed.length - 1) === first;
+					const quote = quoted ? trimmed[0] : "";
+					const value = quoted ? trimmed.slice(1, -1) : trimmed;
+
+					if (!value) return line;
+
+					if (value === rootPath || value.startsWith(`${rootPath}/`)) {
+						return `${assignment}${quote}${workspacePath}${value.slice(rootPath.length)}${quote}`;
+					}
+
+					if (value.startsWith("/")) shared.push(`${key}=${value}`);
+
+					return line;
+				})
+				.join("\n");
+
+			fs.writeFileSync(dst, rewritten);
+
+			if (shared.length > 0) {
+				console.error(`  kept absolute paths outside the root checkout: ${shared.join(", ")}`);
+				console.error("  this workspace shares that state with the root checkout");
+			}
+		' "$SUPERSET_ROOT_PATH/.env.local" .env.local "$SUPERSET_ROOT_PATH" "$ROOT_DIR"
 	fi
 
 	if [ -f "$SUPERSET_ROOT_PATH/var/data/config.yaml" ] && [ ! -f var/data/config.yaml ]; then
@@ -82,11 +130,29 @@ if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPER
 
 	if [ -z "${SUPERSET_SKIP_DB_COPY:-}" ] && [ -f "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ] && [ ! -f var/db/database.sqlite ]; then
 		log "Copying the SQLite database from the root checkout"
+		# Always go through the SQLite backup API. A plain cp of a database the
+		# root backend is writing to can miss committed data still sitting in the
+		# -wal file, or capture a torn page — and setup would report success while
+		# handing over a database that is short of rows or will not open at all.
 		if command -v sqlite3 >/dev/null 2>&1; then
-			# .backup takes a consistent snapshot even if the root backend is running.
-			sqlite3 "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ".backup '$ROOT_DIR/var/db/database.sqlite'"
+			db_copied=$(sqlite3 "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ".backup '$ROOT_DIR/var/db/database.sqlite'" && echo yes || echo no)
 		else
-			cp "$SUPERSET_ROOT_PATH/var/db/database.sqlite" var/db/database.sqlite
+			# Node >= 24 is required by this repo and ships the same backup API.
+			db_copied=$(node -e '
+				const { DatabaseSync, backup } = require("node:sqlite");
+				const [src, dst] = process.argv.slice(1);
+				if (typeof backup !== "function") process.exit(1);
+				const db = new DatabaseSync(src, { readOnly: true });
+				backup(db, dst).then(
+					() => db.close(),
+					(error) => { db.close(); console.error(error.message); process.exit(1); },
+				);
+			' "$SUPERSET_ROOT_PATH/var/db/database.sqlite" "$ROOT_DIR/var/db/database.sqlite" && echo yes || echo no)
+		fi
+
+		if [ "$db_copied" != "yes" ]; then
+			rm -f var/db/database.sqlite
+			warn "Could not snapshot the root database — starting empty. Create a user with 'pnpm run onboard'."
 		fi
 	fi
 fi

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -73,7 +73,14 @@ node init.js
 # needing `pnpm run onboard` first. Existing files are never overwritten.
 
 if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPERSET_ROOT_PATH" != "$ROOT_DIR" ]; then
-	if [ -f "$SUPERSET_ROOT_PATH/.env.local" ] && [ ! -f .env.local ]; then
+	if [ -f "$SUPERSET_ROOT_PATH/.env.local" ] && [ ! -f .env.local ] && flag_enabled "${SUPERSET_ALLOW_SHARED_STATE:-}"; then
+		# Sharing was asked for, so the root's paths are the point — rewriting them
+		# to workspace equivalents would leave nothing for the opt-in to act on and
+		# quietly hand back a copy instead.
+		log "Copying .env.local from the root checkout (paths kept: shared state allowed)"
+		cp "$SUPERSET_ROOT_PATH/.env.local" .env.local
+		chmod 600 .env.local
+	elif [ -f "$SUPERSET_ROOT_PATH/.env.local" ] && [ ! -f .env.local ]; then
 		log "Copying .env.local from the root checkout"
 		# FB_CONFIG_PATH, FB_DB_PATH and FB_ADMIN_UI_PATH are read from the repo
 		# root .env.local by the running backend. Copied verbatim they would point
@@ -143,8 +150,45 @@ env_path() { # env_path <checkout> <KEY> <fallback>
 		const fs = require("fs");
 		const path = require("path");
 		const [checkout, key, fallback] = process.argv.slice(1);
-		const DOUBLE_QUOTE = 34;
-		const SINGLE_QUOTE = 39;
+
+		// Parse with the library the backend itself uses, so this script cannot
+		// read a line differently than the app that will open the result — dotenv
+		// strips an inline comment from `FB_DB_PATH=/tmp/db # local`, a naive
+		// parser keeps it and would prepare a directory nothing opens.
+		const loadDotenvParse = () => {
+			try {
+				return require(
+					require.resolve("dotenv", { paths: [path.join(checkout, "apps/backend"), checkout] }),
+				).parse;
+			} catch (error) {
+				return null;
+			}
+		};
+
+		// Only reached before dependencies are installed. Mirrors dotenv closely:
+		// quoted values are literal, unquoted ones end at the first #.
+		const parseFallback = (content) => {
+			const values = {};
+
+			for (const line of content.split(/\r?\n/)) {
+				const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+				if (!match) continue;
+
+				let value = match[2].trim();
+				const quote = value[0];
+				if (value.length > 1 && (quote === String.fromCharCode(34) || quote === String.fromCharCode(39)) && value.endsWith(quote)) {
+					value = value.slice(1, -1);
+				} else {
+					value = value.split("#")[0].trim();
+				}
+
+				values[match[1]] = value;
+			}
+
+			return values;
+		};
+
+		const parse = loadDotenvParse() || parseFallback;
 
 		const resolveValue = () => {
 			// @nestjs/config keeps an already-exported variable in preference to the
@@ -157,22 +201,8 @@ env_path() { # env_path <checkout> <KEY> <fallback>
 				const full = path.join(checkout, file);
 				if (!fs.existsSync(full)) continue;
 
-				for (const line of fs.readFileSync(full, "utf8").split(/\r?\n/)) {
-					const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-					if (!match || match[1] !== key) continue;
-
-					let value = match[2].trim();
-					const first = value.charCodeAt(0);
-					if (
-						value.length > 1 &&
-						(first === DOUBLE_QUOTE || first === SINGLE_QUOTE) &&
-						value.charCodeAt(value.length - 1) === first
-					) {
-						value = value.slice(1, -1);
-					}
-
-					if (value) return path.resolve(checkout, value);
-				}
+				const value = parse(fs.readFileSync(full, "utf8"))[key];
+				if (value) return path.resolve(checkout, value);
 			}
 
 			return fallback;

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -13,10 +13,14 @@
 # slowest part of bootstrap.
 #
 # Knobs:
-#   SUPERSET_SKIP_DB_COPY=1   start from an empty database instead of copying
-#                             the root checkout's SQLite database
-#   SUPERSET_SKIP_FLUTTER=1   skip the apps/panel steps (`flutter pub get` and
-#                             the `melos rebuild-all` client generation, ~2 min)
+#   SUPERSET_SKIP_DB_COPY=1        start from an empty database instead of
+#                                  copying the root checkout's SQLite database
+#   SUPERSET_SKIP_FLUTTER=1        skip the apps/panel steps (`flutter pub get`
+#                                  and `melos rebuild-all`, ~2 min)
+#   SUPERSET_ALLOW_SHARED_STATE=1  let FB_CONFIG_PATH/FB_DB_PATH point outside
+#                                  the worktree instead of falling back to the
+#                                  workspace copies — this branch's migrations
+#                                  then run against that shared database
 #
 set -euo pipefail
 
@@ -191,16 +195,23 @@ inside_workspace() {
 	esac
 }
 
-if ! inside_workspace "$config_dir"; then
-	warn "FB_CONFIG_PATH points outside this workspace ($config_dir)"
-	warn "Preparing workspace-local configuration instead; unset it here to have the backend use that copy"
-	config_dir="$ROOT_DIR/var/data"
-fi
+if [ -n "${SUPERSET_ALLOW_SHARED_STATE:-}" ]; then
+	if ! inside_workspace "$config_dir" || ! inside_workspace "$db_dir"; then
+		warn "SUPERSET_ALLOW_SHARED_STATE is set — using state outside this workspace as-is"
+		warn "Migrations from this branch will be applied to whatever else runs on it"
+	fi
+else
+	if ! inside_workspace "$config_dir"; then
+		warn "FB_CONFIG_PATH points outside this workspace ($config_dir)"
+		warn "Preparing workspace-local configuration instead; .superset/run.sh keeps the backend on it"
+		config_dir="$ROOT_DIR/var/data"
+	fi
 
-if ! inside_workspace "$db_dir"; then
-	warn "FB_DB_PATH points outside this workspace ($db_dir)"
-	warn "Preparing a workspace-local database instead; unset it here to have the backend use that copy"
-	db_dir="$ROOT_DIR/var/db"
+	if ! inside_workspace "$db_dir"; then
+		warn "FB_DB_PATH points outside this workspace ($db_dir)"
+		warn "Preparing a workspace-local database instead; .superset/run.sh keeps the backend on it"
+		db_dir="$ROOT_DIR/var/db"
+	fi
 fi
 
 mkdir -p "$config_dir" "$db_dir"

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -110,6 +110,9 @@ if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPER
 				console.error("  this workspace shares that state with the root checkout");
 			}
 		' "$SUPERSET_ROOT_PATH/.env.local" .env.local "$SUPERSET_ROOT_PATH" "$ROOT_DIR"
+		# Written through writeFileSync, so it lands at 0644 under the usual umask
+		# no matter how the source was protected — and it carries FB_TOKEN_SECRET.
+		chmod 600 .env.local
 	fi
 
 fi
@@ -130,6 +133,12 @@ env_path() { # env_path <checkout> <KEY> <fallback>
 		const SINGLE_QUOTE = 39;
 
 		const resolveValue = () => {
+			// @nestjs/config keeps an already-exported variable in preference to the
+			// env files, so an ambient FB_DB_PATH/FB_CONFIG_PATH is what the backend
+			// will actually open — resolve it the same way or setup prepares a
+			// location nothing ever reads.
+			if (process.env[key]) return path.resolve(checkout, process.env[key]);
+
 			for (const file of [".env.local", ".env"]) {
 				const full = path.join(checkout, file);
 				if (!fs.existsSync(full)) continue;
@@ -159,14 +168,50 @@ env_path() { # env_path <checkout> <KEY> <fallback>
 	' "$1" "$2" "$3"
 }
 
-config_dir="$(env_path "$ROOT_DIR" FB_CONFIG_PATH "$ROOT_DIR/var/data")"
-db_dir="$(env_path "$ROOT_DIR" FB_DB_PATH "$ROOT_DIR/var/db")"
-mkdir -p "$config_dir" "$db_dir"
-
+# Resolve the root checkout's locations first: env_path honours ambient
+# variables, and the exports below would otherwise answer for both sides.
+root_config_dir=""
+root_db_dir=""
 if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPERSET_ROOT_PATH" != "$ROOT_DIR" ]; then
 	root_config_dir="$(env_path "$SUPERSET_ROOT_PATH" FB_CONFIG_PATH "$SUPERSET_ROOT_PATH/var/data")"
 	root_db_dir="$(env_path "$SUPERSET_ROOT_PATH" FB_DB_PATH "$SUPERSET_ROOT_PATH/var/db")"
+fi
 
+config_dir="$(env_path "$ROOT_DIR" FB_CONFIG_PATH "$ROOT_DIR/var/data")"
+db_dir="$(env_path "$ROOT_DIR" FB_DB_PATH "$ROOT_DIR/var/db")"
+
+# A location outside the worktree belongs to someone else — the root checkout or
+# whatever an exported variable points at. Setup falls back to the workspace
+# defaults there: it must not copy over live files, and it must not apply this
+# branch's migrations to a database another checkout is running on.
+inside_workspace() {
+	case "$1/" in
+	"$ROOT_DIR"/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+if ! inside_workspace "$config_dir"; then
+	warn "FB_CONFIG_PATH points outside this workspace ($config_dir)"
+	warn "Preparing workspace-local configuration instead; unset it here to have the backend use that copy"
+	config_dir="$ROOT_DIR/var/data"
+fi
+
+if ! inside_workspace "$db_dir"; then
+	warn "FB_DB_PATH points outside this workspace ($db_dir)"
+	warn "Preparing a workspace-local database instead; unset it here to have the backend use that copy"
+	db_dir="$ROOT_DIR/var/db"
+fi
+
+mkdir -p "$config_dir" "$db_dir"
+
+# Pin every later step to these. Generating the OpenAPI spec boots the whole
+# Nest app, so without this an ambient FB_DB_PATH would have setup opening — and
+# writing to — the database of another checkout.
+export FB_CONFIG_PATH="$config_dir"
+export FB_DB_PATH="$db_dir"
+
+if [ -n "$root_config_dir" ]; then
 	if [ -f "$root_config_dir/config.yaml" ] && [ ! -f "$config_dir/config.yaml" ]; then
 		log "Copying config.yaml from the root checkout"
 		cp "$root_config_dir/config.yaml" "$config_dir/config.yaml"
@@ -229,7 +274,7 @@ pnpm run generate:openapi
 log "Applying database migrations"
 # The migration CLI reads its env from apps/backend, not the repo root, so it
 # would default to var/db even when FB_DB_PATH moves the database elsewhere.
-FB_DB_PATH="$db_dir" pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
+pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
 
 # --- Flutter panel (optional) ------------------------------------------------
 #

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -15,7 +15,8 @@
 # Knobs:
 #   SUPERSET_SKIP_DB_COPY=1   start from an empty database instead of copying
 #                             the root checkout's SQLite database
-#   SUPERSET_SKIP_FLUTTER=1   skip `flutter pub get` for apps/panel
+#   SUPERSET_SKIP_FLUTTER=1   skip the apps/panel steps (`flutter pub get` and
+#                             the `melos rebuild-all` client generation, ~2 min)
 #
 set -euo pipefail
 
@@ -111,31 +112,85 @@ if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPER
 		' "$SUPERSET_ROOT_PATH/.env.local" .env.local "$SUPERSET_ROOT_PATH" "$ROOT_DIR"
 	fi
 
-	if [ -f "$SUPERSET_ROOT_PATH/var/data/config.yaml" ] && [ ! -f var/data/config.yaml ]; then
-		log "Copying var/data/config.yaml from the root checkout"
-		cp "$SUPERSET_ROOT_PATH/var/data/config.yaml" var/data/config.yaml
-		chmod 600 var/data/config.yaml
+fi
+
+# --- effective config & database locations -----------------------------------
+#
+# FB_CONFIG_PATH and FB_DB_PATH may move either directory somewhere other than
+# var/data and var/db, so resolve them from the env files rather than assuming
+# the defaults — copying into (and migrating) the wrong directory would leave
+# the workspace with empty state.
+
+env_path() { # env_path <checkout> <KEY> <fallback>
+	node -e '
+		const fs = require("fs");
+		const path = require("path");
+		const [checkout, key, fallback] = process.argv.slice(1);
+		const DOUBLE_QUOTE = 34;
+		const SINGLE_QUOTE = 39;
+
+		const resolveValue = () => {
+			for (const file of [".env.local", ".env"]) {
+				const full = path.join(checkout, file);
+				if (!fs.existsSync(full)) continue;
+
+				for (const line of fs.readFileSync(full, "utf8").split(/\r?\n/)) {
+					const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+					if (!match || match[1] !== key) continue;
+
+					let value = match[2].trim();
+					const first = value.charCodeAt(0);
+					if (
+						value.length > 1 &&
+						(first === DOUBLE_QUOTE || first === SINGLE_QUOTE) &&
+						value.charCodeAt(value.length - 1) === first
+					) {
+						value = value.slice(1, -1);
+					}
+
+					if (value) return path.resolve(checkout, value);
+				}
+			}
+
+			return fallback;
+		};
+
+		console.log(resolveValue());
+	' "$1" "$2" "$3"
+}
+
+config_dir="$(env_path "$ROOT_DIR" FB_CONFIG_PATH "$ROOT_DIR/var/data")"
+db_dir="$(env_path "$ROOT_DIR" FB_DB_PATH "$ROOT_DIR/var/db")"
+mkdir -p "$config_dir" "$db_dir"
+
+if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPERSET_ROOT_PATH" != "$ROOT_DIR" ]; then
+	root_config_dir="$(env_path "$SUPERSET_ROOT_PATH" FB_CONFIG_PATH "$SUPERSET_ROOT_PATH/var/data")"
+	root_db_dir="$(env_path "$SUPERSET_ROOT_PATH" FB_DB_PATH "$SUPERSET_ROOT_PATH/var/db")"
+
+	if [ -f "$root_config_dir/config.yaml" ] && [ ! -f "$config_dir/config.yaml" ]; then
+		log "Copying config.yaml from the root checkout"
+		cp "$root_config_dir/config.yaml" "$config_dir/config.yaml"
+		chmod 600 "$config_dir/config.yaml"
 		# ConfigService stores its own absolute location in the file — repoint it
 		# at this workspace so the copied value is not misleading.
 		node -e '
 			const fs = require("fs");
-			const file = "var/data/config.yaml";
-			const target = `${process.cwd()}/${file}`;
+			const [file] = process.argv.slice(1);
 			const content = fs.readFileSync(file, "utf8");
 			if (/^path: .*$/m.test(content)) {
-				fs.writeFileSync(file, content.replace(/^path: .*$/m, `path: ${target}`));
+				fs.writeFileSync(file, content.replace(/^path: .*$/m, `path: ${file}`));
 			}
-		'
+		' "$config_dir/config.yaml"
 	fi
 
-	if [ -z "${SUPERSET_SKIP_DB_COPY:-}" ] && [ -f "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ] && [ ! -f var/db/database.sqlite ]; then
+	if [ -z "${SUPERSET_SKIP_DB_COPY:-}" ] && [ -f "$root_db_dir/database.sqlite" ] && [ ! -f "$db_dir/database.sqlite" ]; then
 		log "Copying the SQLite database from the root checkout"
 		# Always go through the SQLite backup API. A plain cp of a database the
 		# root backend is writing to can miss committed data still sitting in the
 		# -wal file, or capture a torn page — and setup would report success while
 		# handing over a database that is short of rows or will not open at all.
 		if command -v sqlite3 >/dev/null 2>&1; then
-			db_copied=$(sqlite3 "$SUPERSET_ROOT_PATH/var/db/database.sqlite" ".backup '$ROOT_DIR/var/db/database.sqlite'" && echo yes || echo no)
+			db_copied=$(sqlite3 "$root_db_dir/database.sqlite" ".backup '$db_dir/database.sqlite'" && echo yes || echo no)
 		else
 			# Node >= 24 is required by this repo and ships the same backup API.
 			db_copied=$(node -e '
@@ -147,11 +202,11 @@ if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -d "$SUPERSET_ROOT_PATH" ] && [ "$SUPER
 					() => db.close(),
 					(error) => { db.close(); console.error(error.message); process.exit(1); },
 				);
-			' "$SUPERSET_ROOT_PATH/var/db/database.sqlite" "$ROOT_DIR/var/db/database.sqlite" && echo yes || echo no)
+			' "$root_db_dir/database.sqlite" "$db_dir/database.sqlite" && echo yes || echo no)
 		fi
 
 		if [ "$db_copied" != "yes" ]; then
-			rm -f var/db/database.sqlite
+			rm -f "$db_dir/database.sqlite"
 			warn "Could not snapshot the root database — starting empty. Create a user with 'pnpm run onboard'."
 		fi
 	fi
@@ -172,13 +227,25 @@ log "Generating the OpenAPI spec and typed API clients"
 pnpm run generate:openapi
 
 log "Applying database migrations"
-pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
+# The migration CLI reads its env from apps/backend, not the repo root, so it
+# would default to var/db even when FB_DB_PATH moves the database elsewhere.
+FB_DB_PATH="$db_dir" pnpm --filter @fastybird/smart-panel-backend run typeorm:migration:run
 
 # --- Flutter panel (optional) ------------------------------------------------
+#
+# apps/panel/lib/api and apps/panel/lib/spec are generated and untracked, so the
+# panel does not compile in a fresh worktree until they are rebuilt.
 
 if [ -z "${SUPERSET_SKIP_FLUTTER:-}" ] && command -v flutter >/dev/null 2>&1; then
 	log "Fetching Flutter packages for apps/panel"
-	(cd apps/panel && flutter pub get) || warn "flutter pub get failed — run it manually before working on the panel app"
+	if ! (cd apps/panel && flutter pub get); then
+		warn "flutter pub get failed — run it manually before working on the panel app"
+	elif command -v melos >/dev/null 2>&1; then
+		log "Generating the panel API client and specs (melos rebuild-all)"
+		melos rebuild-all || warn "melos rebuild-all failed — run it manually before working on the panel app"
+	else
+		warn "melos not found — run 'melos rebuild-all' after installing it to generate apps/panel/lib/{api,spec}"
+	fi
 fi
 
 printf '\n\033[1;32m✓ Workspace ready\033[0m\n'

--- a/.superset/teardown.sh
+++ b/.superset/teardown.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Superset workspace teardown — FastyBird Smart Panel
+#
+# Runs when the workspace is deleted. Setup only writes files inside the
+# worktree (which Superset removes with the workspace), so the only thing worth
+# undoing is Docker: the dev compose stack (backend, admin, InfluxDB, Chronograf)
+# if it was ever started from this workspace.
+#
+# Only compose projects that belong to this workspace are removed. The root
+# checkout's projects ("smart-panel" and "dev", the default name when running
+# `docker compose -f docker/dev/docker-compose.yml`) are explicitly left alone —
+# tearing those down would delete the InfluxDB data of the main checkout.
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+	log "Docker not running — nothing to tear down"
+	exit 0
+fi
+
+projects="$(docker compose ls --all --format json 2>/dev/null || echo '[]')"
+
+for project in "smart-panel-${SUPERSET_WORKSPACE_NAME:-}" "$(basename "$ROOT_DIR")"; do
+	case "$project" in
+	"" | "smart-panel-" | smart-panel | dev)
+		# Not workspace specific — belongs to the root checkout.
+		continue
+		;;
+	esac
+
+	case "$projects" in
+	*"\"Name\":\"$project\""*) ;;
+	*) continue ;;
+	esac
+
+	log "Removing docker compose project '$project'"
+	docker compose -p "$project" down --volumes --remove-orphans || true
+done

--- a/apps/backend/src/modules/buddy/services/buddy-context.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-context.service.spec.ts
@@ -128,11 +128,18 @@ describe('BuddyContextService', () => {
 			getAlerts: jest.fn().mockResolvedValue([]),
 		};
 
+		// Both ends have to come from one clock reading: the service derives the
+		// kWh→kW factor from the interval length, so a millisecond of drift between
+		// two separate `new Date()` calls makes it 300001ms instead of 300000 and
+		// the rate misses the expected value by more than the assertion tolerance.
+		const intervalEnd = new Date();
+		const intervalStart = new Date(intervalEnd.getTime() - 5 * 60 * 1000);
+
 		energyDataService = {
 			getDeltas: jest.fn().mockResolvedValue([
 				{
-					intervalStart: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-					intervalEnd: new Date().toISOString(),
+					intervalStart: intervalStart.toISOString(),
+					intervalEnd: intervalEnd.toISOString(),
 					productionDeltaKwh: 0.4,
 					gridImportDeltaKwh: 0.2,
 					gridExportDeltaKwh: 0.1,


### PR DESCRIPTION
## Summary

Adds `.superset/config.json` and the three scripts it points at, so every Superset workspace (git worktree) of this repo is provisioned identically.

## What each script does

**`setup.sh`** — runs on workspace creation:
- `pnpm install --frozen-lockfile` (falls back to a non-frozen install if the lockfile is out of sync)
- `node init.js` for the `var/` runtime directories
- the codegen the apps cannot compile without: `generate:spec`, the extension SDK build, and `generate:openapi` (`spec/api/v1/openapi.json`, `apps/admin/src/openapi.ts` and `apps/backend/src/spec/` are generated, not committed)
- `typeorm:migration:run`, plus `flutter pub get` when Flutter is on PATH

It deliberately skips the two slowest `pnpm run bootstrap` steps — the backend `nest build` and the admin `vue-tsc` + `vite build` — since the dev servers compile on the fly.

It also copies gitignored local state from `$SUPERSET_ROOT_PATH` when present: `.env.local`, `var/data/config.yaml` (with the absolute `path:` key repointed at the workspace) and `var/db/database.sqlite` via `sqlite3 .backup` for a consistent snapshot. A new workspace therefore boots with an existing user and devices instead of needing `pnpm run onboard`. Opt out with `SUPERSET_SKIP_DB_COPY=1` / `SUPERSET_SKIP_FLUTTER=1`; existing files are never overwritten.

**`run.sh`** — on-demand dev servers, `backend` + `admin` by default (`website` / `testing` / `all` also available). It scans for free ports from 3000/3003/3006 and exports `FB_BACKEND_PORT`/`FB_ADMIN_PORT`, which matters because the root `.env` pins the admin to port 80. Vite's `loadEnv` overlays matching `process.env` keys last and `@nestjs/config` skips keys already in `process.env`, so the exported values win and several workspaces can run beside the root checkout. On exit it snapshots and kills the whole process tree — signalling only the pnpm parent orphans the process actually holding the port.

**`teardown.sh`** — setup only writes inside the worktree, so the only thing to undo is Docker. It removes compose projects named for *this* workspace and explicitly skips `smart-panel` and `dev` (the root checkout's project names); `docker/dev/docker-compose.yml` uses fixed container names, so an unscoped `down -v` would delete the main checkout's InfluxDB volume.

## Testing

Exercised end to end in a real workspace:
- `setup.sh` completed in ~2 min (warm pnpm store): 7 migrations applied, copied database carried 1 user and 84 devices, all generated artifacts present
- admin: with 3003 occupied the scan picked 3004 and served HTTP 200
- backend: booted to "Nest application successfully started" on a pinned port while 3000 stayed free; only `memory-storage-plugin` started (integrations disabled for the test)
- shutdown leaves no listening processes behind; `teardown.sh` exits 0 and leaves the root checkout's `smart-panel` compose project untouched

## Note (not addressed here)

The backend logs `IntentSpecLoader: Failed to load builtin enums/intents/modes/suggestions` on every boot, unrelated to this PR: `apps/backend/nest-cli.json` still copies `modules/spaces/spec/definitions/**/*.yaml`, but those files moved to `plugins/spaces-home-control/spec/definitions/` in c0a4809aa, so they never reach `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)