### PR TITLE
feat(backend): add MCP protocol and tool foundations

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,6 +87,8 @@
     "@fastify/static": "^10.1.2",
     "@fastybird/smart-panel-extension-sdk": "workspace:*",
     "@influxdata/influxdb-client": "^1.35.0",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.1.16",
     "@nestjs/config": "^4.0.3",
@@ -136,11 +138,13 @@
     "ulid": "^3.0.2",
     "uuid": "^13.0.0",
     "ws": "^8.19.0",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
+    "@modelcontextprotocol/client": "2.0.0",
     "@nestjs/cli": "^11.0.16",
     "@nestjs/schematics": "^11.0.9",
     "@nestjs/testing": "^11.1.16",

--- a/apps/backend/src/modules/devices/devices.module.ts
+++ b/apps/backend/src/modules/devices/devices.module.ts
@@ -164,6 +164,7 @@ import { DeviceNotHiddenConstraintValidator } from './validators/device-not-hidd
 		DevicesSeederService,
 		PlatformRegistryService,
 		PropertyValueSourceRegistryService,
+		PropertyCommandService,
 		DeviceExistsConstraintValidator,
 		DeviceNotHiddenConstraintValidator,
 		ChannelExistsConstraintValidator,

--- a/apps/backend/src/modules/devices/services/device-control-tool.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/device-control-tool.service.spec.ts
@@ -1,206 +1,150 @@
-import { IntentTargetStatus } from '../../intents/intents.constants';
-import { IntentsService } from '../../intents/services/intents.service';
+import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 
-import { ChannelsPropertiesService } from './channels.properties.service';
 import { DeviceControlToolService } from './device-control-tool.service';
-import { DevicesService } from './devices.service';
-import { PlatformRegistryService } from './platform.registry.service';
+import { PropertyCommandService } from './property-command.service';
 
 describe('DeviceControlToolService', () => {
 	let service: DeviceControlToolService;
-	let intentsService: Record<string, jest.Mock>;
-	let devicesService: Record<string, jest.Mock>;
-	let channelsPropertiesService: Record<string, jest.Mock>;
-	let platformRegistry: Record<string, jest.Mock>;
+	let propertyCommandService: { executePropertyCommandById: jest.Mock };
 	let shortIdMapping: ShortIdMappingService;
 
 	beforeEach(() => {
-		intentsService = {
-			createIntent: jest.fn().mockReturnValue({ id: 'intent-1' }),
-			completeIntent: jest.fn().mockReturnValue(null),
+		propertyCommandService = {
+			executePropertyCommandById: jest.fn(),
 		};
-
-		devicesService = {
-			findOne: jest.fn(),
-		};
-
-		channelsPropertiesService = {
-			findOne: jest.fn(),
-		};
-
-		platformRegistry = {
-			get: jest.fn(),
-		};
-
 		shortIdMapping = new ShortIdMappingService();
+		service = new DeviceControlToolService(propertyCommandService as unknown as PropertyCommandService, shortIdMapping);
+	});
 
-		service = new DeviceControlToolService(
-			intentsService as unknown as IntentsService,
-			devicesService as unknown as DevicesService,
-			channelsPropertiesService as unknown as ChannelsPropertiesService,
-			platformRegistry as unknown as PlatformRegistryService,
-			shortIdMapping,
+	it('declares a Buddy/MCP write tool with input and output schemas', () => {
+		const [definition] = service.getToolDefinitions();
+
+		expect(definition.name).toBe('control_device');
+		expect(definition.audiences).toEqual([ToolAudience.BUDDY, ToolAudience.MCP]);
+		expect(definition.access).toBe(ToolAccessKind.WRITE);
+		expect(definition.parameters).toEqual(
+			expect.objectContaining({ type: 'object', required: ['property_id', 'value'] }),
+		);
+		expect(definition.inputSchema).toBeDefined();
+		expect(definition.outputSchema).toBeDefined();
+	});
+
+	it('uses the shared property command path and propagates MCP context', async () => {
+		const shortId = shortIdMapping.shorten('property-1');
+
+		propertyCommandService.executePropertyCommandById.mockResolvedValue({
+			device: 'device-1',
+			deviceName: 'Kitchen Light',
+			channel: 'channel-1',
+			property: 'property-1',
+			value: true,
+			success: true,
+		});
+
+		const result = await service.executeTool(
+			{
+				id: 'request-1',
+				name: 'control_device',
+				arguments: { property_id: shortId, value: true },
+			},
+			{ audience: ToolAudience.MCP, source: 'mcp', actorId: 'client-1' },
+		);
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				data: {
+					device_id: 'device-1',
+					channel_id: 'channel-1',
+					property_id: 'property-1',
+					value: true,
+				},
+			}),
+		);
+		expect(propertyCommandService.executePropertyCommandById).toHaveBeenCalledWith(
+			'property-1',
+			true,
+			expect.any(Object),
+		);
+		const firstCall = propertyCommandService.executePropertyCommandById.mock.calls[0] as unknown as [
+			string,
+			unknown,
+			{ requestId?: string; context?: { origin?: string; extra?: Record<string, unknown> } },
+		];
+
+		expect(firstCall[2]).toMatchObject({
+			requestId: 'request-1',
+			context: { origin: 'api', extra: { source: 'mcp', audience: ToolAudience.MCP, actorId: 'client-1' } },
+		});
+	});
+
+	it('preserves Buddy as the default execution source', async () => {
+		propertyCommandService.executePropertyCommandById.mockResolvedValue({
+			device: 'device-1',
+			deviceName: 'Light',
+			channel: 'channel-1',
+			property: 'property-1',
+			value: 50,
+			success: true,
+		});
+
+		await service.executeTool({
+			id: 'call-1',
+			name: 'control_device',
+			arguments: { property_id: 'property-1', value: 50 },
+		});
+
+		expect(propertyCommandService.executePropertyCommandById).toHaveBeenCalledWith(
+			'property-1',
+			50,
+			expect.any(Object),
+		);
+		const firstCall = propertyCommandService.executePropertyCommandById.mock.calls[0] as unknown as [
+			string,
+			unknown,
+			{ context?: { extra?: Record<string, unknown> } },
+		];
+
+		expect(firstCall[2]).toMatchObject({
+			context: { extra: { source: 'buddy', audience: ToolAudience.BUDDY } },
+		});
+	});
+
+	it('returns a structured failure from the command service', async () => {
+		propertyCommandService.executePropertyCommandById.mockResolvedValue({
+			device: 'device-1',
+			success: false,
+			reason: 'Property is not writable',
+		});
+
+		const result = await service.executeTool({
+			id: 'call-1',
+			name: 'control_device',
+			arguments: { property_id: 'property-1', value: true },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'Property is not writable',
+				errorCode: 'DEVICE_PROPERTY_WRITE_FAILED',
+			}),
 		);
 	});
 
-	describe('getToolDefinitions', () => {
-		it('should return one tool definition', () => {
-			const tools = service.getToolDefinitions();
+	it('rejects missing parameters before invoking the command service', async () => {
+		const result = await service.executeTool({ id: 'call-1', name: 'control_device', arguments: {} });
 
-			expect(tools).toHaveLength(1);
-			expect(tools[0].name).toBe('control_device');
-		});
-
-		it('should define control_device with required parameters', () => {
-			const tools = service.getToolDefinitions();
-			const controlDevice = tools.find((t) => t.name === 'control_device');
-
-			expect(controlDevice).toBeDefined();
-			expect(controlDevice?.parameters).toEqual(
-				expect.objectContaining({
-					type: 'object',
-					required: ['property_id', 'value'],
-				}),
-			);
-		});
+		expect(result).toEqual(
+			expect.objectContaining({ status: ToolExecutionStatus.FAILED, errorCode: 'INVALID_TOOL_ARGUMENTS' }),
+		);
+		expect(propertyCommandService.executePropertyCommandById).not.toHaveBeenCalled();
 	});
 
-	describe('executeTool - control_device', () => {
-		it('should control a device property using short ID', async () => {
-			const shortId = shortIdMapping.shorten('prop-1');
-			const mockDevice = { id: 'dev-1', name: 'Kitchen Light', type: 'local' };
-			const mockChannel = { id: 'chan-1', device: mockDevice };
-			const mockProperty = { id: 'prop-1', channel: mockChannel };
-			const mockPlatform = { process: jest.fn().mockResolvedValue(true) };
-
-			channelsPropertiesService.findOne.mockResolvedValue(mockProperty);
-			platformRegistry.get.mockReturnValue(mockPlatform);
-
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {
-					property_id: shortId,
-					value: true,
-				},
-			});
-
-			expect(result.success).toBe(true);
-			expect(result.message).toContain('Kitchen Light');
-			expect(channelsPropertiesService.findOne).toHaveBeenCalledWith('prop-1');
-			expect(intentsService.createIntent).toHaveBeenCalled();
-			expect(intentsService.completeIntent).toHaveBeenCalledWith(
-				'intent-1',
-				expect.arrayContaining([expect.objectContaining({ status: IntentTargetStatus.SUCCESS })]),
-			);
-		});
-
-		it('should fall back to raw ID if short ID not found in mapping', async () => {
-			const mockDevice = { id: 'dev-1', name: 'Light', type: 'local' };
-			const mockChannel = { id: 'chan-1', device: mockDevice };
-			const mockProperty = { id: 'prop-uuid', channel: mockChannel };
-			const mockPlatform = { process: jest.fn().mockResolvedValue(true) };
-
-			channelsPropertiesService.findOne.mockResolvedValue(mockProperty);
-			platformRegistry.get.mockReturnValue(mockPlatform);
-
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {
-					property_id: 'prop-uuid',
-					value: true,
-				},
-			});
-
-			expect(result.success).toBe(true);
-			expect(channelsPropertiesService.findOne).toHaveBeenCalledWith('prop-uuid');
-		});
-
-		it('should return failure for non-existent property', async () => {
-			channelsPropertiesService.findOne.mockResolvedValue(null);
-
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {
-					property_id: 'nonexistent',
-					value: true,
-				},
-			});
-
-			expect(result.success).toBe(false);
-			expect(result.message).toContain('not found');
-		});
-
-		it('should return failure when platform rejects write', async () => {
-			const mockDevice = { id: 'dev-1', name: 'Light', type: 'local' };
-			const mockChannel = { id: 'chan-1', device: mockDevice };
-			const mockProperty = { id: 'prop-1', channel: mockChannel };
-			const mockPlatform = { process: jest.fn().mockResolvedValue(false) };
-
-			channelsPropertiesService.findOne.mockResolvedValue(mockProperty);
-			platformRegistry.get.mockReturnValue(mockPlatform);
-
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {
-					property_id: 'prop-1',
-					value: 50,
-				},
-			});
-
-			expect(result.success).toBe(false);
-			expect(intentsService.completeIntent).toHaveBeenCalledWith(
-				'intent-1',
-				expect.arrayContaining([expect.objectContaining({ status: IntentTargetStatus.FAILED })]),
-			);
-		});
-
-		it('should return failure when no platform registered', async () => {
-			const mockDevice = { id: 'dev-1', name: 'Light', type: 'local' };
-			const mockChannel = { id: 'chan-1', device: mockDevice };
-			const mockProperty = { id: 'prop-1', channel: mockChannel };
-
-			channelsPropertiesService.findOne.mockResolvedValue(mockProperty);
-			platformRegistry.get.mockReturnValue(null);
-
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {
-					property_id: 'prop-1',
-					value: true,
-				},
-			});
-
-			expect(result.success).toBe(false);
-			expect(result.message).toContain('No platform registered');
-		});
-
-		it('should return failure when missing parameters', async () => {
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'control_device',
-				arguments: {},
-			});
-
-			expect(result.success).toBe(false);
-			expect(result.message).toContain('Missing required parameters');
-		});
-	});
-
-	describe('executeTool - unknown tool', () => {
-		it('should return null for unknown tool name', async () => {
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'unknown_tool',
-				arguments: {},
-			});
-
-			expect(result).toBeNull();
-		});
+	it('returns null for an unknown tool name', async () => {
+		await expect(service.executeTool({ id: 'call-1', name: 'unknown_tool', arguments: {} })).resolves.toBeNull();
 	});
 });

--- a/apps/backend/src/modules/devices/services/device-control-tool.service.ts
+++ b/apps/backend/src/modules/devices/services/device-control-tool.service.ts
@@ -1,32 +1,50 @@
+import { z } from 'zod';
+
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
-import { IntentTargetStatus, IntentType } from '../../intents/intents.constants';
-import { IntentsService } from '../../intents/services/intents.service';
-import { LlmToolCall, ToolDefinition, ToolExecutionResult } from '../../tools/platforms/tool-provider.platform';
+import {
+	LlmToolCall,
+	ToolAccessKind,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolDefinition,
+} from '../../tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
 
-import { ChannelsPropertiesService } from './channels.properties.service';
-import { DevicesService } from './devices.service';
-import { PlatformRegistryService } from './platform.registry.service';
+import { PropertyCommandService } from './property-command.service';
 
 const DEVICE_CONTROL_TOOLS_PROVIDER = 'device-control-tools';
 
