### PR TITLE
fix(backend): let a constraint declare what its validate() actually is

### DIFF
--- a/apps/backend/src/common/validation/async-constraints.spec.ts
+++ b/apps/backend/src/common/validation/async-constraints.spec.ts
@@ -1,0 +1,77 @@
+import { getMetadataStorage } from 'class-validator';
+import { readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * `@ValidatorConstraint({ async })` has to agree with what `validate()` actually is.
+ *
+ * Today the two disagreeing is survivable: class-validator 0.15 dispatches on whether the returned
+ * value is a promise, not on the flag, so an `async validate()` declared `async: false` is still
+ * awaited (`ValidationExecutor.customValidations`, the `isPromise(validatedValue)` branch).
+ *
+ * It is survivable and not safe. The flag is read in one place that matters —
+ * `if (customConstraintMetadata.async && this.ignoreAsyncValidations) return;` — which is how
+ * `validateSync()` skips async constraints. A constraint that lies about being sync is *not* skipped
+ * there: it runs, its promise goes on a queue `validateSync()` never awaits, and whatever it would
+ * have rejected passes instead. Nothing reached by `validateSync()` uses one of these today — it
+ * validates configuration, and these validate device, channel, user and scene references — so this
+ * is a trap rather than a defect, and one nobody would think to look for after wiring a validator
+ * into a config DTO.
+ *
+ * Asserted by asking each class rather than by listing the ones known to be wrong, so a validator
+ * added later cannot join them quietly.
+ */
+describe('validator constraints declare what they are', () => {
+	const validatorFiles = (directory: string): string[] =>
+		readdirSync(directory).flatMap((entry) => {
+			const path = join(directory, entry);
+
+			if (statSync(path).isDirectory()) {
+				return validatorFiles(path);
+			}
+
+			return path.endsWith('.validator.ts') && !path.endsWith('.spec.ts') ? [path] : [];
+		});
+
+	it('declares every asynchronous constraint async, and every synchronous one not', async () => {
+		const mismatched: string[] = [];
+		let checked = 0;
+
+		for (const file of validatorFiles(join(__dirname, '..', '..'))) {
+			const module = (await import(file)) as Record<string, unknown>;
+
+			for (const exported of Object.values(module)) {
+				if (typeof exported !== 'function') {
+					continue;
+				}
+
+				// One entry when the class carries `@ValidatorConstraint`, none when it is anything else
+				// this file happens to export.
+				const [constraint] = getMetadataStorage().getTargetValidatorConstraints(exported);
+
+				const validate = (exported as { prototype?: { validate?: (...args: unknown[]) => unknown } }).prototype
+					?.validate;
+
+				if (!constraint || !validate) {
+					continue;
+				}
+
+				checked++;
+
+				// The only honest question available statically, and the one that matters: a method declared
+				// `async` always returns a promise, whatever it does inside.
+				const isAsync = validate.constructor.name === 'AsyncFunction';
+
+				if (isAsync !== constraint.async) {
+					mismatched.push(
+						`${exported.name} validates ${isAsync ? 'asynchronously' : 'synchronously'} but declares async: ${String(constraint.async)}`,
+					);
+				}
+			}
+		}
+
+		expect(mismatched).toEqual([]);
+		// The sweep is only worth anything if it found the validators at all.
+		expect(checked).toBeGreaterThan(20);
+	});
+});

--- a/apps/backend/src/modules/devices/validators/channel-exists-constraint.validator.ts
+++ b/apps/backend/src/modules/devices/validators/channel-exists-constraint.validator.ts
@@ -12,7 +12,7 @@ import { ChannelsService } from '../services/channels.service';
 import { DevicesService } from '../services/devices.service';
 
 @Injectable()
-@ValidatorConstraint({ name: 'DeviceChannelExistsValidation', async: false })
+@ValidatorConstraint({ name: 'DeviceChannelExistsValidation', async: true })
 export class ChannelExistsConstraintValidator implements ValidatorConstraintInterface {
 	constructor(
 		private readonly devicesService: DevicesService,

--- a/apps/backend/src/modules/devices/validators/device-exists-constraint.validator.ts
+++ b/apps/backend/src/modules/devices/validators/device-exists-constraint.validator.ts
@@ -11,7 +11,7 @@ import { Injectable } from '@nestjs/common';
 import { DevicesService } from '../services/devices.service';
 
 @Injectable()
-@ValidatorConstraint({ name: 'DeviceExistsValidation', async: false })
+@ValidatorConstraint({ name: 'DeviceExistsValidation', async: true })
 export class DeviceExistsConstraintValidator implements ValidatorConstraintInterface {
 	constructor(private readonly devicesService: DevicesService) {}
 

--- a/apps/backend/src/modules/scenes/validators/scene-exists-constraint.validator.ts
+++ b/apps/backend/src/modules/scenes/validators/scene-exists-constraint.validator.ts
@@ -11,7 +11,7 @@ import { Injectable } from '@nestjs/common';
 import { ScenesService } from '../services/scenes.service';
 
 @Injectable()
-@ValidatorConstraint({ name: 'SceneExistsValidation', async: false })
+@ValidatorConstraint({ name: 'SceneExistsValidation', async: true })
 export class SceneExistsConstraintValidator implements ValidatorConstraintInterface {
 	constructor(private readonly scenesService: ScenesService) {}
 

--- a/apps/backend/src/modules/users/validators/user-exists-constraint.validator.ts
+++ b/apps/backend/src/modules/users/validators/user-exists-constraint.validator.ts
@@ -11,7 +11,7 @@ import { Injectable } from '@nestjs/common';
 import { UsersService } from '../services/users.service';
 
 @Injectable()
-@ValidatorConstraint({ name: 'UserExistsValidation', async: false })
+@ValidatorConstraint({ name: 'UserExistsValidation', async: true })
 export class UserExistsConstraintValidator implements ValidatorConstraintInterface {
 	constructor(private readonly usersService: UsersService) {}
 

--- a/apps/backend/src/plugins/data-sources-device-channel/validators/device-channel-exists-constraint.validator.ts
+++ b/apps/backend/src/plugins/data-sources-device-channel/validators/device-channel-exists-constraint.validator.ts
@@ -12,7 +12,7 @@ import { ChannelsService } from '../../../modules/devices/services/channels.serv
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 
 @Injectable()
-@ValidatorConstraint({ name: 'DeviceChannelExistsValidation', async: false })
+@ValidatorConstraint({ name: 'DeviceChannelExistsValidation', async: true })
 export class DeviceChannelExistsConstraintValidator implements ValidatorConstraintInterface {
 	constructor(
 		private readonly deviceService: DevicesService,

--- a/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
+++ b/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
@@ -210,9 +210,15 @@ Still worth doing eventually: fix shelly-v1's subscriber to re-read the row and 
 
 The same comment appears on earlier migrations in `src/migrations/`, which are presumably in the same state. Not touched here: `1000000000000-InitialSetup` must not be modified (alpha installations have run it), and the others were out of scope. Worth auditing whether any of them also breaks revert-then-run. Note the restrictions that do still apply — a column may not be dropped while it is indexed, part of a primary key, or referenced by a partial index or `CHECK` constraint — so each one needs checking rather than a blanket rewrite.
 
-### 3.2 `device-exists-constraint.validator.ts:14` declares `async: false` on an async `validate()` (medium)
+### 3.2 `device-exists-constraint.validator.ts:14` declares `async: false` on an async `validate()` (medium → low) — DONE
 
-A returned Promise is truthy, so `class-validator` may never await it — meaning that validator can silently pass. The validators added on the virtual-devices branch declare `async: true` correctly and do not inherit this.
+The premise as filed does not hold on the version in use, and the risk is real anyway.
+
+class-validator 0.15.1 dispatches on whether `validate()` *returned* a promise rather than on the declared flag (`ValidationExecutor.customValidations`, the `isPromise(validatedValue)` branch), so these validators were being awaited and did reject. Verified by driving a DTO through `validate()` with a stubbed container rather than by reading the source alone.
+
+The flag is read in exactly one place, and it is the one that bites: `if (customConstraintMetadata.async && this.ignoreAsyncValidations) return;` — how `validateSync()` skips async constraints. A constraint that calls itself sync is *not* skipped there. It runs, its promise joins a queue `validateSync()` never awaits, and whatever it would have rejected passes. Nothing reached by `validateSync()` uses one today — it validates configuration, and these validate device, channel, user and scene references — so this was a trap rather than a defect, and one nobody would think to look for after wiring such a validator into a config DTO.
+
+Five carried it, not one: `DeviceExists`, `ChannelExists`, `UserExists`, `SceneExists`, `DeviceChannelExists`. All corrected, and a sweep now asks each constraint class whether its `validate` is an `AsyncFunction` and compares that with what it declares — so a validator added later cannot join them quietly.
 
 ### 3.3 TypeORM sqlite shared-`QueryRunner` TOCTOU (high, but pre-existing)
 


### PR DESCRIPTION
Closes follow-up [`3.2`](../blob/main/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md) — with a correction to what it claimed, which does not change the conclusion.

## What the follow-up said, and what is actually true

It recorded one validator declaring `async: false` over an `async validate()`, and read it as a live defect: *"a returned Promise is truthy, so class-validator may never await it — meaning that validator can silently pass."*

That is not what happens on the version in use. class-validator 0.15.1 dispatches on whether `validate()` **returned** a promise, not on the declared flag (`ValidationExecutor.customValidations`, the `isPromise(validatedValue)` branch), so these constraints were awaited and did reject. I checked it by driving a DTO through `validate()` with a stubbed container rather than by reading the source alone — a non-existent device id produced the error it should.

**The flag is read in exactly one place, and it is the one that bites:**

```js
if (customConstraintMetadata.async && this.ignoreAsyncValidations) return;
```

That is how `validateSync()` skips async constraints. A constraint that calls itself sync is *not* skipped there — it runs, its promise joins a queue `validateSync()` never awaits, and whatever it would have rejected passes instead.

Nothing reached by `validateSync()` uses one of these today: it validates configuration, and these validate device, channel, user and scene references. So this was a trap rather than a defect — and precisely the kind nobody would think to look for after wiring an existence check into a config DTO one day.

## The fix

**Five carried it, not one** — `DeviceExists`, `ChannelExists`, `UserExists`, `SceneExists`, `DeviceChannelExists` — found by sweeping every `*.validator.ts` rather than by following the one the note named.

Each now declares `async: true`, which is what it is.

## The guard

A test that asks each constraint class whether its `validate` is an `AsyncFunction` and compares that with what `@ValidatorConstraint` declares — in both directions, so a synchronous validator claiming to be async is caught too. It walks the validator files and reads the constraint metadata through the public API, so a validator added later cannot join them quietly, and it asserts it found something (>20 constraints) rather than passing vacuously if the walk ever breaks.

It listed exactly these five before the fix:

```
ChannelExistsConstraintValidator validates asynchronously but declares async: false
DeviceExistsConstraintValidator validates asynchronously but declares async: false
SceneExistsConstraintValidator validates asynchronously but declares async: false
UserExistsConstraintValidator validates asynchronously but declares async: false
DeviceChannelExistsConstraintValidator validates asynchronously but declares async: false
```

3836 backend unit tests green; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
