### PR TITLE
feat(backend): add OAuth resource validation

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -61,6 +61,7 @@ import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.ser
 import { McpOAuthProxyPolicyService } from './services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from './services/mcp-oauth-public-url.service';
 import { McpOAuthRefreshTokenService } from './services/mcp-oauth-refresh-token.service';
+import { McpOAuthResourceServerService } from './services/mcp-oauth-resource-server.service';
 import { McpOAuthRuntimeService } from './services/mcp-oauth-runtime.service';
 import { McpPolicyService } from './services/mcp-policy.service';
 import { McpServerService } from './services/mcp-server.service';
@@ -115,6 +116,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
 		McpOAuthRefreshTokenService,
+		McpOAuthResourceServerService,
 		McpOAuthRuntimeService,
 		McpPolicyService,
 		McpServerService,
@@ -145,6 +147,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
 		McpOAuthRefreshTokenService,
+		McpOAuthResourceServerService,
 		McpOAuthRuntimeService,
 		McpPolicyService,
 		McpServerService,

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-metadata.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-metadata.ts
@@ -1,0 +1,33 @@
+import { AuthorizationServerMetadata } from '@modelcontextprotocol/server';
+
+import { McpOAuthScope } from '../mcp.constants';
+
+import { McpOAuthPublicUrls } from './mcp-oauth.types';
+
+export type McpOAuthAuthorizationServerMetadata = AuthorizationServerMetadata & {
+	issuer: string;
+	authorization_endpoint: string;
+	token_endpoint: string;
+	revocation_endpoint: string;
+	response_types_supported: string[];
+	grant_types_supported: string[];
+	code_challenge_methods_supported: string[];
+	scopes_supported: string[];
+	token_endpoint_auth_methods_supported: string[];
+	authorization_response_iss_parameter_supported: boolean;
+};
+
+export const buildMcpOAuthAuthorizationServerMetadata = (
+	urls: McpOAuthPublicUrls,
+): McpOAuthAuthorizationServerMetadata => ({
+	issuer: urls.issuer,
+	authorization_endpoint: urls.authorizationEndpoint,
+	token_endpoint: urls.tokenEndpoint,
+	revocation_endpoint: urls.revocationEndpoint,
+	response_types_supported: ['code'],
+	grant_types_supported: ['authorization_code', 'refresh_token'],
+	code_challenge_methods_supported: ['S256'],
+	scopes_supported: Object.values(McpOAuthScope),
+	token_endpoint_auth_methods_supported: ['none'],
+	authorization_response_iss_parameter_supported: true,
+});

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -15,24 +15,12 @@ import {
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
 
+import { McpOAuthAuthorizationServerMetadata, buildMcpOAuthAuthorizationServerMetadata } from './mcp-oauth-metadata';
 import { createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
 import { loadMcpOAuthProvider } from './mcp-oauth-provider.loader';
 import { McpOAuthPublicUrls } from './mcp-oauth.types';
 
 const toSeconds = (milliseconds: number): number => Math.floor(milliseconds / 1_000);
-
-export interface McpOAuthAuthorizationServerMetadata {
-	issuer: string;
-	authorization_endpoint: string;
-	token_endpoint: string;
-	revocation_endpoint: string;
-	response_types_supported: string[];
-	grant_types_supported: string[];
-	code_challenge_methods_supported: string[];
-	scopes_supported: string[];
-	token_endpoint_auth_methods_supported: string[];
-	authorization_response_iss_parameter_supported: boolean;
-}
 
 export interface McpOAuthProviderRuntime {
 	provider: Provider;
@@ -220,7 +208,7 @@ export class McpOAuthProviderFactory {
 			});
 		};
 
-		return { provider, callback, urls, metadata: this.projectMetadata(urls) };
+		return { provider, callback, urls, metadata: buildMcpOAuthAuthorizationServerMetadata(urls) };
 	}
 
 	assertTokenRequestResource(parameters: URLSearchParams): void {
@@ -229,21 +217,6 @@ export class McpOAuthProviderFactory {
 		if ((grantType === 'authorization_code' || grantType === 'refresh_token') && !parameters.get('resource')) {
 			throw new Error('invalid_target: The MCP resource parameter is required at the token endpoint');
 		}
-	}
-
-	private projectMetadata(urls: McpOAuthPublicUrls): McpOAuthAuthorizationServerMetadata {
-		return {
-			issuer: urls.issuer,
-			authorization_endpoint: urls.authorizationEndpoint,
-			token_endpoint: urls.tokenEndpoint,
-			revocation_endpoint: urls.revocationEndpoint,
-			response_types_supported: ['code'],
-			grant_types_supported: ['authorization_code', 'refresh_token'],
-			code_challenge_methods_supported: ['S256'],
-			scopes_supported: Object.values(McpOAuthScope),
-			token_endpoint_auth_methods_supported: ['none'],
-			authorization_response_iss_parameter_supported: true,
-		};
 	}
 
 	private async dispatchProviderRequest(

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-scope.utils.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-scope.utils.ts
@@ -1,0 +1,25 @@
+import { McpCapability, McpOAuthScope } from '../mcp.constants';
+
+export const toMcpCapability = (scope: McpOAuthScope): McpCapability | undefined => {
+	switch (scope) {
+		case McpOAuthScope.READ:
+			return McpCapability.READ;
+		case McpOAuthScope.WRITE:
+			return McpCapability.WRITE;
+		case McpOAuthScope.TRIGGER:
+			return McpCapability.TRIGGER;
+		case McpOAuthScope.OFFLINE_ACCESS:
+			return undefined;
+	}
+};
+
+export const toMcpOAuthScope = (capability: McpCapability): McpOAuthScope => {
+	switch (capability) {
+		case McpCapability.READ:
+			return McpOAuthScope.READ;
+		case McpCapability.WRITE:
+			return McpOAuthScope.WRITE;
+		case McpCapability.TRIGGER:
+			return McpOAuthScope.TRIGGER;
+	}
+};

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
@@ -1,4 +1,4 @@
-import { MCP_OAUTH_PRINCIPAL_TYPE, McpOAuthScope } from '../mcp.constants';
+import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
 
 export interface McpOAuthPrincipal {
 	type: typeof MCP_OAUTH_PRINCIPAL_TYPE;
@@ -8,6 +8,7 @@ export interface McpOAuthPrincipal {
 	installationId: string;
 	refreshFamilyId?: string;
 	scopes: McpOAuthScope[];
+	effectiveCapabilities: McpCapability[];
 }
 
 export interface McpOAuthPublicUrls {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-client.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-client.service.ts
@@ -7,16 +7,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ConfigService } from '../../config/services/config.service';
 import { CreateMcpOAuthClientDto, UpdateMcpOAuthClientDto } from '../dto/mcp-oauth-client.dto';
 import { McpOAuthClientEntity } from '../entities/mcp-oauth.entity';
-import { MCP_MODULE_NAME, McpCapability, McpOAuthScope } from '../mcp.constants';
+import { MCP_MODULE_NAME, McpOAuthScope } from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
 import { McpOAuthClientModel } from '../models/mcp-oauth-client.model';
+import { toMcpCapability } from '../oauth/mcp-oauth-scope.utils';
 import { matchesMcpOAuthRedirectUri } from '../validators/is-mcp-oauth-redirect-uri.validator';
-
-const scopeCapability = new Map<McpOAuthScope, McpCapability>([
-	[McpOAuthScope.READ, McpCapability.READ],
-	[McpOAuthScope.WRITE, McpCapability.WRITE],
-	[McpOAuthScope.TRIGGER, McpCapability.TRIGGER],
-]);
 
 @Injectable()
 export class McpOAuthClientService {
@@ -98,7 +93,7 @@ export class McpOAuthClientService {
 		const disallowed = scopes.filter((scope) => {
 			if (scope === McpOAuthScope.OFFLINE_ACCESS) return false;
 
-			const capability = scopeCapability.get(scope);
+			const capability = toMcpCapability(scope);
 
 			return capability === undefined || !ceiling.includes(capability);
 		});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
@@ -1,0 +1,270 @@
+import { Repository } from 'typeorm';
+
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import { ConfigService } from '../../config/services/config.service';
+import { UserRole } from '../../users/users.constants';
+import {
+	McpOAuthGrantEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRevokedGrantEntity,
+} from '../entities/mcp-oauth.entity';
+import { McpCapability, McpOAuthScope } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+import { McpOAuthPublicUrls } from '../oauth/mcp-oauth.types';
+
+import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthPublicUrlService } from './mcp-oauth-public-url.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
+
+const RAW_TOKEN = 'opaque-access-token';
+const PROVIDER_GRANT_ID = 'provider-grant-id';
+const TOKEN_ID = hashToken(RAW_TOKEN);
+const PROVIDER_GRANT_ID_HASH = hashToken(PROVIDER_GRANT_ID);
+const INSTALLATION_ID = 'installation-id';
+const CLIENT_IDENTIFIER = 'public-client-id';
+const APPROVER_ID = 'approver-id';
+
+const urls: McpOAuthPublicUrls = {
+	publicBaseUrl: 'https://panel.example.com/smart-panel',
+	resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
+	protectedResourceMetadata:
+		'https://panel.example.com/.well-known/oauth-protected-resource/smart-panel/api/v1/modules/mcp',
+	issuer: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth',
+	authorizationServerMetadata:
+		'https://panel.example.com/.well-known/oauth-authorization-server/smart-panel/api/v1/modules/mcp/oauth',
+	authorizationEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/authorize',
+	tokenEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token',
+	revocationEndpoint: 'https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token/revocation',
+};
+
+describe('McpOAuthResourceServerService', () => {
+	let artifact: McpOAuthProviderArtifactEntity;
+	let grant: McpOAuthGrantEntity;
+	let config: McpConfigModel;
+	let payload: Record<string, unknown>;
+	let artifactRepository: { findOneBy: jest.Mock };
+	let revokedGrantRepository: { findOneBy: jest.Mock };
+	let grantRepository: { findOne: jest.Mock };
+	let service: McpOAuthResourceServerService;
+
+	beforeEach(() => {
+		config = Object.assign(new McpConfigModel(), {
+			enabled: true,
+			capabilities: [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER],
+		});
+		payload = {
+			grantId: PROVIDER_GRANT_ID,
+			accountId: APPROVER_ID,
+			clientId: CLIENT_IDENTIFIER,
+			aud: urls.resource,
+			scope: 'mcp:read mcp:write mcp:trigger',
+		};
+		artifact = Object.assign(new McpOAuthProviderArtifactEntity(), {
+			model: 'AccessToken',
+			idHash: TOKEN_ID,
+			payload: JSON.stringify(payload),
+			grantIdHash: PROVIDER_GRANT_ID_HASH,
+			expiresAt: Date.now() + 60_000,
+		});
+		grant = Object.assign(new McpOAuthGrantEntity(), {
+			id: 'grant-id',
+			providerGrantIdHash: PROVIDER_GRANT_ID_HASH,
+			clientId: 'client-id',
+			client: {
+				id: 'client-id',
+				clientIdentifier: CLIENT_IDENTIFIER,
+				enabled: true,
+				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+			},
+			approvedById: APPROVER_ID,
+			approvedBy: { id: APPROVER_ID, role: UserRole.OWNER },
+			installationId: INSTALLATION_ID,
+			issuer: urls.issuer,
+			resource: urls.resource,
+			approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+			expiresAt: new Date(Date.now() + 60_000),
+			revokedAt: null,
+		});
+		artifactRepository = { findOneBy: jest.fn().mockImplementation(() => Promise.resolve(artifact)) };
+		revokedGrantRepository = { findOneBy: jest.fn().mockResolvedValue(null) };
+		grantRepository = { findOne: jest.fn().mockImplementation(() => Promise.resolve(grant)) };
+		service = new McpOAuthResourceServerService(
+			artifactRepository as unknown as Repository<McpOAuthProviderArtifactEntity>,
+			revokedGrantRepository as unknown as Repository<McpOAuthProviderRevokedGrantEntity>,
+			grantRepository as unknown as Repository<McpOAuthGrantEntity>,
+			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
+			{ getInstallationId: jest.fn().mockResolvedValue(INSTALLATION_ID) } as unknown as McpInstallationService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+		);
+	});
+
+	it('builds path-aware protected-resource and bounded authorization-server metadata', () => {
+		expect({
+			protectedResource: service.getProtectedResourceMetadata(),
+			authorizationServer: service.getAuthorizationServerMetadata(),
+		}).toMatchInlineSnapshot(`
+{
+  "authorizationServer": {
+    "authorization_endpoint": "https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/authorize",
+    "authorization_response_iss_parameter_supported": true,
+    "code_challenge_methods_supported": [
+      "S256",
+    ],
+    "grant_types_supported": [
+      "authorization_code",
+      "refresh_token",
+    ],
+    "issuer": "https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth",
+    "response_types_supported": [
+      "code",
+    ],
+    "revocation_endpoint": "https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token/revocation",
+    "scopes_supported": [
+      "mcp:read",
+      "mcp:write",
+      "mcp:trigger",
+      "offline_access",
+    ],
+    "token_endpoint": "https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth/token",
+    "token_endpoint_auth_methods_supported": [
+      "none",
+    ],
+  },
+  "protectedResource": {
+    "authorization_servers": [
+      "https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth",
+    ],
+    "resource": "https://panel.example.com/smart-panel/api/v1/modules/mcp",
+    "resource_documentation": undefined,
+    "resource_name": "FastyBird Smart Panel MCP",
+    "scopes_supported": [
+      "mcp:read",
+      "mcp:write",
+      "mcp:trigger",
+    ],
+  },
+}
+`);
+	});
+
+	it('maps the four-way live scope intersection to MCP capabilities', async () => {
+		config.capabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
+		grant.client.maximumScopes = [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER];
+		grant.approvedScopes = [McpOAuthScope.READ, McpOAuthScope.WRITE];
+		payload.scope = 'mcp:read mcp:trigger';
+		artifact.payload = JSON.stringify(payload);
+
+		const authInfo = await service.verifyAccessToken(RAW_TOKEN);
+
+		expect(authInfo).toEqual(
+			expect.objectContaining({
+				clientId: CLIENT_IDENTIFIER,
+				scopes: [McpOAuthScope.READ],
+				resource: new URL(urls.resource),
+			}),
+		);
+		expect(authInfo.extra?.principal).toEqual(
+			expect.objectContaining({ effectiveCapabilities: [McpCapability.READ], installationId: INSTALLATION_ID }),
+		);
+	});
+
+	it('returns internal capabilities only after the SDK bearer verifier enforces OAuth scopes', async () => {
+		const authInfo = await service.verifyMcpBearerToken(`Bearer ${RAW_TOKEN}`, [McpCapability.READ]);
+
+		expect(authInfo.scopes).toEqual([McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER]);
+	});
+
+	it('caps the resource-server authorization deadline at the grant expiry', async () => {
+		grant.expiresAt = new Date(Date.now() + 30_000);
+		artifact.expiresAt = Date.now() + 60_000;
+
+		const authInfo = await service.verifyAccessToken(RAW_TOKEN);
+
+		expect(authInfo.expiresAt).toBe(Math.floor(grant.expiresAt.getTime() / 1_000));
+	});
+
+	it('builds RFC 6750 invalid-token and insufficient-scope challenges with discovery', async () => {
+		let invalidError: unknown;
+
+		try {
+			await service.verifyMcpBearerToken(undefined, [McpCapability.READ]);
+		} catch (error) {
+			invalidError = error;
+		}
+
+		payload.scope = 'mcp:read';
+		artifact.payload = JSON.stringify(payload);
+		let scopeError: unknown;
+
+		try {
+			await service.verifyMcpBearerToken(`Bearer ${RAW_TOKEN}`, [McpCapability.WRITE]);
+		} catch (error) {
+			scopeError = error;
+		}
+
+		const invalidResponse = service.getBearerChallenge(invalidError, [McpCapability.READ]);
+		const scopeResponse = service.getBearerChallenge(scopeError, [McpCapability.WRITE]);
+
+		expect({
+			invalid: {
+				status: invalidResponse.status,
+				challenge: invalidResponse.headers.get('www-authenticate'),
+			},
+			insufficient: {
+				status: scopeResponse.status,
+				challenge: scopeResponse.headers.get('www-authenticate'),
+			},
+		}).toMatchInlineSnapshot(`
+{
+  "insufficient": {
+    "challenge": "Bearer error="insufficient_scope", error_description="Insufficient scope", scope="mcp:write", resource_metadata="https://panel.example.com/.well-known/oauth-protected-resource/smart-panel/api/v1/modules/mcp"",
+    "status": 403,
+  },
+  "invalid": {
+    "challenge": "Bearer error="invalid_token", error_description="Missing Authorization header", scope="mcp:read", resource_metadata="https://panel.example.com/.well-known/oauth-protected-resource/smart-panel/api/v1/modules/mcp"",
+    "status": 401,
+  },
+}
+`);
+	});
+
+	it.each([
+		['wrong provider grant', () => (payload.grantId = 'other-provider-grant')],
+		['wrong issuer', () => (grant.issuer = 'https://other.example.com/oauth')],
+		['wrong canonical resource', () => (grant.resource = 'https://other.example.com/mcp')],
+		['wrong audience', () => (payload.aud = 'https://other.example.com/mcp')],
+		['cross-client token', () => (payload.clientId = 'other-client')],
+		['wrong installation', () => (grant.installationId = 'other-installation')],
+		['expired token', () => (artifact.expiresAt = Date.now() - 1)],
+		['expired grant', () => (grant.expiresAt = new Date(Date.now() - 1))],
+		['revoked grant', () => (grant.revokedAt = new Date())],
+		['disabled client', () => (grant.client.enabled = false)],
+		['deleted approver', () => (grant.approvedBy = null)],
+		['demoted approver', () => (grant.approvedBy.role = UserRole.USER)],
+		['unknown scope', () => (payload.scope = 'mcp:read mcp:unknown')],
+		['disabled module', () => (config.enabled = false)],
+	])('rejects a token with %s', async (_label, mutate) => {
+		mutate();
+		artifact.payload = JSON.stringify(payload);
+
+		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+	});
+
+	it('rejects a provider-revoked grant tombstone', async () => {
+		revokedGrantRepository.findOneBy.mockResolvedValue({ grantIdHash: PROVIDER_GRANT_ID_HASH });
+
+		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toBeInstanceOf(OAuthError);
+	});
+
+	it('rejects a token whose stored provider artifact has the wrong token type', async () => {
+		const refreshArtifact = Object.assign(new McpOAuthProviderArtifactEntity(), artifact, { model: 'RefreshToken' });
+		artifactRepository.findOneBy.mockImplementation(({ model, idHash }) =>
+			Promise.resolve(model === refreshArtifact.model && idHash === refreshArtifact.idHash ? refreshArtifact : null),
+		);
+
+		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+		expect(artifactRepository.findOneBy).toHaveBeenCalledWith({ model: 'AccessToken', idHash: TOKEN_ID });
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
@@ -1,0 +1,251 @@
+import { Repository } from 'typeorm';
+
+import {
+	AuthInfo,
+	OAuthError,
+	OAuthErrorCode,
+	OAuthProtectedResourceMetadata,
+	OAuthTokenVerifier,
+	bearerAuthChallengeResponse,
+	buildOAuthProtectedResourceMetadata,
+	verifyBearerToken,
+} from '@modelcontextprotocol/server';
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import { ConfigService } from '../../config/services/config.service';
+import { UserRole } from '../../users/users.constants';
+import {
+	McpOAuthGrantEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRevokedGrantEntity,
+} from '../entities/mcp-oauth.entity';
+import { MCP_MODULE_NAME, MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+import {
+	McpOAuthAuthorizationServerMetadata,
+	buildMcpOAuthAuthorizationServerMetadata,
+} from '../oauth/mcp-oauth-metadata';
+import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
+import { McpOAuthPrincipal, McpOAuthPublicUrls } from '../oauth/mcp-oauth.types';
+
+import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthPublicUrlService } from './mcp-oauth-public-url.service';
+
+interface ProviderAccessTokenPayload {
+	accountId?: unknown;
+	aud?: unknown;
+	clientId?: unknown;
+	grantId?: unknown;
+	scope?: unknown;
+}
+
+export interface McpOAuthAuthorizationContext {
+	client: { id: string };
+	effectiveCapabilities: McpCapability[];
+	installationId: string;
+	tokenId: string;
+}
+
+@Injectable()
+export class McpOAuthResourceServerService implements OAuthTokenVerifier {
+	constructor(
+		@InjectRepository(McpOAuthProviderArtifactEntity)
+		private readonly artifactRepository: Repository<McpOAuthProviderArtifactEntity>,
+		@InjectRepository(McpOAuthProviderRevokedGrantEntity)
+		private readonly revokedGrantRepository: Repository<McpOAuthProviderRevokedGrantEntity>,
+		@InjectRepository(McpOAuthGrantEntity)
+		private readonly grantRepository: Repository<McpOAuthGrantEntity>,
+		private readonly configService: ConfigService,
+		private readonly installationService: McpInstallationService,
+		private readonly publicUrlService: McpOAuthPublicUrlService,
+	) {}
+
+	getAuthorizationServerMetadata(): McpOAuthAuthorizationServerMetadata {
+		return buildMcpOAuthAuthorizationServerMetadata(this.requireUrls());
+	}
+
+	getProtectedResourceMetadata(): OAuthProtectedResourceMetadata {
+		const urls = this.requireUrls();
+
+		return buildOAuthProtectedResourceMetadata({
+			oauthMetadata: this.getAuthorizationServerMetadata(),
+			resourceServerUrl: new URL(urls.resource),
+			resourceName: 'FastyBird Smart Panel MCP',
+			scopesSupported: Object.values(McpOAuthScope).filter((scope) => scope !== McpOAuthScope.OFFLINE_ACCESS),
+		});
+	}
+
+	getResourceMetadataUrl(): string {
+		return this.requireUrls().protectedResourceMetadata;
+	}
+
+	async verifyAccessToken(token: string): Promise<AuthInfo> {
+		const tokenId = hashToken(token);
+		const artifact = await this.artifactRepository.findOneBy({ model: 'AccessToken', idHash: tokenId });
+
+		if (!artifact || artifact.expiresAt === null || artifact.expiresAt <= Date.now() || !artifact.grantIdHash) {
+			this.invalidToken();
+		}
+
+		const payload = this.parsePayload(artifact.payload);
+
+		if (typeof payload.grantId !== 'string' || hashToken(payload.grantId) !== artifact.grantIdHash) {
+			this.invalidToken();
+		}
+
+		const [revokedGrant, grant] = await Promise.all([
+			this.revokedGrantRepository.findOneBy({ grantIdHash: artifact.grantIdHash }),
+			this.grantRepository.findOne({
+				where: { providerGrantIdHash: artifact.grantIdHash },
+				relations: { approvedBy: true, client: true },
+			}),
+		]);
+		const urls = this.requireUrls();
+		const installationId = await this.installationService.getInstallationId();
+		const config = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+
+		if (
+			revokedGrant ||
+			!grant ||
+			!grant.client ||
+			!grant.client.enabled ||
+			!grant.approvedBy ||
+			!grant.approvedById ||
+			![UserRole.OWNER, UserRole.ADMIN].includes(grant.approvedBy.role) ||
+			grant.revokedAt !== null ||
+			grant.expiresAt <= new Date() ||
+			grant.issuer !== urls.issuer ||
+			grant.resource !== urls.resource ||
+			grant.installationId !== installationId ||
+			payload.aud !== urls.resource ||
+			payload.clientId !== grant.client.clientIdentifier ||
+			payload.accountId !== grant.approvedById ||
+			!config.enabled
+		) {
+			this.invalidToken();
+		}
+
+		const tokenScopes = this.parseScopes(payload.scope);
+		const effectiveCapabilities = this.intersectCapabilities(
+			config.capabilities,
+			grant.client.maximumScopes,
+			grant.approvedScopes,
+			tokenScopes,
+		);
+		const principal: McpOAuthPrincipal = {
+			type: MCP_OAUTH_PRINCIPAL_TYPE,
+			accessTokenId: tokenId,
+			clientId: grant.client.id,
+			grantId: grant.id,
+			installationId,
+			scopes: tokenScopes,
+			effectiveCapabilities,
+		};
+
+		return {
+			token,
+			clientId: grant.client.clientIdentifier,
+			scopes: effectiveCapabilities.map(toMcpOAuthScope),
+			expiresAt: Math.floor(Math.min(artifact.expiresAt, grant.expiresAt.getTime()) / 1_000),
+			resource: new URL(urls.resource),
+			extra: { principal, installationId, tokenId },
+		};
+	}
+
+	async verifyMcpBearerToken(
+		authorizationHeader: string | null | undefined,
+		requiredCapabilities: McpCapability[] = [],
+	): Promise<AuthInfo> {
+		const authInfo = await verifyBearerToken(authorizationHeader, {
+			verifier: this,
+			requiredScopes: requiredCapabilities.map(toMcpOAuthScope),
+			resourceMetadataUrl: this.getResourceMetadataUrl(),
+		});
+		const principal = this.getPrincipal(authInfo);
+
+		return { ...authInfo, scopes: [...principal.effectiveCapabilities] };
+	}
+
+	getBearerChallenge(error: unknown, requiredCapabilities: McpCapability[] = []): Response {
+		return bearerAuthChallengeResponse(error, {
+			requiredScopes: requiredCapabilities.map(toMcpOAuthScope),
+			resourceMetadataUrl: this.getResourceMetadataUrl(),
+		});
+	}
+
+	async authorizeAccessToken(token: string, capability: McpCapability): Promise<McpOAuthAuthorizationContext> {
+		const authInfo = await this.verifyAccessToken(token);
+		const principal = this.getPrincipal(authInfo);
+
+		if (!principal.effectiveCapabilities.includes(capability)) {
+			throw new OAuthError(OAuthErrorCode.InsufficientScope, `MCP scope '${toMcpOAuthScope(capability)}' is required`);
+		}
+
+		return {
+			client: { id: principal.clientId },
+			effectiveCapabilities: principal.effectiveCapabilities,
+			installationId: principal.installationId,
+			tokenId: principal.accessTokenId,
+		};
+	}
+
+	private getPrincipal(authInfo: AuthInfo): McpOAuthPrincipal {
+		const principal = authInfo.extra?.principal as McpOAuthPrincipal | undefined;
+
+		if (principal?.type !== MCP_OAUTH_PRINCIPAL_TYPE) this.invalidToken();
+
+		return principal;
+	}
+
+	private intersectCapabilities(
+		moduleCapabilities: McpCapability[],
+		clientScopes: McpOAuthScope[],
+		grantScopes: McpOAuthScope[],
+		tokenScopes: McpOAuthScope[],
+	): McpCapability[] {
+		return moduleCapabilities.filter((capability) => {
+			const scope = toMcpOAuthScope(capability);
+
+			return clientScopes.includes(scope) && grantScopes.includes(scope) && tokenScopes.includes(scope);
+		});
+	}
+
+	private parsePayload(value: string): ProviderAccessTokenPayload {
+		try {
+			const payload = JSON.parse(value) as unknown;
+
+			if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) this.invalidToken();
+
+			return payload as ProviderAccessTokenPayload;
+		} catch (error) {
+			if (OAuthError.isInstance(error)) throw error;
+
+			this.invalidToken();
+		}
+	}
+
+	private parseScopes(value: unknown): McpOAuthScope[] {
+		if (typeof value !== 'string') this.invalidToken();
+
+		const scopes = [...new Set(value.split(' ').filter(Boolean))];
+		const knownScopes = new Set<string>(Object.values(McpOAuthScope));
+
+		if (scopes.length === 0 || scopes.some((scope) => !knownScopes.has(scope))) this.invalidToken();
+
+		return scopes as McpOAuthScope[];
+	}
+
+	private requireUrls(): McpOAuthPublicUrls {
+		const urls = this.publicUrlService.getUrls();
+
+		if (!urls) throw new ServiceUnavailableException('MCP OAuth public URL is not configured');
+
+		return urls;
+	}
+
+	private invalidToken(): never {
+		throw new OAuthError(OAuthErrorCode.InvalidToken, 'The MCP OAuth access token is invalid or no longer active');
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest } from 'fastify';
 
+import { AuthInfo, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
 import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService as NestConfigService } from '@nestjs/config';
 
@@ -7,11 +8,12 @@ import { TokenOwnerType } from '../../auth/auth.constants';
 import { ConfigService } from '../../config/services/config.service';
 import { UserRole } from '../../users/users.constants';
 import { McpClientEntity } from '../entities/mcp-client.entity';
-import { McpCapability } from '../mcp.constants';
+import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability } from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
 
 import { McpClientService } from './mcp-client.service';
 import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
 import { McpPolicyContext, McpPolicyService } from './mcp-policy.service';
 
 const CLIENT_ID = 'client-id';
@@ -33,6 +35,7 @@ describe('McpPolicyService', () => {
 	let config: McpConfigModel;
 	let client: McpClientEntity;
 	let clientService: jest.Mocked<Pick<McpClientService, 'findActiveByToken'>>;
+	let oauthResourceServerService: { authorizeAccessToken: jest.Mock };
 	let service: McpPolicyService;
 
 	const auth = {
@@ -60,6 +63,7 @@ describe('McpPolicyService', () => {
 		clientService = {
 			findActiveByToken: jest.fn().mockResolvedValue(client),
 		};
+		oauthResourceServerService = { authorizeAccessToken: jest.fn() };
 		service = new McpPolicyService(
 			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
 			{
@@ -67,6 +71,7 @@ describe('McpPolicyService', () => {
 			} as unknown as NestConfigService,
 			clientService as unknown as McpClientService,
 			{ getInstallationId: jest.fn().mockResolvedValue(INSTALLATION_ID) } as unknown as McpInstallationService,
+			oauthResourceServerService as unknown as McpOAuthResourceServerService,
 		);
 	});
 
@@ -148,6 +153,65 @@ describe('McpPolicyService', () => {
 		releaseLookup();
 
 		await expect(authorization).rejects.toThrow(ForbiddenException);
+	});
+
+	it('preserves static-client authorization through an AuthInfo recheck', async () => {
+		const authInfo: AuthInfo = {
+			token: 'static-token',
+			clientId: CLIENT_ID,
+			scopes: [McpCapability.READ],
+			extra: { tokenId: TOKEN_ID },
+		};
+
+		await expect(service.authorizeAuthInfo(authInfo, McpCapability.READ)).resolves.toEqual(
+			expect.objectContaining({ client, tokenId: TOKEN_ID }),
+		);
+		expect(oauthResourceServerService.authorizeAccessToken).not.toHaveBeenCalled();
+	});
+
+	it('revalidates an OAuth token before every authorization decision', async () => {
+		const oauthContext = {
+			client: { id: 'oauth-client-id' },
+			config,
+			effectiveCapabilities: [McpCapability.READ],
+			installationId: INSTALLATION_ID,
+			tokenId: 'oauth-token-id',
+		};
+		oauthResourceServerService.authorizeAccessToken.mockResolvedValue(oauthContext);
+		const authInfo: AuthInfo = {
+			token: 'opaque-token',
+			clientId: 'public-client-id',
+			scopes: [McpCapability.READ],
+			extra: { principal: { type: MCP_OAUTH_PRINCIPAL_TYPE } },
+		};
+
+		await expect(service.authorizeAuthInfo(authInfo, McpCapability.READ)).resolves.toBe(oauthContext);
+		await expect(service.authorizeAuthInfo(authInfo, McpCapability.READ)).resolves.toBe(oauthContext);
+		expect(oauthResourceServerService.authorizeAccessToken).toHaveBeenNthCalledWith(
+			1,
+			'opaque-token',
+			McpCapability.READ,
+		);
+		expect(oauthResourceServerService.authorizeAccessToken).toHaveBeenNthCalledWith(
+			2,
+			'opaque-token',
+			McpCapability.READ,
+		);
+	});
+
+	it.each([
+		[OAuthErrorCode.InvalidToken, UnauthorizedException],
+		[OAuthErrorCode.InsufficientScope, ForbiddenException],
+	])('maps OAuth %s failures to the tool policy boundary', async (code, expectedError) => {
+		oauthResourceServerService.authorizeAccessToken.mockRejectedValue(new OAuthError(code, 'private OAuth detail'));
+		const authInfo: AuthInfo = {
+			token: 'opaque-token',
+			clientId: 'public-client-id',
+			scopes: [],
+			extra: { principal: { type: MCP_OAUTH_PRINCIPAL_TYPE } },
+		};
+
+		await expect(service.authorizeAuthInfo(authInfo, McpCapability.READ)).rejects.toThrow(expectedError);
 	});
 
 	it.each([

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest } from 'fastify';
 
+import { AuthInfo, OAuthError } from '@modelcontextprotocol/server';
 import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService as NestConfigService } from '@nestjs/config';
 
@@ -8,12 +9,13 @@ import { TokenOwnerType } from '../../auth/auth.constants';
 import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
 import { ConfigService } from '../../config/services/config.service';
 import { McpClientEntity } from '../entities/mcp-client.entity';
-import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { MCP_MODULE_NAME, MCP_OAUTH_PRINCIPAL_TYPE, McpCapability } from '../mcp.constants';
 import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpConfigModel } from '../models/config.model';
 
 import { McpClientService } from './mcp-client.service';
 import { McpInstallationService } from './mcp-installation.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
 
 export interface McpPolicyContext {
 	client: McpClientEntity;
@@ -22,6 +24,13 @@ export interface McpPolicyContext {
 	installationId: string;
 	clientPolicyRevision?: number;
 	policyRevision?: number;
+	tokenId: string;
+}
+
+export interface McpAuthorizationContext {
+	client: { id: string };
+	effectiveCapabilities: McpCapability[];
+	installationId: string;
 	tokenId: string;
 }
 
@@ -36,6 +45,7 @@ export class McpPolicyService {
 		private readonly nestConfigService: NestConfigService,
 		private readonly clientService: McpClientService,
 		private readonly installationService: McpInstallationService,
+		private readonly oauthResourceServerService: McpOAuthResourceServerService,
 	) {}
 
 	async resolve(auth: AuthenticatedRequest['auth']): Promise<McpPolicyContext> {
@@ -92,6 +102,31 @@ export class McpPolicyService {
 		return policy;
 	}
 
+	async authorizeAuthInfo(authInfo: AuthInfo, capability: McpCapability): Promise<McpAuthorizationContext> {
+		if (authInfo.extra?.principal && this.isOAuthPrincipal(authInfo.extra.principal)) {
+			try {
+				return await this.oauthResourceServerService.authorizeAccessToken(authInfo.token, capability);
+			} catch (error) {
+				if (OAuthError.isInstance(error) && String(error.code) === 'insufficient_scope') {
+					throw new ForbiddenException(`MCP capability '${capability}' is not granted`);
+				}
+				if (OAuthError.isInstance(error)) {
+					throw new UnauthorizedException('MCP OAuth credential is no longer active');
+				}
+
+				throw error;
+			}
+		}
+
+		const tokenId = this.getExtraString(authInfo.extra?.tokenId);
+
+		if (!authInfo.clientId || !tokenId) {
+			throw new UnauthorizedException('MCP request identity is unavailable');
+		}
+
+		return this.authorizeClient(tokenId, authInfo.clientId, capability);
+	}
+
 	validateRequestOrigin(request: FastifyRequest, policy: McpPolicyContext): void {
 		const host = this.getHeader(request.headers.host);
 		const allowedOrigins = new Set(policy.config.allowedOrigins);
@@ -139,5 +174,13 @@ export class McpPolicyService {
 
 	private getHeader(value: string | string[] | undefined): string {
 		return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+	}
+
+	private getExtraString(value: unknown): string | undefined {
+		return typeof value === 'string' ? value : undefined;
+	}
+
+	private isOAuthPrincipal(value: unknown): value is { type: typeof MCP_OAUTH_PRINCIPAL_TYPE } {
+		return typeof value === 'object' && value !== null && 'type' in value && value.type === MCP_OAUTH_PRINCIPAL_TYPE;
 	}
 }

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -28,7 +28,7 @@ describe('McpReadToolService', () => {
 		getWeather: jest.Mock;
 		listSpaces: jest.Mock;
 	};
-	let policyService: { authorizeClient: jest.Mock };
+	let policyService: { authorizeAuthInfo: jest.Mock };
 	let auditService: { getRequestId: jest.Mock; recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let registerResource: jest.Mock;
@@ -51,7 +51,7 @@ describe('McpReadToolService', () => {
 			listSpaces: jest.fn().mockResolvedValue({ spaces: [], nextCursor: undefined }),
 		};
 		policyService = {
-			authorizeClient: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
+			authorizeAuthInfo: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
 		};
 		auditService = {
 			getRequestId: jest.fn().mockReturnValue('17'),
@@ -102,7 +102,10 @@ describe('McpReadToolService', () => {
 		expect(callback).toBeDefined();
 		const result = await callback?.({}, requestContext());
 
-		expect(policyService.authorizeClient).toHaveBeenCalledWith('token-id', 'client-id', McpCapability.READ);
+		expect(policyService.authorizeAuthInfo).toHaveBeenCalledWith(
+			expect.objectContaining({ clientId: 'client-id', token: 'raw-token' }),
+			McpCapability.READ,
+		);
 		expect(contextService.getSecurityStatus).toHaveBeenCalledTimes(1);
 		expect(result?.isError).toBeUndefined();
 		expect(result?.structuredContent.installation).toEqual(expect.objectContaining({ id: 'installation-id' }));
@@ -121,7 +124,7 @@ describe('McpReadToolService', () => {
 	});
 
 	it('returns a sanitized denial when live policy no longer grants read', async () => {
-		policyService.authorizeClient.mockRejectedValue(new ForbiddenException('private policy detail'));
+		policyService.authorizeAuthInfo.mockRejectedValue(new ForbiddenException('private policy detail'));
 		service.register(server(), authInfo([McpCapability.READ]));
 		const result = await callbacks.get('get_security_status')?.({}, requestContext());
 
@@ -144,7 +147,7 @@ describe('McpReadToolService', () => {
 	});
 
 	it('distinguishes a live credential rejection from a capability denial', async () => {
-		policyService.authorizeClient.mockRejectedValue(new UnauthorizedException('private credential detail'));
+		policyService.authorizeAuthInfo.mockRejectedValue(new UnauthorizedException('private credential detail'));
 		service.register(server(), authInfo([McpCapability.READ]));
 
 		const result = await callbacks.get('get_security_status')?.({}, requestContext());
@@ -158,7 +161,7 @@ describe('McpReadToolService', () => {
 	});
 
 	it('audits a module-disable race as an endpoint denial without confusing domain not-found errors', async () => {
-		policyService.authorizeClient.mockRejectedValue(new McpEndpointDisabledException());
+		policyService.authorizeAuthInfo.mockRejectedValue(new McpEndpointDisabledException());
 		service.register(server(), authInfo([McpCapability.READ]));
 
 		const result = await callbacks.get('get_security_status')?.({}, requestContext());
@@ -248,7 +251,7 @@ describe('McpReadToolService', () => {
 	});
 
 	it('audits a resource policy denial without exposing the resource request', async () => {
-		policyService.authorizeClient.mockRejectedValue(new ForbiddenException('private resource policy'));
+		policyService.authorizeAuthInfo.mockRejectedValue(new ForbiddenException('private resource policy'));
 		service.register(server(), authInfo([McpCapability.READ]));
 		const resultPromise = resourceCallbacks.get('installation')?.(
 			new URL('smart-panel://installation'),

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.ts
@@ -350,7 +350,10 @@ export class McpReadToolService {
 	private async readResource(
 		uri: URL,
 		ctx: ServerContext,
-		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeClient']>>, endpoint?: string) => Promise<unknown>,
+		callback: (
+			policy: Awaited<ReturnType<McpPolicyService['authorizeAuthInfo']>>,
+			endpoint?: string,
+		) => Promise<unknown>,
 	): Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }> {
 		return this.runResourceOperation(
 			'resources/read',
@@ -368,13 +371,12 @@ export class McpReadToolService {
 
 	private async authorizeRead(ctx: ServerContext) {
 		const authInfo = ctx.http?.authInfo;
-		const tokenId = this.getExtraString(authInfo?.extra?.tokenId);
 
-		if (!authInfo?.clientId || !tokenId) {
+		if (!authInfo) {
 			throw new UnauthorizedException('MCP request identity is unavailable');
 		}
 
-		return this.policyService.authorizeClient(tokenId, authInfo.clientId, McpCapability.READ);
+		return this.policyService.authorizeAuthInfo(authInfo, McpCapability.READ);
 	}
 
 	private getInstallationFallback(ctx: ServerContext): McpInstallationContext {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -42,7 +42,7 @@ describe('McpTargetDiscoveryToolService', () => {
 	let spacesService: { findLightingTriggerSummaryPage: jest.Mock };
 	let toolRegistry: { getAllToolDefinitions: jest.Mock; executeTool: jest.Mock };
 	let contextService: { getInstallation: jest.Mock };
-	let policyService: { authorizeClient: jest.Mock };
+	let policyService: { authorizeAuthInfo: jest.Mock };
 	let auditService: { getRequestId: jest.Mock; recordPolicyDenial: jest.Mock; recordToolResult: jest.Mock };
 	let registerTool: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
@@ -81,7 +81,7 @@ describe('McpTargetDiscoveryToolService', () => {
 			}),
 		};
 		policyService = {
-			authorizeClient: jest.fn().mockImplementation((_tokenId, _clientId, capability: McpCapability) =>
+			authorizeAuthInfo: jest.fn().mockImplementation((_authInfo, capability: McpCapability) =>
 				Promise.resolve({
 					client: { id: 'client-id' },
 					effectiveCapabilities: [capability],
@@ -141,7 +141,10 @@ describe('McpTargetDiscoveryToolService', () => {
 		const result = await callbacks.get('list_writable_properties')?.({}, requestContext([McpCapability.WRITE]));
 		const data = result?.structuredContent.data as { properties: Array<Record<string, unknown>> };
 
-		expect(policyService.authorizeClient).toHaveBeenCalledWith('token-id', 'client-id', McpCapability.WRITE);
+		expect(policyService.authorizeAuthInfo).toHaveBeenCalledWith(
+			expect.objectContaining({ clientId: 'client-id', token: 'raw-token' }),
+			McpCapability.WRITE,
+		);
 		expect(data.properties).toEqual([
 			expect.objectContaining({
 				property_id: connected.id,
@@ -447,7 +450,7 @@ describe('McpTargetDiscoveryToolService', () => {
 
 	it('audits a module-disable race as an endpoint denial for write and trigger tools', async () => {
 		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
-		policyService.authorizeClient.mockRejectedValue(new McpEndpointDisabledException());
+		policyService.authorizeAuthInfo.mockRejectedValue(new McpEndpointDisabledException());
 		service.register(server(), authInfo([McpCapability.TRIGGER]));
 
 		const result = await callbacks.get('run_scene')?.(
@@ -468,7 +471,7 @@ describe('McpTargetDiscoveryToolService', () => {
 
 	it('distinguishes a live credential rejection from a capability denial for mutating tools', async () => {
 		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
-		policyService.authorizeClient.mockRejectedValue(new UnauthorizedException('private credential detail'));
+		policyService.authorizeAuthInfo.mockRejectedValue(new UnauthorizedException('private credential detail'));
 		service.register(server(), authInfo([McpCapability.TRIGGER]));
 
 		const result = await callbacks.get('run_scene')?.(

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.ts
@@ -288,7 +288,7 @@ export class McpTargetDiscoveryToolService {
 		tool: string,
 		capability: McpCapability,
 		ctx: ServerContext,
-		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeClient']>>) => Promise<ToolData>,
+		callback: (policy: Awaited<ReturnType<McpPolicyService['authorizeAuthInfo']>>) => Promise<ToolData>,
 		timeoutMs: number | null = MCP_TOOL_CALL_TIMEOUT_MS,
 		auditArguments?: Record<string, unknown>,
 	): Promise<{
@@ -383,13 +383,12 @@ export class McpTargetDiscoveryToolService {
 
 	private async authorize(ctx: ServerContext, capability: McpCapability) {
 		const authInfo = ctx.http?.authInfo;
-		const tokenId = this.getExtraString(authInfo?.extra?.tokenId);
 
-		if (!authInfo?.clientId || !tokenId) {
+		if (!authInfo) {
 			throw new UnauthorizedException('MCP request identity is unavailable');
 		}
 
-		return this.policyService.authorizeClient(tokenId, authInfo.clientId, capability);
+		return this.policyService.authorizeAuthInfo(authInfo, capability);
 	}
 
 	private hasProviderTool(name: string, access: ToolAccessKind): boolean {

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -166,7 +166,7 @@ describe('MCP endpoint', () => {
 			),
 		};
 		const policyService = {
-			authorizeClient: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
+			authorizeAuthInfo: jest.fn().mockResolvedValue({ effectiveCapabilities: [McpCapability.READ] }),
 		};
 		const auditService = new McpAuditService();
 		const readTools = new McpReadToolService(

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { AuthInfo } from '@modelcontextprotocol/server';
 import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
@@ -223,7 +224,7 @@ describe('MCP simulator operations', () => {
 			})),
 		};
 		const policyService = {
-			authorizeClient: jest.fn().mockImplementation(async (_tokenId, clientId: string, capability: McpCapability) => {
+			authorizeAuthInfo: jest.fn().mockImplementation(async (authInfo: AuthInfo, capability: McpCapability) => {
 				authorizationStartedSignal?.resolve();
 
 				if (policyChangeGate !== null) {
@@ -234,7 +235,7 @@ describe('MCP simulator operations', () => {
 					throw new ForbiddenException(`MCP capability '${capability}' is not granted`);
 				}
 
-				return { client: { id: clientId }, effectiveCapabilities: [...runtimeCapabilities] };
+				return { client: { id: authInfo.clientId }, effectiveCapabilities: [...runtimeCapabilities] };
 			}),
 		};
 		const auditService = new McpAuditService();

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -24,6 +24,7 @@ import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
@@ -155,6 +156,7 @@ describe('MCP disabled restart', () => {
 					provide: McpInstallationService,
 					useValue: { getInstallationId: jest.fn().mockResolvedValue('restart-installation') },
 				},
+				{ provide: McpOAuthResourceServerService, useValue: { authorizeAccessToken: jest.fn() } },
 				McpAuditService,
 				McpClientGuard,
 				McpPolicyService,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 3 complete — browser authorization and consent flow implemented behind the internal test-only gate
+**Status:** Phase 4 complete — discovery, challenges, and OAuth resource validation implemented behind the internal gate
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -95,17 +95,17 @@ amend ADR 0002.
 
 **Goal:** Complete and test the standards surface without making it reachable in production.
 
-- [ ] Publish path-aware RFC 9728 protected-resource metadata for the canonical MCP resource.
-- [ ] Publish path-aware RFC 8414 authorization-server metadata containing only implemented capabilities.
-- [ ] Add RFC 6750 `WWW-Authenticate` challenges with `resource_metadata` and minimum scopes.
-- [ ] Require exact issuer/resource/audience/client/installation/expiry/grant/token validation for OAuth bearer tokens,
+- [x] Publish path-aware RFC 9728 protected-resource metadata for the canonical MCP resource.
+- [x] Publish path-aware RFC 8414 authorization-server metadata containing only implemented capabilities.
+- [x] Add RFC 6750 `WWW-Authenticate` challenges with `resource_metadata` and minimum scopes.
+- [x] Require exact issuer/resource/audience/client/installation/expiry/grant/token validation for OAuth bearer tokens,
       including the grant approver's current owner/admin role.
-- [ ] Keep static URN-audience validation working through its existing isolated path.
-- [ ] Map `mcp:read`, `mcp:write`, and `mcp:trigger` to the four-way live capability intersection.
-- [ ] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
-- [ ] Add discovery/challenge snapshots and wrong-token-type, issuer, resource, audience, cross-client, and scope
+- [x] Keep static URN-audience validation working through its existing isolated path.
+- [x] Map `mcp:read`, `mcp:write`, and `mcp:trigger` to the four-way live capability intersection.
+- [x] Return protocol-correct 401 versus 403 scope challenges and recheck scopes before every tool execution.
+- [x] Add discovery/challenge snapshots and wrong-token-type, issuer, resource, audience, cross-client, and scope
       negative tests.
-- [ ] Keep OAuth well-known, authorization, token, revocation, and OAuth-bearing MCP paths absent from production until
+- [x] Keep OAuth well-known, authorization, token, revocation, and OAuth-bearing MCP paths absent from production until
       Phase 5 adds the complete bootstrap-time gated route set; do not attempt runtime route mounting, and leave the
       existing static bearer behavior unchanged with no user-settable OAuth enable switch.
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 3 internal-gated authorization and consent flow complete
+Status: in progress — Phase 4 internal-gated discovery, challenges, and resource validation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add internally gated RFC 9728 protected-resource and RFC 8414 authorization-server metadata
- validate opaque MCP OAuth access tokens against the live installation, issuer, resource, audience, client, grant, approver role, expiry, and revocation state
- map OAuth scopes through the live module/client/grant/token capability intersection and recheck authorization before every tool execution
- preserve the existing static MCP bearer path and keep all public OAuth routes unmounted until Phase 5

## Impact

This completes Phase 4 of the MCP OAuth implementation. The standards and resource-server validation boundary is implemented and tested, while production OAuth discovery, authorization, token, revocation, and OAuth-bearing MCP routes remain unavailable until the complete Phase 5 route set can be exposed atomically.

## Validation

- backend type-check
- backend lint (two pre-existing warnings in unrelated buddy Discord/Telegram providers)
- 295 backend unit suites: 3,845 passed, 2 skipped
- 124 focused MCP OAuth/policy/tool tests
- 24 MCP end-to-end tests
- embedded OAuth provider spike: 11 tests
- `git diff --check`