### PR TITLE
feat(backend): add MCP OAuth readiness gate foundation

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -71,8 +71,11 @@ import { McpOAuthManagementService } from './services/mcp-oauth-management.servi
 import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
 import { McpOAuthProxyPolicyService } from './services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from './services/mcp-oauth-public-url.service';
+import { McpOAuthReadinessRegistrationService } from './services/mcp-oauth-readiness-registration.service';
+import { McpOAuthReadinessService } from './services/mcp-oauth-readiness.service';
 import { McpOAuthRefreshTokenService } from './services/mcp-oauth-refresh-token.service';
 import { McpOAuthResourceServerService } from './services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from './services/mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from './services/mcp-oauth-runtime.service';
 import { McpPolicyService } from './services/mcp-policy.service';
 import { McpServerService } from './services/mcp-server.service';
@@ -140,8 +143,11 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthProxyPolicyService,
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
+		McpOAuthReadinessRegistrationService,
+		McpOAuthReadinessService,
 		McpOAuthRefreshTokenService,
 		McpOAuthResourceServerService,
+		McpOAuthRouteGateService,
 		McpOAuthRuntimeService,
 		McpPolicyService,
 		McpServerService,
@@ -173,8 +179,10 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthProxyPolicyService,
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
+		McpOAuthReadinessService,
 		McpOAuthRefreshTokenService,
 		McpOAuthResourceServerService,
