### PR TITLE
feat(websocket): authenticate during the handshake, not after admission

### DIFF
--- a/apps/backend/src/modules/websocket/gateway/websocket.gateway.spec.ts
+++ b/apps/backend/src/modules/websocket/gateway/websocket.gateway.spec.ts
@@ -19,6 +19,7 @@ import { ClientUserDto } from '../dto/client-user.dto';
 import { CommandMessageDto } from '../dto/command-message.dto';
 import { CommandEventRegistryService } from '../services/command-event-registry.service';
 import { WsAuthService } from '../services/ws-auth.service';
+import { WebsocketNotAllowedException } from '../websocket.exceptions';
 
 import { WebsocketGateway } from './websocket.gateway';
 
@@ -30,7 +31,22 @@ describe('WebsocketGateway', () => {
 
 	const mockServer = {
 		emit: jest.fn(),
+		use: jest.fn(),
 	} as unknown as Server;
+
+	/** Runs the handshake middleware the gateway registered and reports what it passed to next(). */
+	const runHandshakeMiddleware = async (socket: Socket): Promise<Error | undefined> => {
+		gateway.afterInit();
+
+		const middleware = (mockServer.use as jest.Mock).mock.calls[0][0] as (
+			socket: Socket,
+			next: (err?: Error) => void,
+		) => void;
+
+		return new Promise<Error | undefined>((resolve) => {
+			middleware(socket, (err?: Error) => resolve(err));
+		});
+	};
 
 	const mockClientUser: ClientUserDto = {
 		id: null,
@@ -116,12 +132,53 @@ describe('WebsocketGateway', () => {
 		it('should not throw when the gateway starts', () => {
 			expect(() => gateway.afterInit()).not.toThrow();
 		});
+
+		it('should register a handshake middleware', () => {
+			gateway.afterInit();
+
+			expect(mockServer.use).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('handshake authentication', () => {
+		it('should admit a client with valid credentials', async () => {
+			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(true);
+
+			await expect(runHandshakeMiddleware(mockSocket)).resolves.toBeUndefined();
+
+			expect(mockSocket.disconnect).not.toHaveBeenCalled();
+		});
+
+		it('should refuse a client with no credentials before it is admitted', async () => {
+			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(false);
+
+			const error = await runHandshakeMiddleware(mockSocket);
+
+			expect(error).toBeInstanceOf(Error);
+			// The panel classifies an auth failure by matching the message, so the wording is
+			// part of the contract rather than cosmetic.
+			expect(error?.message.toLowerCase()).toContain('unauthorized');
+
+			// Refusing during the handshake means the socket is never admitted, so there is
+			// nothing to disconnect and no room to leave.
+			expect(mockSocket.disconnect).not.toHaveBeenCalled();
+			expect(mockSocket.join).not.toHaveBeenCalled();
+		});
+
+		it('should refuse a client whose token validation throws', async () => {
+			jest
+				.spyOn(wsAuthService, 'validateClient')
+				.mockRejectedValue(new WebsocketNotAllowedException('Invalid or expired token'));
+
+			const error = await runHandshakeMiddleware(mockSocket);
+
+			expect(error).toBeInstanceOf(Error);
+			expect(mockSocket.join).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('handleConnection', () => {
 		it('should log when a client connects and join the default room', async () => {
-			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(true);
-
 			const logSpy = jest.spyOn(Logger.prototype, 'log');
 
 			await gateway.handleConnection(mockSocket);
@@ -133,22 +190,13 @@ describe('WebsocketGateway', () => {
 			expect(mockSocket.join).toHaveBeenCalledWith('default-room');
 		});
 
-		it('should disconnect an unauthorized client without admitting it', async () => {
-			// validateClient resolves false when the handshake carries no token at all - an
-			// invalid one throws instead - so this is the plain unauthenticated connection.
-			jest.spyOn(wsAuthService, 'validateClient').mockResolvedValue(false);
-
-			const logSpy = jest.spyOn(Logger.prototype, 'log');
+		it('should not re-authenticate a client the handshake already cleared', async () => {
+			const validateSpy = jest.spyOn(wsAuthService, 'validateClient');
 
 			await gateway.handleConnection(mockSocket);
 
-			expect(mockSocket.disconnect).toHaveBeenCalled();
-			expect(mockSocket.join).not.toHaveBeenCalled();
-			expect(logSpy).not.toHaveBeenCalledWith(
-				`[WebsocketGateway] Client connected: ${mockSocket.id}`,
-				expect.anything(),
-			);
-			expect(eventEmitter.emit).not.toHaveBeenCalled();
+			expect(validateSpy).not.toHaveBeenCalled();
+			expect(eventEmitter.emit).toHaveBeenCalled();
 		});
 	});
 

--- a/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
+++ b/apps/backend/src/modules/websocket/gateway/websocket.gateway.ts
@@ -77,24 +77,50 @@ export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnG
 		return this.server?.of('/')?.adapter?.rooms?.get(room)?.size ?? 0;
 	}
 
-	afterInit(): void {
+	afterInit(server?: Server): void {
+		const io = server ?? this.server;
+
+		// Authenticate during the handshake, before the namespace sends its CONNECT packet.
+		//
+		// Refusing from handleConnection instead admits the socket first and only then kicks it,
+		// because socket.io emits `connection` after CONNECT has already gone out. The client
+		// therefore sees `connect` followed by `disconnect` and cannot tell a refusal from a
+		// dropped link without waiting to see what happens next. Refusing here surfaces as
+		// `connect_error`, which says what it means and arrives before the client is ever admitted.
+		io?.use((client: Socket, next: (err?: Error) => void): void => {
+			this.wsAuthService
+				.validateClient(client)
+				.then((isAllowed): void => {
+					if (!isAllowed) {
+						this.logger.warn(`Unauthorized client is trying to connect: ${client.handshake?.headers.host}`);
+
+						next(new WebsocketNotAllowedException('Unauthorized'));
+
+						return;
+					}
+
+					next();
+				})
+				.catch((error: unknown): void => {
+					const err = error as Error;
+
+					this.logger.warn(
+						`Unauthorized client is trying to connect: ${client.handshake?.headers.host}, ${err.message}`,
+					);
+
+					// Deliberately not forwarding err.message: the client only needs to know it was
+					// refused, and the reason is already in the log.
+					next(new WebsocketNotAllowedException('Unauthorized'));
+				});
+		});
+
 		this.logger.debug('Websockets gateway started');
 	}
 
+	// Only reached by clients the handshake middleware in afterInit already cleared, so this
+	// admits rather than authenticates.
 	async handleConnection(client: Socket): Promise<void> {
 		try {
-			const isAllowed = await this.wsAuthService.validateClient(client);
-
-			if (!isAllowed) {
-				this.logger.warn(`Unauthorized client is trying to connect: ${client.handshake?.headers.host}`);
-
-				client.disconnect();
-
-				// Without this the rejected client carried on into the admission below: it joined
-				// the broadcast rooms, logged itself as connected and raised CLIENT_CONNECTED.
-				return;
-			}
-
 			this.logger.log(`Client connected: ${client.id}`);
 
 			await client.join(CLIENT_DEFAULT_ROOM);
@@ -124,7 +150,9 @@ export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnG
 		} catch (error) {
 			const err = error as Error;
 
-			this.logger.warn(`Unauthorized client is trying to connect: ${client.handshake?.headers.host}, ${err.message}`);
+			// Authentication is settled before we get here, so anything failing now is the
+			// admission itself - joining a room or announcing the client.
+			this.logger.error(`Admitting client failed: ${client.id}, ${err.message}`);
 
 			client.disconnect();
 		}

--- a/tasks/technical/tech-backend-ws-handshake-auth.md
+++ b/tasks/technical/tech-backend-ws-handshake-auth.md
@@ -1,0 +1,100 @@
+# Task: Authenticate websocket clients during the handshake
+ID: TECH-BACKEND-WS-HANDSHAKE-AUTH
+Type: technical
+Scope: backend
+Size: small
+Parent: BUG-BACKEND-WS-UNAUTHORIZED-ADMITTED
+Status: review
+
+## 1. Business goal
+
+In order for a client to be able to tell "you are not allowed in" from "the link dropped"
+As a connecting client
+I want to be refused before I am admitted, not admitted and then kicked
+
+## 2. Context
+
+Authentication ran in `WebsocketGateway.handleConnection`, which socket.io invokes from its
+`connection` event. `_doConnect` in `socket.io/dist/namespace.js` sends the namespace CONNECT
+packet *before* emitting that event, and its own comment insists on the order:
+
+```js
+socket._onconnect();                      // CONNECT packet goes out here
+if (fn) fn(socket);
+this.emitReserved("connect", socket);
+this.emitReserved("connection", socket);  // Nest's handleConnection hangs off this
+```
+
+Refusing there therefore reached the client as `connect` followed by `disconnect`, never as
+`connect_error`. Three consequences:
+
+1. A client could not distinguish a refusal from a dropped link without waiting to see whether a
+   disconnect followed. The admin has to hold its verdict for a grace window purely because of
+   this — see §7.2b of `bug-admin-socket-wake-recovery.md`.
+2. The window between CONNECT and the refusal is real. `WsAuthService.validateUserAccessToken`
+   does two database round trips, and message handlers are dispatched independently of the
+   in-flight `handleConnection`, so an unauthenticated client's messages could be processed
+   before the refusal landed.
+3. `handleConnection` mixed authenticating with admitting, which is how
+   BUG-BACKEND-WS-UNAUTHORIZED-ADMITTED went unnoticed — a missing `return` let a refused client
+   fall through into the admission path.
+
+## 3. Scope
+
+**In scope**
+
+- Register a Socket.IO handshake middleware from `afterInit` that runs `validateClient` and
+  refuses with an error, so refusal happens before CONNECT.
+- Reduce `handleConnection` to admission only.
+- Cover both the accepted and refused handshake paths in the gateway spec.
+
+**Out of scope**
+
+- Removing the admin's auth grace window. It is now belt-and-braces rather than load-bearing, and
+  removing it is an admin change that belongs with the admin app.
+- Any change to what `validateClient` considers valid. Only *where* it runs changes.
+
+## 4. Acceptance criteria
+
+- [x] A client with no credentials is refused during the handshake and never admitted — it joins
+      no room and raises no `CLIENT_CONNECTED`.
+- [x] A client whose token validation throws is refused the same way.
+- [x] A client with valid credentials is admitted unchanged, joining `CLIENT_DEFAULT_ROOM` and
+      raising `CLIENT_CONNECTED`.
+- [x] `handleConnection` no longer calls `validateClient`.
+- [x] The refusal message contains `unauthorized`, which the panel matches on to classify an auth
+      failure (`_classifyConnectionError` in `apps/panel/lib/core/services/socket.dart`).
+- [x] The refusal reason is logged but not forwarded to the client.
+- [x] `pnpm --filter ./apps/backend run lint:js` and `test:unit` pass.
+
+## 5. Example scenarios
+
+### Scenario: Connection without a token
+
+Given a client opens a socket with no token in the handshake
+When the middleware validates it
+Then the client receives `connect_error` and is never admitted to the namespace
+
+### Scenario: Connection with a valid token
+
+Given a client opens a socket with a valid token
+When the middleware validates it
+Then the handshake completes and the client joins the default room
+
+## 6. Client impact
+
+Refusal now arrives as `connect_error` instead of `connect` + `disconnect`. Reconnect semantics
+are unchanged: the client's `CONNECT_ERROR` branch calls `destroy()` before emitting, which
+unsubscribes the manager exactly as the `io server disconnect` path did, so `socket.active`
+becomes `false` either way and a refused client still needs a deliberate reconnect.
+
+- **Admin** — `ensureSocketConnection` already treats `connect_error` as a failed attempt, so the
+  failure toast now fires immediately instead of waiting out the grace window.
+- **Panel** — `socket.dart` already registers `onConnectError` with the comment "authentication
+  failures, etc." and classifies auth errors by message. That path was previously unreachable for
+  auth refusals; it now works as written.
+
+## 7. Technical constraints
+
+- Do not change `WsAuthService`; only where it is invoked from.
+- Tests are expected for both handshake outcomes.


### PR DESCRIPTION
Closes `tasks/technical/tech-backend-ws-handshake-auth.md`. This is follow-up (1) of the two recorded in #610 and #609.

## Problem

Authentication ran in `WebsocketGateway.handleConnection`, which socket.io invokes from its `connection` event. But `_doConnect` in `socket.io/dist/namespace.js` sends the namespace CONNECT packet **before** emitting that event, and its own comment insists on the order:

```js
socket._onconnect();                      // CONNECT packet goes out here
if (fn) fn(socket);
this.emitReserved("connect", socket);
this.emitReserved("connection", socket);  // Nest's handleConnection hangs off this
```

So a refusal always reached the client as `connect` followed by `disconnect`, never as `connect_error`. Three consequences:

1. **A client could not tell a refusal from a dropped link** without waiting to see whether a disconnect followed. The admin holds its verdict for a grace window purely because of this — §7.2b of `bug-admin-socket-wake-recovery.md`.
2. **The window is real, not theoretical.** `WsAuthService.validateUserAccessToken` does two database round trips, and `@SubscribeMessage` handlers are dispatched independently of the in-flight `handleConnection` — so an unauthenticated client's messages could be processed before the refusal landed.
3. **`handleConnection` mixed authenticating with admitting**, which is the shape that hid the missing `return` fixed in #610.

## Changes

- `afterInit` registers a Socket.IO handshake middleware that runs `validateClient` and refuses via `next(err)` — before CONNECT.
- `handleConnection` is reduced to admission only, and no longer calls `validateClient`.
- Its `catch` no longer claims "Unauthorized client is trying to connect": auth is settled by then, so anything failing there is the admission itself.

The refusal message is just `Unauthorized` — enough for the panel to classify it, with the actual reason kept in the log rather than handed to the client.

## Client impact — checked, not assumed

Refusal now arrives as `connect_error` instead of `connect` + `disconnect`.

**Reconnect semantics are unchanged.** I verified against the installed client: the `CONNECT_ERROR` branch calls `this.destroy()` before emitting, which unsubscribes the manager exactly as the `io server disconnect` path did. `socket.active` ends up `false` either way, so a refused client still needs a deliberate reconnect.

- **Admin** — `ensureSocketConnection` already treats `connect_error` as a failed attempt, so the failure toast now fires immediately instead of waiting out the grace window.
- **Panel** — `socket.dart:348` already registers `onConnectError` with the comment *"authentication failures, etc."* and classifies auth errors by matching `unauthorized`/`forbidden`/`authentication`/`token` in the message. That path was previously **unreachable** for auth refusals; it now works as written, which is why the message wording is asserted in the spec rather than left cosmetic.

## Tests

Four new tests, watched fail first (6 failures before the change):

- `afterInit` registers a handshake middleware
- middleware admits a client with valid credentials
- middleware refuses a client with no credentials, which then joins no room and needs no disconnect
- middleware refuses a client whose token validation throws

The existing `handleConnection` test no longer needs `validateClient` mocked at all, and a new one asserts it is never called — pinning the separation.

## Verification

- Backend: 220 suites / 2847 tests pass (2 skipped)
- `lint:js`: exit 0 (2 pre-existing warnings in an unrelated plugin)

## Not included

Removing the admin's grace window. It is now belt-and-braces rather than load-bearing, but deleting it is an admin-side change and does not belong in a backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)