### PR TITLE
fix(ci): archive the flutter-pi bundle from its actual output path

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -323,7 +323,7 @@ jobs:
 
       - name: "Archive ARM64 Flutter Assets"
         run: |
-          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter_assets .
+          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter-pi/aarch64-generic .
           shasum -a 256 smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz > smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz.sha256
 
       - name: "Upload ARM64 Artifact for (64-bit)"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -323,7 +323,7 @@ jobs:
 
       - name: "Archive ARM64 Flutter Assets"
         run: |
-          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter_assets .
+          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter-pi/aarch64-generic .
           shasum -a 256 smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz > smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz.sha256
 
       - name: "Upload ARM64 Artifact for (64-bit)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
 
       - name: "Archive ARM64 Flutter Assets"
         run: |
-          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter_assets .
+          tar -czvf smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz -C ./apps/panel/build/flutter-pi/aarch64-generic .
           shasum -a 256 smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz > smart-panel-display-flutterpi-${{ needs.sync-versions.outputs.version }}-arm64.tar.gz.sha256
 
       - name: "Upload ARM64 Artifact (64-bit)"

--- a/apps/panel/README.md
+++ b/apps/panel/README.md
@@ -86,7 +86,7 @@ lib/
 
 ```shell
 git clone https://github.com/fastybird/smart-panel.git
-cd apps/panel
+cd smart-panel/apps/panel
 ```
 
 ### 2️⃣ Install Dependencies
@@ -158,14 +158,22 @@ dart run flutterpi_tool build --arch=arm64 --release
 
 ### 2️⃣ Transfer the app to your Pi
 
+Recreate the destination first, then copy the bundle's **contents** into it.
+Copying the directory itself would nest it on every redeploy
+(`smart-panel/aarch64-generic`), leaving the Pi running the previous build:
+
 ```shell
-scp -r build/flutter-pi/aarch64-generic pi@raspberrypi:/home/pi/smart-panel
+ssh pi@raspberrypi 'rm -rf ~/smart-panel && mkdir -p ~/smart-panel'
+scp -r build/flutter-pi/aarch64-generic/. pi@raspberrypi:~/smart-panel/
 ```
 
 ### 3️⃣ Run on Raspberry Pi
 
+The bundle ships its own `flutter-pi` binary, so you can run either the one
+you copied or a system-wide install:
+
 ```shell
-flutter-pi /home/pi/smart-panel
+flutter-pi --release ~/smart-panel
 ```
 
 ## 👨‍💻 Contributing

--- a/apps/panel/README.md
+++ b/apps/panel/README.md
@@ -116,8 +116,9 @@ melos build-panel-arm64-release
 ```
 
 This writes a self-contained flutter-pi bundle to
-`apps/panel/build/flutter-pi/aarch64-generic/` — the Flutter assets plus
-`icudtl.dat`, `libflutter_engine.so` and the `flutter-pi` binary itself.
+`build/flutter-pi/aarch64-generic/` (relative to this `apps/panel` directory)
+— the Flutter assets plus `icudtl.dat`, `libflutter_engine.so` and the
+`flutter-pi` binary itself.
 
 Then run it on the Pi:
 
@@ -150,7 +151,7 @@ melos build-panel-arm64-release
 ### 2️⃣ Transfer the app to your Pi
 
 ```shell
-scp -r apps/panel/build/flutter-pi/aarch64-generic pi@raspberrypi:/home/pi/smart-panel
+scp -r build/flutter-pi/aarch64-generic pi@raspberrypi:/home/pi/smart-panel
 ```
 
 ### 3️⃣ Run on Raspberry Pi

--- a/apps/panel/README.md
+++ b/apps/panel/README.md
@@ -123,10 +123,12 @@ This writes a self-contained flutter-pi bundle to
 — the Flutter assets plus `icudtl.dat`, `libflutter_engine.so` and the
 `flutter-pi` binary itself.
 
-Then run it on the Pi:
+Then run it on the Pi. The bundle ships its own `flutter-pi`, so invoke that
+binary directly — a bare `flutter-pi` only works if one is installed on your
+`PATH`:
 
 ```shell
