### PR TITLE
docs(tasks): close the virtual devices epic

### DIFF
--- a/docs/superpowers/specs/2026-07-31-virtual-devices-design.md
+++ b/docs/superpowers/specs/2026-07-31-virtual-devices-design.md
@@ -3,7 +3,7 @@
 **Status:** Approved
 **Date:** 2026-07-31
 **Author:** Adam Kadlec
-**Related:** `tasks/epics/EPIC-VIRTUAL-DEVICES.md` (supersedes its key architectural decisions), `tasks/features/FEATURE-DEVICE-SPLITTER-PLUGIN.md`, `tasks/features/FEATURE-DEVICE-COMPOSITE-PLUGIN.md`
+**Related:** `tasks/archive/EPIC-VIRTUAL-DEVICES.md` (supersedes its key architectural decisions), `tasks/features/FEATURE-DEVICE-SPLITTER-PLUGIN.md`, `tasks/features/FEATURE-DEVICE-COMPOSITE-PLUGIN.md`
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-31-virtual-devices-design.md
+++ b/docs/superpowers/specs/2026-07-31-virtual-devices-design.md
@@ -240,7 +240,7 @@ Blocked categories are filtered from the wizard with *"needs a controller — pl
 3. Map each slot to a source property, filtered by data type and permissions — an `rw` slot needs an `rw` source, `ro` accepts either. The `device_information` channel is exempt: it is synthesized automatically as owned properties and is never presented for mapping.
 4. Shortcut *"take this whole channel"*: pick a source channel and the wizard expands it into per-property links against a chosen slot. This is the split flow, with no second data model.
 5. Name, room, zones.
-6. Live validation preview via `DeviceValidationService.validateDeviceStructure` (`device-validation.service.ts:239`), which already exists for exactly this.
+6. ~~Live validation preview via `DeviceValidationService.validateDeviceStructure`.~~ **Superseded during implementation.** Readiness is derived from the specification directly — every required slot filled, plus the constraint alerts a slot count cannot express — and each individual pairing is verified against `POST /plugins/devices-virtual/devices/compatibility`, which judges what `validateDeviceStructure` never looks at: the source's data type, permissions, format and sentinel against the slot's. A structural preview would have answered a question the wizard's own gate already answers, while staying silent on the one that actually refuses a create. Structure is still validated server-side on create, and the device list surfaces the stored validation state afterwards.
 7. Create, then optionally hide the source device(s).
 
 A source property may feed more than one virtual device — one sensor legitimately serves two rooms' climate. The energy guard skips projections wholesale, so this cannot double-count.

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -207,15 +207,15 @@ All onboarding device setup tasks complete.
 
 ## 8. Virtual Devices (Epic)
 
-> [EPIC-VIRTUAL-DEVICES](epics/EPIC-VIRTUAL-DEVICES.md) — Status: :construction: In Progress
+> [EPIC-VIRTUAL-DEVICES](archive/EPIC-VIRTUAL-DEVICES.md) — Status: :white_check_mark: Done
 
 Build a device from properties of other devices — splitting one physical device into several, or composing one logical device from several — so the result is indistinguishable from a native device. The two originally-planned plugins (`devices-split`, `devices-combined`) were superseded before implementation by a single `devices-virtual` plugin; see [`docs/superpowers/specs/2026-07-31-virtual-devices-design.md`](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md).
 
 | # | Task | Scope | Status | Notes |
 |---|------|-------|--------|-------|
-| 1 | [FEATURE-DEVICE-VIRTUAL-PLUGIN](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md) | backend, admin, panel | :construction: In Progress | Backend `devices-virtual` plugin + panel registration done; admin creation wizard and `hidden`-flag filtering in admin pickers not started |
+| 1 | [FEATURE-DEVICE-VIRTUAL-PLUGIN](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md) | backend, admin, panel | :white_check_mark: Done | Backend plugin, admin wizard and detail page with remap, `hidden` filtering across every picker, panel rendering. The six closed-loop categories stay blocked by the design's v1 boundary |
 
