### PR TITLE
feat(backend): add OAuth artifact management identity

### DIFF
--- a/apps/backend/src/migrations/1000000000013-AddMcpOAuthProviderManagementIds.ts
+++ b/apps/backend/src/migrations/1000000000013-AddMcpOAuthProviderManagementIds.ts
@@ -1,0 +1,107 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const managementIdExpression =
+	`lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || ` +
+	`substr(hex(randomblob(2)), 2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || ` +
+	`substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6)))`;
+
+export class AddMcpOAuthProviderManagementIds1000000000013 implements MigrationInterface {
+	name = 'AddMcpOAuthProviderManagementIds1000000000013';
+
+	async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "temporary_mcp_module_oauth_provider_artifacts" (` +
+				`"model" varchar NOT NULL, ` +
+				`"idHash" varchar NOT NULL, ` +
+				`"managementId" varchar NOT NULL, ` +
+				`"payload" text NOT NULL, ` +
+				`"grantIdHash" varchar, ` +
+				`"refreshFamilyId" varchar, ` +
+				`"userCodeHash" varchar, ` +
+				`"uidHash" varchar, ` +
+				`"consumedAt" integer, ` +
+				`"expiresAt" integer, ` +
+				`CONSTRAINT "PK_mcp_oauth_provider_artifact" PRIMARY KEY ("model", "idHash"))`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "temporary_mcp_module_oauth_provider_artifacts" (` +
+				`"model", "idHash", "managementId", "payload", "grantIdHash", "refreshFamilyId", ` +
+				`"userCodeHash", "uidHash", "consumedAt", "expiresAt") ` +
+				`SELECT "model", "idHash", ${managementIdExpression}, "payload", "grantIdHash", NULL, ` +
+				`"userCodeHash", "uidHash", "consumedAt", "expiresAt" ` +
+				`FROM "mcp_module_oauth_provider_artifacts"`,
+		);
+		await queryRunner.query(
+			`UPDATE "temporary_mcp_module_oauth_provider_artifacts" AS "artifact" ` +
+				`SET "refreshFamilyId" = (` +
+					`SELECT MIN("family"."managementId") ` +
+					`FROM "temporary_mcp_module_oauth_provider_artifacts" AS "family" ` +
+					`WHERE "family"."model" = 'RefreshToken' ` +
+					`AND "family"."grantIdHash" = "artifact"."grantIdHash") ` +
+				`WHERE "artifact"."model" IN ('AccessToken', 'RefreshToken') ` +
+				`AND "artifact"."grantIdHash" IS NOT NULL`,
+		);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_provider_artifacts"`);
+		await queryRunner.query(
+			`ALTER TABLE "temporary_mcp_module_oauth_provider_artifacts" RENAME TO "mcp_module_oauth_provider_artifacts"`,
+		);
+		await this.createIndexes(queryRunner);
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "temporary_mcp_module_oauth_provider_artifacts" (` +
+				`"model" varchar NOT NULL, ` +
+				`"idHash" varchar NOT NULL, ` +
+				`"payload" text NOT NULL, ` +
+				`"grantIdHash" varchar, ` +
+				`"userCodeHash" varchar, ` +
+				`"uidHash" varchar, ` +
+				`"consumedAt" integer, ` +
+				`"expiresAt" integer, ` +
+				`CONSTRAINT "PK_mcp_oauth_provider_artifact" PRIMARY KEY ("model", "idHash"))`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "temporary_mcp_module_oauth_provider_artifacts" (` +
+				`"model", "idHash", "payload", "grantIdHash", "userCodeHash", "uidHash", "consumedAt", "expiresAt") ` +
+				`SELECT "model", "idHash", "payload", "grantIdHash", "userCodeHash", "uidHash", "consumedAt", "expiresAt" ` +
+				`FROM "mcp_module_oauth_provider_artifacts"`,
+		);
+		await queryRunner.query(`DROP TABLE "mcp_module_oauth_provider_artifacts"`);
+		await queryRunner.query(
+			`ALTER TABLE "temporary_mcp_module_oauth_provider_artifacts" RENAME TO "mcp_module_oauth_provider_artifacts"`,
+		);
+		await this.createLegacyIndexes(queryRunner);
+	}
+
+	private async createIndexes(queryRunner: QueryRunner): Promise<void> {
+		await this.createLegacyIndexes(queryRunner);
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "IDX_mcp_oauth_provider_artifact_management" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("managementId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_provider_artifact_family" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("refreshFamilyId")`,
+		);
+	}
+
+	private async createLegacyIndexes(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_provider_artifact_grant" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("grantIdHash")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_provider_artifact_user_code" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("userCodeHash")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_provider_artifact_uid" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("uidHash")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_mcp_oauth_provider_artifact_expiry" ` +
+				`ON "mcp_module_oauth_provider_artifacts" ("expiresAt")`,
+		);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000013-AddMcpOAuthProviderManagementIds.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000013-AddMcpOAuthProviderManagementIds.spec.ts
@@ -1,0 +1,99 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddMcpOAuthProviderManagementIds1000000000013 } from '../1000000000013-AddMcpOAuthProviderManagementIds';
+
+describe('AddMcpOAuthProviderManagementIds1000000000013', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+	const migration = new AddMcpOAuthProviderManagementIds1000000000013();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:' });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_provider_artifacts" (` +
+				`"model" varchar NOT NULL, "idHash" varchar NOT NULL, "payload" text NOT NULL, ` +
+				`"grantIdHash" varchar, "userCodeHash" varchar, "uidHash" varchar, ` +
+				`"consumedAt" integer, "expiresAt" integer, ` +
+				`PRIMARY KEY ("model", "idHash"))`,
+		);
+		await createLegacyIndexes(queryRunner);
+		await queryRunner.query(
+			`INSERT INTO "mcp_module_oauth_provider_artifacts" ` +
+				`("model", "idHash", "payload", "grantIdHash", "expiresAt") VALUES ` +
+				`('AccessToken', 'access-one', '{}', 'grant-one', 2000), ` +
+				`('RefreshToken', 'refresh-one', '{}', 'grant-one', 3000), ` +
+				`('RefreshToken', 'refresh-two', '{}', 'grant-one', 4000), ` +
+				`('AccessToken', 'access-two', '{}', 'grant-two', 5000)`,
+		);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('backfills unique non-secret management IDs and stable refresh-family IDs', async () => {
+		await migration.up(queryRunner);
+
+		const columns = (await queryRunner.query(`PRAGMA table_info("mcp_module_oauth_provider_artifacts")`)) as Array<{
+			name: string;
+			notnull: number;
+		}>;
+		const rows = (await queryRunner.query(
+			`SELECT "model", "idHash", "managementId", "refreshFamilyId" ` +
+				`FROM "mcp_module_oauth_provider_artifacts" ORDER BY "idHash"`,
+		)) as Array<{ model: string; idHash: string; managementId: string; refreshFamilyId: string | null }>;
+		const grantOne = rows.filter(({ idHash }) => ['access-one', 'refresh-one', 'refresh-two'].includes(idHash));
+
+		expect(columns).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: 'managementId', notnull: 1 }),
+				expect.objectContaining({ name: 'refreshFamilyId' }),
+			]),
+		);
+		expect(new Set(rows.map(({ managementId }) => managementId)).size).toBe(rows.length);
+		expect(rows.every(({ managementId }) => /^[0-9a-f-]{36}$/.test(managementId))).toBe(true);
+		expect(new Set(grantOne.map(({ refreshFamilyId }) => refreshFamilyId))).toEqual(
+			new Set([grantOne[0]?.refreshFamilyId]),
+		);
+		expect(grantOne[0]?.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(rows.find(({ idHash }) => idHash === 'access-two')?.refreshFamilyId).toBeNull();
+	});
+
+	it('removes management columns without losing provider artifacts', async () => {
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		const columns = (await queryRunner.query(`PRAGMA table_info("mcp_module_oauth_provider_artifacts")`)) as Array<{
+			name: string;
+		}>;
+		const rows = (await queryRunner.query(
+			`SELECT "model", "idHash", "grantIdHash" FROM "mcp_module_oauth_provider_artifacts"`,
+		)) as Array<{ model: string; idHash: string; grantIdHash: string }>;
+
+		expect(columns.map(({ name }) => name)).not.toContain('managementId');
+		expect(columns.map(({ name }) => name)).not.toContain('refreshFamilyId');
+		expect(rows).toHaveLength(4);
+	});
+});
+
+const createLegacyIndexes = async (queryRunner: QueryRunner): Promise<void> => {
+	await queryRunner.query(
+		`CREATE INDEX "IDX_mcp_oauth_provider_artifact_grant" ` +
+			`ON "mcp_module_oauth_provider_artifacts" ("grantIdHash")`,
+	);
+	await queryRunner.query(
+		`CREATE INDEX "IDX_mcp_oauth_provider_artifact_user_code" ` +
+			`ON "mcp_module_oauth_provider_artifacts" ("userCodeHash")`,
+	);
+	await queryRunner.query(
+		`CREATE INDEX "IDX_mcp_oauth_provider_artifact_uid" ` +
+			`ON "mcp_module_oauth_provider_artifacts" ("uidHash")`,
+	);
+	await queryRunner.query(
+		`CREATE INDEX "IDX_mcp_oauth_provider_artifact_expiry" ` +
+			`ON "mcp_module_oauth_provider_artifacts" ("expiresAt")`,
+	);
+};

