### PR TITLE
feat(cross): add MCP OAuth revoke-all recovery

### DIFF
--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
@@ -112,6 +112,26 @@ describe('useMcpOAuthManagement', () => {
 		expect(management.accessTokens.value).toEqual([]);
 	});
 
+	it('revokes all OAuth authorization and preserves registered clients', async () => {
+		backendClient.GET.mockResolvedValueOnce({ data: { data: [client] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [grant] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [accessToken] }, response: { status: 200 } })
+			.mockResolvedValueOnce({ data: { data: [family] }, response: { status: 200 } });
+		backendClient.POST.mockResolvedValue({ data: undefined, response: { status: 204, ok: true } });
+		const management = useMcpOAuthManagement();
+		await management.fetchAll();
+
+		await management.revokeAll();
+
+		expect(backendClient.POST).toHaveBeenCalledWith('/modules/mcp/oauth/revoke-all', {});
+		expect(management.clients.value).toEqual([client]);
+		expect(management.grants.value).toEqual([
+			expect.objectContaining({ id: grant.id, active: false, revokedAt: expect.any(String) }),
+		]);
+		expect(management.accessTokens.value).toEqual([]);
+		expect(management.refreshFamilies.value).toEqual([]);
+	});
+
 	it('updates a grant through the reduction-only generated API contract', async () => {
 		const reduced = { ...grant, approvedScopes: [McpOAuthScope.READ] };
 		backendClient.GET.mockResolvedValueOnce({ data: { data: [client] }, response: { status: 200 } })

--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
@@ -117,7 +117,7 @@ describe('useMcpOAuthManagement', () => {
 			.mockResolvedValueOnce({ data: { data: [grant] }, response: { status: 200 } })
 			.mockResolvedValueOnce({ data: { data: [accessToken] }, response: { status: 200 } })
 			.mockResolvedValueOnce({ data: { data: [family] }, response: { status: 200 } });
-		backendClient.POST.mockResolvedValue({ data: undefined, response: { status: 204, ok: true } });
+		backendClient.POST.mockResolvedValue({ data: { data: { revoked: true } }, response: { status: 200, ok: true } });
 		const management = useMcpOAuthManagement();
 		await management.fetchAll();
 

--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
@@ -37,6 +37,7 @@ interface IUseMcpOAuthManagement {
 	updateGrant: (id: string, payload: IMcpOAuthUpdateGrant) => Promise<IMcpOAuthGrant>;
 	revokeAccessToken: (id: string) => Promise<void>;
 	revokeRefreshFamily: (id: string) => Promise<void>;
+	revokeAll: () => Promise<void>;
 }
 
 const oauthPath = `/modules/${MCP_MODULE_PREFIX}/oauth` as const;
@@ -50,6 +51,7 @@ const accessTokensPath = `${oauthPath}/access-tokens` as const;
 const revokeAccessTokenPath = `${oauthPath}/access-tokens/{id}/revoke` as const;
 const refreshFamiliesPath = `${oauthPath}/refresh-families` as const;
 const revokeRefreshFamilyPath = `${oauthPath}/refresh-families/{id}/revoke` as const;
+const revokeAllPath = `${oauthPath}/revoke-all` as const;
 
 export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 	const backend = useBackend();
@@ -192,6 +194,21 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 		accessTokens.value = accessTokens.value.filter((token) => token.refreshFamilyId !== id);
 	};
 
+	const revokeAll = async (): Promise<void> => {
+		const { response } = await backend.client.POST(revokeAllPath, {});
+
+		if (!response.ok) throw new McpApiException('Failed to revoke all MCP OAuth authorization.', response.status);
+
+		const revokedAt = new Date().toISOString();
+		grants.value = grants.value.map((grant) => ({
+			...grant,
+			active: false,
+			revokedAt: grant.revokedAt ?? revokedAt,
+		}));
+		accessTokens.value = [];
+		refreshFamilies.value = [];
+	};
+
 	return {
 		clients,
 		grants,
@@ -207,5 +224,6 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 		updateGrant,
 		revokeAccessToken,
 		revokeRefreshFamily,
+		revokeAll,
 	};
 };

--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
@@ -195,9 +195,11 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 	};
 
 	const revokeAll = async (): Promise<void> => {
-		const { response } = await backend.client.POST(revokeAllPath, {});
+		const { data, response } = await backend.client.POST(revokeAllPath, {});
 
-		if (!response.ok) throw new McpApiException('Failed to revoke all MCP OAuth authorization.', response.status);
+		if (!data?.data.revoked) {
+			throw new McpApiException('Failed to revoke all MCP OAuth authorization.', response.status);
+		}
 
 		const revokedAt = new Date().toISOString();
 		grants.value = grants.value.map((grant) => ({

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -133,7 +133,7 @@
 		"title": "MCP OAuth access",
 		"subtitle": "Pre-register remote clients and revoke their grants and tokens.",
 		"securityTitle": "OAuth secrets are never displayed",
-		"securityDescription": "This page exposes only non-secret management identifiers. Revocation immediately closes matching MCP subscriptions.",
+		"securityDescription": "This page exposes only non-secret management identifiers. Revocation immediately closes matching MCP subscriptions. Resetting a Smart Panel password does not revoke OAuth access.",
 		"tabs": {
 			"clients": "Clients",
 			"grants": "Grants",
@@ -159,6 +159,7 @@
 		"familyId": "Family ID",
 		"redirectUris": "Redirect URIs",
 		"createClient": "Pre-register OAuth client",
+		"revokeAll": "Revoke all OAuth access",
 		"editClient": "Edit OAuth client",
 		"editGrant": "Reduce OAuth grant scopes",
 		"name": "Name",
@@ -183,6 +184,7 @@
 			"offline_access": "Offline access"
 		},
 		"confirm": {
+			"all": "Revoke every MCP OAuth grant and token and close every OAuth subscription? Static MCP credentials and streams remain active. Use this explicit recovery action because resetting a Smart Panel password does not revoke OAuth access.",
 			"client": "Disable {name}, revoke all of its grants and tokens, and close its OAuth subscriptions?",
 			"grant": "Revoke this grant for {name}, its tokens, and matching subscriptions?",
 			"accessToken": "Revoke this access token for {name} and close its matching subscription?",
@@ -200,6 +202,7 @@
 			"grantUpdateFailed": "OAuth grant scopes could not be updated.",
 			"accessTokenRevoked": "OAuth access token revoked.",
 			"refreshFamilyRevoked": "OAuth refresh family revoked.",
+			"allRevoked": "All MCP OAuth access revoked.",
 			"revokeFailed": "OAuth authorization could not be revoked."
 		}
 	},

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 	revokeGrant: vi.fn().mockResolvedValue(undefined),
 	revokeAccessToken: vi.fn(),
 	revokeRefreshFamily: vi.fn(),
+	revokeAll: vi.fn().mockResolvedValue(undefined),
 	flashSuccess: vi.fn(),
 	flashError: vi.fn(),
 }));
@@ -56,6 +57,7 @@ vi.mock('../composables/useMcpOAuthManagement', () => ({
 		revokeGrant: mocks.revokeGrant,
 		revokeAccessToken: mocks.revokeAccessToken,
 		revokeRefreshFamily: mocks.revokeRefreshFamily,
+		revokeAll: mocks.revokeAll,
 	}),
 }));
 
