### PR TITLE
fix(admin): guard the Shelly discovery polls against session races

### DIFF
--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -608,15 +608,25 @@ describe('useDevicesWizard', () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 
-		// The scan survives the blip and keeps updating.
-		await vi.advanceTimersByTimeAsync(2_000);
-		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+		// The scan survives the blip: it retries and the next snapshot lands. The gap widens after
+		// a failure, so this asserts recovery rather than a fixed cadence.
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThan(1);
+		expect(findControl<IWizardProgressControl>(adapter.controls.value, 'scan').percentage).toBeGreaterThanOrEqual(0);
+		expect(adapter.rows.value.length).toBe(1);
 	});
 
-	it('keeps retrying a recoverable outage for as long as the session could still be running', async () => {
-		// The session runs for 30s. An outage lasting several ticks must not abandon it — the
-		// backend is still discovering, and devices found after connectivity returns would never
-		// reach the UI. Any fixed retry cap shorter than the window has this failure mode.
+	it('keeps retrying past the nominal expiry and still picks up the final snapshot', async () => {
+		// The backend keeps a finished session fetchable for five minutes
+		// (FINISHED_SESSION_TTL_MS), so passing `remainingSeconds` is not a definitive failure.
+		// Giving up at expiry during an outage strands the UI on stale devices and a `running`
+		// status that never resolves, because the terminal snapshot is what stops polling.
+		const finishedSession: IShellyNgDiscoverySession = {
+			...discoverySession,
+			status: 'finished',
+			remainingSeconds: 0,
+		};
+
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -627,16 +637,29 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		await vi.advanceTimersByTimeAsync(10_000);
+		// Outage spans the whole 30s window and beyond.
+		await vi.advanceTimersByTimeAsync(60_000);
 
-		// Ten seconds into a thirty-second window: still trying.
-		expect(backendClient.GET.mock.calls.length).toBeGreaterThanOrEqual(9);
+		// Connectivity returns well after expiry — the final snapshot must still be fetched.
+		backendClient.GET.mockResolvedValue({
+			data: { data: finishedSession },
+			response: { status: 200 },
+		});
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// The terminal snapshot landed: the scan reads as complete rather than perpetually running.
+		expect(findControl<IWizardProgressControl>(adapter.controls.value, 'scan').percentage).toBe(100);
+
+		// And polling stopped on its own, because the session is no longer running.
+		backendClient.GET.mockClear();
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 
-	it('stops once the session can no longer be running', async () => {
-		// The flip side: the natural bound is the session's own lifetime. Once it has certainly
-		// expired there is nothing left to discover, so a persistently broken backend is not
-		// polled for the life of the view.
+	it('backs off while the backend is unreachable instead of polling every second', async () => {
+		// Never giving up must not mean hammering: an unreachable backend should see a widening
+		// gap, not one request per second for as long as the wizard stays open.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -647,13 +670,37 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		// The fixture session has 30s left when it arrives.
-		await vi.advanceTimersByTimeAsync(35_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
-		backendClient.GET.mockClear();
+		// One request per second would be 60; backoff must keep it far below that.
+		expect(backendClient.GET.mock.calls.length).toBeLessThan(15);
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThan(3);
+	});
+
+	it('returns to the normal cadence once polling recovers', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValueOnce(new Error('blip'))
+			.mockRejectedValueOnce(new Error('blip'))
+			.mockResolvedValue({
+				data: { data: discoverySession },
+				response: { status: 200 },
+			});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		// Ride out the two failures and the recovery.
+		await vi.advanceTimersByTimeAsync(10_000);
+		const afterRecovery = backendClient.GET.mock.calls.length;
+
+		// Back at a 1s cadence, ten more seconds is roughly ten more polls.
 		await vi.advanceTimersByTimeAsync(10_000);
 
-		expect(backendClient.GET).not.toHaveBeenCalled();
+		expect(backendClient.GET.mock.calls.length - afterRecovery).toBeGreaterThanOrEqual(8);
 	});
 
 	it('restores polling and clears the busy flag when the rescan request rejects outright', async () => {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -561,17 +561,21 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 
-	it('stops polling after a refresh error instead of hammering a cleaned-up session', async () => {
-		// The most likely refresh failure is a 404 after the backend garbage-collects a finished
-		// session — there is no point re-hitting a missing endpoint every second until the
-		// component unmounts. The user can hit "Scan again" to start a fresh one. Swallowing the
-		// error and continuing also never self-heals: `applySession` never runs, so the session
+	it('stops polling once the backend reports the session is gone', async () => {
+		// A 404 is definitive: the backend garbage-collected the session and it will never come
+		// back, so there is no point re-hitting a missing endpoint every second until the
+		// component unmounts. The user can hit "Scan again" to start a fresh one. Swallowing it
+		// and continuing never self-heals either — `applySession` never runs, so the session
 		// status stays `running` and the non-running `stopPolling()` escape never fires.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
-		backendClient.GET.mockRejectedValue(new Error('session not found'));
+		backendClient.GET.mockResolvedValue({
+			data: undefined,
+			error: { error: 'not found' },
+			response: { status: 404 },
+		});
 
 		const adapter = useDevicesWizard();
 
@@ -580,9 +584,88 @@ describe('useDevicesWizard', () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 
-		// The interval must NOT fire again — the failed poll stopped it.
+		// The interval must NOT fire again — the 404 stopped it.
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps polling through a transient refresh failure', async () => {
+		// A blip or a 5xx is not a dead session. Treating every failure as the 404 case would
+		// permanently freeze an otherwise healthy scan on one dropped request.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		// The scan survives the blip and keeps updating.
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+	});
+
+	it('gives up after repeated refresh failures rather than retrying forever', async () => {
+		// The flip side of tolerating a blip: a backend that is persistently broken must not be
+		// hammered at 1 req/s for the life of the view.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValue(new Error('backend down'));
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(20_000);
+
+		const calls = backendClient.GET.mock.calls.length;
+
+		expect(calls).toBeGreaterThan(1);
+		expect(calls).toBeLessThanOrEqual(5);
+
+		// Confirm it has actually stopped, not merely slowed.
+		backendClient.GET.mockClear();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(backendClient.GET).not.toHaveBeenCalled();
+	});
+
+	it('restores polling and clears the busy flag when the rescan request rejects outright', async () => {
+		// `openapi-fetch` rethrows a transport failure rather than returning `{ error, response }`,
+		// so execution leaves `startDiscovery` at the await. The interval was already stopped and
+		// `formResult` is still WORKING — without recovery the wizard is frozen behind a spinner
+		// that never resolves, with the retained session no longer updating.
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		backendClient.POST.mockRejectedValueOnce(new Error('backend unreachable'));
+		await expect(adapter.start()).rejects.toThrow('backend unreachable');
+
+		expect(adapter.busy.value).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
 	it('drops a poll response that resolves after a rescan replaced the session', async () => {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -634,6 +634,84 @@ describe('useDevicesWizard', () => {
 		expect(adapter.sessionKey?.value).toBe('session-2');
 	});
 
+	it('keeps polling the retained session when a rescan fails to start', async () => {
+		// "Scan again" stops the interval before its POST so no poll targets the session being
+		// replaced. If that POST then fails, the old session stays on screen — and must stay
+		// live. Leaving it stopped freezes the snapshot while the backend session is very much
+		// still discovering, so the table silently stops updating with no visible cause.
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: undefined,
+			error: { error: 'boom' },
+			response: { status: 500 },
+		});
+		await expect(adapter.start()).rejects.toThrow();
+
+		// The retained session must still be polled.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not let a stale poll rejection stop the replacement session polling', async () => {
+		// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s generation
+		// check never runs and the rejection reaches the interval's catch. That catch calls
+		// `stopPolling()` on the shared timer handle — which by then belongs to session B, not to
+		// the session whose poll just failed. B would be installed and never polled again.
+		const sessionB: IShellyNgDiscoverySession = { ...discoverySession, id: 'session-2' };
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		let rejectStalePoll: (() => void) | undefined;
+		backendClient.GET.mockImplementationOnce(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectStalePoll = (): void => reject(new Error('session not found'));
+				})
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(typeof rejectStalePoll).toBe('function');
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		await adapter.start();
+
+		// Session A's poll now fails, long after A stopped being the current session.
+		rejectStalePoll?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		backendClient.GET.mockClear();
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
 	it('adopts the selection handed over by the shell through the devices store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -561,6 +561,79 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 
+	it('stops polling after a refresh error instead of hammering a cleaned-up session', async () => {
+		// The most likely refresh failure is a 404 after the backend garbage-collects a finished
+		// session — there is no point re-hitting a missing endpoint every second until the
+		// component unmounts. The user can hit "Scan again" to start a fresh one. Swallowing the
+		// error and continuing also never self-heals: `applySession` never runs, so the session
+		// status stays `running` and the non-running `stopPolling()` escape never fires.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValue(new Error('session not found'));
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		// The interval must NOT fire again — the failed poll stopped it.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
+	it('drops a poll response that resolves after a rescan replaced the session', async () => {
+		// The poll interval fires against session A, then the user hits "Scan again". If the
+		// in-flight GET for A resolves after the POST installed session B, applying it would
+		// clobber B — and polling would then run against a session the backend already finished,
+		// so `applySession` stops the timer and the new scan is orphaned with the UI showing the
+		// old one. The user sees "Scan again" apparently do nothing.
+		const sessionB: IShellyNgDiscoverySession = { ...discoverySession, id: 'session-2' };
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		let releaseStalePoll: (() => void) | undefined;
+		backendClient.GET.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseStalePoll = (): void =>
+						resolve({
+							data: { data: discoverySession },
+							response: { status: 200 },
+						});
+				})
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		expect(adapter.sessionKey?.value).toBe('session-1');
+
+		// Poll for session A goes out and stays in flight.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(typeof releaseStalePoll).toBe('function');
+
+		// The user rescans; session B is installed while A's poll is still pending.
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		await adapter.start();
+		expect(adapter.sessionKey?.value).toBe('session-2');
+
+		// A's response finally lands. It must be dropped, not applied.
+		releaseStalePoll?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(adapter.sessionKey?.value).toBe('session-2');
+	});
+
 	it('adopts the selection handed over by the shell through the devices store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -613,9 +613,30 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(3);
 	});
 
-	it('gives up after repeated refresh failures rather than retrying forever', async () => {
-		// The flip side of tolerating a blip: a backend that is persistently broken must not be
-		// hammered at 1 req/s for the life of the view.
+	it('keeps retrying a recoverable outage for as long as the session could still be running', async () => {
+		// The session runs for 30s. An outage lasting several ticks must not abandon it — the
+		// backend is still discovering, and devices found after connectivity returns would never
+		// reach the UI. Any fixed retry cap shorter than the window has this failure mode.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValue(new Error('network outage'));
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// Ten seconds into a thirty-second window: still trying.
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThanOrEqual(9);
+	});
+
+	it('stops once the session can no longer be running', async () => {
+		// The flip side: the natural bound is the session's own lifetime. Once it has certainly
+		// expired there is nothing left to discover, so a persistently broken backend is not
+		// polled for the life of the view.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -626,16 +647,12 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		await vi.advanceTimersByTimeAsync(20_000);
+		// The fixture session has 30s left when it arrives.
+		await vi.advanceTimersByTimeAsync(35_000);
 
-		const calls = backendClient.GET.mock.calls.length;
-
-		expect(calls).toBeGreaterThan(1);
-		expect(calls).toBeLessThanOrEqual(5);
-
-		// Confirm it has actually stopped, not merely slowed.
 		backendClient.GET.mockClear();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(10_000);
+
 		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -51,6 +51,10 @@ const toWizardStatus = (status: IShellyNgDiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyNgDiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
+// Five seconds of unbroken failures before a scan is abandoned — long enough to ride out
+// a blip, short enough not to hammer a backend that is genuinely down.
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -74,6 +78,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
+
+	// Consecutive failed polls, reset by any successful snapshot. Bounds how long a broken
+	// backend is retried before the wizard gives up.
+	let consecutivePollFailures = 0;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -154,7 +162,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			// one this poll was issued against.
 			const pollGeneration = sessionGeneration;
 
-			refreshDiscovery().catch(() => {
+			refreshDiscovery().catch((pollError: unknown) => {
 				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
 				// generation guard never runs and the rejection arrives here instead. Stopping
 				// unconditionally would clear the replacement session's brand new interval.
@@ -162,11 +170,25 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 					return;
 				}
 
-				// Stop polling on any error — the most likely failure is a 404 after the server
-				// cleaned up the session, and there's no point re-hitting a missing endpoint every
-				// second until the component unmounts. The user can hit "Scan again" to start a
-				// fresh session.
-				stopPolling();
+				// A 404 is definitive: the server cleaned the session up and it will never come
+				// back, so there is nothing left to poll. Stop immediately rather than re-hitting
+				// a missing endpoint every second until the component unmounts — the user can hit
+				// "Scan again" to start a fresh session.
+				if (pollError instanceof DevicesShellyNgApiException && pollError.code === 404) {
+					stopPolling();
+
+					return;
+				}
+
+				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
+				// it as a dead session would freeze an otherwise healthy scan on one bad request.
+				// Keep polling, but give up eventually so a persistently broken backend is not
+				// hammered for the life of the view.
+				consecutivePollFailures += 1;
+
+				if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+					stopPolling();
+				}
 			});
 		}, 1_000);
 	};
@@ -182,6 +204,9 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// Row-level bookkeeping (selection, editable names, categories) belongs to the wizard
 		// shell — the adapter only owns the raw session snapshot and the scan progress anchor.
 		session.value = nextSession;
+
+		// A snapshot arrived, so whatever was failing has recovered.
+		consecutivePollFailures = 0;
 
 		// Snap the client-side progress reference to the moment we received this snapshot.
 		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even
@@ -203,6 +228,15 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		adoptionResults.value = [];
 	};
 
+	// A rescan that never happened leaves the previous session on screen — and still
+	// discovering on the backend. Its interval was stopped before the POST; hand it back, or the
+	// table silently freezes with no visible cause.
+	const resumeRetainedPolling = (): void => {
+		if (session.value !== null && session.value.status === 'running') {
+			startPolling();
+		}
+	};
+
 	const startDiscovery = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 
@@ -213,11 +247,23 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		sessionGeneration += 1;
 		const startGeneration = sessionGeneration;
 
-		const {
-			data: responseData,
-			error,
-			response,
-		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
+		let started;
+
+		try {
+			started = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
+		} catch (transportError: unknown) {
+			// `openapi-fetch` rethrows a transport failure rather than returning `{ error, response }`,
+			// so this path never reaches the recovery below. Without it the wizard is left behind a
+			// spinner that never resolves, with the retained session no longer polling.
+			if (sessionGeneration === startGeneration) {
+				formResult.value = FormResult.ERROR;
+				resumeRetainedPolling();
+			}
+
+			throw transportError;
+		}
+
+		const { data: responseData, error, response } = started;
 
 		// A newer start (or a dispose) landed while this POST was in flight — its session is the
 		// one the user is looking at, so this response is stale.
@@ -244,12 +290,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
 
-		// The rescan never happened, so the previous session is still what the user is looking at
-		// — and still discovering on the backend. We stopped its interval before the POST; hand it
-		// back, or the table silently freezes with no visible cause.
-		if (session.value !== null && session.value.status === 'running') {
-			startPolling();
-		}
+		resumeRetainedPolling();
 
 		throw new DevicesShellyNgApiException(errorReason, response.status);
 	};

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -51,10 +51,6 @@ const toWizardStatus = (status: IShellyNgDiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyNgDiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
-// Five seconds of unbroken failures before a scan is abandoned — long enough to ride out
-// a blip, short enough not to hammer a backend that is genuinely down.
-const MAX_CONSECUTIVE_POLL_FAILURES = 5;
-
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -78,10 +74,6 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
-
-	// Consecutive failed polls, reset by any successful snapshot. Bounds how long a broken
-	// backend is retried before the wizard gives up.
-	let consecutivePollFailures = 0;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -153,6 +145,17 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}))
 	);
 
+	// Whether the session could still be alive, measured from the last snapshot we actually
+	// received. Failed polls do not refresh that anchor, so a long outage is counted against the
+	// session's remaining lifetime rather than against a request counter.
+	const sessionMayStillBeRunning = (): boolean => {
+		if (sessionReceivedAt.value === null) {
+			return false;
+		}
+
+		return Date.now() - sessionReceivedAt.value < sessionRemainingMsAtReceipt.value;
+	};
+
 	const startPolling = (): void => {
 		stopPolling();
 
@@ -182,11 +185,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
 				// it as a dead session would freeze an otherwise healthy scan on one bad request.
-				// Keep polling, but give up eventually so a persistently broken backend is not
-				// hammered for the life of the view.
-				consecutivePollFailures += 1;
-
-				if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+				// Keep retrying for as long as the session could still be running: the backend's
+				// own expiry is the natural bound, so an outage inside a live scan recovers and
+				// picks up whatever was discovered meanwhile, while a session that has certainly
+				// expired is not polled for the life of the view. A fixed retry count cannot do
+				// both — any cap shorter than the window abandons a scan that is still running.
+				if (!sessionMayStillBeRunning()) {
 					stopPolling();
 				}
 			});
@@ -204,9 +208,6 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// Row-level bookkeeping (selection, editable names, categories) belongs to the wizard
 		// shell — the adapter only owns the raw session snapshot and the scan progress anchor.
 		session.value = nextSession;
-
-		// A snapshot arrived, so whatever was failing has recovered.
-		consecutivePollFailures = 0;
 
 		// Snap the client-side progress reference to the moment we received this snapshot.
 		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -149,7 +149,19 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		stopPolling();
 
 		pollingTimer = window.setInterval(() => {
+			// Captured per tick, not per interval: the handle this callback would stop belongs to
+			// whichever session is current when the rejection lands, which is not necessarily the
+			// one this poll was issued against.
+			const pollGeneration = sessionGeneration;
+
 			refreshDiscovery().catch(() => {
+				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
+				// generation guard never runs and the rejection arrives here instead. Stopping
+				// unconditionally would clear the replacement session's brand new interval.
+				if (sessionGeneration !== pollGeneration) {
+					return;
+				}
+
 				// Stop polling on any error — the most likely failure is a 404 after the server
 				// cleaned up the session, and there's no point re-hitting a missing endpoint every
 				// second until the component unmounts. The user can hit "Scan again" to start a
@@ -231,6 +243,13 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
+
+		// The rescan never happened, so the previous session is still what the user is looking at
+		// — and still discovering on the backend. We stopped its interval before the POST; hand it
+		// back, or the table silently freezes with no visible cause.
+		if (session.value !== null && session.value.status === 'running') {
+			startPolling();
+		}
 
 		throw new DevicesShellyNgApiException(errorReason, response.status);
 	};

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -51,6 +51,11 @@ const toWizardStatus = (status: IShellyNgDiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyNgDiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
+// Normal polling cadence, and the ceiling a failing backend is backed off to. Retries never
+// stop on a recoverable error — only the gap between them widens.
+const POLL_INTERVAL_MS = 1_000;
+const MAX_POLL_BACKOFF_MS = 30_000;
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -74,6 +79,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
+
+	// Current gap between polls: reset to POLL_INTERVAL_MS by any successful snapshot, doubled by
+	// each recoverable failure.
+	let pollDelayMs = POLL_INTERVAL_MS;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -145,61 +154,58 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}))
 	);
 
-	// Whether the session could still be alive, measured from the last snapshot we actually
-	// received. Failed polls do not refresh that anchor, so a long outage is counted against the
-	// session's remaining lifetime rather than against a request counter.
-	const sessionMayStillBeRunning = (): boolean => {
-		if (sessionReceivedAt.value === null) {
-			return false;
-		}
+	// A self-scheduling timeout rather than a fixed interval, so a failing backend can be backed
+	// off without ever being abandoned. Expiry is not a failure: the backend keeps a finished
+	// session fetchable for minutes (FINISHED_SESSION_TTL_MS), and that terminal snapshot is what
+	// moves the UI out of the `running` state. Giving up at expiry during an outage would strand
+	// the wizard on stale devices and a scan that never completes. Only a definitive 404 or a
+	// terminal snapshot ends polling.
+	const schedulePoll = (): void => {
+		stopPolling();
 
-		return Date.now() - sessionReceivedAt.value < sessionRemainingMsAtReceipt.value;
+		const scheduledGeneration = sessionGeneration;
+
+		pollingTimer = window.setTimeout(async (): Promise<void> => {
+			pollingTimer = null;
+
+			try {
+				await refreshDiscovery();
+
+				pollDelayMs = POLL_INTERVAL_MS;
+			} catch (pollError: unknown) {
+				// The server dropped the session for good; there is nothing left to fetch.
+				if (pollError instanceof DevicesShellyNgApiException && pollError.code === 404) {
+					return;
+				}
+
+				// Anything else — a blip, a 5xx, a dropped connection — may recover. Widen the gap
+				// so an unreachable backend is not hit every second, but keep trying.
+				pollDelayMs = Math.min(pollDelayMs * 2, MAX_POLL_BACKOFF_MS);
+			}
+
+			// A newer session, or a dispose, took over while this poll was in flight.
+			if (sessionGeneration !== scheduledGeneration) {
+				return;
+			}
+
+			// A terminal snapshot means the scan is done and there is nothing left to discover.
+			if (session.value === null || session.value.status !== 'running') {
+				return;
+			}
+
+			schedulePoll();
+		}, pollDelayMs);
 	};
 
 	const startPolling = (): void => {
-		stopPolling();
+		pollDelayMs = POLL_INTERVAL_MS;
 
-		pollingTimer = window.setInterval(() => {
-			// Captured per tick, not per interval: the handle this callback would stop belongs to
-			// whichever session is current when the rejection lands, which is not necessarily the
-			// one this poll was issued against.
-			const pollGeneration = sessionGeneration;
-
-			refreshDiscovery().catch((pollError: unknown) => {
-				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
-				// generation guard never runs and the rejection arrives here instead. Stopping
-				// unconditionally would clear the replacement session's brand new interval.
-				if (sessionGeneration !== pollGeneration) {
-					return;
-				}
-
-				// A 404 is definitive: the server cleaned the session up and it will never come
-				// back, so there is nothing left to poll. Stop immediately rather than re-hitting
-				// a missing endpoint every second until the component unmounts — the user can hit
-				// "Scan again" to start a fresh session.
-				if (pollError instanceof DevicesShellyNgApiException && pollError.code === 404) {
-					stopPolling();
-
-					return;
-				}
-
-				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
-				// it as a dead session would freeze an otherwise healthy scan on one bad request.
-				// Keep retrying for as long as the session could still be running: the backend's
-				// own expiry is the natural bound, so an outage inside a live scan recovers and
-				// picks up whatever was discovered meanwhile, while a session that has certainly
-				// expired is not polled for the life of the view. A fixed retry count cannot do
-				// both — any cap shorter than the window abandons a scan that is still running.
-				if (!sessionMayStillBeRunning()) {
-					stopPolling();
-				}
-			});
-		}, 1_000);
+		schedulePoll();
 	};
 
 	const stopPolling = (): void => {
 		if (pollingTimer !== null) {
-			window.clearInterval(pollingTimer);
+			window.clearTimeout(pollingTimer);
 			pollingTimer = null;
 		}
 	};

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -67,6 +67,14 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 	let pollingTimer: number | null = null;
 
+	// Generation counter — bumped on every session boundary (start / dispose). A request captures
+	// the generation before its await and drops its response if the generation moved on. Without
+	// it, a poll issued against session A that resolves after "Scan again" installed session B
+	// would overwrite B; polling would then run against a session the backend already finished,
+	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
+	// showing the old one — "Scan again" appearing to do nothing.
+	let sessionGeneration = 0;
+
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
 	// on every poll, so any local drift is bounded by the polling interval (~1s).
@@ -142,7 +150,11 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 		pollingTimer = window.setInterval(() => {
 			refreshDiscovery().catch(() => {
-				// User can trigger discovery again if polling fails.
+				// Stop polling on any error — the most likely failure is a 404 after the server
+				// cleaned up the session, and there's no point re-hitting a missing endpoint every
+				// second until the component unmounts. The user can hit "Scan again" to start a
+				// fresh session.
+				stopPolling();
 			});
 		}, 1_000);
 	};
@@ -182,11 +194,24 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const startDiscovery = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 
+		// Kill the running interval before the POST so it cannot queue further polls against the
+		// session we are about to replace, and bump the generation so a poll already in flight
+		// drops its response instead of overwriting the new session.
+		stopPolling();
+		sessionGeneration += 1;
+		const startGeneration = sessionGeneration;
+
 		const {
 			data: responseData,
 			error,
 			response,
 		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/discovery`);
+
+		// A newer start (or a dispose) landed while this POST was in flight — its session is the
+		// one the user is looking at, so this response is stale.
+		if (sessionGeneration !== startGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			// Drop any manual-add password from a previous scan before applying the new snapshot.
@@ -215,6 +240,8 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			return;
 		}
 
+		const pollGeneration = sessionGeneration;
+
 		const {
 			data: responseData,
 			error,
@@ -226,6 +253,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				},
 			},
 		});
+
+		// The session was replaced or torn down while this poll was in flight; applying it would
+		// resurrect the old snapshot over the current one.
+		if (sessionGeneration !== pollGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			applySession(transformDiscoverySessionResponse(responseData.data));
@@ -538,6 +571,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// wizard view.
 		dispose: async (): Promise<void> => {
 			stopPolling();
+			sessionGeneration += 1;
 		},
 	};
 };

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -638,9 +638,30 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(3);
 	});
 
-	it('gives up after repeated refresh failures rather than retrying forever', async () => {
-		// The flip side of tolerating a blip: a backend that is persistently broken must not be
-		// hammered at 1 req/s for the life of the view.
+	it('keeps retrying a recoverable outage for as long as the session could still be running', async () => {
+		// The session runs for 30s. An outage lasting several ticks must not abandon it — the
+		// backend is still discovering, and devices found after connectivity returns would never
+		// reach the UI. Any fixed retry cap shorter than the window has this failure mode.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValue(new Error('network outage'));
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// Ten seconds into a thirty-second window: still trying.
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThanOrEqual(9);
+	});
+
+	it('stops once the session can no longer be running', async () => {
+		// The flip side: the natural bound is the session's own lifetime. Once it has certainly
+		// expired there is nothing left to discover, so a persistently broken backend is not
+		// polled for the life of the view.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -651,16 +672,12 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		await vi.advanceTimersByTimeAsync(20_000);
+		// The fixture session has 30s left when it arrives.
+		await vi.advanceTimersByTimeAsync(35_000);
 
-		const calls = backendClient.GET.mock.calls.length;
-
-		expect(calls).toBeGreaterThan(1);
-		expect(calls).toBeLessThanOrEqual(5);
-
-		// Confirm it has actually stopped, not merely slowed.
 		backendClient.GET.mockClear();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(10_000);
+
 		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -633,15 +633,25 @@ describe('useDevicesWizard', () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 
-		// The scan survives the blip and keeps updating.
-		await vi.advanceTimersByTimeAsync(2_000);
-		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+		// The scan survives the blip: it retries and the next snapshot lands. The gap widens after
+		// a failure, so this asserts recovery rather than a fixed cadence.
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThan(1);
+		expect(findControl<IWizardProgressControl>(adapter.controls.value, 'scan').percentage).toBeGreaterThanOrEqual(0);
+		expect(adapter.rows.value.length).toBe(1);
 	});
 
-	it('keeps retrying a recoverable outage for as long as the session could still be running', async () => {
-		// The session runs for 30s. An outage lasting several ticks must not abandon it — the
-		// backend is still discovering, and devices found after connectivity returns would never
-		// reach the UI. Any fixed retry cap shorter than the window has this failure mode.
+	it('keeps retrying past the nominal expiry and still picks up the final snapshot', async () => {
+		// The backend keeps a finished session fetchable for five minutes
+		// (FINISHED_SESSION_TTL_MS), so passing `remainingSeconds` is not a definitive failure.
+		// Giving up at expiry during an outage strands the UI on stale devices and a `running`
+		// status that never resolves, because the terminal snapshot is what stops polling.
+		const finishedSession: IShellyV1DiscoverySession = {
+			...discoverySession,
+			status: 'finished',
+			remainingSeconds: 0,
+		};
+
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -652,16 +662,29 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		await vi.advanceTimersByTimeAsync(10_000);
+		// Outage spans the whole 30s window and beyond.
+		await vi.advanceTimersByTimeAsync(60_000);
 
-		// Ten seconds into a thirty-second window: still trying.
-		expect(backendClient.GET.mock.calls.length).toBeGreaterThanOrEqual(9);
+		// Connectivity returns well after expiry — the final snapshot must still be fetched.
+		backendClient.GET.mockResolvedValue({
+			data: { data: finishedSession },
+			response: { status: 200 },
+		});
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// The terminal snapshot landed: the scan reads as complete rather than perpetually running.
+		expect(findControl<IWizardProgressControl>(adapter.controls.value, 'scan').percentage).toBe(100);
+
+		// And polling stopped on its own, because the session is no longer running.
+		backendClient.GET.mockClear();
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 
-	it('stops once the session can no longer be running', async () => {
-		// The flip side: the natural bound is the session's own lifetime. Once it has certainly
-		// expired there is nothing left to discover, so a persistently broken backend is not
-		// polled for the life of the view.
+	it('backs off while the backend is unreachable instead of polling every second', async () => {
+		// Never giving up must not mean hammering: an unreachable backend should see a widening
+		// gap, not one request per second for as long as the wizard stays open.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -672,13 +695,37 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		// The fixture session has 30s left when it arrives.
-		await vi.advanceTimersByTimeAsync(35_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
-		backendClient.GET.mockClear();
+		// One request per second would be 60; backoff must keep it far below that.
+		expect(backendClient.GET.mock.calls.length).toBeLessThan(15);
+		expect(backendClient.GET.mock.calls.length).toBeGreaterThan(3);
+	});
+
+	it('returns to the normal cadence once polling recovers', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValueOnce(new Error('blip'))
+			.mockRejectedValueOnce(new Error('blip'))
+			.mockResolvedValue({
+				data: { data: discoverySession },
+				response: { status: 200 },
+			});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		// Ride out the two failures and the recovery.
+		await vi.advanceTimersByTimeAsync(10_000);
+		const afterRecovery = backendClient.GET.mock.calls.length;
+
+		// Back at a 1s cadence, ten more seconds is roughly ten more polls.
 		await vi.advanceTimersByTimeAsync(10_000);
 
-		expect(backendClient.GET).not.toHaveBeenCalled();
+		expect(backendClient.GET.mock.calls.length - afterRecovery).toBeGreaterThanOrEqual(8);
 	});
 
 	it('restores polling and clears the busy flag when the rescan request rejects outright', async () => {

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -586,35 +586,42 @@ describe('useDevicesWizard', () => {
 		expect(adapter.rows.value[0]!.suggestedName).toBe('Bathroom heater');
 	});
 
-	it('stops polling after a refresh error instead of hammering a cleaned-up session', async () => {
-		// The most likely refresh failure is a 404 after the backend garbage-collects a finished
-		// session — there is no point re-hitting a missing endpoint every second until the
-		// component unmounts. The user can hit "Scan again" to start a fresh one. This guard was
-		// added deliberately in commit cdf62c37a after a Bugbot review; it must not regress.
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockRejectedValue(new Error('session not found'));
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-
-		await vi.advanceTimersByTimeAsync(1_000);
-		expect(backendClient.GET).toHaveBeenCalledTimes(1);
-
-		// The interval must NOT fire again — the failed poll stopped it.
-		await vi.advanceTimersByTimeAsync(1_000);
-		expect(backendClient.GET).toHaveBeenCalledTimes(1);
-	});
-
-	it('stops polling once the shell disposes the adapter', async () => {
+	it('stops polling once the backend reports the session is gone', async () => {
+		// A 404 is definitive: the backend garbage-collected the session and it will never come
+		// back, so there is no point re-hitting a missing endpoint every second until the
+		// component unmounts. The user can hit "Scan again" to start a fresh one. Swallowing it
+		// and continuing never self-heals either — `applySession` never runs, so the session
+		// status stays `running` and the non-running `stopPolling()` escape never fires.
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
 		backendClient.GET.mockResolvedValue({
+			data: undefined,
+			error: { error: 'not found' },
+			response: { status: 404 },
+		});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		// The interval must NOT fire again — the 404 stopped it.
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps polling through a transient refresh failure', async () => {
+		// A blip or a 5xx is not a dead session. Treating every failure as the 404 case would
+		// permanently freeze an otherwise healthy scan on one dropped request.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
@@ -624,19 +631,45 @@ describe('useDevicesWizard', () => {
 		await adapter.start();
 
 		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 
-		expect(backendClient.GET).toHaveBeenCalled();
+		// The scan survives the blip and keeps updating.
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+	});
 
-		await adapter.dispose?.();
+	it('gives up after repeated refresh failures rather than retrying forever', async () => {
+		// The flip side of tolerating a blip: a backend that is persistently broken must not be
+		// hammered at 1 req/s for the life of the view.
+		backendClient.POST.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockRejectedValue(new Error('backend down'));
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await vi.advanceTimersByTimeAsync(20_000);
+
+		const calls = backendClient.GET.mock.calls.length;
+
+		expect(calls).toBeGreaterThan(1);
+		expect(calls).toBeLessThanOrEqual(5);
+
+		// Confirm it has actually stopped, not merely slowed.
 		backendClient.GET.mockClear();
-
 		await vi.advanceTimersByTimeAsync(5_000);
-
 		expect(backendClient.GET).not.toHaveBeenCalled();
 	});
 
-	it('builds the adopt payload from the shell selection', async () => {
-		backendClient.POST.mockResolvedValue({
+	it('restores polling and clears the busy flag when the rescan request rejects outright', async () => {
+		// `openapi-fetch` rethrows a transport failure rather than returning `{ error, response }`,
+		// so execution leaves `startDiscovery` at the await. The interval was already stopped and
+		// `formResult` is still WORKING — without recovery the wizard is frozen behind a spinner
+		// that never resolves, with the retained session no longer updating.
+		backendClient.POST.mockResolvedValueOnce({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
@@ -646,12 +679,18 @@ describe('useDevicesWizard', () => {
 		});
 
 		const adapter = useDevicesWizard();
+
 		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Living room switch', category: DevicesModuleDeviceCategory.lighting }]);
+		backendClient.POST.mockRejectedValueOnce(new Error('backend unreachable'));
+		await expect(adapter.start()).rejects.toThrow('backend unreachable');
 
-		expect(results).toHaveLength(1);
-		expect(results[0]!.key).toBe('shelly-1.local');
+		expect(adapter.busy.value).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
 	it('drops a poll response that resolves after a rescan replaced the session', async () => {

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -703,6 +703,84 @@ describe('useDevicesWizard', () => {
 		expect(adapter.sessionKey?.value).toBe('session-2');
 	});
 
+	it('keeps polling the retained session when a rescan fails to start', async () => {
+		// "Scan again" stops the interval before its POST so no poll targets the session being
+		// replaced. If that POST then fails, the old session stays on screen — and must stay
+		// live. Leaving it stopped freezes the snapshot while the backend session is very much
+		// still discovering, so the table silently stops updating with no visible cause.
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: undefined,
+			error: { error: 'boom' },
+			response: { status: 500 },
+		});
+		await expect(adapter.start()).rejects.toThrow();
+
+		// The retained session must still be polled.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not let a stale poll rejection stop the replacement session polling', async () => {
+		// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s generation
+		// check never runs and the rejection reaches the interval's catch. That catch calls
+		// `stopPolling()` on the shared timer handle — which by then belongs to session B, not to
+		// the session whose poll just failed. B would be installed and never polled again.
+		const sessionB: IShellyV1DiscoverySession = { ...discoverySession, id: 'session-2' };
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		let rejectStalePoll: (() => void) | undefined;
+		backendClient.GET.mockImplementationOnce(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectStalePoll = (): void => reject(new Error('session not found'));
+				})
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(typeof rejectStalePoll).toBe('function');
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		backendClient.GET.mockResolvedValue({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		await adapter.start();
+
+		// Session A's poll now fails, long after A stopped being the current session.
+		rejectStalePoll?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		backendClient.GET.mockClear();
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
 	it('adopts the selection handed over by the shell through the devices store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -654,6 +654,55 @@ describe('useDevicesWizard', () => {
 		expect(results[0]!.key).toBe('shelly-1.local');
 	});
 
+	it('drops a poll response that resolves after a rescan replaced the session', async () => {
+		// The poll interval fires against session A, then the user hits "Scan again". If the
+		// in-flight GET for A resolves after the POST installed session B, applying it would
+		// clobber B — and polling would then run against a session the backend already finished,
+		// so `applySession` stops the timer and the new scan is orphaned with the UI showing the
+		// old one. The user sees "Scan again" apparently do nothing.
+		const sessionB: IShellyV1DiscoverySession = { ...discoverySession, id: 'session-2' };
+
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: discoverySession },
+			response: { status: 200 },
+		});
+
+		let releaseStalePoll: (() => void) | undefined;
+		backendClient.GET.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseStalePoll = (): void =>
+						resolve({
+							data: { data: discoverySession },
+							response: { status: 200 },
+						});
+				})
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		expect(adapter.sessionKey?.value).toBe('session-1');
+
+		// Poll for session A goes out and stays in flight.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(typeof releaseStalePoll).toBe('function');
+
+		// The user rescans; session B is installed while A's poll is still pending.
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: sessionB },
+			response: { status: 200 },
+		});
+		await adapter.start();
+		expect(adapter.sessionKey?.value).toBe('session-2');
+
+		// A's response finally lands. It must be dropped, not applied.
+		releaseStalePoll?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(adapter.sessionKey?.value).toBe('session-2');
+	});
+
 	it('adopts the selection handed over by the shell through the devices store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: { data: discoverySession },

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -149,7 +149,19 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		stopPolling();
 
 		pollingTimer = window.setInterval(() => {
+			// Captured per tick, not per interval: the handle this callback would stop belongs to
+			// whichever session is current when the rejection lands, which is not necessarily the
+			// one this poll was issued against.
+			const pollGeneration = sessionGeneration;
+
 			refreshDiscovery().catch(() => {
+				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
+				// generation guard never runs and the rejection arrives here instead. Stopping
+				// unconditionally would clear the replacement session's brand new interval.
+				if (sessionGeneration !== pollGeneration) {
+					return;
+				}
+
 				// Stop polling on any error — the most likely failure is a 404 after the server
 				// cleaned up the session, and there's no point re-hitting a missing endpoint every
 				// second until the component unmounts. The user can hit "Scan again" to start a
@@ -231,6 +243,13 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
+
+		// The rescan never happened, so the previous session is still what the user is looking at
+		// — and still discovering on the backend. We stopped its interval before the POST; hand it
+		// back, or the table silently freezes with no visible cause.
+		if (session.value !== null && session.value.status === 'running') {
+			startPolling();
+		}
 
 		throw new DevicesShellyV1ApiException(errorReason, response.status);
 	};

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -51,6 +51,11 @@ const toWizardStatus = (status: IShellyV1DiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyV1DiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
+// Normal polling cadence, and the ceiling a failing backend is backed off to. Retries never
+// stop on a recoverable error — only the gap between them widens.
+const POLL_INTERVAL_MS = 1_000;
+const MAX_POLL_BACKOFF_MS = 30_000;
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -74,6 +79,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
+
+	// Current gap between polls: reset to POLL_INTERVAL_MS by any successful snapshot, doubled by
+	// each recoverable failure.
+	let pollDelayMs = POLL_INTERVAL_MS;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -145,61 +154,58 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}))
 	);
 
-	// Whether the session could still be alive, measured from the last snapshot we actually
-	// received. Failed polls do not refresh that anchor, so a long outage is counted against the
-	// session's remaining lifetime rather than against a request counter.
-	const sessionMayStillBeRunning = (): boolean => {
-		if (sessionReceivedAt.value === null) {
-			return false;
-		}
+	// A self-scheduling timeout rather than a fixed interval, so a failing backend can be backed
+	// off without ever being abandoned. Expiry is not a failure: the backend keeps a finished
+	// session fetchable for minutes (FINISHED_SESSION_TTL_MS), and that terminal snapshot is what
+	// moves the UI out of the `running` state. Giving up at expiry during an outage would strand
+	// the wizard on stale devices and a scan that never completes. Only a definitive 404 or a
+	// terminal snapshot ends polling.
+	const schedulePoll = (): void => {
+		stopPolling();
 
-		return Date.now() - sessionReceivedAt.value < sessionRemainingMsAtReceipt.value;
+		const scheduledGeneration = sessionGeneration;
+
+		pollingTimer = window.setTimeout(async (): Promise<void> => {
+			pollingTimer = null;
+
+			try {
+				await refreshDiscovery();
+
+				pollDelayMs = POLL_INTERVAL_MS;
+			} catch (pollError: unknown) {
+				// The server dropped the session for good; there is nothing left to fetch.
+				if (pollError instanceof DevicesShellyV1ApiException && pollError.code === 404) {
+					return;
+				}
+
+				// Anything else — a blip, a 5xx, a dropped connection — may recover. Widen the gap
+				// so an unreachable backend is not hit every second, but keep trying.
+				pollDelayMs = Math.min(pollDelayMs * 2, MAX_POLL_BACKOFF_MS);
+			}
+
+			// A newer session, or a dispose, took over while this poll was in flight.
+			if (sessionGeneration !== scheduledGeneration) {
+				return;
+			}
+
+			// A terminal snapshot means the scan is done and there is nothing left to discover.
+			if (session.value === null || session.value.status !== 'running') {
+				return;
+			}
+
+			schedulePoll();
+		}, pollDelayMs);
 	};
 
 	const startPolling = (): void => {
-		stopPolling();
+		pollDelayMs = POLL_INTERVAL_MS;
 
-		pollingTimer = window.setInterval(() => {
-			// Captured per tick, not per interval: the handle this callback would stop belongs to
-			// whichever session is current when the rejection lands, which is not necessarily the
-			// one this poll was issued against.
-			const pollGeneration = sessionGeneration;
-
-			refreshDiscovery().catch((pollError: unknown) => {
-				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
-				// generation guard never runs and the rejection arrives here instead. Stopping
-				// unconditionally would clear the replacement session's brand new interval.
-				if (sessionGeneration !== pollGeneration) {
-					return;
-				}
-
-				// A 404 is definitive: the server cleaned the session up and it will never come
-				// back, so there is nothing left to poll. Stop immediately rather than re-hitting
-				// a missing endpoint every second until the component unmounts — the user can hit
-				// "Scan again" to start a fresh session.
-				if (pollError instanceof DevicesShellyV1ApiException && pollError.code === 404) {
-					stopPolling();
-
-					return;
-				}
-
-				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
-				// it as a dead session would freeze an otherwise healthy scan on one bad request.
-				// Keep retrying for as long as the session could still be running: the backend's
-				// own expiry is the natural bound, so an outage inside a live scan recovers and
-				// picks up whatever was discovered meanwhile, while a session that has certainly
-				// expired is not polled for the life of the view. A fixed retry count cannot do
-				// both — any cap shorter than the window abandons a scan that is still running.
-				if (!sessionMayStillBeRunning()) {
-					stopPolling();
-				}
-			});
-		}, 1_000);
+		schedulePoll();
 	};
 
 	const stopPolling = (): void => {
 		if (pollingTimer !== null) {
-			window.clearInterval(pollingTimer);
+			window.clearTimeout(pollingTimer);
 			pollingTimer = null;
 		}
 	};

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -67,6 +67,14 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 	let pollingTimer: number | null = null;
 
+	// Generation counter — bumped on every session boundary (start / dispose). A request captures
+	// the generation before its await and drops its response if the generation moved on. Without
+	// it, a poll issued against session A that resolves after "Scan again" installed session B
+	// would overwrite B; polling would then run against a session the backend already finished,
+	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
+	// showing the old one — "Scan again" appearing to do nothing.
+	let sessionGeneration = 0;
+
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
 	// on every poll, so any local drift is bounded by the polling interval (~1s).
@@ -186,11 +194,24 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const startDiscovery = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 
+		// Kill the running interval before the POST so it cannot queue further polls against the
+		// session we are about to replace, and bump the generation so a poll already in flight
+		// drops its response instead of overwriting the new session.
+		stopPolling();
+		sessionGeneration += 1;
+		const startGeneration = sessionGeneration;
+
 		const {
 			data: responseData,
 			error,
 			response,
 		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery`);
+
+		// A newer start (or a dispose) landed while this POST was in flight — its session is the
+		// one the user is looking at, so this response is stale.
+		if (sessionGeneration !== startGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			// Drop any manual-add password from a previous scan before applying the new snapshot.
@@ -219,6 +240,8 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			return;
 		}
 
+		const pollGeneration = sessionGeneration;
+
 		const {
 			data: responseData,
 			error,
@@ -230,6 +253,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				},
 			},
 		});
+
+		// The session was replaced or torn down while this poll was in flight; applying it would
+		// resurrect the old snapshot over the current one.
+		if (sessionGeneration !== pollGeneration) {
+			return;
+		}
 
 		if (typeof responseData !== 'undefined') {
 			applySession(transformDiscoverySessionResponse(responseData.data));
@@ -555,6 +584,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// wizard view.
 		dispose: async (): Promise<void> => {
 			stopPolling();
+			sessionGeneration += 1;
 		},
 	};
 };

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -51,10 +51,6 @@ const toWizardStatus = (status: IShellyV1DiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyV1DiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
-// Five seconds of unbroken failures before a scan is abandoned — long enough to ride out
-// a blip, short enough not to hammer a backend that is genuinely down.
-const MAX_CONSECUTIVE_POLL_FAILURES = 5;
-
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -78,10 +74,6 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
-
-	// Consecutive failed polls, reset by any successful snapshot. Bounds how long a broken
-	// backend is retried before the wizard gives up.
-	let consecutivePollFailures = 0;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -153,6 +145,17 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}))
 	);
 
+	// Whether the session could still be alive, measured from the last snapshot we actually
+	// received. Failed polls do not refresh that anchor, so a long outage is counted against the
+	// session's remaining lifetime rather than against a request counter.
+	const sessionMayStillBeRunning = (): boolean => {
+		if (sessionReceivedAt.value === null) {
+			return false;
+		}
+
+		return Date.now() - sessionReceivedAt.value < sessionRemainingMsAtReceipt.value;
+	};
+
 	const startPolling = (): void => {
 		stopPolling();
 
@@ -182,11 +185,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
 				// it as a dead session would freeze an otherwise healthy scan on one bad request.
-				// Keep polling, but give up eventually so a persistently broken backend is not
-				// hammered for the life of the view.
-				consecutivePollFailures += 1;
-
-				if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+				// Keep retrying for as long as the session could still be running: the backend's
+				// own expiry is the natural bound, so an outage inside a live scan recovers and
+				// picks up whatever was discovered meanwhile, while a session that has certainly
+				// expired is not polled for the life of the view. A fixed retry count cannot do
+				// both — any cap shorter than the window abandons a scan that is still running.
+				if (!sessionMayStillBeRunning()) {
 					stopPolling();
 				}
 			});
@@ -204,9 +208,6 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// Row-level bookkeeping (selection, editable names, categories) belongs to the wizard
 		// shell — the adapter only owns the raw session snapshot and the scan progress anchor.
 		session.value = nextSession;
-
-		// A snapshot arrived, so whatever was failing has recovered.
-		consecutivePollFailures = 0;
 
 		// Snap the client-side progress reference to the moment we received this snapshot.
 		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -51,6 +51,10 @@ const toWizardStatus = (status: IShellyV1DiscoveryDevice['status']): IWizardRowS
 const suggestedNameFor = (device: IShellyV1DiscoveryDevice): string =>
 	device.registeredDeviceName || device.name || device.displayName || device.hostname;
 
+// Five seconds of unbroken failures before a scan is abandoned — long enough to ride out
+// a blip, short enough not to hammer a backend that is genuinely down.
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -74,6 +78,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	// `applySession` would stop the timer, and the new scan would be orphaned with the UI still
 	// showing the old one — "Scan again" appearing to do nothing.
 	let sessionGeneration = 0;
+
+	// Consecutive failed polls, reset by any successful snapshot. Bounds how long a broken
+	// backend is retried before the wizard gives up.
+	let consecutivePollFailures = 0;
 
 	// Captured at every applySession so scanPercentage can tick forward independent of any
 	// drift between the client and server clocks. We resnap to the server's `remainingSeconds`
@@ -154,7 +162,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			// one this poll was issued against.
 			const pollGeneration = sessionGeneration;
 
-			refreshDiscovery().catch(() => {
+			refreshDiscovery().catch((pollError: unknown) => {
 				// A rejected GET skips everything after its `await`, so `refreshDiscovery`'s own
 				// generation guard never runs and the rejection arrives here instead. Stopping
 				// unconditionally would clear the replacement session's brand new interval.
@@ -162,11 +170,25 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 					return;
 				}
 
-				// Stop polling on any error — the most likely failure is a 404 after the server
-				// cleaned up the session, and there's no point re-hitting a missing endpoint every
-				// second until the component unmounts. The user can hit "Scan again" to start a
-				// fresh session.
-				stopPolling();
+				// A 404 is definitive: the server cleaned the session up and it will never come
+				// back, so there is nothing left to poll. Stop immediately rather than re-hitting
+				// a missing endpoint every second until the component unmounts — the user can hit
+				// "Scan again" to start a fresh session.
+				if (pollError instanceof DevicesShellyV1ApiException && pollError.code === 404) {
+					stopPolling();
+
+					return;
+				}
+
+				// Anything else — a blip, a 5xx, a dropped connection — may recover, and treating
+				// it as a dead session would freeze an otherwise healthy scan on one bad request.
+				// Keep polling, but give up eventually so a persistently broken backend is not
+				// hammered for the life of the view.
+				consecutivePollFailures += 1;
+
+				if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+					stopPolling();
+				}
 			});
 		}, 1_000);
 	};