+const CONTROL_DEVICE_INPUT_SCHEMA = z.object({
+	property_id: z.string().min(1).describe('Short property ID from the home context (the p=... value)'),
+	value: z
+		.union([z.string(), z.number(), z.boolean()])
+		.describe('Value matching the property data type and constraints'),
+});
+
+const CONTROL_DEVICE_OUTPUT_SCHEMA = z.object({
+	device_id: z.string(),
+	channel_id: z.string(),
+	property_id: z.string(),
+	value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
 /**
  * Tool provider for device control.
- * Allows the AI assistant to control individual device properties.
+ * Allows agent surfaces to control individual device properties through the shared command service.
  */
 @Injectable()
 export class DeviceControlToolService extends BaseToolProviderService {
 	protected readonly logger = createExtensionLogger(DEVICES_MODULE_NAME, 'DeviceControlToolService');
 
 	constructor(
-		private readonly intentsService: IntentsService,
-		private readonly devicesService: DevicesService,
-		private readonly channelsPropertiesService: ChannelsPropertiesService,
-		private readonly platformRegistry: PlatformRegistryService,
+		private readonly propertyCommandService: PropertyCommandService,
 		private readonly shortIdMapping: ShortIdMappingService,
 	) {
 		super();
@@ -38,157 +56,63 @@ export class DeviceControlToolService extends BaseToolProviderService {
 
 	getToolDefinitions(): ToolDefinition[] {
 		return [
-			{
+			createToolDefinition({
 				name: 'control_device',
 				description:
 					'Set a device property value. Use this to control individual devices like lights, switches, thermostats, etc. ' +
 					'Use the short property ID (p=...) from the home context. The device and channel are resolved automatically.',
-				parameters: {
-					type: 'object',
-					properties: {
-						property_id: {
-							type: 'string',
-							description: 'Short property ID from the home context (the p=... value)',
-						},
-						value: {
-							description: 'The value to set (string, number, or boolean depending on the property)',
-						},
-					},
-					required: ['property_id', 'value'],
-				},
-			},
+				audiences: [ToolAudience.BUDDY, ToolAudience.MCP],
+				access: ToolAccessKind.WRITE,
+				inputSchema: CONTROL_DEVICE_INPUT_SCHEMA,
+				outputSchema: CONTROL_DEVICE_OUTPUT_SCHEMA,
+			}),
 		];
 	}
 
-	protected async handleToolCall(toolCall: LlmToolCall): Promise<ToolExecutionResult> {
-		return this.executeControlDevice(toolCall.arguments);
-	}
+	protected async handleToolCall(toolCall: LlmToolCall, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+		const parsed = CONTROL_DEVICE_INPUT_SCHEMA.safeParse(toolCall.arguments);
 
-	private async executeControlDevice(args: Record<string, unknown>): Promise<ToolExecutionResult> {
-		const rawPropertyId = typeof args.property_id === 'string' ? args.property_id : '';
-		const value = args.value;
-
-		if (!rawPropertyId || value === undefined || value === null) {
-			return { success: false, message: 'Missing required parameters: property_id, value' };
+		if (!parsed.success) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'Missing or invalid required parameters: property_id, value',
+				errorCode: 'INVALID_TOOL_ARGUMENTS',
+			};
 		}
 
-		// Resolve short ID to full UUID (falls back to raw value if not found — may already be a UUID)
-		const propertyId = this.shortIdMapping.resolve(rawPropertyId) ?? rawPropertyId;
-
-		// Find the property (findOne joins channel and device relations)
-		const property = await this.channelsPropertiesService.findOne(propertyId);
-		const propertyChannel = property?.channel;
-		const channelEntity = propertyChannel && typeof propertyChannel !== 'string' ? propertyChannel : null;
-
-		if (!property || !channelEntity) {
-			return { success: false, message: `Property "${rawPropertyId}" not found` };
-		}
-
-		// Resolve device from channel
-		const channelDevice = channelEntity.device;
-		const device =
-			channelDevice && typeof channelDevice !== 'string'
-				? channelDevice
-				: await this.devicesService.findOne(typeof channelDevice === 'string' ? channelDevice : '');
-
-		if (!device) {
-			return { success: false, message: `Device for property "${rawPropertyId}" not found` };
-		}
-
-		const deviceId = device.id;
-		const channelId = channelEntity.id;
-
-		// Get the platform for this device
-		const platform = this.platformRegistry.get(device);
-
-		if (!platform) {
-			return { success: false, message: `No platform registered for device "${device.name}"` };
-		}
-
-		// Coerce value to a type the platform accepts.
-		const coercedValue = this.coerceValue(value);
-
-		// Create an intent for tracking
-		const intent = this.intentsService.createIntent({
-			type: IntentType.DEVICE_SET_PROPERTY,
+		const propertyId = this.shortIdMapping.resolve(parsed.data.property_id) ?? parsed.data.property_id;
+		const result = await this.propertyCommandService.executePropertyCommandById(propertyId, parsed.data.value, {
+			requestId: context.requestId,
 			context: {
 				origin: 'api',
-				extra: { source: 'buddy' },
+				extra: {
+					source: context.source,
+					audience: context.audience,
+					actorId: context.actorId,
+				},
 			},
-			targets: [{ deviceId, channelId, propertyId }],
-			value: coercedValue,
 		});
 
-		// Execute the property write through the platform
-		let success: boolean;
-
-		try {
-			success = await platform.process({
-				device,
-				channel: channelEntity,
-				property,
-				value: coercedValue,
-			});
-		} catch (error) {
-			const err = error as Error;
-
-			// Ensure the intent is always resolved, even on unexpected errors
-			this.intentsService.completeIntent(intent.id, [
-				{
-					deviceId,
-					channelId,
-					propertyId,
-					status: IntentTargetStatus.FAILED,
-					error: err.message,
-				},
-			]);
-
-			return { success: false, message: `Failed to set property on device "${device.name}": ${err.message}` };
+		if (!result.success || !result.channel || !result.property || result.value === undefined) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: result.reason ?? 'Failed to set device property',
+				errorCode: 'DEVICE_PROPERTY_WRITE_FAILED',
+			};
 		}
 
-		// Complete the intent
-		this.intentsService.completeIntent(intent.id, [
-			{
-				deviceId,
-				channelId,
-				propertyId,
-				status: success ? IntentTargetStatus.SUCCESS : IntentTargetStatus.FAILED,
-				error: success ? undefined : 'Platform rejected the property write',
+		return {
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: `Set ${result.deviceName ?? result.device} property to ${String(result.value)}`,
+			data: {
+				device_id: result.device,
+				channel_id: result.channel,
+				property_id: result.property,
+				value: result.value,
 			},
-		]);
-
-		if (success) {
-			return { success: true, message: `Set ${device.name} property to ${coercedValue}` };
-		}
-
-		return { success: false, message: `Failed to set property on device "${device.name}"` };
-	}
-
-	private coerceValue(value: unknown): string | number | boolean {
-		if (typeof value === 'boolean') {
-			return value;
-		}
-
-		if (typeof value === 'number') {
-			return value;
-		}
-
-		if (typeof value === 'string') {
-			// Parse string representations of booleans
-			if (value.toLowerCase() === 'true') return true;
-			if (value.toLowerCase() === 'false') return false;
-
-			// Parse string representations of numbers
-			const num = Number(value);
-
-			if (value.trim() !== '' && !Number.isNaN(num) && Number.isFinite(num)) {
-				return num;
-			}
-
-			return value;
-		}
-
-		// Fallback for objects or other types
-		return JSON.stringify(value);
+		};
 	}
 }

--- a/apps/backend/src/modules/devices/services/property-command.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.spec.ts
@@ -80,6 +80,7 @@ describe('PropertyCommandService', () => {
 	let channelsService: ChannelsService;
 	let channelsPropertiesService: ChannelsPropertiesService;
 	let platformRegistryService: PlatformRegistryService;
+	let intentsService: IntentsService;
 	let mockPlatform: IDevicePlatform;
 	let loggerErrorSpy: jest.SpiedFunction<any>;
 	let loggerWarnSpy: jest.SpiedFunction<any>;
@@ -198,6 +199,7 @@ describe('PropertyCommandService', () => {
 		channelsService = module.get<ChannelsService>(ChannelsService);
 		channelsPropertiesService = module.get<ChannelsPropertiesService>(ChannelsPropertiesService);
 		platformRegistryService = module.get<PlatformRegistryService>(PlatformRegistryService);
+		intentsService = module.get<IntentsService>(IntentsService);
 
 		mockPlatform = {
 			getType: jest.fn().mockReturnValue('mock'),
@@ -327,6 +329,64 @@ describe('PropertyCommandService', () => {
 			undefined,
 			expect.objectContaining({ tag: 'devices-module' }),
 		);
+	});
+
+	it('executes a property-id command through validation, intent tracking, and batch dispatch', async () => {
+		const device = { ...mockDevice } as unknown as MockDevice;
+		const channel = { ...mockChannel, device } as unknown as MockChannel;
+		const property = { ...mockChannelProperty, channel } as unknown as MockChannelProperty;
+
+		jest.spyOn(devicesService, 'findOne').mockResolvedValue(device);
+		jest.spyOn(channelsService, 'findOne').mockResolvedValue(channel);
+		jest.spyOn(channelsPropertiesService, 'findOne').mockResolvedValue(property);
+		jest.spyOn(platformRegistryService, 'get').mockReturnValue(mockPlatform);
+		jest.spyOn(mockPlatform, 'processBatch').mockResolvedValue(true);
+
+		const result = await service.executePropertyCommandById(property.id, 'true', {
+			requestId: 'request-1',
+			context: { origin: 'api', extra: { source: 'mcp' } },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				device: device.id,
+				channel: channel.id,
+				property: property.id,
+				value: true,
+				success: true,
+			}),
+		);
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		expect(mockPlatform.processBatch).toHaveBeenCalledWith([
+			expect.objectContaining({ device, channel, property, value: true }),
+		]);
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		expect(intentsService.createIntent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestId: 'request-1',
+				context: { origin: 'api', extra: { source: 'mcp' } },
+			}),
+		);
+	});
+
+	it('should reject writes to read-only properties before platform dispatch', async () => {
+		const readOnlyProperty = { ...mockChannelProperty, permissions: [PermissionType.READ_ONLY] };
+
+		jest.spyOn(devicesService, 'findOne').mockResolvedValue(toInstance(MockDevice, mockDevice));
+		jest.spyOn(channelsService, 'findOne').mockResolvedValue(toInstance(MockChannel, mockChannel));
+		jest
+			.spyOn(channelsPropertiesService, 'findOne')
+			.mockResolvedValue(toInstance(MockChannelProperty, readOnlyProperty));
+		jest.spyOn(platformRegistryService, 'get').mockReturnValue(mockPlatform);
+
+		const result = await service.handleInternal(mockWsUser, validPayload);
+
+		expect(result).toEqual({
+			success: false,
+			results: [{ device: mockDevice.id, success: false, reason: 'Property is not writable' }],
+		});
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		expect(mockPlatform.processBatch).not.toHaveBeenCalled();
 	});
 
 	describe('ACL permissions', () => {

--- a/apps/backend/src/modules/devices/services/property-command.service.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.ts
@@ -11,14 +11,33 @@ import { IntentsService } from '../../intents/services/intents.service';
 import { UserRole } from '../../users/users.constants';
 import { ClientUserDto } from '../../websocket/dto/client-user.dto';
 import { WebsocketNotAllowedException } from '../../websocket/websocket.exceptions';
-import { ConnectionState, DEVICES_MODULE_NAME, DataTypeType } from '../devices.constants';
+import { ConnectionState, DEVICES_MODULE_NAME, PermissionType } from '../devices.constants';
 import { PropertyCommandDto, PropertyCommandValueDto } from '../dto/property-command.dto';
 import { IDevicePropertyData } from '../platforms/device.platform';
+import { PropertyCommandValue, validatePropertyCommandValue } from '../utils/property-command-value.utils';
 
 import { ChannelsPropertiesService } from './channels.properties.service';
 import { ChannelsService } from './channels.service';
 import { DevicesService } from './devices.service';
 import { PlatformRegistryService } from './platform.registry.service';
+
+export interface PropertyCommandExecutionOptions {
+	requestId?: string;
+	context?: IntentContext;
+}
+
+export interface DevicePropertyCommandResult {
+	device: string;
+	success: boolean;
+	reason?: string;
+}
+
+export interface SinglePropertyCommandResult extends DevicePropertyCommandResult {
+	deviceName?: string;
+	channel?: string;
+	property?: string;
+	value?: PropertyCommandValue;
+}
 
 @Injectable()
 export class PropertyCommandService {
@@ -62,28 +81,6 @@ export class PropertyCommandService {
 			return { success: false, results: 'Invalid payload' };
 		}
 
-		// Extract request_id from payload for tracking (snake_case from client)
-		const requestId = (payload as { request_id?: string })?.request_id;
-
-		// Build intent targets with UUIDs (deviceId, channelId, propertyId)
-		const targets: IntentTarget[] = dtoInstance.properties.map((prop) => ({
-			deviceId: prop.device,
-			channelId: prop.channel,
-			propertyId: prop.property,
-		}));
-
-		// Determine intent type based on the first property (could be enhanced to detect property type)
-		const intentType = IntentType.DEVICE_SET_PROPERTY;
-
-		// Build a map of "device:deviceId:channelId:propertyId" -> value for multi-property support
-		// Using composite key with "device:" prefix for consistency with intent target key format
-		const valueMap: Record<string, unknown> = {};
-
-		for (const prop of dtoInstance.properties) {
-			const compositeKey = `device:${prop.device}:${prop.channel}:${prop.property}`;
-			valueMap[compositeKey] = prop.value;
-		}
-
 		// Transform context from DTO (snake_case) to IntentContext (camelCase)
 		let intentContext: IntentContext | undefined;
 
@@ -97,24 +94,129 @@ export class PropertyCommandService {
 			};
 		}
 
+		return this.executeCommands(dtoInstance.properties, {
+			requestId: dtoInstance.request_id,
+			context: intentContext,
+		});
+	}
+
+	async executePropertyCommandById(
+		propertyId: string,
+		rawValue: unknown,
+		options: PropertyCommandExecutionOptions = {},
+	): Promise<SinglePropertyCommandResult> {
+		const property = await this.channelsPropertiesService.findOne(propertyId);
+
+		if (!property) {
+			return { device: '', success: false, reason: 'Property not found' };
+		}
+
+		const propertyChannel = property.channel;
+		const channel =
+			typeof propertyChannel === 'string' ? await this.channelsService.findOne(propertyChannel) : propertyChannel;
+
+		if (!channel) {
+			return { device: '', success: false, property: property.id, reason: 'Channel not found' };
+		}
+
+		const channelDevice = channel.device;
+		const device = typeof channelDevice === 'string' ? await this.devicesService.findOne(channelDevice) : channelDevice;
+
+		if (!device) {
+			return {
+				device: '',
+				success: false,
+				channel: channel.id,
+				property: property.id,
+				reason: 'Device not found',
+			};
+		}
+
+		if (
+			!property.permissions.some((permission) =>
+				[PermissionType.READ_WRITE, PermissionType.WRITE_ONLY].includes(permission),
+			)
+		) {
+			return {
+				device: device.id,
+				deviceName: device.name,
+				channel: channel.id,
+				property: property.id,
+				success: false,
+				reason: 'Property is not writable',
+			};
+		}
+
+		const validation = validatePropertyCommandValue(property, rawValue);
+
+		if (!validation.valid || validation.value === undefined) {
+			return {
+				device: device.id,
+				deviceName: device.name,
+				channel: channel.id,
+				property: property.id,
+				success: false,
+				reason: validation.reason ?? 'Invalid property value',
+			};
+		}
+
+		const execution = await this.executeCommands(
+			[
+				{
+					device: device.id,
+					channel: channel.id,
+					property: property.id,
+					value: validation.value,
+				},
+			],
+			options,
+		);
+		const result = Array.isArray(execution.results) ? execution.results[0] : undefined;
+
+		return {
+			device: device.id,
+			deviceName: device.name,
+			channel: channel.id,
+			property: property.id,
+			value: validation.value,
+			success: result?.success ?? false,
+			reason: result?.reason ?? (typeof execution.results === 'string' ? execution.results : undefined),
+		};
+	}
+
+	private async executeCommands(
+		commands: PropertyCommandValueDto[],
+		options: PropertyCommandExecutionOptions,
+	): Promise<{ success: boolean; results: DevicePropertyCommandResult[] | string }> {
+		const targets: IntentTarget[] = commands.map((command) => ({
+			deviceId: command.device,
+			channelId: command.channel,
+			propertyId: command.property,
+		}));
+		const valueMap: Record<string, unknown> = {};
+
+		for (const command of commands) {
+			valueMap[`device:${command.device}:${command.channel}:${command.property}`] = command.value;
+		}
+
 		// Create the intent with the value map and optional requestId for tracking
 		const intent = this.intentsService.createIntent({
-			requestId,
-			type: intentType,
-			context: intentContext,
+			requestId: options.requestId,
+			type: IntentType.DEVICE_SET_PROPERTY,
+			context: options.context,
 			targets,
 			value: valueMap,
 			ttlMs: DEFAULT_TTL_DEVICE_COMMAND,
 		});
 
 		this.logger.log(
-			`Created intent ${intent.id} for ${targets.length} target(s)${requestId ? ` requestId=${requestId}` : ''}`,
+			`Created intent ${intent.id} for ${targets.length} target(s)${options.requestId ? ` requestId=${options.requestId}` : ''}`,
 		);
 
 		// Group properties by device ID
 		const groupedProperties: Record<string, PropertyCommandValueDto[]> = {};
 
-		dtoInstance.properties.forEach((prop) => {
+		commands.forEach((prop) => {
 			if (!groupedProperties[prop.device]) {
 				groupedProperties[prop.device] = [];
 			}
@@ -122,7 +224,7 @@ export class PropertyCommandService {
 			groupedProperties[prop.device].push(prop);
 		});
 
-		const results: Array<{ device: string; success: boolean; reason?: string }> = [];
+		const results: DevicePropertyCommandResult[] = [];
 
 		try {
 			// Process commands per device
@@ -135,7 +237,7 @@ export class PropertyCommandService {
 			// Map results to IntentTargetResult format - create a result for each property
 			const intentResults: IntentTargetResult[] = [];
 
-			for (const prop of dtoInstance.properties) {
+			for (const prop of commands) {
 				const deviceResult = results.find((r) => r.device === prop.device);
 
 				intentResults.push({
@@ -163,7 +265,7 @@ export class PropertyCommandService {
 			);
 
 			// Build failure results for all targeted properties
-			const failedResults: IntentTargetResult[] = dtoInstance.properties.map((prop) => ({
+			const failedResults: IntentTargetResult[] = commands.map((prop) => ({
 				deviceId: prop.device,
 				channelId: prop.channel,
 				propertyId: prop.property,
@@ -228,15 +330,29 @@ export class PropertyCommandService {
 				return { device: deviceId, success: false, reason: 'Property not found' };
 			}
 
-			if (!this.validateValueType(property.dataType, command.value)) {
-				this.logger.warn(`Invalid value type for property id=${property.id} expected=${property.dataType}`);
+			if (
+				!property.permissions.some((permission) =>
+					[PermissionType.READ_WRITE, PermissionType.WRITE_ONLY].includes(permission),
+				)
+			) {
+				this.logger.warn(`Property is not writable id=${property.id}`);
 
-				return { device: deviceId, success: false, reason: 'Invalid value type' };
+				return { device: deviceId, success: false, reason: 'Property is not writable' };
 			}
 
-			this.logger.log(`Adding command for propertyId=${property.id} value=${command.value}`);
+			const validation = validatePropertyCommandValue(property, command.value);
 
-			propertyUpdates.push({ device, channel, property, value: command.value });
+			if (!validation.valid || validation.value === undefined) {
+				this.logger.warn(
+					`Invalid value for property id=${property.id} dataType=${property.dataType} reason=${validation.reason}`,
+				);
+
+				return { device: deviceId, success: false, reason: validation.reason ?? 'Invalid property value' };
+			}
+
+			this.logger.log(`Adding command for propertyId=${property.id} value=${validation.value}`);
+
+			propertyUpdates.push({ device, channel, property, value: validation.value });
 		}
 
 		// Process the batch of commands in one request
@@ -257,7 +373,7 @@ export class PropertyCommandService {
 
 	/**
 	 * Process a device command triggered by an API PATCH request.
-	 * This sends the value to the physical device via its platform, without WebSocket auth or intent tracking.
+	 * This sends the value through the same validation, intent, and platform path as WebSocket and agent commands.
 	 */
 	async processApiPropertyCommand(
 		deviceId: string,
@@ -265,32 +381,16 @@ export class PropertyCommandService {
 		propertyId: string,
 		value: string | number | boolean,
 	): Promise<void> {
-		const result = await this.processDeviceCommands(deviceId, [
-			{ device: deviceId, channel: channelId, property: propertyId, value },
-		]);
+		const execution = await this.executeCommands(
+			[{ device: deviceId, channel: channelId, property: propertyId, value }],
+			{ context: { origin: 'api' } },
+		);
+		const result = Array.isArray(execution.results) ? execution.results[0] : undefined;
 
-		if (!result.success) {
-			this.logger.warn(`[API Command] Failed for deviceId=${deviceId}: ${result.reason}`);
-		}
-	}
+		if (!execution.success) {
+			const reason = result?.reason ?? (typeof execution.results === 'string' ? execution.results : 'Execution failed');
 
-	private validateValueType(dataType: DataTypeType, value: unknown): boolean {
-		switch (dataType) {
-			case DataTypeType.STRING:
-			case DataTypeType.ENUM:
-				return typeof value === 'string';
-			case DataTypeType.BOOL:
-				return typeof value === 'boolean';
-			case DataTypeType.CHAR:
-			case DataTypeType.UCHAR:
-			case DataTypeType.SHORT:
-			case DataTypeType.USHORT:
-			case DataTypeType.INT:
-			case DataTypeType.UINT:
-			case DataTypeType.FLOAT:
-				return typeof value === 'number';
-			default:
-				return false;
+			this.logger.warn(`[API Command] Failed for deviceId=${deviceId}: ${reason}`);
 		}
 	}
 }

--- a/apps/backend/src/modules/devices/utils/property-command-value.utils.spec.ts
+++ b/apps/backend/src/modules/devices/utils/property-command-value.utils.spec.ts
@@ -32,6 +32,17 @@ describe('validatePropertyCommandValue', () => {
 		});
 	});
 
+	it('rejects empty string and enum values', () => {
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.STRING }), '')).toEqual({
+			valid: false,
+			reason: 'Value must not be empty',
+		});
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.ENUM }), '')).toEqual({
+			valid: false,
+			reason: 'Value must not be empty',
+		});
+	});
+
 	it('enforces enum membership', () => {
 		const enumProperty = property({ dataType: DataTypeType.ENUM, format: ['on', 'off'] });
 

--- a/apps/backend/src/modules/devices/utils/property-command-value.utils.spec.ts
+++ b/apps/backend/src/modules/devices/utils/property-command-value.utils.spec.ts
@@ -1,0 +1,77 @@
+import { DataTypeType } from '../devices.constants';
+import { ChannelPropertyEntity } from '../entities/devices.entity';
+
+import { validatePropertyCommandValue } from './property-command-value.utils';
+
+const property = (overrides: Partial<ChannelPropertyEntity>): ChannelPropertyEntity =>
+	({
+		dataType: DataTypeType.BOOL,
+		format: null,
+		invalid: null,
+		step: null,
+		...overrides,
+	}) as ChannelPropertyEntity;
+
+describe('validatePropertyCommandValue', () => {
+	it('normalizes safe boolean and numeric string values', () => {
+		expect(validatePropertyCommandValue(property({}), 'true')).toEqual({ valid: true, value: true });
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.INT }), '42')).toEqual({
+			valid: true,
+			value: 42,
+		});
+	});
+
+	it('rejects objects and non-finite numeric values', () => {
+		expect(validatePropertyCommandValue(property({}), { value: true })).toEqual({
+			valid: false,
+			reason: 'Value must be a boolean',
+		});
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.FLOAT }), Number.POSITIVE_INFINITY)).toEqual({
+			valid: false,
+			reason: 'Value must be a finite number',
+		});
+	});
+
+	it('enforces enum membership', () => {
+		const enumProperty = property({ dataType: DataTypeType.ENUM, format: ['on', 'off'] });
+
+		expect(validatePropertyCommandValue(enumProperty, 'on')).toEqual({ valid: true, value: 'on' });
+		expect(validatePropertyCommandValue(enumProperty, 'auto')).toEqual({
+			valid: false,
+			reason: 'Value must be one of: on, off',
+		});
+	});
+
+	it('enforces numeric format, integer range, and step constraints', () => {
+		const percentage = property({ dataType: DataTypeType.UCHAR, format: [0, 100], step: 5 });
+
+		expect(validatePropertyCommandValue(percentage, 95)).toEqual({ valid: true, value: 95 });
+		expect(validatePropertyCommandValue(percentage, 101)).toEqual({
+			valid: false,
+			reason: 'Value must be less than or equal to 100',
+		});
+		expect(validatePropertyCommandValue(percentage, 42)).toEqual({
+			valid: false,
+			reason: 'Value must align to step 5 from base 0',
+		});
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.UCHAR }), -1)).toEqual({
+			valid: false,
+			reason: 'Value must be between 0 and 255',
+		});
+	});
+
+	it('rejects fractional values for integer data types and sentinel values', () => {
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.INT }), 1.5)).toEqual({
+			valid: false,
+			reason: 'Value must be an integer',
+		});
+		expect(validatePropertyCommandValue(property({ invalid: false }), false)).toEqual({
+			valid: false,
+			reason: 'Value is reserved as an invalid/sentinel value',
+		});
+		expect(validatePropertyCommandValue(property({ dataType: DataTypeType.INT, invalid: '-1' }), -1)).toEqual({
+			valid: false,
+			reason: 'Value is reserved as an invalid/sentinel value',
+		});
+	});
+});

--- a/apps/backend/src/modules/devices/utils/property-command-value.utils.ts
+++ b/apps/backend/src/modules/devices/utils/property-command-value.utils.ts
@@ -87,6 +87,10 @@ export const validatePropertyCommandValue = (
 				return { valid: false, reason: 'Value must be a string' };
 			}
 
+			if (rawValue.length === 0) {
+				return { valid: false, reason: 'Value must not be empty' };
+			}
+
 			value = rawValue;
 			break;
 

--- a/apps/backend/src/modules/devices/utils/property-command-value.utils.ts
+++ b/apps/backend/src/modules/devices/utils/property-command-value.utils.ts
@@ -1,0 +1,165 @@
+import { DataTypeType } from '../devices.constants';
+import { ChannelPropertyEntity } from '../entities/devices.entity';
+
+export type PropertyCommandValue = string | number | boolean;
+
+export interface PropertyCommandValueValidation {
+	valid: boolean;
+	value?: PropertyCommandValue;
+	reason?: string;
+}
+
+const INTEGER_RANGES: Partial<Record<DataTypeType, readonly [number, number]>> = {
+	[DataTypeType.CHAR]: [-128, 127],
+	[DataTypeType.UCHAR]: [0, 255],
+	[DataTypeType.SHORT]: [-32_768, 32_767],
+	[DataTypeType.USHORT]: [0, 65_535],
+	[DataTypeType.INT]: [-2_147_483_648, 2_147_483_647],
+	[DataTypeType.UINT]: [0, 4_294_967_295],
+};
+
+const normalizeNumber = (value: unknown): number | null => {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value : null;
+	}
+
+	if (typeof value !== 'string' || value.trim() === '') {
+		return null;
+	}
+
+	const normalized = Number(value);
+
+	return Number.isFinite(normalized) ? normalized : null;
+};
+
+const matchesStep = (value: number, step: number, base: number): boolean => {
+	const quotient = (value - base) / step;
+	const nearest = Math.round(quotient);
+	const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16;
+
+	return Math.abs(quotient - nearest) <= tolerance;
+};
+
+const matchesInvalidValue = (invalidValue: string | number | boolean, value: PropertyCommandValue): boolean => {
+	if (invalidValue === value) {
+		return true;
+	}
+
+	if (typeof invalidValue === 'string' && typeof value === 'number' && invalidValue.trim() !== '') {
+		const normalized = Number(invalidValue);
+
+		return Number.isFinite(normalized) && normalized === value;
+	}
+
+	if (typeof invalidValue === 'number' && typeof value === 'string' && value.trim() !== '') {
+		const normalized = Number(value);
+
+		return Number.isFinite(normalized) && normalized === invalidValue;
+	}
+
+	if (typeof invalidValue === 'string' && typeof value === 'boolean') {
+		return invalidValue.toLowerCase() === String(value);
+	}
+
+	return false;
+};
+
+export const validatePropertyCommandValue = (
+	property: ChannelPropertyEntity,
+	rawValue: unknown,
+): PropertyCommandValueValidation => {
+	let value: PropertyCommandValue;
+
+	switch (property.dataType) {
+		case DataTypeType.BOOL:
+			if (typeof rawValue === 'boolean') {
+				value = rawValue;
+			} else if (typeof rawValue === 'string' && ['true', 'false'].includes(rawValue.toLowerCase())) {
+				value = rawValue.toLowerCase() === 'true';
+			} else {
+				return { valid: false, reason: 'Value must be a boolean' };
+			}
+			break;
+
+		case DataTypeType.STRING:
+		case DataTypeType.ENUM:
+			if (typeof rawValue !== 'string') {
+				return { valid: false, reason: 'Value must be a string' };
+			}
+
+			value = rawValue;
+			break;
+
+		case DataTypeType.CHAR:
+		case DataTypeType.UCHAR:
+		case DataTypeType.SHORT:
+		case DataTypeType.USHORT:
+		case DataTypeType.INT:
+		case DataTypeType.UINT:
+		case DataTypeType.FLOAT: {
+			const normalized = normalizeNumber(rawValue);
+
+			if (normalized === null) {
+				return { valid: false, reason: 'Value must be a finite number' };
+			}
+
+			if (property.dataType !== DataTypeType.FLOAT && !Number.isInteger(normalized)) {
+				return { valid: false, reason: 'Value must be an integer' };
+			}
+
+			const dataTypeRange = INTEGER_RANGES[property.dataType];
+
+			if (dataTypeRange && (normalized < dataTypeRange[0] || normalized > dataTypeRange[1])) {
+				return {
+					valid: false,
+					reason: `Value must be between ${dataTypeRange[0]} and ${dataTypeRange[1]}`,
+				};
+			}
+
+			value = normalized;
+			break;
+		}
+
+		default:
+			return { valid: false, reason: `Unsupported property data type: ${property.dataType}` };
+	}
+
+	if (property.invalid !== null && matchesInvalidValue(property.invalid, value)) {
+		return { valid: false, reason: 'Value is reserved as an invalid/sentinel value' };
+	}
+
+	if (property.dataType === DataTypeType.ENUM && property.format?.length) {
+		const allowedValues = property.format.filter((item): item is string => typeof item === 'string');
+
+		if (allowedValues.length !== property.format.length || !allowedValues.includes(value as string)) {
+			return { valid: false, reason: `Value must be one of: ${allowedValues.join(', ')}` };
+		}
+	}
+
+	if (typeof value === 'number' && property.format?.length) {
+		const minimum = typeof property.format[0] === 'number' ? property.format[0] : null;
+		const maximum = typeof property.format[1] === 'number' ? property.format[1] : null;
+
+		if (minimum !== null && value < minimum) {
+			return { valid: false, reason: `Value must be greater than or equal to ${minimum}` };
+		}
+
+		if (maximum !== null && value > maximum) {
+			return { valid: false, reason: `Value must be less than or equal to ${maximum}` };
+		}
+	}
+
+	if (typeof value === 'number' && property.step !== null) {
+		if (!Number.isFinite(property.step) || property.step <= 0) {
+			return { valid: false, reason: 'Property has an invalid step constraint' };
+		}
+
+		const base = typeof property.format?.[0] === 'number' ? property.format[0] : 0;
+
+		if (!matchesStep(value, property.step, base)) {
+			return { valid: false, reason: `Value must align to step ${property.step} from base ${base}` };
+		}
+	}
+
+	return { valid: true, value };
+};

--- a/apps/backend/src/modules/scenes/services/scene-executor.service.ts
+++ b/apps/backend/src/modules/scenes/services/scene-executor.service.ts
@@ -3,7 +3,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { DEFAULT_TTL_SCENE, IntentTargetStatus, IntentType } from '../../intents/intents.constants';
-import { IntentTarget, IntentTargetResult } from '../../intents/models/intent.model';
+import { IntentContext, IntentTarget, IntentTargetResult } from '../../intents/models/intent.model';
 import { IntentsService } from '../../intents/services/intents.service';
 import { SceneActionEntity, SceneEntity } from '../entities/scenes.entity';
 import { ActionExecutionResultModel, SceneExecutionResultModel } from '../models/scenes.model';
@@ -76,7 +76,11 @@ export class SceneExecutorService {
 	/**
 	 * Trigger a scene execution
 	 */
-	async triggerScene(sceneId: string, triggeredBy?: string): Promise<SceneExecutionResultModel> {
+	async triggerScene(
+		sceneId: string,
+		triggeredBy?: string,
+		executionContext?: IntentContext,
+	): Promise<SceneExecutionResultModel> {
 		const scene = await this.scenesService.getOneOrThrow(sceneId);
 
 		// Check if scene is triggerable
@@ -107,6 +111,7 @@ export class SceneExecutorService {
 		const intent = this.intentsService.createIntent({
 			type: IntentType.SCENE_RUN,
 			context: {
+				...executionContext,
 				spaceId: scene.primarySpaceId || undefined,
 			},
 			targets,

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
@@ -144,7 +144,9 @@ describe('SceneToolService', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.status).toBe(ToolExecutionStatus.FAILED);
-			expect(result.message).toContain('failed');
+			expect(result.message).toBe('Scene "Lights" failed to execute');
+			expect(result.message).not.toContain('No platforms registered');
+			expect(result.errorCode).toBe('SCENE_EXECUTION_FAILED');
 		});
 	});
 

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
@@ -1,3 +1,4 @@
+import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 
 import { SceneExecutorService } from './scene-executor.service';
@@ -31,6 +32,9 @@ describe('SceneToolService', () => {
 
 			expect(tools).toHaveLength(1);
 			expect(tools[0].name).toBe('run_scene');
+			expect(tools[0].audiences).toEqual([ToolAudience.BUDDY, ToolAudience.MCP]);
+			expect(tools[0].access).toBe(ToolAccessKind.TRIGGER);
+			expect(tools[0].outputSchema).toBeDefined();
 		});
 
 		it('should define run_scene with required parameters', () => {
@@ -63,9 +67,20 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(true);
+			expect(result.status).toBe(ToolExecutionStatus.COMPLETED);
 			expect(result.message).toContain('Movie Night');
 			expect(result.message).toContain('executed successfully');
-			expect(sceneExecutor.triggerScene).toHaveBeenCalledWith('scene-1', 'buddy');
+			expect(sceneExecutor.triggerScene).toHaveBeenCalledWith('scene-1', 'buddy', expect.any(Object));
+			const firstCall = sceneExecutor.triggerScene.mock.calls[0] as unknown as [
+				string,
+				string,
+				{ origin?: string; extra?: Record<string, unknown> },
+			];
+
+			expect(firstCall[2]).toMatchObject({
+				origin: 'api',
+				extra: { source: 'buddy', audience: ToolAudience.BUDDY },
+			});
 		});
 
 		it('should return failure for non-existent scene', async () => {
@@ -89,7 +104,7 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.message).toContain('Missing required parameter');
+			expect(result.message).toContain('Missing or invalid required parameter');
 		});
 
 		it('should handle partially completed scene', async () => {
@@ -107,6 +122,7 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(true);
+			expect(result.status).toBe(ToolExecutionStatus.PARTIAL);
 			expect(result.message).toContain('partially completed');
 			expect(result.message).toContain('2/3');
 		});
@@ -127,6 +143,7 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
+			expect(result.status).toBe(ToolExecutionStatus.FAILED);
 			expect(result.message).toContain('failed');
 		});
 	});
