### PR TITLE
feat(backend): bind validated OAuth subscriptions

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -32,6 +32,8 @@ export const MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL: string | null = null;
 
 export const MCP_OAUTH_PRINCIPAL_TYPE = 'mcp_oauth';
 
+export const MCP_OAUTH_SERVER_STATE_KEY = 'primary';
+
 export const MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
 
 export const MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth.types.ts
@@ -3,9 +3,14 @@ import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.c
 export interface McpOAuthPrincipal {
 	type: typeof MCP_OAUTH_PRINCIPAL_TYPE;
 	accessTokenId: string;
+	authorizationDeadline: number;
 	clientId: string;
+	clientGeneration: number;
+	effectiveScopes: McpOAuthScope[];
 	grantId: string;
+	grantGeneration: number;
 	installationId: string;
+	modulePolicyGeneration: number;
 	refreshFamilyId?: string;
 	scopes: McpOAuthScope[];
 	effectiveCapabilities: McpCapability[];

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
@@ -9,6 +9,7 @@ import {
 	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
 import { McpCapability, McpOAuthScope } from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
@@ -47,6 +48,7 @@ describe('McpOAuthResourceServerService', () => {
 	let artifactRepository: { findOneBy: jest.Mock };
 	let revokedGrantRepository: { findOneBy: jest.Mock };
 	let grantRepository: { findOne: jest.Mock };
+	let serverStateRepository: { findOneBy: jest.Mock };
 	let service: McpOAuthResourceServerService;
 
 	beforeEach(() => {
@@ -64,6 +66,7 @@ describe('McpOAuthResourceServerService', () => {
 		artifact = Object.assign(new McpOAuthProviderArtifactEntity(), {
 			model: 'AccessToken',
 			idHash: TOKEN_ID,
+			managementId: 'access-token-management-id',
 			payload: JSON.stringify(payload),
 			grantIdHash: PROVIDER_GRANT_ID_HASH,
 			refreshFamilyId: 'refresh-family-id',
@@ -77,6 +80,7 @@ describe('McpOAuthResourceServerService', () => {
 				id: 'client-id',
 				clientIdentifier: CLIENT_IDENTIFIER,
 				enabled: true,
+				generation: 2,
 				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
 			},
 			approvedById: APPROVER_ID,
@@ -86,15 +90,20 @@ describe('McpOAuthResourceServerService', () => {
 			resource: urls.resource,
 			approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
 			expiresAt: new Date(Date.now() + 60_000),
+			generation: 3,
 			revokedAt: null,
 		});
 		artifactRepository = { findOneBy: jest.fn().mockImplementation(() => Promise.resolve(artifact)) };
 		revokedGrantRepository = { findOneBy: jest.fn().mockResolvedValue(null) };
 		grantRepository = { findOne: jest.fn().mockImplementation(() => Promise.resolve(grant)) };
+		serverStateRepository = {
+			findOneBy: jest.fn().mockResolvedValue({ key: 'primary', modulePolicyGeneration: 1 }),
+		};
 		service = new McpOAuthResourceServerService(
 			artifactRepository as unknown as Repository<McpOAuthProviderArtifactEntity>,
 			revokedGrantRepository as unknown as Repository<McpOAuthProviderRevokedGrantEntity>,
 			grantRepository as unknown as Repository<McpOAuthGrantEntity>,
+			serverStateRepository as unknown as Repository<McpOAuthServerStateEntity>,
 			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
 			{ getInstallationId: jest.fn().mockResolvedValue(INSTALLATION_ID) } as unknown as McpInstallationService,
 			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
@@ -168,8 +177,13 @@ describe('McpOAuthResourceServerService', () => {
 		);
 		expect(authInfo.extra?.principal).toEqual(
 			expect.objectContaining({
+				accessTokenId: 'access-token-management-id',
+				clientGeneration: 2,
 				effectiveCapabilities: [McpCapability.READ],
+				effectiveScopes: [McpOAuthScope.READ],
+				grantGeneration: 3,
 				installationId: INSTALLATION_ID,
+				modulePolicyGeneration: 1,
 				refreshFamilyId: 'refresh-family-id',
 			}),
 		);
@@ -188,6 +202,15 @@ describe('McpOAuthResourceServerService', () => {
 		const authInfo = await service.verifyAccessToken(RAW_TOKEN);
 
 		expect(authInfo.expiresAt).toBe(Math.floor(grant.expiresAt.getTime() / 1_000));
+		expect(authInfo.extra?.principal).toEqual(
+			expect.objectContaining({ authorizationDeadline: grant.expiresAt.getTime() }),
+		);
+	});
+
+	it('fails closed when the persistent authorization generation state is unavailable', async () => {
+		serverStateRepository.findOneBy.mockResolvedValue(null);
+
+		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
 	});
 
 	it('builds RFC 6750 invalid-token and insufficient-scope challenges with discovery', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
@@ -20,8 +20,15 @@ import {
 	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
-import { MCP_MODULE_NAME, MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
+import {
+	MCP_MODULE_NAME,
+	MCP_OAUTH_PRINCIPAL_TYPE,
+	MCP_OAUTH_SERVER_STATE_KEY,
+	McpCapability,
+	McpOAuthScope,
+} from '../mcp.constants';
 import { McpConfigModel } from '../models/config.model';
 import {
 	McpOAuthAuthorizationServerMetadata,
@@ -57,6 +64,8 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 		private readonly revokedGrantRepository: Repository<McpOAuthProviderRevokedGrantEntity>,
 		@InjectRepository(McpOAuthGrantEntity)
 		private readonly grantRepository: Repository<McpOAuthGrantEntity>,
+		@InjectRepository(McpOAuthServerStateEntity)
+		private readonly serverStateRepository: Repository<McpOAuthServerStateEntity>,
 		private readonly configService: ConfigService,
 		private readonly installationService: McpInstallationService,
 		private readonly publicUrlService: McpOAuthPublicUrlService,
@@ -95,12 +104,13 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 			this.invalidToken();
 		}
 
-		const [revokedGrant, grant] = await Promise.all([
+		const [revokedGrant, grant, serverState] = await Promise.all([
 			this.revokedGrantRepository.findOneBy({ grantIdHash: artifact.grantIdHash }),
 			this.grantRepository.findOne({
 				where: { providerGrantIdHash: artifact.grantIdHash },
 				relations: { approvedBy: true, client: true },
 			}),
+			this.serverStateRepository.findOneBy({ key: MCP_OAUTH_SERVER_STATE_KEY }),
 		]);
 		const urls = this.requireUrls();
 		const installationId = await this.installationService.getInstallationId();
@@ -110,6 +120,7 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 			revokedGrant ||
 			!grant ||
 			!grant.client ||
+			!serverState ||
 			!grant.client.enabled ||
 			!grant.approvedBy ||
 			!grant.approvedById ||
@@ -134,12 +145,19 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 			grant.approvedScopes,
 			tokenScopes,
 		);
+		const effectiveScopes = effectiveCapabilities.map(toMcpOAuthScope);
+		const authorizationDeadline = Math.min(artifact.expiresAt, grant.expiresAt.getTime());
 		const principal: McpOAuthPrincipal = {
 			type: MCP_OAUTH_PRINCIPAL_TYPE,
-			accessTokenId: tokenId,
+			accessTokenId: artifact.managementId,
+			authorizationDeadline,
 			clientId: grant.client.id,
+			clientGeneration: grant.client.generation,
+			effectiveScopes,
 			grantId: grant.id,
+			grantGeneration: grant.generation,
 			installationId,
+			modulePolicyGeneration: serverState.modulePolicyGeneration,
 			...(artifact.refreshFamilyId ? { refreshFamilyId: artifact.refreshFamilyId } : {}),
 			scopes: tokenScopes,
 			effectiveCapabilities,
@@ -148,8 +166,8 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 		return {
 			token,
 			clientId: grant.client.clientIdentifier,
-			scopes: effectiveCapabilities.map(toMcpOAuthScope),
-			expiresAt: Math.floor(Math.min(artifact.expiresAt, grant.expiresAt.getTime()) / 1_000),
+			scopes: effectiveScopes,
+			expiresAt: Math.floor(authorizationDeadline / 1_000),
 			resource: new URL(urls.resource),
 			extra: { principal, installationId, tokenId },
 		};

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -1,6 +1,9 @@
 import { FastifyReply } from 'fastify';
 
+import { AuthInfo } from '@modelcontextprotocol/server';
 import { UnauthorizedException } from '@nestjs/common';
+
+import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpPolicyRequest } from './mcp-policy.service';
@@ -94,6 +97,73 @@ describe('McpServerService policy revision', () => {
 		expect(firstToolsChanged).toHaveBeenCalledTimes(1);
 		expect(secondToolsChanged).not.toHaveBeenCalled();
 		expect(subscriptions.touchClient).toHaveBeenCalledWith('client-a');
+	});
+
+	it('binds OAuth subscription registration to validated artifact, scope, deadline, and generation identities', () => {
+		const authorizationDeadline = Date.now() + 60_000;
+		const authInfo: AuthInfo = {
+			token: 'opaque-token',
+			clientId: 'public-client-id',
+			scopes: [McpOAuthScope.READ],
+			extra: {
+				principal: {
+					type: MCP_OAUTH_PRINCIPAL_TYPE,
+					accessTokenId: 'access-token-id',
+					authorizationDeadline,
+					clientId: 'internal-client-id',
+					clientGeneration: 2,
+					effectiveScopes: [McpOAuthScope.READ],
+					grantId: 'grant-id',
+					grantGeneration: 3,
+					installationId: 'installation-id',
+					modulePolicyGeneration: 1,
+					refreshFamilyId: 'refresh-family-id',
+					scopes: [McpOAuthScope.READ],
+					effectiveCapabilities: [McpCapability.READ],
+				},
+			},
+		};
+		const internalService = service as unknown as {
+			getSubscriptionRegistration(
+				clientId: string,
+				authInfo?: AuthInfo,
+			): {
+				clientId: string;
+				oauth?: unknown;
+			};
+		};
+
+		expect(internalService.getSubscriptionRegistration('handler-client-id', authInfo)).toEqual({
+			clientId: 'internal-client-id',
+			oauth: {
+				accessTokenId: 'access-token-id',
+				grantId: 'grant-id',
+				refreshFamilyId: 'refresh-family-id',
+				authorizationDeadline: new Date(authorizationDeadline),
+				effectiveScopes: [McpOAuthScope.READ],
+				modulePolicyGeneration: 1,
+				clientGeneration: 2,
+				grantGeneration: 3,
+			},
+		});
+	});
+
+	it('preserves static subscription registration and rejects malformed OAuth identities', () => {
+		const internalService = service as unknown as {
+			getSubscriptionRegistration(clientId: string, authInfo?: AuthInfo): unknown;
+		};
+
+		expect(internalService.getSubscriptionRegistration('static-client-id')).toEqual({
+			clientId: 'static-client-id',
+		});
+		expect(() =>
+			internalService.getSubscriptionRegistration('handler-client-id', {
+				token: 'opaque-token',
+				clientId: 'public-client-id',
+				scopes: [McpOAuthScope.READ],
+				extra: { principal: { type: MCP_OAUTH_PRINCIPAL_TYPE } },
+			}),
+		).toThrow(new UnauthorizedException('MCP OAuth subscription identity is unavailable'));
 	});
 
 	it('audits initialization and discovery without passing request parameters', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -10,11 +10,19 @@ import { ModuleRef } from '@nestjs/core';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { extractAccessTokenFromHeader } from '../../auth/utils/token.utils';
-import { MCP_CATALOG_REGISTRAR, MCP_MAX_SUBSCRIPTIONS_PER_CLIENT, MCP_MODULE_NAME } from '../mcp.constants';
+import {
+	MCP_CATALOG_REGISTRAR,
+	MCP_MAX_SUBSCRIPTIONS_PER_CLIENT,
+	MCP_MODULE_NAME,
+	MCP_OAUTH_PRINCIPAL_TYPE,
+	McpOAuthScope,
+} from '../mcp.constants';
+import { McpOAuthPrincipal } from '../oauth/mcp-oauth.types';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import {
+	McpOAuthSubscriptionBinding,
 	McpSubscriptionCapacityError,
 	McpSubscriptionHandle,
 	McpSubscriptionRegistryService,
@@ -39,6 +47,11 @@ interface JsonRpcRequestBody {
 
 interface McpCatalogRegistrar {
 	register(server: McpServer, authInfo?: AuthInfo): void;
+}
+
+interface McpSubscriptionRegistration {
+	clientId: string;
+	oauth?: McpOAuthSubscriptionBinding;
 }
 
 @Injectable()
@@ -221,7 +234,13 @@ export class McpServerService implements OnApplicationShutdown {
 				let subscription: McpSubscriptionHandle;
 
 				try {
-					subscription = this.subscriptions.open(clientId, this.auditService.getRequestId(options?.parsedBody));
+					const registration = this.getSubscriptionRegistration(clientId, options?.authInfo);
+
+					subscription = this.subscriptions.open(
+						registration.clientId,
+						this.auditService.getRequestId(options?.parsedBody),
+						registration.oauth,
+					);
 				} catch (error) {
 					if (error instanceof McpSubscriptionCapacityError) {
 						return this.subscriptionLimitResponse(options?.parsedBody);
@@ -285,6 +304,54 @@ export class McpServerService implements OnApplicationShutdown {
 
 	private getRequestBody(body: unknown): JsonRpcRequestBody {
 		return body && typeof body === 'object' && !Array.isArray(body) ? (body as JsonRpcRequestBody) : {};
+	}
+
+	private getSubscriptionRegistration(clientId: string, authInfo?: AuthInfo): McpSubscriptionRegistration {
+		const value = authInfo?.extra?.principal;
+
+		if (value === undefined) return { clientId };
+		if (!this.isOAuthPrincipal(value)) {
+			throw new UnauthorizedException('MCP OAuth subscription identity is unavailable');
+		}
+
+		return {
+			clientId: value.clientId,
+			oauth: {
+				accessTokenId: value.accessTokenId,
+				grantId: value.grantId,
+				...(value.refreshFamilyId ? { refreshFamilyId: value.refreshFamilyId } : {}),
+				authorizationDeadline: new Date(value.authorizationDeadline),
+				effectiveScopes: [...value.effectiveScopes],
+				modulePolicyGeneration: value.modulePolicyGeneration,
+				clientGeneration: value.clientGeneration,
+				grantGeneration: value.grantGeneration,
+			},
+		};
+	}
+
+	private isOAuthPrincipal(value: unknown): value is McpOAuthPrincipal {
+		if (typeof value !== 'object' || value === null) return false;
+
+		const principal = value as Partial<McpOAuthPrincipal>;
+		const generations = [principal.modulePolicyGeneration, principal.clientGeneration, principal.grantGeneration];
+
+		return (
+			principal.type === MCP_OAUTH_PRINCIPAL_TYPE &&
+			this.isNonEmptyString(principal.accessTokenId) &&
+			this.isNonEmptyString(principal.clientId) &&
+			this.isNonEmptyString(principal.grantId) &&
+			(principal.refreshFamilyId === undefined || this.isNonEmptyString(principal.refreshFamilyId)) &&
+			typeof principal.authorizationDeadline === 'number' &&
+			Number.isFinite(principal.authorizationDeadline) &&
+			principal.authorizationDeadline > 0 &&
+			Array.isArray(principal.effectiveScopes) &&
+			principal.effectiveScopes.every((scope) => Object.values(McpOAuthScope).includes(scope)) &&
+			generations.every((generation) => Number.isInteger(generation) && (generation ?? -1) >= 0)
+		);
+	}
+
+	private isNonEmptyString(value: unknown): value is string {
+		return typeof value === 'string' && value.length > 0;
 	}
 
 	private trackSubscriptionResponse(response: Response, subscription: McpSubscriptionHandle): Response {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -2,10 +2,26 @@ import {
 	MCP_MAX_ACTIVE_SUBSCRIPTIONS,
 	MCP_MAX_SUBSCRIPTIONS_PER_CLIENT,
 	MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS,
+	McpOAuthScope,
 } from '../mcp.constants';
 
 import { McpAuditService } from './mcp-audit.service';
-import { McpSubscriptionCapacityError, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+import {
+	McpOAuthSubscriptionBinding,
+	McpSubscriptionCapacityError,
+	McpSubscriptionRegistryService,
+} from './mcp-subscription-registry.service';
+
+const oauthBinding = (overrides: Partial<McpOAuthSubscriptionBinding> = {}): McpOAuthSubscriptionBinding => ({
+	accessTokenId: 'access-one',
+	grantId: 'grant-one',
+	authorizationDeadline: new Date(Date.now() + 60_000),
+	effectiveScopes: [McpOAuthScope.READ],
+	modulePolicyGeneration: 1,
+	clientGeneration: 2,
+	grantGeneration: 3,
+	...overrides,
+});
 
 describe('McpSubscriptionRegistryService', () => {
 	let service: McpSubscriptionRegistryService;
@@ -92,18 +108,24 @@ describe('McpSubscriptionRegistryService', () => {
 
 	it('closes only OAuth streams matching a revoked artifact identity', () => {
 		const staticStream = service.open('client-a');
-		const first = service.open('client-a', 'one', {
-			accessTokenId: 'access-one',
-			grantId: 'grant-one',
-			refreshFamilyId: 'family-one',
-			authorizationDeadline: new Date(Date.now() + 60_000),
-		});
-		const other = service.open('client-a', 'two', {
-			accessTokenId: 'access-two',
-			grantId: 'grant-two',
-			refreshFamilyId: 'family-two',
-			authorizationDeadline: new Date(Date.now() + 60_000),
-		});
+		const first = service.open(
+			'client-a',
+			'one',
+			oauthBinding({
+				accessTokenId: 'access-one',
+				grantId: 'grant-one',
+				refreshFamilyId: 'family-one',
+			}),
+		);
+		const other = service.open(
+			'client-a',
+			'two',
+			oauthBinding({
+				accessTokenId: 'access-two',
+				grantId: 'grant-two',
+				refreshFamilyId: 'family-two',
+			}),
+		);
 
 		service.closeOAuthAccessToken('access-one');
 
@@ -119,11 +141,13 @@ describe('McpSubscriptionRegistryService', () => {
 
 	it('closes OAuth streams at their authorization deadline', () => {
 		jest.useFakeTimers();
-		const subscription = service.open('client-a', 'deadline', {
-			accessTokenId: 'access-one',
-			grantId: 'grant-one',
-			authorizationDeadline: new Date(Date.now() + 1_000),
-		});
+		const subscription = service.open(
+			'client-a',
+			'deadline',
+			oauthBinding({
+				authorizationDeadline: new Date(Date.now() + 1_000),
+			}),
+		);
 
 		jest.advanceTimersByTime(500);
 		subscription.touch();
@@ -141,11 +165,13 @@ describe('McpSubscriptionRegistryService', () => {
 
 	it('cancels the authorization deadline timer when an OAuth stream closes early', () => {
 		jest.useFakeTimers();
-		const subscription = service.open('client-a', 'early-close', {
-			accessTokenId: 'access-one',
-			grantId: 'grant-one',
-			authorizationDeadline: new Date(Date.now() + 60_000),
-		});
+		const subscription = service.open(
+			'client-a',
+			'early-close',
+			oauthBinding({
+				authorizationDeadline: new Date(Date.now() + 60_000),
+			}),
+		);
 
 		expect(jest.getTimerCount()).toBe(2);
 

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -6,6 +6,7 @@ import {
 	MCP_MAX_ACTIVE_SUBSCRIPTIONS,
 	MCP_MAX_SUBSCRIPTIONS_PER_CLIENT,
 	MCP_SUBSCRIPTION_IDLE_TIMEOUT_MS,
+	McpOAuthScope,
 } from '../mcp.constants';
 
 import { McpAuditService, McpSubscriptionCloseReason } from './mcp-audit.service';
@@ -30,6 +31,10 @@ export interface McpOAuthSubscriptionBinding {
 	grantId: string;
 	refreshFamilyId?: string;
 	authorizationDeadline: Date;
+	effectiveScopes: McpOAuthScope[];
+	modulePolicyGeneration: number;
+	clientGeneration: number;
+	grantGeneration: number;
 }
 
 interface SubscriptionRecord {
@@ -64,7 +69,12 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 			requestId,
 			controller,
 			timer: this.createIdleTimer(id),
-			...(oauth ? { oauth: { ...oauth }, authorizationTimer: this.createAuthorizationTimer(id, oauth) } : {}),
+			...(oauth
+				? {
+						oauth: { ...oauth, effectiveScopes: [...oauth.effectiveScopes] },
+						authorizationTimer: this.createAuthorizationTimer(id, oauth),
+					}
+				: {}),
 		};
 
 		this.subscriptions.set(id, record);

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — targeted OAuth subscription identity and deadline foundation implemented
+**Status:** Phase 5 in progress — validated OAuth subscription binding implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -129,11 +129,21 @@ amend ADR 0002.
 - [x] Add targeted client/grant/access-token/refresh-family and OAuth-only closure primitives.
 - [x] Automatically abort OAuth streams at their authorization deadline and audit expiry versus revocation distinctly.
 
+### Phase 5c — Validated OAuth subscription binding
+
+- [x] Carry the stable access-token management ID, exact authorization deadline, effective OAuth scopes, and current
+      module/client/grant authorization generations through the validated OAuth principal.
+- [x] Fail closed when the persistent module-policy generation state is unavailable.
+- [x] Register OAuth listen streams under the validated internal client and artifact identities while preserving the
+      existing static subscription registration path.
+- [x] Record effective scopes and module/client/grant generations on the internal OAuth subscription binding for the
+      authoritative registration/invalidation gate.
+
 ### Remaining Phase 5 controls
 
 - [ ] Add list/inspect/disable/revoke APIs for OAuth clients, grants, access tokens, and refresh families.
 - [ ] Add Admin client/grant/token management views and revoke confirmations.
-- [ ] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
+- [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
       deadline equal to the earlier of access-token or grant expiry; also record their effective scopes and the
       generations of the module/client/grant authorization inputs that produced them.
 - [ ] Serialize subscription registration and invalidation through one authoritative generation gate: atomically

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 targeted OAuth subscription invalidation foundation complete
+Status: in progress — Phase 5 validated OAuth subscription binding complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- carry the stable access-token management ID, exact authorization deadline, effective OAuth scopes, and module/client/grant generations through validated OAuth principals
- fail closed when persistent module-policy generation state is unavailable
- bind OAuth listen subscriptions to validated internal client and artifact identities
- record effective scopes and authorization generations on subscription records while preserving static subscription behavior
- update the Phase 5 implementation plan to mark validated subscription binding complete

## Why

The targeted invalidation registry added in Phase 5b was not yet connected to validated OAuth requests. Phase 5c establishes that runtime identity boundary so future revocation and scope-contraction mutations can target streams using non-secret management identities and generation snapshots.

## Impact

No public OAuth routes or user-facing enable switch are exposed. Static MCP subscription registration remains unchanged. The authoritative subscription registration/invalidation generation gate remains intentionally deferred to the next Phase 5 slice.

## Validation

- backend TypeScript type-check
- targeted backend lint
- Prettier verification
- 38 focused tests
- 2 snapshots
- `git diff --check`
