### PR TITLE
docs(website): complete MCP rollout documentation

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -131,9 +131,11 @@ Connects trusted MCP-compatible agents to a curated set of Smart Panel tools and
 ## Security posture
 
 - Uses installation-local MCP credentials rather than ordinary user, display, or REST tokens
+- Returns each finite-lived credential once; rotate it if the secret was not saved or may have leaked
 - Exposes only explicitly registered tools and resources; it is not an OpenAPI proxy
 - Rechecks the installation capability ceiling and client grant for every operation
-- Targets trusted LAN or VPN deployments for the initial static-bearer release
+- Targets trusted LAN or VPN deployments behind HTTPS for the initial static-bearer release
+- Requires users to verify the installation hostname and reported name before approving write or trigger tools
 
 ## Configuration
 
@@ -143,7 +145,7 @@ Connects trusted MCP-compatible agents to a curated set of Smart Panel tools and
 | \`capabilities\` | Allowed combination of \`read\`, \`write\`, and \`trigger\` | \`read\` |
 | \`allowed_origins\` | Additional browser origins allowed to call the endpoint | empty |`,
 			links: {
-				documentation: 'https://smart-panel.fastybird.com/docs',
+				documentation: 'https://smart-panel.fastybird.com/docs/admin-management/mcp',
 				repository: 'https://github.com/FastyBird/smart-panel',
 			},
 		});

--- a/apps/website/app/docs/admin-management/_meta.js
+++ b/apps/website/app/docs/admin-management/_meta.js
@@ -22,5 +22,6 @@ export default {
     title: "System Management",
   },
   configuration: "Configuration",
