### PR TITLE
feat(backend): audit MCP OAuth invalidations

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.spec.ts
@@ -143,6 +143,22 @@ describe('McpAuditService', () => {
 		});
 	});
 
+	it('audits allowlisted automatic OAuth invalidation details without credential material', () => {
+		service.recordOAuthAuthorizationInvalidation({
+			reasons: ['module_disabled', 'public_identity_changed', 'module_disabled'],
+			authorizationProfile: 'all',
+			outcome: McpAuditOutcome.COMPLETED,
+		});
+
+		expect(log).toHaveBeenCalledWith('MCP audit event', {
+			event: 'oauth_authorization_invalidation',
+			request_id: 'administrative',
+			reasons: ['module_disabled', 'public_identity_changed'],
+			authorization_profile: 'all',
+			outcome: McpAuditOutcome.COMPLETED,
+		});
+	});
+
 	it('counts policy-resolution outages as failures without incrementing denials', () => {
 		service.recordRequestFailure({ requestId: '1', clientId: 'client-1' }, 'policy_resolution_error');
 

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -27,6 +27,13 @@ export type McpAuditRequestFailureReason = 'policy_resolution_error';
 
 export type McpOAuthManagementArtifact = 'access_token' | 'client' | 'grant' | 'refresh_family';
 export type McpOAuthManagementAction = 'disabled' | 'revoked' | 'scopes_updated';
+export type McpOAuthInvalidationReason =
+	| 'approver_authority_changed'
+	| 'module_disabled'
+	| 'module_enabled_reconciliation'
+	| 'module_policy_changed'
+	| 'public_identity_changed';
+export type McpOAuthAuthorizationProfile = 'all' | 'oauth';
 
 export type McpSubscriptionCloseReason =
 	| 'authorization_expired'
@@ -150,6 +157,24 @@ export class McpAuditService {
 			{
 				actor_id: actorId,
 				action: 'revoked_all',
+			},
+		);
+	}
+
+	recordOAuthAuthorizationInvalidation(input: {
+		reasons: McpOAuthInvalidationReason[];
+		authorizationProfile: McpOAuthAuthorizationProfile;
+		outcome: McpAuditOutcome.COMPLETED | McpAuditOutcome.PARTIAL;
+		target?: { type: 'approver'; id: string };
+	}): void {
+		this.log(
+			'oauth_authorization_invalidation',
+			{ requestId: 'administrative' },
+			{
+				reasons: [...new Set(input.reasons)],
+				authorization_profile: input.authorizationProfile,
+				outcome: input.outcome,
+				...(input.target ? { target_type: input.target.type, target_id: input.target.id } : {}),
 			},
 		);
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-approver-authority.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-approver-authority.service.spec.ts
@@ -20,6 +20,11 @@ import { McpSubscriptionRegistryService } from './mcp-subscription-registry.serv
 describe('McpOAuthApproverAuthorityService', () => {
 	let dataSource: DataSource;
 	let subscriptions: McpSubscriptionRegistryService;
+	let auditService: {
+		recordOAuthAuthorizationInvalidation: jest.Mock;
+		recordSubscriptionClosed: jest.Mock;
+		recordSubscriptionOpened: jest.Mock;
+	};
 	let service: McpOAuthApproverAuthorityService;
 	let approver: UserEntity;
 	let otherApprover: UserEntity;
@@ -41,12 +46,17 @@ describe('McpOAuthApproverAuthorityService', () => {
 			synchronize: true,
 		});
 		await dataSource.initialize();
-		const audit = { recordSubscriptionClosed: jest.fn(), recordSubscriptionOpened: jest.fn() };
-		subscriptions = new McpSubscriptionRegistryService(audit as unknown as McpAuditService);
+		auditService = {
+			recordOAuthAuthorizationInvalidation: jest.fn(),
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
 		service = new McpOAuthApproverAuthorityService(
 			dataSource.getRepository(McpOAuthApproverAuthorityEntity),
 			dataSource,
 			subscriptions,
+			auditService as unknown as McpAuditService,
 		);
 		const users = dataSource.getRepository(UserEntity);
 		approver = await users.save(users.create(user('approver', UserRole.ADMIN)));
@@ -118,6 +128,12 @@ describe('McpOAuthApproverAuthorityService', () => {
 		expect(matching.signal.aborted).toBe(true);
 		expect(other.signal.aborted).toBe(false);
 		expect(staticStream.signal.aborted).toBe(false);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['approver_authority_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+			target: { type: 'approver', id: approver.id },
+		});
 	});
 
 	it('closes approver streams and propagates an invalidation failure', async () => {
@@ -128,6 +144,7 @@ describe('McpOAuthApproverAuthorityService', () => {
 
 		expect(matching.signal.aborted).toBe(true);
 		expect(await service.getGeneration(approver.id)).toBe(0);
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
 	});
 
 	it('rolls back both demotion and invalidation when the atomic user commit fails', async () => {
@@ -147,6 +164,7 @@ describe('McpOAuthApproverAuthorityService', () => {
 			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
 		).toBeNull();
 		expect(matching.signal.aborted).toBe(true);
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
 	});
 
 	it('keeps deletion inside the gate so queued consent observes the removed user', async () => {
@@ -186,6 +204,7 @@ describe('McpOAuthApproverAuthorityService', () => {
 		expect(
 			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
 		).toBeNull();
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
 	});
 
 	it('rejects a consent queued behind approver invalidation and keeps restored roles on the new generation', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-approver-authority.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-approver-authority.service.ts
@@ -16,6 +16,7 @@ import {
 	McpOAuthProviderRevokedGrantEntity,
 } from '../entities/mcp-oauth.entity';
 
+import { McpAuditOutcome, McpAuditService } from './mcp-audit.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 const APPROVER_ROLES = [UserRole.OWNER, UserRole.ADMIN];
@@ -27,6 +28,7 @@ export class McpOAuthApproverAuthorityService implements UserLifecycleMutationHa
 		private readonly authorities: Repository<McpOAuthApproverAuthorityEntity>,
 		private readonly dataSource: DataSource,
 		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly auditService: McpAuditService,
 	) {}
 
 	async getGeneration(approverId: string): Promise<number> {
@@ -85,6 +87,13 @@ export class McpOAuthApproverAuthorityService implements UserLifecycleMutationHa
 
 		if (invalidationError) throw invalidationError;
 		if (!committed) throw new ServiceUnavailableException('MCP OAuth approver invalidation did not commit');
+
+		this.auditService.recordOAuthAuthorizationInvalidation({
+			reasons: ['approver_authority_changed'],
+			authorizationProfile: 'oauth',
+			outcome: McpAuditOutcome.COMPLETED,
+			target: { type: 'approver', id: approverId },
+		});
 
 		return result;
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -42,6 +42,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 	let configService: { getModuleConfig: jest.Mock; reload: jest.Mock };
 	let serverState: { increment: jest.Mock };
 	let globalInvalidation: { invalidate: jest.Mock; invalidateAll: jest.Mock };
+	let auditService: {
+		recordOAuthAuthorizationInvalidation: jest.Mock;
+		recordSubscriptionClosed: jest.Mock;
+		recordSubscriptionOpened: jest.Mock;
+	};
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
 
@@ -60,7 +65,8 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void> | void) => commit()),
 			invalidateAll: jest.fn(async (_generations: string[], commit: () => Promise<void> | void) => commit()),
 		};
-		const auditService = {
+		auditService = {
+			recordOAuthAuthorizationInvalidation: jest.fn(),
 			recordSubscriptionClosed: jest.fn(),
 			recordSubscriptionOpened: jest.fn(),
 		};
@@ -70,6 +76,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			serverState as unknown as Repository<McpOAuthServerStateEntity>,
 			subscriptions,
 			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
+			auditService as unknown as McpAuditService,
 		);
 	});
 
@@ -103,6 +110,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(readStream.signal.aborted).toBe(false);
 		expect(writeStream.signal.aborted).toBe(true);
 		expect(staticStream.signal.aborted).toBe(false);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 	});
 
 	it('holds queued OAuth registration until the new policy has committed', async () => {
@@ -147,6 +159,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		const newReadStream = await registration;
 
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 		expect(observedCapabilities).toEqual([[McpCapability.READ]]);
 		expect(oldWriteStream.signal.aborted).toBe(true);
 		expect(newReadStream.signal.aborted).toBe(false);
@@ -168,6 +185,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 
 		expect(serverState.increment).toHaveBeenCalledTimes(1);
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 		expect(readStream.signal.aborted).toBe(false);
 	});
 
@@ -184,6 +206,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 
 		expect(serverState.increment).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
 	});
 
 	it('routes public OAuth identity changes through global invalidation', async () => {
@@ -200,6 +223,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['publicIdentityGeneration'], expect.any(Function));
 		expect(serverState.increment).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['public_identity_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 	});
 
 	it('routes module disable through global invalidation and all-stream closure', async () => {
@@ -212,6 +240,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(globalInvalidation.invalidateAll).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
 		expect(globalInvalidation.invalidate).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_disabled'],
+			authorizationProfile: 'all',
+			outcome: 'completed',
+		});
 	});
 
 	it('advances every changed global generation together when disabling the module', async () => {
@@ -234,6 +267,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		);
 		expect(globalInvalidation.invalidate).not.toHaveBeenCalled();
 		expect(serverState.increment).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_disabled', 'public_identity_changed', 'module_policy_changed'],
+			authorizationProfile: 'all',
+			outcome: 'completed',
+		});
 	});
 
 	it('reloads configuration and propagates a failed module-disable commit after invalidation', async () => {
@@ -246,6 +284,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		).rejects.toBe(commitError);
 
 		expect(configService.reload).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_disabled'],
+			authorizationProfile: 'all',
+			outcome: 'partial',
+		});
 	});
 
 	it('invalidates legacy OAuth state before re-enabling a disabled module', async () => {
@@ -259,6 +302,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
 		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_enabled_reconciliation'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 	});
 
 	it('combines re-enable reconciliation with other changed OAuth generations', async () => {
@@ -281,6 +329,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			expect.any(Function),
 		);
 		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_enabled_reconciliation', 'public_identity_changed', 'module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 	});
 
 	it('reloads configuration and propagates a failed re-enable commit after invalidation', async () => {
@@ -292,6 +345,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		).rejects.toBe(commitError);
 
 		expect(configService.reload).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_enabled_reconciliation'],
+			authorizationProfile: 'oauth',
+			outcome: 'partial',
+		});
 	});
 
 	it('advances public identity and module policy together when both inputs change', async () => {
@@ -312,6 +370,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			expect.any(Function),
 		);
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['public_identity_changed', 'module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
 	});
 
 	it('reloads configuration and propagates a failed public identity commit after invalidation', async () => {
@@ -326,6 +389,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		).rejects.toBe(commitError);
 
 		expect(configService.reload).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['public_identity_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'partial',
+		});
 	});
 
 	it('does not commit or close streams when policy generation cannot advance', async () => {
@@ -344,6 +412,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 
 		expect(commit).not.toHaveBeenCalled();
 		expect(writeStream.signal.aborted).toBe(false);
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
 	});
 
 	it('closes contracted streams before propagating a configuration commit failure', async () => {
@@ -368,6 +437,11 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(configService.reload).toHaveBeenCalledTimes(1);
 		expect(readStream.signal.aborted).toBe(false);
 		expect(writeStream.signal.aborted).toBe(true);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: 'partial',
+		});
 	});
 
 	it('discards an unpersisted capability expansion before propagating a commit failure', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -11,6 +11,7 @@ import { MCP_MODULE_NAME, MCP_OAUTH_SERVER_STATE_KEY, McpCapability } from '../m
 import { McpConfigModel } from '../models/config.model';
 import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
 
+import { McpAuditOutcome, McpAuditService, McpOAuthInvalidationReason } from './mcp-audit.service';
 import { McpOAuthGlobalGeneration, McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
@@ -22,6 +23,7 @@ export class McpOAuthModuleConfigMutationService {
 		private readonly serverState: Repository<McpOAuthServerStateEntity>,
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
+		private readonly auditService: McpAuditService,
 	) {}
 
 	async update(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
@@ -42,14 +44,16 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.globalInvalidation.invalidateAll(generations, async () => {
-				try {
-					await commit();
-				} catch (error) {
-					this.configService.reload();
-					throw error;
-				}
-			});
+			await this.runGlobalInvalidation(
+				generations,
+				[
+					'module_disabled',
+					...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
+					...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
+				],
+				'all',
+				commit,
+			);
 			return;
 		}
 
@@ -60,14 +64,16 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.globalInvalidation.invalidate(generations, async () => {
-				try {
-					await commit();
-				} catch (error) {
-					this.configService.reload();
-					throw error;
-				}
-			});
+			await this.runGlobalInvalidation(
+				generations,
+				[
+					'module_enabled_reconciliation',
+					...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
+					...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
+				],
+				'oauth',
+				commit,
+			);
 			return;
 		}
 
@@ -77,14 +83,12 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.globalInvalidation.invalidate(generations, async () => {
-				try {
-					await commit();
-				} catch (error) {
-					this.configService.reload();
-					throw error;
-				}
-			});
+			await this.runGlobalInvalidation(
+				generations,
+				['public_identity_changed', ...(capabilitiesChanged ? (['module_policy_changed'] as const) : [])],
+				'oauth',
+				commit,
+			);
 			return;
 		}
 
