### PR TITLE
feat(backend): add MCP OAuth switch-off invalidation

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -78,6 +78,7 @@ import { McpOAuthRefreshTokenService } from './services/mcp-oauth-refresh-token.
 import { McpOAuthResourceServerService } from './services/mcp-oauth-resource-server.service';
 import { McpOAuthRouteGateService } from './services/mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from './services/mcp-oauth-runtime.service';
+import { McpOAuthSwitchOffService } from './services/mcp-oauth-switch-off.service';
 import { McpPolicyService } from './services/mcp-policy.service';
 import { McpServerService } from './services/mcp-server.service';
 import { McpSubscriptionRegistryService } from './services/mcp-subscription-registry.service';
@@ -151,6 +152,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthResourceServerService,
 		McpOAuthRouteGateService,
 		McpOAuthRuntimeService,
+		McpOAuthSwitchOffService,
 		McpPolicyService,
 		McpServerService,
 		McpAuditService,
@@ -186,6 +188,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthResourceServerService,
 		McpOAuthRouteGateService,
 		McpOAuthRuntimeService,
+		McpOAuthSwitchOffService,
 		McpPolicyService,
 		McpServerService,
 	],

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -32,6 +32,7 @@ export type McpOAuthInvalidationReason =
 	| 'module_disabled'
 	| 'module_enabled_reconciliation'
 	| 'module_policy_changed'
