### PR TITLE
feat(backend): persist MCP OAuth authorization snapshots

### DIFF
--- a/apps/backend/src/migrations/1000000000017-AddMcpOAuthAuthorizationSnapshots.ts
+++ b/apps/backend/src/migrations/1000000000017-AddMcpOAuthAuthorizationSnapshots.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const grantSnapshotColumns = [
+	['oauthEnabledGeneration', 'integer NOT NULL DEFAULT (0)'],
+	['serverSecretVersion', 'integer NOT NULL DEFAULT (1)'],
+	['publicIdentityGeneration', 'integer NOT NULL DEFAULT (0)'],
+	['clientGeneration', 'integer NOT NULL DEFAULT (0)'],
+	['modulePolicyGeneration', 'integer NOT NULL DEFAULT (0)'],
+] as const;
+
+const artifactSnapshotColumns = [
+	'oauthEnabledGeneration',
+	'serverSecretVersion',
+	'publicIdentityGeneration',
+	'clientGeneration',
+	'grantGeneration',
+	'modulePolicyGeneration',
+	'approverAuthorityGeneration',
+] as const;
+
+export class AddMcpOAuthAuthorizationSnapshots1000000000017 implements MigrationInterface {
+	name = 'AddMcpOAuthAuthorizationSnapshots1000000000017';
+
+	async up(queryRunner: QueryRunner): Promise<void> {
+		for (const [column, definition] of grantSnapshotColumns) {
+			await queryRunner.query(`ALTER TABLE "mcp_module_oauth_grants" ADD COLUMN "${column}" ${definition}`);
+		}
+		for (const column of artifactSnapshotColumns) {
+			await queryRunner.query(`ALTER TABLE "mcp_module_oauth_provider_artifacts" ADD COLUMN "${column}" integer`);
+		}
+
+		await queryRunner.query(
+			`UPDATE "mcp_module_oauth_grants" SET ` +
+				`"oauthEnabledGeneration" = COALESCE((SELECT "oauthEnabledGeneration" ` +
+				`FROM "mcp_module_oauth_server_state" WHERE "key" = 'primary'), 0), ` +
+				`"serverSecretVersion" = COALESCE((SELECT "serverSecretVersion" ` +
+				`FROM "mcp_module_oauth_server_state" WHERE "key" = 'primary'), 1), ` +
+				`"publicIdentityGeneration" = COALESCE((SELECT "publicIdentityGeneration" ` +
+				`FROM "mcp_module_oauth_server_state" WHERE "key" = 'primary'), 0), ` +
+				`"clientGeneration" = COALESCE((SELECT "generation" FROM "mcp_module_oauth_clients" ` +
+				`WHERE "id" = "mcp_module_oauth_grants"."clientId"), 0), ` +
+				`"modulePolicyGeneration" = COALESCE((SELECT "modulePolicyGeneration" ` +
+				`FROM "mcp_module_oauth_server_state" WHERE "key" = 'primary'), 0)`,
+		);
+		await queryRunner.query(
+			`UPDATE "mcp_module_oauth_provider_artifacts" SET ` +
+				`"oauthEnabledGeneration" = (SELECT "oauthEnabledGeneration" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"serverSecretVersion" = (SELECT "serverSecretVersion" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"publicIdentityGeneration" = (SELECT "publicIdentityGeneration" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"clientGeneration" = (SELECT "clientGeneration" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"grantGeneration" = (SELECT "generation" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"modulePolicyGeneration" = (SELECT "modulePolicyGeneration" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash"), ` +
+				`"approverAuthorityGeneration" = (SELECT "approverAuthorityGeneration" FROM "mcp_module_oauth_grants" ` +
+				`WHERE "providerGrantIdHash" = "mcp_module_oauth_provider_artifacts"."grantIdHash") ` +
+				`WHERE "model" IN ('AuthorizationCode', 'AccessToken', 'RefreshToken')`,
+		);
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		for (const column of [...artifactSnapshotColumns].reverse()) {
+			await queryRunner.query(`ALTER TABLE "mcp_module_oauth_provider_artifacts" DROP COLUMN "${column}"`);
+		}
+		for (const [column] of [...grantSnapshotColumns].reverse()) {
+			await queryRunner.query(`ALTER TABLE "mcp_module_oauth_grants" DROP COLUMN "${column}"`);
+		}
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000017-AddMcpOAuthAuthorizationSnapshots.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000017-AddMcpOAuthAuthorizationSnapshots.spec.ts
@@ -1,0 +1,96 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddMcpOAuthAuthorizationSnapshots1000000000017 } from '../1000000000017-AddMcpOAuthAuthorizationSnapshots';
+
+describe('AddMcpOAuthAuthorizationSnapshots1000000000017', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+	const migration = new AddMcpOAuthAuthorizationSnapshots1000000000017();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:' });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_clients" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "generation" integer NOT NULL DEFAULT (0))`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_grants" (` +
+				`"id" varchar PRIMARY KEY NOT NULL, "clientId" varchar NOT NULL, ` +
+				`"providerGrantIdHash" varchar, "generation" integer NOT NULL DEFAULT (0), ` +
+				`"approverAuthorityGeneration" integer NOT NULL DEFAULT (0))`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_server_state" (` +
+				`"key" varchar PRIMARY KEY NOT NULL, "oauthEnabledGeneration" integer NOT NULL, ` +
+				`"serverSecretVersion" integer NOT NULL, "publicIdentityGeneration" integer NOT NULL, ` +
+				`"modulePolicyGeneration" integer NOT NULL)`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "mcp_module_oauth_provider_artifacts" (` +
+				`"model" varchar NOT NULL, "idHash" varchar NOT NULL, "grantIdHash" varchar, ` +
+				`PRIMARY KEY ("model", "idHash"))`,
+		);
+		await queryRunner.query(`INSERT INTO "mcp_module_oauth_clients" VALUES ('client-one', 4)`);
+		await queryRunner.query(
+			`INSERT INTO "mcp_module_oauth_grants" VALUES ('grant-one', 'client-one', 'provider-grant', 3, 2)`,
+		);
+		await queryRunner.query(`INSERT INTO "mcp_module_oauth_server_state" VALUES ('primary', 5, 6, 7, 8)`);
+		await queryRunner.query(
+			`INSERT INTO "mcp_module_oauth_provider_artifacts" VALUES ` +
+				`('AccessToken', 'access-token', 'provider-grant'), ('Session', 'session', NULL)`,
+		);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('backfills grant and bearer-artifact authorization snapshots', async () => {
+		await migration.up(queryRunner);
+
+		const [grant] = (await queryRunner.query(`SELECT * FROM "mcp_module_oauth_grants"`)) as Array<
+			Record<string, unknown>
+		>;
+		const artifacts = (await queryRunner.query(
+			`SELECT * FROM "mcp_module_oauth_provider_artifacts" ORDER BY "model"`,
+		)) as Array<Record<string, unknown>>;
+
+		expect(grant).toMatchObject({
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 6,
+			publicIdentityGeneration: 7,
+			clientGeneration: 4,
+			modulePolicyGeneration: 8,
+		});
+		expect(artifacts[0]).toMatchObject({
+			model: 'AccessToken',
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 6,
+			publicIdentityGeneration: 7,
+			clientGeneration: 4,
+			grantGeneration: 3,
+			modulePolicyGeneration: 8,
+			approverAuthorityGeneration: 2,
+		});
+		expect(artifacts[1]).toMatchObject({ model: 'Session', oauthEnabledGeneration: null });
+	});
+
+	it('removes only the authorization snapshot columns on rollback', async () => {
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		const grantColumns = (await queryRunner.query(`PRAGMA table_info("mcp_module_oauth_grants")`)) as Array<{
+			name: string;
+		}>;
+		const artifactColumns = (await queryRunner.query(
+			`PRAGMA table_info("mcp_module_oauth_provider_artifacts")`,
+		)) as Array<{ name: string }>;
+
+		expect(grantColumns.map(({ name }) => name)).not.toContain('oauthEnabledGeneration');
+		expect(artifactColumns.map(({ name }) => name)).not.toContain('grantGeneration');
+		expect(await queryRunner.query(`SELECT * FROM "mcp_module_oauth_provider_artifacts"`)).toHaveLength(2);
+	});
+});

--- a/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
+++ b/apps/backend/src/modules/mcp/entities/mcp-oauth.entity.ts
@@ -81,6 +81,21 @@ export class McpOAuthGrantEntity extends BaseEntity {
 
 	@Column({ type: 'integer', default: 0 })
 	approverAuthorityGeneration: number;
+
+	@Column({ type: 'integer', default: 0 })
+	oauthEnabledGeneration: number;
+
+	@Column({ type: 'integer', default: 1 })
+	serverSecretVersion: number;
+
+	@Column({ type: 'integer', default: 0 })
+	publicIdentityGeneration: number;
+
+	@Column({ type: 'integer', default: 0 })
+	clientGeneration: number;
+
+	@Column({ type: 'integer', default: 0 })
+	modulePolicyGeneration: number;
 }
 
 @Entity('mcp_module_oauth_interactions')
@@ -371,6 +386,27 @@ export class McpOAuthProviderArtifactEntity {
 	@Index()
 	@Column({ type: 'integer', nullable: true })
 	expiresAt: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	oauthEnabledGeneration: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	serverSecretVersion: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	publicIdentityGeneration: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	clientGeneration: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	grantGeneration: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	modulePolicyGeneration: number | null;
+
+	@Column({ type: 'integer', nullable: true })
+	approverAuthorityGeneration: number | null;
 }
 
 @Entity('mcp_module_oauth_provider_revoked_grants')

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.spec.ts
@@ -1,12 +1,19 @@
 import { DataSource } from 'typeorm';
 
 import { hashToken } from '../../auth/utils/token.utils';
+import { UserEntity } from '../../users/entities/users.entity';
+import { UserLanguage, UserRole } from '../../users/users.constants';
 import {
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRefreshFamilyLineageEntity,
 	McpOAuthProviderRevokedGrantEntity,
 	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
+import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../mcp.constants';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 
 import { createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
@@ -19,14 +26,67 @@ describe('MCP OAuth provider adapter management identity', () => {
 			type: 'sqlite',
 			database: ':memory:',
 			entities: [
+				UserEntity,
+				McpOAuthApproverAuthorityEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
 				McpOAuthProviderArtifactEntity,
 				McpOAuthProviderRefreshFamilyLineageEntity,
 				McpOAuthProviderRevokedGrantEntity,
 				McpOAuthProviderRevokedRefreshFamilyEntity,
+				McpOAuthServerStateEntity,
 			],
 			synchronize: true,
 		});
 		await dataSource.initialize();
+		const user = await dataSource.getRepository(UserEntity).save({
+			username: 'owner',
+			password: null,
+			email: null,
+			firstName: null,
+			lastName: null,
+			role: UserRole.OWNER,
+			language: UserLanguage.EN,
+			isHidden: false,
+		});
+		const client = await dataSource.getRepository(McpOAuthClientEntity).save({
+			clientIdentifier: 'public-client',
+			name: 'Codex',
+			redirectUris: ['http://127.0.0.1/callback'],
+			maximumScopes: [McpOAuthScope.READ],
+			enabled: true,
+			generation: 2,
+			createdById: user.id,
+		});
+		await dataSource.getRepository(McpOAuthServerStateEntity).save({
+			key: MCP_OAUTH_SERVER_STATE_KEY,
+			serverSecretVersion: 3,
+			keyVersion: 1,
+			publicIdentityGeneration: 4,
+			oauthEnabledGeneration: 5,
+			modulePolicyGeneration: 6,
+			createdAt: new Date(),
+			updatedAt: null,
+		});
+		await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({ approverId: user.id, generation: 7 });
+		await dataSource.getRepository(McpOAuthGrantEntity).save({
+			providerGrantIdHash: hashToken('provider-grant-id'),
+			clientId: client.id,
+			approvedById: user.id,
+			installationId: 'installation-id',
+			issuer: 'https://panel.example.com/oauth',
+			resource: 'https://panel.example.com/mcp',
+			approvedScopes: [McpOAuthScope.READ],
+			expiresAt: new Date(Date.now() + 60_000),
+			revokedAt: null,
+			generation: 8,
+			approverAuthorityGeneration: 7,
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 3,
+			publicIdentityGeneration: 4,
+			clientGeneration: 2,
+			modulePolicyGeneration: 6,
+		});
 	});
 
 	afterEach(async () => {
@@ -62,6 +122,15 @@ describe('MCP OAuth provider adapter management identity', () => {
 		expect(firstRefresh.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
 		expect(secondRefresh.refreshFamilyId).toBe(firstRefresh.refreshFamilyId);
 		expect(linkedAccess.refreshFamilyId).toBe(firstRefresh.refreshFamilyId);
+		expect(linkedAccess).toMatchObject({
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 3,
+			publicIdentityGeneration: 4,
+			clientGeneration: 2,
+			grantGeneration: 8,
+			modulePolicyGeneration: 6,
+			approverAuthorityGeneration: 7,
+		});
 		expect(
 			await dataSource.getRepository(McpOAuthProviderRefreshFamilyLineageEntity).findOneByOrFail({
 				grantIdHash: hashToken(grantId),
@@ -69,6 +138,28 @@ describe('MCP OAuth provider adapter management identity', () => {
 		).toMatchObject({ refreshFamilyId: firstRefresh.refreshFamilyId });
 		expect(JSON.stringify([linkedAccess, firstRefresh, secondRefresh])).not.toContain('access-token');
 		expect(JSON.stringify([linkedAccess, firstRefresh, secondRefresh])).not.toContain('refresh-token-one');
+	});
+
+	it('refuses stale bearer artifacts after an authorization generation advances', async () => {
+		const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+			allowTestInMemory: true,
+		});
+		const accessAdapter = new Adapter('AccessToken');
+		const payload = {
+			grantId: 'provider-grant-id',
+			clientId: 'public-client',
+			scope: 'mcp:read',
+			gty: 'authorization_code',
+		};
+
+		await accessAdapter.upsert('stale-access-token', payload, 60);
+		await dataSource
+			.getRepository(McpOAuthServerStateEntity)
+			.increment({ key: MCP_OAUTH_SERVER_STATE_KEY }, 'publicIdentityGeneration', 1);
+
+		await expect(accessAdapter.find('stale-access-token')).resolves.toBeUndefined();
+		await expect(accessAdapter.upsert('late-access-token', payload, 60)).rejects.toThrow('already consumed');
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).countBy({ model: 'AccessToken' })).toBe(1);
 	});
 
 	async function find(model: string, rawValue: string): Promise<McpOAuthProviderArtifactEntity> {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
@@ -4,11 +4,15 @@ import { DataSource, IsNull, LessThanOrEqual, Not, Repository } from 'typeorm';
 
 import { hashToken } from '../../auth/utils/token.utils';
 import {
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRefreshFamilyLineageEntity,
 	McpOAuthProviderRevokedGrantEntity,
 	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
+import { MCP_OAUTH_SERVER_STATE_KEY } from '../mcp.constants';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 
 export interface McpOAuthProviderAdapterOptions {
@@ -21,6 +25,27 @@ const isInMemoryDataSource = (dataSource: DataSource): boolean =>
 	'database' in dataSource.options && dataSource.options.database === ':memory:';
 
 const HASH_ONLY_BEARER_MODELS = new Set(['AuthorizationCode', 'AccessToken', 'RefreshToken']);
+
+type McpOAuthAuthorizationSnapshot = Pick<
+	McpOAuthProviderArtifactEntity,
+	| 'oauthEnabledGeneration'
+	| 'serverSecretVersion'
+	| 'publicIdentityGeneration'
+	| 'clientGeneration'
+	| 'grantGeneration'
+	| 'modulePolicyGeneration'
+	| 'approverAuthorityGeneration'
+>;
+
+const EMPTY_AUTHORIZATION_SNAPSHOT: McpOAuthAuthorizationSnapshot = {
+	oauthEnabledGeneration: null,
+	serverSecretVersion: null,
+	publicIdentityGeneration: null,
+	clientGeneration: null,
+	grantGeneration: null,
+	modulePolicyGeneration: null,
+	approverAuthorityGeneration: null,
+};
 
 const serializePayload = (model: string, payload: AdapterPayload): string => {
 	if (!HASH_ONLY_BEARER_MODELS.has(model)) return JSON.stringify(payload);
@@ -66,8 +91,14 @@ export const createMcpOAuthProviderAdapter = (
 			const idHash = hashToken(id);
 			const existing = await repository.findOneBy({ model: this.model, idHash });
 			const refreshFamilyId = await this.resolveRefreshFamilyId(repository, existing, grantIdHash, payload);
+			const authorizationSnapshot = HASH_ONLY_BEARER_MODELS.has(this.model)
+				? await this.resolveAuthorizationSnapshot(grantIdHash)
+				: EMPTY_AUTHORIZATION_SNAPSHOT;
 
-			if (refreshFamilyId !== null && (await this.isRefreshFamilyRevoked(refreshFamilyId))) {
+			if (
+				(HASH_ONLY_BEARER_MODELS.has(this.model) && authorizationSnapshot === null) ||
+				(refreshFamilyId !== null && (await this.isRefreshFamilyRevoked(refreshFamilyId)))
+			) {
 				throw this.artifactReuseError();
 			}
 
@@ -84,6 +115,7 @@ export const createMcpOAuthProviderAdapter = (
 					uidHash: typeof payload.uid === 'string' ? hashToken(payload.uid) : null,
 					consumedAt: null,
 					expiresAt: expiresIn === undefined ? null : Date.now() + expiresIn * 1_000,
+					...(authorizationSnapshot ?? EMPTY_AUTHORIZATION_SNAPSHOT),
 				},
 				['model', 'idHash'],
 			);
@@ -267,6 +299,11 @@ export const createMcpOAuthProviderAdapter = (
 			presentedId?: string,
 		): Promise<AdapterPayload | undefined> {
 			if (!record) return undefined;
+			if (HASH_ONLY_BEARER_MODELS.has(record.model)) {
+				const snapshot = await this.resolveAuthorizationSnapshot(record.grantIdHash);
+
+				if (!snapshot || !this.sameAuthorizationSnapshot(record, snapshot)) return undefined;
+			}
 
 			const [grantRevoked, refreshFamilyRevoked] = await Promise.all([
 				record.grantIdHash === null ? false : this.isGrantRevoked(record.grantIdHash),
@@ -285,6 +322,60 @@ export const createMcpOAuthProviderAdapter = (
 			}
 
 			return readPayload(record, presentedId);
+		}
+
+		private async resolveAuthorizationSnapshot(
+			grantIdHash: string | null,
+		): Promise<McpOAuthAuthorizationSnapshot | null> {
+			if (!grantIdHash) return null;
+
+			const [grant, serverState] = await Promise.all([
+				dataSource.getRepository(McpOAuthGrantEntity).findOne({
+					where: { providerGrantIdHash: grantIdHash },
+					relations: { client: true },
+				}),
+				dataSource.getRepository(McpOAuthServerStateEntity).findOneBy({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+			]);
+
+			if (!grant?.client || !grant.approvedById || !serverState) return null;
+
+			const approverAuthority = await dataSource
+				.getRepository(McpOAuthApproverAuthorityEntity)
+				.findOneBy({ approverId: grant.approvedById });
+			const approverAuthorityGeneration = approverAuthority?.generation ?? 0;
+
+			if (
+				!grant.client.enabled ||
+				grant.revokedAt !== null ||
+				grant.expiresAt <= new Date() ||
+				grant.oauthEnabledGeneration !== serverState.oauthEnabledGeneration ||
+				grant.serverSecretVersion !== serverState.serverSecretVersion ||
+				grant.publicIdentityGeneration !== serverState.publicIdentityGeneration ||
+				grant.clientGeneration !== grant.client.generation ||
+				grant.modulePolicyGeneration !== serverState.modulePolicyGeneration ||
+				grant.approverAuthorityGeneration !== approverAuthorityGeneration
+			) {
+				return null;
+			}
+
+			return {
+				oauthEnabledGeneration: serverState.oauthEnabledGeneration,
+				serverSecretVersion: serverState.serverSecretVersion,
+				publicIdentityGeneration: serverState.publicIdentityGeneration,
+				clientGeneration: grant.client.generation,
+				grantGeneration: grant.generation,
+				modulePolicyGeneration: serverState.modulePolicyGeneration,
+				approverAuthorityGeneration,
+			};
+		}
+
+		private sameAuthorizationSnapshot(
+			record: McpOAuthProviderArtifactEntity,
+			snapshot: McpOAuthAuthorizationSnapshot,
+		): boolean {
+			return (Object.keys(snapshot) as Array<keyof McpOAuthAuthorizationSnapshot>).every(
+				(key) => record[key] === snapshot[key],
+			);
 		}
 
 		private async isGrantRevoked(grantIdHash: string): Promise<boolean> {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.spec.ts
@@ -12,8 +12,9 @@ import {
 	McpOAuthInteractionEntity,
 	McpOAuthRefreshTokenEntity,
 	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
-import { McpOAuthScope } from '../mcp.constants';
+import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../mcp.constants';
 import { McpOAuthPublicUrls } from '../oauth/mcp-oauth.types';
 
 import { McpInstallationService } from './mcp-installation.service';
@@ -40,10 +41,21 @@ describe('McpOAuthArtifactService', () => {
 				McpOAuthInteractionEntity,
 				McpOAuthRefreshTokenEntity,
 				McpOAuthRefreshTokenFamilyEntity,
+				McpOAuthServerStateEntity,
 			],
 			synchronize: true,
 		});
 		await dataSource.initialize();
+		await dataSource.getRepository(McpOAuthServerStateEntity).save({
+			key: MCP_OAUTH_SERVER_STATE_KEY,
+			serverSecretVersion: 2,
+			keyVersion: 1,
+			publicIdentityGeneration: 3,
+			oauthEnabledGeneration: 4,
+			modulePolicyGeneration: 5,
+			createdAt: new Date(),
+			updatedAt: null,
+		});
 		approver = await dataSource.getRepository(UserEntity).save(
 			dataSource.getRepository(UserEntity).create({
 				username: 'owner',
@@ -66,6 +78,7 @@ describe('McpOAuthArtifactService', () => {
 			dataSource.getRepository(McpOAuthAuthorizationCodeEntity),
 			dataSource.getRepository(McpOAuthAccessTokenEntity),
 			dataSource.getRepository(McpOAuthRefreshTokenFamilyEntity),
+			dataSource.getRepository(McpOAuthServerStateEntity),
 			installationService,
 			publicUrlService,
 		);
@@ -150,7 +163,15 @@ describe('McpOAuthArtifactService', () => {
 		});
 
 		expect(firstGrant.installationId).toMatch(/^[0-9a-f-]{36}$/);
-		expect(firstGrant).toMatchObject({ issuer: urls.issuer, resource: urls.resource });
+		expect(firstGrant).toMatchObject({
+			issuer: urls.issuer,
+			resource: urls.resource,
+			oauthEnabledGeneration: 4,
+			serverSecretVersion: 2,
+			publicIdentityGeneration: 3,
+			clientGeneration: 0,
+			modulePolicyGeneration: 5,
+		});
 		expect(access.artifact).toMatchObject({
 			installationId: firstGrant.installationId,
 			issuer: urls.issuer,

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-artifact.service.ts
@@ -13,11 +13,13 @@ import {
 	McpOAuthInteractionEntity,
 	McpOAuthRefreshTokenEntity,
 	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
 import {
 	MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS,
 	MCP_OAUTH_GRANT_LIFETIME_MS,
 	MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS,
+	MCP_OAUTH_SERVER_STATE_KEY,
 	McpOAuthScope,
 } from '../mcp.constants';
 
@@ -44,6 +46,8 @@ export class McpOAuthArtifactService {
 		private readonly accessTokens: Repository<McpOAuthAccessTokenEntity>,
 		@InjectRepository(McpOAuthRefreshTokenFamilyEntity)
 		private readonly refreshFamilies: Repository<McpOAuthRefreshTokenFamilyEntity>,
+		@InjectRepository(McpOAuthServerStateEntity)
+		private readonly serverState: Repository<McpOAuthServerStateEntity>,
 		private readonly installationService: McpInstallationService,
 		private readonly publicUrlService: McpOAuthPublicUrlService,
 	) {}
@@ -78,9 +82,19 @@ export class McpOAuthArtifactService {
 		const urls = this.requirePublicUrls();
 		const maximumExpiry = new Date(Date.now() + MCP_OAUTH_GRANT_LIFETIME_MS);
 		const expiresAt = this.earliest(input.expiresAt, maximumExpiry);
+		const [client, serverState] = await Promise.all([
+			this.clients.findOneBy({ id: input.clientId, enabled: true }),
+			this.serverState.findOneBy({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+		]);
 
 		if (expiresAt <= new Date()) {
 			throw new BadRequestException('OAuth grant expiry must be in the future');
+		}
+		if (!client) {
+			throw new BadRequestException('OAuth grant client is no longer active');
+		}
+		if (!serverState) {
+			throw new ServiceUnavailableException('MCP OAuth authorization generation state is unavailable');
 		}
 
 		return this.grants.save(
@@ -96,6 +110,11 @@ export class McpOAuthArtifactService {
 				revokedAt: null,
 				generation: 0,
 				approverAuthorityGeneration: input.approverAuthorityGeneration ?? 0,
+				oauthEnabledGeneration: serverState.oauthEnabledGeneration,
+				serverSecretVersion: serverState.serverSecretVersion,
+				publicIdentityGeneration: serverState.publicIdentityGeneration,
+				clientGeneration: client.generation,
+				modulePolicyGeneration: serverState.modulePolicyGeneration,
 			}),
 		);
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
@@ -6,14 +6,16 @@ import { ConfigService } from '../../config/services/config.service';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UserLanguage, UserRole } from '../../users/users.constants';
 import {
+	McpOAuthApproverAuthorityEntity,
 	McpOAuthClientEntity,
 	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRefreshFamilyLineageEntity,
 	McpOAuthProviderRevokedGrantEntity,
 	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../entities/mcp-oauth.entity';
-import { McpOAuthScope } from '../mcp.constants';
+import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../mcp.constants';
 import { McpOAuthClientModel } from '../models/mcp-oauth-client.model';
 import { createMcpOAuthProviderAdapter } from '../oauth/mcp-oauth-provider.adapter';
 
@@ -55,12 +57,14 @@ describe('McpOAuthManagementService', () => {
 			database: ':memory:',
 			entities: [
 				UserEntity,
+				McpOAuthApproverAuthorityEntity,
 				McpOAuthClientEntity,
 				McpOAuthGrantEntity,
 				McpOAuthProviderArtifactEntity,
 				McpOAuthProviderRefreshFamilyLineageEntity,
 				McpOAuthProviderRevokedGrantEntity,
 				McpOAuthProviderRevokedRefreshFamilyEntity,
+				McpOAuthServerStateEntity,
 			],
 			synchronize: true,
 		});
@@ -85,6 +89,17 @@ describe('McpOAuthManagementService', () => {
 			}),
 		);
 		const clients = dataSource.getRepository(McpOAuthClientEntity);
+		await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({ approverId: user.id, generation: 0 });
+		await dataSource.getRepository(McpOAuthServerStateEntity).save({
+			key: MCP_OAUTH_SERVER_STATE_KEY,
+			serverSecretVersion: 1,
+			keyVersion: 1,
+			publicIdentityGeneration: 0,
+			oauthEnabledGeneration: 0,
+			modulePolicyGeneration: 0,
+			createdAt: new Date(),
+			updatedAt: null,
+		});
 		client = await clients.save(
 			clients.create({
 				clientIdentifier: uuid(),

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
@@ -73,6 +73,13 @@ describe('McpOAuthResourceServerService', () => {
 			grantIdHash: PROVIDER_GRANT_ID_HASH,
 			refreshFamilyId: 'refresh-family-id',
 			expiresAt: Date.now() + 60_000,
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 6,
+			publicIdentityGeneration: 7,
+			clientGeneration: 2,
+			grantGeneration: 3,
+			modulePolicyGeneration: 1,
+			approverAuthorityGeneration: 4,
 		});
 		grant = Object.assign(new McpOAuthGrantEntity(), {
 			id: 'grant-id',
@@ -94,6 +101,11 @@ describe('McpOAuthResourceServerService', () => {
 			expiresAt: new Date(Date.now() + 60_000),
 			generation: 3,
 			approverAuthorityGeneration: 4,
+			oauthEnabledGeneration: 5,
+			serverSecretVersion: 6,
+			publicIdentityGeneration: 7,
+			clientGeneration: 2,
+			modulePolicyGeneration: 1,
 			revokedAt: null,
 		});
 		artifactRepository = { findOneBy: jest.fn().mockImplementation(() => Promise.resolve(artifact)) };
@@ -101,7 +113,13 @@ describe('McpOAuthResourceServerService', () => {
 		grantRepository = { findOne: jest.fn().mockImplementation(() => Promise.resolve(grant)) };
 		approverAuthorityRepository = { findOneBy: jest.fn().mockResolvedValue({ generation: 4 }) };
 		serverStateRepository = {
-			findOneBy: jest.fn().mockResolvedValue({ key: 'primary', modulePolicyGeneration: 1 }),
+			findOneBy: jest.fn().mockResolvedValue({
+				key: 'primary',
+				oauthEnabledGeneration: 5,
+				serverSecretVersion: 6,
+				publicIdentityGeneration: 7,
+				modulePolicyGeneration: 1,
+			}),
 		};
 		service = new McpOAuthResourceServerService(
 			artifactRepository as unknown as Repository<McpOAuthProviderArtifactEntity>,
@@ -204,6 +222,20 @@ describe('McpOAuthResourceServerService', () => {
 
 	it('rejects a grant from an earlier approver authority generation', async () => {
 		approverAuthorityRepository.findOneBy.mockResolvedValue({ generation: 5 });
+
+		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
+	});
+
+	it.each([
+		['OAuth enablement', 'oauthEnabledGeneration'],
+		['server secret', 'serverSecretVersion'],
+		['public identity', 'publicIdentityGeneration'],
+		['client', 'clientGeneration'],
+		['grant', 'grantGeneration'],
+		['module policy', 'modulePolicyGeneration'],
+		['approver authority', 'approverAuthorityGeneration'],
+	] as const)('rejects an access token from an earlier %s generation', async (_label, key) => {
+		artifact[key] = (artifact[key] ?? 0) - 1;
 
 		await expect(service.verifyAccessToken(RAW_TOKEN)).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken });
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.ts
@@ -127,6 +127,18 @@ export class McpOAuthResourceServerService implements OAuthTokenVerifier {
 			!grant ||
 			!grant.client ||
 			!serverState ||
+			artifact.oauthEnabledGeneration !== serverState?.oauthEnabledGeneration ||
+			artifact.serverSecretVersion !== serverState?.serverSecretVersion ||
+			artifact.publicIdentityGeneration !== serverState?.publicIdentityGeneration ||
+			artifact.modulePolicyGeneration !== serverState?.modulePolicyGeneration ||
+			artifact.clientGeneration !== grant?.client?.generation ||
+			artifact.grantGeneration !== grant?.generation ||
+			artifact.approverAuthorityGeneration !== (approverAuthority?.generation ?? 0) ||
+			grant.oauthEnabledGeneration !== serverState?.oauthEnabledGeneration ||
+			grant.serverSecretVersion !== serverState?.serverSecretVersion ||
+			grant.publicIdentityGeneration !== serverState?.publicIdentityGeneration ||
+			grant.clientGeneration !== grant.client.generation ||
+			grant.modulePolicyGeneration !== serverState?.modulePolicyGeneration ||
 			!grant.client.enabled ||
 			!grant.approvedBy ||
 			!grant.approvedById ||

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -5,25 +5,31 @@ import { AddressInfo } from 'node:net';
 import type Provider from 'oidc-provider';
 import { DataSource } from 'typeorm';
 
-import { McpOAuthClientEntity } from '../src/modules/mcp/entities/mcp-oauth.entity';
 import {
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRefreshFamilyLineageEntity,
 	McpOAuthProviderRevokedGrantEntity,
 	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthServerStateEntity,
 } from '../src/modules/mcp/entities/mcp-oauth.entity';
-import { McpOAuthScope } from '../src/modules/mcp/mcp.constants';
+import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../src/modules/mcp/mcp.constants';
 import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
 import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+import { UserEntity } from '../src/modules/users/entities/users.entity';
+import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
 
 const CLIENT_ID = 'phase3-public-client';
 const ACCOUNT_ID = 'owner-1';
 const REGISTERED_REDIRECT_URI = 'http://127.0.0.1:1455/callback';
 let consentPromptCount = 0;
+let persistSmartPanelGrant = (_providerGrantId: string): Promise<void> => Promise.resolve();
 
 interface TokenResponse {
 	access_token: string;
@@ -61,6 +67,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isStringArray = (value: unknown): value is string[] =>
 	Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const hash = (value: string): string => createHash('sha256').update(value).digest('hex');
 
 const finishInteraction = async (
 	provider: Provider,
@@ -100,6 +108,7 @@ const finishInteraction = async (
 	if (isStringArray(missingOidcScope)) grant.addOIDCScope(missingOidcScope.join(' '));
 
 	const grantId = await grant.save();
+	await persistSmartPanelGrant(grantId);
 	await provider.interactionFinished(
 		request,
 		response,
@@ -121,10 +130,15 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			type: 'sqlite',
 			database: ':memory:',
 			entities: [
+				UserEntity,
+				McpOAuthApproverAuthorityEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
 				McpOAuthProviderArtifactEntity,
 				McpOAuthProviderRefreshFamilyLineageEntity,
 				McpOAuthProviderRevokedGrantEntity,
 				McpOAuthProviderRevokedRefreshFamilyEntity,
+				McpOAuthServerStateEntity,
 			],
 			synchronize: true,
 		});
@@ -144,13 +158,61 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			tokenEndpoint: `${origin}/api/v1/modules/mcp/oauth/token`,
 			revocationEndpoint: `${origin}/api/v1/modules/mcp/oauth/token/revocation`,
 		};
-		const client = Object.assign(new McpOAuthClientEntity(), {
+		const user = await dataSource.getRepository(UserEntity).save({
+			id: ACCOUNT_ID,
+			username: 'owner',
+			password: null,
+			email: null,
+			firstName: null,
+			lastName: null,
+			role: UserRole.OWNER,
+			language: UserLanguage.EN,
+			isHidden: false,
+		});
+		const client = await dataSource.getRepository(McpOAuthClientEntity).save({
 			clientIdentifier: CLIENT_ID,
 			name: 'Phase 3 public client',
 			redirectUris: [REGISTERED_REDIRECT_URI],
 			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
 			enabled: true,
+			generation: 0,
+			createdById: user.id,
 		});
+		await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({ approverId: user.id, generation: 0 });
+		await dataSource.getRepository(McpOAuthServerStateEntity).save({
+			key: MCP_OAUTH_SERVER_STATE_KEY,
+			serverSecretVersion: 1,
+			keyVersion: 1,
+			publicIdentityGeneration: 0,
+			oauthEnabledGeneration: 0,
+			modulePolicyGeneration: 0,
+			createdAt: new Date(),
+			updatedAt: null,
+		});
+		persistSmartPanelGrant = async (providerGrantId: string): Promise<void> => {
+			const grants = dataSource.getRepository(McpOAuthGrantEntity);
+
+			if (await grants.existsBy({ providerGrantIdHash: hash(providerGrantId) })) return;
+
+			await grants.save({
+				providerGrantIdHash: hash(providerGrantId),
+				clientId: client.id,
+				approvedById: user.id,
+				installationId: 'phase3-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+		};
 		const clientsService = {
 			findActiveByIdentifier: jest.fn((clientIdentifier: string) =>
 				Promise.resolve(clientIdentifier === CLIENT_ID ? client : null),
@@ -508,6 +570,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		const adapter = new Adapter('RefreshToken');
 		const rawRefreshToken = `refresh-${randomBytes(24).toString('base64url')}`;
 		const rawGrantId = `grant-${randomBytes(24).toString('base64url')}`;
+		await persistSmartPanelGrant(rawGrantId);
 
 		await adapter.upsert(
 			rawRefreshToken,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — authoritative artifact request gate foundation implemented
+**Status:** Phase 5 in progress — durable authorization-generation snapshot foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -203,6 +203,16 @@ amend ADR 0002.
       approver-authority gate so demotion cannot interleave between consent and code issuance.
 - [x] Prove both gate orderings deterministically: provider work that commits first is visible to the following
       invalidation, while provider work queued behind invalidation observes the advanced authorization state and fails.
+
+### Phase 5j — Durable authorization-generation snapshot foundation
+
+- [x] Persist the OAuth-enabled, server-secret, public-identity, client, and module-policy generations captured by each
+      approved grant, with an incremental migration that safely backfills existing grants.
+- [x] Persist the complete applicable grant and authorization-input generation snapshot on authorization-code,
+      access-token, and refresh-token provider artifacts without storing raw bearer values.
+- [x] Fail provider artifact lookup/issuance and resource-server access-token validation when any captured generation is
+      unavailable or differs from live state, so advancing a generation permanently prevents stale artifact reuse.
+- [x] Backfill existing linked bearer artifacts and prove all seven generation dimensions fail closed after advancement.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 authoritative artifact request gate foundation complete
+Status: in progress — Phase 5 durable authorization-generation snapshot foundation complete
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- persist OAuth-enabled, server-secret, public-identity, client, and module-policy generation snapshots on approved MCP OAuth grants
- persist the complete applicable generation snapshot on authorization codes, access tokens, and refresh tokens
- reject provider artifact lookup, issuance, refresh, and resource-server validation when a captured generation no longer matches live authority state
- add incremental migration `1000000000017` with safe backfill and rollback coverage
- update the OAuth protocol harness and implementation plan for Phase 5j

## Why

The authoritative request gate prevents invalidation from interleaving with artifact commits, but artifacts previously retained only their provider payload and grant link. Validation therefore depended on current state alone. If authorization inputs were later restored, a stale artifact could become usable again.

Persisted monotonic generation snapshots make the authorization decision durable: once any applicable authority generation advances, artifacts issued under the earlier state remain invalid.

## Impact

Existing linked grants and bearer artifacts are backfilled during migration. Artifacts without a valid linked grant snapshot fail closed. No raw bearer tokens or token hashes are exposed by the new fields.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp src/migrations/__tests__/1000000000017-AddMcpOAuthAuthorizationSnapshots.spec.ts` — 346 tests passed
- `pnpm run test:oauth-spike` — 26 tests passed
- `pnpm run type-check`
- focused ESLint on changed backend and OAuth spike files
- `git diff --check`
