### PR TITLE
refactor(admin): let stores declare their own refresh contract

### DIFF
--- a/apps/admin/src/common/services/data-refresh.spec.ts
+++ b/apps/admin/src/common/services/data-refresh.spec.ts
@@ -8,8 +8,8 @@ describe('refreshLoadedStores', () => {
 		const untouchedRefresh = vi.fn(async (): Promise<void> => {});
 
 		await refreshLoadedStores([
-			{ loaded: (): boolean => true, refresh: loadedRefresh },
-			{ loaded: (): boolean => false, refresh: untouchedRefresh },
+			{ isLoaded: (): boolean => true, refresh: loadedRefresh },
+			{ isLoaded: (): boolean => false, refresh: untouchedRefresh },
 		]);
 
 		expect(loadedRefresh).toHaveBeenCalledTimes(1);
@@ -20,7 +20,7 @@ describe('refreshLoadedStores', () => {
 		await expect(
 			refreshLoadedStores([
 				{
-					loaded: (): boolean => true,
+					isLoaded: (): boolean => true,
 					refresh: async (): Promise<void> => {
 						throw new Error('fetch failed');
 					},

--- a/apps/admin/src/common/services/data-refresh.ts
+++ b/apps/admin/src/common/services/data-refresh.ts
@@ -3,15 +3,14 @@ import { type App, type InjectionKey, inject as _inject, hasInjectionContext } f
 import type { DataRefreshErrorHandler, DataRefreshHandler, DataRefreshKey, IDataRefreshRegistry, IRefreshableStore } from './types';
 
 /**
- * Re-fetches the given stores, skipping the ones that never loaded.
+ * Re-reads the given stores, skipping the ones that never loaded.
  *
- * A wake must not pull data the user never opened, so each candidate reports whether it holds
- * anything worth refreshing. Collection stores answer that with `firstLoadFinished()`; the
- * singleton stores built around `get()` never set that flag, so they compare their own `data`
- * against null instead. Each store reports through the signal it actually maintains.
+ * A wake must not pull data the user never opened, so each store is asked whether it holds
+ * anything worth re-reading. What that means differs per store, which is exactly why the store
+ * answers it rather than the caller.
  */
-export const refreshLoadedStores = async (candidates: IRefreshableStore[]): Promise<void> => {
-	await Promise.all(candidates.filter((candidate) => candidate.loaded()).map((candidate) => candidate.refresh()));
+export const refreshLoadedStores = async (stores: IRefreshableStore[]): Promise<void> => {
+	await Promise.all(stores.filter((store) => store.isLoaded()).map((store) => store.refresh()));
 };
 
 export const dataRefreshRegistryKey: InjectionKey<DataRefreshRegistry | undefined> = Symbol('FB-App-DataRefreshRegistry');

--- a/apps/admin/src/common/services/types.ts
+++ b/apps/admin/src/common/services/types.ts
@@ -81,9 +81,18 @@ export interface IConnectionRecoveryOptions {
 	authGrace?: number;
 }
 
+/**
+ * What a store must expose to take part in the reconnect refresh.
+ *
+ * Both answers belong to the store rather than to the caller. Callers previously had to work out
+ * "is this loaded" from the outside, which meant knowing that `firstLoad` is set by `fetch()` but
+ * not by `get()`, and not at all by the singleton stores - a distinction that silently excluded
+ * whole modules from the refresh.
+ */
 export interface IRefreshableStore {
-	/** Whether the store already holds data, i.e. whether refreshing it is worthwhile. */
-	loaded: () => boolean;
+	/** Whether the store holds anything worth re-reading. */
+	isLoaded: () => boolean;
+	/** Re-read whatever this store is responsible for. */
 	refresh: () => Promise<unknown>;
 }
 

--- a/apps/admin/src/modules/config/config.module.ts
+++ b/apps/admin/src/modules/config/config.module.ts
@@ -6,14 +6,14 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
 
 import { CONFIG_MODULE_EVENT_PREFIX, CONFIG_MODULE_NAME, EventType } from './config.constants';
@@ -21,11 +21,7 @@ import { locales } from './locales';
 import { ModuleRoutes } from './router';
 import { registerConfigModuleStore } from './store/config-modules.store';
 import { registerConfigPluginStore } from './store/config-plugins.store';
-import {
-	configAppStoreKey,
-	configModulesStoreKey,
-	configPluginsStoreKey,
-} from './store/keys';
+import { configAppStoreKey, configModulesStoreKey, configPluginsStoreKey } from './store/keys';
 import { registerConfigAppStore } from './store/stores';
 
 const configAdminModuleKey: ModuleInjectionKey<IModule> = Symbol('FB-Module-Config');
@@ -80,12 +76,7 @@ export default {
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
 		dataRefreshRegistry.register(
 			configAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => configAppStore.data !== null, refresh: (): Promise<unknown> => configAppStore.get() },
-					{ loaded: (): boolean => configModulesStore.firstLoadFinished() || configModulesStore.findAll().length > 0, refresh: (): Promise<unknown> => configModulesStore.fetch() },
-					{ loaded: (): boolean => configPluginsStore.firstLoadFinished() || configPluginsStore.findAll().length > 0, refresh: (): Promise<unknown> => configPluginsStore.fetch() },
-				])
+			(): Promise<void> => refreshLoadedStores([configAppStore, configModulesStore, configPluginsStore])
 		);
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {

--- a/apps/admin/src/modules/config/store/config-app.store.ts
+++ b/apps/admin/src/modules/config/store/config-app.store.ts
@@ -170,7 +170,15 @@ export const useConfigApp = defineStore<'config-module_config_app', ConfigAppSto
 		}
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => data.value !== null;
+
+	const refresh = (): Promise<unknown> => get();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/config/store/config-app.store.types.ts
+++ b/apps/admin/src/modules/config/store/config-app.store.types.ts
@@ -43,6 +43,8 @@ export interface IConfigAppStoreActions {
 	onEvent: (payload: IConfigAppOnEventActionPayload) => IConfigApp;
 	set: (payload: IConfigAppSetActionPayload) => IConfigApp;
 	get: () => Promise<IConfigApp>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type ConfigAppStoreSetup = IConfigAppStoreState & IConfigAppStoreActions;

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -290,7 +290,15 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 			}
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+		const refresh = (): Promise<unknown> => fetch();
+
 		return {
+			isLoaded,
+			refresh,
 			semaphore,
 			firstLoad,
 			data,

--- a/apps/admin/src/modules/config/store/config-modules.store.types.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.types.ts
@@ -56,6 +56,8 @@ export interface IConfigModulesStoreActions {
 	get: (payload: IConfigModulesGetActionPayload) => Promise<IConfigModule>;
 	fetch: () => Promise<IConfigModule[]>;
 	edit: (payload: IConfigModulesEditActionPayload) => Promise<IConfigModule>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type ConfigModulesStoreSetup = IConfigModulesStoreState & IConfigModulesStoreActions;

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -334,7 +334,15 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 			return { valid: false, errors: [{ message: 'Validation request failed' }] };
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+		const refresh = (): Promise<unknown> => fetch();
+
 		return {
+			isLoaded,
+			refresh,
 			semaphore,
 			firstLoad,
 			data,

--- a/apps/admin/src/modules/config/store/config-plugins.store.types.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.types.ts
@@ -74,6 +74,8 @@ export interface IConfigPluginsStoreActions {
 	fetch: () => Promise<IConfigPlugin[]>;
 	edit: (payload: IConfigPluginsEditActionPayload) => Promise<IConfigPlugin>;
 	validateConfig: (payload: IConfigPluginsValidateActionPayload) => Promise<IConfigPluginValidationResult>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type ConfigPluginsStoreSetup = IConfigPluginsStoreState & IConfigPluginsStoreActions;

--- a/apps/admin/src/modules/dashboard/dashboard.module.ts
+++ b/apps/admin/src/modules/dashboard/dashboard.module.ts
@@ -6,14 +6,14 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
 
 import { DASHBOARD_MODULE_EVENT_PREFIX, DASHBOARD_MODULE_NAME, EventType } from './dashboard.constants';
@@ -72,13 +72,7 @@ export default {
 		}
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			dashboardAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => pagesStore.firstLoadFinished() || pagesStore.findAll().length > 0, refresh: (): Promise<unknown> => pagesStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(dashboardAdminModuleKey, (): Promise<void> => refreshLoadedStores([pagesStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(DASHBOARD_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/dashboard/store/pages.store.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.ts
@@ -588,7 +588,15 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 		tilesStore.firstLoad.push(page.id);
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/dashboard/store/pages.store.types.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.types.ts
@@ -72,6 +72,8 @@ export interface IPagesStoreActions {
 	edit: (payload: IPagesEditActionPayload) => Promise<IPage>;
 	save: (payload: IPagesSaveActionPayload) => Promise<IPage>;
 	remove: (payload: IPagesRemoveActionPayload) => Promise<boolean>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type PagesStoreSetup = IPagesStoreState & IPagesStoreActions;

--- a/apps/admin/src/modules/devices/devices.module.ts
+++ b/apps/admin/src/modules/devices/devices.module.ts
@@ -6,6 +6,8 @@ import { defaultsDeep, get } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
@@ -13,8 +15,6 @@ import {
 	injectStoresManager,
 	refreshLoadedStores,
 	snakeToCamel,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
 
 import { DEVICES_MODULE_EVENT_PREFIX, DEVICES_MODULE_NAME, EventType } from './devices.constants';
@@ -98,14 +98,7 @@ export default {
 		}
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			devicesAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => devicesStore.firstLoadFinished() || devicesStore.findAll().length > 0, refresh: (): Promise<unknown> => devicesStore.fetch() },
-					{ loaded: (): boolean => devicesValidationStore.firstLoadFinished() || devicesValidationStore.findAll().length > 0, refresh: (): Promise<unknown> => devicesValidationStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(devicesAdminModuleKey, (): Promise<void> => refreshLoadedStores([devicesStore, devicesValidationStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(DEVICES_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -652,7 +652,15 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 		channelsStore.firstLoad.push(device.id);
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/devices/store/devices.store.types.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.types.ts
@@ -80,6 +80,8 @@ export interface IDevicesStoreActions {
 	remove: (payload: IDevicesRemoveActionPayload) => Promise<boolean>;
 	addZone: (payload: IDevicesAddZoneActionPayload) => Promise<IDevice>;
 	removeZone: (payload: IDevicesRemoveZoneActionPayload) => Promise<IDevice>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type DevicesStoreSetup = IDevicesStoreState & IDevicesStoreActions;

--- a/apps/admin/src/modules/devices/store/devices.validation.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.validation.store.ts
@@ -216,6 +216,12 @@ export const useDevicesValidationStore = defineStore<'devices_module-devices_val
 			firstLoad.value = false;
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+		const refresh = (): Promise<unknown> => fetch();
+
 		return {
 			semaphore,
 			firstLoad,
@@ -228,6 +234,8 @@ export const useDevicesValidationStore = defineStore<'devices_module-devices_val
 			fetch,
 			get,
 			clear,
+			isLoaded,
+			refresh,
 		};
 	}
 );

--- a/apps/admin/src/modules/devices/store/devices.validation.store.types.ts
+++ b/apps/admin/src/modules/devices/store/devices.validation.store.types.ts
@@ -56,6 +56,8 @@ export interface IDevicesValidationStoreActions {
 	fetch: () => Promise<IDevicesValidation>;
 	get: (payload: IDevicesValidationGetActionPayload) => Promise<IDeviceValidationResult>;
 	clear: () => void;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type DevicesValidationStoreSetup = IDevicesValidationStoreState & IDevicesValidationStoreActions;

--- a/apps/admin/src/modules/displays/displays.module.ts
+++ b/apps/admin/src/modules/displays/displays.module.ts
@@ -6,16 +6,15 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
-
 import { CONFIG_MODULE_MODULE_TYPE, CONFIG_MODULE_NAME } from '../config';
 
 import { DisplaysConfigForm } from './components/components';
@@ -80,13 +79,7 @@ export default {
 		}
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			displaysAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => displaysStore.firstLoadFinished() || displaysStore.findAll().length > 0, refresh: (): Promise<unknown> => displaysStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(displaysAdminModuleKey, (): Promise<void> => refreshLoadedStores([displaysStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(DISPLAYS_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/displays/store/displays.store.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.ts
@@ -512,7 +512,15 @@ export const useDisplays = defineStore<'displays_module-displays', DisplaysStore
 		};
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/displays/store/displays.store.types.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.types.ts
@@ -82,6 +82,8 @@ export interface IDisplaysStoreActions {
 	getTokens: (payload: IDisplaysGetActionPayload) => Promise<IDisplayToken[]>;
 	revokeToken: (payload: IDisplaysRevokeTokenActionPayload) => Promise<boolean>;
 	refreshTokensForDisplay: (payload: IDisplaysGetActionPayload) => void;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type DisplaysStoreSetup = IDisplaysStoreState & IDisplaysStoreActions;

--- a/apps/admin/src/modules/scenes/scenes.module.ts
+++ b/apps/admin/src/modules/scenes/scenes.module.ts
@@ -6,26 +6,25 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
-
 import { CONFIG_MODULE_MODULE_TYPE, CONFIG_MODULE_NAME } from '../config';
 
 import { ScenesConfigForm } from './components/components';
-import { SCENES_MODULE_EVENT_PREFIX, SCENES_MODULE_NAME, EventType } from './scenes.constants';
-import { ScenesConfigEditFormSchema } from './schemas/config.schemas';
-import { ScenesConfigSchema, ScenesConfigUpdateReqSchema } from './store/config.store.schemas';
 import { locales } from './locales';
 import { ModuleRoutes } from './router';
+import { EventType, SCENES_MODULE_EVENT_PREFIX, SCENES_MODULE_NAME } from './scenes.constants';
+import { ScenesConfigEditFormSchema } from './schemas/config.schemas';
+import { ScenesConfigSchema, ScenesConfigUpdateReqSchema } from './store/config.store.schemas';
+import { scenesActionsStoreKey, scenesStoreKey } from './store/keys';
 import { registerScenesActionsStore } from './store/scenes.actions.store';
 import { registerScenesStore } from './store/scenes.store';
-import { scenesActionsStoreKey, scenesStoreKey } from './store/keys';
 
 const scenesAdminModuleKey: ModuleInjectionKey<IModule> = Symbol('FB-Module-Scenes');
 
@@ -83,13 +82,7 @@ export default {
 		}
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			scenesAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => scenesStore.firstLoadFinished() || scenesStore.findAll().length > 0, refresh: (): Promise<unknown> => scenesStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(scenesAdminModuleKey, (): Promise<void> => refreshLoadedStores([scenesStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(SCENES_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/scenes/store/scenes.store.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.store.ts
@@ -527,7 +527,15 @@ export const useScenesStore = defineStore<'scenes_module-scenes', ScenesStoreSet
 		}
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		data,
 		semaphore,
 		firstLoad,

--- a/apps/admin/src/modules/scenes/store/scenes.store.types.ts
+++ b/apps/admin/src/modules/scenes/store/scenes.store.types.ts
@@ -75,6 +75,8 @@ export interface IScenesStoreActions {
 	save: (payload: IScenesSaveActionPayload) => Promise<IScene>;
 	remove: (payload: IScenesRemoveActionPayload) => Promise<void>;
 	trigger: (payload: IScenesTriggerActionPayload) => Promise<ISceneExecutionResult>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export interface IScenesStore extends IScenesStoreState, IScenesStoreActions {}

--- a/apps/admin/src/modules/spaces/spaces.module.ts
+++ b/apps/admin/src/modules/spaces/spaces.module.ts
@@ -8,11 +8,11 @@ import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import { injectDataRefreshRegistry, injectLogger, injectModulesManager, injectSockets, injectStoresManager, refreshLoadedStores } from '../../common';
 
-import { EventType, SPACES_MODULE_EVENT_PREFIX, SPACES_MODULE_NAME } from './spaces.constants';
 import { locales } from './locales';
 import { ModuleRoutes } from './router';
-import { registerSpacesStore } from './store/spaces.store';
+import { EventType, SPACES_MODULE_EVENT_PREFIX, SPACES_MODULE_NAME } from './spaces.constants';
 import { spacesRefreshSignalsKey, spacesStoreKey } from './store/keys';
+import { registerSpacesStore } from './store/spaces.store';
 
 const spacesDataRefreshKey = Symbol('FB-Module-Spaces-DataRefresh');
 
@@ -73,13 +73,7 @@ export default {
 
 		// Set up WebSocket event listeners
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			spacesDataRefreshKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => spacesStore.firstLoadFinished() || spacesStore.findAll().length > 0, refresh: (): Promise<unknown> => spacesStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(spacesDataRefreshKey, (): Promise<void> => refreshLoadedStores([spacesStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(SPACES_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
@@ -58,6 +58,41 @@ describe('Spaces store', () => {
 		vi.clearAllMocks();
 	});
 
+	describe('refresh contract', () => {
+		it('reports itself unloaded before anything is fetched', () => {
+			expect(store.isLoaded()).toBe(false);
+		});
+
+		it('reports itself loaded after a fetch, even when the collection came back empty', async () => {
+			backendClient.GET.mockResolvedValueOnce({ data: { data: [] }, error: undefined });
+
+			await store.fetch();
+
+			// An empty collection is still a loaded one - a space created during sleep has to be
+			// picked up, so this must not read as "nothing to refresh".
+			expect(store.isLoaded()).toBe(true);
+		});
+
+		it('reports itself loaded when only a detail route populated it', async () => {
+			// `/space/:id/plugin` populates a single entity through get(), never touching fetch()
+			// and so never setting firstLoad. Gating on that flag alone skipped the space on screen.
+			backendClient.GET.mockResolvedValueOnce({ data: { data: spaceResponse(keptId, 'Kept') }, error: undefined });
+
+			await store.get({ id: keptId });
+
+			expect(store.firstLoadFinished()).toBe(false);
+			expect(store.isLoaded()).toBe(true);
+		});
+
+		it('re-reads the collection when refreshed', async () => {
+			backendClient.GET.mockResolvedValueOnce({ data: { data: [spaceResponse(keptId, 'Kept')] }, error: undefined });
+
+			await store.refresh();
+
+			expect(store.findById(keptId)).not.toBeNull();
+		});
+	});
+
 	it('drops spaces the server no longer returns', async () => {
 		backendClient.GET.mockResolvedValueOnce({
 			data: { data: [spaceResponse(keptId, 'Kept'), spaceResponse(removedId, 'Removed')] },

--- a/apps/admin/src/modules/spaces/store/spaces.store.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.ts
@@ -266,7 +266,15 @@ export const useSpacesStore = defineStore<'spaces_module-spaces', SpacesStoreSet
 		data.value[space.id] = space;
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		data,
 		semaphore,
 		firstLoad,

--- a/apps/admin/src/modules/spaces/store/spaces.store.types.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.types.ts
@@ -75,6 +75,8 @@ export interface ISpacesStoreActions {
 	set: (payload: { id: ISpace['id']; data: Partial<ISpace> }) => void;
 	unset: (payload: { id: ISpace['id'] }) => void;
 	onEvent: (payload: { id: ISpace['id']; data: Record<string, unknown> }) => void;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type ISpacesStore = ISpacesStoreState & ISpacesStoreActions;

--- a/apps/admin/src/modules/stats/stats.module.ts
+++ b/apps/admin/src/modules/stats/stats.module.ts
@@ -6,14 +6,14 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
 
 import { locales } from './locales';
@@ -60,13 +60,7 @@ export default {
 		});
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			statsAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => statsStore.data !== null, refresh: (): Promise<unknown> => statsStore.get() },
-				])
-		);
+		dataRefreshRegistry.register(statsAdminModuleKey, (): Promise<void> => refreshLoadedStores([statsStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(STATS_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/stats/store/stats.store.spec.ts
+++ b/apps/admin/src/modules/stats/store/stats.store.spec.ts
@@ -75,6 +75,28 @@ describe('Stats Store', () => {
 		vi.clearAllMocks();
 	});
 
+	describe('refresh contract', () => {
+		it('reports itself unloaded before anything is read', () => {
+			expect(store.isLoaded()).toBe(false);
+		});
+
+		it('reports itself loaded once it holds data', () => {
+			store.set({ data: mockStats });
+
+			// firstLoad is never set on this store, which is why loaded state is answered from the
+			// data itself rather than from that flag.
+			expect(store.isLoaded()).toBe(true);
+		});
+
+		it('re-reads its data when refreshed', async () => {
+			(backendClient.GET as Mock).mockResolvedValue({ data: { data: mockStatsRes }, error: undefined });
+
+			await store.refresh();
+
+			expect(store.data).toEqual(mockStats);
+		});
+	});
+
 	it('should set stats data successfully', () => {
 		const result = store.set({ data: mockStats });
 

--- a/apps/admin/src/modules/stats/store/stats.store.ts
+++ b/apps/admin/src/modules/stats/store/stats.store.ts
@@ -105,7 +105,15 @@ export const useStats = defineStore<'stats_module-stats', StatsStoreSetup>('stat
 		}
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => data.value !== null;
+
+	const refresh = (): Promise<unknown> => get();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/stats/store/stats.store.types.ts
+++ b/apps/admin/src/modules/stats/store/stats.store.types.ts
@@ -43,6 +43,8 @@ export interface IStatsStoreActions {
 	onEvent: (payload: IStatsOnEventActionPayload) => IStats;
 	set: (payload: IStatsSetActionPayload) => IStats;
 	get: () => Promise<IStats>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type StatsStoreSetup = IStatsStoreState & IStatsStoreActions;

--- a/apps/admin/src/modules/system/store/system-info.store.ts
+++ b/apps/admin/src/modules/system/store/system-info.store.ts
@@ -105,7 +105,15 @@ export const useSystemInfo = defineStore<'system_module-system_info', SystemInfo
 		}
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => data.value !== null;
+
+	const refresh = (): Promise<unknown> => get();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/system/store/system-info.store.types.ts
+++ b/apps/admin/src/modules/system/store/system-info.store.types.ts
@@ -43,6 +43,8 @@ export interface ISystemInfoStoreActions {
 	onEvent: (payload: ISystemInfoOnEventActionPayload) => ISystemInfo;
 	set: (payload: ISystemInfoSetActionPayload) => ISystemInfo;
 	get: () => Promise<ISystemInfo>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type SystemInfoStoreSetup = ISystemInfoStoreState & ISystemInfoStoreActions;

--- a/apps/admin/src/modules/system/store/throttle-status.store.ts
+++ b/apps/admin/src/modules/system/store/throttle-status.store.ts
@@ -111,7 +111,15 @@ export const useThrottleStatus = defineStore<'system_module-throttle_status', Th
 			}
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => data.value !== null;
+
+		const refresh = (): Promise<unknown> => get();
+
 		return {
+			isLoaded,
+			refresh,
 			semaphore,
 			firstLoad,
 			data,

--- a/apps/admin/src/modules/system/store/throttle-status.store.types.ts
+++ b/apps/admin/src/modules/system/store/throttle-status.store.types.ts
@@ -43,6 +43,8 @@ export interface IThrottleStatusStoreActions {
 	onEvent: (payload: IThrottleStatusOnEventActionPayload) => IThrottleStatus;
 	set: (payload: IThrottleStatusSetActionPayload) => IThrottleStatus;
 	get: () => Promise<IThrottleStatus | null>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type ThrottleStatusStoreSetup = IThrottleStatusStoreState & IThrottleStatusStoreActions;

--- a/apps/admin/src/modules/system/system.module.ts
+++ b/apps/admin/src/modules/system/system.module.ts
@@ -8,6 +8,8 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectAccountManager,
 	injectDataRefreshRegistry,
 	injectLogger,
@@ -15,21 +17,18 @@ import {
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
-
 import { SystemModuleNetworkMode } from '../../openapi.constants';
 import { CONFIG_MODULE_MODULE_TYPE, CONFIG_MODULE_NAME } from '../config';
 
 import { SystemConfigForm } from './components/components';
 import { locales } from './locales';
-import { SystemConfigEditFormSchema } from './schemas/config.schemas';
-import { SystemConfigSchema, SystemConfigUpdateReqSchema } from './store/config.store.schemas';
 import { ModuleMaintenanceRoutes, ModuleRoutes } from './router';
+import { SystemConfigEditFormSchema } from './schemas/config.schemas';
 import { SystemActionsService, provideSystemActionsService } from './services/system-actions.service';
 import { SystemLogsReporterService, provideSystemLogsReporter } from './services/system-logs-reporter.service';
 import { emitUpdateEvent } from './services/update-events.service';
+import { SystemConfigSchema, SystemConfigUpdateReqSchema } from './store/config.store.schemas';
 import { logsEntriesStoreKey, systemInfoStoreKey, throttleStatusStoreKey } from './store/keys';
 import { registerLogsEntriesStore, registerSystemInfoStore, registerThrottleStatusStore } from './store/stores';
 import { EventType, SYSTEM_MODULE_EVENT_PREFIX, SYSTEM_MODULE_NAME } from './system.constants';
@@ -113,14 +112,7 @@ export default {
 		let lastNetworkMode: string = SystemModuleNetworkMode.online;
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			systemAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => systemInfoStore.data !== null, refresh: (): Promise<unknown> => systemInfoStore.get() },
-					{ loaded: (): boolean => throttleStatusStore.data !== null, refresh: (): Promise<unknown> => throttleStatusStore.get() },
-				])
-		);
+		dataRefreshRegistry.register(systemAdminModuleKey, (): Promise<void> => refreshLoadedStores([systemInfoStore, throttleStatusStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(SYSTEM_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/users/store/users.store.ts
+++ b/apps/admin/src/modules/users/store/users.store.ts
@@ -436,7 +436,15 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 		return true;
 	};
 
+	// Reconnect refresh contract: the store itself says whether it holds anything worth
+	// re-reading, so the caller never has to guess from a flag it does not maintain.
+	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+	const refresh = (): Promise<unknown> => fetch();
+
 	return {
+		isLoaded,
+		refresh,
 		semaphore,
 		firstLoad,
 		data,

--- a/apps/admin/src/modules/users/store/users.store.types.ts
+++ b/apps/admin/src/modules/users/store/users.store.types.ts
@@ -72,6 +72,8 @@ export interface IUsersStoreActions {
 	edit: (payload: IUsersEditActionPayload) => Promise<IUser>;
 	save: (payload: IUsersSaveActionPayload) => Promise<IUser>;
 	remove: (payload: IUsersRemoveActionPayload) => Promise<boolean>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type UsersStoreSetup = IUsersStoreState & IUsersStoreActions;

--- a/apps/admin/src/modules/users/users.module.ts
+++ b/apps/admin/src/modules/users/users.module.ts
@@ -6,6 +6,8 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IAppUser, IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
@@ -13,8 +15,6 @@ import {
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
 
 import { locales } from './locales';
@@ -67,13 +67,7 @@ export default {
 		}
 
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
-		dataRefreshRegistry.register(
-			usersAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => usersStore.firstLoadFinished() || usersStore.findAll().length > 0, refresh: (): Promise<unknown> => usersStore.fetch() },
-				])
-		);
+		dataRefreshRegistry.register(usersAdminModuleKey, (): Promise<void> => refreshLoadedStores([usersStore]));
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(USERS_MODULE_EVENT_PREFIX)) {

--- a/apps/admin/src/modules/weather/store/locations.store.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.ts
@@ -486,7 +486,15 @@ export const useWeatherLocations = defineStore<'weather_module-locations', Weath
 			}
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
+
+		const refresh = (): Promise<unknown> => fetch();
+
 		return {
+			isLoaded,
+			refresh,
 			data,
 			semaphore,
 			firstLoad,

--- a/apps/admin/src/modules/weather/store/locations.store.types.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.types.ts
@@ -89,6 +89,8 @@ export interface IWeatherLocationsStoreActions {
 	edit: (payload: IWeatherLocationsEditActionPayload) => Promise<IWeatherLocation>;
 	save: (payload: IWeatherLocationsSaveActionPayload) => Promise<IWeatherLocation>;
 	remove: (payload: IWeatherLocationsRemoveActionPayload) => Promise<boolean>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type WeatherLocationsStoreSetup = IWeatherLocationsStoreState & IWeatherLocationsStoreActions;

--- a/apps/admin/src/modules/weather/store/weather-day.store.ts
+++ b/apps/admin/src/modules/weather/store/weather-day.store.ts
@@ -107,7 +107,15 @@ export const useWeatherDay = defineStore<'weather_module-weather-day', WeatherDa
 			}
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => data.value !== null;
+
+		const refresh = (): Promise<unknown> => get();
+
 		return {
+			isLoaded,
+			refresh,
 			semaphore,
 			firstLoad,
 			data,

--- a/apps/admin/src/modules/weather/store/weather-day.store.types.ts
+++ b/apps/admin/src/modules/weather/store/weather-day.store.types.ts
@@ -43,6 +43,8 @@ export interface IWeatherDayStoreActions {
 	onEvent: (payload: IWeatherDayOnEventActionPayload) => IWeatherDay;
 	set: (payload: IWeatherDaySetActionPayload) => IWeatherDay;
 	get: () => Promise<IWeatherDay>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type WeatherDayStoreSetup = IWeatherDayStoreState & IWeatherDayStoreActions;

--- a/apps/admin/src/modules/weather/store/weather-forecast.store.ts
+++ b/apps/admin/src/modules/weather/store/weather-forecast.store.ts
@@ -107,7 +107,15 @@ export const useWeatherForecast = defineStore<'weather_module-weather-forecast',
 			}
 		};
 
+		// Reconnect refresh contract: the store itself says whether it holds anything worth
+		// re-reading, so the caller never has to guess from a flag it does not maintain.
+		const isLoaded = (): boolean => data.value !== null;
+
+		const refresh = (): Promise<unknown> => get();
+
 		return {
+			isLoaded,
+			refresh,
 			semaphore,
 			firstLoad,
 			data,

--- a/apps/admin/src/modules/weather/store/weather-forecast.store.types.ts
+++ b/apps/admin/src/modules/weather/store/weather-forecast.store.types.ts
@@ -43,6 +43,8 @@ export interface IWeatherForecastStoreActions {
 	onEvent: (payload: IWeatherForecastOnEventActionPayload) => IWeatherForecast;
 	set: (payload: IWeatherForecastSetActionPayload) => IWeatherForecast;
 	get: () => Promise<IWeatherForecast>;
+	isLoaded: () => boolean;
+	refresh: () => Promise<unknown>;
 }
 
 export type WeatherForecastStoreSetup = IWeatherForecastStoreState & IWeatherForecastStoreActions;

--- a/apps/admin/src/modules/weather/weather.module.ts
+++ b/apps/admin/src/modules/weather/weather.module.ts
@@ -6,16 +6,15 @@ import { defaultsDeep } from 'lodash';
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
 import {
+	type IModule,
+	type ModuleInjectionKey,
 	injectDataRefreshRegistry,
 	injectLogger,
 	injectModulesManager,
 	injectSockets,
 	injectStoresManager,
 	refreshLoadedStores,
-	type IModule,
-	type ModuleInjectionKey,
 } from '../../common';
-
 import { CONFIG_MODULE_MODULE_TYPE, CONFIG_MODULE_NAME } from '../config';
 
 import { WeatherConfigForm } from './components/components';
@@ -93,12 +92,7 @@ export default {
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
 		dataRefreshRegistry.register(
 			weatherAdminModuleKey,
-			(): Promise<void> =>
-				refreshLoadedStores([
-					{ loaded: (): boolean => weatherDayStore.data !== null, refresh: (): Promise<unknown> => weatherDayStore.get() },
-					{ loaded: (): boolean => weatherForecastStore.data !== null, refresh: (): Promise<unknown> => weatherForecastStore.get() },
-					{ loaded: (): boolean => weatherLocationsStore.firstLoadFinished() || weatherLocationsStore.findAll().length > 0, refresh: (): Promise<unknown> => weatherLocationsStore.fetch() },
-				])
+			(): Promise<void> => refreshLoadedStores([weatherDayStore, weatherForecastStore, weatherLocationsStore])
 		);
 
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
@@ -127,12 +121,7 @@ export default {
 
 				case EventType.LOCATION_CREATED:
 				case EventType.LOCATION_UPDATED:
-					if (
-						'id' in data.payload &&
-						typeof data.payload.id === 'string' &&
-						'type' in data.payload &&
-						typeof data.payload.type === 'string'
-					) {
+					if ('id' in data.payload && typeof data.payload.id === 'string' && 'type' in data.payload && typeof data.payload.type === 'string') {
 						weatherLocationsStore.onEvent({
 							id: data.payload.id,
 							type: data.payload.type,

--- a/tasks/bugs/bug-admin-socket-wake-recovery.md
+++ b/tasks/bugs/bug-admin-socket-wake-recovery.md
@@ -190,6 +190,11 @@ the ids the response omits.
 
 ### 7.2d Contract mismatch worth revisiting
 
+> **Resolved** by TECH-ADMIN-STORE-REFRESH-CONTRACT. Stores now expose `isLoaded()` / `refresh()`
+> themselves, so the per-store allowances described below no longer live in the modules. The
+> analysis is kept because it is why that task exists.
+
+
 Every defect found in review so far traces to the same assumption: that these stores share a
 contract. They do not — `firstLoad` is maintained by some and not others, `fetch()` replaces in
 some and merges in others, and backing shapes vary between records and maps. Each handler now

--- a/tasks/technical/tech-admin-store-refresh-contract.md
+++ b/tasks/technical/tech-admin-store-refresh-contract.md
@@ -1,0 +1,104 @@
+# Task: Give stores an explicit refresh contract
+ID: TECH-ADMIN-STORE-REFRESH-CONTRACT
+Type: technical
+Scope: admin
+Size: medium
+Parent: BUG-ADMIN-SOCKET-WAKE-RECOVERY
+Status: review
+
+## 1. Business goal
+
+In order to stop the reconnect refresh silently skipping stores
+As a developer adding or changing a store
+I want the store itself to declare whether it holds anything worth re-reading, instead of every
+caller having to work it out from the outside
+
+## 2. Context
+
+The reconnect refresh added in BUG-ADMIN-SOCKET-WAKE-RECOVERY had each module describe, from the
+outside, how to tell whether its stores were loaded and how to re-read them:
+
+```ts
+refreshLoadedStores([
+    { loaded: (): boolean => statsStore.data !== null, refresh: (): Promise<unknown> => statsStore.get() },
+])
+```
+
+That required the caller to know things the stores never advertised, and the stores disagree with
+each other:
+
+| assumption | reality |
+| --- | --- |
+| `firstLoadFinished()` means "loaded" | six `get()`-based stores declare `firstLoad` and never assign it |
+| `fetch()` is the only way to load | detail routes populate a single entity through `get()`, which sets no flag |
+| collections are plain records | `scenes` is backed by a `Map` |
+
+**Four of the six defects found in review of that PR were the same mistake in different places**:
+a caller guessing at a store's state and guessing wrong. Each was fixed by adjusting that module's
+predicate, which worked but left the next store free to disagree again.
+
+## 3. Scope
+
+**In scope**
+
+- Add `isLoaded()` and `refresh()` to every store registered for reconnect refresh (16 stores),
+  and to their `*StoreActions` interfaces.
+- Change `IRefreshableStore` to that pair, so a store satisfies it structurally.
+- Reduce the module handlers to a list of stores.
+
+**Out of scope**
+
+- Stores not registered for reconnect refresh. Parameterised stores (channels-by-device,
+  properties-by-channel, scene actions, cards, announcements) stay view-driven, as recorded in §8
+  of the parent task.
+- Any change to what the stores fetch or how.
+
+## 4. Acceptance criteria
+
+- [x] Every registered store exposes `isLoaded()` and `refresh()`, declared in its actions
+      interface.
+- [x] Singleton stores report loaded from their own data, since `get()` sets no flag.
+- [x] Collection stores report loaded from a completed full load **or** any entity present, so a
+      detail route that only ran `get()` still refreshes.
+- [x] A collection that loaded and came back empty still reports loaded — an entity created during
+      sleep has to be picked up.
+- [x] `refreshLoadedStores` takes stores directly; no module restates loading rules.
+- [x] Contract tests cover a collection store and a singleton store.
+- [x] `lint:js`, `type-check` and `test:unit` pass.
+
+## 5. Example scenarios
+
+### Scenario: Detail route only
+
+Given the admin was opened straight at a space detail route, which loads through `get()`
+When the socket reconnects
+Then the spaces store reports itself loaded and is refreshed
+
+### Scenario: Collection loaded empty
+
+Given a collection was fetched and returned no entities
+When the socket reconnects
+Then the store still reports itself loaded, so an entity created during the gap is picked up
+
+### Scenario: Store never opened
+
+Given a module's store was never read
+When the socket reconnects
+Then it reports itself unloaded and no request is made for it
+
+## 6. Result
+
+Module handlers went from restating each store's rules to naming the stores:
+
+```ts
+dataRefreshRegistry.register(systemAdminModuleKey, (): Promise<void> =>
+    refreshLoadedStores([systemInfoStore, throttleStatusStore]));
+```
+
+A store that answers `isLoaded()` wrongly is now wrong in one place, next to the data it describes,
+rather than in whichever module happened to register it.
+
+## 7. Technical constraints
+
+- Do not change fetch behaviour; only add the two accessors.
+- Tests are expected for the contract itself, not for each of the sixteen stores.


### PR DESCRIPTION
Closes `tasks/technical/tech-admin-store-refresh-contract.md`. This is follow-up (2) of the two recorded in #609 — the one I flagged there as the actual fix rather than another symptom patch.

## Problem

The reconnect refresh added in #609 had each module describe, **from the outside**, how to tell whether its stores were loaded and how to re-read them:

```ts
refreshLoadedStores([
    { loaded: (): boolean => statsStore.data !== null, refresh: (): Promise<unknown> => statsStore.get() },
])
```

That required callers to know things the stores never advertised — and the stores disagree with each other:

| the caller had to assume | the reality |
| --- | --- |
| `firstLoadFinished()` means "loaded" | six `get()`-based stores declare `firstLoad` and **never assign it** |
| `fetch()` is the only way to load | detail routes populate one entity via `get()`, which sets no flag |
| collections are plain records | `scenes` is backed by a `Map` |

**Four of the six defects found reviewing #609 were the same mistake in different places**: a caller guessing at a store's state and guessing wrong. Each got fixed by adjusting that module's predicate — which worked, but left the next store free to disagree again. One of them (P1) meant the feature did nothing for `/stats`, the exact screen the original bug was reported against.

## Change

Every store registered for reconnect refresh (16) now exposes `isLoaded()` and `refresh()`, declared in its `*StoreActions` interface. `IRefreshableStore` is that pair, so a store satisfies it structurally.

- **Singletons** answer from their own data, since `get()` sets no flag.
- **Collections** answer from a completed full load **or** any entity present — so a detail route that only ran `get()` still refreshes, and a collection that loaded empty still counts as loaded (an entity created during sleep has to be picked up; gating on non-empty alone would have traded one bug for its mirror image).

Handlers reduce to naming the stores:

```ts
dataRefreshRegistry.register(systemAdminModuleKey, (): Promise<void> =>
    refreshLoadedStores([systemInfoStore, throttleStatusStore]));
```

A store that answers `isLoaded()` wrongly is now wrong in **one place, next to the data it describes**, rather than in whichever module happened to register it.

## Tests

Seven new contract tests, watched fail first (`store.isLoaded is not a function`), covering one collection store and one singleton:

- reports unloaded before anything is read
- reports loaded after a fetch, **including when the collection came back empty**
- reports loaded when only a detail route populated it — asserting `firstLoadFinished()` is still `false` there, pinning exactly the gap that caused the P1
- re-reads its data when refreshed

One of my own tests was wrong first time round: it used `set()`, which on the spaces store only updates existing entries. Rewritten to use `get()`, which is the path `useSpace.ts:34` actually takes.

## Verification

- 223 files / 1408 tests pass
- `lint:js`: exit 0
- `type-check`: clean

## Notes for review

- The diff is wide (49 files) but shallow: two accessors per store, two lines per types file, one line per handler.
- Some touched module files show import reordering from `prettier --write`. I reverted it on the four modules I had no other reason to touch (`buddy`, `mdns`, `storage`, `extensions`) to keep the diff honest.
- Parameterised stores (channels-by-device, properties-by-channel, scene actions, cards, announcements) are deliberately **not** included — they stay view-driven, per §8 of the parent task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)