@@ -75,6 +77,18 @@ describe('ViewMcpOAuthManagement', () => {
 
 		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
 		expect(mocks.revokeGrant).toHaveBeenCalledWith(grant.id);
+	});
+
+	it('requires confirmation before revoking all OAuth authorization', async () => {
+		const wrapper = shallowMount(ViewMcpOAuthManagement);
+		const vm = wrapper.vm as unknown as { confirmGlobalRevoke: () => Promise<void> };
+
+		await vm.confirmGlobalRevoke();
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
+		expect(mocks.revokeAll).toHaveBeenCalledOnce();
+		expect(mocks.flashSuccess).toHaveBeenCalledWith('mcpModule.oauthManagement.messages.allRevoked');
 	});
 
 	it('labels an unusable grant with the backend inactive state', () => {

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
@@ -6,6 +6,14 @@
 	>
 		<template #extra>
 			<el-button
+				type="danger"
+				plain
+				@click="confirmGlobalRevoke"
+			>
+				<icon icon="mdi:shield-remove-outline" />
+				{{ t('mcpModule.oauthManagement.revokeAll') }}
+			</el-button>
+			<el-button
 				type="primary"
 				@click="openCreate"
 			>
@@ -452,6 +460,7 @@ const {
 	revokeGrant,
 	revokeAccessToken,
 	revokeRefreshFamily,
+	revokeAll,
 } = useMcpOAuthManagement();
 
 const activeTab = ref('clients');
@@ -617,6 +626,12 @@ const confirmRefreshFamilyRevoke = (family: IMcpOAuthRefreshFamily): Promise<voi
 		t('mcpModule.oauthManagement.confirm.refreshFamily', { name: family.clientName }),
 		() => revokeRefreshFamily(family.id),
 		'mcpModule.oauthManagement.messages.refreshFamilyRevoked'
+	);
+const confirmGlobalRevoke = (): Promise<void> =>
+	confirmRevoke(
+		t('mcpModule.oauthManagement.confirm.all'),
+		() => revokeAll(),
+		'mcpModule.oauthManagement.messages.allRevoked'
 	);
 
 const grantStatus = (grant: IMcpOAuthGrant): { key: 'active' | 'expired' | 'inactive' | 'revoked'; type: 'success' | 'danger' | 'warning' } => {

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
@@ -25,4 +25,17 @@ describe('McpOAuthManagementController', () => {
 		expect(response.data).toBe(grant);
 		expect(updateGrant).toHaveBeenCalledWith(grantId, dto, actorId);
 	});
+
+	it('forwards a global OAuth revocation for the authenticated administrator', async () => {
+		const actorId = uuid();
+		const revokeAll = jest.fn().mockResolvedValue(undefined);
+		const controller = new McpOAuthManagementController({ revokeAll } as unknown as McpOAuthManagementService);
+		const request = {
+			auth: { type: 'user', id: actorId, role: UserRole.ADMIN },
+		} as unknown as AuthenticatedRequest;
+
+		await controller.revokeAll(request);
+
+		expect(revokeAll).toHaveBeenCalledWith(actorId);
+	});
 });

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.spec.ts
@@ -34,8 +34,9 @@ describe('McpOAuthManagementController', () => {
 			auth: { type: 'user', id: actorId, role: UserRole.ADMIN },
 		} as unknown as AuthenticatedRequest;
 
-		await controller.revokeAll(request);
+		const response = await controller.revokeAll(request);
 
 		expect(revokeAll).toHaveBeenCalledWith(actorId);
+		expect(response.data).toEqual({ revoked: true });
 	});
 });

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
@@ -218,6 +218,20 @@ export class McpOAuthManagementController {
 		await this.managementService.revokeRefreshFamily(id, this.getActorId(req));
 	}
 
