### PR TITLE
feat(cross): finalize OpenAPI management contract

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -64,10 +64,10 @@ export type ConfigModuleUpdateModuleSchema = components['schemas']['ConfigModule
 // MCP Module Schemas
 export type McpModuleClientSchema = components['schemas']['McpModuleDataClient'];
 export type McpModuleClientCredentialSchema = components['schemas']['McpModuleDataClientCredential'];
-export type McpModuleCreateClientSchema = components['schemas']['CreateMcpClientDto'];
-export type McpModuleUpdateClientSchema = components['schemas']['UpdateMcpClientDto'];
-export type McpModuleRotateClientTokenSchema = components['schemas']['RotateMcpClientTokenDto'];
-export { CreateMcpClientDtoCapabilities as McpModuleCapability } from './openapi';
+export type McpModuleCreateClientSchema = components['schemas']['McpModuleCreateClient'];
+export type McpModuleUpdateClientSchema = components['schemas']['McpModuleUpdateClient'];
+export type McpModuleRotateClientTokenSchema = components['schemas']['McpModuleRotateClientToken'];
+export { McpModuleCreateClientCapabilities as McpModuleCapability } from './openapi';
 
 // Displays Module Schemas
 export type DisplaysModuleDisplaySchema = components['schemas']['DisplaysModuleDataDisplay'];
@@ -315,6 +315,7 @@ export type ConfigModuleGetConfigOperation = operations['get-config-module-confi
 
 // MCP Module Operations
 export type McpModuleGetClientsOperation = operations['get-mcp-module-clients'];
+export type McpModuleGetClientOperation = operations['get-mcp-module-client'];
 export type McpModuleCreateClientOperation = operations['create-mcp-module-client'];
 export type McpModuleUpdateClientOperation = operations['update-mcp-module-client'];
 export type McpModuleRotateClientTokenOperation = operations['rotate-mcp-module-client-token'];

--- a/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-client.dto.ts
@@ -20,6 +20,7 @@ import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
 import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, MCP_MAX_TOKEN_EXPIRATION_DAYS, McpCapability } from '../mcp.constants';
 
+@ApiSchema({ name: 'McpModuleCreateClient' })
 export class CreateMcpClientDto {
 	@ApiProperty({ description: 'Human-readable client name', type: 'string', example: 'Home assistant agent' })
 	@Expose()
@@ -68,6 +69,7 @@ export class CreateMcpClientDto {
 	expiresInDays: number = MCP_DEFAULT_TOKEN_EXPIRATION_DAYS;
 }
 
+@ApiSchema({ name: 'McpModuleUpdateClient' })
 export class UpdateMcpClientDto {
 	@ApiPropertyOptional({ description: 'Human-readable client name', type: 'string' })
 	@Expose()
@@ -104,6 +106,7 @@ export class UpdateMcpClientDto {
 	capabilities?: McpCapability[];
 }
 
+@ApiSchema({ name: 'McpModuleRotateClientToken' })
 export class RotateMcpClientTokenDto {
 	@ApiPropertyOptional({
 		name: 'expires_in_days',

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 9 complete — Phase 10 pending
+**Status:** Phase 10 complete — Phase 11 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -582,14 +582,19 @@ status views, localized copy, and focused schema/API/security interaction tests 
 
 ### Task 13: OpenAPI regeneration and generated clients
 
-- [ ] Add Swagger decorators and response models for MCP client-management endpoints.
-- [ ] Register all MCP management models in `mcp.openapi.ts`.
-- [ ] Run `pnpm run generate:openapi`.
-- [ ] Update only manually maintained exports in `apps/admin/src/openapi.constants.ts`.
-- [ ] Run the API convention and OpenAPI linters.
-- [ ] Confirm the raw MCP endpoint is not incorrectly represented as a normal JSON REST operation.
-- [ ] Run `melos rebuild-all` only if generated panel API changes are intentionally part of the repository's normal
+- [x] Add Swagger decorators and response models for MCP client-management endpoints.
+- [x] Register all MCP management models in `mcp.openapi.ts`.
+- [x] Run `pnpm run generate:openapi`.
+- [x] Update only manually maintained exports in `apps/admin/src/openapi.constants.ts`.
+- [x] Run the API convention and OpenAPI linters.
+- [x] Confirm the raw MCP endpoint is not incorrectly represented as a normal JSON REST operation.
+- [x] Run `melos rebuild-all` only if generated panel API changes are intentionally part of the repository's normal
       OpenAPI regeneration workflow; do not manually edit generated Dart files.
+
+**Outcome:** MCP management DTOs, request wrappers, response envelopes, client data, and configuration models are
+registered under module-scoped OpenAPI schema names. All seven management operations generate typed admin contracts,
+while the raw Streamable HTTP MCP transport remains excluded from the JSON REST specification. Panel regeneration was
+not run because generated panel API changes are not part of this admin management-contract phase.
 
 ### Task 14: End-to-end and compatibility verification
 


### PR DESCRIPTION
## Summary

- assign module-scoped OpenAPI schema names to MCP create, update, and credential-rotation DTOs
- update manually maintained admin schema and capability aliases to the regenerated contract
- expose the missing typed operation alias for retrieving one MCP client
- record Phase 10 completion and generated-client decisions in the MCP implementation plan

## Why

Phase 10 completes the MCP client-management OpenAPI contract. The DTOs previously relied on class-derived schema names, which did not follow the repository’s module naming conventions and made the generated client surface less stable.

## Impact

The seven MCP management operations now use consistently named schemas and complete typed admin aliases. The raw Streamable HTTP MCP transport remains excluded from the JSON REST specification. No panel source or generated Dart files are changed.

## Validation

- `pnpm run generate:openapi`
- `pnpm run lint:api` in `apps/backend`
- `pnpm run lint:openapi:spec` in `apps/backend`
- focused MCP DTO/module Jest tests — 2 suites, 6 tests passed
- admin Vue type-check passed
- focused backend/admin ESLint passed