@@ -142,6 +159,7 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
+			expect(result.status).toBe(ToolExecutionStatus.DENIED);
 			expect(result.message).toContain('disabled');
 		});
 
@@ -156,7 +174,9 @@ describe('SceneToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.message).toContain('Connection timeout');
+			expect(result.status).toBe(ToolExecutionStatus.FAILED);
+			expect(result.message).toBe('Failed to execute tool "run_scene"');
+			expect(result.message).not.toContain('Connection timeout');
 		});
 	});
 

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.ts
@@ -1,7 +1,18 @@
+import { z } from 'zod';
+
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
-import { LlmToolCall, ToolDefinition, ToolExecutionResult } from '../../tools/platforms/tool-provider.platform';
+import {
+	LlmToolCall,
+	ToolAccessKind,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolDefinition,
+} from '../../tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { SCENES_MODULE_NAME, SceneExecutionStatus } from '../scenes.constants';
@@ -11,10 +22,18 @@ import { ScenesService } from './scenes.service';
 
 const SCENE_TOOLS_PROVIDER = 'scene-tools';
 
-/**
- * Tool provider for scene execution.
- * Allows the AI assistant to trigger pre-configured automation scenes.
- */
+const RUN_SCENE_INPUT_SCHEMA = z.object({
+	scene_id: z.string().min(1).describe('Short scene ID from the home context (the id=... value)'),
+});
+
+const RUN_SCENE_OUTPUT_SCHEMA = z.object({
+	scene_id: z.string(),
+	status: z.enum(['completed', 'partially_completed', 'failed']),
+	successful_actions: z.number().int().nonnegative(),
+	total_actions: z.number().int().nonnegative(),
+});
+
+/** Tool provider for scene execution. */
 @Injectable()
 export class SceneToolService extends BaseToolProviderService {
 	protected readonly logger = createExtensionLogger(SCENES_MODULE_NAME, 'SceneToolService');
@@ -33,65 +52,96 @@ export class SceneToolService extends BaseToolProviderService {
 
 	getToolDefinitions(): ToolDefinition[] {
 		return [
-			{
+			createToolDefinition({
 				name: 'run_scene',
 				description:
 					'Execute a scene by its ID. Scenes are pre-configured automations that control multiple devices at once. ' +
 					'Available scenes are listed in the home context.',
-				parameters: {
-					type: 'object',
-					properties: {
-						scene_id: {
-							type: 'string',
-							description: 'Short scene ID from the home context (the id=... value)',
-						},
-					},
-					required: ['scene_id'],
-				},
-			},
+				audiences: [ToolAudience.BUDDY, ToolAudience.MCP],
+				access: ToolAccessKind.TRIGGER,
+				inputSchema: RUN_SCENE_INPUT_SCHEMA,
+				outputSchema: RUN_SCENE_OUTPUT_SCHEMA,
+			}),
 		];
 	}
 
-	protected async handleToolCall(toolCall: LlmToolCall): Promise<ToolExecutionResult> {
-		return this.executeRunScene(toolCall.arguments);
-	}
+	protected async handleToolCall(toolCall: LlmToolCall, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+		const parsed = RUN_SCENE_INPUT_SCHEMA.safeParse(toolCall.arguments);
 
-	private async executeRunScene(args: Record<string, unknown>): Promise<ToolExecutionResult> {
-		const rawSceneId = typeof args.scene_id === 'string' ? args.scene_id : '';
-
-		if (!rawSceneId) {
-			return { success: false, message: 'Missing required parameter: scene_id' };
+		if (!parsed.success) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'Missing or invalid required parameter: scene_id',
+				errorCode: 'INVALID_TOOL_ARGUMENTS',
+			};
 		}
 
-		const sceneId = this.shortIdMapping.resolve(rawSceneId) ?? rawSceneId;
-
-		// Verify scene exists
+		const sceneId = this.shortIdMapping.resolve(parsed.data.scene_id) ?? parsed.data.scene_id;
 		const scene = await this.scenesService.findOne(sceneId);
 
 		if (!scene) {
-			return { success: false, message: `Scene with ID "${sceneId}" not found` };
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: `Scene with ID "${sceneId}" not found`,
+				errorCode: 'SCENE_NOT_FOUND',
+			};
 		}
 
 		if (!scene.enabled) {
-			return { success: false, message: `Scene "${scene.name}" is disabled` };
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: `Scene "${scene.name}" is disabled`,
+				errorCode: 'SCENE_DISABLED',
+			};
 		}
 
-		const result = await this.sceneExecutor.triggerScene(sceneId, 'buddy');
+		const result = await this.sceneExecutor.triggerScene(sceneId, context.source, {
+			origin: 'api',
+			extra: {
+				source: context.source,
+				audience: context.audience,
+				actorId: context.actorId,
+				requestId: context.requestId,
+			},
+		});
+		const terminalSceneStatus =
+			result.status === SceneExecutionStatus.COMPLETED || result.status === SceneExecutionStatus.PARTIALLY_COMPLETED
+				? result.status
+				: SceneExecutionStatus.FAILED;
+		const data = {
+			scene_id: sceneId,
+			status: terminalSceneStatus,
+			successful_actions: result.successfulActions,
+			total_actions: result.totalActions,
+		};
 
 		if (result.status === SceneExecutionStatus.COMPLETED) {
-			return { success: true, message: `Scene "${scene.name}" executed successfully` };
+			return {
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				message: `Scene "${scene.name}" executed successfully`,
+				data,
+			};
 		}
 
 		if (result.status === SceneExecutionStatus.PARTIALLY_COMPLETED) {
 			return {
 				success: true,
+				status: ToolExecutionStatus.PARTIAL,
 				message: `Scene "${scene.name}" partially completed (${result.successfulActions}/${result.totalActions} actions succeeded)`,
+				data,
 			};
 		}
 
 		return {
 			success: false,
+			status: ToolExecutionStatus.FAILED,
 			message: `Scene "${scene.name}" failed: ${result.error ?? 'unknown error'}`,
+			data,
+			errorCode: 'SCENE_EXECUTION_FAILED',
 		};
 	}
 }

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.ts
@@ -136,10 +136,12 @@ export class SceneToolService extends BaseToolProviderService {
 			};
 		}
 