+	@ApiOperation({
+		tags: [MCP_MODULE_API_TAG_NAME],
+		summary: 'Revoke all MCP OAuth authorization',
+		description:
+			'Advance the authorization-server security epoch, revoke every OAuth grant and artifact, and close every OAuth subscription while preserving static MCP access',
+		operationId: 'revoke-all-mcp-module-oauth-authorization',
+	})
+	@ApiNoContentResponse({ description: 'All MCP OAuth authorization revoked successfully' })
+	@HttpCode(204)
+	@Post('revoke-all')
+	async revokeAll(@Req() req: AuthenticatedRequest): Promise<void> {
+		await this.managementService.revokeAll(this.getActorId(req));
+	}
+
 	private getActorId(req: AuthenticatedRequest): string {
 		if (req.auth?.type === 'user') return req.auth.id;
 		if (req.auth?.type === 'token' && req.auth.ownerId) return req.auth.ownerId;

--- a/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp-oauth-management.controller.ts
@@ -25,11 +25,13 @@ import { MCP_MODULE_API_TAG_NAME } from '../mcp.constants';
 import {
 	McpOAuthAccessTokenResponseModel,
 	McpOAuthAccessTokensResponseModel,
+	McpOAuthGlobalRevocationResponseModel,
 	McpOAuthGrantResponseModel,
 	McpOAuthGrantsResponseModel,
 	McpOAuthRefreshFamiliesResponseModel,
 	McpOAuthRefreshFamilyResponseModel,
 } from '../models/mcp-oauth-management-response.model';
+import { McpOAuthGlobalRevocationModel } from '../models/mcp-oauth-management.model';
 import { McpOAuthManagementService } from '../services/mcp-oauth-management.service';
 
 @ApiTags(MCP_MODULE_API_TAG_NAME)
@@ -225,11 +227,15 @@ export class McpOAuthManagementController {
 			'Advance the authorization-server security epoch, revoke every OAuth grant and artifact, and close every OAuth subscription while preserving static MCP access',
 		operationId: 'revoke-all-mcp-module-oauth-authorization',
 	})
