### PR TITLE
fix(admin): attach socket listeners when useSockets runs outside a component

### DIFF
--- a/apps/admin/src/common/composables/useSockets.spec.ts
+++ b/apps/admin/src/common/composables/useSockets.spec.ts
@@ -8,10 +8,15 @@ const mockTimeout = vi.fn(() => ({
 	emitWithAck: mockEmitWithAck,
 }));
 
+const mockOn = vi.fn();
+const mockOff = vi.fn();
+
 const socketInstanceMock = {
 	connected: false,
 	active: false,
 	timeout: mockTimeout,
+	on: mockOn,
+	off: mockOff,
 };
 
 vi.mock('../services/sockets', () => ({
@@ -24,6 +29,62 @@ describe('useSockets', () => {
 		socketInstanceMock.active = true;
 
 		mockEmitWithAck.mockReset();
+		mockOn.mockReset();
+		mockOff.mockReset();
+	});
+
+	it('subscribes to connect and disconnect when called outside a component setup', () => {
+		// `useSockets` is called from `scenes.store.ts` — a Pinia store setup, which runs with no
+		// active component instance. Plain `onMounted` silently declines to register there (Vue
+		// only warns), so the listeners were never attached and `connected` / `active` on that
+		// instance stayed frozen at their initial values for the life of the app.
+		useSockets();
+
+		expect(mockOn).toHaveBeenCalledWith('connect', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('disconnect', expect.any(Function));
+	});
+
+	it('tracks connect and disconnect events when called outside a component setup', () => {
+		socketInstanceMock.connected = false;
+		socketInstanceMock.active = false;
+
+		const { connected, active } = useSockets();
+
+		const onConnect = mockOn.mock.calls.find(([event]) => event === 'connect')?.[1] as () => void;
+		const onDisconnect = mockOn.mock.calls.find(([event]) => event === 'disconnect')?.[1] as () => void;
+
+		onConnect();
+		expect(connected.value).toBe(true);
+		expect(active.value).toBe(true);
+
+		onDisconnect();
+		expect(connected.value).toBe(false);
+		expect(active.value).toBe(false);
+	});
+
+	it('still defers to the component lifecycle when called inside a component setup', async () => {
+		// The fix must not regress the ordinary path: inside a component the subscription has to
+		// wait for mount and be released on unmount, not run eagerly during setup.
+		const { defineComponent } = await import('vue');
+		const { mount } = await import('@vue/test-utils');
+
+		const Host = defineComponent({
+			setup() {
+				useSockets();
+
+				return () => null;
+			},
+		});
+
+		const wrapper = mount(Host);
+
+		expect(mockOn).toHaveBeenCalledWith('connect', expect.any(Function));
+		expect(mockOff).not.toHaveBeenCalled();
+
+		wrapper.unmount();
+
+		expect(mockOff).toHaveBeenCalledWith('connect', expect.any(Function));
+		expect(mockOff).toHaveBeenCalledWith('disconnect', expect.any(Function));
 	});
 
 	it('returns connected and active state', () => {

--- a/apps/admin/src/common/composables/useSockets.ts
+++ b/apps/admin/src/common/composables/useSockets.ts
@@ -1,6 +1,8 @@
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { ref } from 'vue';
 
 import { v4 as uuid } from 'uuid';
+
+import { tryOnMounted, tryOnScopeDispose } from '@vueuse/core';
 
 import { injectSockets } from '../services/sockets';
 
@@ -22,7 +24,13 @@ export const useSockets = (): IUseSockets => {
 		active.value = false;
 	};
 
-	onMounted(() => {
+	// `tryOnMounted`, not `onMounted`: this composable is also called from a Pinia store setup
+	// (`scenes_module-scenes`) and from composables that stores reach through, none of which run
+	// with an active component instance. Plain `onMounted` only warns and declines to register
+	// there, so the listeners were never attached and `connected` / `active` stayed frozen at
+	// their initial values. `tryOnMounted` runs the callback immediately when there is no
+	// instance to defer to.
+	tryOnMounted(() => {
 		// Sync initial state (may have changed since ref was created)
 		connected.value = sockets.connected;
 		active.value = sockets.active;
@@ -31,7 +39,10 @@ export const useSockets = (): IUseSockets => {
 		sockets.on('disconnect', onDisconnect);
 	});
 
-	onBeforeUnmount(() => {
+	// Scope-based rather than `onBeforeUnmount` for the same reason, and because it is the
+	// correct counterpart: a store's effect scope outlives every component, so its listeners are
+	// released when the scope is disposed instead of when some unrelated component unmounts.
+	tryOnScopeDispose(() => {
 		sockets.off('connect', onConnect);
 		sockets.off('disconnect', onDisconnect);
 	});


### PR DESCRIPTION
Fixes the `onMounted is called when there is no active component instance` warning that fires once per page load, and the dead listeners behind it.

## The bug

`useSockets` registered its connect/disconnect handlers with `onMounted`:

```ts
onMounted(() => {
	connected.value = sockets.connected;
	active.value = sockets.active;
	sockets.on('connect', onConnect);
	sockets.on('disconnect', onDisconnect);
});
```

But it is also called from **`modules/scenes/store/scenes.store.ts:57` — inside a Pinia store setup**, which runs with no active component instance. Vue only *warns* there and declines to register the hook, so **those listeners were never attached**: `connected` and `active` on that instance stayed frozen at their construction-time values for the life of the app.

Two further call sites reach the same path: `modules/system/composables/useSystemActions.ts` and `modules/devices/composables/useDeviceControl.ts`.

This is what produces the paired `onMounted` / `onBeforeUnmount` warnings in the dev console — 19 of them in a single ~100-minute session, one per page load.

## The fix

`tryOnMounted` / `tryOnScopeDispose` from `@vueuse/core` — the pattern four Shelly composables in this repo already use. `tryOnMounted` runs the callback immediately when there is no instance to defer to, and still defers to mount when there is one.

`tryOnScopeDispose` rather than `onBeforeUnmount` is the correct counterpart for a store: its effect scope outlives every component, so listeners are released when that scope is disposed instead of when some unrelated component happens to unmount.

## Why the existing tests missed it

The spec's socket mock had **no `on` or `off` at all**, so the mount hook was never exercised — had it ever fired in a test, it would have thrown `sockets.on is not a function`.

Both are now mocked, with three added tests:

- listeners attach when called outside a component setup
- the attached handlers actually drive `connected` / `active` through connect and disconnect
- called inside a component, it still waits for mount and releases on unmount

Verified by fault injection: reverting to plain `onMounted` / `onBeforeUnmount` fails exactly the two outside-a-component tests and leaves the in-component one passing.

1578 admin tests pass; type-check clean; lint at the existing baseline.

## Not included

One other real warning remains, left as a separate follow-up: `Extraneous non-props attributes (type)` on `ViewDevices`. The parent `devices` route uses `props: true`, so when the `wizard/:type` child matches, `route.params.type` is spread onto the parent, which declares only `id?` and renders a fragment. Cosmetic — no behavioural impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)