@@ -112,7 +116,55 @@ export class McpOAuthModuleConfigMutationService {
 			}
 		});
 
+		this.auditService.recordOAuthAuthorizationInvalidation({
+			reasons: ['module_policy_changed'],
+			authorizationProfile: 'oauth',
+			outcome: commitFailed ? McpAuditOutcome.PARTIAL : McpAuditOutcome.COMPLETED,
+		});
+
 		if (commitFailed) throw commitError;
+	}
+
+	private async runGlobalInvalidation(
+		generations: McpOAuthGlobalGeneration[],
+		reasons: McpOAuthInvalidationReason[],
+		authorizationProfile: 'all' | 'oauth',
+		commit: ModuleConfigCommit,
+	): Promise<void> {
+		let commitFailed = false;
+		const persist = async (): Promise<void> => {
+			try {
+				await commit();
+			} catch (error) {
+				commitFailed = true;
+				this.configService.reload();
+				throw error;
+			}
+		};
+
+		try {
+			if (authorizationProfile === 'all') {
+				await this.globalInvalidation.invalidateAll(generations, persist);
+			} else {
+				await this.globalInvalidation.invalidate(generations, persist);
+			}
+		} catch (error) {
+			if (commitFailed) {
+				this.auditService.recordOAuthAuthorizationInvalidation({
+					reasons,
+					authorizationProfile,
+					outcome: McpAuditOutcome.PARTIAL,
+				});
+			}
+
+			throw error;
+		}
+
+		this.auditService.recordOAuthAuthorizationInvalidation({
+			reasons,
+			authorizationProfile,
+			outcome: McpAuditOutcome.COMPLETED,
+		});
 	}
 
 	private sameCapabilities(first: McpCapability[], second: McpCapability[]): boolean {

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -271,6 +271,17 @@ amend ADR 0002.
 - [x] Prove browser issuance that wins the gate finishes before invalidation enumeration, while work queued behind an
       invalidation observes current authorization inputs before any artifact commit.
 
+### Phase 5p — Automatic invalidation audit coverage
+
+- [x] Define one structured, secret-free audit event for automatic OAuth authorization invalidation with allowlisted
+      reasons, affected authorization profile, outcome, and an optional internal target identifier.
+- [x] Audit module disable, legacy re-enable reconciliation, public-identity change, module-policy change, and
+      approver-authority invalidation only after their awaited security mutation completes.
+- [x] Record configuration-persistence failure as a partial outcome when generation advancement, artifact revocation,
+      and stream closure still completed; do not report an event when invalidation itself failed.
+- [x] Add unit coverage for successful, partial, and failed automatic invalidation audit behavior; retain end-to-end
+      audit verification for the Phase 6 security-profile suite.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -297,7 +308,8 @@ amend ADR 0002.
       rotation, advance the applicable artifact generation before revoke-all, revoke every OAuth artifact, and close
       every OAuth subscription while preserving static MCP credentials and streams.
 - [x] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
-- [ ] Add audit events and unit/e2e coverage for targeted and global invalidation.
+- [ ] Add audit events and unit/e2e coverage for targeted and global invalidation. Automatic and owner/admin unit
+      coverage is complete; end-to-end audit verification remains in Phase 6.
 - [x] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
       invalidation failure, and never leave a demoted/deleted approver's grant usable.
 - [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted


### PR DESCRIPTION
## Summary

- add a structured, secret-free audit event for automatic OAuth authorization invalidations
- audit module disable, legacy re-enable reconciliation, public-identity changes, module-policy changes, and approver-authority invalidation
- distinguish completed invalidations from partial outcomes where security invalidation succeeded but configuration persistence failed
- suppress success events when generation advancement or the invalidation transaction itself fails
- add success, partial, and failure unit coverage and update the Phase 5 implementation plan

## Why

Owner/admin revocation actions already produced audit records, but automatic invalidations caused by configuration and user-lifecycle changes did not. This left important security state transitions invisible operationally.

The new event records only allowlisted reasons, affected authorization profile, outcome, and an optional internal target identifier. It does not include bearer/provider values, cookies, signing keys, or configuration secrets.

## Validation

- `pnpm exec jest --runInBand src/modules/mcp` — 36 suites, 372 tests passed
- focused audit/module/approver suites — 33 tests passed
- backend TypeScript check passed
- changed-file ESLint passed
- formatting and diff checks passed
