### PR TITLE
test(backend): complete phase 11 verification

### DIFF
--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -9,6 +9,9 @@ import { Test } from '@nestjs/testing';
 
 import { OpenApiResponseInterceptor } from '../src/modules/api/interceptors/open-api-response.interceptor';
 import { TransformResponseInterceptor } from '../src/modules/api/interceptors/transform-response.interceptor';
+import { ChannelsPropertiesService } from '../src/modules/devices/services/channels.properties.service';
+import { DeviceConnectionStateService } from '../src/modules/devices/services/device-connection-state.service';
+import { PlatformRegistryService } from '../src/modules/devices/services/platform.registry.service';
 import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
 import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
 import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
@@ -21,19 +24,18 @@ import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { McpReadToolService } from '../src/modules/mcp/tools/mcp-read-tool.service';
+import { McpTargetDiscoveryToolService } from '../src/modules/mcp/tools/mcp-target-discovery-tool.service';
+import { ScenesService } from '../src/modules/scenes/services/scenes.service';
+import { SpacesService } from '../src/modules/spaces/services/spaces.service';
+import {
+	ToolAccessKind,
+	ToolAudience,
+	createToolDefinition,
+} from '../src/modules/tools/platforms/tool-provider.platform';
+import { ToolProviderRegistryService } from '../src/modules/tools/services/tool-provider-registry.service';
 
 const AUTH_TOKEN = 'phase-4-client';
 const ALL_CAPABILITIES = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
