### PR TITLE
feat(backend): add MCP OAuth endpoint rate limits

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -65,6 +65,7 @@ import { McpInstallationService } from './services/mcp-installation.service';
 import { McpOAuthApproverAuthorityService } from './services/mcp-oauth-approver-authority.service';
 import { McpOAuthArtifactService } from './services/mcp-oauth-artifact.service';
 import { McpOAuthClientService } from './services/mcp-oauth-client.service';
+import { McpOAuthEndpointRateLimitService } from './services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from './services/mcp-oauth-global-invalidation.service';
 import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.service';
 import { McpOAuthManagementService } from './services/mcp-oauth-management.service';
@@ -136,6 +137,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthArtifactService,
 		McpOAuthApproverAuthorityService,
 		McpOAuthClientService,
+		McpOAuthEndpointRateLimitService,
 		McpOAuthGlobalInvalidationService,
 		McpOAuthInteractionService,
 		McpOAuthManagementService,

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -68,9 +68,16 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 	it('rejects a blocked provider endpoint before entering the artifact mutation gate', async () => {
 		consumeRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 17 });
 		const request = createRequest();
+		request.method = 'POST';
+		request.headers['content-length'] = '1048576';
 		request.headers['x-forwarded-for'] = '198.51.100.40';
+		const destroy = jest.fn();
+		request.destroy = destroy;
 		const setHeader = jest.fn();
