### PR TITLE
fix: stop stranding installs on dead release channels

### DIFF
--- a/.github/scripts/monorepo-version-sync.js
+++ b/.github/scripts/monorepo-version-sync.js
@@ -216,7 +216,15 @@ const updatePubspecYaml = (filePath, baseVersion, tag, buildNumber) => {
 
 	const { fullVersion, buildNumber } = computeVersionInfo(baseVersion, allPublishedVersions);
 
-	const appVersion = tag === "latest" ? baseVersion : `${baseVersion}-${tag}`;
+	// A release must have exactly ONE identity. `fullVersion` is what gets written into
+	// every package.json, so it is also what the git tag, version.json and asset names
+	// have to carry. Publishing the build-number-less `1.0.0-beta` alongside a package
+	// version of `1.0.0-beta.2` made image installs compare their own version against a
+	// lower-precedence advertised one, rank themselves as newer, and never be offered an
+	// update again. It also meant every beta of a base version re-used the same tag and
+	// silently overwrote the previous release.
+	// For the stable channel `fullVersion === baseVersion`, so this is a no-op there.
+	const appVersion = fullVersion;
 
 	// Update all target files
 	for (const pkg of PACKAGES) {

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -204,6 +204,159 @@ describe('UpdateService', () => {
 		});
 	});
 
