### PR TITLE
feat(backend): invalidate MCP OAuth public identity

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -65,6 +65,7 @@ import { McpInstallationService } from './services/mcp-installation.service';
 import { McpOAuthApproverAuthorityService } from './services/mcp-oauth-approver-authority.service';
 import { McpOAuthArtifactService } from './services/mcp-oauth-artifact.service';
 import { McpOAuthClientService } from './services/mcp-oauth-client.service';
+import { McpOAuthGlobalInvalidationService } from './services/mcp-oauth-global-invalidation.service';
 import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.service';
 import { McpOAuthManagementService } from './services/mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
@@ -132,6 +133,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthArtifactService,
 		McpOAuthApproverAuthorityService,
 		McpOAuthClientService,
+		McpOAuthGlobalInvalidationService,
 		McpOAuthInteractionService,
 		McpOAuthManagementService,
 		McpOAuthModuleConfigMutationService,

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
@@ -185,6 +185,21 @@ describe('McpOAuthGlobalInvalidationService', () => {
 		).toMatchObject({ publicIdentityGeneration: 1 });
 	});
 
+	it.each([undefined, null])('propagates a falsy external commit failure (%s)', async (commitError) => {
+		let rejected = false;
+
+		try {
+			// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- Regression coverage requires falsy rejection reasons.
+			await service.invalidate(['publicIdentityGeneration'], () => Promise.reject(commitError));
+		} catch (error) {
+			rejected = true;
+			expect(error).toBe(commitError);
+		}
+
+		expect(rejected).toBe(true);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+	});
+
 	it('holds queued OAuth work until identity advancement and revocation complete', async () => {
 		const commitStarted = deferred();
 		const releaseCommit = deferred();

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
@@ -1,0 +1,256 @@
+import { DataSource } from 'typeorm';
+
+import { UserEntity } from '../../users/entities/users.entity';
+import { UserLanguage, UserRole } from '../../users/users.constants';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRefreshFamilyLineageEntity,
+	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
+} from '../entities/mcp-oauth.entity';
+import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../mcp.constants';
+
+import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+	let resolve = (): void => undefined;
+	const promise = new Promise<void>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
+describe('McpOAuthGlobalInvalidationService', () => {
+	let dataSource: DataSource;
+	let subscriptions: McpSubscriptionRegistryService;
+	let service: McpOAuthGlobalInvalidationService;
+	let grant: McpOAuthGrantEntity;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				McpOAuthAccessTokenEntity,
+				McpOAuthApproverAuthorityEntity,
+				McpOAuthAuthorizationCodeEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
+				McpOAuthInteractionEntity,
+				McpOAuthProviderArtifactEntity,
+				McpOAuthProviderRefreshFamilyLineageEntity,
+				McpOAuthProviderRevokedGrantEntity,
+				McpOAuthRefreshTokenEntity,
+				McpOAuthRefreshTokenFamilyEntity,
+				McpOAuthServerStateEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+		const user = await dataSource.getRepository(UserEntity).save({
+			username: 'owner',
+			password: null,
+			email: null,
+			firstName: null,
+			lastName: null,
+			role: UserRole.OWNER,
+			language: UserLanguage.EN,
+			isHidden: false,
+		});
+		const client = await dataSource.getRepository(McpOAuthClientEntity).save({
+			clientIdentifier: 'public-client',
+			name: 'Codex',
+			redirectUris: ['http://127.0.0.1/callback'],
+			maximumScopes: [McpOAuthScope.READ],
+			enabled: true,
+			generation: 0,
+			createdById: user.id,
+		});
+		await dataSource.getRepository(McpOAuthServerStateEntity).save({
+			key: MCP_OAUTH_SERVER_STATE_KEY,
+			serverSecretVersion: 1,
+			keyVersion: 1,
+			publicIdentityGeneration: 0,
+			oauthEnabledGeneration: 0,
+			modulePolicyGeneration: 0,
+			createdAt: new Date(),
+			updatedAt: null,
+		});
+		grant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+			providerGrantIdHash: 'provider-grant-hash',
+			clientId: client.id,
+			approvedById: user.id,
+			installationId: 'installation-id',
+			issuer: 'https://panel.example.com/oauth',
+			resource: 'https://panel.example.com/mcp',
+			approvedScopes: [McpOAuthScope.READ],
+			expiresAt: new Date(Date.now() + 60_000),
+			revokedAt: null,
+			generation: 0,
+			approverAuthorityGeneration: 0,
+			oauthEnabledGeneration: 0,
+			serverSecretVersion: 1,
+			publicIdentityGeneration: 0,
+			clientGeneration: 0,
+			modulePolicyGeneration: 0,
+		});
+		await dataSource.getRepository(McpOAuthProviderArtifactEntity).save({
+			model: 'AccessToken',
+			idHash: 'access-token-hash',
+			managementId: 'access-token-id',
+			payload: JSON.stringify({ scope: 'mcp:read' }),
+			grantIdHash: grant.providerGrantIdHash,
+			refreshFamilyId: 'refresh-family-id',
+			userCodeHash: null,
+			uidHash: null,
+			consumedAt: null,
+			expiresAt: Date.now() + 60_000,
+			oauthEnabledGeneration: 0,
+			serverSecretVersion: 1,
+			publicIdentityGeneration: 0,
+			clientGeneration: 0,
+			grantGeneration: 0,
+			modulePolicyGeneration: 0,
+			approverAuthorityGeneration: 0,
+		});
+		await dataSource.getRepository(McpOAuthProviderRefreshFamilyLineageEntity).save({
+			grantIdHash: grant.providerGrantIdHash,
+			refreshFamilyId: 'refresh-family-id',
+		});
+		const auditService = {
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
+		service = new McpOAuthGlobalInvalidationService(dataSource, subscriptions);
+	});
+
+	afterEach(async () => {
+		await subscriptions.closeAll();
+		await dataSource.destroy();
+	});
+
+	it('advances identity state, revokes every OAuth artifact, and preserves static streams', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const oauthStream = await openOAuthSubscription();
+		const commit = jest.fn();
+
+		await service.invalidate(['publicIdentityGeneration'], commit);
+
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(staticStream.signal.aborted).toBe(false);
+		expect(oauthStream.signal.aborted).toBe(true);
+		expect(
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+		).toMatchObject({ publicIdentityGeneration: 1 });
+		const revokedGrant = await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id });
+
+		expect(revokedGrant.generation).toBe(1);
+		expect(revokedGrant.revokedAt).toBeInstanceOf(Date);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderRevokedGrantEntity)
+				.existsBy({ grantIdHash: grant.providerGrantIdHash }),
+		).toBe(true);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+		expect(await dataSource.getRepository(McpOAuthProviderRefreshFamilyLineageEntity).count()).toBe(0);
+	});
+
+	it('remains fail-closed and closes OAuth streams when the external commit fails', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const oauthStream = await openOAuthSubscription();
+		const commitError = new Error('configuration persistence failed');
+
+		await expect(service.invalidate(['publicIdentityGeneration'], () => Promise.reject(commitError))).rejects.toBe(
+			commitError,
+		);
+
+		expect(staticStream.signal.aborted).toBe(false);
+		expect(oauthStream.signal.aborted).toBe(true);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+		expect(
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+		).toMatchObject({ publicIdentityGeneration: 1 });
+	});
+
+	it('holds queued OAuth work until identity advancement and revocation complete', async () => {
+		const commitStarted = deferred();
+		const releaseCommit = deferred();
+		const invalidation = service.invalidate(['publicIdentityGeneration'], async () => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+		});
+
+		await commitStarted.promise;
+
+		const observedGenerations: number[] = [];
+		const queuedMutation = subscriptions.runOAuthMutation(async () => {
+			const state = await dataSource
+				.getRepository(McpOAuthServerStateEntity)
+				.findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY });
+			observedGenerations.push(state.publicIdentityGeneration);
+		});
+		await Promise.resolve();
+
+		expect(observedGenerations).toEqual([]);
+		releaseCommit.resolve();
+		await invalidation;
+		await queuedMutation;
+
+		expect(observedGenerations).toEqual([1]);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+	});
+
+	it('does not commit, revoke, or close streams when persistent generation state is unavailable', async () => {
+		const oauthStream = await openOAuthSubscription();
+		const commit = jest.fn();
+		await dataSource.getRepository(McpOAuthServerStateEntity).delete({ key: MCP_OAUTH_SERVER_STATE_KEY });
+
+		await expect(service.invalidate(['publicIdentityGeneration'], commit)).rejects.toThrow(
+			'MCP OAuth publicIdentityGeneration state is unavailable',
+		);
+
+		expect(commit).not.toHaveBeenCalled();
+		expect(oauthStream.signal.aborted).toBe(false);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(1);
+		expect(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).toMatchObject({
+			revokedAt: null,
+			generation: 0,
+		});
+	});
+
+	async function openOAuthSubscription() {
+		return subscriptions.openOAuth('oauth-request', () =>
+			Promise.resolve({
+				clientId: 'client-id',
+				binding: {
+					accessTokenId: 'access-token-id',
+					approverAuthorityGeneration: 0,
+					approverId: 'approver-id',
+					grantId: grant.id,
+					refreshFamilyId: 'refresh-family-id',
+					authorizationDeadline: new Date(Date.now() + 60_000),
+					effectiveScopes: [McpOAuthScope.READ],
+					modulePolicyGeneration: 0,
+					oauthEnabledGeneration: 0,
+					publicIdentityGeneration: 0,
+					serverSecretVersion: 1,
+					clientGeneration: 0,
+					grantGeneration: 0,
+				},
+			}),
+		);
+	}
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
@@ -32,6 +32,7 @@ export class McpOAuthGlobalInvalidationService {
 
 	async invalidate(generations: McpOAuthGlobalGeneration[], commit: () => Promise<void> | void): Promise<void> {
 		let commitError: unknown;
+		let commitFailed = false;
 
 		await this.subscriptions.closeAllOAuth(async () => {
 			await this.dataSource.transaction((manager) => this.advanceAndRevoke(manager, generations));
@@ -39,11 +40,12 @@ export class McpOAuthGlobalInvalidationService {
 			try {
 				await commit();
 			} catch (error) {
+				commitFailed = true;
 				commitError = error;
 			}
 		});
 
-		if (commitError) throw commitError;
+		if (commitFailed) throw commitError;
 	}
 
 	private async advanceAndRevoke(manager: EntityManager, generations: McpOAuthGlobalGeneration[]): Promise<void> {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
@@ -1,0 +1,93 @@
+import { DataSource, EntityManager, In, IsNull } from 'typeorm';
+
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRefreshFamilyLineageEntity,
+	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
+} from '../entities/mcp-oauth.entity';
+import { MCP_OAUTH_SERVER_STATE_KEY } from '../mcp.constants';
+
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+export type McpOAuthGlobalGeneration =
+	| 'oauthEnabledGeneration'
+	| 'serverSecretVersion'
+	| 'publicIdentityGeneration'
+	| 'modulePolicyGeneration';
+
+@Injectable()
+export class McpOAuthGlobalInvalidationService {
+	constructor(
+		private readonly dataSource: DataSource,
+		private readonly subscriptions: McpSubscriptionRegistryService,
+	) {}
+
+	async invalidate(generations: McpOAuthGlobalGeneration[], commit: () => Promise<void> | void): Promise<void> {
+		let commitError: unknown;
+
+		await this.subscriptions.closeAllOAuth(async () => {
+			await this.dataSource.transaction((manager) => this.advanceAndRevoke(manager, generations));
+
+			try {
+				await commit();
+			} catch (error) {
+				commitError = error;
+			}
+		});
+
+		if (commitError) throw commitError;
+	}
+
+	private async advanceAndRevoke(manager: EntityManager, generations: McpOAuthGlobalGeneration[]): Promise<void> {
+		const serverState = manager.getRepository(McpOAuthServerStateEntity);
+
+		for (const generation of new Set(generations)) {
+			const result = await serverState.increment({ key: MCP_OAUTH_SERVER_STATE_KEY }, generation, 1);
+
+			if (result.affected !== 1) {
+				throw new ServiceUnavailableException(`MCP OAuth ${generation} state is unavailable`);
+			}
+		}
+
+		const grants = manager.getRepository(McpOAuthGrantEntity);
+		const activeGrants = await grants.findBy({ revokedAt: IsNull() });
+		const revokedAt = new Date();
+
+		if (activeGrants.length > 0) {
+			const result = await grants.update(
+				{ id: In(activeGrants.map((grant) => grant.id)), revokedAt: IsNull() },
+				{ revokedAt, generation: () => 'generation + 1' },
+			);
+
+			if (result.affected !== activeGrants.length) {
+				throw new ServiceUnavailableException('MCP OAuth grants changed during global invalidation');
+			}
+
+			const grantHashes = activeGrants
+				.map((grant) => grant.providerGrantIdHash)
+				.filter((hash): hash is string => hash !== null);
+
+			if (grantHashes.length > 0) {
+				await manager.getRepository(McpOAuthProviderRevokedGrantEntity).upsert(
+					grantHashes.map((grantIdHash) => ({ grantIdHash, revokedAt: revokedAt.getTime() })),
+					['grantIdHash'],
+				);
+			}
+		}
+
+		await manager.getRepository(McpOAuthProviderArtifactEntity).deleteAll();
+		await manager.getRepository(McpOAuthProviderRefreshFamilyLineageEntity).deleteAll();
+		await manager.getRepository(McpOAuthAuthorizationCodeEntity).deleteAll();
+		await manager.getRepository(McpOAuthAccessTokenEntity).deleteAll();
+		await manager.getRepository(McpOAuthRefreshTokenFamilyEntity).deleteAll();
+		await manager.getRepository(McpOAuthInteractionEntity).deleteAll();
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -9,6 +9,7 @@ import { MCP_MODULE_NAME, MCP_OAUTH_SERVER_STATE_KEY, McpCapability, McpOAuthSco
 import { McpConfigModel } from '../models/config.model';
 
 import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
 import { McpOAuthSubscriptionBinding, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
@@ -40,6 +41,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 	let config: McpConfigModel;
 	let configService: { getModuleConfig: jest.Mock; reload: jest.Mock };
 	let serverState: { increment: jest.Mock };
+	let globalInvalidation: { invalidate: jest.Mock };
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
 
@@ -53,6 +55,9 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		serverState = {
 			increment: jest.fn().mockResolvedValue({ affected: 1 }),
 		};
+		globalInvalidation = {
+			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void> | void) => commit()),
+		};
 		const auditService = {
 			recordSubscriptionClosed: jest.fn(),
 			recordSubscriptionOpened: jest.fn(),
@@ -62,6 +67,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			configService as unknown as ConfigService,
 			serverState as unknown as Repository<McpOAuthServerStateEntity>,
 			subscriptions,
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 		);
 	});
 
@@ -176,6 +182,56 @@ describe('McpOAuthModuleConfigMutationService', () => {
 
 		expect(serverState.increment).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('routes public OAuth identity changes through global invalidation', async () => {
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn().mockImplementation(() => {
+			config.oauthPublicBaseUrl = 'https://new-panel.example.com';
+		});
+
+		await service.update(
+			{ type: MCP_MODULE_NAME, oauth_public_base_url: 'https://new-panel.example.com' } as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['publicIdentityGeneration'], expect.any(Function));
+		expect(serverState.increment).not.toHaveBeenCalled();
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('advances public identity and module policy together when both inputs change', async () => {
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn();
+
+		await service.update(
+			{
+				type: MCP_MODULE_NAME,
+				oauth_public_base_url: 'https://new-panel.example.com',
+				capabilities: [McpCapability.READ],
+			} as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(
+			['publicIdentityGeneration', 'modulePolicyGeneration'],
+			expect.any(Function),
+		);
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('reloads configuration and propagates a failed public identity commit after invalidation', async () => {
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commitError = new Error('configuration persistence failed');
+
+		await expect(
+			service.update(
+				{ type: MCP_MODULE_NAME, oauth_public_base_url: 'https://new-panel.example.com' } as UpdateMcpConfigDto,
+				() => Promise.reject(commitError),
+			),
+		).rejects.toBe(commitError);
+
+		expect(configService.reload).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not commit or close streams when policy generation cannot advance', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -11,6 +11,7 @@ import { MCP_MODULE_NAME, MCP_OAUTH_SERVER_STATE_KEY, McpCapability } from '../m
 import { McpConfigModel } from '../models/config.model';
 import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
 
+import { McpOAuthGlobalGeneration, McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 @Injectable()
@@ -20,13 +21,35 @@ export class McpOAuthModuleConfigMutationService {
 		@InjectRepository(McpOAuthServerStateEntity)
 		private readonly serverState: Repository<McpOAuthServerStateEntity>,
 		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
 	) {}
 
 	async update(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
 		const current = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
 		const nextCapabilities = update.capabilities ?? current.capabilities;
+		const capabilitiesChanged = !this.sameCapabilities(current.capabilities, nextCapabilities);
+		const nextPublicBaseUrl =
+			update.oauth_public_base_url === undefined ? current.oauthPublicBaseUrl : update.oauth_public_base_url;
+		const publicIdentityChanged = current.oauthPublicBaseUrl !== nextPublicBaseUrl;
 
-		if (this.sameCapabilities(current.capabilities, nextCapabilities)) {
+		if (publicIdentityChanged) {
+			const generations: McpOAuthGlobalGeneration[] = [
+				'publicIdentityGeneration',
+				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
+			];
+
+			await this.globalInvalidation.invalidate(generations, async () => {
+				try {
+					await commit();
+				} catch (error) {
+					this.configService.reload();
+					throw error;
+				}
+			});
+			return;
+		}
+
+		if (!capabilitiesChanged) {
 			await commit();
 			return;
 		}

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — complete subscription authorization binding implemented
+**Status:** Phase 5 in progress — awaited public-identity invalidation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -224,6 +224,17 @@ amend ADR 0002.
       same authoritative gate used by artifact and policy invalidation before registering the stream.
 - [x] Prove a racing registration either opens before invalidation and is closed or runs after generation advancement
       and fails revalidation, while static MCP subscriptions remain outside the OAuth gate.
+
+### Phase 5l — Awaited public-identity invalidation
+
+- [x] Add one reusable global OAuth invalidation transaction that advances selected persistent generations, revokes all
+      active grants, tombstones their provider identities, and deletes every provider and legacy OAuth artifact.
+- [x] Route changes to the canonical OAuth public base URL through that transaction before the configuration mutation
+      reports success, advancing module-policy generation in the same transaction when both inputs change.
+- [x] Close every OAuth subscription after revocation while preserving static MCP subscriptions; if configuration
+      persistence fails, reload configuration but keep the advanced generation, revoked artifacts, and closed streams.
+- [x] Prove queued provider work cannot enter the authoritative gate until identity advancement and revocation finish,
+      and prove missing persistent generation state prevents commit, revocation, and stream closure.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 complete subscription authorization binding implemented
+Status: in progress — Phase 5 awaited public-identity invalidation implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add a reusable transactional global MCP OAuth invalidation service
- advance selected persistent authorization generations before revoking active grants
- tombstone provider grant identities and remove provider/legacy OAuth artifacts
- close all OAuth subscriptions while preserving static MCP streams
- route canonical OAuth public-base-URL changes through awaited global invalidation
- advance public-identity and module-policy generations together when both inputs change

## Why

Bearer artifacts now retain durable authorization snapshots, but changing the canonical OAuth identity did not yet advance its generation or revoke existing OAuth authority. Configuration could therefore move to a new issuer/resource identity while old grants, tokens, and streams remained present.

The new transaction makes public-identity rotation fail closed. A queued OAuth/provider operation cannot enter the shared mutation gate until generation advancement, artifact revocation, configuration persistence, and stream closure complete.

## Impact

Changing `oauth_public_base_url` now revokes every active OAuth grant and artifact and closes OAuth subscriptions before the update reports success. Static MCP credentials and subscriptions remain active. If configuration persistence fails, configuration is reloaded while the advanced generation and revocation remain in force.

No public API schema or database migration is introduced.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp` — 354 tests passed
- `pnpm run test:oauth-spike` — 26 tests passed
- `pnpm run type-check`
- focused ESLint on all changed backend files
- `git diff --check`
