### PR TITLE
docs(docs): propose OAuth authorization architecture

### DIFF
--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -53,8 +53,9 @@ RFC 9700. It implements RFC 6750, RFC 7009, RFC 7636, RFC 8252, RFC 8414, RFC 87
 applicable.
 
 The only initial interactive flow is authorization code with PKCE `S256`. Codes are single-use and expire after at
-most 60 seconds. Redirect URIs use exact string matching. Authorization responses include `iss`, including error
-responses, and metadata advertises `authorization_response_iss_parameter_supported: true`.
+most 60 seconds. Redirect URIs use exact string matching except for the runtime port of native loopback IP literals, as
+required by RFC 8252. Authorization responses include `iss`, including error responses, and metadata advertises
+`authorization_response_iss_parameter_supported: true`.
 
 Metadata advertises only features that are actually enabled. It explicitly advertises `none` as the sole initial
 token-endpoint authentication method and lists `offline_access` in `scopes_supported` because the refresh policy below
@@ -89,7 +90,10 @@ resource and issuer no longer match; it does not change the installation UUID or
 ### 4. Client registration
 
 The first release uses owner/admin pre-registration. A public client receives a generated client ID, no client secret,
-and exact redirect URI allowlist. Codex and Claude Code both document this configuration path.
+and a redirect URI allowlist. HTTPS redirects and `localhost` hostname redirects match exactly. Native `http` redirects
+using the loopback IP literals `127.0.0.1` or `[::1]` match scheme, literal address, path, query, and trailing slash
+exactly but accept any runtime port, as required by RFC 8252 section 7.3. Codex and Claude Code both document the
+predefined-client configuration path.
 
 CIMD is the preferred direction in MCP `2026-07-28`, but is deferred until its draft revision and outbound metadata
 fetch controls are proven compatible. DCR is deprecated by the current MCP revision and is not required by the two
@@ -189,8 +193,8 @@ reissue or downgrade an OAuth token into a static credential.
 
 | Threat | Required control |
 | --- | --- |
-| Authorization-code interception or replay | PKCE `S256`, 60-second single-use codes, exact client/redirect/resource binding |
-| Redirect exfiltration | Owner-created exact allowlist; HTTPS except exact native loopback URIs; no wildcards, fragments, or prefix matching |
+| Authorization-code interception or replay | PKCE `S256`, 60-second single-use codes, and exact client/resource/redirect binding except the RFC 8252 loopback-IP port |
+| Redirect exfiltration | Owner-created allowlist; HTTPS except native loopback redirects; only loopback IP literals may vary the port; no wildcards, fragments, or general prefix matching |
 | CSRF and login/consent confusion | OAuth `state` handled by clients, same-site interaction cookies, authenticated interaction binding, explicit approve/deny |
 | Authorization-server mix-up | RFC 9207 `iss` in success and error responses; exact issuer in discovery and stored artifacts |
 | Token replay at another service or installation | Exact RFC 8707 resource/audience plus issuer, installation, client, and token-type validation |
@@ -231,7 +235,8 @@ Rejected. It breaks credential isolation, audience semantics, revocation behavio
 
 - Smart Panel remains usable as a standalone installation and owns the complete consent/revocation experience.
 - The backend gains persistent OAuth state and a carefully bounded authorization-server dependency.
-- Owners must pre-register the first Codex/Claude clients and configure fixed exact callback URIs.
+- Owners must pre-register the first Codex/Claude clients and configure callback URIs; native loopback IP callbacks may
+  select an ephemeral runtime port under RFC 8252.
 - DCR's attack surface is avoided, but one-click setup for clients that cannot accept a predefined client ID is
   deferred.
 - Public URL changes intentionally force OAuth reauthorization while static LAN/VPN credentials remain stable.

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -181,9 +181,17 @@ codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or tok
 
 ### 8. Deployment and upgrades
 
-OAuth remains disabled by default. Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy
-configuration, endpoint and login rate limits, current backups, and an incident-response procedure. Forwarded headers
-remain ignored until a separately configured trusted-proxy mechanism validates the immediate proxy.
+OAuth remains disabled by default. Adding persistence, consent, token, discovery, or validation code does not make any
+OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. The user-facing enable
+switch is added only after the application can verify that access-token expiry timers, targeted client/grant/token/family
+subscription aborts, approver update/delete invalidation, public-identity rotation, owner/admin revoke controls, audit
+hooks, and endpoint rate limits are all registered. A failed readiness check leaves protected-resource metadata,
+authorization-server metadata, authorization/token/revocation endpoints, OAuth challenges, and OAuth MCP bearer
+validation unmounted together. The initial static bearer behavior remains unchanged during that failure.
+
+Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy configuration, endpoint and login
+rate limits, current backups, and an incident-response procedure. Forwarded headers remain ignored until a separately
+configured trusted-proxy mechanism validates the immediate proxy.
 
 Database migrations are incremental. Authorization state uses persistent TypeORM storage; in-memory dependency adapters
 are test-only. Backups contain client/grant/token metadata and therefore remain sensitive even though raw bearer values
@@ -212,6 +220,7 @@ reissue or downgrade an OAuth token into a static credential.
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
 | Access token expires while a stream is open | Register the token expiry with the subscription and abort the stream at that deadline |
 | A grant approver is demoted or deleted | Listen for user update/delete events and revoke every grant, token artifact, and subscription approved by a user who is no longer owner/admin |
+| A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or mount any OAuth route until a startup readiness gate verifies every invalidation and admin control |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |
 | Compromised owner/admin account | Existing login hardening, complete OAuth audit, revoke-all control, documented recovery workflow |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -110,7 +110,8 @@ personal tokens, display tokens, or static MCP tokens.
 
 The initial token policy is:
 
-- opaque, high-entropy access tokens stored only as hashes, with a maximum lifetime of 10 minutes;
+- opaque, high-entropy access tokens stored only as hashes, with a maximum lifetime of 10 minutes and an expiry no
+  later than their grant expiry;
 - opaque refresh tokens stored only as hashes, issued only when `offline_access` is explicitly requested and consented;
 - refresh rotation on every use with reuse detection that revokes the entire token family;
 - a maximum refresh-family lifetime of 30 days;