-**Next up:** Admin creation wizard (spec-driven channel/property mapping) and `hidden`-flag filtering in the admin device pickers — the backend API and panel rendering are already in place.
+**Next up:** controller support, which unblocks the six closed-loop categories the v1 boundary excludes — it needs a control loop with hysteresis and minimum cycle protection, plus user-settable setpoints as owned properties. The engineering backlog is tracked in [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md).
 
 ---
 

--- a/tasks/archive/EPIC-VIRTUAL-DEVICES.md
+++ b/tasks/archive/EPIC-VIRTUAL-DEVICES.md
@@ -75,7 +75,7 @@ Home Assistant's **Helpers** concept allows users to create virtual entities fro
 
 Delivered against §3: the `hidden` flag with filtering in every selection UI, the `devices-virtual` plugin, the admin creation wizard, panel rendering through the existing category-based pages, and spec validation against the chosen category.
 
-One step of the design's [creation flow](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#creation-flow) is built differently than written. Step 6 called for a live preview from `DeviceValidationService.validateDeviceStructure`; the wizard instead derives readiness from the specification directly — required slots filled, plus the constraint alerts a slot count cannot express — and verifies every individual pairing against the plugin's own compatibility endpoint, which judges the things structural validation does not (data type, permissions, format, sentinels). Structure is still validated server-side on create, and the device list surfaces the stored validation state afterwards.
+Step 6 of the design's [creation flow](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#creation-flow) was superseded during implementation — the spec records what replaced it and why.
 
 Left out deliberately, and still open:
 

--- a/tasks/archive/EPIC-VIRTUAL-DEVICES.md
+++ b/tasks/archive/EPIC-VIRTUAL-DEVICES.md
@@ -4,7 +4,7 @@ Type: feature
 Scope: backend, admin, panel
 Size: large
 Parent: (none)
-Status: in-progress
+Status: done
 
 ## 1. Business goal
 
@@ -69,7 +69,19 @@ Home Assistant's **Helpers** concept allows users to create virtual entities fro
 |---|------|-------|-------------|
 | 1 | [FEATURE-DEVICE-VIRTUAL-PLUGIN](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md) | backend, admin, panel | Build a device from properties of other devices — splitting one physical device into several, or composing one logical device from several |
 
