### PR TITLE
fix(backend): attribute a split device's consumption to the room it was split into

### DIFF
--- a/apps/backend/src/migrations/1000000000010-AddEnergyClaimToProjections.ts
+++ b/apps/backend/src/migrations/1000000000010-AddEnergyClaimToProjections.ts
@@ -1,0 +1,107 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Gives a projected meter one accountable claimant.
+ *
+ * Energy is additive: a reading may be counted once, and attributed to one room. A source property
+ * may legitimately feed several virtual devices — one sensor serves two rooms' climate — but only one
+ * of them may bill its kWh. `energyClaimPropertyId` is that claim, and the partial unique index below
+ * makes "one claimant per meter" something the database enforces rather than something every write
+ * path remembers to check.
+ *
+ * The backfill awards each meter to the oldest *admissible* projection, which is not the same as the
+ * oldest projection:
+ *
+ * - the **destination** slot has to be energy-bearing — the (channel category, property category)
+ *   pair the ingestion recognises, judged on the projection's own channel, because that is what
+ *   decides whether it is treated as a meter at all. A `generic.consumption` source projected into an
+ *   `electrical_energy` slot is a meter here even though its source is not one anywhere else;
+ * - and where the **source** is itself energy-bearing, the two have to mean the same thing.
+ *   `reportCompatibility` sees nothing separating `grid_import` from `grid_export` — both read-only
+ *   floats in kWh over the same range — so an installation can hold a projection that changes what
+ *   the reading means. Handing it the claim would keep the room's summary wrong in exactly the way
+ *   this migration exists to fix.
+ *
+ * A meter with no admissible projection is left unclaimed and goes on attributing to the physical
+ * device, which is today's behaviour: not right, but not misleading either.
+ */
+export class AddEnergyClaimToProjections1000000000010 implements MigrationInterface {
+	name = 'AddEnergyClaimToProjections1000000000010';
+
+	/**
+	 * The (channel, property) pairs `EnergyIngestionListener.SOURCE_TYPE_MAP` recognises, as a SQL
+	 * expression answering the source type or NULL. Duplicated here rather than imported on purpose: a
+	 * migration is a statement about what the schema looked like at one moment, and it must keep
+	 * producing the same result when the map it was written against changes.
+	 */
+	private static readonly SOURCE_TYPE = (channel: string, property: string): string => `
+		CASE
+			WHEN ${channel} = 'electrical_energy' AND ${property} = 'consumption' THEN 'consumption_import'
+			WHEN ${channel} = 'electrical_generation' AND ${property} = 'production' THEN 'generation_production'
+			WHEN ${channel} = 'electrical_energy' AND ${property} = 'grid_import' THEN 'grid_import'
+			WHEN ${channel} = 'electrical_energy' AND ${property} = 'grid_export' THEN 'grid_export'
+			ELSE NULL
+		END`;
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "devices_module_channels_properties" ADD COLUMN "energyClaimPropertyId" varchar ` +
+				`REFERENCES "devices_module_channels_properties" ("id") ON DELETE SET NULL`,
+		);
+
+		// Partial, so the many projections that claim nothing are not competing for a single NULL slot.
+		// Precedent: 1000000000003-UnifySpaceRoleTables uses the same shape to keep each role subtype's
+		// uniqueness after collapsing four tables into one.
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "UQ_channels_properties_energyClaim" ` +
+				`ON "devices_module_channels_properties" ("energyClaimPropertyId") ` +
+				`WHERE "energyClaimPropertyId" IS NOT NULL`,
+		);
+
+		const destinationType = AddEnergyClaimToProjections1000000000010.SOURCE_TYPE(
+			'destination_channel."category"',
+			'projection."category"',
+		);
+		const sourceType = AddEnergyClaimToProjections1000000000010.SOURCE_TYPE(
+			'source_channel."category"',
+			'source."category"',
+		);
+
+		// One statement, so a half-awarded set cannot survive a failure part-way. `ROW_NUMBER()` picks
+		// the winner per meter; `createdAt` then `id` makes it deterministic, which is what lets the
+		// same installation upgrade twice and land on the same answer.
+		await queryRunner.query(`
+			WITH admissible AS (
+				SELECT projection."id" AS "projectionId",
+				       projection."sourcePropertyId" AS "meterId",
+				       ROW_NUMBER() OVER (
+				           PARTITION BY projection."sourcePropertyId"
+				           ORDER BY projection."createdAt" ASC, projection."id" ASC
+				       ) AS "rank"
+				FROM "devices_module_channels_properties" projection
+				INNER JOIN "devices_module_channels" destination_channel
+				        ON destination_channel."id" = projection."channelId"
+				INNER JOIN "devices_module_channels_properties" source
+				        ON source."id" = projection."sourcePropertyId"
+				INNER JOIN "devices_module_channels" source_channel
+				        ON source_channel."id" = source."channelId"
+				WHERE projection."type" = 'virtual'
+				  AND projection."sourcePropertyId" IS NOT NULL
+				  AND (${destinationType}) IS NOT NULL
+				  AND ((${sourceType}) IS NULL OR (${sourceType}) = (${destinationType}))
+			)
+			UPDATE "devices_module_channels_properties"
+			   SET "energyClaimPropertyId" = (
+			       SELECT "meterId" FROM admissible
+			        WHERE admissible."projectionId" = "devices_module_channels_properties"."id"
+			          AND admissible."rank" = 1
+			   )
+			 WHERE "id" IN (SELECT "projectionId" FROM admissible WHERE "rank" = 1)
+		`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "UQ_channels_properties_energyClaim"`);
+		await queryRunner.query(`ALTER TABLE "devices_module_channels_properties" DROP COLUMN "energyClaimPropertyId"`);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000010-AddEnergyClaimToProjections.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000010-AddEnergyClaimToProjections.spec.ts
@@ -1,0 +1,215 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddEnergyClaimToProjections1000000000010 } from '../1000000000010-AddEnergyClaimToProjections';
+
+/**
+ * The backfill is the whole risk in this migration: after it runs, one projection per meter is
+ * accountable for that meter's kWh, and everything downstream trusts that. Awarding it to the wrong
+ * one is not visible until a room's energy is quietly wrong.
+ *
+ * Run against a real sqlite DataSource for the same reason the sibling spec gives — the claims are
+ * about what SQLite itself does with a partial unique index and a window function, which a mocked
+ * QueryRunner cannot model — and lives in `__tests__/` because TypeORM's migration glob imports every
+ * file directly beside a migration.
+ */
+describe('AddEnergyClaimToProjections1000000000010', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+
+	const migration = new AddEnergyClaimToProjections1000000000010();
+
+	const property = async (
+		id: string,
+		category: string,
+		channelId: string,
+		options: { type?: string; source?: string; createdAt?: string } = {},
+	): Promise<void> => {
+		await queryRunner.query(
+			`INSERT INTO "devices_module_channels_properties"
+			 ("id", "createdAt", "category", "type", "channelId", "sourcePropertyId")
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			[
+				id,
+				options.createdAt ?? '2026-01-01 00:00:00',
+				category,
+				options.type ?? 'mock',
+				channelId,
+				options.source ?? null,
+			],
+		);
+	};
+
+	const channel = async (id: string, category: string): Promise<void> => {
+		await queryRunner.query(`INSERT INTO "devices_module_channels" ("id", "category") VALUES (?, ?)`, [id, category]);
+	};
+
+	const claims = async (): Promise<Record<string, string | null>> => {
+		const rows = (await queryRunner.query(
+			`SELECT "id", "energyClaimPropertyId" FROM "devices_module_channels_properties" WHERE "type" = 'virtual'`,
+		)) as { id: string; energyClaimPropertyId: string | null }[];
+
+		return Object.fromEntries(rows.map((row) => [row.id, row.energyClaimPropertyId]));
+	};
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+
+		await dataSource.initialize();
+
+		queryRunner = dataSource.createQueryRunner();
+
+		await queryRunner.query(
+			`CREATE TABLE "devices_module_channels" ("id" varchar PRIMARY KEY NOT NULL, "category" varchar NOT NULL)`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "devices_module_channels_properties" (
+				"id" varchar PRIMARY KEY NOT NULL,
+				"createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				"category" varchar NOT NULL,
+				"type" varchar NOT NULL,
+				"channelId" varchar,
+				"sourcePropertyId" varchar
+			)`,
+		);
+
+		// The physical side: one ordinary meter, one generation meter, one grid-import meter, and one
+		// `consumption` sitting in a `generic` channel — which the ingestion does not recognise as a
+		// meter on its own, and which is exactly why a projection of it may become one.
+		await channel('meter-channel', 'electrical_energy');
+		await channel('generic-channel', 'generic');
+		await property('meter', 'consumption', 'meter-channel');
+		await property('grid-meter', 'grid_import', 'meter-channel');
+		await property('unrecognised-meter', 'consumption', 'generic-channel');
+
+		// The virtual side.
+		await channel('virtual-energy-a', 'electrical_energy');
+		await channel('virtual-energy-b', 'electrical_energy');
+		await channel('virtual-export', 'electrical_energy');
+		await channel('virtual-light', 'light');
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('awards a meter claimed twice to the older projection', async () => {
+		await property('younger', 'consumption', 'virtual-energy-a', {
+			type: 'virtual',
+			source: 'meter',
+			createdAt: '2026-03-01 00:00:00',
+		});
+		await property('older', 'consumption', 'virtual-energy-b', {
+			type: 'virtual',
+			source: 'meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ older: 'meter', younger: null });
+	});
+
+	// The case `wasIngestedAsSource()` cannot see: the source is not a meter anywhere else, so nothing
+	// skips these projections and both of them ingest today. The claim is what stops the second.
+	it('claims a source the ingestion would not recognise on its own', async () => {
+		await property('first', 'consumption', 'virtual-energy-a', {
+			type: 'virtual',
+			source: 'unrecognised-meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+		await property('second', 'consumption', 'virtual-energy-b', {
+			type: 'virtual',
+			source: 'unrecognised-meter',
+			createdAt: '2026-03-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ first: 'unrecognised-meter', second: null });
+	});
+
+	// Age alone is the wrong rule. A projection that changes what the reading means — import presented
+	// as export — is one the new persistence refuses, and handing it the claim would keep the room's
+	// summary wrong in the way this migration exists to fix.
+	it('passes over an older projection that changes the meaning of the reading', async () => {
+		await property('cross-type', 'grid_export', 'virtual-export', {
+			type: 'virtual',
+			source: 'grid-meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+		await property('faithful', 'grid_import', 'virtual-energy-a', {
+			type: 'virtual',
+			source: 'grid-meter',
+			createdAt: '2026-03-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ 'cross-type': null, faithful: 'grid-meter' });
+	});
+
+	it('leaves a meter unclaimed when no projection of it is admissible', async () => {
+		await property('only-cross-type', 'grid_export', 'virtual-export', {
+			type: 'virtual',
+			source: 'grid-meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ 'only-cross-type': null });
+	});
+
+	// A projection into a slot the ingestion never treats as energy is not a meter claimant at all.
+	it('claims nothing for a projection into a slot that carries no energy', async () => {
+		await property('switch', 'on', 'virtual-light', {
+			type: 'virtual',
+			source: 'meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ switch: null });
+	});
+
+	// What makes the claim a fact rather than a convention: a second claimant is refused by the
+	// database, whatever raced its way there.
+	it('refuses a second claim on the same meter', async () => {
+		// Dated so the winner is not decided by the id tiebreak: the assertion below is about the index
+		// refusing the *other* row, which is only a refusal if that row does not already hold it.
+		await property('holder', 'consumption', 'virtual-energy-a', {
+			type: 'virtual',
+			source: 'meter',
+			createdAt: '2026-02-01 00:00:00',
+		});
+		await property('contender', 'consumption', 'virtual-energy-b', {
+			type: 'virtual',
+			source: 'meter',
+			createdAt: '2026-03-01 00:00:00',
+		});
+
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ holder: 'meter', contender: null });
+
+		await expect(
+			queryRunner.query(
+				`UPDATE "devices_module_channels_properties" SET "energyClaimPropertyId" = 'meter' WHERE "id" = 'contender'`,
+			),
+		).rejects.toThrow(/UNIQUE constraint failed/);
+	});
+
+	// Revert-then-reapply is a supported workflow, and the index has to go with the column or the next
+	// `up()` fails on a name that is still taken.
+	it('reverts cleanly enough to be applied again', async () => {
+		await property('holder', 'consumption', 'virtual-energy-a', { type: 'virtual', source: 'meter' });
+
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+		await migration.up(queryRunner);
+
+		expect(await claims()).toEqual({ holder: 'meter' });
+	});
+});

--- a/apps/backend/src/modules/energy/energy.module.ts
+++ b/apps/backend/src/modules/energy/energy.module.ts
@@ -24,6 +24,7 @@ import { EnergyIngestionListener } from './listeners/energy-ingestion.listener';
 import { EnergyConfigModel } from './models/config.model';
 import { DeltaComputationService } from './services/delta-computation.service';
 import { EnergyCacheService } from './services/energy-cache.service';
+import { EnergyClaimRegistryService } from './services/energy-claim.registry.service';
 import { EnergyCleanupService } from './services/energy-cleanup.service';
 import { EnergyDataService } from './services/energy-data.service';
 import { EnergyMetricsService } from './services/energy-metrics.service';
@@ -45,6 +46,7 @@ import { EnergyModuleResetService } from './services/module-reset.service';
 	providers: [
 		EnergyMetricsService,
 		DeltaComputationService,
+		EnergyClaimRegistryService,
 		EnergyDataService,
 		EnergyCacheService,
 		EnergyIngestionListener,
@@ -52,7 +54,9 @@ import { EnergyModuleResetService } from './services/module-reset.service';
 		EnergyModuleResetService,
 	],
 	controllers: [EnergyController, EnergySpacesController, EnergyHomeController],
-	exports: [EnergyDataService],
+	// The claim registry is exported for the same reason DevicesModule exports its value-source
+	// registry: the plugin that owns a claim is the one that has to declare it.
+	exports: [EnergyDataService, EnergyClaimRegistryService],
 })
 export class EnergyModule implements OnModuleInit {
 	private readonly logger = createExtensionLogger(ENERGY_MODULE_NAME, 'EnergyModule');

--- a/apps/backend/src/modules/energy/listeners/energy-attribution.spec.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-attribution.spec.ts
@@ -1,0 +1,309 @@
+import { DataSource, Repository } from 'typeorm';
+
+import {
+	ThirdPartyChannelEntity,
+	ThirdPartyChannelPropertyEntity,
+	ThirdPartyDeviceEntity,
+} from '../../../plugins/devices-third-party/entities/devices-third-party.entity';
+import {
+	VirtualChannelEntity,
+	VirtualChannelPropertyEntity,
+	VirtualDeviceEntity,
+	VirtualValueOrigin,
+} from '../../../plugins/devices-virtual/entities/devices-virtual.entity';
+import { VirtualEnergyClaimService } from '../../../plugins/devices-virtual/services/virtual-energy-claim.service';
+import { VirtualPropertyIndexService } from '../../../plugins/devices-virtual/services/virtual-property-index.service';
+import { VirtualValueSourceService } from '../../../plugins/devices-virtual/services/virtual-value-source.service';
+import { RoomSpaceEntity } from '../../../plugins/spaces-home-control/entities/room-space.entity';
+import {
+	ChannelCategory,
+	DataTypeType,
+	DeviceCategory,
+	PermissionType,
+	PropertyCategory,
+} from '../../devices/devices.constants';
+import { ChannelEntity, ChannelPropertyEntity } from '../../devices/entities/devices.entity';
+import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
+import { EnergyDeltaEntity } from '../entities/energy-delta.entity';
+import { DeltaComputationService } from '../services/delta-computation.service';
+import { EnergyClaimRegistryService } from '../services/energy-claim.registry.service';
+import { EnergyDataService } from '../services/energy-data.service';
+import { EnergyMetricsService } from '../services/energy-metrics.service';
+
+import { EnergyIngestionListener } from './energy-ingestion.listener';
+
+/**
+ * The bug's own reproduction, kept as the regression test:
+ * `BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION` was filed with these numbers, produced by driving the real
+ * listener and the real `EnergyDataService` against sqlite. Splitting a multi-channel device moved
+ * the devices into rooms but not their energy — a room holding only virtual devices reported zero,
+ * and the room holding the hardware was billed for channels it no longer presents.
+ *
+ * Real components throughout, because every piece of this is a seam between two of them: the value
+ * source registry decides what a projection *is*, the claim registry decides who is accountable, the
+ * baseline lives in `DeltaComputationService` keyed by device and channel, and the summary reads
+ * `delta.roomId` back out. A mock at any of those seams would test the mock.
+ *
+ * Events are fed straight to the handler. In production `VirtualProjectionListener` re-emits
+ * CHANNEL_PROPERTY_VALUE_SET for each projection of a reading, so both the source's event and the
+ * projection's arrive — which is exactly what these cases feed, since counting one reading twice is
+ * half of what the fix is about.
+ */
+describe('energy attribution across a split device', () => {
+	let dataSource: DataSource;
+	let listener: EnergyIngestionListener;
+	let energyData: EnergyDataService;
+	let deltas: Repository<EnergyDeltaEntity>;
+
+	const RANGE_START = new Date('2026-08-01T00:00:00.000Z');
+	const RANGE_END = new Date('2026-08-02T00:00:00.000Z');
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [__dirname + '/../../../**/*.entity.ts'],
+			synchronize: true,
+		});
+
+		await dataSource.initialize();
+
+		const metrics = new EnergyMetricsService();
+		const valueSources = new PropertyValueSourceRegistryService();
+		const claims = new EnergyClaimRegistryService();
+
+		valueSources.register(new VirtualValueSourceService());
+		claims.register(
+			new VirtualEnergyClaimService(
+				new VirtualPropertyIndexService(dataSource.getRepository(VirtualChannelPropertyEntity)),
+			),
+		);
+
+		deltas = dataSource.getRepository(EnergyDeltaEntity);
+		energyData = new EnergyDataService(deltas);
+
+		// Rooms are real rows: `roomId` is a foreign key, and the point of the whole exercise is which
+		// room a delta lands in.
+		for (const room of ['kitchen', 'office', 'utility']) {
+			await dataSource.getRepository(RoomSpaceEntity).insert({ id: room, name: room } as never);
+		}
+
+		listener = new EnergyIngestionListener(
+			dataSource.getRepository(ChannelEntity),
+			dataSource.getRepository(ChannelPropertyEntity),
+			new DeltaComputationService(metrics),
+			energyData,
+			metrics,
+			valueSources,
+			claims,
+		);
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	/** A physical device, its energy channel and the cumulative meter on it. */
+	const givenMeter = async (
+		id: string,
+		roomId: string | null,
+		options: { channelCategory?: ChannelCategory } = {},
+	): Promise<ChannelPropertyEntity> => {
+		await dataSource.getRepository(ThirdPartyDeviceEntity).insert({
+			id: `${id}-device`,
+			category: DeviceCategory.GENERIC,
+			name: id,
+			roomId,
+		} as never);
+		await dataSource.getRepository(ThirdPartyChannelEntity).insert({
+			id: `${id}-channel`,
+			category: options.channelCategory ?? ChannelCategory.ELECTRICAL_ENERGY,
+			name: id,
+			device: `${id}-device`,
+		} as never);
+		await dataSource.getRepository(ThirdPartyChannelPropertyEntity).insert({
+			id,
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+			channel: `${id}-channel`,
+		} as never);
+
+		return await read(id);
+	};
+
+	/**
+	 * A virtual device in `roomId` presenting `meter` as its own. `claims` is what the projection's
+	 * write path settles; it is set directly here so the case is about the ingestion rather than about
+	 * `settleEnergyClaim`, which has its own tests — and so a legacy unclaimed projection, the shape an
+	 * upgraded installation holds, can be expressed at all.
+	 */
+	const givenProjection = async (
+		id: string,
+		roomId: string | null,
+		meter: string,
+		options: { claims?: boolean } = {},
+	): Promise<ChannelPropertyEntity> => {
+		await dataSource.getRepository(VirtualDeviceEntity).insert({
+			id: `${id}-device`,
+			category: DeviceCategory.GENERIC,
+			name: id,
+			roomId,
+		} as never);
+		await dataSource.getRepository(VirtualChannelEntity).insert({
+			id: `${id}-channel`,
+			category: ChannelCategory.ELECTRICAL_ENERGY,
+			name: id,
+			device: `${id}-device`,
+		} as never);
+		await dataSource.getRepository(VirtualChannelPropertyEntity).insert({
+			id,
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+			channel: `${id}-channel`,
+			valueOrigin: VirtualValueOrigin.SOURCE,
+			sourcePropertyId: meter,
+			energyClaimPropertyId: options.claims === false ? null : meter,
+		} as never);
+
+		return await read(id);
+	};
+
+	/**
+	 * Loaded the way an event payload arrives: a real entity — single-table inheritance resolves the
+	 * projection to its own class, which is what the value source registry keys on — carrying the
+	 * channel the ingestion reads its category from.
+	 */
+	const read = async (id: string): Promise<ChannelPropertyEntity> => {
+		const property = await dataSource
+			.getRepository(ChannelPropertyEntity)
+			.findOne({ where: { id }, relations: ['channel'] });
+
+		if (!property) {
+			throw new Error(`Fixture ${id} was not stored`);
+		}
+
+		return property;
+	};
+
+	/**
+	 * One reading, delivered the way the system delivers it: to the meter, and then to every property
+	 * presenting the meter's value as its own.
+	 */
+	const reports = async (
+		meter: ChannelPropertyEntity,
+		kwh: number,
+		at: string,
+		...projections: ChannelPropertyEntity[]
+	): Promise<void> => {
+		for (const property of [meter, ...projections]) {
+			// Assigned onto the entity rather than spread into a copy: `type` is a getter on the
+			// prototype, and a projection that loses it is no longer recognisable as one.
+			(property as { value: unknown }).value = { value: kwh, lastUpdated: at, trend: 'stable' };
+
+			await listener.handlePropertyValueSet(property);
+		}
+	};
+
+	const consumptionOf = async (roomId?: string): Promise<number> =>
+		(await energyData.getSummary(RANGE_START, RANGE_END, roomId)).totalConsumptionKwh;
+
+	// §2(a): the epic's headline example — a multi-channel device whose relays belong to different
+	// rooms. Before the fix both rooms reported zero and the whole 7 kWh sat on a device in no room.
+	it('bills each room for the channel its own device presents', async () => {
+		const kitchenMeter = await givenMeter('kitchen-relay', null);
+		const officeMeter = await givenMeter('office-relay', null);
+		const kitchenLight = await givenProjection('kitchen-projection', 'kitchen', kitchenMeter.id);
+		const officeLight = await givenProjection('office-projection', 'office', officeMeter.id);
+
+		await reports(kitchenMeter, 10, '2026-08-01T10:00:00.000Z', kitchenLight);
+		await reports(officeMeter, 100, '2026-08-01T10:00:00.000Z', officeLight);
+		await reports(kitchenMeter, 12, '2026-08-01T10:05:00.000Z', kitchenLight);
+		await reports(officeMeter, 105, '2026-08-01T10:05:00.000Z', officeLight);
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(2);
+		await expect(consumptionOf('office')).resolves.toBe(5);
+		// The house is billed once for each reading, not once per projection of it.
+		await expect(consumptionOf()).resolves.toBe(7);
+	});
+
+	// §2(b): the hardware sits in the utility room, the channel is presented in the kitchen.
+	it('bills the room the device is seen in, not the one the hardware sits in', async () => {
+		const meter = await givenMeter('utility-meter', 'utility');
+		const kitchenLight = await givenProjection('kitchen-projection', 'kitchen', meter.id);
+
+		await reports(meter, 100, '2026-08-01T10:00:00.000Z', kitchenLight);
+		await reports(meter, 105, '2026-08-01T10:05:00.000Z', kitchenLight);
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(5);
+		await expect(consumptionOf('utility')).resolves.toBe(0);
+	});
+
+	// A meter nothing has taken over is billed where it always was. The fix moves attribution; it does
+	// not require a virtual device to exist for energy to be recorded at all.
+	it('leaves an unprojected meter where it is', async () => {
+		const meter = await givenMeter('utility-meter', 'utility');
+
+		await reports(meter, 100, '2026-08-01T10:00:00.000Z');
+		await reports(meter, 105, '2026-08-01T10:05:00.000Z');
+
+		await expect(consumptionOf('utility')).resolves.toBe(5);
+	});
+
+	// The "missing meter" shape: a `consumption` property in a `generic` channel is not energy to the
+	// ingestion, so only the projection's event carries a qualifying classification. Two projections of
+	// it both ingested before the claim existed, doubling the household total.
+	it('counts an unrecognised meter once, through the projection that claims it', async () => {
+		const meter = await givenMeter('hidden-meter', null, { channelCategory: ChannelCategory.GENERIC });
+		const claimant = await givenProjection('kitchen-projection', 'kitchen', meter.id);
+		const legacy = await givenProjection('office-projection', 'office', meter.id, { claims: false });
+
+		await reports(meter, 10, '2026-08-01T10:00:00.000Z', claimant, legacy);
+		await reports(meter, 12, '2026-08-01T10:05:00.000Z', claimant, legacy);
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(2);
+		await expect(consumptionOf('office')).resolves.toBe(0);
+		await expect(consumptionOf()).resolves.toBe(2);
+	});
+
+	// The transition is the test: the baseline is keyed to the physical meter, so the first reading
+	// after a projection appears is still measured against the reading before it. Keyed to the
+	// claimant instead, `computeDelta` would meet a key it has never seen, answer null, and drop the
+	// 3 kWh accumulated in between — invisibly, since nothing reports a delta that was never computed.
+	it('keeps the meter running across the moment it is projected', async () => {
+		const meter = await givenMeter('utility-meter', 'utility');
+
+		await reports(meter, 10, '2026-08-01T10:00:00.000Z');
+		await reports(meter, 12, '2026-08-01T10:05:00.000Z');
+
+		const kitchenLight = await givenProjection('kitchen-projection', 'kitchen', meter.id);
+
+		await reports(meter, 15, '2026-08-01T10:10:00.000Z', kitchenLight);
+
+		await expect(consumptionOf('utility')).resolves.toBe(2);
+		await expect(consumptionOf('kitchen')).resolves.toBe(3);
+		// Nothing is lost in the handover: 15 kWh measured, 5 of it since the first sample.
+		await expect(consumptionOf()).resolves.toBe(5);
+	});
+
+	// History is not re-attributed. What was recorded under the utility room stays there, which is the
+	// promise the task makes to anyone expecting a backfill — and the readers have to agree with it.
+	it('leaves what was already recorded where it was recorded', async () => {
+		const meter = await givenMeter('utility-meter', 'utility');
+
+		await reports(meter, 10, '2026-08-01T10:00:00.000Z');
+		await reports(meter, 12, '2026-08-01T10:05:00.000Z');
+
+		const kitchenLight = await givenProjection('kitchen-projection', 'kitchen', meter.id);
+
+		await reports(meter, 15, '2026-08-01T10:10:00.000Z', kitchenLight);
+
+		const recorded = await deltas.find({ order: { intervalStart: 'ASC' } });
+
+		expect(recorded.map((delta) => [delta.deviceId, delta.roomId, delta.deltaKwh])).toEqual([
+			['utility-meter-device', 'utility', 2],
+			['kitchen-projection-device', 'kitchen', 3],
+		]);
+	});
+});

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
@@ -9,6 +9,7 @@ import { ChannelEntity, ChannelPropertyEntity } from '../../devices/entities/dev
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { EnergySourceType } from '../energy.constants';
 import { DeltaComputationService } from '../services/delta-computation.service';
+import { EnergyClaimRegistryService } from '../services/energy-claim.registry.service';
 import { EnergyDataService } from '../services/energy-data.service';
 import { EnergyMetricsService } from '../services/energy-metrics.service';
 
@@ -20,6 +21,7 @@ describe('EnergyIngestionListener', () => {
 	let valueSourceRegistry: jest.Mocked<PropertyValueSourceRegistryService>;
 	let deltaComputation: jest.Mocked<DeltaComputationService>;
 	let energyData: jest.Mocked<EnergyDataService>;
+	let energyClaims: jest.Mocked<EnergyClaimRegistryService>;
 	let channelQueryBuilder: { innerJoinAndSelect: jest.Mock; where: jest.Mock; getOne: jest.Mock };
 	let propertyQueryBuilder: { innerJoinAndSelect: jest.Mock; where: jest.Mock; getOne: jest.Mock };
 
@@ -41,12 +43,31 @@ describe('EnergyIngestionListener', () => {
 		});
 	};
 
-	/** Answers the source-eligibility lookup with a source property in a channel of `category`. */
+	/**
+	 * Answers the source-eligibility lookup with a source property in a channel of `category`. The
+	 * source carries its device, because the delta is computed against the *physical* meter whichever
+	 * property presents it.
+	 */
 	const sourceIsIn = (category: ChannelCategory, propertyCategory = PropertyCategory.CONSUMPTION): void => {
 		propertyQueryBuilder.getOne.mockResolvedValue({
 			id: 'source-1',
 			category: propertyCategory,
-			channel: { id: 'source-channel-1', category },
+			channel: { id: 'source-channel-1', category, device: { id: 'source-device-1', roomId: 'utility' } },
+		});
+	};
+
+	/** Makes `claimant` the property accountable for the meter, presenting it from `room`. */
+	const claimedBy = (
+		claimant: string,
+		room: string | null,
+		category = PropertyCategory.CONSUMPTION,
+		channelCategory = ChannelCategory.ELECTRICAL_ENERGY,
+	): void => {
+		energyClaims.resolveClaimant.mockResolvedValue(claimant);
+		propertyQueryBuilder.getOne.mockResolvedValue({
+			id: claimant,
+			category,
+			channel: { id: 'virtual-channel-1', category: channelCategory, device: { id: 'virtual-device-1', roomId: room } },
 		});
 	};
 
@@ -106,6 +127,12 @@ describe('EnergyIngestionListener', () => {
 					useValue: { recordSampleProcessed: jest.fn(), recordDeltaCreated: jest.fn() },
 				},
 				{
+					provide: EnergyClaimRegistryService,
+					// Nothing claims anything unless a case says so, which is every installation running no
+					// plugin that takes a meter over.
+					useValue: { resolveClaimant: jest.fn().mockResolvedValue(null) },
+				},
+				{
 					provide: PropertyValueSourceRegistryService,
 					// The registry's fallback for a property no plugin claims is the property's own id,
 					// which is what "not projected" means to the listener.
@@ -119,6 +146,7 @@ describe('EnergyIngestionListener', () => {
 		valueSourceRegistry = module.get(PropertyValueSourceRegistryService);
 		deltaComputation = module.get(DeltaComputationService);
 		energyData = module.get(EnergyDataService);
+		energyClaims = module.get(EnergyClaimRegistryService);
 	});
 
 	afterEach(() => {
@@ -152,9 +180,12 @@ describe('EnergyIngestionListener', () => {
 
 		await listener.handlePropertyValueSet(consumptionProperty);
 
+		// Computed against the physical meter, so a projection appearing or the claim moving does not
+		// present the baseline with a key it has never seen — which answers null and drops everything
+		// accumulated since the previous sample.
 		expect(deltaComputation.computeDelta).toHaveBeenCalledWith(
-			'device-1',
-			'channel-1',
+			'source-device-1',
+			'source-channel-1',
 			EnergySourceType.CONSUMPTION_IMPORT,
 			1200,
 			new Date('2026-08-01T00:00:00.000Z'),
@@ -189,6 +220,88 @@ describe('EnergyIngestionListener', () => {
 		await listener.handlePropertyValueSet(consumptionProperty);
 
 		expect(energyData.saveDelta).toHaveBeenCalled();
+	});
+
+	// -- attribution follows the claim -------------------------------------------------------------
+	// Splitting a device moves the devices into rooms but not, until now, their energy: the delta was
+	// stamped with the device that owned the property the ingestion read — the physical one — so a
+	// room holding only virtual devices reported zero.
+
+	it('bills a claimed meter to the device presenting it', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		claimedBy('virtual-property-1', 'kitchen');
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(energyClaims.resolveClaimant).toHaveBeenCalledWith('property-1');
+		expect(energyData.saveDelta).toHaveBeenCalledWith(
+			expect.objectContaining({ deviceId: 'virtual-device-1', roomId: 'kitchen' }),
+		);
+	});
+
+	// Attribution moves; the series does not. Keying the baseline to the claimant would restart it the
+	// moment a projection appeared or its claim moved, and `computeDelta` answers null for a key it
+	// has not seen — silently dropping everything the meter accumulated since the previous sample.
+	it('keeps computing a claimed meter against the device that measures it', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		claimedBy('virtual-property-1', 'kitchen');
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(deltaComputation.computeDelta).toHaveBeenCalledWith(
+			'device-1',
+			'channel-1',
+			EnergySourceType.CONSUMPTION_IMPORT,
+			1200,
+			new Date('2026-08-01T00:00:00.000Z'),
+		);
+	});
+
+	// Defence in depth against a claim that outlived the slot it was settled against: moving the kWh
+	// under a heading the claimant's own device contradicts is the failure this whole mechanism exists
+	// to prevent, so the meter keeps its own attribution instead.
+	it('bills the meter itself when its claimant no longer presents the same reading', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		claimedBy('virtual-property-1', 'kitchen', PropertyCategory.GRID_EXPORT);
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(energyData.saveDelta).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1', roomId: null }));
+	});
+
+	it('bills a meter nobody claims to the device holding it', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(energyData.saveDelta).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1', roomId: null }));
+	});
+
+	// A source the ingestion does not recognise on its own is counted by whichever projection holds the
+	// claim, and by that one only — every projection of it carries the qualifying classification, so
+	// without an arbiter each one bills the same kWh again.
+	it('ingests an unrecognised meter through the projection that claims it', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		projectedFromSource();
+		sourceIsIn(ChannelCategory.GENERIC);
+		energyClaims.resolveClaimant.mockResolvedValue(consumptionProperty.id);
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(energyClaims.resolveClaimant).toHaveBeenCalledWith('source-1');
+		expect(energyData.saveDelta).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1' }));
+	});
+
+	it('skips a projection of an unrecognised meter another projection claims', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		projectedFromSource();
+		sourceIsIn(ChannelCategory.GENERIC);
+		energyClaims.resolveClaimant.mockResolvedValue('another-projection');
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(deltaComputation.computeDelta).not.toHaveBeenCalled();
+		expect(energyData.saveDelta).not.toHaveBeenCalled();
 	});
 
 	// -- supplementary cases ----------------------------------------------------------------------

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
@@ -56,18 +56,21 @@ describe('EnergyIngestionListener', () => {
 		});
 	};
 
-	/** Makes `claimant` the property accountable for the meter, presenting it from `room`. */
+	/**
+	 * Makes `claimant` the property accountable for the meter, presenting it from `room`. Answered
+	 * whole, the way the plugin holding the claim answers it: the ingestion never walks from a claimant
+	 * back to its device, because a second read would be racing a remap.
+	 */
 	const claimedBy = (
 		claimant: string,
 		room: string | null,
-		category = PropertyCategory.CONSUMPTION,
-		channelCategory = ChannelCategory.ELECTRICAL_ENERGY,
+		sourceType: EnergySourceType | null = EnergySourceType.CONSUMPTION_IMPORT,
 	): void => {
-		energyClaims.resolveClaimant.mockResolvedValue(claimant);
-		propertyQueryBuilder.getOne.mockResolvedValue({
-			id: claimant,
-			category,
-			channel: { id: 'virtual-channel-1', category: channelCategory, device: { id: 'virtual-device-1', roomId: room } },
+		energyClaims.resolveClaim.mockResolvedValue({
+			propertyId: claimant,
+			deviceId: 'virtual-device-1',
+			roomId: room,
+			sourceType,
 		});
 	};
 
@@ -130,7 +133,7 @@ describe('EnergyIngestionListener', () => {
 					provide: EnergyClaimRegistryService,
 					// Nothing claims anything unless a case says so, which is every installation running no
 					// plugin that takes a meter over.
-					useValue: { resolveClaimant: jest.fn().mockResolvedValue(null) },
+					useValue: { resolveClaim: jest.fn().mockResolvedValue(null) },
 				},
 				{
 					provide: PropertyValueSourceRegistryService,
@@ -233,7 +236,7 @@ describe('EnergyIngestionListener', () => {
 
 		await listener.handlePropertyValueSet(consumptionProperty);
 
-		expect(energyClaims.resolveClaimant).toHaveBeenCalledWith('property-1');
+		expect(energyClaims.resolveClaim).toHaveBeenCalledWith('property-1');
 		expect(energyData.saveDelta).toHaveBeenCalledWith(
 			expect.objectContaining({ deviceId: 'virtual-device-1', roomId: 'kitchen' }),
 		);
@@ -262,7 +265,7 @@ describe('EnergyIngestionListener', () => {
 	// to prevent, so the meter keeps its own attribution instead.
 	it('bills the meter itself when its claimant no longer presents the same reading', async () => {
 		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
-		claimedBy('virtual-property-1', 'kitchen', PropertyCategory.GRID_EXPORT);
+		claimedBy('virtual-property-1', 'kitchen', EnergySourceType.GRID_EXPORT);
 
 		await listener.handlePropertyValueSet(consumptionProperty);
 
@@ -284,11 +287,11 @@ describe('EnergyIngestionListener', () => {
 		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
 		projectedFromSource();
 		sourceIsIn(ChannelCategory.GENERIC);
-		energyClaims.resolveClaimant.mockResolvedValue(consumptionProperty.id);
+		claimedBy(consumptionProperty.id, null);
 
 		await listener.handlePropertyValueSet(consumptionProperty);
 
-		expect(energyClaims.resolveClaimant).toHaveBeenCalledWith('source-1');
+		expect(energyClaims.resolveClaim).toHaveBeenCalledWith('source-1');
 		expect(energyData.saveDelta).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1' }));
 	});
 
@@ -296,7 +299,7 @@ describe('EnergyIngestionListener', () => {
 		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
 		projectedFromSource();
 		sourceIsIn(ChannelCategory.GENERIC);
-		energyClaims.resolveClaimant.mockResolvedValue('another-projection');
+		claimedBy('another-projection', 'office');
 
 		await listener.handlePropertyValueSet(consumptionProperty);
 

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.spec.ts
@@ -307,6 +307,32 @@ describe('EnergyIngestionListener', () => {
 		expect(energyData.saveDelta).not.toHaveBeenCalled();
 	});
 
+	// The two branches fail in opposite directions, and the asymmetry is the point.
+
+	it('bills a meter to itself when its claim cannot be looked up', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		energyClaims.resolveClaim.mockRejectedValue(new Error('database is locked'));
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		// The reading is counted either way; only the room was ever in question.
+		expect(energyData.saveDelta).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1' }));
+	});
+
+	// Every projection of an unrecognised meter is holding the same reading, and nothing else ingests
+	// it — so a lookup error read as "unclaimed" would let all of them through at once and bill one
+	// reading several times over, permanently. One skipped sample is the cheaper mistake.
+	it('skips a projection of an unrecognised meter when the claim cannot be looked up', async () => {
+		propertyIsIn(ChannelCategory.ELECTRICAL_ENERGY);
+		projectedFromSource();
+		sourceIsIn(ChannelCategory.GENERIC);
+		energyClaims.resolveClaim.mockRejectedValue(new Error('database is locked'));
+
+		await listener.handlePropertyValueSet(consumptionProperty);
+
+		expect(energyData.saveDelta).not.toHaveBeenCalled();
+	});
+
 	// -- supplementary cases ----------------------------------------------------------------------
 	// Not in the brief, but pinned by the task's own self-review checklist ("do not change what the
 	// aggregator does with non-projected properties").

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
@@ -5,52 +5,14 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
-import { ChannelCategory, EventType as DevicesEventType, PropertyCategory } from '../../devices/devices.constants';
+import { EventType as DevicesEventType, PropertyCategory } from '../../devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
-import { ENERGY_MODULE_NAME, EnergySourceType } from '../energy.constants';
+import { ENERGY_MODULE_NAME } from '../energy.constants';
 import { DeltaComputationService } from '../services/delta-computation.service';
 import { EnergyDataService } from '../services/energy-data.service';
 import { EnergyMetricsService } from '../services/energy-metrics.service';
-
-/**
- * Maps channel category + property category to an EnergySourceType.
- */
-interface SourceTypeMapping {
-	channelCategory: ChannelCategory;
-	propertyCategory: PropertyCategory;
-	sourceType: EnergySourceType;
-}
-
-const SOURCE_TYPE_MAP: SourceTypeMapping[] = [
-	{
-		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
-		propertyCategory: PropertyCategory.CONSUMPTION,
-		sourceType: EnergySourceType.CONSUMPTION_IMPORT,
-	},
-	{
-		channelCategory: ChannelCategory.ELECTRICAL_GENERATION,
-		propertyCategory: PropertyCategory.PRODUCTION,
-		sourceType: EnergySourceType.GENERATION_PRODUCTION,
-	},
-	{
-		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
-		propertyCategory: PropertyCategory.GRID_IMPORT,
-		sourceType: EnergySourceType.GRID_IMPORT,
-	},
-	{
-		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
-		propertyCategory: PropertyCategory.GRID_EXPORT,
-		sourceType: EnergySourceType.GRID_EXPORT,
-	},
-];
-
-/** The energy classification of a (channel, property) pair, or null when it is not a meter at all. */
-const findSourceType = (
-	channelCategory: ChannelCategory | undefined,
-	propertyCategory: PropertyCategory | undefined,
-): SourceTypeMapping | null =>
-	SOURCE_TYPE_MAP.find((m) => m.channelCategory === channelCategory && m.propertyCategory === propertyCategory) ?? null;
+import { findEnergySourceType } from '../utils/energy-source-type.utils';
 
 @Injectable()
 export class EnergyIngestionListener implements OnModuleInit {
@@ -120,7 +82,7 @@ export class EnergyIngestionListener implements OnModuleInit {
 		}
 
 		// Find the matching source type
-		const mapping = findSourceType(channel.category, property.category);
+		const mapping = findEnergySourceType(channel.category, property.category);
 
 		if (!mapping) {
 			return;
@@ -235,7 +197,7 @@ export class EnergyIngestionListener implements OnModuleInit {
 
 		const sourceChannel = source.channel as ChannelEntity | undefined;
 
-		return findSourceType(sourceChannel?.category, source.category) !== null;
+		return findEnergySourceType(sourceChannel?.category, source.category) !== null;
 	}
 
 	private extractNumericValue(property: ChannelPropertyEntity): number | null {

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
@@ -10,7 +10,7 @@ import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../device
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { ENERGY_MODULE_NAME, EnergySourceType } from '../energy.constants';
 import { DeltaComputationService } from '../services/delta-computation.service';
-import { EnergyClaimRegistryService } from '../services/energy-claim.registry.service';
+import { EnergyClaim, EnergyClaimRegistryService } from '../services/energy-claim.registry.service';
 import { EnergyDataService } from '../services/energy-data.service';
 import { EnergyMetricsService } from '../services/energy-metrics.service';
 import { findEnergySourceType } from '../utils/energy-source-type.utils';
@@ -203,12 +203,12 @@ export class EnergyIngestionListener implements OnModuleInit {
 		// Not a projection: it owns its series, and it is the meter. (An orphaned virtual property
 		// resolves to its own id too — its source is gone, so there is nothing it could be forwarding.)
 		if (sourcePropertyId === property.id) {
-			const claimant = await this.resolveClaimantDevice(property.id, sourceType);
+			const claim = await this.resolveClaim(property.id, sourceType);
 
 			return {
 				meter: { deviceId: device.id, channelId: channel.id },
-				deviceId: claimant?.id ?? device.id,
-				roomId: (claimant ?? device).roomId ?? null,
+				deviceId: claim?.deviceId ?? device.id,
+				roomId: claim ? claim.roomId : (device.roomId ?? null),
 			};
 		}
 
@@ -242,14 +242,14 @@ export class EnergyIngestionListener implements OnModuleInit {
 			return null;
 		}
 
-		const claimant = await this.energyClaims.resolveClaimant(source.id);
+		const claim = await this.energyClaims.resolveClaim(source.id);
 
 		// Skipped only when the meter is *somebody else's*. An unclaimed meter with an unrecognised
 		// source is ingested here rather than dropped: it is the state an installation is in before the
 		// claim mechanism has anything to say — no plugin registered, or a projection created before
 		// the column existed — and today's behaviour bills it to the physical device, which beats
 		// losing it.
-		if (claimant !== null && claimant !== property.id) {
+		if (claim !== null && claim.propertyId !== property.id) {
 			return null;
 		}
 
@@ -263,51 +263,35 @@ export class EnergyIngestionListener implements OnModuleInit {
 	}
 
 	/**
-	 * The device accountable for a meter that measures its own series, or null when nothing has taken
-	 * it over.
+	 * The claim on a meter that measures its own series, or null when nothing has taken it over and it
+	 * is therefore accountable for itself.
 	 *
-	 * A claim is only about attribution, so a claimant that cannot be read back — deleted between the
-	 * two queries, or claiming from a channel with no device — leaves the meter attributed to itself
-	 * rather than dropping the reading.
+	 * One read, answered whole by whichever plugin holds the claim — including the room, so nothing
+	 * here has to walk from a claimant back to its device. A second read would be racing a remap: the
+	 * claimant repointed at another meter in between would still have supplied the device this meter's
+	 * delta is billed to.
 	 */
-	private async resolveClaimantDevice(
-		meterPropertyId: string,
-		sourceType: EnergySourceType,
-	): Promise<DeviceEntity | null> {
-		const claimantId = await this.energyClaims.resolveClaimant(meterPropertyId);
+	private async resolveClaim(meterPropertyId: string, sourceType: EnergySourceType): Promise<EnergyClaim | null> {
+		const claim = await this.energyClaims.resolveClaim(meterPropertyId);
 
-		if (claimantId === null) {
+		if (claim === null) {
 			return null;
 		}
 
-		const claimant = await this.channelPropertyRepository
-			.createQueryBuilder('property')
-			.innerJoinAndSelect('property.channel', 'channel')
-			.innerJoinAndSelect('channel.device', 'device')
-			.where('property.id = :claimantId', { claimantId })
-			.getOne();
-
-		const claimantChannel = claimant?.channel as ChannelEntity | undefined;
-		const claimantDevice = claimantChannel?.device as DeviceEntity | undefined;
-
-		if (!claimantDevice) {
-			this.logger.debug(`Energy claimant ${claimantId} of property ${meterPropertyId} not found`);
-
-			return null;
-		}
-
-		// A claim is settled against the slot the projection presents, and the same rule is checked
-		// here rather than trusted: a claimant whose slot no longer reads what the meter reads would
-		// move the kWh under a heading its own device contradicts.
-		if (findEnergySourceType(claimantChannel?.category, claimant?.category)?.sourceType !== sourceType) {
+		// A claim is settled against the slot the projection presents, and the same rule is checked here
+		// rather than trusted: a claim can outlive the slot it was settled against — a source channel
+		// recategorised underneath it, say — and a claimant that no longer reads what the meter reads
+		// would move the kWh under a heading its own device contradicts. Reconciliation releases such a
+		// claim on the next structural pass; until then the meter is billed to itself.
+		if (claim.sourceType !== sourceType) {
 			this.logger.warn(
-				`Energy claimant ${claimantId} of property ${meterPropertyId} no longer presents ${sourceType}, attributing to the meter`,
+				`Energy claimant ${claim.propertyId} of property ${meterPropertyId} no longer presents ${sourceType}, attributing to the meter`,
 			);
 
 			return null;
 		}
 
-		return claimantDevice;
+		return claim;
 	}
 
 	private extractNumericValue(property: ChannelPropertyEntity): number | null {

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
@@ -8,8 +8,9 @@ import { createExtensionLogger } from '../../../common/logger/extension-logger.s
 import { EventType as DevicesEventType, PropertyCategory } from '../../devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
-import { ENERGY_MODULE_NAME } from '../energy.constants';
+import { ENERGY_MODULE_NAME, EnergySourceType } from '../energy.constants';
 import { DeltaComputationService } from '../services/delta-computation.service';
+import { EnergyClaimRegistryService } from '../services/energy-claim.registry.service';
 import { EnergyDataService } from '../services/energy-data.service';
 import { EnergyMetricsService } from '../services/energy-metrics.service';
 import { findEnergySourceType } from '../utils/energy-source-type.utils';
@@ -27,6 +28,7 @@ export class EnergyIngestionListener implements OnModuleInit {
 		private readonly energyData: EnergyDataService,
 		private readonly metrics: EnergyMetricsService,
 		private readonly valueSourceRegistry: PropertyValueSourceRegistryService,
+		private readonly energyClaims: EnergyClaimRegistryService,
 	) {}
 
 	onModuleInit(): void {
@@ -88,16 +90,17 @@ export class EnergyIngestionListener implements OnModuleInit {
 			return;
 		}
 
-		// A projected property shares its series with its source. If the source's own event was
-		// ingested too, counting this one would double the household total — but only *if* it was:
-		// see the method for why that is not a given.
-		if (await this.wasIngestedAsSource(property)) {
+		const device = channel.device as DeviceEntity;
+
+		// Every reading arrives more than once — on the meter itself, and again on each projection of
+		// it — so the two questions below are "which of those events counts?" and "whose kWh is it?".
+		const accounting = await this.resolveAccounting(property, channel, device, mapping.sourceType);
+
+		if (!accounting) {
 			return;
 		}
 
-		const device = channel.device as DeviceEntity;
-		const deviceId = device.id;
-		const roomId = device.roomId ?? null;
+		const { meter, deviceId, roomId } = accounting;
 
 		// Use the actual measurement timestamp from the property value,
 		// falling back to current time only if unavailable.
@@ -118,9 +121,18 @@ export class EnergyIngestionListener implements OnModuleInit {
 
 		this.metrics.recordSampleProcessed();
 
-		// Compute delta from cumulative reading (keyed per-channel to avoid
-		// false meter-reset warnings when a device has multiple energy channels)
-		const delta = this.deltaComputation.computeDelta(deviceId, channel.id, mapping.sourceType, numericValue, timestamp);
+		// Computed against the *meter*, persisted against the accountable device. Keyed per-channel to
+		// avoid false meter-reset warnings when a device has multiple energy channels, and per physical
+		// device so that a projection appearing, moving or being removed does not present the baseline
+		// with a key it has never seen — which would answer null and silently drop everything the meter
+		// accumulated since the previous sample.
+		const delta = this.deltaComputation.computeDelta(
+			meter.deviceId,
+			meter.channelId,
+			mapping.sourceType,
+			numericValue,
+			timestamp,
+		);
 
 		if (!delta) {
 			return;
@@ -140,64 +152,162 @@ export class EnergyIngestionListener implements OnModuleInit {
 	}
 
 	/**
-	 * True when the event for this property's *source* was itself ingested, so ingesting this one
-	 * would count the same watts twice.
+	 * Decides whether this event is the one that counts for its meter, and whose consumption it is.
 	 *
-	 * Only a projection can answer "yes" — a property that owns its series has no source to have been
-	 * counted for it, and `resolve()` returns its own id, which is the first check below.
+	 * Returns null to skip the event entirely; otherwise the meter to compute against — always the
+	 * physical property's device and channel — and the device the delta is billed to.
 	 *
-	 * ## Why "is it projected?" is not the question
+	 * ## Which event counts
 	 *
-	 * It used to be, and that dropped meters. A virtual device projects a source property into a
-	 * channel of the *user's* choosing, and it is the channel category that decides whether a reading
-	 * is energy at all: a `consumption` property sitting in a `generic` channel is projected into an
-	 * `electrical_energy` one, and only the projected event carries the qualifying classification. The
-	 * source's own event never made it past the SOURCE_TYPE_MAP lookup, so nothing was double-counted
-	 * — the plain projection guard simply discarded the only event that would have ingested that
-	 * meter, and it stayed missing from every total with nothing to surface it.
+	 * Every reading arrives once on the property that measured it and once more on each projection of
+	 * that property, and `processPropertyValue` writes one delta per event it accepts, so exactly one
+	 * of those events may be accepted. Which one depends on whether the *source's own* slot is
+	 * recognised as energy, and both cases are real:
 	 *
-	 * The symmetric case is real too, which is why this is narrowed rather than removed (unlike
-	 * SecurityStateListener's, where re-arming one debounce timer made it unnecessary): here
-	 * processPropertyValue() writes one delta per event, so a source and a projection that *both*
-	 * qualify would genuinely bill the same kWh twice.
+	 * - **the source qualifies** (`electrical_energy.consumption`, the ordinary meter): its own event
+	 *   ingests and every projection of it is skipped. Accepting a projection as well would bill the
+	 *   same kWh twice;
+	 * - **the source does not qualify** (`generic.consumption` projected into an `electrical_energy`
+	 *   slot): nothing recognises the source's own event as energy — `findEnergySourceType` answers
+	 *   null for its channel — so unless a projection ingests, the meter is missing from every total
+	 *   with nothing to surface it. There the claim-holding projection ingests, and the others are
+	 *   skipped. This is the case a projection guard cannot see, and where today's duplicates come
+	 *   from: nothing arbitrated between two projections of one unrecognised meter.
+	 *
+	 * Stated the other way round: a projection ingests only when its source would not have ingested on
+	 * its own *and* no other projection holds the claim.
+	 *
+	 * ## Whose kWh it is
+	 *
+	 * The claim, and only the claim. A split device's channels are presented by virtual devices that
+	 * live in the rooms the operator put them in, and billing the room where the hardware happens to
+	 * sit is the defect this whole mechanism exists to fix. An unclaimed meter is billed to the device
+	 * holding it, which is both today's behaviour and the right answer when nothing has taken it over.
 	 *
 	 * ## Cost
 	 *
 	 * This fires on every property value change from every device in the system, so it deliberately
 	 * sits *after* the category filter, the value extraction, the channel resolution and the mapping
 	 * lookup the handler already performs. An event this listener would not have ingested anyway never
-	 * reaches it — which is strictly less work than the old placement, where the registry was consulted
-	 * for every event including the overwhelming majority that are not energy at all. The one added
-	 * query rides only on events already known to be ingestion-worthy *and* projected: bounded by the
-	 * number of linked virtual energy properties, which is a handful.
+	 * reaches it. What remains is one indexed claim lookup per qualifying reading, plus — only for a
+	 * projection — the source read that decides which event counts.
 	 */
-	private async wasIngestedAsSource(property: ChannelPropertyEntity): Promise<boolean> {
+	private async resolveAccounting(
+		property: ChannelPropertyEntity,
+		channel: ChannelEntity,
+		device: DeviceEntity,
+		sourceType: EnergySourceType,
+	): Promise<{ meter: { deviceId: string; channelId: string }; deviceId: string; roomId: string | null } | null> {
 		const sourcePropertyId = this.valueSourceRegistry.resolve(property);
 
-		// Not a projection: it owns its series. (An orphaned virtual property resolves to its own id
-		// too — its source is gone, so there is no source event to have been ingested.)
+		// Not a projection: it owns its series, and it is the meter. (An orphaned virtual property
+		// resolves to its own id too — its source is gone, so there is nothing it could be forwarding.)
 		if (sourcePropertyId === property.id) {
-			return false;
+			const claimant = await this.resolveClaimantDevice(property.id, sourceType);
+
+			return {
+				meter: { deviceId: device.id, channelId: channel.id },
+				deviceId: claimant?.id ?? device.id,
+				roomId: (claimant ?? device).roomId ?? null,
+			};
 		}
 
 		const source = await this.channelPropertyRepository
 			.createQueryBuilder('property')
 			.innerJoinAndSelect('property.channel', 'channel')
+			.innerJoinAndSelect('channel.device', 'device')
 			.where('property.id = :sourcePropertyId', { sourcePropertyId })
 			.getOne();
 
 		if (!source) {
-			// The registry named a source that is no longer readable. Nothing ingested on its behalf,
-			// so ingesting here is the safe side of the trade: a missing meter is silent, a duplicated
-			// one is at least visible in the totals.
+			// The registry named a source that is no longer readable. Nothing ingested on its behalf, so
+			// ingesting here is the safe side of the trade: a missing meter is silent, a duplicated one is
+			// at least visible in the totals. With no source row there is no physical meter to key the
+			// baseline to either, so this projection stands in for one.
 			this.logger.debug(`Source property ${sourcePropertyId} of projection ${property.id} not found`);
 
-			return false;
+			return {
+				meter: { deviceId: device.id, channelId: channel.id },
+				deviceId: device.id,
+				roomId: device.roomId ?? null,
+			};
 		}
 
-		const sourceChannel = source.channel as ChannelEntity | undefined;
+		const sourceChannel = source.channel as ChannelEntity;
+		const sourceDevice = sourceChannel.device as DeviceEntity;
 
-		return findEnergySourceType(sourceChannel?.category, source.category) !== null;
+		if (findEnergySourceType(sourceChannel.category, source.category) !== null) {
+			// The source's own event ingests, carrying this projection's attribution if it holds the
+			// claim. Nothing left for this one to do.
+			return null;
+		}
+
+		const claimant = await this.energyClaims.resolveClaimant(source.id);
+
+		// Skipped only when the meter is *somebody else's*. An unclaimed meter with an unrecognised
+		// source is ingested here rather than dropped: it is the state an installation is in before the
+		// claim mechanism has anything to say — no plugin registered, or a projection created before
+		// the column existed — and today's behaviour bills it to the physical device, which beats
+		// losing it.
+		if (claimant !== null && claimant !== property.id) {
+			return null;
+		}
+
+		return {
+			// The meter is the physical property, whichever projection is presenting it. Keying the
+			// baseline to the claimant instead would restart it every time the claim moved.
+			meter: { deviceId: sourceDevice.id, channelId: sourceChannel.id },
+			deviceId: device.id,
+			roomId: device.roomId ?? null,
+		};
+	}
+
+	/**
+	 * The device accountable for a meter that measures its own series, or null when nothing has taken
+	 * it over.
+	 *
+	 * A claim is only about attribution, so a claimant that cannot be read back — deleted between the
+	 * two queries, or claiming from a channel with no device — leaves the meter attributed to itself
+	 * rather than dropping the reading.
+	 */
+	private async resolveClaimantDevice(
+		meterPropertyId: string,
+		sourceType: EnergySourceType,
+	): Promise<DeviceEntity | null> {
+		const claimantId = await this.energyClaims.resolveClaimant(meterPropertyId);
+
+		if (claimantId === null) {
+			return null;
+		}
+
+		const claimant = await this.channelPropertyRepository
+			.createQueryBuilder('property')
+			.innerJoinAndSelect('property.channel', 'channel')
+			.innerJoinAndSelect('channel.device', 'device')
+			.where('property.id = :claimantId', { claimantId })
+			.getOne();
+
+		const claimantChannel = claimant?.channel as ChannelEntity | undefined;
+		const claimantDevice = claimantChannel?.device as DeviceEntity | undefined;
+
+		if (!claimantDevice) {
+			this.logger.debug(`Energy claimant ${claimantId} of property ${meterPropertyId} not found`);
+
+			return null;
+		}
+
+		// A claim is settled against the slot the projection presents, and the same rule is checked
+		// here rather than trusted: a claimant whose slot no longer reads what the meter reads would
+		// move the kWh under a heading its own device contradicts.
+		if (findEnergySourceType(claimantChannel?.category, claimant?.category)?.sourceType !== sourceType) {
+			this.logger.warn(
+				`Energy claimant ${claimantId} of property ${meterPropertyId} no longer presents ${sourceType}, attributing to the meter`,
+			);
+
+			return null;
+		}
+
+		return claimantDevice;
 	}
 
 	private extractNumericValue(property: ChannelPropertyEntity): number | null {

--- a/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
+++ b/apps/backend/src/modules/energy/listeners/energy-ingestion.listener.ts
@@ -242,13 +242,17 @@ export class EnergyIngestionListener implements OnModuleInit {
 			return null;
 		}
 
+		// Fails closed, unlike the branch above, and the asymmetry is the point. Nothing else ingests an
+		// unrecognised meter, so *this* event decides whether the reading is counted at all — and every
+		// projection of that meter is holding the same reading. A lookup error read as "unclaimed"
+		// would let all of them through at once, billing one reading several times over, permanently.
+		// One skipped sample is the cheaper mistake, and it is the one the next reading corrects.
 		const claim = await this.energyClaims.resolveClaim(source.id);
 
-		// Skipped only when the meter is *somebody else's*. An unclaimed meter with an unrecognised
-		// source is ingested here rather than dropped: it is the state an installation is in before the
-		// claim mechanism has anything to say — no plugin registered, or a projection created before
-		// the column existed — and today's behaviour bills it to the physical device, which beats
-		// losing it.
+		// Skipped only when the meter is *somebody else's*. A meter nothing claims is ingested here
+		// rather than dropped: that is the state an installation is in before the claim mechanism has
+		// anything to say — no plugin registered, or a projection created before the column existed —
+		// and counting it beats losing it.
 		if (claim !== null && claim.propertyId !== property.id) {
 			return null;
 		}
@@ -272,7 +276,16 @@ export class EnergyIngestionListener implements OnModuleInit {
 	 * delta is billed to.
 	 */
 	private async resolveClaim(meterPropertyId: string, sourceType: EnergySourceType): Promise<EnergyClaim | null> {
-		const claim = await this.energyClaims.resolveClaim(meterPropertyId);
+		// Fails open, unlike the projection branch: this meter's reading is counted either way, and the
+		// only thing a failed lookup can cost is the room it is billed to — which is where it went
+		// before any of this existed. Dropping the sample instead would lose energy that was measured.
+		const claim = await this.energyClaims.resolveClaim(meterPropertyId).catch((error: unknown): EnergyClaim | null => {
+			this.logger.error(
+				`Failed to resolve the energy claim on property ${meterPropertyId}, attributing to the meter: ${(error as Error).message}`,
+			);
+
+			return null;
+		});
 
 		if (claim === null) {
 			return null;

--- a/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
+++ b/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { ENERGY_MODULE_NAME } from '../energy.constants';
+
+/**
+ * Answers "which property is accountable for this meter's kWh?".
+ *
+ * A meter is normally accountable for itself: the device holding it is where its consumption is
+ * billed. A plugin may declare that some other property has taken that over — a virtual device
+ * assembled from another device's channels presents the meter as its own, and the operator who split
+ * a four-relay switch into four rooms expects each room to be billed for what it shows.
+ *
+ * Energy is the one reading where this cannot be left to each side to decide. A temperature read by
+ * two devices is coherent; a kWh billed to two rooms is not. So there is exactly one accountable
+ * property per meter, whoever holds it, and the ingestion asks rather than deciding for itself —
+ * core stays unaware of any particular plugin, as it does for
+ * {@link IPropertyValueSource} next door.
+ */
+export interface IEnergyClaimSource {
+	/**
+	 * The id of the property accountable for this meter, or null when this source claims nothing for
+	 * it. Asked of storage rather than of a cache: a claim made moments ago decides where the very
+	 * next reading is billed.
+	 */
+	resolveClaimant(meterPropertyId: string): Promise<string | null>;
+}
+
+@Injectable()
+export class EnergyClaimRegistryService {
+	private readonly logger = createExtensionLogger(ENERGY_MODULE_NAME, 'EnergyClaimRegistryService');
+
+	private readonly sources: IEnergyClaimSource[] = [];
+
+	register(source: IEnergyClaimSource): boolean {
+		if (this.sources.includes(source)) {
+			this.logger.warn('Energy claim source already registered');
+
+			return false;
+		}
+
+		this.sources.push(source);
+
+		this.logger.log(`Registered new energy claim source count=${this.sources.length}`);
+
+		return true;
+	}
+
+	/**
+	 * The first claim any registered source reports, or null when the meter is unclaimed — which is
+	 * every meter on an installation running no plugin that claims one.
+	 *
+	 * A source that throws is read as claiming nothing rather than failing the reading. Attribution
+	 * then falls back to the device holding the meter, which is where it went before any of this
+	 * existed; losing the sample instead would be a worse answer to a lookup that is only ever about
+	 * *whose* kWh it is.
+	 */
+	async resolveClaimant(meterPropertyId: string): Promise<string | null> {
+		for (const source of this.sources) {
+			try {
+				const claimant = await source.resolveClaimant(meterPropertyId);
+
+				if (claimant !== null) {
+					return claimant;
+				}
+			} catch (error) {
+				const err = error as Error;
+
+				this.logger.error(`Failed to resolve energy claimant for property ${meterPropertyId}: ${err.message}`);
+			}
+		}
+
+		return null;
+	}
+}

--- a/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
+++ b/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
-import { ENERGY_MODULE_NAME } from '../energy.constants';
+import { ENERGY_MODULE_NAME, EnergySourceType } from '../energy.constants';
 
 /**
  * Answers "which property is accountable for this meter's kWh?".
@@ -16,14 +16,37 @@ import { ENERGY_MODULE_NAME } from '../energy.constants';
  * property per meter, whoever holds it, and the ingestion asks rather than deciding for itself —
  * core stays unaware of any particular plugin, as it does for
  * {@link IPropertyValueSource} next door.
+ *
+ * Everything the ingestion needs about a claim, read at one instant.
+ *
+ * Answered whole rather than as an id to look up afterwards, because the two reads that would take
+ * are racing a remap: a claimant repointed at another meter between them would still supply the
+ * device this meter's delta is billed to. One read cannot disagree with itself — whoever held the
+ * claim when it ran, and where that device is.
  */
+export interface EnergyClaim {
+	/** The property presenting the meter, so a claimant can be told apart from a claim it does not hold. */
+	propertyId: string;
+
+	deviceId: string;
+
+	roomId: string | null;
+
+	/**
+	 * What the claimant's own slot presents. The ingestion refuses to bill a claim that no longer reads
+	 * what the meter reads rather than trusting the claim outright — a claim settled against one slot
+	 * can outlive it, and moving kWh under a heading the claimant's own device contradicts is the
+	 * failure this whole mechanism exists to prevent.
+	 */
+	sourceType: EnergySourceType | null;
+}
+
 export interface IEnergyClaimSource {
 	/**
-	 * The id of the property accountable for this meter, or null when this source claims nothing for
-	 * it. Asked of storage rather than of a cache: a claim made moments ago decides where the very
-	 * next reading is billed.
+	 * The claim on this meter, or null when this source claims nothing for it. Asked of storage rather
+	 * than of a cache: a claim made moments ago decides where the very next reading is billed.
 	 */
-	resolveClaimant(meterPropertyId: string): Promise<string | null>;
+	resolveClaim(meterPropertyId: string): Promise<EnergyClaim | null>;
 }
 
 @Injectable()
@@ -55,13 +78,13 @@ export class EnergyClaimRegistryService {
 	 * existed; losing the sample instead would be a worse answer to a lookup that is only ever about
 	 * *whose* kWh it is.
 	 */
-	async resolveClaimant(meterPropertyId: string): Promise<string | null> {
+	async resolveClaim(meterPropertyId: string): Promise<EnergyClaim | null> {
 		for (const source of this.sources) {
 			try {
-				const claimant = await source.resolveClaimant(meterPropertyId);
+				const claim = await source.resolveClaim(meterPropertyId);
 
-				if (claimant !== null) {
-					return claimant;
+				if (claim !== null) {
+					return claim;
 				}
 			} catch (error) {
 				const err = error as Error;

--- a/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
+++ b/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
@@ -4,25 +4,12 @@ import { createExtensionLogger } from '../../../common/logger/extension-logger.s
 import { ENERGY_MODULE_NAME, EnergySourceType } from '../energy.constants';
 
 /**
- * Answers "which property is accountable for this meter's kWh?".
- *
- * A meter is normally accountable for itself: the device holding it is where its consumption is
- * billed. A plugin may declare that some other property has taken that over — a virtual device
- * assembled from another device's channels presents the meter as its own, and the operator who split
- * a four-relay switch into four rooms expects each room to be billed for what it shows.
- *
- * Energy is the one reading where this cannot be left to each side to decide. A temperature read by
- * two devices is coherent; a kWh billed to two rooms is not. So there is exactly one accountable
- * property per meter, whoever holds it, and the ingestion asks rather than deciding for itself —
- * core stays unaware of any particular plugin, as it does for
- * {@link IPropertyValueSource} next door.
- *
- * Everything the ingestion needs about a claim, read at one instant.
+ * Everything the ingestion needs to bill a claimed meter, read at one instant.
  *
  * Answered whole rather than as an id to look up afterwards, because the two reads that would take
  * are racing a remap: a claimant repointed at another meter between them would still supply the
- * device this meter's delta is billed to. One read cannot disagree with itself — whoever held the
- * claim when it ran, and where that device is.
+ * device this meter's delta is billed to. One read cannot disagree with itself — it is whoever held
+ * the claim when it ran, and where that device was.
  */
 export interface EnergyClaim {
 	/** The property presenting the meter, so a claimant can be told apart from a claim it does not hold. */
@@ -41,6 +28,19 @@ export interface EnergyClaim {
 	sourceType: EnergySourceType | null;
 }
 
+/**
+ * Answers "which property is accountable for this meter's kWh?".
+ *
+ * A meter is normally accountable for itself: the device holding it is where its consumption is
+ * billed. A plugin may declare that some other property has taken that over — a virtual device
+ * assembled from another device's channels presents the meter as its own, and the operator who split
+ * a four-relay switch into four rooms expects each room to be billed for what it shows.
+ *
+ * Energy is the one reading where this cannot be left to each side to decide. A temperature read by
+ * two devices is coherent; a kWh billed to two rooms is not. So there is exactly one accountable
+ * property per meter, whoever holds it, and the ingestion asks rather than deciding for itself —
+ * core stays unaware of any particular plugin, as it does for {@link IPropertyValueSource} next door.
+ */
 export interface IEnergyClaimSource {
 	/**
 	 * The claim on this meter, or null when this source claims nothing for it. Asked of storage rather

--- a/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
+++ b/apps/backend/src/modules/energy/services/energy-claim.registry.service.ts
@@ -73,23 +73,19 @@ export class EnergyClaimRegistryService {
 	 * The first claim any registered source reports, or null when the meter is unclaimed — which is
 	 * every meter on an installation running no plugin that claims one.
 	 *
-	 * A source that throws is read as claiming nothing rather than failing the reading. Attribution
-	 * then falls back to the device holding the meter, which is where it went before any of this
-	 * existed; losing the sample instead would be a worse answer to a lookup that is only ever about
-	 * *whose* kWh it is.
+	 * Throws when a source cannot answer, rather than reporting the meter as unclaimed. The two are
+	 * not the same fact and the caller does not treat them the same: "nobody claims this" is a settled
+	 * answer that decides where a reading is billed, while "I could not find out" leaves the decision
+	 * open — and reading a failure as `null` is how a transient database error turns several
+	 * projections of one meter into several deltas for one reading, permanently. See
+	 * `EnergyIngestionListener.resolveAccounting()` for which way each branch fails.
 	 */
 	async resolveClaim(meterPropertyId: string): Promise<EnergyClaim | null> {
 		for (const source of this.sources) {
-			try {
-				const claim = await source.resolveClaim(meterPropertyId);
+			const claim = await source.resolveClaim(meterPropertyId);
 
-				if (claim !== null) {
-					return claim;
-				}
-			} catch (error) {
-				const err = error as Error;
-
-				this.logger.error(`Failed to resolve energy claimant for property ${meterPropertyId}: ${err.message}`);
+			if (claim !== null) {
+				return claim;
 			}
 		}
 

--- a/apps/backend/src/modules/energy/utils/energy-source-type.utils.ts
+++ b/apps/backend/src/modules/energy/utils/energy-source-type.utils.ts
@@ -1,0 +1,48 @@
+import { ChannelCategory, PropertyCategory } from '../../devices/devices.constants';
+import { EnergySourceType } from '../energy.constants';
+
+export interface EnergySourceMapping {
+	channelCategory: ChannelCategory;
+	propertyCategory: PropertyCategory;
+	sourceType: EnergySourceType;
+}
+
+/**
+ * Which (channel, property) pairs the energy module reads as meters.
+ *
+ * Lives here rather than inside the ingestion listener because two callers need the same answer and
+ * must not drift: the listener, deciding whether an event is energy at all, and the virtual devices
+ * plugin, deciding whether a projection is a *meter* — which is what makes it subject to the
+ * one-claimant rule, and what its claim has to agree with.
+ */
+const SOURCE_TYPE_MAP: EnergySourceMapping[] = [
+	{
+		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
+		propertyCategory: PropertyCategory.CONSUMPTION,
+		sourceType: EnergySourceType.CONSUMPTION_IMPORT,
+	},
+	{
+		channelCategory: ChannelCategory.ELECTRICAL_GENERATION,
+		propertyCategory: PropertyCategory.PRODUCTION,
+		sourceType: EnergySourceType.GENERATION_PRODUCTION,
+	},
+	{
+		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
+		propertyCategory: PropertyCategory.GRID_IMPORT,
+		sourceType: EnergySourceType.GRID_IMPORT,
+	},
+	{
+		channelCategory: ChannelCategory.ELECTRICAL_ENERGY,
+		propertyCategory: PropertyCategory.GRID_EXPORT,
+		sourceType: EnergySourceType.GRID_EXPORT,
+	},
+];
+
+/** The energy classification of a (channel, property) pair, or null when it is not a meter at all. */
+export const findEnergySourceType = (
+	channelCategory: ChannelCategory | undefined,
+	propertyCategory: PropertyCategory | undefined,
+): EnergySourceMapping | null =>
+	SOURCE_TYPE_MAP.find(
+		(mapping) => mapping.channelCategory === channelCategory && mapping.propertyCategory === propertyCategory,
+	) ?? null;

--- a/apps/backend/src/plugins/devices-virtual/controllers/virtual-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/controllers/virtual-devices.controller.spec.ts
@@ -23,6 +23,7 @@ describe('VirtualDevicesController', () => {
 		reportCompatibility: jest.Mock;
 		assertSourceNotVirtual: jest.Mock;
 		assertCategoryAllowed: jest.Mock;
+		describeEnergyClaimConflict: jest.Mock;
 	};
 	let channelsPropertiesService: { findOne: jest.Mock };
 
@@ -39,6 +40,8 @@ describe('VirtualDevicesController', () => {
 			// A blocked category is refused before any candidate is looked at; the default is a category
 			// virtual devices support.
 			assertCategoryAllowed: jest.fn(),
+			// Nothing bills anything by default, which is the answer for every slot that carries no energy.
+			describeEnergyClaimConflict: jest.fn().mockResolvedValue(null),
 		};
 		channelsPropertiesService = { findOne: jest.fn() };
 
@@ -152,6 +155,35 @@ describe('VirtualDevicesController', () => {
 			expect(response.data[0].reason).toContain('nesting virtual devices is not allowed');
 			// The slot predicate is not even consulted: this candidate cannot be persisted whatever it says.
 			expect(virtualDevicesService.reportCompatibility).not.toHaveBeenCalled();
+		});
+
+		// The wizard greys out what it is told is incompatible, so a false green is the one answer a user
+		// acts on — and a meter already presented by another virtual device matches an energy slot as
+		// well as any other, which is precisely what the pairwise slot report cannot see.
+		it('reports a meter another virtual device already bills as incompatible', async () => {
+			channelsPropertiesService.findOne.mockResolvedValue({ id: 'claimed-meter' } as ChannelPropertyEntity);
+			virtualDevicesService.describeEnergyClaimConflict.mockResolvedValue(
+				'Source property id=claimed-meter is already the energy meter of virtual property id=holder',
+			);
+
+			const response = await controller.checkCompatibility(request([candidate('claimed-meter')]));
+
+			expect(response.data[0].compatible).toBe(false);
+			expect(response.data[0].reason).toContain('already the energy meter');
+		});
+
+		// Nesting stands in front: a candidate that may not be projected at all is not worth describing
+		// as an energy conflict as well.
+		it('reports the nesting refusal rather than the claim when both apply', async () => {
+			channelsPropertiesService.findOne.mockResolvedValue({ id: 'nested-meter' } as ChannelPropertyEntity);
+			virtualDevicesService.assertSourceNotVirtual.mockRejectedValue(
+				new VirtualNestingNotAllowedException('nesting virtual devices is not allowed'),
+			);
+			virtualDevicesService.describeEnergyClaimConflict.mockResolvedValue('already the energy meter');
+
+			const response = await controller.checkCompatibility(request([candidate('nested-meter')]));
+
+			expect(response.data[0].reason).toContain('nesting virtual devices is not allowed');
 		});
 
 		// The property was just read, so a chain that does not resolve means its channel or device does

--- a/apps/backend/src/plugins/devices-virtual/controllers/virtual-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-virtual/controllers/virtual-devices.controller.ts
@@ -157,6 +157,14 @@ export class VirtualDevicesController {
 		// `assertPermissionsCompatible`'s.
 		const nestingRefusals = new Map<string, string>();
 
+		// And the other rule a pairwise slot report cannot see: whether this meter is already billed
+		// somewhere. `reportCompatibility` compares a candidate against a slot, and a meter already
+		// presented by another virtual device matches an energy slot as well as any other — so without
+		// this the wizard would offer it, and the create would refuse it. Keyed per candidate rather
+		// than per source, because whether a claim is even at stake depends on the slot: only an
+		// energy-bearing destination bills anything.
+		const claimRefusals = new Map<string, string>();
+
 		for (const candidate of candidates) {
 			if (sourceProperties.has(candidate.source_property)) {
 				continue;
@@ -197,18 +205,42 @@ export class VirtualDevicesController {
 			}
 		}
 
+		// Asked once per distinct (slot, source) pair, after resolution: a claim only matters where the
+		// destination bills something, and the same meter is often checked against several slots at once.
+		for (const candidate of candidates) {
+			const sourceProperty = sourceProperties.get(candidate.source_property);
+			const key = `${candidate.spec_channel}:${candidate.spec_property}:${candidate.source_property}`;
+
+			if (!sourceProperty || claimRefusals.has(key)) {
+				continue;
+			}
+
+			const conflict = await this.virtualDevicesService.describeEnergyClaimConflict(
+				{ channel: candidate.spec_channel, property: candidate.spec_property },
+				sourceProperty,
+			);
+
+			if (conflict !== null) {
+				claimRefusals.set(key, conflict);
+			}
+		}
+
 		const reports = candidates.map((candidate) => {
 			const sourceProperty = sourceProperties.get(candidate.source_property);
 
-			const nesting = nestingRefusals.get(candidate.source_property);
+			// Nesting first: a candidate that may not be projected at all is not worth describing as an
+			// energy conflict too, and the slot report is the fallback both refusals stand in front of.
+			const refusal =
+				nestingRefusals.get(candidate.source_property) ??
+				claimRefusals.get(`${candidate.spec_channel}:${candidate.spec_property}:${candidate.source_property}`);
 
 			const result =
-				nesting === undefined
+				refusal === undefined
 					? this.virtualDevicesService.reportCompatibility(
 							{ category, channel: candidate.spec_channel, property: candidate.spec_property },
 							sourceProperty,
 						)
-					: { compatible: false, reason: nesting };
+					: { compatible: false, reason: refusal };
 
 			const report = new CompatibilityReportModel();
 

--- a/apps/backend/src/plugins/devices-virtual/devices-virtual.plugin.ts
+++ b/apps/backend/src/plugins/devices-virtual/devices-virtual.plugin.ts
@@ -17,6 +17,8 @@ import { ChannelsPropertiesTypeMapperService } from '../../modules/devices/servi
 import { DevicesTypeMapperService } from '../../modules/devices/services/devices-type-mapper.service';
 import { PlatformRegistryService } from '../../modules/devices/services/platform.registry.service';
 import { PropertyValueSourceRegistryService } from '../../modules/devices/services/property-value-source.registry.service';
+import { EnergyModule } from '../../modules/energy/energy.module';
+import { EnergyClaimRegistryService } from '../../modules/energy/services/energy-claim.registry.service';
 import { ExtensionsModule } from '../../modules/extensions/extensions.module';
 import { ExtensionsService } from '../../modules/extensions/services/extensions.service';
 import { ApiTag } from '../../modules/swagger/decorators/api-tag.decorator';
@@ -59,6 +61,7 @@ import { VirtualStatusListener } from './listeners/virtual-status.listener';
 import { VirtualConfigModel } from './models/config.model';
 import { VirtualDevicePlatform } from './platforms/virtual-device.platform';
 import { VirtualDevicesService } from './services/virtual-devices.service';
+import { VirtualEnergyClaimService } from './services/virtual-energy-claim.service';
 import { VirtualPropertyIndexService } from './services/virtual-property-index.service';
 import { VirtualValueSourceService } from './services/virtual-value-source.service';
 import { CategoryAllowedConstraintValidator } from './validators/category-allowed-constraint.validator';
@@ -82,9 +85,13 @@ import { SourceNotVirtualConstraintValidator } from './validators/source-not-vir
 		ConfigModule,
 		ExtensionsModule,
 		SwaggerModule,
+		// For the energy claim registry alone: a projected meter is billed to the virtual device that
+		// presents it, and the energy module has no way to know that without being told.
+		EnergyModule,
 	],
 	providers: [
 		VirtualValueSourceService,
+		VirtualEnergyClaimService,
 		VirtualDevicePlatform,
 		VirtualPropertyIndexService,
 		VirtualDevicesService,
@@ -109,6 +116,8 @@ export class DevicesVirtualPlugin {
 		private readonly extensionsService: ExtensionsService,
 		private readonly virtualValueSourceService: VirtualValueSourceService,
 		private readonly propertyValueSourceRegistry: PropertyValueSourceRegistryService,
+		private readonly virtualEnergyClaimService: VirtualEnergyClaimService,
+		private readonly energyClaimRegistry: EnergyClaimRegistryService,
 		private readonly virtualDevicePlatform: VirtualDevicePlatform,
 		private readonly platformRegistryService: PlatformRegistryService,
 		private readonly deviceInformationListener: VirtualDeviceInformationListener,
@@ -354,6 +363,8 @@ export class DevicesVirtualPlugin {
 		});
 
 		this.propertyValueSourceRegistry.register(this.virtualValueSourceService);
+
+		this.energyClaimRegistry.register(this.virtualEnergyClaimService);
 
 		this.platformRegistryService.register(this.virtualDevicePlatform);
 

--- a/apps/backend/src/plugins/devices-virtual/entities/devices-virtual.entity.ts
+++ b/apps/backend/src/plugins/devices-virtual/entities/devices-virtual.entity.ts
@@ -167,6 +167,33 @@ export class VirtualChannelPropertyEntity extends ChannelPropertyEntity {
 	@JoinColumn({ name: 'sourcePropertyId' })
 	sourceProperty: ChannelPropertyEntity | null;
 
+	/**
+	 * The meter this projection is the one accountable for, or null.
+	 *
+	 * Energy is additive, so a reading may be counted once and attributed to one place. A source
+	 * property can legitimately feed several virtual devices — one sensor serves two rooms' climate —
+	 * but only one of them may bill its kWh, and it is the room of *that* device the consumption
+	 * lands in. This column is that claim: it holds the claimed source property's id, and a partial
+	 * unique index over it makes "one claimant per meter" something the database enforces rather than
+	 * something the application remembers to check.
+	 *
+	 * Set only where the *destination* slot is energy-bearing — the pair `findSourceType` recognises,
+	 * judged on this property's own channel — because that is what decides whether the ingestion will
+	 * treat it as a meter at all. A `generic.consumption` source projected into an `electrical_energy`
+	 * slot is a meter here even though its source is not one anywhere else.
+	 *
+	 * Its value is always either null or exactly `sourcePropertyId`; it carries the id rather than a
+	 * flag so the unique index has something per-meter to be unique *on*. Same `ON DELETE SET NULL` as
+	 * the link beside it, so a deleted meter takes the claim with it in the one statement that orphans
+	 * the projection — nothing application-side runs there.
+	 */
+	@Column({ nullable: true, default: null })
+	energyClaimPropertyId: string | null;
+
+	@ManyToOne(() => ChannelPropertyEntity, { nullable: true, onDelete: 'SET NULL' })
+	@JoinColumn({ name: 'energyClaimPropertyId' })
+	energyClaim: ChannelPropertyEntity | null;
+
 	@ApiProperty({
 		description: 'Channel property type',
 		type: 'string',

--- a/apps/backend/src/plugins/devices-virtual/entities/devices-virtual.entity.ts
+++ b/apps/backend/src/plugins/devices-virtual/entities/devices-virtual.entity.ts
@@ -114,6 +114,20 @@ export class VirtualChannelEntity extends ChannelEntity {
 }
 
 @ApiSchema({ name: 'DevicesVirtualPluginDataChannelProperty' })
+/**
+ * Declared here as well as in the migration, because the two build the schema in different places:
+ * a migration creates it for an installation that upgrades, and `synchronize` — which CI and the e2e
+ * suite run with `FB_DB_SYNC=true` — creates it from these decorators. Without it here the column
+ * would exist in those environments while the constraint that gives it meaning would not, so a
+ * concurrent pair of claims would persist and the tests meant to prove they cannot would pass for the
+ * wrong reason.
+ *
+ * Partial, so the many projections that claim nothing are not all competing for one NULL slot.
+ */
+@Index('UQ_channels_properties_energyClaim', ['energyClaimPropertyId'], {
+	unique: true,
+	where: '"energyClaimPropertyId" IS NOT NULL',
+})
 @ChildEntity()
 export class VirtualChannelPropertyEntity extends ChannelPropertyEntity {
 	@ApiProperty({

--- a/apps/backend/src/plugins/devices-virtual/entities/energy-claim-constraint.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/entities/energy-claim-constraint.spec.ts
@@ -62,6 +62,64 @@ describe('the energy claim constraint under synchronize', () => {
 		await expect(projection('contender', 'meter')).rejects.toThrow(/UNIQUE constraint failed/);
 	});
 
+	// The case a read-then-write check cannot answer, and the reason the claim is a constraint rather
+	// than a validation: two creates that both find the meter unclaimed. Whichever order they end up
+	// in, one of them has to lose — and it has to lose at the write, since neither's read saw the
+	// other.
+	it('lets only one of two claims made at once persist', async () => {
+		await dataSource.getRepository(ChannelPropertyEntity).insert({
+			id: 'contested-meter',
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+		} as never);
+
+		const outcomes = await Promise.allSettled([
+			projection('claimant-a', 'contested-meter'),
+			projection('claimant-b', 'contested-meter'),
+		]);
+
+		expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+		expect(outcomes.filter((outcome) => outcome.status === 'rejected')).toHaveLength(1);
+
+		const claimants = await dataSource
+			.getRepository(VirtualChannelPropertyEntity)
+			.count({ where: { energyClaimPropertyId: 'contested-meter' } });
+
+		expect(claimants).toBe(1);
+	});
+
+	// The other race the task names: the holder going away while somebody claims the meter it is
+	// letting go of. The constraint's promise here is narrower and worth stating exactly — never two,
+	// whichever order they land in. Never *none* is not something a constraint can promise: if the
+	// claim is refused first and the holder then leaves, the meter is simply unclaimed, which is what
+	// `VirtualIndexMaintenanceListener.reconcileEnergyClaims()` sweeps up on the pass the deletion
+	// schedules.
+	it('never lets a claim racing the holder going away leave two claimants', async () => {
+		await dataSource.getRepository(ChannelPropertyEntity).insert({
+			id: 'released-meter',
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+		} as never);
+
+		await projection('leaving', 'released-meter');
+
+		const [, arriving] = await Promise.allSettled([
+			dataSource.getRepository(VirtualChannelPropertyEntity).delete({ id: 'leaving' }),
+			projection('arriving', 'released-meter'),
+		]);
+
+		const claimants = await dataSource
+			.getRepository(VirtualChannelPropertyEntity)
+			.find({ where: { energyClaimPropertyId: 'released-meter' } });
+
+		expect(claimants.length).toBeLessThanOrEqual(1);
+		// And the one that holds it, if any, is the one whose write succeeded — not whichever row
+		// happens to still be there.
+		expect(claimants.map((claimant) => claimant.id)).toEqual(arriving.status === 'fulfilled' ? ['arriving'] : []);
+	});
+
 	// Partial, or every projection that claims nothing would be competing for one NULL slot — which is
 	// most of them, since only an energy-bearing destination ever earns a claim.
 	it('lets any number of projections claim nothing', async () => {

--- a/apps/backend/src/plugins/devices-virtual/entities/energy-claim-constraint.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/entities/energy-claim-constraint.spec.ts
@@ -1,0 +1,97 @@
+import { DataSource } from 'typeorm';
+
+import { DataTypeType, PermissionType, PropertyCategory } from '../../../modules/devices/devices.constants';
+import { ChannelPropertyEntity } from '../../../modules/devices/entities/devices.entity';
+
+import { VirtualChannelPropertyEntity } from './devices-virtual.entity';
+
+/**
+ * The claim is only worth something if the database refuses a second one, and there are two places
+ * that build the schema: the migration, for an installation that upgrades, and `synchronize`, which
+ * CI and the e2e suite run with `FB_DB_SYNC=true`. The migration has its own spec; this one holds the
+ * other half, because a constraint declared in only one of them is absent exactly where the tests
+ * that rely on it run.
+ */
+describe('the energy claim constraint under synchronize', () => {
+	let dataSource: DataSource;
+
+	beforeAll(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			// The whole graph, so the single-table inheritance the projection lives in resolves.
+			entities: [__dirname + '/../../../**/*.entity.ts'],
+			synchronize: true,
+		});
+
+		await dataSource.initialize();
+	});
+
+	afterAll(async () => {
+		await dataSource.destroy();
+	});
+
+	const projection = async (id: string, claim: string | null): Promise<void> => {
+		await dataSource.getRepository(VirtualChannelPropertyEntity).insert({
+			id,
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+			energyClaimPropertyId: claim,
+		} as never);
+	};
+
+	it('is created from the entity metadata, not only by the migration', async () => {
+		const indexes: { name: string }[] = await dataSource.query(
+			`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'devices_module_channels_properties'`,
+		);
+
+		expect(indexes.map((index) => index.name)).toContain('UQ_channels_properties_energyClaim');
+	});
+
+	it('refuses a second claimant on the same meter', async () => {
+		await dataSource.getRepository(ChannelPropertyEntity).insert({
+			id: 'meter',
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+		} as never);
+
+		await projection('holder', 'meter');
+
+		await expect(projection('contender', 'meter')).rejects.toThrow(/UNIQUE constraint failed/);
+	});
+
+	// Partial, or every projection that claims nothing would be competing for one NULL slot — which is
+	// most of them, since only an energy-bearing destination ever earns a claim.
+	it('lets any number of projections claim nothing', async () => {
+		await projection('owned-a', null);
+		await projection('owned-b', null);
+
+		const unclaimed = await dataSource
+			.getRepository(VirtualChannelPropertyEntity)
+			.count({ where: { energyClaimPropertyId: null } });
+
+		expect(unclaimed).toBeGreaterThanOrEqual(2);
+	});
+
+	// The claim is a link like the one beside it: deleting the meter releases it in the same statement
+	// that orphans the projection, with nothing application-side involved.
+	it('releases the claim when the meter row is deleted', async () => {
+		await dataSource.getRepository(ChannelPropertyEntity).insert({
+			id: 'doomed-meter',
+			category: PropertyCategory.CONSUMPTION,
+			permissions: [PermissionType.READ_ONLY],
+			dataType: DataTypeType.FLOAT,
+		} as never);
+
+		await projection('claimant', 'doomed-meter');
+
+		await dataSource.query(`PRAGMA foreign_keys = ON`);
+		await dataSource.query(`DELETE FROM "devices_module_channels_properties" WHERE "id" = 'doomed-meter'`);
+
+		const after = await dataSource.getRepository(VirtualChannelPropertyEntity).findOne({ where: { id: 'claimant' } });
+
+		expect(after?.energyClaimPropertyId ?? null).toBeNull();
+	});
+});

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -445,7 +445,19 @@ describe('VirtualIndexMaintenanceListener', () => {
 	it('keeps the pending announcements when the read-back fails, and makes them on the next pass', async () => {
 		const orphan = { id: 'virtual-property', isProjecting: true, sourcePropertyId: null };
 
-		orphanQueryStub.find.mockRejectedValueOnce(new Error('database is locked'));
+		// Failed for the announcement read specifically, which shares this stub with the claim sweep —
+		// so a bare `mockRejectedValueOnce` would land on whichever read the pass happens to make first.
+		let failed = false;
+
+		orphanQueryStub.find.mockImplementation((options: unknown) => {
+			if (!failed && JSON.stringify(options).includes('"device"')) {
+				failed = true;
+
+				return Promise.reject(new Error('database is locked'));
+			}
+
+			return Promise.resolve([]);
+		});
 		index.rebuild.mockResolvedValue({ rewiredVirtualDeviceIds: ['virtual-device'], abandonedSourceDeviceIds: [] });
 
 		listener.handleStructuralChange();
@@ -456,6 +468,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 		// The next pass reports nothing re-wired — the index has already taken the change in — and the
 		// announcement has to come from the queue that survived.
+		orphanQueryStub.find.mockReset();
 		orphanQueryStub.find.mockResolvedValue([orphan]);
 		index.rebuild.mockResolvedValue(NO_CHANGES);
 
@@ -562,6 +575,45 @@ describe('VirtualIndexMaintenanceListener', () => {
 		await flushMicrotasks();
 
 		expect(promotionQueryStub).not.toHaveBeenCalled();
+	});
+
+	// The migration awards a contested meter deterministically — oldest admissible, ties by id — which
+	// is defensible and arbitrary. The operator is the only one who knows whether the room it landed in
+	// is the one they meant, and nothing else will ever mention it.
+	it('reports a meter that was projected into more than one energy slot, once at startup', async () => {
+		const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+		orphanQueryStub.find.mockResolvedValue([
+			projectionOf('holder', 'meter', 'meter'),
+			projectionOf('loser', 'meter', null),
+		]);
+
+		await listener.onApplicationBootstrap();
+
+		expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+			'billed to virtual property id=holder and not to loser',
+		);
+
+		warn.mockRestore();
+	});
+
+	// Said once per start, not on every structural change for the life of the process.
+	it('says nothing about it on an ordinary structural pass', async () => {
+		const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+		orphanQueryStub.find.mockResolvedValue([
+			projectionOf('holder', 'meter', 'meter'),
+			projectionOf('loser', 'meter', null),
+		]);
+		index.rebuild.mockResolvedValue(NO_CHANGES);
+
+		listener.handleStructuralChange();
+
+		await flushMicrotasks();
+
+		expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('billed to virtual property');
+
+		warn.mockRestore();
 	});
 
 	// Scoped to the diff, so a device orphaned long ago is not re-announced by every later rebuild.

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -155,12 +155,22 @@ describe('VirtualIndexMaintenanceListener', () => {
 		// The conditional UPDATE that hands a released meter to the next projection of it.
 		query: promotionQueryStub,
 		find: jest.fn().mockResolvedValue([]),
+		// The meter the promotion reads to see what the candidate would be presenting. Absent by
+		// default, which is the unrecognised source the claim mechanism exists for.
+		findOne: jest.fn().mockResolvedValue(null),
 		createQueryBuilder: jest.fn(() => ({
 			innerJoin: jest.fn().mockReturnThis(),
 			where: jest.fn().mockReturnThis(),
 			getCount: referenceCountStub,
 		})),
 	};
+
+	/**
+	 * The announcement read, told apart from the claim sweep that shares this repository stub: only
+	 * the announcement scopes itself to the devices a rebuild reported re-wired.
+	 */
+	const announcementReads = (): unknown[] =>
+		orphanQueryStub.find.mock.calls.filter((call) => JSON.stringify(call).includes('"device"'));
 
 	const dataSourceStub = {
 		createQueryRunner: () => ({ isTransactionActive: false }),
@@ -170,6 +180,8 @@ describe('VirtualIndexMaintenanceListener', () => {
 	beforeEach(() => {
 		orphanQueryStub.find.mockReset();
 		orphanQueryStub.find.mockResolvedValue([]);
+		orphanQueryStub.findOne.mockReset();
+		orphanQueryStub.findOne.mockResolvedValue(null);
 		promotionQueryStub.mockReset();
 		promotionQueryStub.mockResolvedValue(undefined);
 		referenceCountStub.mockReset();
@@ -421,7 +433,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 		// Scoped to the devices the rebuild reported re-wired, not swept across the whole table — and asked
 		// once for the set rather than once per device.
-		expect(orphanQueryStub.find).toHaveBeenCalledTimes(1);
+		expect(announcementReads()).toHaveLength(1);
 		expect(JSON.stringify(orphanQueryStub.find.mock.calls)).toContain('virtual-device');
 		expect(eventEmitterStub.emit).toHaveBeenCalledWith(EventType.CHANNEL_PROPERTY_UPDATED, orphan);
 	});
@@ -488,6 +500,70 @@ describe('VirtualIndexMaintenanceListener', () => {
 		expect(eventEmitterStub.emit).not.toHaveBeenCalledWith(EventType.CHANNEL_PROPERTY_UPDATED, expect.anything());
 	});
 
+	// -- claims released by a path that cannot offer them on --------------------------------------
+	//
+	// Deleting the holder takes its row and its claim with it; remapping the holder settles a claim on
+	// the new meter in a hook that never sees the old one. Neither can name the meter it released, so
+	// the sweep asks the state instead — and for a source the ingestion does not recognise on its own,
+	// an unclaimed meter is not merely misattributed, it stops being counted at all.
+
+	const projectionOf = (
+		id: string,
+		meter: string | null,
+		claim: string | null,
+		category = 'consumption',
+		channelCategory = 'electrical_energy',
+	) => ({
+		id,
+		category,
+		isProjecting: true,
+		sourcePropertyId: meter,
+		energyClaimPropertyId: claim,
+		channel: { id: `${id}-channel`, category: channelCategory },
+	});
+
+	it('gives a meter nobody claims back to a projection of it', async () => {
+		orphanQueryStub.find.mockResolvedValue([projectionOf('heir', 'meter', null)]);
+		index.rebuild.mockResolvedValue(NO_CHANGES);
+
+		listener.handleStructuralChange();
+
+		await flushMicrotasks();
+
+		expect(promotionQueryStub).toHaveBeenCalledTimes(1);
+
+		const [, params] = promotionQueryStub.mock.calls[0] as [string, unknown[]];
+
+		expect(params).toEqual(['meter', 'heir', 'meter']);
+	});
+
+	it('leaves a meter alone while a projection of it still holds the claim', async () => {
+		orphanQueryStub.find.mockResolvedValue([
+			projectionOf('holder', 'meter', 'meter'),
+			projectionOf('other', 'meter', null),
+		]);
+		index.rebuild.mockResolvedValue(NO_CHANGES);
+
+		listener.handleStructuralChange();
+
+		await flushMicrotasks();
+
+		expect(promotionQueryStub).not.toHaveBeenCalled();
+	});
+
+	// The many `light.on` links an ordinary installation is full of: not claimants, and not worth a
+	// query each on every structural change either.
+	it('does not offer a meter to projections that could never claim it', async () => {
+		orphanQueryStub.find.mockResolvedValue([projectionOf('switch', 'meter', null, 'on', 'light')]);
+		index.rebuild.mockResolvedValue(NO_CHANGES);
+
+		listener.handleStructuralChange();
+
+		await flushMicrotasks();
+
+		expect(promotionQueryStub).not.toHaveBeenCalled();
+	});
+
 	// Scoped to the diff, so a device orphaned long ago is not re-announced by every later rebuild.
 	it('asks about nothing when the rebuild re-wired no device', async () => {
 		index.rebuild.mockResolvedValue(NO_CHANGES);
@@ -496,7 +572,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 		await flushMicrotasks();
 
-		expect(orphanQueryStub.find).not.toHaveBeenCalled();
+		expect(announcementReads()).toHaveLength(0);
 	});
 
 	it('recomputes nothing when the rebuild changed no virtual device wiring', async () => {

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -149,7 +149,11 @@ describe('VirtualIndexMaintenanceListener', () => {
 	// `find` answers the orphan read-back; the builder answers the reference count the unhide decision
 	// makes against storage. Nothing referencing anything, unless a test says otherwise.
 	const referenceCountStub = jest.fn().mockResolvedValue(0);
+	const promotionQueryStub = jest.fn().mockResolvedValue(undefined);
 	const orphanQueryStub = {
+		metadata: { tableName: 'devices_module_channels_properties' },
+		// The conditional UPDATE that hands a released meter to the next projection of it.
+		query: promotionQueryStub,
 		find: jest.fn().mockResolvedValue([]),
 		createQueryBuilder: jest.fn(() => ({
 			innerJoin: jest.fn().mockReturnThis(),
@@ -166,6 +170,8 @@ describe('VirtualIndexMaintenanceListener', () => {
 	beforeEach(() => {
 		orphanQueryStub.find.mockReset();
 		orphanQueryStub.find.mockResolvedValue([]);
+		promotionQueryStub.mockReset();
+		promotionQueryStub.mockResolvedValue(undefined);
 		referenceCountStub.mockReset();
 		referenceCountStub.mockResolvedValue(0);
 
@@ -2130,6 +2136,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 				}),
 				execute: executed,
 			};
+			const promotion = jest.fn().mockResolvedValue(undefined);
 			const findOne = jest.fn().mockResolvedValue({ ...dependent, sourcePropertyId: null });
 			const find = jest.fn().mockResolvedValue(dependents);
 			const emit = jest.fn();
@@ -2157,6 +2164,10 @@ describe('VirtualIndexMaintenanceListener', () => {
 				{ emit } as unknown as EventEmitter2,
 				{
 					getRepository: jest.fn().mockReturnValue({
+						// The promotion that follows a successful orphaning: one conditional UPDATE handing the
+						// released meter to the next projection of it.
+						metadata: { tableName: 'devices_module_channels_properties' },
+						query: promotion,
 						update,
 						findOne,
 						find,
@@ -2178,6 +2189,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 				describeProjectionConstraintMismatch,
 				wheres,
 				executed,
+				promotion,
 			};
 		};
 
@@ -2190,7 +2202,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 			await subject.handleSourceMetadataChange(sourceProperty);
 
 			// Keyed on the link *and* the source's version — see the two cases below for what each guards.
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 			expect(JSON.stringify(wheres)).toContain('sourcePropertyId = :sourceId');
 			expect(JSON.stringify(wheres)).toContain('src.dataType IS :sourceDataType');
 			// Announced, or an open admin keeps the stale link and never shows the remap action.
@@ -2198,6 +2210,39 @@ describe('VirtualIndexMaintenanceListener', () => {
 				EventType.CHANNEL_PROPERTY_UPDATED,
 				expect.objectContaining({ sourcePropertyId: null }),
 			);
+		});
+
+		// Releasing a claim without offering it on is how a meter goes quiet. For a source the ingestion
+		// does not recognise on its own — a `consumption` property in a `generic` channel — nothing
+		// ingests once no projection holds the claim, so the consumption leaves the totals entirely
+		// rather than merely landing in the wrong room.
+		it('offers the released meter to another projection of it', async () => {
+			const { subject, promotion } = build({ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' });
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			expect(promotion).toHaveBeenCalledTimes(1);
+
+			const [sql, params] = promotion.mock.calls[0] as [string, unknown[]];
+
+			// A single conditional statement: `NOT EXISTS` is what lets it run beside a create claiming the
+			// same meter without the two both succeeding, and what makes running it twice promote once.
+			expect(sql).toContain('NOT EXISTS');
+			expect(sql).toContain('ORDER BY "createdAt" ASC, "id" ASC');
+			expect(params).toContain(sourceProperty.id);
+		});
+
+		it('offers nothing when the orphaning write matched no row', async () => {
+			const { subject, promotion } = build(
+				{ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' },
+				[dependent],
+				null,
+				0,
+			);
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			expect(promotion).not.toHaveBeenCalled();
 		});
 
 		it('leaves a projection the source can still feed alone', async () => {
@@ -2224,7 +2269,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 			await subject.handleSourceMetadataChange(enumSource);
 
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 		});
 
 		// A property's own row is not the only thing that decides what it means: `resolvePropertyUnit`
@@ -2238,7 +2283,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 			await subject.handleSourceChannelChange({ id: 'source-channel' } as unknown as ChannelEntity);
 
 			expect(channelsPropertiesStub.findAll).toHaveBeenCalledWith('source-channel');
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 		});
 
 		it('does nothing for a property nothing projects', async () => {
@@ -2260,7 +2305,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 			await subject.handleSourceMetadataChange(sourceProperty);
 
 			expect(find).toHaveBeenCalledWith(expect.objectContaining({ where: { sourcePropertyId: 'source-property' } }));
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 		});
 
 		// The device relation decides which slot the report is asked about, and neither hop is populated
@@ -2294,7 +2339,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 			await subject.handleSourceMetadataChange(sourceProperty);
 
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 		});
 
 		// The payload is a snapshot from when the event was emitted, and this handler is asynchronous. Two
@@ -2343,7 +2388,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 			await subject.handleSourceMetadataChange(sourceProperty);
 
-			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null });
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
 			expect(emit).not.toHaveBeenCalled();
 		});
 

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -534,7 +534,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 		const [, params] = promotionQueryStub.mock.calls[0] as [string, unknown[]];
 
-		expect(params).toEqual(['meter', 'heir', 'meter']);
+		expect(params).toEqual(['meter', 'heir', 'meter', 'meter']);
 	});
 
 	it('leaves a meter alone while a projection of it still holds the claim', async () => {
@@ -2214,6 +2214,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 			// the event was emitted.
 			current: unknown = sourceProperty,
 			constraintMismatch: string | null = null,
+			meaningConflict: string | null = null,
 		) => {
 			channelsPropertiesStub.findOne.mockResolvedValue(current);
 			const update = jest.fn().mockResolvedValue({ affected });
@@ -2248,6 +2249,9 @@ describe('VirtualIndexMaintenanceListener', () => {
 			const reportCompatibility = jest.fn().mockReturnValue(report);
 			const describeSentinelMismatch = jest.fn().mockReturnValue(sentinelMismatch);
 			const describeProjectionConstraintMismatch = jest.fn().mockReturnValue(constraintMismatch);
+			// The energy question, which the structural checks cannot answer: null unless a case says the
+			// source and the slot now read different things.
+			const describeEnergyMeaningConflict = jest.fn().mockReturnValue(meaningConflict);
 
 			const subject = new VirtualIndexMaintenanceListener(
 				{
@@ -2263,6 +2267,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 					reportCompatibility,
 					describeSentinelMismatch,
 					describeProjectionConstraintMismatch,
+					describeEnergyMeaningConflict,
 				} as unknown as VirtualDevicesService,
 				channelsPropertiesStub as unknown as ChannelsPropertiesService,
 				new DeviceStructureLockService(),
@@ -2293,6 +2298,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 				findOne,
 				describeSentinelMismatch,
 				describeProjectionConstraintMismatch,
+				describeEnergyMeaningConflict,
 				wheres,
 				executed,
 				promotion,
@@ -2338,7 +2344,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 			// A single conditional statement: `NOT EXISTS` is what lets it run beside a create claiming the
 			// same meter without the two both succeeding, and what makes running it twice promote once.
 			expect(sql).toContain('NOT EXISTS');
-			expect(params).toEqual([sourceProperty.id, energyHeir.id, sourceProperty.id]);
+			expect(params).toEqual([sourceProperty.id, energyHeir.id, sourceProperty.id, sourceProperty.id]);
 			// Deterministic, by the rule the migration's backfill uses, so an installation that reaches
 			// this state twice reaches the same answer.
 			expect(find).toHaveBeenLastCalledWith(expect.objectContaining({ order: { createdAt: 'ASC', id: 'ASC' } }));
@@ -2379,7 +2385,48 @@ describe('VirtualIndexMaintenanceListener', () => {
 
 			const [, params] = promotion.mock.calls[0] as [string, unknown[]];
 
-			expect(params).toEqual([sourceProperty.id, faithful.id, sourceProperty.id]);
+			expect(params).toEqual([sourceProperty.id, faithful.id, sourceProperty.id, sourceProperty.id]);
+		});
+
+		// The structural checks all pass here — both sides are read-only kWh floats over the same range —
+		// and only the energy question separates them. A source cannot have its property category
+		// PATCHed, but its channel can be recategorised underneath it, and a projection that then
+		// presents generation as consumption is one the write path would have refused. Left attached, it
+		// would also hold the meter's unique claim under semantics its own slot contradicts.
+		it('orphans a projection whose source no longer reads what the slot presents', async () => {
+			const { subject, update, emit } = build(
+				{ compatible: true },
+				[dependent],
+				null,
+				1,
+				sourceProperty,
+				null,
+				"source id=source-property reads 'generation_production' while this slot presents 'consumption_import'",
+			);
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			expect(update).toHaveBeenCalledWith({ sourcePropertyId: null, energyClaimPropertyId: null });
+			expect(emit).toHaveBeenCalledWith(
+				EventType.CHANNEL_PROPERTY_UPDATED,
+				expect.objectContaining({ sourcePropertyId: null }),
+			);
+		});
+
+		// The heir was chosen from a read, and a PATCH landing in the window after it can point that row
+		// at another source or drop the link entirely. The claim is either null or equal to the link, so
+		// the write names the link too: a stale heir makes it a no-op rather than a projection billing a
+		// meter it no longer reads while holding the slot against one that does.
+		it('writes the claim only onto a row that still reads the meter', async () => {
+			const { subject, promotion, find } = build({ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' });
+
+			find.mockResolvedValueOnce([dependent]).mockResolvedValueOnce([energyHeir]);
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			const [sql] = promotion.mock.calls[0] as [string, unknown[]];
+
+			expect(sql).toContain('"sourcePropertyId" = ?');
 		});
 
 		it('offers nothing when the orphaning write matched no row', async () => {

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.spec.ts
@@ -2093,6 +2093,35 @@ describe('VirtualIndexMaintenanceListener', () => {
 			channel: { id: 'virtual-channel', category: 'light', device: { id: 'virtual-device', category: 'lighting' } },
 		};
 
+		// The rest of the projections a released meter could be offered to. Only the first two are
+		// claimants at all: an upgraded installation can be holding a projection into a slot that carries
+		// no energy, or one that presents an import as an export, and the migration passed over both
+		// deliberately — so age alone must not hand either the claim now.
+		const energyHeir = {
+			id: 'energy-heir',
+			category: 'consumption',
+			isProjecting: true,
+			channel: { id: 'heir-channel', category: 'electrical_energy' },
+		};
+		const faithful = {
+			id: 'faithful',
+			category: 'grid_import',
+			isProjecting: true,
+			channel: { id: 'faithful-channel', category: 'electrical_energy' },
+		};
+		const legacySwitch = {
+			id: 'legacy-switch',
+			category: 'on',
+			isProjecting: true,
+			channel: { id: 'legacy-channel', category: 'light' },
+		};
+		const crossType = {
+			id: 'cross-type',
+			category: 'grid_export',
+			isProjecting: true,
+			channel: { id: 'cross-channel', category: 'electrical_energy' },
+		};
+
 		// Built here rather than reusing the suite's shared stubs: this is the only group that reaches
 		// `getRepository`, and widening those stubs would loosen every other case's expectations for no
 		// benefit.
@@ -2185,6 +2214,7 @@ describe('VirtualIndexMaintenanceListener', () => {
 				reportCompatibility,
 				emit,
 				find,
+				findOne,
 				describeSentinelMismatch,
 				describeProjectionConstraintMismatch,
 				wheres,
@@ -2217,7 +2247,11 @@ describe('VirtualIndexMaintenanceListener', () => {
 		// ingests once no projection holds the claim, so the consumption leaves the totals entirely
 		// rather than merely landing in the wrong room.
 		it('offers the released meter to another projection of it', async () => {
-			const { subject, promotion } = build({ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' });
+			const { subject, promotion, find } = build({ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' });
+
+			// The dependents query answers first, the candidate query second: a second projection of the
+			// same meter, into a slot that does carry energy.
+			find.mockResolvedValueOnce([dependent]).mockResolvedValueOnce([energyHeir]);
 
 			await subject.handleSourceMetadataChange(sourceProperty);
 
@@ -2228,8 +2262,48 @@ describe('VirtualIndexMaintenanceListener', () => {
 			// A single conditional statement: `NOT EXISTS` is what lets it run beside a create claiming the
 			// same meter without the two both succeeding, and what makes running it twice promote once.
 			expect(sql).toContain('NOT EXISTS');
-			expect(sql).toContain('ORDER BY "createdAt" ASC, "id" ASC');
-			expect(params).toContain(sourceProperty.id);
+			expect(params).toEqual([sourceProperty.id, energyHeir.id, sourceProperty.id]);
+			// Deterministic, by the rule the migration's backfill uses, so an installation that reaches
+			// this state twice reaches the same answer.
+			expect(find).toHaveBeenLastCalledWith(expect.objectContaining({ order: { createdAt: 'ASC', id: 'ASC' } }));
+		});
+
+		// Age alone is the wrong rule, and it is the one an upgraded installation exposes: the migration
+		// left a legacy projection unclaimed on purpose, and letting it inherit the meter now would
+		// attribute the kWh under semantics its own slot contradicts — while holding the unique slot
+		// against a projection that fits.
+		it('passes over a projection into a slot that carries no energy', async () => {
+			const { subject, promotion, find } = build({ compatible: false, reason: 'permissions [ro] do not satisfy [rw]' });
+
+			find.mockResolvedValueOnce([dependent]).mockResolvedValueOnce([legacySwitch]);
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			expect(promotion).not.toHaveBeenCalled();
+		});
+
+		it('passes over an older projection that changes the meaning of the reading', async () => {
+			const meter = {
+				id: sourceProperty.id,
+				category: 'grid_import',
+				channel: { id: 'source-channel', category: 'electrical_energy' },
+			};
+			const { subject, promotion, find, findOne } = build({
+				compatible: false,
+				reason: 'permissions [ro] do not satisfy [rw]',
+			});
+
+			// The source read the promotion makes: what the meter itself reads is what decides whether a
+			// candidate renames it. The re-read that follows, for the orphaning announcement, falls through
+			// to the default.
+			findOne.mockResolvedValueOnce(meter);
+			find.mockResolvedValueOnce([dependent]).mockResolvedValueOnce([crossType, faithful]);
+
+			await subject.handleSourceMetadataChange(sourceProperty);
+
+			const [, params] = promotion.mock.calls[0] as [string, unknown[]];
+
+			expect(params).toEqual([sourceProperty.id, faithful.id, sourceProperty.id]);
 		});
 
 		it('offers nothing when the orphaning write matched no row', async () => {

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
@@ -1,4 +1,4 @@
-import { DataSource, In, IsNull, Repository } from 'typeorm';
+import { DataSource, In, IsNull, Not, Repository } from 'typeorm';
 
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
@@ -318,6 +318,8 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 			await this.recomputeStatuses(hydrated.rewiredVirtualDeviceIds, 'aggregated from source devices at startup');
 
 			await this.reconcileSystemHiddenSources();
+
+			await this.reconcileEnergyClaims();
 		} catch (error) {
 			this.logger.error(
 				`Failed to hydrate the virtual property index at bootstrap: ${error}. The index starts empty and will be rebuilt on the next structural change.`,
@@ -463,6 +465,10 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 					// Gated on the same settled condition as the unhide above, and for the same reason — it
 					// writes `hidden`, which no repair pass can take back.
 					await this.reconcileSystemHiddenSources();
+
+					// The same shape of sweep, for the same kind of gap: a claim released by a path that
+					// offers it to nobody. See reconcileEnergyClaims().
+					await this.reconcileEnergyClaims();
 				}
 			} while (this.pending);
 		} finally {
@@ -1060,6 +1066,62 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 				`Failed to promote a new energy claimant for source property id=${sourcePropertyId}`,
 				error instanceof Error ? error : undefined,
 			);
+		}
+	}
+
+	/**
+	 * Gives back a claim that was released without being offered on.
+	 *
+	 * `promoteEnergyClaim` covers the one path that can name the meter it is releasing — reconciliation
+	 * orphaning a projection. The others cannot: deleting the holder takes its row and its claim with
+	 * it, and remapping the holder onto a different meter settles the new claim in a hook that never
+	 * sees the old one. Both leave a meter with projections and no claimant, and for a source the
+	 * ingestion does not recognise on its own that means it stops being counted at all.
+	 *
+	 * So this asks the state rather than the transition, exactly as `reconcileSystemHiddenSources`
+	 * above does and for the same reason: a sweep needs no path to have remembered to call it, which
+	 * is what makes it right for the paths that structurally cannot.
+	 *
+	 * One query on a settled pass. Meters whose only projections could never claim them — the many
+	 * `light.on` links an ordinary installation is full of — are filtered out here rather than by
+	 * asking `promoteEnergyClaim` about each in turn, so the common case costs nothing beyond that
+	 * read. A meter whose only energy projection is inadmissible is re-examined on every structural
+	 * pass; that is two queries, rarely, against a state somebody has to repair by hand anyway.
+	 */
+	private async reconcileEnergyClaims(): Promise<void> {
+		try {
+			const projections = await this.dataSource.getRepository(VirtualChannelPropertyEntity).find({
+				where: { sourcePropertyId: Not(IsNull()) },
+				relations: ['channel'],
+			});
+
+			const claimed = new Set(
+				projections
+					.map((projection) => projection.energyClaimPropertyId)
+					.filter((meterId): meterId is string => meterId !== null),
+			);
+
+			const unclaimed = new Set(
+				projections
+					.filter(
+						(projection) =>
+							projection.isProjecting &&
+							projection.sourcePropertyId !== null &&
+							!claimed.has(projection.sourcePropertyId) &&
+							// Judged by `findEnergySourceType`, like every other decision about what a claim is
+							// for, so this filter cannot quietly exclude a meter the promotion would have taken.
+							findEnergySourceType(channelOf(projection)?.category, projection.category) !== null,
+					)
+					.map((projection) => projection.sourcePropertyId),
+			);
+
+			for (const meterId of unclaimed) {
+				await this.promoteEnergyClaim(meterId);
+			}
+		} catch (error) {
+			// Not fatal to the pass: an unclaimed meter attributes to the physical device, and the next
+			// structural change sweeps again.
+			this.logger.error('Failed to reconcile energy claims', error instanceof Error ? error : undefined);
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
@@ -1050,13 +1050,21 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 
 			// `NOT EXISTS` is what lets this run beside a create claiming the same meter without both
 			// succeeding, and what makes running it twice promote once.
+			//
+			// `sourcePropertyId` is named as well, because it is the invariant: the claim is either null
+			// or equal to the link. The heir was chosen from a read, and a PATCH landing in the window
+			// after it can point that row at another source or drop the link entirely — writing the claim
+			// anyway would leave a projection billing a meter it no longer reads, holding the unique slot
+			// against one that does. Matching on the link makes the write a no-op instead, and the next
+			// pass sweeps the meter up.
 			await repository.query(
 				`UPDATE "${table}"
 				    SET "energyClaimPropertyId" = ?
 				  WHERE "id" = ?
 				    AND "energyClaimPropertyId" IS NULL
+				    AND "sourcePropertyId" = ?
 				    AND NOT EXISTS (SELECT 1 FROM "${table}" WHERE "energyClaimPropertyId" = ?)`,
-				[sourcePropertyId, heir.id, sourcePropertyId],
+				[sourcePropertyId, heir.id, sourcePropertyId, sourcePropertyId],
 			);
 		} catch (error) {
 			// Not fatal to the pass that called it: the meter is unclaimed, which attributes to the
@@ -1271,7 +1279,27 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 				property: dependent.category,
 			});
 
-			if (report.compatible && !representationDiverged && sentinelMismatch === null && constraintMismatch === null) {
+			// And what the reading now *means*, which is a question about energy rather than about shape
+			// and which nothing above can answer. A source cannot have its property category PATCHed, but
+			// its channel can be recategorised — `handleSourceChannelChange` exists for exactly that — and
+			// a `production` property whose channel becomes `electrical_generation` starts reading
+			// generation while a projection goes on presenting it as consumption. Every structural check
+			// passes: both are read-only kWh floats over the same range. Refused at the write, so refused
+			// here too, or an installation reaches by edit a state it could not have reached by create —
+			// and a claim held under the wrong semantics keeps the meter's unique slot besides.
+			const meaningConflict = this.virtualDevicesService.describeEnergyMeaningConflict(
+				{ channel: channel.category, property: dependent.category },
+				sourceChannel.category,
+				source,
+			);
+
+			if (
+				report.compatible &&
+				!representationDiverged &&
+				sentinelMismatch === null &&
+				constraintMismatch === null &&
+				meaningConflict === null
+			) {
 				continue;
 			}
 
@@ -1279,7 +1307,7 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 				? (report.reason ?? 'incompatible')
 				: representationDiverged
 					? `its representation changed to '${source.dataType}' while the projection declares '${dependent.dataType}'`
-					: (sentinelMismatch ?? constraintMismatch ?? 'incompatible');
+					: (sentinelMismatch ?? constraintMismatch ?? meaningConflict ?? 'incompatible');
 
 			this.logger.warn(
 				`Source property id=${payload.id} no longer fits the slot filled by virtual property id=${dependent.id}: ${reason}. Orphaning it.`,

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
@@ -968,6 +968,52 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 	}
 
 	/**
+	 * Hands a meter's claim to another projection of it, when the holder has just let go.
+	 *
+	 * A claim is what makes one projection accountable for a meter's kWh. Releasing it without offering
+	 * it on is how a meter goes quiet: for a source the ingestion does not recognise on its own — a
+	 * `consumption` property in a `generic` channel — *nothing* ingests once no projection holds the
+	 * claim, so the consumption disappears from the totals rather than merely landing in the wrong room.
+	 *
+	 * A single conditional UPDATE rather than read-then-write. `NOT EXISTS` is what makes it safe to run
+	 * concurrently with a create claiming the same meter: whichever statement lands second sees the
+	 * other's row and does nothing, so the two cannot both succeed and the unique index is never asked
+	 * to arbitrate. Idempotent for the same reason — running it twice promotes once.
+	 *
+	 * Deterministic, and by the same rule the migration uses: oldest first, ties broken by id, so an
+	 * installation that reaches this state twice reaches the same answer.
+	 */
+	private async promoteEnergyClaim(sourcePropertyId: string): Promise<void> {
+		const repository = this.dataSource.getRepository(VirtualChannelPropertyEntity);
+		const table = repository.metadata.tableName;
+
+		try {
+			await repository.query(
+				`UPDATE "${table}"
+				    SET "energyClaimPropertyId" = ?
+				  WHERE "id" = (
+				        SELECT "id" FROM "${table}"
+				         WHERE "sourcePropertyId" = ?
+				           AND "energyClaimPropertyId" IS NULL
+				           AND "type" = ?
+				         ORDER BY "createdAt" ASC, "id" ASC
+				         LIMIT 1
+				  )
+				    AND NOT EXISTS (SELECT 1 FROM "${table}" WHERE "energyClaimPropertyId" = ?)`,
+				[sourcePropertyId, sourcePropertyId, DEVICES_VIRTUAL_TYPE, sourcePropertyId],
+			);
+		} catch (error) {
+			// Not fatal to the pass that called it: the meter is unclaimed, which attributes to the
+			// physical device — where it went before any of this existed. The next orphaning or create on
+			// the same meter tries again.
+			this.logger.error(
+				`Failed to promote a new energy claimant for source property id=${sourcePropertyId}`,
+				error instanceof Error ? error : undefined,
+			);
+		}
+	}
+
+	/**
 	 * Re-runs the channel checks whose property read failed earlier.
 	 *
 	 * Drained on a settled pass, like the other two queues: a read that failed against an open
@@ -1232,7 +1278,11 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 			const orphaning = await repository
 				.createQueryBuilder()
 				.update(VirtualChannelPropertyEntity)
-				.set({ sourcePropertyId: null })
+				// The claim goes with the link, in the same statement. This write is a plain conditional
+				// UPDATE — no foreign key fires, no hook runs — so a claim left behind would sit on an
+				// orphan holding a meter nothing can bill, and the unique index would refuse every
+				// replacement until somebody deleted the row by hand.
+				.set({ sourcePropertyId: null, energyClaimPropertyId: null })
 				.where('id = :dependentId', { dependentId: dependent.id })
 				.andWhere('sourcePropertyId = :sourceId', { sourceId: payload.id })
 				.andWhere('permissions IS :dependentPermissions', dependentState)
@@ -1244,6 +1294,10 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 				.andWhere(channelUnchanged, sourceState)
 				.andWhere(targetCategoryUnchanged, sourceState)
 				.execute();
+
+			if (orphaning.affected) {
+				await this.promoteEnergyClaim(payload.id);
+			}
 
 			if (!orphaning.affected) {
 				// Either the projection was repointed first, or the source was edited again after this pass

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
@@ -10,12 +10,20 @@ import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../mod
 import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
 import { DeviceStructureLockService } from '../../../modules/devices/services/device-structure-lock.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { findEnergySourceType } from '../../../modules/energy/utils/energy-source-type.utils';
 import { DEVICES_VIRTUAL_PLUGIN_NAME, DEVICES_VIRTUAL_TYPE } from '../devices-virtual.constants';
 import { VirtualChannelPropertyEntity } from '../entities/devices-virtual.entity';
 import { VirtualDevicesService } from '../services/virtual-devices.service';
 import { VirtualIndexRebuildResult, VirtualPropertyIndexService } from '../services/virtual-property-index.service';
 
 import { VirtualStatusListener } from './virtual-status.listener';
+
+/**
+ * The channel a property was loaded with, or undefined when it was loaded without one — `channel`
+ * holds an id string unless the read asked for the relation.
+ */
+const channelOf = (property: ChannelPropertyEntity): ChannelEntity | undefined =>
+	typeof property.channel === 'string' ? undefined : property.channel;
 
 /**
  * Owns VirtualPropertyIndexService's contents — the first hydration at bootstrap and every rebuild
@@ -975,32 +983,74 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 	 * `consumption` property in a `generic` channel — *nothing* ingests once no projection holds the
 	 * claim, so the consumption disappears from the totals rather than merely landing in the wrong room.
 	 *
+	 * Offered only to a projection that could have earned the claim in the first place — the same two
+	 * rules the migration's backfill and `settleEnergyClaim` apply. An installation that upgrades keeps
+	 * whatever it already had, including a projection into a slot carrying no energy, or one that
+	 * presents an import as an export; the migration passed those over deliberately, and age alone must
+	 * not hand one the claim now. It would attribute the meter under semantics its own slot
+	 * contradicts, and hold the unique slot against a projection that fits.
+	 *
+	 * Admissibility is `findEnergySourceType` — the same function the projection gate and the ingestion
+	 * ask — so candidate selection here cannot drift from either. That is why the choice is made in
+	 * TypeScript and only the winning write is SQL: expressing the rules as a predicate would be a
+	 * fourth copy of a table that already exists once, and the part that has to be atomic is the write.
+	 *
 	 * A single conditional UPDATE rather than read-then-write. `NOT EXISTS` is what makes it safe to run
 	 * concurrently with a create claiming the same meter: whichever statement lands second sees the
 	 * other's row and does nothing, so the two cannot both succeed and the unique index is never asked
-	 * to arbitrate. Idempotent for the same reason — running it twice promotes once.
+	 * to arbitrate. Idempotent for the same reason — running it twice promotes once. The read that
+	 * chose the heir may be stale by then, which costs a no-op rather than a wrong claim.
 	 *
 	 * Deterministic, and by the same rule the migration uses: oldest first, ties broken by id, so an
 	 * installation that reaches this state twice reaches the same answer.
 	 */
 	private async promoteEnergyClaim(sourcePropertyId: string): Promise<void> {
 		const repository = this.dataSource.getRepository(VirtualChannelPropertyEntity);
-		const table = repository.metadata.tableName;
 
 		try {
+			const candidates = await repository.find({
+				where: { sourcePropertyId, energyClaimPropertyId: IsNull() },
+				relations: ['channel'],
+				order: { createdAt: 'ASC', id: 'ASC' },
+			});
+
+			if (candidates.length === 0) {
+				return;
+			}
+
+			const source = await this.dataSource
+				.getRepository(ChannelPropertyEntity)
+				.findOne({ where: { id: sourcePropertyId }, relations: ['channel'] });
+			const sourceType = source ? findEnergySourceType(channelOf(source)?.category, source.category) : null;
+
+			const heir = candidates.find((candidate) => {
+				if (!candidate.isProjecting) {
+					return false;
+				}
+
+				// Judged on the destination, as everywhere else: what makes a reading energy is the slot it
+				// is presented in, not where it came from. A source the ingestion does not recognise on its
+				// own is still claimable — that is the case this whole mechanism exists for.
+				const destination = findEnergySourceType(channelOf(candidate)?.category, candidate.category);
+
+				return destination !== null && (sourceType === null || sourceType.sourceType === destination.sourceType);
+			});
+
+			if (!heir) {
+				return;
+			}
+
+			const table = repository.metadata.tableName;
+
+			// `NOT EXISTS` is what lets this run beside a create claiming the same meter without both
+			// succeeding, and what makes running it twice promote once.
 			await repository.query(
 				`UPDATE "${table}"
 				    SET "energyClaimPropertyId" = ?
-				  WHERE "id" = (
-				        SELECT "id" FROM "${table}"
-				         WHERE "sourcePropertyId" = ?
-				           AND "energyClaimPropertyId" IS NULL
-				           AND "type" = ?
-				         ORDER BY "createdAt" ASC, "id" ASC
-				         LIMIT 1
-				  )
+				  WHERE "id" = ?
+				    AND "energyClaimPropertyId" IS NULL
 				    AND NOT EXISTS (SELECT 1 FROM "${table}" WHERE "energyClaimPropertyId" = ?)`,
-				[sourcePropertyId, sourcePropertyId, DEVICES_VIRTUAL_TYPE, sourcePropertyId],
+				[sourcePropertyId, heir.id, sourcePropertyId],
 			);
 		} catch (error) {
 			// Not fatal to the pass that called it: the meter is unclaimed, which attributes to the

--- a/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
+++ b/apps/backend/src/plugins/devices-virtual/listeners/virtual-index-maintenance.listener.ts
@@ -319,7 +319,9 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 
 			await this.reconcileSystemHiddenSources();
 
-			await this.reconcileEnergyClaims();
+			// Announced here and nowhere else: a claim the migration had to choose between candidates for
+			// is worth saying once per start, not on every structural change for the life of the process.
+			await this.reconcileEnergyClaims({ announce: true });
 		} catch (error) {
 			this.logger.error(
 				`Failed to hydrate the virtual property index at bootstrap: ${error}. The index starts empty and will be rebuilt on the next structural change.`,
@@ -410,6 +412,16 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 
 				this.pending = false;
 
+				// First, and before the rebuild: a released meter is unattributed until somebody takes it,
+				// and every reading that arrives in the meantime is billed to the physical device for good.
+				// This sweep reads storage rather than the index, so it owes the rebuild nothing — putting
+				// it after would add the rebuild, the status recomputation and the announcements to a
+				// window measured in samples. Gated on `settled` like every other write here: it acts on
+				// committed state or not at all, and the pass that follows a repair runs it again.
+				if (settled) {
+					await this.reconcileEnergyClaims();
+				}
+
 				const rebuilt = await this.rebuildWithRetry();
 
 				// null means the index was never refreshed, so it reported no transitions — not because
@@ -465,10 +477,6 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 					// Gated on the same settled condition as the unhide above, and for the same reason — it
 					// writes `hidden`, which no repair pass can take back.
 					await this.reconcileSystemHiddenSources();
-
-					// The same shape of sweep, for the same kind of gap: a claim released by a path that
-					// offers it to nobody. See reconcileEnergyClaims().
-					await this.reconcileEnergyClaims();
 				}
 			} while (this.pending);
 		} finally {
@@ -1095,13 +1103,27 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 	 * asking `promoteEnergyClaim` about each in turn, so the common case costs nothing beyond that
 	 * read. A meter whose only energy projection is inadmissible is re-examined on every structural
 	 * pass; that is two queries, rarely, against a state somebody has to repair by hand anyway.
+	 *
+	 * `announce` is for the startup pass only, and reports the other half: meters that *are* claimed but
+	 * had a choice. The migration awards those deterministically — oldest admissible, ties by id — which
+	 * is defensible and arbitrary, and the operator is the only one who knows whether the room it landed
+	 * in is the one they meant. Said once, at startup, rather than on every structural change.
 	 */
-	private async reconcileEnergyClaims(): Promise<void> {
+	private async reconcileEnergyClaims(options: { announce?: boolean } = {}): Promise<void> {
 		try {
 			const projections = await this.dataSource.getRepository(VirtualChannelPropertyEntity).find({
 				where: { sourcePropertyId: Not(IsNull()) },
 				relations: ['channel'],
 			});
+
+			// Judged by `findEnergySourceType`, like every other decision about what a claim is for, so
+			// this filter cannot quietly exclude a meter the promotion would have taken.
+			const claimants = projections.filter(
+				(projection) =>
+					projection.isProjecting &&
+					projection.sourcePropertyId !== null &&
+					findEnergySourceType(channelOf(projection)?.category, projection.category) !== null,
+			);
 
 			const claimed = new Set(
 				projections
@@ -1109,22 +1131,31 @@ export class VirtualIndexMaintenanceListener implements OnApplicationBootstrap {
 					.filter((meterId): meterId is string => meterId !== null),
 			);
 
-			const unclaimed = new Set(
-				projections
-					.filter(
-						(projection) =>
-							projection.isProjecting &&
-							projection.sourcePropertyId !== null &&
-							!claimed.has(projection.sourcePropertyId) &&
-							// Judged by `findEnergySourceType`, like every other decision about what a claim is
-							// for, so this filter cannot quietly exclude a meter the promotion would have taken.
-							findEnergySourceType(channelOf(projection)?.category, projection.category) !== null,
-					)
-					.map((projection) => projection.sourcePropertyId),
-			);
+			const byMeter = new Map<string, VirtualChannelPropertyEntity[]>();
 
-			for (const meterId of unclaimed) {
-				await this.promoteEnergyClaim(meterId);
+			for (const claimant of claimants) {
+				const meterId = claimant.sourcePropertyId;
+
+				byMeter.set(meterId, [...(byMeter.get(meterId) ?? []), claimant]);
+			}
+
+			for (const [meterId, candidates] of byMeter) {
+				if (!claimed.has(meterId)) {
+					await this.promoteEnergyClaim(meterId);
+
+					continue;
+				}
+
+				if (options.announce && candidates.length > 1) {
+					const holder = candidates.find((candidate) => candidate.energyClaimPropertyId === meterId);
+					const losers = candidates.filter((candidate) => candidate.id !== holder?.id).map((candidate) => candidate.id);
+
+					// Warn rather than debug: nothing else will ever mention it, the consequence is a room
+					// quietly billed for somebody else's consumption, and rebuilding the device is the repair.
+					this.logger.warn(
+						`Source property id=${meterId} is projected into ${candidates.length} energy slots; its consumption is billed to virtual property id=${holder?.id ?? 'unknown'} and not to ${losers.join(', ')}. The others go on reporting the reading but not its energy — rebuild the device if that is the wrong way round.`,
+					);
+				}
 			}
 		} catch (error) {
 			// Not fatal to the pass: an unclaimed meter attributes to the physical device, and the next

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
@@ -37,7 +37,11 @@ describe('VirtualDevicesService', () => {
 	let channelsPropertiesService: { findOne: jest.Mock; findAll: jest.Mock };
 	let channelsService: { findOne: jest.Mock; findAll: jest.Mock };
 	let devicesService: { findOne: jest.Mock };
-	let index: { loadLinksByVirtualDevice: jest.Mock; findLinksByVirtualDevice: jest.Mock };
+	let index: {
+		loadLinksByVirtualDevice: jest.Mock;
+		findLinksByVirtualDevice: jest.Mock;
+		findEnergyClaimant: jest.Mock;
+	};
 	let deviceValidationService: { validateDeviceStructure: jest.Mock };
 
 	// -- fixtures --------------------------------------------------------------------------------
@@ -93,6 +97,9 @@ describe('VirtualDevicesService', () => {
 		index = {
 			loadLinksByVirtualDevice: jest.fn().mockResolvedValue([]),
 			findLinksByVirtualDevice: jest.fn().mockReturnValue([]),
+			// No meter is spoken for unless a test says so. Read from storage rather than from the index's
+			// maps, because a claim made since the last rebuild is committed and invisible to them.
+			findEnergyClaimant: jest.fn().mockResolvedValue(null),
 		};
 
 		service = new VirtualDevicesService(
@@ -549,7 +556,13 @@ describe('VirtualDevicesService', () => {
 
 		// Resolves channel -> device the way the assertion walks them, so a test only has to say which
 		// source property is on the other end.
+		// Remembered so the source-channel lookup below can answer for the destination too: the energy
+		// claim resolves *both* channels, and a mock that pinned one would silently retarget the slot.
+		let destinationChannel: ChannelCategory = ChannelCategory.GENERIC;
+
 		const givenSlot = (channelCategory: ChannelCategory, deviceCategory: DeviceCategory): void => {
+			destinationChannel = channelCategory;
+
 			channelsService.findOne.mockResolvedValue({ id: CHANNEL_ID, category: channelCategory, device: DEVICE_ID });
 			devicesService.findOne.mockResolvedValue({ id: DEVICE_ID, category: deviceCategory });
 		};
@@ -581,6 +594,120 @@ describe('VirtualDevicesService', () => {
 
 			return entity;
 		};
+
+		// -- the energy claim ----------------------------------------------------------------------
+		//
+		// Energy is the one quantity where two virtual devices reading one source is wrong rather than
+		// merely redundant: a temperature is non-additive, a kWh billed twice is arithmetic nobody asked
+		// for. The claim written here is what decides, later, which room a reading lands in.
+
+		const meter = (id: string, category: PropertyCategory, channelCategory: ChannelCategory): ChannelPropertyEntity => {
+			const entity = new ChannelPropertyEntity();
+
+			Object.assign(entity, {
+				id,
+				category,
+				permissions: [PermissionType.READ_ONLY],
+				dataType: DataTypeType.FLOAT,
+				// The slot is formatted [0, null] — an open-ended cumulative counter — and a source has to
+				// show it stays inside that, so a real meter declares the same.
+				format: [0, null],
+				unit: 'kWh',
+				channel: `${id}-channel`,
+			});
+
+			// The assertion resolves the source's own channel to classify it.
+			channelsService.findOne.mockImplementation((channelId: string) =>
+				Promise.resolve(
+					channelId === `${id}-channel`
+						? { id: channelId, category: channelCategory, device: 'physical-device' }
+						: { id: CHANNEL_ID, category: destinationChannel, device: DEVICE_ID },
+				),
+			);
+
+			return entity;
+		};
+
+		const energyProjection = (sourcePropertyId: string, category: PropertyCategory): VirtualChannelPropertyEntity =>
+			projecting(sourcePropertyId, category, {
+				permissions: [PermissionType.READ_ONLY],
+				dataType: DataTypeType.FLOAT,
+				format: [0, null],
+				unit: 'kWh',
+			});
+
+		it('makes a projection into an energy slot the claimant of its meter', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const source = meter('meter', PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY);
+
+			channelsPropertiesService.findOne.mockResolvedValue(source);
+
+			const projection = energyProjection('meter', PropertyCategory.CONSUMPTION);
+
+			await service.assertProjectionCompatible(projection, CHANNEL_ID);
+
+			// Written onto the row that is about to be saved, so the claim and the projection arrive in one
+			// statement and the unique index arbitrates whoever else is trying.
+			expect(projection.energyClaimPropertyId).toBe('meter');
+		});
+
+		// The case nothing skips today: the source is not a meter in its own channel, so
+		// `wasIngestedAsSource()` never suppresses these projections and each of them ingests.
+		it('claims a source that is only a meter once projected', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const source = meter('unrecognised', PropertyCategory.CONSUMPTION, ChannelCategory.GENERIC);
+
+			channelsPropertiesService.findOne.mockResolvedValue(source);
+
+			const projection = energyProjection('unrecognised', PropertyCategory.CONSUMPTION);
+
+			await service.assertProjectionCompatible(projection, CHANNEL_ID);
+
+			expect(projection.energyClaimPropertyId).toBe('unrecognised');
+		});
+
+		it('claims nothing for a projection into a slot that carries no energy', async () => {
+			givenSlot(ChannelCategory.LIGHT, DeviceCategory.LIGHTING);
+			channelsPropertiesService.findOne.mockResolvedValue(
+				property({ id: 'relay', permissions: [PermissionType.READ_WRITE], dataType: DataTypeType.BOOL }),
+			);
+
+			const projection = projecting('relay', PropertyCategory.ON);
+
+			await service.assertProjectionCompatible(projection, CHANNEL_ID);
+
+			expect(projection.energyClaimPropertyId).toBeNull();
+		});
+
+		it('refuses a second projection of a meter another already bills', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const source = meter('meter', PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY);
+
+			channelsPropertiesService.findOne.mockResolvedValue(source);
+			index.findEnergyClaimant.mockResolvedValue('another-virtual-property');
+
+			await expect(
+				service.assertProjectionCompatible(energyProjection('meter', PropertyCategory.CONSUMPTION), CHANNEL_ID),
+			).rejects.toThrow(/already the energy meter/);
+		});
+
+		// A remap that lands back on the meter this very property already bills is not a second claimant.
+		it('lets the current claimant keep its own meter', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const source = meter('meter', PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY);
+
+			channelsPropertiesService.findOne.mockResolvedValue(source);
+			index.findEnergyClaimant.mockResolvedValue('virtual-property');
+
+			const projection = energyProjection('meter', PropertyCategory.CONSUMPTION);
+
+			await expect(service.assertProjectionCompatible(projection, CHANNEL_ID)).resolves.toBeUndefined();
+			expect(projection.energyClaimPropertyId).toBe('meter');
+		});
 
 		it('refuses a read-only source on a writable slot, carrying the reason', async () => {
 			givenSlot(ChannelCategory.LIGHT, DeviceCategory.LIGHTING);

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
@@ -717,7 +717,7 @@ describe('VirtualDevicesService', () => {
 			const source = meter('meter', PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY);
 
 			channelsPropertiesService.findOne.mockResolvedValue(source);
-			index.findEnergyClaimant.mockResolvedValue('another-virtual-property');
+			index.findEnergyClaimant.mockResolvedValue({ id: 'another-virtual-property' });
 
 			await expect(
 				service.assertProjectionCompatible(energyProjection('meter', PropertyCategory.CONSUMPTION), CHANNEL_ID),
@@ -731,7 +731,7 @@ describe('VirtualDevicesService', () => {
 			const source = meter('meter', PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY);
 
 			channelsPropertiesService.findOne.mockResolvedValue(source);
-			index.findEnergyClaimant.mockResolvedValue('virtual-property');
+			index.findEnergyClaimant.mockResolvedValue({ id: 'virtual-property' });
 
 			const projection = energyProjection('meter', PropertyCategory.CONSUMPTION);
 

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.spec.ts
@@ -668,6 +668,36 @@ describe('VirtualDevicesService', () => {
 			expect(projection.energyClaimPropertyId).toBe('unrecognised');
 		});
 
+		// A claim is a statement about what the property projects *now*. A PATCH that turns a claimed
+		// projection into an owned property returns before the settlement at the end, and a claim
+		// surviving that would hold its meter forever — the unique index refusing every replacement, with
+		// nothing but deleting the stale row to release it.
+		it('releases the meter when a claimed projection becomes owned', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const projection = energyProjection('meter', PropertyCategory.CONSUMPTION);
+
+			projection.energyClaimPropertyId = 'meter';
+			projection.valueOrigin = VirtualValueOrigin.LOCAL;
+
+			await service.assertProjectionCompatible(projection, CHANNEL_ID);
+
+			expect(projection.energyClaimPropertyId).toBeNull();
+		});
+
+		it('releases the meter when a claimed projection loses its source', async () => {
+			givenSlot(ChannelCategory.ELECTRICAL_ENERGY, DeviceCategory.OUTLET);
+
+			const projection = energyProjection('meter', PropertyCategory.CONSUMPTION);
+
+			projection.energyClaimPropertyId = 'meter';
+			projection.sourcePropertyId = null;
+
+			await service.assertProjectionCompatible(projection, CHANNEL_ID);
+
+			expect(projection.energyClaimPropertyId).toBeNull();
+		});
+
 		it('claims nothing for a projection into a slot that carries no energy', async () => {
 			givenSlot(ChannelCategory.LIGHT, DeviceCategory.LIGHTING);
 			channelsPropertiesService.findOne.mockResolvedValue(

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
@@ -953,6 +953,22 @@ export class VirtualDevicesService {
 	}
 
 	async assertProjectionCompatible(property: VirtualChannelPropertyEntity, channelId: string): Promise<void> {
+		// Cleared before anything is judged, and re-earned below by a row that still qualifies.
+		//
+		// The claim is a statement about what this property projects *now*, so every path that leaves
+		// this method has to leave it consistent — including the ones that leave early. A PATCH turning a
+		// claimed projection into an owned property or into an orphan returns before the settlement at
+		// the end, and a claim surviving that would hold its meter forever: the unique index would then
+		// refuse a legitimate replacement, and nothing but deleting the stale row would release it.
+		//
+		// Clearing is also the conservative direction where the source or channel cannot be resolved at
+		// all. An unclaimed meter attributes to the physical device, which is where it went before any of
+		// this existed — wrong for a split, but not misleading.
+		//
+		// The meter this releases may be left with no claimant, which is what the promotion path picks
+		// up; see `settleEnergyClaim`.
+		property.energyClaimPropertyId = null;
+
 		// Only an *explicit* `local` is skipped. `valueOrigin` deliberately carries no class-field
 		// initializer (see the entity), so a create that supplies `source_property` and omits the
 		// optional `value_origin` arrives here as `undefined` and only becomes `source` when the column
@@ -1132,8 +1148,6 @@ export class VirtualDevicesService {
 		const destination = findEnergySourceType(destinationChannelCategory, property.category);
 
 		if (destination === null) {
-			property.energyClaimPropertyId = null;
-
 			return;
 		}
 

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
@@ -1194,8 +1194,8 @@ export class VirtualDevicesService {
 
 		const claimant = await this.index.findEnergyClaimant(sourceProperty.id);
 
-		if (claimant !== null && claimant !== holder) {
-			return `Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`;
+		if (claimant !== null && claimant.id !== holder) {
+			return `Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant.id}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`;
 		}
 
 		return null;

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
@@ -6,7 +6,7 @@ import {
 	PermissionType,
 	PropertyCategory,
 } from '../../../modules/devices/devices.constants';
-import { ChannelPropertyEntity, DeviceEntity } from '../../../modules/devices/entities/devices.entity';
+import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../modules/devices/entities/devices.entity';
 import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
 import { ChannelsService } from '../../../modules/devices/services/channels.service';
 import { DeviceValidationService, ValidationIssue } from '../../../modules/devices/services/device-validation.service';
@@ -14,6 +14,7 @@ import { DevicesService } from '../../../modules/devices/services/devices.servic
 import { matchesInvalidValue, matchesStep } from '../../../modules/devices/utils/property-command-value.utils';
 import { resolvePropertyUnit } from '../../../modules/devices/utils/property-metadata.utils';
 import { getAllProperties, isChannelAllowed, isValidDataType } from '../../../modules/devices/utils/schema.utils';
+import { findEnergySourceType } from '../../../modules/energy/utils/energy-source-type.utils';
 import { DEVICES_VIRTUAL_TYPE, VIRTUAL_BLOCKED_CATEGORIES } from '../devices-virtual.constants';
 import {
 	VirtualCategoryChangeUnsafeException,
@@ -1098,6 +1099,81 @@ export class VirtualDevicesService {
 				);
 			}
 		}
+
+		await this.settleEnergyClaim(property, channel.category, sourceProperty);
+	}
+
+	/**
+	 * Decides whether this projection is the one accountable for its source's kWh, and writes that onto
+	 * the row about to be saved.
+	 *
+	 * A gate that mutates, which is worth justifying: this is the one point holding everything the
+	 * decision needs — the destination channel, the property's own category, and the source it was just
+	 * judged against — and the value it derives is a function of exactly what it judged. Setting it here
+	 * also means the claim and the projection are written by the same statement, so no failure can leave
+	 * one without the other, and the unique index arbitrates concurrent claimants without a transaction
+	 * spanning these hooks.
+	 *
+	 * Energy is the one quantity where two virtual devices reading one source is not merely redundant
+	 * but wrong. A temperature is non-additive — two rooms observing the same thermometer is coherent,
+	 * and the design allows it deliberately — while a kWh billed to two rooms is arithmetic nobody
+	 * asked for.
+	 */
+	private async settleEnergyClaim(
+		property: VirtualChannelPropertyEntity,
+		destinationChannelCategory: ChannelCategory,
+		sourceProperty: ChannelPropertyEntity,
+	): Promise<void> {
+		// Judged on the *destination*: what makes a reading energy is the slot it is presented in, which
+		// is the pair the ingestion classifies when it handles this projection's own event. A
+		// `consumption` property sitting in a `generic` channel is not a meter anywhere else and becomes
+		// one here — which is exactly the case that double-counts today, since nothing skips those
+		// projections.
+		const destination = findEnergySourceType(destinationChannelCategory, property.category);
+
+		if (destination === null) {
+			property.energyClaimPropertyId = null;
+
+			return;
+		}
+
+		const sourceChannel = await this.resolveChannelOf(sourceProperty);
+		const source = findEnergySourceType(sourceChannel?.category, sourceProperty.category);
+
+		// A projection may not change what a reading means. Nothing structural separates `grid_import`
+		// from `grid_export` — both read-only floats in kWh over the same range — so the slot report
+		// accepts the pairing, and the room would then be shown an import under the heading of an
+		// export. Refused rather than relabelled: an import meter is not an export meter, and quietly
+		// filing it as one is worse than saying the mapping is wrong.
+		//
+		// Dormant today, and deliberately kept: `electrical_energy.consumption` is the only energy slot
+		// a virtual device can currently reach, so no two reachable slots disagree. The other three are
+		// unreachable for reasons that have nothing to do with energy — `mapPropertyCategory` in
+		// `schema.utils.ts` omits `grid_import` and `grid_export` (34 of the spec's 100 property keys are
+		// missing from it), and no device category declares an `electrical_generation` channel at all.
+		// Both are recorded as follow-ups; this guard is what stops the gap reopening when either is
+		// fixed, which is exactly when nobody would think to look for it.
+		if (source !== null && source.sourceType !== destination.sourceType) {
+			throw new VirtualProjectionIncompatibleException(
+				`Property id=${property.id} presents source id=${sourceProperty.id} as '${destination.sourceType}', but that source reads '${source.sourceType}'; a projection forwards its source's value unchanged, so it cannot change what the reading means`,
+			);
+		}
+
+		const claimant = await this.index.findEnergyClaimant(sourceProperty.id);
+
+		if (claimant !== null && claimant !== property.id) {
+			throw new VirtualProjectionIncompatibleException(
+				`Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`,
+			);
+		}
+
+		property.energyClaimPropertyId = sourceProperty.id;
+	}
+
+	private async resolveChannelOf(property: ChannelPropertyEntity): Promise<ChannelEntity | null> {
+		const channelId = typeof property.channel === 'string' ? property.channel : property.channel?.id;
+
+		return channelId ? await this.channelsService.findOne(channelId) : null;
 	}
 
 	private async resolveOwningDevice(propertyId: string): Promise<DeviceEntity | null> {

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
@@ -1180,14 +1180,53 @@ export class VirtualDevicesService {
 		sourceProperty: ChannelPropertyEntity,
 		holder?: string,
 	): Promise<string | null> {
+		const sourceChannel = await this.resolveChannelOf(sourceProperty);
+
+		const meaning = this.describeEnergyMeaningConflict(slot, sourceChannel?.category, sourceProperty);
+
+		if (meaning !== null) {
+			return meaning;
+		}
+
+		if (findEnergySourceType(slot.channel, slot.property) === null) {
+			return null;
+		}
+
+		const claimant = await this.index.findEnergyClaimant(sourceProperty.id);
+
+		if (claimant !== null && claimant !== holder) {
+			return `Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Why this slot may not present this source's reading as its own, or null when it may.
+	 *
+	 * The half of the rule above that asks nothing of storage, split out because the reconciliation
+	 * needs exactly this one: a source can move underneath a projection that was judged when it was
+	 * written, and a projection that no longer *means* what its source reads is wrong whether or not it
+	 * happens to hold the claim. Which projection is accountable is a separate question, and asking it
+	 * there would orphan an innocent second projection for the crime of not holding a claim.
+	 */
+	describeEnergyMeaningConflict(
+		slot: { channel: ChannelCategory; property: PropertyCategory },
+		sourceChannelCategory: ChannelCategory | undefined,
+		sourceProperty: ChannelPropertyEntity,
+	): string | null {
+		// Judged on the *destination*: what makes a reading energy is the slot it is presented in, which
+		// is the pair the ingestion classifies when it handles this projection's own event. A
+		// `consumption` property sitting in a `generic` channel is not a meter anywhere else and becomes
+		// one here — which is exactly the case that double-counts today, since nothing skips those
+		// projections.
 		const destination = findEnergySourceType(slot.channel, slot.property);
 
 		if (destination === null) {
 			return null;
 		}
 
-		const sourceChannel = await this.resolveChannelOf(sourceProperty);
-		const source = findEnergySourceType(sourceChannel?.category, sourceProperty.category);
+		const source = findEnergySourceType(sourceChannelCategory, sourceProperty.category);
 
 		// A projection may not change what a reading means. Nothing structural separates `grid_import`
 		// from `grid_export` — both read-only floats in kWh over the same range — so the slot report
@@ -1195,21 +1234,17 @@ export class VirtualDevicesService {
 		// export. Refused rather than relabelled: an import meter is not an export meter, and quietly
 		// filing it as one is worse than saying the mapping is wrong.
 		//
-		// Dormant today, and deliberately kept: `electrical_energy.consumption` is the only energy slot
-		// a virtual device can currently reach, so no two reachable slots disagree. The other three are
+		// Nearly dormant, and deliberately kept: `electrical_energy.consumption` is the only energy slot
+		// a virtual device can currently reach, so no two reachable *destinations* disagree — but a
+		// source can still arrive at a second type sideways, by having its channel recategorised
+		// underneath it, which is what the reconciliation asks about. The other three destinations are
 		// unreachable for reasons that have nothing to do with energy — `mapPropertyCategory` in
 		// `schema.utils.ts` omits `grid_import` and `grid_export` (34 of the spec's 100 property keys are
 		// missing from it), and no device category declares an `electrical_generation` channel at all.
 		// Both are recorded as follow-ups; this guard is what stops the gap reopening when either is
 		// fixed, which is exactly when nobody would think to look for it.
 		if (source !== null && source.sourceType !== destination.sourceType) {
-			return `Source id=${sourceProperty.id} would be presented as '${destination.sourceType}', but it reads '${source.sourceType}'; a projection forwards its source's value unchanged, so it cannot change what the reading means`;
-		}
-
-		const claimant = await this.index.findEnergyClaimant(sourceProperty.id);
-
-		if (claimant !== null && claimant !== holder) {
-			return `Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`;
+			return `source id=${sourceProperty.id} reads '${source.sourceType}' while this slot presents '${destination.sourceType}'; a projection forwards its source's value unchanged, so it cannot change what the reading means`;
 		}
 
 		return null;

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-devices.service.ts
@@ -1140,15 +1140,50 @@ export class VirtualDevicesService {
 		destinationChannelCategory: ChannelCategory,
 		sourceProperty: ChannelPropertyEntity,
 	): Promise<void> {
+		const conflict = await this.describeEnergyClaimConflict(
+			{ channel: destinationChannelCategory, property: property.category },
+			sourceProperty,
+			property.id,
+		);
+
+		if (conflict !== null) {
+			throw new VirtualProjectionIncompatibleException(conflict);
+		}
+
 		// Judged on the *destination*: what makes a reading energy is the slot it is presented in, which
 		// is the pair the ingestion classifies when it handles this projection's own event. A
 		// `consumption` property sitting in a `generic` channel is not a meter anywhere else and becomes
 		// one here — which is exactly the case that double-counts today, since nothing skips those
 		// projections.
-		const destination = findEnergySourceType(destinationChannelCategory, property.category);
+		if (findEnergySourceType(destinationChannelCategory, property.category) === null) {
+			return;
+		}
+
+		property.energyClaimPropertyId = sourceProperty.id;
+	}
+
+	/**
+	 * Why this slot may not bill this source's kWh, or null when it may — and null, too, for the many
+	 * slots that carry no energy at all and so have nothing to bill.
+	 *
+	 * Separate from the settlement above because two callers need the same answer: the gate, which
+	 * refuses the write, and the wizard's compatibility preview, which greys the pairing out before
+	 * anyone tries. A preview that offered a meter the very next request rejects is the shape of false
+	 * green the nesting rule already avoids the same way — the user acts on green.
+	 *
+	 * `holder` is the property allowed to be holding the claim already: its own id at the gate, so a
+	 * PATCH that leaves the source alone is not read as a second claimant, and nothing in the preview,
+	 * where the property being described does not exist yet.
+	 */
+	async describeEnergyClaimConflict(
+		slot: { channel: ChannelCategory; property: PropertyCategory },
+		sourceProperty: ChannelPropertyEntity,
+		holder?: string,
+	): Promise<string | null> {
+		const destination = findEnergySourceType(slot.channel, slot.property);
 
 		if (destination === null) {
-			return;
+			return null;
 		}
 
 		const sourceChannel = await this.resolveChannelOf(sourceProperty);
@@ -1168,20 +1203,16 @@ export class VirtualDevicesService {
 		// Both are recorded as follow-ups; this guard is what stops the gap reopening when either is
 		// fixed, which is exactly when nobody would think to look for it.
 		if (source !== null && source.sourceType !== destination.sourceType) {
-			throw new VirtualProjectionIncompatibleException(
-				`Property id=${property.id} presents source id=${sourceProperty.id} as '${destination.sourceType}', but that source reads '${source.sourceType}'; a projection forwards its source's value unchanged, so it cannot change what the reading means`,
-			);
+			return `Source id=${sourceProperty.id} would be presented as '${destination.sourceType}', but it reads '${source.sourceType}'; a projection forwards its source's value unchanged, so it cannot change what the reading means`;
 		}
 
 		const claimant = await this.index.findEnergyClaimant(sourceProperty.id);
 
-		if (claimant !== null && claimant !== property.id) {
-			throw new VirtualProjectionIncompatibleException(
-				`Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`,
-			);
+		if (claimant !== null && claimant !== holder) {
+			return `Source property id=${sourceProperty.id} is already the energy meter of virtual property id=${claimant}; a meter's consumption is billed to one place, so it can only be projected into one energy slot`;
 		}
 
-		property.energyClaimPropertyId = sourceProperty.id;
+		return null;
 	}
 
 	private async resolveChannelOf(property: ChannelPropertyEntity): Promise<ChannelEntity | null> {

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.spec.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.spec.ts
@@ -1,0 +1,58 @@
+import { ChannelCategory, PropertyCategory } from '../../../modules/devices/devices.constants';
+import { EnergySourceType } from '../../../modules/energy/energy.constants';
+import { VirtualChannelPropertyEntity } from '../entities/devices-virtual.entity';
+
+import { VirtualEnergyClaimService } from './virtual-energy-claim.service';
+import { VirtualPropertyIndexService } from './virtual-property-index.service';
+
+/**
+ * The seam the energy module asks across. What matters here is that a claim is answered *whole*:
+ * the ingestion is holding a meter and needs the room its kWh is billed to, and any answer it has to
+ * follow up on is an answer that can be overtaken by a remap in between.
+ */
+describe('VirtualEnergyClaimService', () => {
+	const claimant = (category: PropertyCategory, channelCategory: ChannelCategory, roomId: string | null) =>
+		({
+			id: 'claimant',
+			category,
+			channel: { id: 'virtual-channel', category: channelCategory, device: { id: 'virtual-device', roomId } },
+		}) as unknown as VirtualChannelPropertyEntity;
+
+	const subject = (found: VirtualChannelPropertyEntity | null): VirtualEnergyClaimService =>
+		new VirtualEnergyClaimService({
+			findEnergyClaimant: jest.fn().mockResolvedValue(found),
+		} as unknown as VirtualPropertyIndexService);
+
+	it('answers the claim whole: the device, its room, and what the claimant presents', async () => {
+		const claim = await subject(
+			claimant(PropertyCategory.CONSUMPTION, ChannelCategory.ELECTRICAL_ENERGY, 'kitchen'),
+		).resolveClaim('meter');
+
+		expect(claim).toEqual({
+			propertyId: 'claimant',
+			deviceId: 'virtual-device',
+			roomId: 'kitchen',
+			sourceType: EnergySourceType.CONSUMPTION_IMPORT,
+		});
+	});
+
+	// Reported rather than hidden, because the ingestion refuses a claim that does not read what the
+	// meter reads: a claimant whose slot has drifted must not quietly take the kWh with it.
+	it('reports what a claimant presents even when that is not energy at all', async () => {
+		const claim = await subject(claimant(PropertyCategory.ON, ChannelCategory.LIGHT, 'kitchen')).resolveClaim('meter');
+
+		expect(claim?.sourceType).toBeNull();
+	});
+
+	it('claims nothing for a meter no projection holds', async () => {
+		await expect(subject(null).resolveClaim('meter')).resolves.toBeNull();
+	});
+
+	// A claim is only about attribution, so a claimant that cannot be resolved to a device leaves the
+	// meter billed to itself rather than costing the reading.
+	it('claims nothing when the claimant resolves to no device', async () => {
+		const orphan = { id: 'claimant', category: PropertyCategory.CONSUMPTION, channel: 'virtual-channel' };
+
+		await expect(subject(orphan as unknown as VirtualChannelPropertyEntity).resolveClaim('meter')).resolves.toBeNull();
+	});
+});

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+
+import { IEnergyClaimSource } from '../../../modules/energy/services/energy-claim.registry.service';
+
+import { VirtualPropertyIndexService } from './virtual-property-index.service';
+
+/**
+ * Tells the energy module which projection, if any, has taken over a meter.
+ *
+ * The whole answer already exists on the projection row — `energyClaimPropertyId`, settled when the
+ * projection is written and released with the link it belongs to — so this is a thin adapter rather
+ * than a second source of truth. What it adds is direction: the claim is stored on the *claimant* and
+ * the ingestion arrives holding the *meter*, and this is the seam that lets it ask without core
+ * knowing the column exists.
+ */
+@Injectable()
+export class VirtualEnergyClaimService implements IEnergyClaimSource {
+	constructor(private readonly index: VirtualPropertyIndexService) {}
+
+	async resolveClaimant(meterPropertyId: string): Promise<string | null> {
+		return await this.index.findEnergyClaimant(meterPropertyId);
+	}
+}

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-energy-claim.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { IEnergyClaimSource } from '../../../modules/energy/services/energy-claim.registry.service';
+import { EnergyClaim, IEnergyClaimSource } from '../../../modules/energy/services/energy-claim.registry.service';
+import { findEnergySourceType } from '../../../modules/energy/utils/energy-source-type.utils';
 
 import { VirtualPropertyIndexService } from './virtual-property-index.service';
 
@@ -12,12 +13,36 @@ import { VirtualPropertyIndexService } from './virtual-property-index.service';
  * than a second source of truth. What it adds is direction: the claim is stored on the *claimant* and
  * the ingestion arrives holding the *meter*, and this is the seam that lets it ask without core
  * knowing the column exists.
+ *
+ * Answered in a single read, down to the room. Splitting it — an id here, a device lookup there —
+ * would put a remap between the two: a claimant repointed at another meter in that window would still
+ * supply the device this meter's delta is billed to.
  */
 @Injectable()
 export class VirtualEnergyClaimService implements IEnergyClaimSource {
 	constructor(private readonly index: VirtualPropertyIndexService) {}
 
-	async resolveClaimant(meterPropertyId: string): Promise<string | null> {
-		return await this.index.findEnergyClaimant(meterPropertyId);
+	async resolveClaim(meterPropertyId: string): Promise<EnergyClaim | null> {
+		const claimant = await this.index.findEnergyClaimant(meterPropertyId);
+
+		if (!claimant) {
+			return null;
+		}
+
+		const channel = typeof claimant.channel === 'string' ? undefined : claimant.channel;
+		const device = channel?.device;
+
+		if (!device || typeof device === 'string') {
+			return null;
+		}
+
+		return {
+			propertyId: claimant.id,
+			deviceId: device.id,
+			roomId: device.roomId ?? null,
+			// The claimant's own slot, classified by the same function the ingestion classifies the meter
+			// with, so the two answers are comparable and a claim that has drifted can be refused.
+			sourceType: findEnergySourceType(channel?.category, claimant.category)?.sourceType ?? null,
+		};
 	}
 }

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-property-index.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-property-index.service.ts
@@ -151,14 +151,15 @@ export class VirtualPropertyIndexService {
 	 * here, and a check that missed it would hand a second projection the same meter. The unique index
 	 * would then refuse the write, so the answer would be a 409 rather than the sentence naming what
 	 * already holds it.
+	 *
+	 * Returned whole, with the device it hangs on, because the ingestion needs the room as well and a
+	 * second read to find it would be racing a remap — see `VirtualEnergyClaimService`.
 	 */
-	async findEnergyClaimant(sourcePropertyId: string): Promise<string | null> {
-		const claimant = await this.repository.findOne({
+	async findEnergyClaimant(sourcePropertyId: string): Promise<VirtualChannelPropertyEntity | null> {
+		return await this.repository.findOne({
 			where: { energyClaimPropertyId: sourcePropertyId },
-			select: ['id'],
+			relations: ['channel', 'channel.device'],
 		});
-
-		return claimant?.id ?? null;
 	}
 
 	/** Which virtual properties project the given source property. O(1), synchronous, no I/O. */

--- a/apps/backend/src/plugins/devices-virtual/services/virtual-property-index.service.ts
+++ b/apps/backend/src/plugins/devices-virtual/services/virtual-property-index.service.ts
@@ -143,6 +143,24 @@ export class VirtualPropertyIndexService {
 		return referencing > 0;
 	}
 
+	/**
+	 * Which projection, if any, is accountable for this meter's kWh — read from storage.
+	 *
+	 * Asked of the database rather than of the maps below for the same reason
+	 * `isSourceDeviceReferenced` is: a claim made since the last rebuild is committed and invisible
+	 * here, and a check that missed it would hand a second projection the same meter. The unique index
+	 * would then refuse the write, so the answer would be a 409 rather than the sentence naming what
+	 * already holds it.
+	 */
+	async findEnergyClaimant(sourcePropertyId: string): Promise<string | null> {
+		const claimant = await this.repository.findOne({
+			where: { energyClaimPropertyId: sourcePropertyId },
+			select: ['id'],
+		});
+
+		return claimant?.id ?? null;
+	}
+
 	/** Which virtual properties project the given source property. O(1), synchronous, no I/O. */
 	findBySourceProperty(id: string): VirtualChannelPropertyEntity[] {
 		return this.bySourceProperty.get(id) ?? [];

--- a/apps/backend/test/devices-virtual.e2e-spec.ts
+++ b/apps/backend/test/devices-virtual.e2e-spec.ts
@@ -2529,6 +2529,161 @@ describe('devices-virtual plugin (e2e)', () => {
 		});
 	});
 
+	// ─── One meter, one claimant ─────────────────────────────────────────────────────────
+	//
+	// A source property may legitimately feed several virtual devices — one sensor serves two rooms'
+	// climate — and for a reading that is coherent. Energy is not: a kWh billed to two rooms is
+	// arithmetic nobody asked for, and attribution needs one accountable device. The rule is enforced
+	// where it cannot be raced, on the row itself, and this is the API's view of it.
+
+	describe('a meter already presented by another virtual device', () => {
+		let meterDeviceId: string;
+		let meterPropertyId: string;
+		let firstClaimantId: string;
+
+		const virtualOutlet = (name: string, meter: string) => ({
+			data: {
+				type: DEVICES_VIRTUAL_TYPE,
+				category: DeviceCategory.OUTLET,
+				name,
+				channels: [
+					{
+						type: DEVICES_VIRTUAL_TYPE,
+						category: ChannelCategory.ELECTRICAL_ENERGY,
+						identifier: 'electrical_energy',
+						name: 'Energy',
+						properties: [
+							{
+								type: DEVICES_VIRTUAL_TYPE,
+								category: PropertyCategory.CONSUMPTION,
+								identifier: 'consumption',
+								name: 'Consumption',
+								permissions: [PermissionType.READ_ONLY],
+								data_type: DataTypeType.FLOAT,
+								format: [0, null],
+								source_property: meter,
+							},
+						],
+					},
+				],
+			},
+		});
+
+		it('creates a physical device carrying a cumulative meter', async () => {
+			const response = await authPost('/modules/devices/devices')
+				.send({
+					data: {
+						type: SIMULATOR_TYPE,
+						category: DeviceCategory.OUTLET,
+						name: 'E2E Metered Outlet',
+						channels: [
+							{
+								type: SIMULATOR_TYPE,
+								category: ChannelCategory.ELECTRICAL_ENERGY,
+								identifier: 'electrical_energy',
+								name: 'Energy',
+								properties: [
+									{
+										type: SIMULATOR_TYPE,
+										category: PropertyCategory.CONSUMPTION,
+										identifier: 'consumption',
+										name: 'Consumption',
+										permissions: [PermissionType.READ_ONLY],
+										data_type: DataTypeType.FLOAT,
+										format: [0, null],
+									},
+								],
+							},
+						],
+					},
+				})
+				.expect(201);
+
+			const body = response.body as { data: DeviceBody };
+
+			meterDeviceId = body.data.id;
+			meterPropertyId =
+				body.data.channels
+					.find((channel) => channel.category === String(ChannelCategory.ELECTRICAL_ENERGY))
+					?.properties.find((property) => property.category === PropertyCategory.CONSUMPTION)?.id ?? '';
+
+			expect(meterPropertyId).toBeTruthy();
+		});
+
+		it('lets the first virtual device present it', async () => {
+			const response = await authPost('/modules/devices/devices')
+				.send(virtualOutlet('E2E Kitchen Meter', meterPropertyId))
+				.expect(201);
+
+			firstClaimantId = (response.body as { data: DeviceBody }).data.id;
+
+			expect(firstClaimantId).toBeTruthy();
+		});
+
+		// The nested device-create path reports its own generic envelope rather than the guard's reason —
+		// the same shape every other nested failure gets here — so the status is what this pins. The
+		// reason has to reach the user somewhere, and the case below is where: the wizard asks before it
+		// writes.
+		it('refuses a second one', async () => {
+			const rejected = await authPost('/modules/devices/devices').send(
+				virtualOutlet('E2E Office Meter', meterPropertyId),
+			);
+
+			expect(rejected.status).toBe(422);
+		});
+
+		// A false green is the one answer a user acts on. `reportCompatibility` compares a candidate
+		// against a slot and a claimed meter fits an energy slot as well as any other, so without the
+		// claim folded in the wizard would offer this pairing and the create would then refuse it.
+		it('tells the wizard the pairing is incompatible, and why', async () => {
+			const preview = await authPost('/plugins/devices-virtual/devices/compatibility')
+				.send({
+					data: {
+						category: DeviceCategory.OUTLET,
+						candidates: [
+							{
+								spec_channel: ChannelCategory.ELECTRICAL_ENERGY,
+								spec_property: PropertyCategory.CONSUMPTION,
+								source_property: meterPropertyId,
+							},
+						],
+					},
+				})
+				.expect(201);
+
+			const [report] = (preview.body as { data: { compatible: boolean; reason: string }[] }).data;
+
+			expect(report.compatible).toBe(false);
+			expect(report.reason).toContain('is already the energy meter of virtual property');
+		});
+
+		// The claim and the projection are one row written by one statement, so a refusal cannot leave
+		// half of either behind — but that is the kind of thing worth asserting rather than reasoning
+		// about, since the failure mode is a device that exists and bills nothing.
+		it('leaves nothing of the refused device behind', async () => {
+			const devices = await authGet('/modules/devices/devices').expect(200);
+
+			const names = (devices.body as { data: { id: string; name: string }[] }).data.map((device) => device.name);
+
+			expect(names).toContain('E2E Kitchen Meter');
+			expect(names).not.toContain('E2E Office Meter');
+		});
+
+		// Deleting the holder takes its claim with the row, and the meter is free again — which is also
+		// the path `reconcileEnergyClaims` sweeps behind, since a delete cannot name what it released.
+		it('lets the meter be presented again once the holder is gone', async () => {
+			await ensureDeviceDeleted(authGet, authDelete, firstClaimantId);
+
+			const successor = await authPost('/modules/devices/devices')
+				.send(virtualOutlet('E2E Office Meter', meterPropertyId))
+				.expect(201);
+
+			// Tidied up in reverse, so nothing is deleted out from under a projection that still reads it.
+			await ensureDeviceDeleted(authGet, authDelete, (successor.body as { data: DeviceBody }).data.id);
+			await ensureDeviceDeleted(authGet, authDelete, meterDeviceId);
+		});
+	});
+
 	// ─── Auth enforcement ────────────────────────────────────────────────────────────────
 
 	describe('authentication', () => {

--- a/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md
+++ b/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md
@@ -5,7 +5,7 @@ Type: bug
 Scope: backend
 Size: medium
 Parent: EPIC-VIRTUAL-DEVICES
-Status: planned
+Status: in-progress
 
 ## 1. Summary
 
@@ -243,44 +243,50 @@ fix must not introduce a lookup that assumes otherwise.
 
 ## 5. Acceptance criteria
 
-- [ ] A delta for a projected energy property carries the projecting device's `deviceId` and `roomId`
-- [ ] A device's unprojected energy channels still attribute to the device itself
-- [ ] **The split case, with one claimant per meter:** two energy-bearing channels of one physical
+Split across two PRs. [#649](https://github.com/FastyBird/smart-panel/pull/649) does the claim and
+the attribution — everything below that is ticked. What is left is the *readers*: the space queries
+reach a room by joining the device's current `roomId` instead of the recorded `delta.roomId`, and
+`saveDelta` accumulates into a bucket keyed without the room. Both are pre-existing, neither is about
+attribution, and a split merely makes them routine.
+
+- [x] A delta for a projected energy property carries the projecting device's `deviceId` and `roomId`
+- [x] A device's unprojected energy channels still attribute to the device itself
+- [x] **The split case, with one claimant per meter:** two energy-bearing channels of one physical
       device — a 4PM has one per relay — projected into different rooms put each channel's kWh in its
       own room, nothing in the other, and leave the house total unchanged
-- [ ] A second projection of an already-claimed energy property is refused at persistence, and the
+- [x] A second projection of an already-claimed energy property is refused at persistence, and the
       wizard reports the pairing as incompatible
-- [ ] Two concurrent claims on the same previously unclaimed meter cannot both persist — with a
+- [x] Two concurrent claims on the same previously unclaimed meter cannot both persist — with a
       regression test that drives them concurrently, not one after the other
-- [ ] A **non-qualifying** source (a `consumption` property in a `generic` channel) projected into two
+- [x] A **non-qualifying** source (a `consumption` property in a `generic` channel) projected into two
       `electrical_energy` slots is refused the same way, and the household total does not double
-- [ ] Creating a projection over an already-running meter loses no consumption: a transition test with
+- [x] Creating a projection over an already-running meter loses no consumption: a transition test with
       readings before and after the projection shows the delta spanning them, not a dropped first
       sample
-- [ ] An installation that already holds duplicate claims comes up with exactly one claimant per
+- [x] An installation that already holds duplicate claims comes up with exactly one claimant per
       meter after the migration, deterministically chosen among the mappings the new rules accept —
       an older but cross-type projection does not take the claim from a younger admissible one, and a
       meter with no admissible candidate is left unclaimed rather than misattributed
-- [ ] **And the household total is right afterwards:** the losing projections stop producing deltas,
+- [x] **And the household total is right afterwards:** the losing projections stop producing deltas,
       including where the source is non-qualifying and nothing else would have skipped them — a
       post-migration regression test on the total, not only on the per-room split
-- [ ] A qualifying source that *is* claimed still produces exactly one delta, from the source event,
+- [x] A qualifying source that *is* claimed still produces exactly one delta, from the source event,
       carrying the claimant's room — not two
-- [ ] A pairing whose destination slot means something else — `grid_import` projected into
+- [x] A pairing whose destination slot means something else — `grid_import` projected into
       `grid_export` — is refused, rather than being counted under the source's type in a room that
       displays it as the other
-- [ ] Removing or remapping the claim holder promotes another projection of the same meter, if one
+- [x] Removing or remapping the claim holder promotes another projection of the same meter, if one
       remains, so the meter neither vanishes from the totals nor quietly changes room
-- [ ] A deletion racing a new claim on the same meter leaves exactly one claimant, whichever wins —
+- [x] A deletion racing a new claim on the same meter leaves exactly one claimant, whichever wins —
       tested by driving the delete and the create concurrently, not in sequence
-- [ ] A refused claim leaves nothing behind: no projection without its claim, no claim without its
+- [x] A refused claim leaves nothing behind: no projection without its claim, no claim without its
       projection, asserted after the rejected request rather than only on the winner
-- [ ] A metadata edit that orphans a claimed projection clears its claim in the same statement and
+- [x] A metadata edit that orphans a claimed projection clears its claim in the same statement and
       promotes a successor, leaving no orphan holding a meter
-- [ ] Deleting a claimed source property clears the claim with the link — the orphan holds nothing,
+- [x] Deleting a claimed source property clears the claim with the link — the orphan holds nothing,
       another projection of a recreated property can claim it, and the migration covers rows that
       were already orphaned
-- [ ] An orphaned projection is attributed to the virtual device that holds it — there is no source
+- [x] An orphaned projection is attributed to the virtual device that holds it — there is no source
       left to fall back to. `VirtualValueSourceService.resolve()` answers `null` once
       `sourcePropertyId` is null, the registry then resolves the property to its own id, and
       `wasIngestedAsSource()` reads that as "not a projection" and ingests it. That is already the
@@ -291,7 +297,7 @@ fix must not introduce a lookup that assumes otherwise.
       it was recorded in, and deleting it does not erase that history from the space views
 - [ ] A reading that arrives after a move, inside the same interval bucket, is recorded against the
       new room rather than accumulating into the old one
-- [ ] Regression tests for the split case above and for the refusal — **not** for reproduction (a) as
+- [x] Regression tests for the split case above and for the refusal — **not** for reproduction (a) as
       it stands: it projects one meter into two rooms, which the single-claim rule makes impossible to
       construct, and a test that bypassed persistence to build it would be asserting a split this task
       never defines the rule for (why room A rather than room B owns the delta). Reproduction (a) is

--- a/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
+++ b/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
@@ -317,6 +317,18 @@ What is left is a policy question, and it is not the mapping feature's to answer
 
 `channels.store.ts` and `channels.properties.store.ts` have the same exposure in a milder form: they merge (`data.value = { ...data.value, ...channels }`) rather than replace, so nothing is evicted, but a snapshot assembled before a socket update still overwrites that update's row. Nothing in the virtual-device flows depends on it today, and the fix is the same stamp-and-compare shape, worth doing once across the three stores rather than twice.
 
+### 3.9 `mapPropertyCategory` omits a third of the specification (medium, pre-existing)
+
+`schema.utils.ts`'s `mapPropertyCategory` translates a spec property key into a `PropertyCategory`, and 34 of the specification's 100 keys are missing from it — `grid_import`, `grid_export`, `mute`, `repeat`, `shuffle`, `child_lock`, `alarm_state`, `aqi`, the three `acceleration_*`, the media metadata (`album`, `artist`, `artwork_url`, `media_type`), the water-tank family, and more.
+
+`getAllProperties()` drops every unmapped key, so those slots do not exist as far as anything built on it is concerned. For virtual devices that means the wizard never offers them and `reportCompatibility` refuses a projection into one with "channel category X has no Y property in its specification" — a sentence that reads like a spec error and is actually a translation gap. `DeviceValidationService` reads the same utils, so structural validation cannot see them either.
+
+Found while writing the energy-claim guard, which needs two energy slots to disagree and can only reach one.
+
+### 3.10 No device category declares an `electrical_generation` channel (low, pre-existing)
+
+`spec/devices/devices.yaml` lists `electrical_generation` on no device at all, so the channel — and its `production` property, which the energy module classifies as `generation_production` — cannot appear on any device, virtual or physical. Either a category should carry it (a solar inverter has no home today) or the energy module's mapping for it is dead code. Worth deciding rather than leaving as an asymmetry.
+
 ### 3a.6 Test-coverage gaps (low)
 
 - `view-device.vue`'s virtual-device mount gate has no behavioural test; `view-devices.spec.ts` has a usable template for one.


### PR DESCRIPTION
Implements [`BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION`](../blob/main/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md), less the space-reader half — see *What is deliberately not here*.

## The defect

A delta is stamped with the room of the device that owned the property the ingestion read — the physical one — so a device split across rooms reports zero in every one of them. Reproduced both ways in the task: a 4PM with no room split into two rooms leaves 2 kWh in a null-room bucket and zero in both; placed in `Utility` and projected into `Kitchen`, all 5 kWh stay in `Utility`.

## The claim

Attribution needs someone to attribute *to*, and a meter feeding two virtual devices has two candidates. Energy is the one quantity where that is wrong rather than merely redundant — a temperature is non-additive, so two rooms reading one thermometer is coherent, while a kWh billed twice is arithmetic nobody asked for.

- **`energyClaimPropertyId` on the projection row**, holding the claimed meter's id, with a **partial unique index** so "one claimant per meter" is a database fact rather than something every write path remembers to check. It carries the id rather than a flag precisely so the index has something per-meter to be unique on, and the same `ON DELETE SET NULL` as the link beside it, so a deleted meter takes the claim with it in the one statement that orphans the projection — nothing application-side runs there.
- **Settled inside `assertProjectionCompatible`**, the only point holding the destination channel, the property's own category and the source it was just judged against. Writing it there means the claim and the projection arrive in one statement: no failure leaves one without the other, and no transaction has to span the validation hooks — which matters on a single shared SQLite connection.
- **Energy-bearing is decided by the destination slot**, because that is the pair the ingestion classifies when it handles the projection's own event. A `consumption` property in a `generic` channel is not a meter anywhere else and becomes one here — which is exactly the case that double-counts today.
- **A second claimant is refused** with a sentence naming the holder; a remap back onto the meter a property already bills is not a second claimant.
- **Released and inherited together.** Metadata-driven orphaning clears the claim in the same conditional `UPDATE` that clears the link, then offers the meter on — to a projection that could have earned it, by the two rules the backfill applies, not merely to the oldest one left. Releasing without offering is how a meter goes quiet: for a source the ingestion does not recognise on its own, *nothing* ingests once no projection holds the claim.
- **And swept, for the paths that cannot hand it on.** Deleting the holder takes its row and its claim with it; remapping settles the new claim in a hook that never sees the old meter. Neither can name what it released, so `reconcileEnergyClaims` asks the state instead — one read per settled pass, beside the system-hidden sweep that exists for the same kind of gap. Found by the concurrency test the task asks for.
- **The wizard is told before it writes.** A claimed meter fits an energy slot as well as any other, so the pairwise slot report cannot see the conflict and the preview would have offered a pairing the create then refuses — a false green being the one answer a user acts on. The claim refusal is folded into `/compatibility` exactly as the nesting refusal already is, both reading one `describeEnergyClaimConflict`, so the preview and the gate cannot disagree.
- **And kept honest when the source moves underneath.** A source's property category cannot be PATCHed, but its channel can be recategorised, and a `production` property whose channel becomes `electrical_generation` starts reading generation while its projection goes on presenting it as consumption — every structural check passing, both being read-only kWh floats over the same range. The reconciliation now asks the energy-meaning half of the rule as well, and a divergence orphans the projection like any other source that stopped fitting, which releases the claim and promotes a successor.
- **Failing in the right direction.** A claim lookup that cannot answer is not the same fact as a meter nobody claims, and the two branches want opposite answers. A meter measuring its own series is counted either way, so a failed lookup costs only the room and falls back to the device holding it. A projection of an unrecognised source is the *only* event that would count that reading, and every projection of that meter holds the same one — so there a failure read as "unclaimed" bills one reading several times over, permanently. That branch fails closed.
- **And an upgrade that had a choice says so.** The startup reconciliation reports each meter projected into more than one energy slot, naming the holder and the projections that keep reporting the reading but not its energy. Once per start: the migration's choice is deterministic and arbitrary, and only the operator knows whether the room it landed in is the one they meant.
- **The migration backfills** each meter to the oldest *admissible* projection — not simply the oldest. One that would change what the reading means is passed over, and a meter with no admissible claimant is left attributing to the physical device, which is today's behaviour and at least not misleading.

## The attribution

- **Whose kWh it is comes from the claim, and only the claim.** An unclaimed meter is billed to the device holding it, which is both today's behaviour and the right answer when nothing has taken it over.
- **The energy module asks rather than knowing.** `EnergyClaimRegistryService` is the seam and the virtual plugin registers against it, so core stays unaware that the column exists — the same shape as the value-source registry it sits beside.
- **One event per meter still computes one delta**, and which event that is depends on the source's own slot. An ordinary meter ingests on its own event, carrying the claimant's room. A source the ingestion does not recognise — `generic.consumption` projected into an `electrical_energy` slot — ingests through the projection that holds the claim, and the others are skipped: that is where today's duplicates come from, since nothing arbitrated between two projections of one unrecognised meter.
- **The baseline stays keyed to the physical device and channel.** Keying it to the claimant would meet an unseen key the first time a projection appeared or a claim moved, answer `null`, and silently drop everything accumulated since the previous sample.

## What is deliberately not here

The task's other half, which is about the *readers* rather than about attribution, and is pre-existing: `getSpaceSummary`, `getSpaceTimeseries` and `getSpaceBreakdown` reach the room by joining the device's *current* `roomId` instead of the recorded `delta.roomId`, so moving a device rewrites its history between spaces and deleting one erases that history. `saveDelta` needs the matching bucket rekey on a room change. Separate PR — this one is already large, and the two do not depend on each other. Room and house summaries (`getSummary`) already read `delta.roomId`, which is why the reproduction passes here.

## Found on the way

Two pre-existing spec gaps, recorded as follow-ups `3.9` and `3.10` rather than fixed here: `mapPropertyCategory` omits 34 of the specification's 100 property keys, so `getAllProperties()` cannot see `grid_import`, `grid_export`, `mute`, the media metadata and 30 others — the wizard never offers them and `reportCompatibility` refuses them with a message that reads like a spec error. And no device category declares an `electrical_generation` channel at all. Between them, `electrical_energy.consumption` is the only energy slot a virtual device can currently reach, which is why the cross-type guard here is correct but dormant — kept, with a comment saying so, because it is what stops the gap reopening when either is fixed.

## Tests

**The reproduction is the regression test.** The task's numbers, driven through the real listener and the real `EnergyDataService` against sqlite, with each reading delivered the way the system delivers it — to the meter, and again to every projection of it. Six cases: each room billed for the channel its own device presents (2 / 5, house 7); the kitchen billed rather than the utility room; an unprojected meter left where it is; an unrecognised meter counted once through the projection that claims it; the meter kept running across the moment it is projected; and history left where it was recorded. Four of the six fail on the behaviour this replaces.

Seven on the migration, pinning that "admissible" is not "oldest". Three on promotion, two of which fail without the admissibility filter: a legacy `light.on` projection of the meter is passed over, and given a cross-type projection older than a faithful one the claim goes to the younger. Three on the sweep, two more on the reconciliation (a projection whose source stops meaning what its slot presents is orphaned; the promotion writes only onto a row that still reads the meter), five on the claim rules, six on the ingestion's own seams.

Two concurrency cases the task asks for, driven concurrently rather than in sequence: two claims on one unclaimed meter leave exactly one, and a claim racing the holder's removal never leaves two — the second is what surfaced the missing sweep.

Six e2e, end to end through the API: a second virtual device presenting a claimed meter is refused, nothing of the refused device survives, the preview says why, and the meter can be presented again once the holder is gone.

3762 backend unit tests green, and the plugin's 56 e2e cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