@@ -133,8 +134,9 @@ module capability ceiling
   ∩ access-token scopes
 ```
 
-The intersection is recomputed for every request and immediately before tool execution. Scope reduction never waits
-for access-token expiry.
+The intersection is recomputed for every request and immediately before tool execution. The grant check also confirms
+that its approving user still exists with owner/admin role. Scope reduction or approver demotion never waits for
+access-token expiry.
 
 ### 6. Login, consent, and recovery
 
@@ -158,23 +160,28 @@ broader scope set, or expired/revoked grant requires a fresh consent decision.
 Account recovery remains the existing owner recovery procedure, including `auth:reset`. Resetting a password or user
 session does not silently revoke OAuth grants. The recovery UI and runbook must offer an explicit “revoke all MCP OAuth
 grants” action for suspected compromise. Deleting an approving user or changing that user to any role other than owner
-or administrator revokes every grant they approved and its matching subscriptions. Disabling MCP or rotating the OAuth
-server secret applies the corresponding global revocation policy.
+or administrator uses an awaited lifecycle path that revokes every grant they approved and its matching subscriptions
+before the user mutation returns success. Disabling MCP or rotating the OAuth server secret applies the corresponding
+global revocation policy; server-secret rotation revokes every OAuth artifact and closes every OAuth subscription.
 
 ### 7. Revocation and administrative control
 
 Owners and administrators can list clients, grants, active access tokens, and refresh-token families without seeing raw
 secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Every OAuth
-subscription is bound to its client, grant, access-token ID, refresh-family ID when present, and access-token expiry.
+subscription is bound to its client, grant, access-token ID, refresh-family ID when present, and an authorization
+deadline equal to the earlier of its access-token expiry or grant expiry.
 Revoking any of those artifacts aborts exactly the matching active subscriptions before the administrative mutation
-reports success. The subscription registry also schedules an abort at access-token expiry, because a long-lived stream
-does not re-run per-request authentication while it is open. Disabling the MCP module closes all MCP subscriptions and
-denies both authorization and resource requests.
+reports success. The subscription registry schedules an abort at the authorization deadline, because a long-lived
+stream does not re-run per-request authentication while it is open. Disabling the MCP module closes all MCP
+subscriptions and denies both authorization and resource requests.
 
-An MCP OAuth lifecycle listener handles `UsersModule.User.Updated` and `UsersModule.User.Deleted`. When the emitted user
-no longer exists or no longer has the owner/admin role required to approve MCP grants, the listener revokes all grants
-approved by that user and their access and refresh artifacts, then closes their matching subscriptions before the
-listener reports completion. A profile-only update by an owner/admin does not revoke grants.
+Approver invalidation must use an awaited lifecycle path, such as a directly orchestrated service or propagated
+`emitAsync`; the existing fire-and-forget `eventEmitter.emit` calls are not sufficient. For
+`UsersModule.User.Updated` and `UsersModule.User.Deleted`, when the user no longer exists or no longer has the
+owner/admin role required to approve MCP grants, the awaited handler revokes all grants approved by that user and their
+access and refresh artifacts, then closes their matching subscriptions before resolving. Its failure prevents the user
+mutation from returning success, while live grant validation still fails closed against the user's persisted role. A
+profile-only update by an owner/admin does not revoke grants.
 
 Client and grant mutations are audited. Logs may contain IDs, scope names, denial codes, and timestamps, but never raw
 codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or token hashes.
@@ -183,9 +190,10 @@ codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or tok
 
 OAuth remains disabled by default. Adding persistence, consent, token, discovery, or validation code does not make any
 OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. The user-facing enable
-switch is added only after the application can verify that access-token expiry timers, targeted client/grant/token/family
-subscription aborts, approver update/delete invalidation, public-identity rotation, owner/admin revoke controls, audit
-hooks, and endpoint rate limits are all registered. A failed readiness check leaves protected-resource metadata,
+switch is added only after the application can verify that access-token/grant authorization-deadline timers, targeted
+client/grant/token/family subscription aborts, awaited approver update/delete invalidation, public-identity and
+server-secret rotation invalidation, owner/admin revoke controls, audit hooks, and endpoint rate limits are all
+registered. A failed readiness check leaves protected-resource metadata,
 authorization-server metadata, authorization/token/revocation endpoints, OAuth challenges, and OAuth MCP bearer
 validation unmounted together. The initial static bearer behavior remains unchanged during that failure.
 
@@ -218,8 +226,9 @@ reissue or downgrade an OAuth token into a static credential.
 | Malicious dynamic/CIMD registration | No DCR/CIMD in the initial profile; later enablement requires SSRF, quota, and redirect-policy review |
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
-| Access token expires while a stream is open | Register the token expiry with the subscription and abort the stream at that deadline |
-| A grant approver is demoted or deleted | Listen for user update/delete events and revoke every grant, token artifact, and subscription approved by a user who is no longer owner/admin |
+| An access token or its grant expires while a stream is open | Cap token expiry at grant expiry and abort the subscription at the earlier authorization deadline |
+| A grant approver is demoted or deleted | Use an awaited user-lifecycle path and do not report the user mutation successful until every affected grant, token artifact, and subscription is revoked |
+| OAuth server secret is rotated after compromise | Revoke all OAuth artifacts and close all OAuth subscriptions as one global invalidation operation |
 | A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or mount any OAuth route until a startup readiness gate verifies every invalidation and admin control |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -157,8 +157,9 @@ broader scope set, or expired/revoked grant requires a fresh consent decision.
 
 Account recovery remains the existing owner recovery procedure, including `auth:reset`. Resetting a password or user
 session does not silently revoke OAuth grants. The recovery UI and runbook must offer an explicit “revoke all MCP OAuth
-grants” action for suspected compromise. Disabling/deleting the approving user, disabling MCP, or rotating the OAuth
-server secret revokes affected grants and subscriptions according to documented policy.
+grants” action for suspected compromise. Deleting an approving user or changing that user to any role other than owner
+or administrator revokes every grant they approved and its matching subscriptions. Disabling MCP or rotating the OAuth
+server secret applies the corresponding global revocation policy.
 
 ### 7. Revocation and administrative control
 
@@ -169,6 +170,11 @@ Revoking any of those artifacts aborts exactly the matching active subscriptions
 reports success. The subscription registry also schedules an abort at access-token expiry, because a long-lived stream
 does not re-run per-request authentication while it is open. Disabling the MCP module closes all MCP subscriptions and
 denies both authorization and resource requests.
+
+An MCP OAuth lifecycle listener handles `UsersModule.User.Updated` and `UsersModule.User.Deleted`. When the emitted user
+no longer exists or no longer has the owner/admin role required to approve MCP grants, the listener revokes all grants
+approved by that user and their access and refresh artifacts, then closes their matching subscriptions before the
+listener reports completion. A profile-only update by an owner/admin does not revoke grants.
 
 Client and grant mutations are audited. Logs may contain IDs, scope names, denial codes, and timestamps, but never raw
 codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or token hashes.
@@ -205,6 +211,7 @@ reissue or downgrade an OAuth token into a static credential.
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
 | Access token expires while a stream is open | Register the token expiry with the subscription and abort the stream at that deadline |
+| A grant approver is demoted or deleted | Listen for user update/delete events and revoke every grant, token artifact, and subscription approved by a user who is no longer owner/admin |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |
 | Compromised owner/admin account | Existing login hardening, complete OAuth audit, revoke-all control, documented recovery workflow |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -194,6 +194,14 @@ before enumerating and closing streams. Therefore an open either registers first
 observes the new generation and fails/revalidates; an in-flight stale request cannot register after invalidation reports
 success.
 
+The global OAuth-enabled generation also serializes every grant, authorization-code, access-token, and refresh-token
+creation or rotation with switch-off. Each handler captures the generation, and its TypeORM transaction conditionally
+rechecks that the gate is open and the generation is unchanged while committing artifacts tagged with that generation.
+Switch-off closes the gate and increments the generation through the same persistent serialization boundary before
+revoke-all begins. A racing handler therefore commits first and its artifact is revoked, or its stale conditional
+commit fails. Artifact validation always requires the current enabled generation, providing a fail-closed backstop
+across disable and readiness-gated re-enable.
+
 Approver invalidation must use an awaited lifecycle path, such as a directly orchestrated service or propagated
 `emitAsync`; the existing fire-and-forget `eventEmitter.emit` calls are not sufficient. For
 `UsersModule.User.Updated` and `UsersModule.User.Deleted`, when the user no longer exists or no longer has the
@@ -208,21 +216,26 @@ codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or tok
 ### 8. Deployment and upgrades
 
 OAuth remains disabled by default. Adding persistence, consent, token, discovery, or validation code does not make any
-OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. The user-facing enable
-switch is added only after the application can verify that access-token/grant authorization-deadline timers, targeted
-client/grant/token/family and live-scope-reduction subscription aborts, awaited approver update/delete invalidation,
-serialized subscription-open/invalidation gates, public-identity/server-secret rotation invalidation, OAuth switch-off
-invalidation, owner/admin revoke controls, audit hooks, and endpoint rate limits are all registered. A failed readiness
-check leaves protected-resource metadata,
-authorization-server metadata, authorization/token/revocation endpoints, OAuth challenges, and OAuth MCP bearer
-validation unmounted together. The initial static bearer behavior remains unchanged during that failure.
+OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. Once Phase 5 ships,
+NestJS/Fastify registers the complete OAuth route table once at process bootstrap; it never mounts or unmounts routes
+after the server starts. Every OAuth route checks one shared fail-closed gate before its handler, so the entire surface
+is unavailable until both the stored enable setting and startup readiness pass.
 
-Switching OAuth off first closes the shared fail-closed runtime gate, so every OAuth discovery, authorization, token,
-revocation, challenge, and OAuth-bearing MCP request is rejected before reaching its handler. The same awaited mutation
-then revokes all outstanding OAuth artifacts and aborts all OAuth subscriptions before reporting success; static MCP
-credentials and streams remain active. An invalidation failure keeps OAuth fail-closed and makes the mutation return an
-error. Re-enabling reruns the complete readiness gate and does not reactivate the revoked artifacts: clients must begin
-a new authorization flow.
+The user-facing enable switch is added only after the application can verify that access-token/grant
+authorization-deadline timers, targeted client/grant/token/family and live-scope-reduction subscription aborts,
+awaited approver update/delete invalidation, serialized subscription-open/invalidation and artifact-issuance gates,
+public-identity/server-secret rotation invalidation, OAuth switch-off invalidation, owner/admin revoke controls, audit
+hooks, and endpoint rate limits are all registered. A failed readiness check keeps the gate closed for
+protected-resource metadata, authorization-server metadata, authorization/token/revocation endpoints, OAuth
+challenges, and OAuth MCP bearer validation together. The initial static bearer behavior remains unchanged during that
+failure.
+
+Switching OAuth off first closes the shared fail-closed runtime gate and atomically increments its persistent
+generation, so every later OAuth request is rejected before its handler and every in-flight artifact commit with the
+old generation fails. The same awaited mutation then revokes all outstanding OAuth artifacts and aborts all OAuth
+subscriptions before reporting success; static MCP credentials and streams remain active. An invalidation failure
+keeps OAuth fail-closed and makes the mutation return an error. Re-enabling reruns the complete readiness gate under a
+new generation and does not reactivate the revoked artifacts: clients must begin a new authorization flow.
 
 Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy configuration, endpoint and login
 rate limits, current backups, and an incident-response procedure. Forwarded headers remain ignored until a separately
@@ -256,11 +269,12 @@ reissue or downgrade an OAuth token into a static credential.
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
 | A validated listen request races artifact invalidation | Atomically recheck authorization generations while registering under the same serialization boundary used to gate and close streams |
+| Artifact issuance races OAuth switch-off | Conditionally commit every artifact against the persistent enabled generation; switch-off closes and increments that generation before revoke-all |
 | An access token or its grant expires while a stream is open | Cap token expiry at grant expiry and abort the subscription at the earlier authorization deadline |
 | A grant approver is demoted or deleted | Use an awaited user-lifecycle path and do not report the user mutation successful until every affected grant, token artifact, and subscription is revoked |
 | OAuth server secret is rotated after compromise | Revoke all OAuth artifacts and close all OAuth subscriptions as one global invalidation operation |
 | OAuth is switched off while subscriptions are open | Fail closed for all OAuth traffic, revoke OAuth artifacts, and close OAuth streams atomically while preserving static MCP streams |
-| A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or mount any OAuth route until a startup readiness gate verifies every invalidation and admin control |
+| A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or open the shared route gate until startup readiness verifies every invalidation and admin control |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |
 | Compromised owner/admin account | Existing login hardening, complete OAuth audit, revoke-all control, documented recovery workflow |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -113,7 +113,8 @@ The initial token policy is:
 - opaque, high-entropy access tokens stored only as hashes, with a maximum lifetime of 10 minutes and an expiry no
   later than their grant expiry;
 - opaque refresh tokens stored only as hashes, issued only when `offline_access` is explicitly requested and consented;
-- refresh rotation on every use with reuse detection that revokes the entire token family;
+- refresh rotation on every use through an atomic compare-and-consume transaction, with a unique predecessor/successor
+  constraint and reuse detection that revokes the entire token family;
 - a maximum refresh-family lifetime of 30 days;
 - a maximum grant lifetime of 90 days, with no “never expires” option; and
 - immediate database-backed revocation checks for every MCP request.
@@ -136,10 +137,10 @@ module capability ceiling
 
 The intersection is recomputed for every request and immediately before tool execution. The grant check also confirms
 that its approving user still exists with owner/admin role. An OAuth subscription records the effective scope set and
-the identities or versions of every input that produced it. An awaited invalidation path closes an affected stream
-before a module capability ceiling, registered-client maximum, or approved-grant scope reduction reports success; a
-configuration notification alone is not sufficient. Scope reduction or approver demotion never waits for access-token
-expiry.
+the generation of every input that produced it. An awaited invalidation path closes an affected stream on any effective
+scope contraction before a module capability ceiling, registered-client maximum, or approved-grant scope reduction
+reports success; a configuration notification alone is not sufficient. Scope reduction or approver demotion never
+waits for access-token expiry.
 
 ### 6. Login, consent, and recovery
 
@@ -172,16 +173,26 @@ global revocation policy; server-secret rotation revokes every OAuth artifact an
 Owners and administrators can list clients, grants, active access tokens, and refresh-token families without seeing raw
 secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Every OAuth
 subscription is bound to its client, grant, access-token ID, refresh-family ID when present, effective scopes, the
-module/client/grant authorization inputs that produced those scopes, and an authorization deadline equal to the earlier
-of its access-token expiry or grant expiry.
+generation of the module/client/grant authorization inputs that produced those scopes, and an authorization deadline
+equal to the earlier of its access-token expiry or grant expiry.
 
 Revoking an artifact aborts exactly the matching active subscriptions before the administrative mutation reports
 success. Reducing the module ceiling, registered-client maximum, or approved-grant scopes uses the same awaited path to
-abort every OAuth subscription whose required `mcp:read` capability is no longer effective. This path is invoked by the
-authoritative mutation, not only by the existing asynchronous MCP configuration listener. The subscription registry
-also schedules an abort at the authorization deadline, because a long-lived stream does not re-run per-request
+abort every OAuth subscription whose effective scope set contracts, including removal of `mcp:write` or `mcp:trigger`
+while `mcp:read` remains. Closing is required because the MCP server and its advertised tools are shaped and cached at
+stream creation; clients may open a newly authorized stream if they still retain `mcp:read`. This path is invoked by
+the authoritative mutation, not only by the existing asynchronous MCP configuration listener. The subscription
+registry also schedules an abort at the authorization deadline, because a long-lived stream does not re-run per-request
 authentication while it is open. Disabling the MCP module closes all MCP subscriptions and denies both authorization
 and resource requests.
+
+Subscription opening and invalidation share one authoritative serialization boundary. Authentication captures the
+OAuth-enabled generation and the client, grant, token, refresh-family, and authorization-input generations.
+Registration atomically rechecks those generations and the live effective scopes while adding the stream. An
+invalidating mutation closes the applicable gate or increments the applicable generation within the same boundary
+before enumerating and closing streams. Therefore an open either registers first and is included in invalidation, or
+observes the new generation and fails/revalidates; an in-flight stale request cannot register after invalidation reports
+success.
 
 Approver invalidation must use an awaited lifecycle path, such as a directly orchestrated service or propagated
 `emitAsync`; the existing fire-and-forget `eventEmitter.emit` calls are not sufficient. For
@@ -200,8 +211,9 @@ OAuth remains disabled by default. Adding persistence, consent, token, discovery
 OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. The user-facing enable
 switch is added only after the application can verify that access-token/grant authorization-deadline timers, targeted
 client/grant/token/family and live-scope-reduction subscription aborts, awaited approver update/delete invalidation,
-public-identity/server-secret rotation invalidation, OAuth switch-off invalidation, owner/admin revoke controls, audit
-hooks, and endpoint rate limits are all registered. A failed readiness check leaves protected-resource metadata,
+serialized subscription-open/invalidation gates, public-identity/server-secret rotation invalidation, OAuth switch-off
+invalidation, owner/admin revoke controls, audit hooks, and endpoint rate limits are all registered. A failed readiness
+check leaves protected-resource metadata,
 authorization-server metadata, authorization/token/revocation endpoints, OAuth challenges, and OAuth MCP bearer
 validation unmounted together. The initial static bearer behavior remains unchanged during that failure.
 
@@ -237,11 +249,13 @@ reissue or downgrade an OAuth token into a static credential.
 | Token replay at another service or installation | Exact RFC 8707 resource/audience plus issuer, installation, client, and token-type validation |
 | Stolen access token | Ten-minute maximum lifetime, hashed persistence, TLS, log redaction, immediate revocation check |
 | Stolen/replayed refresh token | Rotation, family reuse detection, 30-day absolute lifetime, hashed persistence |
+| Concurrent refresh-token replay forks a family | Atomically compare-and-consume the token, allow at most one successor row, and make every losing reuse attempt revoke the whole family including the successor |
 | Scope escalation or stale permission | Four-way live intersection and recheck immediately before tool execution |
 | A live scope input shrinks while an OAuth stream is open | Bind the stream to its module/client/grant inputs and abort it through the awaited authoritative mutation path before the reduction reports success |
 | Malicious dynamic/CIMD registration | No DCR/CIMD in the initial profile; later enablement requires SSRF, quota, and redirect-policy review |
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
+| A validated listen request races artifact invalidation | Atomically recheck authorization generations while registering under the same serialization boundary used to gate and close streams |
 | An access token or its grant expires while a stream is open | Cap token expiry at grant expiry and abort the subscription at the earlier authorization deadline |
 | A grant approver is demoted or deleted | Use an awaited user-lifecycle path and do not report the user mutation successful until every affected grant, token artifact, and subscription is revoked |
 | OAuth server secret is rotated after compromise | Revoke all OAuth artifacts and close all OAuth subscriptions as one global invalidation operation |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -85,7 +85,9 @@ and scopes all match the current request.
 The existing static MCP credential audience
 `urn:fastybird:smart-panel:<installation-uuid>:mcp` remains unchanged. Static and OAuth credentials have separate token
 types and validation paths. Changing the public base URL immediately invalidates outstanding OAuth tokens because their
-resource and issuer no longer match; it does not change the installation UUID or static credential audience.
+resource and issuer no longer match. The change also advances the public-identity generation, revokes OAuth artifacts,
+and closes OAuth subscriptions, but it does not change the installation UUID, static credential audience, or static
+subscriptions.
 
 ### 4. Client registration
 
@@ -194,21 +196,25 @@ before enumerating and closing streams. Therefore an open either registers first
 observes the new generation and fails/revalidates; an in-flight stale request cannot register after invalidation reports
 success.
 
-The global OAuth-enabled generation also serializes every grant, authorization-code, access-token, and refresh-token
-creation or rotation with switch-off. Each handler captures the generation, and its TypeORM transaction conditionally
-rechecks that the gate is open and the generation is unchanged while committing artifacts tagged with that generation.
-Switch-off closes the gate and increments the generation through the same persistent serialization boundary before
-revoke-all begins. A racing handler therefore commits first and its artifact is revoked, or its stale conditional
-commit fails. Artifact validation always requires the current enabled generation, providing a fail-closed backstop
-across disable and readiness-gated re-enable.
+Every grant, authorization-code, access-token, and refresh-token creation or rotation is serialized with every state
+change that can invalidate it. Each handler captures the OAuth-enabled, server-secret, public-identity, client, grant,
+module-policy, and approving-user authority generations that apply to its artifact. Its TypeORM transaction
+conditionally rechecks the current states and generations while committing the artifact with that snapshot. An
+invalidating mutation advances its persistent generation through the same serialization boundary before enumerating
+and revoking existing artifacts. A racing handler therefore commits first and is included in invalidation, or its stale
+conditional commit fails. Artifact validation also requires every stored generation to match the current generation,
+providing a fail-closed backstop if a client, role, or setting is later restored.
 
 Approver invalidation must use an awaited lifecycle path, such as a directly orchestrated service or propagated
 `emitAsync`; the existing fire-and-forget `eventEmitter.emit` calls are not sufficient. For
 `UsersModule.User.Updated` and `UsersModule.User.Deleted`, when the user no longer exists or no longer has the
-owner/admin role required to approve MCP grants, the awaited handler revokes all grants approved by that user and their
-access and refresh artifacts, then closes their matching subscriptions before resolving. Its failure prevents the user
-mutation from returning success, while live grant validation still fails closed against the user's persisted role. A
-profile-only update by an owner/admin does not revoke grants.
+owner/admin role required to approve MCP grants, the mutation first advances that user's authority generation through
+the shared artifact-commit boundary. It then revokes all grants approved by that user and their access and refresh
+artifacts and closes their matching subscriptions before resolving. A paused consent using the previous generation
+cannot commit afterward, and restoring the role creates a new generation rather than reviving old grants. Invalidation
+failure prevents the user mutation from returning success, while live grant validation still fails closed against the
+user's persisted role and generation. A profile-only update by an owner/admin does not advance the authority generation
+or revoke grants.
 
 Client and grant mutations are audited. Logs may contain IDs, scope names, denial codes, and timestamps, but never raw
 codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or token hashes.
@@ -223,19 +229,22 @@ is unavailable until both the stored enable setting and startup readiness pass.
 
 The user-facing enable switch is added only after the application can verify that access-token/grant
 authorization-deadline timers, targeted client/grant/token/family and live-scope-reduction subscription aborts,
-awaited approver update/delete invalidation, serialized subscription-open/invalidation and artifact-issuance gates,
-public-identity/server-secret rotation invalidation, OAuth switch-off invalidation, owner/admin revoke controls, audit
-hooks, and endpoint rate limits are all registered. A failed readiness check keeps the gate closed for
+awaited approver update/delete invalidation, serialized subscription-open/invalidation and all-generation
+artifact-issuance gates, public-identity/server-secret rotation invalidation, OAuth switch-off invalidation,
+owner/admin revoke controls, audit hooks, and endpoint rate limits are all registered. A failed readiness check keeps
+the gate closed for
 protected-resource metadata, authorization-server metadata, authorization/token/revocation endpoints, OAuth
 challenges, and OAuth MCP bearer validation together. The initial static bearer behavior remains unchanged during that
 failure.
 
 Switching OAuth off first closes the shared fail-closed runtime gate and atomically increments its persistent
-generation, so every later OAuth request is rejected before its handler and every in-flight artifact commit with the
-old generation fails. The same awaited mutation then revokes all outstanding OAuth artifacts and aborts all OAuth
-subscriptions before reporting success; static MCP credentials and streams remain active. An invalidation failure
-keeps OAuth fail-closed and makes the mutation return an error. Re-enabling reruns the complete readiness gate under a
-new generation and does not reactivate the revoked artifacts: clients must begin a new authorization flow.
+generation through the common artifact-commit boundary, so every later OAuth request is rejected before its handler and
+every in-flight artifact commit with the old generation fails. Server-secret or public-identity rotation likewise
+advances its own generation before revoke-all. Each awaited mutation then revokes all outstanding OAuth artifacts and
+aborts all OAuth subscriptions before reporting success; static MCP credentials and streams remain active. An
+invalidation failure keeps OAuth fail-closed and makes the mutation return an error. Re-enabling reruns the complete
+readiness gate under a new generation and does not reactivate the revoked artifacts: clients must begin a new
+authorization flow.
 
 Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy configuration, endpoint and login
 rate limits, current backups, and an incident-response procedure. Forwarded headers remain ignored until a separately
@@ -269,10 +278,10 @@ reissue or downgrade an OAuth token into a static credential.
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
 | A validated listen request races artifact invalidation | Atomically recheck authorization generations while registering under the same serialization boundary used to gate and close streams |
-| Artifact issuance races OAuth switch-off | Conditionally commit every artifact against the persistent enabled generation; switch-off closes and increments that generation before revoke-all |
+| Artifact issuance races an invalidating mutation | Conditionally commit against all persistent enabled/secret/identity/client/grant/policy/approver generations; advance the affected generation before revocation |
 | An access token or its grant expires while a stream is open | Cap token expiry at grant expiry and abort the subscription at the earlier authorization deadline |
-| A grant approver is demoted or deleted | Use an awaited user-lifecycle path and do not report the user mutation successful until every affected grant, token artifact, and subscription is revoked |
-| OAuth server secret is rotated after compromise | Revoke all OAuth artifacts and close all OAuth subscriptions as one global invalidation operation |
+| A grant approver is demoted or deleted | Advance the approver-authority generation, then await revocation and stream closure before success so a paused consent cannot escape or later revive |
+| OAuth server secret or public identity rotates | Advance its artifact generation before revoke-all, then revoke OAuth artifacts and close OAuth subscriptions while preserving static streams |
 | OAuth is switched off while subscriptions are open | Fail closed for all OAuth traffic, revoke OAuth artifacts, and close OAuth streams atomically while preserving static MCP streams |
 | A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or open the shared route gate until startup readiness verifies every invalidation and admin control |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -57,9 +57,10 @@ most 60 seconds. Redirect URIs use exact string matching. Authorization response
 responses, and metadata advertises `authorization_response_iss_parameter_supported: true`.
 
 Metadata advertises only features that are actually enabled. It explicitly advertises `none` as the sole initial
-token-endpoint authentication method. No OIDC scopes, ID tokens, user-info endpoint, introspection endpoint, JWKS URI,
-signing algorithm, confidential-client authentication method, or registration endpoint is advertised merely because
-the selected dependency can implement it.
+token-endpoint authentication method and lists `offline_access` in `scopes_supported` because the refresh policy below
+implements its explicit-consent semantics. No OIDC identity scopes (`openid`, `profile`, `email`, or similar), ID
+tokens, user-info endpoint, introspection endpoint, JWKS URI, signing algorithm, confidential-client authentication
+method, or registration endpoint is advertised merely because the selected dependency can implement it.
 
 ### 3. Canonical URLs and resource binding
 
@@ -117,8 +118,9 @@ signing-key distribution problem. Issuer, resource/audience, client, installatio
 bindings are stored server-side. Authorization-server metadata therefore advertises no signing algorithms unless a
 later accepted change actually introduces a signed artifact.
 
-OAuth scopes are `mcp:read`, `mcp:write`, and `mcp:trigger`. `offline_access` controls refresh eligibility but is not an
-MCP capability. Effective authorization remains:
+OAuth scopes are `mcp:read`, `mcp:write`, `mcp:trigger`, and `offline_access`. `offline_access` is advertised and
+consented only to control refresh eligibility; it is not an OIDC login request or an MCP capability. Omitting it means
+the token endpoint returns no refresh token. Effective authorization remains:
 
 ```text
 module capability ceiling
