### PR TITLE
fix(backend): count one sensor once, however many devices present it

### DIFF
--- a/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
@@ -4,6 +4,7 @@ import { ChannelCategory, DeviceCategory, PropertyCategory } from '../../devices
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueState } from '../../devices/models/property-value-state.model';
 import { DevicesService } from '../../devices/services/devices.service';
+import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { ArmedState, SecurityAlertType, Severity } from '../security.constants';
 import { DetectionRulesLoaderService } from '../spec/detection-rules-loader.service';
 import { ResolvedSensorRule } from '../spec/detection-rules.types';
@@ -105,6 +106,7 @@ function buildDefaultRules(): Map<string, ResolvedSensorRule> {
 
 describe('SecuritySensorsProvider', () => {
 	let provider: SecuritySensorsProvider;
+	let testingModule: TestingModule;
 	let devicesService: { findAll: jest.Mock };
 	let rulesLoader: { getSensorRules: jest.Mock };
 
@@ -117,9 +119,14 @@ describe('SecuritySensorsProvider', () => {
 				SecuritySensorsProvider,
 				{ provide: DevicesService, useValue: devicesService },
 				{ provide: DetectionRulesLoaderService, useValue: rulesLoader },
+				// The real registry: with no plugin registered it answers every property with its own id,
+				// which is what "this device owns its sensor" means and is the state of every case below
+				// that does not deliberately project one.
+				PropertyValueSourceRegistryService,
 			],
 		}).compile();
 
+		testingModule = module;
 		provider = module.get<SecuritySensorsProvider>(SecuritySensorsProvider);
 	});
 
@@ -607,5 +614,112 @@ describe('SecuritySensorsProvider', () => {
 
 		expect(signal.activeAlertsCount).toBe(0);
 		expect(signal.activeAlerts).toEqual([]);
+	});
+	// -- one physical sensor, several devices presenting it ---------------------------------------
+	//
+	// A virtual device that projects a physical sensor has a channel of that category too, and the
+	// projection's value *is* the source's, so the walk reads one detector off two devices and files
+	// two alerts under different ids. `mergeAlerts` de-duplicates by id downstream and cannot help,
+	// because the ids differ precisely because the devices do.
+
+	/** A property that reads another property's series, the way a projection does. */
+	const projecting = (category: PropertyCategory, value: boolean, sourceId: string): ChannelPropertyEntity => {
+		const property = createProperty(category, value);
+
+		property.id = `${sourceId}-projection`;
+		// `type` is a getter on the entity, as it is on every plugin's subclass, so the discriminator the
+		// registry keys on is shadowed rather than assigned.
+		Object.defineProperty(property, 'type', { value: 'virtual-test' });
+		(property as unknown as { sourcePropertyId: string }).sourcePropertyId = sourceId;
+
+		return property;
+	};
+
+	const registerProjections = (module: TestingModule): void => {
+		module.get(PropertyValueSourceRegistryService).register({
+			getType: () => 'virtual-test',
+			resolve: (property) => (property as unknown as { sourcePropertyId?: string }).sourcePropertyId ?? null,
+		});
+	};
+
+	it('counts one sensor once, however many devices present it', async () => {
+		registerProjections(testingModule);
+
+		const source = createProperty(PropertyCategory.DETECTED, true);
+		source.id = 'smoke-detector';
+
+		devicesService.findAll.mockResolvedValue([
+			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]),
+			createDevice('virtual', [
+				createChannel(ChannelCategory.SMOKE, [projecting(PropertyCategory.DETECTED, true, 'smoke-detector')]),
+			]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlertsCount).toBe(1);
+	});
+
+	// Splitting hides a source device once nothing of it is left unprojected, which is exactly when its
+	// projection should speak for it: an alert naming a device that appears nowhere is one nobody can
+	// act on.
+	it('names the visible device rather than the hidden one', async () => {
+		registerProjections(testingModule);
+
+		const source = createProperty(PropertyCategory.DETECTED, true);
+		source.id = 'smoke-detector';
+
+		const physical = createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]);
+
+		physical.hidden = true;
+
+		devicesService.findAll.mockResolvedValue([
+			physical,
+			createDevice('virtual', [
+				createChannel(ChannelCategory.SMOKE, [projecting(PropertyCategory.DETECTED, true, 'smoke-detector')]),
+			]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlerts).toEqual([expect.objectContaining({ sourceDeviceId: 'virtual' })]);
+	});
+
+	// A partially split device stays visible for the channels it kept, but the sensor in question is
+	// the one the operator deliberately moved into a room device.
+	it('names the projection when both devices are visible', async () => {
+		registerProjections(testingModule);
+
+		const source = createProperty(PropertyCategory.DETECTED, true);
+		source.id = 'smoke-detector';
+
+		devicesService.findAll.mockResolvedValue([
+			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]),
+			createDevice('virtual', [
+				createChannel(ChannelCategory.SMOKE, [projecting(PropertyCategory.DETECTED, true, 'smoke-detector')]),
+			]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlerts).toEqual([expect.objectContaining({ sourceDeviceId: 'virtual' })]);
+	});
+
+	// Nothing is dropped by de-duplication: suppressing a smoke alarm because somebody hid its device
+	// is not de-duplication, and two detectors are two alerts however they are arranged.
+	it('keeps a hidden device’s own sensor, and keeps two sensors two', async () => {
+		const hidden = createDevice('hidden', [createDetectedChannel(ChannelCategory.SMOKE, true)]);
+
+		hidden.hidden = true;
+
+		devicesService.findAll.mockResolvedValue([
+			hidden,
+			createDevice('other', [createDetectedChannel(ChannelCategory.LEAK, true)]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlertsCount).toBe(2);
+		expect(signal.activeAlerts.map((alert) => alert.sourceDeviceId).sort()).toEqual(['hidden', 'other']);
 	});
 });

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
@@ -825,4 +825,35 @@ describe('SecuritySensorsProvider', () => {
 
 		expect(signal.activeAlertsCount).toBe(1);
 	});
