### PR TITLE
feat(backend): add OAuth domain foundation

### DIFF
--- a/apps/backend/src/migrations/1000000000010-AddMcpOAuthFoundation.ts
+++ b/apps/backend/src/migrations/1000000000010-AddMcpOAuthFoundation.ts
@@ -1,0 +1,180 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMcpOAuthFoundation1000000000010 implements MigrationInterface {
+	name = 'AddMcpOAuthFoundation1000000000010';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_clients" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "clientIdentifier" varchar NOT NULL, "name" varchar NOT NULL, ` +
+				`"redirectUris" text NOT NULL, "maximumScopes" text NOT NULL, "enabled" boolean NOT NULL DEFAULT (1), ` +
+				`"generation" integer NOT NULL DEFAULT (0), "createdById" varchar, ` +
+				`CONSTRAINT "UQ_mcp_oauth_client_identifier" UNIQUE ("clientIdentifier"), ` +
+				`CONSTRAINT "FK_mcp_oauth_client_creator" FOREIGN KEY ("createdById") ` +
+				`REFERENCES "users_module_users" ("id") ON DELETE SET NULL)`,
+		);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_oauth_client_enabled" ON "mcp_module_oauth_clients" ("enabled")`);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_grants" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "clientId" varchar NOT NULL, "approvedById" varchar, ` +
+				`"installationId" varchar NOT NULL, "issuer" varchar NOT NULL, "resource" varchar NOT NULL, ` +
+				`"approvedScopes" text NOT NULL, "expiresAt" datetime NOT NULL, "revokedAt" datetime, ` +
+				`"generation" integer NOT NULL DEFAULT (0), "approverAuthorityGeneration" integer NOT NULL DEFAULT (0), ` +
+				`CONSTRAINT "FK_mcp_oauth_grant_client" FOREIGN KEY ("clientId") ` +
+				`REFERENCES "mcp_module_oauth_clients" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_grant_approver" FOREIGN KEY ("approvedById") ` +
+				`REFERENCES "users_module_users" ("id") ON DELETE SET NULL)`,
+		);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_oauth_grant_client" ON "mcp_module_oauth_grants" ("clientId")`);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_grant_approver" ON "mcp_module_oauth_grants" ("approvedById")`,
+		);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_oauth_grant_expiry" ON "mcp_module_oauth_grants" ("expiresAt")`);
+		await queryRunner.query(`CREATE INDEX "IDX_mcp_oauth_grant_revoked" ON "mcp_module_oauth_grants" ("revokedAt")`);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_interactions" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "uidHash" varchar NOT NULL, "clientId" varchar NOT NULL, ` +
+				`"authenticatedUserId" varchar, "redirectUri" varchar NOT NULL, "requestedScopes" text NOT NULL, ` +
+				`"expiresAt" datetime NOT NULL, "consumedAt" datetime, ` +
+				`CONSTRAINT "UQ_mcp_oauth_interaction_hash" UNIQUE ("uidHash"), ` +
+				`CONSTRAINT "FK_mcp_oauth_interaction_client" FOREIGN KEY ("clientId") ` +
+				`REFERENCES "mcp_module_oauth_clients" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_interaction_user" FOREIGN KEY ("authenticatedUserId") ` +
+				`REFERENCES "users_module_users" ("id") ON DELETE SET NULL)`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_interaction_client" ON "mcp_module_oauth_interactions" ("clientId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_interaction_expiry" ON "mcp_module_oauth_interactions" ("expiresAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_refresh_families" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "clientId" varchar NOT NULL, "grantId" varchar NOT NULL, ` +
+				`"installationId" varchar NOT NULL, "expiresAt" datetime NOT NULL, "revokedAt" datetime, ` +
+				`"revocationReason" varchar, "generation" integer NOT NULL DEFAULT (0), ` +
+				`CONSTRAINT "FK_mcp_oauth_family_client" FOREIGN KEY ("clientId") ` +
+				`REFERENCES "mcp_module_oauth_clients" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_family_grant" FOREIGN KEY ("grantId") ` +
+				`REFERENCES "mcp_module_oauth_grants" ("id") ON DELETE CASCADE)`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_family_client" ON "mcp_module_oauth_refresh_families" ("clientId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_family_grant" ON "mcp_module_oauth_refresh_families" ("grantId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_family_expiry" ON "mcp_module_oauth_refresh_families" ("expiresAt")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_family_revoked" ON "mcp_module_oauth_refresh_families" ("revokedAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_refresh_tokens" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "tokenHash" varchar NOT NULL, "familyId" varchar NOT NULL, ` +
+				`"predecessorId" varchar, "expiresAt" datetime NOT NULL, "consumedAt" datetime, "revokedAt" datetime, ` +
+				`CONSTRAINT "UQ_mcp_oauth_refresh_hash" UNIQUE ("tokenHash"), ` +
+				`CONSTRAINT "UQ_mcp_oauth_refresh_predecessor" UNIQUE ("predecessorId"), ` +
+				`CONSTRAINT "FK_mcp_oauth_refresh_family" FOREIGN KEY ("familyId") ` +
+				`REFERENCES "mcp_module_oauth_refresh_families" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_refresh_predecessor" FOREIGN KEY ("predecessorId") ` +
+				`REFERENCES "mcp_module_oauth_refresh_tokens" ("id") ON DELETE SET NULL)`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_refresh_family" ON "mcp_module_oauth_refresh_tokens" ("familyId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_refresh_expiry" ON "mcp_module_oauth_refresh_tokens" ("expiresAt")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_refresh_consumed" ON "mcp_module_oauth_refresh_tokens" ("consumedAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_authorization_codes" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "codeHash" varchar NOT NULL, "clientId" varchar NOT NULL, ` +
+				`"grantId" varchar NOT NULL, "interactionId" varchar NOT NULL, "installationId" varchar NOT NULL, ` +
+				`"issuer" varchar NOT NULL, "resource" varchar NOT NULL, "redirectUri" varchar NOT NULL, ` +
+				`"scopes" text NOT NULL, "codeChallenge" varchar NOT NULL, "expiresAt" datetime NOT NULL, "consumedAt" datetime, ` +
+				`CONSTRAINT "UQ_mcp_oauth_code_hash" UNIQUE ("codeHash"), ` +
+				`CONSTRAINT "UQ_mcp_oauth_code_interaction" UNIQUE ("interactionId"), ` +
+				`CONSTRAINT "FK_mcp_oauth_code_client" FOREIGN KEY ("clientId") ` +
+				`REFERENCES "mcp_module_oauth_clients" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_code_grant" FOREIGN KEY ("grantId") ` +
+				`REFERENCES "mcp_module_oauth_grants" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_code_interaction" FOREIGN KEY ("interactionId") ` +
+				`REFERENCES "mcp_module_oauth_interactions" ("id") ON DELETE CASCADE)`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_code_client" ON "mcp_module_oauth_authorization_codes" ("clientId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_code_grant" ON "mcp_module_oauth_authorization_codes" ("grantId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_code_expiry" ON "mcp_module_oauth_authorization_codes" ("expiresAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_access_tokens" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime, "tokenHash" varchar NOT NULL, "clientId" varchar NOT NULL, ` +
+				`"grantId" varchar NOT NULL, "refreshFamilyId" varchar, "installationId" varchar NOT NULL, ` +
+				`"issuer" varchar NOT NULL, "resource" varchar NOT NULL, "scopes" text NOT NULL, ` +
+				`"expiresAt" datetime NOT NULL, "revokedAt" datetime, ` +
+				`CONSTRAINT "UQ_mcp_oauth_access_hash" UNIQUE ("tokenHash"), ` +
+				`CONSTRAINT "FK_mcp_oauth_access_client" FOREIGN KEY ("clientId") ` +
+				`REFERENCES "mcp_module_oauth_clients" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_access_grant" FOREIGN KEY ("grantId") ` +
+				`REFERENCES "mcp_module_oauth_grants" ("id") ON DELETE CASCADE, ` +
+				`CONSTRAINT "FK_mcp_oauth_access_family" FOREIGN KEY ("refreshFamilyId") ` +
+				`REFERENCES "mcp_module_oauth_refresh_families" ("id") ON DELETE CASCADE)`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_access_client" ON "mcp_module_oauth_access_tokens" ("clientId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_access_grant" ON "mcp_module_oauth_access_tokens" ("grantId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_access_family" ON "mcp_module_oauth_access_tokens" ("refreshFamilyId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_access_expiry" ON "mcp_module_oauth_access_tokens" ("expiresAt")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_access_revoked" ON "mcp_module_oauth_access_tokens" ("revokedAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_server_state" (` +
+				`"key" varchar PRIMARY KEY NOT NULL, "serverSecretVersion" integer NOT NULL DEFAULT (1), ` +
+				`"keyVersion" integer NOT NULL DEFAULT (1), "publicIdentityGeneration" integer NOT NULL DEFAULT (0), ` +
+				`"oauthEnabledGeneration" integer NOT NULL DEFAULT (0), "modulePolicyGeneration" integer NOT NULL DEFAULT (0), ` +
+				`"createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime)`,
+		);
+		await queryRunner.query(`INSERT INTO "mcp_module_oauth_server_state" ("key") VALUES ('primary')`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_server_state"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_access_tokens"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_authorization_codes"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_refresh_tokens"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_refresh_families"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_interactions"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_grants"`);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_clients"`);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000010-AddMcpOAuthFoundation.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000010-AddMcpOAuthFoundation.spec.ts
@@ -1,0 +1,81 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddMcpOAuthFoundation1000000000010 } from '../1000000000010-AddMcpOAuthFoundation';
+
+describe('AddMcpOAuthFoundation1000000000010', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+	const migration = new AddMcpOAuthFoundation1000000000010();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:' });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(`CREATE TABLE "users_module_users" ("id" varchar PRIMARY KEY NOT NULL)`);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('creates the inactive OAuth domain with protected relationships and version state', async () => {
+		await migration.up(queryRunner);
+
+		const tables = (await queryRunner.query(
+			`SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'mcp_module_oauth_%' ORDER BY name`,
+		)) as { name: string }[];
+		const refreshIndexes = (await queryRunner.query(`PRAGMA index_list("mcp_module_oauth_refresh_tokens")`)) as {
+			name: string;
+			unique: number;
+		}[];
+		const uniqueRefreshIndexColumns = await Promise.all(
+			refreshIndexes
+				.filter(({ unique }) => unique === 1)
+				.map(async ({ name }) => {
+					const columns = (await queryRunner.query(`PRAGMA index_info("${name}")`)) as { name: string }[];
+
+					return columns.map((column) => column.name);
+				}),
+		);
+		const accessForeignKeys = (await queryRunner.query(
+			`PRAGMA foreign_key_list("mcp_module_oauth_access_tokens")`,
+		)) as { from: string; on_delete: string; table: string }[];
+		const state = (await queryRunner.query(
+			`SELECT "key", "serverSecretVersion", "keyVersion" FROM "mcp_module_oauth_server_state"`,
+		)) as Array<{ key: string; serverSecretVersion: number; keyVersion: number }>;
+
+		expect(tables.map(({ name }) => name)).toEqual([
+			'mcp_module_oauth_access_tokens',
+			'mcp_module_oauth_authorization_codes',
+			'mcp_module_oauth_clients',
+			'mcp_module_oauth_grants',
+			'mcp_module_oauth_interactions',
+			'mcp_module_oauth_refresh_families',
+			'mcp_module_oauth_refresh_tokens',
+			'mcp_module_oauth_server_state',
+		]);
+		expect(uniqueRefreshIndexColumns).toEqual(
+			expect.arrayContaining([['tokenHash'], ['predecessorId']]),
+		);
+		expect(accessForeignKeys).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					from: 'refreshFamilyId',
+					table: 'mcp_module_oauth_refresh_families',
+					on_delete: 'CASCADE',
+				}),
+			]),
+		);
+		expect(state).toEqual([{ key: 'primary', serverSecretVersion: 1, keyVersion: 1 }]);
+	});
+
+	it('can be reverted and reapplied without touching the existing MCP tables', async () => {
+		await queryRunner.query(`CREATE TABLE "mcp_module_clients" ("id" varchar PRIMARY KEY NOT NULL)`);
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		await expect(migration.up(queryRunner)).resolves.toBeUndefined();
+		await expect(queryRunner.query(`SELECT * FROM "mcp_module_clients"`)).resolves.toEqual([]);
+	});
+});

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -13,7 +13,7 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { IS_MCP_ENDPOINT_KEY } from '../../mcp/mcp.constants';
+import { IS_MCP_ENDPOINT_KEY, MCP_OAUTH_PRINCIPAL_TYPE } from '../../mcp/mcp.constants';
 import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
@@ -609,6 +609,25 @@ describe('AuthGuard', () => {
 
 			await expect(guard.canActivate(context)).rejects.toThrow('MCP credentials are only valid on the MCP endpoint');
 		});
+
+		it.each([false, true])(
+			'should reject an OAuth MCP discriminator on static/ordinary auth paths (%s)',
+			async (mcp) => {
+				const context = createMockExecutionContext({ authorization: 'Bearer oauth-token' });
+				jest
+					.spyOn(reflector, 'getAllAndOverride')
+					.mockImplementation((key: string) => (key === IS_MCP_ENDPOINT_KEY ? mcp : false));
+				jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+					sub: 'oauth-access-token',
+					type: MCP_OAUTH_PRINCIPAL_TYPE,
+				});
+
+				await expect(guard.canActivate(context)).rejects.toThrow(
+					'OAuth MCP credentials require the isolated OAuth verifier',
+				);
+				expect(tokensService.findOneByHashedToken).not.toHaveBeenCalled();
+			},
+		);
 
 		it('should reject a personal token on an MCP endpoint', async () => {
 			const context = createMockExecutionContext({ authorization: `Bearer ${mockLongLiveToken}` });

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -15,7 +15,7 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 
 import { createExtensionLogger } from '../../../common/logger';
-import { IS_MCP_ENDPOINT_KEY, McpCapability } from '../../mcp/mcp.constants';
+import { IS_MCP_ENDPOINT_KEY, MCP_OAUTH_PRINCIPAL_TYPE, McpCapability } from '../../mcp/mcp.constants';
 import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
@@ -145,6 +145,10 @@ export class AuthGuard implements CanActivate {
 				: await this.jwtService.verifyAsync(token);
 		} catch {
 			throw new UnauthorizedException('Invalid or expired token');
+		}
+
+		if (payload.type === MCP_OAUTH_PRINCIPAL_TYPE) {
+			throw new UnauthorizedException('OAuth MCP credentials require the isolated OAuth verifier');
 		}
 
 		if (isMcpEndpoint) {

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
@@ -5,6 +5,7 @@ import {
 	MCP_DEFAULT_ALLOWED_ORIGINS,
 	MCP_DEFAULT_CAPABILITIES,
 	MCP_DEFAULT_ENABLED,
+	MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 	MCP_MODULE_NAME,
 	McpCapability,
 } from '../mcp.constants';
@@ -32,8 +33,34 @@ describe('MCP configuration', () => {
 			enabled: MCP_DEFAULT_ENABLED,
 			capabilities: MCP_DEFAULT_CAPABILITIES,
 			allowedOrigins: MCP_DEFAULT_ALLOWED_ORIGINS,
+			oauthPublicBaseUrl: MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 		});
 		expect(await validate(config)).toHaveLength(0);
+	});
+
+	it('accepts only a normalized HTTPS OAuth public base URL and permits clearing it', async () => {
+		for (const value of ['https://panel.example.com', 'https://panel.example.com/smart-panel', null]) {
+			const dto = plainToInstance(UpdateMcpConfigDto, {
+				type: MCP_MODULE_NAME,
+				oauth_public_base_url: value,
+			});
+
+			expect(await validate(dto)).toHaveLength(0);
+		}
+
+		for (const value of [
+			'http://panel.example.com',
+			'https://panel.example.com/',
+			'https://panel.example.com/path/',
+			'https://panel.example.com?redirect=other',
+		]) {
+			const dto = plainToInstance(UpdateMcpConfigDto, {
+				type: MCP_MODULE_NAME,
+				oauth_public_base_url: value,
+			});
+
+			expect(await validate(dto)).not.toHaveLength(0);
+		}
 	});
 
 	it.each(CAPABILITY_COMBINATIONS)('accepts capability combination %j', async (...capabilities) => {
@@ -90,12 +117,14 @@ describe('MCP configuration', () => {
 		config.enabled = true;
 		config.capabilities = [McpCapability.WRITE, McpCapability.TRIGGER];
 		config.allowedOrigins = ['https://panel.example.com'];
+		config.oauthPublicBaseUrl = 'https://panel.example.com/smart-panel';
 
 		expect(instanceToPlain(config)).toEqual({
 			type: MCP_MODULE_NAME,
 			enabled: true,
 			capabilities: [McpCapability.WRITE, McpCapability.TRIGGER],
 			allowed_origins: ['https://panel.example.com'],
+			oauth_public_base_url: 'https://panel.example.com/smart-panel',
 		});
 	});
 });

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.ts
@@ -5,6 +5,7 @@ import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
 import { UpdateModuleConfigDto } from '../../config/dto/config.dto';
 import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { IsMcpOAuthPublicBaseUrlConstraint } from '../validators/is-mcp-oauth-public-base-url.validator';
 import { IsMcpOriginConstraint } from '../validators/is-mcp-origin.validator';
 
 @ApiSchema({ name: 'ConfigModuleUpdateMcp' })
@@ -51,4 +52,19 @@ export class UpdateMcpConfigDto extends UpdateModuleConfigDto {
 			'[{"field":"allowed_origins","reason":"Each origin must be a normalized absolute HTTP(S) origin without a path, query, fragment, or credentials."}]',
 	})
 	allowed_origins?: string[];
+
+	@ApiPropertyOptional({
+		name: 'oauth_public_base_url',
+		description: 'Explicit canonical HTTPS base URL used to derive the inactive MCP OAuth identity',
+		type: 'string',
+		nullable: true,
+		example: 'https://panel.example.com',
+	})
+	@Expose({ name: 'oauth_public_base_url' })
+	@IsOptional()
+	@Validate(IsMcpOAuthPublicBaseUrlConstraint, {
+		message:
+			'[{"field":"oauth_public_base_url","reason":"OAuth public base URL must be a normalized absolute HTTPS URL without credentials, query, fragment, or trailing slash."}]',
+	})
+	oauth_public_base_url?: string | null;
 }

--- a/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
+++ b/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
@@ -1,0 +1,321 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryColumn } from 'typeorm';
+
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { UserEntity } from '../../users/entities/users.entity';
+import { McpOAuthScope } from '../mcp.constants';
+
+@Entity('mcp_module_oauth_clients')
+export class McpOAuthClientEntity extends BaseEntity {
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	clientIdentifier: string;
+
+	@Column({ type: 'varchar' })
+	name: string;
+
+	@Column({ type: 'simple-json' })
+	redirectUris: string[];
+
+	@Column({ type: 'simple-json' })
+	maximumScopes: McpOAuthScope[];
+
+	@Index()
+	@Column({ type: 'boolean', default: true })
+	enabled: boolean;
+
+	@Column({ type: 'integer', default: 0 })
+	generation: number;
+
+	@Column({ type: 'varchar', nullable: true })
+	createdById: string | null;
+
+	@ManyToOne(() => UserEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'createdById' })
+	createdBy?: UserEntity | null;
+}
+
+@Entity('mcp_module_oauth_grants')
+export class McpOAuthGrantEntity extends BaseEntity {
+	@Index()
+	@Column({ type: 'varchar' })
+	clientId: string;
+
+	@ManyToOne(() => McpOAuthClientEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'clientId' })
+	client?: McpOAuthClientEntity;
+
+	@Index()
+	@Column({ type: 'varchar', nullable: true })
+	approvedById: string | null;
+
+	@ManyToOne(() => UserEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'approvedById' })
+	approvedBy?: UserEntity | null;
+
+	@Column({ type: 'varchar' })
+	installationId: string;
+
+	@Column({ type: 'varchar' })
+	issuer: string;
+
+	@Column({ type: 'varchar' })
+	resource: string;
+
+	@Column({ type: 'simple-json' })
+	approvedScopes: McpOAuthScope[];
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Index()
+	@Column({ type: 'datetime', nullable: true })
+	revokedAt: Date | null;
+
+	@Column({ type: 'integer', default: 0 })
+	generation: number;
+
+	@Column({ type: 'integer', default: 0 })
+	approverAuthorityGeneration: number;
+}
+
+@Entity('mcp_module_oauth_interactions')
+export class McpOAuthInteractionEntity extends BaseEntity {
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	uidHash: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	clientId: string;
+
+	@ManyToOne(() => McpOAuthClientEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'clientId' })
+	client?: McpOAuthClientEntity;
+
+	@Column({ type: 'varchar', nullable: true })
+	authenticatedUserId: string | null;
+
+	@ManyToOne(() => UserEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'authenticatedUserId' })
+	authenticatedUser?: UserEntity | null;
+
+	@Column({ type: 'varchar' })
+	redirectUri: string;
+
+	@Column({ type: 'simple-json' })
+	requestedScopes: McpOAuthScope[];
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Column({ type: 'datetime', nullable: true })
+	consumedAt: Date | null;
+}
+
+@Entity('mcp_module_oauth_authorization_codes')
+export class McpOAuthAuthorizationCodeEntity extends BaseEntity {
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	codeHash: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	clientId: string;
+
+	@ManyToOne(() => McpOAuthClientEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'clientId' })
+	client?: McpOAuthClientEntity;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	grantId: string;
+
+	@ManyToOne(() => McpOAuthGrantEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'grantId' })
+	grant?: McpOAuthGrantEntity;
+
+	@Column({ type: 'varchar' })
+	interactionId: string;
+
+	@OneToOne(() => McpOAuthInteractionEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'interactionId' })
+	interaction?: McpOAuthInteractionEntity;
+
+	@Column({ type: 'varchar' })
+	installationId: string;
+
+	@Column({ type: 'varchar' })
+	issuer: string;
+
+	@Column({ type: 'varchar' })
+	resource: string;
+
+	@Column({ type: 'varchar' })
+	redirectUri: string;
+
+	@Column({ type: 'simple-json' })
+	scopes: McpOAuthScope[];
+
+	@Column({ type: 'varchar' })
+	codeChallenge: string;
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Column({ type: 'datetime', nullable: true })
+	consumedAt: Date | null;
+}
+
+@Entity('mcp_module_oauth_refresh_families')
+export class McpOAuthRefreshTokenFamilyEntity extends BaseEntity {
+	@Index()
+	@Column({ type: 'varchar' })
+	clientId: string;
+
+	@ManyToOne(() => McpOAuthClientEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'clientId' })
+	client?: McpOAuthClientEntity;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	grantId: string;
+
+	@ManyToOne(() => McpOAuthGrantEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'grantId' })
+	grant?: McpOAuthGrantEntity;
+
+	@Column({ type: 'varchar' })
+	installationId: string;
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Index()
+	@Column({ type: 'datetime', nullable: true })
+	revokedAt: Date | null;
+
+	@Column({ type: 'varchar', nullable: true })
+	revocationReason: string | null;
+
+	@Column({ type: 'integer', default: 0 })
+	generation: number;
+
+	@OneToMany(() => McpOAuthRefreshTokenEntity, (token) => token.family)
+	tokens?: McpOAuthRefreshTokenEntity[];
+}
+
+@Entity('mcp_module_oauth_refresh_tokens')
+export class McpOAuthRefreshTokenEntity extends BaseEntity {
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	tokenHash: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	familyId: string;
+
+	@ManyToOne(() => McpOAuthRefreshTokenFamilyEntity, (family) => family.tokens, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'familyId' })
+	family?: McpOAuthRefreshTokenFamilyEntity;
+
+	@Index({ unique: true })
+	@Column({ type: 'varchar', nullable: true })
+	predecessorId: string | null;
+
+	@OneToOne(() => McpOAuthRefreshTokenEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'predecessorId' })
+	predecessor?: McpOAuthRefreshTokenEntity | null;
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Index()
+	@Column({ type: 'datetime', nullable: true })
+	consumedAt: Date | null;
+
+	@Column({ type: 'datetime', nullable: true })
+	revokedAt: Date | null;
+}
+
+@Entity('mcp_module_oauth_access_tokens')
+export class McpOAuthAccessTokenEntity extends BaseEntity {
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	tokenHash: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	clientId: string;
+
+	@ManyToOne(() => McpOAuthClientEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'clientId' })
+	client?: McpOAuthClientEntity;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	grantId: string;
+
+	@ManyToOne(() => McpOAuthGrantEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'grantId' })
+	grant?: McpOAuthGrantEntity;
+
+	@Index()
+	@Column({ type: 'varchar', nullable: true })
+	refreshFamilyId: string | null;
+
+	@ManyToOne(() => McpOAuthRefreshTokenFamilyEntity, { nullable: true, onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'refreshFamilyId' })
+	refreshFamily?: McpOAuthRefreshTokenFamilyEntity | null;
+
+	@Column({ type: 'varchar' })
+	installationId: string;
+
+	@Column({ type: 'varchar' })
+	issuer: string;
+
+	@Column({ type: 'varchar' })
+	resource: string;
+
+	@Column({ type: 'simple-json' })
+	scopes: McpOAuthScope[];
+
+	@Index()
+	@Column({ type: 'datetime' })
+	expiresAt: Date;
+
+	@Index()
+	@Column({ type: 'datetime', nullable: true })
+	revokedAt: Date | null;
+}
+
+@Entity('mcp_module_oauth_server_state')
+export class McpOAuthServerStateEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	key: string;
+
+	@Column({ type: 'integer', default: 1 })
+	serverSecretVersion: number;
+
+	@Column({ type: 'integer', default: 1 })
+	keyVersion: number;
+
+	@Column({ type: 'integer', default: 0 })
+	publicIdentityGeneration: number;
+
+	@Column({ type: 'integer', default: 0 })
+	oauthEnabledGeneration: number;
+
+	@Column({ type: 'integer', default: 0 })
+	modulePolicyGeneration: number;
+
+	@Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date | string;
+
+	@Column({ type: 'datetime', onUpdate: 'CURRENT_TIMESTAMP', nullable: true })
+	updatedAt: Date | string | null;
+}

--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -15,11 +15,28 @@ export enum McpCapability {
 	TRIGGER = 'trigger',
 }
 
+export enum McpOAuthScope {
+	READ = 'mcp:read',
+	WRITE = 'mcp:write',
+	TRIGGER = 'mcp:trigger',
+	OFFLINE_ACCESS = 'offline_access',
+}
+
 export const MCP_DEFAULT_ENABLED = false;
 
 export const MCP_DEFAULT_CAPABILITIES: readonly McpCapability[] = [McpCapability.READ];
 
 export const MCP_DEFAULT_ALLOWED_ORIGINS: readonly string[] = [];
+
+export const MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL: string | null = null;
+
+export const MCP_OAUTH_PRINCIPAL_TYPE = 'mcp_oauth';
+
+export const MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
+
+export const MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const MCP_OAUTH_GRANT_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000;
 
 export const MCP_DEFAULT_TOKEN_EXPIRATION_DAYS = 90;
 

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -24,6 +24,16 @@ import { McpController } from './controllers/mcp.controller';
 import { UpdateMcpConfigDto } from './dto/update-config.dto';
 import { McpClientEntity } from './entities/mcp-client.entity';
 import { McpInstallationEntity } from './entities/mcp-installation.entity';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
+} from './entities/mcp-oauth.entity';
 import { McpClientGuard } from './guards/mcp-client.guard';
 import { McpConfigListener } from './listeners/mcp-config.listener';
 import {
@@ -40,6 +50,10 @@ import { McpAuditService } from './services/mcp-audit.service';
 import { McpClientService } from './services/mcp-client.service';
 import { McpContextService } from './services/mcp-context.service';
 import { McpInstallationService } from './services/mcp-installation.service';
+import { McpOAuthArtifactService } from './services/mcp-oauth-artifact.service';
+import { McpOAuthProxyPolicyService } from './services/mcp-oauth-proxy-policy.service';
+import { McpOAuthPublicUrlService } from './services/mcp-oauth-public-url.service';
+import { McpOAuthRefreshTokenService } from './services/mcp-oauth-refresh-token.service';
 import { McpPolicyService } from './services/mcp-policy.service';
 import { McpServerService } from './services/mcp-server.service';
 import { McpSubscriptionRegistryService } from './services/mcp-subscription-registry.service';
@@ -62,7 +76,18 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		SpacesModule,
 		StatsModule,
 		SwaggerModule,
-		TypeOrmModule.forFeature([McpClientEntity, McpInstallationEntity]),
+		TypeOrmModule.forFeature([
+			McpClientEntity,
+			McpInstallationEntity,
+			McpOAuthAccessTokenEntity,
+			McpOAuthAuthorizationCodeEntity,
+			McpOAuthClientEntity,
+			McpOAuthGrantEntity,
+			McpOAuthInteractionEntity,
+			McpOAuthRefreshTokenEntity,
+			McpOAuthRefreshTokenFamilyEntity,
+			McpOAuthServerStateEntity,
+		]),
 		ToolsModule,
 		WeatherModule,
 	],
@@ -73,6 +98,10 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpConfigListener,
 		McpContextService,
 		McpInstallationService,
+		McpOAuthArtifactService,
+		McpOAuthProxyPolicyService,
+		McpOAuthPublicUrlService,
+		McpOAuthRefreshTokenService,
 		McpPolicyService,
 		McpServerService,
 		McpAuditService,
@@ -91,7 +120,17 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 			inject: [McpReadToolService, McpTargetDiscoveryToolService],
 		},
 	],
-	exports: [McpAuditService, McpClientService, McpInstallationService, McpPolicyService, McpServerService],
+	exports: [
+		McpAuditService,
+		McpClientService,
+		McpInstallationService,
+		McpOAuthArtifactService,
+		McpOAuthProxyPolicyService,
+		McpOAuthPublicUrlService,
+		McpOAuthRefreshTokenService,
+		McpPolicyService,
+		McpServerService,
+	],
 })
 export class McpModule implements OnModuleInit {
 	constructor(
@@ -143,7 +182,8 @@ Connects trusted MCP-compatible agents to a curated set of Smart Panel tools and
 |--------|-------------|---------|
 | \`enabled\` | Accept MCP protocol requests | \`false\` |
 | \`capabilities\` | Allowed combination of \`read\`, \`write\`, and \`trigger\` | \`read\` |
-| \`allowed_origins\` | Additional browser origins allowed to call the endpoint | empty |`,
+| \`allowed_origins\` | Additional browser origins allowed to call the endpoint | empty |
+| \`oauth_public_base_url\` | Canonical HTTPS base used by the inactive OAuth foundation | empty |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs/admin-management/mcp',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/mcp/models/config.model.ts
+++ b/apps/backend/src/modules/mcp/models/config.model.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsString, Validate } from 'class-validator';
+import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsOptional, IsString, Validate } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -8,9 +8,11 @@ import {
 	MCP_DEFAULT_ALLOWED_ORIGINS,
 	MCP_DEFAULT_CAPABILITIES,
 	MCP_DEFAULT_ENABLED,
+	MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 	MCP_MODULE_NAME,
 	McpCapability,
 } from '../mcp.constants';
+import { IsMcpOAuthPublicBaseUrlConstraint } from '../validators/is-mcp-oauth-public-base-url.validator';
 import { IsMcpOriginConstraint } from '../validators/is-mcp-origin.validator';
 
 @ApiSchema({ name: 'ConfigModuleDataMcp' })
@@ -57,4 +59,16 @@ export class McpConfigModel extends ModuleConfigModel {
 	@ArrayUnique()
 	@Validate(IsMcpOriginConstraint, { each: true })
 	allowedOrigins: string[] = [...MCP_DEFAULT_ALLOWED_ORIGINS];
+
+	@ApiProperty({
+		name: 'oauth_public_base_url',
+		description: 'Explicit canonical HTTPS base URL used to derive the inactive MCP OAuth identity',
+		type: 'string',
+		nullable: true,
+		example: 'https://panel.example.com',
+	})
+	@Expose({ name: 'oauth_public_base_url' })
+	@IsOptional()
+	@Validate(IsMcpOAuthPublicBaseUrlConstraint)
+	oauthPublicBaseUrl: string | null = MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL;
 }

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-redaction.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-redaction.spec.ts
@@ -1,0 +1,31 @@
+import { redactMcpOAuthLogValue } from './mcp-oauth-redaction';
+
+describe('redactMcpOAuthLogValue', () => {
+	it('redacts OAuth artifacts recursively while preserving safe audit identifiers', () => {
+		const raw = 'raw-secret-value';
+		const redacted = redactMcpOAuthLogValue({
+			clientId: 'client-1',
+			grantId: 'grant-1',
+			access_token: raw,
+			nested: {
+				codeVerifier: raw,
+				cookie: raw,
+				tokenHash: raw,
+				reason: 'invalid_grant',
+			},
+		});
+
+		expect(redacted).toEqual({
+			clientId: 'client-1',
+			grantId: 'grant-1',
+			access_token: '[REDACTED]',
+			nested: {
+				codeVerifier: '[REDACTED]',
+				cookie: '[REDACTED]',
+				tokenHash: '[REDACTED]',
+				reason: 'invalid_grant',
+			},
+		});
+		expect(JSON.stringify(redacted)).not.toContain(raw);
+	});
+});

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-redaction.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-redaction.ts
@@ -1,0 +1,18 @@
+const SENSITIVE_KEY = /(?:authorization|code|cookie|password|pkce|secret|token|verifier|hash)/i;
+
+export function redactMcpOAuthLogValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => redactMcpOAuthLogValue(item));
+	}
+
+	if (!value || typeof value !== 'object') {
+		return value;
+	}
+
+	return Object.fromEntries(
+		Object.entries(value).map(([key, entry]) => [
+			key,
+			SENSITIVE_KEY.test(key) ? '[REDACTED]' : redactMcpOAuthLogValue(entry),
+		]),
+	);
+}

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
@@ -1,0 +1,22 @@
+import { MCP_OAUTH_PRINCIPAL_TYPE, McpOAuthScope } from '../mcp.constants';
+
+export interface McpOAuthPrincipal {
+	type: typeof MCP_OAUTH_PRINCIPAL_TYPE;
+	accessTokenId: string;
+	clientId: string;
+	grantId: string;
+	installationId: string;
+	refreshFamilyId?: string;
+	scopes: McpOAuthScope[];
+}
+
+export interface McpOAuthPublicUrls {
+	publicBaseUrl: string;
+	resource: string;
+	protectedResourceMetadata: string;
+	issuer: string;
+	authorizationServerMetadata: string;
+	authorizationEndpoint: string;
+	tokenEndpoint: string;
+	revocationEndpoint: string;
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.spec.ts
@@ -1,0 +1,186 @@
+import { DataSource } from 'typeorm';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import { UserEntity } from '../../users/entities/users.entity';
+import { UserLanguage, UserRole } from '../../users/users.constants';
+import { McpInstallationEntity } from '../entities/mcp-installation.entity';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+} from '../entities/mcp-oauth.entity';
+import { McpOAuthScope } from '../mcp.constants';
+import { McpOAuthPublicUrls } from '../oauth/mcp-oauth.types';
+
+import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthArtifactService } from './mcp-oauth-artifact.service';
+import { McpOAuthPublicUrlService } from './mcp-oauth-public-url.service';
+
+describe('McpOAuthArtifactService', () => {
+	let dataSource: DataSource;
+	let service: McpOAuthArtifactService;
+	let urls: McpOAuthPublicUrls;
+	let approver: UserEntity;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				McpInstallationEntity,
+				McpOAuthAccessTokenEntity,
+				McpOAuthAuthorizationCodeEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
+				McpOAuthInteractionEntity,
+				McpOAuthRefreshTokenEntity,
+				McpOAuthRefreshTokenFamilyEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+		approver = await dataSource.getRepository(UserEntity).save(
+			dataSource.getRepository(UserEntity).create({
+				username: 'owner',
+				password: null,
+				email: null,
+				firstName: null,
+				lastName: null,
+				role: UserRole.OWNER,
+				language: UserLanguage.EN,
+				isHidden: false,
+			}),
+		);
+		urls = publicUrls('https://panel.example.com');
+		const installationService = new McpInstallationService(dataSource.getRepository(McpInstallationEntity));
+		const publicUrlService = { getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService;
+		service = new McpOAuthArtifactService(
+			dataSource.getRepository(McpOAuthClientEntity),
+			dataSource.getRepository(McpOAuthGrantEntity),
+			dataSource.getRepository(McpOAuthInteractionEntity),
+			dataSource.getRepository(McpOAuthAuthorizationCodeEntity),
+			dataSource.getRepository(McpOAuthAccessTokenEntity),
+			dataSource.getRepository(McpOAuthRefreshTokenFamilyEntity),
+			installationService,
+			publicUrlService,
+		);
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	it('stores only hashes for interactions, codes, access tokens, and refresh tokens', async () => {
+		const client = await createClient(service, approver.id);
+		const grant = await service.createGrant({
+			clientId: client.id,
+			approvedById: approver.id,
+			approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+		});
+		const interaction = await service.createInteraction({
+			clientId: client.id,
+			redirectUri: 'http://127.0.0.1:49152/callback',
+			requestedScopes: [McpOAuthScope.READ],
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+		const code = await service.issueAuthorizationCode({
+			clientId: client.id,
+			grant,
+			interactionId: interaction.artifact.id,
+			redirectUri: interaction.artifact.redirectUri,
+			scopes: [McpOAuthScope.READ],
+			codeChallenge: 's256-challenge',
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+		const family = await service.issueRefreshFamily({ clientId: client.id, grant });
+		const access = await service.issueAccessToken({
+			clientId: client.id,
+			grant,
+			scopes: [McpOAuthScope.READ],
+			refreshFamilyId: family.family.id,
+		});
+
+		expect(interaction.artifact.uidHash).toBe(hashToken(interaction.rawValue));
+		expect(code.artifact.codeHash).toBe(hashToken(code.rawValue));
+		expect(access.artifact.tokenHash).toBe(hashToken(access.rawValue));
+		expect(family.refreshToken.artifact.tokenHash).toBe(hashToken(family.refreshToken.rawValue));
+
+		const persisted = JSON.stringify({
+			interaction: await dataSource.getRepository(McpOAuthInteractionEntity).find(),
+			codes: await dataSource.getRepository(McpOAuthAuthorizationCodeEntity).find(),
+			access: await dataSource.getRepository(McpOAuthAccessTokenEntity).find(),
+			refresh: await dataSource.getRepository(McpOAuthRefreshTokenEntity).find(),
+		});
+
+		for (const raw of [interaction.rawValue, code.rawValue, access.rawValue, family.refreshToken.rawValue]) {
+			expect(persisted).not.toContain(raw);
+		}
+	});
+
+	it('binds grants and tokens to the installation/public identity and caps access expiry at grant expiry', async () => {
+		const client = await createClient(service, approver.id);
+		const grantExpiry = new Date(Date.now() + 90_000);
+		const firstGrant = await service.createGrant({
+			clientId: client.id,
+			approvedById: approver.id,
+			approvedScopes: [McpOAuthScope.READ],
+			expiresAt: grantExpiry,
+		});
+		const access = await service.issueAccessToken({
+			clientId: client.id,
+			grant: firstGrant,
+			scopes: [McpOAuthScope.READ],
+			expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+		});
+
+		expect(firstGrant.installationId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(firstGrant).toMatchObject({ issuer: urls.issuer, resource: urls.resource });
+		expect(access.artifact).toMatchObject({
+			installationId: firstGrant.installationId,
+			issuer: urls.issuer,
+			resource: urls.resource,
+			expiresAt: grantExpiry,
+		});
+
+		urls = publicUrls('https://new-panel.example.com');
+		const secondGrant = await service.createGrant({
+			clientId: client.id,
+			approvedById: approver.id,
+			approvedScopes: [McpOAuthScope.READ],
+		});
+
+		expect(secondGrant.installationId).toBe(firstGrant.installationId);
+		expect(secondGrant.resource).toBe('https://new-panel.example.com/api/v1/modules/mcp');
+		expect(firstGrant.resource).toBe('https://panel.example.com/api/v1/modules/mcp');
+	});
+
+	function publicUrls(base: string): McpOAuthPublicUrls {
+		const resource = `${base}/api/v1/modules/mcp`;
+		const issuer = `${resource}/oauth`;
+
+		return {
+			publicBaseUrl: base,
+			resource,
+			protectedResourceMetadata: `${base}/.well-known/oauth-protected-resource/api/v1/modules/mcp`,
+			issuer,
+			authorizationServerMetadata: `${base}/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth`,
+			authorizationEndpoint: `${issuer}/authorize`,
+			tokenEndpoint: `${issuer}/token`,
+			revocationEndpoint: `${issuer}/token/revocation`,
+		};
+	}
+
+	async function createClient(artifactService: McpOAuthArtifactService, createdById: string) {
+		return artifactService.createClient({
+			name: 'Codex',
+			redirectUris: ['http://127.0.0.1:49152/callback'],
+			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+			createdById,
+		});
+	}
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.ts
@@ -1,0 +1,244 @@
+import { randomBytes } from 'node:crypto';
+import { Repository } from 'typeorm';
+
+import { BadRequestException, Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+} from '../entities/mcp-oauth.entity';
+import {
+	MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS,
+	MCP_OAUTH_GRANT_LIFETIME_MS,
+	MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS,
+	McpOAuthScope,
+} from '../mcp.constants';
+
+import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthPublicUrlService } from './mcp-oauth-public-url.service';
+
+export interface McpOAuthRawArtifact<TEntity> {
+	rawValue: string;
+	artifact: TEntity;
+}
+
+@Injectable()
+export class McpOAuthArtifactService {
+	constructor(
+		@InjectRepository(McpOAuthClientEntity)
+		private readonly clients: Repository<McpOAuthClientEntity>,
+		@InjectRepository(McpOAuthGrantEntity)
+		private readonly grants: Repository<McpOAuthGrantEntity>,
+		@InjectRepository(McpOAuthInteractionEntity)
+		private readonly interactions: Repository<McpOAuthInteractionEntity>,
+		@InjectRepository(McpOAuthAuthorizationCodeEntity)
+		private readonly authorizationCodes: Repository<McpOAuthAuthorizationCodeEntity>,
+		@InjectRepository(McpOAuthAccessTokenEntity)
+		private readonly accessTokens: Repository<McpOAuthAccessTokenEntity>,
+		@InjectRepository(McpOAuthRefreshTokenFamilyEntity)
+		private readonly refreshFamilies: Repository<McpOAuthRefreshTokenFamilyEntity>,
+		private readonly installationService: McpInstallationService,
+		private readonly publicUrlService: McpOAuthPublicUrlService,
+	) {}
+
+	async createClient(input: {
+		name: string;
+		redirectUris: string[];
+		maximumScopes: McpOAuthScope[];
+		createdById: string;
+	}): Promise<McpOAuthClientEntity> {
+		return this.clients.save(
+			this.clients.create({
+				clientIdentifier: this.generateOpaqueValue(16),
+				name: input.name,
+				redirectUris: [...input.redirectUris],
+				maximumScopes: [...input.maximumScopes],
+				enabled: true,
+				generation: 0,
+				createdById: input.createdById,
+			}),
+		);
+	}
+
+	async createGrant(input: {
+		clientId: string;
+		approvedById: string;
+		approvedScopes: McpOAuthScope[];
+		expiresAt?: Date;
+		approverAuthorityGeneration?: number;
+	}): Promise<McpOAuthGrantEntity> {
+		const urls = this.requirePublicUrls();
+		const maximumExpiry = new Date(Date.now() + MCP_OAUTH_GRANT_LIFETIME_MS);
+		const expiresAt = this.earliest(input.expiresAt, maximumExpiry);
+
+		if (expiresAt <= new Date()) {
+			throw new BadRequestException('OAuth grant expiry must be in the future');
+		}
+
+		return this.grants.save(
+			this.grants.create({
+				clientId: input.clientId,
+				approvedById: input.approvedById,
+				installationId: await this.installationService.getInstallationId(),
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [...input.approvedScopes],
+				expiresAt,
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: input.approverAuthorityGeneration ?? 0,
+			}),
+		);
+	}
+
+	async createInteraction(input: {
+		clientId: string;
+		redirectUri: string;
+		requestedScopes: McpOAuthScope[];
+		expiresAt: Date;
+	}): Promise<McpOAuthRawArtifact<McpOAuthInteractionEntity>> {
+		const rawValue = this.generateOpaqueValue();
+		const artifact = await this.interactions.save(
+			this.interactions.create({
+				uidHash: hashToken(rawValue),
+				clientId: input.clientId,
+				authenticatedUserId: null,
+				redirectUri: input.redirectUri,
+				requestedScopes: [...input.requestedScopes],
+				expiresAt: input.expiresAt,
+				consumedAt: null,
+			}),
+		);
+
+		return { rawValue, artifact };
+	}
+
+	async issueAuthorizationCode(input: {
+		clientId: string;
+		grant: McpOAuthGrantEntity;
+		interactionId: string;
+		redirectUri: string;
+		scopes: McpOAuthScope[];
+		codeChallenge: string;
+		expiresAt: Date;
+	}): Promise<McpOAuthRawArtifact<McpOAuthAuthorizationCodeEntity>> {
+		const rawValue = this.generateOpaqueValue();
+		const artifact = await this.authorizationCodes.save(
+			this.authorizationCodes.create({
+				codeHash: hashToken(rawValue),
+				clientId: input.clientId,
+				grantId: input.grant.id,
+				interactionId: input.interactionId,
+				installationId: input.grant.installationId,
+				issuer: input.grant.issuer,
+				resource: input.grant.resource,
+				redirectUri: input.redirectUri,
+				scopes: [...input.scopes],
+				codeChallenge: input.codeChallenge,
+				expiresAt: input.expiresAt,
+				consumedAt: null,
+			}),
+		);
+
+		return { rawValue, artifact };
+	}
+
+	async issueAccessToken(input: {
+		clientId: string;
+		grant: McpOAuthGrantEntity;
+		scopes: McpOAuthScope[];
+		refreshFamilyId?: string;
+		expiresAt?: Date;
+	}): Promise<McpOAuthRawArtifact<McpOAuthAccessTokenEntity>> {
+		this.assertGrantActive(input.grant);
+		const rawValue = this.generateOpaqueValue();
+		const maximumExpiry = new Date(Date.now() + MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS);
+		const artifact = await this.accessTokens.save(
+			this.accessTokens.create({
+				tokenHash: hashToken(rawValue),
+				clientId: input.clientId,
+				grantId: input.grant.id,
+				refreshFamilyId: input.refreshFamilyId ?? null,
+				installationId: input.grant.installationId,
+				issuer: input.grant.issuer,
+				resource: input.grant.resource,
+				scopes: [...input.scopes],
+				expiresAt: this.earliest(input.expiresAt, maximumExpiry, input.grant.expiresAt),
+				revokedAt: null,
+			}),
+		);
+
+		return { rawValue, artifact };
+	}
+
+	async issueRefreshFamily(input: { clientId: string; grant: McpOAuthGrantEntity; expiresAt?: Date }): Promise<{
+		family: McpOAuthRefreshTokenFamilyEntity;
+		refreshToken: McpOAuthRawArtifact<McpOAuthRefreshTokenEntity>;
+	}> {
+		this.assertGrantActive(input.grant);
+		const maximumExpiry = new Date(Date.now() + MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS);
+		const expiresAt = this.earliest(input.expiresAt, maximumExpiry, input.grant.expiresAt);
+
+		return this.refreshFamilies.manager.transaction(async (manager) => {
+			const familyRepository = manager.getRepository(McpOAuthRefreshTokenFamilyEntity);
+			const tokenRepository = manager.getRepository(McpOAuthRefreshTokenEntity);
+			const family = await familyRepository.save(
+				familyRepository.create({
+					clientId: input.clientId,
+					grantId: input.grant.id,
+					installationId: input.grant.installationId,
+					expiresAt,
+					revokedAt: null,
+					revocationReason: null,
+					generation: 0,
+				}),
+			);
+			const rawValue = this.generateOpaqueValue();
+			const artifact = await tokenRepository.save(
+				tokenRepository.create({
+					tokenHash: hashToken(rawValue),
+					familyId: family.id,
+					predecessorId: null,
+					expiresAt,
+					consumedAt: null,
+					revokedAt: null,
+				}),
+			);
+
+			return { family, refreshToken: { rawValue, artifact } };
+		});
+	}
+
+	private requirePublicUrls() {
+		const urls = this.publicUrlService.getUrls();
+
+		if (!urls) {
+			throw new ServiceUnavailableException('MCP OAuth public URL is not configured');
+		}
+
+		return urls;
+	}
+
+	private generateOpaqueValue(bytes = 32): string {
+		return randomBytes(bytes).toString('base64url');
+	}
+
+	private earliest(...values: Array<Date | undefined>): Date {
+		return new Date(
+			Math.min(...values.filter((value): value is Date => value !== undefined).map((value) => value.getTime())),
+		);
+	}
+
+	private assertGrantActive(grant: McpOAuthGrantEntity): void {
+		if (grant.revokedAt || grant.expiresAt <= new Date()) {
+			throw new BadRequestException('OAuth grant is revoked or expired');
+		}
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-proxy-policy.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-proxy-policy.service.spec.ts
@@ -1,0 +1,42 @@
+import { FastifyRequest } from 'fastify';
+
+import { ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { McpOAuthProxyPolicyService } from './mcp-oauth-proxy-policy.service';
+
+describe('McpOAuthProxyPolicyService', () => {
+	function request(headers: Record<string, string>, remoteAddress = '192.0.2.10'): FastifyRequest {
+		return {
+			headers,
+			raw: { socket: { remoteAddress } },
+		} as unknown as FastifyRequest;
+	}
+
+	it('rejects forwarded identity headers from an untrusted immediate peer', () => {
+		const configService = { get: jest.fn().mockReturnValue('198.51.100.4') };
+		const service = new McpOAuthProxyPolicyService(configService as unknown as ConfigService);
+
+		expect(() => service.assertForwardedHeadersTrusted(request({ 'x-forwarded-host': 'attacker.example' }))).toThrow(
+			ForbiddenException,
+		);
+	});
+
+	it('accepts forwarded headers only from an explicitly listed immediate proxy', () => {
+		const configService = { get: jest.fn().mockReturnValue('198.51.100.4, 192.0.2.10') };
+		const service = new McpOAuthProxyPolicyService(configService as unknown as ConfigService);
+
+		expect(() =>
+			service.assertForwardedHeadersTrusted(
+				request({ forwarded: 'host=attacker.example;proto=http', 'x-forwarded-proto': 'http' }),
+			),
+		).not.toThrow();
+	});
+
+	it('does not require proxy trust when no forwarded headers are present', () => {
+		const configService = { get: jest.fn().mockReturnValue('invalid-value') };
+		const service = new McpOAuthProxyPolicyService(configService as unknown as ConfigService);
+
+		expect(() => service.assertForwardedHeadersTrusted(request({ host: 'panel.example.com' }))).not.toThrow();
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-proxy-policy.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-proxy-policy.service.ts
@@ -1,0 +1,38 @@
+import { FastifyRequest } from 'fastify';
+import { isIP } from 'node:net';
+
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { getEnvValue } from '../../../common/utils/config.utils';
+
+const FORWARDED_HEADERS = ['forwarded', 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-port', 'x-forwarded-proto'];
+
+@Injectable()
+export class McpOAuthProxyPolicyService {
+	constructor(private readonly configService: ConfigService) {}
+
+	assertForwardedHeadersTrusted(request: FastifyRequest): void {
+		if (!FORWARDED_HEADERS.some((header) => request.headers[header] !== undefined)) {
+			return;
+		}
+
+		const immediateProxy = request.raw.socket.remoteAddress ?? '';
+		const trustedProxies = this.getTrustedProxies();
+
+		if (!trustedProxies.has(immediateProxy)) {
+			throw new ForbiddenException('Forwarded headers are not accepted from this proxy');
+		}
+	}
+
+	private getTrustedProxies(): Set<string> {
+		const configured = getEnvValue<string>(this.configService, 'FB_MCP_OAUTH_TRUSTED_PROXIES', '');
+
+		return new Set(
+			configured
+				.split(',')
+				.map((value) => value.trim())
+				.filter((value) => isIP(value) !== 0),
+		);
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-public-url.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-public-url.service.spec.ts
@@ -1,0 +1,42 @@
+import { ConfigService } from '../../config/services/config.service';
+import { MCP_MODULE_NAME } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+
+import { McpOAuthPublicUrlService } from './mcp-oauth-public-url.service';
+
+describe('McpOAuthPublicUrlService', () => {
+	it('derives every identifier from the stored HTTPS base including a reverse-proxy prefix', () => {
+		const config = Object.assign(new McpConfigModel(), {
+			oauthPublicBaseUrl: 'https://panel.example.com/smart-panel',
+		});
+		const configService = {
+			getModuleConfig: jest.fn().mockImplementation((type: string) => {
+				expect(type).toBe(MCP_MODULE_NAME);
+				return config;
+			}),
+		};
+		const service = new McpOAuthPublicUrlService(configService as unknown as ConfigService);
+
+		expect(service.getUrls()).toEqual({
+			publicBaseUrl: 'https://panel.example.com/smart-panel',
+			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
+			protectedResourceMetadata:
+				'https://panel.example.com/.well-known/oauth-protected-resource/smart-panel/api/v1/modules/mcp',
+			issuer: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth',
+			authorizationServerMetadata:
+				'https://panel.example.com/.well-known/oauth-authorization-server/smart-panel/api/v1/modules/mcp/oauth',
+			authorizationEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/authorize',
+			tokenEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token',
+			revocationEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token/revocation',
+		});
+	});
+
+	it('returns no public identity until the explicit configuration exists', () => {
+		const configService = {
+			getModuleConfig: jest.fn().mockReturnValue(new McpConfigModel()),
+		};
+		const service = new McpOAuthPublicUrlService(configService as unknown as ConfigService);
+
+		expect(service.getUrls()).toBeNull();
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-public-url.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-public-url.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+
+import { ConfigService } from '../../config/services/config.service';
+import { MCP_MODULE_NAME } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+import { McpOAuthPublicUrls } from '../oauth/mcp-oauth.types';
+
+@Injectable()
+export class McpOAuthPublicUrlService {
+	constructor(private readonly configService: ConfigService) {}
+
+	getUrls(): McpOAuthPublicUrls | null {
+		const publicBaseUrl = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME).oauthPublicBaseUrl;
+
+		if (!publicBaseUrl) {
+			return null;
+		}
+
+		const base = new URL(publicBaseUrl);
+		const prefix = base.pathname === '/' ? '' : base.pathname;
+		const resourcePath = `${prefix}/api/v1/modules/mcp`;
+		const issuerPath = `${resourcePath}/oauth`;
+		const issuer = `${base.origin}${issuerPath}`;
+
+		return {
+			publicBaseUrl,
+			resource: `${base.origin}${resourcePath}`,
+			protectedResourceMetadata: `${base.origin}/.well-known/oauth-protected-resource${resourcePath}`,
+			issuer,
+			authorizationServerMetadata: `${base.origin}/.well-known/oauth-authorization-server${issuerPath}`,
+			authorizationEndpoint: `${issuer}/authorize`,
+			tokenEndpoint: `${issuer}/token`,
+			revocationEndpoint: `${issuer}/token/revocation`,
+		};
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-refresh-token.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-refresh-token.service.spec.ts
@@ -1,0 +1,172 @@
+import { DataSource } from 'typeorm';
+
+import { UnauthorizedException } from '@nestjs/common';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import { UserEntity } from '../../users/entities/users.entity';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+} from '../entities/mcp-oauth.entity';
+import { McpOAuthScope } from '../mcp.constants';
+
+import { McpOAuthRefreshTokenService } from './mcp-oauth-refresh-token.service';
+
+describe('McpOAuthRefreshTokenService', () => {
+	let dataSource: DataSource;
+	let service: McpOAuthRefreshTokenService;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				McpOAuthAccessTokenEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
+				McpOAuthRefreshTokenEntity,
+				McpOAuthRefreshTokenFamilyEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+		service = new McpOAuthRefreshTokenService(dataSource);
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	it('compare-and-consumes sequential refresh use and revokes the complete family on replay', async () => {
+		const seeded = await seedFamily('sequential-refresh');
+		const successor = await service.rotate(seeded.rawToken);
+
+		expect(successor.artifact.predecessorId).toBe(seeded.token.id);
+		await expect(service.rotate(seeded.rawToken)).rejects.toBeInstanceOf(UnauthorizedException);
+		await expect(service.rotate(successor.rawValue)).rejects.toBeInstanceOf(UnauthorizedException);
+
+		const family = await dataSource.getRepository(McpOAuthRefreshTokenFamilyEntity).findOneByOrFail({
+			id: seeded.family.id,
+		});
+		const tokens = await dataSource.getRepository(McpOAuthRefreshTokenEntity).findBy({
+			familyId: seeded.family.id,
+		});
+		const access = await dataSource.getRepository(McpOAuthAccessTokenEntity).findOneByOrFail({
+			id: seeded.access.id,
+		});
+
+		expect(family).toMatchObject({ revocationReason: 'refresh_token_reuse', generation: 1 });
+		expect(family.revokedAt).toBeInstanceOf(Date);
+		expect(tokens).toHaveLength(2);
+		expect(tokens.every(({ revokedAt }) => revokedAt instanceof Date)).toBe(true);
+		expect(access.revokedAt).toBeInstanceOf(Date);
+	});
+
+	it('allows at most one barrier-synchronized successor and leaves no usable fork', async () => {
+		const seeded = await seedFamily('concurrent-refresh');
+		let release: () => void;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const rotations = [
+			barrier.then(() => service.rotate(seeded.rawToken)),
+			barrier.then(() => service.rotate(seeded.rawToken)),
+		];
+
+		release();
+		const results = await Promise.allSettled(rotations);
+		const fulfilled = results.filter((result) => result.status === 'fulfilled');
+
+		expect(fulfilled).toHaveLength(1);
+		expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+
+		const family = await dataSource.getRepository(McpOAuthRefreshTokenFamilyEntity).findOneByOrFail({
+			id: seeded.family.id,
+		});
+		const successors = await dataSource.getRepository(McpOAuthRefreshTokenEntity).findBy({
+			predecessorId: seeded.token.id,
+		});
+		const tokens = await dataSource.getRepository(McpOAuthRefreshTokenEntity).findBy({
+			familyId: seeded.family.id,
+		});
+
+		expect(family.revocationReason).toBe('refresh_token_reuse');
+		expect(successors).toHaveLength(1);
+		expect(tokens.every(({ revokedAt }) => revokedAt instanceof Date)).toBe(true);
+	});
+
+	async function seedFamily(rawToken: string) {
+		const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+		const clientRepository = dataSource.getRepository(McpOAuthClientEntity);
+		const client = await clientRepository.save(
+			clientRepository.create({
+				clientIdentifier: `client-${rawToken}`,
+				name: 'Codex',
+				redirectUris: ['http://127.0.0.1:49152/callback'],
+				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				enabled: true,
+				generation: 0,
+				createdById: null,
+			}),
+		);
+		const grantRepository = dataSource.getRepository(McpOAuthGrantEntity);
+		const grant = await grantRepository.save(
+			grantRepository.create({
+				clientId: client.id,
+				approvedById: null,
+				installationId: 'installation-1',
+				issuer: 'https://panel.example.com/api/v1/modules/mcp/oauth',
+				resource: 'https://panel.example.com/api/v1/modules/mcp',
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				expiresAt,
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+			}),
+		);
+		const familyRepository = dataSource.getRepository(McpOAuthRefreshTokenFamilyEntity);
+		const family = await familyRepository.save(
+			familyRepository.create({
+				clientId: client.id,
+				grantId: grant.id,
+				installationId: grant.installationId,
+				expiresAt,
+				revokedAt: null,
+				revocationReason: null,
+				generation: 0,
+			}),
+		);
+		const tokenRepository = dataSource.getRepository(McpOAuthRefreshTokenEntity);
+		const token = await tokenRepository.save(
+			tokenRepository.create({
+				tokenHash: hashToken(rawToken),
+				familyId: family.id,
+				predecessorId: null,
+				expiresAt,
+				consumedAt: null,
+				revokedAt: null,
+			}),
+		);
+		const accessRepository = dataSource.getRepository(McpOAuthAccessTokenEntity);
+		const access = await accessRepository.save(
+			accessRepository.create({
+				tokenHash: hashToken(`access-${rawToken}`),
+				clientId: client.id,
+				grantId: grant.id,
+				refreshFamilyId: family.id,
+				installationId: grant.installationId,
+				issuer: grant.issuer,
+				resource: grant.resource,
+				scopes: [McpOAuthScope.READ],
+				expiresAt,
+				revokedAt: null,
+			}),
+		);
+
+		return { rawToken, client, grant, family, token, access };
+	}
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-refresh-token.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-refresh-token.service.ts
@@ -1,0 +1,105 @@
+import { randomBytes } from 'node:crypto';
+import { DataSource, EntityManager, IsNull, MoreThan } from 'typeorm';
+
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+} from '../entities/mcp-oauth.entity';
+
+type RotationResult =
+	| { status: 'rotated'; rawValue: string; artifact: McpOAuthRefreshTokenEntity }
+	| { status: 'invalid' | 'reused' };
+
+@Injectable()
+export class McpOAuthRefreshTokenService {
+	private rotationQueue: Promise<void> = Promise.resolve();
+
+	constructor(private readonly dataSource: DataSource) {}
+
+	async rotate(rawToken: string): Promise<{ rawValue: string; artifact: McpOAuthRefreshTokenEntity }> {
+		let release: () => void;
+		const previous = this.rotationQueue;
+		this.rotationQueue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+
+		try {
+			return await this.rotateTransaction(rawToken);
+		} finally {
+			release();
+		}
+	}
+
+	private async rotateTransaction(
+		rawToken: string,
+	): Promise<{ rawValue: string; artifact: McpOAuthRefreshTokenEntity }> {
+		const result = await this.dataSource.transaction<RotationResult>(async (manager) => {
+			const now = new Date();
+			const tokenRepository = manager.getRepository(McpOAuthRefreshTokenEntity);
+			const familyRepository = manager.getRepository(McpOAuthRefreshTokenFamilyEntity);
+			const token = await tokenRepository.findOne({ where: { tokenHash: hashToken(rawToken) } });
+
+			if (!token) {
+				return { status: 'invalid' };
+			}
+
+			const family = await familyRepository.findOne({ where: { id: token.familyId } });
+
+			if (!family || family.revokedAt || family.expiresAt <= now || token.revokedAt || token.expiresAt <= now) {
+				return { status: 'invalid' };
+			}
+
+			const consumed = await tokenRepository.update(
+				{
+					id: token.id,
+					consumedAt: IsNull(),
+					revokedAt: IsNull(),
+					expiresAt: MoreThan(now),
+				},
+				{ consumedAt: now },
+			);
+
+			if (!consumed.affected) {
+				await this.revokeFamily(manager, family.id, now, 'refresh_token_reuse');
+				return { status: 'reused' };
+			}
+
+			const rawValue = randomBytes(32).toString('base64url');
+			const artifact = await tokenRepository.save(
+				tokenRepository.create({
+					tokenHash: hashToken(rawValue),
+					familyId: family.id,
+					predecessorId: token.id,
+					expiresAt: family.expiresAt,
+					consumedAt: null,
+					revokedAt: null,
+				}),
+			);
+
+			return { status: 'rotated', rawValue, artifact };
+		});
+
+		if (result.status !== 'rotated') {
+			throw new UnauthorizedException(
+				result.status === 'reused' ? 'Refresh token reuse revoked the token family' : 'Invalid refresh token',
+			);
+		}
+
+		return result;
+	}
+
+	private async revokeFamily(manager: EntityManager, familyId: string, revokedAt: Date, reason: string): Promise<void> {
+		await manager
+			.getRepository(McpOAuthRefreshTokenFamilyEntity)
+			.update({ id: familyId }, { revokedAt, revocationReason: reason, generation: () => 'generation + 1' });
+		await manager.getRepository(McpOAuthRefreshTokenEntity).update({ familyId, revokedAt: IsNull() }, { revokedAt });
+		await manager
+			.getRepository(McpOAuthAccessTokenEntity)
+			.update({ refreshFamilyId: familyId, revokedAt: IsNull() }, { revokedAt });
+	}
+}

--- a/apps/backend/src/modules/mcp/validators/is-mcp-oauth-public-base-url.validator.spec.ts
+++ b/apps/backend/src/modules/mcp/validators/is-mcp-oauth-public-base-url.validator.spec.ts
@@ -1,0 +1,22 @@
+import { normalizeMcpOAuthPublicBaseUrl } from './is-mcp-oauth-public-base-url.validator';
+
+describe('normalizeMcpOAuthPublicBaseUrl', () => {
+	it.each(['https://panel.example.com', 'https://panel.example.com/prefix', 'https://[2001:db8::1]:8443/panel'])(
+		'accepts normalized HTTPS base %s',
+		(value) => {
+			expect(normalizeMcpOAuthPublicBaseUrl(value)).toBe(value);
+		},
+	);
+
+	it.each([
+		'http://panel.example.com',
+		'https://panel.example.com/',
+		'https://panel.example.com/prefix/',
+		'https://panel.example.com:443',
+		'https://user:secret@panel.example.com',
+		'https://panel.example.com?host=other',
+		'https://panel.example.com#fragment',
+	])('rejects non-canonical or unsafe base %s', (value) => {
+		expect(normalizeMcpOAuthPublicBaseUrl(value)).toBeNull();
+	});
+});

--- a/apps/backend/src/modules/mcp/validators/is-mcp-oauth-public-base-url.validator.ts
+++ b/apps/backend/src/modules/mcp/validators/is-mcp-oauth-public-base-url.validator.ts
@@ -1,0 +1,41 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+
+import { Injectable } from '@nestjs/common';
+
+export function normalizeMcpOAuthPublicBaseUrl(value: string): string | null {
+	let url: URL;
+
+	try {
+		url = new URL(value);
+	} catch {
+		return null;
+	}
+
+	if (
+		url.protocol !== 'https:' ||
+		!url.hostname ||
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		(url.pathname !== '/' && url.pathname.endsWith('/'))
+	) {
+		return null;
+	}
+
+	const normalized = `${url.origin}${url.pathname === '/' ? '' : url.pathname}`;
+
+	return normalized === value ? normalized : null;
+}
+
+@ValidatorConstraint({ name: 'isMcpOAuthPublicBaseUrl', async: false })
+@Injectable()
+export class IsMcpOAuthPublicBaseUrlConstraint implements ValidatorConstraintInterface {
+	validate(value: unknown): boolean {
+		return typeof value === 'string' && normalizeMcpOAuthPublicBaseUrl(value) !== null;
+	}
+
+	defaultMessage(_args: ValidationArguments): string {
+		return 'OAuth public base URL must be a normalized absolute HTTPS URL without credentials, query, fragment, or trailing slash.';
+	}
+}

--- a/apps/backend/src/modules/websocket/services/ws-auth.service.spec.ts
+++ b/apps/backend/src/modules/websocket/services/ws-auth.service.spec.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 
 import { TokenOwnerType } from '../../auth/auth.constants';
 import { TokensService } from '../../auth/services/tokens.service';
+import { MCP_OAUTH_PRINCIPAL_TYPE } from '../../mcp/mcp.constants';
 import { UsersService } from '../../users/services/users.service';
 import { WebsocketNotAllowedException } from '../websocket.exceptions';
 
@@ -24,6 +25,27 @@ describe('WsAuthService', () => {
 		);
 		const client = {
 			handshake: { auth: { token: 'mcp-token' } },
+			data: {},
+		} as unknown as Socket;
+
+		await expect(service.validateClient(client)).rejects.toBeInstanceOf(WebsocketNotAllowedException);
+		expect(tokensService.findAll).not.toHaveBeenCalled();
+	});
+
+	it('rejects OAuth MCP credentials before generic long-lived-token validation', async () => {
+		const jwtService = {
+			verifyAsync: jest.fn().mockResolvedValue({ sub: 'oauth-access-token', type: MCP_OAUTH_PRINCIPAL_TYPE }),
+		};
+		const tokensService = {
+			findAll: jest.fn(),
+		};
+		const service = new WsAuthService(
+			jwtService as unknown as JwtService,
+			tokensService as unknown as TokensService,
+			{} as UsersService,
+		);
+		const client = {
+			handshake: { auth: { token: 'oauth-token' } },
 			data: {},
 		} as unknown as Socket;
 

--- a/apps/backend/src/modules/websocket/services/ws-auth.service.ts
+++ b/apps/backend/src/modules/websocket/services/ws-auth.service.ts
@@ -9,6 +9,7 @@ import { TokenOwnerType } from '../../auth/auth.constants';
 import { AccessTokenEntity, LongLiveTokenEntity } from '../../auth/entities/auth.entity';
 import { TokensService } from '../../auth/services/tokens.service';
 import { hashToken } from '../../auth/utils/token.utils';
+import { MCP_OAUTH_PRINCIPAL_TYPE } from '../../mcp/mcp.constants';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
@@ -55,6 +56,10 @@ export class WsAuthService {
 
 		if ((payload.type as TokenOwnerType) === TokenOwnerType.MCP) {
 			throw new WebsocketNotAllowedException('MCP credentials cannot authenticate WebSocket connections');
+		}
+
+		if (payload.type === MCP_OAUTH_PRINCIPAL_TYPE) {
+			throw new WebsocketNotAllowedException('OAuth MCP credentials cannot authenticate WebSocket connections');
 		}
 
 		// Check if this is a display token (type: TokenOwnerType.DISPLAY in payload)

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 1 complete — authorization-component executable spike passed
+**Status:** Phase 2 complete — inactive persistent OAuth domain foundation and public URL policy implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -61,18 +61,18 @@ amend ADR 0002.
 
 **Goal:** Add inactive OAuth data/configuration foundations without publishing incomplete discovery.
 
-- [ ] Add an incremental migration for OAuth clients, grants, authorization interactions/codes, access tokens, refresh
+- [x] Add an incremental migration for OAuth clients, grants, authorization interactions/codes, access tokens, refresh
       token families, and server-secret/key version metadata.
-- [ ] Add MCP-owned entities and services with raw artifacts hashed at creation.
-- [ ] Add an explicit HTTPS public base URL configuration, but no user-settable OAuth enable switch yet.
-- [ ] Derive resource, issuer, well-known, authorization, token, and revocation URLs only from trusted configuration.
-- [ ] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
-- [ ] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
+- [x] Add MCP-owned entities and services with raw artifacts hashed at creation.
+- [x] Add an explicit HTTPS public base URL configuration, but no user-settable OAuth enable switch yet.
+- [x] Derive resource, issuer, well-known, authorization, token, and revocation URLs only from trusted configuration.
+- [x] Reject forwarded headers unless a separately explicit trusted-proxy policy validates the immediate proxy.
+- [x] Add a distinct OAuth MCP principal/token type and prove rejection by REST, WebSocket, display, user, personal, and
       static-MCP validation paths.
-- [ ] Implement refresh rotation as a TypeORM compare-and-consume transaction with a conditional consumed-state update
+- [x] Implement refresh rotation as a TypeORM compare-and-consume transaction with a conditional consumed-state update
       and unique predecessor/successor constraint: at most one concurrent request creates a successor, and every loser
       revokes the whole family including that successor.
-- [ ] Add unit tests for access-token expiry capped at grant expiry, sequential and barrier-synchronized concurrent
+- [x] Add unit tests for access-token expiry capped at grant expiry, sequential and barrier-synchronized concurrent
       family rotation/reuse, installation binding, public URL changes, and log redaction.
 
 ## Phase 3 — Authorization, consent, and token endpoints

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 1 authorization-component spike complete
+Status: in progress — Phase 2 persistent OAuth foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add the inactive Phase 2 OAuth persistence domain for clients, grants, interactions, authorization codes, opaque access tokens, refresh-token families, and server key/secret version state
- store security artifacts only as SHA-256 hashes and cap access/refresh lifetimes at their approved grant expiry
- add canonical HTTPS public-base configuration and derive every resource, issuer, well-known, authorization, token, and revocation URL solely from that trusted value
- reject forwarded identity headers unless the immediate proxy IP is explicitly trusted
- introduce a distinct MCP OAuth principal discriminator and reject it through ordinary REST, WebSocket, display, personal-token, and static-MCP authentication paths
- implement TypeORM compare-and-consume refresh rotation with a unique predecessor/successor constraint and whole-family revocation on sequential or concurrent reuse
- mark Phase 2 complete in the OAuth implementation plan; no OAuth routes or user-facing enable switch are introduced

## Security behavior

This is deliberately inactive infrastructure. Static MCP credentials and endpoints retain their existing behavior. Public OAuth discovery and authorization endpoints remain absent until the later gated route phases are complete.

Concurrent SQLite rotation is serialized through a short service queue so TypeORM does not start overlapping transactions on its single connection. Inside each transaction, the conditional consumed-state update and unique predecessor constraint remain authoritative; a reuse loser revokes the family, any successor, and associated access tokens.

## Verification

- backend lint and type-check passed; lint reports only the two existing Buddy floating-promise warnings
- backend unit: 284 suites passed, 3,737 tests passed, 2 skipped
- Admin lint and type-check passed; lint reports four existing wizard-spec warnings
- Admin unit: 261 files and 1,836 tests passed
- MCP E2E: 4 suites and 26 tests passed
- OAuth compatibility spike: 15 tests and 1 snapshot passed
- backend build passed
- OpenAPI generation and API lint passed
- full serial backend E2E assertions: 10 suites and 120 tests passed; the local command still exited 1 afterward due the existing Influx/system-information teardown failure