+  mcp: "Model Context Protocol",
   users: "Users & Roles",
 };

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -1,0 +1,257 @@
+import { Callout, Steps } from "nextra/components";
+
+# Model Context Protocol (MCP)
+
+Smart Panel's Model Context Protocol module lets trusted AI agents inspect and control one installation through a
+small, explicitly registered catalog. It is disabled by default, uses installation-local credentials, and never turns
+the REST or OpenAPI surface into agent tools automatically.
+
+<Callout type="warning">
+  The initial release uses static bearer credentials and is intended for a
+  trusted LAN or VPN. Put remote connections behind HTTPS on a reverse proxy. Do
+  not expose the MCP endpoint directly to the public internet.
+</Callout>
+
+The endpoint for an installation is:
+
+```text
+https://<installation-host>/api/v1/modules/mcp
+```
+
+## Before You Begin
+
+- Sign in as an **owner or administrator**. Other roles cannot configure MCP or manage its clients.
+- Decide which agent and device will hold the credential. A credential is shown only once.
+- Start with `read` unless the agent genuinely needs to change device state.
+- Confirm the hostname identifies the intended Smart Panel installation before creating a client.
+
+## Enable MCP
+
+<Steps>
+	### Open the module configuration
+
+    Go to **Config → Modules → Model Context Protocol** in the Admin UI.
+
+    ### Choose the installation capability ceiling
+
+    Turn on **Enable MCP endpoint**, then select any combination of:
+
+    - **Read** — inspect bounded home, device, history, energy, weather, and security context.
+    - **Write** — discover writable properties and set a concrete device property.
+    - **Trigger** — discover and run scenes or supported space-lighting actions.
+
+    An empty capability set is valid and exposes no tools or resources. The capability ceiling limits every client;
+    a client can receive fewer capabilities, but never more.
+
+    ### Configure browser origins only when needed
+
+    Server-side agents on the LAN normally send no `Origin` header and do not need an entry. For a browser-based client
+    on another origin, add the exact normalized HTTP(S) origin, such as `https://agent.example.com`. Do not include a
+    path, query, fragment, credentials, or wildcard.
+
+    ### Save and copy the endpoint
+
+    Save the configuration, then use **Copy endpoint**. Configuration changes apply immediately; a backend restart is
+    not required.
+
+</Steps>
+
+<Callout type="warning">
+  `write` and `trigger` can affect physical devices. Before approving one of
+  those tools, verify both the installation hostname and the installation name
+  reported by the MCP server.
+</Callout>
+
+## Create a Client Credential
+
+<Steps>
+	### Open MCP clients
+
+    Open **MCP clients** from the module's Admin navigation and select **Create client**.
+
+    ### Name and restrict the client
+
+    Use a name that identifies the agent and host, for example `Workshop Codex laptop`. Select only the capabilities the
+    client needs. The form prevents grants outside the current module ceiling.
+
+    ### Choose a finite lifetime
+
+    Set the credential lifetime in days. MCP credentials cannot be created without an expiry.
+
+    ### Copy the one-time token
+
+    After creation, copy the token immediately and place it in a password manager or the agent host's secret store. The
+    raw token cannot be retrieved after the dialog closes; Smart Panel stores only its normal token hash.
+
+</Steps>
+
+## Capability Examples
+
+Create separate clients when agents have different responsibilities.
+
+| Client profile             | Grant                      | What it can do                                                         | What it cannot do                                                     |
+| -------------------------- | -------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Monitoring agent           | `read`                     | Inspect context, device state, history, energy, weather, and security  | Change properties or run actions                                      |
+| Direct device controller   | `write`                    | Discover writable property metadata and set a property                 | Browse general state/history or run scenes                            |
+| Automation runner          | `trigger`                  | Discover trigger targets, run scenes, and set supported lighting modes | Browse general state or write a property directly                     |
+| Trusted full-control agent | `read`, `write`, `trigger` | Use the complete curated catalog                                       | Access arbitrary REST, configuration, users, files, or shell commands |
+
+For a new integration, begin with a read-only client. Add `write` or `trigger` only after reviewing the exact tools and
+the agent's approval behavior.
+
+## Connect an Agent
+
+The client must support **Streamable HTTP** and a preconfigured bearer token or `Authorization` header. Stdio-only,
+legacy HTTP+SSE-only, OAuth-only, and persistent-session-only clients are not supported by this initial profile.
+
+### Codex CLI, app, or IDE extension
+
+Keep the token in an environment variable available to the Codex process:
+
+```bash copy
+export SMART_PANEL_MCP_TOKEN='<copied-mcp-token>'
+codex mcp add smart-panel \
+  --url https://panel.example.lan/api/v1/modules/mcp \
+  --bearer-token-env-var SMART_PANEL_MCP_TOKEN
+```
+
+Confirm the entry and connection:
+
+```bash copy
+codex mcp list
+```
+
+The ChatGPT desktop app, Codex CLI, and Codex IDE extension share the same local MCP configuration. Restart the app or
+extension after adding the server, then inspect its MCP server list before approving tools.
+
+The equivalent `~/.codex/config.toml` entry is:
+
+```toml
+[mcp_servers.smart_panel]
+url = "https://panel.example.lan/api/v1/modules/mcp"
+bearer_token_env_var = "SMART_PANEL_MCP_TOKEN"
+```
+
+### Other compatible agents
+
+Configure a **Streamable HTTP** server with the copied endpoint and this request header:
+
+```text
+Authorization: Bearer <copied-mcp-token>
+```
+
+Use the client's secret or environment-variable support instead of committing the token to a repository. Claude Code
+and the official MCP TypeScript SDK have been verified with bearer-authenticated Streamable HTTP. Client profiles that
+require standards-based remote OAuth must wait for the planned OAuth authorization follow-up.
+
+## Curated Catalog
+
+Only the following tools and resources are registered. Smart Panel does **not** convert OpenAPI operations into MCP
+tools, and enabling MCP does not grant access to arbitrary REST requests, SQL, files, configuration, extensions, users,
+backups, updates, restarts, reboots, or power controls.
+
+### Read tools
+
+| Tool                      | Purpose                                                     |
+| ------------------------- | ----------------------------------------------------------- |
+| `get_home_context`        | Return a bounded installation or space overview             |
+| `get_device_state`        | Return one device with channels and current property values |
+| `get_property_timeseries` | Return bounded, downsampled history for one property        |
+| `get_energy_summary`      | Return a home or space energy summary                       |
+| `get_weather`             | Return current conditions and a short forecast              |
+| `get_security_status`     | Return security state and bounded active alerts             |
+
+Read resources are `smart-panel://installation`, `smart-panel://home/context`, and the
+`smart-panel://spaces/{spaceId}/snapshot` resource template. They are available only when `read` is effective.
+
+### Write tools
+
+| Tool                       | Purpose                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `list_writable_properties` | Return bounded identifiers and validation metadata needed for direct writes |
+| `set_device_property`      | Set one currently available, writable property                              |
+
+`list_writable_properties` belongs to the `write` capability even though discovery itself does not mutate state. This
+allows a write-only client to identify a safe target without gaining general read access.
+
+### Trigger tools
+
+| Tool                   | Purpose                                                   |
+| ---------------------- | --------------------------------------------------------- |
+| `list_trigger_targets` | Return bounded enabled scenes and lighting-capable spaces |
+| `run_scene`            | Run one enabled scene                                     |
+| `set_space_lighting`   | Apply a supported lighting mode to one space              |
+
+`set_space_lighting` is advertised only when its optional provider is installed and available.
+
+## Rotate, Restrict, Revoke, or Delete a Client
+
+- **Edit** a client to reduce its capabilities. Active clients are notified and new operations use the reduced grant
+  immediately.
+- **Rotate** when a token may have leaked or when moving an agent to a new host. The previous credential is revoked
+  immediately, active streams are closed, and the replacement token is shown once.
+- **Revoke** to disable the current credential immediately. Connected streams for that client are closed.
+- **Delete** to revoke the credential and permanently remove the client record.
+
+Changing the module capability ceiling applies to every client immediately. Disabling the module closes active MCP
+streams and makes the endpoint return `404` until it is enabled again.
+
+## Troubleshooting
+
+### The endpoint returns `404`
+
+The MCP module is disabled. Enable it under **Config → Modules → Model Context Protocol** and save.
+
+### The client receives `401 Unauthorized`
+
+Check that the client sends the MCP token as a bearer credential, the token has not expired or been rotated/revoked,
+and the credential belongs to this installation. User access tokens, personal access tokens, and display tokens do not
+work on the MCP endpoint.
+
+### The client receives `403 Forbidden`
+
+The requested tool may be outside the effective capability intersection, the request hostname may not identify this
+installation, or a browser `Origin` may be missing from the explicit allowlist. Add only an exact normalized origin;
+do not use a wildcard.
+
+### The client connects but shows no tools
+
+Both the module and the client need the relevant capability. An enabled module or client with no capabilities is valid
+and intentionally advertises an empty catalog. `set_space_lighting` also requires its optional provider.
+
+### The one-time token was not saved
+
+It cannot be recovered. Rotate the credential and copy the replacement token, or delete the client and create a new
+one.
+
+### A configuration change is not visible
+
+Reconnect clients that do not consume MCP list-change notifications. Authorization is still rechecked for every tool
+execution, so a stale client cannot keep using a removed capability.
+
+## Upgrade Notes
+
+Existing installations receive MCP through the incremental `1000000000008-AddMcpClients` migration. Migrations run
+automatically during a normal update and create the installation identity and MCP client tables; no existing user,
+personal-access-token, display-token, or device records are converted.
+
+The new configuration defaults are safe and do not expose an upgraded installation:
+
+```yaml
+modules:
+  mcp-module:
+    enabled: false
+    capabilities:
+      - read
+    allowed_origins: []
+```
+
+Back up the database and configuration before updating. After the update, an owner or administrator must explicitly
+enable MCP and create each finite-lived client credential. If an operator explicitly reverts this migration during a
+rollback, its down migration deletes MCP-owned credentials before older authentication code can load them.
+
+## What's Next?
+
+- [Configuration](/docs/admin-management/configuration) — manage core module settings
+- [Users & Roles](/docs/admin-management/users) — understand owner and administrator access
+- [Updating & Backup](/docs/updating) — back up the installation before an upgrade

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -43,11 +43,15 @@ https://<installation-host>/api/v1/modules/mcp
     An empty capability set is valid and exposes no tools or resources. The capability ceiling limits every client;
     a client can receive fewer capabilities, but never more.
 
