### PR TITLE
feat(backend): add secure audit observability

### DIFF
--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -14,6 +14,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { IS_MCP_ENDPOINT_KEY } from '../../mcp/mcp.constants';
+import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
 import { UserEntity } from '../../users/entities/users.entity';
@@ -45,6 +46,7 @@ describe('AuthGuard', () => {
 	let tokensService: TokensService;
 	let usersService: UsersService;
 	let mcpClientsService: McpClientService;
+	let mcpAuditService: { getRequestId: jest.Mock; recordAuthenticationFailure: jest.Mock };
 
 	const mockUserId = uuid().toString();
 	const mockDisplayId = uuid().toString();
@@ -142,6 +144,10 @@ describe('AuthGuard', () => {
 	};
 
 	beforeEach(async () => {
+		mcpAuditService = {
+			getRequestId: jest.fn().mockReturnValue('request-1'),
+			recordAuthenticationFailure: jest.fn(),
+		};
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				AuthGuard,
@@ -186,6 +192,10 @@ describe('AuthGuard', () => {
 					useValue: {
 						getAudience: jest.fn().mockResolvedValue(mockMcpAudience),
 					},
+				},
+				{
+					provide: McpAuditService,
+					useValue: mcpAuditService,
 				},
 				{
 					provide: CACHE_MANAGER,
@@ -604,6 +614,10 @@ describe('AuthGuard', () => {
 			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({ sub: mockUserId, type: 'personal' });
 
 			await expect(guard.canActivate(context)).rejects.toThrow('An MCP credential is required');
+			expect(mcpAuditService.recordAuthenticationFailure).toHaveBeenCalledWith(
+				{ requestId: 'request-1' },
+				'invalid_credential',
+			);
 		});
 
 		it('should reject a rotated or disabled MCP client credential', async () => {

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -633,6 +633,26 @@ describe('AuthGuard', () => {
 			await expect(guard.canActivate(context)).rejects.toThrow(
 				'MCP client is disabled or the credential has been rotated',
 			);
+			expect(mcpAuditService.recordAuthenticationFailure).toHaveBeenCalledWith(
+				{ requestId: 'request-1' },
+				'invalid_credential',
+			);
+		});
+
+		it('should distinguish an MCP authentication backend failure from an invalid credential', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockMcpToken}` });
+			markMcpEndpoint();
+			jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+				sub: mockMcpClientId,
+				type: TokenOwnerType.MCP,
+			});
+			jest.spyOn(tokensService, 'findOneByHashedToken').mockRejectedValue(new Error('database unavailable'));
+
+			await expect(guard.canActivate(context)).rejects.toThrow('database unavailable');
+			expect(mcpAuditService.recordAuthenticationFailure).toHaveBeenCalledWith(
+				{ requestId: 'request-1' },
+				'authentication_error',
+			);
 		});
 	});
 

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -46,6 +46,7 @@ describe('AuthGuard', () => {
 	let tokensService: TokensService;
 	let usersService: UsersService;
 	let mcpClientsService: McpClientService;
+	let mcpInstallationService: McpInstallationService;
 	let mcpAuditService: { getRequestId: jest.Mock; recordAuthenticationFailure: jest.Mock };
 
 	const mockUserId = uuid().toString();
@@ -213,6 +214,7 @@ describe('AuthGuard', () => {
 		tokensService = module.get<TokensService>(TokensService);
 		usersService = module.get<UsersService>(UsersService);
 		mcpClientsService = module.get<McpClientService>(McpClientService);
+		mcpInstallationService = module.get<McpInstallationService>(McpInstallationService);
 	});
 
 	afterEach(() => {
@@ -649,6 +651,19 @@ describe('AuthGuard', () => {
 			jest.spyOn(tokensService, 'findOneByHashedToken').mockRejectedValue(new Error('database unavailable'));
 
 			await expect(guard.canActivate(context)).rejects.toThrow('database unavailable');
+			expect(mcpAuditService.recordAuthenticationFailure).toHaveBeenCalledWith(
+				{ requestId: 'request-1' },
+				'authentication_error',
+			);
+		});
+
+		it('should preserve an MCP audience lookup failure as an authentication backend error', async () => {
+			const context = createMockExecutionContext({ authorization: `Bearer ${mockMcpToken}` });
+			markMcpEndpoint();
+			jest.spyOn(mcpInstallationService, 'getAudience').mockRejectedValue(new Error('database unavailable'));
+
+			await expect(guard.canActivate(context)).rejects.toThrow('database unavailable');
+			expect(jwtService.verifyAsync).not.toHaveBeenCalled();
 			expect(mcpAuditService.recordAuthenticationFailure).toHaveBeenCalledWith(
 				{ requestId: 'request-1' },
 				'authentication_error',

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -137,10 +137,11 @@ export class AuthGuard implements CanActivate {
 
 	private async validateToken(request: AuthenticatedRequest, token: string, isMcpEndpoint: boolean): Promise<boolean> {
 		let payload: { sub?: string; type?: string; role?: string };
+		const audience = isMcpEndpoint ? await this.mcpInstallationService.getAudience() : undefined;
 
 		try {
 			payload = isMcpEndpoint
-				? await this.jwtService.verifyAsync(token, { audience: await this.mcpInstallationService.getAudience() })
+				? await this.jwtService.verifyAsync(token, { audience })
 				: await this.jwtService.verifyAsync(token);
 		} catch {
 			throw new UnauthorizedException('Invalid or expired token');

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -115,7 +115,7 @@ export class AuthGuard implements CanActivate {
 			if (isMcpEndpoint) {
 				this.mcpAuditService.recordAuthenticationFailure(
 					{ requestId: this.mcpAuditService.getRequestId(request.body) },
-					'invalid_credential',
+					error instanceof UnauthorizedException ? 'invalid_credential' : 'authentication_error',
 				);
 			}
 

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -16,6 +16,7 @@ import { JwtService } from '@nestjs/jwt';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { IS_MCP_ENDPOINT_KEY, McpCapability } from '../../mcp/mcp.constants';
+import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
 import { ApiPublic } from '../../swagger/decorators/api-documentation.decorator';
@@ -79,6 +80,7 @@ export class AuthGuard implements CanActivate {
 		private readonly usersService: UsersService,
 		private readonly mcpClientsService: McpClientService,
 		private readonly mcpInstallationService: McpInstallationService,
+		private readonly mcpAuditService: McpAuditService,
 		@Inject(CACHE_MANAGER)
 		private readonly cacheManager: Cache,
 	) {}
@@ -105,12 +107,30 @@ export class AuthGuard implements CanActivate {
 		// Try authenticating with JWT (Bearer token)
 		const token = extractAccessTokenFromHeader(request);
 
-		if (token && (await this.validateToken(request, token, isMcpEndpoint))) {
-			return true;
+		try {
+			if (token && (await this.validateToken(request, token, isMcpEndpoint))) {
+				return true;
+			}
+		} catch (error) {
+			if (isMcpEndpoint) {
+				this.mcpAuditService.recordAuthenticationFailure(
+					{ requestId: this.mcpAuditService.getRequestId(request.body) },
+					'invalid_credential',
+				);
+			}
+
+			throw error;
 		}
 
 		// If auth method didn't work, reject the request
 		this.logger.warn('Unauthorized request, missing valid credentials');
+
+		if (isMcpEndpoint) {
+			this.mcpAuditService.recordAuthenticationFailure(
+				{ requestId: this.mcpAuditService.getRequestId(request.body) },
+				'authentication_required',
+			);
+		}
 
 		throw new UnauthorizedException('Authentication required');
 	}

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
@@ -1,5 +1,6 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 
+import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditService } from '../services/mcp-audit.service';
 import { McpPolicyContext, McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
@@ -36,5 +37,72 @@ describe('McpClientGuard', () => {
 		expect(policyService.validateRequestOrigin).toHaveBeenCalledWith(request, policy);
 		expect(serverService.getClientPolicyRevision).toHaveBeenCalledWith('client-id');
 		expect(request.mcpPolicy).toEqual({ ...policy, clientPolicyRevision: 3, policyRevision: 7 });
+	});
+
+	it.each([
+		[new McpEndpointDisabledException(), 'endpoint_disabled'],
+		[new ForbiddenException('Origin is not allowed'), 'origin_denied'],
+		[new UnauthorizedException('MCP client is disabled'), 'request_denied'],
+	])('records known policy rejections as denials', async (error, reason) => {
+		const request = {
+			auth: { type: 'token', ownerId: 'client-id' },
+			body: { id: 'request-1' },
+		} as McpPolicyRequest;
+		const policyService = {
+			resolve: jest.fn().mockRejectedValue(error),
+			validateRequestOrigin: jest.fn(),
+		};
+		const auditService = {
+			getRequestId: jest.fn().mockReturnValue('request-1'),
+			recordPolicyDenial: jest.fn(),
+			recordRequestFailure: jest.fn(),
+		};
+		const guard = new McpClientGuard(
+			policyService as unknown as McpPolicyService,
+			{ getClientPolicyRevision: jest.fn(), getPolicyRevision: jest.fn() } as unknown as McpServerService,
+			auditService as unknown as McpAuditService,
+		);
+		const context = {
+			switchToHttp: () => ({ getRequest: () => request }),
+		} as ExecutionContext;
+
+		await expect(guard.canActivate(context)).rejects.toBe(error);
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: 'request-1', clientId: 'client-id' },
+			reason,
+		);
+		expect(auditService.recordRequestFailure).not.toHaveBeenCalled();
+	});
+
+	it('records policy-resolution outages as request failures instead of denials', async () => {
+		const error = new Error('database unavailable');
+		const request = {
+			auth: { type: 'token', ownerId: 'client-id' },
+			body: { id: 'request-1' },
+		} as McpPolicyRequest;
+		const policyService = {
+			resolve: jest.fn().mockRejectedValue(error),
+			validateRequestOrigin: jest.fn(),
+		};
+		const auditService = {
+			getRequestId: jest.fn().mockReturnValue('request-1'),
+			recordPolicyDenial: jest.fn(),
+			recordRequestFailure: jest.fn(),
+		};
+		const guard = new McpClientGuard(
+			policyService as unknown as McpPolicyService,
+			{ getClientPolicyRevision: jest.fn(), getPolicyRevision: jest.fn() } as unknown as McpServerService,
+			auditService as unknown as McpAuditService,
+		);
+		const context = {
+			switchToHttp: () => ({ getRequest: () => request }),
+		} as ExecutionContext;
+
+		await expect(guard.canActivate(context)).rejects.toBe(error);
+		expect(auditService.recordPolicyDenial).not.toHaveBeenCalled();
+		expect(auditService.recordRequestFailure).toHaveBeenCalledWith(
+			{ requestId: 'request-1', clientId: 'client-id' },
+			'policy_resolution_error',
+		);
 	});
 });

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
@@ -1,5 +1,6 @@
 import { ExecutionContext } from '@nestjs/common';
 
+import { McpAuditService } from '../services/mcp-audit.service';
 import { McpPolicyContext, McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
 
@@ -17,9 +18,14 @@ describe('McpClientGuard', () => {
 			getClientPolicyRevision: jest.fn().mockReturnValue(3),
 			getPolicyRevision: jest.fn().mockReturnValue(7),
 		};
+		const auditService = {
+			getRequestId: jest.fn().mockReturnValue('request-1'),
+			recordPolicyDenial: jest.fn(),
+		};
 		const guard = new McpClientGuard(
 			policyService as unknown as McpPolicyService,
 			serverService as unknown as McpServerService,
+			auditService as unknown as McpAuditService,
 		);
 		const context = {
 			switchToHttp: () => ({ getRequest: () => request }),

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
@@ -1,5 +1,6 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 
+import { McpAuditDenialReason, McpAuditService } from '../services/mcp-audit.service';
 import { McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
 
@@ -8,6 +9,7 @@ export class McpClientGuard implements CanActivate {
 	constructor(
 		private readonly policyService: McpPolicyService,
 		private readonly serverService: McpServerService,
+		private readonly auditService: McpAuditService,
 	) {}
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -17,11 +19,35 @@ export class McpClientGuard implements CanActivate {
 			request.auth?.type === 'token' && request.auth.ownerId
 				? this.serverService.getClientPolicyRevision(request.auth.ownerId)
 				: 0;
-		const policy = await this.policyService.resolve(request.auth);
+		try {
+			const policy = await this.policyService.resolve(request.auth);
 
-		this.policyService.validateRequestOrigin(request, policy);
-		request.mcpPolicy = { ...policy, clientPolicyRevision, policyRevision };
+			this.policyService.validateRequestOrigin(request, policy);
+			request.mcpPolicy = { ...policy, clientPolicyRevision, policyRevision };
+		} catch (error) {
+			this.auditService.recordPolicyDenial(
+				{
+					requestId: this.auditService.getRequestId(request.body),
+					...(request.auth?.type === 'token' && request.auth.ownerId ? { clientId: request.auth.ownerId } : {}),
+				},
+				this.getDenialReason(error),
+			);
+
+			throw error;
+		}
 
 		return true;
+	}
+
+	private getDenialReason(error: unknown): McpAuditDenialReason {
+		if (error instanceof NotFoundException) {
+			return 'endpoint_disabled';
+		}
+
+		if (error instanceof ForbiddenException) {
+			return 'origin_denied';
+		}
+
+		return 'request_denied';
 	}
 }

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
@@ -1,5 +1,6 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 
+import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditDenialReason, McpAuditService } from '../services/mcp-audit.service';
 import { McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
@@ -25,13 +26,17 @@ export class McpClientGuard implements CanActivate {
 			this.policyService.validateRequestOrigin(request, policy);
 			request.mcpPolicy = { ...policy, clientPolicyRevision, policyRevision };
 		} catch (error) {
-			this.auditService.recordPolicyDenial(
-				{
-					requestId: this.auditService.getRequestId(request.body),
-					...(request.auth?.type === 'token' && request.auth.ownerId ? { clientId: request.auth.ownerId } : {}),
-				},
-				this.getDenialReason(error),
-			);
+			const identity = {
+				requestId: this.auditService.getRequestId(request.body),
+				...(request.auth?.type === 'token' && request.auth.ownerId ? { clientId: request.auth.ownerId } : {}),
+			};
+			const denialReason = this.getDenialReason(error);
+
+			if (denialReason) {
+				this.auditService.recordPolicyDenial(identity, denialReason);
+			} else {
+				this.auditService.recordRequestFailure(identity, 'policy_resolution_error');
+			}
 
 			throw error;
 		}
@@ -39,8 +44,8 @@ export class McpClientGuard implements CanActivate {
 		return true;
 	}
 
-	private getDenialReason(error: unknown): McpAuditDenialReason {
-		if (error instanceof NotFoundException) {
+	private getDenialReason(error: unknown): McpAuditDenialReason | null {
+		if (error instanceof McpEndpointDisabledException) {
 			return 'endpoint_disabled';
 		}
 
@@ -48,6 +53,6 @@ export class McpClientGuard implements CanActivate {
 			return 'origin_denied';
 		}
 
-		return 'request_denied';
+		return error instanceof UnauthorizedException ? 'request_denied' : null;
 	}
 }

--- a/apps/backend/src/modules/mcp/mcp.exceptions.ts
+++ b/apps/backend/src/modules/mcp/mcp.exceptions.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class McpEndpointDisabledException extends NotFoundException {
+	constructor() {
+		super('MCP endpoint is disabled');
+	}
+}

--- a/apps/backend/src/modules/mcp/mcp.module.spec.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.spec.ts
@@ -1,5 +1,6 @@
 import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
 import { ExtensionsService } from '../extensions/services/extensions.service';
+import { StatsRegistryService } from '../stats/services/stats-registry.service';
 import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models-registry.service';
 
 import { UpdateMcpConfigDto } from './dto/update-config.dto';
@@ -7,16 +8,21 @@ import { MCP_MODULE_NAME, McpCapability } from './mcp.constants';
 import { McpModule } from './mcp.module';
 import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
 import { McpConfigModel } from './models/config.model';
+import { McpStatsProvider } from './providers/mcp-stats.provider';
 
 describe('McpModule', () => {
 	it('registers configuration, Swagger models, and disabled-by-default metadata', () => {
 		const swaggerRegistry = { register: jest.fn() };
 		const modulesMapperService = { registerMapping: jest.fn() };
 		const extensionsService = { registerModuleMetadata: jest.fn() };
+		const statsRegistryService = { register: jest.fn() };
+		const statsProvider = {} as McpStatsProvider;
 		const module = new McpModule(
 			swaggerRegistry as unknown as SwaggerModelsRegistryService,
 			modulesMapperService as unknown as ModulesTypeMapperService,
 			extensionsService as unknown as ExtensionsService,
+			statsRegistryService as unknown as StatsRegistryService,
+			statsProvider,
 		);
 
 		module.onModuleInit();
@@ -39,5 +45,6 @@ describe('McpModule', () => {
 				capabilities: Object.values(McpCapability),
 			}),
 		);
+		expect(statsRegistryService.register).toHaveBeenCalledWith(MCP_MODULE_NAME, statsProvider);
 	});
 });

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -11,6 +11,8 @@ import { ExtensionsService } from '../extensions/services/extensions.service';
 import { ScenesModule } from '../scenes/scenes.module';
 import { SecurityModule } from '../security/security.module';
 import { SpacesModule } from '../spaces/spaces.module';
+import { StatsRegistryService } from '../stats/services/stats-registry.service';
+import { StatsModule } from '../stats/stats.module';
 import { ApiTag } from '../swagger/decorators/api-tag.decorator';
 import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models-registry.service';
 import { SwaggerModule } from '../swagger/swagger.module';
@@ -33,6 +35,8 @@ import {
 } from './mcp.constants';
 import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
 import { McpConfigModel } from './models/config.model';
+import { McpStatsProvider } from './providers/mcp-stats.provider';
+import { McpAuditService } from './services/mcp-audit.service';
 import { McpClientService } from './services/mcp-client.service';
 import { McpContextService } from './services/mcp-context.service';
 import { McpInstallationService } from './services/mcp-installation.service';
@@ -56,6 +60,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		ScenesModule,
 		SecurityModule,
 		SpacesModule,
+		StatsModule,
 		SwaggerModule,
 		TypeOrmModule.forFeature([McpClientEntity, McpInstallationEntity]),
 		ToolsModule,
@@ -70,6 +75,8 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpInstallationService,
 		McpPolicyService,
 		McpServerService,
+		McpAuditService,
+		McpStatsProvider,
 		McpSubscriptionRegistryService,
 		McpReadToolService,
 		McpTargetDiscoveryToolService,
@@ -84,13 +91,15 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 			inject: [McpReadToolService, McpTargetDiscoveryToolService],
 		},
 	],
-	exports: [McpClientService, McpInstallationService, McpPolicyService, McpServerService],
+	exports: [McpAuditService, McpClientService, McpInstallationService, McpPolicyService, McpServerService],
 })
 export class McpModule implements OnModuleInit {
 	constructor(
 		private readonly swaggerRegistry: SwaggerModelsRegistryService,
 		private readonly modulesMapperService: ModulesTypeMapperService,
 		private readonly extensionsService: ExtensionsService,
+		private readonly statsRegistryService: StatsRegistryService,
+		private readonly statsProvider: McpStatsProvider,
 	) {}
 
 	onModuleInit(): void {
@@ -103,6 +112,8 @@ export class McpModule implements OnModuleInit {
 		for (const model of MCP_SWAGGER_EXTRA_MODELS) {
 			this.swaggerRegistry.register(model);
 		}
+
+		this.statsRegistryService.register(MCP_MODULE_NAME, this.statsProvider);
 
 		this.extensionsService.registerModuleMetadata({
 			type: MCP_MODULE_NAME,

--- a/apps/backend/src/modules/mcp/providers/mcp-stats.provider.spec.ts
+++ b/apps/backend/src/modules/mcp/providers/mcp-stats.provider.spec.ts
@@ -20,11 +20,14 @@ describe('McpStatsProvider', () => {
 		const stats = await provider.getStats();
 
 		expect(stats.activeSubscriptions.value).toBe(2);
-		expect(stats.callsByCapability[McpCapability.READ]?.value).toBe(3);
-		expect(stats.callsByTool.set_device_property?.value).toBe(1);
+		expect(stats[`callsByCapability_${McpCapability.READ}`]?.value).toBe(3);
+		expect(stats.callsByTool_set_device_property?.value).toBe(1);
 		expect(stats.failures.value).toBe(1);
 		expect(stats.denials.value).toBe(2);
 		expect(stats.timeouts.value).toBe(1);
 		expect(stats.activeSubscriptions.last_updated).toBeInstanceOf(Date);
+		expect(
+			Object.values(stats).every((stat) => typeof stat.value === 'number' && stat.last_updated instanceof Date),
+		).toBe(true);
 	});
 });

--- a/apps/backend/src/modules/mcp/providers/mcp-stats.provider.spec.ts
+++ b/apps/backend/src/modules/mcp/providers/mcp-stats.provider.spec.ts
@@ -1,0 +1,30 @@
+import { McpCapability } from '../mcp.constants';
+import { McpAuditService } from '../services/mcp-audit.service';
+
+import { McpStatsProvider } from './mcp-stats.provider';
+
+describe('McpStatsProvider', () => {
+	it('projects MCP counters into the shared stats leaf format', async () => {
+		const auditService = {
+			getMetricsSnapshot: jest.fn().mockReturnValue({
+				activeSubscriptions: 2,
+				callsByCapability: { read: 3, write: 1, trigger: 0 },
+				callsByTool: { get_home_context: 3, set_device_property: 1 },
+				failures: 1,
+				denials: 2,
+				timeouts: 1,
+			}),
+		};
+		const provider = new McpStatsProvider(auditService as unknown as McpAuditService);
+
+		const stats = await provider.getStats();
+
+		expect(stats.activeSubscriptions.value).toBe(2);
+		expect(stats.callsByCapability[McpCapability.READ]?.value).toBe(3);
+		expect(stats.callsByTool.set_device_property?.value).toBe(1);
+		expect(stats.failures.value).toBe(1);
+		expect(stats.denials.value).toBe(2);
+		expect(stats.timeouts.value).toBe(1);
+		expect(stats.activeSubscriptions.last_updated).toBeInstanceOf(Date);
+	});
+});

--- a/apps/backend/src/modules/mcp/providers/mcp-stats.provider.ts
+++ b/apps/backend/src/modules/mcp/providers/mcp-stats.provider.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+import { StatsProvider } from '../../stats/stats.interfaces';
+import { McpAuditService } from '../services/mcp-audit.service';
+
+interface StatValue {
+	value: number;
+	last_updated: Date;
+}
+
+export interface McpStatsSnapshot {
+	activeSubscriptions: StatValue;
+	callsByCapability: Record<string, StatValue>;
+	callsByTool: Record<string, StatValue>;
+	failures: StatValue;
+	denials: StatValue;
+	timeouts: StatValue;
+}
+
+@Injectable()
+export class McpStatsProvider implements StatsProvider<McpStatsSnapshot> {
+	constructor(private readonly auditService: McpAuditService) {}
+
+	getStats(): Promise<McpStatsSnapshot> {
+		const snapshot = this.auditService.getMetricsSnapshot();
+		const lastUpdated = new Date();
+		const values = (entries: Record<string, number>): Record<string, StatValue> =>
+			Object.fromEntries(Object.entries(entries).map(([key, value]) => [key, { value, last_updated: lastUpdated }]));
+
+		return Promise.resolve({
+			activeSubscriptions: { value: snapshot.activeSubscriptions, last_updated: lastUpdated },
+			callsByCapability: values(snapshot.callsByCapability),
+			callsByTool: values(snapshot.callsByTool),
+			failures: { value: snapshot.failures, last_updated: lastUpdated },
+			denials: { value: snapshot.denials, last_updated: lastUpdated },
+			timeouts: { value: snapshot.timeouts, last_updated: lastUpdated },
+		});
+	}
+}

--- a/apps/backend/src/modules/mcp/providers/mcp-stats.provider.ts
+++ b/apps/backend/src/modules/mcp/providers/mcp-stats.provider.ts
@@ -9,9 +9,8 @@ interface StatValue {
 }
 
 export interface McpStatsSnapshot {
+	[metric: string]: StatValue;
 	activeSubscriptions: StatValue;
-	callsByCapability: Record<string, StatValue>;
-	callsByTool: Record<string, StatValue>;
 	failures: StatValue;
 	denials: StatValue;
 	timeouts: StatValue;
@@ -24,13 +23,15 @@ export class McpStatsProvider implements StatsProvider<McpStatsSnapshot> {
 	getStats(): Promise<McpStatsSnapshot> {
 		const snapshot = this.auditService.getMetricsSnapshot();
 		const lastUpdated = new Date();
-		const values = (entries: Record<string, number>): Record<string, StatValue> =>
-			Object.fromEntries(Object.entries(entries).map(([key, value]) => [key, { value, last_updated: lastUpdated }]));
+		const values = (prefix: string, entries: Record<string, number>): Record<string, StatValue> =>
+			Object.fromEntries(
+				Object.entries(entries).map(([key, value]) => [`${prefix}_${key}`, { value, last_updated: lastUpdated }]),
+			);
 
 		return Promise.resolve({
 			activeSubscriptions: { value: snapshot.activeSubscriptions, last_updated: lastUpdated },
-			callsByCapability: values(snapshot.callsByCapability),
-			callsByTool: values(snapshot.callsByTool),
+			...values('callsByCapability', snapshot.callsByCapability),
+			...values('callsByTool', snapshot.callsByTool),
 			failures: { value: snapshot.failures, last_updated: lastUpdated },
 			denials: { value: snapshot.denials, last_updated: lastUpdated },
 			timeouts: { value: snapshot.timeouts, last_updated: lastUpdated },

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -111,9 +111,15 @@ describe('McpAuditService', () => {
 	});
 
 	it('normalizes client-controlled string request identifiers before logging', () => {
+		const bearerLikeId = 'Bearer raw-secret';
+		const normalizedId = service.getRequestId({ id: bearerLikeId });
+
 		expect(service.getRequestId({ id: 17, token: 'secret' })).toBe('17');
-		expect(service.getRequestId({ id: 'Bearer raw-secret' })).toBe('string');
-		expect(service.getRequestId({ id: 'x'.repeat(10_000) })).toBe('string');
+		expect(normalizedId).toMatch(/^string:[A-Za-z0-9_-]{16}$/);
+		expect(service.getRequestId({ id: bearerLikeId })).toBe(normalizedId);
+		expect(service.getRequestId({ id: 'another-id' })).not.toBe(normalizedId);
+		expect(service.getRequestId({ id: 'x'.repeat(10_000) })).toMatch(/^string:[A-Za-z0-9_-]{16}$/);
+		expect(normalizedId).not.toContain('raw-secret');
 		expect(service.getRequestId({ id: Number.POSITIVE_INFINITY })).toBe('unknown');
 		expect(service.getRequestId({ id: { nested: true } })).toBe('unknown');
 		expect(service.getRequestId(null)).toBe('unknown');

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -1,0 +1,103 @@
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+
+import { McpAuditOutcome, McpAuditService } from './mcp-audit.service';
+
+describe('McpAuditService', () => {
+	let service: McpAuditService;
+	let log: jest.SpyInstance;
+
+	beforeEach(() => {
+		service = new McpAuditService();
+		const logger = (service as unknown as { logger: { log: (...args: unknown[]) => void } }).logger;
+		log = jest.spyOn(logger, 'log').mockImplementation(() => undefined);
+	});
+
+	it('logs only allowlisted write targets and never records raw values or credentials', () => {
+		service.recordToolResult({
+			requestId: 'request-1',
+			clientId: 'client-1',
+			tool: 'set_device_property',
+			capability: McpCapability.WRITE,
+			durationMs: 12.4,
+			outcome: McpAuditOutcome.COMPLETED,
+			arguments: {
+				property_id: 'property-1',
+				value: 'private-device-value',
+				authorization: 'Bearer raw-secret',
+				token_hash: 'hashed-secret',
+			},
+		});
+
+		expect(log).toHaveBeenCalledWith('MCP audit event', {
+			event: 'tool_execution',
+			request_id: 'request-1',
+			client_id: 'client-1',
+			tool: 'set_device_property',
+			capability: McpCapability.WRITE,
+			duration_ms: 12,
+			outcome: McpAuditOutcome.COMPLETED,
+			property_id: 'property-1',
+		});
+		const captured = JSON.stringify(log.mock.calls);
+
+		expect(captured).not.toContain('private-device-value');
+		expect(captured).not.toContain('raw-secret');
+		expect(captured).not.toContain('hashed-secret');
+		expect(captured).not.toContain('authorization');
+		expect(captured).not.toContain('token_hash');
+	});
+
+	it('tracks calls by capability and tool plus failure outcomes', () => {
+		service.recordToolResult({
+			requestId: '1',
+			tool: 'get_weather',
+			capability: McpCapability.READ,
+			durationMs: 1,
+			outcome: McpAuditOutcome.FAILED,
+		});
+		service.recordToolResult({
+			requestId: '2',
+			tool: 'set_device_property',
+			capability: McpCapability.WRITE,
+			durationMs: 2,
+			outcome: McpAuditOutcome.DENIED,
+		});
+		service.recordToolResult({
+			requestId: '3',
+			tool: 'run_scene',
+			capability: McpCapability.TRIGGER,
+			durationMs: 3,
+			outcome: McpAuditOutcome.TIMED_OUT,
+		});
+
+		expect(service.getMetricsSnapshot()).toEqual({
+			activeSubscriptions: 0,
+			callsByCapability: { read: 1, write: 1, trigger: 1 },
+			callsByTool: { get_weather: 1, set_device_property: 1, run_scene: 1 },
+			failures: 1,
+			denials: 1,
+			timeouts: 1,
+		});
+	});
+
+	it('tracks the active subscription gauge without allowing it to become negative', () => {
+		service.recordSubscriptionOpened({ requestId: '1', clientId: 'client-1' }, 'subscription-1');
+		service.recordSubscriptionClosed({ requestId: '1', clientId: 'client-1' }, 'subscription-1', 'completed');
+		service.recordSubscriptionClosed({ requestId: '1', clientId: 'client-1' }, 'subscription-1', 'completed');
+
+		expect(service.getMetricsSnapshot().activeSubscriptions).toBe(0);
+	});
+
+	it('extracts only JSON-RPC string and numeric request identifiers', () => {
+		expect(service.getRequestId({ id: 17, token: 'secret' })).toBe('17');
+		expect(service.getRequestId({ id: { nested: true } })).toBe('unknown');
+		expect(service.getRequestId(null)).toBe('unknown');
+	});
+
+	it('uses the MCP module logger source for every record', () => {
+		service.recordAuthenticationFailure({ requestId: '1' }, 'invalid_credential');
+		const logger = (service as unknown as { logger: { extensionType: string } }).logger;
+
+		expect(logger.extensionType).toBe(MCP_MODULE_NAME);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -62,6 +62,10 @@ describe('McpAuditService', () => {
 			durationMs: 2,
 			outcome: McpAuditOutcome.DENIED,
 		});
+		service.recordPolicyDenial({ requestId: '2', clientId: 'client-1' }, 'capability_denied', {
+			capability: McpCapability.WRITE,
+			tool: 'set_device_property',
+		});
 		service.recordToolResult({
 			requestId: '3',
 			tool: 'run_scene',
@@ -78,6 +82,24 @@ describe('McpAuditService', () => {
 			denials: 1,
 			timeouts: 1,
 		});
+	});
+
+	it('counts a policy denial without tool execution and avoids double-counting tool denials', () => {
+		service.recordPolicyDenial({ requestId: '1', clientId: 'client-1' }, 'origin_denied');
+		service.recordPolicyDenial({ requestId: '2', clientId: 'client-1' }, 'capability_denied', {
+			capability: McpCapability.READ,
+			tool: 'get_home_context',
+		});
+		service.recordToolResult({
+			requestId: '2',
+			clientId: 'client-1',
+			tool: 'get_home_context',
+			capability: McpCapability.READ,
+			durationMs: 2,
+			outcome: McpAuditOutcome.DENIED,
+		});
+
+		expect(service.getMetricsSnapshot().denials).toBe(2);
 	});
 
 	it('tracks the active subscription gauge without allowing it to become negative', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -110,8 +110,11 @@ describe('McpAuditService', () => {
 		expect(service.getMetricsSnapshot().activeSubscriptions).toBe(0);
 	});
 
-	it('extracts only JSON-RPC string and numeric request identifiers', () => {
+	it('normalizes client-controlled string request identifiers before logging', () => {
 		expect(service.getRequestId({ id: 17, token: 'secret' })).toBe('17');
+		expect(service.getRequestId({ id: 'Bearer raw-secret' })).toBe('string');
+		expect(service.getRequestId({ id: 'x'.repeat(10_000) })).toBe('string');
+		expect(service.getRequestId({ id: Number.POSITIVE_INFINITY })).toBe('unknown');
 		expect(service.getRequestId({ id: { nested: true } })).toBe('unknown');
 		expect(service.getRequestId(null)).toBe('unknown');
 	});
@@ -125,6 +128,13 @@ describe('McpAuditService', () => {
 
 	it('counts policy-resolution outages as failures without incrementing denials', () => {
 		service.recordRequestFailure({ requestId: '1', clientId: 'client-1' }, 'policy_resolution_error');
+
+		expect(service.getMetricsSnapshot()).toMatchObject({ failures: 1, denials: 0 });
+	});
+
+	it('counts authentication backend errors as failures without counting credential rejections', () => {
+		service.recordAuthenticationFailure({ requestId: '1' }, 'invalid_credential');
+		service.recordAuthenticationFailure({ requestId: '2' }, 'authentication_error');
 
 		expect(service.getMetricsSnapshot()).toMatchObject({ failures: 1, denials: 0 });
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -122,4 +122,10 @@ describe('McpAuditService', () => {
 
 		expect(logger.extensionType).toBe(MCP_MODULE_NAME);
 	});
+
+	it('counts policy-resolution outages as failures without incrementing denials', () => {
+		service.recordRequestFailure({ requestId: '1', clientId: 'client-1' }, 'policy_resolution_error');
+
+		expect(service.getMetricsSnapshot()).toMatchObject({ failures: 1, denials: 0 });
+	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -14,6 +14,7 @@ export enum McpAuditOutcome {
 export type McpAuditDenialReason =
 	| 'authentication_required'
 	| 'invalid_credential'
+	| 'authentication_error'
 	| 'endpoint_disabled'
 	| 'origin_denied'
 	| 'policy_changed'

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -21,6 +21,8 @@ export type McpAuditDenialReason =
 	| 'capability_denied'
 	| 'request_denied';
 
+export type McpAuditRequestFailureReason = 'policy_resolution_error';
+
 export type McpSubscriptionCloseReason = 'cancelled' | 'client_closed' | 'completed' | 'error' | 'idle' | 'shutdown';
 
 export interface McpAuditMetricsSnapshot {
@@ -74,6 +76,11 @@ export class McpAuditService {
 			...(options?.capability ? { capability: options.capability } : {}),
 			...(options?.tool ? { tool: options.tool } : {}),
 		});
+	}
+
+	recordRequestFailure(identity: RequestIdentity, reason: McpAuditRequestFailureReason): void {
+		this.failures += 1;
+		this.log('request_failure', identity, { reason });
 	}
 
 	recordProtocolRequest(

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -1,3 +1,5 @@
+import { createHmac, randomBytes } from 'crypto';
+
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
@@ -50,6 +52,7 @@ interface ToolResult extends RequestIdentity {
 @Injectable()
 export class McpAuditService {
 	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpAuditService');
+	private readonly requestIdHmacKey = randomBytes(32);
 	private activeSubscriptions = 0;
 	private readonly callsByCapability: Record<McpCapability, number> = {
 		[McpCapability.READ]: 0,
@@ -152,7 +155,13 @@ export class McpAuditService {
 			return String(id);
 		}
 
-		return typeof id === 'string' ? 'string' : 'unknown';
+		if (typeof id === 'string') {
+			const digest = createHmac('sha256', this.requestIdHmacKey).update(id).digest('base64url').slice(0, 16);
+
+			return `string:${digest}`;
+		}
+
+		return 'unknown';
 	}
 
 	private getTargetIds(tool: string, args?: Record<string, unknown>): Record<string, string> {

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -62,6 +62,10 @@ export class McpAuditService {
 	private timeouts = 0;
 
 	recordAuthenticationFailure(identity: RequestIdentity, reason: McpAuditDenialReason): void {
+		if (reason === 'authentication_error') {
+			this.failures += 1;
+		}
+
 		this.log('authentication_failure', identity, { reason });
 	}
 
@@ -144,7 +148,11 @@ export class McpAuditService {
 
 		const id = (body as { id?: unknown }).id;
 
-		return typeof id === 'string' || typeof id === 'number' ? String(id) : 'unknown';
+		if (typeof id === 'number' && Number.isFinite(id)) {
+			return String(id);
+		}
+
+		return typeof id === 'string' ? 'string' : 'unknown';
 	}
 
 	private getTargetIds(tool: string, args?: Record<string, unknown>): Record<string, string> {

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -67,6 +67,7 @@ export class McpAuditService {
 		reason: McpAuditDenialReason,
 		options?: { capability?: McpCapability; tool?: string },
 	): void {
+		this.denials += 1;
 		this.log('policy_denial', identity, {
 			reason,
 			...(options?.capability ? { capability: options.capability } : {}),
@@ -102,9 +103,7 @@ export class McpAuditService {
 		this.callsByCapability[result.capability] += 1;
 		this.callsByTool.set(result.tool, (this.callsByTool.get(result.tool) ?? 0) + 1);
 
-		if (result.outcome === McpAuditOutcome.DENIED) {
-			this.denials += 1;
-		} else if (result.outcome === McpAuditOutcome.TIMED_OUT) {
+		if (result.outcome === McpAuditOutcome.TIMED_OUT) {
 			this.timeouts += 1;
 		} else if (result.outcome === McpAuditOutcome.FAILED) {
 			this.failures += 1;

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -1,0 +1,172 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+
+export enum McpAuditOutcome {
+	COMPLETED = 'completed',
+	PARTIAL = 'partial',
+	FAILED = 'failed',
+	TIMED_OUT = 'timed_out',
+	DENIED = 'denied',
+}
+
+export type McpAuditDenialReason =
+	| 'authentication_required'
+	| 'invalid_credential'
+	| 'endpoint_disabled'
+	| 'origin_denied'
+	| 'policy_changed'
+	| 'capability_denied'
+	| 'request_denied';
+
+export type McpSubscriptionCloseReason = 'cancelled' | 'client_closed' | 'completed' | 'error' | 'idle' | 'shutdown';
+
+export interface McpAuditMetricsSnapshot {
+	activeSubscriptions: number;
+	callsByCapability: Record<McpCapability, number>;
+	callsByTool: Record<string, number>;
+	failures: number;
+	denials: number;
+	timeouts: number;
+}
+
+interface RequestIdentity {
+	requestId: string;
+	clientId?: string;
+}
+
+interface ToolResult extends RequestIdentity {
+	tool: string;
+	capability: McpCapability;
+	durationMs: number;
+	outcome: McpAuditOutcome;
+	arguments?: Record<string, unknown>;
+}
+
+@Injectable()
+export class McpAuditService {
+	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpAuditService');
+	private activeSubscriptions = 0;
+	private readonly callsByCapability: Record<McpCapability, number> = {
+		[McpCapability.READ]: 0,
+		[McpCapability.WRITE]: 0,
+		[McpCapability.TRIGGER]: 0,
+	};
+	private readonly callsByTool = new Map<string, number>();
+	private failures = 0;
+	private denials = 0;
+	private timeouts = 0;
+
+	recordAuthenticationFailure(identity: RequestIdentity, reason: McpAuditDenialReason): void {
+		this.log('authentication_failure', identity, { reason });
+	}
+
+	recordPolicyDenial(
+		identity: RequestIdentity,
+		reason: McpAuditDenialReason,
+		options?: { capability?: McpCapability; tool?: string },
+	): void {
+		this.log('policy_denial', identity, {
+			reason,
+			...(options?.capability ? { capability: options.capability } : {}),
+			...(options?.tool ? { tool: options.tool } : {}),
+		});
+	}
+
+	recordProtocolRequest(
+		identity: RequestIdentity,
+		options: { kind: 'discovery' | 'initialization'; method: string; protocolVersion?: string },
+	): void {
+		this.log(options.kind, identity, {
+			method: options.method,
+			...(options.protocolVersion ? { protocol_version: options.protocolVersion } : {}),
+		});
+	}
+
+	recordSubscriptionOpened(identity: RequestIdentity, subscriptionId: string): void {
+		this.activeSubscriptions += 1;
+		this.log('subscription_open', identity, { subscription_id: subscriptionId });
+	}
+
+	recordSubscriptionClosed(
+		identity: RequestIdentity,
+		subscriptionId: string,
+		reason: McpSubscriptionCloseReason,
+	): void {
+		this.activeSubscriptions = Math.max(0, this.activeSubscriptions - 1);
+		this.log('subscription_close', identity, { subscription_id: subscriptionId, reason });
+	}
+
+	recordToolResult(result: ToolResult): void {
+		this.callsByCapability[result.capability] += 1;
+		this.callsByTool.set(result.tool, (this.callsByTool.get(result.tool) ?? 0) + 1);
+
+		if (result.outcome === McpAuditOutcome.DENIED) {
+			this.denials += 1;
+		} else if (result.outcome === McpAuditOutcome.TIMED_OUT) {
+			this.timeouts += 1;
+		} else if (result.outcome === McpAuditOutcome.FAILED) {
+			this.failures += 1;
+		}
+
+		this.log('tool_execution', result, {
+			tool: result.tool,
+			capability: result.capability,
+			duration_ms: Math.max(0, Math.round(result.durationMs)),
+			outcome: result.outcome,
+			...this.getTargetIds(result.tool, result.arguments),
+		});
+	}
+
+	getMetricsSnapshot(): McpAuditMetricsSnapshot {
+		return {
+			activeSubscriptions: this.activeSubscriptions,
+			callsByCapability: { ...this.callsByCapability },
+			callsByTool: Object.fromEntries(this.callsByTool),
+			failures: this.failures,
+			denials: this.denials,
+			timeouts: this.timeouts,
+		};
+	}
+
+	getRequestId(body: unknown): string {
+		if (!body || typeof body !== 'object' || Array.isArray(body)) {
+			return 'unknown';
+		}
+
+		const id = (body as { id?: unknown }).id;
+
+		return typeof id === 'string' || typeof id === 'number' ? String(id) : 'unknown';
+	}
+
+	private getTargetIds(tool: string, args?: Record<string, unknown>): Record<string, string> {
+		if (!args) {
+			return {};
+		}
+
+		const key =
+			tool === 'set_device_property'
+				? 'property_id'
+				: tool === 'run_scene'
+					? 'scene_id'
+					: tool === 'set_space_lighting'
+						? 'space_id'
+						: undefined;
+
+		if (!key || typeof args[key] !== 'string') {
+			return {};
+		}
+
+		return { [key]: args[key] };
+	}
+
+	private log(event: string, identity: RequestIdentity, details: Record<string, unknown>): void {
+		this.logger.log('MCP audit event', {
+			event,
+			request_id: identity.requestId,
+			...(identity.clientId ? { client_id: identity.clientId } : {}),
+			...details,
+		});
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 
-import { ForbiddenException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService as NestConfigService } from '@nestjs/config';
 
 import { getEnvValue } from '../../../common/utils/config.utils';
@@ -9,6 +9,7 @@ import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
 import { ConfigService } from '../../config/services/config.service';
 import { McpClientEntity } from '../entities/mcp-client.entity';
 import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpConfigModel } from '../models/config.model';
 
 import { McpClientService } from './mcp-client.service';
@@ -49,7 +50,7 @@ export class McpPolicyService {
 		const config = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
 
 		if (!config.enabled) {
-			throw new NotFoundException('MCP endpoint is disabled');
+			throw new McpEndpointDisabledException();
 		}
 
 		const client = await this.clientService.findActiveByToken(tokenId, clientId);

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -115,6 +115,11 @@ describe('McpServerService policy revision', () => {
 			'2',
 			'client-a',
 		);
+		internalService.auditProtocolRequest(
+			{ id: 3, method: 'initialize', params: { protocolVersion: 'Bearer private-version' } },
+			'3',
+			'client-a',
+		);
 
 		expect(auditService.recordProtocolRequest).toHaveBeenNthCalledWith(
 			1,
@@ -126,8 +131,14 @@ describe('McpServerService policy revision', () => {
 			{ requestId: '2', clientId: 'client-a' },
 			{ kind: 'discovery', method: 'tools/list' },
 		);
+		expect(auditService.recordProtocolRequest).toHaveBeenNthCalledWith(
+			3,
+			{ requestId: '3', clientId: 'client-a' },
+			{ kind: 'initialization', method: 'initialize' },
+		);
 		expect(JSON.stringify(auditService.recordProtocolRequest.mock.calls)).not.toContain('secret');
 		expect(JSON.stringify(auditService.recordProtocolRequest.mock.calls)).not.toContain('private-cursor');
+		expect(JSON.stringify(auditService.recordProtocolRequest.mock.calls)).not.toContain('private-version');
 	});
 
 	it('refreshes the idle deadline when subscription traffic is forwarded', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -2,6 +2,7 @@ import { FastifyReply } from 'fastify';
 
 import { UnauthorizedException } from '@nestjs/common';
 
+import { McpAuditService } from './mcp-audit.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import { McpServerService } from './mcp-server.service';
 import { McpSubscriptionHandle, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
@@ -9,6 +10,12 @@ import { McpSubscriptionHandle, McpSubscriptionRegistryService } from './mcp-sub
 describe('McpServerService policy revision', () => {
 	let service: McpServerService;
 	let subscriptions: { closeAll: jest.Mock; closeClient: jest.Mock; touchClient: jest.Mock };
+	let auditService: {
+		getRequestId: jest.Mock;
+		recordAuthenticationFailure: jest.Mock;
+		recordPolicyDenial: jest.Mock;
+		recordProtocolRequest: jest.Mock;
+	};
 
 	beforeEach(() => {
 		subscriptions = {
@@ -16,7 +23,16 @@ describe('McpServerService policy revision', () => {
 			closeClient: jest.fn(),
 			touchClient: jest.fn(),
 		};
-		service = new McpServerService(subscriptions as unknown as McpSubscriptionRegistryService);
+		auditService = {
+			getRequestId: jest.fn().mockReturnValue('request-1'),
+			recordAuthenticationFailure: jest.fn(),
+			recordPolicyDenial: jest.fn(),
+			recordProtocolRequest: jest.fn(),
+		};
+		service = new McpServerService(
+			subscriptions as unknown as McpSubscriptionRegistryService,
+			auditService as unknown as McpAuditService,
+		);
 	});
 
 	it('invalidates only the targeted client policy before closing it', async () => {
@@ -47,6 +63,10 @@ describe('McpServerService policy revision', () => {
 		await expect(service.handle(request, {} as FastifyReply)).rejects.toThrow(
 			new UnauthorizedException('MCP request policy is no longer current'),
 		);
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: 'request-1', clientId: 'client-id' },
+			'policy_changed',
+		);
 	});
 
 	it('invalidates in-flight policies before closing all clients', async () => {
@@ -74,6 +94,40 @@ describe('McpServerService policy revision', () => {
 		expect(firstToolsChanged).toHaveBeenCalledTimes(1);
 		expect(secondToolsChanged).not.toHaveBeenCalled();
 		expect(subscriptions.touchClient).toHaveBeenCalledWith('client-a');
+	});
+
+	it('audits initialization and discovery without passing request parameters', () => {
+		const internalService = service as unknown as {
+			auditProtocolRequest(body: unknown, requestId: string, clientId: string): void;
+		};
+
+		internalService.auditProtocolRequest(
+			{
+				id: 1,
+				method: 'initialize',
+				params: { protocolVersion: '2025-06-18', authorization: 'Bearer secret' },
+			},
+			'1',
+			'client-a',
+		);
+		internalService.auditProtocolRequest(
+			{ id: 2, method: 'tools/list', params: { cursor: 'private-cursor' } },
+			'2',
+			'client-a',
+		);
+
+		expect(auditService.recordProtocolRequest).toHaveBeenNthCalledWith(
+			1,
+			{ requestId: '1', clientId: 'client-a' },
+			{ kind: 'initialization', method: 'initialize', protocolVersion: '2025-06-18' },
+		);
+		expect(auditService.recordProtocolRequest).toHaveBeenNthCalledWith(
+			2,
+			{ requestId: '2', clientId: 'client-a' },
+			{ kind: 'discovery', method: 'tools/list' },
+		);
+		expect(JSON.stringify(auditService.recordProtocolRequest.mock.calls)).not.toContain('secret');
+		expect(JSON.stringify(auditService.recordProtocolRequest.mock.calls)).not.toContain('private-cursor');
 	});
 
 	it('refreshes the idle deadline when subscription traffic is forwarded', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -329,14 +329,14 @@ export class McpServerService implements OnApplicationShutdown {
 		const request = this.getRequestBody(body);
 
 		if (request.method === 'initialize') {
-			const protocolVersion = request.params?.protocolVersion;
+			const protocolVersion = this.getProtocolVersion(request.params?.protocolVersion);
 
 			this.auditService.recordProtocolRequest(
 				{ requestId, clientId },
 				{
 					kind: 'initialization',
 					method: request.method,
-					...(typeof protocolVersion === 'string' ? { protocolVersion } : {}),
+					...(protocolVersion ? { protocolVersion } : {}),
 				},
 			);
 
@@ -349,6 +349,10 @@ export class McpServerService implements OnApplicationShutdown {
 				{ kind: 'discovery', method: request.method ?? 'unknown' },
 			);
 		}
+	}
+
+	private getProtocolVersion(value: unknown): string | undefined {
+		return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined;
 	}
 
 	private notify(clientId: string | undefined, callback: (handler: McpHttpHandler) => void): void {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -12,6 +12,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { extractAccessTokenFromHeader } from '../../auth/utils/token.utils';
 import { MCP_CATALOG_REGISTRAR, MCP_MAX_SUBSCRIPTIONS_PER_CLIENT, MCP_MODULE_NAME } from '../mcp.constants';
 
+import { McpAuditService } from './mcp-audit.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import {
 	McpSubscriptionCapacityError,
@@ -33,6 +34,7 @@ interface ClientHandler {
 interface JsonRpcRequestBody {
 	id?: number | string | null;
 	method?: string;
+	params?: { protocolVersion?: unknown };
 }
 
 interface McpCatalogRegistrar {
@@ -48,17 +50,25 @@ export class McpServerService implements OnApplicationShutdown {
 
 	constructor(
 		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly auditService: McpAuditService,
 		@Optional() private readonly moduleRef?: ModuleRef,
 	) {}
 
 	async handle(request: McpPolicyRequest, reply: FastifyReply): Promise<void> {
+		const requestId = this.auditService.getRequestId(request.body);
+
 		if (!request.mcpPolicy) {
+			this.auditService.recordPolicyDenial({ requestId }, 'request_denied');
 			throw new UnauthorizedException('MCP request policy was not resolved');
 		}
 
 		const token = extractAccessTokenFromHeader(request);
 
 		if (!token) {
+			this.auditService.recordAuthenticationFailure(
+				{ requestId, clientId: request.mcpPolicy.client.id },
+				'authentication_required',
+			);
 			throw new UnauthorizedException('Authentication required');
 		}
 
@@ -68,8 +78,11 @@ export class McpServerService implements OnApplicationShutdown {
 			policy.policyRevision !== this.policyRevision ||
 			policy.clientPolicyRevision !== this.getClientPolicyRevision(policy.client.id)
 		) {
+			this.auditService.recordPolicyDenial({ requestId, clientId: policy.client.id }, 'policy_changed');
 			throw new UnauthorizedException('MCP request policy is no longer current');
 		}
+
+		this.auditProtocolRequest(request.body, requestId, policy.client.id);
 
 		const clientHandler = this.getOrCreateHandler(policy.client.id);
 		const rawRequest = request.raw as AuthenticatedIncomingMessage;
@@ -208,7 +221,7 @@ export class McpServerService implements OnApplicationShutdown {
 				let subscription: McpSubscriptionHandle;
 
 				try {
-					subscription = this.subscriptions.open(clientId);
+					subscription = this.subscriptions.open(clientId, this.auditService.getRequestId(options?.parsedBody));
 				} catch (error) {
 					if (error instanceof McpSubscriptionCapacityError) {
 						return this.subscriptionLimitResponse(options?.parsedBody);
@@ -223,7 +236,7 @@ export class McpServerService implements OnApplicationShutdown {
 				try {
 					response = await fetch(new Request(webRequest, { signal }), options);
 				} catch (error) {
-					subscription.close();
+					subscription.close('error');
 					throw error;
 				}
 
@@ -276,7 +289,7 @@ export class McpServerService implements OnApplicationShutdown {
 
 	private trackSubscriptionResponse(response: Response, subscription: McpSubscriptionHandle): Response {
 		if (!response.body || !response.headers.get('content-type')?.includes('text/event-stream')) {
-			subscription.close();
+			subscription.close('completed');
 			return response;
 		}
 
@@ -287,7 +300,7 @@ export class McpServerService implements OnApplicationShutdown {
 					const result = await reader.read();
 
 					if (result.done) {
-						subscription.close();
+						subscription.close('completed');
 						controller.close();
 						return;
 					}
@@ -295,12 +308,12 @@ export class McpServerService implements OnApplicationShutdown {
 					subscription.touch();
 					controller.enqueue(result.value);
 				} catch (error) {
-					subscription.close();
+					subscription.close('error');
 					controller.error(error);
 				}
 			},
 			cancel: async (reason) => {
-				subscription.close();
+				subscription.close('cancelled');
 				await reader.cancel(reason);
 			},
 		});
@@ -310,6 +323,32 @@ export class McpServerService implements OnApplicationShutdown {
 			statusText: response.statusText,
 			headers: response.headers,
 		});
+	}
+
+	private auditProtocolRequest(body: unknown, requestId: string, clientId: string): void {
+		const request = this.getRequestBody(body);
+
+		if (request.method === 'initialize') {
+			const protocolVersion = request.params?.protocolVersion;
+
+			this.auditService.recordProtocolRequest(
+				{ requestId, clientId },
+				{
+					kind: 'initialization',
+					method: request.method,
+					...(typeof protocolVersion === 'string' ? { protocolVersion } : {}),
+				},
+			);
+
+			return;
+		}
+
+		if (['resources/list', 'resources/templates/list', 'tools/list'].includes(request.method ?? '')) {
+			this.auditService.recordProtocolRequest(
+				{ requestId, clientId },
+				{ kind: 'discovery', method: request.method ?? 'unknown' },
+			);
+		}
 	}
 
 	private notify(clientId: string | undefined, callback: (handler: McpHttpHandler) => void): void {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -4,13 +4,19 @@ import {
 	MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS,
 } from '../mcp.constants';
 
+import { McpAuditService } from './mcp-audit.service';
 import { McpSubscriptionCapacityError, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 describe('McpSubscriptionRegistryService', () => {
 	let service: McpSubscriptionRegistryService;
+	let auditService: { recordSubscriptionClosed: jest.Mock; recordSubscriptionOpened: jest.Mock };
 
 	beforeEach(() => {
-		service = new McpSubscriptionRegistryService();
+		auditService = {
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		service = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
 	});
 
 	afterEach(() => {
@@ -30,6 +36,8 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(other.signal.aborted).toBe(false);
 		expect(service.activeCount).toBe(1);
 		expect(service.countForClient('client-b')).toBe(1);
+		expect(auditService.recordSubscriptionOpened).toHaveBeenCalledTimes(3);
+		expect(auditService.recordSubscriptionClosed).toHaveBeenCalledTimes(2);
 	});
 
 	it('enforces the per-client cap', () => {
@@ -64,6 +72,11 @@ describe('McpSubscriptionRegistryService', () => {
 
 		expect(subscription.signal.aborted).toBe(true);
 		expect(service.activeCount).toBe(0);
+		expect(auditService.recordSubscriptionClosed).toHaveBeenCalledWith(
+			{ requestId: 'unknown', clientId: 'client-a' },
+			subscription.id,
+			'idle',
+		);
 	});
 
 	it('cleans up every stream during application shutdown', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -8,6 +8,8 @@ import {
 	MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS,
 } from '../mcp.constants';
 
+import { McpAuditService, McpSubscriptionCloseReason } from './mcp-audit.service';
+
 export class McpSubscriptionCapacityError extends Error {
 	constructor() {
 		super('Subscription limit reached');
@@ -19,13 +21,14 @@ export interface McpSubscriptionHandle {
 	id: string;
 	clientId: string;
 	signal: AbortSignal;
-	close: () => void;
+	close: (reason?: McpSubscriptionCloseReason) => void;
 	touch: () => void;
 }
 
 interface SubscriptionRecord {
 	id: string;
 	clientId: string;
+	requestId: string;
 	controller: AbortController;
 	timer: NodeJS.Timeout;
 }
@@ -34,7 +37,9 @@ interface SubscriptionRecord {
 export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	private readonly subscriptions = new Map<string, SubscriptionRecord>();
 
-	open(clientId: string): McpSubscriptionHandle {
+	constructor(private readonly auditService: McpAuditService) {}
+
+	open(clientId: string, requestId = 'unknown'): McpSubscriptionHandle {
 		if (
 			this.subscriptions.size >= MCP_MAX_ACTIVE_SUBSCRIPTIONS ||
 			this.countForClient(clientId) >= MCP_MAX_SUBSCRIPTIONS_PER_CLIENT
@@ -47,17 +52,19 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		const record: SubscriptionRecord = {
 			id,
 			clientId,
+			requestId,
 			controller,
 			timer: this.createIdleTimer(id),
 		};
 
 		this.subscriptions.set(id, record);
+		this.auditService.recordSubscriptionOpened({ requestId, clientId }, id);
 
 		return {
 			id,
 			clientId,
 			signal: controller.signal,
-			close: () => this.close(id),
+			close: (reason = 'completed') => this.close(id, reason),
 			touch: () => this.touch(id),
 		};
 	}
@@ -89,14 +96,14 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	closeClient(clientId: string): void {
 		for (const subscription of [...this.subscriptions.values()]) {
 			if (subscription.clientId === clientId) {
-				this.close(subscription.id);
+				this.close(subscription.id, 'client_closed');
 			}
 		}
 	}
 
 	closeAll(): void {
 		for (const id of [...this.subscriptions.keys()]) {
-			this.close(id);
+			this.close(id, 'shutdown');
 		}
 	}
 
@@ -115,7 +122,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		subscription.timer = this.createIdleTimer(id);
 	}
 
-	private close(id: string): void {
+	private close(id: string, reason: McpSubscriptionCloseReason): void {
 		const subscription = this.subscriptions.get(id);
 
 		if (!subscription) {
@@ -125,10 +132,15 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		this.subscriptions.delete(id);
 		clearTimeout(subscription.timer);
 		subscription.controller.abort();
+		this.auditService.recordSubscriptionClosed(
+			{ requestId: subscription.requestId, clientId: subscription.clientId },
+			subscription.id,
+			reason,
+		);
 	}
 
 	private createIdleTimer(id: string): NodeJS.Timeout {
-		const timer = setTimeout(() => this.close(id), MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS);
+		const timer = setTimeout(() => this.close(id, 'idle'), MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS);
 		timer.unref();
 
 		return timer;

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -3,6 +3,7 @@ import { ForbiddenException } from '@nestjs/common';
 
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
 import { MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
+import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
@@ -141,6 +142,25 @@ describe('McpReadToolService', () => {
 		);
 	});
 
+	it('audits a module-disable race as an endpoint denial without confusing domain not-found errors', async () => {
+		policyService.authorizeClient.mockRejectedValue(new McpEndpointDisabledException());
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_security_status')?.({}, requestContext());
+
+		expect(result?.isError).toBe(true);
+		expect(result?.structuredContent.error).toEqual({
+			code: 'not_found',
+			message: 'The requested Smart Panel item was not found.',
+		});
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'endpoint_disabled',
+			{ capability: McpCapability.READ, tool: 'get_security_status' },
+		);
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'denied' }));
+	});
+
 	it('returns a sanitized error when a domain call exceeds the MCP deadline', async () => {
 		jest.useFakeTimers();
 		contextService.getSecurityStatus.mockReturnValue(new Promise(() => undefined));
@@ -177,6 +197,8 @@ describe('McpReadToolService', () => {
 			code: 'not_found',
 			message: 'The requested Smart Panel item was not found.',
 		});
+		expect(auditService.recordPolicyDenial).not.toHaveBeenCalled();
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
 	});
 
 	it('enforces the same deadline for resource reads', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -3,6 +3,7 @@ import { ForbiddenException } from '@nestjs/common';
 
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
 import { MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
+import { McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -27,6 +28,7 @@ describe('McpReadToolService', () => {
 		listSpaces: jest.Mock;
 	};
 	let policyService: { authorizeClient: jest.Mock };
+	let auditService: { recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let registerResource: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
@@ -50,6 +52,10 @@ describe('McpReadToolService', () => {
 		policyService = {
 			authorizeClient: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
 		};
+		auditService = {
+			recordPolicyDenial: jest.fn(),
+			recordToolResult: jest.fn(),
+		};
 		callbacks = new Map();
 		resourceCallbacks = new Map();
 		resourceListCallback = undefined;
@@ -62,6 +68,7 @@ describe('McpReadToolService', () => {
 		service = new McpReadToolService(
 			contextService as unknown as McpContextService,
 			policyService as unknown as McpPolicyService,
+			auditService as unknown as McpAuditService,
 		);
 	});
 
@@ -100,6 +107,15 @@ describe('McpReadToolService', () => {
 		expect(result?.structuredContent.tool).toBe('get_security_status');
 		expect(result?.structuredContent.request_id).toBe('17');
 		expect(result?.structuredContent.data).toEqual({ active_alerts_count: 0 });
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestId: '17',
+				clientId: 'client-id',
+				tool: 'get_security_status',
+				capability: McpCapability.READ,
+				outcome: 'completed',
+			}),
+		);
 	});
 
 	it('returns a sanitized denial when live policy no longer grants read', async () => {
@@ -118,6 +134,11 @@ describe('McpReadToolService', () => {
 			}),
 		);
 		expect(contextService.getSecurityStatus).not.toHaveBeenCalled();
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'capability_denied',
+			{ capability: McpCapability.READ, tool: 'get_security_status' },
+		);
 	});
 
 	it('returns a sanitized error when a domain call exceeds the MCP deadline', async () => {
@@ -136,6 +157,7 @@ describe('McpReadToolService', () => {
 				code: 'read_failed',
 				message: 'Smart Panel could not complete the requested read operation.',
 			});
+			expect(auditService.recordToolResult).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'timed_out' }));
 		} finally {
 			jest.useRealTimers();
 		}
@@ -179,6 +201,26 @@ describe('McpReadToolService', () => {
 		} finally {
 			jest.useRealTimers();
 		}
+	});
+
+	it('audits a resource policy denial without exposing the resource request', async () => {
+		policyService.authorizeClient.mockRejectedValue(new ForbiddenException('private resource policy'));
+		service.register(server(), authInfo([McpCapability.READ]));
+		const resultPromise = resourceCallbacks.get('installation')?.(
+			new URL('smart-panel://installation'),
+			requestContext(),
+		);
+
+		if (resultPromise === undefined) {
+			throw new Error('Installation resource callback was not registered');
+		}
+
+		await expect(resultPromise).rejects.toThrow('The MCP client is not authorized for this read operation.');
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'capability_denied',
+			{ capability: McpCapability.READ },
+		);
 	});
 
 	it('paginates resource discovery without repeating static resources', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -1,5 +1,5 @@
 import { AuthInfo, McpServer, ServerContext } from '@modelcontextprotocol/server';
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
 import { MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
@@ -29,7 +29,7 @@ describe('McpReadToolService', () => {
 		listSpaces: jest.Mock;
 	};
 	let policyService: { authorizeClient: jest.Mock };
-	let auditService: { recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
+	let auditService: { getRequestId: jest.Mock; recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let registerResource: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
@@ -54,6 +54,7 @@ describe('McpReadToolService', () => {
 			authorizeClient: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
 		};
 		auditService = {
+			getRequestId: jest.fn().mockReturnValue('17'),
 			recordPolicyDenial: jest.fn(),
 			recordToolResult: jest.fn(),
 		};
@@ -138,6 +139,20 @@ describe('McpReadToolService', () => {
 		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
 			{ requestId: '17', clientId: 'client-id' },
 			'capability_denied',
+			{ capability: McpCapability.READ, tool: 'get_security_status' },
+		);
+	});
+
+	it('distinguishes a live credential rejection from a capability denial', async () => {
+		policyService.authorizeClient.mockRejectedValue(new UnauthorizedException('private credential detail'));
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_security_status')?.({}, requestContext());
+
+		expect(result?.isError).toBe(true);
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'invalid_credential',
 			{ capability: McpCapability.READ, tool: 'get_security_status' },
 		);
 	});

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -220,6 +220,13 @@ describe('McpReadToolService', () => {
 
 			await jest.advanceTimersByTimeAsync(MCP_TOOL_CALL_TIMEOUT_MS);
 			await rejection;
+			expect(auditService.recordToolResult).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tool: 'resources/read',
+					capability: McpCapability.READ,
+					outcome: 'timed_out',
+				}),
+			);
 		} finally {
 			jest.useRealTimers();
 		}
@@ -241,7 +248,10 @@ describe('McpReadToolService', () => {
 		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
 			{ requestId: '17', clientId: 'client-id' },
 			'capability_denied',
-			{ capability: McpCapability.READ },
+			{ capability: McpCapability.READ, tool: 'resources/read' },
+		);
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ tool: 'resources/read', outcome: 'denied' }),
 		);
 	});
 
@@ -260,6 +270,9 @@ describe('McpReadToolService', () => {
 		]);
 		expect(firstPage?.nextCursor).toBe('51');
 		expect(contextService.listSpaces).toHaveBeenLastCalledWith(undefined);
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ tool: 'resources/list', outcome: 'completed' }),
+		);
 
 		const nextPage = await resourceListCallback?.({ params: { cursor: '50' } }, requestContext());
 		expect(nextPage?.resources.map((resource) => resource.uri)).toEqual(['smart-panel://spaces/space-51/snapshot']);

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
@@ -7,7 +7,8 @@ import { withTimeout } from '../../../common/utils/http.utils';
 import { BucketDuration } from '../../devices/services/property-timeseries.service';
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
 import { MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
-import { McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
+import { McpEndpointDisabledException } from '../mcp.exceptions';
+import { McpAuditDenialReason, McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService, McpInstallationContext } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -321,8 +322,10 @@ export class McpReadToolService {
 				error: sanitized,
 			};
 
-			if (outcome === McpAuditOutcome.DENIED) {
-				this.auditService.recordPolicyDenial(identity, 'capability_denied', {
+			const denialReason = this.getPolicyDenialReason(error);
+
+			if (denialReason) {
+				this.auditService.recordPolicyDenial(identity, denialReason, {
 					capability: McpCapability.READ,
 					tool,
 				});
@@ -398,7 +401,9 @@ export class McpReadToolService {
 		try {
 			return await this.withDeadline(label, callback);
 		} catch (error) {
-			if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+			const denialReason = this.getPolicyDenialReason(error);
+
+			if (denialReason) {
 				const authInfo = ctx.http?.authInfo;
 
 				this.auditService.recordPolicyDenial(
@@ -406,7 +411,7 @@ export class McpReadToolService {
 						requestId: String(ctx.mcpReq.id),
 						...(authInfo?.clientId ? { clientId: authInfo.clientId } : {}),
 					},
-					'capability_denied',
+					denialReason,
 					{ capability: McpCapability.READ },
 				);
 			}
@@ -432,7 +437,7 @@ export class McpReadToolService {
 	}
 
 	private getAuditOutcome(error: unknown): McpAuditOutcome {
-		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+		if (this.getPolicyDenialReason(error)) {
 			return McpAuditOutcome.DENIED;
 		}
 
@@ -441,6 +446,18 @@ export class McpReadToolService {
 		}
 
 		return McpAuditOutcome.FAILED;
+	}
+
+	private getPolicyDenialReason(error: unknown): McpAuditDenialReason | null {
+		if (error instanceof McpEndpointDisabledException) {
+			return 'endpoint_disabled';
+		}
+
+		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+			return 'capability_denied';
+		}
+
+		return null;
 	}
 
 	private getEndpoint(authInfo?: AuthInfo): string | undefined {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
@@ -219,7 +219,7 @@ export class McpReadToolService {
 		// read and template handlers remain SDK-managed while resource discovery can be paginated correctly.
 		server.server.setRequestHandler('resources/list', async (request, ctx) =>
 			this.runResourceOperation(
-				'resource listing',
+				'resources/list',
 				async () => {
 					await this.authorizeRead(ctx);
 					const cursor = request.params?.cursor;
@@ -353,7 +353,7 @@ export class McpReadToolService {
 		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeClient']>>, endpoint?: string) => Promise<unknown>,
 	): Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }> {
 		return this.runResourceOperation(
-			`resource ${uri.href}`,
+			'resources/read',
 			async () => {
 				const policy = await this.authorizeRead(ctx);
 				const data = await callback(policy, this.getEndpoint(ctx.http?.authInfo));
@@ -397,24 +397,43 @@ export class McpReadToolService {
 		return withTimeout(Promise.resolve().then(callback), MCP_TOOL_CALL_TIMEOUT_MS, `MCP ${label}`);
 	}
 
-	private async runResourceOperation<T>(label: string, callback: () => Promise<T>, ctx: ServerContext): Promise<T> {
+	private async runResourceOperation<T>(operation: string, callback: () => Promise<T>, ctx: ServerContext): Promise<T> {
+		const identity = {
+			requestId: String(ctx.mcpReq.id),
+			...(ctx.http?.authInfo?.clientId ? { clientId: ctx.http.authInfo.clientId } : {}),
+		};
+		const startedAt = Date.now();
+
 		try {
-			return await this.withDeadline(label, callback);
+			const result = await this.withDeadline(operation, callback);
+
+			this.auditService.recordToolResult({
+				...identity,
+				tool: operation,
+				capability: McpCapability.READ,
+				durationMs: Date.now() - startedAt,
+				outcome: McpAuditOutcome.COMPLETED,
+			});
+
+			return result;
 		} catch (error) {
 			const denialReason = this.getPolicyDenialReason(error);
+			const outcome = this.getAuditOutcome(error);
 
 			if (denialReason) {
-				const authInfo = ctx.http?.authInfo;
-
-				this.auditService.recordPolicyDenial(
-					{
-						requestId: String(ctx.mcpReq.id),
-						...(authInfo?.clientId ? { clientId: authInfo.clientId } : {}),
-					},
-					denialReason,
-					{ capability: McpCapability.READ },
-				);
+				this.auditService.recordPolicyDenial(identity, denialReason, {
+					capability: McpCapability.READ,
+					tool: operation,
+				});
 			}
+
+			this.auditService.recordToolResult({
+				...identity,
+				tool: operation,
+				capability: McpCapability.READ,
+				durationMs: Date.now() - startedAt,
+				outcome,
+			});
 
 			throw new Error(this.sanitizeError(error).message, { cause: error });
 		}

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
@@ -272,7 +272,7 @@ export class McpReadToolService {
 		structuredContent: ToolEnvelope;
 		isError?: boolean;
 	}> {
-		const requestId = String(ctx.mcpReq.id);
+		const requestId = this.auditService.getRequestId({ id: ctx.mcpReq.id });
 		const startedAt = Date.now();
 		const identity = {
 			requestId,
@@ -399,7 +399,7 @@ export class McpReadToolService {
 
 	private async runResourceOperation<T>(operation: string, callback: () => Promise<T>, ctx: ServerContext): Promise<T> {
 		const identity = {
-			requestId: String(ctx.mcpReq.id),
+			requestId: this.auditService.getRequestId({ id: ctx.mcpReq.id }),
 			...(ctx.http?.authInfo?.clientId ? { clientId: ctx.http.authInfo.clientId } : {}),
 		};
 		const startedAt = Date.now();
@@ -472,8 +472,12 @@ export class McpReadToolService {
 			return 'endpoint_disabled';
 		}
 
-		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+		if (error instanceof ForbiddenException) {
 			return 'capability_denied';
+		}
+
+		if (error instanceof UnauthorizedException) {
+			return 'invalid_credential';
 		}
 
 		return null;

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
@@ -7,6 +7,7 @@ import { withTimeout } from '../../../common/utils/http.utils';
 import { BucketDuration } from '../../devices/services/property-timeseries.service';
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
 import { MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
+import { McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService, McpInstallationContext } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -52,6 +53,7 @@ export class McpReadToolService {
 	constructor(
 		private readonly contextService: McpContextService,
 		private readonly policyService: McpPolicyService,
+		private readonly auditService: McpAuditService,
 	) {}
 
 	register(server: McpServer, authInfo?: AuthInfo): void {
@@ -215,44 +217,48 @@ export class McpReadToolService {
 		// the built-in aggregator drops nextCursor. Replace only that low-level handler so the existing registered
 		// read and template handlers remain SDK-managed while resource discovery can be paginated correctly.
 		server.server.setRequestHandler('resources/list', async (request, ctx) =>
-			this.runResourceOperation('resource listing', async () => {
-				await this.authorizeRead(ctx);
-				const cursor = request.params?.cursor;
-				const page = await this.contextService.listSpaces(cursor);
-				const staticResources =
-					cursor === undefined
-						? [
-								{
-									uri: 'smart-panel://installation',
-									name: 'installation',
-									title: 'Smart Panel installation',
-									description: 'Installation identity, version, timezone, endpoint, and effective MCP capabilities.',
-									mimeType: 'application/json',
-								},
-								{
-									uri: 'smart-panel://home/context',
-									name: 'home-context',
-									title: 'Current home context',
-									description: 'Bounded current context for the Smart Panel installation.',
-									mimeType: 'application/json',
-								},
-							]
-						: [];
+			this.runResourceOperation(
+				'resource listing',
+				async () => {
+					await this.authorizeRead(ctx);
+					const cursor = request.params?.cursor;
+					const page = await this.contextService.listSpaces(cursor);
+					const staticResources =
+						cursor === undefined
+							? [
+									{
+										uri: 'smart-panel://installation',
+										name: 'installation',
+										title: 'Smart Panel installation',
+										description: 'Installation identity, version, timezone, endpoint, and effective MCP capabilities.',
+										mimeType: 'application/json',
+									},
+									{
+										uri: 'smart-panel://home/context',
+										name: 'home-context',
+										title: 'Current home context',
+										description: 'Bounded current context for the Smart Panel installation.',
+										mimeType: 'application/json',
+									},
+								]
+							: [];
 
-				return {
-					resources: [
-						...staticResources,
-						...page.spaces.map((space) => ({
-							uri: `smart-panel://spaces/${space.id}/snapshot`,
-							name: `${space.name} snapshot`,
-							title: `${space.name} snapshot`,
-							description: `Current bounded context for the ${space.name} ${space.type}.`,
-							mimeType: 'application/json',
-						})),
-					],
-					...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
-				};
-			}),
+					return {
+						resources: [
+							...staticResources,
+							...page.spaces.map((space) => ({
+								uri: `smart-panel://spaces/${space.id}/snapshot`,
+								name: `${space.name} snapshot`,
+								title: `${space.name} snapshot`,
+								description: `Current bounded context for the ${space.name} ${space.type}.`,
+								mimeType: 'application/json',
+							})),
+						],
+						...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+					};
+				},
+				ctx,
+			),
 		);
 	}
 
