### PR TITLE
feat(backend): add targeted OAuth subscription invalidation

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -25,7 +25,15 @@ export type McpAuditDenialReason =
 
 export type McpAuditRequestFailureReason = 'policy_resolution_error';
 
-export type McpSubscriptionCloseReason = 'cancelled' | 'client_closed' | 'completed' | 'error' | 'idle' | 'shutdown';
+export type McpSubscriptionCloseReason =
+	| 'authorization_expired'
+	| 'authorization_revoked'
+	| 'cancelled'
+	| 'client_closed'
+	| 'completed'
+	| 'error'
+	| 'idle'
+	| 'shutdown';
 
 export interface McpAuditMetricsSnapshot {
 	activeSubscriptions: number;

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
@@ -66,6 +66,7 @@ describe('McpOAuthResourceServerService', () => {
 			idHash: TOKEN_ID,
 			payload: JSON.stringify(payload),
 			grantIdHash: PROVIDER_GRANT_ID_HASH,
+			refreshFamilyId: 'refresh-family-id',
 			expiresAt: Date.now() + 60_000,
 		});
 		grant = Object.assign(new McpOAuthGrantEntity(), {
@@ -166,7 +167,11 @@ describe('McpOAuthResourceServerService', () => {
 			}),
 		);
 		expect(authInfo.extra?.principal).toEqual(
-			expect.objectContaining({ effectiveCapabilities: [McpCapability.READ], installationId: INSTALLATION_ID }),
+			expect.objectContaining({
+				effectiveCapabilities: [McpCapability.READ],
+				installationId: INSTALLATION_ID,
+				refreshFamilyId: 'refresh-family-id',
+			}),
 		);
 	});
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
@@ -140,6 +140,7 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 			clientId: grant.client.id,
 			grantId: grant.id,
 			installationId,
+			...(artifact.refreshFamilyId ? { refreshFamilyId: artifact.refreshFamilyId } : {}),
 			scopes: tokenScopes,
 			effectiveCapabilities,
 		};

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -125,7 +125,9 @@ describe('McpSubscriptionRegistryService', () => {
 			authorizationDeadline: new Date(Date.now() + 1_000),
 		});
 
-		jest.advanceTimersByTime(999);
+		jest.advanceTimersByTime(500);
+		subscription.touch();
+		jest.advanceTimersByTime(499);
 		expect(subscription.signal.aborted).toBe(false);
 		jest.advanceTimersByTime(1);
 
@@ -135,5 +137,21 @@ describe('McpSubscriptionRegistryService', () => {
 			subscription.id,
 			'authorization_expired',
 		);
+	});
+
+	it('cancels the authorization deadline timer when an OAuth stream closes early', () => {
+		jest.useFakeTimers();
+		const subscription = service.open('client-a', 'early-close', {
+			accessTokenId: 'access-one',
+			grantId: 'grant-one',
+			authorizationDeadline: new Date(Date.now() + 60_000),
+		});
+
+		expect(jest.getTimerCount()).toBe(2);
+
+		subscription.close();
+
+		expect(subscription.signal.aborted).toBe(true);
+		expect(jest.getTimerCount()).toBe(0);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -89,4 +89,51 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(second.signal.aborted).toBe(true);
 		expect(service.activeCount).toBe(0);
 	});
