### PR TITLE
feat(backend): persist MCP OAuth provider material

### DIFF
--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -30,6 +30,8 @@ export const MCP_DEFAULT_ALLOWED_ORIGINS: readonly string[] = [];
 
 export const MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL: string | null = null;
 
+export const MCP_OAUTH_PROVIDER_MATERIAL_FILENAME = '.mcp-oauth-provider.json';
+
 export const MCP_OAUTH_PRINCIPAL_TYPE = 'mcp_oauth';
 
 export const MCP_OAUTH_SERVER_STATE_KEY = 'primary';

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -71,6 +71,7 @@ import { McpOAuthGlobalInvalidationService } from './services/mcp-oauth-global-i
 import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.service';
 import { McpOAuthManagementService } from './services/mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
+import { McpOAuthProviderMaterialService } from './services/mcp-oauth-provider-material.service';
 import { McpOAuthProxyPolicyService } from './services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from './services/mcp-oauth-public-url.service';
 import { McpOAuthReadinessRegistrationService } from './services/mcp-oauth-readiness-registration.service';
@@ -146,6 +147,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthManagementService,
 		McpOAuthModuleConfigMutationService,
 		McpOAuthProxyPolicyService,
+		McpOAuthProviderMaterialService,
 		McpOAuthProviderFactory,
 		McpOAuthPublicUrlService,
 		McpOAuthReadinessRegistrationService,

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -7,6 +7,7 @@ import {
 	McpOAuthEndpointRateLimitService,
 	McpOAuthRateLimitedEndpoint,
 } from '../services/mcp-oauth-endpoint-rate-limit.service';
+import { McpOAuthProviderMaterialService } from '../services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
@@ -58,11 +59,38 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			{} as DataSource,
 			{} as McpOAuthClientService,
 			{} as McpOAuthPublicUrlService,
+			{} as McpOAuthProviderMaterialService,
 			subscriptions,
 			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
 		);
 		const target = factory as unknown as { dispatchProviderRequest: ProviderDispatcher };
 		dispatch = (...args) => target.dispatchProviderRequest(...args);
