### PR TITLE
feat(backend): serialize OAuth subscription lifecycle

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -9,7 +9,11 @@ import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import { McpServerService } from './mcp-server.service';
-import { McpSubscriptionHandle, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+import {
+	McpSubscriptionClosingError,
+	McpSubscriptionHandle,
+	McpSubscriptionRegistryService,
+} from './mcp-subscription-registry.service';
 
 const oauthAuthInfo = (clientGeneration = 2): AuthInfo => ({
 	token: 'opaque-token',
@@ -219,6 +223,21 @@ describe('McpServerService policy revision', () => {
 		expect(response.status).toBe(401);
 		expect(response.headers.get('www-authenticate')).toContain('invalid_token');
 		expect(oauthResourceServerService.getBearerChallenge).toHaveBeenCalledWith(error);
+	});
+
+	it('returns a controlled protocol error when subscription cleanup is in progress', async () => {
+		const error = new McpSubscriptionClosingError();
+		const internalService = service as unknown as {
+			getSubscriptionErrorResponse(error: McpSubscriptionClosingError, body?: unknown): Response;
+		};
+		const response = internalService.getSubscriptionErrorResponse(error, { id: 7 });
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			jsonrpc: '2.0',
+			id: 7,
+			error: { code: -32603, message: 'Subscription service is closing' },
+		});
 	});
 
 	it('opens static subscriptions without entering OAuth revalidation', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -6,24 +6,57 @@ import { UnauthorizedException } from '@nestjs/common';
 import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
 
 import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import { McpServerService } from './mcp-server.service';
 import { McpSubscriptionHandle, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
+const oauthAuthInfo = (clientGeneration = 2): AuthInfo => ({
+	token: 'opaque-token',
+	clientId: 'public-client-id',
+	scopes: [McpOAuthScope.READ],
+	extra: {
+		principal: {
+			type: MCP_OAUTH_PRINCIPAL_TYPE,
+			accessTokenId: 'access-token-id',
+			authorizationDeadline: Date.now() + 60_000,
+			clientId: 'internal-client-id',
+			clientGeneration,
+			effectiveScopes: [McpOAuthScope.READ],
+			grantId: 'grant-id',
+			grantGeneration: 3,
+			installationId: 'installation-id',
+			modulePolicyGeneration: 1,
+			refreshFamilyId: 'refresh-family-id',
+			scopes: [McpOAuthScope.READ],
+			effectiveCapabilities: [McpCapability.READ],
+		},
+	},
+});
+
 describe('McpServerService policy revision', () => {
 	let service: McpServerService;
-	let subscriptions: { closeAll: jest.Mock; closeClient: jest.Mock; touchClient: jest.Mock };
+	let subscriptions: {
+		closeAll: jest.Mock;
+		closeClient: jest.Mock;
+		open: jest.Mock;
+		openOAuth: jest.Mock;
+		touchClient: jest.Mock;
+	};
 	let auditService: {
 		getRequestId: jest.Mock;
 		recordAuthenticationFailure: jest.Mock;
 		recordPolicyDenial: jest.Mock;
 		recordProtocolRequest: jest.Mock;
 	};
+	let oauthResourceServerService: { verifyAccessToken: jest.Mock };
 
 	beforeEach(() => {
 		subscriptions = {
 			closeAll: jest.fn(),
 			closeClient: jest.fn(),
+			open: jest.fn(),
+			openOAuth: jest.fn(),
 			touchClient: jest.fn(),
 		};
 		auditService = {
@@ -32,9 +65,11 @@ describe('McpServerService policy revision', () => {
 			recordPolicyDenial: jest.fn(),
 			recordProtocolRequest: jest.fn(),
 		};
+		oauthResourceServerService = { verifyAccessToken: jest.fn() };
 		service = new McpServerService(
 			subscriptions as unknown as McpSubscriptionRegistryService,
 			auditService as unknown as McpAuditService,
+			oauthResourceServerService as unknown as McpOAuthResourceServerService,
 		);
 	});
 
@@ -101,28 +136,8 @@ describe('McpServerService policy revision', () => {
 
 	it('binds OAuth subscription registration to validated artifact, scope, deadline, and generation identities', () => {
 		const authorizationDeadline = Date.now() + 60_000;
-		const authInfo: AuthInfo = {
-			token: 'opaque-token',
-			clientId: 'public-client-id',
-			scopes: [McpOAuthScope.READ],
-			extra: {
-				principal: {
-					type: MCP_OAUTH_PRINCIPAL_TYPE,
-					accessTokenId: 'access-token-id',
-					authorizationDeadline,
-					clientId: 'internal-client-id',
-					clientGeneration: 2,
-					effectiveScopes: [McpOAuthScope.READ],
-					grantId: 'grant-id',
-					grantGeneration: 3,
-					installationId: 'installation-id',
-					modulePolicyGeneration: 1,
-					refreshFamilyId: 'refresh-family-id',
-					scopes: [McpOAuthScope.READ],
-					effectiveCapabilities: [McpCapability.READ],
-				},
-			},
-		};
+		const authInfo = oauthAuthInfo();
+		(authInfo.extra?.principal as { authorizationDeadline: number }).authorizationDeadline = authorizationDeadline;
 		const internalService = service as unknown as {
 			getSubscriptionRegistration(
 				clientId: string,
@@ -146,6 +161,66 @@ describe('McpServerService policy revision', () => {
 				grantGeneration: 3,
 			},
 		});
+	});
+
+	it('revalidates OAuth authorization inside the registration gate and serves with the refreshed AuthInfo', async () => {
+		const initialAuthInfo = oauthAuthInfo(2);
+		const currentAuthInfo = oauthAuthInfo(4);
+		const handle = { id: 'subscription-id' } as unknown as McpSubscriptionHandle;
+
+		oauthResourceServerService.verifyAccessToken.mockResolvedValue(currentAuthInfo);
+		subscriptions.openOAuth.mockImplementation(
+			async (requestId: string, revalidate: () => Promise<{ clientId: string; binding: unknown }>) => {
+				expect(requestId).toBe('request-1');
+				const registration = await revalidate();
+
+				expect(registration.clientId).toBe('internal-client-id');
+				expect(registration.binding).toEqual(expect.objectContaining({ clientGeneration: 4 }));
+
+				return handle;
+			},
+		);
+		const internalService = service as unknown as {
+			openSubscription(
+				clientId: string,
+				requestId: string,
+				authInfo?: AuthInfo,
+			): Promise<{
+				authInfo?: AuthInfo;
+				handle: McpSubscriptionHandle;
+			}>;
+		};
+
+		await expect(internalService.openSubscription('handler-client-id', 'request-1', initialAuthInfo)).resolves.toEqual({
+			authInfo: currentAuthInfo,
+			handle,
+		});
+		expect(oauthResourceServerService.verifyAccessToken).toHaveBeenCalledWith('opaque-token');
+		expect(subscriptions.open).not.toHaveBeenCalled();
+	});
+
+	it('opens static subscriptions without entering OAuth revalidation', async () => {
+		const handle = { id: 'static-subscription-id' } as unknown as McpSubscriptionHandle;
+
+		subscriptions.open.mockReturnValue(handle);
+		const internalService = service as unknown as {
+			openSubscription(
+				clientId: string,
+				requestId: string,
+				authInfo?: AuthInfo,
+			): Promise<{
+				authInfo?: AuthInfo;
+				handle: McpSubscriptionHandle;
+			}>;
+		};
+
+		await expect(internalService.openSubscription('static-client-id', 'request-1')).resolves.toEqual({
+			authInfo: undefined,
+			handle,
+		});
+		expect(subscriptions.open).toHaveBeenCalledWith('static-client-id', 'request-1');
+		expect(subscriptions.openOAuth).not.toHaveBeenCalled();
+		expect(oauthResourceServerService.verifyAccessToken).not.toHaveBeenCalled();
 	});
 
 	it('preserves static subscription registration and rejects malformed OAuth identities', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -1,6 +1,6 @@
 import { FastifyReply } from 'fastify';
 
-import { AuthInfo } from '@modelcontextprotocol/server';
+import { AuthInfo, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
 import { UnauthorizedException } from '@nestjs/common';
 
 import { MCP_OAUTH_PRINCIPAL_TYPE, McpCapability, McpOAuthScope } from '../mcp.constants';
@@ -49,7 +49,7 @@ describe('McpServerService policy revision', () => {
 		recordPolicyDenial: jest.Mock;
 		recordProtocolRequest: jest.Mock;
 	};
-	let oauthResourceServerService: { verifyAccessToken: jest.Mock };
+	let oauthResourceServerService: { getBearerChallenge: jest.Mock; verifyMcpBearerToken: jest.Mock };
 
 	beforeEach(() => {
 		subscriptions = {
@@ -65,7 +65,10 @@ describe('McpServerService policy revision', () => {
 			recordPolicyDenial: jest.fn(),
 			recordProtocolRequest: jest.fn(),
 		};
-		oauthResourceServerService = { verifyAccessToken: jest.fn() };
+		oauthResourceServerService = {
+			getBearerChallenge: jest.fn(),
+			verifyMcpBearerToken: jest.fn(),
+		};
 		service = new McpServerService(
 			subscriptions as unknown as McpSubscriptionRegistryService,
 			auditService as unknown as McpAuditService,
@@ -165,10 +168,10 @@ describe('McpServerService policy revision', () => {
 
 	it('revalidates OAuth authorization inside the registration gate and serves with the refreshed AuthInfo', async () => {
 		const initialAuthInfo = oauthAuthInfo(2);
-		const currentAuthInfo = oauthAuthInfo(4);
+		const currentAuthInfo = { ...oauthAuthInfo(4), scopes: [McpCapability.READ] };
 		const handle = { id: 'subscription-id' } as unknown as McpSubscriptionHandle;
 
-		oauthResourceServerService.verifyAccessToken.mockResolvedValue(currentAuthInfo);
+		oauthResourceServerService.verifyMcpBearerToken.mockResolvedValue(currentAuthInfo);
 		subscriptions.openOAuth.mockImplementation(
 			async (requestId: string, revalidate: () => Promise<{ clientId: string; binding: unknown }>) => {
 				expect(requestId).toBe('request-1');
@@ -195,8 +198,27 @@ describe('McpServerService policy revision', () => {
 			authInfo: currentAuthInfo,
 			handle,
 		});
-		expect(oauthResourceServerService.verifyAccessToken).toHaveBeenCalledWith('opaque-token');
+		expect(oauthResourceServerService.verifyMcpBearerToken).toHaveBeenCalledWith('Bearer opaque-token');
 		expect(subscriptions.open).not.toHaveBeenCalled();
+	});
+
+	it('maps gated OAuth revalidation failures to the resource-server bearer challenge', () => {
+		const error = new OAuthError(OAuthErrorCode.InvalidToken, 'The access token expired');
+		const challenge = new Response(null, {
+			status: 401,
+			headers: { 'www-authenticate': 'Bearer error="invalid_token"' },
+		});
+
+		oauthResourceServerService.getBearerChallenge.mockReturnValue(challenge);
+		const internalService = service as unknown as {
+			getSubscriptionErrorResponse(error: OAuthError, body?: unknown): Response;
+		};
+		const response = internalService.getSubscriptionErrorResponse(error);
+
+		expect(response).toBe(challenge);
+		expect(response.status).toBe(401);
+		expect(response.headers.get('www-authenticate')).toContain('invalid_token');
+		expect(oauthResourceServerService.getBearerChallenge).toHaveBeenCalledWith(error);
 	});
 
 	it('opens static subscriptions without entering OAuth revalidation', async () => {
@@ -220,7 +242,7 @@ describe('McpServerService policy revision', () => {
 		});
 		expect(subscriptions.open).toHaveBeenCalledWith('static-client-id', 'request-1');
 		expect(subscriptions.openOAuth).not.toHaveBeenCalled();
-		expect(oauthResourceServerService.verifyAccessToken).not.toHaveBeenCalled();
+		expect(oauthResourceServerService.verifyMcpBearerToken).not.toHaveBeenCalled();
 	});
 
 	it('preserves static subscription registration and rejects malformed OAuth identities', () => {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -24,9 +24,9 @@ import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.servi
 import { McpPolicyRequest } from './mcp-policy.service';
 import {
 	McpOAuthSubscriptionBinding,
-	McpSubscriptionCapacityError,
 	McpSubscriptionHandle,
 	McpSubscriptionRegistryService,
+	McpSubscriptionUnavailableError,
 } from './mcp-subscription-registry.service';
 
 const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../../../../package.json'), 'utf-8')) as {
@@ -253,7 +253,7 @@ export class McpServerService implements OnApplicationShutdown {
 						options = { ...requestOptions, authInfo: opened.authInfo };
 					}
 				} catch (error) {
-					if (error instanceof McpSubscriptionCapacityError) {
+					if (error instanceof McpSubscriptionUnavailableError) {
 						return this.getSubscriptionErrorResponse(error, requestOptions?.parsedBody);
 					}
 					if (OAuthError.isInstance(error)) return this.getSubscriptionErrorResponse(error);
@@ -301,22 +301,22 @@ export class McpServerService implements OnApplicationShutdown {
 		return this.getRequestBody(body).method === 'subscriptions/listen';
 	}
 
-	private subscriptionLimitResponse(body: unknown): Response {
+	private subscriptionUnavailableResponse(error: McpSubscriptionUnavailableError, body: unknown): Response {
 		const request = this.getRequestBody(body);
 
 		return Response.json(
 			{
 				jsonrpc: '2.0',
 				id: request.id ?? null,
-				error: { code: -32603, message: 'Subscription limit reached' },
+				error: { code: -32603, message: error.message },
 			},
 			{ status: 200 },
 		);
 	}
 
-	private getSubscriptionErrorResponse(error: McpSubscriptionCapacityError | OAuthError, body?: unknown): Response {
-		return error instanceof McpSubscriptionCapacityError
-			? this.subscriptionLimitResponse(body)
+	private getSubscriptionErrorResponse(error: McpSubscriptionUnavailableError | OAuthError, body?: unknown): Response {
+		return error instanceof McpSubscriptionUnavailableError
+			? this.subscriptionUnavailableResponse(error, body)
 			: this.oauthResourceServerService.getBearerChallenge(error);
 	}
 

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -4,7 +4,7 @@ import { IncomingMessage } from 'http';
 import { resolve } from 'path';
 
 import { toNodeHandler } from '@modelcontextprotocol/node';
-import { AuthInfo, McpHttpHandler, McpServer, createMcpHandler } from '@modelcontextprotocol/server';
+import { AuthInfo, McpHttpHandler, McpServer, OAuthError, createMcpHandler } from '@modelcontextprotocol/server';
 import { Injectable, OnApplicationShutdown, Optional, UnauthorizedException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
@@ -177,7 +177,7 @@ export class McpServerService implements OnApplicationShutdown {
 
 	async closeAll(): Promise<void> {
 		this.invalidatePolicies();
-		this.subscriptions.closeAll();
+		await this.subscriptions.closeAll();
 		const handlers = [...this.handlers.values()];
 		this.handlers.clear();
 		const results = await Promise.allSettled(handlers.map(({ handler }) => handler.close()));
@@ -254,8 +254,9 @@ export class McpServerService implements OnApplicationShutdown {
 					}
 				} catch (error) {
 					if (error instanceof McpSubscriptionCapacityError) {
-						return this.subscriptionLimitResponse(requestOptions?.parsedBody);
+						return this.getSubscriptionErrorResponse(error, requestOptions?.parsedBody);
 					}
+					if (OAuthError.isInstance(error)) return this.getSubscriptionErrorResponse(error);
 
 					throw error;
 				}
@@ -313,6 +314,12 @@ export class McpServerService implements OnApplicationShutdown {
 		);
 	}
 
+	private getSubscriptionErrorResponse(error: McpSubscriptionCapacityError | OAuthError, body?: unknown): Response {
+		return error instanceof McpSubscriptionCapacityError
+			? this.subscriptionLimitResponse(body)
+			: this.oauthResourceServerService.getBearerChallenge(error);
+	}
+
 	private getRequestBody(body: unknown): JsonRpcRequestBody {
 		return body && typeof body === 'object' && !Array.isArray(body) ? (body as JsonRpcRequestBody) : {};
 	}
@@ -356,7 +363,7 @@ export class McpServerService implements OnApplicationShutdown {
 
 		let currentAuthInfo: AuthInfo | undefined;
 		const handle = await this.subscriptions.openOAuth(requestId, async () => {
-			currentAuthInfo = await this.oauthResourceServerService.verifyAccessToken(authInfo.token);
+			currentAuthInfo = await this.oauthResourceServerService.verifyMcpBearerToken(`Bearer ${authInfo.token}`);
 			const current = this.getSubscriptionRegistration(clientId, currentAuthInfo);
 
 			if (!current.oauth) {

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -20,6 +20,7 @@ import {
 import { McpOAuthPrincipal } from '../oauth/mcp-oauth.types';
 
 import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
 import { McpPolicyRequest } from './mcp-policy.service';
 import {
 	McpOAuthSubscriptionBinding,
@@ -54,6 +55,11 @@ interface McpSubscriptionRegistration {
 	oauth?: McpOAuthSubscriptionBinding;
 }
 
+interface McpOpenedSubscription {
+	authInfo?: AuthInfo;
+	handle: McpSubscriptionHandle;
+}
+
 @Injectable()
 export class McpServerService implements OnApplicationShutdown {
 	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpServerService');
@@ -64,6 +70,7 @@ export class McpServerService implements OnApplicationShutdown {
 	constructor(
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly auditService: McpAuditService,
+		private readonly oauthResourceServerService: McpOAuthResourceServerService,
 		@Optional() private readonly moduleRef?: ModuleRef,
 	) {}
 
@@ -225,25 +232,29 @@ export class McpServerService implements OnApplicationShutdown {
 		const fetch = handler.fetch;
 		const wrappedHandler = {
 			fetch: async (...args: Parameters<McpHttpHandler['fetch']>): Promise<Response> => {
-				const [webRequest, options] = args;
+				const [webRequest, requestOptions] = args;
 
-				if (!this.isSubscriptionListen(options?.parsedBody)) {
-					return fetch(webRequest, options);
+				if (!this.isSubscriptionListen(requestOptions?.parsedBody)) {
+					return fetch(webRequest, requestOptions);
 				}
 
 				let subscription: McpSubscriptionHandle;
+				let options = requestOptions;
 
 				try {
-					const registration = this.getSubscriptionRegistration(clientId, options?.authInfo);
-
-					subscription = this.subscriptions.open(
-						registration.clientId,
-						this.auditService.getRequestId(options?.parsedBody),
-						registration.oauth,
+					const opened = await this.openSubscription(
+						clientId,
+						this.auditService.getRequestId(requestOptions?.parsedBody),
+						requestOptions?.authInfo,
 					);
+
+					subscription = opened.handle;
+					if (opened.authInfo !== requestOptions?.authInfo) {
+						options = { ...requestOptions, authInfo: opened.authInfo };
+					}
 				} catch (error) {
 					if (error instanceof McpSubscriptionCapacityError) {
-						return this.subscriptionLimitResponse(options?.parsedBody);
+						return this.subscriptionLimitResponse(requestOptions?.parsedBody);
 					}
 
 					throw error;
@@ -327,6 +338,39 @@ export class McpServerService implements OnApplicationShutdown {
 				grantGeneration: value.grantGeneration,
 			},
 		};
+	}
+
+	private async openSubscription(
+		clientId: string,
+		requestId: string,
+		authInfo?: AuthInfo,
+	): Promise<McpOpenedSubscription> {
+		const registration = this.getSubscriptionRegistration(clientId, authInfo);
+
+		if (!registration.oauth) {
+			return { authInfo, handle: this.subscriptions.open(registration.clientId, requestId) };
+		}
+		if (!authInfo) {
+			throw new UnauthorizedException('MCP OAuth subscription identity is unavailable');
+		}
+
+		let currentAuthInfo: AuthInfo | undefined;
+		const handle = await this.subscriptions.openOAuth(requestId, async () => {
+			currentAuthInfo = await this.oauthResourceServerService.verifyAccessToken(authInfo.token);
+			const current = this.getSubscriptionRegistration(clientId, currentAuthInfo);
+
+			if (!current.oauth) {
+				throw new UnauthorizedException('MCP OAuth subscription identity is unavailable');
+			}
+
+			return { clientId: current.clientId, binding: current.oauth };
+		});
+
+		if (!currentAuthInfo) {
+			throw new UnauthorizedException('MCP OAuth subscription revalidation did not complete');
+		}
+
+		return { authInfo: currentAuthInfo, handle };
 	}
 
 	private isOAuthPrincipal(value: unknown): value is McpOAuthPrincipal {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -8,9 +8,19 @@ import {
 import { McpAuditService } from './mcp-audit.service';
 import {
 	McpOAuthSubscriptionBinding,
+	McpOAuthSubscriptionRegistration,
 	McpSubscriptionCapacityError,
 	McpSubscriptionRegistryService,
 } from './mcp-subscription-registry.service';
+
+const deferred = <T = void>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+	let resolve = (_value: T): void => undefined;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
 
 const oauthBinding = (overrides: Partial<McpOAuthSubscriptionBinding> = {}): McpOAuthSubscriptionBinding => ({
 	accessTokenId: 'access-one',
@@ -21,6 +31,11 @@ const oauthBinding = (overrides: Partial<McpOAuthSubscriptionBinding> = {}): Mcp
 	clientGeneration: 2,
 	grantGeneration: 3,
 	...overrides,
+});
+
+const oauthRegistration = (overrides: Partial<McpOAuthSubscriptionBinding> = {}): McpOAuthSubscriptionRegistration => ({
+	clientId: 'client-a',
+	binding: oauthBinding(overrides),
 });
 
 describe('McpSubscriptionRegistryService', () => {
@@ -106,47 +121,113 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(service.activeCount).toBe(0);
 	});
 
-	it('closes only OAuth streams matching a revoked artifact identity', () => {
+	it('closes only OAuth streams matching a revoked artifact identity', async () => {
 		const staticStream = service.open('client-a');
-		const first = service.open(
-			'client-a',
-			'one',
-			oauthBinding({
-				accessTokenId: 'access-one',
-				grantId: 'grant-one',
-				refreshFamilyId: 'family-one',
-			}),
+		const first = await service.openOAuth('one', () =>
+			Promise.resolve(
+				oauthRegistration({
+					accessTokenId: 'access-one',
+					grantId: 'grant-one',
+					refreshFamilyId: 'family-one',
+				}),
+			),
 		);
-		const other = service.open(
-			'client-a',
-			'two',
-			oauthBinding({
-				accessTokenId: 'access-two',
-				grantId: 'grant-two',
-				refreshFamilyId: 'family-two',
-			}),
+		const other = await service.openOAuth('two', () =>
+			Promise.resolve(
+				oauthRegistration({
+					accessTokenId: 'access-two',
+					grantId: 'grant-two',
+					refreshFamilyId: 'family-two',
+				}),
+			),
 		);
 
-		service.closeOAuthAccessToken('access-one');
+		await service.closeOAuthAccessToken('access-one', () => Promise.resolve());
 
 		expect(first.signal.aborted).toBe(true);
 		expect(other.signal.aborted).toBe(false);
 		expect(staticStream.signal.aborted).toBe(false);
 
-		service.closeOAuthRefreshFamily('family-two');
+		await service.closeOAuthRefreshFamily('family-two', () => Promise.resolve());
 
 		expect(other.signal.aborted).toBe(true);
 		expect(staticStream.signal.aborted).toBe(false);
 	});
 
-	it('closes OAuth streams at their authorization deadline', () => {
+	it('closes a registration that wins the gate before matching invalidation', async () => {
+		const revalidationStarted = deferred();
+		const releaseRevalidation = deferred();
+		const advanceGeneration = jest.fn().mockResolvedValue(undefined);
+		const registrationPromise = service.openOAuth('racing-open', async () => {
+			revalidationStarted.resolve();
+			await releaseRevalidation.promise;
+
+			return oauthRegistration();
+		});
+
+		await revalidationStarted.promise;
+
+		const invalidationPromise = service.closeOAuthAccessToken('access-one', advanceGeneration);
+
+		await Promise.resolve();
+		expect(advanceGeneration).not.toHaveBeenCalled();
+
+		releaseRevalidation.resolve();
+		const subscription = await registrationPromise;
+
+		await invalidationPromise;
+
+		expect(advanceGeneration).toHaveBeenCalledTimes(1);
+		expect(subscription.signal.aborted).toBe(true);
+		expect(auditService.recordSubscriptionClosed).toHaveBeenCalledWith(
+			{ requestId: 'racing-open', clientId: 'client-a' },
+			subscription.id,
+			'authorization_revoked',
+		);
+	});
+
+	it('makes a registration queued behind invalidation revalidate after its generation advances', async () => {
+		const advanceStarted = deferred();
+		const releaseAdvance = deferred();
+		const invalidationPromise = service.closeOAuthGrant('grant-one', async () => {
+			advanceStarted.resolve();
+			await releaseAdvance.promise;
+		});
+
+		await advanceStarted.promise;
+
+		const revalidate = jest.fn().mockRejectedValue(new Error('stale authorization generation'));
+		const registrationPromise = service.openOAuth('stale-open', revalidate);
+		const rejectedRegistration = expect(registrationPromise).rejects.toThrow('stale authorization generation');
+
+		await Promise.resolve();
+		expect(revalidate).not.toHaveBeenCalled();
+
+		releaseAdvance.resolve();
+		await invalidationPromise;
+		await rejectedRegistration;
+		expect(revalidate).toHaveBeenCalledTimes(1);
+		expect(service.activeCount).toBe(0);
+	});
+
+	it('propagates generation-advance failure without closing matching OAuth streams', async () => {
+		const subscription = await service.openOAuth('failed-invalidation', () => Promise.resolve(oauthRegistration()));
+
+		await expect(
+			service.closeOAuthAccessToken('access-one', () => Promise.reject(new Error('generation update failed'))),
+		).rejects.toThrow('generation update failed');
+
+		expect(subscription.signal.aborted).toBe(false);
+	});
+
+	it('closes OAuth streams at their authorization deadline', async () => {
 		jest.useFakeTimers();
-		const subscription = service.open(
-			'client-a',
-			'deadline',
-			oauthBinding({
-				authorizationDeadline: new Date(Date.now() + 1_000),
-			}),
+		const subscription = await service.openOAuth('deadline', () =>
+			Promise.resolve(
+				oauthRegistration({
+					authorizationDeadline: new Date(Date.now() + 1_000),
+				}),
+			),
 		);
 
 		jest.advanceTimersByTime(500);
@@ -163,14 +244,14 @@ describe('McpSubscriptionRegistryService', () => {
 		);
 	});
 
-	it('cancels the authorization deadline timer when an OAuth stream closes early', () => {
+	it('cancels the authorization deadline timer when an OAuth stream closes early', async () => {
 		jest.useFakeTimers();
-		const subscription = service.open(
-			'client-a',
-			'early-close',
-			oauthBinding({
-				authorizationDeadline: new Date(Date.now() + 60_000),
-			}),
+		const subscription = await service.openOAuth('early-close', () =>
+			Promise.resolve(
+				oauthRegistration({
+					authorizationDeadline: new Date(Date.now() + 60_000),
+				}),
+			),
 		);
 
 		expect(jest.getTimerCount()).toBe(2);

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -50,8 +50,8 @@ describe('McpSubscriptionRegistryService', () => {
 		service = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
 	});
 
-	afterEach(() => {
-		service.closeAll();
+	afterEach(async () => {
+		await service.closeAll();
 		jest.useRealTimers();
 	});
 
@@ -110,11 +110,11 @@ describe('McpSubscriptionRegistryService', () => {
 		);
 	});
 
-	it('cleans up every stream during application shutdown', () => {
+	it('cleans up every stream during application shutdown', async () => {
 		const first = service.open('client-a');
 		const second = service.open('client-b');
 
-		service.onApplicationShutdown();
+		await service.onApplicationShutdown();
 
 		expect(first.signal.aborted).toBe(true);
 		expect(second.signal.aborted).toBe(true);
@@ -183,6 +183,35 @@ describe('McpSubscriptionRegistryService', () => {
 			{ requestId: 'racing-open', clientId: 'client-a' },
 			subscription.id,
 			'authorization_revoked',
+		);
+	});
+
+	it('serializes close-all behind a pending OAuth registration and closes the resulting stream', async () => {
+		const revalidationStarted = deferred();
+		const releaseRevalidation = deferred();
+		const registrationPromise = service.openOAuth('shutdown-race', async () => {
+			revalidationStarted.resolve();
+			await releaseRevalidation.promise;
+
+			return oauthRegistration();
+		});
+
+		await revalidationStarted.promise;
+
+		const closePromise = service.closeAll();
+
+		expect(service.activeCount).toBe(0);
+		releaseRevalidation.resolve();
+		const subscription = await registrationPromise;
+
+		await closePromise;
+
+		expect(subscription.signal.aborted).toBe(true);
+		expect(service.activeCount).toBe(0);
+		expect(auditService.recordSubscriptionClosed).toHaveBeenCalledWith(
+			{ requestId: 'shutdown-race', clientId: 'client-a' },
+			subscription.id,
+			'shutdown',
 		);
 	});
 

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -10,6 +10,7 @@ import {
 	McpOAuthSubscriptionBinding,
 	McpOAuthSubscriptionRegistration,
 	McpSubscriptionCapacityError,
+	McpSubscriptionClosingError,
 	McpSubscriptionRegistryService,
 } from './mcp-subscription-registry.service';
 
@@ -215,6 +216,30 @@ describe('McpSubscriptionRegistryService', () => {
 			subscription.id,
 			'shutdown',
 		);
+	});
+
+	it('rejects OAuth registrations that arrive after close-all joins the gate', async () => {
+		const advanceStarted = deferred();
+		const releaseAdvance = deferred();
+		const invalidationPromise = service.closeAllOAuth(async () => {
+			advanceStarted.resolve();
+			await releaseAdvance.promise;
+		});
+
+		await advanceStarted.promise;
+
+		const closePromise = service.closeAll();
+		const revalidate = jest.fn().mockResolvedValue(oauthRegistration());
+
+		await expect(service.openOAuth('late-open', revalidate)).rejects.toThrow(McpSubscriptionClosingError);
+		expect(revalidate).not.toHaveBeenCalled();
+
+		releaseAdvance.resolve();
+		await invalidationPromise;
+		await closePromise;
+
+		expect(service.activeCount).toBe(0);
+		await expect(service.openOAuth('post-close-open', revalidate)).resolves.toEqual(expect.any(Object));
 	});
 
 	it('makes a registration queued behind invalidation revalidate after its generation advances', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -187,6 +187,7 @@ describe('McpSubscriptionRegistryService', () => {
 	});
 
 	it('serializes close-all behind a pending OAuth registration and closes the resulting stream', async () => {
+		const staticStream = service.open('static-client');
 		const revalidationStarted = deferred();
 		const releaseRevalidation = deferred();
 		const registrationPromise = service.openOAuth('shutdown-race', async () => {
@@ -201,6 +202,7 @@ describe('McpSubscriptionRegistryService', () => {
 		const closePromise = service.closeAll();
 
 		expect(service.activeCount).toBe(0);
+		expect(staticStream.signal.aborted).toBe(true);
 		releaseRevalidation.resolve();
 		const subscription = await registrationPromise;
 

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -173,14 +173,18 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		await this.closeOAuthMatching(advanceGeneration, (subscription) => subscription.oauth !== undefined);
 	}
 
-	closeAll(): void {
-		for (const id of [...this.subscriptions.keys()]) {
-			this.close(id, 'shutdown');
-		}
+	async closeAll(): Promise<void> {
+		await this.withOAuthGate(() => {
+			for (const id of [...this.subscriptions.keys()]) {
+				this.close(id, 'shutdown');
+			}
+
+			return Promise.resolve();
+		});
 	}
 
-	onApplicationShutdown(): void {
-		this.closeAll();
+	async onApplicationShutdown(): Promise<void> {
+		await this.closeAll();
 	}
 
 	private touch(id: string): void {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -37,6 +37,13 @@ export interface McpOAuthSubscriptionBinding {
 	grantGeneration: number;
 }
 
+export interface McpOAuthSubscriptionRegistration {
+	clientId: string;
+	binding: McpOAuthSubscriptionBinding;
+}
+
+export type McpOAuthGenerationAdvance = () => Promise<void>;
+
 interface SubscriptionRecord {
 	id: string;
 	clientId: string;
@@ -50,10 +57,26 @@ interface SubscriptionRecord {
 @Injectable()
 export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	private readonly subscriptions = new Map<string, SubscriptionRecord>();
+	private oauthGateTail: Promise<void> = Promise.resolve();
 
 	constructor(private readonly auditService: McpAuditService) {}
 
-	open(clientId: string, requestId = 'unknown', oauth?: McpOAuthSubscriptionBinding): McpSubscriptionHandle {
+	open(clientId: string, requestId = 'unknown'): McpSubscriptionHandle {
+		return this.openRecord(clientId, requestId);
+	}
+
+	async openOAuth(
+		requestId: string,
+		revalidate: () => Promise<McpOAuthSubscriptionRegistration>,
+	): Promise<McpSubscriptionHandle> {
+		return this.withOAuthGate(async () => {
+			const registration = await revalidate();
+
+			return this.openRecord(registration.clientId, requestId, registration.binding);
+		});
+	}
+
+	private openRecord(clientId: string, requestId: string, oauth?: McpOAuthSubscriptionBinding): McpSubscriptionHandle {
 		if (
 			this.subscriptions.size >= MCP_MAX_ACTIVE_SUBSCRIPTIONS ||
 			this.countForClient(clientId) >= MCP_MAX_SUBSCRIPTIONS_PER_CLIENT
@@ -121,24 +144,33 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		}
 	}
 
-	closeOAuthClient(clientId: string): void {
-		this.closeMatching((subscription) => subscription.clientId === clientId && subscription.oauth !== undefined);
+	async closeOAuthClient(clientId: string, advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
+		await this.closeOAuthMatching(
+			advanceGeneration,
+			(subscription) => subscription.clientId === clientId && subscription.oauth !== undefined,
+		);
 	}
 
-	closeOAuthGrant(grantId: string): void {
-		this.closeMatching((subscription) => subscription.oauth?.grantId === grantId);
+	async closeOAuthGrant(grantId: string, advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
+		await this.closeOAuthMatching(advanceGeneration, (subscription) => subscription.oauth?.grantId === grantId);
 	}
 
-	closeOAuthAccessToken(accessTokenId: string): void {
-		this.closeMatching((subscription) => subscription.oauth?.accessTokenId === accessTokenId);
+	async closeOAuthAccessToken(accessTokenId: string, advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
+		await this.closeOAuthMatching(
+			advanceGeneration,
+			(subscription) => subscription.oauth?.accessTokenId === accessTokenId,
+		);
 	}
 
-	closeOAuthRefreshFamily(refreshFamilyId: string): void {
-		this.closeMatching((subscription) => subscription.oauth?.refreshFamilyId === refreshFamilyId);
+	async closeOAuthRefreshFamily(refreshFamilyId: string, advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
+		await this.closeOAuthMatching(
+			advanceGeneration,
+			(subscription) => subscription.oauth?.refreshFamilyId === refreshFamilyId,
+		);
 	}
 
-	closeAllOAuth(): void {
-		this.closeMatching((subscription) => subscription.oauth !== undefined);
+	async closeAllOAuth(advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
+		await this.closeOAuthMatching(advanceGeneration, (subscription) => subscription.oauth !== undefined);
 	}
 
 	closeAll(): void {
@@ -198,6 +230,33 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	private closeMatching(predicate: (subscription: SubscriptionRecord) => boolean): void {
 		for (const subscription of [...this.subscriptions.values()]) {
 			if (predicate(subscription)) this.close(subscription.id, 'authorization_revoked');
+		}
+	}
+
+	private async closeOAuthMatching(
+		advanceGeneration: McpOAuthGenerationAdvance,
+		predicate: (subscription: SubscriptionRecord) => boolean,
+	): Promise<void> {
+		await this.withOAuthGate(async () => {
+			await advanceGeneration();
+			this.closeMatching(predicate);
+		});
+	}
+
+	private async withOAuthGate<T>(operation: () => Promise<T>): Promise<T> {
+		const previous = this.oauthGateTail;
+		let release = (): void => undefined;
+
+		this.oauthGateTail = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		await previous;
+
+		try {
+			return await operation();
+		} finally {
+			release();
 		}
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -174,6 +174,10 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	}
 
 	async closeAll(): Promise<void> {
+		for (const id of [...this.subscriptions.keys()]) {
+			this.close(id, 'shutdown');
+		}
+
 		await this.withOAuthGate(() => {
 			for (const id of [...this.subscriptions.keys()]) {
 				this.close(id, 'shutdown');

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -11,10 +11,19 @@ import {
 
 import { McpAuditService, McpSubscriptionCloseReason } from './mcp-audit.service';
 
-export class McpSubscriptionCapacityError extends Error {
+export class McpSubscriptionUnavailableError extends Error {}
+
+export class McpSubscriptionCapacityError extends McpSubscriptionUnavailableError {
 	constructor() {
 		super('Subscription limit reached');
 		this.name = McpSubscriptionCapacityError.name;
+	}
+}
+
+export class McpSubscriptionClosingError extends McpSubscriptionUnavailableError {
+	constructor() {
+		super('Subscription service is closing');
+		this.name = McpSubscriptionClosingError.name;
 	}
 }
 
@@ -58,6 +67,7 @@ interface SubscriptionRecord {
 export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	private readonly subscriptions = new Map<string, SubscriptionRecord>();
 	private oauthGateTail: Promise<void> = Promise.resolve();
+	private closeAllOperations = 0;
 
 	constructor(private readonly auditService: McpAuditService) {}
 
@@ -69,6 +79,10 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		requestId: string,
 		revalidate: () => Promise<McpOAuthSubscriptionRegistration>,
 	): Promise<McpSubscriptionHandle> {
+		if (this.closeAllOperations > 0) {
+			throw new McpSubscriptionClosingError();
+		}
+
 		return this.withOAuthGate(async () => {
 			const registration = await revalidate();
 
@@ -174,17 +188,23 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	}
 
 	async closeAll(): Promise<void> {
-		for (const id of [...this.subscriptions.keys()]) {
-			this.close(id, 'shutdown');
-		}
+		this.closeAllOperations += 1;
 
-		await this.withOAuthGate(() => {
+		try {
 			for (const id of [...this.subscriptions.keys()]) {
 				this.close(id, 'shutdown');
 			}
 
-			return Promise.resolve();
-		});
+			await this.withOAuthGate(() => {
+				for (const id of [...this.subscriptions.keys()]) {
+					this.close(id, 'shutdown');
+				}
+
+				return Promise.resolve();
+			});
+		} finally {
+			this.closeAllOperations -= 1;
+		}
 	}
 
 	async onApplicationShutdown(): Promise<void> {

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -229,7 +229,7 @@ describe('MCP endpoint', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
-				{ provide: McpOAuthResourceServerService, useValue: { verifyAccessToken: jest.fn() } },
+				{ provide: McpOAuthResourceServerService, useValue: { verifyMcpBearerToken: jest.fn() } },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: catalog },

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -25,6 +25,7 @@ import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
@@ -228,6 +229,7 @@ describe('MCP endpoint', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
+				{ provide: McpOAuthResourceServerService, useValue: { verifyAccessToken: jest.fn() } },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: catalog },

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -21,6 +21,7 @@ import { MCP_CATALOG_REGISTRAR, McpCapability } from '../src/modules/mcp/mcp.con
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
@@ -254,6 +255,7 @@ describe('MCP simulator operations', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
+				{ provide: McpOAuthResourceServerService, useValue: { verifyAccessToken: jest.fn() } },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: targetTools },

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -255,7 +255,7 @@ describe('MCP simulator operations', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
-				{ provide: McpOAuthResourceServerService, useValue: { verifyAccessToken: jest.fn() } },
+				{ provide: McpOAuthResourceServerService, useValue: { verifyMcpBearerToken: jest.fn() } },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: targetTools },

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -158,7 +158,7 @@ describe('MCP disabled restart', () => {
 				},
 				{
 					provide: McpOAuthResourceServerService,
-					useValue: { authorizeAccessToken: jest.fn(), verifyAccessToken: jest.fn() },
+					useValue: { authorizeAccessToken: jest.fn(), verifyMcpBearerToken: jest.fn() },
 				},
 				McpAuditService,
 				McpClientGuard,

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -156,7 +156,10 @@ describe('MCP disabled restart', () => {
 					provide: McpInstallationService,
 					useValue: { getInstallationId: jest.fn().mockResolvedValue('restart-installation') },
 				},
-				{ provide: McpOAuthResourceServerService, useValue: { authorizeAccessToken: jest.fn() } },
+				{
+					provide: McpOAuthResourceServerService,
+					useValue: { authorizeAccessToken: jest.fn(), verifyAccessToken: jest.fn() },
+				},
 				McpAuditService,
 				McpClientGuard,
 				McpPolicyService,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — validated OAuth subscription binding implemented
+**Status:** Phase 5 in progress — authoritative OAuth subscription gate foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -138,6 +138,17 @@ amend ADR 0002.
       existing static subscription registration path.
 - [x] Record effective scopes and module/client/grant generations on the internal OAuth subscription binding for the
       authoritative registration/invalidation gate.
+
+### Phase 5d — Authoritative subscription gate foundation
+
+- [x] Serialize OAuth subscription revalidation/registration and generation-advancing invalidation through one
+      exclusive registry boundary while leaving static registration independent.
+- [x] Revalidate the raw OAuth access token inside that boundary immediately before registration and pass the refreshed
+      scopes, generations, and authorization deadline into MCP server creation.
+- [x] Require targeted and OAuth-global invalidation callers to finish their generation advance before matching
+      subscriptions are enumerated and closed; propagate advance failures without partially closing streams.
+- [x] Prove both race orderings with barriers: a registration that wins is subsequently closed, while a registration
+      queued behind invalidation revalidates only after the generation advances.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 validated OAuth subscription binding complete
+Status: in progress — Phase 5 authoritative OAuth subscription gate foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- serialize OAuth subscription revalidation/registration and generation-advancing invalidation through one exclusive registry boundary
- revalidate the raw OAuth access token inside the gate immediately before opening a listen stream
- pass refreshed scopes, generations, and authorization deadline into MCP server creation
- require generation advancement before targeted or OAuth-global stream enumeration and closure
- preserve static subscription registration outside the OAuth gate
- make the generic subscription `open()` API static-only so OAuth registration cannot bypass the gate
- add barrier tests for both race orderings and failure propagation
- update standalone MCP E2E harnesses and Phase 5 task tracking

## Why

A validated listen request could otherwise race an administrative invalidation and register after that mutation reported success. This gate ensures registration either wins first and is closed by invalidation, or waits and revalidates only after the applicable generation advances.

## Impact

No public OAuth routes or user-facing enable switch are exposed. Static MCP streams retain their existing path. Concrete client, grant, token, refresh-family, and scope mutations still need to be wired through this gate in the next Phase 5 slice.

## Validation

- backend TypeScript type-check
- targeted backend lint
- Prettier verification
- 21 focused unit tests
- 24 MCP endpoint/operations/restart E2E tests
- `git diff --check`