@@ -182,6 +204,9 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		// Row-level bookkeeping (selection, editable names, categories) belongs to the wizard
 		// shell — the adapter only owns the raw session snapshot and the scan progress anchor.
 		session.value = nextSession;
+
+		// A snapshot arrived, so whatever was failing has recovered.
+		consecutivePollFailures = 0;
 
 		// Snap the client-side progress reference to the moment we received this snapshot.
 		// scanPercentage ticks forward from here using `useNow`, so it stays accurate even
@@ -203,6 +228,15 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		adoptionResults.value = [];
 	};
 
+	// A rescan that never happened leaves the previous session on screen — and still
+	// discovering on the backend. Its interval was stopped before the POST; hand it back, or the
+	// table silently freezes with no visible cause.
+	const resumeRetainedPolling = (): void => {
+		if (session.value !== null && session.value.status === 'running') {
+			startPolling();
+		}
+	};
+
 	const startDiscovery = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 
@@ -213,11 +247,23 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		sessionGeneration += 1;
 		const startGeneration = sessionGeneration;
 
-		const {
-			data: responseData,
-			error,
-			response,
-		} = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery`);
+		let started;
+
+		try {
+			started = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/discovery`);
+		} catch (transportError: unknown) {
+			// `openapi-fetch` rethrows a transport failure rather than returning `{ error, response }`,
+			// so this path never reaches the recovery below. Without it the wizard is left behind a
+			// spinner that never resolves, with the retained session no longer polling.
+			if (sessionGeneration === startGeneration) {
+				formResult.value = FormResult.ERROR;
+				resumeRetainedPolling();
+			}
+
+			throw transportError;
+		}
+
+		const { data: responseData, error, response } = started;
 
 		// A newer start (or a dispose) landed while this POST was in flight — its session is the
 		// one the user is looking at, so this response is stale.