-    ### Configure browser origins only when needed
+    ### Allow the endpoint hostname and any browser origin
 
-    Server-side agents on the LAN normally send no `Origin` header and do not need an entry. For a browser-based client
-    on another origin, add the exact normalized HTTP(S) origin, such as `https://agent.example.com`. Do not include a
-    path, query, fragment, credentials, or wildcard.
+    Every request hostname must be loopback, the hostname configured by `FB_APP_HOST`, or the hostname of an entry in
+    **Allowed origins**. If the copied LAN or reverse-proxy endpoint uses another hostname, either set `FB_APP_HOST` to
+    that external HTTP(S) origin and restart the backend, or add the endpoint's complete origin to **Allowed origins**.
+    This hostname check also applies to server-side agents that send no `Origin` header.
+
+    For a browser-based client on another origin, also add the client's exact normalized HTTP(S) origin, such as
+    `https://agent.example.com`. Do not include a path, query, fragment, credentials, or wildcard.
 
     ### Save and copy the endpoint
 
@@ -210,9 +214,9 @@ work on the MCP endpoint.
 
 ### The client receives `403 Forbidden`
 
-The requested tool may be outside the effective capability intersection, the request hostname may not identify this
-installation, or a browser `Origin` may be missing from the explicit allowlist. Add only an exact normalized origin;
-do not use a wildcard.
+Smart Panel rejected the request's `Host` or browser `Origin`. Ensure the endpoint hostname is loopback, matches the
+hostname in `FB_APP_HOST`, or belongs to an origin in **Allowed origins**. For a cross-origin browser client, add its
+exact normalized origin too. Do not use a wildcard.
 
 ### The client connects but shows no tools
 

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -119,14 +119,17 @@ codex mcp add smart-panel \
   --bearer-token-env-var SMART_PANEL_MCP_TOKEN
 ```
 
-Confirm the entry and connection:
+Confirm that the configuration entry exists:
 
 ```bash copy
 codex mcp list
 ```
 
-The ChatGPT desktop app, Codex CLI, and Codex IDE extension share the same local MCP configuration. Restart the app or
-extension after adding the server, then inspect its MCP server list before approving tools.
+This command does not contact the endpoint. Start a Codex session and ask it to list the Smart Panel tools or call a
+read tool such as `get_home_context`; a successful tool list or call verifies endpoint reachability and authentication.
+
+The Codex app, Codex CLI, and Codex IDE extension share the same local MCP configuration. Restart the app or extension
+after adding the server, then complete the connectivity check before approving tools.
 
 The equivalent `~/.codex/config.toml` entry is:
 

--- a/apps/website/app/docs/updating/page.mdx
+++ b/apps/website/app/docs/updating/page.mdx
@@ -163,6 +163,12 @@ If any step fails, the symlink is reverted to the previous version automatically
 
 If you need to manually revert to a previous version:
 
+<Callout type="warning">
+	If the target version predates the MCP migration, stop the backend and satisfy the
+	[MCP rollback precondition](#model-context-protocol-upgrade-notes) before switching the symlink or restarting the
+	service. Switching application versions does not run down migrations automatically.
+</Callout>
+
 ```bash copy
 # List available versions
 ls -la /opt/smart-panel/