-const CAPABILITY_SETS: McpCapability[][] = [
-	[],
-	[McpCapability.READ],
-	[McpCapability.WRITE],
-	[McpCapability.TRIGGER],
-	[McpCapability.READ, McpCapability.WRITE],
-	[McpCapability.READ, McpCapability.TRIGGER],
-	[McpCapability.WRITE, McpCapability.TRIGGER],
-	[...ALL_CAPABILITIES],
-];
 const READ_TOOLS = [
 	'get_home_context',
 	'get_device_state',
@@ -44,6 +46,25 @@ const READ_TOOLS = [
 ];
 const WRITE_TOOLS = ['list_writable_properties', 'set_device_property'];
 const TRIGGER_TOOLS = ['list_trigger_targets', 'run_scene', 'set_space_lighting'];
+const CAPABILITY_CASES: { capabilities: McpCapability[]; expectedTools: string[] }[] = [
+	{ capabilities: [], expectedTools: [] },
+	{ capabilities: [McpCapability.READ], expectedTools: [...READ_TOOLS] },
+	{ capabilities: [McpCapability.WRITE], expectedTools: [...WRITE_TOOLS] },
+	{ capabilities: [McpCapability.TRIGGER], expectedTools: [...TRIGGER_TOOLS] },
+	{
+		capabilities: [McpCapability.READ, McpCapability.WRITE],
+		expectedTools: [...READ_TOOLS, ...WRITE_TOOLS],
+	},
+	{
+		capabilities: [McpCapability.READ, McpCapability.TRIGGER],
+		expectedTools: [...READ_TOOLS, ...TRIGGER_TOOLS],
+	},
+	{
+		capabilities: [McpCapability.WRITE, McpCapability.TRIGGER],
+		expectedTools: [...WRITE_TOOLS, ...TRIGGER_TOOLS],
+	},
+	{ capabilities: [...ALL_CAPABILITIES], expectedTools: [...READ_TOOLS, ...WRITE_TOOLS, ...TRIGGER_TOOLS] },
+];
 
 interface TestClientPolicy {
 	capabilities: McpCapability[];
@@ -146,24 +167,54 @@ describe('MCP endpoint', () => {
 			policyService as unknown as McpPolicyService,
 			auditService,
 		);
+		const toolRegistry = new ToolProviderRegistryService();
+
+		toolRegistry.register({
+			getType: () => 'mcp-endpoint-catalog',
+			getToolDefinitions: () => [
+				createToolDefinition({
+					name: 'control_device',
+					description: 'Test device control provider.',
+					audiences: [ToolAudience.MCP],
+					access: ToolAccessKind.WRITE,
+					inputSchema: z.object({}),
+					outputSchema: z.object({}),
+				}),
+				createToolDefinition({
+					name: 'run_scene',
+					description: 'Test scene provider.',
+					audiences: [ToolAudience.MCP],
+					access: ToolAccessKind.TRIGGER,
+					inputSchema: z.object({}),
+					outputSchema: z.object({}),
+				}),
+				createToolDefinition({
+					name: 'set_space_lighting',
+					description: 'Test space lighting provider.',
+					audiences: [ToolAudience.MCP],
+					access: ToolAccessKind.TRIGGER,
+					inputSchema: z.object({}),
+					outputSchema: z.object({}),
+				}),
+			],
+			executeTool: jest.fn().mockResolvedValue(null),
+		});
+
+		const targetTools = new McpTargetDiscoveryToolService(
+			{} as ChannelsPropertiesService,
+			{} as DeviceConnectionStateService,
+			{} as PlatformRegistryService,
+			{} as ScenesService,
+			{} as SpacesService,
+			toolRegistry,
+			contextService as unknown as McpContextService,
+			policyService as unknown as McpPolicyService,
+			auditService,
+		);
 		const catalog = {
 			register(server: McpServer, authInfo?: AuthInfo): void {
 				readTools.register(server, authInfo);
-
-				for (const name of supplementalCatalogTools(authInfo?.scopes ?? [])) {
-					server.registerTool(
-						name,
-						{
-							description: `Test ${name} operation.`,
-							inputSchema: z.object({}),
-							outputSchema: z.object({ tool: z.string() }),
-						},
-						() => ({
-							content: [{ type: 'text', text: name }],
-							structuredContent: { tool: name },
-						}),
-					);
-				}
+				targetTools.register(server, authInfo);
 			},
 		};
 		const moduleRef = await Test.createTestingModule({
@@ -264,9 +315,9 @@ describe('MCP endpoint', () => {
 		}
 	});
 
-	it.each(CAPABILITY_SETS.map((capabilities, index) => ({ capabilities, index })))(
+	it.each(CAPABILITY_CASES.map((testCase, index) => ({ ...testCase, index })))(
 		'exposes the exact catalog for module capability set $capabilities',
-		async ({ capabilities, index }) => {
+		async ({ capabilities, expectedTools, index }) => {
 			const clientId = `module-matrix-${index}`;
 
 			moduleCapabilities = [...capabilities];
@@ -279,7 +330,7 @@ describe('MCP endpoint', () => {
 				const tools = await client.listTools();
 				const resources = await client.listResources();
 
-				expect(tools.tools.map(({ name }) => name)).toEqual(catalogTools(capabilities));
+				expect(tools.tools.map(({ name }) => name)).toEqual(expectedTools);
 				expect(resources.resources.length > 0).toBe(capabilities.includes(McpCapability.READ));
 			} finally {
 				await client.close();
@@ -318,7 +369,7 @@ describe('MCP endpoint', () => {
 				const tools = await client.listTools();
 				const resources = await client.listResources();
 
-				expect(tools.tools.map(({ name }) => name)).toEqual(catalogTools(expected));
+				expect(tools.tools.map(({ name }) => name)).toEqual(expectedCatalogTools(expected));
 				expect(resources.resources.length > 0).toBe(expected.includes(McpCapability.READ));
 			} finally {
 				await client.close();
@@ -394,7 +445,9 @@ describe('MCP endpoint', () => {
 
 			serverService.notifyToolsChanged('client-a');
 
-			await expect(Promise.race([notification, timeout(2_000)])).resolves.toBeUndefined();
+			await expect(
+				Promise.race([notification, rejectAfter(2_000, 'Timed out waiting for tools/list_changed')]),
+			).resolves.toBeUndefined();
 
 			const secondClosedBeforeTargetClose = await Promise.race([
 				secondSubscription.closed.then(() => true),
@@ -433,14 +486,16 @@ describe('MCP endpoint', () => {
 			const subscription = await connection.client.listen({ toolsListChanged: true });
 
 			expect((await connection.client.listTools()).tools.map(({ name }) => name)).toEqual(
-				catalogTools(ALL_CAPABILITIES),
+				expectedCatalogTools(ALL_CAPABILITIES),
 			);
 
 			clientPolicies.set(clientId, { capabilities: [McpCapability.READ] });
 			serverService.invalidateClientPolicy(clientId);
 			serverService.notifyToolsChanged(clientId);
 
-			await expect(Promise.race([notification, timeout(2_000)])).resolves.toBeUndefined();
+			await expect(
+				Promise.race([notification, rejectAfter(2_000, 'Timed out waiting for tools/list_changed')]),
+			).resolves.toBeUndefined();
 			expect((await connection.client.listTools()).tools.map(({ name }) => name)).toEqual(READ_TOOLS);
 			expect(subscriptions.countForClient(clientId)).toBe(1);
 
@@ -496,15 +551,16 @@ describe('MCP endpoint', () => {
 		});
 	}
 
-	function catalogTools(capabilities: readonly string[]): string[] {
-		return [
-			...(capabilities.includes(McpCapability.READ) ? READ_TOOLS : []),
-			...supplementalCatalogTools(capabilities),
-		];
+	function rejectAfter(milliseconds: number, message: string): Promise<never> {
+		return new Promise((_, reject) => {
+			const timer = setTimeout(() => reject(new Error(message)), milliseconds);
+			timer.unref();
+		});
 	}
 
-	function supplementalCatalogTools(capabilities: readonly string[]): string[] {
+	function expectedCatalogTools(capabilities: readonly string[]): string[] {
 		return [
+			...(capabilities.includes(McpCapability.READ) ? READ_TOOLS : []),
 			...(capabilities.includes(McpCapability.WRITE) ? WRITE_TOOLS : []),
 			...(capabilities.includes(McpCapability.TRIGGER) ? TRIGGER_TOOLS : []),
 		];

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -470,8 +470,13 @@ describe('MCP endpoint', () => {
 		const notification = new Promise<void>((resolve) => {
 			resolveNotification = resolve;
 		});
+		let resolveUnexpectedNotification!: () => void;
+		const unexpectedNotification = new Promise<void>((resolve) => {
+			resolveUnexpectedNotification = resolve;
+		});
 
 		first.client.setNotificationHandler('notifications/tools/list_changed', () => resolveNotification());
+		second.client.setNotificationHandler('notifications/tools/list_changed', () => resolveUnexpectedNotification());
 
 		try {
 			await first.client.connect(first.transport);
@@ -498,8 +503,13 @@ describe('MCP endpoint', () => {
 				secondSubscription.closed.then(() => true),
 				timeout(50).then(() => false),
 			]);
+			const secondNotified = await Promise.race([
+				unexpectedNotification.then(() => true),
+				timeout(50).then(() => false),
+			]);
 
 			expect(secondClosedBeforeTargetClose).toBe(false);
+			expect(secondNotified).toBe(false);
 
 			await serverService.closeClient('client-a');
 

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -1,5 +1,8 @@
+import { z } from 'zod';
+
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthInfo, McpServer } from '@modelcontextprotocol/server';
+import { CanActivate, ExecutionContext, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
@@ -20,6 +23,36 @@ import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-
 import { McpReadToolService } from '../src/modules/mcp/tools/mcp-read-tool.service';
 
 const AUTH_TOKEN = 'phase-4-client';
+const ALL_CAPABILITIES = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
+const CAPABILITY_SETS: McpCapability[][] = [
+	[],
+	[McpCapability.READ],
+	[McpCapability.WRITE],
+	[McpCapability.TRIGGER],
+	[McpCapability.READ, McpCapability.WRITE],
+	[McpCapability.READ, McpCapability.TRIGGER],
+	[McpCapability.WRITE, McpCapability.TRIGGER],
+	[...ALL_CAPABILITIES],
+];
+const READ_TOOLS = [
+	'get_home_context',
+	'get_device_state',
+	'get_property_timeseries',
+	'get_energy_summary',
+	'get_weather',
+	'get_security_status',
+];
+const WRITE_TOOLS = ['list_writable_properties', 'set_device_property'];
+const TRIGGER_TOOLS = ['list_trigger_targets', 'run_scene', 'set_space_lighting'];
+
+interface TestClientPolicy {
+	capabilities: McpCapability[];
+	revoked?: boolean;
+}
+
+let endpointEnabled = true;
+let moduleCapabilities = [...ALL_CAPABILITIES];
+const clientPolicies = new Map<string, TestClientPolicy>();
 
 @Injectable()
 class TestMcpClientGuard implements CanActivate {
@@ -28,11 +61,24 @@ class TestMcpClientGuard implements CanActivate {
 	canActivate(context: ExecutionContext): boolean {
 		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
 		const clientId = request.headers.authorization?.replace(/^Bearer /, '') || AUTH_TOKEN;
+		const clientPolicy = clientPolicies.get(clientId) ?? { capabilities: [McpCapability.READ] };
+
+		if (!endpointEnabled) {
+			throw new NotFoundException('MCP endpoint is disabled');
+		}
+
+		if (clientPolicy.revoked) {
+			throw new UnauthorizedException('MCP credential is no longer active');
+		}
+
+		const effectiveCapabilities = clientPolicy.capabilities.filter((capability) =>
+			moduleCapabilities.includes(capability),
+		);
 		const client = {
 			id: clientId,
 			name: `Test ${clientId}`,
 			enabled: true,
-			capabilities: [McpCapability.READ],
+			capabilities: [...clientPolicy.capabilities],
 			tokenId: `token-${clientId}`,
 			token: {
 				id: `token-${clientId}`,
@@ -46,9 +92,9 @@ class TestMcpClientGuard implements CanActivate {
 			clientPolicyRevision: this.serverService.getClientPolicyRevision(client.id),
 			config: Object.assign(new McpConfigModel(), {
 				enabled: true,
-				capabilities: [McpCapability.READ],
+				capabilities: [...moduleCapabilities],
 			}),
-			effectiveCapabilities: [McpCapability.READ],
+			effectiveCapabilities,
 			installationId: 'phase-4-installation',
 			policyRevision: this.serverService.getPolicyRevision(),
 			tokenId: client.tokenId,
@@ -100,13 +146,33 @@ describe('MCP endpoint', () => {
 			policyService as unknown as McpPolicyService,
 			auditService,
 		);
+		const catalog = {
+			register(server: McpServer, authInfo?: AuthInfo): void {
+				readTools.register(server, authInfo);
+
+				for (const name of supplementalCatalogTools(authInfo?.scopes ?? [])) {
+					server.registerTool(
+						name,
+						{
+							description: `Test ${name} operation.`,
+							inputSchema: z.object({}),
+							outputSchema: z.object({ tool: z.string() }),
+						},
+						() => ({
+							content: [{ type: 'text', text: name }],
+							structuredContent: { tool: name },
+						}),
+					);
+				}
+			},
+		};
 		const moduleRef = await Test.createTestingModule({
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
 				McpServerService,
 				McpSubscriptionRegistryService,
-				{ provide: MCP_CATALOG_REGISTRAR, useValue: readTools },
+				{ provide: MCP_CATALOG_REGISTRAR, useValue: catalog },
 			],
 		})
 			.overrideGuard(McpClientGuard)
@@ -126,6 +192,9 @@ describe('MCP endpoint', () => {
 
 	afterEach(async () => {
 		await serverService.closeAll();
+		endpointEnabled = true;
+		moduleCapabilities = [...ALL_CAPABILITIES];
+		clientPolicies.clear();
 	});
 
 	afterAll(async () => {
@@ -195,6 +264,68 @@ describe('MCP endpoint', () => {
 		}
 	});
 
+	it.each(CAPABILITY_SETS.map((capabilities, index) => ({ capabilities, index })))(
+		'exposes the exact catalog for module capability set $capabilities',
+		async ({ capabilities, index }) => {
+			const clientId = `module-matrix-${index}`;
+
+			moduleCapabilities = [...capabilities];
+			clientPolicies.set(clientId, { capabilities: [...ALL_CAPABILITIES] });
+			const { client, transport } = createClient(clientId, 'auto');
+
+			try {
+				await client.connect(transport);
+
+				const tools = await client.listTools();
+				const resources = await client.listResources();
+
+				expect(tools.tools.map(({ name }) => name)).toEqual(catalogTools(capabilities));
+				expect(resources.resources.length > 0).toBe(capabilities.includes(McpCapability.READ));
+			} finally {
+				await client.close();
+			}
+		},
+	);
+
+	it.each([
+		{
+			module: [McpCapability.READ, McpCapability.WRITE],
+			client: [McpCapability.WRITE, McpCapability.TRIGGER],
+			expected: [McpCapability.WRITE],
+		},
+		{
+			module: [McpCapability.READ, McpCapability.TRIGGER],
+			client: [McpCapability.READ, McpCapability.WRITE],
+			expected: [McpCapability.READ],
+		},
+		{
+			module: [McpCapability.WRITE, McpCapability.TRIGGER],
+			client: [McpCapability.TRIGGER],
+			expected: [McpCapability.TRIGGER],
+		},
+		{ module: [...ALL_CAPABILITIES], client: [], expected: [] },
+	])(
+		'intersects module $module with client $client before discovery',
+		async ({ module, client: clientCapabilities, expected }) => {
+			const clientId = `intersection-${module.join('-')}-${clientCapabilities.join('-') || 'none'}`;
+
+			moduleCapabilities = [...module];
+			clientPolicies.set(clientId, { capabilities: [...clientCapabilities] });
+			const { client, transport } = createClient(clientId, 'auto');
+
+			try {
+				await client.connect(transport);
+				const tools = await client.listTools();
+				const resources = await client.listResources();
+
+				expect(tools.tools.map(({ name }) => name)).toEqual(catalogTools(expected));
+				expect(resources.resources.length > 0).toBe(expected.includes(McpCapability.READ));
+			} finally {
+				await client.close();
+			}
+		},
+	);
+
 	it.each(['GET', 'DELETE'])('returns the SDK-defined 405 for legacy %s operations', async (method) => {
 		const response = await fetch(endpoint, {
 			method,
@@ -235,6 +366,8 @@ describe('MCP endpoint', () => {
 	});
 
 	it('delivers targeted list changes and closes only the selected client stream', async () => {
+		clientPolicies.set('client-a', { capabilities: [McpCapability.READ] });
+		clientPolicies.set('client-b', { capabilities: [McpCapability.TRIGGER] });
 		const first = createClient('client-a', 'auto');
 		const second = createClient('client-b', 'auto');
 		let resolveNotification!: () => void;
@@ -247,8 +380,14 @@ describe('MCP endpoint', () => {
 		try {
 			await first.client.connect(first.transport);
 			await second.client.connect(second.transport);
+			const [firstTools, secondTools] = await Promise.all([first.client.listTools(), second.client.listTools()]);
 			const firstSubscription = await first.client.listen({ toolsListChanged: true });
 			const secondSubscription = await second.client.listen({ toolsListChanged: true });
+
+			expect(firstTools.tools.map(({ name }) => name)).toEqual(READ_TOOLS);
+			expect(secondTools.tools.map(({ name }) => name)).toEqual(TRIGGER_TOOLS);
+			expect(first.client.getInstructions()).toContain('Client Test client-a. Effective capabilities: read.');
+			expect(second.client.getInstructions()).toContain('Client Test client-b. Effective capabilities: trigger.');
 
 			expect(subscriptions.countForClient('client-a')).toBe(1);
 			expect(subscriptions.countForClient('client-b')).toBe(1);
@@ -277,6 +416,70 @@ describe('MCP endpoint', () => {
 		}
 	});
 
+	it('applies a permission reduction and notifies a client that remains connected', async () => {
+		const clientId = 'mutable-client';
+
+		clientPolicies.set(clientId, { capabilities: [...ALL_CAPABILITIES] });
+		const connection = createClient(clientId, 'auto');
+		let resolveNotification!: () => void;
+		const notification = new Promise<void>((resolve) => {
+			resolveNotification = resolve;
+		});
+
+		connection.client.setNotificationHandler('notifications/tools/list_changed', () => resolveNotification());
+
+		try {
+			await connection.client.connect(connection.transport);
+			const subscription = await connection.client.listen({ toolsListChanged: true });
+
+			expect((await connection.client.listTools()).tools.map(({ name }) => name)).toEqual(
+				catalogTools(ALL_CAPABILITIES),
+			);
+
+			clientPolicies.set(clientId, { capabilities: [McpCapability.READ] });
+			serverService.invalidateClientPolicy(clientId);
+			serverService.notifyToolsChanged(clientId);
+
+			await expect(Promise.race([notification, timeout(2_000)])).resolves.toBeUndefined();
+			expect((await connection.client.listTools()).tools.map(({ name }) => name)).toEqual(READ_TOOLS);
+			expect(subscriptions.countForClient(clientId)).toBe(1);
+
+			await subscription.close();
+		} finally {
+			await connection.client.close();
+		}
+	});
+
+	it('closes only the revoked client and rejects its next request', async () => {
+		const revokedId = 'revoked-client';
+		const activeId = 'active-client';
+
+		clientPolicies.set(revokedId, { capabilities: [McpCapability.READ] });
+		clientPolicies.set(activeId, { capabilities: [McpCapability.READ] });
+		const revoked = createClient(revokedId, 'auto');
+		const active = createClient(activeId, 'auto');
+
+		try {
+			await revoked.client.connect(revoked.transport);
+			await active.client.connect(active.transport);
+			const revokedSubscription = await revoked.client.listen({ toolsListChanged: true });
+			const activeSubscription = await active.client.listen({ toolsListChanged: true });
+
+			clientPolicies.set(revokedId, { capabilities: [McpCapability.READ], revoked: true });
+			await serverService.closeClient(revokedId);
+
+			await expect(revokedSubscription.closed).resolves.toBe('remote');
+			await expect(revoked.client.listTools()).rejects.toThrow();
+			expect((await active.client.listTools()).tools.map(({ name }) => name)).toEqual(READ_TOOLS);
+			expect(subscriptions.countForClient(activeId)).toBe(1);
+
+			await activeSubscription.close();
+		} finally {
+			await revoked.client.close();
+			await active.client.close();
+		}
+	});
+
 	function createClient(name: string, mode?: 'auto') {
 		const client = new Client({ name, version: '1.0.0' }, mode ? { versionNegotiation: { mode } } : undefined);
 		const transport = new StreamableHTTPClientTransport(endpoint, {
@@ -291,5 +494,19 @@ describe('MCP endpoint', () => {
 			const timer = setTimeout(resolve, milliseconds);
 			timer.unref();
 		});
+	}
+
+	function catalogTools(capabilities: readonly string[]): string[] {
+		return [
+			...(capabilities.includes(McpCapability.READ) ? READ_TOOLS : []),
+			...supplementalCatalogTools(capabilities),
+		];
+	}
+
+	function supplementalCatalogTools(capabilities: readonly string[]): string[] {
+		return [
+			...(capabilities.includes(McpCapability.WRITE) ? WRITE_TOOLS : []),
+			...(capabilities.includes(McpCapability.TRIGGER) ? TRIGGER_TOOLS : []),
+		];
 	}
 });

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -1,14 +1,18 @@
+import { DataSource, Repository } from 'typeorm';
 import { z } from 'zod';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { AuthInfo, McpServer } from '@modelcontextprotocol/server';
 import { CanActivate, ExecutionContext, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
 
 import { OpenApiResponseInterceptor } from '../src/modules/api/interceptors/open-api-response.interceptor';
 import { TransformResponseInterceptor } from '../src/modules/api/interceptors/transform-response.interceptor';
+import { TokensService } from '../src/modules/auth/services/tokens.service';
+import { ConfigService } from '../src/modules/config/services/config.service';
 import { ChannelsPropertiesService } from '../src/modules/devices/services/channels.properties.service';
 import { DeviceConnectionStateService } from '../src/modules/devices/services/device-connection-state.service';
 import { PlatformRegistryService } from '../src/modules/devices/services/platform.registry.service';
@@ -18,7 +22,9 @@ import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
 import { MCP_CATALOG_REGISTRAR, McpCapability } from '../src/modules/mcp/mcp.constants';
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
+import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
@@ -128,6 +134,7 @@ class TestMcpClientGuard implements CanActivate {
 describe('MCP endpoint', () => {
 	let app: NestFastifyApplication;
 	let endpoint: URL;
+	let clientsService: McpClientService;
 	let serverService: McpServerService;
 	let subscriptions: McpSubscriptionRegistryService;
 
@@ -237,6 +244,44 @@ describe('MCP endpoint', () => {
 		await app.listen(0, '127.0.0.1');
 
 		serverService = app.get(McpServerService);
+		const repository = {
+			findOne: jest.fn(({ where }: { where: { id: string } }) => Promise.resolve(toClientEntity(where.id))),
+		};
+		const managedRepository = {
+			update: jest.fn((criteria: { id: string }, update: Partial<McpClientEntity>) => {
+				const policy = clientPolicies.get(criteria.id);
+
+				if (!policy) {
+					return Promise.resolve({ affected: 0 });
+				}
+
+				if (update.capabilities) {
+					policy.capabilities = [...update.capabilities];
+				}
+
+				if (update.enabled === false) {
+					policy.revoked = true;
+				}
+
+				return Promise.resolve({ affected: 1 });
+			}),
+		};
+		const dataSource = {
+			transaction: jest.fn((callback: (manager: { getRepository: () => typeof managedRepository }) => unknown) =>
+				callback({ getRepository: () => managedRepository }),
+			),
+		};
+		clientsService = new McpClientService(
+			repository as unknown as Repository<McpClientEntity>,
+			dataSource as unknown as DataSource,
+			{ revoke: jest.fn().mockResolvedValue(undefined) } as unknown as TokensService,
+			{} as JwtService,
+			{
+				getModuleConfig: jest.fn(() => ({ capabilities: [...moduleCapabilities] })),
+			} as unknown as ConfigService,
+			{} as McpInstallationService,
+			serverService,
+		);
 		subscriptions = app.get(McpSubscriptionRegistryService);
 		endpoint = new URL('/', await app.getUrl());
 	});
@@ -489,9 +534,7 @@ describe('MCP endpoint', () => {
 				expectedCatalogTools(ALL_CAPABILITIES),
 			);
 
-			clientPolicies.set(clientId, { capabilities: [McpCapability.READ] });
-			serverService.invalidateClientPolicy(clientId);
-			serverService.notifyToolsChanged(clientId);
+			await clientsService.update(clientId, { capabilities: [McpCapability.READ] });
 
 			await expect(
 				Promise.race([notification, rejectAfter(2_000, 'Timed out waiting for tools/list_changed')]),
@@ -520,8 +563,7 @@ describe('MCP endpoint', () => {
 			const revokedSubscription = await revoked.client.listen({ toolsListChanged: true });
 			const activeSubscription = await active.client.listen({ toolsListChanged: true });
 
-			clientPolicies.set(revokedId, { capabilities: [McpCapability.READ], revoked: true });
-			await serverService.closeClient(revokedId);
+			await clientsService.revoke(revokedId);
 
 			await expect(revokedSubscription.closed).resolves.toBe('remote');
 			await expect(revoked.client.listTools()).rejects.toThrow();
@@ -542,6 +584,29 @@ describe('MCP endpoint', () => {
 		});
 
 		return { client, transport };
+	}
+
+	function toClientEntity(clientId: string): McpClientEntity | null {
+		const policy = clientPolicies.get(clientId);
+
+		if (!policy) {
+			return null;
+		}
+
+		return {
+			id: clientId,
+			name: `Test ${clientId}`,
+			description: null,
+			enabled: !policy.revoked,
+			capabilities: [...policy.capabilities],
+			createdById: null,
+			tokenId: `token-${clientId}`,
+			token: {
+				id: `token-${clientId}`,
+				revoked: Boolean(policy.revoked),
+				expiresAt: new Date(Date.now() + 60_000),
+			},
+		} as McpClientEntity;
 	}
 
 	function timeout(milliseconds: number): Promise<void> {

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -1,0 +1,377 @@
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+
+import { OpenApiResponseInterceptor } from '../src/modules/api/interceptors/open-api-response.interceptor';
+import { TransformResponseInterceptor } from '../src/modules/api/interceptors/transform-response.interceptor';
+import { PermissionType } from '../src/modules/devices/devices.constants';
+import { ChannelEntity, ChannelPropertyEntity } from '../src/modules/devices/entities/devices.entity';
+import { ChannelsPropertiesService } from '../src/modules/devices/services/channels.properties.service';
+import { DeviceConnectionStateService } from '../src/modules/devices/services/device-connection-state.service';
+import { DeviceControlToolService } from '../src/modules/devices/services/device-control-tool.service';
+import { PlatformRegistryService } from '../src/modules/devices/services/platform.registry.service';
+import { PropertyCommandService } from '../src/modules/devices/services/property-command.service';
+import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
+import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
+import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
+import { MCP_CATALOG_REGISTRAR, McpCapability } from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
+import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+import { McpTargetDiscoveryToolService } from '../src/modules/mcp/tools/mcp-target-discovery-tool.service';
+import { SceneExecutorService } from '../src/modules/scenes/services/scene-executor.service';
+import { SceneToolService } from '../src/modules/scenes/services/scene-tool.service';
+import { ScenesService } from '../src/modules/scenes/services/scenes.service';
+import { SpacesService } from '../src/modules/spaces/services/spaces.service';
+import { ToolAudience } from '../src/modules/tools/platforms/tool-provider.platform';
+import { ShortIdMappingService } from '../src/modules/tools/services/short-id-mapping.service';
+import { ToolProviderRegistryService } from '../src/modules/tools/services/tool-provider-registry.service';
+import { SimulatorDeviceEntity } from '../src/plugins/simulator/entities/simulator.entity';
+import { SimulatorDevicePlatform } from '../src/plugins/simulator/platforms/simulator-device.platform';
+import { DeviceBehaviorManagerService } from '../src/plugins/simulator/services/device-behavior-manager.service';
+import { SIMULATOR_TYPE } from '../src/plugins/simulator/simulator.constants';
+import { SpaceLightingToolService } from '../src/plugins/spaces-home-control/services/space-lighting-tool.service';
+
+const CLIENT_ID = 'simulator-client';
+const PROPERTY_ID = '10000000-0000-4000-8000-000000000001';
+const CHANNEL_ID = '20000000-0000-4000-8000-000000000001';
+const DEVICE_ID = '30000000-0000-4000-8000-000000000001';
+const SCENE_ID = '40000000-0000-4000-8000-000000000001';
+const SPACE_ID = '50000000-0000-4000-8000-000000000001';
+const ALL_CAPABILITIES = [McpCapability.WRITE, McpCapability.TRIGGER];
+let runtimeCapabilities = [...ALL_CAPABILITIES];
+
+@Injectable()
+class TestOperationsGuard implements CanActivate {
+	constructor(private readonly serverService: McpServerService) {}
+
+	canActivate(context: ExecutionContext): boolean {
+		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
+		const client = {
+			id: CLIENT_ID,
+			name: 'Simulator MCP client',
+			enabled: true,
+			capabilities: [...ALL_CAPABILITIES],
+			tokenId: 'simulator-token-id',
+			token: {
+				id: 'simulator-token-id',
+				revoked: false,
+				expiresAt: new Date(Date.now() + 60_000),
+			},
+		} as McpClientEntity;
+
+		request.mcpPolicy = {
+			client,
+			clientPolicyRevision: this.serverService.getClientPolicyRevision(client.id),
+			config: Object.assign(new McpConfigModel(), { enabled: true, capabilities: [...ALL_CAPABILITIES] }),
+			effectiveCapabilities: [...ALL_CAPABILITIES],
+			installationId: 'simulator-installation',
+			policyRevision: this.serverService.getPolicyRevision(),
+			tokenId: client.tokenId,
+		};
+
+		return true;
+	}
+}
+
+describe('MCP simulator operations', () => {
+	let app: NestFastifyApplication;
+	let endpoint: URL;
+	let serverService: McpServerService;
+	let channelsPropertiesService: { findOne: jest.Mock; findWritableCandidates: jest.Mock; update: jest.Mock };
+	let propertyCommandService: { executePropertyCommandById: jest.Mock };
+	let behaviorManager: { handlePropertyChange: jest.Mock };
+	let sceneExecutor: { triggerScene: jest.Mock };
+	let spaceIntentService: { executeLightingIntent: jest.Mock };
+	let simulatorProperty: ChannelPropertyEntity;
+
+	beforeAll(async () => {
+		const simulatorDevice = {
+			id: DEVICE_ID,
+			name: 'Simulator outlet',
+			type: SIMULATOR_TYPE,
+			enabled: true,
+			hidden: false,
+		} as SimulatorDeviceEntity;
+		const simulatorChannel = {
+			id: CHANNEL_ID,
+			name: 'Simulator outlet channel',
+			category: 'outlet',
+			device: simulatorDevice,
+		} as unknown as ChannelEntity;
+
+		simulatorProperty = {
+			id: PROPERTY_ID,
+			name: 'On',
+			type: SIMULATOR_TYPE,
+			category: 'on',
+			permissions: [PermissionType.READ_WRITE],
+			dataType: 'bool',
+			value: { value: false },
+			channel: simulatorChannel,
+		} as ChannelPropertyEntity;
+		channelsPropertiesService = {
+			findOne: jest.fn().mockResolvedValue(simulatorProperty),
+			findWritableCandidates: jest.fn().mockResolvedValue({ properties: [simulatorProperty], total: 1 }),
+			update: jest.fn().mockImplementation((_id: string, dto: { value: unknown }) => {
+				simulatorProperty.value = { value: dto.value } as ChannelPropertyEntity['value'];
+
+				return Promise.resolve();
+			}),
+		};
+		behaviorManager = { handlePropertyChange: jest.fn() };
+		const simulatorPlatform = new SimulatorDevicePlatform(
+			channelsPropertiesService as unknown as ChannelsPropertiesService,
+			behaviorManager as unknown as DeviceBehaviorManagerService,
+		);
+		propertyCommandService = {
+			executePropertyCommandById: jest
+				.fn()
+				.mockImplementation(async (propertyId: string, value: string | number | boolean) => ({
+					device: DEVICE_ID,
+					deviceName: simulatorDevice.name,
+					channel: CHANNEL_ID,
+					property: PROPERTY_ID,
+					value,
+					success:
+						propertyId === PROPERTY_ID &&
+						(await simulatorPlatform.process({
+							device: simulatorDevice,
+							channel: simulatorChannel,
+							property: simulatorProperty,
+							value,
+						})),
+				})),
+		};
+		const scenesService = {
+			findOne: jest.fn().mockResolvedValue({ id: SCENE_ID, name: 'Simulator evening', enabled: true }),
+			findTriggerableSummaryPage: jest.fn().mockResolvedValue({
+				scenes: [
+					{
+						id: SCENE_ID,
+						name: 'Simulator evening',
+						category: 'generic',
+						primarySpaceId: SPACE_ID,
+						enabled: true,
+						triggerable: true,
+					},
+				],
+				total: 1,
+			}),
+		};
+		sceneExecutor = {
+			triggerScene: jest.fn().mockResolvedValue({ status: 'completed', successfulActions: 1, totalActions: 1 }),
+		};
+		const spacesService = {
+			findOne: jest.fn().mockResolvedValue({ id: SPACE_ID, name: 'Simulator living room' }),
+			findLightingTriggerSummaryPage: jest.fn().mockResolvedValue({
+				spaces: [{ id: SPACE_ID, name: 'Simulator living room', type: 'room' }],
+				total: 1,
+			}),
+		};
+		spaceIntentService = {
+			executeLightingIntent: jest
+				.fn()
+				.mockResolvedValue({ success: true, affectedDevices: 1, failedDevices: 0, skippedOfflineDevices: 0 }),
+		};
+		const shortIds = new ShortIdMappingService();
+		const deviceProvider = new DeviceControlToolService(
+			propertyCommandService as unknown as PropertyCommandService,
+			shortIds,
+		);
+		const sceneProvider = new SceneToolService(
+			scenesService as unknown as ScenesService,
+			sceneExecutor as unknown as SceneExecutorService,
+			shortIds,
+		);
+		const lightingProvider = new SpaceLightingToolService(
+			spacesService as unknown as SpacesService,
+			{ get: jest.fn().mockReturnValue(spaceIntentService) } as never,
+			shortIds,
+		);
+
+		await lightingProvider.onModuleInit();
+
+		const toolRegistry = new ToolProviderRegistryService();
+
+		toolRegistry.register(deviceProvider);
+		toolRegistry.register(sceneProvider);
+		toolRegistry.register(lightingProvider);
+
+		const contextService = {
+			getInstallation: jest.fn().mockImplementation((capabilities: McpCapability[], endpointUrl?: string) => ({
+				id: 'simulator-installation',
+				name: 'MCP E2E Simulator',
+				version: '1.0.0',
+				timezone: 'UTC',
+				endpoint: endpointUrl ?? null,
+				effective_capabilities: [...capabilities],
+			})),
+		};
+		const policyService = {
+			authorizeClient: jest.fn().mockImplementation((_tokenId, clientId: string, capability: McpCapability) => {
+				if (!runtimeCapabilities.includes(capability)) {
+					throw new ForbiddenException(`MCP capability '${capability}' is not granted`);
+				}
+
+				return { client: { id: clientId }, effectiveCapabilities: [...runtimeCapabilities] };
+			}),
+		};
+		const auditService = new McpAuditService();
+		const targetTools = new McpTargetDiscoveryToolService(
+			channelsPropertiesService as unknown as ChannelsPropertiesService,
+			{ readLatestMany: jest.fn().mockResolvedValue(new Map()) } as unknown as DeviceConnectionStateService,
+			{ get: jest.fn().mockReturnValue(simulatorPlatform) } as unknown as PlatformRegistryService,
+			scenesService as unknown as ScenesService,
+			spacesService as unknown as SpacesService,
+			toolRegistry,
+			contextService as unknown as McpContextService,
+			policyService as unknown as McpPolicyService,
+			auditService,
+		);
+		const moduleRef = await Test.createTestingModule({
+			controllers: [McpController],
+			providers: [
+				{ provide: McpAuditService, useValue: auditService },
+				McpServerService,
+				McpSubscriptionRegistryService,
+				{ provide: MCP_CATALOG_REGISTRAR, useValue: targetTools },
+			],
+		})
+			.overrideGuard(McpClientGuard)
+			.useClass(TestOperationsGuard)
+			.compile();
+
+		app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+		const reflector = app.get(Reflector);
+
+		app.useGlobalInterceptors(new OpenApiResponseInterceptor(reflector), new TransformResponseInterceptor(reflector));
+		await app.listen(0, '127.0.0.1');
+
+		serverService = app.get(McpServerService);
+		endpoint = new URL('/', await app.getUrl());
+	}, 30_000);
+
+	afterAll(async () => {
+		await serverService.closeAll();
+		await app.close();
+	});
+
+	it('executes write and trigger tools against the simulator with MCP traces', async () => {
+		const client = new Client(
+			{ name: 'simulator-e2e-client', version: '1.0.0' },
+			{ versionNegotiation: { mode: 'auto' } },
+		);
+		const transport = new StreamableHTTPClientTransport(endpoint, {
+			requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
+		});
+
+		try {
+			await client.connect(transport);
+
+			const tools = await client.listTools();
+			const writeResult = await client.callTool({
+				name: 'set_device_property',
+				arguments: { property_id: PROPERTY_ID, value: true },
+			});
+			const sceneResult = await client.callTool({ name: 'run_scene', arguments: { scene_id: SCENE_ID } });
+			const lightingResult = await client.callTool({
+				name: 'set_space_lighting',
+				arguments: { space_id: SPACE_ID, mode: 'relax' },
+			});
+
+			expect(tools.tools.map(({ name }) => name)).toEqual([
+				'list_writable_properties',
+				'set_device_property',
+				'list_trigger_targets',
+				'run_scene',
+				'set_space_lighting',
+			]);
+			expect(writeResult.isError).not.toBe(true);
+			expect(sceneResult.isError).not.toBe(true);
+			expect(lightingResult.isError).not.toBe(true);
+			expect(channelsPropertiesService.update).toHaveBeenCalledWith(
+				PROPERTY_ID,
+				expect.objectContaining({ type: SIMULATOR_TYPE, value: true }),
+			);
+			expect(behaviorManager.handlePropertyChange).toHaveBeenCalled();
+
+			const propertyTrace = propertyCommandService.executePropertyCommandById.mock.calls[0] as unknown as [
+				string,
+				unknown,
+				{ requestId: string; context: { origin: string; extra: Record<string, unknown> } },
+			];
+
+			expect(propertyTrace[2]).toMatchObject({
+				context: { origin: 'api', extra: { source: 'mcp', audience: ToolAudience.MCP, actorId: CLIENT_ID } },
+			});
+			const sceneTrace = sceneExecutor.triggerScene.mock.calls[0] as unknown as [
+				string,
+				string,
+				{ origin: string; extra: Record<string, unknown> },
+			];
+			const lightingTrace = spaceIntentService.executeLightingIntent.mock.calls[0] as unknown as [
+				string,
+				{ type: string; mode?: string },
+				{ origin: string; extra: Record<string, unknown> },
+			];
+
+			expect(sceneTrace[0]).toBe(SCENE_ID);
+			expect(sceneTrace[1]).toBe('mcp');
+			expect(sceneTrace[2]).toMatchObject({
+				origin: 'api',
+				extra: { source: 'mcp', audience: ToolAudience.MCP, actorId: CLIENT_ID },
+			});
+			expect(lightingTrace[0]).toBe(SPACE_ID);
+			expect(lightingTrace[1]).toMatchObject({ type: 'set_mode', mode: 'relax' });
+			expect(lightingTrace[2]).toMatchObject({
+				origin: 'api',
+				extra: { source: 'mcp', audience: ToolAudience.MCP, actorId: CLIENT_ID },
+			});
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('rechecks a stale advertised capability immediately before execution', async () => {
+		const client = new Client(
+			{ name: 'simulator-policy-client', version: '1.0.0' },
+			{ versionNegotiation: { mode: 'auto' } },
+		);
+		const transport = new StreamableHTTPClientTransport(endpoint, {
+			requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
+		});
+
+		try {
+			runtimeCapabilities = [...ALL_CAPABILITIES];
+			await client.connect(transport);
+			expect((await client.listTools()).tools.map(({ name }) => name)).toContain('set_device_property');
+
+			propertyCommandService.executePropertyCommandById.mockClear();
+			runtimeCapabilities = [McpCapability.TRIGGER];
+			const result = await client.callTool({
+				name: 'set_device_property',
+				arguments: { property_id: PROPERTY_ID, value: false },
+			});
+
+			expect(result.isError).toBe(true);
+			const structuredContent = result.structuredContent as {
+				error?: { code?: string };
+				tool?: string;
+			};
+
+			expect(structuredContent.tool).toBe('set_device_property');
+			expect(structuredContent.error?.code).toBe('permission_denied');
+			expect(propertyCommandService.executePropertyCommandById).not.toHaveBeenCalled();
+		} finally {
+			runtimeCapabilities = [...ALL_CAPABILITIES];
+			await client.close();
+		}
+	});
+});

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -47,6 +47,14 @@ const SPACE_ID = '50000000-0000-4000-8000-000000000001';
 const ALL_CAPABILITIES = [McpCapability.WRITE, McpCapability.TRIGGER];
 let runtimeCapabilities = [...ALL_CAPABILITIES];
 
+interface Deferred {
+	promise: Promise<void>;
+	resolve: () => void;
+}
+
+let authorizationStartedSignal: Deferred | null = null;
+let policyChangeGate: Deferred | null = null;
+
 @Injectable()
 class TestOperationsGuard implements CanActivate {
 	constructor(private readonly serverService: McpServerService) {}
@@ -215,7 +223,13 @@ describe('MCP simulator operations', () => {
 			})),
 		};
 		const policyService = {
-			authorizeClient: jest.fn().mockImplementation((_tokenId, clientId: string, capability: McpCapability) => {
+			authorizeClient: jest.fn().mockImplementation(async (_tokenId, clientId: string, capability: McpCapability) => {
+				authorizationStartedSignal?.resolve();
+
+				if (policyChangeGate !== null) {
+					await policyChangeGate.promise;
+				}
+
 				if (!runtimeCapabilities.includes(capability)) {
 					throw new ForbiddenException(`MCP capability '${capability}' is not granted`);
 				}
@@ -339,7 +353,7 @@ describe('MCP simulator operations', () => {
 		}
 	});
 
-	it('rechecks a stale advertised capability immediately before execution', async () => {
+	it('rejects an in-flight tool call when its advertised capability is reduced before authorization', async () => {
 		const client = new Client(
 			{ name: 'simulator-policy-client', version: '1.0.0' },
 			{ versionNegotiation: { mode: 'auto' } },
@@ -347,6 +361,8 @@ describe('MCP simulator operations', () => {
 		const transport = new StreamableHTTPClientTransport(endpoint, {
 			requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
 		});
+		const authorizationStarted = createDeferred();
+		const authorizationGate = createDeferred();
 
 		try {
 			runtimeCapabilities = [...ALL_CAPABILITIES];
@@ -354,11 +370,19 @@ describe('MCP simulator operations', () => {
 			expect((await client.listTools()).tools.map(({ name }) => name)).toContain('set_device_property');
 
 			propertyCommandService.executePropertyCommandById.mockClear();
-			runtimeCapabilities = [McpCapability.TRIGGER];
-			const result = await client.callTool({
+			authorizationStartedSignal = authorizationStarted;
+			policyChangeGate = authorizationGate;
+			const resultPromise = client.callTool({
 				name: 'set_device_property',
 				arguments: { property_id: PROPERTY_ID, value: false },
 			});
+
+			await expect(
+				Promise.race([authorizationStarted.promise, rejectAfter(2_000, 'Timed out waiting for tool authorization')]),
+			).resolves.toBeUndefined();
+			runtimeCapabilities = [McpCapability.TRIGGER];
+			authorizationGate.resolve();
+			const result = await resultPromise;
 
 			expect(result.isError).toBe(true);
 			const structuredContent = result.structuredContent as {
@@ -370,8 +394,27 @@ describe('MCP simulator operations', () => {
 			expect(structuredContent.error?.code).toBe('permission_denied');
 			expect(propertyCommandService.executePropertyCommandById).not.toHaveBeenCalled();
 		} finally {
+			authorizationGate.resolve();
+			authorizationStartedSignal = null;
+			policyChangeGate = null;
 			runtimeCapabilities = [...ALL_CAPABILITIES];
 			await client.close();
 		}
 	});
+
+	function rejectAfter(milliseconds: number, message: string): Promise<never> {
+		return new Promise((_, reject) => {
+			const timer = setTimeout(() => reject(new Error(message)), milliseconds);
+			timer.unref();
+		});
+	}
+
+	function createDeferred(): Deferred {
+		let resolve!: () => void;
+		const promise = new Promise<void>((deferredResolve) => {
+			resolve = deferredResolve;
+		});
+
+		return { promise, resolve };
+	}
 });

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -1,48 +1,49 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import { CanActivate, ExecutionContext, Injectable, NotFoundException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ConfigService as NestConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
 
+import { TokenOwnerType } from '../src/modules/auth/auth.constants';
+import { AuthenticatedRequest } from '../src/modules/auth/guards/auth.guard';
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { ModulesTypeMapperService } from '../src/modules/config/services/modules-type-mapper.service';
+import { PluginsTypeMapperService } from '../src/modules/config/services/plugins-type-mapper.service';
 import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
+import { UpdateMcpConfigDto } from '../src/modules/mcp/dto/update-config.dto';
 import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
 import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
-import { MCP_CATALOG_REGISTRAR } from '../src/modules/mcp/mcp.constants';
+import { MCP_CATALOG_REGISTRAR, MCP_MODULE_NAME } from '../src/modules/mcp/mcp.constants';
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
-import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
+import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+import { PlatformService } from '../src/modules/platform/services/platform.service';
+import { UserRole } from '../src/modules/users/users.constants';
 
 const CLIENT_ID = 'restart-client';
-let enabled = true;
+const TOKEN_ID = 'restart-token-id';
 
 @Injectable()
-class RestartPolicyGuard implements CanActivate {
-	constructor(private readonly serverService: McpServerService) {}
-
+class TestAuthenticationGuard implements CanActivate {
 	canActivate(context: ExecutionContext): boolean {
-		if (!enabled) {
-			throw new NotFoundException('MCP endpoint is disabled');
-		}
+		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
 
-		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
-		const client = {
-			id: CLIENT_ID,
-			name: 'Restart test client',
-			enabled: true,
-			capabilities: [],
-			tokenId: 'restart-token-id',
-			token: { id: 'restart-token-id', revoked: false, expiresAt: new Date(Date.now() + 60_000) },
-		} as McpClientEntity;
-
-		request.mcpPolicy = {
-			client,
-			clientPolicyRevision: this.serverService.getClientPolicyRevision(client.id),
-			config: Object.assign(new McpConfigModel(), { enabled, capabilities: [] }),
-			effectiveCapabilities: [],
-			installationId: 'restart-installation',
-			policyRevision: this.serverService.getPolicyRevision(),
-			tokenId: client.tokenId,
+		request.auth = {
+			type: 'token',
+			tokenId: TOKEN_ID,
+			ownerType: TokenOwnerType.MCP,
+			ownerId: CLIENT_ID,
+			role: UserRole.USER,
 		};
 
 		return true;
@@ -51,74 +52,124 @@ class RestartPolicyGuard implements CanActivate {
 
 describe('MCP disabled restart', () => {
 	it('is reachable while enabled and unreachable after a disabled restart', async () => {
-		enabled = true;
-		const first = await bootstrap();
-		const client = new Client(
-			{ name: 'restart-e2e-client', version: '1.0.0' },
-			{ versionNegotiation: { mode: 'auto' } },
-		);
-		const firstTransport = new StreamableHTTPClientTransport(first.endpoint, {
-			requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
-		});
+		const configPath = await mkdtemp(join(tmpdir(), 'smart-panel-mcp-restart-'));
 
 		try {
-			await client.connect(firstTransport);
-			await expect(client.listTools()).resolves.toMatchObject({ tools: [] });
-		} finally {
-			await client.close();
-			await first.close();
-		}
-
-		enabled = false;
-		const restarted = await bootstrap();
-
-		try {
-			const response = await fetch(restarted.endpoint, {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json, text/event-stream',
-					Authorization: `Bearer ${CLIENT_ID}`,
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					jsonrpc: '2.0',
-					id: 1,
-					method: 'initialize',
-					params: {
-						protocolVersion: '2026-07-28',
-						capabilities: {},
-						clientInfo: { name: 'restart-probe', version: '1.0.0' },
-					},
-				}),
+			const first = await bootstrap(configPath);
+			const client = new Client(
+				{ name: 'restart-e2e-client', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const firstTransport = new StreamableHTTPClientTransport(first.endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
 			});
 
-			expect(response.status).toBe(404);
-			expect(await response.json()).toMatchObject({ statusCode: 404 });
+			try {
+				first.configService.setModuleConfig(
+					MCP_MODULE_NAME,
+					Object.assign(new UpdateMcpConfigDto(), { enabled: true, capabilities: [] }),
+				);
+				await client.connect(firstTransport);
+				await expect(client.listTools()).resolves.toMatchObject({ tools: [] });
+				first.configService.setModuleConfig(
+					MCP_MODULE_NAME,
+					Object.assign(new UpdateMcpConfigDto(), { enabled: false }),
+				);
+			} finally {
+				await client.close();
+				await first.close();
+			}
+
+			const restarted = await bootstrap(configPath);
+
+			try {
+				expect(restarted.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME).enabled).toBe(false);
+
+				const response = await fetch(restarted.endpoint, {
+					method: 'POST',
+					headers: {
+						Accept: 'application/json, text/event-stream',
+						Authorization: `Bearer ${CLIENT_ID}`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						jsonrpc: '2.0',
+						id: 1,
+						method: 'initialize',
+						params: {
+							protocolVersion: '2026-07-28',
+							capabilities: {},
+							clientInfo: { name: 'restart-probe', version: '1.0.0' },
+						},
+					}),
+				});
+
+				expect(response.status).toBe(404);
+				expect(await response.json()).toMatchObject({ statusCode: 404 });
+			} finally {
+				await restarted.close();
+			}
 		} finally {
-			await restarted.close();
-			enabled = true;
+			await rm(configPath, { recursive: true, force: true });
 		}
 	});
 
-	async function bootstrap(): Promise<{ endpoint: URL; close: () => Promise<void> }> {
+	async function bootstrap(
+		configPath: string,
+	): Promise<{ endpoint: URL; configService: ConfigService; close: () => Promise<void> }> {
+		const modulesMapper = new ModulesTypeMapperService();
+		const pluginsMapper = new PluginsTypeMapperService();
+		const nestConfigService = {
+			get: jest.fn((key: string) => (key === 'FB_CONFIG_PATH' ? configPath : undefined)),
+		} as unknown as NestConfigService;
+		const configService = new ConfigService(
+			nestConfigService,
+			pluginsMapper,
+			modulesMapper,
+			{} as PlatformService,
+			{ emit: jest.fn() } as unknown as EventEmitter2,
+		);
+
+		modulesMapper.registerMapping({
+			type: MCP_MODULE_NAME,
+			class: McpConfigModel,
+			configDto: UpdateMcpConfigDto,
+		});
+
+		const client = {
+			id: CLIENT_ID,
+			name: 'Restart test client',
+			enabled: true,
+			capabilities: [],
+			tokenId: TOKEN_ID,
+			token: { id: TOKEN_ID, revoked: false, expiresAt: new Date(Date.now() + 60_000) },
+		} as McpClientEntity;
 		const moduleRef = await Test.createTestingModule({
 			controllers: [McpController],
 			providers: [
+				{ provide: APP_GUARD, useClass: TestAuthenticationGuard },
+				{ provide: ConfigService, useValue: configService },
+				{ provide: NestConfigService, useValue: nestConfigService },
+				{ provide: McpClientService, useValue: { findActiveByToken: jest.fn().mockResolvedValue(client) } },
+				{
+					provide: McpInstallationService,
+					useValue: { getInstallationId: jest.fn().mockResolvedValue('restart-installation') },
+				},
 				McpAuditService,
+				McpClientGuard,
+				McpPolicyService,
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: { register: () => undefined } },
 			],
-		})
-			.overrideGuard(McpClientGuard)
-			.useClass(RestartPolicyGuard)
-			.compile();
+		}).compile();
 		const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
 
 		await app.listen(0, '127.0.0.1');
 
 		return {
 			endpoint: new URL('/', await app.getUrl()),
+			configService,
 			close: async () => {
 				await app.get(McpServerService).closeAll();
 				await app.close();

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -1,0 +1,128 @@
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { CanActivate, ExecutionContext, Injectable, NotFoundException } from '@nestjs/common';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+
+import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
+import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
+import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
+import { MCP_CATALOG_REGISTRAR } from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+
+const CLIENT_ID = 'restart-client';
+let enabled = true;
+
+@Injectable()
+class RestartPolicyGuard implements CanActivate {
+	constructor(private readonly serverService: McpServerService) {}
+
+	canActivate(context: ExecutionContext): boolean {
+		if (!enabled) {
+			throw new NotFoundException('MCP endpoint is disabled');
+		}
+
+		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
+		const client = {
+			id: CLIENT_ID,
+			name: 'Restart test client',
+			enabled: true,
+			capabilities: [],
+			tokenId: 'restart-token-id',
+			token: { id: 'restart-token-id', revoked: false, expiresAt: new Date(Date.now() + 60_000) },
+		} as McpClientEntity;
+
+		request.mcpPolicy = {
+			client,
+			clientPolicyRevision: this.serverService.getClientPolicyRevision(client.id),
+			config: Object.assign(new McpConfigModel(), { enabled, capabilities: [] }),
+			effectiveCapabilities: [],
+			installationId: 'restart-installation',
+			policyRevision: this.serverService.getPolicyRevision(),
+			tokenId: client.tokenId,
+		};
+
+		return true;
+	}
+}
+
+describe('MCP disabled restart', () => {
+	it('is reachable while enabled and unreachable after a disabled restart', async () => {
+		enabled = true;
+		const first = await bootstrap();
+		const client = new Client(
+			{ name: 'restart-e2e-client', version: '1.0.0' },
+			{ versionNegotiation: { mode: 'auto' } },
+		);
+		const firstTransport = new StreamableHTTPClientTransport(first.endpoint, {
+			requestInit: { headers: { Authorization: `Bearer ${CLIENT_ID}` } },
+		});
+
+		try {
+			await client.connect(firstTransport);
+			await expect(client.listTools()).resolves.toMatchObject({ tools: [] });
+		} finally {
+			await client.close();
+			await first.close();
+		}
+
+		enabled = false;
+		const restarted = await bootstrap();
+
+		try {
+			const response = await fetch(restarted.endpoint, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json, text/event-stream',
+					Authorization: `Bearer ${CLIENT_ID}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'initialize',
+					params: {
+						protocolVersion: '2026-07-28',
+						capabilities: {},
+						clientInfo: { name: 'restart-probe', version: '1.0.0' },
+					},
+				}),
+			});
+
+			expect(response.status).toBe(404);
+			expect(await response.json()).toMatchObject({ statusCode: 404 });
+		} finally {
+			await restarted.close();
+			enabled = true;
+		}
+	});
+
+	async function bootstrap(): Promise<{ endpoint: URL; close: () => Promise<void> }> {
+		const moduleRef = await Test.createTestingModule({
+			controllers: [McpController],
+			providers: [
+				McpAuditService,
+				McpServerService,
+				McpSubscriptionRegistryService,
+				{ provide: MCP_CATALOG_REGISTRAR, useValue: { register: () => undefined } },
+			],
+		})
+			.overrideGuard(McpClientGuard)
+			.useClass(RestartPolicyGuard)
+			.compile();
+		const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+		await app.listen(0, '127.0.0.1');
+
+		return {
+			endpoint: new URL('/', await app.getUrl()),
+			close: async () => {
+				await app.get(McpServerService).closeAll();
+				await app.close();
+			},
+		};
+	}
+});

--- a/apps/backend/test/support/mcp-host-smoke-server.ts
+++ b/apps/backend/test/support/mcp-host-smoke-server.ts
@@ -1,0 +1,69 @@
+import Fastify from 'fastify';
+import { IncomingMessage } from 'http';
+import { z } from 'zod';
+
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { AuthInfo, McpServer, createMcpHandler } from '@modelcontextprotocol/server';
+
+const TOKEN = 'phase-11-host-smoke-token';
+type AuthenticatedIncomingMessage = IncomingMessage & { auth?: AuthInfo };
+
+const handler = createMcpHandler(
+	() => {
+		const server = new McpServer({ name: 'smart-panel-mcp-host-smoke', version: '1.0.0' });
+
+		server.registerTool(
+			'get_installation_identity',
+			{
+				description: 'Returns the identity of the compatibility smoke-test installation.',
+				inputSchema: z.object({}),
+				outputSchema: z.object({ installation: z.string() }),
+			},
+			() => ({
+				content: [{ type: 'text', text: 'MCP Phase 11 host smoke test' }],
+				structuredContent: { installation: 'MCP Phase 11 host smoke test' },
+			}),
+		);
+
+		return server;
+	},
+	{ legacy: 'stateless' },
+);
+const nodeHandler = toNodeHandler(handler);
+const app = Fastify();
+
+app.all('/', async (request, reply) => {
+	if (request.headers.authorization !== `Bearer ${TOKEN}`) {
+		await reply.code(401).send({ error: 'Unauthorized' });
+
+		return;
+	}
+
+	const rawRequest = request.raw as AuthenticatedIncomingMessage;
+
+	rawRequest.auth = {
+		token: TOKEN,
+		clientId: 'phase-11-host-client',
+		scopes: ['read'],
+		extra: { installationId: 'phase-11-host-smoke' },
+	};
+	reply.hijack();
+	await nodeHandler(rawRequest, reply.raw, request.body);
+});
+
+async function main(): Promise<void> {
+	const address = await app.listen({ host: '127.0.0.1', port: 0 });
+
+	process.stdout.write(
+		`${JSON.stringify({ endpoint: `${address}/`, tokenEnvironmentVariable: 'MCP_PHASE_11_TOKEN' })}\n`,
+	);
+
+	await new Promise<void>((resolve) => {
+		process.once('SIGINT', resolve);
+		process.once('SIGTERM', resolve);
+	});
+	await handler.close();
+	await app.close();
+}
+
+void main();

--- a/docs/mcp-compatibility-verification.md
+++ b/docs/mcp-compatibility-verification.md
@@ -1,0 +1,43 @@
+# MCP Client Compatibility Verification
+
+This record captures the release-gate checks for the initial static bearer-token MCP transport. It is test evidence,
+not end-user setup documentation.
+
+## Verified clients
+
+Verification was performed on 2026-08-08 against the loopback Streamable HTTP fixture in
+`apps/backend/test/support/mcp-host-smoke-server.ts`. The fixture requires an `Authorization: Bearer` header, advertises
+one tool, and returns `MCP Phase 11 host smoke test` when the tool is called.
+
+| Client                     | Version | Bearer configuration                  | Result                                                    |
+| -------------------------- | ------- | ------------------------------------- | --------------------------------------------------------- |
+| OpenAI Codex CLI           | 0.136.0 | `--bearer-token-env-var` equivalent   | Connected, discovered the tool, and called it successfully |
+| Anthropic Claude Code      | 2.1.225 | HTTP MCP `headers.Authorization`      | Connected, discovered the tool, and called it successfully |
+| Official MCP TypeScript SDK | 2.0.0   | Streamable HTTP request headers       | Modern and stateless legacy endpoint E2E suites pass       |
+
+The Codex and Claude Code checks used noninteractive no-approval modes only for the harmless fixture tool. The bearer
+value was synthetic and was not an installation credential.
+
+## Repeatable host fixture
+
+Start the fixture from `apps/backend`:
+
+```bash
+pnpm exec ts-node test/support/mcp-host-smoke-server.ts
+```
+
+The process prints its loopback endpoint and the bearer-token environment-variable name. Use the synthetic
+`phase-11-host-smoke-token` value and stop the fixture with `SIGINT` after the host checks.
+
+## Unsupported client profiles
+
+- Hosts that cannot attach a preconfigured bearer token or custom `Authorization` header are unsupported by the
+  initial release. Hosts that support only standards-based remote authorization require the planned OAuth 2.1 and MCP
+  protected-resource discovery follow-up.
+- Stdio-only and legacy HTTP+SSE-only clients are unsupported. OAuth alone does not make those transports compatible;
+  the host must support Streamable HTTP.
+- Legacy clients that require a persistent server session are unsupported. The initial release supports the bounded
+  SDK stateless legacy path; such clients must upgrade or demonstrate a concrete need before a stateful adapter is
+  added.
+- Public-internet use is not a supported authorization profile for static tokens. The first release is intended for
+  trusted LAN or VPN deployments, preferably behind HTTPS.

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 10 complete — Phase 11 pending
+**Status:** Phase 11 complete — Phase 12 pending
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -598,18 +598,25 @@ not run because generated panel API changes are not part of this admin managemen
 
 ### Task 14: End-to-end and compatibility verification
 
-- [ ] Add backend E2E coverage using an in-process MCP client or the SDK's supported test transport.
-- [ ] Test all eight module capability combinations.
-- [ ] Test module/client capability intersections.
-- [ ] Test two simultaneous clients with different permissions and ensure authenticated contexts and subscriptions
+- [x] Add backend E2E coverage using an in-process MCP client or the SDK's supported test transport.
+- [x] Test all eight module capability combinations.
+- [x] Test module/client capability intersections.
+- [x] Test two simultaneous clients with different permissions and ensure authenticated contexts and subscriptions
       cannot cross.
-- [ ] Test a permission change and token revocation while clients remain connected.
-- [ ] Test against a simulator installation so writes/triggers cannot affect real hardware.
-- [ ] Verify `set_device_property`, `run_scene`, and `set_space_lighting` produce the expected intent/event traces.
-- [ ] Run targeted backend unit tests, backend E2E tests, admin unit tests, type checks, and JS lint.
-- [ ] Smoke-test at least two supported agent hosts/clients using a static bearer-header configuration.
-- [ ] Record unsupported clients and whether they require the follow-up OAuth flow.
-- [ ] Confirm MCP remains unreachable when disabled after a restart.
+- [x] Test a permission change and token revocation while clients remain connected.
+- [x] Test against a simulator installation so writes/triggers cannot affect real hardware.
+- [x] Verify `set_device_property`, `run_scene`, and `set_space_lighting` produce the expected intent/event traces.
+- [x] Run targeted backend unit tests, backend E2E tests, admin unit tests, type checks, and JS lint.
+- [x] Smoke-test at least two supported agent hosts/clients using a static bearer-header configuration.
+- [x] Record unsupported clients and whether they require the follow-up OAuth flow.
+- [x] Confirm MCP remains unreachable when disabled after a restart.
+
+**Outcome:** The release-gate suite now covers the full capability matrix, effective client intersections, concurrent
+client and subscription isolation, live permission reduction, revocation, and disabled restart behavior through the
+real MCP HTTP transport. Simulator-backed write and trigger calls preserve MCP execution traces. Codex CLI and Claude
+Code both passed static-bearer host smoke tests; unsupported client profiles and OAuth requirements are recorded in
+`docs/mcp-compatibility-verification.md`. Targeted backend tests, the full backend E2E suite, all admin unit tests, both
+type checks, and repository JS lint pass.
 
 ### Task 15: Documentation and rollout
 


### PR DESCRIPTION
## Summary

- expand MCP endpoint E2E coverage across all eight module capability combinations and representative module/client intersections
- verify simultaneous-client isolation, targeted subscriptions, live permission reductions, revocation, and disabled restart behavior
- exercise write and trigger operations through the real MCP adapter/provider registry and simulator platform, including MCP execution traces
- add a repeatable bearer-authenticated host fixture and record Codex CLI, Claude Code, modern SDK, legacy SDK, and unsupported-client compatibility evidence
- mark Phase 11 complete and advance the implementation plan to Phase 12

## Impact

This closes the MCP release verification gate without exposing real hardware. It proves the curated catalog follows effective capabilities, stale permissions are rejected at execution time, client streams remain isolated, and supported hosts can connect using the initial static bearer-token profile.

## Validation

- targeted backend unit tests: 21 suites, 230 tests
- backend E2E tests: 10 suites, 114 tests
- focused MCP E2E tests: 3 suites, 24 tests
- admin unit tests: 237 files, 1,613 tests
- backend type check
- admin type check
- repository JavaScript lint (existing unrelated warnings only)
- Codex CLI 0.136.0 host smoke test
- Claude Code 2.1.225 host smoke test