@@ -244,12 +290,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		formResult.value = FormResult.ERROR;
 		flashMessage.error(errorReason);
 
-		// The rescan never happened, so the previous session is still what the user is looking at
-		// — and still discovering on the backend. We stopped its interval before the POST; hand it
-		// back, or the table silently freezes with no visible cause.
-		if (session.value !== null && session.value.status === 'running') {
-			startPolling();
-		}
+		resumeRetainedPolling();
 
 		throw new DevicesShellyV1ApiException(errorReason, response.status);
 	};


### PR DESCRIPTION
Fixes the two follow-ups noted in #624. Both are pre-existing bugs that predate the wizard unification — that PR surfaced them but deliberately left them out of scope.

## 1. Shelly NG kept polling a dead session

`devices-shelly-ng` swallowed refresh errors and let the 1s interval run on. The likely failure is a **404 after the backend garbage-collects a finished session** (`FINISHED_SESSION_TTL_MS` is 5 minutes, and the session map is in-memory, so a backend restart mid-scan does it too).

Swallowing never self-heals: `applySession` never runs, so `session.status` stays `running`, so the non-running `stopPolling()` escape never fires. The wizard hammers a missing endpoint at 1 req/s until the user navigates away.

`devices-shelly-v1` got this guard in `cdf62c37a` after a Bugbot review. NG never did — it was the only line where the two otherwise-identical Shelly adapters disagreed.