+	// Who names the sensor and when it happened are separate questions, and answering them together got
+	// the second one wrong. A rule with alternatives lets one device trigger on a fresh reading while
+	// another still matches a stale one — so the projection can win the naming while the physical
+	// channel holds the newer occurrence, and carrying the winner's stale timestamp would leave a new
+	// life-safety event looking like the acknowledged one.
+	it('carries the newest occurrence even when another device names the sensor', async () => {
+		registerProjections(testingModule);
+
+		const detected = createProperty(PropertyCategory.DETECTED, true);
+		const concentration = createProperty(PropertyCategory.CONCENTRATION, 40);
+
+		detected.value = new PropertyValueState(true, '2026-08-01T11:00:00.000Z');
+		concentration.value = new PropertyValueState(40, '2026-08-01T10:00:00.000Z');
+
+		const projectedConcentration = projecting(PropertyCategory.CONCENTRATION, 40, concentration.id);
+
+		projectedConcentration.value = new PropertyValueState(40, '2026-08-01T10:00:00.000Z');
+
+		devicesService.findAll.mockResolvedValue([
+			createDevice('physical', [
+				createChannel(ChannelCategory.CARBON_MONOXIDE, [detected, concentration], 'physical-co'),
+			]),
+			createDevice('virtual', [createChannel(ChannelCategory.CARBON_MONOXIDE, [projectedConcentration])]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlerts).toEqual([
+			expect.objectContaining({ sourceDeviceId: 'virtual', timestamp: '2026-08-01T11:00:00.000Z' }),
+		]);
+	});
 });

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelCategory, DeviceCategory, PropertyCategory } from '../../devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueState } from '../../devices/models/property-value-state.model';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
 import { DevicesService } from '../../devices/services/devices.service';
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { ArmedState, SecurityAlertType, Severity } from '../security.constants';
@@ -116,6 +117,7 @@ function buildDefaultRules(): Map<string, ResolvedSensorRule> {
 describe('SecuritySensorsProvider', () => {
 	let provider: SecuritySensorsProvider;
 	let testingModule: TestingModule;
+	let channelsPropertiesService: { findOne: jest.Mock };
 	let devicesService: { findAll: jest.Mock };
 	let rulesLoader: { getSensorRules: jest.Mock };
 
@@ -123,11 +125,16 @@ describe('SecuritySensorsProvider', () => {
 		devicesService = { findAll: jest.fn().mockResolvedValue([]) };
 		rulesLoader = { getSensorRules: jest.fn().mockReturnValue(buildDefaultRules()) };
 
+		channelsPropertiesService = { findOne: jest.fn().mockResolvedValue(null) };
+
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				SecuritySensorsProvider,
 				{ provide: DevicesService, useValue: devicesService },
 				{ provide: DetectionRulesLoaderService, useValue: rulesLoader },
+				// Only reached for a projected property whose channel is outside the pass — see the bounded
+				// case below. Answers nothing by default, which is the fallback every other case takes.
+				{ provide: ChannelsPropertiesService, useValue: channelsPropertiesService },
 				// The real registry: with no plugin registered it answers every property with its own id,
 				// which is what "this device owns its sensor" means and is the state of every case below
 				// that does not deliberately project one.
@@ -762,5 +769,60 @@ describe('SecuritySensorsProvider', () => {
 
 		expect(signal.activeAlertsCount).toBe(1);
 		expect(signal.activeAlerts).toEqual([expect.objectContaining({ sourceDeviceId: 'virtual' })]);
+	});
+	// Two sensors of one category on one device share an alert id by construction, and the id is what
+	// survives downstream. The timestamp is not decoration on a life-safety path:
+	// `SecurityStateListener.syncAckRecords()` reads it to decide whether an alert is a new occurrence,
+	// so keeping the older of two smoke alerts leaves the second showing as acknowledged because the
+	// first was.
+	it('keeps the newest of two alerts that share an id', async () => {
+		const older = createProperty(PropertyCategory.DETECTED, true);
+		const newer = createProperty(PropertyCategory.DETECTED, true);
+
+		older.value = new PropertyValueState(true, '2026-08-01T10:00:00.000Z');
+		newer.value = new PropertyValueState(true, '2026-08-01T11:00:00.000Z');
+
+		devicesService.findAll.mockResolvedValue([
+			createDevice('d1', [
+				createChannel(ChannelCategory.SMOKE, [older], 'smoke-a'),
+				createChannel(ChannelCategory.SMOKE, [newer], 'smoke-b'),
+			]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlertsCount).toBe(1);
+		expect(signal.activeAlerts[0].timestamp).toBe('2026-08-01T11:00:00.000Z');
+	});
+
+	// `aggregateBounded()` hands the provider a scoped device set, so a hidden or out-of-scope source
+	// device is simply not in it. Two virtual devices projecting different properties of one hidden
+	// channel would then fall back to two property ids and be counted twice — while the same pair
+	// counts once at home. A sensor's identity cannot depend on which pass is asking.
+	it('counts one sensor once even when its source device is outside the pass', async () => {
+		registerProjections(testingModule);
+
+		// The source channel is nowhere in the devices below; only the read-back can place it.
+		channelsPropertiesService.findOne.mockImplementation((id: string) =>
+			Promise.resolve(
+				id === 'co-detected' || id === 'co-concentration' ? { id, channel: { id: 'hidden-co-channel' } } : null,
+			),
+		);
+
+		const signal = await provider.getSignals({
+			devices: [
+				createDevice('virtual-a', [
+					createChannel(ChannelCategory.CARBON_MONOXIDE, [projecting(PropertyCategory.DETECTED, true, 'co-detected')]),
+				]),
+				createDevice('virtual-b', [
+					createChannel(ChannelCategory.CARBON_MONOXIDE, [
+						projecting(PropertyCategory.CONCENTRATION, 40, 'co-concentration'),
+					]),
+				]),
+			],
+			armedState: null,
+		});
+
+		expect(signal.activeAlertsCount).toBe(1);
 	});
 });

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.spec.ts
@@ -11,16 +11,25 @@ import { ResolvedSensorRule } from '../spec/detection-rules.types';
 
 import { SecuritySensorsProvider } from './security-sensors.provider';
 
+let propertySequence = 0;
+
 function createProperty(category: PropertyCategory, value: string | number | boolean | null): ChannelPropertyEntity {
 	const prop = new ChannelPropertyEntity();
+	prop.id = `property-${++propertySequence}`;
 	prop.category = category;
 	prop.value = value != null ? new PropertyValueState(value) : null;
 
 	return prop;
 }
 
-function createChannel(category: ChannelCategory, properties: ChannelPropertyEntity[]): ChannelEntity {
+let channelSequence = 0;
+
+function createChannel(category: ChannelCategory, properties: ChannelPropertyEntity[], id?: string): ChannelEntity {
 	const channel = new ChannelEntity();
+	// Identified, because a sensor is identified by the channel it is reported from — see
+	// SecuritySensorsProvider.identifySensor(). A fixture without one is not a channel any pass would
+	// meet.
+	channel.id = id ?? `channel-${++channelSequence}`;
 	channel.category = category;
 	channel.properties = properties;
 
@@ -623,7 +632,11 @@ describe('SecuritySensorsProvider', () => {
 	// because the ids differ precisely because the devices do.
 
 	/** A property that reads another property's series, the way a projection does. */
-	const projecting = (category: PropertyCategory, value: boolean, sourceId: string): ChannelPropertyEntity => {
+	const projecting = (
+		category: PropertyCategory,
+		value: string | number | boolean,
+		sourceId: string,
+	): ChannelPropertyEntity => {
 		const property = createProperty(category, value);
 
 		property.id = `${sourceId}-projection`;
@@ -649,7 +662,7 @@ describe('SecuritySensorsProvider', () => {
 		source.id = 'smoke-detector';
 
 		devicesService.findAll.mockResolvedValue([
-			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]),
+			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source], 'physical-smoke')]),
 			createDevice('virtual', [
 				createChannel(ChannelCategory.SMOKE, [projecting(PropertyCategory.DETECTED, true, 'smoke-detector')]),
 			]),
@@ -669,7 +682,7 @@ describe('SecuritySensorsProvider', () => {
 		const source = createProperty(PropertyCategory.DETECTED, true);
 		source.id = 'smoke-detector';
 
-		const physical = createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]);
+		const physical = createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source], 'physical-smoke')]);
 
 		physical.hidden = true;
 
@@ -694,7 +707,7 @@ describe('SecuritySensorsProvider', () => {
 		source.id = 'smoke-detector';
 
 		devicesService.findAll.mockResolvedValue([
-			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source])]),
+			createDevice('physical', [createChannel(ChannelCategory.SMOKE, [source], 'physical-smoke')]),
 			createDevice('virtual', [
 				createChannel(ChannelCategory.SMOKE, [projecting(PropertyCategory.DETECTED, true, 'smoke-detector')]),
 			]),
@@ -721,5 +734,33 @@ describe('SecuritySensorsProvider', () => {
 
 		expect(signal.activeAlertsCount).toBe(2);
 		expect(signal.activeAlerts.map((alert) => alert.sourceDeviceId).sort()).toEqual(['hidden', 'other']);
+	});
+	// The reviewer's case, and the reason identity cannot be the property that matched: the built-in CO
+	// rule checks `detected` before `concentration`, so the physical channel matches on one and a
+	// projection that took only the concentration matches on the other. Keyed by whichever matched,
+	// they would be two sensors — and would collapse into one again the moment the readings changed.
+	it('counts one sensor once when each device matches on a different property', async () => {
+		registerProjections(testingModule);
+
+		const detected = createProperty(PropertyCategory.DETECTED, true);
+		const concentration = createProperty(PropertyCategory.CONCENTRATION, 40);
+
+		devicesService.findAll.mockResolvedValue([
+			createDevice('physical', [
+				createChannel(ChannelCategory.CARBON_MONOXIDE, [detected, concentration], 'physical-co'),
+			]),
+			// Took the concentration and kept a local `detected` of its own, which reads false.
+			createDevice('virtual', [
+				createChannel(ChannelCategory.CARBON_MONOXIDE, [
+					createProperty(PropertyCategory.DETECTED, false),
+					projecting(PropertyCategory.CONCENTRATION, 40, concentration.id),
+				]),
+			]),
+		]);
+
+		const signal = await provider.getSignals();
+
+		expect(signal.activeAlertsCount).toBe(1);
+		expect(signal.activeAlerts).toEqual([expect.objectContaining({ sourceDeviceId: 'virtual' })]);
 	});
 });

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.ts
@@ -65,6 +65,10 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 		const rules = this.detectionRulesLoader.getSensorRules();
 		const armedState = context?.armedState ?? null;
 
+		// Where every property in this pass lives, so a projected one can be traced back to the channel
+		// it reads rather than to the property that happened to carry it.
+		const channelOfProperty = this.mapPropertiesToChannels(devices);
+
 		const candidates: SensorAlertCandidate[] = [];
 
 		for (const device of devices) {
@@ -83,9 +87,11 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 
 				const result = this.evaluateRule(channel, rule);
 
-				if (result.triggered && result.property) {
+				if (result.triggered) {
 					// Lower severity for intrusion/entry alerts when disarmed
 					const severity = this.adjustSeverityForArmedState(rule.alertType, rule.severity, armedState);
+
+					const sensor = this.identifySensor(channel, rule, channelOfProperty);
 
 					candidates.push({
 						alert: {
@@ -97,9 +103,8 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 							acknowledged: false,
 						},
 						device,
-						// The series behind the reading, not the property that carried it here.
-						sensorId: this.valueSourceRegistry.resolve(result.property),
-						isProjection: this.valueSourceRegistry.isProjected(result.property),
+						sensorId: sensor.id,
+						isProjection: sensor.isProjection,
 					});
 				}
 			}
@@ -145,6 +150,79 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 		};
 	}
 
+	/** Every property in this pass, by the channel it belongs to. */
+	private mapPropertiesToChannels(devices: DeviceEntity[]): Map<string, string> {
+		const channelOfProperty = new Map<string, string>();
+
+		for (const device of devices) {
+			for (const channel of device.channels ?? []) {
+				if (!(channel instanceof ChannelEntity)) {
+					continue;
+				}
+
+				for (const property of channel.properties ?? []) {
+					if (property instanceof ChannelPropertyEntity) {
+						channelOfProperty.set(property.id, channel.id);
+					}
+				}
+			}
+		}
+
+		return channelOfProperty;
+	}
+
+	/**
+	 * Which sensor this channel is reporting, as an identity two devices can agree on.
+	 *
+	 * Asked of the channel rather than of the property that happened to satisfy the rule first, because
+	 * that property is not a stable answer: a rule may list alternatives — the built-in carbon monoxide
+	 * rule checks `detected` before `concentration` — so which one matches depends on the readings at
+	 * that instant. A physical channel matching on `detected` and a projection of it matching on
+	 * `concentration` would then be keyed differently and both survive, and the same pair would
+	 * de-duplicate correctly a moment later. An identity that moves with the values is not an identity.
+	 *
+	 * So the sensor is the *channel* the readings come from: every rule-relevant property that reads
+	 * somebody else's series is traced back to the channel that owns that series, and the channel's own
+	 * id stands in when it projects nothing. A projection sharing one source channel therefore agrees
+	 * with the source however either of them triggered, and however much of the channel was projected —
+	 * the case that matters, since a partly-projected channel keeps local properties of its own.
+	 *
+	 * A channel assembled from *several* sources is a distinct thing the operator built, and keeps its
+	 * own identity: it names them all, so it matches another channel assembled the same way and nothing
+	 * else. Rare enough to be worth stating rather than special-casing.
+	 */
+	private identifySensor(
+		channel: ChannelEntity,
+		rule: ResolvedSensorRule,
+		channelOfProperty: Map<string, string>,
+	): { id: string; isProjection: boolean } {
+		const sourceChannels = new Set<string>();
+
+		for (const check of rule.properties) {
+			const property = this.findProperty(channel, check.property);
+
+			if (!property) {
+				continue;
+			}
+
+			const storageKey = this.valueSourceRegistry.resolve(property);
+
+			if (storageKey === property.id) {
+				continue;
+			}
+
+			// The channel that owns the series, or the series itself when its channel is outside this
+			// pass — still stable, and still shared by everything projecting it.
+			sourceChannels.add(channelOfProperty.get(storageKey) ?? storageKey);
+		}
+
+		if (sourceChannels.size === 0) {
+			return { id: channel.id, isProjection: false };
+		}
+
+		return { id: Array.from(sourceChannels).sort().join('+'), isProjection: true };
+	}
+
 	/**
 	 * One alert per sensor, whatever number of devices are presenting it.
 	 *
@@ -155,11 +233,11 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 	 * and `SecurityAggregatorService.mergeAlerts()` cannot help: it de-duplicates by alert id, and the
 	 * ids differ precisely because the devices do.
 	 *
-	 * Asked of the registry rather than guessed from the device type. "Two channels reading one series"
-	 * is exactly what it answers, and it is the same seam the energy module bills a projected meter
-	 * through — the alternative, skipping any channel whose properties are all projections, is wrong
-	 * for the case virtual devices exist to serve, where the virtual device is the one the user thinks
-	 * of as the sensor.
+	 * Asked of the registry rather than guessed from the device type — see identifySensor() for what
+	 * "the same sensor" resolves to. It is the same seam the energy module bills a projected meter
+	 * through; the alternative, skipping any channel whose properties are all projections, is wrong for
+	 * the case virtual devices exist to serve, where the virtual device is the one the user thinks of
+	 * as the sensor.
 	 *
 	 * Which device the survivor names is the part that is a judgement rather than a mechanism:
 	 *

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.ts
@@ -5,12 +5,23 @@ import { PropertyCategory } from '../../devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueState } from '../../devices/models/property-value-state.model';
 import { DevicesService } from '../../devices/services/devices.service';
+import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { SecurityAggregationContext } from '../contracts/security-aggregation-context.type';
 import { SecurityAlert, SecuritySignal } from '../contracts/security-signal.type';
 import { SecurityStateProviderInterface } from '../contracts/security-state-provider.interface';
 import { ArmedState, SECURITY_MODULE_NAME, SEVERITY_RANK, SecurityAlertType, Severity } from '../security.constants';
 import { DetectionRulesLoaderService } from '../spec/detection-rules-loader.service';
 import { ResolvedPropertyCheck, ResolvedSensorRule } from '../spec/detection-rules.types';
+
+/** One device's account of one triggered sensor, before duplicates of the same sensor are collapsed. */
+interface SensorAlertCandidate {
+	alert: SecurityAlert;
+	device: DeviceEntity;
+	/** The series the reading came from: the same for every device presenting one physical sensor. */
+	sensorId: string;
+	/** Whether this device is presenting somebody else's sensor rather than its own. */
+	isProjection: boolean;
+}
 
 /** Alert types that represent intrusion/entry detection (not life-safety) */
 const INTRUSION_ALERT_TYPES: Set<SecurityAlertType> = new Set([
@@ -25,6 +36,9 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 	constructor(
 		private readonly devicesService: DevicesService,
 		private readonly detectionRulesLoader: DetectionRulesLoaderService,
+		// Answers which series a property reads, which is what tells one sensor reported by two devices
+		// apart from two sensors. See dedupeBySensor().
+		private readonly valueSourceRegistry: PropertyValueSourceRegistryService,
 	) {}
 
 	getKey(): string {
@@ -51,7 +65,7 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 		const rules = this.detectionRulesLoader.getSensorRules();
 		const armedState = context?.armedState ?? null;
 
-		const alerts: SecurityAlert[] = [];
+		const candidates: SensorAlertCandidate[] = [];
 
 		for (const device of devices) {
 			const channels = device.channels ?? [];
@@ -69,21 +83,29 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 
 				const result = this.evaluateRule(channel, rule);
 
-				if (result.triggered) {
+				if (result.triggered && result.property) {
 					// Lower severity for intrusion/entry alerts when disarmed
 					const severity = this.adjustSeverityForArmedState(rule.alertType, rule.severity, armedState);
 
-					alerts.push({
-						id: `sensor:${device.id}:${rule.alertType}`,
-						type: rule.alertType,
-						severity,
-						sourceDeviceId: device.id,
-						timestamp: result.lastUpdated ?? new Date().toISOString(),
-						acknowledged: false,
+					candidates.push({
+						alert: {
+							id: `sensor:${device.id}:${rule.alertType}`,
+							type: rule.alertType,
+							severity,
+							sourceDeviceId: device.id,
+							timestamp: result.lastUpdated ?? new Date().toISOString(),
+							acknowledged: false,
+						},
+						device,
+						// The series behind the reading, not the property that carried it here.
+						sensorId: this.valueSourceRegistry.resolve(result.property),
+						isProjection: this.valueSourceRegistry.isProjected(result.property),
 					});
 				}
 			}
 		}
+
+		const alerts = this.dedupeBySensor(candidates);
 
 		if (alerts.length === 0) {
 			return {
@@ -123,10 +145,80 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 		};
 	}
 
+	/**
+	 * One alert per sensor, whatever number of devices are presenting it.
+	 *
+	 * A virtual device that projects a physical sensor has a channel of that category too, and the
+	 * projection's value *is* the source's — `ChannelPropertyEntitySubscriber` populates it through the
+	 * value-source registry — so the walk above reads the same live reading off both devices and files
+	 * two alerts under different ids for one smoke detector. `activeAlertsCount` then counts it twice,
+	 * and `SecurityAggregatorService.mergeAlerts()` cannot help: it de-duplicates by alert id, and the
+	 * ids differ precisely because the devices do.
+	 *
+	 * Asked of the registry rather than guessed from the device type. "Two channels reading one series"
+	 * is exactly what it answers, and it is the same seam the energy module bills a projected meter
+	 * through — the alternative, skipping any channel whose properties are all projections, is wrong
+	 * for the case virtual devices exist to serve, where the virtual device is the one the user thinks
+	 * of as the sensor.
+	 *
+	 * Which device the survivor names is the part that is a judgement rather than a mechanism:
+	 *
+	 * - a device the user can see is preferred to a hidden one, since an alert naming a device that
+	 *   does not appear anywhere is an alert nobody can act on. Splitting hides a source device once
+	 *   nothing of it is left unprojected, which is exactly when its projection should speak for it;
+	 * - between two visible devices, the projection wins. A partially split device stays visible for
+	 *   the channels it kept, but the sensor in question is the one the operator deliberately moved
+	 *   into a room device, and that room device is where they will look for it;
+	 * - anything still tied is settled by device id, so the same state always produces the same alert.
+	 *
+	 * Nothing is dropped by this: every distinct sensor keeps its alert, including one on a hidden
+	 * device that nothing projects. Suppressing a smoke alarm because somebody hid its device is not a
+	 * de-duplication.
+	 */
+	private dedupeBySensor(candidates: SensorAlertCandidate[]): SecurityAlert[] {
+		const bySensor = new Map<string, SensorAlertCandidate>();
+
+		for (const candidate of candidates) {
+			const key = `${candidate.sensorId}:${candidate.alert.type}`;
+			const held = bySensor.get(key);
+
+			if (!held || this.namesTheSensorBetter(candidate, held)) {
+				bySensor.set(key, candidate);
+			}
+		}
+
+		// And by alert id after that, because the id is what survives downstream: two sensors of one
+		// category on one device share an id, so counting both here reports a number the merged list
+		// never shows. The louder of the two wins, and their ids are identical by construction.
+		const byId = new Map<string, SecurityAlert>();
+
+		for (const { alert } of bySensor.values()) {
+			const held = byId.get(alert.id);
+
+			if (!held || SEVERITY_RANK[alert.severity] > SEVERITY_RANK[held.severity]) {
+				byId.set(alert.id, alert);
+			}
+		}
+
+		return Array.from(byId.values());
+	}
+
+	private namesTheSensorBetter(candidate: SensorAlertCandidate, held: SensorAlertCandidate): boolean {
+		if (candidate.device.hidden !== held.device.hidden) {
+			return !candidate.device.hidden;
+		}
+
+		if (candidate.isProjection !== held.isProjection) {
+			return candidate.isProjection;
+		}
+
+		return candidate.device.id.localeCompare(held.device.id) < 0;
+	}
+
 	private evaluateRule(
 		channel: ChannelEntity,
 		rule: ResolvedSensorRule,
-	): { triggered: boolean; lastUpdated: string | null } {
+	): { triggered: boolean; lastUpdated: string | null; property: ChannelPropertyEntity | null } {
 		for (const check of rule.properties) {
 			const prop = this.findProperty(channel, check.property);
 
@@ -153,11 +245,13 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 			}
 
 			if (this.matchesCondition(actual, check)) {
-				return { triggered: true, lastUpdated };
+				// The property is carried out with the verdict: which series it reads is what decides
+				// whether another device's alert is the same sensor or a different one.
+				return { triggered: true, lastUpdated, property: prop };
 			}
 		}
 
-		return { triggered: false, lastUpdated: null };
+		return { triggered: false, lastUpdated: null, property: null };
 	}
 
 	private findProperty(channel: ChannelEntity, category: PropertyCategory): ChannelPropertyEntity | null {

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.ts
@@ -296,15 +296,41 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 	 * de-duplication.
 	 */
 	private dedupeBySensor(candidates: SensorAlertCandidate[]): SecurityAlert[] {
-		const bySensor = new Map<string, SensorAlertCandidate>();
+		const bySensor = new Map<string, { representative: SensorAlertCandidate; alert: SecurityAlert }>();
 
 		for (const candidate of candidates) {
 			const key = `${candidate.sensorId}:${candidate.alert.type}`;
 			const held = bySensor.get(key);
 
-			if (!held || this.namesTheSensorBetter(candidate, held)) {
-				bySensor.set(key, candidate);
+			if (!held) {
+				bySensor.set(key, { representative: candidate, alert: candidate.alert });
+
+				continue;
 			}
+
+			// Two separate questions, and answering them together got the second one wrong. *Who* names
+			// the sensor is the judgement below; *when it happened* is the newest of what the devices
+			// reported, whichever of them won the naming. A rule with alternatives lets one device
+			// trigger on a fresh reading while another still matches on a stale one — the physical
+			// channel's `detected` going true now, beside a projection matching an old above-threshold
+			// concentration — and carrying the winner's stale timestamp leaves
+			// `SecurityStateListener.syncAckRecords()` treating a new life-safety event as the
+			// acknowledged one.
+			const representative = this.namesTheSensorBetter(candidate, held.representative)
+				? candidate
+				: held.representative;
+
+			bySensor.set(key, {
+				representative,
+				alert: {
+					...representative.alert,
+					timestamp: this.newerTimestamp(held.alert.timestamp, candidate.alert.timestamp),
+					severity:
+						SEVERITY_RANK[candidate.alert.severity] > SEVERITY_RANK[held.alert.severity]
+							? candidate.alert.severity
+							: held.alert.severity,
+				},
+			});
 		}
 
 		// And by alert id after that, because the id is what survives downstream: two sensors of one
@@ -336,10 +362,19 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 			return severityDiff > 0;
 		}
 
-		const heldTime = new Date(held.timestamp).getTime();
-		const time = new Date(alert.timestamp).getTime();
+		return this.newerTimestamp(held.timestamp, alert.timestamp) === alert.timestamp;
+	}
 
-		return !Number.isNaN(time) && (Number.isNaN(heldTime) || time > heldTime);
+	/** The later of two reported times, preferring one that parses over one that does not. */
+	private newerTimestamp(held: string, candidate: string): string {
+		const heldTime = new Date(held).getTime();
+		const candidateTime = new Date(candidate).getTime();
+
+		if (Number.isNaN(candidateTime)) {
+			return held;
+		}
+
+		return Number.isNaN(heldTime) || candidateTime > heldTime ? candidate : held;
 	}
 
 	private namesTheSensorBetter(candidate: SensorAlertCandidate, held: SensorAlertCandidate): boolean {

--- a/apps/backend/src/modules/security/providers/security-sensors.provider.ts
+++ b/apps/backend/src/modules/security/providers/security-sensors.provider.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { PropertyCategory } from '../../devices/devices.constants';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
 import { PropertyValueState } from '../../devices/models/property-value-state.model';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
 import { DevicesService } from '../../devices/services/devices.service';
 import { PropertyValueSourceRegistryService } from '../../devices/services/property-value-source.registry.service';
 import { SecurityAggregationContext } from '../contracts/security-aggregation-context.type';
@@ -36,6 +37,9 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 	constructor(
 		private readonly devicesService: DevicesService,
 		private readonly detectionRulesLoader: DetectionRulesLoaderService,
+		// Reads back a source property this pass never saw — see identifySensor(), and
+		// `aggregateBounded()` for how a pass comes to be missing one.
+		private readonly channelsPropertiesService: ChannelsPropertiesService,
 		// Answers which series a property reads, which is what tells one sensor reported by two devices
 		// apart from two sensors. See dedupeBySensor().
 		private readonly valueSourceRegistry: PropertyValueSourceRegistryService,
@@ -91,7 +95,7 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 					// Lower severity for intrusion/entry alerts when disarmed
 					const severity = this.adjustSeverityForArmedState(rule.alertType, rule.severity, armedState);
 
-					const sensor = this.identifySensor(channel, rule, channelOfProperty);
+					const sensor = await this.identifySensor(channel, rule, channelOfProperty);
 
 					candidates.push({
 						alert: {
@@ -191,11 +195,11 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 	 * own identity: it names them all, so it matches another channel assembled the same way and nothing
 	 * else. Rare enough to be worth stating rather than special-casing.
 	 */
-	private identifySensor(
+	private async identifySensor(
 		channel: ChannelEntity,
 		rule: ResolvedSensorRule,
 		channelOfProperty: Map<string, string>,
-	): { id: string; isProjection: boolean } {
+	): Promise<{ id: string; isProjection: boolean }> {
 		const sourceChannels = new Set<string>();
 
 		for (const check of rule.properties) {
@@ -211,9 +215,7 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 				continue;
 			}
 
-			// The channel that owns the series, or the series itself when its channel is outside this
-			// pass — still stable, and still shared by everything projecting it.
-			sourceChannels.add(channelOfProperty.get(storageKey) ?? storageKey);
+			sourceChannels.add((await this.resolveOwningChannel(storageKey, channelOfProperty)) ?? storageKey);
 		}
 
 		if (sourceChannels.size === 0) {
@@ -221,6 +223,46 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 		}
 
 		return { id: Array.from(sourceChannels).sort().join('+'), isProjection: true };
+	}
+
+	/**
+	 * The channel a source property belongs to, whether or not this pass happened to walk it.
+	 *
+	 * The in-pass map answers most of it for nothing. It cannot answer all of it: `aggregateBounded()`
+	 * hands the provider a scoped device set, and a hidden or out-of-scope source device is simply not
+	 * in it — so two virtual devices projecting *different properties of one hidden channel* would fall
+	 * back to two different property ids and be counted twice, while the same pair counts once in the
+	 * full-home pass. A sensor's identity cannot depend on which pass is asking.
+	 *
+	 * Read back one property at a time, cached for the pass, and only ever for a property that is
+	 * projected and whose channel is outside it — bounded by the projections in scope, which is a
+	 * handful. A read that fails leaves the caller with the series key, which is what it had before:
+	 * still stable, still shared by everything projecting that exact property.
+	 */
+	private async resolveOwningChannel(
+		propertyId: string,
+		channelOfProperty: Map<string, string>,
+	): Promise<string | null> {
+		const known = channelOfProperty.get(propertyId);
+
+		if (known !== undefined) {
+			return known;
+		}
+
+		try {
+			const property = await this.channelsPropertiesService.findOne(propertyId);
+			const channelId = typeof property?.channel === 'string' ? property.channel : property?.channel?.id;
+
+			// Cached either way: a source that does not resolve is not worth asking about twice in one
+			// pass, and `null` is a different answer from "not looked up yet".
+			channelOfProperty.set(propertyId, channelId ?? '');
+
+			return channelId ?? null;
+		} catch (error) {
+			this.logger.warn(`Failed to resolve the channel of source property ${propertyId}: ${error}`);
+
+			return null;
+		}
 	}
 
 	/**
@@ -267,18 +309,37 @@ export class SecuritySensorsProvider implements SecurityStateProviderInterface {
 
 		// And by alert id after that, because the id is what survives downstream: two sensors of one
 		// category on one device share an id, so counting both here reports a number the merged list
-		// never shows. The louder of the two wins, and their ids are identical by construction.
+		// never shows.
+		//
+		// The louder wins, and at equal volume — which is the ordinary case, since both came from the
+		// same rule — the *newer* does, matching `SecurityAggregatorService.mergeAlerts()`. The
+		// timestamp is not decoration on a life-safety path: `SecurityStateListener.syncAckRecords()`
+		// reads it to decide whether an alert is a new occurrence, so keeping the older of two smoke
+		// alerts leaves the second one showing as acknowledged because the first was.
 		const byId = new Map<string, SecurityAlert>();
 
 		for (const { alert } of bySensor.values()) {
 			const held = byId.get(alert.id);
 
-			if (!held || SEVERITY_RANK[alert.severity] > SEVERITY_RANK[held.severity]) {
+			if (!held || this.speaksForTheAlertId(alert, held)) {
 				byId.set(alert.id, alert);
 			}
 		}
 
 		return Array.from(byId.values());
+	}
+
+	private speaksForTheAlertId(alert: SecurityAlert, held: SecurityAlert): boolean {
+		const severityDiff = SEVERITY_RANK[alert.severity] - SEVERITY_RANK[held.severity];
+
+		if (severityDiff !== 0) {
+			return severityDiff > 0;
+		}
+
+		const heldTime = new Date(held.timestamp).getTime();
+		const time = new Date(alert.timestamp).getTime();
+
+		return !Number.isNaN(time) && (Number.isNaN(heldTime) || time > heldTime);
 	}
 
 	private namesTheSensorBetter(candidate: SensorAlertCandidate, held: SensorAlertCandidate): boolean {

--- a/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
+++ b/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md
@@ -243,7 +243,7 @@ Jest's "worker process has failed to exit gracefully" warning appears across the
 - No test exercises `DeviceHiddenFilter.TRUE`; a mutation flipping only that branch would go undetected.
 - `permissionSatisfied` is restated in `VirtualDevicesService` rather than reused, because the canonical method is private on `DeviceValidationService`. Extracting it would remove the drift risk.
 
-### 3.7 The security aggregator double-counts a projected sensor (medium)
+### 3.7 The security aggregator double-counts a projected sensor (medium) — DONE
 
 `SecuritySensorsProvider.buildSignals()` walks every device's channels and emits one alert per channel matching a detection rule, keyed `sensor:<deviceId>:<alertType>`. A virtual device that projects a physical motion/smoke/contact sensor has its own channel of that category, and `ChannelPropertyEntitySubscriber.afterLoad` populates the projection's `value` through `PropertyValueService.readLatest()` — which resolves the storage key through the value-source registry — so the provider reads the source's live value off the virtual device too.
 
@@ -253,7 +253,11 @@ Not caused by this branch's listener work and not fixable there: `SecurityStateL
 
 Fixing it means deciding, in the provider, which of the two channels represents the sensor. The obvious rule — skip a channel whose properties are all projections — is wrong for the case virtual devices exist to serve, where the virtual device is the one the user thinks of as the sensor. It is a product decision about which device an alert should name, not a mechanical de-duplication.
 
-The same shape almost certainly applies to any other provider or module that scans `devices → channels → properties` and aggregates per match; only the security sensors provider was checked.
+Settled as: **the device the user can see, and between two visible ones the projection.** Splitting hides a source device once nothing of it is left unprojected, which is exactly when its projection should speak for it; a partially split device stays visible for the channels it kept, but the sensor in question is the one the operator deliberately moved into a room device. Ties go to the lower device id, so the same state always produces the same alert.
+
+The counting half needed no decision. "Two channels reading one series" is what `PropertyValueSourceRegistryService` answers, and it is the same seam the energy module bills a projected meter through. De-duplication drops nothing: every distinct sensor keeps its alert, including one on a hidden device that nothing projects — suppressing a smoke alarm because somebody hid its device is not a de-duplication. Alerts are also collapsed by id afterwards, since two sensors of one category on one device share an id and counting both reported a number the merged list never showed.
+
+The same shape almost certainly applies to any other provider or module that scans `devices → channels → properties` and aggregates per match; only the security sensors provider was checked, and it is the only one fixed.
 
 ### 3.8 Two virtual properties projecting one non-qualifying source both ingest (low) — DONE
 


### PR DESCRIPTION
Closes follow-up [`3.7`](../blob/main/tasks/technical/TECH-VIRTUAL-DEVICES-FOLLOWUPS.md), which was left open because it needed a product decision. The decision is in the code and in the task file; the mechanism around it needed none.

## The defect

`SecuritySensorsProvider` walks devices → channels and emits `sensor:<deviceId>:<alertType>` for each channel matching a detection rule. A virtual device projecting a physical smoke detector **has a channel of that category too**, and `ChannelPropertyEntitySubscriber` populates the projection's value through the value-source registry — so the walk reads the same live reading off both devices.

Two alerts, different ids, for one detector. `activeAlertsCount` counts it twice, and `SecurityAggregatorService.mergeAlerts()` cannot help: it de-duplicates by alert id, and the ids differ precisely because the devices do.

Splitting makes this routine rather than exotic — a multi-sensor split into per-room devices double-counts every sensor it projects.

## The mechanism, which needed no decision

"Two channels reading one series" is exactly what `PropertyValueSourceRegistryService` answers, and it is the same seam the energy module bills a projected meter through. `evaluateRule` now carries out *which property* matched, and its resolved storage key is the sensor's identity.

The alternative considered in the follow-up — skip a channel whose properties are all projections — is wrong for the case virtual devices exist to serve, where the virtual device is the one the user thinks of as the sensor.

## The decision, which did

Which device the survivor names:

- **a device the user can see beats a hidden one.** An alert naming a device that appears nowhere is one nobody can act on, and splitting hides a source device once nothing of it is left unprojected — exactly when its projection should speak for it;
- **between two visible devices, the projection wins.** A partially split device stays visible for the channels it kept, but the sensor in question is the one the operator deliberately moved into a room device, and that is where they will look for it;
- **ties go to the lower device id**, so the same state always produces the same alert.

## What is not dropped

Every distinct sensor keeps its alert, including one on a hidden device that nothing projects. Suppressing a smoke alarm because somebody hid its device is not a de-duplication, and this is a change to a life-safety path — so it collapses duplicates of one series and nothing else.

One extra collapse, by alert id: two sensors of the same category on one device share an id by construction, so counting both reported a number the merged list downstream never showed. The louder of the two survives.

## Tests

Four, all verified to fail without the change (three of them; the fourth pins what must not change):

- one detector presented by two devices counts once;
- the visible device names it, not the hidden source;
- the projection names it when both are visible;
- a hidden device's *own* sensor keeps its alert, and two genuinely different sensors stay two.

The existing 181 pass untouched. 3840 backend unit tests green; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
