### PR TITLE
fix(websocket): stop admitting clients the gateway just refused

### DIFF
--- a/apps/backend/src/modules/websocket/gateway/websocket.gateway.spec.ts
+++ b/apps/backend/src/modules/websocket/gateway/websocket.gateway.spec.ts
@@ -25,6 +25,8 @@ import { WebsocketGateway } from './websocket.gateway';
 describe('WebsocketGateway', () => {
 	let gateway: WebsocketGateway;
 	let eventRegistry: CommandEventRegistryService;
+	let wsAuthService: WsAuthService;
+	let eventEmitter: EventEmitter2;
 
 	const mockServer = {
 		emit: jest.fn(),
@@ -87,6 +89,8 @@ describe('WebsocketGateway', () => {
 
 		gateway = module.get<WebsocketGateway>(WebsocketGateway);
 		eventRegistry = module.get<CommandEventRegistryService>(CommandEventRegistryService);
+		wsAuthService = module.get<WsAuthService>(WsAuthService);
+		eventEmitter = module.get<EventEmitter2>(EventEmitter2);
 
 		jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
 		jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
@@ -116,6 +120,8 @@ describe('WebsocketGateway', () => {
 
 	describe('handleConnection', () => {
 		it('should log when a client connects and join the default room', async () => {
+			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(true);
+
 			const logSpy = jest.spyOn(Logger.prototype, 'log');
 
 			await gateway.handleConnection(mockSocket);
@@ -125,6 +131,24 @@ describe('WebsocketGateway', () => {
 				expect.objectContaining({ tag: 'websocket-module' }),
 			);
 			expect(mockSocket.join).toHaveBeenCalledWith('default-room');
+		});
+
+		it('should disconnect an unauthorized client without admitting it', async () => {
+			// validateClient resolves false when the handshake carries no token at all - an
+			// invalid one throws instead - so this is the plain unauthenticated connection.
+			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(false);
+
+			const logSpy = jest.spyOn(Logger.prototype, 'log');
+
+			await gateway.handleConnection(mockSocket);
+
+			expect(mockSocket.disconnect).toHaveBeenCalled();
+			expect(mockSocket.join).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalledWith(
+				`[WebsocketGateway] Client connected: ${mockSocket.id}`,
+				expect.anything(),
+			);
+			expect(eventEmitter.emit).not.toHaveBeenCalled();
 		});
 	});
 

--- a/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
+++ b/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
@@ -89,6 +89,10 @@ export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnG
 				this.logger.warn(`Unauthorized client is trying to connect: ${client.handshake?.headers.host}`);
 
 				client.disconnect();
+
+				// Without this the rejected client carried on into the admission below: it joined
+				// the broadcast rooms, logged itself as connected and raised CLIENT_CONNECTED.
+				return;
 			}
 
 			this.logger.log(`Client connected: ${client.id}`);

--- a/tasks/bugs/bug-backend-unauthorized-ws-client-admitted.md
+++ b/tasks/bugs/bug-backend-unauthorized-ws-client-admitted.md
@@ -1,0 +1,110 @@
+# Task: Stop admitting unauthorized websocket clients
+ID: BUG-BACKEND-WS-UNAUTHORIZED-ADMITTED
+Type: bug
+Scope: backend
+Size: tiny
+Parent: (none)
+Status: review
+
+## 1. Business goal
+
+In order to keep unauthenticated connections out of the broadcast rooms and out of the client
+metrics
+As an operator
+I want the gateway to stop processing a connection as soon as it has refused it
+
+## 2. Context
+
+`WebsocketGateway.handleConnection` refused unauthorized clients with `client.disconnect()` but did
+not return, so execution fell straight through into the admission path meant for accepted clients.
+
+```ts
+if (!isAllowed) {
+    this.logger.warn(`Unauthorized client is trying to connect: ...`);
+
+    client.disconnect();   // <- no return
+}
+
+this.logger.log(`Client connected: ${client.id}`);
+await client.join(CLIENT_DEFAULT_ROOM);
+...
+this.eventEmitter.emit(WsEventType.CLIENT_CONNECTED, wsClientDto);
+```
+
+A refused client therefore:
+
+- joined `CLIENT_DEFAULT_ROOM`, and `DISPLAY_INTERNAL_ROOM` plus its per-display room when the
+  unvalidated `client.data.user` claimed `ownerType: DISPLAY`
+- logged `Client connected: <id>` at info level, contradicting the warning logged a line earlier
+- raised `WsEventType.CLIENT_CONNECTED` carrying that unvalidated user, which feeds the exchange
+  bus and the client metrics
+
+### When it triggered
+
+`WsAuthService.validateClient` **throws** for a malformed or expired token, and that path was
+already handled by the surrounding `catch`. It **returns false** when the handshake carries no
+token at all — so the fall-through was reached by the plain unauthenticated connection, not by an
+exotic edge case.
+
+### How it survived
+
+`websocket.gateway.spec.ts` mocked `WsAuthService.validateClient` as a bare `jest.fn()`, which
+resolves `undefined`. Every existing `handleConnection` assertion therefore ran through the
+refusal branch, and the test asserting that a client "connects and joins the default room" was
+passing *because of* the bug rather than in spite of it.
+
+Found while tracing BUG-ADMIN-SOCKET-WAKE-RECOVERY, which is what made the refusal path visible.
+
+## 3. Scope
+
+**In scope**
+
+- Return immediately after refusing the client.
+- Cover both the accepted and the refused path in the gateway spec, with `validateClient` mocked
+  explicitly in each.
+
+**Out of scope**
+
+- Moving authentication into a Socket.IO middleware so refusal happens before the namespace
+  CONNECT packet is sent. See "Follow-up" below.
+
+## 4. Acceptance criteria
+
+- [x] A refused client is disconnected and joins no room.
+- [x] A refused client does not log `Client connected`.
+- [x] A refused client does not raise `WsEventType.CLIENT_CONNECTED`.
+- [x] An accepted client still joins `CLIENT_DEFAULT_ROOM` and raises `CLIENT_CONNECTED`.
+- [x] The accepted-path test mocks `validateClient` explicitly instead of relying on the default
+      `undefined`.
+- [x] `pnpm --filter ./apps/backend run lint:js` and `test:unit` pass.
+
+## 5. Example scenarios
+
+### Scenario: Connection without a token
+
+Given a client opens a socket with no token in the handshake
+When the gateway validates it
+Then the client is disconnected, joins no room, and no `CLIENT_CONNECTED` event is raised
+
+### Scenario: Connection with a valid token
+
+Given a client opens a socket with a valid token
+When the gateway validates it
+Then the client joins the default room and `CLIENT_CONNECTED` is raised
+
+## 6. Technical constraints
+
+- Keep the change inside `handleConnection`; the refusal semantics themselves are unchanged.
+- Tests are expected for both paths.
+
+## 7. Follow-up
+
+`socket.io` sends the namespace CONNECT packet before Nest runs `handleConnection`, so refusing
+there always reaches the client as `connect` followed by `disconnect` rather than as
+`connect_error`. That ordering is why the admin has to hold its verdict for a grace window before
+deciding a reconnect succeeded — see §7.2b of `bug-admin-socket-wake-recovery.md`.
+
+Authenticating in a Socket.IO middleware (`server.use(...)` from `afterInit`) would refuse before
+CONNECT, making the refusal deterministic and letting the admin drop that grace window entirely.
+It changes the shape of the auth flow — `client.data.user` population, display and third-party
+token handling — so it is deliberately not bundled with this one-line correctness fix.


### PR DESCRIPTION
Closes `tasks/bugs/bug-backend-unauthorized-ws-client-admitted.md`. Split out of #609, as agreed there.

## Problem

`WebsocketGateway.handleConnection` refused unauthorized clients with `client.disconnect()` but never returned, so execution fell straight through into the admission path meant for accepted clients:

```ts
if (!isAllowed) {
    this.logger.warn(`Unauthorized client is trying to connect: ...`);

    client.disconnect();   // <- no return
}

this.logger.log(`Client connected: ${client.id}`);
await client.join(CLIENT_DEFAULT_ROOM);
...
this.eventEmitter.emit(WsEventType.CLIENT_CONNECTED, wsClientDto);
```

A refused client therefore:

- joined `CLIENT_DEFAULT_ROOM` — and `DISPLAY_INTERNAL_ROOM` plus its per-display room whenever the **unvalidated** `client.data.user` claimed `ownerType: DISPLAY`
- logged `Client connected: <id>` at info level, one line after the warning saying it was not
- raised `WsEventType.CLIENT_CONNECTED` carrying that unvalidated user into the exchange bus and the client metrics

## When it actually triggered

This is not an exotic edge case. `WsAuthService.validateClient` **throws** for a malformed or expired token, and that path was already handled by the surrounding `catch`. It **returns false** when the handshake carries no token at all — so the fall-through was reached by the ordinary unauthenticated connection.

## How it survived review and tests

`websocket.gateway.spec.ts` mocked `WsAuthService.validateClient` as a bare `jest.fn()`, which resolves `undefined` — falsy. Every existing `handleConnection` assertion therefore ran through the refusal branch, and the test asserting a client *"connects and joins the default room"* was passing **because of** the bug rather than in spite of it.

That test now mocks `validateClient` explicitly, so it exercises the path it claims to.

## Changes

- `return` after refusing the client.
- Gateway spec: both paths mocked explicitly, with a new test asserting a refused client is disconnected, joins **no** room, does not log `Client connected`, and raises no `CLIENT_CONNECTED`.

The new test was watched fail first — it reported `join` called twice, with `default-room` **and** `display-room`.

## Verification

- Backend: 220 suites / 2843 tests pass (2 skipped)
- Admin: 1401 tests pass
- `lint:js`: exit 0 (2 pre-existing warnings in an unrelated plugin)

## Follow-up, deliberately not bundled

`socket.io` sends the namespace CONNECT packet before Nest runs `handleConnection` (`_doConnect` in `socket.io/dist/namespace.js`), so refusing there always reaches the client as `connect` followed by `disconnect`, never as `connect_error`. That ordering is precisely why the admin has to hold its verdict for a grace window before concluding a reconnect succeeded — see §7.2b of `bug-admin-socket-wake-recovery.md`.

Authenticating in a Socket.IO middleware (`server.use(...)` from `afterInit`) would refuse *before* CONNECT, making refusal deterministic and letting the admin drop that grace window entirely. It reshapes the auth flow — `client.data.user` population, display and third-party token handling — so it does not belong bundled with a one-line correctness fix. Happy to take it as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)