### PR TITLE
feat(backend): add MCP client credential management and isolation

### DIFF
--- a/apps/backend/src/migrations/1000000000008-AddMcpClients.ts
+++ b/apps/backend/src/migrations/1000000000008-AddMcpClients.ts
@@ -33,6 +33,9 @@ export class AddMcpClients1000000000008 implements MigrationInterface {
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {
+		// A parent-version AuthGuard does not recognize the MCP owner type and would accept these
+		// credentials through its generic long-lived-token branch after a downgrade.
+		await queryRunner.query(`DELETE FROM "auth_module_tokens" WHERE "ownerType" = 'mcp'`);
 		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_mcp_client_creator"`);
 		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_mcp_client_enabled"`);
 		await queryRunner.query(`DROP TABLE "mcp_module_clients"`);

--- a/apps/backend/src/migrations/1000000000008-AddMcpClients.ts
+++ b/apps/backend/src/migrations/1000000000008-AddMcpClients.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMcpClients1000000000008 implements MigrationInterface {
+	name = 'AddMcpClients1000000000008';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_installation" (` +
+				`"key" varchar PRIMARY KEY NOT NULL, ` +
+				`"installationId" varchar NOT NULL, ` +
+				`"createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`CONSTRAINT "UQ_mcp_installation_id" UNIQUE ("installationId"))`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_clients" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, ` +
+				`"createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, ` +
+				`"name" varchar NOT NULL, ` +
+				`"description" varchar, ` +
+				`"enabled" boolean NOT NULL DEFAULT (1), ` +
+				`"capabilities" text NOT NULL, ` +
+				`"createdById" varchar, ` +
+				`"tokenId" varchar, ` +
+				`CONSTRAINT "UQ_mcp_client_token" UNIQUE ("tokenId"), ` +
+				`CONSTRAINT "FK_mcp_client_creator" FOREIGN KEY ("createdById") ` +
+				`REFERENCES "users_module_users" ("id") ON DELETE SET NULL, ` +
+				`CONSTRAINT "FK_mcp_client_token" FOREIGN KEY ("tokenId") ` +
+				`REFERENCES "auth_module_tokens" ("id") ON DELETE SET NULL)`,
+		);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_client_enabled" ON "mcp_module_clients" ("enabled")`);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_client_creator" ON "mcp_module_clients" ("createdById")`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_mcp_client_creator"`);
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_mcp_client_enabled"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_clients"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_installation"`);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000008-AddMcpClients.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000008-AddMcpClients.spec.ts
@@ -12,7 +12,9 @@ describe('AddMcpClients1000000000008', () => {
 		await dataSource.initialize();
 		queryRunner = dataSource.createQueryRunner();
 		await queryRunner.query(`CREATE TABLE "users_module_users" ("id" varchar PRIMARY KEY NOT NULL)`);
-		await queryRunner.query(`CREATE TABLE "auth_module_tokens" ("id" varchar PRIMARY KEY NOT NULL)`);
+		await queryRunner.query(
+			`CREATE TABLE "auth_module_tokens" ("id" varchar PRIMARY KEY NOT NULL, "ownerType" varchar)`,
+		);
 	});
 
 	afterEach(async () => {
@@ -48,5 +50,19 @@ describe('AddMcpClients1000000000008', () => {
 		await migration.down(queryRunner);
 
 		await expect(migration.up(queryRunner)).resolves.toBeUndefined();
+	});
+
+	it('deletes MCP credentials while preserving other tokens when reverted', async () => {
+		await migration.up(queryRunner);
+		await queryRunner.query(
+			`INSERT INTO "auth_module_tokens" ("id", "ownerType") VALUES ('mcp-token', 'mcp'), ('user-token', 'user')`,
+		);
+
+		await migration.down(queryRunner);
+
+		const tokens = (await queryRunner.query(`SELECT "id" FROM "auth_module_tokens" ORDER BY "id"`)) as {
+			id: string;
+		}[];
+		expect(tokens).toEqual([{ id: 'user-token' }]);
 	});
 });

--- a/apps/backend/src/migrations/__tests__/1000000000008-AddMcpClients.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000008-AddMcpClients.spec.ts
@@ -1,0 +1,52 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddMcpClients1000000000008 } from '../1000000000008-AddMcpClients';
+
+describe('AddMcpClients1000000000008', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+	const migration = new AddMcpClients1000000000008();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:' });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(`CREATE TABLE "users_module_users" ("id" varchar PRIMARY KEY NOT NULL)`);
+		await queryRunner.query(`CREATE TABLE "auth_module_tokens" ("id" varchar PRIMARY KEY NOT NULL)`);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('creates the installation identity and client tables with protected relationships', async () => {
+		await migration.up(queryRunner);
+
+		const tables = (await queryRunner.query(
+			`SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'mcp_module_%'`,
+		)) as { name: string }[];
+		const foreignKeys = (await queryRunner.query(`PRAGMA foreign_key_list("mcp_module_clients")`)) as {
+			from: string;
+			on_delete: string;
+			table: string;
+		}[];
+
+		expect(tables.map((table) => table.name)).toEqual(
+			expect.arrayContaining(['mcp_module_installation', 'mcp_module_clients']),
+		);
+		expect(foreignKeys).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ from: 'createdById', table: 'users_module_users', on_delete: 'SET NULL' }),
+				expect.objectContaining({ from: 'tokenId', table: 'auth_module_tokens', on_delete: 'SET NULL' }),
+			]),
+		);
+	});
+
+	it('can be reverted and reapplied', async () => {
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		await expect(migration.up(queryRunner)).resolves.toBeUndefined();
+	});
+});

--- a/apps/backend/src/modules/auth/auth.constants.ts
+++ b/apps/backend/src/modules/auth/auth.constants.ts
@@ -17,6 +17,7 @@ export enum TokenOwnerType {
 	USER = 'user',
 	DISPLAY = 'display',
 	THIRD_PARTY = 'third_party',
+	MCP = 'mcp',
 }
 
 export const ACCESS_TOKEN_TYPE = 'Bearer';

--- a/apps/backend/src/modules/auth/controllers/tokens.controller.spec.ts
+++ b/apps/backend/src/modules/auth/controllers/tokens.controller.spec.ts
@@ -1,0 +1,49 @@
+import { JwtService } from '@nestjs/jwt';
+
+import { UsersService } from '../../users/services/users.service';
+import { UserRole } from '../../users/users.constants';
+import { TokenOwnerType } from '../auth.constants';
+import { LongLiveTokenEntity } from '../entities/auth.entity';
+import { TokensTypeMapperService } from '../services/tokens-type-mapper.service';
+import { TokensService } from '../services/tokens.service';
+
+import { TokensController } from './tokens.controller';
+
+describe('TokensController MCP isolation', () => {
+	const userToken = Object.assign(new LongLiveTokenEntity(), {
+		id: 'user-token',
+		ownerType: TokenOwnerType.USER,
+	});
+	const mcpToken = Object.assign(new LongLiveTokenEntity(), {
+		id: 'mcp-token',
+		ownerType: TokenOwnerType.MCP,
+	});
+	const tokensService = {
+		findAll: jest.fn(),
+		findOne: jest.fn(),
+	};
+	const controller = new TokensController(
+		tokensService as unknown as TokensService,
+		{} as TokensTypeMapperService,
+		{} as JwtService,
+		{} as UsersService,
+	);
+
+	beforeEach(() => jest.clearAllMocks());
+
+	it('omits MCP credentials from the administrator token list', async () => {
+		tokensService.findAll.mockResolvedValue([userToken, mcpToken]);
+
+		const response = await controller.findAll({
+			auth: { type: 'user', id: 'admin', role: UserRole.ADMIN },
+		} as never);
+
+		expect(response.data).toEqual([userToken]);
+	});
+
+	it('does not expose an MCP credential through the generic token detail endpoint', async () => {
+		tokensService.findOne.mockResolvedValue(mcpToken);
+
+		await expect(controller.findOne(mcpToken.id)).rejects.toThrow('Requested token does not exist');
+	});
+});

--- a/apps/backend/src/modules/auth/controllers/tokens.controller.ts
+++ b/apps/backend/src/modules/auth/controllers/tokens.controller.ts
@@ -74,6 +74,7 @@ export class TokensController {
 
 		if (auth && (auth.role === UserRole.OWNER || auth.role === UserRole.ADMIN)) {
 			tokens = await this.tokensService.findAll<LongLiveTokenEntity>(LongLiveTokenEntity);
+			tokens = tokens.filter((token) => token.ownerType !== TokenOwnerType.MCP);
 		} else if (auth) {
 			const callerId = auth.type === 'user' ? auth.id : auth.type === 'token' ? auth.ownerId : null;
 
@@ -177,6 +178,10 @@ export class TokensController {
 			this.logger.error(`Validation failed for token creation error=${JSON.stringify(errors)}`);
 
 			throw ValidationExceptionFactory.createException(errors);
+		}
+
+		if ((dtoInstance as { ownerType?: TokenOwnerType }).ownerType === TokenOwnerType.MCP) {
+			throw new BadRequestException('MCP credentials must be created through the MCP clients API');
 		}
 
 		const token = await this.tokensService.create(createDto.data);
@@ -402,6 +407,10 @@ export class TokensController {
 		if (!token) {
 			this.logger.error(`token with id=${id} not found`);
 
+			throw new NotFoundException('Requested token does not exist');
+		}
+
+		if (token instanceof LongLiveTokenEntity && token.ownerType === TokenOwnerType.MCP) {
 			throw new NotFoundException('Requested token does not exist');
 		}
 

--- a/apps/backend/src/modules/auth/entities/auth.entity.spec.ts
+++ b/apps/backend/src/modules/auth/entities/auth.entity.spec.ts
@@ -1,0 +1,15 @@
+import { hashToken } from '../utils/token.utils';
+
+import { LongLiveTokenEntity } from './auth.entity';
+
+describe('LongLiveTokenEntity', () => {
+	it('hashes a raw credential before persistence', () => {
+		const entity = new LongLiveTokenEntity();
+		entity.hashedToken = 'raw-mcp-token';
+
+		entity.updateToken();
+
+		expect(entity.hashedToken).toBe(hashToken('raw-mcp-token'));
+		expect(entity.hashedToken).not.toContain('raw-mcp-token');
+	});
+});

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -13,6 +13,9 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { IS_MCP_ENDPOINT_KEY } from '../../mcp/mcp.constants';
+import { McpClientService } from '../../mcp/services/mcp-client.service';
+import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
@@ -41,6 +44,7 @@ describe('AuthGuard', () => {
 	let reflector: Reflector;
 	let tokensService: TokensService;
 	let usersService: UsersService;
+	let mcpClientsService: McpClientService;
 
 	const mockUserId = uuid().toString();
 	const mockDisplayId = uuid().toString();
@@ -63,6 +67,9 @@ describe('AuthGuard', () => {
 	const mockAccessToken = 'valid-access-token';
 	const mockDisplayToken = 'valid-display-token';
 	const mockLongLiveToken = 'valid-long-live-token';
+	const mockMcpToken = 'valid-mcp-token';
+	const mockMcpClientId = uuid().toString();
+	const mockMcpAudience = 'urn:fastybird:smart-panel:installation-id:mcp';
 
 	// Create mock refresh token
 	const mockRefreshTokenEntity = {
@@ -110,6 +117,14 @@ describe('AuthGuard', () => {
 		createdAt: new Date(),
 		ownerType: TokenOwnerType.THIRD_PARTY,
 		ownerId: null,
+	} as unknown as LongLiveTokenEntity;
+
+	const mockMcpLongLiveToken = {
+		...mockThirdPartyLongLiveToken,
+		id: uuid().toString(),
+		hashedToken: `hashed-${mockMcpToken}`,
+		ownerType: TokenOwnerType.MCP,
+		ownerId: mockMcpClientId,
 	} as unknown as LongLiveTokenEntity;
 
 	const createMockExecutionContext = (headers: Record<string, string> = {}): ExecutionContext => {
@@ -160,6 +175,19 @@ describe('AuthGuard', () => {
 					},
 				},
 				{
+					provide: McpClientService,
+					useValue: {
+						findActiveByToken: jest.fn(),
+						getEffectiveCapabilities: jest.fn().mockReturnValue([]),
+					},
+				},
+				{
+					provide: McpInstallationService,
+					useValue: {
+						getAudience: jest.fn().mockResolvedValue(mockMcpAudience),
+					},
+				},
+				{
 					provide: CACHE_MANAGER,
 					useValue: {
 						get: jest.fn(),
@@ -174,6 +202,7 @@ describe('AuthGuard', () => {
 		reflector = module.get<Reflector>(Reflector);
 		tokensService = module.get<TokensService>(TokensService);
 		usersService = module.get<UsersService>(UsersService);
+		mcpClientsService = module.get<McpClientService>(McpClientService);
 	});
 
 	afterEach(() => {
@@ -528,6 +557,68 @@ describe('AuthGuard', () => {
 				ownerId: null,
 				role: UserRole.USER,
 			});
+		});
+	});
+
+	describe('MCP endpoint isolation', () => {
+		const markMcpEndpoint = () => {
+			jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key: string) => {
+				return key === IS_MCP_ENDPOINT_KEY;
+			});
+		};
+
+		it('should authenticate an active MCP client only on an MCP endpoint', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockMcpToken}` });
+			const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+			markMcpEndpoint();
+			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+				sub: mockMcpClientId,
+				type: TokenOwnerType.MCP,
+			});
+			jest.spyOn(tokensService, 'findOneByHashedToken').mockResolvedValue(mockMcpLongLiveToken);
+			jest.spyOn(mcpClientsService, 'findActiveByToken').mockResolvedValue({ id: mockMcpClientId } as never);
+
+			await expect(guard.canActivate(context)).resolves.toBe(true);
+			expect(jwtService.verifyAsync).toHaveBeenCalledWith(mockMcpToken, { audience: mockMcpAudience });
+			expect(request.auth).toMatchObject({
+				ownerType: TokenOwnerType.MCP,
+				ownerId: mockMcpClientId,
+				capabilities: [],
+			});
+		});
+
+		it('should reject an MCP credential on an ordinary REST endpoint', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockMcpToken}` });
+			jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+				sub: mockMcpClientId,
+				type: TokenOwnerType.MCP,
+			});
+
+			await expect(guard.canActivate(context)).rejects.toThrow('MCP credentials are only valid on the MCP endpoint');
+		});
+
+		it('should reject a personal token on an MCP endpoint', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockLongLiveToken}` });
+			markMcpEndpoint();
+			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({ sub: mockUserId, type: 'personal' });
+
+			await expect(guard.canActivate(context)).rejects.toThrow('An MCP credential is required');
+		});
+
+		it('should reject a rotated or disabled MCP client credential', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockMcpToken}` });
+			markMcpEndpoint();
+			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+				sub: mockMcpClientId,
+				type: TokenOwnerType.MCP,
+			});
+			jest.spyOn(tokensService, 'findOneByHashedToken').mockResolvedValue(mockMcpLongLiveToken);
+			jest.spyOn(mcpClientsService, 'findActiveByToken').mockResolvedValue(null);
+
+			await expect(guard.canActivate(context)).rejects.toThrow(
+				'MCP client is disabled or the credential has been rotated',
+			);
 		});
 	});
 

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -15,6 +15,9 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 
 import { createExtensionLogger } from '../../../common/logger';