@@ -243,8 +249,12 @@ default: MCP is disabled, `read` is preselected as the enablement default, and t
 is empty.
 
 After updating, an owner or administrator must explicitly enable MCP and create finite-lived client credentials. Back
-up both the database and configuration first. If your rollback procedure explicitly reverts the migration, its down
-migration removes MCP-owned credentials before older authentication code can load them.
+up both the database and configuration first.
+
+Before starting any Smart Panel version that predates this migration, stop the backend and either restore a database
+backup created before the MCP upgrade or explicitly revert `1000000000008-AddMcpClients` with the current release's
+migration tooling. Do not only switch a symlink or container tag: application rollback does not run down migrations.
+The migration's down step deletes MCP-owned tokens before older authentication code can load them.
 
 See [Model Context Protocol](/docs/admin-management/mcp) for setup, security guidance, and the exact curated catalog.
 
@@ -280,8 +290,9 @@ If an update causes problems:
 4. Start the services
 
 <Callout type="info">
-	For pre-built image installations, rollback is simpler — just switch the symlink to a previous version as described
-	in the [Manual Rollback](#manual-rollback-image-install) section above.
+	For pre-built image installations, switch the symlink as described in
+	[Manual Rollback](#manual-rollback-image-install) only after satisfying any schema rollback requirements. A target
+	version that predates MCP must follow the [MCP rollback precondition](#model-context-protocol-upgrade-notes).
 </Callout>
 
 <Callout type="warning">

--- a/apps/website/app/docs/updating/page.mdx
+++ b/apps/website/app/docs/updating/page.mdx
@@ -229,6 +229,21 @@ Database migrations run automatically when the backend starts.
 
 ---
 
+## Model Context Protocol Upgrade Notes
+
+The MCP module is added through the incremental `1000000000008-AddMcpClients` migration. It creates installation
+identity and MCP client tables without converting existing users or credentials. Upgraded installations remain safe by
+default: MCP is disabled, `read` is preselected as the enablement default, and the additional browser-origin allowlist
+is empty.
+
+After updating, an owner or administrator must explicitly enable MCP and create finite-lived client credentials. Back
+up both the database and configuration first. If your rollback procedure explicitly reverts the migration, its down
+migration removes MCP-owned credentials before older authentication code can load them.
+
+See [Model Context Protocol](/docs/admin-management/mcp) for setup, security guidance, and the exact curated catalog.
+
+---
+
 ## Pinning a Version
 
 ### Docker

--- a/apps/website/app/docs/updating/page.mdx
+++ b/apps/website/app/docs/updating/page.mdx
@@ -90,6 +90,12 @@ docker run --rm -v smart-panel-data:/data -v $(pwd):/backup alpine \
 docker compose up -d
 ```
 
+<Callout type="warning">
+	If you restore a backup into a second or cloned installation, the database also copies the installation UUID, MCP
+	clients, and token hashes. Before allowing access to the clone, immediately rotate or revoke every copied MCP
+	credential; otherwise, existing bearer tokens remain valid against both installations under the same audience.
+</Callout>
+
 ---
 
 ## Updating

--- a/tasks/plans/plan-mcp-module.md
+++ b/tasks/plans/plan-mcp-module.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP Module — Implementation Plan
 
-**Status:** Phase 11 complete — Phase 12 pending
+**Status:** Phase 12 complete — implementation finished
 
 **Architecture decision:** [ADR 0001: MCP Protocol and Security Foundation](../../docs/adr/0001-mcp-protocol-and-security-foundation.md)
 supersedes the original stateful-session transport assumptions in this plan.
@@ -626,15 +626,20 @@ type checks, and repository JS lint pass.
 - Update module metadata README
 - Update this plan's completed checkboxes and task status when implementation ships
 
-- [ ] Document enabling MCP, choosing capabilities, creating a client, copying the one-time token, connecting an agent,
+- [x] Document enabling MCP, choosing capabilities, creating a client, copying the one-time token, connecting an agent,
       rotating/revoking credentials, and troubleshooting.
-- [ ] Provide distinct examples for read-only, write-only, trigger-only, and read+write+trigger clients.
-- [ ] Warn users to verify the installation hostname/name before approving write or trigger operations.
-- [ ] Recommend LAN/VPN access and HTTPS through a reverse proxy; do not recommend direct public exposure for the
+- [x] Provide distinct examples for read-only, write-only, trigger-only, and read+write+trigger clients.
+- [x] Warn users to verify the installation hostname/name before approving write or trigger operations.
+- [x] Recommend LAN/VPN access and HTTPS through a reverse proxy; do not recommend direct public exposure for the
       static-token release.
-- [ ] Document the exact curated catalog and state explicitly that OpenAPI endpoints are not automatically exposed.
-- [ ] Add upgrade notes for configuration defaults and the new incremental migration.
-- [ ] Create a follow-up task for standards-compliant MCP OAuth/protected-resource discovery before public internet use.
+- [x] Document the exact curated catalog and state explicitly that OpenAPI endpoints are not automatically exposed.
+- [x] Add upgrade notes for configuration defaults and the new incremental migration.
+- [x] Create a follow-up task for standards-compliant MCP OAuth/protected-resource discovery before public internet use.
+
+**Outcome:** The website now documents secure enablement, least-privilege client profiles, one-time credential handling,
+verified agent connection patterns, the complete curated catalog, live credential management, troubleshooting, and
+upgrade behavior. In-product module metadata links directly to the guide. Public-internet authorization remains
+explicitly deferred to `TECH-MCP-OAUTH-AUTHORIZATION`, which scopes protected-resource discovery and OAuth 2.1 work.
 
 ---
 
@@ -642,42 +647,42 @@ type checks, and repository JS lint pass.
 
 ### Configuration and administration
 
-- [ ] MCP is a core module visible in Admin and disabled by default.
-- [ ] An owner/admin can enable any combination of read, write, and trigger.
-- [ ] Backend authorization rejects module-configuration changes from ordinary users, user-owned PATs, and display
+- [x] MCP is a core module visible in Admin and disabled by default.
+- [x] An owner/admin can enable any combination of read, write, and trigger.
+- [x] Backend authorization rejects module-configuration changes from ordinary users, user-owned PATs, and display
       tokens; denied requests do not mutate persisted or in-memory MCP configuration.
-- [ ] Configuration persists across restart and applies without requiring a restart.
-- [ ] An owner/admin can create, restrict, rotate, and revoke MCP client credentials.
-- [ ] Raw client tokens are displayed only once and always have a finite expiry.
+- [x] Configuration persists across restart and applies without requiring a restart.
+- [x] An owner/admin can create, restrict, rotate, and revoke MCP client credentials.
+- [x] Raw client tokens are displayed only once and always have a finite expiry.
 
 ### Protocol and catalog
 
-- [ ] A modern MCP client can discover `/api/v1/modules/mcp`, and a compatible legacy client can initialize through the
+- [x] A modern MCP client can discover `/api/v1/modules/mcp`, and a compatible legacy client can initialize through the
       stateless fallback.
-- [ ] `tools/list`, `resources/list`, `tools/call`, resource reads, subscriptions, and shutdown behave according to the
+- [x] `tools/list`, `resources/list`, `tools/call`, resource reads, subscriptions, and shutdown behave according to the
       negotiated protocol version.
-- [ ] Only explicitly registered tools appear; no generic OpenAPI proxy exists.
-- [ ] Tool/resource discovery matches the effective capability intersection.
-- [ ] Disabled capabilities are enforced again at execution time.
-- [ ] Configuration changes notify active clients and immediately prevent stale calls.
+- [x] Only explicitly registered tools appear; no generic OpenAPI proxy exists.
+- [x] Tool/resource discovery matches the effective capability intersection.
+- [x] Disabled capabilities are enforced again at execution time.
+- [x] Configuration changes notify active clients and immediately prevent stale calls.
 
 ### Security
 
-- [ ] MCP tokens work only on the MCP endpoint.
-- [ ] Ordinary access/PAT/display tokens do not work on the MCP endpoint.
-- [ ] Revoked, expired, disabled-client, wrong-audience, and invalid-origin requests are rejected.
-- [ ] Subscription streams and any approved legacy sessions remain bound to the correct bearer token and MCP client.
-- [ ] Logs and results contain no credential material.
-- [ ] The MCP endpoint is rate-limited and bounded by subscription, body-size, context-size, and history limits.
+- [x] MCP tokens work only on the MCP endpoint.
+- [x] Ordinary access/PAT/display tokens do not work on the MCP endpoint.
+- [x] Revoked, expired, disabled-client, wrong-audience, and invalid-origin requests are rejected.
+- [x] Subscription streams and any approved legacy sessions remain bound to the correct bearer token and MCP client.
+- [x] Logs and results contain no credential material.
+- [x] The MCP endpoint is rate-limited and bounded by subscription, body-size, context-size, and history limits.
 
 ### Operations
 
-- [ ] Read-only clients cannot write or trigger.
-- [ ] Write-only clients can discover writable properties and set them but cannot access general reads or triggers.
-- [ ] Trigger-only clients can discover trigger targets and invoke them but cannot access general reads or direct
+- [x] Read-only clients cannot write or trigger.
+- [x] Write-only clients can discover writable properties and set them but cannot access general reads or triggers.
+- [x] Trigger-only clients can discover trigger targets and invoke them but cannot access general reads or direct
       property writes.
-- [ ] Existing Buddy tool execution continues to work unchanged from the user's perspective.
-- [ ] Existing REST, PAT, display-token, WebSocket, and admin flows have no regressions.
+- [x] Existing Buddy tool execution continues to work unchanged from the user's perspective.
+- [x] Existing REST, PAT, display-token, WebSocket, and admin flows have no regressions.
 
 ---
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -1,0 +1,126 @@
+# Task: Add standards-compliant OAuth authorization for remote MCP
+
+ID: TECH-MCP-OAUTH-AUTHORIZATION
+Type: technical
+Scope: backend, admin
+Size: large
+Parent: Smart Panel MCP Module
+Status: planned
+
+## 1. Business goal
+
+In order to connect standards-compliant remote MCP hosts without distributing static installation credentials,
+as a Smart Panel owner,
+I want MCP protected-resource discovery and an OAuth 2.1 authorization flow suitable for explicitly secured remote
+access.
+
+## 2. Context
+
+- The initial MCP release supports Streamable HTTP with a preconfigured static bearer token for trusted LAN or VPN
+  deployments.
+- The MCP resource is installation-local at `/api/v1/modules/mcp` and uses the stable audience
+  `urn:fastybird:smart-panel:<installation-uuid>:mcp`.
+- `docs/adr/0001-mcp-protocol-and-security-foundation.md` deliberately defers public-internet authorization.
+- `apps/backend/src/modules/mcp/` owns MCP policy, endpoint authentication, clients, subscriptions, and auditing.
+- Existing user, personal-access-token, display-token, and MCP static-token flows must remain isolated.
+
+Before implementation, add an ADR that chooses whether Smart Panel acts as the authorization server or delegates to a
+supported external identity provider. The choice must include deployment, account-recovery, consent, revocation, and
+upgrade consequences.
+
+## 3. Scope
+
+**In scope**
+
+- MCP protected-resource metadata and authorization-server discovery.
+- OAuth 2.1 authorization-code flow with PKCE (`S256`) for supported remote MCP clients.
+- Resource/audience binding, finite access tokens, refresh-token policy, revocation, and scope-to-capability mapping.
+- Consent UI and owner/admin controls needed to approve, inspect, and revoke OAuth clients or grants.
+- Protocol-correct `401` challenges that identify the protected-resource metadata.
+- Compatibility tests against supported OAuth-capable MCP hosts and reverse-proxy deployments.
+- Migration and coexistence guidance for the initial installation-local static bearer clients.
+
+**Out of scope**
+
+- Making the full REST/OpenAPI surface available through OAuth or MCP.
+- Password, implicit, or resource-owner-password credential grants.
+- Reusing user, display, personal-access, or static MCP tokens as OAuth access tokens.
+- Treating OAuth as a substitute for HTTPS, trusted-proxy configuration, rate limiting, or tool-level authorization.
+- Enabling direct public exposure by default.
+
+## 4. Acceptance criteria
+
+- [ ] An ADR documents the authorization-server architecture and a threat model for internet-reachable MCP.
+- [ ] The MCP endpoint publishes standards-compliant protected-resource metadata with its canonical resource identifier
+      and authorization-server location.
+- [ ] Unauthenticated MCP responses include a protocol-correct bearer challenge pointing clients to protected-resource
+      metadata without leaking installation or credential secrets.
+- [ ] Authorization-server metadata is standards compliant and advertises only implemented endpoints, response types,
+      grant types, PKCE methods, scopes, and signing algorithms.
+- [ ] Authorization uses the code flow with PKCE `S256`, exact redirect-URI matching, state validation, short-lived
+      codes, and replay prevention.
+- [ ] Access tokens are finite, issuer/resource/audience bound, revocable, and rejected by ordinary REST, WebSocket,
+      display, and personal-access-token paths.
+- [ ] OAuth scopes map to the curated `read`, `write`, and `trigger` capabilities and remain bounded by the live module
+      ceiling and approved grant.
+- [ ] Consent clearly names the installation, requesting client, redirect destination, expiry, and physical-device
+      impact of write/trigger scopes.
+- [ ] Owners/admins can list and revoke OAuth clients, grants, access tokens, and refresh tokens; revocation closes the
+      affected MCP subscriptions immediately.
+- [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
+      explicit registration policy; otherwise the supported registration path is documented.
+- [ ] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
+      configured as trusted.
+- [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
+      migration policy is approved.
+- [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
+      revocation, wrong issuer/resource/audience, cross-client isolation, and log redaction.
+- [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
+      refresh, and revocation smoke tests.
+- [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident
+      response, and rollback guidance.
+
+## 5. Example scenarios
+
+### Scenario: A remote host discovers and authorizes read-only access
+
+Given MCP is enabled with `read`
+and the host has no Smart Panel credential
+when it connects to the MCP resource
+then it discovers the protected-resource and authorization-server metadata
+and the owner can approve a read-only grant using authorization code plus PKCE
+and the resulting access token cannot call write or trigger tools.
+
+### Scenario: A grant is revoked while subscribed
+
+Given an OAuth client has an active MCP subscription
+when an owner revokes its grant
+then its access and refresh tokens stop working immediately
+and only that client's active subscription streams are closed.
+
+## 6. Technical constraints
+
+- Follow the current MCP policy, client-isolation, audit, and subscription boundaries.
+- Use current final OAuth/MCP standards and record exact revisions in the ADR before implementation.
+- Keep signing keys and client secrets in the existing secure-storage conventions; never log or return them after their
+  one-time delivery point.
+- Use incremental migrations only; never edit `1000000000008-AddMcpClients.ts`.
+- Do not introduce an authorization dependency until the ADR and compatibility spike justify it.
+- Do not edit generated OpenAPI clients manually.
+
+## 7. Implementation hints
+
+- Keep resource-server validation independent from interactive consent and authorization-server concerns.
+- Reuse the effective-capability intersection so an existing token cannot retain a scope removed from module config.
+- Preserve the installation UUID as stable identity while deriving externally visible URLs only from explicit trusted
+  configuration.
+- Treat dynamic registration and refresh tokens as separate risk decisions, not automatic consequences of adding
+  discovery metadata.
+
+## 8. AI instructions
+
+- Read this file and the MCP plan/ADR completely before making code changes.
+- Start with the compatibility spike and ADR; do not implement endpoints before the architecture is approved.
+- Keep security-sensitive changes split into reviewable phases with focused negative tests.
+- For each acceptance criterion, implement it or explain why it remains deferred.
+- Respect global rules from `AGENTS.md` and `/.ai-rules/GUIDELINES.md` when present.


### PR DESCRIPTION
## Summary

- add a comprehensive MCP administration guide covering secure enablement, least-privilege client profiles, agent setup, the exact curated catalog, credential lifecycle, and troubleshooting
- add MCP migration and configuration-default guidance to the upgrade documentation
- link the MCP module metadata directly to its administration guide
- mark Phase 12 and the initial MCP implementation plan complete
- add a separate follow-up task for standards-compliant OAuth and protected-resource discovery

## Why

Phase 12 closes the documentation and rollout requirements for the initial static-bearer MCP release. It gives administrators an end-to-end setup path, makes the LAN/VPN and HTTPS security posture explicit, and keeps public-internet OAuth work clearly separated as a future security-sensitive project.

## Impact

The initial MCP implementation is now documented as complete. Existing installations remain unaffected because MCP stays disabled by default and requires explicitly created finite-lived credentials.

## Validation

- `pnpm --filter ./apps/website run build`
- backend `pnpm run type-check`
- focused ESLint for `src/modules/mcp/mcp.module.ts`
- focused Jest test for `src/modules/mcp/mcp.module.spec.ts`
- Git diff and whitespace checks
