### PR TITLE
feat(backend): serialize MCP OAuth artifact requests

### DIFF
--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -28,14 +28,21 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		tokenEndpoint: 'https://panel.example/api/v1/modules/mcp/oauth/token',
 		revocationEndpoint: 'https://panel.example/api/v1/modules/mcp/oauth/token/revocation',
 	} satisfies McpOAuthPublicUrls;
-	const request = {
-		method: 'GET',
-		url: '/api/v1/modules/mcp/oauth/authorize',
-		headers: {},
-	} as IncomingMessage;
-	const response = {} as ServerResponse;
 	let subscriptions: McpSubscriptionRegistryService;
 	let dispatch: ProviderDispatcher;
+	const createRequest = (): IncomingMessage =>
+		({
+			method: 'GET',
+			url: '/api/v1/modules/mcp/oauth/authorize',
+			headers: {},
+			aborted: false,
+		}) as IncomingMessage;
+	const createResponse = (): ServerResponse =>
+		({
+			closed: false,
+			destroyed: false,
+			writableEnded: false,
+		}) as ServerResponse;
 
 	beforeEach(() => {
 		const audit = { recordSubscriptionClosed: jest.fn(), recordSubscriptionOpened: jest.fn() };
@@ -66,7 +73,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			await release;
 			artifactCommitted = true;
 		});