+import { IS_MCP_ENDPOINT_KEY, McpCapability } from '../../mcp/mcp.constants';
+import { McpClientService } from '../../mcp/services/mcp-client.service';
+import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
 import { ApiPublic } from '../../swagger/decorators/api-documentation.decorator';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
@@ -44,6 +47,7 @@ export interface AuthenticatedLongLiveToken {
 	ownerType: TokenOwnerType;
 	ownerId: string | null;
 	role: UserRole;
+	capabilities?: McpCapability[];
 }
 
 /**
@@ -73,6 +77,8 @@ export class AuthGuard implements CanActivate {
 		private readonly reflector: Reflector,
 		private readonly tokensService: TokensService,
 		private readonly usersService: UsersService,
+		private readonly mcpClientsService: McpClientService,
+		private readonly mcpInstallationService: McpInstallationService,
 		@Inject(CACHE_MANAGER)
 		private readonly cacheManager: Cache,
 	) {}
@@ -89,12 +95,17 @@ export class AuthGuard implements CanActivate {
 			return true;
 		}
 
+		const isMcpEndpoint = this.reflector.getAllAndOverride<boolean>(IS_MCP_ENDPOINT_KEY, [
+			context.getHandler(),
+			context.getClass(),
+		]);
+
 		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
 
 		// Try authenticating with JWT (Bearer token)
 		const token = extractAccessTokenFromHeader(request);
 
-		if (token && (await this.validateToken(request, token))) {
+		if (token && (await this.validateToken(request, token, isMcpEndpoint))) {
 			return true;
 		}
 
@@ -104,13 +115,27 @@ export class AuthGuard implements CanActivate {
 		throw new UnauthorizedException('Authentication required');
 	}
 
-	private async validateToken(request: AuthenticatedRequest, token: string): Promise<boolean> {
+	private async validateToken(request: AuthenticatedRequest, token: string, isMcpEndpoint: boolean): Promise<boolean> {
 		let payload: { sub?: string; type?: string; role?: string };
 
 		try {
-			payload = await this.jwtService.verifyAsync(token);
+			payload = isMcpEndpoint
+				? await this.jwtService.verifyAsync(token, { audience: await this.mcpInstallationService.getAudience() })
+				: await this.jwtService.verifyAsync(token);
 		} catch {
 			throw new UnauthorizedException('Invalid or expired token');
+		}
+
+		if (isMcpEndpoint) {
+			if ((payload.type as TokenOwnerType) !== TokenOwnerType.MCP || !payload.sub) {
+				throw new UnauthorizedException('An MCP credential is required');
+			}
+
+			return this.validateLongLiveToken(request, token, TokenOwnerType.MCP, payload.sub);
+		}
+
+		if ((payload.type as TokenOwnerType) === TokenOwnerType.MCP) {
+			throw new UnauthorizedException('MCP credentials are only valid on the MCP endpoint');
 		}
 
 		// Check if this is a display token (type: TokenOwnerType.DISPLAY in payload)
@@ -193,6 +218,10 @@ export class AuthGuard implements CanActivate {
 			throw new UnauthorizedException('Token expired');
 		}
 
+		if (storedToken.ownerType !== TokenOwnerType.DISPLAY || storedToken.ownerId !== _displayId) {
+			throw new UnauthorizedException('Invalid display token owner');
+		}
+
 		// Update lastUsedAt asynchronously
 		void this.tokensService.updateLastUsedAt(storedToken.id);
 
@@ -209,9 +238,15 @@ export class AuthGuard implements CanActivate {
 		return true;
 	}
 
-	private async validateLongLiveToken(request: AuthenticatedRequest, token: string): Promise<boolean> {
+	private async validateLongLiveToken(
+		request: AuthenticatedRequest,
+		token: string,
+		expectedOwnerType?: TokenOwnerType,
+		expectedOwnerId?: string,
+	): Promise<boolean> {
 		const hashedValue = hashToken(token);
 		const storedLongLiveToken = await this.tokensService.findOneByHashedToken(hashedValue);
+		let effectiveMcpCapabilities: McpCapability[] | undefined;
 
 		if (!storedLongLiveToken) {
 			this.logger.warn('Long-live token not found');
@@ -226,6 +261,27 @@ export class AuthGuard implements CanActivate {
 		if (storedLongLiveToken.expiresAt && storedLongLiveToken.expiresAt < new Date()) {
 			this.logger.warn('Long-live token is expired');
 			throw new UnauthorizedException('Token expired');
+		}
+
+		if (expectedOwnerType) {
+			if (storedLongLiveToken.ownerType !== expectedOwnerType || storedLongLiveToken.ownerId !== expectedOwnerId) {
+				throw new UnauthorizedException('Token owner does not match the credential');
+			}
+		} else if (storedLongLiveToken.ownerType === TokenOwnerType.MCP) {
+			throw new UnauthorizedException('MCP credentials are only valid on the MCP endpoint');
+		}
+
+		if (storedLongLiveToken.ownerType === TokenOwnerType.MCP) {
+			const client = await this.mcpClientsService.findActiveByToken(
+				storedLongLiveToken.id,
+				storedLongLiveToken.ownerId ?? '',
+			);
+
+			if (!client) {
+				throw new UnauthorizedException('MCP client is disabled or the credential has been rotated');
+			}
+
+			effectiveMcpCapabilities = this.mcpClientsService.getEffectiveCapabilities(client);
 		}
 
 		// Update lastUsedAt asynchronously (fire-and-forget, don't block the request)
@@ -247,6 +303,7 @@ export class AuthGuard implements CanActivate {
 			ownerType: storedLongLiveToken.ownerType,
 			ownerId: storedLongLiveToken.ownerId,
 			role: role,
+			...(effectiveMcpCapabilities ? { capabilities: effectiveMcpCapabilities } : {}),
 		};
 
 		this.logger.debug(`Long-live token authentication successful (ownerType=${storedLongLiveToken.ownerType})`);

--- a/apps/backend/src/modules/auth/services/tokens.service.ts
+++ b/apps/backend/src/modules/auth/services/tokens.service.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import isUndefined from 'lodash.isundefined';
 import omitBy from 'lodash.omitby';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -134,8 +134,8 @@ export class TokensService {
 		this.logger.debug(`Successfully revoked tokens for ownerId=${ownerId}`);
 	}
 
-	async revoke(id: string): Promise<void> {
-		const repository = this.dataSource.getRepository(LongLiveTokenEntity);
+	async revoke(id: string, manager?: EntityManager): Promise<void> {
+		const repository = (manager ?? this.dataSource).getRepository(LongLiveTokenEntity);
 		const result = await repository.update(id, { revoked: true });
 
 		if (!result.affected) {
@@ -412,17 +412,20 @@ export class TokensService {
 		return this.createLongLiveToken(data);
 	}
 
-	async createLongLiveToken(data: {
-		token: string;
-		ownerType: TokenOwnerType;
-		ownerId: string;
-		name: string;
-		description: string | null;
-		expiresAt: Date | null;
-	}): Promise<LongLiveTokenEntity> {
+	async createLongLiveToken(
+		data: {
+			token: string;
+			ownerType: TokenOwnerType;
+			ownerId: string;
+			name: string;
+			description: string | null;
+			expiresAt: Date | null;
+		},
+		manager?: EntityManager,
+	): Promise<LongLiveTokenEntity> {
 		this.logger.debug(`Creating long-live token for ownerType=${data.ownerType}`);
 
-		const repository = this.dataSource.getRepository(LongLiveTokenEntity);
+		const repository = (manager ?? this.dataSource).getRepository(LongLiveTokenEntity);
 
 		const entity = new LongLiveTokenEntity();
 		entity.hashedToken = data.token; // Will be hashed by @BeforeInsert

--- a/apps/backend/src/modules/auth/services/tokens.service.ts
+++ b/apps/backend/src/modules/auth/services/tokens.service.ts
@@ -134,6 +134,15 @@ export class TokensService {
 		this.logger.debug(`Successfully revoked tokens for ownerId=${ownerId}`);
 	}
 
+	async revoke(id: string): Promise<void> {
+		const repository = this.dataSource.getRepository(LongLiveTokenEntity);
+		const result = await repository.update(id, { revoked: true });
+
+		if (!result.affected) {
+			throw new AuthNotFoundException('Requested token does not exist');
+		}
+	}
+
 	async findOneByHashedToken(hashedToken: string): Promise<LongLiveTokenEntity | null> {
 		this.logger.debug('Finding long-live token by hashed value');
 
@@ -396,9 +405,22 @@ export class TokensService {
 		ownerId: string;
 		name: string;
 		description: string | null;
-		expiresAt: Date;
+		expiresAt: Date | null;
 	}): Promise<LongLiveTokenEntity> {
 		this.logger.debug('Creating personal access token');
+
+		return this.createLongLiveToken(data);
+	}
+
+	async createLongLiveToken(data: {
+		token: string;
+		ownerType: TokenOwnerType;
+		ownerId: string;
+		name: string;
+		description: string | null;
+		expiresAt: Date | null;
+	}): Promise<LongLiveTokenEntity> {
+		this.logger.debug(`Creating long-live token for ownerType=${data.ownerType}`);
 
 		const repository = this.dataSource.getRepository(LongLiveTokenEntity);
 
@@ -415,10 +437,10 @@ export class TokensService {
 		const result = await repository.findOne({ where: { id: saved.id } });
 
 		if (!result) {
-			throw new AuthException('Failed to create personal token');
+			throw new AuthException('Failed to create long-live token');
 		}
 
-		this.logger.debug(`Created personal access token id=${result.id}`);
+		this.logger.debug(`Created long-live token id=${result.id}`);
 
 		return result;
 	}

--- a/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.spec.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.spec.ts
@@ -1,0 +1,50 @@
+import { FastifyReply as Response } from 'fastify';
+import { v4 as uuid } from 'uuid';
+
+import { MODULES_PREFIX } from '../../../app.constants';
+import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
+import { UserRole } from '../../users/users.constants';
+import { CreateMcpClientDto } from '../dto/mcp-client.dto';
+import { McpClientEntity } from '../entities/mcp-client.entity';
+import { MCP_MODULE_PREFIX, McpCapability } from '../mcp.constants';
+import { McpClientCredentialModel } from '../models/mcp-client.model';
+import { McpClientService } from '../services/mcp-client.service';
+
+import { McpClientsController } from './mcp-clients.controller';
+
+describe('McpClientsController', () => {
+	it('returns the mounted module route in the created client Location header', async () => {
+		const creatorId = uuid();
+		const clientId = uuid();
+		const createDto: CreateMcpClientDto = {
+			name: 'Agent',
+			capabilities: [McpCapability.READ],
+			expiresInDays: 30,
+		};
+		const credential = {
+			client: { id: clientId } as McpClientEntity,
+			token: 'raw-mcp-token',
+		} as McpClientCredentialModel;
+		const create = jest.fn().mockResolvedValue(credential);
+		const controller = new McpClientsController({ create } as unknown as McpClientService);
+		const request = {
+			url: `/api/v1/${MODULES_PREFIX}/${MCP_MODULE_PREFIX}/clients`,
+			protocol: 'http',
+			hostname: 'localhost',
+			headers: { host: 'localhost:3000' },
+			socket: { localPort: 3000 },
+			auth: { type: 'user', id: creatorId, role: UserRole.ADMIN },
+		} as unknown as AuthenticatedRequest;
+		const header = jest.fn();
+		const response = { header } as unknown as Response;
+
+		const result = await controller.create({ data: createDto }, request, response);
+
+		expect(result.data).toBe(credential);
+		expect(create).toHaveBeenCalledWith(createDto, creatorId);
+		expect(header).toHaveBeenCalledWith(
+			'Location',
+			`http://localhost:3000/api/v1/${MODULES_PREFIX}/${MCP_MODULE_PREFIX}/clients/${clientId}`,
+		);
+	});
+});

--- a/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.ts
@@ -1,0 +1,186 @@
+import { FastifyReply as Response } from 'fastify';
+
+import {
+	Body,
+	Controller,
+	Delete,
+	ForbiddenException,
+	Get,
+	HttpCode,
+	Param,
+	ParseUUIDPipe,
+	Patch,
+	Post,
+	Req,
+	Res,
+} from '@nestjs/common';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { setLocationHeader } from '../../api/utils/location-header.utils';
+import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
+import {
+	ApiBadRequestResponse,
+	ApiCreatedSuccessResponse,
+	ApiForbiddenResponse,
+	ApiInternalServerErrorResponse,
+	ApiNotFoundResponse,
+	ApiSuccessResponse,
+} from '../../swagger/decorators/api-documentation.decorator';
+import { Roles } from '../../users/guards/roles.guard';
+import { UserRole } from '../../users/users.constants';
+import { ReqCreateMcpClientDto, ReqRotateMcpClientTokenDto, ReqUpdateMcpClientDto } from '../dto/mcp-client.dto';
+import { MCP_MODULE_API_TAG_NAME, MCP_MODULE_PREFIX } from '../mcp.constants';
+import {
+	McpClientCredentialResponseModel,
+	McpClientResponseModel,
+	McpClientsResponseModel,
+} from '../models/mcp-client-response.model';
+import { McpClientService } from '../services/mcp-client.service';
+
+@ApiTags(MCP_MODULE_API_TAG_NAME)
+@Controller('clients')
+@Roles(UserRole.OWNER, UserRole.ADMIN)
+export class McpClientsController {
+	constructor(private readonly clientsService: McpClientService) {}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Get MCP clients',
+		description: 'List installation-local MCP client credentials and grants',
+		operationId: 'get-mcp-module-clients',
+	})
+	@ApiSuccessResponse(McpClientsResponseModel, 'MCP clients retrieved successfully')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Get()
+	async findAll(): Promise<McpClientsResponseModel> {
+		const response = new McpClientsResponseModel();
+		response.data = await this.clientsService.findAll();
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Get an MCP client',
+		description: 'Retrieve an MCP client by identifier',
+		operationId: 'get-mcp-module-client',
+	})
+	@ApiParam({ name: 'id', description: 'MCP client ID', type: 'string', format: 'uuid' })
+	@ApiSuccessResponse(McpClientResponseModel, 'MCP client retrieved successfully')
+	@ApiNotFoundResponse('MCP client not found')
+	@Get(':id')
+	async findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string): Promise<McpClientResponseModel> {
+		const response = new McpClientResponseModel();
+		response.data = await this.clientsService.getOneOrThrow(id);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Create an MCP client',
+		description: 'Create an MCP client and return its credential exactly once',
+		operationId: 'create-mcp-module-client',
+	})
+	@ApiBody({ type: ReqCreateMcpClientDto })
+	@ApiCreatedSuccessResponse(McpClientCredentialResponseModel, 'MCP client created successfully')
+	@ApiBadRequestResponse('Invalid client data or capability grant')
+	@ApiForbiddenResponse('Owner or administrator access required')
+	@Post()
+	async create(
+		@Body() body: ReqCreateMcpClientDto,
+		@Req() req: AuthenticatedRequest,
+		@Res({ passthrough: true }) res: Response,
+	): Promise<McpClientCredentialResponseModel> {
+		const creatorId = this.getActorId(req);
+		const credential = await this.clientsService.create(body.data, creatorId);
+		setLocationHeader(req, res, MCP_MODULE_PREFIX, 'clients', credential.client.id);
+
+		const response = new McpClientCredentialResponseModel();
+		response.data = credential;
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Update an MCP client',
+		description: 'Update client metadata, enabled state, or capability grant',
+		operationId: 'update-mcp-module-client',
+	})
+	@ApiParam({ name: 'id', description: 'MCP client ID', type: 'string', format: 'uuid' })
+	@ApiBody({ type: ReqUpdateMcpClientDto })
+	@ApiSuccessResponse(McpClientResponseModel, 'MCP client updated successfully')
+	@ApiBadRequestResponse('Invalid client data or capability grant')
+	@ApiNotFoundResponse('MCP client not found')
+	@Patch(':id')
+	async update(
+		@Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+		@Body() body: ReqUpdateMcpClientDto,
+	): Promise<McpClientResponseModel> {
+		const response = new McpClientResponseModel();
+		response.data = await this.clientsService.update(id, body.data);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Rotate an MCP client credential',
+		description: 'Issue a replacement credential and revoke the previous credential',
+		operationId: 'rotate-mcp-module-client-token',
+	})
+	@ApiParam({ name: 'id', description: 'MCP client ID', type: 'string', format: 'uuid' })
+	@ApiBody({ type: ReqRotateMcpClientTokenDto })
+	@ApiSuccessResponse(McpClientCredentialResponseModel, 'MCP client credential rotated successfully')
+	@ApiNotFoundResponse('MCP client not found')
+	@Post(':id/rotate')
+	async rotate(
+		@Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+		@Body() body: ReqRotateMcpClientTokenDto,
+	): Promise<McpClientCredentialResponseModel> {
+		const response = new McpClientCredentialResponseModel();
+		response.data = await this.clientsService.rotate(id, body.data);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Revoke an MCP client',
+		description: 'Disable the client and revoke its current credential',
+		operationId: 'revoke-mcp-module-client',
+	})
+	@ApiParam({ name: 'id', description: 'MCP client ID', type: 'string', format: 'uuid' })
+	@ApiSuccessResponse(McpClientResponseModel, 'MCP client revoked successfully')
+	@ApiNotFoundResponse('MCP client not found')
+	@Post(':id/revoke')
+	async revoke(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string): Promise<McpClientResponseModel> {
+		const response = new McpClientResponseModel();
+		response.data = await this.clientsService.revoke(id);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Delete an MCP client',
+		description: 'Revoke the current credential and delete the client record',
+		operationId: 'delete-mcp-module-client',
+	})
+	@ApiParam({ name: 'id', description: 'MCP client ID', type: 'string', format: 'uuid' })
+	@ApiNoContentResponse({ description: 'MCP client deleted successfully' })
+	@ApiNotFoundResponse('MCP client not found')
+	@HttpCode(204)
+	@Delete(':id')
+	async remove(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string): Promise<void> {
+		await this.clientsService.remove(id);
+	}
+
+	private getActorId(req: AuthenticatedRequest): string {
+		if (req.auth?.type === 'user') return req.auth.id;
+		if (req.auth?.type === 'token' && req.auth.ownerId) return req.auth.ownerId;
+
+		throw new ForbiddenException('The authenticated credential is not associated with a user');
+	}
+}

--- a/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-clients.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
+import { MODULES_PREFIX } from '../../../app.constants';
 import { setLocationHeader } from '../../api/utils/location-header.utils';
 import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
 import {
@@ -94,7 +95,7 @@ export class McpClientsController {
 	): Promise<McpClientCredentialResponseModel> {
 		const creatorId = this.getActorId(req);
 		const credential = await this.clientsService.create(body.data, creatorId);
-		setLocationHeader(req, res, MCP_MODULE_PREFIX, 'clients', credential.client.id);
+		setLocationHeader(req, res, `${MODULES_PREFIX}/${MCP_MODULE_PREFIX}`, 'clients', credential.client.id);
 
 		const response = new McpClientCredentialResponseModel();
 		response.data = credential;

--- a/apps/backend/src/modules/mcp/decorators/mcp-endpoint.decorator.ts
+++ b/apps/backend/src/modules/mcp/decorators/mcp-endpoint.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { IS_MCP_ENDPOINT_KEY } from '../mcp.constants';
+
+/** Marks the protocol endpoint as accepting only installation-local MCP credentials. */
+export const McpEndpoint = () => SetMetadata(IS_MCP_ENDPOINT_KEY, true);

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.spec.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.spec.ts
@@ -1,0 +1,25 @@
+import { validate } from 'class-validator';
+
+import { toInstance } from '../../../common/utils/transform.utils';
+import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, McpCapability } from '../mcp.constants';
+
+import { CreateMcpClientDto, RotateMcpClientTokenDto } from './mcp-client.dto';
+
+describe('MCP client credential DTOs', () => {
+	it('uses the default lifetime when client creation omits expiry', async () => {
+		const dto = toInstance(CreateMcpClientDto, {
+			name: 'Agent',
+			capabilities: [McpCapability.READ],
+		});
+
+		expect(dto.expiresInDays).toBe(MCP_DEFAULT_TOKEN_EXPIRATION_DAYS);
+		await expect(validate(dto)).resolves.toEqual([]);
+	});
+
+	it('uses the default lifetime when credential rotation omits expiry', async () => {
+		const dto = toInstance(RotateMcpClientTokenDto, {});
+
+		expect(dto.expiresInDays).toBe(MCP_DEFAULT_TOKEN_EXPIRATION_DAYS);
+		await expect(validate(dto)).resolves.toEqual([]);
+	});
+});

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.spec.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.spec.ts
@@ -1,11 +1,24 @@
+import { ClassConstructor } from 'class-transformer';
 import { validate } from 'class-validator';
 
 import { toInstance } from '../../../common/utils/transform.utils';
 import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, McpCapability } from '../mcp.constants';
 