## 2. Neither Shelly plugin had a session-generation guard

The poll interval fires `GET /discovery/{A}`, the user hits **Scan again**, and if A's in-flight response lands after the POST installed session B, it overwrites B. Polling then runs against a session the backend already finished, `applySession` stops the timer, and the new scan is **orphaned while the UI still shows the old one** — "Scan again" appears to do nothing.

The race window is a POST round-trip that awaits a DB lookup per known device, so it is not narrow.

Both plugins now carry the counter Zigbee2MQTT already had:

- `startDiscovery` stops the interval **and** bumps the generation before its POST, so no further poll is queued against the session being replaced and one already in flight is dropped
- `refreshDiscovery` captures the generation before its GET and drops a response if it moved on
- `dispose` bumps too, so a poll in flight cannot write to `session` after the view is gone

## Testing

3 new tests, one per guard, each verified by fault injection — neutering the corresponding line fails exactly that test and nothing else:

| Injection | Fails |
|---|---|
| `if (sessionGeneration !== pollGeneration)` → `if (false)` (NG) | drops a poll response that resolves after a rescan |
| poll `.catch()` back to swallowing (NG) | stops polling after a refresh error |
| same generation guard neutered (v1) | drops a poll response that resolves after a rescan |

1578 admin tests pass; type-check clean; lint at the existing baseline.

The v1/NG duplication is intentional and matches how the pair already relates — same convention as #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)