### PR TITLE
feat(backend): add MCP module configuration foundation

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -33,6 +33,8 @@ import { EXTENSIONS_MODULE_PREFIX } from './modules/extensions/extensions.consta
 import { ExtensionsModule } from './modules/extensions/extensions.module';
 import { FactoryResetModule } from './modules/factory-reset/factory-reset.module';
 import { IntentsModule } from './modules/intents/intents.module';
+import { MCP_MODULE_PREFIX } from './modules/mcp/mcp.constants';
+import { McpModule } from './modules/mcp/mcp.module';
 import { MdnsModule } from './modules/mdns/mdns.module';
 import { ModuleRegistryModule } from './modules/module-registry/module-registry.module';
 import { PlatformModule } from './modules/platform/platform.module';
@@ -272,6 +274,10 @@ export class AppModule {
 								module: BuddyModule,
 							},
 							{
+								path: MCP_MODULE_PREFIX,
+								module: McpModule,
+							},
+							{
 								path: AUTH_MODULE_PREFIX,
 								module: ApiModule,
 							},
@@ -416,6 +422,7 @@ export class AppModule {
 				ScenesModule,
 				SecurityModule,
 				BuddyModule,
+				McpModule,
 				SpacesModule,
 				SeedModule,
 				StatsModule,

--- a/apps/backend/src/modules/config/controllers/config.controller.spec.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.spec.ts
@@ -8,6 +8,8 @@ handling of Jest mocks, which ESLint rules flag unnecessarily.
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { ROLES_KEY } from '../../users/guards/roles.guard';
+import { UserRole } from '../../users/users.constants';
 import { ConfigException } from '../config.exceptions';
 import { UpdateModuleConfigDto } from '../dto/config.dto';
 import { AppConfigModel, ModuleConfigModel } from '../models/config.model';
@@ -131,6 +133,10 @@ describe('ConfigController', () => {
 	});
 
 	describe('updateModuleConfig', () => {
+		it('requires an owner or administrator role', () => {
+			expect(Reflect.getMetadata(ROLES_KEY, controller.updateModuleConfig)).toEqual([UserRole.OWNER, UserRole.ADMIN]);
+		});
+
 		it('should update and return the module configuration', async () => {
 			const updateDto: UpdateModuleConfigDto = { type: 'mock-module', enabled: false };
 			const updatedModule = { ...mockConfig.modules[0], enabled: false } as ModuleConfigModel;

--- a/apps/backend/src/modules/config/controllers/config.controller.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.ts
@@ -12,6 +12,8 @@ import {
 	ApiNotFoundResponse,
 	ApiSuccessResponse,
 } from '../../swagger/decorators/api-documentation.decorator';
+import { Roles } from '../../users/guards/roles.guard';
+import { UserRole } from '../../users/users.constants';
 import { CONFIG_MODULE_API_TAG_NAME, CONFIG_MODULE_NAME } from '../config.constants';
 import { ConfigException } from '../config.exceptions';
 import {
@@ -330,6 +332,7 @@ export class ConfigController {
 	@ApiBadRequestResponse('Invalid module configuration data or unsupported module type')
 	@ApiNotFoundResponse('Module configuration not found')
 	@ApiInternalServerErrorResponse('Internal server error')
+	@Roles(UserRole.OWNER, UserRole.ADMIN)
 	async updateModuleConfig(
 		@Param('module') module: string,
 		@Body() moduleConfig: { data: object },

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
@@ -1,0 +1,101 @@
+import { instanceToPlain, plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import {
+	MCP_DEFAULT_ALLOWED_ORIGINS,
+	MCP_DEFAULT_CAPABILITIES,
+	MCP_DEFAULT_ENABLED,
+	MCP_MODULE_NAME,
+	McpCapability,
+} from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+
+import { UpdateMcpConfigDto } from './update-config.dto';
+
+const CAPABILITY_COMBINATIONS: McpCapability[][] = [
+	[],
+	[McpCapability.READ],
+	[McpCapability.WRITE],
+	[McpCapability.TRIGGER],
+	[McpCapability.READ, McpCapability.WRITE],
+	[McpCapability.READ, McpCapability.TRIGGER],
+	[McpCapability.WRITE, McpCapability.TRIGGER],
+	[McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER],
+];
+
+describe('MCP configuration', () => {
+	it('uses disabled, read-selected defaults', async () => {
+		const config = new McpConfigModel();
+
+		expect(config).toMatchObject({
+			type: MCP_MODULE_NAME,
+			enabled: MCP_DEFAULT_ENABLED,
+			capabilities: MCP_DEFAULT_CAPABILITIES,
+			allowedOrigins: MCP_DEFAULT_ALLOWED_ORIGINS,
+		});
+		expect(await validate(config)).toHaveLength(0);
+	});
+
+	it.each(CAPABILITY_COMBINATIONS)('accepts capability combination %j', async (...capabilities) => {
+		const dto = plainToInstance(UpdateMcpConfigDto, {
+			type: MCP_MODULE_NAME,
+			capabilities,
+		});
+
+		expect(await validate(dto)).toHaveLength(0);
+	});
+
+	it('rejects duplicate and unknown capabilities', async () => {
+		const duplicate = plainToInstance(UpdateMcpConfigDto, {
+			type: MCP_MODULE_NAME,
+			capabilities: [McpCapability.READ, McpCapability.READ],
+		});
+		const unknown = plainToInstance(UpdateMcpConfigDto, {
+			type: MCP_MODULE_NAME,
+			capabilities: ['read', 'admin'],
+		});
+
+		expect(await validate(duplicate)).not.toHaveLength(0);
+		expect(await validate(unknown)).not.toHaveLength(0);
+	});
+
+	it('accepts normalized HTTP origins and rejects non-origin URLs', async () => {
+		const valid = plainToInstance(UpdateMcpConfigDto, {
+			type: MCP_MODULE_NAME,
+			allowed_origins: ['https://panel.example.com', 'http://localhost:3000', 'http://[::1]:3000'],
+		});
+		const invalidOrigins = [
+			'https://panel.example.com/',
+			'https://panel.example.com/path',
+			'https://panel.example.com?query=yes',
+			'https://user:secret@panel.example.com',
+			'ftp://panel.example.com',
+			'*',
+		];
+
+		expect(await validate(valid)).toHaveLength(0);
+
+		for (const origin of invalidOrigins) {
+			const invalid = plainToInstance(UpdateMcpConfigDto, {
+				type: MCP_MODULE_NAME,
+				allowed_origins: [origin],
+			});
+
+			expect(await validate(invalid)).not.toHaveLength(0);
+		}
+	});
+
+	it('serializes the persisted model using API field names', () => {
+		const config = new McpConfigModel();
+		config.enabled = true;
+		config.capabilities = [McpCapability.WRITE, McpCapability.TRIGGER];
+		config.allowedOrigins = ['https://panel.example.com'];
+
+		expect(instanceToPlain(config)).toEqual({
+			type: MCP_MODULE_NAME,
+			enabled: true,
+			capabilities: [McpCapability.WRITE, McpCapability.TRIGGER],
+			allowed_origins: ['https://panel.example.com'],
+		});
+	});
+});

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.ts
@@ -1,0 +1,54 @@
+import { Expose } from 'class-transformer';
+import { ArrayUnique, IsArray, IsEnum, IsOptional, IsString, Validate } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { UpdateModuleConfigDto } from '../../config/dto/config.dto';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { IsMcpOriginConstraint } from '../validators/is-mcp-origin.validator';
+
+@ApiSchema({ name: 'ConfigModuleUpdateMcp' })
+export class UpdateMcpConfigDto extends UpdateModuleConfigDto {
+	@ApiProperty({
+		description: 'Module identifier',
+		type: 'string',
+		example: MCP_MODULE_NAME,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: string = MCP_MODULE_NAME;
+
+	@ApiPropertyOptional({
+		description: 'Installation-wide ceiling for capabilities that MCP clients may receive',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpCapability) },
+		example: [McpCapability.READ],
+	})
+	@Expose()
+	@IsOptional()
+	@IsArray({ message: '[{"field":"capabilities","reason":"Capabilities must be provided as an array."}]' })
+	@ArrayUnique({ message: '[{"field":"capabilities","reason":"Capabilities must not contain duplicates."}]' })
+	@IsEnum(McpCapability, {
+		each: true,
+		message: '[{"field":"capabilities","reason":"Each capability must be read, write, or trigger."}]',
+	})
+	capabilities?: McpCapability[];
+
+	@ApiPropertyOptional({
+		name: 'allowed_origins',
+		description: 'Additional normalized browser origins permitted to call the MCP endpoint',
+		type: 'array',
+		items: { type: 'string' },
+		example: ['https://panel.example.com'],
+	})
+	@Expose({ name: 'allowed_origins' })
+	@IsOptional()
+	@IsArray({ message: '[{"field":"allowed_origins","reason":"Allowed origins must be provided as an array."}]' })
+	@ArrayUnique({ message: '[{"field":"allowed_origins","reason":"Allowed origins must not contain duplicates."}]' })
+	@Validate(IsMcpOriginConstraint, {
+		each: true,
+		message:
+			'[{"field":"allowed_origins","reason":"Each origin must be a normalized absolute HTTP(S) origin without a path, query, fragment, or credentials."}]',
+	})
+	allowed_origins?: string[];
+}

--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -1,0 +1,30 @@
+export const MCP_MODULE_PREFIX = 'mcp';
+
+export const MCP_MODULE_NAME = 'mcp-module';
+
+export const MCP_MODULE_API_TAG_NAME = 'MCP module';
+
+export const MCP_MODULE_API_TAG_DESCRIPTION =
+	'Model Context Protocol integration for exposing a curated, capability-scoped smart home agent surface.';
+
+export enum McpCapability {
+	READ = 'read',
+	WRITE = 'write',
+	TRIGGER = 'trigger',
+}
+
+export const MCP_DEFAULT_ENABLED = false;
+
+export const MCP_DEFAULT_CAPABILITIES: readonly McpCapability[] = [McpCapability.READ];
+
+export const MCP_DEFAULT_ALLOWED_ORIGINS: readonly string[] = [];
+
+export const MCP_REQUEST_BODY_LIMIT_BYTES = 1024 * 1024;
+
+export const MCP_TOOL_CALL_TIMEOUT_MS = 30_000;
+
+export const MCP_MAX_ACTIVE_SUBSCRIPTIONS = 100;
+
+export const MCP_MAX_SUBSCRIPTIONS_PER_CLIENT = 5;
+
+export const MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS = 5 * 60 * 1000;

--- a/apps/backend/src/modules/mcp/mcp.module.spec.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.spec.ts
@@ -1,0 +1,43 @@
+import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
+import { ExtensionsService } from '../extensions/services/extensions.service';
+import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models-registry.service';
+
+import { UpdateMcpConfigDto } from './dto/update-config.dto';
+import { MCP_MODULE_NAME, McpCapability } from './mcp.constants';
+import { McpModule } from './mcp.module';
+import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
+import { McpConfigModel } from './models/config.model';
+
+describe('McpModule', () => {
+	it('registers configuration, Swagger models, and disabled-by-default metadata', () => {
+		const swaggerRegistry = { register: jest.fn() };
+		const modulesMapperService = { registerMapping: jest.fn() };
+		const extensionsService = { registerModuleMetadata: jest.fn() };
+		const module = new McpModule(
+			swaggerRegistry as unknown as SwaggerModelsRegistryService,
+			modulesMapperService as unknown as ModulesTypeMapperService,
+			extensionsService as unknown as ExtensionsService,
+		);
+
+		module.onModuleInit();
+
+		expect(modulesMapperService.registerMapping).toHaveBeenCalledWith({
+			type: MCP_MODULE_NAME,
+			class: McpConfigModel,
+			configDto: UpdateMcpConfigDto,
+		});
+		expect(swaggerRegistry.register).toHaveBeenCalledTimes(MCP_SWAGGER_EXTRA_MODELS.length);
+
+		for (const model of MCP_SWAGGER_EXTRA_MODELS) {
+			expect(swaggerRegistry.register).toHaveBeenCalledWith(model);
+		}
+		expect(extensionsService.registerModuleMetadata).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: MCP_MODULE_NAME,
+				name: 'Model Context Protocol',
+				defaultEnabled: false,
+				capabilities: Object.values(McpCapability),
+			}),
+		);
+	});
+});

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -1,0 +1,78 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+
+import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
+import { ExtensionsService } from '../extensions/services/extensions.service';
+import { ApiTag } from '../swagger/decorators/api-tag.decorator';
+import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models-registry.service';
+import { SwaggerModule } from '../swagger/swagger.module';
+
+import { UpdateMcpConfigDto } from './dto/update-config.dto';
+import {
+	MCP_MODULE_API_TAG_DESCRIPTION,
+	MCP_MODULE_API_TAG_NAME,
+	MCP_MODULE_NAME,
+	McpCapability,
+} from './mcp.constants';
+import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
+import { McpConfigModel } from './models/config.model';
+
+@ApiTag({
+	tagName: MCP_MODULE_NAME,
+	displayName: MCP_MODULE_API_TAG_NAME,
+	description: MCP_MODULE_API_TAG_DESCRIPTION,
+})
+@Module({
+	imports: [SwaggerModule],
+})
+export class McpModule implements OnModuleInit {
+	constructor(
+		private readonly swaggerRegistry: SwaggerModelsRegistryService,
+		private readonly modulesMapperService: ModulesTypeMapperService,
+		private readonly extensionsService: ExtensionsService,
+	) {}
+
+	onModuleInit(): void {
+		this.modulesMapperService.registerMapping<McpConfigModel, UpdateMcpConfigDto>({
+			type: MCP_MODULE_NAME,
+			class: McpConfigModel,
+			configDto: UpdateMcpConfigDto,
+		});
+
+		for (const model of MCP_SWAGGER_EXTRA_MODELS) {
+			this.swaggerRegistry.register(model);
+		}
+
+		this.extensionsService.registerModuleMetadata({
+			type: MCP_MODULE_NAME,
+			name: 'Model Context Protocol',
+			description: 'Curated, capability-scoped agent access to this Smart Panel installation',
+			author: 'FastyBird',
+			defaultEnabled: false,
+			capabilities: Object.values(McpCapability),
+			readme: `# Model Context Protocol
+
+> Module · by FastyBird
+
+Connects trusted MCP-compatible agents to a curated set of Smart Panel tools and resources. The module is disabled by default and its read, direct-write, and higher-level trigger capabilities can be enabled independently.
+
+## Security posture
+
+- Uses installation-local MCP credentials rather than ordinary user, display, or REST tokens
+- Exposes only explicitly registered tools and resources; it is not an OpenAPI proxy
+- Rechecks the installation capability ceiling and client grant for every operation
+- Targets trusted LAN or VPN deployments for the initial static-bearer release
+
+## Configuration
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| \`enabled\` | Accept MCP protocol requests | \`false\` |
+| \`capabilities\` | Allowed combination of \`read\`, \`write\`, and \`trigger\` | \`read\` |
+| \`allowed_origins\` | Additional browser origins allowed to call the endpoint | empty |`,
+			links: {
+				documentation: 'https://smart-panel.fastybird.com/docs',
+				repository: 'https://github.com/FastyBird/smart-panel',
+			},
+		});
+	}
+}

--- a/apps/backend/src/modules/mcp/mcp.openapi.ts
+++ b/apps/backend/src/modules/mcp/mcp.openapi.ts
@@ -1,0 +1,4 @@
+import { UpdateMcpConfigDto } from './dto/update-config.dto';
+import { McpConfigModel } from './models/config.model';
+
+export const MCP_SWAGGER_EXTRA_MODELS = [McpConfigModel, UpdateMcpConfigDto];

--- a/apps/backend/src/modules/mcp/models/config.model.ts
+++ b/apps/backend/src/modules/mcp/models/config.model.ts
@@ -1,0 +1,60 @@
+import { Expose } from 'class-transformer';
+import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsString, Validate } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { ModuleConfigModel } from '../../config/models/config.model';
+import {
+	MCP_DEFAULT_ALLOWED_ORIGINS,
+	MCP_DEFAULT_CAPABILITIES,
+	MCP_DEFAULT_ENABLED,
+	MCP_MODULE_NAME,
+	McpCapability,
+} from '../mcp.constants';
+import { IsMcpOriginConstraint } from '../validators/is-mcp-origin.validator';
+
+@ApiSchema({ name: 'ConfigModuleDataMcp' })
+export class McpConfigModel extends ModuleConfigModel {
+	@ApiProperty({
+		description: 'Module identifier',
+		type: 'string',
+		example: MCP_MODULE_NAME,
+	})
+	@Expose()
+	@IsString()
+	type: string = MCP_MODULE_NAME;
+
+	@ApiProperty({
+		description: 'Module enabled state',
+		type: 'boolean',
+		example: MCP_DEFAULT_ENABLED,
+	})
+	@Expose()
+	@IsBoolean()
+	override enabled: boolean = MCP_DEFAULT_ENABLED;
+
+	@ApiProperty({
+		description: 'Installation-wide ceiling for capabilities that MCP clients may receive',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpCapability) },
+		example: [McpCapability.READ],
+	})
+	@Expose()
+	@IsArray()
+	@ArrayUnique()
+	@IsEnum(McpCapability, { each: true })
+	capabilities: McpCapability[] = [...MCP_DEFAULT_CAPABILITIES];
+
+	@ApiProperty({
+		name: 'allowed_origins',
+		description: 'Additional normalized browser origins permitted to call the MCP endpoint',
+		type: 'array',
+		items: { type: 'string' },
+		example: ['https://panel.example.com'],
+	})
+	@Expose({ name: 'allowed_origins' })
+	@IsArray()
+	@ArrayUnique()
+	@Validate(IsMcpOriginConstraint, { each: true })
+	allowedOrigins: string[] = [...MCP_DEFAULT_ALLOWED_ORIGINS];
+}

--- a/apps/backend/src/modules/mcp/validators/is-mcp-origin.validator.ts
+++ b/apps/backend/src/modules/mcp/validators/is-mcp-origin.validator.ts
@@ -1,0 +1,27 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+
+@ValidatorConstraint({ name: 'isMcpOrigin', async: false })
+export class IsMcpOriginConstraint implements ValidatorConstraintInterface {
+	validate(value: unknown): boolean {
+		if (typeof value !== 'string') {
+			return false;
+		}
+
+		try {
+			const url = new URL(value);
+
+			return (
+				(url.protocol === 'http:' || url.protocol === 'https:') &&
+				url.username === '' &&
+				url.password === '' &&
+				url.origin === value
+			);
+		} catch {
+			return false;
+		}
+	}
+
+	defaultMessage(_validationArguments: ValidationArguments): string {
+		return 'Origin must be a normalized absolute HTTP(S) origin without a path, query, fragment, or credentials.';
+	}
+}

--- a/apps/backend/test/config-authorization.e2e-spec.ts
+++ b/apps/backend/test/config-authorization.e2e-spec.ts
@@ -1,0 +1,144 @@
+/*
+eslint-disable @typescript-eslint/no-unsafe-argument
+*/
+import request from 'supertest';
+
+import { CanActivate, ExecutionContext, INestApplication, Injectable, UnauthorizedException } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+
+import { TokenOwnerType } from '../src/modules/auth/auth.constants';
+import { AuthenticatedEntity, AuthenticatedRequest } from '../src/modules/auth/guards/auth.guard';
+import { ConfigController } from '../src/modules/config/controllers/config.controller';
+import { UpdateModuleConfigDto } from '../src/modules/config/dto/config.dto';
+import { ModuleConfigModel } from '../src/modules/config/models/config.model';
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { ModulesTypeMapperService } from '../src/modules/config/services/modules-type-mapper.service';
+import { PluginConfigValidatorService } from '../src/modules/config/services/plugin-config-validator.service';
+import { PluginsTypeMapperService } from '../src/modules/config/services/plugins-type-mapper.service';
+import { RolesGuard } from '../src/modules/users/guards/roles.guard';
+import { UserRole } from '../src/modules/users/users.constants';
+
+const TEST_CREDENTIALS: Record<string, AuthenticatedEntity> = {
+	'owner-user': { type: 'user', id: 'owner-user', role: UserRole.OWNER },
+	'admin-user': { type: 'user', id: 'admin-user', role: UserRole.ADMIN },
+	'regular-user': { type: 'user', id: 'regular-user', role: UserRole.USER },
+	'owner-pat': {
+		type: 'token',
+		tokenId: 'owner-pat',
+		ownerType: TokenOwnerType.USER,
+		ownerId: 'owner-user',
+		role: UserRole.OWNER,
+	},
+	'admin-pat': {
+		type: 'token',
+		tokenId: 'admin-pat',
+		ownerType: TokenOwnerType.USER,
+		ownerId: 'admin-user',
+		role: UserRole.ADMIN,
+	},
+	'user-pat': {
+		type: 'token',
+		tokenId: 'user-pat',
+		ownerType: TokenOwnerType.USER,
+		ownerId: 'regular-user',
+		role: UserRole.USER,
+	},
+	'display-token': {
+		type: 'token',
+		tokenId: 'display-token',
+		ownerType: TokenOwnerType.DISPLAY,
+		ownerId: 'display-1',
+		role: UserRole.USER,
+	},
+};
+
+@Injectable()
+class TestCredentialGuard implements CanActivate {
+	canActivate(context: ExecutionContext): boolean {
+		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+		const credential = request.headers.authorization?.replace(/^Bearer /, '');
+		const auth = credential ? TEST_CREDENTIALS[credential] : undefined;
+
+		if (!auth) {
+			throw new UnauthorizedException('Authentication required');
+		}
+
+		request.auth = auth;
+
+		return true;
+	}
+}
+
+describe('Module configuration authorization (e2e)', () => {
+	let app: INestApplication;
+	let configService: { getModuleConfig: jest.Mock; setModuleConfig: jest.Mock };
+
+	beforeAll(async () => {
+		configService = {
+			getModuleConfig: jest.fn().mockReturnValue({ type: 'mock-module', enabled: false } as ModuleConfigModel),
+			setModuleConfig: jest.fn(),
+		};
+
+		const moduleFixture = await Test.createTestingModule({
+			controllers: [ConfigController],
+			providers: [
+				{ provide: APP_GUARD, useClass: TestCredentialGuard },
+				{ provide: APP_GUARD, useClass: RolesGuard },
+				{ provide: ConfigService, useValue: configService },
+				{ provide: PluginsTypeMapperService, useValue: { getMapping: jest.fn() } },
+				{
+					provide: ModulesTypeMapperService,
+					useValue: {
+						getMapping: jest.fn().mockReturnValue({
+							type: 'mock-module',
+							class: ModuleConfigModel,
+							configDto: UpdateModuleConfigDto,
+						}),
+					},
+				},
+				{
+					provide: PluginConfigValidatorService,
+					useValue: { validate: jest.fn(), hasValidator: jest.fn() },
+				},
+			],
+		}).compile();
+
+		app = moduleFixture.createNestApplication();
+		await app.init();
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	beforeEach(() => {
+		configService.setModuleConfig.mockClear();
+	});
+
+	it.each(['owner-user', 'admin-user', 'owner-pat', 'admin-pat'])(
+		'allows module updates with %s credentials',
+		async (credential) => {
+			await request(app.getHttpServer())
+				.patch('/config/module/mock-module')
+				.set('Authorization', `Bearer ${credential}`)
+				.send({ data: { type: 'mock-module', enabled: false } })
+				.expect(200);
+
+			expect(configService.setModuleConfig).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it.each(['regular-user', 'user-pat', 'display-token'])(
+		'denies module updates with %s credentials without mutating configuration',
+		async (credential) => {
+			await request(app.getHttpServer())
+				.patch('/config/module/mock-module')
+				.set('Authorization', `Bearer ${credential}`)
+				.send({ data: { type: 'mock-module', enabled: false } })
+				.expect(403);
+
+			expect(configService.setModuleConfig).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 1 complete — Phase 2 pending
+**Status:** Phase 2 complete — Phase 3 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -271,30 +271,38 @@ Task 14 because it requires external target clients.
 - Create: `apps/backend/src/modules/mcp/dto/update-config.dto.ts`
 - Create: `apps/backend/src/modules/mcp/mcp.openapi.ts`
 - Create: `apps/backend/src/modules/mcp/mcp.module.ts`
+- Create: `apps/backend/test/config-authorization.e2e-spec.ts`
 - Modify: `apps/backend/src/app.module.ts`
 - Modify: `apps/backend/src/modules/config/controllers/config.controller.ts`
 - Modify: `apps/backend/src/modules/config/controllers/config.controller.spec.ts`
 
-- [ ] Define `MCP_MODULE_NAME`, `MCP_MODULE_PREFIX`, API tag metadata, capability values, defaults, session limits, and
+- [x] Define `MCP_MODULE_NAME`, `MCP_MODULE_PREFIX`, API tag metadata, capability values, defaults, subscription limits, and
       timeout constants.
-- [ ] Add `McpConfigModel extends ModuleConfigModel` with `enabled`, `capabilities`, and `allowedOrigins`.
-- [ ] Add DTO validation that accepts any unique combination of `read`, `write`, and `trigger`; reject unknown and
+- [x] Add `McpConfigModel extends ModuleConfigModel` with `enabled`, `capabilities`, and `allowedOrigins`.
+- [x] Add DTO validation that accepts any unique combination of `read`, `write`, and `trigger`; reject unknown and
       duplicate values.
-- [ ] Register the config model through `ModulesTypeMapperService`.
-- [ ] Register module metadata through `ExtensionsService`.
-- [ ] Mount the module under `modules/mcp` and import it as a core module.
-- [ ] Enforce `@Roles(UserRole.OWNER, UserRole.ADMIN)` on the backend `PATCH config/module/:module` route used to save
+- [x] Validate `allowed_origins` as unique, normalized absolute HTTP(S) origins without paths, queries, fragments,
+      credentials, wildcards, or non-HTTP schemes.
+- [x] Register the config model through `ModulesTypeMapperService`.
+- [x] Register module metadata through `ExtensionsService`.
+- [x] Mount the module under `modules/mcp` and import it as a core module.
+- [x] Enforce `@Roles(UserRole.OWNER, UserRole.ADMIN)` on the backend `PATCH config/module/:module` route used to save
       MCP settings. Do not rely on Admin UI visibility for authorization.
-- [ ] Verify the role guard runs before module mapping or persistence: ordinary users, display tokens, and personal
+- [x] Verify the role guard runs before module mapping or persistence: ordinary users, display tokens, and personal
       access tokens whose owning user lacks the owner/admin role must receive HTTP 403 and leave configuration
       unchanged. Owner/admin user credentials and owner/admin-owned PATs retain the repository's existing role
       semantics.
-- [ ] Add Swagger models only for the management/config REST APIs, not for the MCP JSON-RPC endpoint.
-- [ ] Keep the module disabled by default with `read` preselected as the safe enablement default.
+- [x] Add Swagger models only for the management/config REST APIs, not for the MCP JSON-RPC endpoint.
+- [x] Keep the module disabled by default with `read` preselected as the safe enablement default.
 
 **Tests:** config defaults, all eight capability combinations, invalid values, config serialization, module metadata,
 controller role metadata, and HTTP authorization coverage for owner, admin, user, user-owned PAT, and display-token
 requests.
+
+**Outcome:** The MCP core module is registered under `modules/mcp`, appears in extension/config discovery, and defaults
+to disabled with `read` selected. Its DTO accepts all eight capability combinations and strict normalized origins. The
+shared module-configuration write route now enforces owner/admin authorization before validation or persistence, with
+HTTP regression coverage for user credentials, user-owned PATs, and display tokens.
 
 ### Task 3: Extend the internal tool contract with access metadata and execution context
 


### PR DESCRIPTION
## Summary

- add the core MCP module, constants, typed configuration model, update DTO, Swagger registration, and extension metadata
- support every unique combination of `read`, `write`, and `trigger` capabilities
- validate additional browser origins as normalized absolute HTTP(S) origins
- mount the module under `modules/mcp` while keeping it disabled by default with `read` preselected
- restrict the shared module-configuration write endpoint to owners and administrators
- add HTTP authorization coverage for user credentials, user-owned PATs, and display tokens
- update the tracked MCP implementation plan through Phase 2

## Why

The MCP protocol endpoint and client credentials need a stable, security-checked configuration ceiling before they can be introduced. Module configuration was also writable without explicit role metadata, which would allow lower-privileged authenticated credentials to reach validation and persistence.

## Impact

MCP now appears as a configurable core module but exposes no protocol endpoint yet. It remains disabled by default. All module configuration writes now require owner or administrator privileges; owner/admin-owned PATs retain their existing role semantics, while ordinary users, user-owned PATs without those roles, and display tokens receive HTTP 403 before persistence.

## Validation

- 21 focused unit tests passed
- 10 focused E2E tests passed
- backend TypeScript type-check passed
- backend build passed
- backend ESLint passed with two pre-existing Buddy provider warnings
- `git diff --check` passed

The monorepo-wide lint command could not run because this worktree does not have dependencies installed for the unrelated Admin, Testing, and extension SDK workspaces.