-import { CreateMcpClientDto, RotateMcpClientTokenDto } from './mcp-client.dto';
+import {
+	CreateMcpClientDto,
+	ReqCreateMcpClientDto,
+	ReqRotateMcpClientTokenDto,
+	ReqUpdateMcpClientDto,
+	RotateMcpClientTokenDto,
+} from './mcp-client.dto';
 
 describe('MCP client credential DTOs', () => {
+	const requestDtos: ClassConstructor<object>[] = [
+		ReqCreateMcpClientDto,
+		ReqUpdateMcpClientDto,
+		ReqRotateMcpClientTokenDto,
+	];
+
 	it('uses the default lifetime when client creation omits expiry', async () => {
 		const dto = toInstance(CreateMcpClientDto, {
 			name: 'Agent',
@@ -21,5 +34,14 @@ describe('MCP client credential DTOs', () => {
 
 		expect(dto.expiresInDays).toBe(MCP_DEFAULT_TOKEN_EXPIRATION_DAYS);
 		await expect(validate(dto)).resolves.toEqual([]);
+	});
+
+	it.each(requestDtos)('rejects a %p request that omits its data wrapper', async (requestDto) => {
+		const dto = toInstance(requestDto, {});
+		const errors = await validate(dto);
+
+		expect(errors).toHaveLength(1);
+		expect(errors[0].property).toBe('data');
+		expect(errors[0].constraints).toHaveProperty('isDefined');
 	});
 });

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
@@ -56,8 +56,9 @@ export class CreateMcpClientDto {
 		default: MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
 	})
 	@Expose({ name: 'expires_in_days' })
-	@Transform(({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
-		obj.expires_in_days !== undefined ? obj.expires_in_days : obj.expiresInDays,
+	@Transform(
+		({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
+			obj.expires_in_days ?? obj.expiresInDays ?? MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
 	)
 	@IsOptional()
 	@IsInt()
@@ -112,8 +113,9 @@ export class RotateMcpClientTokenDto {
 		default: MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
 	})
 	@Expose({ name: 'expires_in_days' })
-	@Transform(({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
-		obj.expires_in_days !== undefined ? obj.expires_in_days : obj.expiresInDays,
+	@Transform(
+		({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
+			obj.expires_in_days ?? obj.expiresInDays ?? MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
 	)
 	@IsOptional()
 	@IsInt()

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
@@ -1,0 +1,150 @@
+import { Expose, Transform, Type } from 'class-transformer';
+import {
+	ArrayUnique,
+	IsArray,
+	IsBoolean,
+	IsEnum,
+	IsInt,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	Max,
+	MaxLength,
+	Min,
+	ValidateIf,
+	ValidateNested,
+} from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, MCP_MAX_TOKEN_EXPIRATION_DAYS, McpCapability } from '../mcp.constants';
+
+export class CreateMcpClientDto {
+	@ApiProperty({ description: 'Human-readable client name', type: 'string', example: 'Home assistant agent' })
+	@Expose()
+	@IsNotEmpty()
+	@IsString()
+	@MaxLength(100)
+	name: string;
+
+	@ApiPropertyOptional({ description: 'Optional client description', type: 'string', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@MaxLength(500)
+	@ValidateIf((_, value) => value !== null)
+	description?: string | null;
+
+	@ApiProperty({
+		description: 'Capability subset granted to this client',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpCapability) },
+		example: [McpCapability.READ],
+	})
+	@Expose()
+	@IsArray()
+	@ArrayUnique()
+	@IsEnum(McpCapability, { each: true })
+	capabilities: McpCapability[];
+
+	@ApiPropertyOptional({
+		name: 'expires_in_days',
+		description: 'Finite credential lifetime in days',
+		type: 'integer',
+		minimum: 1,
+		maximum: MCP_MAX_TOKEN_EXPIRATION_DAYS,
+		default: MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
+	})
+	@Expose({ name: 'expires_in_days' })
+	@Transform(({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
+		obj.expires_in_days !== undefined ? obj.expires_in_days : obj.expiresInDays,
+	)
+	@IsOptional()
+	@IsInt()
+	@Min(1)
+	@Max(MCP_MAX_TOKEN_EXPIRATION_DAYS)
+	expiresInDays: number = MCP_DEFAULT_TOKEN_EXPIRATION_DAYS;
+}
+
+export class UpdateMcpClientDto {
+	@ApiPropertyOptional({ description: 'Human-readable client name', type: 'string' })
+	@Expose()
+	@IsOptional()
+	@IsNotEmpty()
+	@IsString()
+	@MaxLength(100)
+	name?: string;
+
+	@ApiPropertyOptional({ description: 'Optional client description', type: 'string', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@MaxLength(500)
+	@ValidateIf((_, value) => value !== null)
+	description?: string | null;
+
+	@ApiPropertyOptional({ description: 'Whether the client may authenticate', type: 'boolean' })
+	@Expose()
+	@IsOptional()
+	@IsBoolean()
+	enabled?: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Capability subset granted to this client',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpCapability) },
+	})
+	@Expose()
+	@IsOptional()
+	@IsArray()
+	@ArrayUnique()
+	@IsEnum(McpCapability, { each: true })
+	capabilities?: McpCapability[];
+}
+
+export class RotateMcpClientTokenDto {
+	@ApiPropertyOptional({
+		name: 'expires_in_days',
+		description: 'Finite lifetime of the replacement credential in days',
+		type: 'integer',
+		minimum: 1,
+		maximum: MCP_MAX_TOKEN_EXPIRATION_DAYS,
+		default: MCP_DEFAULT_TOKEN_EXPIRATION_DAYS,
+	})
+	@Expose({ name: 'expires_in_days' })
+	@Transform(({ obj }: { obj: { expires_in_days?: number; expiresInDays?: number } }) =>
+		obj.expires_in_days !== undefined ? obj.expires_in_days : obj.expiresInDays,
+	)
+	@IsOptional()
+	@IsInt()
+	@Min(1)
+	@Max(MCP_MAX_TOKEN_EXPIRATION_DAYS)
+	expiresInDays: number = MCP_DEFAULT_TOKEN_EXPIRATION_DAYS;
+}
+
+@ApiSchema({ name: 'McpModuleReqCreateClient' })
+export class ReqCreateMcpClientDto {
+	@ApiProperty({ type: () => CreateMcpClientDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => CreateMcpClientDto)
+	data: CreateMcpClientDto;
+}
+
+@ApiSchema({ name: 'McpModuleReqUpdateClient' })
+export class ReqUpdateMcpClientDto {
+	@ApiProperty({ type: () => UpdateMcpClientDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => UpdateMcpClientDto)
+	data: UpdateMcpClientDto;
+}
+
+@ApiSchema({ name: 'McpModuleReqRotateClientToken' })
+export class ReqRotateMcpClientTokenDto {
+	@ApiProperty({ type: () => RotateMcpClientTokenDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => RotateMcpClientTokenDto)
+	data: RotateMcpClientTokenDto;
+}

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
@@ -3,6 +3,7 @@ import {
 	ArrayUnique,
 	IsArray,
 	IsBoolean,
+	IsDefined,
 	IsEnum,
 	IsInt,
 	IsNotEmpty,
@@ -128,6 +129,7 @@ export class RotateMcpClientTokenDto {
 export class ReqCreateMcpClientDto {
 	@ApiProperty({ type: () => CreateMcpClientDto })
 	@Expose()
+	@IsDefined()
 	@ValidateNested()
 	@Type(() => CreateMcpClientDto)
 	data: CreateMcpClientDto;
@@ -137,6 +139,7 @@ export class ReqCreateMcpClientDto {
 export class ReqUpdateMcpClientDto {
 	@ApiProperty({ type: () => UpdateMcpClientDto })
 	@Expose()
+	@IsDefined()
 	@ValidateNested()
 	@Type(() => UpdateMcpClientDto)
 	data: UpdateMcpClientDto;
@@ -146,6 +149,7 @@ export class ReqUpdateMcpClientDto {
 export class ReqRotateMcpClientTokenDto {
 	@ApiProperty({ type: () => RotateMcpClientTokenDto })
 	@Expose()
+	@IsDefined()
 	@ValidateNested()
 	@Type(() => RotateMcpClientTokenDto)
 	data: RotateMcpClientTokenDto;

--- a/apps/backend/src/modules/mcp/entities/mcp-client.entity.ts
+++ b/apps/backend/src/modules/mcp/entities/mcp-client.entity.ts
@@ -1,0 +1,92 @@
+import { Exclude, Expose, Transform } from 'class-transformer';
+import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { Column, Entity, Index, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { LongLiveTokenEntity } from '../../auth/entities/auth.entity';
+import { UserEntity } from '../../users/entities/users.entity';
+import { McpCapability } from '../mcp.constants';
+
+@ApiSchema({ name: 'McpModuleDataClient' })
+@Entity('mcp_module_clients')
+export class McpClientEntity extends BaseEntity {
+	@ApiProperty({ description: 'Human-readable client name', type: 'string', example: 'Home assistant agent' })
+	@Expose()
+	@IsString()
+	@Column({ type: 'varchar' })
+	name: string;
+
+	@ApiPropertyOptional({ description: 'Optional client description', type: 'string', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@Column({ type: 'varchar', nullable: true })
+	description: string | null;
+
+	@ApiProperty({ description: 'Whether this client may authenticate', type: 'boolean', default: true })
+	@Expose()
+	@IsBoolean()
+	@Index()
+	@Column({ type: 'boolean', default: true })
+	enabled: boolean;
+
+	@ApiProperty({
+		description: 'Capabilities granted to the client',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpCapability) },
+	})
+	@Expose()
+	@IsArray()
+	@ArrayUnique()
+	@IsEnum(McpCapability, { each: true })
+	@Column({ type: 'simple-json' })
+	capabilities: McpCapability[];
+
+	@ApiPropertyOptional({
+		name: 'created_by_id',
+		description: 'User who created the client',
+		type: 'string',
+		format: 'uuid',
+		nullable: true,
+	})
+	@Expose({ name: 'created_by_id' })
+	@IsOptional()
+	@IsUUID()
+	@Transform(
+		({ obj }: { obj: { created_by_id?: string; createdById?: string } }) => obj.created_by_id ?? obj.createdById,
+		{
+			toClassOnly: true,
+		},
+	)
+	@Column({ type: 'varchar', nullable: true })
+	createdById: string | null;
+
+	@ManyToOne(() => UserEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'createdById' })
+	@Exclude()
+	createdBy?: UserEntity | null;
+
+	@ApiPropertyOptional({
+		name: 'token_id',
+		description: 'Current credential record identifier',
+		type: 'string',
+		format: 'uuid',
+		nullable: true,
+	})
+	@Expose({ name: 'token_id' })
+	@IsOptional()
+	@IsUUID()
+	@Transform(({ obj }: { obj: { token_id?: string; tokenId?: string } }) => obj.token_id ?? obj.tokenId, {
+		toClassOnly: true,
+	})
+	@Index({ unique: true })
+	@Column({ type: 'varchar', nullable: true })
+	tokenId: string | null;
+
+	@OneToOne(() => LongLiveTokenEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'tokenId' })
+	@Exclude()
+	token?: LongLiveTokenEntity | null;
+}

--- a/apps/backend/src/modules/mcp/entities/mcp-installation.entity.ts
+++ b/apps/backend/src/modules/mcp/entities/mcp-installation.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('mcp_module_installation')
+export class McpInstallationEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	key: string;
+
+	@Column({ type: 'varchar', unique: true })
+	installationId: string;
+
+	@Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date | string;
+}

--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -19,6 +19,12 @@ export const MCP_DEFAULT_CAPABILITIES: readonly McpCapability[] = [McpCapability
 
 export const MCP_DEFAULT_ALLOWED_ORIGINS: readonly string[] = [];
 
+export const MCP_DEFAULT_TOKEN_EXPIRATION_DAYS = 90;
+
+export const MCP_MAX_TOKEN_EXPIRATION_DAYS = 3650;
+
+export const IS_MCP_ENDPOINT_KEY = 'isMcpEndpoint';
+
 export const MCP_REQUEST_BODY_LIMIT_BYTES = 1024 * 1024;
 
 export const MCP_TOOL_CALL_TIMEOUT_MS = 30_000;

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -1,12 +1,17 @@
 import { Module, OnModuleInit } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AuthModule } from '../auth/auth.module';
 import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
 import { ExtensionsService } from '../extensions/services/extensions.service';
 import { ApiTag } from '../swagger/decorators/api-tag.decorator';
 import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models-registry.service';
 import { SwaggerModule } from '../swagger/swagger.module';
 
+import { McpClientsController } from './controllers/mcp-clients.controller';
 import { UpdateMcpConfigDto } from './dto/update-config.dto';
+import { McpClientEntity } from './entities/mcp-client.entity';
+import { McpInstallationEntity } from './entities/mcp-installation.entity';
 import {
 	MCP_MODULE_API_TAG_DESCRIPTION,
 	MCP_MODULE_API_TAG_NAME,
@@ -15,6 +20,8 @@ import {
 } from './mcp.constants';
 import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
 import { McpConfigModel } from './models/config.model';
+import { McpClientService } from './services/mcp-client.service';
+import { McpInstallationService } from './services/mcp-installation.service';
 
 @ApiTag({
 	tagName: MCP_MODULE_NAME,
@@ -22,7 +29,10 @@ import { McpConfigModel } from './models/config.model';
 	description: MCP_MODULE_API_TAG_DESCRIPTION,
 })
 @Module({
-	imports: [SwaggerModule],
+	imports: [AuthModule, SwaggerModule, TypeOrmModule.forFeature([McpClientEntity, McpInstallationEntity])],
+	controllers: [McpClientsController],
+	providers: [McpClientService, McpInstallationService],
+	exports: [McpClientService, McpInstallationService],
 })
 export class McpModule implements OnModuleInit {
 	constructor(

--- a/apps/backend/src/modules/mcp/mcp.openapi.ts
+++ b/apps/backend/src/modules/mcp/mcp.openapi.ts
@@ -1,4 +1,33 @@
+import {
+	CreateMcpClientDto,
+	ReqCreateMcpClientDto,
+	ReqRotateMcpClientTokenDto,
+	ReqUpdateMcpClientDto,
+	RotateMcpClientTokenDto,
+	UpdateMcpClientDto,
+} from './dto/mcp-client.dto';
 import { UpdateMcpConfigDto } from './dto/update-config.dto';
+import { McpClientEntity } from './entities/mcp-client.entity';
 import { McpConfigModel } from './models/config.model';
+import {
+	McpClientCredentialResponseModel,
+	McpClientResponseModel,
+	McpClientsResponseModel,
+} from './models/mcp-client-response.model';
+import { McpClientCredentialModel } from './models/mcp-client.model';
 
-export const MCP_SWAGGER_EXTRA_MODELS = [McpConfigModel, UpdateMcpConfigDto];
+export const MCP_SWAGGER_EXTRA_MODELS = [
+	McpConfigModel,
+	UpdateMcpConfigDto,
+	McpClientEntity,
+	CreateMcpClientDto,
+	UpdateMcpClientDto,
+	RotateMcpClientTokenDto,
+	ReqCreateMcpClientDto,
+	ReqUpdateMcpClientDto,
+	ReqRotateMcpClientTokenDto,
+	McpClientCredentialModel,
+	McpClientResponseModel,
+	McpClientsResponseModel,
+	McpClientCredentialResponseModel,
+];

--- a/apps/backend/src/modules/mcp/models/mcp-client-response.model.ts
+++ b/apps/backend/src/modules/mcp/models/mcp-client-response.model.ts
@@ -1,0 +1,29 @@
+import { Expose } from 'class-transformer';
+
+import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+
+import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { McpClientEntity } from '../entities/mcp-client.entity';
+
+import { McpClientCredentialModel } from './mcp-client.model';
+
+@ApiSchema({ name: 'McpModuleResClient' })
+export class McpClientResponseModel extends BaseSuccessResponseModel<McpClientEntity> {
+	@ApiProperty({ type: () => McpClientEntity })
+	@Expose()
+	declare data: McpClientEntity;
+}
+
+@ApiSchema({ name: 'McpModuleResClients' })
+export class McpClientsResponseModel extends BaseSuccessResponseModel<McpClientEntity[]> {
+	@ApiProperty({ type: 'array', items: { $ref: getSchemaPath(McpClientEntity) } })
+	@Expose()
+	declare data: McpClientEntity[];
+}
+
+@ApiSchema({ name: 'McpModuleResClientCredential' })
+export class McpClientCredentialResponseModel extends BaseSuccessResponseModel<McpClientCredentialModel> {
+	@ApiProperty({ type: () => McpClientCredentialModel })
+	@Expose()
+	declare data: McpClientCredentialModel;
+}

--- a/apps/backend/src/modules/mcp/models/mcp-client.model.ts
+++ b/apps/backend/src/modules/mcp/models/mcp-client.model.ts
@@ -1,0 +1,19 @@
+import { Expose } from 'class-transformer';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { McpClientEntity } from '../entities/mcp-client.entity';
+
+@ApiSchema({ name: 'McpModuleDataClientCredential' })
+export class McpClientCredentialModel {
+	@ApiProperty({ description: 'Created or rotated client', type: () => McpClientEntity })
+	@Expose()
+	client: McpClientEntity;
+
+	@ApiProperty({
+		description: 'One-time credential value. It cannot be retrieved after this response.',
+		type: 'string',
+	})
+	@Expose()
+	token: string;
+}

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -228,7 +228,7 @@ describe('McpClientService', () => {
 
 		expect(currentClient.tokenId).toBe(previousToken.id);
 		expect(repository.update).toHaveBeenCalledWith(
-			expect.objectContaining({ id: currentClient.id, tokenId: previousToken.id }),
+			expect.objectContaining({ id: currentClient.id, tokenId: previousToken.id, enabled: true }),
 			expect.objectContaining({ enabled: true }),
 		);
 	});
@@ -265,6 +265,28 @@ describe('McpClientService', () => {
 		const result = await service.revoke(currentClient.id);
 
 		expect(result.enabled).toBe(false);
-		expect(tokensService.revoke).toHaveBeenCalledWith(token.id);
+		expect(tokensService.revoke).toHaveBeenCalledWith(token.id, expect.anything());
+		expect(repository.save).not.toHaveBeenCalled();
+	});
+
+	it('rejects a stale revocation when rotation already changed the token pointer', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			enabled: true,
+			token: previousToken,
+			tokenId: previousToken.id,
+		} as McpClientEntity;
+		repository.update.mockResolvedValueOnce({ affected: 0 });
+
+		await expect(service.revoke(currentClient.id)).rejects.toThrow(
+			'The MCP client credential was changed by another request',
+		);
+
+		expect(currentClient.tokenId).toBe(previousToken.id);
+		expect(repository.update).toHaveBeenCalledWith(
+			expect.objectContaining({ id: currentClient.id, tokenId: previousToken.id }),
+			{ enabled: false },
+		);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -22,6 +22,7 @@ describe('McpClientService', () => {
 		findOne: jest.Mock;
 		remove: jest.Mock;
 		save: jest.Mock;
+		update: jest.Mock;
 	};
 	let tokensService: { createLongLiveToken: jest.Mock; revoke: jest.Mock };
 	let dataSource: { transaction: jest.Mock };
@@ -40,6 +41,10 @@ describe('McpClientService', () => {
 				if (!client.id) client.id = uuid();
 				currentClient = client;
 				return Promise.resolve(client);
+			}),
+			update: jest.fn().mockImplementation((_criteria: unknown, update: Partial<McpClientEntity>) => {
+				if (currentClient) Object.assign(currentClient, update);
+				return Promise.resolve({ affected: 1 });
 			}),
 		};
 		tokensService = {
@@ -180,7 +185,31 @@ describe('McpClientService', () => {
 		await expect(service.rotate(currentClient.id, { expiresInDays: 60 })).rejects.toThrow('Database unavailable');
 
 		expect(currentClient.tokenId).toBe(previousToken.id);
-		expect(repository.save).not.toHaveBeenCalled();
+		expect(repository.update).not.toHaveBeenCalled();
+	});
+
+	it('rejects a stale concurrent rotation instead of returning an unselected credential', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId: previousToken.id,
+			token: previousToken,
+		} as McpClientEntity;
+		repository.update.mockResolvedValueOnce({ affected: 0 });
+
+		await expect(service.rotate(currentClient.id, { expiresInDays: 60 })).rejects.toThrow(
+			'The MCP client credential was changed by another request',
+		);
+
+		expect(currentClient.tokenId).toBe(previousToken.id);
+		expect(repository.update).toHaveBeenCalledWith(
+			expect.objectContaining({ id: currentClient.id, tokenId: previousToken.id }),
+			expect.objectContaining({ enabled: true }),
+		);
 	});
 
 	it('adds unique entropy to credentials issued within the same second', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -18,6 +18,7 @@ describe('McpClientService', () => {
 	let service: McpClientService;
 	let repository: {
 		create: jest.Mock;
+		delete: jest.Mock;
 		find: jest.Mock;
 		findOne: jest.Mock;
 		remove: jest.Mock;
@@ -35,6 +36,7 @@ describe('McpClientService', () => {
 		currentClient = null;
 		repository = {
 			create: jest.fn((value) => value as McpClientEntity),
+			delete: jest.fn().mockResolvedValue({ affected: 1 }),
 			find: jest.fn().mockResolvedValue([]),
 			findOne: jest.fn().mockImplementation(() => Promise.resolve(currentClient)),
 			remove: jest.fn().mockResolvedValue(undefined),
@@ -319,6 +321,37 @@ describe('McpClientService', () => {
 		expect(repository.update).toHaveBeenCalledWith(
 			expect.objectContaining({ id: currentClient.id, tokenId: previousToken.id }),
 			{ enabled: false },
+		);
+	});
+
+	it('atomically revokes the credential and deletes the client', async () => {
+		const token = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			enabled: true,
+			token,
+			tokenId: token.id,
+		} as McpClientEntity;
+
+		await service.remove(currentClient.id);
+
+		expect(tokensService.revoke).toHaveBeenCalledWith(token.id, expect.anything());
+		expect(repository.delete).toHaveBeenCalledWith({ id: currentClient.id, tokenId: token.id });
+		expect(repository.remove).not.toHaveBeenCalled();
+	});
+
+	it('rolls back deletion when the token pointer changed concurrently', async () => {
+		const token = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			enabled: true,
+			token,
+			tokenId: token.id,
+		} as McpClientEntity;
+		repository.delete.mockResolvedValueOnce({ affected: 0 });
+
+		await expect(service.remove(currentClient.id)).rejects.toThrow(
+			'The MCP client credential was changed by another request',
 		);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -139,6 +139,27 @@ describe('McpClientService', () => {
 		expect(service.getEffectiveCapabilities(client)).toEqual([McpCapability.READ]);
 	});
 
+	it('updates only requested metadata without persisting a stale token pointer', async () => {
+		const tokenId = uuid();
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId,
+		} as McpClientEntity;
+
+		await service.update(currentClient.id, { name: 'Renamed agent', enabled: false });
+
+		expect(repository.update).toHaveBeenCalledWith(currentClient.id, {
+			name: 'Renamed agent',
+			enabled: false,
+		});
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(currentClient.tokenId).toBe(tokenId);
+	});
+
 	it('atomically creates a replacement before revoking the previous credential', async () => {
 		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
 		currentClient = {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -1,0 +1,164 @@
+import { Repository } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+
+import { BadRequestException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+import { TokenOwnerType } from '../../auth/auth.constants';
+import { LongLiveTokenEntity } from '../../auth/entities/auth.entity';
+import { TokensService } from '../../auth/services/tokens.service';
+import { ConfigService } from '../../config/services/config.service';
+import { McpClientEntity } from '../entities/mcp-client.entity';
+import { McpCapability } from '../mcp.constants';
+
+import { McpClientService } from './mcp-client.service';
+import { McpInstallationService } from './mcp-installation.service';
+
+describe('McpClientService', () => {
+	let service: McpClientService;
+	let repository: {
+		create: jest.Mock;
+		find: jest.Mock;
+		findOne: jest.Mock;
+		remove: jest.Mock;
+		save: jest.Mock;
+	};
+	let tokensService: { createLongLiveToken: jest.Mock; revoke: jest.Mock };
+	let jwtService: { signAsync: jest.Mock };
+	let configService: { getModuleConfig: jest.Mock };
+	let currentClient: McpClientEntity | null;
+
+	beforeEach(() => {
+		currentClient = null;
+		repository = {
+			create: jest.fn((value) => value as McpClientEntity),
+			find: jest.fn().mockResolvedValue([]),
+			findOne: jest.fn().mockImplementation(() => Promise.resolve(currentClient)),
+			remove: jest.fn().mockResolvedValue(undefined),
+			save: jest.fn().mockImplementation((client: McpClientEntity) => {
+				if (!client.id) client.id = uuid();
+				currentClient = client;
+				return Promise.resolve(client);
+			}),
+		};
+		tokensService = {
+			createLongLiveToken: jest.fn().mockImplementation(() => {
+				const token = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+				if (currentClient) currentClient.token = token;
+				return Promise.resolve(token);
+			}),
+			revoke: jest.fn().mockResolvedValue(undefined),
+		};
+		jwtService = { signAsync: jest.fn().mockResolvedValue('raw-mcp-token') };
+		configService = {
+			getModuleConfig: jest.fn().mockReturnValue({
+				capabilities: [McpCapability.READ, McpCapability.WRITE],
+			}),
+		};
+		const installationService = { getAudience: jest.fn().mockResolvedValue('mcp-audience') };
+
+		service = new McpClientService(
+			repository as unknown as Repository<McpClientEntity>,
+			tokensService as unknown as TokensService,
+			jwtService as unknown as JwtService,
+			configService as unknown as ConfigService,
+			installationService as unknown as McpInstallationService,
+		);
+	});
+
+	it('issues a finite, audience-bound credential and returns the raw value once', async () => {
+		const result = await service.create(
+			{
+				name: 'Agent',
+				description: null,
+				capabilities: [McpCapability.READ],
+				expiresInDays: 30,
+			},
+			uuid(),
+		);
+
+		expect(result.token).toBe('raw-mcp-token');
+		expect(jwtService.signAsync).toHaveBeenCalledWith(
+			expect.objectContaining({ sub: result.client.id, type: TokenOwnerType.MCP }),
+			{ audience: 'mcp-audience', expiresIn: 30 * 24 * 60 * 60 },
+		);
+		expect(tokensService.createLongLiveToken).toHaveBeenCalledWith(
+			expect.objectContaining({
+				token: 'raw-mcp-token',
+				ownerType: TokenOwnerType.MCP,
+				ownerId: result.client.id,
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				expiresAt: expect.any(Date),
+			}),
+		);
+		expect(result.client).not.toHaveProperty('rawToken');
+	});
+
+	it('rejects capability grants above the installation ceiling', async () => {
+		await expect(
+			service.create(
+				{
+					name: 'Agent',
+					capabilities: [McpCapability.TRIGGER],
+					expiresInDays: 30,
+				},
+				uuid(),
+			),
+		).rejects.toBeInstanceOf(BadRequestException);
+		expect(repository.save).not.toHaveBeenCalled();
+	});
+
+	it('intersects an existing grant with the current module ceiling', () => {
+		const client = {
+			capabilities: [McpCapability.READ, McpCapability.WRITE],
+		} as McpClientEntity;
+		configService.getModuleConfig.mockReturnValue({ capabilities: [McpCapability.READ] });
+
+		expect(service.getEffectiveCapabilities(client)).toEqual([McpCapability.READ]);
+	});
+
+	it('creates a replacement before revoking the previous credential', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId: previousToken.id,
+			token: previousToken,
+		} as McpClientEntity;
+		const events: string[] = [];
+		tokensService.createLongLiveToken.mockImplementation(() => {
+			events.push('create');
+			const token = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+			if (currentClient) currentClient.token = token;
+			return Promise.resolve(token);
+		});
+		tokensService.revoke.mockImplementation(() => {
+			events.push('revoke');
+			return Promise.resolve();
+		});
+
+		const result = await service.rotate(currentClient.id, { expiresInDays: 60 });
+
+		expect(events).toEqual(['create', 'revoke']);
+		expect(tokensService.revoke).toHaveBeenCalledWith(previousToken.id);
+		expect(result.token).toBe('raw-mcp-token');
+	});
+
+	it('disables a client and revokes its current credential', async () => {
+		const token = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			enabled: true,
+			token,
+			tokenId: token.id,
+		} as McpClientEntity;
+
+		const result = await service.revoke(currentClient.id);
+
+		expect(result.enabled).toBe(false);
+		expect(tokensService.revoke).toHaveBeenCalledWith(token.id);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -24,6 +24,7 @@ describe('McpClientService', () => {
 		save: jest.Mock;
 		update: jest.Mock;
 	};
+	let tokenRepository: { findOne: jest.Mock };
 	let tokensService: { createLongLiveToken: jest.Mock; revoke: jest.Mock };
 	let dataSource: { transaction: jest.Mock };
 	let jwtService: { signAsync: jest.Mock };
@@ -55,10 +56,15 @@ describe('McpClientService', () => {
 			}),
 			revoke: jest.fn().mockResolvedValue(undefined),
 		};
+		tokenRepository = {
+			findOne: jest.fn().mockImplementation(() => Promise.resolve(currentClient?.token ?? null)),
+		};
 		dataSource = {
 			transaction: jest.fn().mockImplementation((operation: (manager: EntityManager) => Promise<unknown>) => {
 				const manager = {
-					getRepository: jest.fn().mockReturnValue(repository),
+					getRepository: jest
+						.fn()
+						.mockImplementation((entity: unknown) => (entity === McpClientEntity ? repository : tokenRepository)),
 				} as unknown as EntityManager;
 
 				return operation(manager);
@@ -152,12 +158,38 @@ describe('McpClientService', () => {
 
 		await service.update(currentClient.id, { name: 'Renamed agent', enabled: false });
 
-		expect(repository.update).toHaveBeenCalledWith(currentClient.id, {
-			name: 'Renamed agent',
-			enabled: false,
-		});
+		expect(repository.update).toHaveBeenCalledWith(
+			{ id: currentClient.id, tokenId },
+			{
+				name: 'Renamed agent',
+				enabled: false,
+			},
+		);
 		expect(repository.save).not.toHaveBeenCalled();
 		expect(currentClient.tokenId).toBe(tokenId);
+	});
+
+	it('rejects enabling a client whose current credential is revoked', async () => {
+		const token = {
+			id: uuid(),
+			revoked: true,
+			expiresAt: new Date(Date.now() + 60_000),
+		} as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: false,
+			capabilities: [McpCapability.READ],
+			tokenId: token.id,
+			token,
+		} as McpClientEntity;
+
+		await expect(service.update(currentClient.id, { enabled: true })).rejects.toThrow(
+			'Rotate the MCP client credential before enabling this client',
+		);
+
+		expect(repository.update).not.toHaveBeenCalled();
 	});
 
 	it('atomically creates a replacement before revoking the previous credential', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -1,4 +1,4 @@
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { BadRequestException } from '@nestjs/common';
@@ -136,6 +136,24 @@ describe('McpClientService', () => {
 			),
 		).rejects.toBeInstanceOf(BadRequestException);
 		expect(repository.save).not.toHaveBeenCalled();
+	});
+
+	it('cleans up a failed initial issuance only while the client has no credential', async () => {
+		tokensService.createLongLiveToken.mockRejectedValueOnce(new Error('Database unavailable'));
+
+		await expect(
+			service.create(
+				{
+					name: 'Agent',
+					capabilities: [McpCapability.READ],
+					expiresInDays: 30,
+				},
+				uuid(),
+			),
+		).rejects.toThrow('Database unavailable');
+
+		expect(repository.delete).toHaveBeenCalledWith({ id: currentClient?.id, tokenId: IsNull() });
+		expect(repository.remove).not.toHaveBeenCalled();
 	});
 
 	it('intersects an existing grant with the current module ceiling', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -224,6 +224,58 @@ describe('McpClientService', () => {
 		expect(result.token).toBe('raw-mcp-token');
 	});
 
+	it('loads the rotated client before the credential transaction commits', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId: previousToken.id,
+			token: previousToken,
+		} as McpClientEntity;
+		const transactionEvents: string[] = [];
+		repository.findOne.mockImplementation(() => {
+			transactionEvents.push('load');
+			return Promise.resolve(currentClient);
+		});
+		dataSource.transaction.mockImplementation(async (operation: (manager: EntityManager) => Promise<unknown>) => {
+			const manager = {
+				getRepository: jest
+					.fn()
+					.mockImplementation((entity: unknown) => (entity === McpClientEntity ? repository : tokenRepository)),
+			} as unknown as EntityManager;
+
+			const result = await operation(manager);
+			transactionEvents.push('commit');
+			return result;
+		});
+
+		await service.rotate(currentClient.id, { expiresInDays: 60 });
+
+		expect(transactionEvents).toEqual(['load', 'load', 'commit']);
+	});
+
+	it('fails the credential transaction when the rotated client cannot be reloaded', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId: previousToken.id,
+			token: previousToken,
+		} as McpClientEntity;
+		repository.findOne.mockResolvedValueOnce(currentClient).mockRejectedValueOnce(new Error('Database unavailable'));
+
+		await expect(service.rotate(currentClient.id, { expiresInDays: 60 })).rejects.toThrow('Database unavailable');
+
+		expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+		expect(repository.findOne).toHaveBeenCalledTimes(2);
+	});
+
 	it('leaves the previous credential selected when revocation fails', async () => {
 		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
 		currentClient = {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { BadRequestException } from '@nestjs/common';
@@ -24,6 +24,7 @@ describe('McpClientService', () => {
 		save: jest.Mock;
 	};
 	let tokensService: { createLongLiveToken: jest.Mock; revoke: jest.Mock };
+	let dataSource: { transaction: jest.Mock };
 	let jwtService: { signAsync: jest.Mock };
 	let configService: { getModuleConfig: jest.Mock };
 	let currentClient: McpClientEntity | null;
@@ -49,6 +50,15 @@ describe('McpClientService', () => {
 			}),
 			revoke: jest.fn().mockResolvedValue(undefined),
 		};
+		dataSource = {
+			transaction: jest.fn().mockImplementation((operation: (manager: EntityManager) => Promise<unknown>) => {
+				const manager = {
+					getRepository: jest.fn().mockReturnValue(repository),
+				} as unknown as EntityManager;
+
+				return operation(manager);
+			}),
+		};
 		jwtService = { signAsync: jest.fn().mockResolvedValue('raw-mcp-token') };
 		configService = {
 			getModuleConfig: jest.fn().mockReturnValue({
@@ -59,6 +69,7 @@ describe('McpClientService', () => {
 
 		service = new McpClientService(
 			repository as unknown as Repository<McpClientEntity>,
+			dataSource as unknown as DataSource,
 			tokensService as unknown as TokensService,
 			jwtService as unknown as JwtService,
 			configService as unknown as ConfigService,
@@ -79,7 +90,12 @@ describe('McpClientService', () => {
 
 		expect(result.token).toBe('raw-mcp-token');
 		expect(jwtService.signAsync).toHaveBeenCalledWith(
-			expect.objectContaining({ sub: result.client.id, type: TokenOwnerType.MCP }),
+			expect.objectContaining({
+				sub: result.client.id,
+				type: TokenOwnerType.MCP,
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				jti: expect.any(String),
+			}),
 			{ audience: 'mcp-audience', expiresIn: 30 * 24 * 60 * 60 },
 		);
 		expect(tokensService.createLongLiveToken).toHaveBeenCalledWith(
@@ -90,6 +106,7 @@ describe('McpClientService', () => {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				expiresAt: expect.any(Date),
 			}),
+			expect.anything(),
 		);
 		expect(result.client).not.toHaveProperty('rawToken');
 	});
@@ -117,7 +134,7 @@ describe('McpClientService', () => {
 		expect(service.getEffectiveCapabilities(client)).toEqual([McpCapability.READ]);
 	});
 
-	it('creates a replacement before revoking the previous credential', async () => {
+	it('atomically creates a replacement before revoking the previous credential', async () => {
 		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
 		currentClient = {
 			id: uuid(),
@@ -143,8 +160,47 @@ describe('McpClientService', () => {
 		const result = await service.rotate(currentClient.id, { expiresInDays: 60 });
 
 		expect(events).toEqual(['create', 'revoke']);
-		expect(tokensService.revoke).toHaveBeenCalledWith(previousToken.id);
+		expect(tokensService.revoke).toHaveBeenCalledWith(previousToken.id, expect.anything());
 		expect(result.token).toBe('raw-mcp-token');
+	});
+
+	it('leaves the previous credential selected when revocation fails', async () => {
+		const previousToken = { id: uuid(), revoked: false } as LongLiveTokenEntity;
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ],
+			tokenId: previousToken.id,
+			token: previousToken,
+		} as McpClientEntity;
+		tokensService.revoke.mockRejectedValue(new Error('Database unavailable'));
+
+		await expect(service.rotate(currentClient.id, { expiresInDays: 60 })).rejects.toThrow('Database unavailable');
+
+		expect(currentClient.tokenId).toBe(previousToken.id);
+		expect(repository.save).not.toHaveBeenCalled();
+	});
+
+	it('adds unique entropy to credentials issued within the same second', async () => {
+		jwtService.signAsync.mockImplementation((payload: { jti: string }) => Promise.resolve(`token-${payload.jti}`));
+		const first = await service.create(
+			{
+				name: 'Agent',
+				capabilities: [McpCapability.READ],
+				expiresInDays: 30,
+			},
+			uuid(),
+		);
+		const second = await service.rotate(first.client.id, { expiresInDays: 30 });
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		const firstPayload = jwtService.signAsync.mock.calls[0][0] as { jti: string };
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		const secondPayload = jwtService.signAsync.mock.calls[1][0] as { jti: string };
+
+		expect(firstPayload.jti).not.toBe(secondPayload.jti);
+		expect(first.token).not.toBe(second.token);
 	});
 
 	it('disables a client and revokes its current credential', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -85,17 +85,25 @@ export class McpClientService {
 	}
 
 	async update(id: string, dto: UpdateMcpClientDto): Promise<McpClientEntity> {
-		const client = await this.getOneOrThrow(id);
+		await this.getOneOrThrow(id);
+		const updates: {
+			name?: string;
+			description?: string | null;
+			enabled?: boolean;
+			capabilities?: McpCapability[];
+		} = {};
 
 		if (dto.capabilities !== undefined) {
 			this.assertCapabilitiesAllowed(dto.capabilities);
-			client.capabilities = [...dto.capabilities];
+			updates.capabilities = [...dto.capabilities];
 		}
-		if (dto.name !== undefined) client.name = dto.name;
-		if (dto.description !== undefined) client.description = dto.description;
-		if (dto.enabled !== undefined) client.enabled = dto.enabled;
+		if (dto.name !== undefined) updates.name = dto.name;
+		if (dto.description !== undefined) updates.description = dto.description;
+		if (dto.enabled !== undefined) updates.enabled = dto.enabled;
 
-		await this.repository.save(client);
+		if (Object.keys(updates).length > 0) {
+			await this.repository.update(id, updates);
+		}
 
 		return this.getOneOrThrow(id);
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -159,11 +159,20 @@ export class McpClientService {
 	async remove(id: string): Promise<void> {
 		const client = await this.getOneOrThrow(id);
 
-		if (client.token) {
-			await this.tokensService.revoke(client.token.id);
-		}
+		await this.dataSource.transaction(async (manager) => {
+			if (client.token) {
+				await this.tokensService.revoke(client.token.id, manager);
+			}
 
-		await this.repository.remove(client);
+			const deleteResult = await manager.getRepository(McpClientEntity).delete({
+				id: client.id,
+				tokenId: client.token ? client.token.id : IsNull(),
+			});
+
+			if (!deleteResult.affected) {
+				throw new ConflictException('The MCP client credential was changed by another request');
+			}
+		});
 	}
 
 	private async issueCredential(

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -116,13 +116,24 @@ export class McpClientService {
 
 	async revoke(id: string): Promise<McpClientEntity> {
 		const client = await this.getOneOrThrow(id);
-		client.enabled = false;
 
-		if (client.token) {
-			await this.tokensService.revoke(client.token.id);
-		}
+		await this.dataSource.transaction(async (manager) => {
+			if (client.token) {
+				await this.tokensService.revoke(client.token.id, manager);
+			}
 
-		await this.repository.save(client);
+			const updateResult = await manager.getRepository(McpClientEntity).update(
+				{
+					id: client.id,
+					tokenId: client.token ? client.token.id : IsNull(),
+				},
+				{ enabled: false },
+			);
+
+			if (!updateResult.affected) {
+				throw new ConflictException('The MCP client credential was changed by another request');
+			}
+		});
 
 		return this.getOneOrThrow(id);
 	}
@@ -179,6 +190,7 @@ export class McpClientService {
 				{
 					id: client.id,
 					tokenId: previousToken ? previousToken.id : IsNull(),
+					enabled: client.enabled,
 				},
 				{ tokenId: token.id, enabled: true },
 			);

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -79,7 +79,7 @@ export class McpClientService {
 		try {
 			return await this.issueCredential(client, dto.expiresInDays);
 		} catch (error) {
-			await this.repository.remove(client);
+			await this.repository.delete({ id: client.id, tokenId: IsNull() });
 			throw error;
 		}
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -1,4 +1,5 @@
-import { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { DataSource, Repository } from 'typeorm';
 
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -23,6 +24,7 @@ export class McpClientService {
 	constructor(
 		@InjectRepository(McpClientEntity)
 		private readonly repository: Repository<McpClientEntity>,
+		private readonly dataSource: DataSource,
 		private readonly tokensService: TokensService,
 		private readonly jwtService: JwtService,
 		private readonly configService: ConfigService,
@@ -100,14 +102,8 @@ export class McpClientService {
 
 	async rotate(id: string, dto: RotateMcpClientTokenDto): Promise<McpClientCredentialModel> {
 		const client = await this.getOneOrThrow(id);
-		const previousToken = client.token;
-		const credential = await this.issueCredential(client, dto.expiresInDays);
 
-		if (previousToken) {
-			await this.tokensService.revoke(previousToken.id);
-		}
-
-		return credential;
+		return this.issueCredential(client, dto.expiresInDays, client.token ?? undefined);
 	}
 
 	async revoke(id: string): Promise<McpClientEntity> {
@@ -133,7 +129,11 @@ export class McpClientService {
 		await this.repository.remove(client);
 	}
 
-	private async issueCredential(client: McpClientEntity, expiresInDays: number): Promise<McpClientCredentialModel> {
+	private async issueCredential(
+		client: McpClientEntity,
+		expiresInDays: number,
+		previousToken?: LongLiveTokenEntity,
+	): Promise<McpClientCredentialModel> {
 		const issuedAt = Math.floor(Date.now() / 1000);
 		const expiresIn = expiresInDays * SECONDS_PER_DAY;
 		const rawToken = await this.jwtService.signAsync(
@@ -141,33 +141,35 @@ export class McpClientService {
 				sub: client.id,
 				type: TokenOwnerType.MCP,
 				iat: issuedAt,
+				jti: randomUUID(),
 			},
 			{
 				audience: await this.installationService.getAudience(),
 				expiresIn,
 			},
 		);
-		let token: LongLiveTokenEntity | undefined;
 
-		try {
-			token = await this.tokensService.createLongLiveToken({
-				token: rawToken,
-				ownerType: TokenOwnerType.MCP,
-				ownerId: client.id,
-				name: client.name,
-				description: client.description,
-				expiresAt: new Date((issuedAt + expiresIn) * 1000),
-			});
+		await this.dataSource.transaction(async (manager) => {
+			const token = await this.tokensService.createLongLiveToken(
+				{
+					token: rawToken,
+					ownerType: TokenOwnerType.MCP,
+					ownerId: client.id,
+					name: client.name,
+					description: client.description,
+					expiresAt: new Date((issuedAt + expiresIn) * 1000),
+				},
+				manager,
+			);
+
+			if (previousToken) {
+				await this.tokensService.revoke(previousToken.id, manager);
+			}
 
 			client.tokenId = token.id;
 			client.enabled = true;
-			await this.repository.save(client);
-		} catch (error) {
-			if (token) {
-				await this.tokensService.revoke(token.id);
-			}
-			throw error;
-		}
+			await manager.getRepository(McpClientEntity).save(client);
+		});
 
 		const credential = new McpClientCredentialModel();
 		credential.client = await this.getOneOrThrow(client.id);

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -1,0 +1,191 @@
+import { Repository } from 'typeorm';
+
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { TokenOwnerType } from '../../auth/auth.constants';
+import { LongLiveTokenEntity } from '../../auth/entities/auth.entity';
+import { TokensService } from '../../auth/services/tokens.service';
+import { ConfigService } from '../../config/services/config.service';
+import { CreateMcpClientDto, RotateMcpClientTokenDto, UpdateMcpClientDto } from '../dto/mcp-client.dto';
+import { McpClientEntity } from '../entities/mcp-client.entity';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+import { McpClientCredentialModel } from '../models/mcp-client.model';
+
+import { McpInstallationService } from './mcp-installation.service';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+@Injectable()
+export class McpClientService {
+	constructor(
+		@InjectRepository(McpClientEntity)
+		private readonly repository: Repository<McpClientEntity>,
+		private readonly tokensService: TokensService,
+		private readonly jwtService: JwtService,
+		private readonly configService: ConfigService,
+		private readonly installationService: McpInstallationService,
+	) {}
+
+	async findAll(): Promise<McpClientEntity[]> {
+		return this.repository.find({ relations: { token: true }, order: { createdAt: 'DESC' } });
+	}
+
+	async findOne(id: string): Promise<McpClientEntity | null> {
+		return this.repository.findOne({ where: { id }, relations: { token: true } });
+	}
+
+	async getOneOrThrow(id: string): Promise<McpClientEntity> {
+		const client = await this.findOne(id);
+
+		if (!client) {
+			throw new NotFoundException('Requested MCP client does not exist');
+		}
+
+		return client;
+	}
+
+	async findActiveByToken(tokenId: string, clientId: string): Promise<McpClientEntity | null> {
+		return this.repository.findOne({
+			where: { id: clientId, tokenId, enabled: true },
+			relations: { token: true },
+		});
+	}
+
+	getEffectiveCapabilities(client: McpClientEntity): McpCapability[] {
+		const ceiling = this.getCapabilityCeiling();
+
+		return client.capabilities.filter((capability) => ceiling.includes(capability));
+	}
+
+	async create(dto: CreateMcpClientDto, createdById: string): Promise<McpClientCredentialModel> {
+		this.assertCapabilitiesAllowed(dto.capabilities);
+
+		const client = await this.repository.save(
+			this.repository.create({
+				name: dto.name,
+				description: dto.description ?? null,
+				enabled: true,
+				capabilities: [...dto.capabilities],
+				createdById,
+				tokenId: null,
+			}),
+		);
+
+		try {
+			return await this.issueCredential(client, dto.expiresInDays);
+		} catch (error) {
+			await this.repository.remove(client);
+			throw error;
+		}
+	}
+
+	async update(id: string, dto: UpdateMcpClientDto): Promise<McpClientEntity> {
+		const client = await this.getOneOrThrow(id);
+
+		if (dto.capabilities !== undefined) {
+			this.assertCapabilitiesAllowed(dto.capabilities);
+			client.capabilities = [...dto.capabilities];
+		}
+		if (dto.name !== undefined) client.name = dto.name;
+		if (dto.description !== undefined) client.description = dto.description;
+		if (dto.enabled !== undefined) client.enabled = dto.enabled;
+
+		await this.repository.save(client);
+
+		return this.getOneOrThrow(id);
+	}
+
+	async rotate(id: string, dto: RotateMcpClientTokenDto): Promise<McpClientCredentialModel> {
+		const client = await this.getOneOrThrow(id);
+		const previousToken = client.token;
+		const credential = await this.issueCredential(client, dto.expiresInDays);
+
+		if (previousToken) {
+			await this.tokensService.revoke(previousToken.id);
+		}
+
+		return credential;
+	}
+
+	async revoke(id: string): Promise<McpClientEntity> {
+		const client = await this.getOneOrThrow(id);
+		client.enabled = false;
+
+		if (client.token) {
+			await this.tokensService.revoke(client.token.id);
+		}
+
+		await this.repository.save(client);
+
+		return this.getOneOrThrow(id);
+	}
+
+	async remove(id: string): Promise<void> {
+		const client = await this.getOneOrThrow(id);
+
+		if (client.token) {
+			await this.tokensService.revoke(client.token.id);
+		}
+
+		await this.repository.remove(client);
+	}
+
+	private async issueCredential(client: McpClientEntity, expiresInDays: number): Promise<McpClientCredentialModel> {
+		const issuedAt = Math.floor(Date.now() / 1000);
+		const expiresIn = expiresInDays * SECONDS_PER_DAY;
+		const rawToken = await this.jwtService.signAsync(
+			{
+				sub: client.id,
+				type: TokenOwnerType.MCP,
+				iat: issuedAt,
+			},
+			{
+				audience: await this.installationService.getAudience(),
+				expiresIn,
+			},
+		);
+		let token: LongLiveTokenEntity | undefined;
+
+		try {
+			token = await this.tokensService.createLongLiveToken({
+				token: rawToken,
+				ownerType: TokenOwnerType.MCP,
+				ownerId: client.id,
+				name: client.name,
+				description: client.description,
+				expiresAt: new Date((issuedAt + expiresIn) * 1000),
+			});
+
+			client.tokenId = token.id;
+			client.enabled = true;
+			await this.repository.save(client);
+		} catch (error) {
+			if (token) {
+				await this.tokensService.revoke(token.id);
+			}
+			throw error;
+		}
+
+		const credential = new McpClientCredentialModel();
+		credential.client = await this.getOneOrThrow(client.id);
+		credential.token = rawToken;
+
+		return credential;
+	}
+
+	private assertCapabilitiesAllowed(capabilities: McpCapability[]): void {
+		const ceiling = this.getCapabilityCeiling();
+		const disallowed = capabilities.filter((capability) => !ceiling.includes(capability));
+
+		if (disallowed.length > 0) {
+			throw new BadRequestException(`Capabilities exceed the module ceiling: ${disallowed.join(', ')}`);
+		}
+	}
+
+	private getCapabilityCeiling(): McpCapability[] {
+		return this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME).capabilities;
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, IsNull, Repository } from 'typeorm';
 
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -166,9 +166,21 @@ export class McpClientService {
 				await this.tokensService.revoke(previousToken.id, manager);
 			}
 
+			const clientRepository = manager.getRepository(McpClientEntity);
+			const updateResult = await clientRepository.update(
+				{
+					id: client.id,
+					tokenId: previousToken ? previousToken.id : IsNull(),
+				},
+				{ tokenId: token.id, enabled: true },
+			);
+
+			if (!updateResult.affected) {
+				throw new ConflictException('The MCP client credential was changed by another request');
+			}
+
 			client.tokenId = token.id;
 			client.enabled = true;
-			await manager.getRepository(McpClientEntity).save(client);
 		});
 
 		const credential = new McpClientCredentialModel();

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -85,7 +85,7 @@ export class McpClientService {
 	}
 
 	async update(id: string, dto: UpdateMcpClientDto): Promise<McpClientEntity> {
-		await this.getOneOrThrow(id);
+		const client = await this.getOneOrThrow(id);
 		const updates: {
 			name?: string;
 			description?: string | null;
@@ -102,7 +102,25 @@ export class McpClientService {
 		if (dto.enabled !== undefined) updates.enabled = dto.enabled;
 
 		if (Object.keys(updates).length > 0) {
-			await this.repository.update(id, updates);
+			await this.dataSource.transaction(async (manager) => {
+				if (dto.enabled === true) {
+					const token = client.tokenId
+						? await manager.getRepository(LongLiveTokenEntity).findOne({ where: { id: client.tokenId } })
+						: null;
+
+					if (!token || token.revoked || (token.expiresAt && token.expiresAt < new Date())) {
+						throw new ConflictException('Rotate the MCP client credential before enabling this client');
+					}
+				}
+
+				const updateResult = await manager
+					.getRepository(McpClientEntity)
+					.update({ id, tokenId: client.tokenId ?? IsNull() }, updates);
+
+				if (!updateResult.affected) {
+					throw new ConflictException('The MCP client credential was changed by another request');
+				}
+			});
 		}
 
 		return this.getOneOrThrow(id);

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -195,7 +195,7 @@ export class McpClientService {
 			},
 		);
 
-		await this.dataSource.transaction(async (manager) => {
+		const issuedClient = await this.dataSource.transaction(async (manager) => {
 			const token = await this.tokensService.createLongLiveToken(
 				{
 					token: rawToken,
@@ -226,12 +226,20 @@ export class McpClientService {
 				throw new ConflictException('The MCP client credential was changed by another request');
 			}
 
-			client.tokenId = token.id;
-			client.enabled = true;
+			const updatedClient = await clientRepository.findOne({
+				where: { id: client.id },
+				relations: { token: true },
+			});
+
+			if (!updatedClient) {
+				throw new NotFoundException('Requested MCP client does not exist');
+			}
+
+			return updatedClient;
 		});
 
 		const credential = new McpClientCredentialModel();
-		credential.client = await this.getOneOrThrow(client.id);
+		credential.client = issuedClient;
 		credential.token = rawToken;
 
 		return credential;

--- a/apps/backend/src/modules/mcp/services/mcp-installation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-installation.service.spec.ts
@@ -1,0 +1,27 @@
+import { Repository } from 'typeorm';
+
+import { McpInstallationEntity } from '../entities/mcp-installation.entity';
+
+import { McpInstallationService } from './mcp-installation.service';
+
+describe('McpInstallationService', () => {
+	it('persists and reuses a stable installation-specific audience', async () => {
+		let stored: McpInstallationEntity | null = null;
+		const repository = {
+			findOne: jest.fn().mockImplementation(() => Promise.resolve(stored)),
+			create: jest.fn((value: Partial<McpInstallationEntity>) => value),
+			save: jest.fn().mockImplementation((value: McpInstallationEntity) => {
+				stored = value;
+				return Promise.resolve(stored);
+			}),
+		};
+		const service = new McpInstallationService(repository as unknown as Repository<McpInstallationEntity>);
+
+		const first = await service.getAudience();
+		const second = await service.getAudience();
+
+		expect(first).toMatch(/^urn:fastybird:smart-panel:[0-9a-f-]+:mcp$/);
+		expect(second).toBe(first);
+		expect(repository.save).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-installation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-installation.service.ts
@@ -1,0 +1,50 @@
+import { Repository } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { McpInstallationEntity } from '../entities/mcp-installation.entity';
+
+const INSTALLATION_KEY = 'installation';
+
+@Injectable()
+export class McpInstallationService {
+	private installationId?: string;
+
+	constructor(
+		@InjectRepository(McpInstallationEntity)
+		private readonly repository: Repository<McpInstallationEntity>,
+	) {}
+
+	async getInstallationId(): Promise<string> {
+		if (this.installationId) {
+			return this.installationId;
+		}
+
+		let installation = await this.repository.findOne({ where: { key: INSTALLATION_KEY } });
+
+		if (!installation) {
+			try {
+				installation = await this.repository.save(
+					this.repository.create({ key: INSTALLATION_KEY, installationId: uuid() }),
+				);
+			} catch {
+				// Another process may have created the singleton concurrently.
+				installation = await this.repository.findOne({ where: { key: INSTALLATION_KEY } });
+			}
+		}
+
+		if (!installation) {
+			throw new Error('Failed to initialize MCP installation identity');
+		}
+
+		this.installationId = installation.installationId;
+
+		return this.installationId;
+	}
+
+	async getAudience(): Promise<string> {
+		return `urn:fastybird:smart-panel:${await this.getInstallationId()}:mcp`;
+	}
+}

--- a/apps/backend/src/modules/websocket/services/ws-auth.service.spec.ts
+++ b/apps/backend/src/modules/websocket/services/ws-auth.service.spec.ts
@@ -1,0 +1,33 @@
+import { Socket } from 'socket.io';
+
+import { JwtService } from '@nestjs/jwt';
+
+import { TokenOwnerType } from '../../auth/auth.constants';
+import { TokensService } from '../../auth/services/tokens.service';
+import { UsersService } from '../../users/services/users.service';
+import { WebsocketNotAllowedException } from '../websocket.exceptions';
+
+import { WsAuthService } from './ws-auth.service';
+
+describe('WsAuthService', () => {
+	it('rejects MCP credentials before generic long-lived-token validation', async () => {
+		const jwtService = {
+			verifyAsync: jest.fn().mockResolvedValue({ sub: 'mcp-client', type: TokenOwnerType.MCP }),
+		};
+		const tokensService = {
+			findAll: jest.fn(),
+		};
+		const service = new WsAuthService(
+			jwtService as unknown as JwtService,
+			tokensService as unknown as TokensService,
+			{} as UsersService,
+		);
+		const client = {
+			handshake: { auth: { token: 'mcp-token' } },
+			data: {},
+		} as unknown as Socket;
+
+		await expect(service.validateClient(client)).rejects.toBeInstanceOf(WebsocketNotAllowedException);
+		expect(tokensService.findAll).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/modules/websocket/services/ws-auth.service.ts
+++ b/apps/backend/src/modules/websocket/services/ws-auth.service.ts
@@ -53,6 +53,10 @@ export class WsAuthService {
 			throw new WebsocketNotAllowedException('Invalid or expired token');
 		}
 
+		if ((payload.type as TokenOwnerType) === TokenOwnerType.MCP) {
+			throw new WebsocketNotAllowedException('MCP credentials cannot authenticate WebSocket connections');
+		}
+
 		// Check if this is a display token (type: TokenOwnerType.DISPLAY in payload)
 		if ((payload.type as TokenOwnerType) === TokenOwnerType.DISPLAY && payload.sub) {
 			return this.validateDisplayToken(client, token, payload.sub);

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 2 complete — Phase 3 pending
+**Status:** Phase 3 complete — Phase 4 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -368,23 +368,28 @@ report partial or failed operations honestly without exposing internal exception
 - Create: incremental migration `apps/backend/src/migrations/<next>-AddMcpClients.ts`
 - Modify auth constants, token service, HTTP auth guard, and WebSocket auth service
 
-- [ ] Add `TokenOwnerType.MCP`.
-- [ ] Store MCP client name, description, enabled state, capability subset, creator user ID, timestamps, and associated
+- [x] Add `TokenOwnerType.MCP`.
+- [x] Store MCP client name, description, enabled state, capability subset, creator user ID, timestamps, and associated
       long-lived token ID/owner relationship.
-- [ ] Generate an MCP JWT with `type: mcp`, MCP client ID as subject/owner, finite expiry, and canonical endpoint
+- [x] Generate an MCP JWT with `type: mcp`, MCP client ID as subject/owner, finite expiry, and canonical endpoint
       audience.
-- [ ] Store only the normal token hash; return the raw token exactly once.
-- [ ] Add owner/admin-only list, create, update, rotate, revoke/delete management endpoints.
-- [ ] Validate requested client capabilities against the module's configured ceiling at creation/update time.
-- [ ] Also intersect capabilities at request time so later module reductions apply immediately.
-- [ ] Extend `AuthGuard` with explicit MCP-endpoint metadata: MCP tokens are accepted only on that endpoint and all
+- [x] Store only the normal token hash; return the raw token exactly once.
+- [x] Add owner/admin-only list, create, update, rotate, revoke/delete management endpoints.
+- [x] Validate requested client capabilities against the module's configured ceiling at creation/update time.
+- [x] Also intersect capabilities at request time so later module reductions apply immediately.
+- [x] Extend `AuthGuard` with explicit MCP-endpoint metadata: MCP tokens are accepted only on that endpoint and all
       other token types are rejected there.
-- [ ] Reject MCP tokens in `WsAuthService` before they reach the generic long-lived-token branch.
-- [ ] Ensure profile PAT lists and display-token flows do not accidentally include or manage MCP credentials.
-- [ ] Use an incremental migration; never edit an existing migration.
+- [x] Reject MCP tokens in `WsAuthService` before they reach the generic long-lived-token branch.
+- [x] Ensure profile PAT lists and display-token flows do not accidentally include or manage MCP credentials.
+- [x] Use an incremental migration; never edit an existing migration.
 
 **Tests:** one-time secret, hash storage, expiry, audience, revocation, rotation, capability subset validation, MCP token
 rejected on REST, PAT rejected on MCP, MCP token rejected on WebSocket, and existing display/PAT auth regressions.
+
+**Outcome:** MCP clients now have installation-local records, finite audience-bound credentials, one-time secret
+delivery, capability ceilings with request-time intersection, and owner/admin lifecycle APIs. HTTP, WebSocket,
+personal-access-token, and display authentication paths explicitly isolate MCP credentials, backed by an incremental
+SQLite migration and focused regression coverage.
 
 ### Task 6: Implement policy and subscription services
 


### PR DESCRIPTION
## Summary

- add persisted MCP installation identity and MCP client records through an incremental migration
- add owner/admin client-management APIs for create, list, update, rotate, revoke, and delete flows
- issue finite, installation-audience-bound MCP JWTs while storing only the normal token hash and returning the raw secret once
- enforce capability grants against the configured module ceiling and recompute the effective intersection on every MCP-authenticated request
- isolate MCP credentials from ordinary REST, personal-access-token, display-token, and WebSocket authentication paths
- update the MCP implementation plan to mark Phase 3 complete

## Why

MCP agents need credentials with a narrower trust boundary than user, display, or generic long-lived tokens. This introduces an installation-local client lifecycle and makes credential acceptance explicit at the MCP endpoint rather than allowing MCP tokens to fall through generic authentication branches.

## Impact

Owners and administrators can provision and rotate finite MCP credentials with capability subsets. Reducing the installation capability ceiling applies immediately, and disabling, revoking, rotating, or deleting a client prevents subsequent authentication. Existing PAT and display behavior remains isolated from MCP records.

## Validation

- 39 focused MCP/auth/migration tests pass
- backend type-check passes
- backend build passes
- API conventions lint passes
- full backend lint reports 0 errors and 2 pre-existing unrelated warnings
- all 253 backend suites completed with 3,278 passing tests and 2 skipped; after completion, the local Jest process encountered an existing Home Assistant WebSocket teardown callback error (`this.ws?.terminate is not a function`)