### PR TITLE
fix(admin): declare the wizard route param on the devices view

### DIFF
--- a/apps/admin/src/modules/devices/views/view-devices.spec.ts
+++ b/apps/admin/src/modules/devices/views/view-devices.spec.ts
@@ -3,7 +3,7 @@ import { computed, defineComponent, ref } from 'vue';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 
 import ViewDevices from './view-devices.vue';
 
@@ -124,8 +124,9 @@ vi.mock('../devices.exceptions', () => ({
 	DevicesException: Error,
 }));
 
-const mountView = () =>
+const mountView = (props: Record<string, unknown> = {}) =>
 	mount(ViewDevices, {
+		props,
 		global: {
 			stubs: {
 				ElButton: defineComponent({
@@ -163,6 +164,26 @@ describe('ViewDevices', () => {
 			name: 'devices',
 			matched: [],
 		};
+	});
+
+	it('accepts the wizard route param without leaving it as an extraneous attribute', async () => {
+		// The parent `devices` route uses `props: true`, so whenever the `wizard/:type` child
+		// matches, `route.params.type` is handed to this view as well. It renders a fragment, so
+		// an undeclared `type` cannot be auto-inherited and Vue warns on every render. Sibling
+		// parents (`view-device`, `view-channel`) already declare the params their children
+		// contribute for exactly this reason, even where they never read them.
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		try {
+			mountView({ type: 'devices-zigbee2mqtt-plugin' });
+			await flushPromises();
+
+			const extraneous = warn.mock.calls.filter(([message]) => String(message).includes('Extraneous non-props attributes'));
+
+			expect(extraneous).toEqual([]);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	it('opens the only installed wizard directly without showing the selection dialog', async () => {

--- a/apps/admin/src/modules/devices/views/view-devices.types.ts
+++ b/apps/admin/src/modules/devices/views/view-devices.types.ts
@@ -2,4 +2,12 @@ import type { IDevice } from '../store/devices.store.types';
 
 export interface IViewDevicesProps {
 	id?: IDevice['id'];
+	/**
+	 * Plugin type contributed by the `wizard/:type` child route. This view never reads it — the
+	 * parent route uses `props: true`, so every child param is handed here as well, and an
+	 * undeclared one cannot be auto-inherited onto a fragment root. Declaring it keeps Vue from
+	 * warning on every render, the same way `view-device` and `view-channel` declare the child
+	 * params they do not read.
+	 */
+	type?: string;
 }


### PR DESCRIPTION
Fixes the last of the Vue console warnings found while testing the device wizard — the follow-up left out of #626.

## The warning

```
[Vue warn]: Extraneous non-props attributes (type) were passed to component but could not
be automatically inherited because component renders fragment or text or teleport root nodes.
  at <ViewDevices type="devices-zigbee2mqtt-plugin" …>
```

17 occurrences in a single dev session — one per render while a wizard route is open.

## Cause

The parent `devices` route uses `props: true`:

```ts
{
	path: 'devices',
	component: () => import('../views/view-devices.vue'),
	props: true,
	children: [ …, { path: 'wizard/:type', … } ],
}
```

So whenever the `wizard/:type` child matches, `route.params.type` is handed to the **parent** as well. `view-devices.vue` renders a fragment (17 root nodes), so an undeclared attribute cannot be auto-inherited, and Vue warns on every render.

## Fix

`IViewDevicesProps` declared only `id`. Its sibling parents already declare the params their children contribute, even where they never read them:

| View | Declares | Actually reads |
|---|---|---|
| `view-device` | `id`, `channelId`, `propertyId` | `id` only |
| `view-channel` | `id`, `propertyId` | `id` only |
| `view-devices` | `id` | `id` |

That is why none of the others produce this warning — this view simply missed `type` when the wizard route was added. Added it with a comment explaining why an unread prop is declared.

I considered narrowing this one route to `props: (route) => ({ id: route.params.id })` instead, which is arguably tidier in isolation, but it would leave four sibling routes on a different pattern for no functional gain.

## Testing

The existing spec's `mountView` helper now accepts props. A new test mounts with `type` and asserts no `Extraneous non-props attributes` warning is emitted. Removing the declaration fails it.

1594 admin tests pass; type-check clean; lint at the existing baseline.

## Not a bug

For the record, the bulk of the warnings in that session — ~127 render-function and component-update errors — were HMR artifacts from an in-progress edit, not shipped defects. They stopped once the bundle was consistent and do not reproduce on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)