### PR TITLE
feat(cross): safely reduce approved MCP OAuth grant scopes

### DIFF
--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
@@ -111,4 +111,23 @@ describe('useMcpOAuthManagement', () => {
 		expect(management.refreshFamilies.value).toEqual([]);
 		expect(management.accessTokens.value).toEqual([]);
 	});
+
+	it('updates a grant through the reduction-only generated API contract', async () => {
+		const reduced = { ...grant, approvedScopes: [McpOAuthScope.READ] };
+		backendClient.GET.mockResolvedValueOnce({ data: { data: [client] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [grant] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [accessToken] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [family] }, response: { status: 200 } });
+		backendClient.PATCH.mockResolvedValue({ data: { data: reduced }, response: { status: 200 } });
+		const management = useMcpOAuthManagement();
+		await management.fetchAll();
+
+		await management.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.READ] });
+
+		expect(backendClient.PATCH).toHaveBeenCalledWith('/modules/mcp/oauth/grants/{id}', {
+			params: { path: { id: grant.id } },
+			body: { data: { approved_scopes: [McpOAuthScope.READ] } },
+		});
+		expect(management.grants.value).toEqual([reduced]);
+	});
 });

--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
@@ -10,6 +10,7 @@ import {
 	McpOAuthGrantSchema,
 	McpOAuthRefreshFamilySchema,
 	McpOAuthUpdateClientSchema,
+	McpOAuthUpdateGrantSchema,
 } from '../schemas/oauth-management.schemas';
 import type {
 	IMcpOAuthAccessToken,
@@ -18,6 +19,7 @@ import type {
 	IMcpOAuthGrant,
 	IMcpOAuthRefreshFamily,
 	IMcpOAuthUpdateClient,
+	IMcpOAuthUpdateGrant,
 } from '../schemas/oauth-management.types';
 
 interface IUseMcpOAuthManagement {
@@ -32,6 +34,7 @@ interface IUseMcpOAuthManagement {
 	updateClient: (id: string, payload: IMcpOAuthUpdateClient) => Promise<IMcpOAuthClient>;
 	revokeClient: (id: string) => Promise<IMcpOAuthClient>;
 	revokeGrant: (id: string) => Promise<IMcpOAuthGrant>;
+	updateGrant: (id: string, payload: IMcpOAuthUpdateGrant) => Promise<IMcpOAuthGrant>;
 	revokeAccessToken: (id: string) => Promise<void>;
 	revokeRefreshFamily: (id: string) => Promise<void>;
 }
@@ -41,6 +44,7 @@ const clientsPath = `${oauthPath}/clients` as const;
 const clientPath = `${oauthPath}/clients/{id}` as const;
 const revokeClientPath = `${oauthPath}/clients/{id}/revoke` as const;
 const grantsPath = `${oauthPath}/grants` as const;
+const grantPath = `${oauthPath}/grants/{id}` as const;
 const revokeGrantPath = `${oauthPath}/grants/{id}/revoke` as const;
 const accessTokensPath = `${oauthPath}/access-tokens` as const;
 const revokeAccessTokenPath = `${oauthPath}/access-tokens/{id}/revoke` as const;
@@ -156,6 +160,21 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 		return grant;
 	};
 
+	const updateGrant = async (id: string, payload: IMcpOAuthUpdateGrant): Promise<IMcpOAuthGrant> => {
+		const parsed = McpOAuthUpdateGrantSchema.parse(payload);
+		const { data, response } = await backend.client.PATCH(grantPath, {
+			params: { path: { id } },
+			body: { data: { approved_scopes: parsed.approvedScopes } },
+		});
+
+		if (!data) throw new McpApiException('Failed to update MCP OAuth grant.', response.status);
+
+		const grant = McpOAuthGrantSchema.parse(snakeToCamel(data.data));
+		grants.value = grants.value.map((item) => (item.id === id ? grant : item));
+
+		return grant;
+	};
+
 	const revokeAccessToken = async (id: string): Promise<void> => {
 		const { response } = await backend.client.POST(revokeAccessTokenPath, { params: { path: { id } } });
 
@@ -185,6 +204,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 		updateClient,
 		revokeClient,
 		revokeGrant,
+		updateGrant,
 		revokeAccessToken,
 		revokeRefreshFamily,
 	};

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -160,10 +160,13 @@
 		"redirectUris": "Redirect URIs",
 		"createClient": "Pre-register OAuth client",
 		"editClient": "Edit OAuth client",
+		"editGrant": "Reduce OAuth grant scopes",
 		"name": "Name",
 		"nameRequired": "Enter a client name.",
 		"redirectRequired": "Add at least one exact redirect URI.",
 		"scopesRequired": "Select at least one maximum scope.",
+		"grantScopesRequired": "Keep at least one approved scope.",
+		"grantReductionNotice": "Capability scopes can only be removed. Adding access requires a new approval; revoke the grant to remove offline access.",
 		"addRedirect": "Add redirect URI",
 		"physicalWarning": "Write or trigger scopes can affect physical devices.",
 		"status": {
@@ -193,6 +196,8 @@
 			"updateFailed": "OAuth client could not be updated.",
 			"clientRevoked": "OAuth client disabled and revoked.",
 			"grantRevoked": "OAuth grant revoked.",
+			"grantUpdated": "OAuth grant scopes reduced.",
+			"grantUpdateFailed": "OAuth grant scopes could not be updated.",
 			"accessTokenRevoked": "OAuth access token revoked.",
 			"refreshFamilyRevoked": "OAuth refresh family revoked.",
 			"revokeFailed": "OAuth authorization could not be revoked."

--- a/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
+++ b/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
@@ -55,3 +55,7 @@ export const McpOAuthCreateClientSchema = z.object({
 });
 
 export const McpOAuthUpdateClientSchema = McpOAuthCreateClientSchema.partial();
+
+export const McpOAuthUpdateGrantSchema = z.object({
+	approvedScopes: z.array(scopeSchema).min(1),
+});

--- a/apps/admin/src/modules/mcp/schemas/oauth-management.types.ts
+++ b/apps/admin/src/modules/mcp/schemas/oauth-management.types.ts
@@ -7,6 +7,7 @@ import type {
 	McpOAuthGrantSchema,
 	McpOAuthRefreshFamilySchema,
 	McpOAuthUpdateClientSchema,
+	McpOAuthUpdateGrantSchema,
 } from './oauth-management.schemas';
 
 export type IMcpOAuthClient = z.infer<typeof McpOAuthClientSchema>;
@@ -15,3 +16,4 @@ export type IMcpOAuthAccessToken = z.infer<typeof McpOAuthAccessTokenSchema>;
 export type IMcpOAuthRefreshFamily = z.infer<typeof McpOAuthRefreshFamilySchema>;
 export type IMcpOAuthCreateClient = z.input<typeof McpOAuthCreateClientSchema>;
 export type IMcpOAuthUpdateClient = z.input<typeof McpOAuthUpdateClientSchema>;
+export type IMcpOAuthUpdateGrant = z.input<typeof McpOAuthUpdateGrantSchema>;

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 	fetchAll: vi.fn().mockResolvedValue(undefined),
 	createClient: vi.fn(),
 	updateClient: vi.fn(),
+	updateGrant: vi.fn(),
 	revokeClient: vi.fn(),
 	revokeGrant: vi.fn().mockResolvedValue(undefined),
 	revokeAccessToken: vi.fn(),
@@ -50,6 +51,7 @@ vi.mock('../composables/useMcpOAuthManagement', () => ({
 		fetchAll: mocks.fetchAll,
 		createClient: mocks.createClient,
 		updateClient: mocks.updateClient,
+		updateGrant: mocks.updateGrant,
 		revokeClient: mocks.revokeClient,
 		revokeGrant: mocks.revokeGrant,
 		revokeAccessToken: mocks.revokeAccessToken,
@@ -93,5 +95,15 @@ describe('ViewMcpOAuthManagement', () => {
 		expect(vm.canRevokeGrant({ ...grant, active: false })).toBe(true);
 		expect(vm.canRevokeGrant({ ...grant, active: false, revokedAt: '2026-01-02T00:00:00.000Z' })).toBe(false);
 		expect(vm.canRevokeGrant({ ...grant, active: false, expiresAt: '2020-01-01T00:00:00.000Z' })).toBe(false);
+	});
+
+	it('allows scope editing only while the grant is active', () => {
+		const wrapper = shallowMount(ViewMcpOAuthManagement);
+		const vm = wrapper.vm as unknown as {
+			canEditGrant: (value: IMcpOAuthGrant) => boolean;
+		};
+
+		expect(vm.canEditGrant(grant)).toBe(true);
+		expect(vm.canEditGrant({ ...grant, active: false })).toBe(false);
 	});
 });

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
@@ -150,9 +150,16 @@
 						<el-table-column
 							fixed="right"
 							:label="t('mcpModule.oauthManagement.columns.actions')"
-							width="120"
+							width="190"
 						>
 							<template #default="scope">
+								<el-button
+									size="small"
+									:disabled="!canEditGrant(scope.row)"
+									@click="openGrantEdit(scope.row)"
+								>
+									{{ t('mcpModule.actions.edit') }}
+								</el-button>
 								<el-button
 									size="small"
 									type="danger"
@@ -321,7 +328,7 @@
 				</el-checkbox-group>
 			</el-form-item>
 			<el-alert
-				v-if="hasPhysicalScope"
+				v-if="clientHasPhysicalScope"
 				type="warning"
 				:description="t('mcpModule.oauthManagement.physicalWarning')"
 				:closable="false"
@@ -336,6 +343,59 @@
 				@click="saveClient"
 			>
 				{{ editingClient ? t('mcpModule.actions.save') : t('mcpModule.actions.create') }}
+			</el-button>
+		</template>
+	</el-dialog>
+
+	<el-dialog
+		v-model="showGrantDialog"
+		:title="t('mcpModule.oauthManagement.editGrant')"
+		width="min(560px, 94vw)"
+		@closed="resetGrantForm"
+	>
+		<el-form
+			ref="grantFormEl"
+			:model="grantForm"
+			:rules="grantRules"
+			label-position="top"
+		>
+			<el-form-item
+				:label="t('mcpModule.oauthManagement.columns.scopes')"
+				prop="approvedScopes"
+			>
+				<el-checkbox-group v-model="grantForm.approvedScopes">
+					<el-checkbox
+						v-for="scope in grantScopeOptions"
+						:key="scope"
+						:value="scope"
+						:disabled="scope === McpOAuthScope.OFFLINE_ACCESS"
+					>
+						{{ t(`mcpModule.oauthManagement.scope.${scope}`) }}
+					</el-checkbox>
+				</el-checkbox-group>
+			</el-form-item>
+			<el-alert
+				v-if="grantHasPhysicalScope"
+				type="warning"
+				:description="t('mcpModule.oauthManagement.physicalWarning')"
+				:closable="false"
+				show-icon
+			/>
+			<el-alert
+				type="info"
+				:description="t('mcpModule.oauthManagement.grantReductionNotice')"
+				:closable="false"
+				show-icon
+			/>
+		</el-form>
+		<template #footer>
+			<el-button @click="showGrantDialog = false">{{ t('mcpModule.actions.cancel') }}</el-button>
+			<el-button
+				type="primary"
+				:loading="saving"
+				@click="saveGrant"
+			>
+				{{ t('mcpModule.actions.save') }}
 			</el-button>
 		</template>
 	</el-dialog>
@@ -387,6 +447,7 @@ const {
 	fetchAll,
 	createClient,
 	updateClient,
+	updateGrant,
 	revokeClient,
 	revokeGrant,
 	revokeAccessToken,
@@ -395,13 +456,21 @@ const {
 
 const activeTab = ref('clients');
 const showClientDialog = ref(false);
+const showGrantDialog = ref(false);
 const saving = ref(false);
 const editingClient = ref<IMcpOAuthClient | null>(null);
+const editingGrant = ref<IMcpOAuthGrant | null>(null);
 const clientFormEl = ref<FormInstance>();
+const grantFormEl = ref<FormInstance>();
 const scopeOptions = Object.values(McpOAuthScope);
+const grantScopeOptions = ref<McpOAuthScope[]>([]);
 const clientForm = reactive({ name: '', redirectUris: [''], maximumScopes: [McpOAuthScope.READ] as McpOAuthScope[] });
-const hasPhysicalScope = computed(
+const grantForm = reactive({ approvedScopes: [McpOAuthScope.READ] as McpOAuthScope[] });
+const clientHasPhysicalScope = computed(
 	() => clientForm.maximumScopes.includes(McpOAuthScope.WRITE) || clientForm.maximumScopes.includes(McpOAuthScope.TRIGGER)
+);
+const grantHasPhysicalScope = computed(
+	() => grantForm.approvedScopes.includes(McpOAuthScope.WRITE) || grantForm.approvedScopes.includes(McpOAuthScope.TRIGGER)
 );
 const clientRules = reactive<FormRules>({
 	name: [{ required: true, message: t('mcpModule.oauthManagement.nameRequired'), trigger: 'change' }],
@@ -415,6 +484,9 @@ const clientRules = reactive<FormRules>({
 		},
 	],
 	maximumScopes: [{ type: 'array', min: 1, required: true, message: t('mcpModule.oauthManagement.scopesRequired'), trigger: 'change' }],
+});
+const grantRules = reactive<FormRules>({
+	approvedScopes: [{ type: 'array', min: 1, required: true, message: t('mcpModule.oauthManagement.grantScopesRequired'), trigger: 'change' }],
 });
 
 const ScopeTags = defineComponent({
@@ -449,6 +521,20 @@ const openEdit = (client: IMcpOAuthClient): void => {
 	showClientDialog.value = true;
 };
 
+const resetGrantForm = (): void => {
+	editingGrant.value = null;
+	grantScopeOptions.value = [];
+	grantForm.approvedScopes = [McpOAuthScope.READ];
+	grantFormEl.value?.clearValidate();
+};
+
+const openGrantEdit = (grant: IMcpOAuthGrant): void => {
+	editingGrant.value = grant;
+	grantScopeOptions.value = [...grant.approvedScopes];
+	grantForm.approvedScopes = [...grant.approvedScopes];
+	showGrantDialog.value = true;
+};
+
 const saveClient = async (): Promise<void> => {
 	if (!(await clientFormEl.value?.validate())) return;
 	saving.value = true;
@@ -472,6 +558,21 @@ const saveClient = async (): Promise<void> => {
 		flashMessage.error(
 			t(editingClient.value ? 'mcpModule.oauthManagement.messages.updateFailed' : 'mcpModule.oauthManagement.messages.createFailed')
 		);
+	} finally {
+		saving.value = false;
+	}
+};
+
+const saveGrant = async (): Promise<void> => {
+	if (!editingGrant.value || !(await grantFormEl.value?.validate())) return;
+	saving.value = true;
+
+	try {
+		await updateGrant(editingGrant.value.id, { approvedScopes: [...grantForm.approvedScopes] });
+		flashMessage.success(t('mcpModule.oauthManagement.messages.grantUpdated'));
+		showGrantDialog.value = false;
+	} catch {
+		flashMessage.error(t('mcpModule.oauthManagement.messages.grantUpdateFailed'));
 	} finally {
 		saving.value = false;
 	}
@@ -527,6 +628,7 @@ const grantStatus = (grant: IMcpOAuthGrant): { key: 'active' | 'expired' | 'inac
 };
 
 const canRevokeGrant = (grant: IMcpOAuthGrant): boolean => grant.revokedAt === null && new Date(grant.expiresAt).getTime() > Date.now();
+const canEditGrant = (grant: IMcpOAuthGrant): boolean => grant.active;
 
 const formatDate = (value: string): string => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
 

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
@@ -1,0 +1,28 @@
+import { v4 as uuid } from 'uuid';
+
+import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
+import { UserRole } from '../../users/users.constants';
+import { McpOAuthScope } from '../mcp.constants';
+import { McpOAuthGrantModel } from '../models/mcp-oauth-management.model';
+import { McpOAuthManagementService } from '../services/mcp-oauth-management.service';
+
+import { McpOAuthManagementController } from './mcp-oauth-management.controller';
+
+describe('McpOAuthManagementController', () => {
+	it('forwards an authenticated grant-scope reduction and returns the response envelope', async () => {
+		const actorId = uuid();
+		const grantId = uuid();
+		const dto = { approvedScopes: [McpOAuthScope.READ] };
+		const grant = Object.assign(new McpOAuthGrantModel(), { id: grantId, approvedScopes: dto.approvedScopes });
+		const updateGrant = jest.fn().mockResolvedValue(grant);
+		const controller = new McpOAuthManagementController({ updateGrant } as unknown as McpOAuthManagementService);
+		const request = {
+			auth: { type: 'user', id: actorId, role: UserRole.ADMIN },
+		} as unknown as AuthenticatedRequest;
+
+		const response = await controller.updateGrant(grantId, { data: dto }, request);
+
+		expect(response.data).toBe(grant);
+		expect(updateGrant).toHaveBeenCalledWith(grantId, dto, actorId);
+	});
+});

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
@@ -1,10 +1,26 @@
-import { Controller, ForbiddenException, Get, HttpCode, Param, ParseUUIDPipe, Post, Req } from '@nestjs/common';
-import { ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import {
+	Body,
+	Controller,
+	ForbiddenException,
+	Get,
+	HttpCode,
+	Param,
+	ParseUUIDPipe,
+	Patch,
+	Post,
+	Req,
+} from '@nestjs/common';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
-import { ApiNotFoundResponse, ApiSuccessResponse } from '../../swagger/decorators/api-documentation.decorator';
+import {
+	ApiBadRequestResponse,
+	ApiNotFoundResponse,
+	ApiSuccessResponse,
+} from '../../swagger/decorators/api-documentation.decorator';
 import { Roles } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
+import { ReqUpdateMcpOAuthGrantDto } from '../dto/mcp-oauth-grant.dto';
 import { MCP_MODULE_API_TAG_NAME } from '../mcp.constants';
 import {
 	McpOAuthAccessTokenResponseModel,
@@ -50,6 +66,30 @@ export class McpOAuthManagementController {
 	async findGrant(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string): Promise<McpOAuthGrantResponseModel> {
 		const response = new McpOAuthGrantResponseModel();
 		response.data = await this.managementService.getGrant(id);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Reduce MCP OAuth grant scopes',
+		description:
+			'Replace the approved scopes with a subset and close only subscriptions whose effective scopes contract',
+		operationId: 'update-mcp-module-oauth-grant',
+	})
+	@ApiParam({ name: 'id', description: 'OAuth grant management identifier', type: 'string', format: 'uuid' })
+	@ApiBody({ type: ReqUpdateMcpOAuthGrantDto })
+	@ApiSuccessResponse(McpOAuthGrantResponseModel, 'MCP OAuth grant scopes updated successfully')
+	@ApiBadRequestResponse('Approved scopes must be a non-empty subset of the existing grant')
+	@ApiNotFoundResponse('MCP OAuth grant not found')
+	@Patch('grants/:id')
+	async updateGrant(
+		@Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+		@Body() body: ReqUpdateMcpOAuthGrantDto,
+		@Req() req: AuthenticatedRequest,
+	): Promise<McpOAuthGrantResponseModel> {
+		const response = new McpOAuthGrantResponseModel();
+		response.data = await this.managementService.updateGrant(id, body.data, this.getActorId(req));
 
 		return response;
 	}

--- a/apps/backend/src/modules/mcp/dto/mcp-oauth-grant.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/mcp-oauth-grant.dto.ts
@@ -1,0 +1,33 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsDefined, IsEnum, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { McpOAuthScope } from '../mcp.constants';
+
+@ApiSchema({ name: 'McpModuleUpdateOAuthGrant' })
+export class UpdateMcpOAuthGrantDto {
+	@ApiProperty({
+		name: 'approved_scopes',
+		description:
+			'Replacement subset of the scopes already approved for this grant; offline_access must be preserved and removed by revocation',
+		type: 'array',
+		items: { type: 'string', enum: Object.values(McpOAuthScope) },
+	})
+	@Expose({ name: 'approved_scopes' })
+	@IsArray()
+	@ArrayNotEmpty()
+	@ArrayUnique()
+	@IsEnum(McpOAuthScope, { each: true })
+	approvedScopes: McpOAuthScope[];
+}
+
+@ApiSchema({ name: 'McpModuleReqUpdateOAuthGrant' })
+export class ReqUpdateMcpOAuthGrantDto {
+	@ApiProperty({ type: () => UpdateMcpOAuthGrantDto })
+	@Expose()
+	@IsDefined()
+	@ValidateNested()
+	@Type(() => UpdateMcpOAuthGrantDto)
+	data: UpdateMcpOAuthGrantDto;
+}

--- a/apps/backend/src/modules/mcp/mcp.openapi.ts
+++ b/apps/backend/src/modules/mcp/mcp.openapi.ts
@@ -12,6 +12,7 @@ import {
 	ReqUpdateMcpOAuthClientDto,
 	UpdateMcpOAuthClientDto,
 } from './dto/mcp-oauth-client.dto';
+import { ReqUpdateMcpOAuthGrantDto, UpdateMcpOAuthGrantDto } from './dto/mcp-oauth-grant.dto';
 import { ApproveMcpOAuthInteractionDto, ReqApproveMcpOAuthInteractionDto } from './dto/mcp-oauth-interaction.dto';
 import { UpdateMcpConfigDto } from './dto/update-config.dto';
 import { McpClientEntity } from './entities/mcp-client.entity';
@@ -66,6 +67,8 @@ export const MCP_SWAGGER_EXTRA_MODELS = [
 	McpOAuthClientsResponseModel,
 	ApproveMcpOAuthInteractionDto,
 	ReqApproveMcpOAuthInteractionDto,
+	UpdateMcpOAuthGrantDto,
+	ReqUpdateMcpOAuthGrantDto,
 	McpOAuthInteractionModel,
 	McpOAuthInteractionCompletionModel,
 	McpOAuthInteractionResponseModel,

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -26,7 +26,7 @@ export type McpAuditDenialReason =
 export type McpAuditRequestFailureReason = 'policy_resolution_error';
 
 export type McpOAuthManagementArtifact = 'access_token' | 'client' | 'grant' | 'refresh_family';
-export type McpOAuthManagementAction = 'disabled' | 'revoked';
+export type McpOAuthManagementAction = 'disabled' | 'revoked' | 'scopes_updated';
 
 export type McpSubscriptionCloseReason =
 	| 'authorization_expired'

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
@@ -1,4 +1,4 @@
-import { DataSource } from 'typeorm';
+import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { hashToken } from '../../auth/utils/token.utils';
@@ -22,8 +22,18 @@ import { McpOAuthClientService } from './mcp-oauth-client.service';
 import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
+const deferred = <T = void>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+	let resolve = (_value: T): void => undefined;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
 describe('McpOAuthManagementService', () => {
 	let dataSource: DataSource;
+	let grantRepository: Repository<McpOAuthGrantEntity>;
 	let service: McpOAuthManagementService;
 	let subscriptions: McpSubscriptionRegistryService;
 	let client: McpOAuthClientEntity;
@@ -98,6 +108,7 @@ describe('McpOAuthManagementService', () => {
 			}),
 		);
 		const grants = dataSource.getRepository(McpOAuthGrantEntity);
+		grantRepository = grants;
 		grant = await grants.save(
 			grants.create({
 				providerGrantIdHash: hashToken('grant-one'),
@@ -385,6 +396,191 @@ describe('McpOAuthManagementService', () => {
 		).toBe(true);
 	});
 
+	it('reduces approved grant scopes and closes only matching contracted subscriptions', async () => {
+		await grantRepository.update(
+			{ id: grant.id },
+			{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS] },
+		);
+		const matchingRead = await openSubscription(client.id, grant.id, accessId, familyId, [McpOAuthScope.READ]);
+		const matchingWrite = await openSubscription(client.id, grant.id, uuid(), undefined, [
+			McpOAuthScope.READ,
+			McpOAuthScope.WRITE,
+		]);
+		const other = await openSubscription(otherClient.id, otherGrant.id, uuid(), undefined, [
+			McpOAuthScope.READ,
+			McpOAuthScope.WRITE,
+		]);
+
+		const updated = await service.updateGrant(
+			grant.id,
+			{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] },
+			'actor-id',
+		);
+
+		expect(updated.approvedScopes).toEqual([McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS]);
+		expect((await grantRepository.findOneByOrFail({ id: grant.id })).generation).toBe(1);
+		expect(matchingRead.signal.aborted).toBe(false);
+		expect(matchingWrite.signal.aborted).toBe(true);
+		expect(other.signal.aborted).toBe(false);
+		expect(auditService.recordOAuthManagementAction).toHaveBeenCalledWith(
+			'actor-id',
+			'grant',
+			grant.id,
+			'scopes_updated',
+		);
+	});
+
+	it('rejects grant scope expansion without changing its generation', async () => {
+		await expect(
+			service.updateGrant(
+				grant.id,
+				{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS] },
+				'actor-id',
+			),
+		).rejects.toThrow('can only be reduced');
+
+		expect((await grantRepository.findOneByOrFail({ id: grant.id })).generation).toBe(0);
+	});
+
+	it('requires revocation to remove offline access', async () => {
+		await expect(service.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.READ] }, 'actor-id')).rejects.toThrow(
+			'offline_access can only be removed by revoking',
+		);
+
+		expect((await grantRepository.findOneByOrFail({ id: grant.id })).generation).toBe(0);
+	});
+
+	it('validates a queued grant reduction against the latest authorized scopes', async () => {
+		await grantRepository.update(
+			{ id: grant.id },
+			{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE], generation: 0 },
+		);
+		const mutationStarted = deferred();
+		const releaseMutation = deferred();
+		const precedingMutation = subscriptions.closeOAuthGrant(grant.id, async () => {
+			mutationStarted.resolve();
+			await releaseMutation.promise;
+			await grantRepository.update(
+				{ id: grant.id, generation: 0 },
+				{ approvedScopes: [McpOAuthScope.READ], generation: () => 'generation + 1' },
+			);
+		});
+
+		await mutationStarted.promise;
+		const queuedUpdate = expect(
+			service.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.WRITE] }, 'actor-id'),
+		).rejects.toThrow('can only be reduced');
+		releaseMutation.resolve();
+		await precedingMutation;
+		await queuedUpdate;
+
+		expect(await grantRepository.findOneByOrFail({ id: grant.id })).toMatchObject({
+			approvedScopes: [McpOAuthScope.READ],
+			generation: 1,
+		});
+	});
+
+	it('does not close grant streams when the conditional scope update fails', async () => {
+		await grantRepository.update({ id: grant.id }, { approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] });
+		const matching = await openSubscription(client.id, grant.id, accessId, familyId, [
+			McpOAuthScope.READ,
+			McpOAuthScope.WRITE,
+		]);
+		jest.spyOn(grantRepository, 'update').mockResolvedValue({ affected: 0, raw: [], generatedMaps: [] });
+
+		await expect(service.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.READ] }, 'actor-id')).rejects.toThrow(
+			'changed during scope update',
+		);
+
+		expect(matching.signal.aborted).toBe(false);
+	});
+
+	it('closes a contracted grant registration that wins the gate before the scope update', async () => {
+		await grantRepository.update({ id: grant.id }, { approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] });
+		const revalidationStarted = deferred();
+		const releaseRevalidation = deferred();
+		const registration = subscriptions.openOAuth('winning-grant-registration', async () => {
+			revalidationStarted.resolve();
+			await releaseRevalidation.promise;
+
+			return {
+				clientId: client.id,
+				binding: {
+					accessTokenId: accessId,
+					grantId: grant.id,
+					authorizationDeadline: new Date(Date.now() + 60_000),
+					effectiveScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE],
+					modulePolicyGeneration: 0,
+					clientGeneration: 0,
+					grantGeneration: 0,
+				},
+			};
+		});
+
+		await revalidationStarted.promise;
+
+		const mutation = service.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.READ] }, 'actor-id');
+		await Promise.resolve();
+		expect((await grantRepository.findOneByOrFail({ id: grant.id })).generation).toBe(0);
+
+		releaseRevalidation.resolve();
+		const winning = await registration;
+		await mutation;
+
+		expect(winning.signal.aborted).toBe(true);
+		expect((await grantRepository.findOneByOrFail({ id: grant.id })).generation).toBe(1);
+	});
+
+	it('makes a registration queued behind grant reduction observe the updated generation and scopes', async () => {
+		await grantRepository.update({ id: grant.id }, { approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] });
+		const matching = await openSubscription(client.id, grant.id, accessId, familyId, [
+			McpOAuthScope.READ,
+			McpOAuthScope.WRITE,
+		]);
+		const updateStarted = deferred();
+		const releaseUpdate = deferred();
+		const updateSpy = jest.spyOn(grantRepository, 'update');
+		updateSpy.mockImplementationOnce(async (criteria, partialEntity) => {
+			updateStarted.resolve();
+			await releaseUpdate.promise;
+			updateSpy.mockRestore();
+
+			return grantRepository.update(criteria as FindOptionsWhere<McpOAuthGrantEntity>, partialEntity);
+		});
+		const mutation = service.updateGrant(grant.id, { approvedScopes: [McpOAuthScope.READ] }, 'actor-id');
+
+		await updateStarted.promise;
+
+		const observed: Array<{ generation: number; scopes: McpOAuthScope[] }> = [];
+		const registration = subscriptions.openOAuth('queued-grant-registration', async () => {
+			const liveGrant = await grantRepository.findOneByOrFail({ id: grant.id });
+			observed.push({ generation: liveGrant.generation, scopes: [...liveGrant.approvedScopes] });
+
+			return {
+				clientId: client.id,
+				binding: {
+					accessTokenId: uuid(),
+					grantId: grant.id,
+					authorizationDeadline: new Date(Date.now() + 60_000),
+					effectiveScopes: [McpOAuthScope.READ],
+					modulePolicyGeneration: 0,
+					clientGeneration: 0,
+					grantGeneration: liveGrant.generation,
+				},
+			};
+		});
+		await Promise.resolve();
+		expect(observed).toEqual([]);
+
+		releaseUpdate.resolve();
+		await mutation;
+		const queued = await registration;
+
+		expect(observed).toEqual([{ generation: 1, scopes: [McpOAuthScope.READ] }]);
+		expect(matching.signal.aborted).toBe(true);
+		expect(queued.signal.aborted).toBe(false);
+	});
+
 	it('disables a client, revokes its artifacts, and preserves other clients', async () => {
 		const matching = await openSubscription(client.id, grant.id, accessId, familyId);
 		const otherAccessId = (await service.findAccessTokens()).find((token) => token.clientId === otherClient.id)?.id;
@@ -433,7 +629,13 @@ describe('McpOAuthManagementService', () => {
 		expect(matching.signal.aborted).toBe(true);
 	});
 
-	async function openSubscription(clientId: string, grantId: string, tokenId: string, refreshFamilyId?: string) {
+	async function openSubscription(
+		clientId: string,
+		grantId: string,
+		tokenId: string,
+		refreshFamilyId?: string,
+		effectiveScopes: McpOAuthScope[] = [McpOAuthScope.READ],
+	) {
 		return subscriptions.openOAuth(`request-${tokenId}`, () =>
 			Promise.resolve({
 				clientId,
@@ -442,7 +644,7 @@ describe('McpOAuthManagementService', () => {
 					grantId,
 					...(refreshFamilyId ? { refreshFamilyId } : {}),
 					authorizationDeadline: new Date(Date.now() + 60_000),
-					effectiveScopes: [McpOAuthScope.READ],
+					effectiveScopes,
 					modulePolicyGeneration: 0,
 					clientGeneration: 0,
 					grantGeneration: 0,

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
@@ -1,10 +1,11 @@
 import { DataSource, In, IsNull, MoreThan, Not, Repository } from 'typeorm';
 
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { ConfigService } from '../../config/services/config.service';
 import { UpdateMcpOAuthClientDto } from '../dto/mcp-oauth-client.dto';
+import { UpdateMcpOAuthGrantDto } from '../dto/mcp-oauth-grant.dto';
 import {
 	McpOAuthClientEntity,
 	McpOAuthGrantEntity,
@@ -62,13 +63,8 @@ export class McpOAuthManagementService {
 
 	async getGrant(id: string): Promise<McpOAuthGrantModel> {
 		const grant = await this.getGrantEntity(id);
-		const providerRevocations = await this.getProviderRevocations([grant]);
 
-		return McpOAuthGrantModel.fromEntity(
-			grant,
-			grant.providerGrantIdHash ? (providerRevocations.get(grant.providerGrantIdHash) ?? null) : null,
-			this.isModuleEnabled(),
-		);
+		return this.mapGrant(grant);
 	}
 
 	async findAccessTokens(): Promise<McpOAuthAccessTokenModel[]> {
@@ -195,6 +191,49 @@ export class McpOAuthManagementService {
 		return McpOAuthClientModel.fromEntity(await this.clientsService.getOneOrThrow(id));
 	}
 
+	async updateGrant(id: string, dto: UpdateMcpOAuthGrantDto, actorId: string): Promise<McpOAuthGrantModel> {
+		let current: McpOAuthGrantModel | null = null;
+		let changed = false;
+
+		await this.subscriptions.closeOAuthGrantScopeContractions(id, dto.approvedScopes, async () => {
+			const grant = await this.getGrantEntity(id);
+			const liveGrant = await this.mapGrant(grant);
+			current = liveGrant;
+
+			if (!liveGrant.active) throw new ConflictException('Only an active MCP OAuth grant can be updated');
+
+			const addedScopes = dto.approvedScopes.filter((scope) => !liveGrant.approvedScopes.includes(scope));
+
+			if (addedScopes.length > 0) {
+				throw new BadRequestException(`Approved grant scopes can only be reduced: ${addedScopes.join(', ')}`);
+			}
+
+			if (
+				liveGrant.approvedScopes.includes(McpOAuthScope.OFFLINE_ACCESS) !==
+				dto.approvedScopes.includes(McpOAuthScope.OFFLINE_ACCESS)
+			) {
+				throw new BadRequestException('offline_access can only be removed by revoking the MCP OAuth grant');
+			}
+
+			if (this.sameScopes(liveGrant.approvedScopes, dto.approvedScopes)) return;
+
+			const result = await this.grants.update(
+				{ id, generation: grant.generation, revokedAt: IsNull(), expiresAt: MoreThan(new Date()) },
+				{ approvedScopes: [...dto.approvedScopes], generation: () => 'generation + 1' },
+			);
+
+			if (!result.affected) throw new ConflictException('The MCP OAuth grant changed during scope update');
+			changed = true;
+		});
+
+		if (!current) throw new ConflictException('The MCP OAuth grant could not be updated');
+		if (!changed) return current;
+
+		this.auditService.recordOAuthManagementAction(actorId, 'grant', id, 'scopes_updated');
+
+		return this.getGrant(id);
+	}
+
 	async revokeGrant(id: string, actorId: string): Promise<McpOAuthGrantModel> {
 		const grant = await this.getGrantEntity(id);
 
@@ -262,6 +301,20 @@ export class McpOAuthManagementService {
 		if (!grant) throw new NotFoundException('Requested MCP OAuth grant does not exist');
 
 		return grant;
+	}
+
+	private async mapGrant(grant: McpOAuthGrantEntity): Promise<McpOAuthGrantModel> {
+		const providerRevocations = await this.getProviderRevocations([grant]);
+
+		return McpOAuthGrantModel.fromEntity(
+			grant,
+			grant.providerGrantIdHash ? (providerRevocations.get(grant.providerGrantIdHash) ?? null) : null,
+			this.isModuleEnabled(),
+		);
+	}
+
+	private sameScopes(first: McpOAuthScope[], second: McpOAuthScope[]): boolean {
+		return first.length === second.length && first.every((scope) => second.includes(scope));
 	}
 
 	private async mapAccessTokens(artifacts: McpOAuthProviderArtifactEntity[]): Promise<McpOAuthAccessTokenModel[]> {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -296,6 +296,35 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(staticStream.signal.aborted).toBe(false);
 	});
 
+	it('closes only matching grant streams whose effective scopes exceed the updated approval', async () => {
+		const staticStream = service.open('static-client');
+		const matchingRead = await service.openOAuth('matching-read', () => Promise.resolve(oauthRegistration()));
+		const matchingWrite = await service.openOAuth('matching-write', () =>
+			Promise.resolve(
+				oauthRegistration({
+					effectiveScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE],
+				}),
+			),
+		);
+		const otherGrant = await service.openOAuth('other-grant', () =>
+			Promise.resolve(
+				oauthRegistration({
+					grantId: 'grant-two',
+					effectiveScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE],
+				}),
+			),
+		);
+		const advanceGeneration = jest.fn().mockResolvedValue(undefined);
+
+		await service.closeOAuthGrantScopeContractions('grant-one', [McpOAuthScope.READ], advanceGeneration);
+
+		expect(advanceGeneration).toHaveBeenCalledTimes(1);
+		expect(matchingRead.signal.aborted).toBe(false);
+		expect(matchingWrite.signal.aborted).toBe(true);
+		expect(otherGrant.signal.aborted).toBe(false);
+		expect(staticStream.signal.aborted).toBe(false);
+	});
+
 	it('closes OAuth streams at their authorization deadline', async () => {
 		jest.useFakeTimers();
 		const subscription = await service.openOAuth('deadline', () =>

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -169,6 +169,21 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		await this.closeOAuthMatching(advanceGeneration, (subscription) => subscription.oauth?.grantId === grantId);
 	}
 
+	async closeOAuthGrantScopeContractions(
+		grantId: string,
+		allowedScopes: McpOAuthScope[],
+		advanceGeneration: McpOAuthGenerationAdvance,
+	): Promise<void> {
+		const allowed = new Set(allowedScopes);
+
+		await this.closeOAuthMatching(
+			advanceGeneration,
+			(subscription) =>
+				subscription.oauth?.grantId === grantId &&
+				subscription.oauth.effectiveScopes.some((scope) => !allowed.has(scope)),
+		);
+	}
+
 	async closeOAuthAccessToken(accessTokenId: string, advanceGeneration: McpOAuthGenerationAdvance): Promise<void> {
 		await this.closeOAuthMatching(
 			advanceGeneration,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — module capability-ceiling invalidation implemented
+**Status:** Phase 5 in progress — approved-grant scope invalidation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -171,6 +171,17 @@ amend ADR 0002.
 - [x] Prove a racing OAuth registration queued behind the mutation revalidates only after the new configuration is
       committed, and prove unchanged capability updates bypass the generation barrier.
 
+### Phase 5g — Awaited approved-grant scope invalidation
+
+- [x] Add an owner/admin reduction-only grant-scope API and Admin editor that cannot add scopes without a new consent;
+      preserve `offline_access` because removing refresh authority requires grant revocation and artifact invalidation.
+- [x] Advance the grant generation with a conditional update inside the authoritative OAuth subscription gate and
+      propagate conflicts without closing streams.
+- [x] Close only subscriptions bound to the updated grant whose recorded effective scopes exceed the new approval,
+      preserving unaffected OAuth and static streams.
+- [x] Prove a racing registration queued behind grant reduction observes the updated scopes and generation, while a
+      registration that wins the gate is closed when its effective scope contracts.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -185,10 +196,9 @@ amend ADR 0002.
       client, grant, module-policy, and approver-authority generations and current states. Each invalidation must advance
       its generation before enumeration, so a racing handler either commits first and is revoked or its stale commit
       fails; validation must recheck all generations so later restoration cannot revive an escaped artifact.
-- [ ] Complete approved-grant scope reductions through the awaited authoritative mutation path. Module-ceiling
-      reductions are covered by Phase 5f and registered-client-maximum reductions by Phase 5e; the remaining grant
-      path must close every OAuth subscription whose effective scope set contracts before reporting success,
-      including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains.
+- [x] Route module-ceiling, registered-client-maximum, and approved-grant scope reductions through awaited
+      authoritative mutation paths that close every OAuth subscription whose effective scope set contracts before
+      reporting success, including removal of `mcp:write` or `mcp:trigger` while `mcp:read` remains.
 - [ ] Replace fire-and-forget approver invalidation with an awaited lifecycle path for `UsersModule.User.Updated` and
       `UsersModule.User.Deleted`: when a grant approver is deleted or no longer has owner/admin role, atomically advance
       their authority generation before revoking every grant and token artifact they approved and closing matching

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 module capability-ceiling invalidation complete
+Status: in progress — Phase 5 approved-grant scope invalidation complete
 
 ## 1. Business goal
 
@@ -67,7 +67,7 @@ upgrade consequences.
       impact of write/trigger scopes.
 - [x] Owners/admins can list and revoke OAuth clients, grants, access tokens, and refresh tokens; revocation closes the
       affected MCP subscriptions immediately.
-- [ ] Reducing the live module ceiling, registered-client maximum, or approved-grant scopes closes every OAuth
+- [x] Reducing the live module ceiling, registered-client maximum, or approved-grant scopes closes every OAuth
       subscription whose effective read/write/trigger scope set contracts before the mutation reports success.
 - [ ] Subscription registration is serialized with artifact and policy invalidation so a stale in-flight listen
       request cannot open after invalidation reports success.


### PR DESCRIPTION
## Summary

- add a reduction-only owner/admin API for approved MCP OAuth grant scopes
- add an Admin grant-scope editor that preserves `offline_access` and cannot add scopes without new consent
- serialize validation and generation advancement through the authoritative OAuth subscription gate
- close only subscriptions for the changed grant whose effective scopes exceed the reduced approval
- add controller, service, registry, race, failure, and Admin coverage
- mark Phase 5g and the approved-grant reduction acceptance criterion complete

## Why

Previously, live module and registered-client capability reductions had awaited invalidation paths, but approved-grant reductions did not. Reducing a grant therefore needed a generation-checked mutation that could not race subscription registration or accidentally affect unrelated streams.

`offline_access` is intentionally immutable through this endpoint because removing refresh authority also requires refresh artifact and family invalidation; revoking the grant remains the safe path.

## Impact

Owners and admins can reduce an active grant's read/write/trigger authority from the MCP OAuth management screen. Existing subscriptions are aborted only when their recorded effective scopes contract. Unaffected OAuth subscriptions and static MCP streams remain open.

## Validation

- backend focused unit tests: 36 passed
- Admin focused unit tests: 8 passed
- backend and Admin type checks passed
- touched backend and Admin ESLint checks passed
- OpenAPI generation and Spectral lint passed
- full Admin unit suite: 265 files / 1851 tests passed
- backend E2E suite: 10 suites / 126 tests passed
- full backend Jest assertions passed: 306 suites / 3922 tests (2 skipped); the command still exits after completion because of the pre-existing Home Assistant teardown error `this.ws?.terminate is not a function`
