### PR TITLE
feat(backend): await MCP module disable invalidation

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.spec.ts
@@ -20,7 +20,7 @@ import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../mcp.constants';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
-import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+import { McpSubscriptionClosingError, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 	let resolve = (): void => undefined;
@@ -180,6 +180,50 @@ describe('McpOAuthGlobalInvalidationService', () => {
 			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }),
 		).toMatchObject({ serverSecretVersion: 2 });
 		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+	});
+
+	it('advances OAuth enablement, revokes artifacts, and closes static and OAuth streams before disable completes', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const oauthStream = await openOAuthSubscription();
+		const commitStarted = deferred();
+		const releaseCommit = deferred();
+		const invalidation = service.invalidateAll(['oauthEnabledGeneration'], async () => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+		});
+
+		await commitStarted.promise;
+
+		expect(() => subscriptions.open('late-static-client')).toThrow(McpSubscriptionClosingError);
+		await expect(openOAuthSubscription()).rejects.toBeInstanceOf(McpSubscriptionClosingError);
+		expect(staticStream.signal.aborted).toBe(false);
+		expect(oauthStream.signal.aborted).toBe(false);
+
+		releaseCommit.resolve();
+		await invalidation;
+
+		expect(staticStream.signal.aborted).toBe(true);
+		expect(oauthStream.signal.aborted).toBe(true);
+		expect(
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }),
+		).toMatchObject({ oauthEnabledGeneration: 1 });
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+	});
+
+	it('does not commit, revoke, or close either stream profile when disable generation state is unavailable', async () => {
+		const staticStream = subscriptions.open('static-client');
+		const oauthStream = await openOAuthSubscription();
+		const commit = jest.fn();
+		await dataSource.getRepository(McpOAuthServerStateEntity).delete({ key: MCP_OAUTH_SERVER_STATE_KEY });
+
+		await expect(service.invalidateAll(['oauthEnabledGeneration'], commit)).rejects.toThrow(
+			'MCP OAuth oauthEnabledGeneration state is unavailable',
+		);
+
+		expect(commit).not.toHaveBeenCalled();
+		expect(staticStream.signal.aborted).toBe(false);
+		expect(oauthStream.signal.aborted).toBe(false);
+		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(1);
 	});
 
 	it('remains fail-closed and closes OAuth streams when the external commit fails', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-global-invalidation.service.ts
@@ -31,10 +31,26 @@ export class McpOAuthGlobalInvalidationService {
 	) {}
 
 	async invalidate(generations: McpOAuthGlobalGeneration[], commit: () => Promise<void> | void): Promise<void> {
+		await this.runInvalidation(generations, commit, (advanceGeneration) =>
+			this.subscriptions.closeAllOAuth(advanceGeneration),
+		);
+	}
+
+	async invalidateAll(generations: McpOAuthGlobalGeneration[], commit: () => Promise<void> | void): Promise<void> {
+		await this.runInvalidation(generations, commit, (advanceGeneration) =>
+			this.subscriptions.closeAll(advanceGeneration),
+		);
+	}
+
+	private async runInvalidation(
+		generations: McpOAuthGlobalGeneration[],
+		commit: () => Promise<void> | void,
+		closeSubscriptions: (advanceGeneration: () => Promise<void>) => Promise<void>,
+	): Promise<void> {
 		let commitError: unknown;
 		let commitFailed = false;
 
-		await this.subscriptions.closeAllOAuth(async () => {
+		await closeSubscriptions(async () => {
 			await this.dataSource.transaction((manager) => this.advanceAndRevoke(manager, generations));
 
 			try {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -248,6 +248,52 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(configService.reload).toHaveBeenCalledTimes(1);
 	});
 
+	it('invalidates legacy OAuth state before re-enabling a disabled module', async () => {
+		config.enabled = false;
+		const commit = jest.fn().mockImplementation(() => {
+			config.enabled = true;
+		});
+
+		await service.update({ type: MCP_MODULE_NAME, enabled: true } as UpdateMcpConfigDto, commit);
+
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('combines re-enable reconciliation with other changed OAuth generations', async () => {
+		config.enabled = false;
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn();
+
+		await service.update(
+			{
+				type: MCP_MODULE_NAME,
+				enabled: true,
+				oauth_public_base_url: 'https://new-panel.example.com',
+				capabilities: [McpCapability.READ],
+			} as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(
+			['oauthEnabledGeneration', 'publicIdentityGeneration', 'modulePolicyGeneration'],
+			expect.any(Function),
+		);
+		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
+	});
+
+	it('reloads configuration and propagates a failed re-enable commit after invalidation', async () => {
+		config.enabled = false;
+		const commitError = new Error('configuration persistence failed');
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, enabled: true } as UpdateMcpConfigDto, () => Promise.reject(commitError)),
+		).rejects.toBe(commitError);
+
+		expect(configService.reload).toHaveBeenCalledTimes(1);
+	});
+
 	it('advances public identity and module policy together when both inputs change', async () => {
 		config.oauthPublicBaseUrl = 'https://panel.example.com';
 		const commit = jest.fn();

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -41,12 +41,13 @@ describe('McpOAuthModuleConfigMutationService', () => {
 	let config: McpConfigModel;
 	let configService: { getModuleConfig: jest.Mock; reload: jest.Mock };
 	let serverState: { increment: jest.Mock };
-	let globalInvalidation: { invalidate: jest.Mock };
+	let globalInvalidation: { invalidate: jest.Mock; invalidateAll: jest.Mock };
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
 
 	beforeEach(() => {
 		config = new McpConfigModel();
+		config.enabled = true;
 		config.capabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
 		configService = {
 			getModuleConfig: jest.fn().mockImplementation(() => config),
@@ -57,6 +58,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		};
 		globalInvalidation = {
 			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void> | void) => commit()),
+			invalidateAll: jest.fn(async (_generations: string[], commit: () => Promise<void> | void) => commit()),
 		};
 		const auditService = {
 			recordSubscriptionClosed: jest.fn(),
@@ -198,6 +200,52 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['publicIdentityGeneration'], expect.any(Function));
 		expect(serverState.increment).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('routes module disable through global invalidation and all-stream closure', async () => {
+		const commit = jest.fn().mockImplementation(() => {
+			config.enabled = false;
+		});
+
+		await service.update({ type: MCP_MODULE_NAME, enabled: false } as UpdateMcpConfigDto, commit);
+
+		expect(globalInvalidation.invalidateAll).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(globalInvalidation.invalidate).not.toHaveBeenCalled();
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('advances every changed global generation together when disabling the module', async () => {
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn();
+
+		await service.update(
+			{
+				type: MCP_MODULE_NAME,
+				enabled: false,
+				oauth_public_base_url: 'https://new-panel.example.com',
+				capabilities: [McpCapability.READ],
+			} as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(globalInvalidation.invalidateAll).toHaveBeenCalledWith(
+			['oauthEnabledGeneration', 'publicIdentityGeneration', 'modulePolicyGeneration'],
+			expect.any(Function),
+		);
+		expect(globalInvalidation.invalidate).not.toHaveBeenCalled();
+		expect(serverState.increment).not.toHaveBeenCalled();
+	});
+
+	it('reloads configuration and propagates a failed module-disable commit after invalidation', async () => {
+		const commitError = new Error('configuration persistence failed');
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, enabled: false } as UpdateMcpConfigDto, () =>
+				Promise.reject(commitError),
+			),
+		).rejects.toBe(commitError);
+
+		expect(configService.reload).toHaveBeenCalledTimes(1);
 	});
 
 	it('advances public identity and module policy together when both inputs change', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -26,11 +26,31 @@ export class McpOAuthModuleConfigMutationService {
 
 	async update(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
 		const current = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+		const nextEnabled = update.enabled ?? current.enabled;
+		const moduleDisabled = current.enabled && !nextEnabled;
 		const nextCapabilities = update.capabilities ?? current.capabilities;
 		const capabilitiesChanged = !this.sameCapabilities(current.capabilities, nextCapabilities);
 		const nextPublicBaseUrl =
 			update.oauth_public_base_url === undefined ? current.oauthPublicBaseUrl : update.oauth_public_base_url;
 		const publicIdentityChanged = current.oauthPublicBaseUrl !== nextPublicBaseUrl;
+
+		if (moduleDisabled) {
+			const generations: McpOAuthGlobalGeneration[] = [
+				'oauthEnabledGeneration',
+				...(publicIdentityChanged ? (['publicIdentityGeneration'] as const) : []),
+				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
+			];
+
+			await this.globalInvalidation.invalidateAll(generations, async () => {
+				try {
+					await commit();
+				} catch (error) {
+					this.configService.reload();
+					throw error;
+				}
+			});
+			return;
+		}
 
 		if (publicIdentityChanged) {
 			const generations: McpOAuthGlobalGeneration[] = [

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -28,6 +28,7 @@ export class McpOAuthModuleConfigMutationService {
 		const current = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
 		const nextEnabled = update.enabled ?? current.enabled;
 		const moduleDisabled = current.enabled && !nextEnabled;
+		const moduleEnabled = !current.enabled && nextEnabled;
 		const nextCapabilities = update.capabilities ?? current.capabilities;
 		const capabilitiesChanged = !this.sameCapabilities(current.capabilities, nextCapabilities);
 		const nextPublicBaseUrl =
@@ -42,6 +43,24 @@ export class McpOAuthModuleConfigMutationService {
 			];
 
 			await this.globalInvalidation.invalidateAll(generations, async () => {
+				try {
+					await commit();
+				} catch (error) {
+					this.configService.reload();
+					throw error;
+				}
+			});
+			return;
+		}
+
+		if (moduleEnabled) {
+			const generations: McpOAuthGlobalGeneration[] = [
+				'oauthEnabledGeneration',
+				...(publicIdentityChanged ? (['publicIdentityGeneration'] as const) : []),
+				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
+			];
+
+			await this.globalInvalidation.invalidate(generations, async () => {
 				try {
 					await commit();
 				} catch (error) {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -236,6 +236,7 @@ describe('McpSubscriptionRegistryService', () => {
 		const closePromise = service.closeAll();
 		const revalidate = jest.fn().mockResolvedValue(oauthRegistration());
 
+		expect(() => service.open('late-static-open')).toThrow(McpSubscriptionClosingError);
 		await expect(service.openOAuth('late-open', revalidate)).rejects.toThrow(McpSubscriptionClosingError);
 		expect(revalidate).not.toHaveBeenCalled();
 

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -77,6 +77,10 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 	constructor(private readonly auditService: McpAuditService) {}
 
 	open(clientId: string, requestId = 'unknown'): McpSubscriptionHandle {
+		if (this.closeAllOperations > 0) {
+			throw new McpSubscriptionClosingError();
+		}
+
 		return this.openRecord(clientId, requestId);
 	}
 
@@ -227,20 +231,22 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 		);
 	}
 
-	async closeAll(): Promise<void> {
+	async closeAll(advanceGeneration?: McpOAuthGenerationAdvance): Promise<void> {
 		this.closeAllOperations += 1;
 
 		try {
-			for (const id of [...this.subscriptions.keys()]) {
-				this.close(id, 'shutdown');
-			}
-
-			await this.withOAuthGate(() => {
+			if (!advanceGeneration) {
 				for (const id of [...this.subscriptions.keys()]) {
 					this.close(id, 'shutdown');
 				}
+			}
 
-				return Promise.resolve();
+			await this.withOAuthGate(async () => {
+				if (advanceGeneration) await advanceGeneration();
+
+				for (const id of [...this.subscriptions.keys()]) {
+					this.close(id, 'shutdown');
+				}
 			});
 		} finally {
 			this.closeAllOperations -= 1;

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -255,6 +255,8 @@ amend ADR 0002.
       registrations after disable begins, and close both profiles before reporting success.
 - [x] Combine simultaneous public-identity and module-policy changes into the same invalidation transaction, and keep
       the advanced generations, revoked artifacts, and closed streams when configuration persistence fails.
+- [x] Reconcile installations disabled before the awaited mutation existed by invalidating legacy OAuth state before
+      re-enable, preventing old bearer artifacts from becoming usable when the module becomes active again.
 - [x] Preserve OAuth-only stream closure for public identity changes while proving only MCP module disable closes
       static MCP streams.
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -247,6 +247,17 @@ amend ADR 0002.
 - [x] Audit successful global recovery without recording bearer, provider, cookie, or signing-key material, and
       propagate invalidation failures without reporting or auditing success.
 
+### Phase 5n — Awaited MCP module disable invalidation
+
+- [x] Route MCP module disable through the authoritative global OAuth invalidation transaction, advancing the
+      OAuth-enabled generation before revoking every OAuth grant and artifact.
+- [x] Hold one close-all gate across invalidation and configuration persistence, reject new static and OAuth stream
+      registrations after disable begins, and close both profiles before reporting success.
+- [x] Combine simultaneous public-identity and module-policy changes into the same invalidation transaction, and keep
+      the advanced generations, revoked artifacts, and closed streams when configuration persistence fails.
+- [x] Preserve OAuth-only stream closure for public identity changes while proving only MCP module disable closes
+      static MCP streams.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization


### PR DESCRIPTION
## Summary

- serialize MCP module disable through the global OAuth invalidation transaction
- advance the OAuth-enabled generation, revoke OAuth grants and artifacts, and close both static and OAuth subscriptions before configuration success
- reject late static and OAuth registrations while close-all is in progress
- preserve static streams for OAuth-only public identity invalidation
- document Phase 5n completion in the MCP OAuth implementation plan

## Why

MCP module disable previously persisted configuration and relied on a fire-and-forget listener to close streams afterward. That allowed the update to report success before active streams were closed and did not serialize late registrations with invalidation.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp` — 36 suites, 366 tests passed
- focused changed suites — 38 tests passed
- backend TypeScript check passed
- backend lint passed with two pre-existing Buddy plugin warnings
- full backend assertions: 312 suites, 3,977 passed, 2 skipped; after completion the Jest process hit an unrelated existing Home Assistant teardown error (`this.ws?.terminate is not a function`)