+		this.logger.warn(`[EXECUTE] Scene with id=${sceneId} failed: ${result.error ?? 'Unknown scene execution failure'}`);
+
 		return {
 			success: false,
 			status: ToolExecutionStatus.FAILED,
-			message: `Scene "${scene.name}" failed: ${result.error ?? 'unknown error'}`,
+			message: `Scene "${scene.name}" failed to execute`,
 			data,
 			errorCode: 'SCENE_EXECUTION_FAILED',
 		};

--- a/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
+++ b/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
@@ -1,11 +1,56 @@
+import { z } from 'zod';
+
+export enum ToolAudience {
+	BUDDY = 'buddy',
+	MCP = 'mcp',
+}
+
+export enum ToolAccessKind {
+	READ = 'read',
+	WRITE = 'write',
+	TRIGGER = 'trigger',
+}
+
+export enum ToolExecutionStatus {
+	COMPLETED = 'completed',
+	PARTIAL = 'partial',
+	FAILED = 'failed',
+	TIMED_OUT = 'timed_out',
+	DENIED = 'denied',
+}
+
 /**
  * Tool definition for LLM providers (provider-agnostic format).
  */
 export interface ToolDefinition {
 	name: string;
 	description: string;
+	audiences: ToolAudience[];
+	access: ToolAccessKind;
+	inputSchema: z.ZodType;
+	outputSchema: z.ZodType;
 	parameters: Record<string, unknown>;
 }
+
+export interface CreateToolDefinitionOptions {
+	name: string;
+	description: string;
+	audiences: ToolAudience[];
+	access: ToolAccessKind;
+	inputSchema: z.ZodType;
+	outputSchema: z.ZodType;
+}
+
+export const createToolDefinition = (options: CreateToolDefinitionOptions): ToolDefinition => {
+	const parameters = { ...z.toJSONSchema(options.inputSchema, { target: 'draft-7' }) };
+
+	delete parameters.$schema;
+
+	return {
+		...options,
+		parameters,
+	};
+};
 
 export interface LlmToolCall {
 	id: string;
@@ -18,8 +63,35 @@ export interface LlmToolCall {
  */
 export interface ToolExecutionResult {
 	success: boolean;
+	status: ToolExecutionStatus;
 	message: string;
+	data?: Record<string, unknown>;
+	errorCode?: string;
 }
+
+export interface ToolExecutionContext {
+	audience: ToolAudience;
+	source: string;
+	actorId?: string;
+	requestId?: string;
+	allowedAccessKinds?: ToolAccessKind[];
+}
+
+export interface ToolListingOptions {
+	audience?: ToolAudience;
+	accessKinds?: ToolAccessKind[];
+}
+
+export const createToolExecutionContext = (
+	toolCall: LlmToolCall,
+	context?: Partial<ToolExecutionContext>,
+): ToolExecutionContext => ({
+	audience: context?.audience ?? ToolAudience.BUDDY,
+	source: context?.source ?? ToolAudience.BUDDY,
+	actorId: context?.actorId,
+	requestId: context?.requestId ?? toolCall.id,
+	allowedAccessKinds: context?.allowedAccessKinds,
+});
 
 /**
  * Interface for tool provider implementations.
@@ -44,5 +116,5 @@ export interface IToolProvider {
 	 * @param toolCall The tool call from the LLM
 	 * @returns The result of the tool execution, or null if this provider doesn't handle the tool
 	 */
-	executeTool(toolCall: LlmToolCall): Promise<ToolExecutionResult | null>;
+	executeTool(toolCall: LlmToolCall, context?: Partial<ToolExecutionContext>): Promise<ToolExecutionResult | null>;
 }

--- a/apps/backend/src/modules/tools/services/base-tool-provider.service.ts
+++ b/apps/backend/src/modules/tools/services/base-tool-provider.service.ts
@@ -1,7 +1,17 @@
 import { ExtensionLoggerService } from '../../../common/logger';
-import { IToolProvider, LlmToolCall, ToolDefinition, ToolExecutionResult } from '../platforms/tool-provider.platform';
+import {
+	IToolProvider,
+	LlmToolCall,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolExecutionContext,
+} from '../platforms/tool-provider.platform';
 
 const DEFAULT_TOOL_EXECUTION_TIMEOUT_MS = 5_000;
+
+class ToolExecutionTimeoutError extends Error {}
 
 /**
  * Abstract base class for tool providers that handles common boilerplate:
@@ -23,43 +33,90 @@ export abstract class BaseToolProviderService implements IToolProvider {
 	 * Execute the domain-specific logic for a tool call.
 	 * Return null if this provider does not handle the given tool name.
 	 */
-	protected abstract handleToolCall(toolCall: LlmToolCall): Promise<ToolExecutionResult | null>;
+	protected abstract handleToolCall(
+		toolCall: LlmToolCall,
+		context: ToolExecutionContext,
+	): Promise<ToolExecutionResult | null>;
 
-	async executeTool(toolCall: LlmToolCall): Promise<ToolExecutionResult | null> {
+	async executeTool(
+		toolCall: LlmToolCall,
+		providedContext?: Partial<ToolExecutionContext>,
+	): Promise<ToolExecutionResult | null> {
 		// Quick check: let subclass signal it doesn't own this tool name
-		if (!this.getToolDefinitions().some((t) => t.name === toolCall.name)) {
+		const definition = this.getToolDefinitions().find((tool) => tool.name === toolCall.name);
+
+		if (!definition) {
 			return null;
 		}
 
-		this.logger.debug(`Executing tool: ${toolCall.name} (id=${toolCall.id})`);
+		const context = createToolExecutionContext(toolCall, providedContext);
+
+		if (!definition.audiences.includes(context.audience)) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: `Tool "${toolCall.name}" is not available to ${context.audience}`,
+				errorCode: 'TOOL_AUDIENCE_DENIED',
+			};
+		}
+
+		if (context.allowedAccessKinds && !context.allowedAccessKinds.includes(definition.access)) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: `Tool "${toolCall.name}" requires ${definition.access} access`,
+				errorCode: 'TOOL_ACCESS_DENIED',
+			};
+		}
+
+		this.logger.debug(
+			`Executing tool: ${toolCall.name} (id=${toolCall.id}, source=${context.source}, audience=${context.audience})`,
+		);
 
 		try {
-			const result = await this.executeWithTimeout(toolCall);
+			const result = await this.executeWithTimeout(toolCall, context);
 
-			this.logger.debug(`Tool ${toolCall.name} completed: ${result?.success ? 'success' : 'failure'}`);
+			this.logger.debug(`Tool ${toolCall.name} completed: ${result?.status ?? ToolExecutionStatus.FAILED}`);
 
 			return result;
 		} catch (error) {
 			const err = error as Error;
 
-			this.logger.error(`Tool ${toolCall.name} failed: ${err.message}`);
+			this.logger.error(`Tool ${toolCall.name} failed: ${err.message}`, err.stack);
+
+			if (err instanceof ToolExecutionTimeoutError) {
+				return {
+					success: false,
+					status: ToolExecutionStatus.TIMED_OUT,
+					message: `Tool "${toolCall.name}" timed out`,
+					errorCode: 'TOOL_EXECUTION_TIMEOUT',
+				};
+			}
 
 			return {
 				success: false,
-				message: `Failed to execute ${toolCall.name}: ${err.message}`,
+				status: ToolExecutionStatus.FAILED,
+				message: `Failed to execute tool "${toolCall.name}"`,
+				errorCode: 'TOOL_EXECUTION_FAILED',
 			};
 		}
 	}
 
