### PR TITLE
feat(backend): add MCP OAuth bootstrap route set

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -25,6 +25,7 @@ import { ValidationExceptionFactory } from './common/validation/validation-excep
 import { OAuthCallbackService } from './modules/buddy/services/oauth-callback.service';
 import { getDiscoveredExtensions } from './modules/extensions/services/extensions-discovery-cache';
 import { MCP_MODULE_PREFIX, MCP_REQUEST_BODY_LIMIT_BYTES } from './modules/mcp/mcp.constants';
+import { McpOAuthBootstrapService } from './modules/mcp/services/mcp-oauth-bootstrap.service';
 import { MdnsService } from './modules/mdns/services/mdns.service';
 import { SystemLoggerService } from './modules/system/services/system-logger.service';
 import { SYSTEM_MODULE_PREFIX } from './modules/system/system.constants';
@@ -161,6 +162,8 @@ async function bootstrap() {
 	websocketGateway.enable();
 
 	app.enableCors();
+
+	app.get(McpOAuthBootstrapService).register(fastifyInstance);
 
 	// Swagger UI is not loaded during normal startup — use the CLI command
 	// 'pnpm run cli swagger:serve' to start a standalone Swagger UI server.

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -161,9 +161,9 @@ async function bootstrap() {
 	const websocketGateway = app.get(WebsocketGateway);
 	websocketGateway.enable();
 
-	app.enableCors();
-
 	app.get(McpOAuthBootstrapService).register(fastifyInstance);
+
+	app.enableCors();
 
 	// Swagger UI is not loaded during normal startup — use the CLI command
 	// 'pnpm run cli swagger:serve' to start a standalone Swagger UI server.

--- a/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.spec.ts
@@ -17,6 +17,7 @@ import { IS_MCP_ENDPOINT_KEY, MCP_OAUTH_PRINCIPAL_TYPE } from '../../mcp/mcp.con
 import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
+import { McpOAuthRouteGateService } from '../../mcp/services/mcp-oauth-route-gate.service';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
@@ -48,6 +49,7 @@ describe('AuthGuard', () => {
 	let mcpClientsService: McpClientService;
 	let mcpInstallationService: McpInstallationService;
 	let mcpAuditService: { getRequestId: jest.Mock; recordAuthenticationFailure: jest.Mock };
+	let mcpOAuthRouteGate: { isOpen: boolean };
 
 	const mockUserId = uuid().toString();
 	const mockDisplayId = uuid().toString();
@@ -145,6 +147,7 @@ describe('AuthGuard', () => {
 	};
 
 	beforeEach(async () => {
+		mcpOAuthRouteGate = { isOpen: false };
 		mcpAuditService = {
 			getRequestId: jest.fn().mockReturnValue('request-1'),
 			recordAuthenticationFailure: jest.fn(),
@@ -197,6 +200,10 @@ describe('AuthGuard', () => {
 				{
 					provide: McpAuditService,
 					useValue: mcpAuditService,
+				},
+				{
+					provide: McpOAuthRouteGateService,
+					useValue: mcpOAuthRouteGate,
 				},
 				{
 					provide: CACHE_MANAGER,
@@ -597,6 +604,20 @@ describe('AuthGuard', () => {
 				ownerId: mockMcpClientId,
 				capabilities: [],
 			});
+		});
+
+		it('defers an opaque bearer and missing credentials to the isolated OAuth verifier only while the gate is open', async () => {
+			mcpOAuthRouteGate.isOpen = true;
+			const opaque = createMockExecutionContext({ authorization: 'Bearer opaque-oauth-token' });
+			const missing = createMockExecutionContext();
+			markMcpEndpoint();
+			jest.spyOn(jwtService, 'verifyAsync').mockRejectedValue(new UnauthorizedException('not a static JWT'));
+
+			await expect(guard.canActivate(opaque)).resolves.toBe(true);
+			await expect(guard.canActivate(missing)).resolves.toBe(true);
+			expect(opaque.switchToHttp().getRequest<AuthenticatedRequest>().auth).toBeUndefined();
+			expect(missing.switchToHttp().getRequest<AuthenticatedRequest>().auth).toBeUndefined();
+			expect(mcpAuditService.recordAuthenticationFailure).not.toHaveBeenCalled();
 		});
 
 		it('should reject an MCP credential on an ordinary REST endpoint', async () => {

--- a/apps/backend/src/modules/auth/guards/auth.guard.ts
+++ b/apps/backend/src/modules/auth/guards/auth.guard.ts
@@ -19,6 +19,7 @@ import { IS_MCP_ENDPOINT_KEY, MCP_OAUTH_PRINCIPAL_TYPE, McpCapability } from '..
 import { McpAuditService } from '../../mcp/services/mcp-audit.service';
 import { McpClientService } from '../../mcp/services/mcp-client.service';
 import { McpInstallationService } from '../../mcp/services/mcp-installation.service';
+import { McpOAuthRouteGateService } from '../../mcp/services/mcp-oauth-route-gate.service';
 import { ApiPublic } from '../../swagger/decorators/api-documentation.decorator';
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
@@ -81,6 +82,7 @@ export class AuthGuard implements CanActivate {
 		private readonly mcpClientsService: McpClientService,
 		private readonly mcpInstallationService: McpInstallationService,
 		private readonly mcpAuditService: McpAuditService,
+		private readonly mcpOAuthRouteGate: McpOAuthRouteGateService,
 		@Inject(CACHE_MANAGER)
 		private readonly cacheManager: Cache,
 	) {}
@@ -112,6 +114,10 @@ export class AuthGuard implements CanActivate {
 				return true;
 			}
 		} catch (error) {
+			if (isMcpEndpoint && this.mcpOAuthRouteGate.isOpen && error instanceof UnauthorizedException) {
+				return true;
+			}
+
 			if (isMcpEndpoint) {
 				this.mcpAuditService.recordAuthenticationFailure(
 					{ requestId: this.mcpAuditService.getRequestId(request.body) },
@@ -120,6 +126,10 @@ export class AuthGuard implements CanActivate {
 			}
 
 			throw error;
+		}
+
+		if (isMcpEndpoint && this.mcpOAuthRouteGate.isOpen) {
+			return true;
 		}
 
 		// If auth method didn't work, reject the request

--- a/apps/backend/src/modules/mcp/controllers/mcp.controller.spec.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp.controller.spec.ts
@@ -1,0 +1,91 @@
+import { FastifyReply } from 'fastify';
+import { ServerResponse } from 'node:http';
+
+import { AuthInfo, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
+
+import { McpCapability } from '../mcp.constants';
+import { McpOAuthProxyPolicyService } from '../services/mcp-oauth-proxy-policy.service';
+import { McpOAuthResourceServerService } from '../services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
+import { McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
+import { McpServerService } from '../services/mcp-server.service';
+
+import { McpController } from './mcp.controller';
+
+describe('McpController', () => {
+	let serverService: { handle: jest.Mock; handleOAuth: jest.Mock };
+	let routeGate: { assertOpen: jest.Mock };
+	let proxyPolicy: { assertForwardedHeadersTrusted: jest.Mock };
+	let resourceServer: { verifyMcpBearerToken: jest.Mock; getBearerChallenge: jest.Mock };
+	let policyService: { validateOAuthRequestOrigin: jest.Mock };
+	let controller: McpController;
+
+	beforeEach(() => {
+		serverService = { handle: jest.fn(), handleOAuth: jest.fn() };
+		routeGate = { assertOpen: jest.fn() };
+		proxyPolicy = { assertForwardedHeadersTrusted: jest.fn() };
+		resourceServer = { verifyMcpBearerToken: jest.fn(), getBearerChallenge: jest.fn() };
+		policyService = { validateOAuthRequestOrigin: jest.fn() };
+		controller = new McpController(
+			serverService as unknown as McpServerService,
+			routeGate as unknown as McpOAuthRouteGateService,
+			proxyPolicy as unknown as McpOAuthProxyPolicyService,
+			resourceServer as unknown as McpOAuthResourceServerService,
+			policyService as unknown as McpPolicyService,
+		);
+	});
+
+	it('preserves the existing static MCP request path without consulting OAuth', async () => {
+		const request = { mcpPolicy: { client: { id: 'static-client' } } } as McpPolicyRequest;
+		const reply = {} as FastifyReply;
+
+		await controller.handle(request, reply);
+
+		expect(serverService.handle).toHaveBeenCalledWith(request, reply);
+		expect(routeGate.assertOpen).not.toHaveBeenCalled();
+		expect(resourceServer.verifyMcpBearerToken).not.toHaveBeenCalled();
+	});
+
+	it('routes an OAuth bearer through the shared gate, proxy policy, origin policy, and isolated verifier', async () => {
+		const authInfo = { token: 'opaque', clientId: 'public-client', scopes: ['read'] } as AuthInfo;
+		const request = { headers: { authorization: 'Bearer opaque' } } as McpPolicyRequest;
+		const reply = {} as FastifyReply;
+		resourceServer.verifyMcpBearerToken.mockResolvedValue(authInfo);
+
+		await controller.handle(request, reply);
+
+		expect(routeGate.assertOpen).toHaveBeenCalledTimes(1);
+		expect(proxyPolicy.assertForwardedHeadersTrusted).toHaveBeenCalledWith(request);
+		expect(policyService.validateOAuthRequestOrigin).toHaveBeenCalledWith(request);
+		expect(resourceServer.verifyMcpBearerToken).toHaveBeenCalledWith('Bearer opaque', [McpCapability.READ]);
+		expect(serverService.handleOAuth).toHaveBeenCalledWith(request, reply, authInfo);
+		expect(serverService.handle).not.toHaveBeenCalled();
+	});
+
+	it('returns the bounded RFC 6750 challenge from the OAuth verifier', async () => {
+		const error = new OAuthError(OAuthErrorCode.InvalidToken, 'Invalid token');
+		const challenge = new Response(null, {
+			status: 401,
+			headers: { 'www-authenticate': 'Bearer error="invalid_token", scope="mcp:read"' },
+		});
+		const hijack = jest.fn();
+		const setHeader = jest.fn();
+		const end = jest.fn();
+		const response = {
+			statusCode: 0,
+			setHeader,
+			end,
+		} as unknown as ServerResponse;
+		const reply = { hijack, raw: response } as unknown as FastifyReply;
+		resourceServer.verifyMcpBearerToken.mockRejectedValue(error);
+		resourceServer.getBearerChallenge.mockReturnValue(challenge);
+
+		await controller.handle({ headers: {} } as McpPolicyRequest, reply);
+
+		expect(resourceServer.getBearerChallenge).toHaveBeenCalledWith(error, [McpCapability.READ]);
+		expect(hijack).toHaveBeenCalledTimes(1);
+		expect(response.statusCode).toBe(401);
+		expect(setHeader).toHaveBeenCalledWith('www-authenticate', 'Bearer error="invalid_token", scope="mcp:read"');
+		expect(end).toHaveBeenCalledWith(Buffer.alloc(0));
+	});
+});

--- a/apps/backend/src/modules/mcp/controllers/mcp.controller.ts
+++ b/apps/backend/src/modules/mcp/controllers/mcp.controller.ts
@@ -1,5 +1,6 @@
 import { FastifyReply } from 'fastify';
 
+import { OAuthError } from '@modelcontextprotocol/server';
 import { All, Controller, Req, Res, UseGuards } from '@nestjs/common';
 import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
 import { SkipThrottle } from '@nestjs/throttler';
@@ -7,8 +8,12 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { RawRoute } from '../../api/decorators/raw-route.decorator';
 import { McpEndpoint } from '../decorators/mcp-endpoint.decorator';
 import { McpClientGuard } from '../guards/mcp-client.guard';
-import { MCP_MODULE_API_TAG_NAME } from '../mcp.constants';
+import { MCP_MODULE_API_TAG_NAME, McpCapability } from '../mcp.constants';
+import { McpOAuthProxyPolicyService } from '../services/mcp-oauth-proxy-policy.service';
+import { McpOAuthResourceServerService } from '../services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 import { McpPolicyRequest } from '../services/mcp-policy.service';
+import { McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
 
 @ApiExcludeController()
@@ -18,11 +23,42 @@ import { McpServerService } from '../services/mcp-server.service';
 @UseGuards(McpClientGuard)
 @Controller()
 export class McpController {
-	constructor(private readonly serverService: McpServerService) {}
+	constructor(
+		private readonly serverService: McpServerService,
+		private readonly oauthRouteGate: McpOAuthRouteGateService,
+		private readonly oauthProxyPolicy: McpOAuthProxyPolicyService,
+		private readonly oauthResourceServer: McpOAuthResourceServerService,
+		private readonly policyService: McpPolicyService,
+	) {}
 
 	@RawRoute()
 	@All()
 	async handle(@Req() request: McpPolicyRequest, @Res() reply: FastifyReply): Promise<void> {
-		await this.serverService.handle(request, reply);
+		if (request.mcpPolicy) {
+			await this.serverService.handle(request, reply);
+			return;
+		}
+
+		this.oauthRouteGate.assertOpen();
+		this.oauthProxyPolicy.assertForwardedHeadersTrusted(request);
+		this.policyService.validateOAuthRequestOrigin(request);
+
+		try {
+			const authInfo = await this.oauthResourceServer.verifyMcpBearerToken(request.headers.authorization, [
+				McpCapability.READ,
+			]);
+			await this.serverService.handleOAuth(request, reply, authInfo);
+		} catch (error) {
+			if (!OAuthError.isInstance(error)) throw error;
+
+			await this.writeOAuthResponse(reply, this.oauthResourceServer.getBearerChallenge(error, [McpCapability.READ]));
+		}
+	}
+
+	private async writeOAuthResponse(reply: FastifyReply, response: Response): Promise<void> {
+		reply.hijack();
+		reply.raw.statusCode = response.status;
+		response.headers.forEach((value, name) => reply.raw.setHeader(name, value));
+		reply.raw.end(Buffer.from(await response.arrayBuffer()));
 	}
 }

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.spec.ts
@@ -2,12 +2,30 @@ import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@ne
 
 import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditService } from '../services/mcp-audit.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 import { McpPolicyContext, McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
 
 import { McpClientGuard } from './mcp-client.guard';
 
 describe('McpClientGuard', () => {
+	it('defers an unauthenticated request only to an open OAuth route gate', async () => {
+		const request = {} as McpPolicyRequest;
+		const policyService = { resolve: jest.fn(), validateRequestOrigin: jest.fn() };
+		const guard = new McpClientGuard(
+			policyService as unknown as McpPolicyService,
+			{ getClientPolicyRevision: jest.fn(), getPolicyRevision: jest.fn() } as unknown as McpServerService,
+			{} as McpAuditService,
+			{ isOpen: true } as McpOAuthRouteGateService,
+		);
+		const context = {
+			switchToHttp: () => ({ getRequest: () => request }),
+		} as ExecutionContext;
+
+		await expect(guard.canActivate(context)).resolves.toBe(true);
+		expect(policyService.resolve).not.toHaveBeenCalled();
+	});
+
 	it('resolves policy, validates transport origin, and attaches the context', async () => {
 		const request = { auth: { type: 'token', ownerId: 'client-id' } } as McpPolicyRequest;
 		const policy = { installationId: 'installation-id' } as McpPolicyContext;
@@ -27,6 +45,7 @@ describe('McpClientGuard', () => {
 			policyService as unknown as McpPolicyService,
 			serverService as unknown as McpServerService,
 			auditService as unknown as McpAuditService,
+			{ isOpen: false } as McpOAuthRouteGateService,
 		);
 		const context = {
 			switchToHttp: () => ({ getRequest: () => request }),
@@ -61,6 +80,7 @@ describe('McpClientGuard', () => {
 			policyService as unknown as McpPolicyService,
 			{ getClientPolicyRevision: jest.fn(), getPolicyRevision: jest.fn() } as unknown as McpServerService,
 			auditService as unknown as McpAuditService,
+			{ isOpen: false } as McpOAuthRouteGateService,
 		);
 		const context = {
 			switchToHttp: () => ({ getRequest: () => request }),
@@ -93,6 +113,7 @@ describe('McpClientGuard', () => {
 			policyService as unknown as McpPolicyService,
 			{ getClientPolicyRevision: jest.fn(), getPolicyRevision: jest.fn() } as unknown as McpServerService,
 			auditService as unknown as McpAuditService,
+			{ isOpen: false } as McpOAuthRouteGateService,
 		);
 		const context = {
 			switchToHttp: () => ({ getRequest: () => request }),

--- a/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-client.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, ForbiddenException, Injectable, Unauthor
 
 import { McpEndpointDisabledException } from '../mcp.exceptions';
 import { McpAuditDenialReason, McpAuditService } from '../services/mcp-audit.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 import { McpPolicyRequest, McpPolicyService } from '../services/mcp-policy.service';
 import { McpServerService } from '../services/mcp-server.service';
 
@@ -11,10 +12,14 @@ export class McpClientGuard implements CanActivate {
 		private readonly policyService: McpPolicyService,
 		private readonly serverService: McpServerService,
 		private readonly auditService: McpAuditService,
+		private readonly oauthRouteGate: McpOAuthRouteGateService,
 	) {}
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const request = context.switchToHttp().getRequest<McpPolicyRequest>();
+
+		if (!request.auth && this.oauthRouteGate.isOpen) return true;
+
 		const policyRevision = this.serverService.getPolicyRevision();
 		const clientPolicyRevision =
 			request.auth?.type === 'token' && request.auth.ownerId

--- a/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.spec.ts
@@ -86,6 +86,55 @@ describe('McpThrottleGuard', () => {
 		);
 	});
 
+	it('keeps static and OAuth verification caches isolated', async () => {
+		oauthRouteGate.isOpen = true;
+		jwtService.decode.mockReturnValue({ sub: 'static-client', type: TokenOwnerType.MCP });
+		jwtService.verifyAsync.mockRejectedValue(new Error('not a valid static credential'));
+		oauthResourceServer.verifyMcpBearerToken.mockResolvedValue({ clientId: 'oauth-public-client' });
+
+		await expect(guard.canActivate(context(request('oauth-token-with-jwt-shape')))).resolves.toBe(true);
+
+		expect(oauthResourceServer.verifyMcpBearerToken).toHaveBeenCalledTimes(1);
+		expect(increment).toHaveBeenCalledWith(
+			'mcp-client:oauth:oauth-public-client',
+			MCP_RATE_LIMIT_TTL_MS,
+			MCP_AUTHENTICATED_RATE_LIMIT,
+			MCP_RATE_LIMIT_TTL_MS,
+			'mcp',
+		);
+	});
+
+	it('caches rejected OAuth tokens before charging the unauthenticated request budget', async () => {
+		oauthRouteGate.isOpen = true;
+		jwtService.decode.mockReturnValue(null);
+		oauthResourceServer.verifyMcpBearerToken.mockRejectedValue(new Error('invalid'));
+
+		await expect(guard.canActivate(context(request('rejected-oauth-token')))).resolves.toBe(true);
+		await expect(guard.canActivate(context(request('rejected-oauth-token')))).resolves.toBe(true);
+
+		expect(oauthResourceServer.verifyMcpBearerToken).toHaveBeenCalledTimes(1);
+		expect(increment).toHaveBeenCalledTimes(2);
+	});
+
+	it('bounds verification work for rotating opaque OAuth tokens', async () => {
+		oauthRouteGate.isOpen = true;
+		jwtService.decode.mockReturnValue(null);
+		oauthResourceServer.verifyMcpBearerToken.mockRejectedValue(new Error('invalid'));
+		const now = Date.now();
+		const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+
+		try {
+			for (let index = 0; index <= 200; index += 1) {
+				await expect(guard.canActivate(context(request(`rotating-oauth-token-${index}`)))).resolves.toBe(true);
+			}
+		} finally {
+			nowSpy.mockRestore();
+		}
+
+		expect(oauthResourceServer.verifyMcpBearerToken).toHaveBeenCalledTimes(200);
+		expect(increment).toHaveBeenCalledTimes(201);
+	});
+
 	it.each([
 		['missing token', undefined],
 		['non-MCP token', 'ordinary-token'],

--- a/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.spec.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.spec.ts
@@ -8,6 +8,8 @@ import { ThrottlerException, ThrottlerStorage } from '@nestjs/throttler';
 import { TokenOwnerType } from '../../auth/auth.constants';
 import { MCP_AUTHENTICATED_RATE_LIMIT, MCP_RATE_LIMIT_TTL_MS, MCP_UNAUTHENTICATED_RATE_LIMIT } from '../mcp.constants';
 import { McpInstallationService } from '../services/mcp-installation.service';
+import { McpOAuthResourceServerService } from '../services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 
 import { McpThrottleGuard } from './mcp-throttle.guard';
 
@@ -16,6 +18,8 @@ describe('McpThrottleGuard', () => {
 	let jwtService: jest.Mocked<Pick<JwtService, 'decode' | 'verifyAsync'>>;
 	let storage: jest.Mocked<ThrottlerStorage>;
 	let increment: jest.MockedFunction<ThrottlerStorage['increment']>;
+	let oauthRouteGate: { isOpen: boolean };
+	let oauthResourceServer: { verifyMcpBearerToken: jest.Mock };
 	let guard: McpThrottleGuard;
 
 	beforeEach(() => {
@@ -33,11 +37,15 @@ describe('McpThrottleGuard', () => {
 		storage = {
 			increment,
 		};
+		oauthRouteGate = { isOpen: false };
+		oauthResourceServer = { verifyMcpBearerToken: jest.fn() };
 		guard = new McpThrottleGuard(
 			{ getAllAndOverride: jest.fn(() => isMcpEndpoint) } as unknown as Reflector,
 			jwtService as unknown as JwtService,
 			{ getAudience: jest.fn().mockResolvedValue('audience') } as unknown as McpInstallationService,
 			storage,
+			oauthRouteGate as McpOAuthRouteGateService,
+			oauthResourceServer as unknown as McpOAuthResourceServerService,
 		);
 	});
 
@@ -55,6 +63,22 @@ describe('McpThrottleGuard', () => {
 		await expect(guard.canActivate(context(request('valid-token')))).resolves.toBe(true);
 		expect(increment).toHaveBeenCalledWith(
 			'mcp-client:client-id',
+			MCP_RATE_LIMIT_TTL_MS,
+			MCP_AUTHENTICATED_RATE_LIMIT,
+			MCP_RATE_LIMIT_TTL_MS,
+			'mcp',
+		);
+	});
+
+	it('uses the isolated verified OAuth client identity for the authenticated budget only while the gate is open', async () => {
+		oauthRouteGate.isOpen = true;
+		jwtService.decode.mockReturnValue(null);
+		oauthResourceServer.verifyMcpBearerToken.mockResolvedValue({ clientId: 'oauth-public-client' });
+
+		await expect(guard.canActivate(context(request('opaque-token')))).resolves.toBe(true);
+		expect(oauthResourceServer.verifyMcpBearerToken).toHaveBeenCalledWith('Bearer opaque-token', ['read']);
+		expect(increment).toHaveBeenCalledWith(
+			'mcp-client:oauth:oauth-public-client',
 			MCP_RATE_LIMIT_TTL_MS,
 			MCP_AUTHENTICATED_RATE_LIMIT,
 			MCP_RATE_LIMIT_TTL_MS,

--- a/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.ts
@@ -28,6 +28,8 @@ interface VerifyCacheEntry {
 	expiresAt: number;
 }
 
+type VerifyCacheProfile = 'oauth' | 'static';
+
 const VERIFY_CACHE_TTL_MS = 60_000;
 const VERIFY_CACHE_MAX_ENTRIES = 1_000;
 const MAX_VERIFY_PER_SEC = 200;
@@ -112,11 +114,20 @@ export class McpThrottleGuard implements CanActivate {
 	private async getOAuthClientId(token: string): Promise<string | null> {
 		if (!this.oauthRouteGate?.isOpen || !this.oauthResourceServer) return null;
 
+		const cached = this.readVerifyCache(token, 'oauth');
+
+		if (cached !== undefined) return cached;
+		if (!this.tryConsumeVerifyToken()) return null;
+
 		try {
 			const authInfo = await this.oauthResourceServer.verifyMcpBearerToken(`Bearer ${token}`, [McpCapability.READ]);
+			const clientId = `oauth:${authInfo.clientId}`;
 
-			return `oauth:${authInfo.clientId}`;
+			this.writeVerifyCache(token, clientId, 'oauth');
+
+			return clientId;
 		} catch {
+			this.writeVerifyCache(token, null, 'oauth');
 			return null;
 		}
 	}
@@ -146,8 +157,8 @@ export class McpThrottleGuard implements CanActivate {
 		return true;
 	}
 
-	private readVerifyCache(token: string): string | null | undefined {
-		const key = hashToken(token);
+	private readVerifyCache(token: string, profile: VerifyCacheProfile = 'static'): string | null | undefined {
+		const key = `${profile}:${hashToken(token)}`;
 		const entry = this.verifyCache.get(key);
 
 		if (!entry) {
@@ -162,8 +173,8 @@ export class McpThrottleGuard implements CanActivate {
 		return entry.clientId;
 	}
 
-	private writeVerifyCache(token: string, clientId: string | null): void {
-		const key = hashToken(token);
+	private writeVerifyCache(token: string, clientId: string | null, profile: VerifyCacheProfile = 'static'): void {
+		const key = `${profile}:${hashToken(token)}`;
 
 		if (this.verifyCache.size >= VERIFY_CACHE_MAX_ENTRIES && !this.verifyCache.has(key)) {
 			for (const oldestKey of this.verifyCache.keys()) {

--- a/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.ts
+++ b/apps/backend/src/modules/mcp/guards/mcp-throttle.guard.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, Optional } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { InjectThrottlerStorage, ThrottlerException, ThrottlerStorage } from '@nestjs/throttler';
@@ -12,8 +12,11 @@ import {
 	MCP_AUTHENTICATED_RATE_LIMIT,
 	MCP_RATE_LIMIT_TTL_MS,
 	MCP_UNAUTHENTICATED_RATE_LIMIT,
+	McpCapability,
 } from '../mcp.constants';
 import { McpInstallationService } from '../services/mcp-installation.service';
+import { McpOAuthResourceServerService } from '../services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 
 interface McpJwtPayload {
 	sub?: string;
@@ -41,6 +44,8 @@ export class McpThrottleGuard implements CanActivate {
 		private readonly installationService: McpInstallationService,
 		@InjectThrottlerStorage()
 		private readonly storage: ThrottlerStorage,
+		@Optional() private readonly oauthRouteGate?: McpOAuthRouteGateService,
+		@Optional() private readonly oauthResourceServer?: McpOAuthResourceServerService,
 	) {}
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -76,7 +81,7 @@ export class McpThrottleGuard implements CanActivate {
 		const decoded = this.safeDecode(token);
 
 		if (!decoded || decoded.type !== TokenOwnerType.MCP || !decoded.sub) {
-			return null;
+			return this.getOAuthClientId(token);
 		}
 
 		const cached = this.readVerifyCache(token);
@@ -100,6 +105,18 @@ export class McpThrottleGuard implements CanActivate {
 			return clientId;
 		} catch {
 			this.writeVerifyCache(token, null);
+			return this.getOAuthClientId(token);
+		}
+	}
+
+	private async getOAuthClientId(token: string): Promise<string | null> {
+		if (!this.oauthRouteGate?.isOpen || !this.oauthResourceServer) return null;
+
+		try {
+			const authInfo = await this.oauthResourceServer.verifyMcpBearerToken(`Bearer ${token}`, [McpCapability.READ]);
+
+			return `oauth:${authInfo.clientId}`;
+		} catch {
 			return null;
 		}
 	}

--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -34,6 +34,20 @@ export const MCP_OAUTH_PRINCIPAL_TYPE = 'mcp_oauth';
 
 export const MCP_OAUTH_SERVER_STATE_KEY = 'primary';
 
+export const MCP_OAUTH_RESOURCE_PATH = '/api/v1/modules/mcp';
+
+export const MCP_OAUTH_ISSUER_PATH = `${MCP_OAUTH_RESOURCE_PATH}/oauth`;
+
+export const MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH = `/.well-known/oauth-protected-resource${MCP_OAUTH_RESOURCE_PATH}`;
+
+export const MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH = `/.well-known/oauth-authorization-server${MCP_OAUTH_ISSUER_PATH}`;
+
+export const MCP_OAUTH_AUTHORIZATION_PATH = `${MCP_OAUTH_ISSUER_PATH}/authorize`;
+
+export const MCP_OAUTH_TOKEN_PATH = `${MCP_OAUTH_ISSUER_PATH}/token`;
+
+export const MCP_OAUTH_REVOCATION_PATH = `${MCP_OAUTH_TOKEN_PATH}/revocation`;
+
 export const MCP_OAUTH_ACCESS_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
 
 export const MCP_OAUTH_REFRESH_FAMILY_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -64,6 +64,7 @@ import { McpContextService } from './services/mcp-context.service';
 import { McpInstallationService } from './services/mcp-installation.service';
 import { McpOAuthApproverAuthorityService } from './services/mcp-oauth-approver-authority.service';
 import { McpOAuthArtifactService } from './services/mcp-oauth-artifact.service';
+import { McpOAuthBootstrapService } from './services/mcp-oauth-bootstrap.service';
 import { McpOAuthClientService } from './services/mcp-oauth-client.service';
 import { McpOAuthEndpointRateLimitService } from './services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from './services/mcp-oauth-global-invalidation.service';
@@ -136,6 +137,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpContextService,
 		McpInstallationService,
 		McpOAuthArtifactService,
+		McpOAuthBootstrapService,
 		McpOAuthApproverAuthorityService,
 		McpOAuthClientService,
 		McpOAuthEndpointRateLimitService,
@@ -176,6 +178,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpClientService,
 		McpInstallationService,
 		McpOAuthArtifactService,
+		McpOAuthBootstrapService,
 		McpOAuthApproverAuthorityService,
 		McpOAuthClientService,
 		McpOAuthInteractionService,

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -76,6 +76,11 @@ export class McpOAuthProviderFactory {
 		});
 		const provider = new oidcProvider.default(urls.issuer, {
 			adapter,
+			routes: {
+				authorization: new URL(urls.authorizationEndpoint).pathname,
+				token: new URL(urls.tokenEndpoint).pathname,
+				revocation: new URL(urls.revocationEndpoint).pathname,
+			},
 			clientAuthMethods: ['none'],
 			responseTypes: ['code'],
 			scopes: Object.values(McpOAuthScope),
@@ -304,6 +309,7 @@ export class McpOAuthProviderFactory {
 	private getRateLimitedEndpoint(pathname: string, urls: McpOAuthPublicUrls): McpOAuthRateLimitedEndpoint | null {
 		if (
 			pathname === new URL(urls.authorizationEndpoint).pathname ||
+			pathname === '/authorize' ||
 			pathname === '/auth' ||
 			pathname.startsWith('/auth/')
 		) {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.spec.ts
@@ -31,6 +31,7 @@ describe('McpOAuthBootstrapService', () => {
 	};
 	let runtime: { getActive: jest.Mock };
 	let providerCallback: jest.Mock;
+	let laterPreflightHook: jest.Mock;
 	let service: McpOAuthBootstrapService;
 
 	beforeEach(async () => {
@@ -71,6 +72,13 @@ describe('McpOAuthBootstrapService', () => {
 		);
 		fastify = Fastify();
 		service.register(fastify);
+		laterPreflightHook = jest.fn();
+		fastify.addHook('onRequest', async (request, reply) => {
+			if (request.method !== 'OPTIONS') return;
+
+			laterPreflightHook();
+			await reply.status(204).send();
+		});
 		await fastify.ready();
 	});
 
@@ -101,6 +109,14 @@ describe('McpOAuthBootstrapService', () => {
 		expect(response.headers['cache-control']).toBe('no-store');
 		expect(proxyPolicy.assertForwardedHeadersTrusted).not.toHaveBeenCalled();
 		expect(runtime.getActive).not.toHaveBeenCalled();
+	});
+
+	it('checks the shared gate before a later CORS-style preflight hook can terminate the request', async () => {
+		const response = await fastify.inject({ method: 'OPTIONS', url: MCP_OAUTH_TOKEN_PATH });
+
+		expect(response.statusCode).toBe(503);
+		expect(response.json()).toEqual({ error: 'temporarily_unavailable' });
+		expect(laterPreflightHook).not.toHaveBeenCalled();
 	});
 
 	it('publishes only the bounded metadata projections after the gate opens', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.spec.ts
@@ -1,0 +1,172 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import { IncomingMessage, ServerResponse } from 'node:http';
+
+import { ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
+
+import {
+	MCP_OAUTH_AUTHORIZATION_PATH,
+	MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
+	MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
+	MCP_OAUTH_REVOCATION_PATH,
+	MCP_OAUTH_TOKEN_PATH,
+} from '../mcp.constants';
+import { McpOAuthProviderRuntime } from '../oauth/mcp-oauth-provider.factory';
+
+import { McpOAuthBootstrapService } from './mcp-oauth-bootstrap.service';
+import { McpOAuthProxyPolicyService } from './mcp-oauth-proxy-policy.service';
+import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+describe('McpOAuthBootstrapService', () => {
+	let fastify: FastifyInstance;
+	let gateOpen: boolean;
+	let readiness: { register: jest.Mock };
+	let routeGate: { assertOpen: jest.Mock };
+	let proxyPolicy: { assertForwardedHeadersTrusted: jest.Mock };
+	let resourceServer: {
+		getProtectedResourceMetadata: jest.Mock;
+		getAuthorizationServerMetadata: jest.Mock;
+	};
+	let runtime: { getActive: jest.Mock };
+	let providerCallback: jest.Mock;
+	let service: McpOAuthBootstrapService;
+
+	beforeEach(async () => {
+		gateOpen = false;
+		readiness = { register: jest.fn() };
+		routeGate = {
+			assertOpen: jest.fn(() => {
+				if (!gateOpen) throw new ServiceUnavailableException('closed');
+			}),
+		};
+		proxyPolicy = { assertForwardedHeadersTrusted: jest.fn() };
+		resourceServer = {
+			getProtectedResourceMetadata: jest.fn(() => ({ resource: 'https://panel.example/api/v1/modules/mcp' })),
+			getAuthorizationServerMetadata: jest.fn(() => ({
+				issuer: 'https://panel.example/api/v1/modules/mcp/oauth',
+			})),
+		};
+		providerCallback = jest.fn((request: IncomingMessage, response: ServerResponse) => {
+			response.statusCode = 204;
+			response.setHeader('x-provider-path', request.url ?? '');
+			response.end();
+		});
+		runtime = {
+			getActive: jest.fn(
+				() =>
+					({
+						callback: providerCallback,
+						urls: { issuer: 'https://panel.example/api/v1/modules/mcp/oauth' },
+					}) as unknown as McpOAuthProviderRuntime,
+			),
+		};
+		service = new McpOAuthBootstrapService(
+			readiness as unknown as McpOAuthReadinessService,
+			routeGate as unknown as McpOAuthRouteGateService,
+			proxyPolicy as unknown as McpOAuthProxyPolicyService,
+			resourceServer as unknown as McpOAuthResourceServerService,
+			runtime as unknown as McpOAuthRuntimeService,
+		);
+		fastify = Fastify();
+		service.register(fastify);
+		await fastify.ready();
+	});
+
+	afterEach(async () => {
+		await fastify.close();
+	});
+
+	it('registers the complete route-set readiness control exactly once', () => {
+		expect(readiness.register).toHaveBeenCalledWith(McpOAuthReadinessControl.COMPLETE_ROUTE_SET);
+		expect(() => service.register(fastify)).toThrow('The MCP OAuth bootstrap route set is already registered');
+		expect(readiness.register).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		['protected-resource metadata', 'GET', MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH],
+		['authorization-server metadata', 'GET', MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH],
+		['authorization', 'GET', MCP_OAUTH_AUTHORIZATION_PATH],
+		['authorization resume', 'GET', `${MCP_OAUTH_AUTHORIZATION_PATH}/interaction-id`],
+		['token', 'POST', MCP_OAUTH_TOKEN_PATH],
+		['token preflight', 'OPTIONS', MCP_OAUTH_TOKEN_PATH],
+		['revocation', 'POST', MCP_OAUTH_REVOCATION_PATH],
+		['revocation preflight', 'OPTIONS', MCP_OAUTH_REVOCATION_PATH],
+	])('fails closed for the %s route', async (_label, method, url) => {
+		const response = await fastify.inject({ method: method as 'GET' | 'POST' | 'OPTIONS', url });
+
+		expect(response.statusCode).toBe(503);
+		expect(response.json()).toEqual({ error: 'temporarily_unavailable' });
+		expect(response.headers['cache-control']).toBe('no-store');
+		expect(proxyPolicy.assertForwardedHeadersTrusted).not.toHaveBeenCalled();
+		expect(runtime.getActive).not.toHaveBeenCalled();
+	});
+
+	it('publishes only the bounded metadata projections after the gate opens', async () => {
+		gateOpen = true;
+
+		const protectedResource = await fastify.inject({ method: 'GET', url: MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH });
+		const authorizationServer = await fastify.inject({
+			method: 'GET',
+			url: MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
+		});
+
+		expect(protectedResource.json()).toEqual({ resource: 'https://panel.example/api/v1/modules/mcp' });
+		expect(authorizationServer.json()).toEqual({ issuer: 'https://panel.example/api/v1/modules/mcp/oauth' });
+		expect(resourceServer.getProtectedResourceMetadata).toHaveBeenCalledTimes(1);
+		expect(resourceServer.getAuthorizationServerMetadata).toHaveBeenCalledTimes(1);
+		expect(runtime.getActive).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['GET', `${MCP_OAUTH_AUTHORIZATION_PATH}?client_id=client`, `${MCP_OAUTH_AUTHORIZATION_PATH}?client_id=client`],
+		['GET', `${MCP_OAUTH_AUTHORIZATION_PATH}/interaction-id`, `${MCP_OAUTH_AUTHORIZATION_PATH}/interaction-id`],
+		['POST', MCP_OAUTH_TOKEN_PATH, MCP_OAUTH_TOKEN_PATH],
+		['POST', MCP_OAUTH_REVOCATION_PATH, MCP_OAUTH_REVOCATION_PATH],
+	])('dispatches the finite provider route %s %s without a catch-all', async (method, url, providerPath) => {
+		gateOpen = true;
+
+		const response = await fastify.inject({ method: method as 'GET' | 'POST', url });
+
+		expect(response.statusCode).toBe(204);
+		expect(response.headers['x-provider-path']).toBe(providerPath);
+		expect(providerCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not intercept unregistered dependency or application paths', async () => {
+		gateOpen = true;
+
+		const rawDiscovery = await fastify.inject({
+			method: 'GET',
+			url: '/api/v1/modules/mcp/oauth/.well-known/openid-configuration',
+		});
+		const registration = await fastify.inject({ method: 'POST', url: '/api/v1/modules/mcp/oauth/reg' });
+		const nestedAuthorization = await fastify.inject({
+			method: 'GET',
+			url: `${MCP_OAUTH_AUTHORIZATION_PATH}/interaction-id/nested`,
+		});
+		const unrelated = await fastify.inject({ method: 'GET', url: '/api/v1/modules/devices' });
+
+		expect([
+			rawDiscovery.statusCode,
+			registration.statusCode,
+			nestedAuthorization.statusCode,
+			unrelated.statusCode,
+		]).toEqual([404, 404, 404, 404]);
+		expect(providerCallback).not.toHaveBeenCalled();
+	});
+
+	it('rejects forwarded headers before provider dispatch', async () => {
+		gateOpen = true;
+		proxyPolicy.assertForwardedHeadersTrusted.mockImplementation(() => {
+			throw new ForbiddenException('untrusted proxy');
+		});
+
+		const response = await fastify.inject({ method: 'POST', url: MCP_OAUTH_TOKEN_PATH });
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json()).toEqual({ error: 'access_denied' });
+		expect(providerCallback).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-bootstrap.service.ts
@@ -1,0 +1,128 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { ServerResponse } from 'node:http';
+
+import { ForbiddenException, Injectable, ServiceUnavailableException } from '@nestjs/common';
+
+import {
+	MCP_OAUTH_AUTHORIZATION_PATH,
+	MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
+	MCP_OAUTH_ISSUER_PATH,
+	MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
+	MCP_OAUTH_REVOCATION_PATH,
+	MCP_OAUTH_TOKEN_PATH,
+} from '../mcp.constants';
+
+import { McpOAuthProxyPolicyService } from './mcp-oauth-proxy-policy.service';
+import { McpOAuthReadinessControl, McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthResourceServerService } from './mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+type McpOAuthBootstrapRoute =
+	| 'protected_resource_metadata'
+	| 'authorization_server_metadata'
+	| 'authorization'
+	| 'token'
+	| 'revocation';
+
+@Injectable()
+export class McpOAuthBootstrapService {
+	private registered = false;
+
+	constructor(
+		private readonly readiness: McpOAuthReadinessService,
+		private readonly routeGate: McpOAuthRouteGateService,
+		private readonly proxyPolicy: McpOAuthProxyPolicyService,
+		private readonly resourceServer: McpOAuthResourceServerService,
+		private readonly runtime: McpOAuthRuntimeService,
+	) {}
+
+	register(fastify: FastifyInstance): void {
+		if (this.registered) {
+			throw new ServiceUnavailableException('The MCP OAuth bootstrap route set is already registered');
+		}
+
+		fastify.addHook('onRequest', async (request, reply) => this.handle(request, reply));
+		this.registered = true;
+		this.readiness.register(McpOAuthReadinessControl.COMPLETE_ROUTE_SET);
+	}
+
+	private handle(request: FastifyRequest, reply: FastifyReply): void {
+		const route = this.match(request);
+
+		if (!route) return;
+
+		reply.hijack();
+
+		try {
+			this.routeGate.assertOpen();
+			this.proxyPolicy.assertForwardedHeadersTrusted(request);
+
+			switch (route) {
+				case 'protected_resource_metadata':
+					this.writeJson(reply.raw, 200, this.resourceServer.getProtectedResourceMetadata());
+					return;
+				case 'authorization_server_metadata':
+					this.writeJson(reply.raw, 200, this.resourceServer.getAuthorizationServerMetadata());
+					return;
+				default:
+					this.dispatchProvider(request, reply);
+			}
+		} catch (error) {
+			this.writeRouteError(reply.raw, error);
+		}
+	}
+
+	private match(request: FastifyRequest): McpOAuthBootstrapRoute | null {
+		const pathname = new URL(request.raw.url ?? '/', 'http://localhost').pathname;
+		const method = request.raw.method ?? request.method;
+
+		if (method === 'GET' && pathname === MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH) {
+			return 'protected_resource_metadata';
+		}
+		if (method === 'GET' && pathname === MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH) {
+			return 'authorization_server_metadata';
+		}
+		if (method === 'GET' && this.isAuthorizationPath(pathname)) {
+			return 'authorization';
+		}
+		if ((method === 'POST' || method === 'OPTIONS') && pathname === MCP_OAUTH_TOKEN_PATH) return 'token';
+		if ((method === 'POST' || method === 'OPTIONS') && pathname === MCP_OAUTH_REVOCATION_PATH) return 'revocation';
+
+		return null;
+	}
+
+	private isAuthorizationPath(pathname: string): boolean {
+		if (pathname === MCP_OAUTH_AUTHORIZATION_PATH) return true;
+
+		const resumePrefix = `${MCP_OAUTH_AUTHORIZATION_PATH}/`;
+		const resumeId = pathname.startsWith(resumePrefix) ? pathname.slice(resumePrefix.length) : '';
+
+		return resumeId.length > 0 && !resumeId.includes('/');
+	}
+
+	private dispatchProvider(request: FastifyRequest, reply: FastifyReply): void {
+		const runtime = this.runtime.getActive();
+		const url = new URL(request.raw.url ?? '/', 'http://localhost');
+		const providerIssuerPath = new URL(runtime.urls.issuer).pathname;
+		request.raw.url = `${providerIssuerPath}${url.pathname.slice(MCP_OAUTH_ISSUER_PATH.length)}${url.search}`;
+		runtime.callback(request.raw, reply.raw);
+	}
+
+	private writeRouteError(response: ServerResponse, error: unknown): void {
+		const status = error instanceof ForbiddenException ? 403 : error instanceof ServiceUnavailableException ? 503 : 500;
+		const code = status === 403 ? 'access_denied' : status === 503 ? 'temporarily_unavailable' : 'server_error';
+
+		this.writeJson(response, status, { error: code });
+	}
+
+	private writeJson(response: ServerResponse, status: number, payload: unknown): void {
+		if (response.headersSent || response.writableEnded) return;
+
+		response.statusCode = status;
+		response.setHeader('content-type', 'application/json');
+		response.setHeader('cache-control', 'no-store');
+		response.setHeader('pragma', 'no-cache');
+		response.end(JSON.stringify(payload));
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.spec.ts
@@ -236,6 +236,17 @@ describe('McpPolicyService', () => {
 		);
 	});
 
+	it('accepts only the configured canonical OAuth origin on the OAuth resource path', () => {
+		config.oauthPublicBaseUrl = 'https://oauth-panel.example.com/smart-panel';
+
+		expect(() =>
+			service.validateOAuthRequestOrigin(request('https://oauth-panel.example.com', 'oauth-panel.example.com')),
+		).not.toThrow();
+		expect(() => service.validateRequestOrigin(request(undefined, 'oauth-panel.example.com'), policy())).toThrow(
+			ForbiddenException,
+		);
+	});
+
 	function policy(): McpPolicyContext {
 		return {
 			client,

--- a/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-policy.service.ts
@@ -128,10 +128,24 @@ export class McpPolicyService {
 	}
 
 	validateRequestOrigin(request: FastifyRequest, policy: McpPolicyContext): void {
+		this.validateOrigin(request, policy.config);
+	}
+
+	validateOAuthRequestOrigin(request: FastifyRequest): void {
+		const config = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+
+		if (!config.enabled) throw new McpEndpointDisabledException();
+
+		this.validateOrigin(request, config, config.oauthPublicBaseUrl ? new URL(config.oauthPublicBaseUrl) : undefined);
+	}
+
+	private validateOrigin(request: FastifyRequest, config: McpConfigModel, additionalOrigin?: URL): void {
 		const host = this.getHeader(request.headers.host);
-		const allowedOrigins = new Set(policy.config.allowedOrigins);
+		const allowedOrigins = new Set(config.allowedOrigins);
 		const appOrigin = this.getAppOrigin();
 		const allowedHostnames = new Set(['localhost', '127.0.0.1', '[::1]', appOrigin.hostname]);
+
+		if (additionalOrigin) allowedHostnames.add(additionalOrigin.hostname);
 
 		for (const origin of allowedOrigins) {
 			allowedHostnames.add(new URL(origin).hostname);
@@ -157,7 +171,12 @@ export class McpPolicyService {
 
 		const sameOrigin = `${request.protocol}://${host}`;
 
-		if (origin !== sameOrigin && origin !== appOrigin.origin && !allowedOrigins.has(origin)) {
+		if (
+			origin !== sameOrigin &&
+			origin !== appOrigin.origin &&
+			origin !== additionalOrigin?.origin &&
+			!allowedOrigins.has(origin)
+		) {
 			throw new ForbiddenException('Origin is not allowed for the MCP endpoint');
 		}
 	}

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -129,6 +129,18 @@ export class McpServerService implements OnApplicationShutdown {
 		await clientHandler.nodeHandler(rawRequest, reply.raw, request.body);
 	}
 
+	async handleOAuth(request: McpPolicyRequest, reply: FastifyReply, authInfo: AuthInfo): Promise<void> {
+		const requestId = this.auditService.getRequestId(request.body);
+		this.auditProtocolRequest(request.body, requestId, authInfo.clientId);
+		const clientHandler = this.getOrCreateHandler(`oauth:${authInfo.clientId}`);
+		const rawRequest = request.raw as AuthenticatedIncomingMessage;
+
+		rawRequest.auth = authInfo;
+		reply.hijack();
+
+		await clientHandler.nodeHandler(rawRequest, reply.raw, request.body);
+	}
+
 	notifyToolsChanged(clientId?: string): void {
 		this.notify(clientId, (handler) => handler.notify.toolsChanged());
 	}

--- a/apps/backend/test/mcp-endpoint.e2e-spec.ts
+++ b/apps/backend/test/mcp-endpoint.e2e-spec.ts
@@ -25,7 +25,9 @@ import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
@@ -229,7 +231,10 @@ describe('MCP endpoint', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
+				{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
 				{ provide: McpOAuthResourceServerService, useValue: { verifyMcpBearerToken: jest.fn() } },
+				{ provide: McpOAuthRouteGateService, useValue: { assertOpen: jest.fn(), isOpen: false } },
+				{ provide: McpPolicyService, useValue: policyService },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: catalog },

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -251,17 +251,11 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 			if (
 				url.pathname === `${issuerPath}/authorize` ||
+				url.pathname.startsWith(`${issuerPath}/authorize/`) ||
 				url.pathname === `${issuerPath}/token` ||
-				url.pathname === `${issuerPath}/token/revocation` ||
-				url.pathname.startsWith('/auth/')
+				url.pathname === `${issuerPath}/token/revocation`
 			) {
-				request.url = `${
-					url.pathname.startsWith('/auth/')
-						? url.pathname
-						: url.pathname === `${issuerPath}/authorize`
-							? '/auth'
-							: url.pathname.slice(issuerPath.length)
-				}${url.search}`;
+				request.url = `${url.pathname}${url.search}`;
 				void providerCallback(request, response);
 				return;
 			}

--- a/apps/backend/test/mcp-operations.e2e-spec.ts
+++ b/apps/backend/test/mcp-operations.e2e-spec.ts
@@ -21,7 +21,9 @@ import { MCP_CATALOG_REGISTRAR, McpCapability } from '../src/modules/mcp/mcp.con
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpContextService } from '../src/modules/mcp/services/mcp-context.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpPolicyRequest } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
@@ -255,7 +257,10 @@ describe('MCP simulator operations', () => {
 			controllers: [McpController],
 			providers: [
 				{ provide: McpAuditService, useValue: auditService },
+				{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
 				{ provide: McpOAuthResourceServerService, useValue: { verifyMcpBearerToken: jest.fn() } },
+				{ provide: McpOAuthRouteGateService, useValue: { assertOpen: jest.fn(), isOpen: false } },
+				{ provide: McpPolicyService, useValue: policyService },
 				McpServerService,
 				McpSubscriptionRegistryService,
 				{ provide: MCP_CATALOG_REGISTRAR, useValue: targetTools },

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -25,7 +25,9 @@ import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
@@ -162,6 +164,8 @@ describe('MCP disabled restart', () => {
 					provide: McpOAuthResourceServerService,
 					useValue: { authorizeAccessToken: jest.fn(), verifyMcpBearerToken: jest.fn() },
 				},
+				{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
+				{ provide: McpOAuthRouteGateService, useValue: { assertOpen: jest.fn(), isOpen: false } },
 				McpAuditService,
 				McpClientGuard,
 				McpPolicyService,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — OAuth switch-off invalidation foundation implemented
+**Status:** Phase 5 in progress — complete bootstrap OAuth route-set foundation implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -317,6 +317,21 @@ amend ADR 0002.
       invalidation itself fails, and register the coordinator in the sealed readiness inventory. The complete route
       set remains the only missing readiness control, so the user-facing switch stays absent.
 
+### Phase 5t — Complete bootstrap OAuth route-set foundation
+
+- [x] Install one finite OAuth router before Fastify begins listening, register readiness only after the complete hook
+      is installed, and reject duplicate registration so enable/disable never mounts or unmounts routes.
+- [x] Register only the path-aware protected-resource and bounded authorization-server metadata projections plus the
+      explicit authorization/resume, token, and revocation provider routes; keep dependency discovery, registration,
+      and every unrelated provider route unreachable.
+- [x] Preserve the existing static MCP request path while selecting isolated OAuth bearer verification only when the
+      shared gate is open; apply the same proxy and Host/Origin policy, authenticated request budget, minimum read
+      scope, and RFC 6750 challenge boundary.
+- [x] Prove every registered OAuth route returns one uniform fail-closed response while the gate is closed, public path
+      prefixes are remapped only from trusted runtime URLs, static dispatch remains unchanged, and the provider's full
+      PKCE/refresh/revocation security spike still passes. Keep the user-facing switch absent until activation and
+      switch-off are wired through configuration.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -352,7 +367,7 @@ amend ADR 0002.
       serialized subscription-open/invalidation and all-generation artifact-issuance gates,
       public-identity/server-secret rotation, OAuth switch-off invalidation, revoke controls, audit hooks, and rate
       limits are registered; fail closed and keep the shared OAuth route gate closed if any readiness check fails.
-- [ ] Register the complete protected-resource metadata, authorization-server metadata,
+- [x] Register the complete protected-resource metadata, authorization-server metadata,
       authorization/token/revocation, challenge, and OAuth MCP route set once during NestJS/Fastify bootstrap. Every
       route must check the same fail-closed gate before its handler; never mount or unmount routes after startup.
 - [ ] On enable, rerun readiness and open the shared gate for the complete pre-registered OAuth surface atomically;

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 OAuth switch-off invalidation foundation implemented
+Status: in progress — Phase 5 complete bootstrap OAuth route-set foundation implemented
 
 ## 1. Business goal
 
@@ -78,7 +78,7 @@ upgrade consequences.
       later state restoration cannot make it usable.
 - [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
-- [ ] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
+- [x] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
       runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.
 - [ ] Public OAuth identity and server-secret rotation revoke OAuth artifacts and close OAuth subscriptions while
       preserving static MCP streams; only MCP-module disable closes both authorization profiles.


### PR DESCRIPTION
## Summary

- register the complete finite MCP OAuth route set once during Fastify bootstrap behind the shared fail-closed route gate
- expose only bounded protected-resource and authorization-server metadata plus authorization/resume, token, and revocation provider routes
- preserve static MCP bearer behavior while adding isolated OAuth bearer verification, minimum read scope, proxy and Host/Origin checks, RFC 6750 challenges, and authenticated OAuth throttling
- update the Phase 5 task plan and E2E harnesses for the new controller and guard dependencies

## Why

Phase 5 had all underlying OAuth security controls but intentionally kept the public surface unavailable because the complete bootstrap-time route set was the remaining readiness control. This slice installs that finite surface without runtime route mounting and keeps every route uniformly unavailable until the shared gate is opened by the later activation slice.

## Impact

The OAuth endpoints now exist structurally at startup but remain fail-closed. Raw dependency discovery, dynamic registration, nested authorization paths, and unrelated provider routes are not exposed. Existing static MCP clients continue through the unchanged static policy path.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- `pnpm --filter ./apps/backend run lint:js` (passes with two pre-existing warning-only findings)
- `pnpm --filter ./apps/backend run build`
- focused controller, guard, policy, bootstrap, and provider tests: 155 passed
- full MCP regression set: 45 suites / 454 tests passed
- OAuth provider PKCE, refresh, and revocation spike: 11 passed
- backend E2E: 10 suites / 126 tests passed
- Admin type-check and lint
- Admin unit tests: 265 files / 1,853 tests passed
- full uncached backend unit assertions: 320 suites / 4,035 tests passed; after completion, the local runner encountered an unrelated existing Home Assistant websocket teardown error