-		const end = jest.fn();
+		let responseCompletion: (() => void) | undefined;
+		const end = jest.fn((_body: string, completion: () => void) => {
+			responseCompletion = completion;
+		});
 		const response = {
 			closed: false,
 			destroyed: false,
@@ -87,9 +94,13 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		expect(response.statusCode).toBe(429);
 		expect(setHeader).toHaveBeenCalledWith('retry-after', '17');
 		expect(setHeader).toHaveBeenCalledWith('cache-control', 'no-store');
+		expect(setHeader).toHaveBeenCalledWith('connection', 'close');
 		expect(end).toHaveBeenCalledWith(
 			JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Too many OAuth requests' }),
+			expect.any(Function),
 		);
+		responseCompletion?.();
+		expect(destroy).toHaveBeenCalledTimes(1);
 	});
 
 	it.each([

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -3,6 +3,10 @@ import { DataSource } from 'typeorm';
 
 import { McpAuditService } from '../services/mcp-audit.service';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
+import {
+	McpOAuthEndpointRateLimitService,
+	McpOAuthRateLimitedEndpoint,
+} from '../services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
@@ -30,12 +34,14 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 	} satisfies McpOAuthPublicUrls;
 	let subscriptions: McpSubscriptionRegistryService;
 	let dispatch: ProviderDispatcher;
+	let consumeRateLimit: jest.MockedFunction<McpOAuthEndpointRateLimitService['consume']>;
 	const createRequest = (): IncomingMessage =>
 		({
 			method: 'GET',
 			url: '/api/v1/modules/mcp/oauth/authorize',
 			headers: {},
 			aborted: false,
+			socket: { remoteAddress: '192.0.2.25' },
 		}) as IncomingMessage;
 	const createResponse = (): ServerResponse =>
 		({
@@ -47,14 +53,69 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 	beforeEach(() => {
 		const audit = { recordSubscriptionClosed: jest.fn(), recordSubscriptionOpened: jest.fn() };
 		subscriptions = new McpSubscriptionRegistryService(audit as unknown as McpAuditService);
+		consumeRateLimit = jest.fn().mockResolvedValue({ allowed: true, retryAfterSeconds: 60 });
 		const factory = new McpOAuthProviderFactory(
 			{} as DataSource,
 			{} as McpOAuthClientService,
 			{} as McpOAuthPublicUrlService,
 			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
 		);
 		const target = factory as unknown as { dispatchProviderRequest: ProviderDispatcher };
 		dispatch = (...args) => target.dispatchProviderRequest(...args);
+	});
+
+	it('rejects a blocked provider endpoint before entering the artifact mutation gate', async () => {
+		consumeRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 17 });
+		const request = createRequest();
+		request.headers['x-forwarded-for'] = '198.51.100.40';
+		const setHeader = jest.fn();
+		const end = jest.fn();
+		const response = {
+			closed: false,
+			destroyed: false,
+			writableEnded: false,
+			setHeader,
+			end,
+		} as unknown as ServerResponse;
+		const providerCallback = jest.fn(() => Promise.resolve());
+
+		await dispatch(request, response, providerCallback, urls);
+
+		expect(consumeRateLimit).toHaveBeenCalledWith(McpOAuthRateLimitedEndpoint.AUTHORIZE, '192.0.2.25');
+		expect(providerCallback).not.toHaveBeenCalled();
+		expect(response.statusCode).toBe(429);
+		expect(setHeader).toHaveBeenCalledWith('retry-after', '17');
+		expect(setHeader).toHaveBeenCalledWith('cache-control', 'no-store');
+		expect(end).toHaveBeenCalledWith(
+			JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Too many OAuth requests' }),
+		);
+	});
+
+	it.each([
+		['/api/v1/modules/mcp/oauth/authorize', McpOAuthRateLimitedEndpoint.AUTHORIZE],
+		['/api/v1/modules/mcp/oauth/token', McpOAuthRateLimitedEndpoint.TOKEN],
+		['/api/v1/modules/mcp/oauth/token/revocation', McpOAuthRateLimitedEndpoint.REVOCATION],
+	] as const)('maps %s to its dedicated endpoint budget', async (pathname, endpoint) => {
+		const request = createRequest();
+		request.url = pathname;
+		const providerCallback = jest.fn(() => Promise.resolve());
+
+		await dispatch(request, createResponse(), providerCallback, urls);
+
+		expect(consumeRateLimit).toHaveBeenCalledWith(endpoint, '192.0.2.25');
+		expect(providerCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not apply an OAuth endpoint budget to an unrelated provider path', async () => {
+		const request = createRequest();
+		request.url = '/api/v1/modules/mcp/oauth/unregistered';
+		const providerCallback = jest.fn(() => Promise.resolve());
+
+		await dispatch(request, createResponse(), providerCallback, urls);
+
+		expect(consumeRateLimit).not.toHaveBeenCalled();
+		expect(providerCallback).toHaveBeenCalledTimes(1);
 	});
 
 	it('lets provider work that wins the gate commit before the following invalidation', async () => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -96,6 +96,10 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		['/api/v1/modules/mcp/oauth/authorize', McpOAuthRateLimitedEndpoint.AUTHORIZE],
 		['/api/v1/modules/mcp/oauth/token', McpOAuthRateLimitedEndpoint.TOKEN],
 		['/api/v1/modules/mcp/oauth/token/revocation', McpOAuthRateLimitedEndpoint.REVOCATION],
+		['/auth', McpOAuthRateLimitedEndpoint.AUTHORIZE],
+		['/auth/provider-resume', McpOAuthRateLimitedEndpoint.AUTHORIZE],
+		['/token', McpOAuthRateLimitedEndpoint.TOKEN],
+		['/token/revocation', McpOAuthRateLimitedEndpoint.REVOCATION],
 	] as const)('maps %s to its dedicated endpoint budget', async (pathname, endpoint) => {
 		const request = createRequest();
 		request.url = pathname;

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -240,7 +240,7 @@ export class McpOAuthProviderFactory {
 			const decision = await this.endpointRateLimit.consume(rateLimitedEndpoint, request.socket?.remoteAddress);
 
 			if (!decision.allowed) {
-				this.writeRateLimitError(response, decision.retryAfterSeconds);
+				this.writeRateLimitError(request, response, decision.retryAfterSeconds);
 				return;
 			}
 		}
@@ -319,12 +319,16 @@ export class McpOAuthProviderFactory {
 		return null;
 	}
 
-	private writeRateLimitError(response: ServerResponse, retryAfterSeconds: number): void {
+	private writeRateLimitError(request: IncomingMessage, response: ServerResponse, retryAfterSeconds: number): void {
 		response.statusCode = 429;
 		response.setHeader('content-type', 'application/json');
 		response.setHeader('cache-control', 'no-store');
 		response.setHeader('pragma', 'no-cache');
 		response.setHeader('retry-after', retryAfterSeconds.toString());
-		response.end(JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Too many OAuth requests' }));
+		response.setHeader('connection', 'close');
+		response.end(
+			JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Too many OAuth requests' }),
+			() => request.destroy(),
+		);
 	}
 }

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -302,9 +302,19 @@ export class McpOAuthProviderFactory {
 	}
 
 	private getRateLimitedEndpoint(pathname: string, urls: McpOAuthPublicUrls): McpOAuthRateLimitedEndpoint | null {
-		if (pathname === new URL(urls.authorizationEndpoint).pathname) return McpOAuthRateLimitedEndpoint.AUTHORIZE;
-		if (pathname === new URL(urls.tokenEndpoint).pathname) return McpOAuthRateLimitedEndpoint.TOKEN;
-		if (pathname === new URL(urls.revocationEndpoint).pathname) return McpOAuthRateLimitedEndpoint.REVOCATION;
+		if (
+			pathname === new URL(urls.authorizationEndpoint).pathname ||
+			pathname === '/auth' ||
+			pathname.startsWith('/auth/')
+		) {
+			return McpOAuthRateLimitedEndpoint.AUTHORIZE;
+		}
+		if (pathname === new URL(urls.tokenEndpoint).pathname || pathname === '/token') {
+			return McpOAuthRateLimitedEndpoint.TOKEN;
+		}
+		if (pathname === new URL(urls.revocationEndpoint).pathname || pathname === '/token/revocation') {
+			return McpOAuthRateLimitedEndpoint.REVOCATION;
+		}
 
 		return null;
 	}

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -13,6 +13,10 @@ import {
 	McpOAuthScope,
 } from '../mcp.constants';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
+import {
+	McpOAuthEndpointRateLimitService,
+	McpOAuthRateLimitedEndpoint,
+} from '../services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
@@ -45,6 +49,7 @@ export class McpOAuthProviderFactory {
 		private readonly clientsService: McpOAuthClientService,
 		private readonly publicUrlService: McpOAuthPublicUrlService,
 		private readonly subscriptions: McpSubscriptionRegistryService,
+		private readonly endpointRateLimit: McpOAuthEndpointRateLimitService,
 	) {}
 
 	async create(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
@@ -229,6 +234,16 @@ export class McpOAuthProviderFactory {
 	): Promise<void> {
 		const pathname = new URL(request.url ?? '/', urls.issuer).pathname;
 		const tokenPathname = new URL(urls.tokenEndpoint).pathname;
+		const rateLimitedEndpoint = this.getRateLimitedEndpoint(pathname, urls);
+
+		if (rateLimitedEndpoint) {
+			const decision = await this.endpointRateLimit.consume(rateLimitedEndpoint, request.socket?.remoteAddress);
+
+			if (!decision.allowed) {
+				this.writeRateLimitError(response, decision.retryAfterSeconds);
+				return;
+			}
+		}
 
 		if (request.method === 'POST' && (pathname === tokenPathname || pathname === '/token')) {
 			const contentType = request.headers['content-type']?.split(';', 1)[0]?.trim().toLowerCase();
@@ -284,5 +299,22 @@ export class McpOAuthProviderFactory {
 		response.setHeader('cache-control', 'no-store');
 		response.setHeader('pragma', 'no-cache');
 		response.end(JSON.stringify({ error, error_description: description }));
+	}
+
+	private getRateLimitedEndpoint(pathname: string, urls: McpOAuthPublicUrls): McpOAuthRateLimitedEndpoint | null {
+		if (pathname === new URL(urls.authorizationEndpoint).pathname) return McpOAuthRateLimitedEndpoint.AUTHORIZE;
+		if (pathname === new URL(urls.tokenEndpoint).pathname) return McpOAuthRateLimitedEndpoint.TOKEN;
+		if (pathname === new URL(urls.revocationEndpoint).pathname) return McpOAuthRateLimitedEndpoint.REVOCATION;
+
+		return null;
+	}
+
+	private writeRateLimitError(response: ServerResponse, retryAfterSeconds: number): void {
+		response.statusCode = 429;
+		response.setHeader('content-type', 'application/json');
+		response.setHeader('cache-control', 'no-store');
+		response.setHeader('pragma', 'no-cache');
+		response.setHeader('retry-after', retryAfterSeconds.toString());
+		response.end(JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Too many OAuth requests' }));
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
@@ -37,7 +37,7 @@ describe('McpOAuthEndpointRateLimitService', () => {
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
 			limit,
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
-			`mcp-oauth-${endpoint}`,
+			`mcp-oauth:${endpoint}:192.0.2.15`,
 		);
 	});
 
@@ -49,8 +49,16 @@ describe('McpOAuthEndpointRateLimitService', () => {
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
 			MCP_OAUTH_TOKEN_RATE_LIMIT,
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
-			'mcp-oauth-token',
+			'mcp-oauth:token:unknown',
 		);
+	});
+
+	it('isolates throttler timer groups between immediate peers', async () => {
+		await service.consume(McpOAuthRateLimitedEndpoint.TOKEN, '192.0.2.20');
+		await service.consume(McpOAuthRateLimitedEndpoint.TOKEN, '192.0.2.21');
+
+		expect(increment.mock.calls[0]?.[4]).toBe('mcp-oauth:token:192.0.2.20');
+		expect(increment.mock.calls[1]?.[4]).toBe('mcp-oauth:token:192.0.2.21');
 	});
 
 	it('returns a bounded retry-after value for blocked requests', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
@@ -1,0 +1,69 @@
+import { ThrottlerStorage } from '@nestjs/throttler';
+
+import {
+	MCP_OAUTH_AUTHORIZE_RATE_LIMIT,
+	MCP_OAUTH_RATE_LIMIT_TTL_MS,
+	MCP_OAUTH_REVOCATION_RATE_LIMIT,
+	MCP_OAUTH_TOKEN_RATE_LIMIT,
+} from '../mcp.constants';
+
+import { McpOAuthEndpointRateLimitService, McpOAuthRateLimitedEndpoint } from './mcp-oauth-endpoint-rate-limit.service';
+
+describe('McpOAuthEndpointRateLimitService', () => {
+	let increment: jest.MockedFunction<ThrottlerStorage['increment']>;
+	let service: McpOAuthEndpointRateLimitService;
+
+	beforeEach(() => {
+		increment = jest.fn().mockResolvedValue({
+			totalHits: 1,
+			timeToExpire: MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			isBlocked: false,
+			timeToBlockExpire: 0,
+		});
+		service = new McpOAuthEndpointRateLimitService({ increment } as ThrottlerStorage);
+	});
+
+	it.each([
+		[McpOAuthRateLimitedEndpoint.AUTHORIZE, MCP_OAUTH_AUTHORIZE_RATE_LIMIT],
+		[McpOAuthRateLimitedEndpoint.TOKEN, MCP_OAUTH_TOKEN_RATE_LIMIT],
+		[McpOAuthRateLimitedEndpoint.REVOCATION, MCP_OAUTH_REVOCATION_RATE_LIMIT],
+	])('uses the dedicated %s endpoint budget', async (endpoint, limit) => {
+		await expect(service.consume(endpoint, '192.0.2.15')).resolves.toEqual({
+			allowed: true,
+			retryAfterSeconds: 60,
+		});
+		expect(increment).toHaveBeenCalledWith(
+			`mcp-oauth:${endpoint}:192.0.2.15`,
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			limit,
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			`mcp-oauth-${endpoint}`,
+		);
+	});
+
+	it('fails into a shared unknown-address budget when the immediate peer is unavailable', async () => {
+		await service.consume(McpOAuthRateLimitedEndpoint.TOKEN);
+
+		expect(increment).toHaveBeenCalledWith(
+			'mcp-oauth:token:unknown',
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			MCP_OAUTH_TOKEN_RATE_LIMIT,
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			'mcp-oauth-token',
+		);
+	});
+
+	it('returns a bounded retry-after value for blocked requests', async () => {
+		increment.mockResolvedValue({
+			totalHits: MCP_OAUTH_TOKEN_RATE_LIMIT + 1,
+			timeToExpire: 12_001,
+			isBlocked: true,
+			timeToBlockExpire: 5_001,
+		});
+
+		await expect(service.consume(McpOAuthRateLimitedEndpoint.TOKEN, '192.0.2.15')).resolves.toEqual({
+			allowed: false,
+			retryAfterSeconds: 6,
+		});
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.spec.ts
@@ -1,4 +1,4 @@
-import { ThrottlerStorage } from '@nestjs/throttler';
+import { ThrottlerStorage, ThrottlerStorageService } from '@nestjs/throttler';
 
 import {
 	MCP_OAUTH_AUTHORIZE_RATE_LIMIT,
@@ -16,7 +16,7 @@ describe('McpOAuthEndpointRateLimitService', () => {
 	beforeEach(() => {
 		increment = jest.fn().mockResolvedValue({
 			totalHits: 1,
-			timeToExpire: MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			timeToExpire: 60,
 			isBlocked: false,
 			timeToBlockExpire: 0,
 		});
@@ -56,14 +56,30 @@ describe('McpOAuthEndpointRateLimitService', () => {
 	it('returns a bounded retry-after value for blocked requests', async () => {
 		increment.mockResolvedValue({
 			totalHits: MCP_OAUTH_TOKEN_RATE_LIMIT + 1,
-			timeToExpire: 12_001,
+			timeToExpire: 13,
 			isBlocked: true,
-			timeToBlockExpire: 5_001,
+			timeToBlockExpire: 6,
 		});
 
 		await expect(service.consume(McpOAuthRateLimitedEndpoint.TOKEN, '192.0.2.15')).resolves.toEqual({
 			allowed: false,
 			retryAfterSeconds: 6,
 		});
+	});
+
+	it('preserves the expiry seconds returned by the installed throttler storage', async () => {
+		const storage = new ThrottlerStorageService();
+		const realService = new McpOAuthEndpointRateLimitService(storage);
+		let decision = { allowed: true, retryAfterSeconds: 0 };
+
+		try {
+			for (let attempt = 0; attempt <= MCP_OAUTH_AUTHORIZE_RATE_LIMIT; attempt += 1) {
+				decision = await realService.consume(McpOAuthRateLimitedEndpoint.AUTHORIZE, '192.0.2.16');
+			}
+		} finally {
+			storage.onApplicationShutdown();
+		}
+
+		expect(decision).toEqual({ allowed: false, retryAfterSeconds: 60 });
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
@@ -42,11 +42,11 @@ export class McpOAuthEndpointRateLimitService {
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
 			`mcp-oauth-${endpoint}`,
 		);
-		const retryAfterMs = result.timeToBlockExpire || result.timeToExpire;
+		const retryAfterSeconds = result.timeToBlockExpire || result.timeToExpire;
 
 		return {
 			allowed: !result.isBlocked,
-			retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1_000)),
+			retryAfterSeconds: Math.max(1, Math.ceil(retryAfterSeconds)),
 		};
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectThrottlerStorage, ThrottlerStorage } from '@nestjs/throttler';
+
+import {
+	MCP_OAUTH_AUTHORIZE_RATE_LIMIT,
+	MCP_OAUTH_RATE_LIMIT_TTL_MS,
+	MCP_OAUTH_REVOCATION_RATE_LIMIT,
+	MCP_OAUTH_TOKEN_RATE_LIMIT,
+} from '../mcp.constants';
+
+export enum McpOAuthRateLimitedEndpoint {
+	AUTHORIZE = 'authorize',
+	TOKEN = 'token',
+	REVOCATION = 'revocation',
+}
+
+export interface McpOAuthRateLimitDecision {
+	allowed: boolean;
+	retryAfterSeconds: number;
+}
+
+const ENDPOINT_LIMITS: Readonly<Record<McpOAuthRateLimitedEndpoint, number>> = Object.freeze({
+	[McpOAuthRateLimitedEndpoint.AUTHORIZE]: MCP_OAUTH_AUTHORIZE_RATE_LIMIT,
+	[McpOAuthRateLimitedEndpoint.TOKEN]: MCP_OAUTH_TOKEN_RATE_LIMIT,
+	[McpOAuthRateLimitedEndpoint.REVOCATION]: MCP_OAUTH_REVOCATION_RATE_LIMIT,
+});
+
+@Injectable()
+export class McpOAuthEndpointRateLimitService {
+	constructor(
+		@InjectThrottlerStorage()
+		private readonly storage: ThrottlerStorage,
+	) {}
+
+	async consume(endpoint: McpOAuthRateLimitedEndpoint, immediateAddress?: string): Promise<McpOAuthRateLimitDecision> {
+		const address = immediateAddress?.trim() || 'unknown';
+		const limit = ENDPOINT_LIMITS[endpoint];
+		const result = await this.storage.increment(
+			`mcp-oauth:${endpoint}:${address}`,
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			limit,
+			MCP_OAUTH_RATE_LIMIT_TTL_MS,
+			`mcp-oauth-${endpoint}`,
+		);
+		const retryAfterMs = result.timeToBlockExpire || result.timeToExpire;
+
+		return {
+			allowed: !result.isBlocked,
+			retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1_000)),
+		};
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service.ts
@@ -35,12 +35,13 @@ export class McpOAuthEndpointRateLimitService {
 	async consume(endpoint: McpOAuthRateLimitedEndpoint, immediateAddress?: string): Promise<McpOAuthRateLimitDecision> {
 		const address = immediateAddress?.trim() || 'unknown';
 		const limit = ENDPOINT_LIMITS[endpoint];
+		const storageKey = `mcp-oauth:${endpoint}:${address}`;
 		const result = await this.storage.increment(
-			`mcp-oauth:${endpoint}:${address}`,
+			storageKey,
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
 			limit,
 			MCP_OAUTH_RATE_LIMIT_TTL_MS,
-			`mcp-oauth-${endpoint}`,
+			storageKey,
 		);
 		const retryAfterSeconds = result.timeToBlockExpire || result.timeToExpire;
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
@@ -2,6 +2,7 @@ import { McpOAuthProviderFactory } from '../oauth/mcp-oauth-provider.factory';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthApproverAuthorityService } from './mcp-oauth-approver-authority.service';
+import { McpOAuthEndpointRateLimitService } from './mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
@@ -16,6 +17,7 @@ describe('McpOAuthReadinessRegistrationService', () => {
 			readiness,
 			{} as McpSubscriptionRegistryService,
 			{} as McpOAuthApproverAuthorityService,
+			{} as McpOAuthEndpointRateLimitService,
 			{} as McpOAuthProviderFactory,
 			{} as McpOAuthGlobalInvalidationService,
 			{} as McpOAuthModuleConfigMutationService,
@@ -38,10 +40,10 @@ describe('McpOAuthReadinessRegistrationService', () => {
 			McpOAuthReadinessControl.SERVER_SECRET_ROTATION,
 			McpOAuthReadinessControl.ADMIN_REVOCATION,
 			McpOAuthReadinessControl.AUDIT_HOOKS,
+			McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS,
 		]);
 		expect(readiness.snapshot.missing).toEqual([
 			McpOAuthReadinessControl.OAUTH_SWITCH_OFF_INVALIDATION,
-			McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS,
 			McpOAuthReadinessControl.COMPLETE_ROUTE_SET,
 		]);
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
@@ -4,6 +4,7 @@ import { McpOAuthProviderFactory } from '../oauth/mcp-oauth-provider.factory';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthApproverAuthorityService } from './mcp-oauth-approver-authority.service';
+import { McpOAuthEndpointRateLimitService } from './mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
@@ -16,6 +17,7 @@ export class McpOAuthReadinessRegistrationService implements OnModuleInit {
 		private readonly readiness: McpOAuthReadinessService,
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly approverAuthority: McpOAuthApproverAuthorityService,
+		private readonly endpointRateLimit: McpOAuthEndpointRateLimitService,
 		private readonly providerFactory: McpOAuthProviderFactory,
 		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
 		private readonly moduleConfigMutation: McpOAuthModuleConfigMutationService,
@@ -35,6 +37,7 @@ export class McpOAuthReadinessRegistrationService implements OnModuleInit {
 			[McpOAuthReadinessControl.SERVER_SECRET_ROTATION, this.globalInvalidation],
 			[McpOAuthReadinessControl.ADMIN_REVOCATION, this.management],
 			[McpOAuthReadinessControl.AUDIT_HOOKS, this.audit],
+			[McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS, this.endpointRateLimit],
 		]);
 
 		this.readiness.register(...registrations.keys());

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -20,6 +20,7 @@ import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oaut
 import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
+import { McpOAuthEndpointRateLimitService } from '../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
@@ -224,7 +225,9 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			runOAuthMutation: (operation: () => Promise<unknown>) => operation(),
 		} as unknown as McpSubscriptionRegistryService;
 
-		factory = new McpOAuthProviderFactory(dataSource, clientsService, publicUrlService, subscriptions);
+		factory = new McpOAuthProviderFactory(dataSource, clientsService, publicUrlService, subscriptions, {
+			consume: () => Promise.resolve({ allowed: true, retryAfterSeconds: 60 }),
+		} as unknown as McpOAuthEndpointRateLimitService);
 		const runtime = await factory.create({
 			allowTestInMemory: true,
 			allowInsecureTestCookies: true,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — fail-closed OAuth readiness gate foundation implemented
+**Status:** Phase 5 in progress — embedded OAuth endpoint rate limits implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -293,6 +293,17 @@ amend ADR 0002.
       embedded provider inaccessible while that gate is closed.
 - [x] Prove incomplete readiness stays closed and explicitly reports the remaining switch-off, endpoint-rate-limit,
       and complete-route-set controls without exposing any production OAuth route.
+
+### Phase 5r — Embedded OAuth endpoint rate limits
+
+- [x] Add separate authorize, token, and revocation budgets at the raw embedded-provider boundary, before request-body
+      parsing and the serialized artifact mutation gate.
+- [x] Key raw provider budgets only from the immediate socket peer and ignore forwarded headers until explicit trusted
+      proxy handling exists; use one conservative shared bucket when the immediate address is unavailable.
+- [x] Return a bounded `429` OAuth error with `Retry-After`, `no-store`, and `no-cache`, without entering provider
+      processing or recording artifact state.
+- [x] Register endpoint throttling in the sealed readiness inventory while keeping OAuth closed because switch-off
+      invalidation and the complete bootstrap route set are still absent.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 fail-closed readiness gate foundation implemented
+Status: in progress — Phase 5 embedded OAuth endpoint rate limits implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add independent authorize, token, and revocation budgets at the embedded OAuth provider boundary
- enforce throttling before request-body parsing and serialized artifact mutation
- key limits from the immediate socket peer, ignoring forwarded headers until trusted-proxy support exists
- return bounded OAuth `429` responses with `Retry-After`, `no-store`, and `no-cache`
- register endpoint throttling in the sealed OAuth readiness inventory
- update the implementation plan and executable provider-spike wiring

## Why

The embedded provider callback bypasses Nest controller guards, so its production routes need a dedicated limiter at the raw request boundary. Without this control, the readiness gate must remain closed. This PR completes that readiness item without mounting OAuth routes or adding the user-facing enable switch.

## Impact

OAuth remains unreachable in production. Readiness still fails closed until OAuth switch-off invalidation and the complete bootstrap route set are implemented. Static MCP behavior is unchanged.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- changed-file ESLint
- focused rate-limit/provider/readiness tests: 3 suites, 15 tests passed
- MCP unit suite: 41 suites, 391 tests passed
- executable OAuth provider spike: 2 suites, 26 tests passed