-	private async executeWithTimeout(toolCall: LlmToolCall): Promise<ToolExecutionResult | null> {
+	private async executeWithTimeout(
+		toolCall: LlmToolCall,
+		context: ToolExecutionContext,
+	): Promise<ToolExecutionResult | null> {
 		let timer: ReturnType<typeof setTimeout> | undefined;
 
 		const timeoutPromise = new Promise<never>((_, reject) => {
-			timer = setTimeout(() => reject(new Error('Tool execution timed out')), this.toolExecutionTimeoutMs);
+			timer = setTimeout(
+				() => reject(new ToolExecutionTimeoutError('Tool execution timed out')),
+				this.toolExecutionTimeoutMs,
+			);
 		});
 
 		try {
-			return await Promise.race([this.handleToolCall(toolCall), timeoutPromise]);
+			return await Promise.race([this.handleToolCall(toolCall, context), timeoutPromise]);
 		} finally {
 			clearTimeout(timer);
 		}

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
@@ -1,0 +1,201 @@
+import { z } from 'zod';
+
+import { createExtensionLogger } from '../../../common/logger';
+import {
+	LlmToolCall,
+	ToolAccessKind,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolDefinition,
+} from '../platforms/tool-provider.platform';
+
+import { BaseToolProviderService } from './base-tool-provider.service';
+import { ToolProviderRegistryService } from './tool-provider-registry.service';
+
+const inputSchema = z.object({ value: z.string() });
+const outputSchema = z.object({ value: z.string() });
+
+const definition = (name: string, audiences: ToolAudience[], access: ToolAccessKind): ToolDefinition =>
+	createToolDefinition({
+		name,
+		description: `${name} description`,
+		audiences,
+		access,
+		inputSchema,
+		outputSchema,
+	});
+
+class TestToolProvider extends BaseToolProviderService {
+	protected readonly logger = createExtensionLogger('tools-module', 'TestToolProvider');
+	protected readonly toolExecutionTimeoutMs: number;
+
+	readonly contexts: ToolExecutionContext[] = [];
+
+	constructor(
+		private readonly type: string,
+		private readonly definitions: ToolDefinition[],
+		private readonly handler: (
+			toolCall: LlmToolCall,
+			context: ToolExecutionContext,
+		) => Promise<ToolExecutionResult | null>,
+		timeoutMs = 5_000,
+	) {
+		super();
+		this.toolExecutionTimeoutMs = timeoutMs;
+	}
+
+	getType(): string {
+		return this.type;
+	}
+
+	getToolDefinitions(): ToolDefinition[] {
+		return this.definitions;
+	}
+
+	protected async handleToolCall(
+		toolCall: LlmToolCall,
+		context: ToolExecutionContext,
+	): Promise<ToolExecutionResult | null> {
+		this.contexts.push(context);
+
+		return this.handler(toolCall, context);
+	}
+}
+
+const completed = (value: string): ToolExecutionResult => ({
+	success: true,
+	status: ToolExecutionStatus.COMPLETED,
+	message: value,
+	data: { value },
+});
+
+describe('ToolProviderRegistryService', () => {
+	let registry: ToolProviderRegistryService;
+
+	beforeEach(() => {
+		registry = new ToolProviderRegistryService();
+	});
+
+	it('filters definitions by audience and access kind, defaulting to Buddy', () => {
+		registry.register(
+			new TestToolProvider(
+				'provider-a',
+				[
+					definition('buddy-read', [ToolAudience.BUDDY], ToolAccessKind.READ),
+					definition('shared-write', [ToolAudience.BUDDY, ToolAudience.MCP], ToolAccessKind.WRITE),
+					definition('mcp-trigger', [ToolAudience.MCP], ToolAccessKind.TRIGGER),
+				],
+				() => Promise.resolve(completed('ok')),
+			),
+		);
+
+		expect(registry.getAllToolDefinitions().map(({ name }) => name)).toEqual(['buddy-read', 'shared-write']);
+		expect(
+			registry
+				.getAllToolDefinitions({ audience: ToolAudience.MCP, accessKinds: [ToolAccessKind.TRIGGER] })
+				.map(({ name }) => name),
+		).toEqual(['mcp-trigger']);
+	});
+
+	it('rejects duplicate tool names atomically', () => {
+		registry.register(
+			new TestToolProvider('provider-a', [definition('shared-name', [ToolAudience.BUDDY], ToolAccessKind.READ)], () =>
+				Promise.resolve(completed('a')),
+			),
+		);
+
+		expect(() =>
+			registry.register(
+				new TestToolProvider('provider-b', [definition('shared-name', [ToolAudience.MCP], ToolAccessKind.WRITE)], () =>
+					Promise.resolve(completed('b')),
+				),
+			),
+		).toThrow("Tool name 'shared-name'");
+		expect(registry.list()).toEqual(['provider-a']);
+	});
+
+	it('enforces audience and access before invoking a provider', async () => {
+		const handler = jest.fn(() => Promise.resolve(completed('called')));
+
+		registry.register(
+			new TestToolProvider('provider-a', [definition('write-tool', [ToolAudience.MCP], ToolAccessKind.WRITE)], handler),
+		);
+
+		const audienceDenied = await registry.executeTool({ id: '1', name: 'write-tool', arguments: {} });
+		const accessDenied = await registry.executeTool(
+			{ id: '2', name: 'write-tool', arguments: {} },
+			{ audience: ToolAudience.MCP, source: 'mcp', allowedAccessKinds: [ToolAccessKind.READ] },
+		);
+
+		expect(audienceDenied.status).toBe(ToolExecutionStatus.DENIED);
+		expect(audienceDenied.errorCode).toBe('TOOL_AUDIENCE_DENIED');
+		expect(accessDenied.status).toBe(ToolExecutionStatus.DENIED);
+		expect(accessDenied.errorCode).toBe('TOOL_ACCESS_DENIED');
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('propagates execution context to the indexed provider', async () => {
+		const provider = new TestToolProvider(
+			'provider-a',
+			[definition('read-tool', [ToolAudience.MCP], ToolAccessKind.READ)],
+			() => Promise.resolve(completed('ok')),
+		);
+
+		registry.register(provider);
+
+		const result = await registry.executeTool(
+			{ id: 'request-1', name: 'read-tool', arguments: { value: 'x' } },
+			{ audience: ToolAudience.MCP, source: 'mcp', actorId: 'client-1' },
+		);
+
+		expect(result.status).toBe(ToolExecutionStatus.COMPLETED);
+		expect(provider.contexts).toEqual([
+			expect.objectContaining({
+				audience: ToolAudience.MCP,
+				source: 'mcp',
+				actorId: 'client-1',
+				requestId: 'request-1',
+			}),
+		]);
+	});
+
+	it('returns structured unknown-tool, sanitized-error, and timeout results', async () => {
+		const throwingProvider = new TestToolProvider(
+			'throwing-provider',
+			[definition('throwing-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			() => Promise.reject(new Error('secret internal detail')),
+		);
+		const timeoutProvider = new TestToolProvider(
+			'timeout-provider',
+			[definition('timeout-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			() => new Promise(() => undefined),
+			1,
+		);
+
+		registry.register(throwingProvider);
+		registry.register(timeoutProvider);
+
+		const unknown = await registry.executeTool({ id: '1', name: 'missing', arguments: {} });
+		const failed = await registry.executeTool({ id: '2', name: 'throwing-tool', arguments: { value: 'x' } });
+		const timedOut = await registry.executeTool({ id: '3', name: 'timeout-tool', arguments: { value: 'x' } });
+
+		expect(unknown).toEqual(expect.objectContaining({ status: ToolExecutionStatus.FAILED, errorCode: 'UNKNOWN_TOOL' }));
+		expect(failed).toEqual(
+			expect.objectContaining({
+				status: ToolExecutionStatus.FAILED,
+				errorCode: 'TOOL_EXECUTION_FAILED',
+				message: 'Failed to execute tool "throwing-tool"',
+			}),
+		);
+		expect(failed.message).not.toContain('secret');
+		expect(timedOut).toEqual(
+			expect.objectContaining({
+				status: ToolExecutionStatus.TIMED_OUT,
+				errorCode: 'TOOL_EXECUTION_TIMEOUT',
+			}),
+		);
+	});
+});

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
@@ -1,7 +1,17 @@
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
-import { IToolProvider, LlmToolCall, ToolDefinition, ToolExecutionResult } from '../platforms/tool-provider.platform';
+import {
+	IToolProvider,
+	LlmToolCall,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	ToolListingOptions,
+	createToolExecutionContext,
+} from '../platforms/tool-provider.platform';
 import { TOOLS_MODULE_NAME } from '../tools.constants';
 
 @Injectable()
@@ -9,6 +19,7 @@ export class ToolProviderRegistryService {
 	private readonly logger = createExtensionLogger(TOOLS_MODULE_NAME, 'ToolProviderRegistryService');
 
 	private readonly providers = new Map<string, IToolProvider>();
+	private readonly tools = new Map<string, { definition: ToolDefinition; provider: IToolProvider }>();
 
 	/**
 	 * Register a tool provider implementation
@@ -24,7 +35,30 @@ export class ToolProviderRegistryService {
 			return false;
 		}
 
+		const definitions = provider.getToolDefinitions();
+		const providerToolNames = new Set<string>();
+
+		for (const definition of definitions) {
+			if (providerToolNames.has(definition.name)) {
+				throw new Error(`Tool provider '${type}' declares duplicate tool name '${definition.name}'`);
+			}
+
+			providerToolNames.add(definition.name);
+
+			const registered = this.tools.get(definition.name);
+
+			if (registered) {
+				throw new Error(
+					`Tool name '${definition.name}' from provider '${type}' conflicts with provider '${registered.provider.getType()}'`,
+				);
+			}
+		}
+
 		this.providers.set(type, provider);
+
+		for (const definition of definitions) {
+			this.tools.set(definition.name, { definition, provider });
+		}
 
 		this.logger.log(`Tool provider '${type}' added. Total providers: ${this.providers.size}`);
 
@@ -34,34 +68,70 @@ export class ToolProviderRegistryService {
 	/**
 	 * Get all tool definitions from all registered providers
 	 */
-	getAllToolDefinitions(): ToolDefinition[] {
-		const definitions: ToolDefinition[] = [];
+	getAllToolDefinitions(options: ToolListingOptions = {}): ToolDefinition[] {
+		const audience = options.audience ?? ToolAudience.BUDDY;
 
-		for (const provider of this.providers.values()) {
-			definitions.push(...provider.getToolDefinitions());
-		}
-
-		return definitions;
+		return [...this.tools.values()]
+			.map(({ definition }) => definition)
+			.filter(
+				(definition) =>
+					definition.audiences.includes(audience) &&
+					(options.accessKinds === undefined || options.accessKinds.includes(definition.access)),
+			);
 	}
 
 	/**
 	 * Execute a tool call by routing it to the provider that handles it.
 	 * Iterates through all registered providers until one handles the tool.
 	 */
-	async executeTool(toolCall: LlmToolCall): Promise<ToolExecutionResult> {
-		for (const provider of this.providers.values()) {
-			const result = await provider.executeTool(toolCall);
+	async executeTool(
+		toolCall: LlmToolCall,
+		providedContext?: Partial<ToolExecutionContext>,
+	): Promise<ToolExecutionResult> {
+		const registered = this.tools.get(toolCall.name);
 
-			if (result !== null) {
-				return result;
-			}
+		if (!registered) {
+			this.logger.warn(`No provider found for tool: ${toolCall.name}`);
+
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: `Unknown tool: ${toolCall.name}`,
+				errorCode: 'UNKNOWN_TOOL',
+			};
 		}
 
-		this.logger.warn(`No provider found for tool: ${toolCall.name}`);
+		const context = createToolExecutionContext(toolCall, providedContext);
+
+		if (!registered.definition.audiences.includes(context.audience)) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: `Tool "${toolCall.name}" is not available to ${context.audience}`,
+				errorCode: 'TOOL_AUDIENCE_DENIED',
+			};
+		}
+
+		if (context.allowedAccessKinds && !context.allowedAccessKinds.includes(registered.definition.access)) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: `Tool "${toolCall.name}" requires ${registered.definition.access} access`,
+				errorCode: 'TOOL_ACCESS_DENIED',
+			};
+		}
+
+		const result = await registered.provider.executeTool(toolCall, context);
+
+		if (result !== null) {
+			return result;
+		}
 
 		return {
 			success: false,
-			message: `Unknown tool: ${toolCall.name}`,
+			status: ToolExecutionStatus.FAILED,
+			message: `Provider failed to handle registered tool: ${toolCall.name}`,
+			errorCode: 'TOOL_PROVIDER_MISMATCH',
 		};
 	}
 

--- a/apps/backend/src/plugins/spaces-home-control/services/lighting-intent.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/lighting-intent.service.spec.ts
@@ -29,6 +29,7 @@ describe('LightingIntentService', () => {
 	let service: LightingIntentService;
 	let spacesService: jest.Mocked<SpacesService>;
 	let lightingRoleService: jest.Mocked<SpaceLightingRoleService>;
+	let intentsService: jest.Mocked<IntentsService>;
 
 	const mockSpaceId = uuid();
 	const mockIntentId = uuid();
@@ -148,10 +149,35 @@ describe('LightingIntentService', () => {
 		service = module.get<LightingIntentService>(LightingIntentService);
 		spacesService = module.get(SpacesService);
 		lightingRoleService = module.get(SpaceLightingRoleService);
+		intentsService = module.get(IntentsService);
 
 		// Reset mocks between tests
 		jest.clearAllMocks();
 		mockPlatform.processBatch.mockResolvedValue(true);
+	});
+
+	it('records a supplied agent execution context while keeping the authoritative space', async () => {
+		const onlineDevice = createMockDeviceWithLightChannel('online-device', true, ConnectionState.CONNECTED);
+
+		spacesService.findDevicesBySpace.mockResolvedValue([onlineDevice] as unknown as DeviceEntity[]);
+
+		await service.executeLightingIntent(
+			mockSpaceId,
+			{ type: LightingIntentType.ON },
+			{ origin: 'api', extra: { source: 'mcp', actorId: 'client-1' } },
+		);
+
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		expect(intentsService.createIntent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				context: {
+					origin: 'api',
+					spaceId: mockSpaceId,
+					roleKey: undefined,
+					extra: { source: 'mcp', actorId: 'client-1' },
+				},
+			}),
+		);
 	});
 
 	describe('offline device handling', () => {

--- a/apps/backend/src/plugins/spaces-home-control/services/lighting-intent.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/lighting-intent.service.ts
@@ -7,7 +7,7 @@ import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../mod
 import { IDevicePropertyData } from '../../../modules/devices/platforms/device.platform';
 import { PlatformRegistryService } from '../../../modules/devices/services/platform.registry.service';
 import { DEFAULT_TTL_SPACE_COMMAND, IntentTargetStatus, IntentType } from '../../../modules/intents/intents.constants';
-import { IntentTarget, IntentTargetResult } from '../../../modules/intents/models/intent.model';
+import { IntentContext, IntentTarget, IntentTargetResult } from '../../../modules/intents/models/intent.model';
 import { IntentTimeseriesService } from '../../../modules/intents/services/intent-timeseries.service';
 import { IntentsService } from '../../../modules/intents/services/intents.service';
 import { SpacesService } from '../../../modules/spaces/services/spaces.service';
@@ -161,7 +161,11 @@ export class LightingIntentService extends SpaceIntentBaseService {
 	 * Execute a lighting intent for all lights in a space.
 	 * Returns null if space doesn't exist (controller should throw 404).
 	 */
-	async executeLightingIntent(spaceId: string, intent: LightingIntentDto): Promise<IntentExecutionResult | null> {
+	async executeLightingIntent(
+		spaceId: string,
+		intent: LightingIntentDto,
+		executionContext?: IntentContext,
+	): Promise<IntentExecutionResult | null> {
 		// Verify space exists - return null for controller to throw 404
 		const space = await this.spacesService.findOne(spaceId);
 
@@ -223,7 +227,8 @@ export class LightingIntentService extends SpaceIntentBaseService {
 		const intentRecord = this.intentsService.createIntent({
 			type: this.mapLightingIntentType(intent.type),
 			context: {
-				origin: 'panel.spaces',
+				...executionContext,
+				origin: executionContext?.origin ?? 'panel.spaces',
 				spaceId,
 				roleKey: intent.role ?? undefined,
 			},

--- a/apps/backend/src/plugins/spaces-home-control/services/space-intent.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-intent.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { IntentContext } from '../../../modules/intents/models/intent.model';
 import { ClimateIntentDto } from '../dto/climate-intent.dto';
 import { CoversIntentDto } from '../dto/covers-intent.dto';
 import { LightingIntentDto } from '../dto/lighting-intent.dto';
@@ -44,8 +45,16 @@ export class SpaceIntentService {
 	 * @param intent - The lighting intent to execute (OFF, ON, SET_MODE, BRIGHTNESS_DELTA)
 	 * @returns The execution result with affected/failed device counts, or null if the space doesn't exist
 	 */
-	async executeLightingIntent(spaceId: string, intent: LightingIntentDto): Promise<IntentExecutionResult | null> {
-		return this.lightingIntentService.executeLightingIntent(spaceId, intent);
+	async executeLightingIntent(
+		spaceId: string,
+		intent: LightingIntentDto,
+		executionContext?: IntentContext,
+	): Promise<IntentExecutionResult | null> {
+		if (executionContext === undefined) {
+			return this.lightingIntentService.executeLightingIntent(spaceId, intent);
+		}
+
+		return this.lightingIntentService.executeLightingIntent(spaceId, intent, executionContext);
 	}
 
 	// =====================

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
@@ -2,6 +2,11 @@
 import { ModuleRef } from '@nestjs/core';
 
 import { SpacesService } from '../../../modules/spaces/services/spaces.service';
+import {
+	ToolAccessKind,
+	ToolAudience,
+	ToolExecutionStatus,
+} from '../../../modules/tools/platforms/tool-provider.platform';
 import { ShortIdMappingService } from '../../../modules/tools/services/short-id-mapping.service';
 
 import { SpaceLightingToolService } from './space-lighting-tool.service';
@@ -40,6 +45,9 @@ describe('SpaceLightingToolService', () => {
 
 			expect(tools).toHaveLength(1);
 			expect(tools[0].name).toBe('set_space_lighting');
+			expect(tools[0].audiences).toEqual([ToolAudience.BUDDY, ToolAudience.MCP]);
+			expect(tools[0].access).toBe(ToolAccessKind.TRIGGER);
+			expect(tools[0].outputSchema).toBeDefined();
 		});
 
 		it('should define set_space_lighting with required parameters and mode enum', () => {
@@ -76,11 +84,16 @@ describe('SpaceLightingToolService', () => {
 			});
 
 			expect(result.success).toBe(true);
+			expect(result.status).toBe(ToolExecutionStatus.COMPLETED);
 			expect(result.message).toContain('Living Room');
 			expect(result.message).toContain('"off"');
 			expect(spaceIntentService.executeLightingIntent).toHaveBeenCalledWith(
 				'space-1',
 				expect.objectContaining({ type: 'off' }),
+				expect.objectContaining({
+					origin: 'api',
+					extra: expect.objectContaining({ source: 'buddy', audience: ToolAudience.BUDDY }),
+				}),
 			);
 		});
 
@@ -102,6 +115,7 @@ describe('SpaceLightingToolService', () => {
 			expect(spaceIntentService.executeLightingIntent).toHaveBeenCalledWith(
 				'space-1',
 				expect.objectContaining({ type: 'set_mode', mode: 'relax' }),
+				expect.any(Object),
 			);
 		});
 
@@ -126,7 +140,7 @@ describe('SpaceLightingToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.message).toContain('Invalid lighting mode');
+			expect(result.message).toContain('Missing or invalid required parameters');
 		});
 
 		it('should return failure when missing parameters', async () => {
@@ -137,8 +151,55 @@ describe('SpaceLightingToolService', () => {
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.message).toContain('Missing required parameters');
+			expect(result.message).toContain('Missing or invalid required parameters');
 		});
+
+		it('reports partial device execution honestly', async () => {
+			spaceIntentService.executeLightingIntent.mockResolvedValue({
+				success: false,
+				affectedDevices: 2,
+				failedDevices: 1,
+			});
+			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
+
+			const result = await service.executeTool({
+				id: 'call-1',
+				name: 'set_space_lighting',
+				arguments: { space_id: 'space-1', mode: 'work' },
+			});
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					success: true,
+					status: ToolExecutionStatus.PARTIAL,
+					data: expect.objectContaining({ affected_devices: 2, failed_devices: 1 }),
+				}),
+			);
+		});
+	});
+
+	it('returns a structured failure when the optional lighting service is unavailable', async () => {
+		const unavailableService = new SpaceLightingToolService(
+			spacesService as unknown as SpacesService,
+			{ get: jest.fn().mockReturnValue(undefined) } as unknown as ModuleRef,
+			new ShortIdMappingService(),
+		);
+
+		await unavailableService.onModuleInit();
+
+		const result = await unavailableService.executeTool({
+			id: 'call-1',
+			name: 'set_space_lighting',
+			arguments: { space_id: 'space-1', mode: 'off' },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				errorCode: 'SPACE_LIGHTING_UNAVAILABLE',
+			}),
+		);
 	});
 
 	describe('executeTool - unknown tool', () => {

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
@@ -176,6 +176,60 @@ describe('SpaceLightingToolService', () => {
 				}),
 			);
 		});
+
+		it('reports skipped offline devices as partial execution', async () => {
+			spaceIntentService.executeLightingIntent.mockResolvedValue({
+				success: true,
+				affectedDevices: 2,
+				failedDevices: 0,
+				skippedOfflineDevices: 1,
+			});
+			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
+
+			const result = await service.executeTool({
+				id: 'call-1',
+				name: 'set_space_lighting',
+				arguments: { space_id: 'space-1', mode: 'work' },
+			});
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					success: true,
+					status: ToolExecutionStatus.PARTIAL,
+					data: expect.objectContaining({
+						affected_devices: 2,
+						failed_devices: 0,
+						skipped_offline_devices: 1,
+					}),
+				}),
+			);
+			expect(result.message).toContain('1 offline');
+		});
+
+		it('reports failure when every targeted lighting device is offline', async () => {
+			spaceIntentService.executeLightingIntent.mockResolvedValue({
+				success: true,
+				affectedDevices: 0,
+				failedDevices: 0,
+				skippedOfflineDevices: 2,
+			});
+			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
+
+			const result = await service.executeTool({
+				id: 'call-1',
+				name: 'set_space_lighting',
+				arguments: { space_id: 'space-1', mode: 'work' },
+			});
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					success: false,
+					status: ToolExecutionStatus.FAILED,
+					errorCode: 'NO_ONLINE_LIGHTING_DEVICES',
+					data: expect.objectContaining({ skipped_offline_devices: 2 }),
+				}),
+			);
+		});
 	});
 
 	it('returns a structured failure when the optional lighting service is unavailable', async () => {

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
@@ -34,6 +34,7 @@ const SET_SPACE_LIGHTING_OUTPUT_SCHEMA = z.object({
 	mode: z.enum(LIGHTING_MODES),
 	affected_devices: z.number().int().nonnegative(),
 	failed_devices: z.number().int().nonnegative(),
+	skipped_offline_devices: z.number().int().nonnegative(),
 });
 
 /** Tool provider for space-level lighting control. */
@@ -139,14 +140,16 @@ export class SpaceLightingToolService extends BaseToolProviderService implements
 
 		const space = await this.spacesService.findOne(spaceId);
 		const spaceName = space?.name ?? spaceId;
+		const skippedOfflineDevices = result.skippedOfflineDevices ?? 0;
 		const data = {
 			space_id: spaceId,
 			mode: parsed.data.mode,
 			affected_devices: result.affectedDevices,
 			failed_devices: result.failedDevices,
+			skipped_offline_devices: skippedOfflineDevices,
 		};
 
-		if (result.failedDevices === 0 && result.affectedDevices > 0) {
+		if (result.failedDevices === 0 && skippedOfflineDevices === 0 && result.affectedDevices > 0) {
 			return {
 				success: true,
 				status: ToolExecutionStatus.COMPLETED,
@@ -156,6 +159,16 @@ export class SpaceLightingToolService extends BaseToolProviderService implements
 		}
 
 		if (result.failedDevices === 0 && result.affectedDevices === 0) {
+			if (skippedOfflineDevices > 0) {
+				return {
+					success: false,
+					status: ToolExecutionStatus.FAILED,
+					message: `No online lighting devices available in ${spaceName} (${skippedOfflineDevices} offline)`,
+					data,
+					errorCode: 'NO_ONLINE_LIGHTING_DEVICES',
+				};
+			}
+
 			return {
 				success: false,
 				status: ToolExecutionStatus.FAILED,
@@ -169,7 +182,7 @@ export class SpaceLightingToolService extends BaseToolProviderService implements
 			return {
 				success: true,
 				status: ToolExecutionStatus.PARTIAL,
-				message: `Partially set ${spaceName} lighting to "${parsed.data.mode}" (${result.affectedDevices} succeeded, ${result.failedDevices} failed)`,
+				message: `Partially set ${spaceName} lighting to "${parsed.data.mode}" (${result.affectedDevices} succeeded, ${result.failedDevices} failed, ${skippedOfflineDevices} offline)`,
 				data,
 			};
 		}

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
@@ -6,8 +8,13 @@ import { SpacesService } from '../../../modules/spaces/services/spaces.service';
 import { SPACES_MODULE_NAME } from '../../../modules/spaces/spaces.constants';
 import {
 	LlmToolCall,
+	ToolAccessKind,
+	ToolAudience,
 	ToolDefinition,
+	ToolExecutionContext,
 	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolDefinition,
 } from '../../../modules/tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../../modules/tools/services/base-tool-provider.service';
 import { ShortIdMappingService } from '../../../modules/tools/services/short-id-mapping.service';
@@ -15,14 +22,21 @@ import { LightingIntentDto } from '../dto/lighting-intent.dto';
 import { LightingIntentType, LightingMode } from '../spaces-home-control.constants';
 
 const SPACE_LIGHTING_TOOLS_PROVIDER = 'space-lighting-tools';
+const LIGHTING_MODES = ['off', 'on', 'work', 'relax', 'night'] as const;
 
-/**
- * Tool provider for space lighting control.
- * Allows the AI assistant to set lighting modes for entire spaces.
- *
- * Uses ModuleRef to lazily resolve SpaceIntentService, avoiding a file-level
- * circular import chain (space-intent → lighting-intent → space-context-snapshot → space-intent).
- */
+const SET_SPACE_LIGHTING_INPUT_SCHEMA = z.object({
+	space_id: z.string().min(1).describe('Short space ID from the home context (the id=... value)'),
+	mode: z.enum(LIGHTING_MODES).describe('Lighting mode to set'),
+});
+
+const SET_SPACE_LIGHTING_OUTPUT_SCHEMA = z.object({
+	space_id: z.string(),
+	mode: z.enum(LIGHTING_MODES),
+	affected_devices: z.number().int().nonnegative(),
+	failed_devices: z.number().int().nonnegative(),
+});
+
+/** Tool provider for space-level lighting control. */
 @Injectable()
 export class SpaceLightingToolService extends BaseToolProviderService implements OnModuleInit {
 	protected readonly logger = createExtensionLogger(SPACES_MODULE_NAME, 'SpaceLightingToolService');
@@ -49,109 +63,123 @@ export class SpaceLightingToolService extends BaseToolProviderService implements
 
 	getToolDefinitions(): ToolDefinition[] {
 		return [
-			{
+			createToolDefinition({
 				name: 'set_space_lighting',
 				description:
 					'Set the lighting mode for an entire space (room). ' +
 					'Available modes: "off" (all lights off), "on" (all lights on at full brightness), ' +
 					'"work" (bright, productive lighting), "relax" (dimmed, comfortable lighting), ' +
 					'"night" (very dim night lighting). ' +
-					'Use this instead of controlling individual light devices when you want to change the overall room lighting.',
-				parameters: {
-					type: 'object',
-					properties: {
-						space_id: {
-							type: 'string',
-							description: 'Short space ID from the home context (the id=... value)',
-						},
-						mode: {
-							type: 'string',
-							enum: ['off', 'on', 'work', 'relax', 'night'],
-							description: 'Lighting mode to set',
-						},
-					},
-					required: ['space_id', 'mode'],
-				},
-			},
+					'Use this instead of controlling individual light devices when changing the overall room lighting.',
+				audiences: [ToolAudience.BUDDY, ToolAudience.MCP],
+				access: ToolAccessKind.TRIGGER,
+				inputSchema: SET_SPACE_LIGHTING_INPUT_SCHEMA,
+				outputSchema: SET_SPACE_LIGHTING_OUTPUT_SCHEMA,
+			}),
 		];
 	}
 
-	protected async handleToolCall(toolCall: LlmToolCall): Promise<ToolExecutionResult> {
-		return this.executeSetSpaceLighting(toolCall.arguments);
-	}
+	protected async handleToolCall(toolCall: LlmToolCall, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+		const parsed = SET_SPACE_LIGHTING_INPUT_SCHEMA.safeParse(toolCall.arguments);
 
-	private async executeSetSpaceLighting(args: Record<string, unknown>): Promise<ToolExecutionResult> {
-		const rawSpaceId = typeof args.space_id === 'string' ? args.space_id : '';
-		const mode = typeof args.mode === 'string' ? args.mode : '';
-
-		if (!rawSpaceId || !mode) {
-			return { success: false, message: 'Missing required parameters: space_id, mode' };
+		if (!parsed.success) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'Missing or invalid required parameters: space_id, mode',
+				errorCode: 'INVALID_TOOL_ARGUMENTS',
+			};
 		}
 
-		const spaceId = this.shortIdMapping.resolve(rawSpaceId) ?? rawSpaceId;
+		const spaceId = this.shortIdMapping.resolve(parsed.data.space_id) ?? parsed.data.space_id;
 
 		if (!this.spaceIntentService) {
-			return { success: false, message: 'Space lighting service is not available' };
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'Space lighting service is not available',
+				errorCode: 'SPACE_LIGHTING_UNAVAILABLE',
+			};
 		}
 
-		// Validate mode
-		const validModes = ['off', 'on', 'work', 'relax', 'night'];
-
-		if (!validModes.includes(mode)) {
-			return { success: false, message: `Invalid lighting mode "${mode}". Valid modes: ${validModes.join(', ')}` };
-		}
-
-		// Map mode to intent type and lighting mode
 		let intentType: LightingIntentType;
 		let lightingMode: LightingMode | undefined;
 
-		if (mode === 'off') {
+		if (parsed.data.mode === 'off') {
 			intentType = LightingIntentType.OFF;
-		} else if (mode === 'on') {
+		} else if (parsed.data.mode === 'on') {
 			intentType = LightingIntentType.ON;
 		} else {
 			intentType = LightingIntentType.SET_MODE;
-			lightingMode = mode as LightingMode;
+			lightingMode = parsed.data.mode as LightingMode;
 		}
 
 		const intent: LightingIntentDto = Object.assign(new LightingIntentDto(), {
 			type: intentType,
 			mode: lightingMode,
 		});
-
-		const result = await this.spaceIntentService.executeLightingIntent(spaceId, intent);
+		const result = await this.spaceIntentService.executeLightingIntent(spaceId, intent, {
+			origin: 'api',
+			extra: {
+				source: context.source,
+				audience: context.audience,
+				actorId: context.actorId,
+				requestId: context.requestId,
+			},
+		});
 
 		if (!result) {
-			return { success: false, message: `Space with ID "${spaceId}" not found` };
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: `Space with ID "${spaceId}" not found`,
+				errorCode: 'SPACE_NOT_FOUND',
+			};
 		}
 
 		const space = await this.spacesService.findOne(spaceId);
 		const spaceName = space?.name ?? spaceId;
+		const data = {
+			space_id: spaceId,
+			mode: parsed.data.mode,
+			affected_devices: result.affectedDevices,
+			failed_devices: result.failedDevices,
+		};
 
 		if (result.failedDevices === 0 && result.affectedDevices > 0) {
 			return {
 				success: true,
-				message: `Set ${spaceName} lighting to "${mode}" (${result.affectedDevices} devices updated)`,
+				status: ToolExecutionStatus.COMPLETED,
+				message: `Set ${spaceName} lighting to "${parsed.data.mode}" (${result.affectedDevices} devices updated)`,
+				data,
 			};
 		}
 
 		if (result.failedDevices === 0 && result.affectedDevices === 0) {
 			return {
 				success: false,
+				status: ToolExecutionStatus.FAILED,
 				message: `No lighting devices found in ${spaceName}`,
+				data,
+				errorCode: 'NO_LIGHTING_DEVICES',
 			};
 		}
 
 		if (result.affectedDevices > 0) {
 			return {
 				success: true,
-				message: `Partially set ${spaceName} lighting to "${mode}" (${result.affectedDevices} succeeded, ${result.failedDevices} failed)`,
+				status: ToolExecutionStatus.PARTIAL,
+				message: `Partially set ${spaceName} lighting to "${parsed.data.mode}" (${result.affectedDevices} succeeded, ${result.failedDevices} failed)`,
+				data,
 			};
 		}
 
 		return {
 			success: false,
+			status: ToolExecutionStatus.FAILED,
 			message: `Failed to set lighting in ${spaceName}`,
+			data,
+			errorCode: 'SPACE_LIGHTING_FAILED',
 		};
 	}
 }

--- a/apps/backend/test/mcp-sdk-compatibility.e2e-spec.ts
+++ b/apps/backend/test/mcp-sdk-compatibility.e2e-spec.ts
@@ -1,0 +1,149 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { IncomingMessage } from 'http';
+import { z } from 'zod';
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { AuthInfo, McpRequestContext, McpServer, createMcpHandler } from '@modelcontextprotocol/server';
+import { All, Controller, Req, Res } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+
+import { RawRoute } from '../src/modules/api/decorators/raw-route.decorator';
+import { OpenApiResponseInterceptor } from '../src/modules/api/interceptors/open-api-response.interceptor';
+import { TransformResponseInterceptor } from '../src/modules/api/interceptors/transform-response.interceptor';
+
+const AUTH_TOKEN = 'phase-0-token';
+const CLIENT_ID = 'phase-0-client';
+
+type AuthenticatedIncomingMessage = IncomingMessage & { auth?: AuthInfo };
+
+const observedContexts: McpRequestContext[] = [];
+
+const handler = createMcpHandler(
+	(context) => {
+		observedContexts.push(context);
+
+		const server = new McpServer({
+			name: 'smart-panel-mcp-compatibility-spike',
+			version: '1.0.0',
+		});
+
+		server.registerTool(
+			'echo',
+			{
+				description: 'Returns the supplied message.',
+				inputSchema: z.object({ message: z.string() }),
+				outputSchema: z.object({ message: z.string() }),
+			},
+			({ message }) => ({
+				content: [{ type: 'text', text: message }],
+				structuredContent: { message },
+			}),
+		);
+
+		return server;
+	},
+	{
+		legacy: 'stateless',
+		maxSubscriptions: 4,
+	},
+);
+
+const nodeHandler = toNodeHandler(handler);
+
+@Controller('mcp-sdk-compatibility')
+class McpSdkCompatibilityController {
+	@RawRoute()
+	@All()
+	async handle(@Req() request: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+		const rawRequest = request.raw as AuthenticatedIncomingMessage;
+
+		rawRequest.auth = {
+			token: request.headers.authorization?.replace(/^Bearer /, '') ?? '',
+			clientId: CLIENT_ID,
+			scopes: ['read'],
+			extra: { source: 'compatibility-spike' },
+		};
+
+		reply.hijack();
+
+		await nodeHandler(rawRequest, reply.raw, request.body);
+	}
+}
+
+describe('MCP SDK v2 compatibility', () => {
+	let app: NestFastifyApplication;
+	let endpoint: URL;
+
+	beforeAll(async () => {
+		const moduleRef = await Test.createTestingModule({
+			controllers: [McpSdkCompatibilityController],
+		}).compile();
+
+		app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+		const reflector = app.get(Reflector);
+
+		app.useGlobalInterceptors(new OpenApiResponseInterceptor(reflector), new TransformResponseInterceptor(reflector));
+
+		await app.listen(0, '127.0.0.1');
+
+		endpoint = new URL('/mcp-sdk-compatibility', await app.getUrl());
+	});
+
+	afterEach(() => {
+		observedContexts.length = 0;
+	});
+
+	afterAll(async () => {
+		await handler.close();
+		await app.close();
+	});
+
+	it('serves the modern protocol through the NestJS Fastify raw response', async () => {
+		const client = new Client(
+			{ name: 'modern-compatibility-client', version: '1.0.0' },
+			{ versionNegotiation: { mode: 'auto' } },
+		);
+		const transport = new StreamableHTTPClientTransport(endpoint, {
+			requestInit: { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } },
+		});
+
+		try {
+			await client.connect(transport);
+
+			const tools = await client.listTools();
+			const result = await client.callTool({ name: 'echo', arguments: { message: 'modern' } });
+			const modernContext = observedContexts.find(({ era }) => era === 'modern');
+
+			expect(tools.tools.map(({ name }) => name)).toEqual(['echo']);
+			expect(result.structuredContent).toEqual({ message: 'modern' });
+			expect(modernContext?.authInfo?.token).toBe(AUTH_TOKEN);
+			expect(modernContext?.authInfo?.clientId).toBe(CLIENT_ID);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('serves a legacy client through the stateless compatibility path', async () => {
+		const client = new Client({ name: 'legacy-compatibility-client', version: '1.0.0' });
+		const transport = new StreamableHTTPClientTransport(endpoint, {
+			requestInit: { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } },
+		});
+
+		try {
+			await client.connect(transport);
+
+			const result = await client.callTool({ name: 'echo', arguments: { message: 'legacy' } });
+			const legacyContext = observedContexts.find(({ era }) => era === 'legacy');
+
+			expect(result.structuredContent).toEqual({ message: 'legacy' });
+			expect(legacyContext?.authInfo?.token).toBe(AUTH_TOKEN);
+			expect(legacyContext?.authInfo?.clientId).toBe(CLIENT_ID);
+		} finally {
+			await client.close();
+		}
+	});
+});

--- a/docs/adr/0001-mcp-protocol-and-security-foundation.md
+++ b/docs/adr/0001-mcp-protocol-and-security-foundation.md
@@ -1,0 +1,134 @@
+# ADR 0001: MCP Protocol and Security Foundation
+
+**Status:** Accepted
+
+**Date:** 2026-08-06
+
+**Scope:** Phase 0 of the Smart Panel MCP module
+
+## Context
+
+The original MCP implementation plan was written around the 2025 Streamable HTTP lifecycle: `initialize`, an
+`Mcp-Session-Id`, GET/SSE notification streams, and DELETE-based session teardown. MCP revision 2026-07-28 replaces
+that lifecycle with per-request protocol metadata, `server/discover`, and `subscriptions/listen`. The official
+TypeScript SDK v2 supports both the modern protocol and legacy 2025 clients.
+
+Smart Panel also needs security decisions that remain stable when an installation changes hostname, IP address, or
+reverse-proxy path. Those decisions must be settled before token, client, and transport schemas are implemented.
+
+## Decisions
+
+### 1. Protocol posture
+
+- The primary protocol is MCP revision `2026-07-28` or a later revision explicitly supported by the pinned SDK.
+- The first release uses the official SDK's per-request HTTP handler and modern `subscriptions/listen` event bus.
+- Legacy 2025 traffic is served by the SDK's stateless compatibility path initially.
+- A stateful legacy transport, including session IDs, GET/SSE, and DELETE teardown, is not part of the initial
+  implementation. It will be added only if one of the two release-target MCP hosts fails the stateless compatibility
+  test and cannot use the modern protocol.
+- If legacy stateful support becomes necessary, it will be routed separately with the SDK's `isLegacyRequest`
+  classifier. Modern requests will remain sessionless.
+- Stdio and legacy HTTP+SSE are out of scope.
+
+This replaces the original assumption that stateful sessions are required for change notifications. Modern clients
+receive tool and resource list changes through `subscriptions/listen`.
+
+### 2. SDK packages and HTTP integration
+
+- Pin `@modelcontextprotocol/server`, `@modelcontextprotocol/node`, and the test-only
+  `@modelcontextprotocol/client` to `2.0.0`.
+- Pin Zod to `4.4.3` for input and output schemas.
+- Mount `createMcpHandler` through `toNodeHandler` on the existing NestJS/Fastify server.
+- Do not install `@modelcontextprotocol/fastify`: it is an application factory, not an adapter for a route hosted by
+  the existing NestJS Fastify application.
+- Use Smart Panel's existing `RawRoute` metadata and exclude the protocol endpoint from OpenAPI. The controller must
+  hijack the Fastify reply before the Node adapter writes JSON or SSE to the raw response.
+- Authentication, authorization, body limits, throttling, and Origin/Host validation execute before SDK dispatch.
+  The validated principal is passed to the SDK as `AuthInfo`; the SDK does not authenticate bearer tokens itself.
+
+### 3. Installation identity and token audience
+
+- Every installation receives an immutable UUID generated once and persisted in database-backed storage.
+- Hostname, mDNS name, IP address, and public URL are display/routing metadata and are not installation identity.
+- MCP token audience is the stable URI `urn:fastybird:smart-panel:<installation-uuid>:mcp`.
+- The MCP authentication guard validates that exact audience and accepts the token only at
+  `/api/v1/modules/mcp`.
+- MCP results expose the installation UUID, display name, backend version, and current endpoint URL when it can be
+  determined safely.
+
+This permits DHCP, reverse-proxy, and ingress URL changes without invalidating every MCP token. Token rotation remains
+required if an installation is cloned with its database; operational backup/restore documentation must call this out.
+
+### 4. Origin, Host, and proxy policy
+
+- `allowed_origins` contains normalized absolute HTTP(S) origins only: scheme, hostname, and effective port. Paths,
+  query strings, fragments, credentials, wildcard hosts, and non-HTTP schemes are rejected.
+- A missing `Origin` is accepted for non-browser MCP clients after bearer authentication.
+- A present same-origin request is accepted. A different browser origin must match `allowed_origins` exactly.
+- Host validation is independent of Origin validation. Accepted hosts are derived from loopback defaults, the host in
+  `FB_APP_HOST`, and hosts explicitly present in `allowed_origins`.
+- Forwarded headers are not trusted for MCP security decisions until Smart Panel has an explicit trusted-proxy
+  configuration. Administrators behind a reverse proxy must configure `FB_APP_HOST` to the external origin.
+- Host and Origin failures return HTTP 403 before JSON-RPC parsing.
+
+### 5. Configuration authorization
+
+Saving module configuration is an administrative operation. The generic `PATCH config/module/:module` endpoint will
+be restricted to owners and administrators for every module, rather than adding a hidden MCP-only exception to a
+shared controller. Phase 2 must include regression coverage for every credential type and confirm that existing Admin
+configuration flows use owner/admin credentials.
+
+### 6. Lifecycle and policy invalidation
+
+- Authorization is recalculated for every MCP request and immediately before each tool execution.
+- Modern subscription streams are bounded globally and per client at the application policy layer.
+- Module disable, client disable/revocation, token rotation, and capability reduction invalidate current policy
+  immediately. The event bus sends best-effort list-change notifications; missed notifications never grant access.
+- Targeted revocation aborts subscription streams owned by the affected MCP client. These are application connection
+  records, not MCP protocol sessions.
+- Nest shutdown hooks will be enabled before the production MCP endpoint is registered so handlers and streams close
+  cleanly.
+
+### 7. Tool execution and intent traceability
+
+- The internal tool registry uses provider-neutral `read`, `write`, and `trigger` access kinds and requires every tool
+  to opt into its allowed audiences explicitly.
+- Existing callers that omit execution context retain Buddy-compatible defaults.
+- Domain intents retain the provider-neutral `api` origin. The exact caller source (`buddy`, `mcp`, or a future
+  adapter), audience, and authenticated actor are recorded in intent context metadata.
+- Provider-triggered device writes use the same property constraint validation, intent lifecycle, and platform batch
+  processing path as the REST property-command API.
+- Internal exception details remain in server logs; agent-facing failures contain stable error codes and sanitized
+  messages only.
+
+## Compatibility gate
+
+Before the MCP catalog is considered release-ready, test two intended agent hosts with static bearer-header
+configuration. Each host must complete:
+
+1. Protocol discovery or legacy initialization.
+2. Tool listing.
+3. One structured tool call.
+4. Tool-list change observation when supported by its negotiated protocol.
+5. Immediate denial after token revocation or capability reduction.
+
+If a target host requires legacy stateful Streamable HTTP, record the host/version and add a bounded legacy transport
+registry as a separate compatibility change. Do not add stateful behavior to modern requests.
+
+## Consequences
+
+- Modern MCP behavior follows the current protocol without carrying session identifiers.
+- Basic legacy clients remain usable, but legacy live notifications are not promised unless the compatibility gate
+  demonstrates a need for stateful support.
+- Installation URL changes do not invalidate token audiences.
+- MCP access through a reverse proxy requires an explicit canonical host configuration.
+- Restricting the shared configuration write endpoint is a deliberate cross-module authorization hardening and needs
+  broader regression testing.
+- Tool executions remain attributable to their adapter without expanding the public intent-origin enum for every new
+  agent protocol.
+
+## References
+
+- [MCP 2026-07-28 protocol revision](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
+- [TypeScript SDK v2 protocol version support](https://ts.sdk.modelcontextprotocol.io/v2/protocol-versions)
+- [`createMcpHandler` API](https://ts.sdk.modelcontextprotocol.io/v2/api/%40modelcontextprotocol/server/server/createMcpHandler.html)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.78.0
-        version: 0.78.0(zod@4.3.6)
+        version: 0.78.0(zod@4.4.3)
       '@fastify/helmet':
         specifier: ^13.0.2
         version: 13.1.0
@@ -362,6 +362,12 @@ importers:
       '@influxdata/influxdb-client':
         specifier: ^1.35.0
         version: 1.35.0
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.3(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(cache-manager@7.2.9)(keyv@5.6.0)(rxjs@7.8.2)
@@ -469,7 +475,7 @@ importers:
         version: 6.2.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       openai:
         specifier: ^6.28.0
-        version: 6.49.0(ws@8.21.1)(zod@4.3.6)
+        version: 6.49.0(ws@8.21.1)(zod@4.4.3)
       openweathermap-ts:
         specifier: ^1.2.10
         version: 1.2.10(encoding@0.1.13)
@@ -512,6 +518,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.9.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -519,6 +528,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
       '@nestjs/cli':
         specifier: ^11.0.16
         version: 11.0.24(@swc/cli@0.8.1(@swc/core@1.15.47(@swc/helpers@0.5.17))(chokidar@4.0.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.12.0)(prettier@3.8.1)
@@ -1671,6 +1683,12 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2392,6 +2410,28 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: ^4.11.4
+    peerDependenciesMeta:
+      hono:
+        optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-5qpvOu5IGwDo7MEKVqqyAxF90I6aLj4n07OzpARdgDRfz8UbBztTByBp0RC59r3J1Ij8uzYi6jI7r5Lws7nn6w==}
@@ -6891,6 +6931,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7447,6 +7495,10 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -8031,6 +8083,9 @@ packages:
   joi@18.2.3:
     resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
     engines: {node: '>= 20'}
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -9512,6 +9567,10 @@ packages:
 
   piscina@4.9.3:
     resolution: {integrity: sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -11805,6 +11864,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@5.0.5:
     resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
     engines: {node: '>=12.20.0'}
@@ -11891,11 +11953,11 @@ snapshots:
       package-manager-detector: 1.3.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.78.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -12759,6 +12821,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.5.0(react@19.2.4)
 
+  '@hono/node-server@1.19.17(hono@4.13.0)':
+    dependencies:
+      hono: 4.13.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -13534,6 +13600,32 @@ snapshots:
       '@chevrotain/types': 11.1.2
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.8
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)':
+    dependencies:
+      '@hono/node-server': 1.19.17(hono@4.13.0)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.13.0
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     optional: true
@@ -18561,6 +18653,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -19327,6 +19425,8 @@ snapshots:
   helmet@8.1.0: {}
 
   help-me@5.0.0: {}
+
+  hono@4.13.0: {}
 
   hookable@5.5.3: {}
 
@@ -20115,6 +20215,8 @@ snapshots:
       '@hapi/tlds': 1.1.4
       '@hapi/topo': 6.0.2
       '@standard-schema/spec': 1.1.0
+
+  jose@6.2.8: {}
 
   joycon@3.1.1: {}
 
@@ -21675,10 +21777,10 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@6.49.0(ws@8.21.1)(zod@4.3.6):
+  openai@6.49.0(ws@8.21.1)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.1
-      zod: 4.3.6
+      zod: 4.4.3
 
   openapi-fetch@0.17.0:
     dependencies:
@@ -21964,6 +22066,8 @@ snapshots:
   piscina@4.9.3:
     optionalDependencies:
       '@napi-rs/nice': 1.0.1
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -24688,6 +24792,8 @@ snapshots:
   yoctocolors@2.2.0: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.5(@types/react@19.2.14)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.5.0(react@19.2.4)):
     optionalDependencies:

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,5 +1,10 @@
 # Smart Panel MCP Module — Implementation Plan
 
+**Status:** Phase 1 complete — Phase 2 pending
+
+**Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
+supersedes the original stateful-session transport assumptions in this plan.
+
 > **For agentic workers:** Read this plan completely before changing code. Implement tasks in order, keep the
 > checkboxes current, and run the stated verification after every phase. Do not edit generated OpenAPI clients by
 > hand.
@@ -8,10 +13,12 @@
 installation on which it runs. Owners and administrators control whether MCP is enabled and whether `read`, `write`,
 `trigger`, or any combination of those capabilities is available.
 
-**Architecture:** The backend hosts one authenticated Streamable HTTP MCP endpoint on its existing HTTP server. The
-MCP server calls domain services directly; it does not proxy arbitrary OpenAPI operations and has no environment
-selector. An agent connects to the URL of a particular Smart Panel installation, so testing and production remain
-separate by deployment rather than by MCP configuration.
+**Architecture:** The backend hosts one authenticated Streamable HTTP MCP endpoint on its existing HTTP server. Modern
+MCP requests are sessionless and use `subscriptions/listen` for change events; legacy 2025 requests use the SDK's
+stateless compatibility path unless the release compatibility gate proves that a bounded stateful legacy adapter is
+required. The MCP server calls domain services directly; it does not proxy arbitrary OpenAPI operations and has no
+environment selector. An agent connects to the URL of a particular Smart Panel installation, so testing and production
+remain separate by deployment rather than by MCP configuration.
 
 **Initial endpoint:** `https://<installation>/api/v1/modules/mcp`
 
@@ -78,10 +85,11 @@ inherit general REST access from the creating administrator.
 
 ### 1.5 Transport scope
 
-- Implement Streamable HTTP using the official MCP TypeScript SDK.
-- Use stateful sessions because configuration changes need `notifications/tools/list_changed` and explicit session
-  invalidation.
-- Do not add legacy HTTP+SSE unless a supported target client proves it is required.
+- Implement the modern 2026-07-28 protocol with the official MCP TypeScript SDK v2 per-request HTTP handler.
+- Publish configuration changes through `subscriptions/listen`; modern MCP has no protocol session ID.
+- Serve legacy 2025 requests through the SDK's stateless compatibility path.
+- Add a separately routed, bounded legacy stateful transport only if a supported target client proves it is required.
+- Do not add legacy HTTP+SSE.
 - Do not add stdio in this task; agents connect to the installed application over HTTP.
 - Standards-compliant third-party OAuth discovery/authorization is a follow-up. The first release targets clients that
   support a preconfigured `Authorization: Bearer <MCP token>` header.
@@ -184,7 +192,7 @@ apps/backend/src/modules/mcp/
 │   ├── mcp-context.service.ts
 │   ├── mcp-policy.service.ts
 │   ├── mcp-server.service.ts
-│   └── mcp-session.service.ts
+│   └── mcp-subscription-registry.service.ts
 ├── tools/
 │   ├── mcp-read-tool.service.ts
 │   └── mcp-target-discovery-tool.service.ts
@@ -237,20 +245,22 @@ Existing files expected to change include:
 
 - Modify: `apps/backend/package.json`
 - Modify: `pnpm-lock.yaml`
-- Create temporary test code only if it is either removed or converted into a committed integration test
+- Create: `docs/adr/0001-mcp-protocol-and-security-foundation.md`
+- Create: `apps/backend/test/mcp-sdk-compatibility.e2e-spec.ts`
 
-- [ ] Verify the current stable official MCP server and Fastify adapter packages against Node 24, TypeScript 5.9,
+- [x] Verify the current stable official MCP server and Node adapter packages against Node 24, TypeScript 5.9,
       Fastify 5, NestJS 11, and the repository's ESM/CommonJS build configuration.
-- [ ] Prefer the official `@modelcontextprotocol/server` and `@modelcontextprotocol/fastify` packages.
-- [ ] Pin exact compatible versions; do not use `latest` ranges.
-- [ ] Confirm the adapter can handle POST, GET/SSE, DELETE, protocol-version headers, and an externally supplied
-      authenticated client context without starting a second HTTP server.
-- [ ] Confirm MCP responses can bypass Smart Panel's response-envelope and class-transformer interceptors.
-- [ ] If the newly released SDK v2 is incompatible, use the latest supported v1 SDK and record the reason in this plan
-      and in a dependency comment. Do not upgrade TypeScript or Fastify as an incidental workaround.
-- [ ] Add a minimal in-process protocol initialization test before continuing.
+- [x] Use `@modelcontextprotocol/server` and `@modelcontextprotocol/node`; the Fastify package creates a separate app
+      and is not the route adapter needed by NestJS.
+- [x] Pin exact compatible SDK and Zod versions; do not use `latest` ranges.
+- [x] Confirm modern auto-negotiation and legacy stateless requests work without starting a second application server.
+- [x] Confirm the Node adapter receives externally validated `AuthInfo` and passes it to the per-request server factory.
+- [x] Confirm MCP responses bypass Smart Panel's response-envelope and class-transformer interceptors through
+      `RawRoute` and Fastify reply hijacking.
+- [x] Add an in-process test covering tool listing and structured tool calls for modern and legacy clients.
 
-**Verification:** backend build, type-check, and the initialization test pass.
+**Outcome:** SDK v2 is compatible. The focused E2E test passes. The two-host release compatibility gate remains in
+Task 14 because it requires external target clients.
 
 ### Task 2: Add the backend MCP module and configuration mapping
 
@@ -295,18 +305,24 @@ requests.
 - Modify: `apps/backend/src/modules/tools/services/tool-provider-registry.service.ts`
 - Modify existing tool-provider tests
 
-- [ ] Add a provider-neutral access-kind enum: `read`, `write`, `trigger`.
-- [ ] Add tool audiences so a definition explicitly opts into Buddy, MCP, or both.
-- [ ] Add optional execution context carrying audience, source, authenticated actor/client ID, and request ID.
-- [ ] Make registry listing filter by audience and access kinds.
-- [ ] Make registry execution resolve the registered definition first and reject audience mismatches.
-- [ ] Preserve Buddy behavior and signatures through a small compatibility adapter where necessary.
-- [ ] Reject duplicate tool names across providers at registration; logging and silently keeping one provider is not
+- [x] Add a provider-neutral access-kind enum: `read`, `write`, `trigger`.
+- [x] Add tool audiences so a definition explicitly opts into Buddy, MCP, or both.
+- [x] Add optional execution context carrying audience, source, authenticated actor/client ID, and request ID.
+- [x] Define provider-neutral Zod input/output schemas and derive the legacy JSON Schema representation from them.
+- [x] Return explicit completed, partial, failed, timed-out, or denied execution outcomes.
+- [x] Make registry listing filter by audience and access kinds.
+- [x] Make registry execution resolve the registered definition first and reject audience mismatches.
+- [x] Preserve Buddy behavior and signatures through default execution context values where necessary.
+- [x] Reject duplicate tool names across providers at registration; logging and silently keeping one provider is not
       safe for an externally exposed protocol.
-- [ ] Keep timeout handling in `BaseToolProviderService` and return a structured failure without leaking stack traces.
+- [x] Keep timeout handling in `BaseToolProviderService` and return a structured failure without leaking stack traces.
 
 **Tests:** audience filtering, capability filtering, duplicate names, unknown tools, execution context propagation,
 timeouts, and Buddy regression tests.
+
+**Outcome:** The registry now indexes unique tool names, applies definition-level audience/access policy before provider
+execution, and defaults existing callers to the Buddy context. Tool definitions use Zod as their schema source and all
+execution paths return structured, sanitized outcomes.
 
 ### Task 4: Classify and refactor the existing operational tools
 
@@ -317,17 +333,22 @@ timeouts, and Buddy regression tests.
 - Modify: `apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts`
 - Modify corresponding unit tests
 
-- [ ] Classify device property control as `write` and expose it to Buddy and MCP.
-- [ ] Classify scene execution and space lighting intents as `trigger` and expose them to Buddy and MCP.
-- [ ] Rename only at the MCP adapter boundary if public MCP names need clearer naming; do not break existing Buddy tool
+- [x] Classify device property control as `write` and expose it to Buddy and MCP.
+- [x] Classify scene execution and space lighting intents as `trigger` and expose them to Buddy and MCP.
+- [x] Rename only at the MCP adapter boundary if public MCP names need clearer naming; do not break existing Buddy tool
       names unnecessarily.
-- [ ] Replace hard-coded `buddy`/`api` origin metadata with values derived from the execution context.
-- [ ] Ensure MCP writes use the existing property validation and platform processing paths.
-- [ ] Ensure scene and lighting calls return completed, partial, failed, or timed-out states accurately.
-- [ ] Do not expose a plugin-contributed tool to MCP unless its definition explicitly lists the MCP audience.
+- [x] Keep the domain intent origin provider-neutral and record the exact Buddy/MCP source, audience, and actor from the
+      execution context.
+- [x] Route provider-triggered writes through the shared property validation, intent, and platform processing paths.
+- [x] Ensure scene and lighting calls return completed, partial, failed, or timed-out states accurately.
+- [x] Do not expose a plugin-contributed tool to MCP unless its definition explicitly lists the MCP audience.
 
-**Tests:** Buddy origin remains unchanged, MCP origin is recorded as MCP, capability classification, partial failures,
-disabled scenes, invalid properties, and unavailable optional plugin services.
+**Tests:** Buddy origin remains unchanged, MCP source is recorded in intent context, capability classification, partial
+failures, disabled scenes, invalid properties, and unavailable optional plugin services.
+
+**Outcome:** Device writes now share one constraint-aware property command path for REST and agent tools. Device,
+scene, and optional space-lighting providers explicitly opt into MCP, propagate execution context to intents, and
+report partial or failed operations honestly without exposing internal exceptions.
 
 ### Task 5: Add MCP client records, token issuance, and endpoint isolation
 
@@ -357,28 +378,29 @@ disabled scenes, invalid properties, and unavailable optional plugin services.
 **Tests:** one-time secret, hash storage, expiry, audience, revocation, rotation, capability subset validation, MCP token
 rejected on REST, PAT rejected on MCP, MCP token rejected on WebSocket, and existing display/PAT auth regressions.
 
-### Task 6: Implement policy and session services
+### Task 6: Implement policy and subscription services
 
 **Files:**
 
 - Create: `apps/backend/src/modules/mcp/services/mcp-policy.service.ts`
-- Create: `apps/backend/src/modules/mcp/services/mcp-session.service.ts`
+- Create: `apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts`
 - Create corresponding specs
 
 - [ ] Resolve installation config and authenticated MCP client for every listing/read/call operation.
 - [ ] Compute effective capabilities using the intersection rule.
 - [ ] Recheck module enabled state, client enabled/revoked state, token expiry, and tool capability immediately before
       execution.
-- [ ] Maintain a bounded map of secure, random session IDs associated with exactly one MCP client.
-- [ ] Reject a session ID presented with a different bearer token/client.
+- [ ] Use the SDK event bus for modern `subscriptions/listen` change events.
+- [ ] Track subscription streams by authenticated MCP client so targeted policy changes can abort affected streams.
 - [ ] Add idle expiration and cleanup on disconnect/module shutdown.
-- [ ] Cap concurrent global and per-client sessions to prevent unbounded memory growth.
-- [ ] Provide methods to notify sessions of tool-list changes and to close sessions for a revoked client or disabled
-      module.
-- [ ] Never use a session ID as authentication on its own.
+- [ ] Cap concurrent global and per-client subscription streams to prevent unbounded memory growth.
+- [ ] Provide methods to notify subscribers of tool/resource-list changes and close streams for a revoked client or
+      disabled module.
+- [ ] If legacy stateful support is later approved, keep its session registry separate and bind every session to the
+      authenticated token/client.
 
-**Tests:** intersection matrix, stale sessions, cross-client session reuse, revocation during a session, module disable,
-session caps, and cleanup.
+**Tests:** intersection matrix, cross-client stream isolation, revocation during a subscription, module disable, stream
+caps, and cleanup.
 
 ### Task 7: Implement the raw Streamable HTTP endpoint
 
@@ -390,20 +412,22 @@ session caps, and cleanup.
 - Create: `apps/backend/src/modules/mcp/services/mcp-server.service.ts`
 - Create endpoint/integration specs
 
-- [ ] Expose GET, POST, and DELETE on the module root as required by Streamable HTTP.
+- [ ] Expose the module root to the SDK adapter. Modern traffic uses POST and streaming POST responses; legacy
+      stateless GET/DELETE requests receive the SDK-defined 405 response.
 - [ ] Mark the handler as a raw route so Smart Panel response interceptors do not wrap JSON-RPC or SSE responses.
 - [ ] Exclude the protocol endpoint from OpenAPI while keeping client-management endpoints documented.
 - [ ] Return 404 while the MCP module is disabled.
-- [ ] Authenticate before creating or looking up a session.
+- [ ] Authenticate before SDK dispatch or subscription registration.
 - [ ] Validate `Origin` using same-origin plus configured allowlist rules; return 403 for invalid origins.
-- [ ] Validate content type, accepted response types, protocol version, session header, and bounded request body.
+- [ ] Validate content type, accepted response types, protocol version, method/name headers, and bounded request body.
 - [ ] Attach installation identity and effective capability information to MCP server instructions/metadata.
 - [ ] Add a dedicated throttle keyed by MCP client, with a stricter unauthenticated/IP limit.
 - [ ] Ensure JSON-RPC errors and HTTP auth/transport errors retain protocol-correct shapes and status codes.
-- [ ] Close SDK transports and sessions during Nest application shutdown.
+- [ ] Close SDK handlers and active subscription streams during Nest application shutdown.
 
-**Tests:** initialize, tools/list, tools/call, GET/SSE, DELETE session, malformed JSON-RPC, unsupported protocol version,
-missing/invalid token, invalid origin, disabled module, throttling, and graceful shutdown.
+**Tests:** modern discovery, legacy initialization, tools/list, tools/call, `subscriptions/listen`, legacy GET/DELETE
+behavior, malformed JSON-RPC, unsupported protocol version, missing/invalid token, invalid origin/host, disabled module,
+throttling, and graceful shutdown.
 
 ### Task 8: Implement curated read tools and resources
 
@@ -451,15 +475,16 @@ and optional home-control plugin absence.
 **Files:**
 
 - Create: `apps/backend/src/modules/mcp/listeners/mcp-config.listener.ts`
-- Modify MCP client service/session service
+- Modify MCP client service/subscription registry
 - Add specs
 
 - [ ] Subscribe to the existing configuration-updated event for `mcp-module`.
-- [ ] On capability changes, notify every active session with `notifications/tools/list_changed`.
+- [ ] On capability changes, publish tool-list changes to active modern subscriptions and the negotiated legacy
+      notification equivalent when a legacy stateful adapter exists.
 - [ ] On removal of `read`, also notify resource-list changes where supported.
-- [ ] On module disable, close all active sessions after sending a best-effort shutdown/error indication.
-- [ ] On client capability reduction, notify only that client's sessions.
-- [ ] On client disable/revocation/deletion/rotation, close that client's existing sessions.
+- [ ] On module disable, close all active subscription streams after a best-effort notification.
+- [ ] On client capability reduction, notify only that client's streams.
+- [ ] On client disable/revocation/deletion/rotation, close that client's existing streams.
 - [ ] Execution policy remains authoritative even if a client misses a notification.
 
 **Tests:** every live transition, including a tool call racing with a permission reduction.
@@ -472,11 +497,12 @@ and optional home-control plugin absence.
 - Modify MCP server/policy/client services
 - Add stats provider only if it follows existing metrics patterns cleanly
 
-- [ ] Log initialization, authentication failure, session open/close, tool execution, policy denial, timeout, and result.
+- [ ] Log discovery/legacy initialization, authentication failure, subscription open/close, tool execution, policy
+      denial, timeout, and result.
 - [ ] Include request ID, MCP client ID, tool, capability, duration, and outcome.
 - [ ] Do not log bearer tokens, token hashes, authorization headers, secure values, or unrestricted raw arguments.
 - [ ] Redact or summarize values for device writes while retaining target IDs for investigation.
-- [ ] Add counters for active sessions, calls by capability/tool, failures, denials, and timeouts.
+- [ ] Add counters for active subscriptions, calls by capability/tool, failures, denials, and timeouts.
 - [ ] Make logs identify the source as `mcp-module` and preserve existing system logger conventions.
 
 **Tests:** redaction, success/failure records, metrics increments, and no token material in captured logs.
@@ -522,7 +548,8 @@ revocation confirmation, role restrictions, and responsive layout.
 - [ ] Add backend E2E coverage using an in-process MCP client or the SDK's supported test transport.
 - [ ] Test all eight module capability combinations.
 - [ ] Test module/client capability intersections.
-- [ ] Test two simultaneous clients with different permissions and ensure sessions cannot cross.
+- [ ] Test two simultaneous clients with different permissions and ensure authenticated contexts and subscriptions
+      cannot cross.
 - [ ] Test a permission change and token revocation while clients remain connected.
 - [ ] Test against a simulator installation so writes/triggers cannot affect real hardware.
 - [ ] Verify `set_device_property`, `run_scene`, and `set_space_lighting` produce the expected intent/event traces.
@@ -565,8 +592,9 @@ revocation confirmation, role restrictions, and responsive layout.
 
 ### Protocol and catalog
 
-- [ ] A compatible MCP client can initialize against `/api/v1/modules/mcp` using Streamable HTTP.
-- [ ] `tools/list`, `resources/list`, `tools/call`, resource reads, sessions, and shutdown behave according to the
+- [ ] A modern MCP client can discover `/api/v1/modules/mcp`, and a compatible legacy client can initialize through the
+      stateless fallback.
+- [ ] `tools/list`, `resources/list`, `tools/call`, resource reads, subscriptions, and shutdown behave according to the
       negotiated protocol version.
 - [ ] Only explicitly registered tools appear; no generic OpenAPI proxy exists.
 - [ ] Tool/resource discovery matches the effective capability intersection.
@@ -578,9 +606,9 @@ revocation confirmation, role restrictions, and responsive layout.
 - [ ] MCP tokens work only on the MCP endpoint.
 - [ ] Ordinary access/PAT/display tokens do not work on the MCP endpoint.
 - [ ] Revoked, expired, disabled-client, wrong-audience, and invalid-origin requests are rejected.
-- [ ] Session IDs cannot be used without the correct bearer token or by another client.
+- [ ] Subscription streams and any approved legacy sessions remain bound to the correct bearer token and MCP client.
 - [ ] Logs and results contain no credential material.
-- [ ] The MCP endpoint is rate-limited and bounded by session, body-size, context-size, and history limits.
+- [ ] The MCP endpoint is rate-limited and bounded by subscription, body-size, context-size, and history limits.
 
 ### Operations
 
@@ -609,7 +637,7 @@ revocation confirmation, role restrictions, and responsive layout.
 
 ## 7. Rollout Gates
 
-1. **Foundation gate:** SDK compatibility, disabled module, authentication isolation, and zero-tool initialization.
+1. **Foundation gate:** SDK compatibility, disabled module, authentication isolation, and zero-tool protocol discovery.
 2. **Read gate:** Read-only operation passes E2E tests on a simulator and a testing installation.
 3. **Write gate:** Direct property writes pass value validation, audit, timeout, and permission-revocation tests.
 4. **Trigger gate:** Scene and space intent execution pass partial-failure and repeat-invocation tests.


### PR DESCRIPTION
## Summary

- pin and verify the official MCP v2 server, Node adapter, test client, and Zod dependencies
- document the modern sessionless protocol, legacy compatibility, installation identity, audience, origin, and lifecycle decisions
- extend the internal tool contract with explicit audiences, access kinds, execution context, Zod schemas, structured outcomes, and duplicate-name protection
- route agent device writes through the shared property validation, intent, and platform command path
- classify and update device, scene, and space-lighting tools for Buddy and MCP with accurate partial/failure reporting
- update the MCP implementation plan through Phase 1

## Why

The MCP transport and security assumptions needed to be validated before building the public module. The existing Buddy-oriented tool contract also lacked the policy metadata, execution traceability, schema source, and safe device-write path required for an externally exposed MCP catalog.

## Impact

Existing callers retain Buddy-compatible defaults. MCP adapters can filter and execute only explicitly opted-in tools, propagate authenticated execution context, and receive sanitized structured outcomes. Device property writes now share one validation and platform-processing path across REST and agent tools.

## Validation

- 13 focused backend suites: 176 tests passed
- full backend Jest assertions: 245 suites and 3,245 tests passed; 2 skipped
- `pnpm run type-check`
- `pnpm run build`
- `pnpm run lint:js`
- `git diff --check`

After the successful full Jest summary, an existing Home Assistant WebSocket test teardown asynchronously called a missing mock `terminate()` method. No MCP or tool assertion failed. Lint also reports two pre-existing floating-promise warnings in the Discord and Telegram providers.