### PR TITLE
fix: ignore build metadata when comparing versions

### DIFF
--- a/apps/backend/src/common/utils/semver.spec.ts
+++ b/apps/backend/src/common/utils/semver.spec.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { comparePrereleaseIdentifiers, compareSemver, getUpdateType } from './semver';
+
+describe('compareSemver', () => {
+	it('should order by major, minor and patch', () => {
+		expect(compareSemver('1.0.0', '2.0.0')).toBe(-1);
+		expect(compareSemver('2.0.0', '1.0.0')).toBe(1);
+		expect(compareSemver('1.1.0', '1.0.0')).toBe(1);
+		expect(compareSemver('1.0.1', '1.0.0')).toBe(1);
+		expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+	});
+
+	it('should ignore a leading v', () => {
+		expect(compareSemver('v1.0.0', '1.0.0')).toBe(0);
+		expect(compareSemver('v1.0.1', 'v1.0.0')).toBe(1);
+	});
+
+	it('should rank a pre-release below its release', () => {
+		expect(compareSemver('1.0.0-beta.1', '1.0.0')).toBe(-1);
+		expect(compareSemver('1.0.0', '1.0.0-beta.1')).toBe(1);
+	});
+
+	it('should order pre-releases of the same version', () => {
+		expect(compareSemver('1.0.0-alpha.1', '1.0.0-beta.1')).toBe(-1);
+		expect(compareSemver('1.0.0-beta.1', '1.0.0-beta.2')).toBe(-1);
+		// Fewer identifiers rank lower, so 1.0.0-beta precedes 1.0.0-beta.1
+		expect(compareSemver('1.0.0-beta', '1.0.0-beta.1')).toBe(-1);
+		expect(compareSemver('1.0.0-beta.1', '1.0.0-beta.1')).toBe(0);
+	});
+
+	describe('build metadata', () => {
+		// Semver §10: build metadata MUST be ignored when determining precedence. Splitting on
+		// '-' without discarding it first reads "1.0.0+build-7" as a pre-release of 1.0.0, and
+		// leaves "1.0.1+build" as the base so Number() yields NaN for the patch.
+		it('should be ignored entirely', () => {
+			expect(compareSemver('1.0.0+build-7', '1.0.0')).toBe(0);
+			expect(compareSemver('1.0.0', '1.0.0+build-7')).toBe(0);
+			expect(compareSemver('1.0.0+a', '1.0.0+b')).toBe(0);
+		});
+
+		it('should not swallow the version it is attached to', () => {
+			expect(compareSemver('1.0.1+build-alpha', '1.0.0')).toBe(1);
+			expect(compareSemver('1.0.0', '1.0.1+build-alpha')).toBe(-1);
+		});
+
+		it('should not disturb a real pre-release', () => {
+			expect(compareSemver('1.0.0-beta.2+build', '1.0.0-beta.2')).toBe(0);
+			expect(compareSemver('1.0.0-beta.2+build', '1.0.0-beta.3')).toBe(-1);
+			expect(compareSemver('1.0.0-beta.2+build', '1.0.0')).toBe(-1);
+		});
+	});
+});
+
+describe('comparePrereleaseIdentifiers', () => {
+	it('should rank numeric identifiers below alphanumeric ones', () => {
+		expect(comparePrereleaseIdentifiers('1', 'alpha')).toBe(-1);
+		expect(comparePrereleaseIdentifiers('alpha', '1')).toBe(1);
+	});
+
+	it('should compare numerically where both are numbers', () => {
+		expect(comparePrereleaseIdentifiers('alpha.2', 'alpha.10')).toBe(-1);
+	});
+
+	it('should treat a shorter identifier list as lower', () => {
+		expect(comparePrereleaseIdentifiers('alpha', 'alpha.1')).toBe(-1);
+		expect(comparePrereleaseIdentifiers('alpha.1', 'alpha')).toBe(1);
+	});
+});
+
+describe('getUpdateType', () => {
+	it('should classify by the first differing component', () => {
+		expect(getUpdateType('1.0.0', '2.0.0')).toBe('major');
+		expect(getUpdateType('1.0.0', '1.1.0')).toBe('minor');
+		expect(getUpdateType('1.0.0', '1.0.1')).toBe('patch');
+	});
+
+	it('should disregard pre-release and build metadata', () => {
+		expect(getUpdateType('0.7.0-alpha.1', '1.0.0-beta.2')).toBe('major');
+		expect(getUpdateType('1.0.0', '1.0.1+build-alpha')).toBe('patch');
+		expect(getUpdateType('1.0.0', '2.0.0+build-alpha')).toBe('major');
+	});
+});
+
+describe('shared copy in build/src/utils/version.ts', () => {
+	/**
+	 * The comparison logic is duplicated so the installer package can run without the backend
+	 * installed. Both files say in a header comment that the other must be updated in step,
+	 * which is a convention nothing enforces — this asserts it, since a silent divergence would
+	 * mean the installer and the running app disagree about which version is newer.
+	 */
+	const extract = (source: string, name: string): string => {
+		const start = source.indexOf(`function ${name}(`);
+
+		expect(start).toBeGreaterThan(-1);
+
+		// Walk braces from the function's opening brace to its match.
+		const open = source.indexOf('{', start);
+		let depth = 0;
+
+		for (let i = open; i < source.length; i++) {
+			if (source[i] === '{') depth++;
+			if (source[i] === '}') depth--;
+			if (depth === 0) {
+				return source
+					.slice(open, i + 1)
+					.replace(/\s+/g, ' ')
+					.trim();
+			}
+		}
+
+		throw new Error(`Unbalanced braces while extracting ${name}`);
+	};
+
+	it.each(['compareSemver', 'comparePrereleaseIdentifiers'])('%s is identical in both copies', (name) => {
+		const backendRoot = join(__dirname, '..', '..', '..');
+		const backend = readFileSync(join(backendRoot, 'src/common/utils/semver.ts'), 'utf-8');
+		const build = readFileSync(join(backendRoot, '..', '..', 'build/src/utils/version.ts'), 'utf-8');
+
+		expect(extract(build, name)).toBe(extract(backend, name));
+	});
+});