-`FEATURE-DEVICE-SPLITTER-PLUGIN` and `FEATURE-DEVICE-COMPOSITE-PLUGIN` are superseded (see their headers) and collapsed into this single row. The backend `devices-virtual` plugin, the `hidden` flag foundation, and panel registration are implemented; the admin creation wizard and `hidden`-flag filtering in the admin device pickers are not yet built.
+`FEATURE-DEVICE-SPLITTER-PLUGIN` and `FEATURE-DEVICE-COMPOSITE-PLUGIN` are superseded (see their headers) and collapsed into this single row. All of it is delivered: the `hidden` flag foundation and the backend `devices-virtual` plugin (PR #628), then the admin plugin trio, the creation wizard, the detail page with its remap flow, `hidden` filtering across the space, tile, data-source and scene pickers, and the panel's handling of a source that is hidden underneath it (PR #635).
+
+## 4a. Delivered, and what was left out
+
+Delivered against §3: the `hidden` flag with filtering in every selection UI, the `devices-virtual` plugin, the admin creation wizard, panel rendering through the existing category-based pages, and spec validation against the chosen category.
+
+Left out deliberately, and still open:
+
+- **The six closed-loop categories** stay blocked, as [the design's v1 boundary](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#v1-category-boundary) sets out. Unblocking them needs a control loop with hysteresis and minimum cycle protection, plus user-settable setpoints as owned properties — the schema already accommodates the latter.
+- **Per-channel energy attribution**, so a split device's consumption lands in its own room. Pre-existing limitation, not introduced here.
+- Everything in §3's out-of-scope list: auto-detection of splittable devices, panel-side creation, new device specs, and extension-SDK support for third-party virtual devices.
+
+The engineering backlog this work accumulated lives in [`TECH-VIRTUAL-DEVICES-FOLLOWUPS`](../technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md), which stays open. Nothing there blocks the feature; the ones worth reading first are §3.3 (the TypeORM shared-`QueryRunner` TOCTOU, high but pre-existing), §3.7 and §3a.12 (the security and Buddy aggregates counting a source and its virtual replacement twice), and §3a.14 (tiles, data sources and scenes never reconciling a reference to a device that vanishes).
 
 ## 5. Technical constraints
 

--- a/tasks/archive/EPIC-VIRTUAL-DEVICES.md
+++ b/tasks/archive/EPIC-VIRTUAL-DEVICES.md
@@ -75,6 +75,8 @@ Home Assistant's **Helpers** concept allows users to create virtual entities fro
 
 Delivered against §3: the `hidden` flag with filtering in every selection UI, the `devices-virtual` plugin, the admin creation wizard, panel rendering through the existing category-based pages, and spec validation against the chosen category.
 
+One step of the design's [creation flow](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#creation-flow) is built differently than written. Step 6 called for a live preview from `DeviceValidationService.validateDeviceStructure`; the wizard instead derives readiness from the specification directly — required slots filled, plus the constraint alerts a slot count cannot express — and verifies every individual pairing against the plugin's own compatibility endpoint, which judges the things structural validation does not (data type, permissions, format, sentinels). Structure is still validated server-side on create, and the device list surfaces the stored validation state afterwards.
+
 Left out deliberately, and still open:
 
 - **The six closed-loop categories** stay blocked, as [the design's v1 boundary](../../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#v1-category-boundary) sets out. Unblocking them needs a control loop with hysteresis and minimum cycle protection, plus user-settable setpoints as owned properties — the schema already accommodates the latter.


### PR DESCRIPTION
Closes out `EPIC-VIRTUAL-DEVICES` now that #635 has merged, and settles the one place where the implementation diverged from the design.

**The epic**

- `Status: done`, and the file moves to `tasks/archive/`, where the other completed epics live.
- A new §4a records what was delivered against §3, and what was left out on purpose: the six closed-loop categories the design's v1 boundary excludes, per-channel energy attribution, and §3's own out-of-scope list (auto-detection, panel-side creation, new specs, extension-SDK support).
- `tasks/ROADMAP.md` §8 follows: the epic and its one child row are marked done, and **Next up** now points at controller support rather than the wizard that has been built.

**The divergence**

Step 6 of the design's creation flow specified a live preview from `DeviceValidationService.validateDeviceStructure`. It was not built that way, and on review it should not be: the wizard derives readiness from the specification itself (required slots filled, plus the constraint alerts a slot count cannot express) and verifies each individual pairing against `POST /plugins/devices-virtual/devices/compatibility`, which judges the source's data type, permissions, format and sentinel against the slot's — none of which structural validation looks at. Structure is still validated server-side on create, and the device list surfaces the stored validation state afterwards.

That step is now marked superseded in the design spec, with the reasoning, so the design and the code agree. The epic's §4a points at it rather than repeating it.

**Audit**

Every §3 claim was checked against `main` before closing:

| Claim | Evidence |
|---|---|
| `hidden` filtering across all selection UIs | `@ValidateDeviceNotHidden()` on the create *and* update DTOs of all four picker plugins; every admin picker reads `useDevices()` / `useSpaceDevices`, both of which drop hidden devices |
| `devices-virtual` plugin | plugin, platform, index and listeners; a write to an orphaned projection is refused at `virtual-device.platform.ts:70` |
| Admin creation wizard | four steps, including the whole-channel shortcut, the `device_information` exemption and the optional source hide |
| Panel renders virtual devices as normal devices | `plugin.dart` plus models and mappers carrying `valueOrigin` and `sourceProperty` |
| Spec validation | server-side on create; stored state surfaced in the device list |
| Auto-unhide, degradation over cascade | the maintenance listener, and the status listener forcing `DISCONNECTED` on an orphan |

`TECH-VIRTUAL-DEVICES-FOLLOWUPS` stays open — 25 of its 36 items are unresolved, none blocking. The ones worth reading first are called out in §4a.

Docs only; no code, no tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)