-		const providerRequest = dispatch(request, response, providerCallback, urls);
+		const providerRequest = dispatch(createRequest(), createResponse(), providerCallback, urls);
 
 		await started;
 		const invalidation = subscriptions.closeAllOAuth(() => {
@@ -105,13 +112,49 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		const providerCallback = jest.fn(() =>
 			generation === 0 ? Promise.resolve() : Promise.reject(new Error('stale OAuth authorization generation')),
 		);
-		const providerRequest = dispatch(request, response, providerCallback, urls);
+		const providerRequest = dispatch(createRequest(), createResponse(), providerCallback, urls);
 		await Promise.resolve();
 		expect(providerCallback).not.toHaveBeenCalled();
 
 		releaseInvalidation();
 		await invalidation;
 		await expect(providerRequest).rejects.toThrow('stale OAuth authorization generation');
+		expect(providerCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips provider processing when a queued request disconnects before the gate opens', async () => {
+		let invalidationStarted = (): void => undefined;
+		const started = new Promise<void>((resolve) => {
+			invalidationStarted = resolve;
+		});
+		let releaseInvalidation = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseInvalidation = resolve;
+		});
+		const invalidation = subscriptions.closeAllOAuth(async () => {
+			invalidationStarted();
+			await release;
+		});
+
+		await started;
+		const request = createRequest();
+		const providerCallback = jest.fn(() => Promise.resolve());
+		const providerRequest = dispatch(request, createResponse(), providerCallback, urls);
+		request.aborted = true;
+		releaseInvalidation();
+
+		await invalidation;
+		await providerRequest;
+		expect(providerCallback).not.toHaveBeenCalled();
+	});
+
+	it('processes a completed request stream while its response connection remains open', async () => {
+		const request = createRequest();
+		request.destroyed = true;
+		const providerCallback = jest.fn(() => Promise.resolve());
+
+		await dispatch(request, createResponse(), providerCallback, urls);
+
 		expect(providerCallback).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -1,0 +1,117 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { DataSource } from 'typeorm';
+
+import { McpAuditService } from '../services/mcp-audit.service';
+import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
+import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
+import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
+
+import { McpOAuthProviderFactory } from './mcp-oauth-provider.factory';
+import { McpOAuthPublicUrls } from './mcp-oauth.types';
+
+type ProviderDispatcher = (
+	request: IncomingMessage,
+	response: ServerResponse,
+	providerCallback: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
+	urls: McpOAuthPublicUrls,
+) => Promise<void>;
+
+describe('McpOAuthProviderFactory artifact request gate', () => {
+	const urls = {
+		publicBaseUrl: 'https://panel.example',
+		resource: 'https://panel.example/api/v1/modules/mcp',
+		protectedResourceMetadata: 'https://panel.example/.well-known/oauth-protected-resource/api/v1/modules/mcp',
+		issuer: 'https://panel.example/api/v1/modules/mcp/oauth',
+		authorizationServerMetadata:
+			'https://panel.example/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth',
+		authorizationEndpoint: 'https://panel.example/api/v1/modules/mcp/oauth/authorize',
+		tokenEndpoint: 'https://panel.example/api/v1/modules/mcp/oauth/token',
+		revocationEndpoint: 'https://panel.example/api/v1/modules/mcp/oauth/token/revocation',
+	} satisfies McpOAuthPublicUrls;
+	const request = {
+		method: 'GET',
+		url: '/api/v1/modules/mcp/oauth/authorize',
+		headers: {},
+	} as IncomingMessage;
+	const response = {} as ServerResponse;
+	let subscriptions: McpSubscriptionRegistryService;
+	let dispatch: ProviderDispatcher;
+
+	beforeEach(() => {
+		const audit = { recordSubscriptionClosed: jest.fn(), recordSubscriptionOpened: jest.fn() };
+		subscriptions = new McpSubscriptionRegistryService(audit as unknown as McpAuditService);
+		const factory = new McpOAuthProviderFactory(
+			{} as DataSource,
+			{} as McpOAuthClientService,
+			{} as McpOAuthPublicUrlService,
+			subscriptions,
+		);
+		const target = factory as unknown as { dispatchProviderRequest: ProviderDispatcher };
+		dispatch = (...args) => target.dispatchProviderRequest(...args);
+	});
+
+	it('lets provider work that wins the gate commit before the following invalidation', async () => {
+		let providerStarted = (): void => undefined;
+		const started = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+		let artifactCommitted = false;
+		let invalidationObservedArtifact = false;
+		const providerCallback = jest.fn(async () => {
+			providerStarted();
+			await release;
+			artifactCommitted = true;
+		});
+		const providerRequest = dispatch(request, response, providerCallback, urls);
+
+		await started;
+		const invalidation = subscriptions.closeAllOAuth(() => {
+			invalidationObservedArtifact = artifactCommitted;
+
+			return Promise.resolve();
+		});
+		await Promise.resolve();
+		expect(invalidationObservedArtifact).toBe(false);
+
+		releaseProvider();
+		await providerRequest;
+		await invalidation;
+
+		expect(artifactCommitted).toBe(true);
+		expect(invalidationObservedArtifact).toBe(true);
+	});
+
+	it('makes provider work queued behind invalidation observe the advanced state', async () => {
+		let invalidationStarted = (): void => undefined;
+		const started = new Promise<void>((resolve) => {
+			invalidationStarted = resolve;
+		});
+		let releaseInvalidation = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseInvalidation = resolve;
+		});
+		let generation = 0;
+		const invalidation = subscriptions.closeAllOAuth(async () => {
+			generation += 1;
+			invalidationStarted();
+			await release;
+		});
+
+		await started;
+		const providerCallback = jest.fn(() =>
+			generation === 0 ? Promise.resolve() : Promise.reject(new Error('stale OAuth authorization generation')),
+		);
+		const providerRequest = dispatch(request, response, providerCallback, urls);
+		await Promise.resolve();
+		expect(providerCallback).not.toHaveBeenCalled();
+
+		releaseInvalidation();
+		await invalidation;
+		await expect(providerRequest).rejects.toThrow('stale OAuth authorization generation');
+		expect(providerCallback).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -14,6 +14,7 @@ import {
 } from '../mcp.constants';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
+import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
 import { McpOAuthAuthorizationServerMetadata, buildMcpOAuthAuthorizationServerMetadata } from './mcp-oauth-metadata';
 import { createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
@@ -43,6 +44,7 @@ export class McpOAuthProviderFactory {
 		private readonly dataSource: DataSource,
 		private readonly clientsService: McpOAuthClientService,
 		private readonly publicUrlService: McpOAuthPublicUrlService,
+		private readonly subscriptions: McpSubscriptionRegistryService,
 	) {}
 
 	async create(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
@@ -248,7 +250,7 @@ export class McpOAuthProviderFactory {
 			}
 		}
 
-		await providerCallback(request, response);
+		await this.subscriptions.runOAuthMutation(() => providerCallback(request, response));
 	}
 
 	private async readRequestBody(request: IncomingMessage): Promise<string> {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -250,7 +250,15 @@ export class McpOAuthProviderFactory {
 			}
 		}
 
-		await this.subscriptions.runOAuthMutation(() => providerCallback(request, response));
+		await this.subscriptions.runOAuthMutation(async () => {
+			if (this.isDisconnected(request, response)) return;
+
+			await providerCallback(request, response);
+		});
+	}
+
+	private isDisconnected(request: IncomingMessage, response: ServerResponse): boolean {
+		return request.aborted || response.destroyed || response.closed || response.writableEnded;
 	}
 
 	private async readRequestBody(request: IncomingMessage): Promise<string> {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
@@ -168,6 +168,15 @@ describe('McpOAuthInteractionService', () => {
 	});
 
 	it('creates a finite bounded grant and resumes provider consent', async () => {
+		let finishedInsideAuthorityBoundary = false;
+		approverAuthority.runAuthorized.mockImplementationOnce(
+			async (_userId: string, operation: (generation: number) => Promise<unknown>) => {
+				const result = await operation(4);
+				finishedInsideAuthorityBoundary = interactionFinished.mock.calls.length === 1;
+
+				return result;
+			},
+		);
 		await service.getInteraction(rawUid, userId, request);
 
 		const completion = await service.approve(
@@ -201,6 +210,7 @@ describe('McpOAuthInteractionService', () => {
 		expect(grantInput.expiresAt).toBeInstanceOf(Date);
 		expect(completion.redirectTo).toBe('/auth/resume');
 		expect(interactions.update).toHaveBeenCalled();
+		expect(finishedInsideAuthorityBoundary).toBe(true);
 	});
 
 	it('replaces an existing provider grant so omitted scopes cannot survive reauthorization', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
@@ -188,7 +188,7 @@ export class McpOAuthInteractionService {
 		}
 
 		(providerGrant as unknown as { expiresIn: number }).expiresIn = dto.expiresInDays * 24 * 60 * 60;
-		const grantId = await this.approverAuthority.runAuthorized(userId, async (approverAuthorityGeneration) => {
+		return this.approverAuthority.runAuthorized(userId, async (approverAuthorityGeneration) => {
 			const savedGrantId = await providerGrant.save();
 			await this.artifactService.createGrant({
 				providerGrantId: savedGrantId,
@@ -199,11 +199,8 @@ export class McpOAuthInteractionService {
 				approverAuthorityGeneration,
 			});
 
-			return savedGrantId;
+			return this.finish(provider, request, { consent: { grantId: savedGrantId } }, true);
 		});
-		const completion = await this.finish(provider, request, { consent: { grantId } }, true);
-
-		return completion;
 	}
 
 	async deny(rawUid: string, userId: string, request: IncomingMessage): Promise<McpOAuthInteractionCompletionModel> {

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -18,6 +18,7 @@ import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-prov
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 
 const CLIENT_ID = 'phase3-public-client';
 const ACCOUNT_ID = 'owner-1';
@@ -157,7 +158,11 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		} as unknown as McpOAuthClientService;
 		const publicUrlService = { getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService;
 
-		factory = new McpOAuthProviderFactory(dataSource, clientsService, publicUrlService);
+		const subscriptions = {
+			runOAuthMutation: (operation: () => Promise<unknown>) => operation(),
+		} as unknown as McpSubscriptionRegistryService;
+
+		factory = new McpOAuthProviderFactory(dataSource, clientsService, publicUrlService, subscriptions);
 		const runtime = await factory.create({
 			allowTestInMemory: true,
 			allowInsecureTestCookies: true,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — awaited approver lifecycle invalidation implemented
+**Status:** Phase 5 in progress — authoritative artifact request gate foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -194,6 +194,15 @@ amend ADR 0002.
       subscriptions approved by that user; preserve unrelated OAuth and static streams even when failures propagate.
 - [x] Keep the OAuth gate held through the user-row commit so failed demotions roll back with invalidation and consent
       queued behind deletion observes the removed user before it can create a grant.
+
+### Phase 5i — Authoritative artifact request gate foundation
+
+- [x] Serialize bounded provider authorization, token, refresh, and revocation request processing through the same
+      authoritative OAuth mutation gate used by artifact and policy invalidation.
+- [x] Keep provider-grant persistence, the matching Smart Panel grant, and authorization-code completion inside the
+      approver-authority gate so demotion cannot interleave between consent and code issuance.
+- [x] Prove both gate orderings deterministically: provider work that commits first is visible to the following
+      invalidation, while provider work queued behind invalidation observes the advanced authorization state and fails.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 awaited approver lifecycle invalidation complete
+Status: in progress — Phase 5 authoritative artifact request gate foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- serialize embedded OAuth provider authorization, token, refresh, and revocation processing through the authoritative OAuth mutation gate
- keep provider-grant persistence, Smart Panel grant persistence, and authorization-code completion inside the approver-authority boundary
- skip provider processing when a request disconnects while queued behind the gate, without misclassifying a normally consumed request body
- add deterministic race tests for provider-first, invalidation-first, and queued-disconnect ordering
- record Phase 5i completion in the MCP OAuth implementation task and plan

## Why

Subscription registration and invalidation already shared one gate, but the embedded provider could still create authorization codes or tokens outside that boundary. An invalidation could therefore finish before a late artifact commit became visible.

Provider work now either completes first and is visible to the following invalidation, or waits for invalidation and begins only after the advanced authorization state is visible. Consent completion remains inside the approver gate through authorization-code issuance, so approver demotion cannot interleave after the grant commit.

A request that disconnects while waiting is checked again inside the gate before provider processing starts. This prevents a lost response from consuming a one-time authorization code or rotating a refresh token. The guard relies on abort and response-connection state rather than `IncomingMessage.destroyed`, which can also be true after a valid request body is fully consumed.

This is the request-serialization foundation only. Durable all-generation snapshots and conditional artifact commits remain explicitly tracked as the next Phase 5 control.

## Validation

- focused provider/interaction/subscription/approver suites: 4 suites, 35 tests passed
- embedded-provider OAuth spike: 11 tests passed
- backend type-check passed
- touched-file ESLint passed
- backend lint passed with only the two existing Buddy plugin warnings
- Admin type-check and lint passed; lint reports only four existing test-file warnings
- full Admin unit suite: 265 files, 1,851 tests passed
- `git diff --check` passed

A concurrent full backend unit/E2E cadence attempt hit unrelated SQLite initialization and MCP-operation timeouts under local resource contention. The affected MCP OAuth suites and the real provider spike pass serially; GitHub CI reruns the full backend jobs in isolated workers.