+	});
+
+	it('loads persistent provider material before non-test activation', async () => {
+		const originalNodeEnv = process.env.NODE_ENV;
+		const materialFailure = new Error('provider material unavailable');
+		const get = jest.fn(() => {
+			throw materialFailure;
+		});
+		const factory = new McpOAuthProviderFactory(
+			{} as DataSource,
+			{} as McpOAuthClientService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			{ get } as unknown as McpOAuthProviderMaterialService,
+			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+		);
+
+		try {
+			process.env.NODE_ENV = 'production';
+
+			await expect(factory.create()).rejects.toBe(materialFailure);
+			expect(get).toHaveBeenCalledTimes(1);
+		} finally {
+			if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = originalNodeEnv;
+		}
 	});
 
 	it('rejects a blocked provider endpoint before entering the artifact mutation gate', async () => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -17,6 +17,7 @@ import {
 	McpOAuthEndpointRateLimitService,
 	McpOAuthRateLimitedEndpoint,
 } from '../services/mcp-oauth-endpoint-rate-limit.service';
+import { McpOAuthProviderMaterialService } from '../services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
@@ -48,6 +49,7 @@ export class McpOAuthProviderFactory {
 		private readonly dataSource: DataSource,
 		private readonly clientsService: McpOAuthClientService,
 		private readonly publicUrlService: McpOAuthPublicUrlService,
+		private readonly providerMaterial: McpOAuthProviderMaterialService,
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly endpointRateLimit: McpOAuthEndpointRateLimitService,
 	) {}
@@ -59,15 +61,17 @@ export class McpOAuthProviderFactory {
 			throw new ServiceUnavailableException('MCP OAuth public URL is not configured');
 		}
 
-		if (process.env.NODE_ENV !== 'test' && (!options.cookieKeys?.length || !options.jwks?.keys.length)) {
-			throw new ServiceUnavailableException('Persistent MCP OAuth cookie and signing keys are not available');
-		}
+		const persistentMaterial =
+			process.env.NODE_ENV !== 'test' && (!options.cookieKeys || !options.jwks) ? this.providerMaterial.get() : null;
+		const cookieKeys = options.cookieKeys ?? persistentMaterial?.cookieKeys;
+		const jwks = options.jwks ?? persistentMaterial?.jwks;
+
 		if (process.env.NODE_ENV !== 'test' && options.allowInsecureTestCookies === true) {
 			throw new ServiceUnavailableException('Insecure MCP OAuth cookies are permitted only by explicit test setups');
 		}
 
 		const oidcProvider = await loadMcpOAuthProvider();
-		const testPrivateKey = options.jwks
+		const testPrivateKey = jwks
 			? null
 			: generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({ format: 'jwk' });
 		const adapter = createMcpOAuthProviderAdapter(this.dataSource, this.clientsService, {
@@ -94,7 +98,7 @@ export class McpOAuthProviderFactory {
 			allowOmittingSingleRegisteredRedirectUri: false,
 			acceptQueryParamAccessTokens: false,
 			cookies: {
-				keys: options.cookieKeys ?? [randomBytes(32).toString('base64url')],
+				keys: cookieKeys ?? [randomBytes(32).toString('base64url')],
 				long: {
 					httpOnly: true,
 					sameSite: 'lax',
@@ -199,7 +203,7 @@ export class McpOAuthProviderFactory {
 				Session: 30 * 60,
 			},
 			jwks:
-				options.jwks ??
+				jwks ??
 				({ keys: [{ ...testPrivateKey, use: 'sig', alg: 'RS256', kid: 'mcp-oauth-internal-test' }] } as {
 					keys: JWK[];
 				}),

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-provider-material.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-provider-material.service.spec.ts
@@ -1,0 +1,83 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+import { MCP_OAUTH_PROVIDER_MATERIAL_FILENAME } from '../mcp.constants';
+
+import { McpOAuthProviderMaterialService } from './mcp-oauth-provider-material.service';
+
+describe('McpOAuthProviderMaterialService', () => {
+	let configPath: string;
+
+	beforeEach(() => {
+		configPath = mkdtempSync(path.join(tmpdir(), 'mcp-oauth-provider-'));
+	});
+
+	afterEach(() => {
+		rmSync(configPath, { force: true, recursive: true });
+	});
+
+	const createService = (): McpOAuthProviderMaterialService =>
+		new McpOAuthProviderMaterialService({
+			get: jest.fn((key: string) => (key === 'FB_CONFIG_PATH' ? configPath : undefined)),
+		} as unknown as NestConfigService);
+
+	it('creates private restart-stable cookie and signing material in the backed-up config directory', () => {
+		const first = createService().get();
+		const materialPath = path.join(configPath, MCP_OAUTH_PROVIDER_MATERIAL_FILENAME);
+		const stored = JSON.parse(readFileSync(materialPath, 'utf8')) as Record<string, unknown>;
+		const second = createService().get();
+
+		expect(statSync(materialPath).mode & 0o777).toBe(0o600);
+		expect(stored).toMatchObject({ version: 1 });
+		expect(first.cookieKeys).toHaveLength(2);
+		expect(new Set(first.cookieKeys).size).toBe(2);
+		expect(first.jwks.keys).toHaveLength(1);
+		expect(first.jwks.keys[0]).toMatchObject({ kty: 'RSA', use: 'sig', alg: 'RS256' });
+		expect(first.jwks.keys[0]).toHaveProperty('d');
+		expect(second).toEqual(first);
+	});
+
+	it('returns defensive copies without rewriting the stored material', () => {
+		const service = createService();
+		const first = service.get();
+		first.cookieKeys[0] = 'mutated';
+		first.jwks.keys[0].kid = 'mutated';
+
+		const second = service.get();
+
+		expect(second.cookieKeys[0]).not.toBe('mutated');
+		expect(second.jwks.keys[0].kid).not.toBe('mutated');
+	});
+
+	it('tightens an existing material file to owner-only permissions', () => {
+		const material = createService().get();
+		const materialPath = path.join(configPath, MCP_OAUTH_PROVIDER_MATERIAL_FILENAME);
+		writeFileSync(materialPath, `${JSON.stringify({ version: 1, ...material })}\n`, { mode: 0o644 });
+		chmodSync(materialPath, 0o644);
+
+		createService().get();
+
+		expect(statSync(materialPath).mode & 0o777).toBe(0o600);
+	});
+
+	it('fails closed instead of replacing malformed material', () => {
+		const materialPath = path.join(configPath, MCP_OAUTH_PROVIDER_MATERIAL_FILENAME);
+		writeFileSync(materialPath, '{"version":1,"cookieKeys":[]}\n', { mode: 0o600 });
+
+		expect(() => createService().get()).toThrow('Persistent MCP OAuth provider material is unavailable or invalid');
+		expect(readFileSync(materialPath, 'utf8')).toBe('{"version":1,"cookieKeys":[]}\n');
+	});
+
+	it('rejects a provider-material symlink', () => {
+		const outsideDirectory = path.join(configPath, 'outside');
+		const outsidePath = path.join(outsideDirectory, 'material.json');
+		mkdirSync(outsideDirectory);
+		writeFileSync(outsidePath, '{}', { mode: 0o600 });
+		symlinkSync(outsidePath, path.join(configPath, MCP_OAUTH_PROVIDER_MATERIAL_FILENAME));
+
+		expect(() => createService().get()).toThrow('Persistent MCP OAuth provider material is unavailable or invalid');
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-provider-material.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-provider-material.service.ts
@@ -1,0 +1,157 @@
+import { generateKeyPairSync, randomBytes } from 'node:crypto';
+import {
+	chmodSync,
+	existsSync,
+	linkSync,
+	lstatSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import type { JWK } from 'oidc-provider';
+
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+import { getEnvValue } from '../../../common/utils/config.utils';
+import { MCP_OAUTH_PROVIDER_MATERIAL_FILENAME } from '../mcp.constants';
+
+const MATERIAL_VERSION = 1;
+const COOKIE_KEY_PATTERN = /^[A-Za-z0-9_-]{43,}$/;
+
+interface StoredMcpOAuthProviderMaterial {
+	version: number;
+	cookieKeys: string[];
+	jwks: { keys: JWK[] };
+}
+
+export interface McpOAuthProviderMaterial {
+	cookieKeys: string[];
+	jwks: { keys: JWK[] };
+}
+
+@Injectable()
+export class McpOAuthProviderMaterialService {
+	private material: StoredMcpOAuthProviderMaterial | null = null;
+
+	constructor(private readonly configService: NestConfigService) {}
+
+	get(): McpOAuthProviderMaterial {
+		const material = this.material ?? this.loadOrCreate();
+		this.material = material;
+
+		return {
+			cookieKeys: [...material.cookieKeys],
+			jwks: { keys: material.jwks.keys.map((key) => ({ ...key })) },
+		};
+	}
+
+	private loadOrCreate(): StoredMcpOAuthProviderMaterial {
+		mkdirSync(this.configPath, { recursive: true, mode: 0o700 });
+
+		if (existsSync(this.materialPath)) return this.load();
+
+		const material = this.generate();
+		const temporaryPath = `${this.materialPath}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`;
+
+		try {
+			writeFileSync(temporaryPath, `${JSON.stringify(material)}\n`, {
+				encoding: 'utf8',
+				flag: 'wx',
+				mode: 0o600,
+			});
+			linkSync(temporaryPath, this.materialPath);
+			unlinkSync(temporaryPath);
+		} catch (error) {
+			if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+			if ((error as NodeJS.ErrnoException).code === 'EEXIST') return this.load();
+
+			throw new ServiceUnavailableException('Persistent MCP OAuth provider material could not be created');
+		}
+
+		return material;
+	}
+
+	private load(): StoredMcpOAuthProviderMaterial {
+		try {
+			const file = lstatSync(this.materialPath);
+
+			if (!file.isFile() || file.isSymbolicLink()) {
+				throw new Error('Provider material path is not a regular file');
+			}
+
+			if ((file.mode & 0o077) !== 0) chmodSync(this.materialPath, 0o600);
+
+			const material = JSON.parse(readFileSync(this.materialPath, 'utf8')) as unknown;
+
+			if (!this.isValid(material)) throw new Error('Provider material has an invalid shape');
+
+			return material;
+		} catch {
+			throw new ServiceUnavailableException('Persistent MCP OAuth provider material is unavailable or invalid');
+		}
+	}
+
+	private generate(): StoredMcpOAuthProviderMaterial {
+		const privateKey = generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({ format: 'jwk' });
+		const signingKey: JWK = {
+			...privateKey,
+			alg: 'RS256',
+			kid: randomBytes(16).toString('base64url'),
+			use: 'sig',
+		};
+
+		return {
+			version: MATERIAL_VERSION,
+			cookieKeys: [randomBytes(32).toString('base64url'), randomBytes(32).toString('base64url')],
+			jwks: { keys: [signingKey] },
+		};
+	}
+
+	private isValid(value: unknown): value is StoredMcpOAuthProviderMaterial {
+		if (!value || typeof value !== 'object') return false;
+
+		const candidate = value as Partial<StoredMcpOAuthProviderMaterial>;
+		const cookieKeys = candidate.cookieKeys;
+		const keys = candidate.jwks?.keys;
+
+		return (
+			candidate.version === MATERIAL_VERSION &&
+			Array.isArray(cookieKeys) &&
+			cookieKeys.length >= 2 &&
+			new Set(cookieKeys).size === cookieKeys.length &&
+			cookieKeys.every((key) => typeof key === 'string' && COOKIE_KEY_PATTERN.test(key)) &&
+			Array.isArray(keys) &&
+			keys.length === 1 &&
+			this.isPrivateSigningKey(keys[0])
+		);
+	}
+
+	private isPrivateSigningKey(value: unknown): value is JWK {
+		if (!value || typeof value !== 'object') return false;
+
+		const key = value as Record<string, unknown>;
+		const privateParts = ['n', 'e', 'd', 'p', 'q', 'dp', 'dq', 'qi', 'kid'];
+
+		return (
+			key.kty === 'RSA' &&
+			key.use === 'sig' &&
+			key.alg === 'RS256' &&
+			privateParts.every((part) => typeof key[part] === 'string' && key[part].length > 0)
+		);
+	}
+
+	private get configPath(): string {
+		return getEnvValue<string>(
+			this.configService,
+			'FB_CONFIG_PATH',
+			path.resolve(__dirname, '../../../../../../var/data'),
+		);
+	}
+
+	private get materialPath(): string {
+		return path.resolve(this.configPath, MCP_OAUTH_PROVIDER_MATERIAL_FILENAME);
+	}
+}

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -21,6 +21,7 @@ import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-prov
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthEndpointRateLimitService } from '../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
+import { McpOAuthProviderMaterialService } from '../src/modules/mcp/services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
@@ -225,9 +226,16 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			runOAuthMutation: (operation: () => Promise<unknown>) => operation(),
 		} as unknown as McpSubscriptionRegistryService;
 
-		factory = new McpOAuthProviderFactory(dataSource, clientsService, publicUrlService, subscriptions, {
-			consume: () => Promise.resolve({ allowed: true, retryAfterSeconds: 60 }),
-		} as unknown as McpOAuthEndpointRateLimitService);
+		factory = new McpOAuthProviderFactory(
+			dataSource,
+			clientsService,
+			publicUrlService,
+			{} as McpOAuthProviderMaterialService,
+			subscriptions,
+			{
+				consume: () => Promise.resolve({ allowed: true, retryAfterSeconds: 60 }),
+			} as unknown as McpOAuthEndpointRateLimitService,
+		);
 		const runtime = await factory.create({
 			allowTestInMemory: true,
 			allowInsecureTestCookies: true,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -332,6 +332,17 @@ amend ADR 0002.
       PKCE/refresh/revocation security spike still passes. Keep the user-facing switch absent until activation and
       switch-off are wired through configuration.
 
+### Phase 5u — Persistent OAuth provider material foundation
+
+- [x] Generate the provider's private cookie and RSA signing material once inside the owner-only `FB_CONFIG_PATH`,
+      which is already covered by the system backup boundary; publish the completed file atomically without
+      overwriting material created by a concurrent process.
+- [x] Validate the complete versioned material shape on every cold load, tighten existing file permissions to `0600`,
+      reject symlinks and malformed or incomplete files, and fail closed without replacing unreadable material.
+- [x] Wire non-test provider activation to defensive copies of the persistent material while preserving explicitly
+      isolated ephemeral test setup. Keep the user-facing switch absent until configuration lifecycle activation and
+      invalidation are wired through the shared readiness and route gates.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization


### PR DESCRIPTION
## Summary

- persist restart-stable OAuth provider cookie keys and private RSA signing material in the protected `FB_CONFIG_PATH`
- create the material atomically without overwriting a concurrent writer, validate its versioned shape, enforce owner-only permissions, and reject symlinks or malformed files
- wire non-test provider activation to defensive copies of the persistent material while preserving isolated ephemeral test setup
- record Phase 5u completion in the MCP OAuth implementation plan

## Why

The embedded OAuth provider previously refused production activation unless callers supplied persistent cookie and signing keys. The upcoming user-facing OAuth switch therefore could not safely activate a restart-stable provider.

This phase establishes the private provider-material boundary first. The enable switch remains intentionally absent until the next phase wires configuration changes through readiness checks, provider activation, route-gate opening, and switch-off invalidation.

## Impact

There is no user-facing OAuth activation change yet. On the first future non-test provider activation, Smart Panel will create `.mcp-oauth-provider.json` with mode `0600` inside `FB_CONFIG_PATH`. That directory is already included in system backups.

Invalid, incomplete, or symlinked material fails closed and is not silently replaced.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- `pnpm --filter ./apps/backend run lint:js`
- `pnpm --filter ./apps/backend run test:unit`
- `pnpm --filter ./apps/backend run test:e2e`
- `pnpm --filter ./apps/backend run test:oauth-spike`
- focused provider-material, provider-factory, and runtime unit tests
- Prettier check and `git diff --check`