-flutter-pi --release /path/to/bundle
+/path/to/bundle/flutter-pi --release /path/to/bundle
 ```
 
 > From the repository root the same build is available as the Melos script
@@ -164,16 +166,17 @@ Copying the directory itself would nest it on every redeploy
 
 ```shell
 ssh pi@raspberrypi 'rm -rf ~/smart-panel && mkdir -p ~/smart-panel'
-scp -r build/flutter-pi/aarch64-generic/. pi@raspberrypi:~/smart-panel/
+scp -rp build/flutter-pi/aarch64-generic/. pi@raspberrypi:~/smart-panel/
 ```
 
 ### 3️⃣ Run on Raspberry Pi
 
-The bundle ships its own `flutter-pi` binary, so you can run either the one
-you copied or a system-wide install:
+Run the `flutter-pi` binary that came with the bundle (`-p` above preserves
+its executable bit). Only use a bare `flutter-pi` if you have installed one
+on your `PATH`:
 
 ```shell
-flutter-pi --release ~/smart-panel
+~/smart-panel/flutter-pi --release ~/smart-panel
 ```
 
 ## 👨‍💻 Contributing

--- a/apps/panel/README.md
+++ b/apps/panel/README.md
@@ -109,16 +109,20 @@ flutter run
 
 ## 📦 Building for Raspberry Pi (flutter-pi)
 
-If deploying to **Raspberry Pi** using flutter-pi, build with:
+If deploying to **Raspberry Pi** using flutter-pi, build the ARM64 bundle with:
 
 ```shell
-flutter build bundle
+melos build-panel-arm64-release
 ```
 
-Then run on the Pi:
+This writes a self-contained flutter-pi bundle to
+`apps/panel/build/flutter-pi/aarch64-generic/` — the Flutter assets plus
+`icudtl.dat`, `libflutter_engine.so` and the `flutter-pi` binary itself.
+
+Then run it on the Pi:
 
 ```shell
-flutter-pi --release /path/to/flutter_assets
+flutter-pi --release /path/to/bundle
 ```
 
 ### 🧪 Running Tests
@@ -140,19 +144,19 @@ dart analyze .
 ### 1️⃣ Build the app
 
 ```shell
-flutter build bundle
+melos build-panel-arm64-release
 ```
 
 ### 2️⃣ Transfer the app to your Pi
 
 ```shell
-scp -r build/flutter_assets pi@raspberrypi:/home/pi/
+scp -r apps/panel/build/flutter-pi/aarch64-generic pi@raspberrypi:/home/pi/smart-panel
 ```
 
 ### 3️⃣ Run on Raspberry Pi
 
 ```shell
-flutter-pi /home/pi/flutter_assets
+flutter-pi /home/pi/smart-panel
 ```
 
 ## 👨‍💻 Contributing

--- a/apps/panel/README.md
+++ b/apps/panel/README.md
@@ -112,8 +112,11 @@ flutter run
 If deploying to **Raspberry Pi** using flutter-pi, build the ARM64 bundle with:
 
 ```shell
-melos build-panel-arm64-release
+dart run flutterpi_tool build --arch=arm64 --release
 ```
+
+`flutterpi_tool` is already a dependency of this package, so this works
+straight after `flutter pub get` — no extra tooling required.
 
 This writes a self-contained flutter-pi bundle to
 `build/flutter-pi/aarch64-generic/` (relative to this `apps/panel` directory)
@@ -125,6 +128,11 @@ Then run it on the Pi:
 ```shell
 flutter-pi --release /path/to/bundle
 ```
+
+> From the repository root the same build is available as the Melos script
+> `melos build-panel-arm64-release`, which additionally stamps the app
+> version. Melos is not part of this package, so install it first with
+> `dart pub global activate melos`.
 
 ### 🧪 Running Tests
 
@@ -145,7 +153,7 @@ dart analyze .
 ### 1️⃣ Build the app
 
 ```shell