@@ -157,9 +159,12 @@ server secret revokes affected grants and subscriptions according to documented 
 ### 7. Revocation and administrative control
 
 Owners and administrators can list clients, grants, active access tokens, and refresh-token families without seeing raw
-secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Grant/client
-revocation closes only that client's active MCP subscriptions immediately. Disabling the MCP module closes all MCP
-subscriptions and denies both authorization and resource requests.
+secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Every OAuth
+subscription is bound to its client, grant, access-token ID, refresh-family ID when present, and access-token expiry.
+Revoking any of those artifacts aborts exactly the matching active subscriptions before the administrative mutation
+reports success. The subscription registry also schedules an abort at access-token expiry, because a long-lived stream
+does not re-run per-request authentication while it is open. Disabling the MCP module closes all MCP subscriptions and
+denies both authorization and resource requests.
 
 Client and grant mutations are audited. Logs may contain IDs, scope names, denial codes, and timestamps, but never raw
 codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or token hashes.
@@ -194,7 +199,8 @@ reissue or downgrade an OAuth token into a static credential.
 | Scope escalation or stale permission | Four-way live intersection and recheck immediately before tool execution |
 | Malicious dynamic/CIMD registration | No DCR/CIMD in the initial profile; later enablement requires SSRF, quota, and redirect-policy review |
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
-| Client or grant revocation with an open stream | Targeted subscription abort before the administrative mutation reports success |
+| Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
+| Access token expires while a stream is open | Register the token expiry with the subscription and abort the stream at that deadline |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |
 | Compromised owner/admin account | Existing login hardening, complete OAuth audit, revoke-all control, documented recovery workflow |

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -1,0 +1,243 @@
+# ADR 0002: Embedded OAuth Authorization for Remote MCP
+
+**Status:** Proposed
+
+**Date:** 2026-08-08
+
+**Scope:** Remote authorization for the Smart Panel MCP module
+
+## Context
+
+The first MCP release deliberately uses installation-local static bearer credentials for trusted LAN or VPN access.
+Remote MCP hosts need a browser-mediated authorization flow so an owner does not have to copy a bearer secret into
+every host.
+
+Smart Panel is normally a self-contained appliance. It already owns local users, owner/admin authentication, account
+recovery, the MCP capability ceiling, MCP client policy, targeted subscription closure, and the administrative UI. A
+generic external identity provider can authenticate a person, but it cannot by itself apply Smart Panel's live
+`read`/`write`/`trigger` ceiling, show device-impact consent, or immediately close installation-local subscriptions.
+Requiring an external provider would also make a standalone installation dependent on another service for login and
+recovery.
+
+The standards and client findings used here are recorded in
+[the compatibility spike](../mcp-oauth-compatibility-spike.md).
+
+## Decision
+
+### 1. Authorization-server placement
+
+Smart Panel will host an embedded, MCP-specific OAuth authorization server. It will delegate user authentication and
+account recovery to the existing Smart Panel auth/users modules, but it will own OAuth clients, grants, codes, access
+tokens, refresh tokens, consent, and revocation.
+
+This is not a general Smart Panel identity provider:
+
+- it issues tokens only for the curated MCP resource;
+- only existing owners and administrators may approve grants;
+- OAuth tokens are rejected by REST, WebSocket, display, user-session, personal-token, and static MCP-token paths; and
+- password, implicit, client-credentials, device-code, and resource-owner-password grants are not enabled.
+
+An established authorization-server component must implement the protocol state machine. Smart Panel will provide its
+persistence adapter, interaction UI, policy hooks, audit hooks, and resource-server verifier. The executable dependency
+spike must pass before a dependency is pinned or endpoints are added. Failure returns this ADR to review; it does not
+authorize a handwritten OAuth server.
+
+An external authorization server remains a future deployment option, not a transparent runtime switch. Supporting one
+would require another ADR that defines issuer trust, user-to-installation mapping, grant administration, revocation,
+and recovery behavior.
+
+### 2. Standards profile
+
+The implementation targets MCP authorization revision `2026-07-28` and `draft-ietf-oauth-v2-1-13`, supplemented by
+RFC 9700. It implements RFC 6750, RFC 7009, RFC 7636, RFC 8252, RFC 8414, RFC 8707, RFC 9207, and RFC 9728 where
+applicable.
+
+The only initial interactive flow is authorization code with PKCE `S256`. Codes are single-use and expire after at
+most 60 seconds. Redirect URIs use exact string matching. Authorization responses include `iss`, including error
+responses, and metadata advertises `authorization_response_iss_parameter_supported: true`.
+
+Metadata advertises only features that are actually enabled. It explicitly advertises `none` as the sole initial
+token-endpoint authentication method. No OIDC scopes, ID tokens, user-info endpoint, introspection endpoint, JWKS URI,
+signing algorithm, confidential-client authentication method, or registration endpoint is advertised merely because
+the selected dependency can implement it.
+
+### 3. Canonical URLs and resource binding
+
+OAuth can be enabled only after an owner configures an exact public base URL over HTTPS. A reverse-proxy path prefix is
+allowed. Smart Panel derives all public OAuth URLs from that stored value, never from Host, Origin, `Forwarded`, or
+`X-Forwarded-*` request headers.
+
+For a base such as `https://panel.example.com`, identifiers are:
+
+- resource: `https://panel.example.com/api/v1/modules/mcp`;
+- protected-resource metadata:
+  `https://panel.example.com/.well-known/oauth-protected-resource/api/v1/modules/mcp`;
+- issuer: `https://panel.example.com/api/v1/modules/mcp/oauth`; and
+- authorization-server metadata:
+  `https://panel.example.com/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth`.
+
+The RFC 8707 `resource` value is required and must match exactly at authorization and token exchange. OAuth access
+tokens are accepted only when their stored issuer, resource/audience, client, installation UUID, expiry, grant state,
+and scopes all match the current request.
+
+The existing static MCP credential audience
+`urn:fastybird:smart-panel:<installation-uuid>:mcp` remains unchanged. Static and OAuth credentials have separate token
+types and validation paths. Changing the public base URL immediately invalidates outstanding OAuth tokens because their
+resource and issuer no longer match; it does not change the installation UUID or static credential audience.
+
+### 4. Client registration
+
+The first release uses owner/admin pre-registration. A public client receives a generated client ID, no client secret,
+and exact redirect URI allowlist. Codex and Claude Code both document this configuration path.
+
+CIMD is the preferred direction in MCP `2026-07-28`, but is deferred until its draft revision and outbound metadata
+fetch controls are proven compatible. DCR is deprecated by the current MCP revision and is not required by the two
+initial hosts, so no dynamic registration endpoint is implemented or advertised.
+
+If live compatibility testing proves DCR necessary, it requires a separate security decision covering registration
+rate limits, redirect policy, client quotas, lifetime, cleanup, and administrative approval. It must not be silently
+enabled as a dependency feature.
+
+### 5. Tokens, grants, and scope policy
+
+OAuth artifacts use independent entities and token-type discriminators. They do not reuse `AuthService` access tokens,
+personal tokens, display tokens, or static MCP tokens.
+
+The initial token policy is:
+
+- opaque, high-entropy access tokens stored only as hashes, with a maximum lifetime of 10 minutes;
+- opaque refresh tokens stored only as hashes, issued only when `offline_access` is explicitly requested and consented;
+- refresh rotation on every use with reuse detection that revokes the entire token family;
+- a maximum refresh-family lifetime of 30 days;
+- a maximum grant lifetime of 90 days, with no “never expires” option; and
+- immediate database-backed revocation checks for every MCP request.
+
+Opaque access tokens are intentional: they make immediate per-token and per-grant revocation authoritative without a
+signing-key distribution problem. Issuer, resource/audience, client, installation, scopes, expiry, and token-family
+bindings are stored server-side. Authorization-server metadata therefore advertises no signing algorithms unless a
+later accepted change actually introduces a signed artifact.
+
+OAuth scopes are `mcp:read`, `mcp:write`, and `mcp:trigger`. `offline_access` controls refresh eligibility but is not an
+MCP capability. Effective authorization remains:
+
+```text
+module capability ceiling
+  ∩ registered client maximum
+  ∩ approved grant scopes
+  ∩ access-token scopes
+```
+
+The intersection is recomputed for every request and immediately before tool execution. Scope reduction never waits
+for access-token expiry.
+
+### 6. Login, consent, and recovery
+
+The authorization endpoint creates a short-lived interaction and sends the browser to the Admin application. The
+Admin application uses the existing Smart Panel login flow. Only an authenticated owner or administrator can continue.
+The OAuth component never receives or validates the user's password.
+
+Consent must show:
+
+- installation name and stable installation ID;
+- requesting client name and client ID;
+- exact redirect destination;
+- each requested capability in plain language;
+- an explicit physical-device warning for write or trigger access;
+- access and refresh/grant expiry; and
+- approve and deny actions without a preselected escalation.
+
+Authentication is not consent. Reauthorization can reuse an active Smart Panel login, but a new client, new redirect,
+broader scope set, or expired/revoked grant requires a fresh consent decision.
+
+Account recovery remains the existing owner recovery procedure, including `auth:reset`. Resetting a password or user
+session does not silently revoke OAuth grants. The recovery UI and runbook must offer an explicit “revoke all MCP OAuth
+grants” action for suspected compromise. Disabling/deleting the approving user, disabling MCP, or rotating the OAuth
+server secret revokes affected grants and subscriptions according to documented policy.
+
+### 7. Revocation and administrative control
+
+Owners and administrators can list clients, grants, active access tokens, and refresh-token families without seeing raw
+secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Grant/client
+revocation closes only that client's active MCP subscriptions immediately. Disabling the MCP module closes all MCP
+subscriptions and denies both authorization and resource requests.
+
+Client and grant mutations are audited. Logs may contain IDs, scope names, denial codes, and timestamps, but never raw
+codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or token hashes.
+
+### 8. Deployment and upgrades
+
+OAuth remains disabled by default. Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy
+configuration, endpoint and login rate limits, current backups, and an incident-response procedure. Forwarded headers
+remain ignored until a separately configured trusted-proxy mechanism validates the immediate proxy.
+
+Database migrations are incremental. Authorization state uses persistent TypeORM storage; in-memory dependency adapters
+are test-only. Backups contain client/grant/token metadata and therefore remain sensitive even though raw bearer values
+are hashed. Restoring a cloned database requires an explicit “new installation” operation that rotates OAuth server
+secrets and revokes OAuth/static MCP credentials.
+
+The authorization dependency is pinned exactly. Minor or major upgrades require metadata snapshots, negative OAuth
+tests, both target-host smoke tests, and review of newly enabled defaults. Dependency features never become public only
+because an upgrade enables them internally. Rollback may disable OAuth and preserve static LAN/VPN clients; it must not
+reissue or downgrade an OAuth token into a static credential.
+
+## Threat model
+
+| Threat | Required control |
+| --- | --- |
+| Authorization-code interception or replay | PKCE `S256`, 60-second single-use codes, exact client/redirect/resource binding |
+| Redirect exfiltration | Owner-created exact allowlist; HTTPS except exact native loopback URIs; no wildcards, fragments, or prefix matching |
+| CSRF and login/consent confusion | OAuth `state` handled by clients, same-site interaction cookies, authenticated interaction binding, explicit approve/deny |
+| Authorization-server mix-up | RFC 9207 `iss` in success and error responses; exact issuer in discovery and stored artifacts |
+| Token replay at another service or installation | Exact RFC 8707 resource/audience plus issuer, installation, client, and token-type validation |
+| Stolen access token | Ten-minute maximum lifetime, hashed persistence, TLS, log redaction, immediate revocation check |
+| Stolen/replayed refresh token | Rotation, family reuse detection, 30-day absolute lifetime, hashed persistence |
+| Scope escalation or stale permission | Four-way live intersection and recheck immediately before tool execution |
+| Malicious dynamic/CIMD registration | No DCR/CIMD in the initial profile; later enablement requires SSRF, quota, and redirect-policy review |
+| Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
+| Client or grant revocation with an open stream | Targeted subscription abort before the administrative mutation reports success |
+| Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
+| Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |
+| Compromised owner/admin account | Existing login hardening, complete OAuth audit, revoke-all control, documented recovery workflow |
+
+Out of scope are compromise of the Smart Panel host/root account, compromise of the owner's browser or MCP host, and a
+malicious administrator. The operational response for those cases is credential revocation, key/secret rotation, and
+restore from a trusted backup.
+
+## Alternatives considered
+
+### Delegate entirely to an external identity provider
+
+Rejected for the first release. It reduces protocol implementation burden, but makes standalone deployments depend on
+external availability and recovery. A generic provider also cannot own Smart Panel's device-impact consent, live
+capability intersection, installation-local grant administration, or targeted subscription shutdown without a custom
+broker. Such a broker would again be an authorization server and would add two authorities instead of one.
+
+### Implement OAuth directly in NestJS services
+
+Rejected. The code footprint may appear smaller, but protocol parsing, interaction state, replay protection, metadata,
+error behavior, refresh rotation, and upgrade tracking are security-sensitive and easy to get subtly wrong.
+
+### Reuse static MCP or user JWTs as OAuth access tokens
+
+Rejected. It breaks credential isolation, audience semantics, revocation behavior, and the existing REST/MCP boundary.
+
+## Consequences
+
+- Smart Panel remains usable as a standalone installation and owns the complete consent/revocation experience.
+- The backend gains persistent OAuth state and a carefully bounded authorization-server dependency.
+- Owners must pre-register the first Codex/Claude clients and configure fixed exact callback URIs.
+- DCR's attack surface is avoided, but one-click setup for clients that cannot accept a predefined client ID is
+  deferred.
+- Public URL changes intentionally force OAuth reauthorization while static LAN/VPN credentials remain stable.
+- OAuth can be rolled back or disabled without removing the initial static bearer profile.
+- Supporting an external identity provider later is a separate architecture and migration project.
+
+## References
+
+- [MCP authorization, revision 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [MCP 2026-07-28 release notes](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
+- [OAuth 2.0 Security Best Current Practice, RFC 9700](https://www.rfc-editor.org/rfc/rfc9700)
+- [OAuth 2.0 Protected Resource Metadata, RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)
+- [Resource Indicators for OAuth 2.0, RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
+- [OAuth 2.0 Authorization Server Issuer Identification, RFC 9207](https://www.rfc-editor.org/rfc/rfc9207)
+- [ADR 0001: MCP Protocol and Security Foundation](0001-mcp-protocol-and-security-foundation.md)

--- a/docs/adr/0002-mcp-oauth-authorization.md
+++ b/docs/adr/0002-mcp-oauth-authorization.md
@@ -135,8 +135,11 @@ module capability ceiling
 ```
 
 The intersection is recomputed for every request and immediately before tool execution. The grant check also confirms
-that its approving user still exists with owner/admin role. Scope reduction or approver demotion never waits for
-access-token expiry.
+that its approving user still exists with owner/admin role. An OAuth subscription records the effective scope set and
+the identities or versions of every input that produced it. An awaited invalidation path closes an affected stream
+before a module capability ceiling, registered-client maximum, or approved-grant scope reduction reports success; a
+configuration notification alone is not sufficient. Scope reduction or approver demotion never waits for access-token
+expiry.
 
 ### 6. Login, consent, and recovery
 
@@ -168,12 +171,17 @@ global revocation policy; server-secret rotation revokes every OAuth artifact an
 
 Owners and administrators can list clients, grants, active access tokens, and refresh-token families without seeing raw
 secrets. They can disable a client, revoke a grant, revoke a token family, or revoke one access token. Every OAuth
-subscription is bound to its client, grant, access-token ID, refresh-family ID when present, and an authorization
-deadline equal to the earlier of its access-token expiry or grant expiry.
-Revoking any of those artifacts aborts exactly the matching active subscriptions before the administrative mutation
-reports success. The subscription registry schedules an abort at the authorization deadline, because a long-lived
-stream does not re-run per-request authentication while it is open. Disabling the MCP module closes all MCP
-subscriptions and denies both authorization and resource requests.
+subscription is bound to its client, grant, access-token ID, refresh-family ID when present, effective scopes, the
+module/client/grant authorization inputs that produced those scopes, and an authorization deadline equal to the earlier
+of its access-token expiry or grant expiry.
+
+Revoking an artifact aborts exactly the matching active subscriptions before the administrative mutation reports
+success. Reducing the module ceiling, registered-client maximum, or approved-grant scopes uses the same awaited path to
+abort every OAuth subscription whose required `mcp:read` capability is no longer effective. This path is invoked by the
+authoritative mutation, not only by the existing asynchronous MCP configuration listener. The subscription registry
+also schedules an abort at the authorization deadline, because a long-lived stream does not re-run per-request
+authentication while it is open. Disabling the MCP module closes all MCP subscriptions and denies both authorization
+and resource requests.
 
 Approver invalidation must use an awaited lifecycle path, such as a directly orchestrated service or propagated
 `emitAsync`; the existing fire-and-forget `eventEmitter.emit` calls are not sufficient. For
@@ -191,11 +199,18 @@ codes, access tokens, refresh tokens, PKCE verifiers, cookies, passwords, or tok
 OAuth remains disabled by default. Adding persistence, consent, token, discovery, or validation code does not make any
 OAuth route reachable: implementation phases keep the surface behind an internal test-only gate. The user-facing enable
 switch is added only after the application can verify that access-token/grant authorization-deadline timers, targeted
-client/grant/token/family subscription aborts, awaited approver update/delete invalidation, public-identity and
-server-secret rotation invalidation, owner/admin revoke controls, audit hooks, and endpoint rate limits are all
-registered. A failed readiness check leaves protected-resource metadata,
+client/grant/token/family and live-scope-reduction subscription aborts, awaited approver update/delete invalidation,
+public-identity/server-secret rotation invalidation, OAuth switch-off invalidation, owner/admin revoke controls, audit
+hooks, and endpoint rate limits are all registered. A failed readiness check leaves protected-resource metadata,
 authorization-server metadata, authorization/token/revocation endpoints, OAuth challenges, and OAuth MCP bearer
 validation unmounted together. The initial static bearer behavior remains unchanged during that failure.
+
+Switching OAuth off first closes the shared fail-closed runtime gate, so every OAuth discovery, authorization, token,
+revocation, challenge, and OAuth-bearing MCP request is rejected before reaching its handler. The same awaited mutation
+then revokes all outstanding OAuth artifacts and aborts all OAuth subscriptions before reporting success; static MCP
+credentials and streams remain active. An invalidation failure keeps OAuth fail-closed and makes the mutation return an
+error. Re-enabling reruns the complete readiness gate and does not reactivate the revoked artifacts: clients must begin
+a new authorization flow.
 
 Public deployment requires HTTPS, an explicit public base URL, trusted reverse-proxy configuration, endpoint and login
 rate limits, current backups, and an incident-response procedure. Forwarded headers remain ignored until a separately
@@ -223,12 +238,14 @@ reissue or downgrade an OAuth token into a static credential.
 | Stolen access token | Ten-minute maximum lifetime, hashed persistence, TLS, log redaction, immediate revocation check |
 | Stolen/replayed refresh token | Rotation, family reuse detection, 30-day absolute lifetime, hashed persistence |
 | Scope escalation or stale permission | Four-way live intersection and recheck immediately before tool execution |
+| A live scope input shrinks while an OAuth stream is open | Bind the stream to its module/client/grant inputs and abort it through the awaited authoritative mutation path before the reduction reports success |
 | Malicious dynamic/CIMD registration | No DCR/CIMD in the initial profile; later enablement requires SSRF, quota, and redirect-policy review |
 | Proxy/header spoofing and DNS rebinding | Explicit public URL, trusted Host/Origin policy, ignore forwarded headers unless proxy trust is configured |
 | Client, grant, token, or refresh-family revocation with an open stream | Bind subscriptions to every authorization artifact and abort targeted streams before the mutation reports success |
 | An access token or its grant expires while a stream is open | Cap token expiry at grant expiry and abort the subscription at the earlier authorization deadline |
 | A grant approver is demoted or deleted | Use an awaited user-lifecycle path and do not report the user mutation successful until every affected grant, token artifact, and subscription is revoked |
 | OAuth server secret is rotated after compromise | Revoke all OAuth artifacts and close all OAuth subscriptions as one global invalidation operation |
+| OAuth is switched off while subscriptions are open | Fail closed for all OAuth traffic, revoke OAuth artifacts, and close OAuth streams atomically while preserving static MCP streams |
 | A phased rollout exposes OAuth before revocation controls | Do not add the enable switch or mount any OAuth route until a startup readiness gate verifies every invalidation and admin control |
 | Brute force and artifact enumeration | Separate limits for login, authorize, token, and revocation endpoints; uniform OAuth errors where required |
 | Backup cloning | Preserve installation UUID for identity but rotate/revoke OAuth and static credentials for a new physical installation |

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -55,29 +55,31 @@ the endpoints exist.
 
 | Host | Documented registration paths | Relevant behavior | Release use |
 | --- | --- | --- | --- |
-| Codex CLI/app | Predefined client ID; OAuth discovery used by `codex mcp login`; ChatGPT connectors additionally support CIMD and DCR | Streamable HTTP OAuth, scopes, RFC 8707 resource override, fixed callback port/URL, PKCE | Target 1 |
+| Codex CLI/app | Predefined client ID; OAuth discovery used by `codex mcp login`; ChatGPT connectors additionally support CIMD and DCR | Streamable HTTP OAuth, scopes, RFC 8707 resource override, fixed or ephemeral loopback callback, PKCE | Target 1 |
 | Claude Code | CIMD, DCR, or predefined public/confidential client | RFC 9728 discovery, HTTP OAuth, fixed loopback callback, automatic refresh, scope pinning | Target 2 |
 | MCP TypeScript client / Inspector | Programmatic provider or interactive inspector | Fine-grained discovery, PKCE, token and negative-path tests | Automated harness, not one of the two user hosts |
 | ChatGPT connector | CIMD preferred, DCR fallback, or predefined client | Cloud callback, authorization code plus PKCE, resource binding | Follow-up compatibility target |
 
-Both initial target hosts can use an owner-created public client ID and a fixed, exactly registered loopback redirect.
-That means DCR is not required for the first supported profile. The live smoke test must record exact host versions,
-callback URIs, requested metadata, requested scopes, refresh behavior, and revocation behavior.
+Both initial target hosts can use an owner-created public client ID and a registered loopback redirect. That means DCR
+is not required for the first supported profile. The live smoke test must record exact host versions, callback URIs,
+requested metadata, requested scopes, refresh behavior, and revocation behavior.
 
 ## Registration decision from the spike
 
 The first release supports owner/admin pre-registration of public clients with:
 
 - a generated, non-secret client ID;
-- one or more exact redirect URIs;
+- one or more registered redirect URIs;
 - `authorization_code` and optional `refresh_token` grants only;
 - `none` token-endpoint authentication only;
 - an approved maximum capability set; and
 - an enabled/revoked state.
 
-Loopback HTTP redirect URIs are permitted only for native clients and are stored and compared exactly, including host,
-port, path, and trailing slash. Other redirect URIs require HTTPS. Wildcards, fragments, credentials, and redirect URI
-prefix matching are forbidden.
+Loopback HTTP redirect URIs are permitted only for native clients. For the loopback IP literals `127.0.0.1` and `[::1]`,
+RFC 8252 requires the authorization server to accept any runtime port while matching the scheme, literal address, path,
+query, and trailing slash exactly. A registered `localhost` hostname redirect must keep an exact port because the RFC
+8252 variable-port exception applies only to loopback IP literals. Other redirect URIs require HTTPS and exact string
+matching. Wildcards, fragments, credentials, and general redirect URI prefix matching are forbidden.
 
 CIMD is deferred until the chosen authorization component supports the same draft revision as the current MCP
 specification and Smart Panel has a reviewed SSRF-safe metadata fetch policy. DCR is not implemented unless a supported
@@ -103,7 +105,7 @@ authorization server and therefore do not remove the need for the component spik
 
 ## Risks to prove with live tests
 
-- Exact callback URI formats for current Codex and Claude Code releases.
+- Callback URI formats for current Codex and Claude Code releases, including an ephemeral loopback IP port.
 - RFC 8414 discovery for an issuer containing a path component.
 - `resource` propagation at authorization, code exchange, and refresh.
 - `iss` presence in both successful and error authorization responses.

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -121,6 +121,10 @@ authorization server and therefore do not remove the need for the component spik
 - Global artifact revocation and stream closure on OAuth server-secret rotation.
 - Fail-closed OAuth switch-off that rejects new OAuth traffic, revokes OAuth artifacts, and closes OAuth streams while
   preserving static MCP streams; readiness-gated re-enable must not reactivate old artifacts.
+- Artifact issuance/rotation serialized against the persistent OAuth-enabled generation, so an in-flight handler cannot
+  commit after switch-off revoke-all or produce an artifact that becomes valid after re-enable.
+- Complete bootstrap-time NestJS/Fastify route registration behind one runtime gate; enable/disable must not depend on
+  unsupported post-listen route mounting or unmounting.
 - Atomic production activation only after expiry, revocation, approver-lifecycle, public-identity/server-secret
   rotation, live-scope-reduction, switch-off, admin, audit, and rate-limit controls pass the readiness gate.
 - Reverse-proxy path prefixes without trusting forwarded headers.

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -121,8 +121,11 @@ authorization server and therefore do not remove the need for the component spik
 - Global artifact revocation and stream closure on OAuth server-secret rotation.
 - Fail-closed OAuth switch-off that rejects new OAuth traffic, revokes OAuth artifacts, and closes OAuth streams while
   preserving static MCP streams; readiness-gated re-enable must not reactivate old artifacts.
-- Artifact issuance/rotation serialized against the persistent OAuth-enabled generation, so an in-flight handler cannot
-  commit after switch-off revoke-all or produce an artifact that becomes valid after re-enable.
+- Artifact issuance/rotation serialized against all persistent OAuth-enabled, server-secret, public-identity,
+  client/grant/policy, and approver-authority generations, so an in-flight handler cannot escape invalidation or become
+  valid after the state is restored.
+- Public-identity and server-secret rotation must revoke OAuth artifacts and close OAuth streams without interrupting
+  the separately authorized static MCP streams.
 - Complete bootstrap-time NestJS/Fastify route registration behind one runtime gate; enable/disable must not depend on
   unsupported post-listen route mounting or unmounting.
 - Atomic production activation only after expiry, revocation, approver-lifecycle, public-identity/server-secret

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -112,6 +112,7 @@ authorization server and therefore do not remove the need for the component spik
 - Refresh-token rotation and reuse-family revocation.
 - Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
   access-token expiry.
+- Grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -108,7 +108,8 @@ authorization server and therefore do not remove the need for the component spik
 - `resource` propagation at authorization, code exchange, and refresh.
 - `iss` presence in both successful and error authorization responses.
 - Refresh-token rotation and reuse-family revocation.
-- Immediate denial and subscription closure after grant/client revocation.
+- Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
+  access-token expiry.
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -111,10 +111,11 @@ authorization server and therefore do not remove the need for the component spik
 - `iss` presence in both successful and error authorization responses.
 - Refresh-token rotation and reuse-family revocation.
 - Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
-  access-token expiry.
-- Grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
-- Atomic production activation only after expiry, revocation, approver-lifecycle, identity-rotation, admin, audit, and
-  rate-limit controls pass the readiness gate.
+  the earlier of access-token or grant expiry.
+- Awaited grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
+- Global artifact revocation and stream closure on OAuth server-secret rotation.
+- Atomic production activation only after expiry, revocation, approver-lifecycle, public-identity/server-secret
+  rotation, admin, audit, and rate-limit controls pass the readiness gate.
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -112,10 +112,14 @@ authorization server and therefore do not remove the need for the component spik
 - Refresh-token rotation and reuse-family revocation.
 - Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
   the earlier of access-token or grant expiry.
+- Awaited OAuth stream closure when the module ceiling, registered-client maximum, or approved-grant scopes remove its
+  effective `mcp:read` capability.
 - Awaited grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
 - Global artifact revocation and stream closure on OAuth server-secret rotation.
+- Fail-closed OAuth switch-off that rejects new OAuth traffic, revokes OAuth artifacts, and closes OAuth streams while
+  preserving static MCP streams; readiness-gated re-enable must not reactivate old artifacts.
 - Atomic production activation only after expiry, revocation, approver-lifecycle, public-identity/server-secret
-  rotation, admin, audit, and rate-limit controls pass the readiness gate.
+  rotation, live-scope-reduction, switch-off, admin, audit, and rate-limit controls pass the readiness gate.
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -109,11 +109,14 @@ authorization server and therefore do not remove the need for the component spik
 - RFC 8414 discovery for an issuer containing a path component.
 - `resource` propagation at authorization, code exchange, and refresh.
 - `iss` presence in both successful and error authorization responses.
-- Refresh-token rotation and reuse-family revocation.
+- Transactional refresh-token compare-and-consume under concurrent replay, with at most one successor and whole-family
+  revocation after a losing reuse attempt.
 - Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
   the earlier of access-token or grant expiry.
-- Awaited OAuth stream closure when the module ceiling, registered-client maximum, or approved-grant scopes remove its
-  effective `mcp:read` capability.
+- Awaited OAuth stream closure on every effective-scope contraction from the module ceiling, registered-client maximum,
+  or approved grant, including write/trigger removal while read remains.
+- Atomic subscription registration versus revocation/scope reduction, so a stale in-flight listen request cannot open
+  after invalidation succeeds.
 - Awaited grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
 - Global artifact revocation and stream closure on OAuth server-secret rotation.
 - Fail-closed OAuth switch-off that rejects new OAuth traffic, revokes OAuth artifacts, and closes OAuth streams while

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -113,6 +113,8 @@ authorization server and therefore do not remove the need for the component spik
 - Immediate denial and subscription closure after client, grant, access-token, or refresh-family revocation and at
   access-token expiry.
 - Grant, token, and subscription invalidation when the approving owner/admin is demoted or deleted.
+- Atomic production activation only after expiry, revocation, approver-lifecycle, identity-rotation, admin, audit, and
+  rate-limit controls pass the readiness gate.
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -1,0 +1,121 @@
+# MCP OAuth Compatibility Spike
+
+**Status:** Complete for architecture selection; live interoperability remains a release gate
+
+**Date:** 2026-08-08
+
+**Related task:** `TECH-MCP-OAUTH-AUTHORIZATION`
+
+## Purpose
+
+This spike establishes the standards baseline, registration strategy, target hosts, and authorization-server
+integration risks before Smart Panel adds OAuth endpoints. It is evidence for
+[ADR 0002](adr/0002-mcp-oauth-authorization.md), not an interoperability result: there is no Smart Panel OAuth server to
+exercise yet.
+
+## Standards baseline
+
+Implementation must target the exact revisions below. OAuth 2.1 is still an IETF draft, so documentation and metadata
+must not describe it as a published RFC.
+
+| Concern | Revision used by this task |
+| --- | --- |
+| MCP authorization | MCP `2026-07-28` |
+| OAuth security profile | `draft-ietf-oauth-v2-1-13` plus OAuth 2.0 Security BCP, RFC 9700 |
+| Bearer challenges | RFC 6750 |
+| PKCE | RFC 7636, `S256` only |
+| Authorization-server metadata | RFC 8414 |
+| Resource indicators | RFC 8707 |
+| Authorization-response issuer | RFC 9207 |
+| Protected-resource metadata | RFC 9728 |
+| Token revocation | RFC 7009 |
+| Native loopback redirects | RFC 8252 |
+| Client registration | Pre-registration initially; CIMD draft support tracked separately |
+
+MCP `2026-07-28` requires protected-resource metadata and the `resource` parameter in authorization and token
+requests. It prefers Client ID Metadata Documents (CIMD), permits pre-registration, and deprecates Dynamic Client
+Registration (DCR). DCR remains a compatibility mechanism but is expected to be removed from a future MCP revision.
+
+## Resource identity finding
+
+The existing static MCP credential audience is the stable installation URI
+`urn:fastybird:smart-panel:<installation-uuid>:mcp`. That remains correct for the installation-local static-token
+profile, but it is not the OAuth resource identifier required by MCP.
+
+OAuth will use the exact, explicitly configured public HTTPS MCP URL, for example
+`https://panel.example.com/api/v1/modules/mcp`, as both the RFC 8707 `resource` and access-token audience. Smart Panel
+will continue to keep the installation UUID as stable internal identity. Changing the public URL therefore revokes or
+invalidates OAuth tokens without changing installation identity. Request Host or forwarded headers must never select
+the resource identifier.
+
+## Host capability matrix
+
+The matrix records documented capabilities as of the spike date. “Target” means it will receive a real smoke test once
+the endpoints exist.
+
+| Host | Documented registration paths | Relevant behavior | Release use |
+| --- | --- | --- | --- |
+| Codex CLI/app | Predefined client ID; OAuth discovery used by `codex mcp login`; ChatGPT connectors additionally support CIMD and DCR | Streamable HTTP OAuth, scopes, RFC 8707 resource override, fixed callback port/URL, PKCE | Target 1 |
+| Claude Code | CIMD, DCR, or predefined public/confidential client | RFC 9728 discovery, HTTP OAuth, fixed loopback callback, automatic refresh, scope pinning | Target 2 |
+| MCP TypeScript client / Inspector | Programmatic provider or interactive inspector | Fine-grained discovery, PKCE, token and negative-path tests | Automated harness, not one of the two user hosts |
+| ChatGPT connector | CIMD preferred, DCR fallback, or predefined client | Cloud callback, authorization code plus PKCE, resource binding | Follow-up compatibility target |
+
+Both initial target hosts can use an owner-created public client ID and a fixed, exactly registered loopback redirect.
+That means DCR is not required for the first supported profile. The live smoke test must record exact host versions,
+callback URIs, requested metadata, requested scopes, refresh behavior, and revocation behavior.
+
+## Registration decision from the spike
+
+The first release supports owner/admin pre-registration of public clients with:
+
+- a generated, non-secret client ID;
+- one or more exact redirect URIs;
+- `authorization_code` and optional `refresh_token` grants only;
+- `none` token-endpoint authentication only;
+- an approved maximum capability set; and
+- an enabled/revoked state.
+
+Loopback HTTP redirect URIs are permitted only for native clients and are stored and compared exactly, including host,
+port, path, and trailing slash. Other redirect URIs require HTTPS. Wildcards, fragments, credentials, and redirect URI
+prefix matching are forbidden.
+
+CIMD is deferred until the chosen authorization component supports the same draft revision as the current MCP
+specification and Smart Panel has a reviewed SSRF-safe metadata fetch policy. DCR is not implemented unless a supported
+host fails the pre-registration gate and the failure cannot be fixed with its documented client-ID/callback settings.
+
+## Authorization component survey
+
+Smart Panel must not implement OAuth protocol machinery ad hoc. The leading embedded candidate is `oidc-provider`
+because it implements authorization code, PKCE, RFC 8414, RFC 7009, RFC 8707, RFC 9207, opaque tokens, interactions,
+and pluggable persistence. It is not added in this phase because two integration risks require an executable spike:
+
+1. Current releases are ESM-only while the NestJS backend compiles to CommonJS.
+2. Its CIMD support is experimental and currently tracks a newer draft than the MCP `2026-07-28` text.
+
+The next phase must prove that a pinned release mounts safely on the existing NestJS/Fastify server, uses the TypeORM
+adapter rather than in-memory state, emits only the enabled OAuth features in metadata, and can delegate login/consent
+to authenticated Smart Panel owner/admin UI. If it cannot, the phase stops for another architecture review; it must not
+fall back to handwritten OAuth endpoints.
+
+The official MCP TypeScript SDK v2 already provides resource-server building blocks for bearer verification,
+standards-shaped challenges, protected-resource metadata, and `AuthInfo`. Those helpers do not implement an
+authorization server and therefore do not remove the need for the component spike.
+
+## Risks to prove with live tests
+
+- Exact callback URI formats for current Codex and Claude Code releases.
+- RFC 8414 discovery for an issuer containing a path component.
+- `resource` propagation at authorization, code exchange, and refresh.
+- `iss` presence in both successful and error authorization responses.
+- Refresh-token rotation and reuse-family revocation.
+- Immediate denial and subscription closure after grant/client revocation.
+- Reverse-proxy path prefixes without trusting forwarded headers.
+- Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
+
+## Primary references
+
+- [MCP authorization, revision 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [MCP 2026-07-28 release notes](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
+- [Claude Code MCP OAuth configuration](https://code.claude.com/docs/en/mcp)
+- [OpenAI MCP authentication guidance](https://developers.openai.com/plugins/build/auth)
+- [`oidc-provider` implemented specifications](https://github.com/panva/node-oidc-provider)

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -110,6 +110,9 @@ amend ADR 0002.
 - [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and access-token expiry.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
       success, and automatically close each stream when its access token expires.
+- [ ] Handle `UsersModule.User.Updated` and `UsersModule.User.Deleted`: when a grant approver is deleted or no longer
+      has owner/admin role, revoke every grant and token artifact they approved and close matching subscriptions;
+      preserve grants for profile-only updates by an authorized approver.
 - [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates.
 - [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
@@ -122,7 +125,7 @@ amend ADR 0002.
 - [ ] E2E: discovery, consent approval/denial, PKCE success/failure, RFC 8252 loopback port variation, strict redirect
       rejection otherwise, code replay, scope reduction, expiry, refresh rotation/reuse, revocation, wrong
       issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
-      client/grant/access-token/refresh-family revocation.
+      client/grant/access-token/refresh-family revocation, plus approver demotion/deletion invalidation.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -112,9 +112,13 @@ amend ADR 0002.
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
 - [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
-      deadline equal to the earlier of access-token or grant expiry.
+      deadline equal to the earlier of access-token or grant expiry; also record their effective scopes and the
+      module/client/grant authorization inputs that produced them.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
       success, and automatically close each stream at its authorization deadline.
+- [ ] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through an awaited
+      authoritative mutation path that closes every OAuth subscription that loses `mcp:read` before reporting success;
+      do not rely on the existing asynchronous MCP configuration notification listener.
 - [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
       `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, revoke every grant
       and token artifact they approved and close matching subscriptions before the user mutation returns success;
@@ -127,11 +131,15 @@ amend ADR 0002.
       invalidation failure, and never leave a demoted/deleted approver's grant usable.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
 - [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
-      subscription aborts, awaited approver lifecycle invalidation, public-identity/server-secret rotation, revoke
-      controls, audit hooks, and rate limits are registered; fail closed and leave every OAuth route unmounted if any
-      readiness check fails.
+      artifact and live-scope-reduction subscription aborts, awaited approver lifecycle invalidation,
+      public-identity/server-secret rotation, OAuth switch-off invalidation, revoke controls, audit hooks, and rate
+      limits are registered; fail closed and leave every OAuth route unmounted if any readiness check fails.
 - [ ] On enable, mount protected-resource metadata, authorization-server metadata, authorization/token/revocation
       endpoints, OAuth challenges, and OAuth MCP bearer validation as one surface; never expose a partial subset.
+- [ ] On switch-off, atomically close the shared OAuth runtime gate before handlers accept more traffic, revoke all
+      OAuth artifacts, and abort all OAuth subscriptions before reporting success; preserve static MCP credentials and
+      streams, remain fail-closed if invalidation fails, and require a new authorization flow after readiness-gated
+      re-enable.
 
 ## Phase 6 — E2E, proxy, and compatibility gate
 
@@ -141,7 +149,11 @@ amend ADR 0002.
       rejection otherwise, code replay, scope reduction, expiry, refresh rotation/reuse, revocation, wrong
       issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
       grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
-      invalidation, and global server-secret rotation.
+      invalidation, global server-secret rotation, and each module/client/grant scope reduction that removes a stream's
+      effective `mcp:read` capability.
+- [ ] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
+      streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
+      reruns readiness and old OAuth artifacts remain unusable.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -105,8 +105,9 @@ amend ADR 0002.
 - [ ] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
 - [ ] Add discovery/challenge snapshots and wrong-token-type, issuer, resource, audience, cross-client, and scope
       negative tests.
-- [ ] Keep OAuth well-known, authorization, token, revocation, and OAuth-bearing MCP paths unmounted in production;
-      the existing static bearer behavior remains unchanged and there is still no user-settable OAuth enable switch.
+- [ ] Keep OAuth well-known, authorization, token, revocation, and OAuth-bearing MCP paths absent from production until
+      Phase 5 adds the complete bootstrap-time gated route set; do not attempt runtime route mounting, and leave the
+      existing static bearer behavior unchanged with no user-settable OAuth enable switch.
 
 ## Phase 5 — Administration and immediate invalidation
 
@@ -121,6 +122,10 @@ amend ADR 0002.
       recheck the OAuth-enabled and artifact/authorization-input generations plus live scopes while registering, and
       increment or close the applicable gate before an invalidating mutation enumerates streams. A racing open must
       either register first and be closed or observe the new generation and fail/revalidate.
+- [ ] Serialize every grant, authorization-code, access-token, and refresh-token creation/rotation with OAuth
+      switch-off: conditionally commit the artifact and its captured enabled generation only while the persistent gate
+      remains open at that generation. Switch-off must atomically close and increment the generation first, so a racing
+      handler either commits before revoke-all or its stale commit fails.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
       success, and automatically close each stream at its authorization deadline.
 - [ ] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through an awaited
@@ -140,15 +145,18 @@ amend ADR 0002.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
 - [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
       artifact and live-scope-reduction subscription aborts, awaited approver lifecycle invalidation,
-      serialized subscription-open/invalidation gates, public-identity/server-secret rotation, OAuth switch-off
-      invalidation, revoke controls, audit hooks, and rate limits are registered; fail closed and leave every OAuth
-      route unmounted if any readiness check fails.
-- [ ] On enable, mount protected-resource metadata, authorization-server metadata, authorization/token/revocation
-      endpoints, OAuth challenges, and OAuth MCP bearer validation as one surface; never expose a partial subset.
-- [ ] On switch-off, atomically close the shared OAuth runtime gate before handlers accept more traffic, revoke all
-      OAuth artifacts, and abort all OAuth subscriptions before reporting success; preserve static MCP credentials and
-      streams, remain fail-closed if invalidation fails, and require a new authorization flow after readiness-gated
-      re-enable.
+      serialized subscription-open/invalidation and artifact-issuance gates, public-identity/server-secret rotation,
+      OAuth switch-off invalidation, revoke controls, audit hooks, and rate limits are registered; fail closed and keep
+      the shared OAuth route gate closed if any readiness check fails.
+- [ ] Register the complete protected-resource metadata, authorization-server metadata,
+      authorization/token/revocation, challenge, and OAuth MCP route set once during NestJS/Fastify bootstrap. Every
+      route must check the same fail-closed gate before its handler; never mount or unmount routes after startup.
+- [ ] On enable, rerun readiness and open the shared gate for the complete pre-registered OAuth surface atomically;
+      never expose a partial subset.
+- [ ] On switch-off, atomically close and increment the persistent OAuth generation before handlers can commit more
+      artifacts, revoke all OAuth artifacts, and abort all OAuth subscriptions before reporting success; preserve
+      static MCP credentials and streams, remain fail-closed if invalidation fails, and require a new authorization
+      flow after readiness-gated re-enable.
 
 ## Phase 6 — E2E, proxy, and compatibility gate
 
@@ -167,6 +175,11 @@ amend ADR 0002.
 - [ ] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
       reruns readiness and old OAuth artifacts remain unusable.
+- [ ] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
+      off, then resume them; prove each stale-generation commit fails, no late artifact escapes revoke-all, and none
+      becomes usable after re-enable.
+- [ ] E2E: start disabled, enable without restarting, disable without restarting, and re-enable; prove the
+      bootstrap-registered route set is uniformly unreachable/reachable behind one gate and never partially exposed.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -45,14 +45,14 @@ phase; it does not authorize an improvised OAuth implementation.
 - [ ] Mount it in a test-only NestJS/Fastify application without a second listener and without a catch-all route.
 - [ ] Resolve the backend CommonJS versus dependency ESM boundary in production build and Jest.
 - [ ] Provide a minimal TypeORM-backed adapter; reject in-memory persistence outside tests.
-- [ ] Prove authorization code plus PKCE `S256`, exact redirects, `resource`, response `iss`, opaque tokens, rotation,
-      reuse detection, and revocation.
+- [ ] Prove authorization code plus PKCE `S256`, RFC 8252 redirect matching, `resource`, response `iss`, opaque tokens,
+      rotation, reuse detection, and revocation.
 - [ ] Snapshot metadata, explicitly advertise only public-client authentication method `none`, and verify disabled
       dependency features are not advertised.
 - [ ] Prove Smart Panel can own the authenticated login/consent interaction without exposing passwords to the OAuth
       component.
-- [ ] Add focused negative tests for code replay, PKCE downgrade, redirect mismatch, issuer mismatch, and resource
-      mismatch.
+- [ ] Add focused tests for code replay, PKCE downgrade, issuer/resource mismatch, exact non-loopback redirects,
+      accepted ephemeral ports on loopback IP literals, and rejected address/path changes on loopback redirects.
 
 **Gate:** If any required behavior needs handwritten protocol replacement or unsupported dependency internals, stop and
 amend ADR 0002.
@@ -75,7 +75,8 @@ amend ADR 0002.
 
 **Goal:** Complete the browser flow behind the disabled OAuth configuration flag.
 
-- [ ] Add owner/admin client pre-registration APIs with exact redirect validation and no public client secret.
+- [ ] Add owner/admin client pre-registration APIs with exact redirect validation except the RFC 8252 runtime-port rule
+      for native loopback IP literals, and no public client secret.
 - [ ] Implement authorization code plus mandatory PKCE `S256`, required `resource`, response `iss`, single-use codes,
       and protocol-correct OAuth errors through the selected component.
 - [ ] Implement token exchange and optional `offline_access` refresh with rotation/reuse detection; advertise
@@ -118,9 +119,10 @@ amend ADR 0002.
 
 **Goal:** Prove the complete security profile before documenting it as supported.
 
-- [ ] E2E: discovery, consent approval/denial, PKCE success/failure, exact redirects, code replay, scope reduction,
-      expiry, refresh rotation/reuse, revocation, wrong issuer/resource/audience, cross-client isolation, and redaction;
-      cover open-stream abort on token expiry and client/grant/access-token/refresh-family revocation.
+- [ ] E2E: discovery, consent approval/denial, PKCE success/failure, RFC 8252 loopback port variation, strict redirect
+      rejection otherwise, code replay, scope reduction, expiry, refresh rotation/reuse, revocation, wrong
+      issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
+      client/grant/access-token/refresh-family revocation.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -69,7 +69,8 @@ amend ADR 0002.
 - [ ] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
 - [ ] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
       static-MCP validation paths.
-- [ ] Add unit tests for expiry, family rotation/reuse, installation binding, public URL changes, and log redaction.
+- [ ] Add unit tests for access-token expiry capped at grant expiry, family rotation/reuse, installation binding,
+      public URL changes, and log redaction.
 
 ## Phase 3 — Authorization, consent, and token endpoints
 
@@ -94,7 +95,8 @@ amend ADR 0002.
 - [ ] Publish path-aware RFC 9728 protected-resource metadata for the canonical MCP resource.
 - [ ] Publish path-aware RFC 8414 authorization-server metadata containing only implemented capabilities.
 - [ ] Add RFC 6750 `WWW-Authenticate` challenges with `resource_metadata` and minimum scopes.
-- [ ] Require exact issuer/resource/audience/client/installation/expiry/grant/token validation for OAuth bearer tokens.
+- [ ] Require exact issuer/resource/audience/client/installation/expiry/grant/token validation for OAuth bearer tokens,
+      including the grant approver's current owner/admin role.
 - [ ] Keep static URN-audience validation working through its existing isolated path.
 - [ ] Map `mcp:read`, `mcp:write`, and `mcp:trigger` to the four-way live capability intersection.
 - [ ] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
@@ -109,19 +111,25 @@ amend ADR 0002.
 
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
-- [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and access-token expiry.
+- [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
+      deadline equal to the earlier of access-token or grant expiry.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
-      success, and automatically close each stream when its access token expires.
-- [ ] Handle `UsersModule.User.Updated` and `UsersModule.User.Deleted`: when a grant approver is deleted or no longer
-      has owner/admin role, revoke every grant and token artifact they approved and close matching subscriptions;
-      preserve grants for profile-only updates by an authorized approver.
-- [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates.
+      success, and automatically close each stream at its authorization deadline.
+- [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
+      `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, revoke every grant
+      and token artifact they approved and close matching subscriptions before the user mutation returns success;
+      propagate invalidation failures and preserve grants for profile-only updates by an authorized approver.
+- [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates; on OAuth
+      server-secret rotation, revoke every OAuth artifact and close every OAuth subscription.
 - [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
+- [ ] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
+      invalidation failure, and never leave a demoted/deleted approver's grant usable.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
-- [ ] Add the user-facing OAuth enable switch only after startup verifies that expiry timers, targeted subscription
-      aborts, approver lifecycle listeners, public-identity rotation, revoke controls, audit hooks, and rate limits are
-      registered; fail closed and leave every OAuth route unmounted if any readiness check fails.
+- [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
+      subscription aborts, awaited approver lifecycle invalidation, public-identity/server-secret rotation, revoke
+      controls, audit hooks, and rate limits are registered; fail closed and leave every OAuth route unmounted if any
+      readiness check fails.
 - [ ] On enable, mount protected-resource metadata, authorization-server metadata, authorization/token/revocation
       endpoints, OAuth challenges, and OAuth MCP bearer validation as one surface; never expose a partial subset.
 
@@ -132,7 +140,8 @@ amend ADR 0002.
 - [ ] E2E: discovery, consent approval/denial, PKCE success/failure, RFC 8252 loopback port variation, strict redirect
       rejection otherwise, code replay, scope reduction, expiry, refresh rotation/reuse, revocation, wrong
       issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
-      client/grant/access-token/refresh-family revocation, plus approver demotion/deletion invalidation.
+      grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
+      invalidation, and global server-secret rotation.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -122,10 +122,11 @@ amend ADR 0002.
       recheck the OAuth-enabled and artifact/authorization-input generations plus live scopes while registering, and
       increment or close the applicable gate before an invalidating mutation enumerates streams. A racing open must
       either register first and be closed or observe the new generation and fail/revalidate.
-- [ ] Serialize every grant, authorization-code, access-token, and refresh-token creation/rotation with OAuth
-      switch-off: conditionally commit the artifact and its captured enabled generation only while the persistent gate
-      remains open at that generation. Switch-off must atomically close and increment the generation first, so a racing
-      handler either commits before revoke-all or its stale commit fails.
+- [ ] Serialize every grant, authorization-code, access-token, and refresh-token creation/rotation with every
+      invalidating mutation. Conditionally commit against the captured OAuth-enabled, server-secret, public-identity,
+      client, grant, module-policy, and approver-authority generations and current states. Each invalidation must advance
+      its generation before enumeration, so a racing handler either commits first and is revoked or its stale commit
+      fails; validation must recheck all generations so later restoration cannot revive an escaped artifact.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
       success, and automatically close each stream at its authorization deadline.
 - [ ] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through an awaited
@@ -133,11 +134,13 @@ amend ADR 0002.
       reporting success, including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains; do not rely on the
       existing asynchronous MCP configuration notification listener.
 - [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
-      `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, revoke every grant
-      and token artifact they approved and close matching subscriptions before the user mutation returns success;
-      propagate invalidation failures and preserve grants for profile-only updates by an authorized approver.
-- [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates; on OAuth
-      server-secret rotation, revoke every OAuth artifact and close every OAuth subscription.
+      `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, atomically advance
+      their authority generation before revoking every grant and token artifact they approved and closing matching
+      subscriptions. A paused consent using the old generation must fail, role restoration must not revive old grants,
+      invalidation failures propagate, and profile-only updates by an authorized approver preserve the generation.
+- [ ] Close all MCP subscriptions only when the MCP module is disabled. On public OAuth identity or server-secret
+      rotation, advance the applicable artifact generation before revoke-all, revoke every OAuth artifact, and close
+      every OAuth subscription while preserving static MCP credentials and streams.
 - [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
 - [ ] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
@@ -145,9 +148,9 @@ amend ADR 0002.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
 - [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
       artifact and live-scope-reduction subscription aborts, awaited approver lifecycle invalidation,
-      serialized subscription-open/invalidation and artifact-issuance gates, public-identity/server-secret rotation,
-      OAuth switch-off invalidation, revoke controls, audit hooks, and rate limits are registered; fail closed and keep
-      the shared OAuth route gate closed if any readiness check fails.
+      serialized subscription-open/invalidation and all-generation artifact-issuance gates,
+      public-identity/server-secret rotation, OAuth switch-off invalidation, revoke controls, audit hooks, and rate
+      limits are registered; fail closed and keep the shared OAuth route gate closed if any readiness check fails.
 - [ ] Register the complete protected-resource metadata, authorization-server metadata,
       authorization/token/revocation, challenge, and OAuth MCP route set once during NestJS/Fastify bootstrap. Every
       route must check the same fail-closed gate before its handler; never mount or unmount routes after startup.
@@ -178,6 +181,12 @@ amend ADR 0002.
 - [ ] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
       off, then resume them; prove each stale-generation commit fails, no late artifact escapes revoke-all, and none
       becomes usable after re-enable.
+- [ ] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,
+      client disable/re-enable, grant revocation, module/client/grant scope contraction/expansion, and approver
+      demotion/restoration; prove stale commits fail and later state restoration never revives an artifact.
+- [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
+      only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
+      closes both kinds.
 - [ ] E2E: start disabled, enable without restarting, disable without restarting, and re-enable; prove the
       bootstrap-registered route set is uniformly unreachable/reachable behind one gate and never partially exposed.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,0 +1,156 @@
+# Smart Panel MCP OAuth Authorization — Implementation Plan
+
+**Status:** Phase 0 complete — architecture proposed for review
+
+**Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
+
+**Architecture:** [ADR 0002: Embedded OAuth Authorization for Remote MCP](../../docs/adr/0002-mcp-oauth-authorization.md)
+
+**Compatibility evidence:** [MCP OAuth Compatibility Spike](../../docs/mcp-oauth-compatibility-spike.md)
+
+> Read this plan, the task, ADR 0001, ADR 0002, and the compatibility spike before changing code. Keep phases in order
+> and checkboxes current. Do not add authorization endpoints until ADR 0002 is accepted. Never edit generated OpenAPI
+> clients by hand.
+
+## Goal and boundaries
+
+Add standards-compliant, browser-mediated OAuth access to the existing curated MCP resource while preserving static
+bearer access for trusted LAN/VPN clients. OAuth remains MCP-only, disabled by default, and bounded by the current live
+module/client/tool policy.
+
+This plan does not expose REST APIs through OAuth, add external identity providers, enable DCR, or remove static MCP
+credentials.
+
+## Phase 0 — Compatibility spike and architecture
+
+**Deliverables:** documentation only; no dependency or runtime behavior change.
+
+- [x] Record exact current MCP/OAuth revisions and distinguish the OAuth 2.1 draft from final RFCs.
+- [x] Reconcile the static installation URN audience with MCP's canonical HTTPS OAuth resource identifier.
+- [x] Verify documented OAuth configuration paths for Codex and Claude Code.
+- [x] Decide initial client registration policy: owner/admin pre-registration; defer CIMD and DCR.
+- [x] Survey the official MCP SDK resource-server helpers and an established authorization-server candidate.
+- [x] Document embedded versus external authorization-server consequences, including deployment, recovery, consent,
+      revocation, upgrades, rollback, and threat model.
+- [x] Split implementation into reviewable security phases.
+
+**Gate:** ADR 0002 must be accepted before Phase 1. Review disagreement or a failed dependency spike returns to this
+phase; it does not authorize an improvised OAuth implementation.
+
+## Phase 1 — Authorization-component executable spike
+
+**Goal:** Prove the selected established component can be safely embedded before schema or endpoint work expands.
+
+- [ ] Pin a candidate authorization-server dependency only after checking its current security support and license.
+- [ ] Mount it in a test-only NestJS/Fastify application without a second listener and without a catch-all route.
+- [ ] Resolve the backend CommonJS versus dependency ESM boundary in production build and Jest.
+- [ ] Provide a minimal TypeORM-backed adapter; reject in-memory persistence outside tests.
+- [ ] Prove authorization code plus PKCE `S256`, exact redirects, `resource`, response `iss`, opaque tokens, rotation,
+      reuse detection, and revocation.
+- [ ] Snapshot metadata, explicitly advertise only public-client authentication method `none`, and verify disabled
+      dependency features are not advertised.
+- [ ] Prove Smart Panel can own the authenticated login/consent interaction without exposing passwords to the OAuth
+      component.
+- [ ] Add focused negative tests for code replay, PKCE downgrade, redirect mismatch, issuer mismatch, and resource
+      mismatch.
+
+**Gate:** If any required behavior needs handwritten protocol replacement or unsupported dependency internals, stop and
+amend ADR 0002.
+
+## Phase 2 — Persistent domain foundation and public URL policy
+
+**Goal:** Add inactive OAuth data/configuration foundations without publishing incomplete discovery.
+
+- [ ] Add an incremental migration for OAuth clients, grants, authorization interactions/codes, access tokens, refresh
+      token families, and server-secret/key version metadata.
+- [ ] Add MCP-owned entities and services with raw artifacts hashed at creation.
+- [ ] Add an explicit HTTPS public base URL and OAuth-enabled configuration, both disabled by default.
+- [ ] Derive resource, issuer, well-known, authorization, token, and revocation URLs only from trusted configuration.
+- [ ] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
+- [ ] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
+      static-MCP validation paths.
+- [ ] Add unit tests for expiry, family rotation/reuse, installation binding, public URL changes, and log redaction.
+
+## Phase 3 — Authorization, consent, and token endpoints
+
+**Goal:** Complete the browser flow behind the disabled OAuth configuration flag.
+
+- [ ] Add owner/admin client pre-registration APIs with exact redirect validation and no public client secret.
+- [ ] Implement authorization code plus mandatory PKCE `S256`, required `resource`, response `iss`, single-use codes,
+      and protocol-correct OAuth errors through the selected component.
+- [ ] Implement token exchange and optional `offline_access` refresh with rotation/reuse detection.
+- [ ] Implement RFC 7009 revocation for supported token types.
+- [ ] Add Admin login/consent UI showing installation, client, redirect, requested scopes, expiry, and physical-device
+      warnings.
+- [ ] Require fresh consent for new client/redirect, expanded scopes, expired grants, and revoked grants.
+- [ ] Add CSRF/interaction binding, throttling, cache-control, and redaction tests.
+
+## Phase 4 — Discovery, challenges, and MCP resource validation
+
+**Goal:** Enable a complete standards surface atomically; never advertise half-built endpoints.
+
+- [ ] Publish path-aware RFC 9728 protected-resource metadata for the canonical MCP resource.
+- [ ] Publish path-aware RFC 8414 authorization-server metadata containing only implemented capabilities.
+- [ ] Add RFC 6750 `WWW-Authenticate` challenges with `resource_metadata` and minimum scopes.
+- [ ] Require exact issuer/resource/audience/client/installation/expiry/grant/token validation for OAuth bearer tokens.
+- [ ] Keep static URN-audience validation working through its existing isolated path.
+- [ ] Map `mcp:read`, `mcp:write`, and `mcp:trigger` to the four-way live capability intersection.
+- [ ] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
+- [ ] Add discovery/challenge snapshots and wrong-token-type, issuer, resource, audience, cross-client, and scope
+      negative tests.
+
+## Phase 5 — Administration and immediate invalidation
+
+**Goal:** Give owners/admins complete lifecycle control without secret exposure.
+
+- [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
+- [ ] Add Admin client/grant/token management views and revoke confirmations.
+- [ ] Close only the affected client's subscriptions before grant/client revocation reports success.
+- [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates.
+- [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
+- [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
+- [ ] Regenerate OpenAPI/admin types through the normal generators.
+
+## Phase 6 — E2E, proxy, and compatibility gate
+
+**Goal:** Prove the complete security profile before documenting it as supported.
+
+- [ ] E2E: discovery, consent approval/denial, PKCE success/failure, exact redirects, code replay, scope reduction,
+      expiry, refresh rotation/reuse, revocation, wrong issuer/resource/audience, cross-client isolation, and redaction.
+- [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
+      change, and rollback.
+- [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and
+      callback profile.
+- [ ] Claude Code smoke: the same sequence; record exact version and callback profile.
+- [ ] Repeat static bearer compatibility tests to prove coexistence.
+- [ ] Use MCP Inspector/TypeScript client for wire-level negative cases that user hosts do not expose.
+
+## Phase 7 — Deployment, incident response, and rollout
+
+**Goal:** Ship OAuth as an opt-in remote-access profile with a reversible operational path.
+
+- [ ] Document HTTPS and explicit public URL requirements, supported proxy layouts, client pre-registration, Codex and
+      Claude setup, consent, and migration from static credentials.
+- [ ] Document backup sensitivity, clone handling, server-secret rotation, revoke-all, compromise response, and account
+      recovery.
+- [ ] Document dependency upgrades, metadata diffs, smoke-test requirements, rollback, and static-profile retention.
+- [ ] Confirm no DCR/CIMD endpoints are advertised and create explicit follow-up tasks if the release gate justifies
+      either feature.
+- [ ] Update task acceptance criteria and mark completion only after every deferred item has a named follow-up.
+
+## Required verification cadence
+
+Every implementation phase runs the focused backend/Admin tests it changes plus:
+
+```bash
+pnpm --filter ./apps/backend run type-check
+pnpm --filter ./apps/backend run lint:js
+pnpm --filter ./apps/backend run test:unit
+pnpm --filter ./apps/backend run test:e2e
+pnpm --filter ./apps/admin run type-check
+pnpm --filter ./apps/admin run lint:js
+pnpm --filter ./apps/admin run test:unit
+```
+
+Run OpenAPI generation and API lint in phases that change administrative API schemas. Phase 6 additionally runs the
+two recorded external-host smoke profiles.

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -64,7 +64,7 @@ amend ADR 0002.
 - [ ] Add an incremental migration for OAuth clients, grants, authorization interactions/codes, access tokens, refresh
       token families, and server-secret/key version metadata.
 - [ ] Add MCP-owned entities and services with raw artifacts hashed at creation.
-- [ ] Add an explicit HTTPS public base URL and OAuth-enabled configuration, both disabled by default.
+- [ ] Add an explicit HTTPS public base URL configuration, but no user-settable OAuth enable switch yet.
 - [ ] Derive resource, issuer, well-known, authorization, token, and revocation URLs only from trusted configuration.
 - [ ] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
 - [ ] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
@@ -73,7 +73,7 @@ amend ADR 0002.
 
 ## Phase 3 — Authorization, consent, and token endpoints
 
-**Goal:** Complete the browser flow behind the disabled OAuth configuration flag.
+**Goal:** Complete the browser flow behind an internal test-only gate; production routes remain unmounted.
 
 - [ ] Add owner/admin client pre-registration APIs with exact redirect validation except the RFC 8252 runtime-port rule
       for native loopback IP literals, and no public client secret.
@@ -87,9 +87,9 @@ amend ADR 0002.
 - [ ] Require fresh consent for new client/redirect, expanded scopes, expired grants, and revoked grants.
 - [ ] Add CSRF/interaction binding, throttling, cache-control, and redaction tests.
 
-## Phase 4 — Discovery, challenges, and MCP resource validation
+## Phase 4 — Gated discovery, challenges, and MCP resource validation
 
-**Goal:** Enable a complete standards surface atomically; never advertise half-built endpoints.
+**Goal:** Complete and test the standards surface without making it reachable in production.
 
 - [ ] Publish path-aware RFC 9728 protected-resource metadata for the canonical MCP resource.
 - [ ] Publish path-aware RFC 8414 authorization-server metadata containing only implemented capabilities.
@@ -100,10 +100,12 @@ amend ADR 0002.
 - [ ] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
 - [ ] Add discovery/challenge snapshots and wrong-token-type, issuer, resource, audience, cross-client, and scope
       negative tests.
+- [ ] Keep OAuth well-known, authorization, token, revocation, and OAuth-bearing MCP paths unmounted in production;
+      the existing static bearer behavior remains unchanged and there is still no user-settable OAuth enable switch.
 
 ## Phase 5 — Administration and immediate invalidation
 
-**Goal:** Give owners/admins complete lifecycle control without secret exposure.
+**Goal:** Complete every invalidation/admin control, then expose the full OAuth surface atomically.
 
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
@@ -117,6 +119,11 @@ amend ADR 0002.
 - [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
+- [ ] Add the user-facing OAuth enable switch only after startup verifies that expiry timers, targeted subscription
+      aborts, approver lifecycle listeners, public-identity rotation, revoke controls, audit hooks, and rate limits are
+      registered; fail closed and leave every OAuth route unmounted if any readiness check fails.
+- [ ] On enable, mount protected-resource metadata, authorization-server metadata, authorization/token/revocation
+      endpoints, OAuth challenges, and OAuth MCP bearer validation as one surface; never expose a partial subset.
 
 ## Phase 6 — E2E, proxy, and compatibility gate
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -78,7 +78,8 @@ amend ADR 0002.
 - [ ] Add owner/admin client pre-registration APIs with exact redirect validation and no public client secret.
 - [ ] Implement authorization code plus mandatory PKCE `S256`, required `resource`, response `iss`, single-use codes,
       and protocol-correct OAuth errors through the selected component.
-- [ ] Implement token exchange and optional `offline_access` refresh with rotation/reuse detection.
+- [ ] Implement token exchange and optional `offline_access` refresh with rotation/reuse detection; advertise
+      `offline_access` in `scopes_supported` without enabling OIDC identity scopes or ID tokens.
 - [ ] Implement RFC 7009 revocation for supported token types.
 - [ ] Add Admin login/consent UI showing installation, client, redirect, requested scopes, expiry, and physical-device
       warnings.
@@ -105,7 +106,9 @@ amend ADR 0002.
 
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
-- [ ] Close only the affected client's subscriptions before grant/client revocation reports success.
+- [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and access-token expiry.
+- [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
+      success, and automatically close each stream when its access token expires.
 - [ ] Close all MCP subscriptions when the module is disabled or its public OAuth identity rotates.
 - [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
@@ -116,7 +119,8 @@ amend ADR 0002.
 **Goal:** Prove the complete security profile before documenting it as supported.
 
 - [ ] E2E: discovery, consent approval/denial, PKCE success/failure, exact redirects, code replay, scope reduction,
-      expiry, refresh rotation/reuse, revocation, wrong issuer/resource/audience, cross-client isolation, and redaction.
+      expiry, refresh rotation/reuse, revocation, wrong issuer/resource/audience, cross-client isolation, and redaction;
+      cover open-stream abort on token expiry and client/grant/access-token/refresh-family revocation.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -46,7 +46,7 @@ phase; it does not authorize an improvised OAuth implementation.
 - [ ] Resolve the backend CommonJS versus dependency ESM boundary in production build and Jest.
 - [ ] Provide a minimal TypeORM-backed adapter; reject in-memory persistence outside tests.
 - [ ] Prove authorization code plus PKCE `S256`, RFC 8252 redirect matching, `resource`, response `iss`, opaque tokens,
-      rotation, reuse detection, and revocation.
+      atomic refresh rotation under concurrent reuse, family revocation, and token revocation.
 - [ ] Snapshot metadata, explicitly advertise only public-client authentication method `none`, and verify disabled
       dependency features are not advertised.
 - [ ] Prove Smart Panel can own the authenticated login/consent interaction without exposing passwords to the OAuth
@@ -69,8 +69,11 @@ amend ADR 0002.
 - [ ] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
 - [ ] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
       static-MCP validation paths.
-- [ ] Add unit tests for access-token expiry capped at grant expiry, family rotation/reuse, installation binding,
-      public URL changes, and log redaction.
+- [ ] Implement refresh rotation as a TypeORM compare-and-consume transaction with a conditional consumed-state update
+      and unique predecessor/successor constraint: at most one concurrent request creates a successor, and every loser
+      revokes the whole family including that successor.
+- [ ] Add unit tests for access-token expiry capped at grant expiry, sequential and barrier-synchronized concurrent
+      family rotation/reuse, installation binding, public URL changes, and log redaction.
 
 ## Phase 3 — Authorization, consent, and token endpoints
 
@@ -113,12 +116,17 @@ amend ADR 0002.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
 - [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
       deadline equal to the earlier of access-token or grant expiry; also record their effective scopes and the
-      module/client/grant authorization inputs that produced them.
+      generations of the module/client/grant authorization inputs that produced them.
+- [ ] Serialize subscription registration and invalidation through one authoritative generation gate: atomically
+      recheck the OAuth-enabled and artifact/authorization-input generations plus live scopes while registering, and
+      increment or close the applicable gate before an invalidating mutation enumerates streams. A racing open must
+      either register first and be closed or observe the new generation and fail/revalidate.
 - [ ] Close only the matching subscriptions before client, grant, access-token, or refresh-family revocation reports
       success, and automatically close each stream at its authorization deadline.
 - [ ] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through an awaited
-      authoritative mutation path that closes every OAuth subscription that loses `mcp:read` before reporting success;
-      do not rely on the existing asynchronous MCP configuration notification listener.
+      authoritative mutation path that closes every OAuth subscription whose effective scope set contracts before
+      reporting success, including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains; do not rely on the
+      existing asynchronous MCP configuration notification listener.
 - [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
       `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, revoke every grant
       and token artifact they approved and close matching subscriptions before the user mutation returns success;
@@ -132,8 +140,9 @@ amend ADR 0002.
 - [ ] Regenerate OpenAPI/admin types through the normal generators.
 - [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
       artifact and live-scope-reduction subscription aborts, awaited approver lifecycle invalidation,
-      public-identity/server-secret rotation, OAuth switch-off invalidation, revoke controls, audit hooks, and rate
-      limits are registered; fail closed and leave every OAuth route unmounted if any readiness check fails.
+      serialized subscription-open/invalidation gates, public-identity/server-secret rotation, OAuth switch-off
+      invalidation, revoke controls, audit hooks, and rate limits are registered; fail closed and leave every OAuth
+      route unmounted if any readiness check fails.
 - [ ] On enable, mount protected-resource metadata, authorization-server metadata, authorization/token/revocation
       endpoints, OAuth challenges, and OAuth MCP bearer validation as one surface; never expose a partial subset.
 - [ ] On switch-off, atomically close the shared OAuth runtime gate before handlers accept more traffic, revoke all
@@ -150,7 +159,11 @@ amend ADR 0002.
       issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
       grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
       invalidation, global server-secret rotation, and each module/client/grant scope reduction that removes a stream's
-      effective `mcp:read` capability.
+      effective read, write, or trigger scope.
+- [ ] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
+      then resume registration and prove the stale request cannot open after invalidation success.
+- [ ] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
+      stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [ ] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
       reruns readiness and old OAuth artifacts remain unusable.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -67,6 +67,10 @@ upgrade consequences.
       impact of write/trigger scopes.
 - [ ] Owners/admins can list and revoke OAuth clients, grants, access tokens, and refresh tokens; revocation closes the
       affected MCP subscriptions immediately.
+- [ ] Reducing the live module ceiling, registered-client maximum, or approved-grant scopes closes OAuth subscriptions
+      that lose `mcp:read` before the mutation reports success.
+- [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
+      success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
 - [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
       explicit registration policy; otherwise the supported registration path is documented.
 - [ ] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
@@ -74,7 +78,8 @@ upgrade consequences.
 - [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
 - [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
-      revocation, wrong issuer/resource/audience, cross-client isolation, and log redaction.
+      revocation, OAuth switch-off/re-enable, wrong issuer/resource/audience, cross-client isolation, stream closure,
+      and log redaction.
 - [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
       refresh, and revocation smoke tests.
 - [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -73,12 +73,15 @@ upgrade consequences.
       request cannot open after invalidation reports success.
 - [ ] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
       the entire family without leaving a usable fork.
-- [ ] Every OAuth artifact commit is serialized with the persistent enable generation so switch-off cannot miss a
-      racing authorization, exchange, or refresh result and re-enable cannot make it usable.
+- [ ] Every OAuth artifact commit is serialized with all applicable persistent enabled/secret/identity/client/grant/
+      policy/approver generations so no invalidation can miss a racing authorization, exchange, or refresh result and
+      later state restoration cannot make it usable.
 - [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
 - [ ] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
       runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.
+- [ ] Public OAuth identity and server-secret rotation revoke OAuth artifacts and close OAuth subscriptions while
+      preserving static MCP streams; only MCP-module disable closes both authorization profiles.
 - [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
       explicit registration policy; otherwise the supported registration path is documented.
 - [ ] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
@@ -86,8 +89,9 @@ upgrade consequences.
 - [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
 - [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
-      concurrent refresh replay, revocation/listen and switch-off/artifact-commit races, runtime-gated OAuth
-      switch-off/re-enable, wrong issuer/resource/audience, cross-client isolation, stream closure, and log redaction.
+      concurrent refresh replay, revocation/listen and all invalidation/artifact-commit races, runtime-gated OAuth
+      switch-off/re-enable, static-stream preservation, wrong issuer/resource/audience, cross-client isolation, stream
+      closure, and log redaction.
 - [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
       refresh, and revocation smoke tests.
 - [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -67,8 +67,12 @@ upgrade consequences.
       impact of write/trigger scopes.
 - [ ] Owners/admins can list and revoke OAuth clients, grants, access tokens, and refresh tokens; revocation closes the
       affected MCP subscriptions immediately.
-- [ ] Reducing the live module ceiling, registered-client maximum, or approved-grant scopes closes OAuth subscriptions
-      that lose `mcp:read` before the mutation reports success.
+- [ ] Reducing the live module ceiling, registered-client maximum, or approved-grant scopes closes every OAuth
+      subscription whose effective read/write/trigger scope set contracts before the mutation reports success.
+- [ ] Subscription registration is serialized with artifact and policy invalidation so a stale in-flight listen
+      request cannot open after invalidation reports success.
+- [ ] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
+      the entire family without leaving a usable fork.
 - [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
 - [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
@@ -78,8 +82,8 @@ upgrade consequences.
 - [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
 - [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
-      revocation, OAuth switch-off/re-enable, wrong issuer/resource/audience, cross-client isolation, stream closure,
-      and log redaction.
+      concurrent refresh replay, revocation/listen registration races, OAuth switch-off/re-enable, wrong
+      issuer/resource/audience, cross-client isolation, stream closure, and log redaction.
 - [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
       refresh, and revocation smoke tests.
 - [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: planned
+Status: in progress — Phase 0 architecture proposed for review
 
 ## 1. Business goal
 
@@ -50,7 +50,7 @@ upgrade consequences.
 
 ## 4. Acceptance criteria
 
-- [ ] An ADR documents the authorization-server architecture and a threat model for internet-reachable MCP.
+- [x] An ADR documents the authorization-server architecture and a threat model for internet-reachable MCP.
 - [ ] The MCP endpoint publishes standards-compliant protected-resource metadata with its canonical resource identifier
       and authorization-server location.
 - [ ] Unauthenticated MCP responses include a protocol-correct bearer challenge pointing clients to protected-resource

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -73,8 +73,12 @@ upgrade consequences.
       request cannot open after invalidation reports success.
 - [ ] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
       the entire family without leaving a usable fork.
+- [ ] Every OAuth artifact commit is serialized with the persistent enable generation so switch-off cannot miss a
+      racing authorization, exchange, or refresh result and re-enable cannot make it usable.
 - [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
+- [ ] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
+      runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.
 - [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
       explicit registration policy; otherwise the supported registration path is documented.
 - [ ] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
@@ -82,8 +86,8 @@ upgrade consequences.
 - [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
 - [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
-      concurrent refresh replay, revocation/listen registration races, OAuth switch-off/re-enable, wrong
-      issuer/resource/audience, cross-client isolation, stream closure, and log redaction.
+      concurrent refresh replay, revocation/listen and switch-off/artifact-commit races, runtime-gated OAuth
+      switch-off/re-enable, wrong issuer/resource/audience, cross-client isolation, stream closure, and log redaction.
 - [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
       refresh, and revocation smoke tests.
 - [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident


### PR DESCRIPTION
## Summary

- add ADR 0002 selecting an embedded, MCP-specific OAuth authorization server
- record the MCP/OAuth compatibility spike for Codex, Claude Code, registration methods, and canonical resource identity
- add a seven-phase implementation plan with explicit security gates
- mark TECH-MCP-OAUTH-AUTHORIZATION Phase 0 as proposed for review

## Why

The initial MCP implementation intentionally supports static bearer credentials for trusted LAN/VPN deployments. Remote OAuth work needs an approved authorization-server architecture, exact standards baseline, threat model, client-registration policy, and rollback strategy before dependencies or endpoints are introduced.

The proposal keeps Smart Panel self-contained, delegates user authentication and recovery to the existing owner/admin flow, isolates OAuth artifacts from every existing token type, and retains static MCP credentials during migration. It starts with pre-registered public clients because Codex and Claude Code support predefined client IDs and MCP 2026-07-28 deprecates DCR.

## Impact

Documentation only. This PR adds no dependency, migration, endpoint, generated artifact, or runtime behavior. OAuth remains disabled and Phase 1 is blocked until this ADR is accepted.

## Review focus

- embedded authorization server versus external identity provider
- canonical HTTPS OAuth resource versus the existing static installation URN audience
- pre-registration now, with CIMD and DCR deferred
- opaque token, refresh rotation, consent, recovery, proxy, and revocation policies
- proposed phase boundaries and acceptance gates

## Validation

- `git diff --check origin/main...HEAD`
- local Markdown link-target validation
- no runtime tests required for documentation-only changes