--- a/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
+++ b/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
@@ -333,12 +333,20 @@ export class McpOAuthProviderArtifactEntity {
 	@PrimaryColumn({ type: 'varchar' })
 	idHash: string;
 
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	managementId: string;
+
 	@Column({ type: 'text' })
 	payload: string;
 
 	@Index()
 	@Column({ type: 'varchar', nullable: true })
 	grantIdHash: string | null;
+
+	@Index()
+	@Column({ type: 'varchar', nullable: true })
+	refreshFamilyId: string | null;
 
 	@Index()
 	@Column({ type: 'varchar', nullable: true })

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.spec.ts
@@ -1,0 +1,61 @@
+import { DataSource } from 'typeorm';
+
+import { hashToken } from '../../auth/utils/token.utils';
+import { McpOAuthProviderArtifactEntity, McpOAuthProviderRevokedGrantEntity } from '../entities/mcp-oauth.entity';
+import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
+
+import { createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
+
+describe('MCP OAuth provider adapter management identity', () => {
+	let dataSource: DataSource;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [McpOAuthProviderArtifactEntity, McpOAuthProviderRevokedGrantEntity],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	it('preserves non-secret management and refresh-family IDs across provider upserts and rotation', async () => {
+		const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+			allowTestInMemory: true,
+		});
+		const accessAdapter = new Adapter('AccessToken');
+		const refreshAdapter = new Adapter('RefreshToken');
+		const grantId = 'provider-grant-id';
+		const payload = { grantId, clientId: 'public-client', scope: 'mcp:read' };
+
+		await accessAdapter.upsert('access-token', payload, 60);
+		const initialAccess = await find('AccessToken', 'access-token');
+		await accessAdapter.upsert('access-token', { ...payload, scope: 'mcp:read mcp:write' }, 60);
+		const updatedAccess = await find('AccessToken', 'access-token');
+		await refreshAdapter.upsert('refresh-token-one', payload, 120);
+		const firstRefresh = await find('RefreshToken', 'refresh-token-one');
+		const linkedAccess = await find('AccessToken', 'access-token');
+		await refreshAdapter.upsert('refresh-token-two', payload, 120);
+		const secondRefresh = await find('RefreshToken', 'refresh-token-two');
+
+		expect(initialAccess.managementId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(updatedAccess.managementId).toBe(initialAccess.managementId);
+		expect(firstRefresh.managementId).not.toBe(secondRefresh.managementId);
+		expect(firstRefresh.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(secondRefresh.refreshFamilyId).toBe(firstRefresh.refreshFamilyId);
+		expect(linkedAccess.refreshFamilyId).toBe(firstRefresh.refreshFamilyId);
+		expect(JSON.stringify([linkedAccess, firstRefresh, secondRefresh])).not.toContain('access-token');
+		expect(JSON.stringify([linkedAccess, firstRefresh, secondRefresh])).not.toContain('refresh-token-one');
+	});
+
+	async function find(model: string, rawValue: string): Promise<McpOAuthProviderArtifactEntity> {
+		return dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneByOrFail({
+			model,
+			idHash: hashToken(rawValue),
+		});
+	}
+});

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
@@ -1,5 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import type { Adapter, AdapterConstructor, AdapterPayload } from 'oidc-provider';
-import { DataSource, IsNull, LessThanOrEqual } from 'typeorm';
+import { DataSource, IsNull, LessThanOrEqual, Not, Repository } from 'typeorm';
 
 import { hashToken } from '../../auth/utils/token.utils';
 import { McpOAuthProviderArtifactEntity, McpOAuthProviderRevokedGrantEntity } from '../entities/mcp-oauth.entity';
@@ -56,12 +57,17 @@ export const createMcpOAuthProviderAdapter = (
 			}
 
 			const repository = dataSource.getRepository(McpOAuthProviderArtifactEntity);
+			const idHash = hashToken(id);
+			const existing = await repository.findOneBy({ model: this.model, idHash });
+			const refreshFamilyId = await this.resolveRefreshFamilyId(repository, existing, grantIdHash);
 			await repository.upsert(
 				{
 					model: this.model,
-					idHash: hashToken(id),
+					idHash,
+					managementId: existing?.managementId ?? randomUUID(),
 					payload: serializePayload(this.model, payload),
 					grantIdHash,
+					refreshFamilyId,
 					userCodeHash: typeof payload.userCode === 'string' ? hashToken(payload.userCode) : null,
 					uidHash: typeof payload.uid === 'string' ? hashToken(payload.uid) : null,
 					consumedAt: null,
@@ -69,6 +75,10 @@ export const createMcpOAuthProviderAdapter = (
 				},
 				['model', 'idHash'],
 			);
+
+			if (this.model === 'RefreshToken' && grantIdHash && refreshFamilyId) {
+				await repository.update({ model: 'AccessToken', grantIdHash, refreshFamilyId: IsNull() }, { refreshFamilyId });
+			}
 
 			if (grantIdHash !== null && (await this.isGrantRevoked(grantIdHash))) {
 				await repository.delete({ model: this.model, idHash: hashToken(id) });
@@ -177,6 +187,21 @@ export const createMcpOAuthProviderAdapter = (
 
 		private artifactReuseError(): Error {
 			return options.artifactReuseError?.() ?? new Error(`OAuth artifact ${this.model} was already consumed`);
+		}
+
+		private async resolveRefreshFamilyId(
+			repository: Repository<McpOAuthProviderArtifactEntity>,
+			existing: McpOAuthProviderArtifactEntity | null,
+			grantIdHash: string | null,
+		): Promise<string | null> {
+			if (existing?.refreshFamilyId) return existing.refreshFamilyId;
+			if (!grantIdHash || (this.model !== 'AccessToken' && this.model !== 'RefreshToken')) return null;
+
+			const familyArtifact = await repository.findOne({
+				where: { model: 'RefreshToken', grantIdHash, refreshFamilyId: Not(IsNull()) },
+			});
+
+			return familyArtifact?.refreshFamilyId ?? (this.model === 'RefreshToken' ? randomUUID() : null);
 		}
 
 		private async readActiveRecord(

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -321,7 +321,21 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 			expect(JSON.parse(artifact.payload)).not.toHaveProperty('jti');
 			expect(artifact.payload).not.toContain(rawValue);
+			expect(artifact.managementId).toMatch(/^[0-9a-f-]{36}$/);
+			expect(artifact.managementId).not.toBe(artifact.idHash);
 		}
+
+		const accessArtifact = await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneByOrFail({
+			model: 'AccessToken',
+			idHash: createHash('sha256').update(tokens.access_token).digest('hex'),
+		});
+		const refreshArtifact = await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneByOrFail({
+			model: 'RefreshToken',
+			idHash: createHash('sha256').update(tokens.refresh_token).digest('hex'),
+		});
+
+		expect(accessArtifact.refreshFamilyId).toBe(refreshArtifact.refreshFamilyId);
+		expect(refreshArtifact.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
 	});
 
 	it('requires fresh consent even when the browser has an existing client grant', async () => {
@@ -468,6 +482,8 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		const familyExpiry = (initialPayload.iiat + 30 * 24 * 60 * 60) * 1_000;
 
 		expect(refreshResponse.status).toBe(200);
+		expect(successorArtifact.managementId).not.toBe(initialArtifact.managementId);
+		expect(successorArtifact.refreshFamilyId).toBe(initialArtifact.refreshFamilyId);
 		expect(successorArtifact.expiresAt).toBeLessThanOrEqual(familyExpiry);
 		expect(successorArtifact.expiresAt).toBeGreaterThan(familyExpiry - 2_000);
 	});

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 4 complete — discovery, challenges, and OAuth resource validation implemented behind the internal gate
+**Status:** Phase 5 in progress — non-secret provider-artifact management identity foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -112,6 +112,16 @@ amend ADR 0002.
 ## Phase 5 — Administration and immediate invalidation
 
 **Goal:** Complete every invalidation/admin control, then expose the full OAuth surface atomically.
+
+### Phase 5a — Administrative artifact identity foundation
+
+- [x] Add stable, non-secret management IDs for provider artifacts without exposing raw tokens or token hashes.
+- [x] Add stable refresh-family IDs shared by rotated refresh tokens and their associated access tokens.
+- [x] Backfill deployed provider artifacts through an incremental migration and preserve the original schema on rollback.
+- [x] Prove management IDs survive provider upserts, family IDs survive refresh rotation, and raw artifacts remain absent
+      from persistence and management identifiers.
+
+### Remaining Phase 5 controls
 
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 4 internal-gated discovery, challenges, and resource validation complete
+Status: in progress — Phase 5 provider-artifact management identity foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add stable, non-secret management IDs for opaque OAuth provider artifacts
- add refresh-family IDs that survive refresh-token rotation and link associated access tokens
- backfill existing provider artifacts through incremental migration 1000000000013, with rollback preserving all legacy data
- preserve management identity across provider upserts without exposing raw credentials or token hashes
- record Phase 5a completion in the MCP OAuth implementation plan

## Why

Phase 5 administration needs stable identifiers for listing and revoking access tokens and refresh families. The provider currently stores only hashes of opaque artifacts, and those hashes must not be exposed through admin APIs. This slice creates a safe management boundary before adding the administrative endpoints and targeted invalidation controls.

## Impact

There is no public OAuth route or user-facing behavior change. Existing artifacts receive UUID management identifiers during migration. New and rotated artifacts preserve their management/family relationships automatically.

## Validation

- backend type-check
- migration upgrade/rollback and backfill tests
- provider adapter management/upsert/rotation tests
- embedded OAuth provider spike: 11 tests
- targeted lint
- `git diff --check`