### PR TITLE
fix(devices-shelly-ng): stop warning about other devices' mDNS packets

### DIFF
--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.spec.ts
@@ -7,6 +7,7 @@ eslint-disable @typescript-eslint/no-unsafe-function-type, @typescript-eslint/no
 Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
+import { Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 
 import { ConfigService } from '../../../modules/config/services/config.service';
@@ -365,5 +366,64 @@ describe('ShellyNgService', () => {
 		// Access the private config getter by triggering a method that uses it
 		// This would normally be done by PluginServiceManagerService
 		expect(svc.getState()).toBe('started');
+	});
+
+	describe('mDNS discovery errors', () => {
+		const startService = async (): Promise<void> => {
+			const moduleRef = await Test.createTestingModule({
+				providers: [
+					ShellyNgService,
+					{ provide: ConfigService, useFactory: () => mockConfigService(pluginConfigEnabled) },
+					{ provide: DatabaseDiscovererService, useFactory: mockDbDiscoverer },
+					{ provide: DelegatesManagerService, useFactory: mockDelegates },
+					{ provide: DevicesService, useFactory: () => mockDevicesService() },
+					{ provide: DeviceManagerService, useValue: mockDeviceManagerService },
+					{ provide: DeviceConnectivityService, useValue: mockDeviceConnectivityService },
+					{ provide: PluginServiceManagerService, useValue: mockPluginServiceManager },
+					{ provide: ShellyWsServerService, useValue: mockWsServer },
+				],
+			}).compile();
+
+			svc = moduleRef.get(ShellyNgService);
+
+			await svc.start();
+		};
+
+		const emitDiscovererError = (message: string): void => {
+			const ds9 = require('shellies-ds9');
+
+			const discoverer = ds9.__testing.mdnsInstances[0] as { listeners: Record<string, ((error: Error) => void)[]> };
+
+			for (const listener of discoverer.listeners['error'] ?? []) {
+				listener(new Error(message));
+			}
+		};
+
+		test.each([['Cannot decode name (bad label)'], ['Cannot decode name (bad pointer)']])(
+			'reports %s at debug level, since it comes from other devices on the network',
+			async (message) => {
+				const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+				const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+				await startService();
+
+				emitDiscovererError(message);
+
+				// The packet is not ours to parse - any mDNS speaker on the network can produce it,
+				// so it must not surface as a warning about the Shelly plugin.
+				expect(warnSpy).not.toHaveBeenCalled();
+				expect(debugSpy).toHaveBeenCalled();
+			},
+		);
+
+		test('still reports a genuine discovery failure at error level', async () => {
+			const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+			await startService();
+
+			emitDiscovererError('EADDRINUSE: address already in use');
+
+			expect(errorSpy).toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng.service.ts
@@ -283,9 +283,13 @@ export class ShellyNgService extends BaseManagedPluginService {
 				this.shellies.registerDiscoverer(discoverer);
 
 				discoverer.on('error', (error: Error): void => {
-					// Malformed mDNS packets from other devices on the network are expected noise
+					// mDNS is a shared multicast bus: we receive every announcement on the network,
+					// not just Shelly ones, and any speaker with a quirky encoder produces packets
+					// the decoder rejects. There is nothing to act on and nothing wrong with this
+					// plugin, so it belongs at debug - kept rather than dropped because it is still
+					// the first thing worth looking at when discovery misbehaves.
 					if (/bad label|cannot decode/i.test(error.message)) {
-						this.logger.warn('Received malformed mDNS packet (non-Shelly device on network)', {
+						this.logger.debug('Ignoring malformed mDNS packet from another device on the network', {
 							message: error.message,
 						});
 					} else {


### PR DESCRIPTION
## Problem

```
[ShellyService] Received malformed mDNS packet (non-Shelly device on network)
{"message":"Cannot decode name (bad label)"}
```

You're right that these are false positives. mDNS is a **shared multicast bus** — the discoverer receives every announcement on the network, not just Shelly ones. Any speaker with a quirky encoder produces packets the decoder rejects. There's nothing to act on, and nothing wrong with this plugin.

## The actual defect

The handler already *classified* them correctly — its own comment said so:

```ts
// Malformed mDNS packets from other devices on the network are expected noise
if (/bad label|cannot decode/i.test(error.message)) {
    this.logger.warn('Received malformed mDNS packet (non-Shelly device on network)', { … });
```

…and then logged them at `warn` anyway. The classification was right; the level contradicted it.

## Change

`warn` → `debug`, with the reasoning written into the comment.

**Kept rather than dropped.** Silencing entirely would be the tempting move, but a decode-error stream is still the first thing worth looking at when discovery misbehaves — the fix is to stop presenting it as a fault, not to lose it. `debug` is already this plugin's convention for expected conditions (`device-manager.service.ts:168`, `shelly-ws-server.service.ts:82`).

Genuine discovery failures are untouched and still log at `error`.

## Tests

Three added to `shelly-ng.service.spec.ts`, watched fail first (the two decode cases failed; the error case passed, confirming that path already worked):

- `Cannot decode name (bad label)` → debug, not warn
- `Cannot decode name (bad pointer)` → debug, not warn — the other common `dns-packet` decode failure, already matched by the existing `cannot decode` branch but previously untested
- `EADDRINUSE: address already in use` → still `error`

## Verification

- backend: `build` exit 0, `lint:js` 0 errors (2 pre-existing warnings), 220 suites / 2850 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)