+		McpOAuthRouteGateService,
 		McpOAuthRuntimeService,
 		McpPolicyService,
 		McpServerService,

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
@@ -1,0 +1,48 @@
+import { McpOAuthProviderFactory } from '../oauth/mcp-oauth-provider.factory';
+
+import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthApproverAuthorityService } from './mcp-oauth-approver-authority.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthManagementService } from './mcp-oauth-management.service';
+import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
+import { McpOAuthReadinessRegistrationService } from './mcp-oauth-readiness-registration.service';
+import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+describe('McpOAuthReadinessRegistrationService', () => {
+	it('registers only controls backed by the completed Phase 5 services', () => {
+		const readiness = new McpOAuthReadinessService();
+		const service = new McpOAuthReadinessRegistrationService(
+			readiness,
+			{} as McpSubscriptionRegistryService,
+			{} as McpOAuthApproverAuthorityService,
+			{} as McpOAuthProviderFactory,
+			{} as McpOAuthGlobalInvalidationService,
+			{} as McpOAuthModuleConfigMutationService,
+			{} as McpOAuthManagementService,
+			{} as McpAuditService,
+		);
+
+		service.onModuleInit();
+		readiness.onApplicationBootstrap();
+
+		expect(readiness.snapshot.ready).toBe(false);
+		expect(readiness.snapshot.registered).toEqual([
+			McpOAuthReadinessControl.AUTHORIZATION_DEADLINE_ABORT,
+			McpOAuthReadinessControl.TARGETED_SUBSCRIPTION_ABORT,
+			McpOAuthReadinessControl.LIVE_SCOPE_REDUCTION_ABORT,
+			McpOAuthReadinessControl.AWAITED_APPROVER_LIFECYCLE,
+			McpOAuthReadinessControl.SUBSCRIPTION_MUTATION_GATE,
+			McpOAuthReadinessControl.ARTIFACT_ISSUANCE_GATE,
+			McpOAuthReadinessControl.PUBLIC_IDENTITY_ROTATION,
+			McpOAuthReadinessControl.SERVER_SECRET_ROTATION,
+			McpOAuthReadinessControl.ADMIN_REVOCATION,
+			McpOAuthReadinessControl.AUDIT_HOOKS,
+		]);
+		expect(readiness.snapshot.missing).toEqual([
+			McpOAuthReadinessControl.OAUTH_SWITCH_OFF_INVALIDATION,
+			McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS,
+			McpOAuthReadinessControl.COMPLETE_ROUTE_SET,
+		]);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+
+import { McpOAuthProviderFactory } from '../oauth/mcp-oauth-provider.factory';
+
+import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthApproverAuthorityService } from './mcp-oauth-approver-authority.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthManagementService } from './mcp-oauth-management.service';
+import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
+import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
+
+@Injectable()
+export class McpOAuthReadinessRegistrationService implements OnModuleInit {
+	constructor(
+		private readonly readiness: McpOAuthReadinessService,
+		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly approverAuthority: McpOAuthApproverAuthorityService,
+		private readonly providerFactory: McpOAuthProviderFactory,
+		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
+		private readonly moduleConfigMutation: McpOAuthModuleConfigMutationService,
+		private readonly management: McpOAuthManagementService,
+		private readonly audit: McpAuditService,
+	) {}
+
+	onModuleInit(): void {
+		const registrations = new Map<McpOAuthReadinessControl, object>([
+			[McpOAuthReadinessControl.AUTHORIZATION_DEADLINE_ABORT, this.subscriptions],
+			[McpOAuthReadinessControl.TARGETED_SUBSCRIPTION_ABORT, this.subscriptions],
+			[McpOAuthReadinessControl.LIVE_SCOPE_REDUCTION_ABORT, this.moduleConfigMutation],
+			[McpOAuthReadinessControl.AWAITED_APPROVER_LIFECYCLE, this.approverAuthority],
+			[McpOAuthReadinessControl.SUBSCRIPTION_MUTATION_GATE, this.subscriptions],
+			[McpOAuthReadinessControl.ARTIFACT_ISSUANCE_GATE, this.providerFactory],
+			[McpOAuthReadinessControl.PUBLIC_IDENTITY_ROTATION, this.globalInvalidation],
+			[McpOAuthReadinessControl.SERVER_SECRET_ROTATION, this.globalInvalidation],
+			[McpOAuthReadinessControl.ADMIN_REVOCATION, this.management],
+			[McpOAuthReadinessControl.AUDIT_HOOKS, this.audit],
+		]);
+
+		this.readiness.register(...registrations.keys());
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness.service.spec.ts
@@ -1,0 +1,74 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessControl,
+	McpOAuthReadinessService,
+} from './mcp-oauth-readiness.service';
+
+describe('McpOAuthReadinessService', () => {
+	it('remains unverified and fail-closed before application bootstrap', () => {
+		const service = new McpOAuthReadinessService();
+
+		expect(service.snapshot).toEqual({
+			verified: false,
+			ready: false,
+			registered: [],
+			missing: MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+		});
+		expect(() => service.verify()).toThrow(ServiceUnavailableException);
+		expect(() => service.assertReady()).toThrow(ServiceUnavailableException);
+	});
+
+	it('reports every absent control after bootstrap instead of opening a partial profile', () => {
+		const service = new McpOAuthReadinessService();
+		service.register(
+			McpOAuthReadinessControl.AUTHORIZATION_DEADLINE_ABORT,
+			McpOAuthReadinessControl.TARGETED_SUBSCRIPTION_ABORT,
+		);
+
+		service.onApplicationBootstrap();
+
+		expect(service.verify()).toEqual({
+			verified: true,
+			ready: false,
+			registered: [
+				McpOAuthReadinessControl.AUTHORIZATION_DEADLINE_ABORT,
+				McpOAuthReadinessControl.TARGETED_SUBSCRIPTION_ABORT,
+			],
+			missing: MCP_OAUTH_REQUIRED_READINESS_CONTROLS.filter(
+				(control) =>
+					control !== McpOAuthReadinessControl.AUTHORIZATION_DEADLINE_ABORT &&
+					control !== McpOAuthReadinessControl.TARGETED_SUBSCRIPTION_ABORT,
+			),
+		});
+		expect(() => service.assertReady()).toThrow('MCP OAuth security controls are not ready');
+	});
+
+	it('reports ready only after every required control is registered', () => {
+		const service = new McpOAuthReadinessService();
+		service.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+
+		service.onApplicationBootstrap();
+
+		expect(service.verify()).toEqual({
+			verified: true,
+			ready: true,
+			registered: MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+			missing: [],
+		});
+		expect(() => service.assertReady()).not.toThrow();
+	});
+
+	it('seals registration at bootstrap while allowing idempotent pre-bootstrap registration', () => {
+		const service = new McpOAuthReadinessService();
+		service.register(McpOAuthReadinessControl.AUDIT_HOOKS);
+		service.register(McpOAuthReadinessControl.AUDIT_HOOKS);
+		service.onApplicationBootstrap();
+
+		expect(service.snapshot.registered).toEqual([McpOAuthReadinessControl.AUDIT_HOOKS]);
+		expect(() => service.register(McpOAuthReadinessControl.COMPLETE_ROUTE_SET)).toThrow(
+			'MCP OAuth readiness registration is already sealed',
+		);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, OnApplicationBootstrap, ServiceUnavailableException } from '@nestjs/common';
+
+export enum McpOAuthReadinessControl {
+	AUTHORIZATION_DEADLINE_ABORT = 'authorization_deadline_abort',
+	TARGETED_SUBSCRIPTION_ABORT = 'targeted_subscription_abort',
+	LIVE_SCOPE_REDUCTION_ABORT = 'live_scope_reduction_abort',
+	AWAITED_APPROVER_LIFECYCLE = 'awaited_approver_lifecycle',
+	SUBSCRIPTION_MUTATION_GATE = 'subscription_mutation_gate',
+	ARTIFACT_ISSUANCE_GATE = 'artifact_issuance_gate',
+	PUBLIC_IDENTITY_ROTATION = 'public_identity_rotation',
+	SERVER_SECRET_ROTATION = 'server_secret_rotation',
+	OAUTH_SWITCH_OFF_INVALIDATION = 'oauth_switch_off_invalidation',
+	ADMIN_REVOCATION = 'admin_revocation',
+	AUDIT_HOOKS = 'audit_hooks',
+	ENDPOINT_RATE_LIMITS = 'endpoint_rate_limits',
+	COMPLETE_ROUTE_SET = 'complete_route_set',
+}
+
+export const MCP_OAUTH_REQUIRED_READINESS_CONTROLS = Object.freeze(Object.values(McpOAuthReadinessControl));
+
+export interface McpOAuthReadinessSnapshot {
+	verified: boolean;
+	ready: boolean;
+	registered: readonly McpOAuthReadinessControl[];
+	missing: readonly McpOAuthReadinessControl[];
+}
+
+@Injectable()
+export class McpOAuthReadinessService implements OnApplicationBootstrap {
+	private readonly registeredControls = new Set<McpOAuthReadinessControl>();
+	private verified = false;
+
+	register(...controls: McpOAuthReadinessControl[]): void {
+		if (this.verified) {
+			throw new ServiceUnavailableException('MCP OAuth readiness registration is already sealed');
+		}
+
+		for (const control of controls) {
+			this.registeredControls.add(control);
+		}
+	}
+
+	onApplicationBootstrap(): void {
+		this.verified = true;
+	}
+
+	verify(): McpOAuthReadinessSnapshot {
+		if (!this.verified) {
+			throw new ServiceUnavailableException('MCP OAuth readiness has not completed application bootstrap');
+		}
+
+		return this.snapshot;
+	}
+
+	assertReady(): void {
+		const snapshot = this.verify();
+
+		if (!snapshot.ready) {
+			throw new ServiceUnavailableException('MCP OAuth security controls are not ready');
+		}
+	}
+
+	get snapshot(): McpOAuthReadinessSnapshot {
+		const registered = MCP_OAUTH_REQUIRED_READINESS_CONTROLS.filter((control) => this.registeredControls.has(control));
+		const missing = MCP_OAUTH_REQUIRED_READINESS_CONTROLS.filter((control) => !this.registeredControls.has(control));
+
+		return Object.freeze({
+			verified: this.verified,
+			ready: this.verified && missing.length === 0,
+			registered: Object.freeze(registered),
+			missing: Object.freeze(missing),
+		});
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.spec.ts
@@ -1,0 +1,38 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessControl,
+	McpOAuthReadinessService,
+} from './mcp-oauth-readiness.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+
+describe('McpOAuthRouteGateService', () => {
+	it('stays closed when application readiness is incomplete', () => {
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(McpOAuthReadinessControl.AUDIT_HOOKS);
+		readiness.onApplicationBootstrap();
+		const gate = new McpOAuthRouteGateService(readiness);
+
+		expect(gate.isOpen).toBe(false);
+		expect(() => gate.openInternal()).toThrow(ServiceUnavailableException);
+		expect(() => gate.assertOpen()).toThrow('The MCP OAuth route gate is closed');
+	});
+
+	it('opens only after complete readiness and closes synchronously', () => {
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		const gate = new McpOAuthRouteGateService(readiness);
+
+		gate.openInternal();
+
+		expect(gate.isOpen).toBe(true);
+		expect(() => gate.assertOpen()).not.toThrow();
+
+		gate.closeInternal();
+
+		expect(gate.isOpen).toBe(false);
+		expect(() => gate.assertOpen()).toThrow(ServiceUnavailableException);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+
+import { McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+
+@Injectable()
+export class McpOAuthRouteGateService {
+	private open = false;
+
+	constructor(private readonly readiness: McpOAuthReadinessService) {}
+
+	openInternal(): void {
+		this.readiness.assertReady();
+		this.open = true;
+	}
+
+	closeInternal(): void {
+		this.open = false;
+	}
+
+	assertOpen(): void {
+		if (!this.open) {
+			throw new ServiceUnavailableException('The MCP OAuth route gate is closed');
+		}
+
+		this.readiness.assertReady();
+	}
+
+	get isOpen(): boolean {
+		return this.open && this.readiness.snapshot.ready;
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
@@ -1,0 +1,40 @@
+import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../oauth/mcp-oauth-provider.factory';
+
+import { MCP_OAUTH_REQUIRED_READINESS_CONTROLS, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+describe('McpOAuthRuntimeService', () => {
+	it('does not expose an initialized provider until the shared route gate opens', async () => {
+		const runtime = { provider: {}, callback: jest.fn(), urls: {}, metadata: {} } as unknown as McpOAuthProviderRuntime;
+		const providerFactory = { create: jest.fn().mockResolvedValue(runtime) };
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		const routeGate = new McpOAuthRouteGateService(readiness);
+		const service = new McpOAuthRuntimeService(providerFactory as unknown as McpOAuthProviderFactory, routeGate);
+
+		await expect(service.activateInternal()).resolves.toBe(runtime);
+		expect(() => service.getActive()).toThrow('The MCP OAuth route gate is closed');
+
+		routeGate.openInternal();
+
+		expect(service.getActive()).toBe(runtime);
+	});
+
+	it('hides the provider immediately after deactivation', async () => {
+		const runtime = { provider: {}, callback: jest.fn(), urls: {}, metadata: {} } as unknown as McpOAuthProviderRuntime;
+		const providerFactory = { create: jest.fn().mockResolvedValue(runtime) };
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		const routeGate = new McpOAuthRouteGateService(readiness);
+		const service = new McpOAuthRuntimeService(providerFactory as unknown as McpOAuthProviderFactory, routeGate);
+		await service.activateInternal();
+		routeGate.openInternal();
+
+		service.deactivateInternal();
+
+		expect(() => service.getActive()).toThrow('The internal MCP OAuth route gate is closed');
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
@@ -6,12 +6,17 @@ import {
 	McpOAuthProviderRuntime,
 } from '../oauth/mcp-oauth-provider.factory';
 
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+
 @Injectable()
 export class McpOAuthRuntimeService {
 	private runtime: McpOAuthProviderRuntime | null = null;
 	private activation: Promise<McpOAuthProviderRuntime> | null = null;
 
-	constructor(private readonly providerFactory: McpOAuthProviderFactory) {}
+	constructor(
+		private readonly providerFactory: McpOAuthProviderFactory,
+		private readonly routeGate: McpOAuthRouteGateService,
+	) {}
 
 	async activateInternal(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
 		if (this.runtime) return this.runtime;
@@ -26,6 +31,8 @@ export class McpOAuthRuntimeService {
 	}
 
 	getActive(): McpOAuthProviderRuntime {
+		this.routeGate.assertOpen();
+
 		if (!this.runtime) {
 			throw new ServiceUnavailableException('The internal MCP OAuth route gate is closed');
 		}

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — revoke-all recovery control implemented
+**Status:** Phase 5 in progress — fail-closed OAuth readiness gate foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -281,6 +281,18 @@ amend ADR 0002.
       and stream closure still completed; do not report an event when invalidation itself failed.
 - [x] Add unit coverage for successful, partial, and failed automatic invalidation audit behavior; retain end-to-end
       audit verification for the Phase 6 security-profile suite.
+
+### Phase 5q — Fail-closed readiness and shared route gate foundation
+
+- [x] Define one immutable readiness inventory for authorization-deadline and targeted subscription aborts, live-scope
+      contraction, awaited approver lifecycle invalidation, subscription and artifact issuance gates, global rotation,
+      switch-off, administrative revocation, audit, endpoint throttling, and the complete bootstrap route set.
+- [x] Register only controls backed by completed services during module initialization, then seal the inventory at
+      application bootstrap so late or partial registration cannot make OAuth reachable.
+- [x] Add one shared runtime route gate that cannot open before successful complete readiness verification and make the
+      embedded provider inaccessible while that gate is closed.
+- [x] Prove incomplete readiness stays closed and explicitly reports the remaining switch-off, endpoint-rate-limit,
+      and complete-route-set controls without exposing any production OAuth route.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 revoke-all recovery control implemented
+Status: in progress — Phase 5 fail-closed readiness gate foundation implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- define an immutable MCP OAuth readiness inventory and seal registration at application bootstrap
- register only security controls backed by completed Phase 5 services
- add one shared fail-closed OAuth route gate and keep the provider runtime inaccessible while it is closed
- explicitly retain switch-off invalidation, endpoint rate limits, and the complete bootstrap route set as missing readiness controls
- update the implementation plan and add focused negative coverage

## Why

OAuth must not become partially reachable while its security controls are still being assembled. This phase establishes the readiness contract and shared route gate before adding production discovery, authorization, token, revocation, challenge, or OAuth-bearing MCP routes. The existing static MCP profile is unchanged.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- backend ESLint: no errors (two pre-existing unrelated floating-promise warnings)
- MCP unit suite: 40 suites, 381 tests passed
- full backend unit assertions: 316 suites, 3,992 tests passed; the repository-wide command later exited during an existing Home Assistant WebSocket test teardown (`this.ws?.terminate is not a function`)

No user-facing OAuth switch or production OAuth route is exposed by this PR.