### PR TITLE
feat(backend): await MCP capability-ceiling invalidation

### DIFF
--- a/apps/backend/src/modules/config/config.module.ts
+++ b/apps/backend/src/modules/config/config.module.ts
@@ -20,6 +20,7 @@ import { ConfigController } from './controllers/config.controller';
 import { UpdateConfigModuleConfigDto } from './dto/update-module-config.dto';
 import { ConfigModuleConfigModel } from './models/module-config.model';
 import { ConfigService } from './services/config.service';
+import { ModuleConfigMutationRegistryService } from './services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './services/modules-type-mapper.service';
 import { PluginConfigValidatorService } from './services/plugin-config-validator.service';
 
@@ -31,9 +32,14 @@ import { PluginConfigValidatorService } from './services/plugin-config-validator
 @Global()
 @Module({
 	imports: [NestConfigModule, PlatformModule, SwaggerModule],
-	providers: [ConfigService, PluginConfigValidatorService, GenerateAdminExtensionsCommand],
+	providers: [
+		ConfigService,
+		ModuleConfigMutationRegistryService,
+		PluginConfigValidatorService,
+		GenerateAdminExtensionsCommand,
+	],
 	controllers: [ConfigController],
-	exports: [ConfigService, PluginConfigValidatorService],
+	exports: [ConfigService, ModuleConfigMutationRegistryService, PluginConfigValidatorService],
 })
 export class ConfigModule implements OnModuleInit {
 	constructor(

--- a/apps/backend/src/modules/config/controllers/config.controller.spec.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.spec.ts
@@ -46,7 +46,7 @@ describe('ConfigController', () => {
 						getConfig: jest.fn().mockReturnValue(mockConfig),
 						getModulesConfig: jest.fn().mockReturnValue(mockConfig.modules),
 						getModuleConfig: jest.fn((_module: string) => mockConfig.modules[0]),
-						setModuleConfig: jest.fn(),
+						updateModuleConfig: jest.fn(),
 					},
 				},
 				{
@@ -142,7 +142,7 @@ describe('ConfigController', () => {
 			const updatedModule = { ...mockConfig.modules[0], enabled: false } as ModuleConfigModel;
 
 			jest.spyOn(configService, 'getModuleConfig').mockReturnValue(updatedModule);
-			jest.spyOn(configService, 'setModuleConfig').mockImplementation(() => {});
+			jest.spyOn(configService, 'updateModuleConfig').mockResolvedValue();
 
 			const result = await controller.updateModuleConfig('mock-module', { data: updateDto });
 
@@ -151,7 +151,7 @@ describe('ConfigController', () => {
 				type: 'mock-module',
 				enabled: false,
 			});
-			expect(configService.setModuleConfig).toHaveBeenCalledWith('mock-module', updateDto);
+			expect(configService.updateModuleConfig).toHaveBeenCalledWith('mock-module', updateDto);
 			expect(configService.getModuleConfig).toHaveBeenCalledWith('mock-module');
 		});
 

--- a/apps/backend/src/modules/config/controllers/config.controller.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.ts
@@ -378,7 +378,7 @@ export class ConfigController {
 			throw ValidationExceptionFactory.createException(errors);
 		}
 
-		this.service.setModuleConfig(module, dtoInstance);
+		await this.service.updateModuleConfig(module, dtoInstance);
 
 		const config = this.service.getModuleConfig(module);
 

--- a/apps/backend/src/modules/config/services/config.service.spec.ts
+++ b/apps/backend/src/modules/config/services/config.service.spec.ts
@@ -23,6 +23,7 @@ import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto'
 import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
 
 import { ConfigService } from './config.service';
+import { ModuleConfigMutationRegistryService } from './module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './modules-type-mapper.service';
 import { PluginsTypeMapperService } from './plugins-type-mapper.service';
 
@@ -72,6 +73,7 @@ class ModuleConfigDto extends UpdateModuleConfigDto {
 describe('ConfigService', () => {
 	let service: ConfigService;
 	let eventEmitter: EventEmitter2;
+	let moduleConfigMutations: ModuleConfigMutationRegistryService;
 	let platform: PlatformService;
 
 	const mockRawConfig = {
@@ -114,6 +116,7 @@ describe('ConfigService', () => {
 			imports: [NestConfigModule],
 			providers: [
 				ConfigService,
+				ModuleConfigMutationRegistryService,
 				{
 					provide: PlatformService,
 					useValue: {
@@ -172,6 +175,7 @@ describe('ConfigService', () => {
 
 		service = module.get<ConfigService>(ConfigService);
 		eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+		moduleConfigMutations = module.get<ModuleConfigMutationRegistryService>(ModuleConfigMutationRegistryService);
 		platform = module.get<PlatformService>(PlatformService);
 	});
 
@@ -446,6 +450,20 @@ describe('ConfigService', () => {
 			expect(fs.existsSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']));
 			expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']), 'utf8');
 			expect(yaml.parse).toHaveBeenCalledWith(JSON.stringify(mockRawConfig));
+		});
+	});
+
+	describe('updateModuleConfig', () => {
+		it('runs registered module mutations around persistence', async () => {
+			const commit = jest.spyOn(service, 'setModuleConfig').mockImplementation(() => {});
+			moduleConfigMutations.register('mock-module', async (update, persist) => {
+				expect(update).toMatchObject({ type: 'mock-module', enabled: false });
+				await persist();
+			});
+
+			await service.updateModuleConfig('mock-module', { type: 'mock-module', enabled: false });
+
+			expect(commit).toHaveBeenCalledWith('mock-module', { type: 'mock-module', enabled: false });
 		});
 	});
 });

--- a/apps/backend/src/modules/config/services/config.service.ts
+++ b/apps/backend/src/modules/config/services/config.service.ts
@@ -17,6 +17,7 @@ import { ConfigCorruptedException, ConfigNotFoundException, ConfigValidationExce
 import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto';
 import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
 
+import { ModuleConfigMutationRegistryService } from './module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './modules-type-mapper.service';
 import { PluginsTypeMapperService } from './plugins-type-mapper.service';
 
@@ -31,6 +32,7 @@ export class ConfigService {
 		private readonly configService: NestConfigService,
 		private readonly pluginsMapperService: PluginsTypeMapperService,
 		private readonly modulesMapperService: ModulesTypeMapperService,
+		private readonly moduleConfigMutations: ModuleConfigMutationRegistryService,
 		private readonly platform: PlatformService,
 		private readonly eventEmitter: EventEmitter2,
 	) {
@@ -534,6 +536,10 @@ export class ConfigService {
 		this.eventEmitter.emit(EventType.CONFIG_UPDATED, { source: module, type: 'module' as const });
 
 		this.logger.log(`Configuration update for module=${module} completed successfully`);
+	}
+
+	async updateModuleConfig<TUpdateDto extends UpdateModuleConfigDto>(module: string, value: TUpdateDto): Promise<void> {
+		await this.moduleConfigMutations.execute(module, value, () => this.setModuleConfig(module, value));
 	}
 
 	async resetConfig(): Promise<void> {

--- a/apps/backend/src/modules/config/services/module-config-mutation-registry.service.spec.ts
+++ b/apps/backend/src/modules/config/services/module-config-mutation-registry.service.spec.ts
@@ -1,0 +1,42 @@
+import { ConfigException } from '../config.exceptions';
+import { UpdateModuleConfigDto } from '../dto/config.dto';
+
+import { ModuleConfigMutationRegistryService } from './module-config-mutation-registry.service';
+
+describe('ModuleConfigMutationRegistryService', () => {
+	let service: ModuleConfigMutationRegistryService;
+
+	beforeEach(() => {
+		service = new ModuleConfigMutationRegistryService();
+	});
+
+	it('commits updates without a registered handler', async () => {
+		const commit = jest.fn();
+
+		await service.execute('unregistered-module', { type: 'unregistered-module' }, commit);
+
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('awaits the registered handler around the commit', async () => {
+		const order: string[] = [];
+		const update: UpdateModuleConfigDto = { type: 'secured-module', enabled: false };
+		service.register('secured-module', async (registeredUpdate, commit) => {
+			order.push(`before:${registeredUpdate.enabled}`);
+			await commit();
+			order.push('after');
+		});
+
+		await service.execute('secured-module', update, () => {
+			order.push('commit');
+		});
+
+		expect(order).toEqual(['before:false', 'commit', 'after']);
+	});
+
+	it('rejects duplicate handlers for one module', () => {
+		service.register('secured-module', async (_update, commit) => commit());
+
+		expect(() => service.register('secured-module', async (_update, commit) => commit())).toThrow(ConfigException);
+	});
+});

--- a/apps/backend/src/modules/config/services/module-config-mutation-registry.service.ts
+++ b/apps/backend/src/modules/config/services/module-config-mutation-registry.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+
+import { ConfigException } from '../config.exceptions';
+import { UpdateModuleConfigDto } from '../dto/config.dto';
+
+export type ModuleConfigCommit = () => Promise<void> | void;
+
+export type ModuleConfigMutationHandler<TUpdateDto extends UpdateModuleConfigDto = UpdateModuleConfigDto> = (
+	update: TUpdateDto,
+	commit: ModuleConfigCommit,
+) => Promise<void>;
+
+@Injectable()
+export class ModuleConfigMutationRegistryService {
+	private readonly handlers = new Map<string, ModuleConfigMutationHandler>();
+
+	register<TUpdateDto extends UpdateModuleConfigDto>(
+		module: string,
+		handler: ModuleConfigMutationHandler<TUpdateDto>,
+	): void {
+		if (this.handlers.has(module)) {
+			throw new ConfigException(`Module configuration mutation handler is already registered: ${module}`);
+		}
+
+		this.handlers.set(module, handler as ModuleConfigMutationHandler);
+	}
+
+	async execute<TUpdateDto extends UpdateModuleConfigDto>(
+		module: string,
+		update: TUpdateDto,
+		commit: ModuleConfigCommit,
+	): Promise<void> {
+		const handler = this.handlers.get(module);
+
+		if (!handler) {
+			await commit();
+			return;
+		}
+
+		await handler(update, commit);
+	}
+}

--- a/apps/backend/src/modules/extensions/controllers/extensions.controller.spec.ts
+++ b/apps/backend/src/modules/extensions/controllers/extensions.controller.spec.ts
@@ -120,21 +120,21 @@ describe('ExtensionsController', () => {
 	});
 
 	describe('update', () => {
-		it('should update extension enabled status', () => {
+		it('should update extension enabled status', async () => {
 			const mockExtension = createMockExtension({ type: 'devices-module', enabled: false });
-			jest.spyOn(extensionsService, 'updateEnabled').mockReturnValue(mockExtension);
+			jest.spyOn(extensionsService, 'updateEnabled').mockResolvedValue(mockExtension);
 
-			const result = controller.update('devices-module', { data: { enabled: false } });
+			const result = await controller.update('devices-module', { data: { enabled: false } });
 
 			expect(result.data.enabled).toBe(false);
 			expect(extensionsService.updateEnabled).toHaveBeenCalledWith('devices-module', false);
 		});
 
-		it('should enable extension', () => {
+		it('should enable extension', async () => {
 			const mockExtension = createMockExtension({ type: 'devices-module', enabled: true });
-			jest.spyOn(extensionsService, 'updateEnabled').mockReturnValue(mockExtension);
+			jest.spyOn(extensionsService, 'updateEnabled').mockResolvedValue(mockExtension);
 
-			const result = controller.update('devices-module', { data: { enabled: true } });
+			const result = await controller.update('devices-module', { data: { enabled: true } });
 
 			expect(result.data.enabled).toBe(true);
 			expect(extensionsService.updateEnabled).toHaveBeenCalledWith('devices-module', true);

--- a/apps/backend/src/modules/extensions/controllers/extensions.controller.ts
+++ b/apps/backend/src/modules/extensions/controllers/extensions.controller.ts
@@ -103,8 +103,8 @@ export class ExtensionsController {
 	@ApiSuccessResponse(ExtensionResponseModel, 'Returns the updated extension')
 	@ApiNotFoundResponse('Extension not found')
 	@ApiBadRequestResponse('Cannot modify core extension')
-	update(@Param('type') type: string, @Body() body: ReqUpdateExtensionDto): ExtensionResponseModel {
-		const extension = this.extensionsService.updateEnabled(type, body.data.enabled);
+	async update(@Param('type') type: string, @Body() body: ReqUpdateExtensionDto): Promise<ExtensionResponseModel> {
+		const extension = await this.extensionsService.updateEnabled(type, body.data.enabled);
 
 		const response = new ExtensionResponseModel();
 		response.data = extension;

--- a/apps/backend/src/modules/extensions/services/extensions.service.spec.ts
+++ b/apps/backend/src/modules/extensions/services/extensions.service.spec.ts
@@ -55,7 +55,7 @@ describe('ExtensionsService', () => {
 					useValue: {
 						getModuleConfig: jest.fn().mockReturnValue({ enabled: true }),
 						getPluginConfig: jest.fn().mockReturnValue({ enabled: true }),
-						setModuleConfig: jest.fn(),
+						updateModuleConfig: jest.fn(),
 						setPluginConfig: jest.fn(),
 					},
 				},
@@ -212,17 +212,17 @@ describe('ExtensionsService', () => {
 	});
 
 	describe('updateEnabled', () => {
-		it('should update module enabled status', () => {
-			service.updateEnabled('external-module', false);
+		it('should update module enabled status', async () => {
+			await service.updateEnabled('external-module', false);
 
-			expect(configService.setModuleConfig).toHaveBeenCalledWith('external-module', {
+			expect(configService.updateModuleConfig).toHaveBeenCalledWith('external-module', {
 				type: 'external-module',
 				enabled: false,
 			});
 		});
 
-		it('should update plugin enabled status', () => {
-			service.updateEnabled('pages-tiles-plugin', false);
+		it('should update plugin enabled status', async () => {
+			await service.updateEnabled('pages-tiles-plugin', false);
 
 			expect(configService.setPluginConfig).toHaveBeenCalledWith('pages-tiles-plugin', {
 				type: 'pages-tiles-plugin',
@@ -230,14 +230,16 @@ describe('ExtensionsService', () => {
 			});
 		});
 
-		it('should throw ExtensionNotConfigurableException when plugin DTO has no enabled property', () => {
+		it('should throw ExtensionNotConfigurableException when plugin DTO has no enabled property', async () => {
 			// Mock mapping with no enabled property
 			jest.spyOn(pluginsMapperService, 'getMapping').mockReturnValue({
 				type: 'pages-tiles-plugin',
 				configDto: MockConfigDtoNoEnabled,
 			} as never);
 
-			expect(() => service.updateEnabled('pages-tiles-plugin', false)).toThrow(ExtensionNotConfigurableException);
+			await expect(service.updateEnabled('pages-tiles-plugin', false)).rejects.toThrow(
+				ExtensionNotConfigurableException,
+			);
 		});
 	});
 

--- a/apps/backend/src/modules/extensions/services/extensions.service.ts
+++ b/apps/backend/src/modules/extensions/services/extensions.service.ts
@@ -139,7 +139,7 @@ export class ExtensionsService {
 	/**
 	 * Update extension enabled status
 	 */
-	updateEnabled(type: string, enabled: boolean): ExtensionModel {
+	async updateEnabled(type: string, enabled: boolean): Promise<ExtensionModel> {
 		this.logger.debug(`Updating extension type=${type} enabled=${enabled}`);
 
 		const extension = this.findOne(type);
@@ -152,7 +152,7 @@ export class ExtensionsService {
 		// Update the config based on extension kind
 		// Note: type is required in the DTO validation
 		if (extension.kind === ExtensionKind.MODULE) {
-			this.configService.setModuleConfig(type, { type, enabled } as UpdateModuleConfigDto);
+			await this.configService.updateModuleConfig(type, { type, enabled } as UpdateModuleConfigDto);
 		} else {
 			this.configService.setPluginConfig(type, { type, enabled } as UpdatePluginConfigDto);
 		}

--- a/apps/backend/src/modules/mcp/mcp.module.spec.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.spec.ts
@@ -1,3 +1,7 @@
+import {
+	ModuleConfigMutationHandler,
+	ModuleConfigMutationRegistryService,
+} from '../config/services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
 import { ExtensionsService } from '../extensions/services/extensions.service';
 import { StatsRegistryService } from '../stats/services/stats-registry.service';
@@ -9,17 +13,27 @@ import { McpModule } from './mcp.module';
 import { MCP_SWAGGER_EXTRA_MODELS } from './mcp.openapi';
 import { McpConfigModel } from './models/config.model';
 import { McpStatsProvider } from './providers/mcp-stats.provider';
+import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
 
 describe('McpModule', () => {
 	it('registers configuration, Swagger models, and disabled-by-default metadata', () => {
 		const swaggerRegistry = { register: jest.fn() };
 		const modulesMapperService = { registerMapping: jest.fn() };
+		let mutationHandler: ModuleConfigMutationHandler<UpdateMcpConfigDto> | undefined;
+		const moduleConfigMutations = {
+			register: jest.fn((_module: string, handler: ModuleConfigMutationHandler<UpdateMcpConfigDto>) => {
+				mutationHandler = handler;
+			}),
+		};
+		const moduleConfigMutation = { update: jest.fn() };
 		const extensionsService = { registerModuleMetadata: jest.fn() };
 		const statsRegistryService = { register: jest.fn() };
 		const statsProvider = {} as McpStatsProvider;
 		const module = new McpModule(
 			swaggerRegistry as unknown as SwaggerModelsRegistryService,
 			modulesMapperService as unknown as ModulesTypeMapperService,
+			moduleConfigMutations as unknown as ModuleConfigMutationRegistryService,
+			moduleConfigMutation as unknown as McpOAuthModuleConfigMutationService,
 			extensionsService as unknown as ExtensionsService,
 			statsRegistryService as unknown as StatsRegistryService,
 			statsProvider,
@@ -33,6 +47,16 @@ describe('McpModule', () => {
 			configDto: UpdateMcpConfigDto,
 		});
 		expect(swaggerRegistry.register).toHaveBeenCalledTimes(MCP_SWAGGER_EXTRA_MODELS.length);
+		expect(moduleConfigMutations.register).toHaveBeenCalledWith(MCP_MODULE_NAME, expect.any(Function));
+
+		if (!mutationHandler) {
+			throw new Error('MCP module configuration mutation handler was not registered');
+		}
+
+		const update = new UpdateMcpConfigDto();
+		const commit = jest.fn();
+		void mutationHandler(update, commit);
+		expect(moduleConfigMutation.update).toHaveBeenCalledWith(update, commit);
 
 		for (const model of MCP_SWAGGER_EXTRA_MODELS) {
 			expect(swaggerRegistry.register).toHaveBeenCalledWith(model);

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule as NestConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../auth/auth.module';
+import { ModuleConfigMutationRegistryService } from '../config/services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from '../config/services/modules-type-mapper.service';
 import { DevicesModule } from '../devices/devices.module';
 import { EnergyModule } from '../energy/energy.module';
@@ -62,6 +63,7 @@ import { McpOAuthArtifactService } from './services/mcp-oauth-artifact.service';
 import { McpOAuthClientService } from './services/mcp-oauth-client.service';
 import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.service';
 import { McpOAuthManagementService } from './services/mcp-oauth-management.service';
+import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
 import { McpOAuthProxyPolicyService } from './services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from './services/mcp-oauth-public-url.service';
 import { McpOAuthRefreshTokenService } from './services/mcp-oauth-refresh-token.service';
@@ -125,6 +127,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthClientService,
 		McpOAuthInteractionService,
 		McpOAuthManagementService,
+		McpOAuthModuleConfigMutationService,
 		McpOAuthProxyPolicyService,
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
@@ -171,6 +174,8 @@ export class McpModule implements OnModuleInit {
 	constructor(
 		private readonly swaggerRegistry: SwaggerModelsRegistryService,
 		private readonly modulesMapperService: ModulesTypeMapperService,
+		private readonly moduleConfigMutations: ModuleConfigMutationRegistryService,
+		private readonly moduleConfigMutation: McpOAuthModuleConfigMutationService,
 		private readonly extensionsService: ExtensionsService,
 		private readonly statsRegistryService: StatsRegistryService,
 		private readonly statsProvider: McpStatsProvider,
@@ -182,6 +187,9 @@ export class McpModule implements OnModuleInit {
 			class: McpConfigModel,
 			configDto: UpdateMcpConfigDto,
 		});
+		this.moduleConfigMutations.register<UpdateMcpConfigDto>(MCP_MODULE_NAME, (update, commit) =>
+			this.moduleConfigMutation.update(update, commit),
+		);
 
 		for (const model of MCP_SWAGGER_EXTRA_MODELS) {
 			this.swaggerRegistry.register(model);

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -1,0 +1,215 @@
+import { Repository } from 'typeorm';
+
+import { ServiceUnavailableException } from '@nestjs/common';
+
+import { ConfigService } from '../../config/services/config.service';
+import { UpdateMcpConfigDto } from '../dto/update-config.dto';
+import { McpOAuthServerStateEntity } from '../entities/mcp-oauth.entity';
+import { MCP_MODULE_NAME, MCP_OAUTH_SERVER_STATE_KEY, McpCapability, McpOAuthScope } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+
+import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
+import { McpOAuthSubscriptionBinding, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+const deferred = <T = void>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+	let resolve = (_value: T): void => undefined;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
+const oauthBinding = (effectiveScopes: McpOAuthScope[]): McpOAuthSubscriptionBinding => ({
+	accessTokenId: 'access-one',
+	grantId: 'grant-one',
+	authorizationDeadline: new Date(Date.now() + 60_000),
+	effectiveScopes,
+	modulePolicyGeneration: 1,
+	clientGeneration: 2,
+	grantGeneration: 3,
+});
+
+describe('McpOAuthModuleConfigMutationService', () => {
+	let config: McpConfigModel;
+	let configService: { getModuleConfig: jest.Mock };
+	let serverState: { increment: jest.Mock };
+	let subscriptions: McpSubscriptionRegistryService;
+	let service: McpOAuthModuleConfigMutationService;
+
+	beforeEach(() => {
+		config = new McpConfigModel();
+		config.capabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
+		configService = {
+			getModuleConfig: jest.fn().mockImplementation(() => config),
+		};
+		serverState = {
+			increment: jest.fn().mockResolvedValue({ affected: 1 }),
+		};
+		const auditService = {
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
+		service = new McpOAuthModuleConfigMutationService(
+			configService as unknown as ConfigService,
+			serverState as unknown as Repository<McpOAuthServerStateEntity>,
+			subscriptions,
+		);
+	});
+
+	afterEach(async () => {
+		await subscriptions.closeAll();
+	});
+
+	it('advances policy generation, commits, and selectively closes contracted OAuth streams', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const readStream = await subscriptions.openOAuth('read-stream', () =>
+			Promise.resolve({ clientId: 'read-client', binding: oauthBinding([McpOAuthScope.READ]) }),
+		);
+		const writeStream = await subscriptions.openOAuth('write-stream', () =>
+			Promise.resolve({
+				clientId: 'write-client',
+				binding: oauthBinding([McpOAuthScope.READ, McpOAuthScope.WRITE]),
+			}),
+		);
+		const commit = jest.fn().mockImplementation(() => {
+			config.capabilities = [McpCapability.READ];
+		});
+
+		await service.update({ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ] } as UpdateMcpConfigDto, commit);
+
+		expect(serverState.increment).toHaveBeenCalledWith(
+			{ key: MCP_OAUTH_SERVER_STATE_KEY },
+			'modulePolicyGeneration',
+			1,
+		);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(readStream.signal.aborted).toBe(false);
+		expect(writeStream.signal.aborted).toBe(true);
+		expect(staticStream.signal.aborted).toBe(false);
+	});
+
+	it('holds queued OAuth registration until the new policy has committed', async () => {
+		const oldWriteStream = await subscriptions.openOAuth('old-write', () =>
+			Promise.resolve({
+				clientId: 'old-client',
+				binding: oauthBinding([McpOAuthScope.READ, McpOAuthScope.WRITE]),
+			}),
+		);
+		const incrementStarted = deferred();
+		const releaseIncrement = deferred();
+		serverState.increment.mockImplementation(async () => {
+			incrementStarted.resolve();
+			await releaseIncrement.promise;
+
+			return { affected: 1 };
+		});
+		const commit = jest.fn().mockImplementation(() => {
+			config.capabilities = [McpCapability.READ];
+		});
+		const mutation = service.update(
+			{ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ] } as UpdateMcpConfigDto,
+			commit,
+		);
+
+		await incrementStarted.promise;
+
+		const observedCapabilities: McpCapability[][] = [];
+		const registration = subscriptions.openOAuth('queued-open', () => {
+			observedCapabilities.push([...config.capabilities]);
+
+			return Promise.resolve({
+				clientId: 'new-client',
+				binding: oauthBinding([McpOAuthScope.READ]),
+			});
+		});
+		await Promise.resolve();
+		expect(observedCapabilities).toEqual([]);
+
+		releaseIncrement.resolve();
+		await mutation;
+		const newReadStream = await registration;
+
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(observedCapabilities).toEqual([[McpCapability.READ]]);
+		expect(oldWriteStream.signal.aborted).toBe(true);
+		expect(newReadStream.signal.aborted).toBe(false);
+	});
+
+	it('advances policy generation for capability expansion without closing valid streams', async () => {
+		config.capabilities = [McpCapability.READ];
+		const readStream = await subscriptions.openOAuth('read-stream', () =>
+			Promise.resolve({ clientId: 'read-client', binding: oauthBinding([McpOAuthScope.READ]) }),
+		);
+		const commit = jest.fn().mockImplementation(() => {
+			config.capabilities = [McpCapability.READ, McpCapability.WRITE];
+		});
+
+		await service.update(
+			{ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ, McpCapability.WRITE] } as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(serverState.increment).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(readStream.signal.aborted).toBe(false);
+	});
+
+	it('commits unchanged capabilities without advancing policy generation', async () => {
+		const commit = jest.fn();
+
+		await service.update(
+			{
+				type: MCP_MODULE_NAME,
+				capabilities: [McpCapability.TRIGGER, McpCapability.READ, McpCapability.WRITE],
+			} as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(serverState.increment).not.toHaveBeenCalled();
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not commit or close streams when policy generation cannot advance', async () => {
+		const writeStream = await subscriptions.openOAuth('write-stream', () =>
+			Promise.resolve({
+				clientId: 'write-client',
+				binding: oauthBinding([McpOAuthScope.READ, McpOAuthScope.WRITE]),
+			}),
+		);
+		serverState.increment.mockResolvedValue({ affected: 0 });
+		const commit = jest.fn();
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ] } as UpdateMcpConfigDto, commit),
+		).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+		expect(commit).not.toHaveBeenCalled();
+		expect(writeStream.signal.aborted).toBe(false);
+	});
+
+	it('closes contracted streams before propagating a configuration commit failure', async () => {
+		const readStream = await subscriptions.openOAuth('read-stream', () =>
+			Promise.resolve({ clientId: 'read-client', binding: oauthBinding([McpOAuthScope.READ]) }),
+		);
+		const writeStream = await subscriptions.openOAuth('write-stream', () =>
+			Promise.resolve({
+				clientId: 'write-client',
+				binding: oauthBinding([McpOAuthScope.READ, McpOAuthScope.WRITE]),
+			}),
+		);
+		const commitError = new Error('configuration persistence failed');
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ] } as UpdateMcpConfigDto, () =>
+				Promise.reject(commitError),
+			),
+		).rejects.toBe(commitError);
+
+		expect(serverState.increment).toHaveBeenCalledTimes(1);
+		expect(readStream.signal.aborted).toBe(false);
+		expect(writeStream.signal.aborted).toBe(true);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -33,7 +33,7 @@ const oauthBinding = (effectiveScopes: McpOAuthScope[]): McpOAuthSubscriptionBin
 
 describe('McpOAuthModuleConfigMutationService', () => {
 	let config: McpConfigModel;
-	let configService: { getModuleConfig: jest.Mock };
+	let configService: { getModuleConfig: jest.Mock; reload: jest.Mock };
 	let serverState: { increment: jest.Mock };
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
@@ -43,6 +43,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		config.capabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
 		configService = {
 			getModuleConfig: jest.fn().mockImplementation(() => config),
+			reload: jest.fn(),
 		};
 		serverState = {
 			increment: jest.fn().mockResolvedValue({ affected: 1 }),
@@ -209,7 +210,31 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		).rejects.toBe(commitError);
 
 		expect(serverState.increment).toHaveBeenCalledTimes(1);
+		expect(configService.reload).toHaveBeenCalledTimes(1);
 		expect(readStream.signal.aborted).toBe(false);
 		expect(writeStream.signal.aborted).toBe(true);
+	});
+
+	it('discards an unpersisted capability expansion before propagating a commit failure', async () => {
+		config.capabilities = [McpCapability.READ];
+		configService.reload.mockImplementation(() => {
+			config.capabilities = [McpCapability.READ];
+		});
+		const commitError = new Error('configuration persistence failed');
+		const commit = jest.fn().mockImplementation(() => {
+			config.capabilities = [McpCapability.READ, McpCapability.WRITE];
+			throw commitError;
+		});
+
+		await expect(
+			service.update(
+				{ type: MCP_MODULE_NAME, capabilities: [McpCapability.READ, McpCapability.WRITE] } as UpdateMcpConfigDto,
+				commit,
+			),
+		).rejects.toBe(commitError);
+
+		expect(serverState.increment).toHaveBeenCalledTimes(1);
+		expect(configService.reload).toHaveBeenCalledTimes(1);
+		expect(config.capabilities).toEqual([McpCapability.READ]);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -44,6 +44,7 @@ export class McpOAuthModuleConfigMutationService {
 			try {
 				await commit();
 			} catch (error) {
+				this.configService.reload();
 				commitFailed = true;
 				commitError = error;
 			}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -1,0 +1,58 @@
+import { Repository } from 'typeorm';
+
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { ConfigService } from '../../config/services/config.service';
+import { ModuleConfigCommit } from '../../config/services/module-config-mutation-registry.service';
+import { UpdateMcpConfigDto } from '../dto/update-config.dto';
+import { McpOAuthServerStateEntity } from '../entities/mcp-oauth.entity';
+import { MCP_MODULE_NAME, MCP_OAUTH_SERVER_STATE_KEY, McpCapability } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
+
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+@Injectable()
+export class McpOAuthModuleConfigMutationService {
+	constructor(
+		private readonly configService: ConfigService,
+		@InjectRepository(McpOAuthServerStateEntity)
+		private readonly serverState: Repository<McpOAuthServerStateEntity>,
+		private readonly subscriptions: McpSubscriptionRegistryService,
+	) {}
+
+	async update(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
+		const current = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+		const nextCapabilities = update.capabilities ?? current.capabilities;
+
+		if (this.sameCapabilities(current.capabilities, nextCapabilities)) {
+			await commit();
+			return;
+		}
+
+		let commitError: unknown;
+		let commitFailed = false;
+
+		await this.subscriptions.closeOAuthScopeContractions(nextCapabilities.map(toMcpOAuthScope), async () => {
+			const result = await this.serverState.increment({ key: MCP_OAUTH_SERVER_STATE_KEY }, 'modulePolicyGeneration', 1);
+
+			if (result.affected !== 1) {
+				throw new ServiceUnavailableException('MCP OAuth module policy state is unavailable');
+			}
+
+			try {
+				await commit();
+			} catch (error) {
+				commitFailed = true;
+				commitError = error;
+			}
+		});
+
+		if (commitFailed) throw commitError;
+	}
+
+	private sameCapabilities(first: McpCapability[], second: McpCapability[]): boolean {
+		return first.length === second.length && first.every((capability) => second.includes(capability));
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -276,6 +276,26 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(subscription.signal.aborted).toBe(false);
 	});
 
+	it('closes only OAuth streams whose effective scopes exceed the new module ceiling', async () => {
+		const staticStream = service.open('static-client');
+		const readStream = await service.openOAuth('read-stream', () => Promise.resolve(oauthRegistration()));
+		const writeStream = await service.openOAuth('write-stream', () =>
+			Promise.resolve(
+				oauthRegistration({
+					effectiveScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE],
+				}),
+			),
+		);
+		const advanceGeneration = jest.fn().mockResolvedValue(undefined);
+
+		await service.closeOAuthScopeContractions([McpOAuthScope.READ], advanceGeneration);
+
+		expect(advanceGeneration).toHaveBeenCalledTimes(1);
+		expect(readStream.signal.aborted).toBe(false);
+		expect(writeStream.signal.aborted).toBe(true);
+		expect(staticStream.signal.aborted).toBe(false);
+	});
+
 	it('closes OAuth streams at their authorization deadline', async () => {
 		jest.useFakeTimers();
 		const subscription = await service.openOAuth('deadline', () =>

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -187,6 +187,18 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		await this.closeOAuthMatching(advanceGeneration, (subscription) => subscription.oauth !== undefined);
 	}
 
+	async closeOAuthScopeContractions(
+		allowedScopes: McpOAuthScope[],
+		advanceGeneration: McpOAuthGenerationAdvance,
+	): Promise<void> {
+		const allowed = new Set(allowedScopes);
+
+		await this.closeOAuthMatching(
+			advanceGeneration,
+			(subscription) => subscription.oauth?.effectiveScopes.some((scope) => !allowed.has(scope)) === true,
+		);
+	}
+
 	async closeAll(): Promise<void> {
 		this.closeAllOperations += 1;
 

--- a/apps/backend/test/config-authorization.e2e-spec.ts
+++ b/apps/backend/test/config-authorization.e2e-spec.ts
@@ -72,12 +72,12 @@ class TestCredentialGuard implements CanActivate {
 
 describe('Module configuration authorization (e2e)', () => {
 	let app: INestApplication;
-	let configService: { getModuleConfig: jest.Mock; setModuleConfig: jest.Mock };
+	let configService: { getModuleConfig: jest.Mock; updateModuleConfig: jest.Mock };
 
 	beforeAll(async () => {
 		configService = {
 			getModuleConfig: jest.fn().mockReturnValue({ type: 'mock-module', enabled: false } as ModuleConfigModel),
-			setModuleConfig: jest.fn(),
+			updateModuleConfig: jest.fn().mockResolvedValue(undefined),
 		};
 
 		const moduleFixture = await Test.createTestingModule({
@@ -113,7 +113,7 @@ describe('Module configuration authorization (e2e)', () => {
 	});
 
 	beforeEach(() => {
-		configService.setModuleConfig.mockClear();
+		configService.updateModuleConfig.mockClear();
 	});
 
 	it.each(['owner-user', 'admin-user', 'owner-pat', 'admin-pat'])(
@@ -125,7 +125,7 @@ describe('Module configuration authorization (e2e)', () => {
 				.send({ data: { type: 'mock-module', enabled: false } })
 				.expect(200);
 
-			expect(configService.setModuleConfig).toHaveBeenCalledTimes(1);
+			expect(configService.updateModuleConfig).toHaveBeenCalledTimes(1);
 		},
 	);
 
@@ -138,7 +138,7 @@ describe('Module configuration authorization (e2e)', () => {
 				.send({ data: { type: 'mock-module', enabled: false } })
 				.expect(403);
 
-			expect(configService.setModuleConfig).not.toHaveBeenCalled();
+			expect(configService.updateModuleConfig).not.toHaveBeenCalled();
 		},
 	);
 });

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -13,6 +13,7 @@ import { Test } from '@nestjs/testing';
 import { TokenOwnerType } from '../src/modules/auth/auth.constants';
 import { AuthenticatedRequest } from '../src/modules/auth/guards/auth.guard';
 import { ConfigService } from '../src/modules/config/services/config.service';
+import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from '../src/modules/config/services/modules-type-mapper.service';
 import { PluginsTypeMapperService } from '../src/modules/config/services/plugins-type-mapper.service';
 import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
@@ -127,6 +128,7 @@ describe('MCP disabled restart', () => {
 			nestConfigService,
 			pluginsMapper,
 			modulesMapper,
+			new ModuleConfigMutationRegistryService(),
 			{} as PlatformService,
 			{ emit: jest.fn() } as unknown as EventEmitter2,
 		);

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — administrative artifact controls implemented
+**Status:** Phase 5 in progress — module capability-ceiling invalidation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -158,6 +158,19 @@ amend ADR 0002.
       success, and automatically close each stream at its authorization deadline.
 - [x] Regenerate OpenAPI/admin types through the normal generators.
 
+### Phase 5f — Awaited module capability-ceiling invalidation
+
+- [x] Add a generic awaited module-configuration mutation registry so module-owned security barriers can wrap the
+      existing validated configuration commit without coupling the Config module to MCP.
+- [x] Route MCP capability changes through the authoritative OAuth subscription gate, advance the persistent
+      module-policy generation before commit, and propagate generation failures without changing configuration or
+      closing streams.
+- [x] Close only OAuth streams whose recorded effective scope set exceeds the new module ceiling while preserving
+      unaffected OAuth streams and every static MCP stream; if configuration persistence fails after the generation
+      advances, close the contracted streams before propagating the error so the failure remains fail-closed.
+- [x] Prove a racing OAuth registration queued behind the mutation revalidates only after the new configuration is
+      committed, and prove unchanged capability updates bypass the generation barrier.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -172,10 +185,10 @@ amend ADR 0002.
       client, grant, module-policy, and approver-authority generations and current states. Each invalidation must advance
       its generation before enumeration, so a racing handler either commits first and is revoked or its stale commit
       fails; validation must recheck all generations so later restoration cannot revive an escaped artifact.
-- [ ] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through an awaited
-      authoritative mutation path that closes every OAuth subscription whose effective scope set contracts before
-      reporting success, including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains; do not rely on the
-      existing asynchronous MCP configuration notification listener.
+- [ ] Complete approved-grant scope reductions through the awaited authoritative mutation path. Module-ceiling
+      reductions are covered by Phase 5f and registered-client-maximum reductions by Phase 5e; the remaining grant
+      path must close every OAuth subscription whose effective scope set contracts before reporting success,
+      including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains.
 - [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
       `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, atomically advance
       their authority generation before revoking every grant and token artifact they approved and closing matching

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 administrative artifact controls complete
+Status: in progress — Phase 5 module capability-ceiling invalidation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add an awaited per-module configuration mutation registry
- route MCP capability changes through the authoritative OAuth subscription gate
- advance the persistent module-policy generation before committing capability changes
- close only OAuth subscriptions whose effective scopes exceed the new ceiling, preserving unaffected OAuth and static streams
- fail closed when generation advancement or configuration persistence fails
- update controller, extension-toggle, unit, race, and E2E coverage
- mark Phase 5f complete in the OAuth implementation plan

## Why

MCP module configuration was previously persisted synchronously while OAuth subscription invalidation depended on an asynchronous configuration notification. A capability reduction could therefore report success before affected OAuth streams were closed, and a racing listen registration could escape the reduction.

## Impact

Capability updates are now awaited. OAuth listen registration and capability-policy mutation share one gate: a racing registration either completes first and is selectively closed, or revalidates after the new policy commits. Static MCP subscriptions remain unaffected.

## Verification

- `pnpm --dir apps/backend run type-check`
- `pnpm --dir apps/backend run lint:js` (passes with two existing warnings)
- focused backend unit suites: 68/68, followed by final mutation/registry suites: 20/20
- full backend E2E: 126/126
- Admin type-check and lint (lint passes with four existing warnings)
- Admin unit tests: 1,849/1,849

The full backend unit run executes 305/305 suites and 3,914 passing assertions, then exits nonzero during existing Home Assistant WebSocket teardown because a test mock lacks `terminate()`. Backend Prettier check also reports nine pre-existing migration formatting files outside this PR.