### PR TITLE
fix(backend): read a space's history from the room that recorded it

### DIFF
--- a/apps/backend/src/modules/energy/services/energy-data.service.ts
+++ b/apps/backend/src/modules/energy/services/energy-data.service.ts
@@ -78,6 +78,8 @@ interface BreakdownRawRow {
 	deviceName: string;
 	roomId: string | null;
 	roomName: string | null;
+	/** Selected only to resolve `roomId` and `roomName` against the device's last recorded delta. */
+	lastIntervalStart: string | null;
 	totalKwh: number | null;
 }
 
@@ -114,6 +116,20 @@ export class EnergyDataService {
 		// Uses SQLite's INSERT ... ON CONFLICT ... DO UPDATE to avoid race conditions
 		// when concurrent events target the same (deviceId, sourceType, intervalStart) bucket.
 		// The unique constraint UQ_energy_deltas_device_source_interval enforces this at the DB level.
+		//
+		// The room comes along on conflict, so a device that changes room mid-interval stops filling the
+		// row the old room owns. Without it the readers above would go on adding this device's new
+		// consumption to its former room until the bucket closed, which is the same defect they were
+		// just fixed for, arriving from the write side.
+		//
+		// The bucket *moves* rather than splitting, and that is a deliberate trade. Splitting means the
+		// room joins the unique key, and a nullable column in a SQLite unique index does not conflict
+		// with itself — every reading from a device in no room would open its own row instead of
+		// accumulating. Working around that takes an expression index the entity decorators cannot
+		// declare, which CI and the e2e suite build the schema from. So the residue is that up to one
+		// interval of energy recorded just before a move is attributed to the room the device ended it
+		// in: bounded by DELTA_INTERVAL_MINUTES, and on the side of where the operator has just put the
+		// device rather than where it used to be.
 		await this.deltaRepository.query(
 			`INSERT INTO energy_module_deltas ("id", "deviceId", "roomId", "sourceType", "deltaKwh", "intervalStart", "intervalEnd", "createdAt")
 			 VALUES (
@@ -121,7 +137,7 @@ export class EnergyDataService {
 			   ?, ?, ?, ?, ?, ?, datetime('now')
 			 )
 			 ON CONFLICT ("deviceId", "sourceType", "intervalStart")
-			 DO UPDATE SET "deltaKwh" = "deltaKwh" + excluded."deltaKwh"`,
+			 DO UPDATE SET "deltaKwh" = "deltaKwh" + excluded."deltaKwh", "roomId" = excluded."roomId"`,
 			[deviceId, roomId, sourceType, deltaKwh, intervalStartStr, intervalEndStr],
 		);
 
@@ -248,6 +264,16 @@ export class EnergyDataService {
 	/**
 	 * Get energy summary for a space (aggregated from all rooms belonging to the space).
 	 * If spaceId is 'home' or undefined, aggregates across all rooms/spaces.
+	 *
+	 * Reached through the room the delta was *recorded* with, not the room its device is in now. The
+	 * two differ the moment anything moves, and reaching through the device made a move rewrite
+	 * history: yesterday's consumption left the room that actually consumed it and appeared in the new
+	 * one, while `delta.roomId` sat there unchanged. Deleting the device erased its history from every
+	 * space view outright, since the join dropped the rows.
+	 *
+	 * The room's own membership stays a *current* fact — `parentId` is read from the room row — because
+	 * a room moved to another zone is still the same room, and its history moves with it. What is
+	 * pinned is which room consumed the energy.
 	 */
 	async getSpaceSummary(rangeStart: Date, rangeEnd: Date, spaceId?: string): Promise<SpaceEnergySummary> {
 		const isHome = !spaceId || spaceId === 'home';
@@ -257,7 +283,7 @@ export class EnergyDataService {
 			       SUM(delta."deltaKwh") AS "totalKwh",
 			       MAX(delta."createdAt") AS "lastUpdated"
 			FROM energy_module_deltas delta
-			${isHome ? '' : `INNER JOIN devices_module_devices device ON delta."deviceId" = device."id" INNER JOIN spaces_module_spaces room ON device."roomId" = room."id" WHERE (room."id" = ? OR room."parentId" = ?) AND`}
+			${isHome ? '' : `INNER JOIN spaces_module_spaces room ON delta."roomId" = room."id" WHERE (room."id" = ? OR room."parentId" = ?) AND`}
 			${isHome ? 'WHERE' : ''}
 			delta."intervalStart" >= ?
 			AND delta."intervalStart" < ?
@@ -337,6 +363,10 @@ export class EnergyDataService {
 	 *
 	 * For 1d intervals, buckets are aligned to rangeStart (which is Prague-midnight-aligned)
 	 * rather than UTC midnight, so that "today" in Europe/Prague groups data correctly.
+	 *
+	 * Scoped by the recorded room, for the reasons `getSpaceSummary` gives — and it matters more here:
+	 * a chart is a claim about the past, and one that redraws itself when a device changes room is
+	 * claiming something that never happened.
 	 */
 	async getSpaceTimeseries(
 		rangeStart: Date,
@@ -380,7 +410,7 @@ export class EnergyDataService {
 			       delta."sourceType" AS "sourceType",
 			       SUM(delta."deltaKwh") AS "totalKwh"
 			FROM energy_module_deltas delta
-			${isHome ? '' : `INNER JOIN devices_module_devices device ON delta."deviceId" = device."id" INNER JOIN spaces_module_spaces room ON device."roomId" = room."id" WHERE (room."id" = ? OR room."parentId" = ?) AND`}
+			${isHome ? '' : `INNER JOIN spaces_module_spaces room ON delta."roomId" = room."id" WHERE (room."id" = ? OR room."parentId" = ?) AND`}
 			${isHome ? 'WHERE' : ''}
 			delta."intervalStart" >= ?
 			AND delta."intervalStart" < ?
@@ -496,6 +526,18 @@ export class EnergyDataService {
 	/**
 	 * Get a breakdown of top consuming devices for a space.
 	 * Only considers consumption_import source type.
+	 *
+	 * Scoped and reported by the recorded room, like the two readers above. The device join is a LEFT
+	 * join for the same reason: it supplies a name, and a name that has gone away is no reason to drop
+	 * the consumption from the total — an inner join here erased a deleted device's history from every
+	 * space view, which is not what "history is not re-attributed" is supposed to mean.
+	 *
+	 * One row per device. Where a device consumed in more than one room inside the range, the room
+	 * reported is the one it was last recorded in: SQLite resolves the bare `roomId` and `room.name`
+	 * against the row that supplied `MAX(intervalStart)` (documented bare-column behaviour alongside a
+	 * single min/max aggregate), which is why that aggregate is selected even though nothing reads it.
+	 * The kWh is still the device's whole total for the scope asked about — splitting the row would
+	 * report the same device twice in a list the panel renders as one tile per device.
 	 */
 	async getSpaceBreakdown(
 		rangeStart: Date,
@@ -508,12 +550,13 @@ export class EnergyDataService {
 		const query = `
 			SELECT delta."deviceId" AS "deviceId",
 			       device."name" AS "deviceName",
-			       device."roomId" AS "roomId",
+			       delta."roomId" AS "roomId",
 			       room."name" AS "roomName",
+			       MAX(delta."intervalStart") AS "lastIntervalStart",
 			       SUM(delta."deltaKwh") AS "totalKwh"
 			FROM energy_module_deltas delta
-			INNER JOIN devices_module_devices device ON delta."deviceId" = device."id"
-			LEFT JOIN spaces_module_spaces room ON device."roomId" = room."id"
+			LEFT JOIN devices_module_devices device ON delta."deviceId" = device."id"
+			LEFT JOIN spaces_module_spaces room ON delta."roomId" = room."id"
 			WHERE delta."sourceType" = ?
 			AND delta."intervalStart" >= ?
 			AND delta."intervalStart" < ?

--- a/apps/backend/src/modules/energy/services/energy-space-history.spec.ts
+++ b/apps/backend/src/modules/energy/services/energy-space-history.spec.ts
@@ -1,0 +1,185 @@
+import { DataSource, Repository } from 'typeorm';
+
+import { ThirdPartyDeviceEntity } from '../../../plugins/devices-third-party/entities/devices-third-party.entity';
+import { RoomSpaceEntity } from '../../../plugins/spaces-home-control/entities/room-space.entity';
+import { ZoneSpaceEntity } from '../../../plugins/spaces-home-control/entities/zone-space.entity';
+import { DeviceCategory } from '../../devices/devices.constants';
+import { EnergySourceType } from '../energy.constants';
+import { EnergyDeltaEntity } from '../entities/energy-delta.entity';
+
+import { EnergyDataService } from './energy-data.service';
+
+/**
+ * What a space's energy history is a claim about.
+ *
+ * Every delta carries the room it was recorded in, and the space readers used to ignore it: they
+ * reached the room by joining the device's *current* `roomId`, so moving a device rewrote its past
+ * between spaces and deleting one erased that past outright. Splitting a device into rooms makes both
+ * routine — the whole point of a split is that devices move — so a fix that promised stable history
+ * while the read path contradicted it would be promising nothing.
+ *
+ * Driven against sqlite through the real service, because every claim here is about what the SQL
+ * does: which join decides the room, whether a missing row drops a total, and what the upsert does
+ * with a bucket that is still open when the device moves.
+ */
+describe('energy history across a room change', () => {
+	let dataSource: DataSource;
+	let service: EnergyDataService;
+	let deltas: Repository<EnergyDeltaEntity>;
+
+	const RANGE_START = new Date('2026-08-01T00:00:00.000Z');
+	const RANGE_END = new Date('2026-08-02T00:00:00.000Z');
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [__dirname + '/../../../**/*.entity.ts'],
+			synchronize: true,
+		});
+
+		await dataSource.initialize();
+
+		deltas = dataSource.getRepository(EnergyDeltaEntity);
+		service = new EnergyDataService(deltas);
+
+		await dataSource.getRepository(ZoneSpaceEntity).insert({ id: 'upstairs', name: 'Upstairs' } as never);
+		await dataSource.getRepository(RoomSpaceEntity).insert([
+			{ id: 'kitchen', name: 'Kitchen' },
+			{ id: 'office', name: 'Office', parentId: 'upstairs' },
+			{ id: 'bedroom', name: 'Bedroom', parentId: 'upstairs' },
+		] as never);
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	const givenDevice = async (id: string, roomId: string | null): Promise<void> => {
+		await dataSource
+			.getRepository(ThirdPartyDeviceEntity)
+			.insert({ id, category: DeviceCategory.GENERIC, name: id, roomId } as never);
+	};
+
+	const moveDevice = async (id: string, roomId: string | null): Promise<void> => {
+		await dataSource.getRepository(ThirdPartyDeviceEntity).update({ id }, { roomId });
+	};
+
+	const recorded = async (deviceId: string, roomId: string | null, kwh: number, at: string): Promise<void> => {
+		const intervalStart = new Date(at);
+
+		await service.saveDelta({
+			deviceId,
+			roomId,
+			sourceType: EnergySourceType.CONSUMPTION_IMPORT,
+			deltaKwh: kwh,
+			intervalStart,
+			intervalEnd: new Date(intervalStart.getTime() + 5 * 60 * 1000),
+		});
+	};
+
+	const consumptionOf = async (spaceId?: string): Promise<number> =>
+		(await service.getSpaceSummary(RANGE_START, RANGE_END, spaceId)).totalConsumptionKwh;
+
+	// The promise the task makes to anyone expecting a backfill, kept on the read side too: what was
+	// recorded in the kitchen stays the kitchen's, and only what comes after the move is the office's.
+	it('leaves a moved device’s consumption in the room that consumed it', async () => {
+		await givenDevice('heater', 'kitchen');
+		await recorded('heater', 'kitchen', 3, '2026-08-01T10:00:00.000Z');
+
+		await moveDevice('heater', 'office');
+		await recorded('heater', 'office', 4, '2026-08-01T11:00:00.000Z');
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(3);
+		await expect(consumptionOf('office')).resolves.toBe(4);
+		await expect(consumptionOf('home')).resolves.toBe(7);
+	});
+
+	// A zone reaches its rooms through the room row, which is a *current* fact and stays one: a room
+	// moved to another zone is the same room, and its history moves with it.
+	it('follows a room into the zone it belongs to now', async () => {
+		await givenDevice('lamp', 'office');
+		await recorded('lamp', 'office', 2, '2026-08-01T10:00:00.000Z');
+		await recorded('lamp', 'bedroom', 5, '2026-08-01T11:00:00.000Z');
+
+		await expect(consumptionOf('upstairs')).resolves.toBe(7);
+		await expect(consumptionOf('kitchen')).resolves.toBe(0);
+	});
+
+	// Deleting a device is not a reason for a room to forget what it consumed. The join that supplied
+	// the device's name used to drop the row entirely.
+	it('keeps a deleted device’s consumption in its room', async () => {
+		await givenDevice('kettle', 'kitchen');
+		await recorded('kettle', 'kitchen', 6, '2026-08-01T10:00:00.000Z');
+
+		await dataSource.getRepository(ThirdPartyDeviceEntity).delete({ id: 'kettle' });
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(6);
+
+		const breakdown = await service.getSpaceBreakdown(RANGE_START, RANGE_END, 'kitchen');
+
+		expect(breakdown).toEqual([expect.objectContaining({ deviceId: 'kettle', roomId: 'kitchen', consumptionKwh: 6 })]);
+	});
+
+	// One row per device, reporting the room it was last recorded in — the panel renders this list as
+	// one tile per device, and the same device twice would read as a duplicate rather than as history.
+	it('reports a moved device once, in the room it ended up in', async () => {
+		await givenDevice('heater', 'office');
+		await recorded('heater', 'office', 2, '2026-08-01T10:00:00.000Z');
+		await recorded('heater', 'bedroom', 5, '2026-08-01T11:00:00.000Z');
+
+		const breakdown = await service.getSpaceBreakdown(RANGE_START, RANGE_END, 'upstairs');
+
+		expect(breakdown).toEqual([
+			expect.objectContaining({ deviceId: 'heater', roomId: 'bedroom', roomName: 'Bedroom', consumptionKwh: 7 }),
+		]);
+	});
+
+	// The write side of the same promise. A bucket is open for five minutes, and a device that moves
+	// inside one used to go on filling the row the old room owns.
+	it('stops filling the old room’s bucket once the device has moved', async () => {
+		await givenDevice('heater', 'kitchen');
+		await recorded('heater', 'kitchen', 1, '2026-08-01T10:00:00.000Z');
+
+		await moveDevice('heater', 'office');
+		// Same interval, so the upsert lands on the row that already exists.
+		await recorded('heater', 'office', 2, '2026-08-01T10:00:00.000Z');
+
+		const stored = await deltas.find();
+
+		// One bucket still — the device and the interval are unchanged — carrying the room the device
+		// ended the interval in. Up to one interval of energy moves with it; the alternative is a
+		// nullable column in a unique key, which SQLite does not conflict against itself.
+		expect(stored).toHaveLength(1);
+		expect(stored[0].roomId).toBe('office');
+		expect(stored[0].deltaKwh).toBe(3);
+
+		await expect(consumptionOf('kitchen')).resolves.toBe(0);
+		await expect(consumptionOf('office')).resolves.toBe(3);
+	});
+
+	// A device in no room is not in any space, and must not be lost from the house total either.
+	it('counts an unassigned device at home and in no room', async () => {
+		await givenDevice('boiler', null);
+		await recorded('boiler', null, 8, '2026-08-01T10:00:00.000Z');
+
+		await expect(consumptionOf('home')).resolves.toBe(8);
+		await expect(consumptionOf('kitchen')).resolves.toBe(0);
+	});
+
+	// Charts are claims about the past, and one that redraws itself when a device changes room is
+	// claiming something that never happened.
+	it('does not redraw a room’s chart when a device leaves it', async () => {
+		await givenDevice('heater', 'kitchen');
+		await recorded('heater', 'kitchen', 3, '2026-08-01T10:00:00.000Z');
+
+		const before = await service.getSpaceTimeseries(RANGE_START, RANGE_END, '1h', 'kitchen');
+
+		await moveDevice('heater', 'office');
+
+		const after = await service.getSpaceTimeseries(RANGE_START, RANGE_END, '1h', 'kitchen');
+
+		expect(after).toEqual(before);
+		expect(after.reduce((total, point) => total + point.consumptionDeltaKwh, 0)).toBe(3);
+	});
+});

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -214,12 +214,10 @@ Build a device from properties of other devices — splitting one physical devic
 | # | Task | Scope | Status | Notes |
 |---|------|-------|--------|-------|
 | 1 | [FEATURE-DEVICE-VIRTUAL-PLUGIN](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md) | backend, admin, panel | :white_check_mark: Done | Backend plugin, admin wizard and detail page with remap, `hidden` filtering across every picker, panel rendering. The six closed-loop categories stay blocked by the design's v1 boundary |