-	@ApiNoContentResponse({ description: 'All MCP OAuth authorization revoked successfully' })
-	@HttpCode(204)
+	@ApiSuccessResponse(McpOAuthGlobalRevocationResponseModel, 'All MCP OAuth authorization revoked successfully')
 	@Post('revoke-all')
-	async revokeAll(@Req() req: AuthenticatedRequest): Promise<void> {
+	async revokeAll(@Req() req: AuthenticatedRequest): Promise<McpOAuthGlobalRevocationResponseModel> {
 		await this.managementService.revokeAll(this.getActorId(req));
+
+		const response = new McpOAuthGlobalRevocationResponseModel();
+		response.data = Object.assign(new McpOAuthGlobalRevocationModel(), { revoked: true });
+
+		return response;
 	}
 
 	private getActorId(req: AuthenticatedRequest): string {

--- a/apps/backend/src/modules/mcp/mcp.openapi.ts
+++ b/apps/backend/src/modules/mcp/mcp.openapi.ts
@@ -33,6 +33,7 @@ import { McpOAuthInteractionCompletionModel, McpOAuthInteractionModel } from './
 import {
 	McpOAuthAccessTokenResponseModel,
 	McpOAuthAccessTokensResponseModel,
+	McpOAuthGlobalRevocationResponseModel,
 	McpOAuthGrantResponseModel,
 	McpOAuthGrantsResponseModel,
 	McpOAuthRefreshFamiliesResponseModel,
@@ -40,6 +41,7 @@ import {
 } from './models/mcp-oauth-management-response.model';
 import {
 	McpOAuthAccessTokenModel,
+	McpOAuthGlobalRevocationModel,
 	McpOAuthGrantModel,
 	McpOAuthRefreshFamilyModel,
 } from './models/mcp-oauth-management.model';
@@ -75,11 +77,13 @@ export const MCP_SWAGGER_EXTRA_MODELS = [
 	McpOAuthInteractionCompletionResponseModel,
 	McpOAuthGrantModel,
 	McpOAuthAccessTokenModel,
+	McpOAuthGlobalRevocationModel,
 	McpOAuthRefreshFamilyModel,
 	McpOAuthGrantResponseModel,
 	McpOAuthGrantsResponseModel,
 	McpOAuthAccessTokenResponseModel,
 	McpOAuthAccessTokensResponseModel,
+	McpOAuthGlobalRevocationResponseModel,
 	McpOAuthRefreshFamilyResponseModel,
 	McpOAuthRefreshFamiliesResponseModel,
 ];

--- a/apps/backend/src/modules/mcp/models/mcp-oauth-management-response.model.ts
+++ b/apps/backend/src/modules/mcp/models/mcp-oauth-management-response.model.ts
@@ -4,7 +4,12 @@ import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
 
-import { McpOAuthAccessTokenModel, McpOAuthGrantModel, McpOAuthRefreshFamilyModel } from './mcp-oauth-management.model';
+import {
+	McpOAuthAccessTokenModel,
+	McpOAuthGlobalRevocationModel,
+	McpOAuthGrantModel,
+	McpOAuthRefreshFamilyModel,
+} from './mcp-oauth-management.model';
 
 @ApiSchema({ name: 'McpModuleResOAuthGrant' })
 export class McpOAuthGrantResponseModel extends BaseSuccessResponseModel<McpOAuthGrantModel> {
@@ -46,4 +51,11 @@ export class McpOAuthRefreshFamiliesResponseModel extends BaseSuccessResponseMod
 	@ApiProperty({ type: 'array', items: { $ref: getSchemaPath(McpOAuthRefreshFamilyModel) } })
 	@Expose()
 	declare data: McpOAuthRefreshFamilyModel[];
+}
+
+@ApiSchema({ name: 'McpModuleResOAuthGlobalRevocation' })
+export class McpOAuthGlobalRevocationResponseModel extends BaseSuccessResponseModel<McpOAuthGlobalRevocationModel> {
+	@ApiProperty({ type: () => McpOAuthGlobalRevocationModel })
+	@Expose()
+	declare data: McpOAuthGlobalRevocationModel;
 }

--- a/apps/backend/src/modules/mcp/models/mcp-oauth-management.model.ts
+++ b/apps/backend/src/modules/mcp/models/mcp-oauth-management.model.ts
@@ -145,3 +145,10 @@ export class McpOAuthRefreshFamilyModel {
 	@Expose({ name: 'active_token_count' })
 	activeTokenCount: number;
 }
+
+@ApiSchema({ name: 'McpModuleDataOAuthGlobalRevocation' })
+export class McpOAuthGlobalRevocationModel {
+	@ApiProperty({ description: 'Whether all MCP OAuth authorization was revoked', type: 'boolean', example: true })
+	@Expose()
+	revoked: boolean;
+}

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -132,6 +132,17 @@ describe('McpAuditService', () => {
 		expect(logger.extensionType).toBe(MCP_MODULE_NAME);
 	});
 
+	it('audits global OAuth revocation without credential material', () => {
+		service.recordOAuthGlobalRevocation('owner-id');
+
+		expect(log).toHaveBeenCalledWith('MCP audit event', {
+			event: 'oauth_global_revocation',
+			request_id: 'administrative',
+			actor_id: 'owner-id',
+			action: 'revoked_all',
+		});
+	});
+
 	it('counts policy-resolution outages as failures without incrementing denials', () => {
 		service.recordRequestFailure({ requestId: '1', clientId: 'client-1' }, 'policy_resolution_error');
 

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -143,6 +143,17 @@ export class McpAuditService {
 		);
 	}
 
+	recordOAuthGlobalRevocation(actorId: string): void {
+		this.log(
+			'oauth_global_revocation',
+			{ requestId: 'administrative' },
+			{
+				actor_id: actorId,
+				action: 'revoked_all',
+			},
+		);
+	}
+
 	recordToolResult(result: ToolResult): void {
 		this.callsByCapability[result.capability] += 1;
 		this.callsByTool.set(result.tool, (this.callsByTool.get(result.tool) ?? 0) + 1);

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
@@ -168,6 +168,20 @@ describe('McpOAuthGlobalInvalidationService', () => {
 		expect(await dataSource.getRepository(McpOAuthProviderRefreshFamilyLineageEntity).count()).toBe(0);
 	});
 
+	it('advances the server-security epoch while preserving static streams', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const oauthStream = await openOAuthSubscription();
+
+		await service.invalidate(['serverSecretVersion'], () => Promise.resolve());
+
+		expect(staticStream.signal.aborted).toBe(false);
+		expect(oauthStream.signal.aborted).toBe(true);
+		expect(
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+		).toMatchObject({ serverSecretVersion: 2 });
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+	});
+
 	it('remains fail-closed and closes OAuth streams when the external commit fails', async () => {
 		const staticStream = subscriptions.open('static-client');
 		const oauthStream = await openOAuthSubscription();

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
@@ -21,6 +21,7 @@ import { createMcpOAuthProviderAdapter } from '../oauth/mcp-oauth-provider.adapt
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthClientService } from './mcp-oauth-client.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
@@ -46,10 +47,12 @@ describe('McpOAuthManagementService', () => {
 	let familyId: string;
 	let moduleEnabled: boolean;
 	let auditService: {
+		recordOAuthGlobalRevocation: jest.Mock;
 		recordOAuthManagementAction: jest.Mock;
 		recordSubscriptionClosed: jest.Mock;
 		recordSubscriptionOpened: jest.Mock;
 	};
+	let globalInvalidation: { invalidate: jest.Mock };
 
 	beforeEach(async () => {
 		dataSource = new DataSource({
@@ -70,9 +73,13 @@ describe('McpOAuthManagementService', () => {
 		});
 		await dataSource.initialize();
 		auditService = {
+			recordOAuthGlobalRevocation: jest.fn(),
 			recordOAuthManagementAction: jest.fn(),
 			recordSubscriptionClosed: jest.fn(),
 			recordSubscriptionOpened: jest.fn(),
+		};
+		globalInvalidation = {
+			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void>) => commit()),
 		};
 		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
 		moduleEnabled = true;
@@ -215,6 +222,7 @@ describe('McpOAuthManagementService', () => {
 			{ getModuleConfig: jest.fn(() => ({ enabled: moduleEnabled })) } as unknown as ConfigService,
 			clientsService as unknown as McpOAuthClientService,
 			subscriptions,
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 			auditService as unknown as McpAuditService,
 		);
 	});
@@ -242,6 +250,22 @@ describe('McpOAuthManagementService', () => {
 		expect(serialized).not.toContain(hashToken('access-one'));
 		expect(serialized).not.toContain(hashToken('grant-one'));
 		expect(serialized).not.toContain('access-one');
+	});
+
+	it('revokes all OAuth authorization through the global server-security epoch and audits success', async () => {
+		await service.revokeAll('actor-id');
+
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['serverSecretVersion'], expect.any(Function));
+		expect(auditService.recordOAuthGlobalRevocation).toHaveBeenCalledWith('actor-id');
+	});
+
+	it('does not audit a failed global OAuth revocation', async () => {
+		const failure = new Error('global invalidation failed');
+		globalInvalidation.invalidate.mockRejectedValueOnce(failure);
+
+		await expect(service.revokeAll('actor-id')).rejects.toBe(failure);
+
+		expect(auditService.recordOAuthGlobalRevocation).not.toHaveBeenCalled();
 	});
 
 	it('excludes artifacts whose linked grant has expired', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
@@ -24,6 +24,7 @@ import {
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthClientService } from './mcp-oauth-client.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 interface ProviderArtifactPayload {
@@ -41,6 +42,7 @@ export class McpOAuthManagementService {
 		private readonly configService: ConfigService,
 		private readonly clientsService: McpOAuthClientService,
 		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
 		private readonly auditService: McpAuditService,
 	) {}
 
@@ -290,6 +292,11 @@ export class McpOAuthManagementService {
 			});
 		});
 		this.auditService.recordOAuthManagementAction(actorId, 'refresh_family', id, 'revoked');
+	}
+
+	async revokeAll(actorId: string): Promise<void> {
+		await this.globalInvalidation.invalidate(['serverSecretVersion'], () => Promise.resolve());
+		this.auditService.recordOAuthGlobalRevocation(actorId);
 	}
 
 	private async getGrantEntity(id: string): Promise<McpOAuthGrantEntity> {

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — awaited public-identity invalidation implemented
+**Status:** Phase 5 in progress — revoke-all recovery control implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -236,6 +236,17 @@ amend ADR 0002.
 - [x] Prove queued provider work cannot enter the authoritative gate until identity advancement and revocation finish,
       and prove missing persistent generation state prevents commit, revocation, and stream closure.
 
+### Phase 5m — Revoke-all recovery control
+
+- [x] Add an explicit owner/admin revoke-all action that advances the authorization-server security epoch before
+      revoking every OAuth grant and artifact and closing every OAuth subscription.
+- [x] Preserve registered OAuth clients plus every static MCP credential and stream so recovery invalidates only the
+      browser-mediated OAuth authorization profile.
+- [x] Add the Admin recovery confirmation and explain that resetting a Smart Panel password does not revoke existing
+      OAuth access.
+- [x] Audit successful global recovery without recording bearer, provider, cookie, or signing-key material, and
+      propagate invalidation failures without reporting or auditing success.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -261,7 +272,7 @@ amend ADR 0002.
 - [ ] Close all MCP subscriptions only when the MCP module is disabled. On public OAuth identity or server-secret
       rotation, advance the applicable artifact generation before revoke-all, revoke every OAuth artifact, and close
       every OAuth subscription while preserving static MCP credentials and streams.
-- [ ] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
+- [x] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
 - [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
 - [x] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
       invalidation failure, and never leave a demoted/deleted approver's grant usable.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 awaited public-identity invalidation implemented
+Status: in progress — Phase 5 revoke-all recovery control implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add an owner/admin-only endpoint to revoke all MCP OAuth authorization
- advance the authorization-server security epoch before revoking every OAuth grant and artifact
- close every OAuth subscription while preserving registered clients, static MCP credentials, and static streams
- add an Admin recovery action with explicit confirmation and password-reset guidance
- audit successful global recovery without recording credential material
- update the Phase 5 task status and focused regression coverage

## Why

Resetting a Smart Panel password intentionally does not revoke existing MCP OAuth grants. Owners and administrators need a separate recovery action for suspected OAuth compromise that is serialized with artifact issuance and completes revocation and OAuth stream closure before reporting success.

## Impact

Existing OAuth grants and tokens become permanently unusable and connected OAuth streams close immediately. Pre-registered OAuth clients remain available for a new authorization flow, while the installation-local static MCP profile remains connected and unchanged.

## Validation

- backend focused tests: 40 passed
- backend unit tests: 312 suites, 3,972 passed, 2 skipped
- backend E2E tests: 10 suites, 126 passed
- Admin focused tests: 10 passed
- Admin unit tests: 265 files, 1,853 passed
- backend and Admin type-checks
- backend and Admin ESLint (only unrelated pre-existing warnings)
- API conventions lint
- OpenAPI generation and Spectral lint
- `git diff --check`