### PR TITLE
fix(backend): read a property's category from the specification, not a table

### DIFF
--- a/apps/backend/src/modules/devices/utils/schema.utils.spec.ts
+++ b/apps/backend/src/modules/devices/utils/schema.utils.spec.ts
@@ -21,14 +21,14 @@ describe('schema utils against the specification', () => {
 		const untranslated: string[] = [];
 
 		for (const channel of channels) {
-			const spec = channelsSchema[channel] as { properties?: Record<string, { category?: string }> };
+			const spec = channelsSchema[channel] as { properties?: Record<string, { category?: PropertyCategory }> };
 			const declared = Object.entries(spec.properties ?? {})
 				// `generic` is a channel's untyped escape hatch, not a category anything is matched against.
 				.filter(([, property]) => property.category !== PropertyCategory.GENERIC);
 			const reported = getAllProperties(channel).map((property) => property.category);
 
 			for (const [key, property] of declared) {
-				if (!reported.includes(property.category as PropertyCategory)) {
+				if (property.category && !reported.includes(property.category)) {
 					untranslated.push(`${channel}.${key}`);
 				}
 			}

--- a/apps/backend/src/modules/devices/utils/schema.utils.spec.ts
+++ b/apps/backend/src/modules/devices/utils/schema.utils.spec.ts
@@ -1,0 +1,101 @@
+import { channelsSchema } from '../../../spec/channels';
+import { ChannelCategory, PropertyCategory } from '../devices.constants';
+
+import { getAllProperties, getChannelConstraints, getPropertyMetadata, getRequiredProperties } from './schema.utils';
+
+/**
+ * These utilities are the only route from the specification into the rest of the backend: the
+ * virtual-device wizard offers what `getAllProperties` reports, `reportCompatibility` judges against
+ * `getPropertyMetadata`, and `DeviceValidationService` reads both. A key they cannot translate does
+ * not exist as far as any of that is concerned — which is what two hand-maintained tables did to a
+ * third of the specification, silently.
+ *
+ * So what is asserted here is coverage against the specification itself rather than a list of keys
+ * copied out of it: a test that named the properties it expected would be a third table to keep in
+ * step with the other two.
+ */
+describe('schema utils against the specification', () => {
+	const channels = Object.keys(channelsSchema) as ChannelCategory[];
+
+	it('translates every property the specification declares, in every channel', () => {
+		const untranslated: string[] = [];
+
+		for (const channel of channels) {
+			const spec = channelsSchema[channel] as { properties?: Record<string, { category?: string }> };
+			const declared = Object.entries(spec.properties ?? {})
+				// `generic` is a channel's untyped escape hatch, not a category anything is matched against.
+				.filter(([, property]) => property.category !== PropertyCategory.GENERIC);
+			const reported = getAllProperties(channel).map((property) => property.category);
+
+			for (const [key, property] of declared) {
+				if (!reported.includes(property.category as PropertyCategory)) {
+					untranslated.push(`${channel}.${key}`);
+				}
+			}
+		}
+
+		expect(untranslated).toEqual([]);
+	});
+
+	// The reverse direction, which had its own table and its own omissions: metadata is what a
+	// projection is judged against, so a property the wizard offers and the guard cannot describe is
+	// refused with a message that reads like a specification error.
+	it('describes every property it reports', () => {
+		const undescribed: string[] = [];
+
+		for (const channel of channels) {
+			for (const property of getAllProperties(channel)) {
+				if (getPropertyMetadata(channel, property.category) === null) {
+					undescribed.push(`${channel}.${property.category}`);
+				}
+			}
+		}
+
+		expect(undescribed).toEqual([]);
+	});
+
+	// A key is a name within a channel; the category is what the entry declares. They are usually the
+	// same and deliberately are not always, and translating the key gets that case wrong both ways —
+	// the wizard would offer a slot the metadata lookup then cannot find.
+	it('follows the declared category where it differs from the key', () => {
+		const categories = getAllProperties(ChannelCategory.INDICATOR).map((property) => property.category);
+
+		expect(categories).toContain(PropertyCategory.COLOR_RED);
+		expect(getPropertyMetadata(ChannelCategory.INDICATOR, PropertyCategory.COLOR_RED)).toEqual(
+			expect.objectContaining({ category: PropertyCategory.COLOR_RED, format: expect.any(Array) as string[] }),
+		);
+	});
+
+	// Spot checks on what was invisible, named because these are the ones the energy work ran into:
+	// the claim guard needs two energy slots to disagree and could only ever reach one.
+	it('reports the energy slots a virtual device could not reach', () => {
+		const categories = getAllProperties(ChannelCategory.ELECTRICAL_ENERGY).map((property) => property.category);
+
+		expect(categories).toEqual(expect.arrayContaining([PropertyCategory.GRID_IMPORT, PropertyCategory.GRID_EXPORT]));
+	});
+
+	it('requires what the specification marks required', () => {
+		expect(getRequiredProperties(ChannelCategory.ACCELEROMETER)).toEqual(
+			expect.arrayContaining([
+				PropertyCategory.ACCELERATION_X,
+				PropertyCategory.ACCELERATION_Y,
+				PropertyCategory.ACCELERATION_Z,
+			]),
+		);
+	});
+
+	// A constraint group names properties by key, and a key that could not be translated was dropped
+	// from the group — which quietly turned "aqi or level" into "level", refusing an air-quality
+	// channel that reports an index and no level.
+	it('keeps every property of a constraint group', () => {
+		expect(getChannelConstraints(ChannelCategory.AIR_QUALITY)?.oneOrMoreOf).toEqual([
+			[PropertyCategory.AQI, PropertyCategory.LEVEL],
+		]);
+	});
+
+	it('translates nothing for a channel the specification does not define', () => {
+		expect(getAllProperties('not-a-channel' as ChannelCategory)).toEqual([]);
+		expect(getRequiredProperties('not-a-channel' as ChannelCategory)).toEqual([]);
+		expect(getChannelConstraints('not-a-channel' as ChannelCategory)).toBeNull();
+	});
+});

--- a/apps/backend/src/modules/devices/utils/schema.utils.ts
+++ b/apps/backend/src/modules/devices/utils/schema.utils.ts
@@ -20,6 +20,8 @@ interface DataTypeVariantSpec {
  * Type for property spec from schema
  */
 interface PropertySpec {
+	/** The property category this entry declares, which is not always its key — see resolvePropertyCategory(). */
+	category?: string;
 	required?: boolean;
 	permissions?: string[];
 	data_type?: string;
@@ -89,33 +91,37 @@ interface ChannelConstraintsSpec {
  * @returns Channel constraints or null if none defined
  */
 export function getChannelConstraints(channelCategory: ChannelCategoryType): ChannelConstraints | null {
-	const channelSpec = channelsSchema[channelCategory] as { constraints?: ChannelConstraintsSpec } | undefined;
+	const channelSpec = channelsSchema[channelCategory] as
+		| { constraints?: ChannelConstraintsSpec; properties?: Record<string, PropertySpec> }
+		| undefined;
 
 	if (!channelSpec || typeof channelSpec !== 'object' || !channelSpec.constraints) {
 		return null;
 	}
 
 	const constraints = channelSpec.constraints;
+	// Constraint groups name properties by key, so they are resolved against the channel that declares
+	// them — the same scope `findPropertyKey` works in, and for the same reason.
+	const properties = channelSpec.properties ?? {};
+	const resolve = (key: string): PropertyCategory | null => resolvePropertyCategory(properties[key]);
 
 	const result: ChannelConstraints = {};
 
 	if (constraints.oneOf) {
 		result.oneOf = constraints.oneOf.map((group) =>
-			group.map((p) => mapPropertyCategory(p)).filter((p): p is PropertyCategory => p !== null),
+			group.map((p) => resolve(p)).filter((p): p is PropertyCategory => p !== null),
 		);
 	}
 
 	if (constraints.oneOrMoreOf) {
 		result.oneOrMoreOf = constraints.oneOrMoreOf.map((group) =>
-			group.map((p) => mapPropertyCategory(p)).filter((p): p is PropertyCategory => p !== null),
+			group.map((p) => resolve(p)).filter((p): p is PropertyCategory => p !== null),
 		);
 	}
 
 	if (constraints.mutuallyExclusiveGroups) {
 		result.mutuallyExclusiveGroups = constraints.mutuallyExclusiveGroups.map((groupPair) =>
-			groupPair.map((group) =>
-				group.map((p) => mapPropertyCategory(p)).filter((p): p is PropertyCategory => p !== null),
-			),
+			groupPair.map((group) => group.map((p) => resolve(p)).filter((p): p is PropertyCategory => p !== null)),
 		);
 	}
 
@@ -143,10 +149,9 @@ export function getRequiredProperties(channelCategory: ChannelCategoryType): Pro
 
 	const properties = channelSpec.properties;
 
-	for (const [propKey, propSpec] of Object.entries(properties)) {
+	for (const propSpec of Object.values(properties)) {
 		if (typeof propSpec === 'object' && propSpec.required === true) {
-			// Map property category string to PropertyCategory enum
-			const propertyCategory = mapPropertyCategory(propKey);
+			const propertyCategory = resolvePropertyCategory(propSpec);
 
 			if (propertyCategory) {
 				requiredProperties.push(propertyCategory);
@@ -173,8 +178,7 @@ export function getPropertyMetadata(
 		return null;
 	}
 
-	// Map PropertyCategory enum to schema property key
-	const propertyKey = mapPropertyCategoryToSchemaKey(propertyCategory);
+	const propertyKey = findPropertyKey(channelSpec.properties, propertyCategory);
 
 	if (!propertyKey) {
 		return null;
@@ -286,160 +290,58 @@ export function getPropertyDefaultValue(
 }
 
 /**
- * Map property category string from schema to PropertyCategory enum
- * Note: 'generic' is intentionally not mapped as it's not a valid property category
+ * Every category the devices module recognises, for checking what the specification declares.
+ *
+ * The specification is generated from the same YAML the enum is written against, so the two agree
+ * today; a key that arrives in the spec without a matching enum member is a translation gap, and
+ * answering null for it keeps the old behaviour — invisible — rather than inventing a category.
  */
-function mapPropertyCategory(key: string): PropertyCategory | null {
-	const mapping: Partial<Record<string, PropertyCategory>> = {
-		active: PropertyCategory.ACTIVE,
-		angle: PropertyCategory.ANGLE,
-		average_power: PropertyCategory.AVERAGE_POWER,
-		brightness: PropertyCategory.BRIGHTNESS,
-		color_blue: PropertyCategory.COLOR_BLUE,
-		color_green: PropertyCategory.COLOR_GREEN,
-		color_red: PropertyCategory.COLOR_RED,
-		color_temperature: PropertyCategory.COLOR_TEMPERATURE,
-		color_white: PropertyCategory.COLOR_WHITE,
-		command: PropertyCategory.COMMAND,
-		connection_type: PropertyCategory.CONNECTION_TYPE,
-		consumption: PropertyCategory.CONSUMPTION,
-		current: PropertyCategory.CURRENT,
-		concentration: PropertyCategory.CONCENTRATION,
-		detected: PropertyCategory.DETECTED,
-		direction: PropertyCategory.DIRECTION,
-		distance: PropertyCategory.DISTANCE,
-		duration: PropertyCategory.DURATION,
-		event: PropertyCategory.EVENT,
-		fault: PropertyCategory.FAULT,
-		firmware_revision: PropertyCategory.FIRMWARE_REVISION,
-		frequency: PropertyCategory.FREQUENCY,
-		hardware_revision: PropertyCategory.HARDWARE_REVISION,
-		hue: PropertyCategory.HUE,
-		humidity: PropertyCategory.HUMIDITY,
-		illuminance: PropertyCategory.ILLUMINANCE,
-		in_use: PropertyCategory.IN_USE,
-		infrared: PropertyCategory.INFRARED,
-		level: PropertyCategory.LEVEL,
-		link_quality: PropertyCategory.LINK_QUALITY,
-		locked: PropertyCategory.LOCKED,
-		manufacturer: PropertyCategory.MANUFACTURER,
-		model: PropertyCategory.MODEL,
-		mode: PropertyCategory.MODE,
-		obstruction: PropertyCategory.OBSTRUCTION,
-		on: PropertyCategory.ON,
-		over_current: PropertyCategory.OVER_CURRENT,
-		over_voltage: PropertyCategory.OVER_VOLTAGE,
-		over_power: PropertyCategory.OVER_POWER,
-		pan: PropertyCategory.PAN,
-		peak_level: PropertyCategory.PEAK_LEVEL,
-		percentage: PropertyCategory.PERCENTAGE,
-		position: PropertyCategory.POSITION,
-		power: PropertyCategory.POWER,
-		pressure: PropertyCategory.PRESSURE,
-		production: PropertyCategory.PRODUCTION,
-		rate: PropertyCategory.RATE,
-		remaining: PropertyCategory.REMAINING,
-		remote_key: PropertyCategory.REMOTE_KEY,
-		saturation: PropertyCategory.SATURATION,
-		siren: PropertyCategory.SIREN,
-		serial_number: PropertyCategory.SERIAL_NUMBER,
-		source: PropertyCategory.SOURCE,
-		source_label: PropertyCategory.SOURCE_LABEL,
-		state: PropertyCategory.STATE,
-		speed: PropertyCategory.SPEED,
-		status: PropertyCategory.STATUS,
-		swing: PropertyCategory.SWING,
-		tampered: PropertyCategory.TAMPERED,
-		temperature: PropertyCategory.TEMPERATURE,
-		tilt: PropertyCategory.TILT,
-		triggered: PropertyCategory.TRIGGERED,
-		track: PropertyCategory.TRACK,
-		type: PropertyCategory.TYPE,
-		voltage: PropertyCategory.VOLTAGE,
-		volume: PropertyCategory.VOLUME,
-		zoom: PropertyCategory.ZOOM,
-	};
+const PROPERTY_CATEGORIES = new Set<string>(Object.values(PropertyCategory));
 
-	return mapping[key] ?? null;
+/**
+ * The category a specification entry declares, or null when it declares none this module knows.
+ *
+ * Read from the entry rather than translated from its key, which is what the two hand-maintained
+ * tables here used to do — one per direction, 67 of the specification's 100 keys between them. Every
+ * key they omitted was simply invisible: `getAllProperties()` dropped it, so the virtual-device
+ * wizard never offered `grid_import`, `grid_export`, `mute`, the media metadata or 29 others, and
+ * `reportCompatibility` refused a projection into one with "channel category X has no Y property in
+ * its specification" — a sentence that reads like a specification error and was a translation gap.
+ * `DeviceValidationService` could not see them either.
+ *
+ * A table that has to be extended by hand every time the specification grows is a table that will
+ * drift again, and the spec already states the answer: each entry carries its own `category`, which
+ * is usually its key and deliberately is not always — `indicator.color` declares `color_red`, and
+ * translating the key gets that one wrong in both directions.
+ *
+ * `generic` stays unmapped on purpose: it is a channel's untyped escape hatch rather than a category
+ * anything can be matched against.
+ */
+function resolvePropertyCategory(spec: PropertySpec | undefined): PropertyCategory | null {
+	const category = spec?.category;
+
+	if (!category || !PROPERTY_CATEGORIES.has(category)) {
+		return null;
+	}
+
+	const resolved = category as PropertyCategory;
+
+	return resolved === PropertyCategory.GENERIC ? null : resolved;
 }
 
 /**
- * Map PropertyCategory enum to schema property key
- * Note: GENERIC is intentionally not mapped as it's not a valid property category
+ * The key a channel files a category under — the reverse of the above, and channel-scoped because
+ * that is the only scope in which it is well defined: the same category is reached through different
+ * keys in different channels.
  */
-function mapPropertyCategoryToSchemaKey(category: PropertyCategory): string | null {
-	const mapping: Partial<Record<PropertyCategory, string>> = {
-		[PropertyCategory.ACTIVE]: 'active',
-		[PropertyCategory.ANGLE]: 'angle',
-		[PropertyCategory.AVERAGE_POWER]: 'average_power',
-		[PropertyCategory.BRIGHTNESS]: 'brightness',
-		[PropertyCategory.COLOR_BLUE]: 'color_blue',
-		[PropertyCategory.COLOR_GREEN]: 'color_green',
-		[PropertyCategory.COLOR_RED]: 'color_red',
-		[PropertyCategory.COLOR_TEMPERATURE]: 'color_temperature',
-		[PropertyCategory.COLOR_WHITE]: 'color_white',
-		[PropertyCategory.COMMAND]: 'command',
-		[PropertyCategory.CONNECTION_TYPE]: 'connection_type',
-		[PropertyCategory.CONSUMPTION]: 'consumption',
-		[PropertyCategory.CURRENT]: 'current',
-		[PropertyCategory.CONCENTRATION]: 'concentration',
-		[PropertyCategory.DETECTED]: 'detected',
-		[PropertyCategory.DIRECTION]: 'direction',
-		[PropertyCategory.DISTANCE]: 'distance',
-		[PropertyCategory.DURATION]: 'duration',
-		[PropertyCategory.EVENT]: 'event',
-		[PropertyCategory.FAULT]: 'fault',
-		[PropertyCategory.FIRMWARE_REVISION]: 'firmware_revision',
-		[PropertyCategory.FREQUENCY]: 'frequency',
-		[PropertyCategory.HARDWARE_REVISION]: 'hardware_revision',
-		[PropertyCategory.HUE]: 'hue',
-		[PropertyCategory.HUMIDITY]: 'humidity',
-		[PropertyCategory.ILLUMINANCE]: 'illuminance',
-		[PropertyCategory.IN_USE]: 'in_use',
-		[PropertyCategory.INFRARED]: 'infrared',
-		[PropertyCategory.LEVEL]: 'level',
-		[PropertyCategory.LINK_QUALITY]: 'link_quality',
-		[PropertyCategory.LOCKED]: 'locked',
-		[PropertyCategory.MANUFACTURER]: 'manufacturer',
-		[PropertyCategory.MODEL]: 'model',
-		[PropertyCategory.MODE]: 'mode',
-		[PropertyCategory.MUTE]: 'mute',
-		[PropertyCategory.OBSTRUCTION]: 'obstruction',
-		[PropertyCategory.ON]: 'on',
-		[PropertyCategory.OVER_CURRENT]: 'over_current',
-		[PropertyCategory.OVER_VOLTAGE]: 'over_voltage',
-		[PropertyCategory.OVER_POWER]: 'over_power',
-		[PropertyCategory.PAN]: 'pan',
-		[PropertyCategory.PEAK_LEVEL]: 'peak_level',
-		[PropertyCategory.PERCENTAGE]: 'percentage',
-		[PropertyCategory.POSITION]: 'position',
-		[PropertyCategory.POWER]: 'power',
-		[PropertyCategory.PRESSURE]: 'pressure',
-		[PropertyCategory.PRODUCTION]: 'production',
-		[PropertyCategory.RATE]: 'rate',
-		[PropertyCategory.REMAINING]: 'remaining',
-		[PropertyCategory.REMOTE_KEY]: 'remote_key',
-		[PropertyCategory.SATURATION]: 'saturation',
-		[PropertyCategory.SIREN]: 'siren',
-		[PropertyCategory.SERIAL_NUMBER]: 'serial_number',
-		[PropertyCategory.SOURCE]: 'source',
-		[PropertyCategory.SOURCE_LABEL]: 'source_label',
-		[PropertyCategory.STATE]: 'state',
-		[PropertyCategory.SPEED]: 'speed',
-		[PropertyCategory.STATUS]: 'status',
-		[PropertyCategory.SWING]: 'swing',
-		[PropertyCategory.TAMPERED]: 'tampered',
-		[PropertyCategory.TEMPERATURE]: 'temperature',
-		[PropertyCategory.TILT]: 'tilt',
-		[PropertyCategory.TRIGGERED]: 'triggered',
-		[PropertyCategory.TRACK]: 'track',
-		[PropertyCategory.TYPE]: 'type',
-		[PropertyCategory.VOLTAGE]: 'voltage',
-		[PropertyCategory.VOLUME]: 'volume',
-		[PropertyCategory.ZOOM]: 'zoom',
-	};
+function findPropertyKey(properties: Record<string, PropertySpec>, propertyCategory: PropertyCategory): string | null {
+	for (const [key, spec] of Object.entries(properties)) {
+		if (resolvePropertyCategory(spec) === propertyCategory) {
+			return key;
+		}
+	}
 
-	return mapping[category] ?? null;
+	return null;
 }
 
 /**
@@ -728,8 +630,8 @@ export function getAllProperties(channelCategory: ChannelCategoryType): Property
 
 	const properties: PropertyMetadata[] = [];
 
-	for (const [propKey, propSpec] of Object.entries(channelSpec.properties)) {
-		const propertyCategory = mapPropertyCategory(propKey);
+	for (const propSpec of Object.values(channelSpec.properties)) {
+		const propertyCategory = resolvePropertyCategory(propSpec);
 
 		if (propertyCategory) {
 			// Check if this is a multi-datatype property

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -215,7 +215,7 @@ Build a device from properties of other devices — splitting one physical devic
 |---|------|-------|--------|-------|
 | 1 | [FEATURE-DEVICE-VIRTUAL-PLUGIN](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md) | backend, admin, panel | :white_check_mark: Done | Backend plugin, admin wizard and detail page with remap, `hidden` filtering across every picker, panel rendering. The six closed-loop categories stay blocked by the design's v1 boundary |
 | 2 | [BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION](bugs/BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION.md) | backend | :white_check_mark: Done | A projected meter now has one accountable claimant and is billed to the device presenting it; the space readers scope by the recorded room, so moving or deleting a device no longer rewrites its history |
-| 3 | [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) | backend | :clipboard: Planned | 25 of 36 items open, none blocking; several are pre-existing issues found in passing |
+| 3 | [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) | backend | :clipboard: Planned | 25 of 38 items open, none blocking; several are pre-existing issues found in passing |
 
 **Next up:** [controller support](../docs/superpowers/specs/2026-07-31-virtual-devices-design.md#controller-support), which unblocks the six closed-loop categories the v1 boundary excludes. It starts with a design rather than a task — a control loop touches safety, concurrency and the platform's command path — and the design spec now carries what that design has to answer. [TECH-VIRTUAL-DEVICES-FOLLOWUPS](technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) is the other open thread, none of it blocking.
 

--- a/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
+++ b/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
@@ -249,13 +249,15 @@ Fixing it means deciding, in the provider, which of the two channels represents 
 
 The same shape almost certainly applies to any other provider or module that scans `devices → channels → properties` and aggregates per match; only the security sensors provider was checked.
 
-### 3.8 Two virtual properties projecting one non-qualifying source both ingest (low)
+### 3.8 Two virtual properties projecting one non-qualifying source both ingest (low) — DONE
 
 `EnergyIngestionListener`'s projection guard was narrowed in round 5 to "skip only when the *source* event was itself eligible" — the same asymmetry as §3.7's, found in energy after the security one: a `consumption` property in a `generic` channel projected into an `electrical_energy` one was ingested by nobody, because the source event failed the `SOURCE_TYPE_MAP` lookup and the guard discarded the only event carrying the qualifying classification. Unlike the security case the guard could not simply be removed — `processPropertyValue()` writes one delta per event, so a source and a projection that both qualify would genuinely bill the same kWh twice.
 
 One residual case is knowingly left: if **two** virtual properties project the *same* non-qualifying source into two qualifying channels, both ingest. Each has its own `(deviceId, channelId)` delta key, so they are two meters as far as `DeltaComputationService` is concerned, and the household total counts the watts twice.
 
-It is out of reach of the rule as stated — the guard is a per-event question about the source, and "am I the only projection of this source that qualifies?" is a question about the *set* of projections, which only `VirtualPropertyIndexService` can answer and which the energy module has no business reaching into. Fixing it means either an election (lowest property id wins) or moving de-duplication into `DeltaComputationService`, keyed by storage key rather than by device+channel. Both are larger than the defect: it needs a user to deliberately wire one physical meter into two virtual devices, and unlike the dropped-meter case it is visible — an inflated total, not a silent omission.
+It is out of reach of the rule as stated — the guard is a per-event question about the source, and "am I the only projection of this source that qualifies?" is a question about the *set* of projections, which only `VirtualPropertyIndexService` can answer and which the energy module has no business reaching into.
+
+Closed by `BUG-ENERGY-VIRTUAL-ROOM-ATTRIBUTION` (#649), which had to answer the same question for attribution and answered it once for both. The election this predicted is the energy claim: one projection per meter holds it, the losing projections are skipped, and the energy module asks across a registry rather than reaching into the plugin's index.
 
 ## 3a. Deferred from the admin branch
 
@@ -317,17 +319,21 @@ What is left is a policy question, and it is not the mapping feature's to answer
 
 `channels.store.ts` and `channels.properties.store.ts` have the same exposure in a milder form: they merge (`data.value = { ...data.value, ...channels }`) rather than replace, so nothing is evicted, but a snapshot assembled before a socket update still overwrites that update's row. Nothing in the virtual-device flows depends on it today, and the fix is the same stamp-and-compare shape, worth doing once across the three stores rather than twice.
 
-### 3.9 `mapPropertyCategory` omits a third of the specification (medium, pre-existing)
+### 3.9 `mapPropertyCategory` omits a third of the specification (medium, pre-existing) — DONE
 
-`schema.utils.ts`'s `mapPropertyCategory` translates a spec property key into a `PropertyCategory`, and 34 of the specification's 100 keys are missing from it — `grid_import`, `grid_export`, `mute`, `repeat`, `shuffle`, `child_lock`, `alarm_state`, `aqi`, the three `acceleration_*`, the media metadata (`album`, `artist`, `artwork_url`, `media_type`), the water-tank family, and more.
+`schema.utils.ts` carried two hand-maintained tables translating between a spec property key and a `PropertyCategory`, one per direction, and 33 of the specification's 100 keys were in neither — `grid_import`, `grid_export`, `mute`, `repeat`, `shuffle`, `child_lock`, `alarm_state`, `aqi`, the three `acceleration_*`, the media metadata (`album`, `artist`, `artwork_url`, `media_type`), the water-tank family, and more.
 
-`getAllProperties()` drops every unmapped key, so those slots do not exist as far as anything built on it is concerned. For virtual devices that means the wizard never offers them and `reportCompatibility` refuses a projection into one with "channel category X has no Y property in its specification" — a sentence that reads like a spec error and is actually a translation gap. `DeviceValidationService` reads the same utils, so structural validation cannot see them either.
+`getAllProperties()` dropped every unmapped key, so those slots did not exist as far as anything built on it was concerned. The admin has always read `prop.category` straight from the spec, so the wizard *offered* them and the backend then refused the projection with "channel category X has no Y property in its specification" — a sentence that reads like a spec error and was a translation gap. `DeviceValidationService` reads the same utils, so structural validation could not see them either, and a constraint group naming an unmapped key silently lost that member: `air_quality`'s "aqi or level" was enforced as "level".
 
-Found while writing the energy-claim guard, which needs two energy slots to disagree and can only reach one.
+Found while writing the energy-claim guard, which needs two energy slots to disagree and could only reach one.
+
+Fixed by deleting both tables. Each spec entry already declares its own `category`, so the translation is a read rather than a lookup, and it cannot drift as the specification grows — the reverse direction became channel-scoped, which is the only scope in which it is well defined. It also fixed a case neither table could express: `indicator.color` declares `color_red`, and translating the key got it wrong in both directions.
 
 ### 3.10 No device category declares an `electrical_generation` channel (low, pre-existing)
 
 `spec/devices/devices.yaml` lists `electrical_generation` on no device at all, so the channel — and its `production` property, which the energy module classifies as `generation_production` — cannot appear on any device, virtual or physical. Either a category should carry it (a solar inverter has no home today) or the energy module's mapping for it is dead code. Worth deciding rather than leaving as an asymmetry.
+
+Narrower since §3.9: `grid_import` and `grid_export` are reachable now, so the energy cross-type guard is live for the grid pair rather than dormant. What remains unreachable is generation.
 
 ### 3a.6 Test-coverage gaps (low)
 


### PR DESCRIPTION
Closes follow-up [`3.9`](../blob/main/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md), found while writing the energy-claim guard in #649 — which needs two energy slots to disagree and could only ever reach one.

## The defect

`schema.utils.ts` translated between a specification property key and a `PropertyCategory` through two hand-maintained tables, one per direction. **33 of the specification's 100 keys were in neither**: `grid_import`, `grid_export`, `mute`, `repeat`, `shuffle`, `child_lock`, `alarm_state`, `aqi`, the three `acceleration_*`, the media metadata (`album`, `artist`, `artwork_url`, `media_type`), the water-tank family, and more.

Every consumer reads those utils, so an untranslated key simply did not exist:

- the admin has always read `prop.category` straight from the spec, so the **wizard offered those slots** and the backend then refused the projection with *"channel category X has no Y property in its specification"* — a sentence that reads like a specification error and was a translation gap;
- `DeviceValidationService` could not see them, so structural validation skipped them;
- **a constraint group naming an unmapped key silently lost that member.** `air_quality`'s `oneOrMoreOf: [[aqi, level]]` was enforced as `[[level]]` — an air-quality channel reporting an index and no level was refused.

## The fix

Both tables are deleted. Each spec entry already declares its own `category`, so the translation is a read rather than a lookup — and one that cannot drift as the specification grows, which is the property the tables lacked.

The reverse direction (category → key) became **channel-scoped**, which is the only scope in which it is well defined. That is also what lets `indicator.color` work: it is the one entry whose key and declared category differ (`color` / `color_red`), and translating the key got it wrong in both directions — the wizard offered a slot whose metadata lookup then found nothing.

## What changes behaviour

Measured against the specification rather than assumed:

- **Three properties become required** that were invisible before: `accelerometer.acceleration_x/y/z`. The only producer of accelerometer channels is the ReTerminal plugin, and it already creates all three.
- **One constraint group is relaxed**, never tightened: `air_quality` goes back to "aqi or level".
- **`indicator.color` resolves to `COLOR_RED`** in both directions.
- 33 keys become visible to `getAllProperties`, `getRequiredProperties`, `getPropertyMetadata` and the validation built on them.

No specification, DTO or decorator changed, so nothing regenerates.

## Knock-on for #649

`grid_import` and `grid_export` are reachable now, so the energy cross-type guard that shipped dormant — a projection may not present an import as an export — is live for the grid pair. Follow-up 3.10 (no device category declares an `electrical_generation` channel) is what still makes generation unreachable, and it is a specification decision rather than a code one.

## Tests

Seven, asserting **coverage against the specification itself** rather than a list of keys copied out of it — a test naming the properties it expected would be a third table to keep in step with the other two. Every property every channel declares is translated; everything reported can then be described; the declared category wins where it differs from the key; the energy slots and the required accelerometer trio are named as spot checks; the constraint group keeps both members; and an unknown channel still translates to nothing.

**Five of the seven fail on the tables they replace.** 3828 backend unit tests and the plugin's 56 e2e cases green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