@@ -266,6 +272,11 @@ export class McpReadToolService {
 		isError?: boolean;
 	}> {
 		const requestId = String(ctx.mcpReq.id);
+		const startedAt = Date.now();
+		const identity = {
+			requestId,
+			...(ctx.http?.authInfo?.clientId ? { clientId: ctx.http.authInfo.clientId } : {}),
+		};
 		let installation = this.getInstallationFallback(ctx);
 
 		try {
@@ -286,6 +297,13 @@ export class McpReadToolService {
 				observed_at: new Date().toISOString(),
 				data: execution.result.data,
 			};
+			this.auditService.recordToolResult({
+				...identity,
+				tool,
+				capability: McpCapability.READ,
+				durationMs: Date.now() - startedAt,
+				outcome: McpAuditOutcome.COMPLETED,
+			});
 
 			return {
 				content: [{ type: 'text', text: execution.result.text }],
@@ -293,6 +311,7 @@ export class McpReadToolService {
 			};
 		} catch (error) {
 			const sanitized = this.sanitizeError(error);
+			const outcome = this.getAuditOutcome(error);
 			const structuredContent: ToolEnvelope = {
 				installation,
 				tool,
@@ -301,6 +320,21 @@ export class McpReadToolService {
 				data: null,
 				error: sanitized,
 			};
+
+			if (outcome === McpAuditOutcome.DENIED) {
+				this.auditService.recordPolicyDenial(identity, 'capability_denied', {
+					capability: McpCapability.READ,
+					tool,
+				});
+			}
+
+			this.auditService.recordToolResult({
+				...identity,
+				tool,
+				capability: McpCapability.READ,
+				durationMs: Date.now() - startedAt,
+				outcome,
+			});
 
 			return {
 				content: [{ type: 'text', text: sanitized.message }],
@@ -315,14 +349,18 @@ export class McpReadToolService {
 		ctx: ServerContext,
 		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeClient']>>, endpoint?: string) => Promise<unknown>,
 	): Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }> {
-		return this.runResourceOperation(`resource ${uri.href}`, async () => {
-			const policy = await this.authorizeRead(ctx);
-			const data = await callback(policy, this.getEndpoint(ctx.http?.authInfo));
+		return this.runResourceOperation(
+			`resource ${uri.href}`,
+			async () => {
+				const policy = await this.authorizeRead(ctx);
+				const data = await callback(policy, this.getEndpoint(ctx.http?.authInfo));
 
-			return {
-				contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(data) }],
-			};
-		});
+				return {
+					contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(data) }],
+				};
+			},
+			ctx,
+		);
 	}
 
 	private async authorizeRead(ctx: ServerContext) {
@@ -356,10 +394,23 @@ export class McpReadToolService {
 		return withTimeout(Promise.resolve().then(callback), MCP_TOOL_CALL_TIMEOUT_MS, `MCP ${label}`);
 	}
 
-	private async runResourceOperation<T>(label: string, callback: () => Promise<T>): Promise<T> {
+	private async runResourceOperation<T>(label: string, callback: () => Promise<T>, ctx: ServerContext): Promise<T> {
 		try {
 			return await this.withDeadline(label, callback);
 		} catch (error) {
+			if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+				const authInfo = ctx.http?.authInfo;
+
+				this.auditService.recordPolicyDenial(
+					{
+						requestId: String(ctx.mcpReq.id),
+						...(authInfo?.clientId ? { clientId: authInfo.clientId } : {}),
+					},
+					'capability_denied',
+					{ capability: McpCapability.READ },
+				);
+			}
+
 			throw new Error(this.sanitizeError(error).message, { cause: error });
 		}
 	}
@@ -378,6 +429,18 @@ export class McpReadToolService {
 		}
 
 		return { code: 'read_failed', message: 'Smart Panel could not complete the requested read operation.' };
+	}
+
+	private getAuditOutcome(error: unknown): McpAuditOutcome {
+		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+			return McpAuditOutcome.DENIED;
+		}
+
+		if (error instanceof Error && /timeout after \d+ms$/i.test(error.message)) {
+			return McpAuditOutcome.TIMED_OUT;
+		}
+
+		return McpAuditOutcome.FAILED;
 	}
 
 	private getEndpoint(authInfo?: AuthInfo): string | undefined {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -20,6 +20,7 @@ import { SpaceType } from '../../spaces/spaces.constants';
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import { MCP_MAX_WRITABLE_PROPERTY_CANDIDATES, MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
+import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
@@ -390,6 +391,77 @@ describe('McpTargetDiscoveryToolService', () => {
 			expect.objectContaining({ outcome: 'failed', tool: 'set_device_property' }),
 		);
 		expect(toolRegistry.executeTool).not.toHaveBeenCalled();
+	});
+
+	it('reports a disabled scene as a domain failure without recording a capability denial', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		toolRegistry.executeTool.mockResolvedValue({
+			success: false,
+			status: ToolExecutionStatus.DENIED,
+			message: 'Scene is disabled',
+			errorCode: 'SCENE_DISABLED',
+		});
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('run_scene')?.(
+			{ scene_id: '10000000-0000-4000-8000-000000000001' },
+			requestContext([McpCapability.TRIGGER]),
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(result?.structuredContent.error).toEqual(expect.objectContaining({ code: 'trigger_failed' }));
+		expect(auditService.recordPolicyDenial).not.toHaveBeenCalled();
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: 'failed', tool: 'run_scene' }),
+		);
+	});
+
+	it('continues to audit provider access rejections as capability denials', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		toolRegistry.executeTool.mockResolvedValue({
+			success: false,
+			status: ToolExecutionStatus.DENIED,
+			message: 'Tool access denied',
+			errorCode: 'TOOL_ACCESS_DENIED',
+		});
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('run_scene')?.(
+			{ scene_id: '10000000-0000-4000-8000-000000000001' },
+			requestContext([McpCapability.TRIGGER]),
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(result?.structuredContent.error).toEqual(expect.objectContaining({ code: 'permission_denied' }));
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'capability_denied',
+			{ capability: McpCapability.TRIGGER, tool: 'run_scene' },
+		);
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: 'denied', tool: 'run_scene' }),
+		);
+	});
+
+	it('audits a module-disable race as an endpoint denial for write and trigger tools', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		policyService.authorizeClient.mockRejectedValue(new McpEndpointDisabledException());
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('run_scene')?.(
+			{ scene_id: '10000000-0000-4000-8000-000000000001' },
+			requestContext([McpCapability.TRIGGER]),
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'endpoint_disabled',
+			{ capability: McpCapability.TRIGGER, tool: 'run_scene' },
+		);
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: 'denied', tool: 'run_scene' }),
+		);
 	});
 
 	function server(): McpServer {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -20,6 +20,7 @@ import { SpaceType } from '../../spaces/spaces.constants';
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import { MCP_MAX_WRITABLE_PROPERTY_CANDIDATES, MCP_TOOL_CALL_TIMEOUT_MS, McpCapability } from '../mcp.constants';
+import { McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -40,6 +41,7 @@ describe('McpTargetDiscoveryToolService', () => {
 	let toolRegistry: { getAllToolDefinitions: jest.Mock; executeTool: jest.Mock };
 	let contextService: { getInstallation: jest.Mock };
 	let policyService: { authorizeClient: jest.Mock };
+	let auditService: { recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
 	let providerTools: Array<{ name: string; audiences: ToolAudience[]; access: ToolAccessKind }>;
@@ -84,6 +86,10 @@ describe('McpTargetDiscoveryToolService', () => {
 				}),
 			),
 		};
+		auditService = {
+			recordPolicyDenial: jest.fn(),
+			recordToolResult: jest.fn(),
+		};
 		callbacks = new Map();
 		registerTool = jest.fn((name: string, _config: unknown, callback: ToolCallback) => {
 			callbacks.set(name, callback);
@@ -97,6 +103,7 @@ describe('McpTargetDiscoveryToolService', () => {
 			toolRegistry as unknown as ToolProviderRegistryService,
 			contextService as unknown as McpContextService,
 			policyService as unknown as McpPolicyService,
+			auditService as unknown as McpAuditService,
 		);
 	});
 
@@ -283,6 +290,17 @@ describe('McpTargetDiscoveryToolService', () => {
 		);
 		expect(result?.isError).toBeUndefined();
 		expect(result?.structuredContent.tool).toBe('set_device_property');
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tool: 'set_device_property',
+				capability: McpCapability.WRITE,
+				outcome: 'completed',
+				arguments: {
+					property_id: '10000000-0000-4000-8000-000000000001',
+					value: true,
+				},
+			}),
+		);
 	});
 
 	it('waits for an authoritative provider result after a side effect has started', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -366,6 +366,29 @@ describe('McpTargetDiscoveryToolService', () => {
 
 		expect(result?.isError).toBe(true);
 		expect(result?.structuredContent.error).toEqual(expect.objectContaining({ code: 'not_found' }));
+		expect(auditService.recordPolicyDenial).not.toHaveBeenCalled();
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: 'failed', tool: 'set_device_property' }),
+		);
+		expect(toolRegistry.executeTool).not.toHaveBeenCalled();
+	});
+
+	it('reports an unknown write target without recording a policy denial', async () => {
+		providerTools = [providerTool('control_device', ToolAccessKind.WRITE)];
+		channelsPropertiesService.findOne.mockResolvedValue(null);
+		service.register(server(), authInfo([McpCapability.WRITE]));
+
+		const result = await callbacks.get('set_device_property')?.(
+			{ property_id: '10000000-0000-4000-8000-000000000001', value: true },
+			requestContext([McpCapability.WRITE]),
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(result?.structuredContent.error).toEqual(expect.objectContaining({ code: 'not_found' }));
+		expect(auditService.recordPolicyDenial).not.toHaveBeenCalled();
+		expect(auditService.recordToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: 'failed', tool: 'set_device_property' }),
+		);
 		expect(toolRegistry.executeTool).not.toHaveBeenCalled();
 	});
 

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -1,4 +1,5 @@
 import { AuthInfo, McpServer, ServerContext } from '@modelcontextprotocol/server';