-| 2 | [BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION](bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md) | backend | :clipboard: Planned | A split device's energy stays with the physical device, so the rooms it was split into report zero. Reproduced both ways in the task |
+| 2 | [BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION](bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md) | backend | :white_check_mark: Done | A projected meter now has one accountable claimant and is billed to the device presenting it; the space readers scope by the recorded room, so moving or deleting a device no longer rewrites its history |
 | 3 | [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) | backend | :clipboard: Planned | 25 of 36 items open, none blocking; several are pre-existing issues found in passing |
 
-**Next up:** [BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION](bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md) — it breaks the epic's own headline example, a 4PM split across four rooms, and the fix is blocked only on the single-claim decision the task recommends.
-
-**After that,** [controller support](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#controller-support), which unblocks the six closed-loop categories the v1 boundary excludes. It starts with a design rather than a task — a control loop touches safety, concurrency and the platform's command path — and the design spec now carries what that design has to answer.
+**Next up:** [controller support](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#controller-support), which unblocks the six closed-loop categories the v1 boundary excludes. It starts with a design rather than a task — a control loop touches safety, concurrency and the platform's command path — and the design spec now carries what that design has to answer. [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) is the other open thread, none of it blocking.
 
 ---
 

--- a/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md
+++ b/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md
@@ -5,7 +5,7 @@ Type: bug
 Scope: backend
 Size: medium
 Parent: EPIC-VIRTUAL-DEVICES
-Status: in-progress
+Status: done
 
 ## 1. Summary
 
@@ -243,11 +243,18 @@ fix must not introduce a lookup that assumes otherwise.
 
 ## 5. Acceptance criteria
 
-Split across two PRs. [#649](https://github.com/FastyBird/smart-panel/pull/649) does the claim and
-the attribution — everything below that is ticked. What is left is the *readers*: the space queries
-reach a room by joining the device's current `roomId` instead of the recorded `delta.roomId`, and
-`saveDelta` accumulates into a bucket keyed without the room. Both are pre-existing, neither is about
-attribution, and a split merely makes them routine.
+Delivered in two PRs. [#649](https://github.com/FastyBird/smart-panel/pull/649) did the claim and the
+attribution; the readers followed in the PR that closes this task — the space queries now scope by
+the recorded `delta.roomId` rather than by the device's current room, and a device that changes room
+mid-interval stops filling the bucket the old room owns.
+
+One trade taken deliberately, recorded here because the task left the choice open: the bucket
+*moves* with the device rather than splitting at the move. Splitting means the room joins the unique
+key, and a nullable column in a SQLite unique index does not conflict with itself — every reading
+from a device in no room would open its own row instead of accumulating — and the expression index
+that works around it is one the entity decorators cannot declare, which is how CI and the e2e suite
+build the schema. The residue is bounded by `DELTA_INTERVAL_MINUTES`: up to one interval recorded
+just before a move is attributed to the room the device ended it in.
 
 - [x] A delta for a projected energy property carries the projecting device's `deviceId` and `roomId`
 - [x] A device's unprojected energy channels still attribute to the device itself
@@ -293,9 +300,9 @@ attribution, and a split merely makes them routine.
       behaviour; the criterion is that the fix does not change it, and that an orphan therefore stops
       accruing rather than accruing in the wrong room, since no value reaches it once its meter is
       gone
-- [ ] Moving a projecting virtual device to another room leaves its recorded consumption in the room
+- [x] Moving a projecting virtual device to another room leaves its recorded consumption in the room
       it was recorded in, and deleting it does not erase that history from the space views
-- [ ] A reading that arrives after a move, inside the same interval bucket, is recorded against the
+- [x] A reading that arrives after a move, inside the same interval bucket, is recorded against the
       new room rather than accumulating into the old one
 - [x] Regression tests for the split case above and for the refusal — **not** for reproduction (a) as
       it stands: it projects one meter into two rooms, which the single-claim rule makes impossible to


### PR DESCRIPTION
Closes [`BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION`](../blob/main/tasks/bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md), the second and last of its two PRs. [#649](https://github.com/FastyBird/smart-panel/pull/649) made a projected meter accountable to the device presenting it; this one makes the *readers* agree.

## The defect

Every delta carries the room it was recorded in, and the space queries ignored it. They reached a room by joining the device's **current** `roomId`:

- **moving a device rewrote its past.** Yesterday's consumption left the room that actually consumed it and appeared in the new one — the opposite of the "history is not re-attributed" promise the task makes to anyone expecting a backfill;
- **deleting a device erased its history from every space view**, because the join that supplied the device's name was an inner join and simply dropped the rows.

Pre-existing — every physical device that ever changed rooms has the same shape — but a split makes it routine, since moving devices between rooms is the entire point of one. A fix that promised stable history while the read path contradicted it would be promising nothing.

## The fix

- **`getSpaceSummary`, `getSpaceTimeseries`, `getSpaceBreakdown` scope by `delta.roomId`.** What is pinned is which room consumed the energy.
- **The room's zone membership stays a *current* fact.** `parentId` is still read from the room row, because a room moved to another zone is the same room and its history moves with it. Only the device→room hop was ever the wrong one to follow.
- **The breakdown's device join becomes a LEFT join.** It supplies a name; a name that has gone away is no reason to drop the consumption from the total. One row per device still, reporting the room it was *last* recorded in — the panel renders this list as one tile per device, and the same device twice would read as a duplicate rather than as history.
- **The bucket stops filling the old room.** `saveDelta` accumulates into a row keyed `(deviceId, sourceType, intervalStart)`, so a device that changed room mid-interval went on adding to the row the old room owns. The room now comes along on conflict.

## The trade, taken deliberately

The task left the choice open — the room joins the conflict key, or the bucket splits at the move — and asked that one be chosen and tested. The bucket **moves**.

Splitting means the room joins the unique key, and a nullable column in a SQLite unique index does not conflict with itself: every reading from a device in no room would open its own row instead of accumulating, quietly turning one bucket per interval into one row per sample. The expression index that works around that (`COALESCE("roomId", '')`) is one the entity decorators cannot declare — and the decorators are how CI and the e2e suite build the schema, so it would exist in migrations and be missing exactly where the tests run.

So the residue is bounded by `DELTA_INTERVAL_MINUTES`: up to one interval recorded just before a move is attributed to the room the device ended it in. That falls on the side of where the operator has just put the device rather than where it used to be, which is the side to be wrong on.

## Tests

Seven against sqlite through the real service, because every claim here is about what the SQL does — which join decides the room, whether a missing row drops a total, what the upsert does with a bucket that is still open when the device moves. **Five fail on the behaviour they replace**; the other two pin behaviour that must not change (a room's zone membership stays current, and a device in no room is still counted at home).

A moved device's consumption stays in the room that consumed it (3 kWh kitchen, 4 kWh office, 7 at home); a deleted device keeps its consumption and its breakdown row; a moved device is reported once, in the room it ended up in; a reading after a move inside the same interval lands in the new room; and a room's chart does not redraw itself when a device leaves it.

3795 backend unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
