### PR TITLE
feat(backend): complete MCP OAuth artifact issuance gate

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
@@ -6,7 +6,7 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common';
 
 import { ConfigService } from '../../config/services/config.service';
 import { McpOAuthClientEntity, McpOAuthInteractionEntity } from '../entities/mcp-oauth.entity';
-import { McpOAuthScope } from '../mcp.constants';
+import { MCP_MODULE_NAME, McpCapability, McpOAuthScope } from '../mcp.constants';
 import { McpOAuthInteractionAction } from '../models/mcp-oauth-interaction.model';
 
 import { McpInstallationService } from './mcp-installation.service';
@@ -15,6 +15,7 @@ import { McpOAuthArtifactService } from './mcp-oauth-artifact.service';
 import { McpOAuthClientService } from './mcp-oauth-client.service';
 import { McpOAuthInteractionService } from './mcp-oauth-interaction.service';
 import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 describe('McpOAuthInteractionService', () => {
 	const rawUid = 'opaque-interaction-identifier-123456';
@@ -108,7 +109,16 @@ describe('McpOAuthInteractionService', () => {
 		runAuthorized: jest.fn((_userId: string, operation: (generation: number) => Promise<unknown>) => operation(4)),
 	};
 	const installationService = { getInstallationId: jest.fn(() => Promise.resolve(uuid())) };
-	const configService = { getModuleConfig: jest.fn(() => ({ serviceName: 'Kitchen panel' })) };
+	let mcpEnabled = true;
+	let mcpCapabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
+	const configService = {
+		getModuleConfig: jest.fn((module: string) =>
+			module === MCP_MODULE_NAME
+				? { enabled: mcpEnabled, capabilities: [...mcpCapabilities] }
+				: { serviceName: 'Kitchen panel' },
+		),
+	};
+	const subscriptions = { runOAuthMutation: jest.fn((operation: () => Promise<unknown>) => operation()) };
 	const runtimeService = { getActive: jest.fn(() => ({ provider, urls })) };
 	const request = { headers: { cookie: '_interaction=signed' } } as IncomingMessage;
 	let service: McpOAuthInteractionService;
@@ -116,6 +126,8 @@ describe('McpOAuthInteractionService', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		stored.clear();
+		mcpEnabled = true;
+		mcpCapabilities = [McpCapability.READ, McpCapability.WRITE, McpCapability.TRIGGER];
 		delete (providerGrant as { expiresIn?: number }).expiresIn;
 		interactionDetails.mockResolvedValue({ ...details, prompt: { ...details.prompt } });
 		service = new McpOAuthInteractionService(
@@ -126,6 +138,7 @@ describe('McpOAuthInteractionService', () => {
 			approverAuthority as unknown as McpOAuthApproverAuthorityService,
 			installationService as unknown as McpInstallationService,
 			configService as unknown as ConfigService,
+			subscriptions as unknown as McpSubscriptionRegistryService,
 		);
 	});
 
@@ -238,6 +251,64 @@ describe('McpOAuthInteractionService', () => {
 		).rejects.toBeInstanceOf(BadRequestException);
 	});
 
+	it('rechecks the live module ceiling inside the authoritative approval gate', async () => {
+		await service.getInteraction(rawUid, userId, request);
+		let enterApproval = (): void => undefined;
+		const approvalEntered = new Promise<void>((resolve) => {
+			enterApproval = resolve;
+		});
+		let releaseApproval = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseApproval = resolve;
+		});
+		approverAuthority.runAuthorized.mockImplementationOnce(
+			async (_userId: string, operation: (generation: number) => Promise<unknown>) => {
+				enterApproval();
+				await release;
+
+				return operation(4);
+			},
+		);
+		const approval = service.approve(rawUid, userId, { scopes: [McpOAuthScope.WRITE], expiresInDays: 30 }, request);
+
+		await approvalEntered;
+		mcpCapabilities = [McpCapability.READ];
+		releaseApproval();
+
+		await expect(approval).rejects.toBeInstanceOf(BadRequestException);
+		expect(providerGrant.save).not.toHaveBeenCalled();
+		expect(interactions.update).not.toHaveBeenCalled();
+	});
+
+	it('rejects approval when the module is disabled before the gate opens', async () => {
+		await service.getInteraction(rawUid, userId, request);
+		let enterApproval = (): void => undefined;
+		const approvalEntered = new Promise<void>((resolve) => {
+			enterApproval = resolve;
+		});
+		let releaseApproval = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseApproval = resolve;
+		});
+		approverAuthority.runAuthorized.mockImplementationOnce(
+			async (_userId: string, operation: (generation: number) => Promise<unknown>) => {
+				enterApproval();
+				await release;
+
+				return operation(4);
+			},
+		);
+		const approval = service.approve(rawUid, userId, { scopes: [McpOAuthScope.READ], expiresInDays: 30 }, request);
+
+		await approvalEntered;
+		mcpEnabled = false;
+		releaseApproval();
+
+		await expect(approval).rejects.toBeInstanceOf(ForbiddenException);
+		expect(providerGrant.save).not.toHaveBeenCalled();
+		expect(interactions.update).not.toHaveBeenCalled();
+	});
+
 	it('claims consent before issuing artifacts so concurrent approval cannot escape replay protection', async () => {
 		await service.getInteraction(rawUid, userId, request);
 
@@ -265,5 +336,6 @@ describe('McpOAuthInteractionService', () => {
 			{ mergeWithLastSubmission: false },
 		);
 		expect(interactions.update).toHaveBeenCalled();
+		expect(subscriptions.runOAuthMutation).toHaveBeenCalled();
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
@@ -13,18 +13,27 @@ import { MDNS_DEFAULT_SERVICE_NAME, MDNS_MODULE_NAME } from '../../mdns/mdns.con
 import { MdnsConfigModel } from '../../mdns/models/config.model';
 import { ApproveMcpOAuthInteractionDto } from '../dto/mcp-oauth-interaction.dto';
 import { McpOAuthInteractionEntity } from '../entities/mcp-oauth.entity';
-import { MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS, MCP_OAUTH_GRANT_LIFETIME_MS, McpOAuthScope } from '../mcp.constants';
+import {
+	MCP_MODULE_NAME,
+	MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS,
+	MCP_OAUTH_GRANT_LIFETIME_MS,
+	McpCapability,
+	McpOAuthScope,
+} from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
 import {
 	McpOAuthInteractionAction,
 	McpOAuthInteractionCompletionModel,
 	McpOAuthInteractionModel,
 } from '../models/mcp-oauth-interaction.model';
+import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
 
 import { McpInstallationService } from './mcp-installation.service';
 import { McpOAuthApproverAuthorityService } from './mcp-oauth-approver-authority.service';
 import { McpOAuthArtifactService } from './mcp-oauth-artifact.service';
 import { McpOAuthClientService } from './mcp-oauth-client.service';
 import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1_000;
 
@@ -113,10 +122,20 @@ export class McpOAuthInteractionService {
 		private readonly approverAuthority: McpOAuthApproverAuthorityService,
 		private readonly installationService: McpInstallationService,
 		private readonly configService: ConfigService,
+		private readonly subscriptions: McpSubscriptionRegistryService,
 	) {}
 
 	async getInteraction(rawUid: string, userId: string, request: IncomingMessage): Promise<McpOAuthInteractionModel> {
 		this.assertUid(rawUid);
+
+		return this.subscriptions.runOAuthMutation(() => this.getInteractionWithinGate(rawUid, userId, request));
+	}
+
+	private async getInteractionWithinGate(
+		rawUid: string,
+		userId: string,
+		request: IncomingMessage,
+	): Promise<McpOAuthInteractionModel> {
 		const { provider } = this.runtimeService.getActive();
 		const details = await provider.interactionDetails(request, this.captureResponse());
 
@@ -166,6 +185,19 @@ export class McpOAuthInteractionService {
 		request: IncomingMessage,
 	): Promise<McpOAuthInteractionCompletionModel> {
 		this.assertUid(rawUid);
+
+		return this.approverAuthority.runAuthorized(userId, (approverAuthorityGeneration) =>
+			this.approveWithinGate(rawUid, userId, dto, request, approverAuthorityGeneration),
+		);
+	}
+
+	private async approveWithinGate(
+		rawUid: string,
+		userId: string,
+		dto: ApproveMcpOAuthInteractionDto,
+		request: IncomingMessage,
+		approverAuthorityGeneration: number,
+	): Promise<McpOAuthInteractionCompletionModel> {
 		const { provider, urls } = this.runtimeService.getActive();
 		const details = await provider.interactionDetails(request, this.captureResponse());
 
@@ -174,7 +206,18 @@ export class McpOAuthInteractionService {
 		}
 
 		const context = await this.resolveContext(details, rawUid, userId);
-		this.assertApprovedScopes(dto.scopes, context.requestedScopes, context.client.maximumScopes);
+		const moduleConfig = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+
+		if (!moduleConfig.enabled) {
+			throw new ForbiddenException('The MCP module is disabled');
+		}
+
+		this.assertApprovedScopes(
+			dto.scopes,
+			context.requestedScopes,
+			context.client.maximumScopes,
+			moduleConfig.capabilities,
+		);
 		await this.consumeInteraction(context.interaction, userId);
 
 		const providerGrant = new provider.Grant({ accountId: userId, clientId: context.client.clientIdentifier });
@@ -188,23 +231,30 @@ export class McpOAuthInteractionService {
 		}
 
 		(providerGrant as unknown as { expiresIn: number }).expiresIn = dto.expiresInDays * 24 * 60 * 60;
-		return this.approverAuthority.runAuthorized(userId, async (approverAuthorityGeneration) => {
-			const savedGrantId = await providerGrant.save();
-			await this.artifactService.createGrant({
-				providerGrantId: savedGrantId,
-				clientId: context.client.id,
-				approvedById: userId,
-				approvedScopes: dto.scopes,
-				expiresAt: new Date(Date.now() + dto.expiresInDays * DAYS_TO_MILLISECONDS),
-				approverAuthorityGeneration,
-			});
-
-			return this.finish(provider, request, { consent: { grantId: savedGrantId } }, true);
+		const savedGrantId = await providerGrant.save();
+		await this.artifactService.createGrant({
+			providerGrantId: savedGrantId,
+			clientId: context.client.id,
+			approvedById: userId,
+			approvedScopes: dto.scopes,
+			expiresAt: new Date(Date.now() + dto.expiresInDays * DAYS_TO_MILLISECONDS),
+			approverAuthorityGeneration,
 		});
+
+		return this.finish(provider, request, { consent: { grantId: savedGrantId } }, true);
 	}
 
 	async deny(rawUid: string, userId: string, request: IncomingMessage): Promise<McpOAuthInteractionCompletionModel> {
 		this.assertUid(rawUid);
+
+		return this.subscriptions.runOAuthMutation(() => this.denyWithinGate(rawUid, userId, request));
+	}
+
+	private async denyWithinGate(
+		rawUid: string,
+		userId: string,
+		request: IncomingMessage,
+	): Promise<McpOAuthInteractionCompletionModel> {
 		const { provider } = this.runtimeService.getActive();
 		const details = await provider.interactionDetails(request, this.captureResponse());
 
@@ -275,14 +325,26 @@ export class McpOAuthInteractionService {
 		return { client, redirectUri, requestedScopes, interaction };
 	}
 
-	private assertApprovedScopes(approved: McpOAuthScope[], requested: McpOAuthScope[], maximum: McpOAuthScope[]): void {
+	private assertApprovedScopes(
+		approved: McpOAuthScope[],
+		requested: McpOAuthScope[],
+		clientMaximum: McpOAuthScope[],
+		moduleCapabilities: McpCapability[],
+	): void {
+		const moduleMaximum = new Set(moduleCapabilities.map(toMcpOAuthScope));
+
 		if (
 			approved.length === 0 ||
 			!approved.some((scope) => scope !== McpOAuthScope.OFFLINE_ACCESS) ||
-			approved.some((scope) => !requested.includes(scope) || !maximum.includes(scope))
+			approved.some(
+				(scope) =>
+					!requested.includes(scope) ||
+					!clientMaximum.includes(scope) ||
+					(scope !== McpOAuthScope.OFFLINE_ACCESS && !moduleMaximum.has(scope)),
+			)
 		) {
 			throw new BadRequestException(
-				'Approved scopes must be a capability-bearing subset of the request and client maximum',
+				'Approved scopes must be a capability-bearing subset of the request and live authorization ceilings',
 			);
 		}
 	}

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -260,6 +260,17 @@ amend ADR 0002.
 - [x] Preserve OAuth-only stream closure for public identity changes while proving only MCP module disable closes
       static MCP streams.
 
+### Phase 5o — Complete browser artifact issuance gate
+
+- [x] Serialize login completion and denial with every OAuth invalidation through the same authoritative gate used by
+      provider token/code issuance and subscription registration.
+- [x] Move consent context resolution, replay claiming, grant persistence, and provider continuation inside the
+      awaited approver-authority gate so no browser artifact can commit from pre-invalidation state.
+- [x] Recheck the live MCP enabled state, registered-client maximum, and module capability ceiling inside that gate;
+      a queued approval must fail after disable or scope contraction without consuming consent or creating a grant.
+- [x] Prove browser issuance that wins the gate finishes before invalidation enumeration, while work queued behind an
+      invalidation observes current authorization inputs before any artifact commit.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -269,7 +280,7 @@ amend ADR 0002.
       recheck the OAuth-enabled and artifact/authorization-input generations plus live scopes while registering, and
       increment or close the applicable gate before an invalidating mutation enumerates streams. A racing open must
       either register first and be closed or observe the new generation and fail/revalidate.
-- [ ] Serialize every grant, authorization-code, access-token, and refresh-token creation/rotation with every
+- [x] Serialize every grant, authorization-code, access-token, and refresh-token creation/rotation with every
       invalidating mutation. Conditionally commit against the captured OAuth-enabled, server-secret, public-identity,
       client, grant, module-policy, and approver-authority generations and current states. Each invalidation must advance
       its generation before enumeration, so a racing handler either commits first and is revoked or its stale commit

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -73,7 +73,7 @@ upgrade consequences.
       request cannot open after invalidation reports success.
 - [ ] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
       the entire family without leaving a usable fork.
-- [ ] Every OAuth artifact commit is serialized with all applicable persistent enabled/secret/identity/client/grant/
+- [x] Every OAuth artifact commit is serialized with all applicable persistent enabled/secret/identity/client/grant/
       policy/approver generations so no invalidation can miss a racing authorization, exchange, or refresh result and
       later state restoration cannot make it usable.
 - [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before


### PR DESCRIPTION
## Summary

- serialize OAuth login completion, consent approval, and denial with every authoritative OAuth invalidation
- move consent context resolution, replay claiming, grant persistence, and provider continuation inside the approver-authority gate
- recheck MCP enablement, registered-client limits, and the live module capability ceiling before committing consent
- add queued disable and scope-contraction race coverage
- mark the all-artifact issuance gate complete in the MCP OAuth task specifications

## Why

Provider token and authorization-code requests already used the authoritative mutation gate, but browser interaction work performed part of consent resolution and replay claiming before entering it. An invalidation could therefore complete while approval still held stale client or module-policy input.

The entire browser mutation path now enters the shared gate before reading or changing provider state. A queued approval observes current policy and fails before consuming consent or saving a grant, while approval that enters first completes before invalidation enumeration.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp` — 36 suites, 371 tests passed
- focused interaction/approver/provider suites — 21 tests passed
- backend TypeScript check passed
- changed-file ESLint passed
- formatting and diff checks passed
