### PR TITLE
fix: v1.0.0-beta crash-loops on image installs — package.json resolved outside the install dir

### DIFF
--- a/apps/backend/src/common/package-root-resolution.spec.ts
+++ b/apps/backend/src/common/package-root-resolution.spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+
+/**
+ * Guard against reading the wrong `package.json`.
+ *
+ * Several services read this package's own `package.json` to report the running version.
+ * They do it with a relative walk up from `__dirname`, which is evaluated against the
+ * *compiled* location under `dist/`. Two layouts have to agree:
+ *
+ *   dev     <repo>/apps/backend/dist/modules/system/services
+ *   deployed /opt/smart-panel/v<version>/dist/modules/system/services
+ *
+ * In a dev checkout an over-long walk still lands on a real file — the monorepo root
+ * `package.json` — so the mistake is invisible locally and in CI. Deployed, the same walk
+ * escapes the install directory entirely (`/opt/package.json`) and throws ENOENT. Where the
+ * read happens at module scope that ENOENT is fatal: it fires during `require` and the app
+ * never reaches `listen`, which is exactly how v1.0.0-beta bricked image installs.
+ *
+ * The invariant these call sites must satisfy: the walk resolves to *this* package's root,
+ * identified by name rather than by mere existence.
+ */
+describe('package.json resolution', () => {
+	// This spec lives at src/common, so two levels up is the backend package root.
+	const BACKEND_ROOT = resolve(__dirname, '../..');
+	const EXPECTED_NAME = '@fastybird/smart-panel-backend';
+
+	/** Source files that resolve this package's own package.json from __dirname. */
+	const CALL_SITES = [
+		'modules/system/services/backup.service.ts',
+		'modules/system/services/update.service.ts',
+		'modules/system/controllers/system.controller.ts',
+		'modules/mdns/services/mdns.service.ts',
+	];
+
+	/**
+	 * Pull the relative package.json path out of the source, tolerating both spellings in
+	 * use: resolve(__dirname, '../../../../package.json') and
+	 * join(__dirname, '..', '..', '..', '..', 'package.json').
+	 */
+	const extractRelativePath = (source: string): string => {
+		const singleLiteral = /(?:resolve|join)\(\s*__dirname\s*,\s*'((?:\.\.\/)+package\.json)'\s*\)/.exec(source);
+
+		if (singleLiteral) {
+			return singleLiteral[1];
+		}
+
+		const segmented = /(?:resolve|join)\(\s*__dirname\s*,\s*((?:'\.\.'\s*,\s*)+)'package\.json'\s*\)/.exec(source);
+
+		if (segmented) {
+			const depth = (segmented[1].match(/'\.\.'/g) ?? []).length;
+
+			return `${'../'.repeat(depth)}package.json`;
+		}
+
+		throw new Error('No __dirname-relative package.json resolution found');
+	};
+
+	it.each(CALL_SITES)('%s resolves to this package root once compiled', (relativeSource) => {
+		const source = readFileSync(join(BACKEND_ROOT, 'src', relativeSource), 'utf-8');
+		const relativePath = extractRelativePath(source);
+
+		// Mirror the compiled layout: src/<path>.ts -> dist/<path>.js
+		const compiledDir = join(BACKEND_ROOT, 'dist', dirname(relativeSource));
+		const resolved = resolve(compiledDir, relativePath);
+
+		expect(resolved).toBe(join(BACKEND_ROOT, 'package.json'));
+
+		const pkg = JSON.parse(readFileSync(resolved, 'utf-8')) as { name: string };
+
+		expect(pkg.name).toBe(EXPECTED_NAME);
+	});
+});

--- a/apps/backend/src/modules/system/services/backup.service.ts
+++ b/apps/backend/src/modules/system/services/backup.service.ts
@@ -31,7 +31,12 @@ import { BackupContributionRegistry, BackupContributionType } from './backup-con
 
 const execFileAsync = promisify(execFile);
 
-const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../../../../../../package.json'), 'utf-8')) as {
+// Four levels up from `dist/modules/system/services` is this package's own root — the same
+// depth used by update.service, system.controller and mdns.service. Six levels reaches the
+// monorepo root, which exists in a dev checkout but overshoots to the install's parent
+// directory once deployed (`/opt/package.json`). Because this read happens at module scope,
+// getting it wrong takes the whole app down at require time rather than failing a backup.
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../../../../package.json'), 'utf-8')) as {
 	version: string;
 };
 


### PR DESCRIPTION
## Release blocker — v1.0.0-beta does not boot on a Raspbian image install

Found on a real panel after upgrading `0.7.0-alpha.1` → `1.0.0-beta`. The service crash-looped
(`restart counter is at 36`) and never bound a port, so the admin interface loaded nothing:

```
Error: ENOENT: no such file or directory, open '/opt/package.json'
    at readFileSync (node:fs:440:20)
    at Object.<anonymous> (/opt/smart-panel/v1.0.0-beta/dist/modules/system/services/backup.service.js:32:54)
    ...
    at Object.<anonymous> (/opt/smart-panel/v1.0.0-beta/dist/modules/system/controllers/backup.controller.js:28:26)
```

## Cause

`backup.service.ts` read the package version with a six-level walk:

```ts
const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../../../../../../package.json'), 'utf-8'));
```

From the compiled `dist/modules/system/services`, six levels resolves differently per layout:

| layout | resolves to | exists |
| --- | --- | --- |
| dev — `<repo>/apps/backend/dist/modules/system/services` | `<repo>/package.json` | yes |
| deployed — `/opt/smart-panel/v1.0.0-beta/dist/modules/system/services` | `/opt/package.json` | **no** |

So the mistake is invisible locally and in CI, and only appears once installed. Two things turn
it from a broken backup feature into a dead process:

- the read is at **module scope**, so it throws during `require` rather than when a backup runs
- `backup.controller.js` imports the service, so it is on the boot path

Four levels is correct, and is already what the three other readers of this package's version
use — `update.service.ts:89`, `system.controller.ts:66`, `mdns.service.ts:82`. `backup.service`
is the only one that diverged. It arrived in `e8277314a` ("add backup and restore system"),
i.e. after `v0.7.0-alpha`, which is exactly why the April image boots and the beta does not.

## Scope

Only the `package.json` walk changes. The `var/db` and `var` fallbacks on lines 182/186 use the
same six-level depth deliberately — they target the repo-root `var/` in development and are
overridden by `FB_DB_PATH` / `FB_DATA_DIR` in production, so they neither crash nor resolve
anywhere unexpected. Changing them would move the dev data directory for no benefit.

A scan for module-scope filesystem reads across `apps/backend/src`, `packages/extension-sdk/src`
and `build/src` returns this one line and nothing else, so no other boot-fatal read of this
shape remains.

## Test

`src/common/package-root-resolution.spec.ts` asserts that every `__dirname`-relative
`package.json` walk resolves to this package's root, for all four call sites. It identifies the
target by package **name**, not by file existence — the old depth found a perfectly valid
`package.json`, so an existence check would never have caught this.

Confirmed it actually catches the regression by restoring the old depth:

```
✕ modules/system/services/backup.service.ts resolves to this package root once compiled
  Expected: ".../apps/backend/package.json"
  Received: ".../smart-panel/package.json"
Tests: 1 failed, 3 passed
```

and with the fix in place: 4 passed. System module suite 68 passed, lint clean.

## Note on rollout

This cannot reach an already-bricked panel through the updater — the device has to be patched in
place or rolled back to the previous version directory first. Any 1.0.0 build must include this,
or every image install will be bricked by the upgrade.