+
+	it('closes only OAuth streams matching a revoked artifact identity', () => {
+		const staticStream = service.open('client-a');
+		const first = service.open('client-a', 'one', {
+			accessTokenId: 'access-one',
+			grantId: 'grant-one',
+			refreshFamilyId: 'family-one',
+			authorizationDeadline: new Date(Date.now() + 60_000),
+		});
+		const other = service.open('client-a', 'two', {
+			accessTokenId: 'access-two',
+			grantId: 'grant-two',
+			refreshFamilyId: 'family-two',
+			authorizationDeadline: new Date(Date.now() + 60_000),
+		});
+
+		service.closeOAuthAccessToken('access-one');
+
+		expect(first.signal.aborted).toBe(true);
+		expect(other.signal.aborted).toBe(false);
+		expect(staticStream.signal.aborted).toBe(false);
+
+		service.closeOAuthRefreshFamily('family-two');
+
+		expect(other.signal.aborted).toBe(true);
+		expect(staticStream.signal.aborted).toBe(false);
+	});
+
+	it('closes OAuth streams at their authorization deadline', () => {
+		jest.useFakeTimers();
+		const subscription = service.open('client-a', 'deadline', {
+			accessTokenId: 'access-one',
+			grantId: 'grant-one',
+			authorizationDeadline: new Date(Date.now() + 1_000),
+		});
+
+		jest.advanceTimersByTime(999);
+		expect(subscription.signal.aborted).toBe(false);
+		jest.advanceTimersByTime(1);
+
+		expect(subscription.signal.aborted).toBe(true);
+		expect(auditService.recordSubscriptionClosed).toHaveBeenCalledWith(
+			{ requestId: 'deadline', clientId: 'client-a' },
+			subscription.id,
+			'authorization_expired',
+		);
+	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -25,12 +25,21 @@ export interface McpSubscriptionHandle {
 	touch: () => void;
 }
 
+export interface McpOAuthSubscriptionBinding {
+	accessTokenId: string;
+	grantId: string;
+	refreshFamilyId?: string;
+	authorizationDeadline: Date;
+}
+
 interface SubscriptionRecord {
 	id: string;
 	clientId: string;
 	requestId: string;
 	controller: AbortController;
 	timer: NodeJS.Timeout;
+	authorizationTimer?: NodeJS.Timeout;
+	oauth?: McpOAuthSubscriptionBinding;
 }
 
 @Injectable()
@@ -39,7 +48,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 
 	constructor(private readonly auditService: McpAuditService) {}
 
-	open(clientId: string, requestId = 'unknown'): McpSubscriptionHandle {
+	open(clientId: string, requestId = 'unknown', oauth?: McpOAuthSubscriptionBinding): McpSubscriptionHandle {
 		if (
 			this.subscriptions.size >= MCP_MAX_ACTIVE_SUBSCRIPTIONS ||
 			this.countForClient(clientId) >= MCP_MAX_SUBSCRIPTIONS_PER_CLIENT
@@ -55,6 +64,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 			requestId,
 			controller,
 			timer: this.createIdleTimer(id),
+			...(oauth ? { oauth: { ...oauth }, authorizationTimer: this.createAuthorizationTimer(id, oauth) } : {}),
 		};
 
 		this.subscriptions.set(id, record);
@@ -101,6 +111,26 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		}
 	}
 
+	closeOAuthClient(clientId: string): void {
+		this.closeMatching((subscription) => subscription.clientId === clientId && subscription.oauth !== undefined);
+	}
+
+	closeOAuthGrant(grantId: string): void {
+		this.closeMatching((subscription) => subscription.oauth?.grantId === grantId);
+	}
+
+	closeOAuthAccessToken(accessTokenId: string): void {
+		this.closeMatching((subscription) => subscription.oauth?.accessTokenId === accessTokenId);
+	}
+
+	closeOAuthRefreshFamily(refreshFamilyId: string): void {
+		this.closeMatching((subscription) => subscription.oauth?.refreshFamilyId === refreshFamilyId);
+	}
+
+	closeAllOAuth(): void {
+		this.closeMatching((subscription) => subscription.oauth !== undefined);
+	}
+
 	closeAll(): void {
 		for (const id of [...this.subscriptions.keys()]) {
 			this.close(id, 'shutdown');
@@ -119,6 +149,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		}
 
 		clearTimeout(subscription.timer);
+		if (subscription.authorizationTimer) clearTimeout(subscription.authorizationTimer);
 		subscription.timer = this.createIdleTimer(id);
 	}
 
@@ -144,5 +175,19 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		timer.unref();
 
 		return timer;
+	}
+
+	private createAuthorizationTimer(id: string, oauth: McpOAuthSubscriptionBinding): NodeJS.Timeout {
+		const delay = Math.max(0, oauth.authorizationDeadline.getTime() - Date.now());
+		const timer = setTimeout(() => this.close(id, 'authorization_expired'), delay);
+		timer.unref();
+
+		return timer;
+	}
+
+	private closeMatching(predicate: (subscription: SubscriptionRecord) => boolean): void {
+		for (const subscription of [...this.subscriptions.values()]) {
+			if (predicate(subscription)) this.close(subscription.id, 'authorization_revoked');
+		}
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -149,7 +149,6 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		}
 
 		clearTimeout(subscription.timer);
-		if (subscription.authorizationTimer) clearTimeout(subscription.authorizationTimer);
 		subscription.timer = this.createIdleTimer(id);
 	}
 
@@ -162,6 +161,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 
 		this.subscriptions.delete(id);
 		clearTimeout(subscription.timer);
+		if (subscription.authorizationTimer) clearTimeout(subscription.authorizationTimer);
 		subscription.controller.abort();
 		this.auditService.recordSubscriptionClosed(
 			{ requestId: subscription.requestId, clientId: subscription.clientId },

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — non-secret provider-artifact management identity foundation implemented
+**Status:** Phase 5 in progress — targeted OAuth subscription identity and deadline foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -120,6 +120,14 @@ amend ADR 0002.
 - [x] Backfill deployed provider artifacts through an incremental migration and preserve the original schema on rollback.
 - [x] Prove management IDs survive provider upserts, family IDs survive refresh rotation, and raw artifacts remain absent
       from persistence and management identifiers.
+
+### Phase 5b — Targeted subscription invalidation foundation
+
+- [x] Carry the non-secret refresh-family management ID into the validated OAuth principal.
+- [x] Bind internal OAuth subscription records to client, grant, access-token, optional refresh-family, and
+      authorization-deadline identities while preserving the static subscription path.
+- [x] Add targeted client/grant/access-token/refresh-family and OAuth-only closure primitives.
+- [x] Automatically abort OAuth streams at their authorization deadline and audit expiry versus revocation distinctly.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 provider-artifact management identity foundation complete
+Status: in progress — Phase 5 targeted OAuth subscription invalidation foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- bind internal OAuth subscriptions to client, grant, access-token, optional refresh-family, and authorization-deadline identities
- add targeted OAuth client, grant, access-token, refresh-family, and OAuth-only closure primitives
- close OAuth streams automatically at their authorization deadline and distinguish expiry from revocation in audit events
- carry refresh-family identity through validated OAuth principals while preserving existing static subscription behavior

## Why

Phase 5 administrative revocation must close only affected OAuth streams before mutations report success. This slice establishes the subscription identity and deadline boundary before admin APIs and authoritative generation gates are added.

## Impact

No public OAuth routes are exposed. Static MCP streams remain unaffected by OAuth-specific closures. Future admin revocation and switch-off flows can target OAuth streams safely.

## Validation

- backend TypeScript type-check
- targeted backend lint
- 28 focused tests
- 2 snapshots
- `git diff --check`