+	| 'oauth_disabled'
 	| 'public_identity_changed';
 export type McpOAuthAuthorizationProfile = 'all' | 'oauth';
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.spec.ts
@@ -8,6 +8,7 @@ import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
 import { McpOAuthReadinessRegistrationService } from './mcp-oauth-readiness-registration.service';
 import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 describe('McpOAuthReadinessRegistrationService', () => {
@@ -23,6 +24,7 @@ describe('McpOAuthReadinessRegistrationService', () => {
 			{} as McpOAuthModuleConfigMutationService,
 			{} as McpOAuthManagementService,
 			{} as McpAuditService,
+			{} as McpOAuthSwitchOffService,
 		);
 
 		service.onModuleInit();
@@ -38,13 +40,11 @@ describe('McpOAuthReadinessRegistrationService', () => {
 			McpOAuthReadinessControl.ARTIFACT_ISSUANCE_GATE,
 			McpOAuthReadinessControl.PUBLIC_IDENTITY_ROTATION,
 			McpOAuthReadinessControl.SERVER_SECRET_ROTATION,
+			McpOAuthReadinessControl.OAUTH_SWITCH_OFF_INVALIDATION,
 			McpOAuthReadinessControl.ADMIN_REVOCATION,
 			McpOAuthReadinessControl.AUDIT_HOOKS,
 			McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS,
 		]);
-		expect(readiness.snapshot.missing).toEqual([
-			McpOAuthReadinessControl.OAUTH_SWITCH_OFF_INVALIDATION,
-			McpOAuthReadinessControl.COMPLETE_ROUTE_SET,
-		]);
+		expect(readiness.snapshot.missing).toEqual([McpOAuthReadinessControl.COMPLETE_ROUTE_SET]);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-readiness-registration.service.ts
@@ -9,6 +9,7 @@ import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidati
 import { McpOAuthManagementService } from './mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
 import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class McpOAuthReadinessRegistrationService implements OnModuleInit {
 		private readonly moduleConfigMutation: McpOAuthModuleConfigMutationService,
 		private readonly management: McpOAuthManagementService,
 		private readonly audit: McpAuditService,
+		private readonly switchOff: McpOAuthSwitchOffService,
 	) {}
 
 	onModuleInit(): void {
@@ -38,6 +40,7 @@ export class McpOAuthReadinessRegistrationService implements OnModuleInit {
 			[McpOAuthReadinessControl.ADMIN_REVOCATION, this.management],
 			[McpOAuthReadinessControl.AUDIT_HOOKS, this.audit],
 			[McpOAuthReadinessControl.ENDPOINT_RATE_LIMITS, this.endpointRateLimit],
+			[McpOAuthReadinessControl.OAUTH_SWITCH_OFF_INVALIDATION, this.switchOff],
 		]);
 
 		this.readiness.register(...registrations.keys());

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
@@ -36,6 +36,7 @@ describe('McpOAuthRuntimeService', () => {
 		service.deactivateInternal();
 
 		expect(() => service.getActive()).toThrow('The internal MCP OAuth route gate is closed');
+		await expect(service.activateInternal()).rejects.toThrow('MCP OAuth provider activation is disabled');
 	});
 
 	it('does not retain an activation that finishes after switch-off', async () => {
@@ -71,6 +72,10 @@ describe('McpOAuthRuntimeService', () => {
 
 		await expect(staleActivation).rejects.toThrow('MCP OAuth provider activation was cancelled');
 		expect(() => service.getActive()).toThrow('The internal MCP OAuth route gate is closed');
+		await expect(service.activateInternal()).rejects.toThrow('MCP OAuth provider activation is disabled');
+
+		service.allowActivationInternal();
+
 		await expect(service.activateInternal()).resolves.toBe(freshRuntime);
 		expect(service.getActive()).toBe(freshRuntime);
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.spec.ts
@@ -37,4 +37,41 @@ describe('McpOAuthRuntimeService', () => {
 
 		expect(() => service.getActive()).toThrow('The internal MCP OAuth route gate is closed');
 	});
+
+	it('does not retain an activation that finishes after switch-off', async () => {
+		const staleRuntime = {
+			provider: {},
+			callback: jest.fn(),
+			urls: {},
+			metadata: {},
+		} as unknown as McpOAuthProviderRuntime;
+		const freshRuntime = {
+			provider: {},
+			callback: jest.fn(),
+			urls: {},
+			metadata: {},
+		} as unknown as McpOAuthProviderRuntime;
+		let resolveActivation = (_runtime: McpOAuthProviderRuntime): void => undefined;
+		const delayedActivation = new Promise<McpOAuthProviderRuntime>((resolve) => {
+			resolveActivation = resolve;
+		});
+		const providerFactory = {
+			create: jest.fn().mockReturnValueOnce(delayedActivation).mockResolvedValueOnce(freshRuntime),
+		};
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		const routeGate = new McpOAuthRouteGateService(readiness);
+		const service = new McpOAuthRuntimeService(providerFactory as unknown as McpOAuthProviderFactory, routeGate);
+		routeGate.openInternal();
+		const staleActivation = service.activateInternal();
+
+		service.deactivateInternal();
+		resolveActivation(staleRuntime);
+
+		await expect(staleActivation).rejects.toThrow('MCP OAuth provider activation was cancelled');
+		expect(() => service.getActive()).toThrow('The internal MCP OAuth route gate is closed');
+		await expect(service.activateInternal()).resolves.toBe(freshRuntime);
+		expect(service.getActive()).toBe(freshRuntime);
+	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
@@ -13,6 +13,7 @@ export class McpOAuthRuntimeService {
 	private runtime: McpOAuthProviderRuntime | null = null;
 	private activation: { generation: number; promise: Promise<McpOAuthProviderRuntime> } | null = null;
 	private activationGeneration = 0;
+	private activationBlocked = false;
 
 	constructor(
 		private readonly providerFactory: McpOAuthProviderFactory,
@@ -20,6 +21,10 @@ export class McpOAuthRuntimeService {
 	) {}
 
 	async activateInternal(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
+		if (this.activationBlocked) {
+			throw new ServiceUnavailableException('MCP OAuth provider activation is disabled');
+		}
+
 		if (this.runtime) return this.runtime;
 		const activation =
 			this.activation?.generation === this.activationGeneration
@@ -52,7 +57,12 @@ export class McpOAuthRuntimeService {
 	}
 
 	deactivateInternal(): void {
+		this.activationBlocked = true;
 		this.activationGeneration += 1;
 		this.runtime = null;
+	}
+
+	allowActivationInternal(): void {
+		this.activationBlocked = false;
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-runtime.service.ts
@@ -11,7 +11,8 @@ import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
 @Injectable()
 export class McpOAuthRuntimeService {
 	private runtime: McpOAuthProviderRuntime | null = null;
-	private activation: Promise<McpOAuthProviderRuntime> | null = null;
+	private activation: { generation: number; promise: Promise<McpOAuthProviderRuntime> } | null = null;
+	private activationGeneration = 0;
 
 	constructor(
 		private readonly providerFactory: McpOAuthProviderFactory,
@@ -20,13 +21,23 @@ export class McpOAuthRuntimeService {
 
 	async activateInternal(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
 		if (this.runtime) return this.runtime;
-		this.activation ??= this.providerFactory.create(options);
+		const activation =
+			this.activation?.generation === this.activationGeneration
+				? this.activation
+				: { generation: this.activationGeneration, promise: this.providerFactory.create(options) };
+		this.activation = activation;
 
 		try {
-			this.runtime = await this.activation;
-			return this.runtime;
+			const runtime = await activation.promise;
+
+			if (activation.generation !== this.activationGeneration) {
+				throw new ServiceUnavailableException('MCP OAuth provider activation was cancelled');
+			}
+
+			this.runtime = runtime;
+			return runtime;
 		} finally {
-			this.activation = null;
+			if (this.activation === activation) this.activation = null;
 		}
 	}
 
@@ -41,6 +52,7 @@ export class McpOAuthRuntimeService {
 	}
 
 	deactivateInternal(): void {
+		this.activationGeneration += 1;
 		this.runtime = null;
 	}
 }

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.spec.ts
@@ -1,0 +1,89 @@
+import { McpAuditService } from './mcp-audit.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
+
+describe('McpOAuthSwitchOffService', () => {
+	let routeGate: { closeInternal: jest.Mock; openInternal: jest.Mock };
+	let runtime: { deactivateInternal: jest.Mock };
+	let globalInvalidation: { invalidate: jest.Mock };
+	let auditService: { recordOAuthAuthorizationInvalidation: jest.Mock };
+	let service: McpOAuthSwitchOffService;
+
+	beforeEach(() => {
+		routeGate = { closeInternal: jest.fn(), openInternal: jest.fn() };
+		runtime = { deactivateInternal: jest.fn() };
+		globalInvalidation = {
+			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void>) => commit()),
+		};
+		auditService = { recordOAuthAuthorizationInvalidation: jest.fn() };
+		service = new McpOAuthSwitchOffService(
+			routeGate as unknown as McpOAuthRouteGateService,
+			runtime as unknown as McpOAuthRuntimeService,
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
+			auditService as unknown as McpAuditService,
+		);
+	});
+
+	it('closes the shared gate before advancing OAuth enablement and preserves the static profile', async () => {
+		const order: string[] = [];
+		routeGate.closeInternal.mockImplementation(() => order.push('gate_closed'));
+		runtime.deactivateInternal.mockImplementation(() => order.push('runtime_deactivated'));
+		globalInvalidation.invalidate.mockImplementation(async (_generations, commit: () => Promise<void>) => {
+			order.push('invalidation_started');
+			await commit();
+			order.push('oauth_streams_closed');
+		});
+		const commit = jest.fn(() => {
+			order.push('setting_persisted');
+
+			return Promise.resolve();
+		});
+
+		await service.disableInternal(commit);
+
+		expect(order).toEqual([
+			'gate_closed',
+			'runtime_deactivated',
+			'invalidation_started',
+			'setting_persisted',
+			'oauth_streams_closed',
+		]);
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['oauth_disabled'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
+	});
+
+	it('stays closed and does not audit when generation advancement fails', async () => {
+		const commit = jest.fn();
+		globalInvalidation.invalidate.mockRejectedValue(new Error('generation unavailable'));
+
+		await expect(service.disableInternal(commit)).rejects.toThrow('generation unavailable');
+
+		expect(routeGate.closeInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+		expect(commit).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).not.toHaveBeenCalled();
+	});
+
+	it('audits a partial outcome and stays closed when persistence fails after invalidation', async () => {
+		const commit = jest.fn().mockRejectedValue(new Error('configuration write failed'));
+
+		await expect(service.disableInternal(commit)).rejects.toThrow('configuration write failed');
+
+		expect(routeGate.closeInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['oauth_disabled'],
+			authorizationProfile: 'oauth',
+			outcome: 'partial',
+		});
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+
+import { McpAuditOutcome, McpAuditService } from './mcp-audit.service';
+import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+export type McpOAuthSwitchOffCommit = () => Promise<void> | void;
+
+@Injectable()
+export class McpOAuthSwitchOffService {
+	constructor(
+		private readonly routeGate: McpOAuthRouteGateService,
+		private readonly runtime: McpOAuthRuntimeService,
+		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
+		private readonly auditService: McpAuditService,
+	) {}
+
+	async disableInternal(commit: McpOAuthSwitchOffCommit): Promise<void> {
+		this.routeGate.closeInternal();
+		this.runtime.deactivateInternal();
+
+		let commitFailed = false;
+		const persist = async (): Promise<void> => {
+			try {
+				await commit();
+			} catch (error) {
+				commitFailed = true;
+				throw error;
+			}
+		};
+
+		try {
+			await this.globalInvalidation.invalidate(['oauthEnabledGeneration'], persist);
+		} catch (error) {
+			if (commitFailed) {
+				this.auditService.recordOAuthAuthorizationInvalidation({
+					reasons: ['oauth_disabled'],
+					authorizationProfile: 'oauth',
+					outcome: McpAuditOutcome.PARTIAL,
+				});
+			}
+
+			throw error;
+		}
+
+		this.auditService.recordOAuthAuthorizationInvalidation({
+			reasons: ['oauth_disabled'],
+			authorizationProfile: 'oauth',
+			outcome: McpAuditOutcome.COMPLETED,
+		});
+	}
+}

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — embedded OAuth endpoint rate limits implemented
+**Status:** Phase 5 in progress — OAuth switch-off invalidation foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -304,6 +304,18 @@ amend ADR 0002.
       processing or recording artifact state.
 - [x] Register endpoint throttling in the sealed readiness inventory while keeping OAuth closed because switch-off
       invalidation and the complete bootstrap route set are still absent.
+
+### Phase 5s — OAuth switch-off invalidation foundation
+
+- [x] Add one internal switch-off coordinator that synchronously closes the shared route gate and deactivates the
+      embedded provider before starting persistent invalidation; never reopen the gate automatically after failure.
+- [x] Cancel in-flight provider activation by generation so a late provider result cannot restore stale runtime state
+      after switch-off.
+- [x] Advance the persistent OAuth-enabled generation through the authoritative global invalidation boundary, revoke
+      all OAuth artifacts, and close only OAuth subscriptions while preserving static MCP streams.
+- [x] Audit completed and configuration-persistence-partial switch-off outcomes without reporting success when
+      invalidation itself fails, and register the coordinator in the sealed readiness inventory. The complete route
+      set remains the only missing readiness control, so the user-facing switch stays absent.
 
 ### Remaining Phase 5 controls
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -309,8 +309,8 @@ amend ADR 0002.
 
 - [x] Add one internal switch-off coordinator that synchronously closes the shared route gate and deactivates the
       embedded provider before starting persistent invalidation; never reopen the gate automatically after failure.
-- [x] Cancel in-flight provider activation by generation so a late provider result cannot restore stale runtime state
-      after switch-off.
+- [x] Block new provider activation after deactivation and cancel in-flight activation by generation so no provider
+      created during or after switch-off can be reused until an explicit internal re-enable step allows activation.
 - [x] Advance the persistent OAuth-enabled generation through the authoritative global invalidation boundary, revoke
       all OAuth artifacts, and close only OAuth subscriptions while preserving static MCP streams.
 - [x] Audit completed and configuration-persistence-partial switch-off outcomes without reporting success when

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 embedded OAuth endpoint rate limits implemented
+Status: in progress — Phase 5 OAuth switch-off invalidation foundation implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add an internal fail-closed OAuth switch-off coordinator
- close the shared route gate and deactivate the embedded provider before persistent invalidation begins
- advance the OAuth-enabled generation, revoke OAuth artifacts, and close OAuth subscriptions while preserving static MCP streams
- cancel provider activations that finish after switch-off so stale runtime state cannot be restored
- register switch-off invalidation in the sealed OAuth readiness inventory and update the implementation ledger

## Why

OAuth cannot safely expose a user-facing enable switch until disabling it forms one authoritative security boundary. A switch-off must reject new traffic immediately, invalidate every browser-mediated artifact and stream, preserve the static MCP profile, and remain closed after any failure.

This phase implements that internal boundary without exposing the switch. The complete bootstrap route set is now the only missing readiness control.

## Failure behavior

- generation or invalidation failure propagates without reporting audit success
- configuration persistence failure after security invalidation records a partial outcome
- the shared route gate is never reopened automatically
- late provider activation results are rejected by lifecycle generation

## Validation

- backend changed-file ESLint
- backend TypeScript type-check
- MCP unit suite: 42 suites, 401 tests
- OAuth compatibility/security spike: 2 suites, 26 tests