+	describe('checkServerUpdate channel fall-forward', () => {
+		const NPM_REGISTRY = 'https://registry.npmjs.org/@fastybird/smart-panel';
+		const RELEASES_API = 'https://api.github.com/repos/FastyBird/smart-panel/releases?per_page=20';
+		const STABLE_VERSION_JSON = 'https://github.com/FastyBird/smart-panel/releases/latest/download/version.json';
+
+		let fetchSpy: jest.SpyInstance;
+
+		const mockFetchRoutes = (routes: Record<string, unknown>): void => {
+			fetchSpy = jest.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+				if (!(url in routes)) {
+					return Promise.resolve({ ok: false, status: 404 } as Response);
+				}
+
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve(routes[url]),
+				} as Response);
+			});
+		};
+
+		/** Install detection: no `.image-install` marker anywhere → npm install. */
+		const mockNpmInstall = (currentVersion: string): void => {
+			(readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ version: currentVersion }));
+			(readlinkSync as jest.Mock).mockImplementation(() => {
+				throw new Error('Not a symlink');
+			});
+			(existsSync as jest.Mock).mockReturnValue(false);
+		};
+
+		/** Install detection: `.image-install` marker present → Raspbian image install. */
+		const mockImageInstall = (currentVersion: string): void => {
+			(readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ version: currentVersion }));
+			(readlinkSync as jest.Mock).mockReturnValue('v0.7.0-alpha');
+			(existsSync as jest.Mock).mockImplementation(
+				(path: string) => path === '/opt/smart-panel/v0.7.0-alpha/.image-install',
+			);
+		};
+
+		const release = (tag: string, prerelease: boolean, assetUrl: string | null) => ({
+			tag_name: tag,
+			prerelease,
+			assets: assetUrl ? [{ name: 'version.json', browser_download_url: assetUrl }] : [],
+		});
+
+		afterEach(() => {
+			fetchSpy?.mockRestore();
+		});
+
+		it('should offer the beta release to an npm install stranded on a dead alpha channel', async () => {
+			mockNpmInstall('0.7.0-alpha.1');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '0.5.0-alpha.2', alpha: '0.7.0-alpha.1', beta: '1.0.0-beta.2' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.2');
+			expect(result.updateAvailable).toBe(true);
+			expect(result.updateType).toBe('major');
+		});
+
+		it('should offer the beta release to an image install stranded on a dead alpha channel', async () => {
+			mockImageInstall('0.7.0-alpha.1');
+			mockFetchRoutes({
+				[RELEASES_API]: [
+					release('v1.0.0-beta.2', true, 'https://example.test/beta/version.json'),
+					release('v0.7.0-alpha.1', true, 'https://example.test/alpha/version.json'),
+				],
+				'https://example.test/beta/version.json': { version: '1.0.0-beta.2', channel: 'beta' },
+				'https://example.test/alpha/version.json': { version: '0.7.0-alpha.1', channel: 'alpha' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.2');
+			expect(result.updateAvailable).toBe(true);
+			expect(result.updateType).toBe('major');
+		});
+
+		it('should offer the stable release to a beta install once the beta line ends', async () => {
+			mockNpmInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '1.0.0', alpha: '0.7.0-alpha.1', beta: '1.0.0-beta.2' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0');
+			expect(result.updateAvailable).toBe(true);
+		});
+
+		it('should never offer a less stable channel to a stable install', async () => {
+			mockNpmInstall('1.0.0');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '1.0.0', alpha: '1.1.0-alpha.0', beta: '1.1.0-beta.0' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0');
+			expect(result.updateAvailable).toBe(false);
+		});
+
+		it('should not offer a newer alpha to a beta install', async () => {
+			mockNpmInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '0.5.0-alpha.2', alpha: '1.1.0-alpha.0', beta: '1.0.0-beta.2' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.2');
+			expect(result.updateAvailable).toBe(false);
+		});
+
+		it('should reach the stable release for an image install even when it is absent from the releases page', async () => {
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '1.0.0', channel: 'latest' },
+				[RELEASES_API]: [release('v1.0.0-beta.2', true, 'https://example.test/beta/version.json')],
+				'https://example.test/beta/version.json': { version: '1.0.0-beta.2', channel: 'beta' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0');
+			expect(result.updateAvailable).toBe(true);
+		});
+
+		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {
+			mockImageInstall('0.9.0-beta.1');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '1.0.0', channel: 'latest' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0');
+			expect(result.updateAvailable).toBe(true);
+		});
+	});
+
 	describe('checkServerUpdate cache', () => {
 		it('should return cached result within TTL', async () => {
 			// Pre-populate cache

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -174,6 +174,18 @@ describe('UpdateService', () => {
 			expect(service.detectChannel('2.0.0-beta.1')).toBe('beta');
 			expect(service.detectChannel('2.0.0')).toBe('latest');
 		});
+
+		it('should return null for a pre-release identifier it does not recognise', () => {
+			expect(service.detectChannel('2.0.0-rc.1')).toBeNull();
+			expect(service.detectChannel('2.0.0-nightly')).toBeNull();
+		});
+
+		it('should treat build metadata as stable', () => {
+			// In semver the pre-release sits between '-' and '+', so a '-' inside build metadata
+			// does not make the version a pre-release.
+			expect(service.detectChannel('1.0.0+build-7')).toBe('latest');
+			expect(service.detectChannel('v1.0.0+2026-07-31')).toBe('latest');
+		});
 	});
 
 	describe('update lock', () => {
@@ -572,6 +584,57 @@ describe('UpdateService', () => {
 			expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
 
 			nowSpy.mockRestore();
+		});
+
+		it('should not treat an unrecognised pre-release identifier as stable', async () => {
+			// detectChannel knows alpha and beta. Anything else carrying a pre-release component is
+			// still a pre-release and must not be handed to a stable install just because its
+			// identifier is unfamiliar.
+			mockImageInstall('1.0.0');
+			mockFetchRoutes({
+				[RELEASES_API]: [release('v2.0.0-rc.1', true, 'https://example.test/rc/version.json')],
+				'https://example.test/rc/version.json': { version: '2.0.0-rc.1', channel: 'latest' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBeNull();
+			expect(result.updateAvailable).toBe(false);
+		});
+
+		it('should offer only stable releases to an install on an unrecognised pre-release', async () => {
+			// We cannot place such an install on a pre-release line, so the conservative floor is
+			// stable-only rather than assuming it belongs to the least stable channel.
+			mockNpmInstall('2.0.0-rc.1');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '3.0.0', beta: '3.1.0-beta.0', alpha: '3.2.0-alpha.0' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('3.0.0');
+			expect(result.updateAvailable).toBe(true);
+		});
+
+		it('should take the highest version in a channel, not the first one listed', async () => {
+			// Releases come back newest-created first, which is not the same as highest version: a
+			// backport published after a major pre-release appears above it.
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[RELEASES_API]: [
+					release('v1.5.1-beta.0', true, 'https://example.test/backport/version.json'),
+					release('v2.0.0-beta.0', true, 'https://example.test/major/version.json'),
+				],
+				'https://example.test/backport/version.json': { version: '1.5.1-beta.0', channel: 'beta' },
+				'https://example.test/major/version.json': { version: '2.0.0-beta.0', channel: 'beta' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('2.0.0-beta.0');
+			expect(result.updateAvailable).toBe(true);
 		});
 
 		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -186,6 +186,20 @@ describe('UpdateService', () => {
 			expect(service.detectChannel('1.0.0+build-7')).toBe('latest');
 			expect(service.detectChannel('v1.0.0+2026-07-31')).toBe('latest');
 		});
+
+		it('should ignore channel words appearing inside build metadata', () => {
+			expect(service.detectChannel('1.0.1+build-alpha')).toBe('latest');
+			expect(service.detectChannel('1.0.1+beta-meta')).toBe('latest');
+		});
+
+		it('should match the pre-release identifier rather than a substring of it', () => {
+			// "alpharelease" is not the alpha channel; only the first dot-separated identifier
+			// decides, so anything else is unknown.
+			expect(service.detectChannel('1.0.0-alpharelease.1')).toBeNull();
+			expect(service.detectChannel('1.0.0-prebeta')).toBeNull();
+			expect(service.detectChannel('1.0.0-alpha')).toBe('alpha');
+			expect(service.detectChannel('1.0.0-beta.7')).toBe('beta');
+		});
 	});
 
 	describe('update lock', () => {

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -378,15 +378,15 @@ describe('UpdateService', () => {
 		it('should abandon the releases scan once the overall time budget is spent', async () => {
 			mockImageInstall('0.7.0-alpha.1');
 
-			// Twenty releases, none carrying an accepted channel, so the scan can never
-			// satisfy every requested channel and has nothing to short-circuit on.
+			// Twenty releases that are all alphas, so beta and latest are never resolved and the
+			// "every channel answered" short-circuit can never fire.
 			const releases = Array.from({ length: 20 }, (_, i) =>
-				release(`v9.9.${i}`, true, `https://example.test/r${i}/version.json`),
+				release(`v9.9.${i}-alpha.0`, true, `https://example.test/r${i}/version.json`),
 			);
 			const routes: Record<string, unknown> = { [RELEASES_API]: releases };
 
 			releases.forEach((_, i) => {
-				routes[`https://example.test/r${i}/version.json`] = { version: `9.9.${i}`, channel: 'nightly' };
+				routes[`https://example.test/r${i}/version.json`] = { version: `9.9.${i}-alpha.0`, channel: 'alpha' };
 			});
 
 			mockFetchRoutes(routes);
@@ -402,10 +402,9 @@ describe('UpdateService', () => {
 				return routed(input);
 			});
 
-			const result = await service.checkServerUpdate();
+			await service.checkServerUpdate();
 
-			expect(result.latest).toBeNull();
-			// Without a shared deadline this walks all 20 releases.
+			// Without a budget this walks all 20 releases looking for beta and latest.
 			expect(fetchSpy.mock.calls.length).toBeLessThan(10);
 
 			nowSpy.mockRestore();
@@ -451,6 +450,79 @@ describe('UpdateService', () => {
 			nowSpy.mockRestore();
 		});
 
+		it('should classify a release by its version, not by the channel its version.json claims', async () => {
+			// The `channel` field is hand-written in the release workflow. If the newest release
+			// mislabels an alpha as beta, keying the scan on that label marks beta as answered and
+			// the genuinely newer beta below it is never examined.
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[RELEASES_API]: [
+					release('v1.1.0-alpha.0', true, 'https://example.test/mislabelled/version.json'),
+					release('v1.0.0-beta.5', true, 'https://example.test/beta/version.json'),
+				],
+				'https://example.test/mislabelled/version.json': { version: '1.1.0-alpha.0', channel: 'beta' },
+				'https://example.test/beta/version.json': { version: '1.0.0-beta.5', channel: 'beta' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.5');
+			expect(result.updateAvailable).toBe(true);
+		});
+
+		it('should not cache a stable-only fallback for the full TTL', async () => {
+			// The releases API failed, so the beta/alpha channels were never consulted. Caching
+			// that as a complete answer hides a newer pre-release from GET /status until the TTL
+			// expires, even though the failure was transient.
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '0.9.0', channel: 'latest' },
+			});
+
+			let now = 1_000_000;
+			const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+			const first = await service.checkServerUpdate();
+
+			expect(first.latest).toBe('0.9.0');
+			expect(first.updateAvailable).toBe(false);
+
+			const callsAfterFirst = fetchSpy.mock.calls.length;
+
+			// Ten minutes later the partial answer must no longer be served from cache.
+			now += 10 * 60 * 1000;
+
+			await service.checkServerUpdate();
+
+			expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+
+			nowSpy.mockRestore();
+		});
+
+		it('should cache a complete lookup for the full TTL', async () => {
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '0.9.0', channel: 'latest' },
+				[RELEASES_API]: [release('v1.0.0-beta.5', true, 'https://example.test/beta/version.json')],
+				'https://example.test/beta/version.json': { version: '1.0.0-beta.5', channel: 'beta' },
+			});
+
+			let now = 1_000_000;
+			const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+			await service.checkServerUpdate();
+
+			const callsAfterFirst = fetchSpy.mock.calls.length;
+
+			now += 10 * 60 * 1000;
+
+			await service.checkServerUpdate();
+
+			expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+
+			nowSpy.mockRestore();
+		});
+
 		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {
 			mockImageInstall('0.9.0-beta.1');
 			mockFetchRoutes({
@@ -475,7 +547,7 @@ describe('UpdateService', () => {
 			};
 
 			(service as any).cachedServerInfo.set('latest', cached);
-			(service as any).serverCacheTimestamp.set('latest', Date.now());
+			(service as any).serverCacheExpiresAt.set('latest', Date.now() + 60_000);
 
 			const result = await service.checkServerUpdate('latest');
 

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -411,6 +411,46 @@ describe('UpdateService', () => {
 			nowSpy.mockRestore();
 		});
 
+		it('should bound the stable probe and the releases scan under one shared budget', async () => {
+			// A fall-forward install does both: probe the stable URL, then scan the releases page.
+			// Giving each its own budget means the caller can wait for their sum, so the deadline
+			// has to start before the probe, not after it.
+			mockImageInstall('0.7.0-alpha.1');
+
+			const releases = Array.from({ length: 20 }, (_, i) =>
+				release(`v9.9.${i}`, true, `https://example.test/r${i}/version.json`),
+			);
+			const routes: Record<string, unknown> = {
+				[STABLE_VERSION_JSON]: { version: '0.1.0', channel: 'latest' },
+				[RELEASES_API]: releases,
+			};
+
+			releases.forEach((_, i) => {
+				routes[`https://example.test/r${i}/version.json`] = { version: `9.9.${i}`, channel: 'nightly' };
+			});
+
+			mockFetchRoutes(routes);
+
+			const start = 1_000_000;
+			let now = start;
+			const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+			const routed = fetchSpy.getMockImplementation() as (input: RequestInfo | URL) => Promise<Response>;
+
+			fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+				now += 6_000;
+
+				return routed(input);
+			});
+
+			await service.checkServerUpdate();
+
+			const budget = (UpdateService as unknown as { GITHUB_LOOKUP_TIMEOUT_MS: number }).GITHUB_LOOKUP_TIMEOUT_MS;
+
+			expect(now - start).toBeLessThanOrEqual(budget);
+
+			nowSpy.mockRestore();
+		});
+
 		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {
 			mockImageInstall('0.9.0-beta.1');
 			mockFetchRoutes({

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -523,6 +523,57 @@ describe('UpdateService', () => {
 			nowSpy.mockRestore();
 		});
 
+		it('should keep scanning when the stable probe returns a pre-release', async () => {
+			// The direct download URL is just another source of a version string. If what it
+			// returns is not actually stable, the stable channel is still unanswered and the
+			// releases API has to be consulted for it.
+			mockImageInstall('1.0.0');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '1.1.0-alpha.0', channel: 'latest' },
+				[RELEASES_API]: [release('v1.2.0', false, 'https://example.test/stable/version.json')],
+				'https://example.test/stable/version.json': { version: '1.2.0', channel: 'latest' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.2.0');
+			expect(result.updateAvailable).toBe(true);
+		});
+
+		it('should treat a scan whose last request exhausts the budget as partial', async () => {
+			// The budget check runs at the top of each iteration, so a request that spends the
+			// budget on the final release leaves the loop without it ever firing.
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '0.9.0', channel: 'latest' },
+				[RELEASES_API]: [release('v1.0.0-beta.5', true, 'https://example.test/missing/version.json')],
+				// version.json deliberately absent → the request 404s after consuming the budget
+			});
+
+			let now = 1_000_000;
+			const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+			const routed = fetchSpy.getMockImplementation() as (input: RequestInfo | URL) => Promise<Response>;
+
+			fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+				now += 12_000;
+
+				return routed(input);
+			});
+
+			await service.checkServerUpdate();
+
+			const callsAfterFirst = fetchSpy.mock.calls.length;
+
+			// The beta channel was never actually answered, so this must not be cached for 12h.
+			now += 10 * 60 * 1000;
+
+			await service.checkServerUpdate();
+
+			expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+
+			nowSpy.mockRestore();
+		});
+
 		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {
 			mockImageInstall('0.9.0-beta.1');
 			mockFetchRoutes({

--- a/apps/backend/src/modules/system/services/update.service.spec.ts
+++ b/apps/backend/src/modules/system/services/update.service.spec.ts
@@ -344,6 +344,73 @@ describe('UpdateService', () => {
 			expect(result.updateAvailable).toBe(true);
 		});
 
+		it('should not offer a pre-release that a dist-tag merely labels as stable', async () => {
+			// dist-tags are mutable pointers, not proof of stability — this project's `latest`
+			// tag has in fact pointed at an alpha. A beta install accepts the `latest` channel,
+			// so without checking the version itself an alpha would be offered as an upgrade.
+			mockNpmInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[NPM_REGISTRY]: {
+					'dist-tags': { latest: '1.1.0-alpha.0', beta: '1.0.0-beta.2', alpha: '1.1.0-alpha.0' },
+				},
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.2');
+			expect(result.updateAvailable).toBe(false);
+		});
+
+		it('should not offer a pre-release that a release marks with a more stable channel', async () => {
+			mockImageInstall('1.0.0-beta.2');
+			mockFetchRoutes({
+				[STABLE_VERSION_JSON]: { version: '1.1.0-alpha.0', channel: 'latest' },
+				[RELEASES_API]: [release('v1.0.0-beta.2', true, 'https://example.test/beta/version.json')],
+				'https://example.test/beta/version.json': { version: '1.0.0-beta.2', channel: 'beta' },
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBe('1.0.0-beta.2');
+			expect(result.updateAvailable).toBe(false);
+		});
+
+		it('should abandon the releases scan once the overall time budget is spent', async () => {
+			mockImageInstall('0.7.0-alpha.1');
+
+			// Twenty releases, none carrying an accepted channel, so the scan can never
+			// satisfy every requested channel and has nothing to short-circuit on.
+			const releases = Array.from({ length: 20 }, (_, i) =>
+				release(`v9.9.${i}`, true, `https://example.test/r${i}/version.json`),
+			);
+			const routes: Record<string, unknown> = { [RELEASES_API]: releases };
+
+			releases.forEach((_, i) => {
+				routes[`https://example.test/r${i}/version.json`] = { version: `9.9.${i}`, channel: 'nightly' };
+			});
+
+			mockFetchRoutes(routes);
+
+			// Virtual clock: every request costs 6s, so a 30s budget allows only a handful.
+			let now = 1_000_000;
+			const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+			const routed = fetchSpy.getMockImplementation() as (input: RequestInfo | URL) => Promise<Response>;
+
+			fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+				now += 6_000;
+
+				return routed(input);
+			});
+
+			const result = await service.checkServerUpdate();
+
+			expect(result.latest).toBeNull();
+			// Without a shared deadline this walks all 20 releases.
+			expect(fetchSpy.mock.calls.length).toBeLessThan(10);
+
+			nowSpy.mockRestore();
+		});
+
 		it('should still report a result when the releases API fails but the stable probe succeeds', async () => {
 			mockImageInstall('0.9.0-beta.1');
 			mockFetchRoutes({

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -75,6 +75,13 @@ export class UpdateService {
 	private readonly UPDATE_LOCK_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 	private static readonly FETCH_TIMEOUT_MS = 15_000; // 15 seconds
 
+	// Budget for the entire releases sweep — the listing plus every version.json it opens.
+	// FETCH_TIMEOUT_MS bounds a single request, which is no bound at all on a sequential scan:
+	// when a requested channel has no release at all the loop cannot short-circuit and would
+	// walk the whole page, so the worst case is per-request timeout × page size while an HTTP
+	// caller waits on it.
+	private static readonly RELEASES_SCAN_TIMEOUT_MS = 30_000; // 30 seconds
+
 	/** Release channels ordered least → most stable. */
 	private static readonly CHANNEL_PRECEDENCE: ReadonlyArray<'latest' | 'beta' | 'alpha'> = ['alpha', 'beta', 'latest'];
 
@@ -228,12 +235,25 @@ export class UpdateService {
 		return index === -1 ? ['latest'] : [...UpdateService.CHANNEL_PRECEDENCE.slice(index)];
 	}
 
-	/** Highest version by semver precedence, or null when nothing was resolved. */
-	private pickHighestVersion(versions: string[]): string | null {
-		return versions.reduce<string | null>(
-			(highest, version) => (highest === null || compareSemver(highest, version) < 0 ? version : highest),
-			null,
-		);
+	/**
+	 * Highest version by semver precedence among those whose *own* pre-release identifier is
+	 * within the accepted channels, or null when nothing qualifies.
+	 *
+	 * The channel a version arrives under is only a label: an npm dist-tag is a mutable pointer
+	 * that can be moved to any version (this project's `latest` tag has pointed at an alpha),
+	 * and a release's version.json `channel` is hand-written in the workflow. Trusting either
+	 * would let a version labelled `latest` but numbered `1.1.0-alpha.0` reach a beta install
+	 * and quietly downgrade its stability. The version string is the only self-evident source,
+	 * so the guarantee is enforced against that.
+	 */
+	private pickHighestVersion(versions: string[], channels: Array<'latest' | 'beta' | 'alpha'>): string | null {
+		const accepted = new Set<string>(channels);
+
+		return versions
+			.filter((version) => accepted.has(this.detectChannel(version)))
+			.reduce<
+				string | null
+			>((highest, version) => (highest === null || compareSemver(highest, version) < 0 ? version : highest), null);
 	}
 
 	async checkServerUpdate(channel?: 'latest' | 'beta' | 'alpha'): Promise<VersionInfo> {
@@ -335,7 +355,7 @@ export class UpdateService {
 			}
 		}
 
-		return this.pickHighestVersion(found);
+		return this.pickHighestVersion(found, channels);
 	}
 
 	/**
@@ -373,12 +393,16 @@ export class UpdateService {
 	 * bounds the per-release asset fetches.
 	 */
 	private async fetchVersionsFromReleasesApi(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string[]> {
+		const deadline = Date.now() + UpdateService.RELEASES_SCAN_TIMEOUT_MS;
+		// Never let a single request outlive the sweep it belongs to.
+		const budgetFor = (): number => Math.min(UpdateService.FETCH_TIMEOUT_MS, deadline - Date.now());
+
 		const response = await fetch(`${this.GITHUB_PRERELEASE_API_URL}?per_page=20`, {
 			headers: {
 				Accept: 'application/vnd.github.v3+json',
 				'User-Agent': 'FastyBird-SmartPanel',
 			},
-			signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
+			signal: AbortSignal.timeout(budgetFor()),
 		});
 
 		if (!response.ok) {
@@ -397,6 +421,18 @@ export class UpdateService {
 		for (const release of releases) {
 			if (resolved.size === wanted.size) break;
 
+			// A channel with no release at all never satisfies the check above, so the sweep
+			// would otherwise open every release on the page. Stop at the budget instead and
+			// report on whatever was resolved.
+			if (budgetFor() <= 0) {
+				this.logger.warn(
+					`Releases scan hit its ${UpdateService.RELEASES_SCAN_TIMEOUT_MS}ms budget after resolving ` +
+						`${resolved.size}/${wanted.size} channel(s); continuing with partial results`,
+				);
+
+				break;
+			}
+
 			const versionAsset = release.assets.find((a) => a.name === 'version.json');
 
 			if (!versionAsset) continue;
@@ -404,7 +440,7 @@ export class UpdateService {
 			try {
 				const assetResponse = await fetch(versionAsset.browser_download_url, {
 					headers: { 'User-Agent': 'FastyBird-SmartPanel' },
-					signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
+					signal: AbortSignal.timeout(budgetFor()),
 				});
 
 				if (!assetResponse.ok) continue;
@@ -443,7 +479,10 @@ export class UpdateService {
 		const data = (await response.json()) as { 'dist-tags'?: Record<string, string> };
 		const distTags = data['dist-tags'] ?? {};
 
-		return this.pickHighestVersion(channels.map((channel) => distTags[channel]).filter((v): v is string => !!v));
+		return this.pickHighestVersion(
+			channels.map((channel) => distTags[channel]).filter((v): v is string => !!v),
+			channels,
+		);
 	}
 
 	async fetchReleaseNotes(version: string): Promise<ReleaseNotes> {

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -224,14 +224,25 @@ export class UpdateService {
 	 * guarantee is enforced with, an unrecognised identifier has to mean "unknown", not "safe".
 	 */
 	detectChannel(version?: string): 'latest' | 'beta' | 'alpha' | null {
-		const v = version ?? this.getCurrentVersion();
+		const raw = version ?? this.getCurrentVersion();
 
-		if (v.includes('-alpha')) return 'alpha';
-		if (v.includes('-beta')) return 'beta';
+		// Build metadata carries no precedence and may contain anything, including the words
+		// "alpha" and "beta" — so it is discarded before anything is classified, not after.
+		const core = raw.replace(/^v/, '').split('+')[0];
+		const separator = core.indexOf('-');
 
-		// Strip build metadata before looking for a pre-release separator: in semver the
-		// pre-release component sits between '-' and '+', so "1.0.0+build-7" is stable.
-		return v.replace(/^v/, '').split('+')[0].includes('-') ? null : 'latest';
+		if (separator === -1) {
+			return 'latest';
+		}
+
+		// Compare the first dot-separated pre-release identifier as a whole. A substring match
+		// would read "1.0.0-alpharelease.1" as the alpha channel.
+		const [identifier] = core.slice(separator + 1).split('.');
+
+		if (identifier === 'alpha') return 'alpha';
+		if (identifier === 'beta') return 'beta';
+
+		return null;
 	}
 
 	/**

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -75,12 +75,13 @@ export class UpdateService {
 	private readonly UPDATE_LOCK_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 	private static readonly FETCH_TIMEOUT_MS = 15_000; // 15 seconds
 
-	// Budget for the entire releases sweep — the listing plus every version.json it opens.
-	// FETCH_TIMEOUT_MS bounds a single request, which is no bound at all on a sequential scan:
-	// when a requested channel has no release at all the loop cannot short-circuit and would
-	// walk the whole page, so the worst case is per-request timeout × page size while an HTTP
-	// caller waits on it.
-	private static readonly RELEASES_SCAN_TIMEOUT_MS = 30_000; // 30 seconds
+	// Budget for the *entire* GitHub lookup: the stable probe, the releases listing, and every
+	// version.json the scan opens. FETCH_TIMEOUT_MS bounds a single request, which is no bound at
+	// all across a sequence of them — when a requested channel has no release the scan cannot
+	// short-circuit and would walk the whole page, and a fall-forward install runs the probe
+	// before that scan, so separate budgets would let a caller wait for their sum. One deadline
+	// is created per lookup and every request inside it draws from what is left.
+	private static readonly GITHUB_LOOKUP_TIMEOUT_MS = 30_000; // 30 seconds
 
 	/** Release channels ordered least → most stable. */
 	private static readonly CHANNEL_PRECEDENCE: ReadonlyArray<'latest' | 'beta' | 'alpha'> = ['alpha', 'beta', 'latest'];
@@ -318,6 +319,15 @@ export class UpdateService {
 	}
 
 	/**
+	 * Timeout for one request drawing on a shared lookup deadline: never longer than a single
+	 * request is allowed to take, and never longer than the lookup has left. A value of zero or
+	 * below means the budget is spent and the caller should stop rather than issue the request.
+	 */
+	private requestBudget(deadline: number): number {
+		return Math.min(UpdateService.FETCH_TIMEOUT_MS, deadline - Date.now());
+	}
+
+	/**
 	 * Fetch the highest version advertised by GitHub across the accepted channels (image installs).
 	 *
 	 * The stable channel is probed through the direct `releases/latest/download` URL: it costs no
@@ -328,8 +338,12 @@ export class UpdateService {
 		const found: string[] = [];
 		let stableResolved = false;
 
+		// One deadline for the whole lookup. It starts here rather than inside the scan, because
+		// a fall-forward install runs the probe first and the caller waits for both.
+		const deadline = Date.now() + UpdateService.GITHUB_LOOKUP_TIMEOUT_MS;
+
 		if (channels.includes('latest')) {
-			const stable = await this.fetchStableVersionFromDownloadUrl();
+			const stable = await this.fetchStableVersionFromDownloadUrl(deadline);
 
 			if (stable) {
 				found.push(stable);
@@ -342,7 +356,7 @@ export class UpdateService {
 
 		if (remaining.length > 0) {
 			try {
-				found.push(...(await this.fetchVersionsFromReleasesApi(remaining)));
+				found.push(...(await this.fetchVersionsFromReleasesApi(remaining, deadline)));
 			} catch (error) {
 				const err = error as Error;
 
@@ -362,11 +376,11 @@ export class UpdateService {
 	 * Probe the stable channel via the direct asset download URL — no API rate limit,
 	 * follows the redirect to the asset of whichever release GitHub marks as latest.
 	 */
-	private async fetchStableVersionFromDownloadUrl(): Promise<string | null> {
+	private async fetchStableVersionFromDownloadUrl(deadline: number): Promise<string | null> {
 		try {
 			const response = await fetch(this.GITHUB_VERSION_JSON_URL, {
 				headers: { 'User-Agent': 'FastyBird-SmartPanel' },
-				signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
+				signal: AbortSignal.timeout(this.requestBudget(deadline)),
 			});
 
 			if (response.ok) {
@@ -392,17 +406,24 @@ export class UpdateService {
 	 * they disagree. The scan stops as soon as every requested channel has an answer, which
 	 * bounds the per-release asset fetches.
 	 */
-	private async fetchVersionsFromReleasesApi(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string[]> {
-		const deadline = Date.now() + UpdateService.RELEASES_SCAN_TIMEOUT_MS;
-		// Never let a single request outlive the sweep it belongs to.
-		const budgetFor = (): number => Math.min(UpdateService.FETCH_TIMEOUT_MS, deadline - Date.now());
+	private async fetchVersionsFromReleasesApi(
+		channels: Array<'latest' | 'beta' | 'alpha'>,
+		deadline: number,
+	): Promise<string[]> {
+		// The probe may already have consumed the lookup's budget. Bail out rather than issue a
+		// request with a non-positive timeout, which AbortSignal.timeout rejects outright.
+		if (this.requestBudget(deadline) <= 0) {
+			this.logger.warn('GitHub lookup budget spent before the releases listing; skipping the scan');
+
+			return [];
+		}
 
 		const response = await fetch(`${this.GITHUB_PRERELEASE_API_URL}?per_page=20`, {
 			headers: {
 				Accept: 'application/vnd.github.v3+json',
 				'User-Agent': 'FastyBird-SmartPanel',
 			},
-			signal: AbortSignal.timeout(budgetFor()),
+			signal: AbortSignal.timeout(this.requestBudget(deadline)),
 		});
 
 		if (!response.ok) {
@@ -424,9 +445,9 @@ export class UpdateService {
 			// A channel with no release at all never satisfies the check above, so the sweep
 			// would otherwise open every release on the page. Stop at the budget instead and
 			// report on whatever was resolved.
-			if (budgetFor() <= 0) {
+			if (this.requestBudget(deadline) <= 0) {
 				this.logger.warn(
-					`Releases scan hit its ${UpdateService.RELEASES_SCAN_TIMEOUT_MS}ms budget after resolving ` +
+					`GitHub lookup hit its ${UpdateService.GITHUB_LOOKUP_TIMEOUT_MS}ms budget after resolving ` +
 						`${resolved.size}/${wanted.size} channel(s); continuing with partial results`,
 				);
 
@@ -440,7 +461,7 @@ export class UpdateService {
 			try {
 				const assetResponse = await fetch(versionAsset.browser_download_url, {
 					headers: { 'User-Agent': 'FastyBird-SmartPanel' },
-					signal: AbortSignal.timeout(budgetFor()),
+					signal: AbortSignal.timeout(this.requestBudget(deadline)),
 				});
 
 				if (!assetResponse.ok) continue;

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -217,14 +217,21 @@ export class UpdateService {
 	/**
 	 * Detect the release channel from a semver version string.
 	 * e.g. "0.2.0-alpha.1" → "alpha", "1.0.0-beta.3" → "beta", "1.0.0" → "latest"
+	 *
+	 * Returns null for a version carrying a pre-release identifier this project does not publish,
+	 * such as "2.0.0-rc.1". Falling back to "latest" there would classify a pre-release as stable
+	 * and offer it to a stable install — and since this method is what the minimum-stability
+	 * guarantee is enforced with, an unrecognised identifier has to mean "unknown", not "safe".
 	 */
-	detectChannel(version?: string): 'latest' | 'beta' | 'alpha' {
+	detectChannel(version?: string): 'latest' | 'beta' | 'alpha' | null {
 		const v = version ?? this.getCurrentVersion();
 
 		if (v.includes('-alpha')) return 'alpha';
 		if (v.includes('-beta')) return 'beta';
 
-		return 'latest';
+		// Strip build metadata before looking for a pre-release separator: in semver the
+		// pre-release component sits between '-' and '+', so "1.0.0+build-7" is stable.
+		return v.replace(/^v/, '').split('+')[0].includes('-') ? null : 'latest';
 	}
 
 	/**
@@ -267,7 +274,11 @@ export class UpdateService {
 	}
 
 	async checkServerUpdate(channel?: 'latest' | 'beta' | 'alpha'): Promise<VersionInfo> {
-		const resolvedChannel = channel ?? this.detectChannel();
+		// An install whose own version carries an identifier we do not recognise cannot be placed
+		// on a pre-release line, so it is treated as stable-only: the only thing we can safely
+		// offer it is a release with no pre-release component at all. Normalising here also keeps
+		// the cache keyed by a real channel.
+		const resolvedChannel = channel ?? this.detectChannel() ?? 'latest';
 		const cached = this.cachedServerInfo.get(resolvedChannel);
 		const expiresAt = this.serverCacheExpiresAt.get(resolvedChannel) ?? 0;
 
@@ -394,10 +405,11 @@ export class UpdateService {
 			}
 		}
 
-		// Completeness is derived once, here, rather than tracked at each exit path. The lookup saw
-		// everything if every accepted channel has an answer; failing that, it is only complete if
-		// it ran the search to the end without the API failing and without running out of time.
-		const complete = answered.size === wanted.size || (!apiFailed && this.requestBudget(deadline) > 0);
+		// Completeness is derived once, here, rather than tracked at each exit path. Since the scan
+		// now reads the whole page instead of stopping at the first hit per channel, having an
+		// answer for every channel no longer proves the search finished — only running out of
+		// neither time nor API does.
+		const complete = !apiFailed && this.requestBudget(deadline) > 0;
 
 		return { version: this.pickHighestVersion([...answered.values()], channels), complete };
 	}
@@ -417,9 +429,15 @@ export class UpdateService {
 
 		const channel = this.detectChannel(version);
 
-		if (!wanted.has(channel) || answered.has(channel)) return;
+		if (channel === null || !wanted.has(channel)) return;
 
-		answered.set(channel, version);
+		const held = answered.get(channel);
+
+		// Highest wins, not first seen. GitHub lists releases newest-created first, which is not
+		// the same order as semver: a backport cut after a major pre-release is listed above it.
+		if (held === undefined || compareSemver(held, version) < 0) {
+			answered.set(channel, version);
+		}
 	}
 
 	/**
@@ -486,20 +504,16 @@ export class UpdateService {
 			assets: Array<{ name: string; browser_download_url: string }>;
 		}>;
 
-		const wanted = new Set<string>(channels);
-		const seen = new Set<string>();
 		const versions: string[] = [];
 
+		// The whole page is read rather than stopping at the first hit per channel: releases are
+		// listed newest-created first, so stopping early can miss a higher version further down.
+		// The caller keeps the highest per channel and treats a budget-truncated read as partial.
 		for (const release of releases) {
-			if (seen.size === wanted.size) break;
-
-			// A channel with no release at all never satisfies the check above, so the sweep
-			// would otherwise open every release on the page. Stop at the budget instead; the
-			// caller notices the spent budget and treats the answer as partial.
 			if (this.requestBudget(deadline) <= 0) {
 				this.logger.warn(
-					`GitHub lookup hit its ${UpdateService.GITHUB_LOOKUP_TIMEOUT_MS}ms budget after resolving ` +
-						`${seen.size}/${wanted.size} channel(s); continuing with partial results`,
+					`GitHub lookup hit its ${UpdateService.GITHUB_LOOKUP_TIMEOUT_MS}ms budget after reading ` +
+						`${versions.length} release(s); continuing with partial results`,
 				);
 
 				break;
@@ -520,16 +534,11 @@ export class UpdateService {
 				const versionData = (await assetResponse.json()) as { version?: string; channel?: string };
 				const version = versionData.version?.replace(/^v/, '');
 
-				if (!version) continue;
-
-				// Classified by the version itself, never by version.json's hand-written `channel`.
-				// The caller re-derives the same way, so this only decides when to stop early.
-				const channel = this.detectChannel(version);
-
-				if (!wanted.has(channel) || seen.has(channel)) continue;
-
-				seen.add(channel);
-				versions.push(version);
+				// Only the version is taken. version.json's `channel` is hand-written in the release
+				// workflow and is never consulted — the caller classifies from the version itself.
+				if (version) {
+					versions.push(version);
+				}
 			} catch {
 				continue;
 			}

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -354,48 +354,72 @@ export class UpdateService {
 	private async fetchLatestVersionFromGitHub(
 		channels: Array<'latest' | 'beta' | 'alpha'>,
 	): Promise<{ version: string | null; complete: boolean }> {
-		const found: string[] = [];
-		let stableResolved = false;
-		let complete = true;
+		const wanted = new Set<'latest' | 'beta' | 'alpha'>(channels);
+		// Keyed by the channel a version *actually* belongs to. Every source feeds this same map
+		// through the same classification, so no source can claim a channel it did not answer.
+		const answered = new Map<'latest' | 'beta' | 'alpha', string>();
+		let apiFailed = false;
 
 		// One deadline for the whole lookup. It starts here rather than inside the scan, because
 		// a fall-forward install runs the probe first and the caller waits for both.
 		const deadline = Date.now() + UpdateService.GITHUB_LOOKUP_TIMEOUT_MS;
 
-		if (channels.includes('latest')) {
-			const stable = await this.fetchStableVersionFromDownloadUrl(deadline);
+		if (wanted.has('latest')) {
+			const probed = await this.fetchStableVersionFromDownloadUrl(deadline);
 
-			if (stable) {
-				found.push(stable);
-				stableResolved = true;
-			}
+			// The download URL is just another source of a version string. If what it returns is
+			// not in fact stable, the stable channel is still unanswered and the API must cover it.
+			this.recordCandidate(answered, wanted, probed);
 		}
 
-		// Anything the direct probe did not already answer still has to come from the API.
-		const remaining = channels.filter((channel) => channel !== 'latest' || !stableResolved);
+		const remaining = channels.filter((channel) => !answered.has(channel));
 
 		if (remaining.length > 0) {
 			try {
-				const scan = await this.fetchVersionsFromReleasesApi(remaining, deadline);
-
-				found.push(...scan.versions);
-				complete = scan.complete;
+				for (const version of await this.fetchVersionsFromReleasesApi(remaining, deadline)) {
+					this.recordCandidate(answered, wanted, version);
+				}
 			} catch (error) {
 				const err = error as Error;
 
-				// A rate-limited or failing API must not discard a stable version we already hold,
-				// but the channels it would have covered are now unknown rather than absent.
-				if (found.length === 0) {
+				// A rate-limited or failing API must not discard a version we already hold, but the
+				// channels it would have covered are now unknown rather than absent.
+				if (answered.size === 0) {
 					throw error;
 				}
 
-				complete = false;
+				apiFailed = true;
 
 				this.logger.warn(`Releases API lookup failed (${err.message}), using directly probed version only`);
 			}
 		}
 
-		return { version: this.pickHighestVersion(found, channels), complete };
+		// Completeness is derived once, here, rather than tracked at each exit path. The lookup saw
+		// everything if every accepted channel has an answer; failing that, it is only complete if
+		// it ran the search to the end without the API failing and without running out of time.
+		const complete = answered.size === wanted.size || (!apiFailed && this.requestBudget(deadline) > 0);
+
+		return { version: this.pickHighestVersion([...answered.values()], channels), complete };
+	}
+
+	/**
+	 * File a version under the channel its own version string puts it in, keeping the first (and
+	 * therefore newest, since sources are consulted newest-first) answer per channel. Versions
+	 * outside the accepted channels are dropped rather than recorded, so a channel is only ever
+	 * marked answered by a version that genuinely belongs to it.
+	 */
+	private recordCandidate(
+		answered: Map<'latest' | 'beta' | 'alpha', string>,
+		wanted: Set<'latest' | 'beta' | 'alpha'>,
+		version: string | null | undefined,
+	): void {
+		if (!version) return;
+
+		const channel = this.detectChannel(version);
+
+		if (!wanted.has(channel) || answered.has(channel)) return;
+
+		answered.set(channel, version);
 	}
 
 	/**
@@ -435,13 +459,13 @@ export class UpdateService {
 	private async fetchVersionsFromReleasesApi(
 		channels: Array<'latest' | 'beta' | 'alpha'>,
 		deadline: number,
-	): Promise<{ versions: string[]; complete: boolean }> {
+	): Promise<string[]> {
 		// The probe may already have consumed the lookup's budget. Bail out rather than issue a
 		// request with a non-positive timeout, which AbortSignal.timeout rejects outright.
 		if (this.requestBudget(deadline) <= 0) {
 			this.logger.warn('GitHub lookup budget spent before the releases listing; skipping the scan');
 
-			return { versions: [], complete: false };
+			return [];
 		}
 
 		const response = await fetch(`${this.GITHUB_PRERELEASE_API_URL}?per_page=20`, {
@@ -463,22 +487,20 @@ export class UpdateService {
 		}>;
 
 		const wanted = new Set<string>(channels);
-		const resolved = new Map<string, string>();
-		let truncated = false;
+		const seen = new Set<string>();
+		const versions: string[] = [];
 
 		for (const release of releases) {
-			if (resolved.size === wanted.size) break;
+			if (seen.size === wanted.size) break;
 
 			// A channel with no release at all never satisfies the check above, so the sweep
-			// would otherwise open every release on the page. Stop at the budget instead and
-			// report on whatever was resolved.
+			// would otherwise open every release on the page. Stop at the budget instead; the
+			// caller notices the spent budget and treats the answer as partial.
 			if (this.requestBudget(deadline) <= 0) {
 				this.logger.warn(
 					`GitHub lookup hit its ${UpdateService.GITHUB_LOOKUP_TIMEOUT_MS}ms budget after resolving ` +
-						`${resolved.size}/${wanted.size} channel(s); continuing with partial results`,
+						`${seen.size}/${wanted.size} channel(s); continuing with partial results`,
 				);
-
-				truncated = true;
 
 				break;
 			}
@@ -500,23 +522,20 @@ export class UpdateService {
 
 				if (!version) continue;
 
-				// Classify by the version itself rather than by version.json's `channel`, which is
-				// hand-written in the release workflow. Keying on the label lets a release that
-				// mislabels an alpha as beta mark the beta channel answered, so the genuine beta
-				// below it is never examined and the install is told there is no update.
+				// Classified by the version itself, never by version.json's hand-written `channel`.
+				// The caller re-derives the same way, so this only decides when to stop early.
 				const channel = this.detectChannel(version);
 
-				if (!wanted.has(channel) || resolved.has(channel)) continue;
+				if (!wanted.has(channel) || seen.has(channel)) continue;
 
-				resolved.set(channel, version);
+				seen.add(channel);
+				versions.push(version);
 			} catch {
 				continue;
 			}
 		}
 
-		// Walking the whole page without finding a channel is a complete answer — that channel has
-		// no release. Stopping early is not: the rest of the page went unread.
-		return { versions: [...resolved.values()], complete: !truncated };
+		return versions;
 	}
 
 	/**

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -57,10 +57,19 @@ export class UpdateService {
 
 	private cachedServerInfo: Map<string, VersionInfo> = new Map();
 	private cachedPanelInfo: Map<string, PanelVersionInfo> = new Map();
-	private serverCacheTimestamp: Map<string, number> = new Map();
+	// Absolute expiry rather than write time, so a lookup that only partially succeeded can be
+	// given a shorter life than a complete one.
+	private serverCacheExpiresAt: Map<string, number> = new Map();
 	private panelCacheTimestamp: Map<string, number> = new Map();
 	private cachedReleaseNotes: Map<string, ReleaseNotes> = new Map();
 	private readonly CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+	// A lookup that could not consult every accepted channel — the releases API was unavailable,
+	// or the scan ran out of budget — still produces a usable answer, but an incomplete one: the
+	// channel it failed to reach may hold something newer. Caching that for the full TTL would
+	// let one transient failure report "up to date" to GET /status for half a day. It is kept
+	// only briefly instead, so the next poll retries without hammering a failing API.
+	private static readonly PARTIAL_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 	private updateStatus: UpdateStatusInfo = {
 		status: UpdateStatusType.IDLE,
@@ -260,9 +269,9 @@ export class UpdateService {
 	async checkServerUpdate(channel?: 'latest' | 'beta' | 'alpha'): Promise<VersionInfo> {
 		const resolvedChannel = channel ?? this.detectChannel();
 		const cached = this.cachedServerInfo.get(resolvedChannel);
-		const cacheTime = this.serverCacheTimestamp.get(resolvedChannel) ?? 0;
+		const expiresAt = this.serverCacheExpiresAt.get(resolvedChannel) ?? 0;
 
-		if (cached && Date.now() - cacheTime < this.CACHE_TTL_MS) {
+		if (cached && Date.now() < expiresAt) {
 			return cached;
 		}
 
@@ -272,12 +281,17 @@ export class UpdateService {
 
 		try {
 			let latestVersion: string | null = null;
+			let complete = true;
 
 			if (installType === 'image') {
 				// Image installs: check GitHub version.json or releases API
-				latestVersion = await this.fetchLatestVersionFromGitHub(candidateChannels);
+				const lookup = await this.fetchLatestVersionFromGitHub(candidateChannels);
+
+				latestVersion = lookup.version;
+				complete = lookup.complete;
 			} else {
-				// npm installs: check npm registry dist-tags
+				// npm installs: a single registry document carries every dist-tag, so the lookup
+				// either succeeds outright or throws — it is never partial.
 				latestVersion = await this.fetchLatestVersionFromNpm(candidateChannels);
 			}
 
@@ -301,7 +315,10 @@ export class UpdateService {
 			};
 
 			this.cachedServerInfo.set(resolvedChannel, result);
-			this.serverCacheTimestamp.set(resolvedChannel, Date.now());
+			this.serverCacheExpiresAt.set(
+				resolvedChannel,
+				Date.now() + (complete ? this.CACHE_TTL_MS : UpdateService.PARTIAL_CACHE_TTL_MS),
+			);
 
 			return result;
 		} catch (error) {
@@ -334,9 +351,12 @@ export class UpdateService {
 	 * API rate limit and, unlike the paged releases listing, it cannot be pushed out of view by a
 	 * run of pre-releases. Pre-release channels have no such URL and must come from the API.
 	 */
-	private async fetchLatestVersionFromGitHub(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string | null> {
+	private async fetchLatestVersionFromGitHub(
+		channels: Array<'latest' | 'beta' | 'alpha'>,
+	): Promise<{ version: string | null; complete: boolean }> {
 		const found: string[] = [];
 		let stableResolved = false;
+		let complete = true;
 
 		// One deadline for the whole lookup. It starts here rather than inside the scan, because
 		// a fall-forward install runs the probe first and the caller waits for both.
@@ -356,20 +376,26 @@ export class UpdateService {
 
 		if (remaining.length > 0) {
 			try {
-				found.push(...(await this.fetchVersionsFromReleasesApi(remaining, deadline)));
+				const scan = await this.fetchVersionsFromReleasesApi(remaining, deadline);
+
+				found.push(...scan.versions);
+				complete = scan.complete;
 			} catch (error) {
 				const err = error as Error;
 
-				// A rate-limited or failing API must not discard a stable version we already hold.
+				// A rate-limited or failing API must not discard a stable version we already hold,
+				// but the channels it would have covered are now unknown rather than absent.
 				if (found.length === 0) {
 					throw error;
 				}
+
+				complete = false;
 
 				this.logger.warn(`Releases API lookup failed (${err.message}), using directly probed version only`);
 			}
 		}
 
-		return this.pickHighestVersion(found, channels);
+		return { version: this.pickHighestVersion(found, channels), complete };
 	}
 
 	/**
@@ -409,13 +435,13 @@ export class UpdateService {
 	private async fetchVersionsFromReleasesApi(
 		channels: Array<'latest' | 'beta' | 'alpha'>,
 		deadline: number,
-	): Promise<string[]> {
+	): Promise<{ versions: string[]; complete: boolean }> {
 		// The probe may already have consumed the lookup's budget. Bail out rather than issue a
 		// request with a non-positive timeout, which AbortSignal.timeout rejects outright.
 		if (this.requestBudget(deadline) <= 0) {
 			this.logger.warn('GitHub lookup budget spent before the releases listing; skipping the scan');
 
-			return [];
+			return { versions: [], complete: false };
 		}
 
 		const response = await fetch(`${this.GITHUB_PRERELEASE_API_URL}?per_page=20`, {
@@ -438,6 +464,7 @@ export class UpdateService {
 
 		const wanted = new Set<string>(channels);
 		const resolved = new Map<string, string>();
+		let truncated = false;
 
 		for (const release of releases) {
 			if (resolved.size === wanted.size) break;
@@ -450,6 +477,8 @@ export class UpdateService {
 					`GitHub lookup hit its ${UpdateService.GITHUB_LOOKUP_TIMEOUT_MS}ms budget after resolving ` +
 						`${resolved.size}/${wanted.size} channel(s); continuing with partial results`,
 				);
+
+				truncated = true;
 
 				break;
 			}
@@ -467,21 +496,27 @@ export class UpdateService {
 				if (!assetResponse.ok) continue;
 
 				const versionData = (await assetResponse.json()) as { version?: string; channel?: string };
-				const channel = versionData.channel;
-
-				if (!channel || !wanted.has(channel) || resolved.has(channel)) continue;
-
 				const version = versionData.version?.replace(/^v/, '');
 
-				if (version) {
-					resolved.set(channel, version);
-				}
+				if (!version) continue;
+
+				// Classify by the version itself rather than by version.json's `channel`, which is
+				// hand-written in the release workflow. Keying on the label lets a release that
+				// mislabels an alpha as beta mark the beta channel answered, so the genuine beta
+				// below it is never examined and the install is told there is no update.
+				const channel = this.detectChannel(version);
+
+				if (!wanted.has(channel) || resolved.has(channel)) continue;
+
+				resolved.set(channel, version);
 			} catch {
 				continue;
 			}
 		}
 
-		return [...resolved.values()];
+		// Walking the whole page without finding a channel is a complete answer — that channel has
+		// no release. Stopping early is not: the rest of the page went unread.
+		return { versions: [...resolved.values()], complete: !truncated };
 	}
 
 	/**
@@ -627,7 +662,7 @@ export class UpdateService {
 
 	invalidateServerCache(): void {
 		this.cachedServerInfo.clear();
-		this.serverCacheTimestamp.clear();
+		this.serverCacheExpiresAt.clear();
 	}
 
 	async checkPanelUpdate(prerelease: boolean = false): Promise<PanelVersionInfo> {

--- a/apps/backend/src/modules/system/services/update.service.ts
+++ b/apps/backend/src/modules/system/services/update.service.ts
@@ -75,6 +75,9 @@ export class UpdateService {
 	private readonly UPDATE_LOCK_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 	private static readonly FETCH_TIMEOUT_MS = 15_000; // 15 seconds
 
+	/** Release channels ordered least → most stable. */
+	private static readonly CHANNEL_PRECEDENCE: ReadonlyArray<'latest' | 'beta' | 'alpha'> = ['alpha', 'beta', 'latest'];
+
 	private static readonly IMAGE_BASE_DIR = '/opt/smart-panel';
 	private static readonly IMAGE_CURRENT_LINK = '/opt/smart-panel/current';
 	private static readonly IMAGE_MARKER_FILE = '.image-install';
@@ -207,6 +210,32 @@ export class UpdateService {
 		return 'latest';
 	}
 
+	/**
+	 * Channels an install is willing to accept, ordered least → most stable.
+	 *
+	 * A channel is a *minimum stability*, not an exact match. Every pre-release line is
+	 * finite: once a base version's alpha (or beta) series ends, no further release will
+	 * ever carry that channel again. Matching the channel exactly therefore strands the
+	 * device on it permanently — it keeps asking a dead channel and is truthfully told it
+	 * is up to date, forever. Falling forward lets an alpha install move on to beta and
+	 * then to stable, while never offering anything *less* stable than what is installed.
+	 */
+	private resolveCandidateChannels(channel: 'latest' | 'beta' | 'alpha'): Array<'latest' | 'beta' | 'alpha'> {
+		const index = UpdateService.CHANNEL_PRECEDENCE.indexOf(channel);
+
+		// An unknown channel is treated as stable-only rather than opening the device up
+		// to every pre-release line.
+		return index === -1 ? ['latest'] : [...UpdateService.CHANNEL_PRECEDENCE.slice(index)];
+	}
+
+	/** Highest version by semver precedence, or null when nothing was resolved. */
+	private pickHighestVersion(versions: string[]): string | null {
+		return versions.reduce<string | null>(
+			(highest, version) => (highest === null || compareSemver(highest, version) < 0 ? version : highest),
+			null,
+		);
+	}
+
 	async checkServerUpdate(channel?: 'latest' | 'beta' | 'alpha'): Promise<VersionInfo> {
 		const resolvedChannel = channel ?? this.detectChannel();
 		const cached = this.cachedServerInfo.get(resolvedChannel);
@@ -218,16 +247,17 @@ export class UpdateService {
 
 		const currentVersion = this.getCurrentVersion();
 		const installType = this.getInstallType();
+		const candidateChannels = this.resolveCandidateChannels(resolvedChannel);
 
 		try {
 			let latestVersion: string | null = null;
 
 			if (installType === 'image') {
 				// Image installs: check GitHub version.json or releases API
-				latestVersion = await this.fetchLatestVersionFromGitHub(resolvedChannel);
+				latestVersion = await this.fetchLatestVersionFromGitHub(candidateChannels);
 			} else {
 				// npm installs: check npm registry dist-tags
-				latestVersion = await this.fetchLatestVersionFromNpm(resolvedChannel);
+				latestVersion = await this.fetchLatestVersionFromNpm(candidateChannels);
 			}
 
 			let updateAvailable = false;
@@ -268,46 +298,81 @@ export class UpdateService {
 	}
 
 	/**
-	 * Fetch latest version from GitHub version.json (for image installs).
-	 * For the 'latest' channel, tries the direct download URL first (avoids API rate limits),
-	 * then falls back to the releases API if no stable release exists yet.
-	 * For pre-release channels (alpha/beta), queries the releases API to find matching releases.
+	 * Fetch the highest version advertised by GitHub across the accepted channels (image installs).
+	 *
+	 * The stable channel is probed through the direct `releases/latest/download` URL: it costs no
+	 * API rate limit and, unlike the paged releases listing, it cannot be pushed out of view by a
+	 * run of pre-releases. Pre-release channels have no such URL and must come from the API.
 	 */
-	private async fetchLatestVersionFromGitHub(channel: 'latest' | 'beta' | 'alpha'): Promise<string | null> {
-		if (channel === 'latest') {
-			// Try direct download first — no API rate limit, follows redirect to the asset
-			try {
-				const response = await fetch(this.GITHUB_VERSION_JSON_URL, {
-					headers: { 'User-Agent': 'FastyBird-SmartPanel' },
-					signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
-				});
+	private async fetchLatestVersionFromGitHub(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string | null> {
+		const found: string[] = [];
+		let stableResolved = false;
 
-				if (response.ok) {
-					const data = (await response.json()) as { version?: string; channel?: string };
+		if (channels.includes('latest')) {
+			const stable = await this.fetchStableVersionFromDownloadUrl();
 
-					return data.version?.replace(/^v/, '') ?? null;
-				}
-
-				this.logger.debug(`Direct version.json returned ${response.status}, falling back to releases API`);
-			} catch {
-				this.logger.debug('Direct version.json fetch failed, falling back to releases API');
+			if (stable) {
+				found.push(stable);
+				stableResolved = true;
 			}
-
-			// Fallback: check non-prerelease releases via API
-			return this.fetchVersionFromReleasesApi(channel, false);
 		}
 
-		// Pre-release channels: query the releases API
-		return this.fetchVersionFromReleasesApi(channel, true);
+		// Anything the direct probe did not already answer still has to come from the API.
+		const remaining = channels.filter((channel) => channel !== 'latest' || !stableResolved);
+
+		if (remaining.length > 0) {
+			try {
+				found.push(...(await this.fetchVersionsFromReleasesApi(remaining)));
+			} catch (error) {
+				const err = error as Error;
+
+				// A rate-limited or failing API must not discard a stable version we already hold.
+				if (found.length === 0) {
+					throw error;
+				}
+
+				this.logger.warn(`Releases API lookup failed (${err.message}), using directly probed version only`);
+			}
+		}
+
+		return this.pickHighestVersion(found);
 	}
 
 	/**
-	 * Query the GitHub releases API for a version.json matching the requested channel.
+	 * Probe the stable channel via the direct asset download URL — no API rate limit,
+	 * follows the redirect to the asset of whichever release GitHub marks as latest.
 	 */
-	private async fetchVersionFromReleasesApi(
-		channel: 'latest' | 'beta' | 'alpha',
-		prereleaseOnly: boolean,
-	): Promise<string | null> {
+	private async fetchStableVersionFromDownloadUrl(): Promise<string | null> {
+		try {
+			const response = await fetch(this.GITHUB_VERSION_JSON_URL, {
+				headers: { 'User-Agent': 'FastyBird-SmartPanel' },
+				signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
+			});
+
+			if (response.ok) {
+				const data = (await response.json()) as { version?: string; channel?: string };
+
+				return data.version?.replace(/^v/, '') ?? null;
+			}
+
+			this.logger.debug(`Direct version.json returned ${response.status}, falling back to releases API`);
+		} catch {
+			this.logger.debug('Direct version.json fetch failed, falling back to releases API');
+		}
+
+		return null;
+	}
+
+	/**
+	 * Query the GitHub releases API for the newest version.json of each requested channel.
+	 *
+	 * Releases come back newest-first, so the first hit for a channel is that channel's head.
+	 * Matching is done on the version.json `channel` field alone rather than on the release's
+	 * `prerelease` flag — the two encode the same thing, and trusting one avoids the case where
+	 * they disagree. The scan stops as soon as every requested channel has an answer, which
+	 * bounds the per-release asset fetches.
+	 */
+	private async fetchVersionsFromReleasesApi(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string[]> {
 		const response = await fetch(`${this.GITHUB_PRERELEASE_API_URL}?per_page=20`, {
 			headers: {
 				Accept: 'application/vnd.github.v3+json',
@@ -326,9 +391,11 @@ export class UpdateService {
 			assets: Array<{ name: string; browser_download_url: string }>;
 		}>;
 
+		const wanted = new Set<string>(channels);
+		const resolved = new Map<string, string>();
+
 		for (const release of releases) {
-			if (prereleaseOnly && !release.prerelease) continue;
-			if (!prereleaseOnly && release.prerelease) continue;
+			if (resolved.size === wanted.size) break;
 
 			const versionAsset = release.assets.find((a) => a.name === 'version.json');
 
@@ -343,22 +410,28 @@ export class UpdateService {
 				if (!assetResponse.ok) continue;
 
 				const versionData = (await assetResponse.json()) as { version?: string; channel?: string };
+				const channel = versionData.channel;
 
-				if (versionData.channel === channel) {
-					return versionData.version?.replace(/^v/, '') ?? null;
+				if (!channel || !wanted.has(channel) || resolved.has(channel)) continue;
+
+				const version = versionData.version?.replace(/^v/, '');
+
+				if (version) {
+					resolved.set(channel, version);
 				}
 			} catch {
 				continue;
 			}
 		}
 
-		return null;
+		return [...resolved.values()];
 	}
 
 	/**
-	 * Fetch latest version from npm registry (for npm installs).
+	 * Fetch the highest version across the accepted channels' dist-tags (npm installs).
+	 * The registry document carries every dist-tag, so all channels cost a single request.
 	 */
-	private async fetchLatestVersionFromNpm(channel: 'latest' | 'beta' | 'alpha'): Promise<string | null> {
+	private async fetchLatestVersionFromNpm(channels: Array<'latest' | 'beta' | 'alpha'>): Promise<string | null> {
 		const response = await fetch(this.NPM_REGISTRY_URL, {
 			signal: AbortSignal.timeout(UpdateService.FETCH_TIMEOUT_MS),
 		});
@@ -368,8 +441,9 @@ export class UpdateService {
 		}
 
 		const data = (await response.json()) as { 'dist-tags'?: Record<string, string> };
+		const distTags = data['dist-tags'] ?? {};
 
-		return data['dist-tags']?.[channel] ?? null;
+		return this.pickHighestVersion(channels.map((channel) => distTags[channel]).filter((v): v is string => !!v));
 	}
 
 	async fetchReleaseNotes(version: string): Promise<ReleaseNotes> {


### PR DESCRIPTION
## Problem

A panel reporting `0.7.0-alpha.1` is not offered the `v1.0.0-beta` release when "check for
updates" is triggered. It reports "up to date" — truthfully, by its own logic.

Two independent defects both produce that answer, and neither is fixed by shipping 1.0.0.

## Root cause 1 — the channel is matched exactly

`UpdateService.detectChannel()` derives the channel from the installed version, and
`checkServerUpdate()` matched it exactly. All three controller call sites invoke it with no
argument, so the HTTP API cannot ask for another channel; only the CLI commands accept
`--channel`, and there is no config setting for it.

Pre-release lines are finite. Once a base version's alpha series ends, no release will ever
carry that channel again, so the device asks a dead channel forever. Reproduced against live
data with the repo's own `compareSemver`:

```
current=0.7.0-alpha.1  detectChannel() => "alpha"

npm    dist-tag alpha: 0.7.0-alpha.1                        cmp=0   updateAvailable=false
image  v1.0.0-beta  channel=beta  → skipped, wrong channel
       v0.7.0-alpha channel=alpha → 0.7.0-alpha             cmp=1   updateAvailable=false

counterfactual, channel="beta":  1.0.0-beta.2               cmp=-1  updateAvailable=true
```

The counterfactual isolates the channel gate as the sole cause. This is not specific to alpha:
every beta tester would be stranded the same way when 1.0.0 ships, because `dist-tags.beta`
would still read `1.0.0-beta.2`.

A channel is now a **minimum stability** rather than an exact match — alpha accepts
alpha/beta/stable, beta accepts beta/stable, stable accepts only stable — and the highest
version across the accepted channels wins. Nothing less stable than what is installed is ever
offered.

## Root cause 2 — releases publish two different version identities

`monorepo-version-sync.js` writes `fullVersion` (`1.0.0-beta.2`) into every `package.json` but
emitted `appVersion` (`1.0.0-beta`, no build number) as the workflow output used for the git
tag, `version.json` and every asset filename. The release body of `v1.0.0-beta` states it
outright: *"Admin App v1.0.0-beta.2 & Backend App v1.0.0-beta.2 & Display App v1.0.0-beta"*.

An image install compares its own `package.json` version against the newest release's
`version.json`. `compareSemver('1.0.0-beta.2', '1.0.0-beta') === 1` — more pre-release
identifiers rank higher — so the device concludes it is **newer than the latest release** and
is never offered an update, permanently. Your device's own numbers are the evidence: installed
`0.7.0-alpha.1`, advertised `0.7.0-alpha`.

It also meant every beta of a base version resolved to the same tag, so each run silently
overwrote the previous release's assets instead of publishing alongside them.

Emitting `fullVersion` makes tag, `version.json`, asset names and package version one string.
For the stable channel `fullVersion === baseVersion`, so nothing changes there.
`install-display.sh` already assumes asset version == tag minus `v`; this change enforces that
assumption rather than breaking it.

## Verification

Seven new tests in `update.service.spec.ts`, written failing first (5 of 7 failed before the
fix; the two "never downgrade stability" guards passed all along, as intended).

The real `UpdateService` was also driven against live GitHub/npm data with only the two
environment probes stubbed:

```
                                          before          after
image @ 0.7.0-alpha.1    ->  latest=0.7.0-alpha  false   1.0.0-beta    true  major
npm   @ 0.7.0-alpha.1    ->  latest=0.7.0-alpha.1 false  1.0.0-beta.2  true  major
npm   @ 1.0.0            ->  (unchanged)                 no pre-release offered
```

The version-sync change was verified in an isolated copy of the repo — tag, `version.json` and
package version now agree on `1.0.0-beta.3` / `1.1.0-alpha.0` / `1.0.0`.

Full suites: backend 2857 passed, admin 1408 passed, lint clean.

## Not covered by this PR

- **The already-deployed device still cannot be reached by this code.** It runs the old logic,
  so the fix only takes effect after it updates — which is the thing it can't do. Reaching it
  needs a data-side change to the published releases, tracked separately.
- Root cause 2's fix is forward-looking. It cannot rename the existing `v1.0.0-beta` release,
  so an image install on `1.0.0-beta.2` still sees `1.0.0-beta` until the next release is cut
  with the corrected script.
- `checkPanelUpdate()` is not channel-aware at all (it takes a plain `prerelease` boolean).
  Out of scope here.
- The npm `latest` dist-tag currently points at `0.5.0-alpha.2`. Pre-existing registry state;
  the 1.0.0 release will move it.