--- a/apps/backend/src/common/utils/semver.ts
+++ b/apps/backend/src/common/utils/semver.ts
@@ -9,7 +9,11 @@
  */
 export function compareSemver(a: string, b: string): number {
 	const parseVersion = (v: string) => {
-		const cleaned = v.replace(/^v/, '');
+		// Build metadata is ignored when determining precedence (semver §10), and it has to go
+		// before the pre-release split rather than after: it may itself contain a '-', so
+		// "1.0.0+build-7" would otherwise parse as a pre-release of 1.0.0 and rank below it,
+		// and "1.0.1+build-alpha" would leave "1.0.1+build" as the base, making the patch NaN.
+		const cleaned = v.replace(/^v/, '').split('+')[0];
 		const [base, ...prereleaseParts] = cleaned.split('-');
 		const parts = base.split('.').map(Number);
 		const prerelease = prereleaseParts.length > 0 ? prereleaseParts.join('-') : null;

--- a/build/src/utils/version.ts
+++ b/build/src/utils/version.ts
@@ -9,7 +9,11 @@
  */
 export function compareSemver(a: string, b: string): number {
 	const parseVersion = (v: string) => {
-		const cleaned = v.replace(/^v/, '');
+		// Build metadata is ignored when determining precedence (semver §10), and it has to go
+		// before the pre-release split rather than after: it may itself contain a '-', so
+		// "1.0.0+build-7" would otherwise parse as a pre-release of 1.0.0 and rank below it,
+		// and "1.0.1+build-alpha" would leave "1.0.1+build" as the base, making the patch NaN.
+		const cleaned = v.replace(/^v/, '').split('+')[0];
 		const [base, ...prereleaseParts] = cleaned.split('-');
 		const parts = base.split('.').map(Number);
 		const prerelease = prereleaseParts.length > 0 ? prereleaseParts.join('-') : null;


### PR DESCRIPTION
Follow-up to #620, where this was identified during review and deliberately left out to avoid
widening that PR mid-review.

## Problem

`compareSemver` split on `-` without first discarding build metadata. Since metadata may itself
contain a `-`, two distinct failures followed:

```
compareSemver('1.0.0+build-7', '1.0.0')     = -1   // "build-7" read as a pre-release of 1.0.0
compareSemver('1.0.1+build-alpha', '1.0.0') = -1   // base "1.0.1+build" -> Number() -> NaN patch
```

Semver §10 states build metadata MUST be ignored when determining precedence. It is now stripped
before the pre-release split rather than after.

## Why it is worth fixing even though nothing is broken today

This pipeline never emits `+` in a package version — `pubspec.yaml` uses it, `package.json` does
not — so no current version can hit this. But the update check compares whatever a GitHub release
or an npm dist-tag advertises, and that is not under our control. #620 made `detectChannel`
classify such versions correctly; ordering was still wrong, so a correctly-classified candidate
could sort below a version it is actually newer than. This closes that gap.

The failure mode was conservative in both directions (such a version sorts low or is filtered
out, never wrongly offered), which is why it is a follow-up rather than part of #620.

## The duplicated copy

The comparison logic is duplicated in `build/src/utils/version.ts` so the installer package can
run without the backend installed. Both files carry a header comment instructing the reader to
update the other — a convention with nothing enforcing it.

Both copies are updated here, and `semver.spec.ts` now asserts that `compareSemver` and
`comparePrereleaseIdentifiers` are byte-identical between them after whitespace normalisation. A
silent divergence would mean the installer and the running app disagree about which version is
newer, which is exactly the class of bug that produced the original report behind #620.

Confirmed the guard works by changing one copy alone:

```
✕ shared copy in build/src/utils/version.ts › compareSemver is identical in both copies
```

## Tests

This module had no spec at all. Added one covering ordering by major/minor/patch, `v` prefix,
pre-release precedence, identifier comparison rules, `getUpdateType`, and the build-metadata
cases — three of which were confirmed failing before the fix:

```
✕ build metadata › should be ignored entirely            Expected: 0  Received: -1
✕ build metadata › should not swallow the version        Expected: 1  Received: -1
✕ build metadata › should not disturb a real pre-release Expected: 0  Received:  1
```

`getUpdateType` was left unchanged: its `split('-')[0]` leaves `NaN` in the patch slot for a
metadata-bearing version, but the patch slot is only ever the fall-through return, so the result
is correct regardless. Noting it rather than changing code that is not wrong.

## Verification

Backend 2891 passed (222 suites), admin 223 files passed, lint clean. `build/src/utils/version.ts`
has no test runner in that package; it is verified by the parity assertion plus the backend spec.
Type-checking `build/` reports 44 pre-existing errors from `build/node_modules` not being
installed (`Cannot find name 'process'`, `node:*` modules) — none in the changed file.
