### PR TITLE
feat(backend): apply live policy changes

### DIFF
--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
@@ -7,13 +7,16 @@ import { McpClientGuard } from './mcp-client.guard';
 
 describe('McpClientGuard', () => {
 	it('resolves policy, validates transport origin, and attaches the context', async () => {
-		const request = { auth: { type: 'token' } } as McpPolicyRequest;
+		const request = { auth: { type: 'token', ownerId: 'client-id' } } as McpPolicyRequest;
 		const policy = { installationId: 'installation-id' } as McpPolicyContext;
 		const policyService = {
 			resolve: jest.fn().mockResolvedValue(policy),
 			validateRequestOrigin: jest.fn(),
 		};
-		const serverService = { getPolicyRevision: jest.fn().mockReturnValue(7) };
+		const serverService = {
+			getClientPolicyRevision: jest.fn().mockReturnValue(3),
+			getPolicyRevision: jest.fn().mockReturnValue(7),
+		};
 		const guard = new McpClientGuard(
 			policyService as unknown as McpPolicyService,
 			serverService as unknown as McpServerService,
@@ -25,6 +28,7 @@ describe('McpClientGuard', () => {
 		await expect(guard.canActivate(context)).resolves.toBe(true);
 		expect(policyService.resolve).toHaveBeenCalledWith(request.auth);
 		expect(policyService.validateRequestOrigin).toHaveBeenCalledWith(request, policy);
-		expect(request.mcpPolicy).toEqual({ ...policy, policyRevision: 7 });
+		expect(serverService.getClientPolicyRevision).toHaveBeenCalledWith('client-id');
+		expect(request.mcpPolicy).toEqual({ ...policy, clientPolicyRevision: 3, policyRevision: 7 });
 	});
 });

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
@@ -13,10 +13,14 @@ export class McpClientGuard implements CanActivate {
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
 		const policyRevision = this.serverService.getPolicyRevision();
+		const clientPolicyRevision =
+			request.auth?.type === 'token' && request.auth.ownerId
+				? this.serverService.getClientPolicyRevision(request.auth.ownerId)
+				: 0;
 		const policy = await this.policyService.resolve(request.auth);
 
 		this.policyService.validateRequestOrigin(request, policy);
-		request.mcpPolicy = { ...policy, policyRevision };
+		request.mcpPolicy = { ...policy, clientPolicyRevision, policyRevision };
 
 		return true;
 	}

--- a/apps/backend/src/modules/mcp/listeners/mcp-config.listener.spec.ts
+++ b/apps/backend/src/modules/mcp/listeners/mcp-config.listener.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '../../config/services/config.service';
-import { MCP_MODULE_NAME } from '../mcp.constants';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
 import { McpServerService } from '../services/mcp-server.service';
 
@@ -16,7 +16,11 @@ describe('McpConfigListener', () => {
 	let listener: McpConfigListener;
 
 	beforeEach(() => {
-		config = Object.assign(new McpConfigModel(), { enabled: true });
+		config = Object.assign(new McpConfigModel(), {
+			enabled: true,
+			capabilities: [McpCapability.READ, McpCapability.WRITE],
+			allowedOrigins: [],
+		});
 		serverService = {
 			closeAll: jest.fn().mockResolvedValue(undefined),
 			invalidatePolicies: jest.fn(),
@@ -27,6 +31,7 @@ describe('McpConfigListener', () => {
 			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
 			serverService as unknown as McpServerService,
 		);
+		listener.onApplicationBootstrap();
 	});
 
 	it('ignores configuration changes outside the MCP module', () => {
@@ -35,30 +40,88 @@ describe('McpConfigListener', () => {
 
 		expect(serverService.closeAll).not.toHaveBeenCalled();
 		expect(serverService.notifyToolsChanged).not.toHaveBeenCalled();
+		expect(serverService.invalidatePolicies).not.toHaveBeenCalled();
 	});
 
-	it('closes all active streams when the MCP module is disabled', () => {
+	it('publishes list changes before closing all active streams when the MCP module is disabled', () => {
+		const order: string[] = [];
+		serverService.invalidatePolicies.mockImplementation(() => order.push('invalidate'));
+		serverService.notifyToolsChanged.mockImplementation(() => order.push('tools'));
+		serverService.notifyResourcesChanged.mockImplementation(() => order.push('resources'));
+		serverService.closeAll.mockImplementation(() => {
+			order.push('close');
+			return Promise.resolve();
+		});
 		config.enabled = false;
 
 		listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' });
 
+		expect(order).toEqual(['invalidate', 'tools', 'resources', 'close']);
 		expect(serverService.closeAll).toHaveBeenCalledTimes(1);
-		expect(serverService.notifyToolsChanged).not.toHaveBeenCalled();
 	});
 
-	it('notifies active clients when enabled policy changes', () => {
+	it('notifies only the tool list when non-read capabilities change', () => {
+		config.capabilities = [McpCapability.READ];
+
+		listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' });
+
+		expect(serverService.notifyToolsChanged).toHaveBeenCalledTimes(1);
+		expect(serverService.notifyResourcesChanged).not.toHaveBeenCalled();
+		expect(serverService.invalidatePolicies).toHaveBeenCalledTimes(1);
+		expect(serverService.closeAll).not.toHaveBeenCalled();
+	});
+
+	it('notifies tool and resource lists when read capability is removed', () => {
+		config.capabilities = [McpCapability.WRITE];
+
 		listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' });
 
 		expect(serverService.notifyToolsChanged).toHaveBeenCalledTimes(1);
 		expect(serverService.notifyResourcesChanged).toHaveBeenCalledTimes(1);
 		expect(serverService.invalidatePolicies).toHaveBeenCalledTimes(1);
+	});
+
+	it('invalidates policy without list notifications when only allowed origins change', () => {
+		config.allowedOrigins = ['https://agent.example.com'];
+
+		listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' });
+
+		expect(serverService.invalidatePolicies).toHaveBeenCalledTimes(1);
+		expect(serverService.notifyToolsChanged).not.toHaveBeenCalled();
+		expect(serverService.notifyResourcesChanged).not.toHaveBeenCalled();
 		expect(serverService.closeAll).not.toHaveBeenCalled();
 	});
 
-	it('closes all active streams when configuration is reset', () => {
+	it('publishes the newly available lists when the module is enabled', () => {
+		config.enabled = false;
+		listener.onApplicationBootstrap();
+		jest.clearAllMocks();
+		config.enabled = true;
+
+		listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' });
+
+		expect(serverService.notifyToolsChanged).toHaveBeenCalledTimes(1);
+		expect(serverService.notifyResourcesChanged).toHaveBeenCalledTimes(1);
+		expect(serverService.closeAll).not.toHaveBeenCalled();
+	});
+
+	it('still closes streams when a best-effort notification fails', () => {
+		serverService.notifyToolsChanged.mockImplementation(() => {
+			throw new Error('Notification failed');
+		});
+		config.enabled = false;
+
+		expect(() => listener.onConfigUpdated({ source: MCP_MODULE_NAME, type: 'module' })).not.toThrow();
+
+		expect(serverService.notifyResourcesChanged).toHaveBeenCalledTimes(1);
+		expect(serverService.closeAll).toHaveBeenCalledTimes(1);
+	});
+
+	it('publishes list changes and closes all active streams when configuration is reset', () => {
 		listener.onConfigReset();
 
+		expect(serverService.notifyToolsChanged).toHaveBeenCalledTimes(1);
+		expect(serverService.notifyResourcesChanged).toHaveBeenCalledTimes(1);
 		expect(serverService.closeAll).toHaveBeenCalledTimes(1);
-		expect(serverService.notifyToolsChanged).not.toHaveBeenCalled();
 	});
 });

--- a/apps/backend/src/modules/mcp/listeners/mcp-config.listener.ts
+++ b/apps/backend/src/modules/mcp/listeners/mcp-config.listener.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { EventType } from '../../config/config.constants';
 import { ConfigService } from '../../config/services/config.service';
-import { MCP_MODULE_NAME } from '../mcp.constants';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
 import { McpServerService } from '../services/mcp-server.service';
 
@@ -13,14 +13,24 @@ interface ConfigUpdatedEvent {
 	type: 'module' | 'plugin';
 }
 
+interface McpConfigSnapshot {
+	enabled: boolean;
+	capabilities: McpCapability[];
+}
+
 @Injectable()
-export class McpConfigListener {
+export class McpConfigListener implements OnApplicationBootstrap {
 	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpConfigListener');
+	private previousConfig?: McpConfigSnapshot;
 
 	constructor(
 		private readonly configService: ConfigService,
 		private readonly serverService: McpServerService,
 	) {}
+
+	onApplicationBootstrap(): void {
+		this.previousConfig = this.snapshot(this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME));
+	}
 
 	@OnEvent(EventType.CONFIG_UPDATED)
 	onConfigUpdated(event: ConfigUpdatedEvent): void {
@@ -28,22 +38,60 @@ export class McpConfigListener {
 			return;
 		}
 
-		const config = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+		const previous = this.previousConfig;
+		const current = this.snapshot(this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME));
+		this.previousConfig = current;
 
-		if (!config.enabled) {
-			this.closeAllStreams('module disable');
-
-			return;
-		}
+		const capabilitiesChanged = !previous || !this.sameCapabilities(previous.capabilities, current.capabilities);
+		const toolsChanged = !previous || previous.enabled !== current.enabled || (current.enabled && capabilitiesChanged);
+		const resourcesChanged =
+			!previous ||
+			(previous.enabled && previous.capabilities.includes(McpCapability.READ)) !==
+				(current.enabled && current.capabilities.includes(McpCapability.READ));
 
 		this.serverService.invalidatePolicies();
-		this.serverService.notifyToolsChanged();
-		this.serverService.notifyResourcesChanged();
+
+		if (toolsChanged) {
+			this.notifyBestEffort('tool-list change', () => this.serverService.notifyToolsChanged());
+		}
+
+		if (resourcesChanged) {
+			this.notifyBestEffort('resource-list change', () => this.serverService.notifyResourcesChanged());
+		}
+
+		if (!current.enabled) {
+			this.closeAllStreams('module disable');
+		}
 	}
 
 	@OnEvent(EventType.CONFIG_RESET)
 	onConfigReset(): void {
+		this.previousConfig = undefined;
+		this.notifyBestEffort('tool-list change before configuration reset', () => this.serverService.notifyToolsChanged());
+		this.notifyBestEffort('resource-list change before configuration reset', () =>
+			this.serverService.notifyResourcesChanged(),
+		);
 		this.closeAllStreams('configuration reset');
+	}
+
+	private snapshot(config: McpConfigModel): McpConfigSnapshot {
+		return { enabled: config.enabled, capabilities: [...config.capabilities] };
+	}
+
+	private sameCapabilities(first: McpCapability[], second: McpCapability[]): boolean {
+		return first.length === second.length && first.every((capability) => second.includes(capability));
+	}
+
+	private notifyBestEffort(reason: string, callback: () => void): void {
+		try {
+			callback();
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error('Unknown MCP notification error');
+			this.logger.error(`Failed to publish MCP ${reason}`, {
+				message: err.message,
+				stack: err.stack,
+			});
+		}
 	}
 
 	private closeAllStreams(reason: string): void {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.spec.ts
@@ -33,7 +33,7 @@ describe('McpClientService', () => {
 	let configService: { getModuleConfig: jest.Mock };
 	let serverService: {
 		closeClient: jest.Mock;
-		invalidatePolicies: jest.Mock;
+		invalidateClientPolicy: jest.Mock;
 		notifyResourcesChanged: jest.Mock;
 		notifyToolsChanged: jest.Mock;
 	};
@@ -87,7 +87,7 @@ describe('McpClientService', () => {
 		};
 		serverService = {
 			closeClient: jest.fn().mockResolvedValue(undefined),
-			invalidatePolicies: jest.fn(),
+			invalidateClientPolicy: jest.fn(),
 			notifyResourcesChanged: jest.fn(),
 			notifyToolsChanged: jest.fn(),
 		};
@@ -218,8 +218,64 @@ describe('McpClientService', () => {
 
 		expect(serverService.notifyToolsChanged).toHaveBeenCalledWith(currentClient.id);
 		expect(serverService.notifyResourcesChanged).toHaveBeenCalledWith(currentClient.id);
-		expect(serverService.invalidatePolicies).toHaveBeenCalledTimes(1);
+		expect(serverService.invalidateClientPolicy).toHaveBeenCalledWith(currentClient.id);
 		expect(serverService.closeClient).not.toHaveBeenCalled();
+	});
+
+	it('does not notify resources when read access is unchanged', async () => {
+		configService.getModuleConfig.mockReturnValue({
+			capabilities: [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER],
+		});
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.WRITE],
+			tokenId: uuid(),
+		} as McpClientEntity;
+
+		await service.update(currentClient.id, { capabilities: [McpCapability.TRIGGER] });
+
+		expect(serverService.notifyToolsChanged).toHaveBeenCalledWith(currentClient.id);
+		expect(serverService.notifyResourcesChanged).not.toHaveBeenCalled();
+		expect(serverService.invalidateClientPolicy).toHaveBeenCalledWith(currentClient.id);
+	});
+
+	it('does not invalidate or notify when the capability set is unchanged', async () => {
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ, McpCapability.WRITE],
+			tokenId: uuid(),
+		} as McpClientEntity;
+
+		await service.update(currentClient.id, { capabilities: [McpCapability.WRITE, McpCapability.READ] });
+
+		expect(serverService.invalidateClientPolicy).not.toHaveBeenCalled();
+		expect(serverService.notifyToolsChanged).not.toHaveBeenCalled();
+		expect(serverService.notifyResourcesChanged).not.toHaveBeenCalled();
+	});
+
+	it('invalidates live policy even when reloading the persisted update fails', async () => {
+		currentClient = {
+			id: uuid(),
+			name: 'Agent',
+			description: null,
+			enabled: true,
+			capabilities: [McpCapability.READ, McpCapability.WRITE],
+			tokenId: uuid(),
+		} as McpClientEntity;
+		repository.findOne.mockResolvedValueOnce(currentClient).mockRejectedValueOnce(new Error('Database unavailable'));
+
+		await expect(service.update(currentClient.id, { capabilities: [McpCapability.READ] })).rejects.toThrow(
+			'Database unavailable',
+		);
+
+		expect(serverService.invalidateClientPolicy).toHaveBeenCalledWith(currentClient.id);
+		expect(serverService.notifyToolsChanged).toHaveBeenCalledWith(currentClient.id);
 	});
 
 	it('rejects enabling a client whose current credential is revoked', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-client.service.ts
@@ -88,6 +88,12 @@ export class McpClientService {
 
 	async update(id: string, dto: UpdateMcpClientDto): Promise<McpClientEntity> {
 		const client = await this.getOneOrThrow(id);
+		const capabilitiesChanged =
+			dto.capabilities !== undefined && !this.sameCapabilities(client.capabilities, dto.capabilities);
+		const resourcesChanged =
+			dto.capabilities !== undefined &&
+			capabilitiesChanged &&
+			client.capabilities.includes(McpCapability.READ) !== dto.capabilities.includes(McpCapability.READ);
 		const updates: {
 			name?: string;
 			description?: string | null;
@@ -125,17 +131,18 @@ export class McpClientService {
 			});
 		}
 
-		const updatedClient = await this.getOneOrThrow(id);
-
 		if (dto.enabled === false) {
 			await this.serverService.closeClient(id);
-		} else if (dto.capabilities !== undefined) {
-			this.serverService.invalidatePolicies();
+		} else if (capabilitiesChanged) {
+			this.serverService.invalidateClientPolicy(id);
 			this.serverService.notifyToolsChanged(id);
-			this.serverService.notifyResourcesChanged(id);
+
+			if (resourcesChanged) {
+				this.serverService.notifyResourcesChanged(id);
+			}
 		}
 
-		return updatedClient;
+		return this.getOneOrThrow(id);
 	}
 
 	async rotate(id: string, dto: RotateMcpClientTokenDto): Promise<McpClientCredentialModel> {
@@ -271,6 +278,10 @@ export class McpClientService {
 		if (disallowed.length > 0) {
 			throw new BadRequestException(`Capabilities exceed the module ceiling: ${disallowed.join(', ')}`);
 		}
+	}
+
+	private sameCapabilities(first: McpCapability[], second: McpCapability[]): boolean {
+		return first.length === second.length && first.every((capability) => second.includes(capability));
 	}
 
 	private getCapabilityCeiling(): McpCapability[] {

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
@@ -125,6 +125,31 @@ describe('McpPolicyService', () => {
 		expect(clientService.findActiveByToken).toHaveBeenCalledTimes(2);
 	});
 
+	it('denies a tool authorization when permission is reduced during the fresh client lookup', async () => {
+		client.capabilities = [McpCapability.READ, McpCapability.WRITE];
+		let releaseLookup: () => void = () => undefined;
+		let markLookupStarted: () => void = () => undefined;
+		const lookupStarted = new Promise<void>((resolve) => {
+			markLookupStarted = resolve;
+		});
+		const lookupReleased = new Promise<void>((resolve) => {
+			releaseLookup = resolve;
+		});
+		clientService.findActiveByToken.mockImplementationOnce(async () => {
+			markLookupStarted();
+			await lookupReleased;
+
+			return client;
+		});
+
+		const authorization = service.authorizeClient(TOKEN_ID, CLIENT_ID, McpCapability.WRITE);
+		await lookupStarted;
+		client.capabilities = [McpCapability.READ];
+		releaseLookup();
+
+		await expect(authorization).rejects.toThrow(ForbiddenException);
+	});
+
 	it.each([
 		['same origin', 'https://panel.example.com', 'panel.example.com'],
 		['configured app origin', 'https://panel.example.com', '127.0.0.1:3000'],

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
@@ -19,6 +19,7 @@ export interface McpPolicyContext {
 	config: McpConfigModel;
 	effectiveCapabilities: McpCapability[];
 	installationId: string;
+	clientPolicyRevision?: number;
 	policyRevision?: number;
 	tokenId: string;
 }

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -8,22 +8,27 @@ import { McpSubscriptionHandle, McpSubscriptionRegistryService } from './mcp-sub
 
 describe('McpServerService policy revision', () => {
 	let service: McpServerService;
-	let subscriptions: { closeAll: jest.Mock; closeClient: jest.Mock };
+	let subscriptions: { closeAll: jest.Mock; closeClient: jest.Mock; touchClient: jest.Mock };
 
 	beforeEach(() => {
 		subscriptions = {
 			closeAll: jest.fn(),
 			closeClient: jest.fn(),
+			touchClient: jest.fn(),
 		};
 		service = new McpServerService(subscriptions as unknown as McpSubscriptionRegistryService);
 	});
 
-	it('invalidates in-flight policies before closing a client', async () => {
-		const revision = service.getPolicyRevision();
+	it('invalidates only the targeted client policy before closing it', async () => {
+		const globalRevision = service.getPolicyRevision();
+		const clientRevision = service.getClientPolicyRevision('client-id');
+		const otherRevision = service.getClientPolicyRevision('other-client');
 
 		await service.closeClient('client-id');
 
-		expect(service.getPolicyRevision()).toBe(revision + 1);
+		expect(service.getPolicyRevision()).toBe(globalRevision);
+		expect(service.getClientPolicyRevision('client-id')).toBe(clientRevision + 1);
+		expect(service.getClientPolicyRevision('other-client')).toBe(otherRevision);
 		expect(subscriptions.closeClient).toHaveBeenCalledWith('client-id');
 	});
 
@@ -32,6 +37,7 @@ describe('McpServerService policy revision', () => {
 			headers: { authorization: 'Bearer token' },
 			mcpPolicy: {
 				client: { id: 'client-id' },
+				clientPolicyRevision: service.getClientPolicyRevision('client-id'),
 				policyRevision: service.getPolicyRevision(),
 			},
 		} as unknown as McpPolicyRequest;
@@ -50,6 +56,24 @@ describe('McpServerService policy revision', () => {
 
 		expect(service.getPolicyRevision()).toBe(revision + 1);
 		expect(subscriptions.closeAll).toHaveBeenCalledTimes(1);
+	});
+
+	it('publishes list changes only to the targeted client handler', () => {
+		const firstToolsChanged = jest.fn();
+		const secondToolsChanged = jest.fn();
+		const handlers = (
+			service as unknown as {
+				handlers: Map<string, { handler: { notify: { toolsChanged: () => void } } }>;
+			}
+		).handlers;
+		handlers.set('client-a', { handler: { notify: { toolsChanged: firstToolsChanged } } });
+		handlers.set('client-b', { handler: { notify: { toolsChanged: secondToolsChanged } } });
+
+		service.notifyToolsChanged('client-a');
+
+		expect(firstToolsChanged).toHaveBeenCalledTimes(1);
+		expect(secondToolsChanged).not.toHaveBeenCalled();
+		expect(subscriptions.touchClient).toHaveBeenCalledWith('client-a');
 	});
 
 	it('refreshes the idle deadline when subscription traffic is forwarded', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -43,6 +43,7 @@ interface McpCatalogRegistrar {
 export class McpServerService implements OnApplicationShutdown {
 	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpServerService');
 	private readonly handlers = new Map<string, ClientHandler>();
+	private readonly clientPolicyRevisions = new Map<string, number>();
 	private policyRevision = 0;
 
 	constructor(
@@ -63,7 +64,10 @@ export class McpServerService implements OnApplicationShutdown {
 
 		const policy = request.mcpPolicy;
 
-		if (policy.policyRevision !== this.policyRevision) {
+		if (
+			policy.policyRevision !== this.policyRevision ||
+			policy.clientPolicyRevision !== this.getClientPolicyRevision(policy.client.id)
+		) {
 			throw new UnauthorizedException('MCP request policy is no longer current');
 		}
 
@@ -104,12 +108,20 @@ export class McpServerService implements OnApplicationShutdown {
 		return this.policyRevision;
 	}
 
+	getClientPolicyRevision(clientId: string): number {
+		return this.clientPolicyRevisions.get(clientId) ?? 0;
+	}
+
 	invalidatePolicies(): void {
 		this.policyRevision += 1;
 	}
 
+	invalidateClientPolicy(clientId: string): void {
+		this.clientPolicyRevisions.set(clientId, this.getClientPolicyRevision(clientId) + 1);
+	}
+
 	async closeClient(clientId: string): Promise<void> {
-		this.invalidatePolicies();
+		this.invalidateClientPolicy(clientId);
 		this.subscriptions.closeClient(clientId);
 		const clientHandler = this.handlers.get(clientId);
 

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -42,6 +42,7 @@ class TestMcpClientGuard implements CanActivate {
 
 		request.mcpPolicy = {
 			client,
+			clientPolicyRevision: this.serverService.getClientPolicyRevision(client.id),
 			config: Object.assign(new McpConfigModel(), {
 				enabled: true,
 				capabilities: [McpCapability.READ],

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 6 complete — Phase 7 pending
+**Status:** Phase 7 complete — Phase 8 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -512,16 +512,21 @@ and optional home-control plugin absence.
 - Modify MCP client service/subscription registry
 - Add specs
 
-- [ ] Subscribe to the existing configuration-updated event for `mcp-module`.
-- [ ] On capability changes, publish tool-list changes to active modern subscriptions and the negotiated legacy
+- [x] Subscribe to the existing configuration-updated event for `mcp-module`.
+- [x] On capability changes, publish tool-list changes to active modern subscriptions and the negotiated legacy
       notification equivalent when a legacy stateful adapter exists.
-- [ ] On removal of `read`, also notify resource-list changes where supported.
-- [ ] On module disable, close all active subscription streams after a best-effort notification.
-- [ ] On client capability reduction, notify only that client's streams.
-- [ ] On client disable/revocation/deletion/rotation, close that client's existing streams.
-- [ ] Execution policy remains authoritative even if a client misses a notification.
+- [x] On removal of `read`, also notify resource-list changes where supported.
+- [x] On module disable, close all active subscription streams after a best-effort notification.
+- [x] On client capability reduction, notify only that client's streams.
+- [x] On client disable/revocation/deletion/rotation, close that client's existing streams.
+- [x] Execution policy remains authoritative even if a client misses a notification.
 
 **Tests:** every live transition, including a tool call racing with a permission reduction.
+
+**Outcome:** Module-wide changes now invalidate global policy, publish only the affected tool/resource list changes,
+and close streams after best-effort disable/reset notifications. Client capability and credential changes use isolated
+per-client policy revisions and targeted notifications/stream closure, while execution-time authorization remains the
+source of truth during permission races.
 
 ### Task 11: Add security-safe auditing and observability
 


### PR DESCRIPTION
## Summary

- apply MCP module enablement and capability changes to active sessions without a restart
- notify affected clients when tool or resource catalogs change, then close streams safely when MCP is disabled or reset
- isolate per-client policy revisions so capability changes and revocations do not invalidate unrelated clients
- reject requests when global or client policy changes race with authorization
- mark Phase 7 of the MCP implementation plan complete

## Impact

MCP configuration and client capability updates now take effect immediately. Connected clients receive targeted catalog notifications, authorization cannot proceed with stale policy, and changes to one client no longer interrupt requests from other clients.

## Validation

- `pnpm --filter ./apps/backend run test:unit` — 269 suites passed, 3,489 tests passed, 2 skipped
- `pnpm --filter ./apps/backend run test:e2e` — 8 suites passed, 98 tests passed
- MCP unit tests — 15 suites passed, 178 tests passed
- MCP endpoint E2E tests — 1 suite passed, 7 tests passed
- ESLint passed for all changed TypeScript files
- Prettier check passed for all changed TypeScript files
- backend TypeScript type-check passed
- `git diff --check` passed