+import { UnauthorizedException } from '@nestjs/common';
 
 import {
 	ChannelCategory,
@@ -42,7 +43,7 @@ describe('McpTargetDiscoveryToolService', () => {
 	let toolRegistry: { getAllToolDefinitions: jest.Mock; executeTool: jest.Mock };
 	let contextService: { getInstallation: jest.Mock };
 	let policyService: { authorizeClient: jest.Mock };
-	let auditService: { recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
+	let auditService: { getRequestId: jest.Mock; recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
 	let providerTools: Array<{ name: string; audiences: ToolAudience[]; access: ToolAccessKind }>;
@@ -88,6 +89,7 @@ describe('McpTargetDiscoveryToolService', () => {
 			),
 		};
 		auditService = {
+			getRequestId: jest.fn().mockReturnValue('17'),
 			recordPolicyDenial: jest.fn(),
 			recordToolResult: jest.fn(),
 		};
@@ -461,6 +463,24 @@ describe('McpTargetDiscoveryToolService', () => {
 		);
 		expect(auditService.recordToolResult).toHaveBeenCalledWith(
 			expect.objectContaining({ outcome: 'denied', tool: 'run_scene' }),
+		);
+	});
+
+	it('distinguishes a live credential rejection from a capability denial for mutating tools', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		policyService.authorizeClient.mockRejectedValue(new UnauthorizedException('private credential detail'));
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('run_scene')?.(
+			{ scene_id: '10000000-0000-4000-8000-000000000001' },
+			requestContext([McpCapability.TRIGGER]),
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(auditService.recordPolicyDenial).toHaveBeenCalledWith(
+			{ requestId: '17', clientId: 'client-id' },
+			'invalid_credential',
+			{ capability: McpCapability.TRIGGER, tool: 'run_scene' },
 		);
 	});
 

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
@@ -257,7 +257,7 @@ export class McpTargetDiscoveryToolService {
 				if (providerName === 'control_device' && !(await this.isAvailableDeviceProperty(args.property_id))) {
 					return this.toProviderToolData(capability, {
 						success: false,
-						status: ToolExecutionStatus.DENIED,
+						status: ToolExecutionStatus.FAILED,
 						message: 'Device property is unavailable',
 						errorCode: 'DEVICE_PROPERTY_NOT_FOUND',
 					});

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
@@ -250,6 +250,8 @@ export class McpTargetDiscoveryToolService {
 		args: Record<string, unknown>,
 		ctx: ServerContext,
 	) {
+		const requestId = this.auditService.getRequestId({ id: ctx.mcpReq.id });
+
 		return this.runTool(
 			publicName,
 			capability,
@@ -265,12 +267,12 @@ export class McpTargetDiscoveryToolService {
 				}
 
 				const result = await this.toolRegistry.executeTool(
-					{ id: String(ctx.mcpReq.id), name: providerName, arguments: args },
+					{ id: requestId, name: providerName, arguments: args },
 					{
 						audience: ToolAudience.MCP,
 						source: 'mcp',
 						actorId: policy.client.id,
-						requestId: String(ctx.mcpReq.id),
+						requestId,
 						allowedAccessKinds: [access],
 					},
 				);
@@ -294,7 +296,7 @@ export class McpTargetDiscoveryToolService {
 		structuredContent: ToolEnvelope;
 		isError?: boolean;
 	}> {
-		const requestId = String(ctx.mcpReq.id);
+		const requestId = this.auditService.getRequestId({ id: ctx.mcpReq.id });
 		const startedAt = Date.now();
 		const identity = {
 			requestId,
@@ -577,8 +579,12 @@ export class McpTargetDiscoveryToolService {
 			return 'endpoint_disabled';
 		}
 
-		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+		if (error instanceof ForbiddenException) {
 			return 'capability_denied';
+		}
+
+		if (error instanceof UnauthorizedException) {
+			return 'invalid_credential';
 		}
 
 		return null;

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
@@ -27,6 +27,7 @@ import {
 	MCP_TOOL_CALL_TIMEOUT_MS,
 	McpCapability,
 } from '../mcp.constants';
+import { McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService, McpInstallationContext } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -73,6 +74,7 @@ interface ToolData {
 	data: Record<string, unknown>;
 	text: string;
 	error?: { code: string; message: string };
+	outcome?: McpAuditOutcome;
 }
 
 interface ToolEnvelope {
@@ -95,6 +97,7 @@ export class McpTargetDiscoveryToolService {
 		private readonly toolRegistry: ToolProviderRegistryService,
 		private readonly contextService: McpContextService,
 		private readonly policyService: McpPolicyService,
+		private readonly auditService: McpAuditService,
 	) {}
 
 	register(server: McpServer, authInfo?: AuthInfo): void {
@@ -274,6 +277,7 @@ export class McpTargetDiscoveryToolService {
 				return this.toProviderToolData(capability, result);
 			},
 			null,
+			args,
 		);
 	}
 
@@ -283,12 +287,18 @@ export class McpTargetDiscoveryToolService {
 		ctx: ServerContext,
 		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeClient']>>) => Promise<ToolData>,
 		timeoutMs: number | null = MCP_TOOL_CALL_TIMEOUT_MS,
+		auditArguments?: Record<string, unknown>,
 	): Promise<{
 		content: Array<{ type: 'text'; text: string }>;
 		structuredContent: ToolEnvelope;
 		isError?: boolean;
 	}> {
 		const requestId = String(ctx.mcpReq.id);
+		const startedAt = Date.now();
+		const identity = {
+			requestId,
+			...(ctx.http?.authInfo?.clientId ? { clientId: ctx.http.authInfo.clientId } : {}),
+		};
 		let installation = this.getInstallationFallback(ctx);
 
 		try {
@@ -314,6 +324,20 @@ export class McpTargetDiscoveryToolService {
 				data: execution.result.data,
 				...(execution.result.error ? { error: execution.result.error } : {}),
 			};
+			const outcome = execution.result.outcome ?? McpAuditOutcome.COMPLETED;
+
+			if (outcome === McpAuditOutcome.DENIED) {
+				this.auditService.recordPolicyDenial(identity, 'capability_denied', { capability, tool });
+			}
+
+			this.auditService.recordToolResult({
+				...identity,
+				tool,
+				capability,
+				durationMs: Date.now() - startedAt,
+				outcome,
+				...(auditArguments ? { arguments: auditArguments } : {}),
+			});
 
 			return {
 				content: [{ type: 'text', text: execution.result.text }],
@@ -322,6 +346,7 @@ export class McpTargetDiscoveryToolService {
 			};
 		} catch (error) {
 			const sanitized = this.sanitizeError(error, capability);
+			const outcome = this.getAuditOutcome(error);
 			const structuredContent: ToolEnvelope = {
 				installation,
 				tool,
@@ -330,6 +355,19 @@ export class McpTargetDiscoveryToolService {
 				data: null,
 				error: sanitized,
 			};
+
+			if (outcome === McpAuditOutcome.DENIED) {
+				this.auditService.recordPolicyDenial(identity, 'capability_denied', { capability, tool });
+			}
+
+			this.auditService.recordToolResult({
+				...identity,
+				tool,
+				capability,
+				durationMs: Date.now() - startedAt,
+				outcome,
+				...(auditArguments ? { arguments: auditArguments } : {}),
+			});
 
 			return {
 				content: [{ type: 'text', text: sanitized.message }],
@@ -461,7 +499,7 @@ export class McpTargetDiscoveryToolService {
 		const data = { status: result.status, ...(result.data ?? {}) };
 
 		if (result.success) {
-			return { data, text: result.message };
+			return { data, text: result.message, outcome: this.toAuditOutcome(result.status) };
 		}
 
 		const invalid = result.errorCode === 'INVALID_TOOL_ARGUMENTS';
@@ -471,6 +509,7 @@ export class McpTargetDiscoveryToolService {
 
 		return {
 			data,
+			outcome: this.toAuditOutcome(result.status),
 			text: invalid
 				? 'The tool arguments are invalid.'
 				: notFound
@@ -511,6 +550,33 @@ export class McpTargetDiscoveryToolService {
 			code: `${operation}_failed`,
 			message: `Smart Panel could not complete the requested ${operation} operation.`,
 		};
+	}
+
+	private getAuditOutcome(error: unknown): McpAuditOutcome {
+		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+			return McpAuditOutcome.DENIED;
+		}
+
+		if (error instanceof Error && /timeout after \d+ms$/i.test(error.message)) {
+			return McpAuditOutcome.TIMED_OUT;
+		}
+
+		return McpAuditOutcome.FAILED;
+	}
+
+	private toAuditOutcome(status: ToolExecutionStatus): McpAuditOutcome {
+		switch (status) {
+			case ToolExecutionStatus.COMPLETED:
+				return McpAuditOutcome.COMPLETED;
+			case ToolExecutionStatus.PARTIAL:
+				return McpAuditOutcome.PARTIAL;
+			case ToolExecutionStatus.TIMED_OUT:
+				return McpAuditOutcome.TIMED_OUT;
+			case ToolExecutionStatus.DENIED:
+				return McpAuditOutcome.DENIED;
+			default:
+				return McpAuditOutcome.FAILED;
+		}
 	}
 
 	private getInstallationFallback(ctx: ServerContext): McpInstallationContext {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
@@ -27,7 +27,8 @@ import {
 	MCP_TOOL_CALL_TIMEOUT_MS,
 	McpCapability,
 } from '../mcp.constants';
-import { McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
+import { McpEndpointDisabledException } from '../mcp.exceptions';
+import { McpAuditDenialReason, McpAuditOutcome, McpAuditService } from '../services/mcp-audit.service';
 import { McpContextService, McpInstallationContext } from '../services/mcp-context.service';
 import { McpPolicyService } from '../services/mcp-policy.service';
 
@@ -347,6 +348,7 @@ export class McpTargetDiscoveryToolService {
 		} catch (error) {
 			const sanitized = this.sanitizeError(error, capability);
 			const outcome = this.getAuditOutcome(error);
+			const denialReason = this.getPolicyDenialReason(error);
 			const structuredContent: ToolEnvelope = {
 				installation,
 				tool,
@@ -356,8 +358,8 @@ export class McpTargetDiscoveryToolService {
 				error: sanitized,
 			};
 
-			if (outcome === McpAuditOutcome.DENIED) {
-				this.auditService.recordPolicyDenial(identity, 'capability_denied', { capability, tool });
+			if (denialReason) {
+				this.auditService.recordPolicyDenial(identity, denialReason, { capability, tool });
 			}
 
 			this.auditService.recordToolResult({
@@ -497,24 +499,30 @@ export class McpTargetDiscoveryToolService {
 
 	private toProviderToolData(capability: McpCapability, result: ToolExecutionResult): ToolData {
 		const data = { status: result.status, ...(result.data ?? {}) };
+		const policyDenied =
+			result.status === ToolExecutionStatus.DENIED &&
+			(result.errorCode === 'TOOL_AUDIENCE_DENIED' || result.errorCode === 'TOOL_ACCESS_DENIED');
+		const outcome =
+			result.status === ToolExecutionStatus.DENIED && !policyDenied
+				? McpAuditOutcome.FAILED
+				: this.toAuditOutcome(result.status);
 
 		if (result.success) {
-			return { data, text: result.message, outcome: this.toAuditOutcome(result.status) };
+			return { data, text: result.message, outcome };
 		}
 
 		const invalid = result.errorCode === 'INVALID_TOOL_ARGUMENTS';
 		const notFound = result.errorCode?.endsWith('_NOT_FOUND') ?? false;
-		const denied = result.status === ToolExecutionStatus.DENIED;
 		const operation = capability === McpCapability.WRITE ? 'write' : 'trigger';
 
 		return {
 			data,
-			outcome: this.toAuditOutcome(result.status),
+			outcome,
 			text: invalid
 				? 'The tool arguments are invalid.'
 				: notFound
 					? 'The requested Smart Panel target was not found.'
-					: denied
+					: policyDenied
 						? `The MCP client is not authorized for this ${operation} operation.`
 						: `Smart Panel could not complete the requested ${operation} operation.`,
 			error: {
@@ -522,14 +530,14 @@ export class McpTargetDiscoveryToolService {
 					? 'invalid_request'
 					: notFound
 						? 'not_found'
-						: denied
+						: policyDenied
 							? 'permission_denied'
 							: `${operation}_failed`,
 				message: invalid
 					? 'The tool arguments are invalid.'
 					: notFound
 						? 'The requested Smart Panel target was not found.'
-						: denied
+						: policyDenied
 							? `The MCP client is not authorized for this ${operation} operation.`
 							: `Smart Panel could not complete the requested ${operation} operation.`,
 			},
@@ -553,7 +561,7 @@ export class McpTargetDiscoveryToolService {
 	}
 
 	private getAuditOutcome(error: unknown): McpAuditOutcome {
-		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+		if (this.getPolicyDenialReason(error)) {
 			return McpAuditOutcome.DENIED;
 		}
 
@@ -562,6 +570,18 @@ export class McpTargetDiscoveryToolService {
 		}
 
 		return McpAuditOutcome.FAILED;
+	}
+
+	private getPolicyDenialReason(error: unknown): McpAuditDenialReason | null {
+		if (error instanceof McpEndpointDisabledException) {
+			return 'endpoint_disabled';
+		}
+
+		if (error instanceof ForbiddenException || error instanceof UnauthorizedException) {
+			return 'capability_denied';
+		}
+
+		return null;
 	}
 
 	private toAuditOutcome(status: ToolExecutionStatus): McpAuditOutcome {

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -1273,6 +1273,10 @@ describe('VirtualIndexMaintenanceListener', () => {
 		});
 
 		it('leaves the source hidden when the deletion it read was rolled back', async () => {
+			let notifyStructuralChangeHandled!: () => void;
+			const structuralChangeHandled = new Promise<void>((resolve) => {
+				notifyStructuralChangeHandled = resolve;
+			});
 			const transaction = dataSource
 				.transaction(async (manager) => {
 					await manager.query('DELETE FROM links WHERE virtual_device_id = ?', ['virtual-device']);
@@ -1280,6 +1284,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 					// What DevicesService.remove() does: EventEmitter2.emit() runs listeners
 					// synchronously, from inside the still-open transaction.
 					subject.handleStructuralChange();
+					notifyStructuralChangeHandled();
 
 					// Holds the transaction open until the listener has given up waiting and read through
 					// it — the expiry this case is about, reproduced rather than assumed.
@@ -1289,6 +1294,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 				})
 				.catch((error: Error) => error.message);
 
+			await structuralChangeHandled;
 			await driveUntil(() => flagAtRebuild.length > 0);
 
 			// Preconditions, not the assertion: the pass really did read inside the open transaction,
@@ -1322,14 +1328,20 @@ describe('VirtualIndexMaintenanceListener', () => {
 		// the index dropped the source on the expired pass and reports no transition on the next one. The
 		// only thing that can unhide this device is the queued id being re-checked and acted on.
 		it('unhides the source once the deletion it read has committed', async () => {
+			let notifyStructuralChangeHandled!: () => void;
+			const structuralChangeHandled = new Promise<void>((resolve) => {
+				notifyStructuralChangeHandled = resolve;
+			});
 			const transaction = dataSource.transaction(async (manager) => {
 				await manager.query('DELETE FROM links WHERE virtual_device_id = ?', ['virtual-device']);
 
 				subject.handleStructuralChange();
+				notifyStructuralChangeHandled();
 
 				await indexStub.nextRead();
 			});
 
+			await structuralChangeHandled;
 			await driveUntil(() => flagAtRebuild.length > 0);
 
 			expect(flagAtRebuild).toEqual([true]);

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -11,6 +11,7 @@ import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
 import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
 import { MCP_CATALOG_REGISTRAR, McpCapability } from '../src/modules/mcp/mcp.constants';
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
@@ -93,13 +94,16 @@ describe('MCP endpoint', () => {
 		const policyService = {
 			authorizeClient: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
 		};
+		const auditService = new McpAuditService();
 		const readTools = new McpReadToolService(
 			contextService as unknown as McpContextService,
 			policyService as unknown as McpPolicyService,
+			auditService,
 		);
 		const moduleRef = await Test.createTestingModule({
 			controllers: [McpController],
 			providers: [
+				{ provide: McpAuditService, useValue: auditService },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: readTools },

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 7 complete — Phase 8 pending
+**Status:** Phase 8 complete — Phase 9 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -536,15 +536,20 @@ source of truth during permission races.
 - Modify MCP server/policy/client services
 - Add stats provider only if it follows existing metrics patterns cleanly
 
-- [ ] Log discovery/legacy initialization, authentication failure, subscription open/close, tool execution, policy
+- [x] Log discovery/legacy initialization, authentication failure, subscription open/close, tool execution, policy
       denial, timeout, and result.
-- [ ] Include request ID, MCP client ID, tool, capability, duration, and outcome.
-- [ ] Do not log bearer tokens, token hashes, authorization headers, secure values, or unrestricted raw arguments.
-- [ ] Redact or summarize values for device writes while retaining target IDs for investigation.
-- [ ] Add counters for active subscriptions, calls by capability/tool, failures, denials, and timeouts.
-- [ ] Make logs identify the source as `mcp-module` and preserve existing system logger conventions.
+- [x] Include request ID, MCP client ID, tool, capability, duration, and outcome.
+- [x] Do not log bearer tokens, token hashes, authorization headers, secure values, or unrestricted raw arguments.
+- [x] Redact or summarize values for device writes while retaining target IDs for investigation.
+- [x] Add counters for active subscriptions, calls by capability/tool, failures, denials, and timeouts.
+- [x] Make logs identify the source as `mcp-module` and preserve existing system logger conventions.
 
 **Tests:** redaction, success/failure records, metrics increments, and no token material in captured logs.
+
+**Outcome:** MCP protocol, policy, subscription, and tool lifecycle events now emit structured allowlisted audit records
+through the module logger. Raw credentials and tool values are excluded while write/trigger target IDs remain available
+for investigation. In-memory counters are exposed through the shared stats registry for active subscriptions, calls by
+capability/tool, failures, denials, and timeouts.
 
 ### Task 12: Build the admin MCP module
 


### PR DESCRIPTION
## Summary

- add structured MCP audit records for authentication failures, policy denials, protocol discovery and initialization, subscription lifecycle, and tool outcomes
- include request/client identity, tool, capability, duration, outcome, and allowlisted write or trigger target IDs
- exclude bearer tokens, token hashes, authorization headers, secure values, and unrestricted tool arguments from audit output
- add in-memory counters for active subscriptions, calls by capability and tool, failures, denials, and timeouts
- expose MCP counters through the shared stats registry and mark Phase 8 complete

## Why

MCP can read state and affect physical devices, so operators need useful investigation and health signals without creating a second sensitive-data exposure path. This change provides consistent module-scoped observability while deliberately omitting credentials and device values.

## Impact

MCP activity can now be traced through the existing `mcp-module` logger source, and operational counters are available through the repository's standard stats aggregation and Prometheus flow. Existing protocol responses and client authorization behavior remain unchanged.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp` — 17 suites passed, 186 tests passed
- `pnpm run test:unit` — 271 suites passed, 3,497 tests passed, 2 skipped
- `pnpm run test:e2e` — 8 suites passed, 98 tests passed
- MCP endpoint E2E — 1 suite passed, 7 tests passed
- backend ESLint passed for all changed TypeScript files
- backend Prettier check passed for all changed TypeScript files
- backend TypeScript type-check passed
- `git diff --check` passed