-melos build-panel-arm64-release
+dart run flutterpi_tool build --arch=arm64 --release
 ```
 
 ### 2️⃣ Transfer the app to your Pi

--- a/build/raspbian/build.sh
+++ b/build/raspbian/build.sh
@@ -137,7 +137,7 @@ prepare_display_files() {
 	melos bootstrap
 
 	# Build the flutter-pi bundle (ARM64)
-	# This produces flutter_assets/ — NOT a Linux desktop app.
+	# This produces build/flutter-pi/aarch64-generic/ — NOT a Linux desktop app.
 	# flutter-pi uses flutter engine assets, not the desktop build path.
 	echo "  -> Building flutter-pi bundle (arm64 release, variant: ${VARIANT})..."
 
@@ -152,7 +152,7 @@ prepare_display_files() {
 	melos run build-panel-arm64-release
 
 	# Copy the built flutter assets bundle
-	cp -r "${PROJECT_ROOT}/apps/panel/build/flutter_assets/"* \
+	cp -r "${PROJECT_ROOT}/apps/panel/build/flutter-pi/aarch64-generic/"* \
 		"${DISPLAY_FILES_DIR}/display-app/"
 
 	echo "  -> Display files prepared in ${DISPLAY_FILES_DIR}/display-app"


### PR DESCRIPTION
## Problem

The `v1.0.0-beta.0` run failed at **Archive ARM64 Flutter Assets**:

```
tar: apps/panel/build/flutter_assets: Cannot open: No such file or directory
```

The build step itself reported **success** — `flutterpi_tool` simply writes somewhere else now.

## Root cause

`flutterpi_tool` resolves its output directory as:

```dart
outDir ??= fs.directory(path.join(getBuildDirectory(), 'flutter-pi', '$target'));
```

and `--arch=arm64` maps to `FlutterpiTargetPlatform.genericAArch64`, whose `shortName` is `aarch64-generic`. So the bundle lands in:

```
apps/panel/build/flutter-pi/aarch64-generic/
```

The workflows still archived `build/flutter_assets`, which is the layout an **older** flutterpi_tool produced.

Corroborated by the CI log itself, which downloads `engine-aarch64-generic-release.tar.xz` — the same `aarch64-generic` target name.

## Why it surfaced now

Latent, not newly introduced:

- Last **green** display build ran **Flutter 3.27.0** (alpha run `24451661621`, 15 Apr)
- Workflows now pin **3.41.5**
- The display job has not run since that bump — ~3½ months

**All three release workflows carry the identical step**, so the production `v1.0.0` release would have failed the same way. Verified by diffing the `build-display` job across alpha/beta/release — identical apart from whitespace.

## Fix

| File | Change |
|---|---|
| `alpha-release.yml`, `beta-release.yml`, `release.yml` | archive `build/flutter-pi/aarch64-generic` |
| `build/raspbian/build.sh` | `cp -r` from the new path (+ stale comment) |
| `apps/panel/README.md` | documented `flutter build bundle` and the old path; now documents the actual `melos build-panel-arm64-release` flow |

**No consumer change needed.** For the `flutterPi` filesystem layout the tool writes assets *flat* into the output dir (`FilesystemLayout.flutterPi => environment.outputDir`) alongside `icudtl.dat`, `libflutter_engine.so` and the `flutter-pi` binary — so the new path is a drop-in **superset** of the old `flutter_assets/` contents. The tarball gains the engine and binary, which makes it self-contained.

## Verification

- ✅ `bash -n build/raspbian/build.sh`
- ✅ All three workflows parse as valid YAML
- ⚠️ **Not verified by a local build** — cross-compiling the ARM64 bundle on macOS isn't a faithful reproduction. The path is derived from flutterpi_tool 0.11.0 source (the pinned version, `pubspec.lock`) and corroborated by the engine artifact name in the CI log. **Real proof is the next beta run.**

## Not in scope

The same beta run also failed **Publish Pre Release Beta Extension SDK** with `npm error 404 ... PUT /@fastybird%2fsmart-panel-extension-sdk`. That package exists on npm (`0.1.0-alpha.5`) and the job succeeded on 15 Apr with an identical workflow, so it's a **credential** issue (npm masks 401/403 as 404 for scoped packages) — `NPM_REGISTRY_TOKEN` needs rotating. Being handled separately by @akadlec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)