### PR TITLE
feat(cross): enable MCP OAuth lifecycle controls

### DIFF
--- a/apps/admin/src/modules/config/store/config-modules.store.transformers.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.transformers.ts
@@ -1,13 +1,11 @@
+import type { ZodType } from 'zod';
+
 import { camelToSnake, logger, snakeToCamel } from '../../../common';
 import { ConfigValidationException } from '../config.exceptions';
 
-import { ConfigModuleSchema, ConfigModuleUpdateReqSchema } from './config-modules.store.schemas';
 import type { IConfigModule, IConfigModuleRes, IConfigModuleUpdateReq, IConfigModulesEditActionPayload } from './config-modules.store.types';
 
-export const transformConfigModuleResponse = <T extends IConfigModule = IConfigModule>(
-	response: IConfigModuleRes,
-	schema: typeof ConfigModuleSchema
-): T => {
+export const transformConfigModuleResponse = <T extends IConfigModule = IConfigModule>(response: IConfigModuleRes, schema: ZodType<T>): T => {
 	const parsedResponse = schema.safeParse(snakeToCamel(response));
 
 	if (!parsedResponse.success) {
@@ -16,12 +14,12 @@ export const transformConfigModuleResponse = <T extends IConfigModule = IConfigM
 		throw new ConfigValidationException('Failed to validate received module config data.');
 	}
 
-	return parsedResponse.data as T;
+	return parsedResponse.data;
 };
 
 export const transformConfigModuleUpdateRequest = <T extends IConfigModuleUpdateReq = IConfigModuleUpdateReq>(
 	config: IConfigModulesEditActionPayload['data'],
-	schema: typeof ConfigModuleUpdateReqSchema
+	schema: ZodType<T>
 ): T => {
 	const parsedRequest = schema.safeParse(camelToSnake(config));
 
@@ -31,6 +29,5 @@ export const transformConfigModuleUpdateRequest = <T extends IConfigModuleUpdate
 		throw new ConfigValidationException('Failed to validate update module config request.');
 	}
 
-	return parsedRequest.data as T;
+	return parsedRequest.data;
 };
-

--- a/apps/admin/src/modules/mcp/components/mcp-config-form.vue
+++ b/apps/admin/src/modules/mcp/components/mcp-config-form.vue
@@ -48,6 +48,47 @@
 
 		<el-divider />
 
+		<el-alert
+			type="warning"
+			:title="t('mcpModule.config.oauth.warningTitle')"
+			:description="t('mcpModule.config.oauth.warningDescription')"
+			:closable="false"
+			show-icon
+			class="mb-4"
+		/>
+
+		<el-form-item
+			:label="t('mcpModule.config.oauth.publicBaseUrlTitle')"
+			prop="oauthPublicBaseUrl"
+		>
+			<el-input
+				v-model="model.oauthPublicBaseUrl"
+				:placeholder="t('mcpModule.config.oauth.publicBaseUrlPlaceholder')"
+				name="oauthPublicBaseUrl"
+				clearable
+			/>
+			<div class="text-sm text-gray-500 mt-1">
+				{{ t('mcpModule.config.oauth.publicBaseUrlDescription') }}
+			</div>
+		</el-form-item>
+
+		<el-form-item
+			:label="t('mcpModule.config.oauth.enabledTitle')"
+			prop="oauthEnabled"
+			label-position="left"
+		>
+			<el-switch
+				v-model="model.oauthEnabled"
+				name="oauthEnabled"
+				:disabled="!model.enabled"
+			/>
+			<div class="w-full text-sm text-gray-500 mt-1">
+				{{ t('mcpModule.config.oauth.enabledDescription') }}
+			</div>
+		</el-form-item>
+
+		<el-divider />
+
 		<el-form-item
 			:label="t('mcpModule.config.capabilities.title')"
 			prop="capabilities"
@@ -134,7 +175,7 @@ import { useFlashMessage } from '../../../common';
 import { FormResult, type FormResultType, Layout, useConfigModuleEditForm } from '../../config';
 import { McpCapability } from '../mcp.constants';
 import { resolveMcpEndpoint } from '../mcp.utils';
-import { McpOriginSchema } from '../schemas/config.schemas';
+import { McpOAuthPublicBaseUrlSchema, McpOriginSchema } from '../schemas/config.schemas';
 import type { IMcpConfigEditForm } from '../schemas/config.types';
 
 import type { IMcpConfigFormProps } from './mcp-config-form.types';
@@ -169,6 +210,17 @@ const { formEl, model, formChanged, submit, formResult } = useConfigModuleEditFo
 });
 
 const rules = reactive<FormRules<IMcpConfigEditForm>>({
+	oauthPublicBaseUrl: [
+		{
+			validator: (_rule, value: string | null, callback): void => {
+				const required = model.enabled && model.oauthEnabled;
+				const missing = value === null || value === '';
+				const valid = missing ? !required : McpOAuthPublicBaseUrlSchema.safeParse(value).success;
+				callback(valid ? undefined : new Error(t('mcpModule.config.oauth.publicBaseUrlInvalid')));
+			},
+			trigger: 'change',
+		},
+	],
 	allowedOrigins: [
 		{
 			validator: (_rule, value: string[], callback): void => {

--- a/apps/admin/src/modules/mcp/locales/cs-CZ.json
+++ b/apps/admin/src/modules/mcp/locales/cs-CZ.json
@@ -28,6 +28,16 @@
 			"title": "Koncový bod MCP této instalace",
 			"description": "Použijte tuto adresu URL s důvěryhodným klientem MCP a jednorázově zobrazenými přihlašovacími údaji."
 		},
+		"oauth": {
+			"warningTitle": "Autorizace dostupná z internetu",
+			"warningDescription": "OAuth zpřístupňuje autorizační trasy pod nastavenou veřejnou identitou. Před povolením použijte důvěryhodný reverzní proxy server a platný certifikát HTTPS.",
+			"publicBaseUrlTitle": "Veřejná základní URL OAuth",
+			"publicBaseUrlDescription": "Kanonická externí HTTPS URL používaná jako identita OAuth. Její změna odvolá veškerý přístup OAuth a zachová statické klienty MCP.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Použijte absolutní HTTPS URL bez přihlašovacích údajů, parametrů, fragmentu a koncového lomítka.",
+			"enabledTitle": "Povolit MCP OAuth",
+			"enabledDescription": "Před otevřením všech tras OAuth ověří připravenost zabezpečení. Vypnutí odvolá všechna oprávnění a tokeny OAuth a uzavře pouze odběry OAuth."
+		},
 		"capabilities": {
 			"title": "Limit oprávnění instalace",
 			"warningTitle": "Přístup k fyzickým zařízením",

--- a/apps/admin/src/modules/mcp/locales/de-DE.json
+++ b/apps/admin/src/modules/mcp/locales/de-DE.json
@@ -31,6 +31,16 @@
 			"title": "MCP-Endpunkt der Installation",
 			"description": "Verwenden Sie diese URL mit einem vertrauenswürdigen MCP-Client und den einmalig angezeigten Zugangsdaten."
 		},
+		"oauth": {
+			"warningTitle": "Öffentlich erreichbare Autorisierung",
+			"warningDescription": "OAuth stellt Autorisierungsrouten unter der konfigurierten öffentlichen Identität bereit. Verwenden Sie vor der Aktivierung einen vertrauenswürdigen Reverse-Proxy und ein gültiges HTTPS-Zertifikat.",
+			"publicBaseUrlTitle": "Öffentliche OAuth-Basis-URL",
+			"publicBaseUrlDescription": "Kanonische externe HTTPS-URL für die OAuth-Identität. Eine Änderung widerruft alle OAuth-Zugriffe, während statische MCP-Clients erhalten bleiben.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Verwenden Sie eine absolute HTTPS-URL ohne Zugangsdaten, Abfrage, Fragment oder abschließenden Schrägstrich.",
+			"enabledTitle": "MCP OAuth aktivieren",
+			"enabledDescription": "Prüft vor dem Öffnen aller OAuth-Routen die Sicherheitsbereitschaft. Beim Deaktivieren werden alle OAuth-Berechtigungen und Tokens widerrufen und nur OAuth-Abonnements geschlossen."
+		},
 		"capabilities": {
 			"title": "Berechtigungsgrenze der Installation",
 			"warningTitle": "Zugriff auf physische Geräte",

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -42,6 +42,16 @@
 			"title": "Installation MCP endpoint",
 			"description": "Use this URL with a trusted MCP client and the one-time bearer credential."
 		},
+		"oauth": {
+			"warningTitle": "Internet-facing authorization",
+			"warningDescription": "OAuth exposes authorization routes at the configured public identity. Use a trusted reverse proxy and valid HTTPS certificate before enabling it.",
+			"publicBaseUrlTitle": "OAuth public base URL",
+			"publicBaseUrlDescription": "Canonical external HTTPS URL used as the OAuth identity. Changing it revokes all OAuth access while preserving static MCP clients.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Use an absolute HTTPS URL without credentials, query, fragment, or trailing slash.",
+			"enabledTitle": "Enable MCP OAuth",
+			"enabledDescription": "Runs readiness checks before opening the complete OAuth route set. Disabling revokes every OAuth grant and token and closes only OAuth subscriptions."
+		},
 		"capabilities": {
 			"title": "Installation capability ceiling",
 			"warningTitle": "Physical device access",

--- a/apps/admin/src/modules/mcp/locales/es-ES.json
+++ b/apps/admin/src/modules/mcp/locales/es-ES.json
@@ -34,6 +34,16 @@
 			"title": "Endpoint MCP de la instalación",
 			"description": "Utiliza esta URL con un cliente MCP de confianza y la credencial mostrada una sola vez."
 		},
+		"oauth": {
+			"warningTitle": "Autorización expuesta a Internet",
+			"warningDescription": "OAuth expone rutas de autorización en la identidad pública configurada. Usa un proxy inverso de confianza y un certificado HTTPS válido antes de habilitarlo.",
+			"publicBaseUrlTitle": "URL base pública de OAuth",
+			"publicBaseUrlDescription": "URL HTTPS externa canónica usada como identidad OAuth. Cambiarla revoca todo el acceso OAuth y conserva los clientes MCP estáticos.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Utiliza una URL HTTPS absoluta sin credenciales, consulta, fragmento ni barra final.",
+			"enabledTitle": "Habilitar MCP OAuth",
+			"enabledDescription": "Comprueba la preparación de seguridad antes de abrir todas las rutas OAuth. Al deshabilitarlo se revocan todas las concesiones y tokens OAuth y solo se cierran las suscripciones OAuth."
+		},
 		"capabilities": {
 			"title": "Límite de capacidades de la instalación",
 			"warningTitle": "Acceso a dispositivos físicos",

--- a/apps/admin/src/modules/mcp/locales/pl-PL.json
+++ b/apps/admin/src/modules/mcp/locales/pl-PL.json
@@ -34,6 +34,16 @@
 			"title": "Endpoint MCP instalacji",
 			"description": "Użyj tego adresu URL z zaufanym klientem MCP i poświadczeniem wyświetlanym tylko raz."
 		},
+		"oauth": {
+			"warningTitle": "Autoryzacja dostępna z Internetu",
+			"warningDescription": "OAuth udostępnia trasy autoryzacji pod skonfigurowaną publiczną tożsamością. Przed włączeniem użyj zaufanego reverse proxy i prawidłowego certyfikatu HTTPS.",
+			"publicBaseUrlTitle": "Publiczny bazowy adres URL OAuth",
+			"publicBaseUrlDescription": "Kanoniczny zewnętrzny adres HTTPS używany jako tożsamość OAuth. Jego zmiana unieważnia cały dostęp OAuth, zachowując statycznych klientów MCP.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Użyj bezwzględnego adresu HTTPS bez poświadczeń, zapytania, fragmentu ani końcowego ukośnika.",
+			"enabledTitle": "Włącz MCP OAuth",
+			"enabledDescription": "Przed otwarciem wszystkich tras OAuth sprawdza gotowość zabezpieczeń. Wyłączenie unieważnia wszystkie granty i tokeny OAuth oraz zamyka tylko subskrypcje OAuth."
+		},
 		"capabilities": {
 			"title": "Limit uprawnień instalacji",
 			"warningTitle": "Dostęp do urządzeń fizycznych",

--- a/apps/admin/src/modules/mcp/locales/sk-SK.json
+++ b/apps/admin/src/modules/mcp/locales/sk-SK.json
@@ -28,6 +28,16 @@
 			"title": "Koncový bod MCP tejto inštalácie",
 			"description": "Použite túto adresu URL s dôveryhodným klientom MCP a jednorazovo zobrazenými prihlasovacími údajmi."
 		},
+		"oauth": {
+			"warningTitle": "Autorizácia dostupná z internetu",
+			"warningDescription": "OAuth sprístupňuje autorizačné trasy pod nastavenou verejnou identitou. Pred povolením použite dôveryhodný reverzný proxy server a platný certifikát HTTPS.",
+			"publicBaseUrlTitle": "Verejná základná URL OAuth",
+			"publicBaseUrlDescription": "Kanonická externá HTTPS URL používaná ako identita OAuth. Jej zmena odvolá všetok prístup OAuth a zachová statických klientov MCP.",
+			"publicBaseUrlPlaceholder": "https://panel.example.com",
+			"publicBaseUrlInvalid": "Použite absolútnu HTTPS URL bez prihlasovacích údajov, parametrov, fragmentu a koncovej lomky.",
+			"enabledTitle": "Povoliť MCP OAuth",
+			"enabledDescription": "Pred otvorením všetkých trás OAuth overí pripravenosť zabezpečenia. Vypnutie odvolá všetky oprávnenia a tokeny OAuth a uzavrie iba odbery OAuth."
+		},
 		"capabilities": {
 			"title": "Limit oprávnení inštalácie",
 			"warningTitle": "Prístup k fyzickým zariadeniam",

--- a/apps/admin/src/modules/mcp/schemas/config.schemas.ts
+++ b/apps/admin/src/modules/mcp/schemas/config.schemas.ts
@@ -19,7 +19,49 @@ export const McpOriginSchema = z
 		{ message: 'Origin must be an absolute HTTP(S) origin without a path, query, fragment, or credentials.' }
 	);
 
+export const McpOAuthPublicBaseUrlSchema = z
+	.string()
+	.trim()
+	.refine(
+		(value): boolean => {
+			try {
+				const url = new URL(value);
+
+				const normalized = `${url.origin}${url.pathname === '/' ? '' : url.pathname}`;
+
+				return (
+					url.protocol === 'https:' &&
+					url.hostname !== '' &&
+					url.username === '' &&
+					url.password === '' &&
+					url.search === '' &&
+					url.hash === '' &&
+					(url.pathname === '/' || !url.pathname.endsWith('/')) &&
+					normalized === value
+				);
+			} catch {
+				return false;
+			}
+		},
+		{ message: 'OAuth public base URL must be an absolute HTTPS URL without credentials, query, fragment, or trailing slash.' }
+	);
+
+const McpOptionalOAuthPublicBaseUrlSchema = z.preprocess(
+	(value): unknown => (value === '' ? null : value),
+	z.union([McpOAuthPublicBaseUrlSchema, z.null()])
+);
+
 export const McpConfigEditFormSchema = ConfigModuleEditFormSchema.extend({
+	oauthEnabled: z.boolean().default(false),
+	oauthPublicBaseUrl: McpOptionalOAuthPublicBaseUrlSchema.default(null),
 	capabilities: z.array(z.nativeEnum(McpCapability)).default([McpCapability.read]),
 	allowedOrigins: z.array(McpOriginSchema).default([]),
+}).superRefine((value, context): void => {
+	if (value.enabled && value.oauthEnabled && value.oauthPublicBaseUrl === null) {
+		context.addIssue({
+			code: 'custom',
+			path: ['oauthPublicBaseUrl'],
+			message: 'Configure the OAuth public base URL before enabling OAuth.',
+		});
+	}
 });

--- a/apps/admin/src/modules/mcp/schemas/mcp.schemas.spec.ts
+++ b/apps/admin/src/modules/mcp/schemas/mcp.schemas.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { transformConfigModuleResponse, transformConfigModuleUpdateRequest } from '../../config/store/config-modules.store.transformers';
 import { McpCapability } from '../mcp.constants';
 import { isCapabilitySubset } from '../mcp.utils';
+import { McpConfigSchema, McpConfigUpdateReqSchema } from '../store/config.store.schemas';
 
 import { McpCreateClientSchema } from './client.schemas';
-import { McpConfigEditFormSchema, McpOriginSchema } from './config.schemas';
+import { McpConfigEditFormSchema, McpOAuthPublicBaseUrlSchema, McpOriginSchema } from './config.schemas';
 
 describe('MCP admin schemas', () => {
 	const capabilityCombinations = [
@@ -35,6 +37,58 @@ describe('MCP admin schemas', () => {
 		expect(McpOriginSchema.safeParse('https://agent.example.com/path').success).toBe(false);
 		expect(McpOriginSchema.safeParse('https://user:secret@agent.example.com').success).toBe(false);
 		expect(McpOriginSchema.safeParse('file:///tmp/agent').success).toBe(false);
+	});
+
+	it('accepts only normalized HTTPS OAuth public identities', () => {
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('https://panel.example.com').success).toBe(true);
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('https://panel.example.com/smart-panel').success).toBe(true);
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('http://panel.example.com').success).toBe(false);
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('https://panel.example.com/').success).toBe(false);
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('https://panel.example.com/path/').success).toBe(false);
+		expect(McpOAuthPublicBaseUrlSchema.safeParse('https://user:secret@panel.example.com').success).toBe(false);
+	});
+
+	it('requires a public identity when active OAuth is enabled', () => {
+		const base = {
+			type: 'mcp-module',
+			enabled: true,
+			capabilities: [McpCapability.read],
+			allowedOrigins: [],
+		};
+
+		expect(
+			McpConfigEditFormSchema.safeParse({
+				...base,
+				oauthEnabled: true,
+				oauthPublicBaseUrl: 'https://panel.example.com',
+			}).success
+		).toBe(true);
+		expect(McpConfigEditFormSchema.safeParse({ ...base, oauthEnabled: true, oauthPublicBaseUrl: null }).success).toBe(false);
+		expect(McpConfigEditFormSchema.safeParse({ ...base, enabled: false, oauthEnabled: true, oauthPublicBaseUrl: null }).success).toBe(true);
+		expect(McpConfigEditFormSchema.safeParse({ ...base, oauthEnabled: false, oauthPublicBaseUrl: '' }).data?.oauthPublicBaseUrl).toBeNull();
+	});
+
+	it('maps the OAuth lifecycle fields across the camel-case Admin and snake-case API boundary', () => {
+		const config = transformConfigModuleResponse(
+			{
+				type: 'mcp-module',
+				enabled: true,
+				oauth_enabled: true,
+				oauth_public_base_url: 'https://panel.example.com',
+				capabilities: [McpCapability.read],
+				allowed_origins: [],
+			} as never,
+			McpConfigSchema
+		) as Record<string, unknown>;
+
+		expect(config).toMatchObject({
+			oauthEnabled: true,
+			oauthPublicBaseUrl: 'https://panel.example.com',
+		});
+		expect(transformConfigModuleUpdateRequest(config as never, McpConfigUpdateReqSchema)).toMatchObject({
+			oauth_enabled: true,
+			oauth_public_base_url: 'https://panel.example.com',
+		});
 	});
 
 	it('requires a finite bounded credential lifetime', () => {

--- a/apps/admin/src/modules/mcp/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/mcp/store/config.store.schemas.ts
@@ -9,6 +9,8 @@ type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 export const McpConfigSchema = ConfigModuleSchema.extend({
 	type: z.literal(MCP_MODULE_NAME),
+	oauthEnabled: z.boolean().default(false),
+	oauthPublicBaseUrl: z.string().nullable().default(null),
 	capabilities: z.array(z.nativeEnum(McpCapability)).default([McpCapability.read]),
 	allowedOrigins: z.array(z.string()).default([]),
 });
@@ -16,6 +18,8 @@ export const McpConfigSchema = ConfigModuleSchema.extend({
 export const McpConfigUpdateReqSchema: ZodType<ApiConfigUpdateModule> = ConfigModuleUpdateReqSchema.and(
 	z.object({
 		type: z.literal(MCP_MODULE_NAME),
+		oauth_enabled: z.boolean().optional(),
+		oauth_public_base_url: z.string().nullable().optional(),
 		capabilities: z.array(z.nativeEnum(McpCapability)).optional(),
 		allowed_origins: z.array(z.string()).optional(),
 	})
@@ -24,6 +28,8 @@ export const McpConfigUpdateReqSchema: ZodType<ApiConfigUpdateModule> = ConfigMo
 export const McpConfigResSchema: ZodType<ApiConfigModule> = ConfigModuleResSchema.and(
 	z.object({
 		type: z.literal(MCP_MODULE_NAME),
+		oauth_enabled: z.boolean(),
+		oauth_public_base_url: z.string().nullable(),
 		capabilities: z.array(z.nativeEnum(McpCapability)),
 		allowed_origins: z.array(z.string()),
 	})

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.spec.ts
@@ -5,6 +5,7 @@ import {
 	MCP_DEFAULT_ALLOWED_ORIGINS,
 	MCP_DEFAULT_CAPABILITIES,
 	MCP_DEFAULT_ENABLED,
+	MCP_DEFAULT_OAUTH_ENABLED,
 	MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 	MCP_MODULE_NAME,
 	McpCapability,
@@ -31,11 +32,20 @@ describe('MCP configuration', () => {
 		expect(config).toMatchObject({
 			type: MCP_MODULE_NAME,
 			enabled: MCP_DEFAULT_ENABLED,
+			oauthEnabled: MCP_DEFAULT_OAUTH_ENABLED,
 			capabilities: MCP_DEFAULT_CAPABILITIES,
 			allowedOrigins: MCP_DEFAULT_ALLOWED_ORIGINS,
 			oauthPublicBaseUrl: MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 		});
 		expect(await validate(config)).toHaveLength(0);
+	});
+
+	it('accepts only a boolean OAuth enabled state', async () => {
+		const enabled = plainToInstance(UpdateMcpConfigDto, { type: MCP_MODULE_NAME, oauth_enabled: true });
+		const invalid = plainToInstance(UpdateMcpConfigDto, { type: MCP_MODULE_NAME, oauth_enabled: 'true' });
+
+		expect(await validate(enabled)).toHaveLength(0);
+		expect(await validate(invalid)).not.toHaveLength(0);
 	});
 
 	it('accepts only a normalized HTTPS OAuth public base URL and permits clearing it', async () => {
@@ -115,6 +125,7 @@ describe('MCP configuration', () => {
 	it('serializes the persisted model using API field names', () => {
 		const config = new McpConfigModel();
 		config.enabled = true;
+		config.oauthEnabled = true;
 		config.capabilities = [McpCapability.WRITE, McpCapability.TRIGGER];
 		config.allowedOrigins = ['https://panel.example.com'];
 		config.oauthPublicBaseUrl = 'https://panel.example.com/smart-panel';
@@ -122,6 +133,7 @@ describe('MCP configuration', () => {
 		expect(instanceToPlain(config)).toEqual({
 			type: MCP_MODULE_NAME,
 			enabled: true,
+			oauth_enabled: true,
 			capabilities: [McpCapability.WRITE, McpCapability.TRIGGER],
 			allowed_origins: ['https://panel.example.com'],
 			oauth_public_base_url: 'https://panel.example.com/smart-panel',

--- a/apps/backend/src/modules/mcp/dto/update-config.dto.ts
+++ b/apps/backend/src/modules/mcp/dto/update-config.dto.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { ArrayUnique, IsArray, IsEnum, IsOptional, IsString, Validate } from 'class-validator';
+import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsOptional, IsString, Validate } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -18,6 +18,17 @@ export class UpdateMcpConfigDto extends UpdateModuleConfigDto {
 	@Expose()
 	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
 	type: string = MCP_MODULE_NAME;
+
+	@ApiPropertyOptional({
+		name: 'oauth_enabled',
+		description: 'Whether the readiness-gated MCP OAuth authorization profile is enabled',
+		type: 'boolean',
+		example: false,
+	})
+	@Expose({ name: 'oauth_enabled' })
+	@IsOptional()
+	@IsBoolean({ message: '[{"field":"oauth_enabled","reason":"OAuth enabled state must be a boolean."}]' })
+	oauth_enabled?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Installation-wide ceiling for capabilities that MCP clients may receive',
@@ -55,7 +66,7 @@ export class UpdateMcpConfigDto extends UpdateModuleConfigDto {
 
 	@ApiPropertyOptional({
 		name: 'oauth_public_base_url',
-		description: 'Explicit canonical HTTPS base URL used to derive the inactive MCP OAuth identity',
+		description: 'Explicit canonical HTTPS base URL used to derive the MCP OAuth identity',
 		type: 'string',
 		nullable: true,
 		example: 'https://panel.example.com',

--- a/apps/backend/src/modules/mcp/mcp.constants.ts
+++ b/apps/backend/src/modules/mcp/mcp.constants.ts
@@ -30,6 +30,8 @@ export const MCP_DEFAULT_ALLOWED_ORIGINS: readonly string[] = [];
 
 export const MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL: string | null = null;
 
+export const MCP_DEFAULT_OAUTH_ENABLED = false;
+
 export const MCP_OAUTH_PROVIDER_MATERIAL_FILENAME = '.mcp-oauth-provider.json';
 
 export const MCP_OAUTH_PRINCIPAL_TYPE = 'mcp_oauth';

--- a/apps/backend/src/modules/mcp/mcp.module.ts
+++ b/apps/backend/src/modules/mcp/mcp.module.ts
@@ -69,6 +69,7 @@ import { McpOAuthClientService } from './services/mcp-oauth-client.service';
 import { McpOAuthEndpointRateLimitService } from './services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from './services/mcp-oauth-global-invalidation.service';
 import { McpOAuthInteractionService } from './services/mcp-oauth-interaction.service';
+import { McpOAuthLifecycleService } from './services/mcp-oauth-lifecycle.service';
 import { McpOAuthManagementService } from './services/mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from './services/mcp-oauth-module-config-mutation.service';
 import { McpOAuthProviderMaterialService } from './services/mcp-oauth-provider-material.service';
@@ -152,6 +153,7 @@ import { McpTargetDiscoveryToolService } from './tools/mcp-target-discovery-tool
 		McpOAuthPublicUrlService,
 		McpOAuthReadinessRegistrationService,
 		McpOAuthReadinessService,
+		McpOAuthLifecycleService,
 		McpOAuthRefreshTokenService,
 		McpOAuthResourceServerService,
 		McpOAuthRouteGateService,
@@ -255,9 +257,10 @@ Connects trusted MCP-compatible agents to a curated set of Smart Panel tools and
 | Option | Description | Default |
 |--------|-------------|---------|
 | \`enabled\` | Accept MCP protocol requests | \`false\` |
+| \`oauth_enabled\` | Enable the readiness-gated OAuth authorization profile | \`false\` |
 | \`capabilities\` | Allowed combination of \`read\`, \`write\`, and \`trigger\` | \`read\` |
 | \`allowed_origins\` | Additional browser origins allowed to call the endpoint | empty |
-| \`oauth_public_base_url\` | Canonical HTTPS base used by the inactive OAuth foundation | empty |`,
+| \`oauth_public_base_url\` | Canonical external HTTPS base used as the OAuth identity | empty |`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs/admin-management/mcp',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/mcp/models/config.model.ts
+++ b/apps/backend/src/modules/mcp/models/config.model.ts
@@ -8,6 +8,7 @@ import {
 	MCP_DEFAULT_ALLOWED_ORIGINS,
 	MCP_DEFAULT_CAPABILITIES,
 	MCP_DEFAULT_ENABLED,
+	MCP_DEFAULT_OAUTH_ENABLED,
 	MCP_DEFAULT_OAUTH_PUBLIC_BASE_URL,
 	MCP_MODULE_NAME,
 	McpCapability,
@@ -36,6 +37,16 @@ export class McpConfigModel extends ModuleConfigModel {
 	override enabled: boolean = MCP_DEFAULT_ENABLED;
 
 	@ApiProperty({
+		name: 'oauth_enabled',
+		description: 'Whether the readiness-gated MCP OAuth authorization profile is enabled',
+		type: 'boolean',
+		example: MCP_DEFAULT_OAUTH_ENABLED,
+	})
+	@Expose({ name: 'oauth_enabled' })
+	@IsBoolean()
+	oauthEnabled: boolean = MCP_DEFAULT_OAUTH_ENABLED;
+
+	@ApiProperty({
 		description: 'Installation-wide ceiling for capabilities that MCP clients may receive',
 		type: 'array',
 		items: { type: 'string', enum: Object.values(McpCapability) },
@@ -62,7 +73,7 @@ export class McpConfigModel extends ModuleConfigModel {
 
 	@ApiProperty({
 		name: 'oauth_public_base_url',
-		description: 'Explicit canonical HTTPS base URL used to derive the inactive MCP OAuth identity',
+		description: 'Explicit canonical HTTPS base URL used to derive the MCP OAuth identity',
 		type: 'string',
 		nullable: true,
 		example: 'https://panel.example.com',

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -9,6 +9,11 @@ import {
 } from '../services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthProviderMaterialService } from '../services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessService,
+} from '../services/mcp-oauth-readiness.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
 import { McpOAuthProviderFactory } from './mcp-oauth-provider.factory';
@@ -36,6 +41,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 	let subscriptions: McpSubscriptionRegistryService;
 	let dispatch: ProviderDispatcher;
 	let consumeRateLimit: jest.MockedFunction<McpOAuthEndpointRateLimitService['consume']>;
+	let routeGate: McpOAuthRouteGateService;
 	const createRequest = (): IncomingMessage =>
 		({
 			method: 'GET',
@@ -55,6 +61,11 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		const audit = { recordSubscriptionClosed: jest.fn(), recordSubscriptionOpened: jest.fn() };
 		subscriptions = new McpSubscriptionRegistryService(audit as unknown as McpAuditService);
 		consumeRateLimit = jest.fn().mockResolvedValue({ allowed: true, retryAfterSeconds: 60 });
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		routeGate = new McpOAuthRouteGateService(readiness);
+		routeGate.openInternal();
 		const factory = new McpOAuthProviderFactory(
 			{} as DataSource,
 			{} as McpOAuthClientService,
@@ -62,6 +73,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			{} as McpOAuthProviderMaterialService,
 			subscriptions,
 			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
 		);
 		const target = factory as unknown as { dispatchProviderRequest: ProviderDispatcher };
 		dispatch = (...args) => target.dispatchProviderRequest(...args);
@@ -80,6 +92,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			{ get } as unknown as McpOAuthProviderMaterialService,
 			subscriptions,
 			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
 		);
 
 		try {
@@ -224,6 +237,35 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		await invalidation;
 		await expect(providerRequest).rejects.toThrow('stale OAuth authorization generation');
 		expect(providerCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects provider work queued across a route gate close and reopen boundary', async () => {
+		let invalidationStarted = (): void => undefined;
+		const started = new Promise<void>((resolve) => {
+			invalidationStarted = resolve;
+		});
+		let releaseInvalidation = (): void => undefined;
+		const release = new Promise<void>((resolve) => {
+			releaseInvalidation = resolve;
+		});
+		const invalidation = subscriptions.closeAllOAuth(async () => {
+			invalidationStarted();
+			await release;
+		});
+
+		await started;
+		const providerCallback = jest.fn(() => Promise.resolve());
+		const providerRequest = dispatch(createRequest(), createResponse(), providerCallback, urls);
+		await Promise.resolve();
+		expect(providerCallback).not.toHaveBeenCalled();
+
+		routeGate.closeInternal();
+		routeGate.openInternal();
+		releaseInvalidation();
+		await invalidation;
+
+		await expect(providerRequest).rejects.toThrow('The MCP OAuth route gate changed while the request was queued');
+		expect(providerCallback).not.toHaveBeenCalled();
 	});
 
 	it('skips provider processing when a queued request disconnects before the gate opens', async () => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -19,6 +19,7 @@ import {
 } from '../services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthProviderMaterialService } from '../services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../services/mcp-oauth-public-url.service';
+import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.service';
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
 import { McpOAuthAuthorizationServerMetadata, buildMcpOAuthAuthorizationServerMetadata } from './mcp-oauth-metadata';
@@ -52,6 +53,7 @@ export class McpOAuthProviderFactory {
 		private readonly providerMaterial: McpOAuthProviderMaterialService,
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly endpointRateLimit: McpOAuthEndpointRateLimitService,
+		private readonly routeGate: McpOAuthRouteGateService,
 	) {}
 
 	async create(options: McpOAuthProviderFactoryOptions = {}): Promise<McpOAuthProviderRuntime> {
@@ -244,6 +246,7 @@ export class McpOAuthProviderFactory {
 		const pathname = new URL(request.url ?? '/', urls.issuer).pathname;
 		const tokenPathname = new URL(urls.tokenEndpoint).pathname;
 		const rateLimitedEndpoint = this.getRateLimitedEndpoint(pathname, urls);
+		const routeGeneration = this.routeGate.assertOpen();
 
 		if (rateLimitedEndpoint) {
 			const decision = await this.endpointRateLimit.consume(rateLimitedEndpoint, request.socket?.remoteAddress);
@@ -276,6 +279,7 @@ export class McpOAuthProviderFactory {
 
 		await this.subscriptions.runOAuthMutation(async () => {
 			if (this.isDisconnected(request, response)) return;
+			this.routeGate.assertOpenGeneration(routeGeneration);
 
 			await providerCallback(request, response);
 		});

--- a/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-audit.service.ts
@@ -33,6 +33,7 @@ export type McpOAuthInvalidationReason =
 	| 'module_enabled_reconciliation'
 	| 'module_policy_changed'
 	| 'oauth_disabled'
+	| 'oauth_enabled_reconciliation'
 	| 'public_identity_changed';
 export type McpOAuthAuthorizationProfile = 'all' | 'oauth';
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-lifecycle.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-lifecycle.service.spec.ts
@@ -1,0 +1,136 @@
+import { ConfigService } from '../../config/services/config.service';
+import { MCP_MODULE_NAME } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+
+import { McpOAuthLifecycleService } from './mcp-oauth-lifecycle.service';
+import { McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+describe('McpOAuthLifecycleService', () => {
+	let config: McpConfigModel;
+	let readiness: { assertReady: jest.Mock };
+	let routeGate: { closeInternal: jest.Mock; openInternal: jest.Mock };
+	let runtime: { allowActivationInternal: jest.Mock; activateInternal: jest.Mock; deactivateInternal: jest.Mock };
+	let service: McpOAuthLifecycleService;
+
+	beforeEach(() => {
+		config = Object.assign(new McpConfigModel(), { enabled: true, oauthEnabled: true });
+		readiness = { assertReady: jest.fn() };
+		routeGate = { closeInternal: jest.fn(), openInternal: jest.fn() };
+		runtime = {
+			allowActivationInternal: jest.fn(),
+			activateInternal: jest.fn().mockResolvedValue({}),
+			deactivateInternal: jest.fn(),
+		};
+		service = new McpOAuthLifecycleService(
+			{
+				getModuleConfig: jest.fn((type: string) => (type === MCP_MODULE_NAME ? config : undefined)),
+			} as unknown as ConfigService,
+			readiness as unknown as McpOAuthReadinessService,
+			routeGate as unknown as McpOAuthRouteGateService,
+			runtime as unknown as McpOAuthRuntimeService,
+		);
+	});
+
+	it('opens the complete route gate only after readiness and provider activation succeed', async () => {
+		const order: string[] = [];
+		routeGate.closeInternal.mockImplementation(() => order.push('closed'));
+		readiness.assertReady.mockImplementation(() => order.push('ready'));
+		runtime.allowActivationInternal.mockImplementation(() => order.push('allowed'));
+		runtime.activateInternal.mockImplementation(() => {
+			order.push('activated');
+
+			return Promise.resolve({});
+		});
+		routeGate.openInternal.mockImplementation(() => order.push('opened'));
+
+		await service.activateInternal();
+
+		expect(order).toEqual(['closed', 'ready', 'allowed', 'activated', 'ready', 'opened']);
+	});
+
+	it('deactivates and remains closed when provider activation fails', async () => {
+		const failure = new Error('provider material unavailable');
+		runtime.activateInternal.mockRejectedValue(failure);
+
+		await expect(service.activateInternal()).rejects.toBe(failure);
+
+		expect(routeGate.closeInternal).toHaveBeenCalledTimes(2);
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+	});
+
+	it('closes the old runtime before mutation and reactivates only after it commits', async () => {
+		const order: string[] = [];
+		routeGate.closeInternal.mockImplementation(() => order.push('closed'));
+		runtime.deactivateInternal.mockImplementation(() => order.push('deactivated'));
+		readiness.assertReady.mockImplementation(() => order.push('ready'));
+		runtime.allowActivationInternal.mockImplementation(() => order.push('allowed'));
+		runtime.activateInternal.mockImplementation(() => {
+			order.push('activated');
+
+			return Promise.resolve({});
+		});
+		routeGate.openInternal.mockImplementation(() => order.push('opened'));
+
+		await service.reconfigureInternal(() => {
+			order.push('committed');
+		});
+
+		expect(order).toEqual([
+			'closed',
+			'deactivated',
+			'committed',
+			'closed',
+			'ready',
+			'allowed',
+			'activated',
+			'ready',
+			'opened',
+		]);
+	});
+
+	it('does not reactivate after a failed invalidating mutation', async () => {
+		const failure = new Error('invalidation failed');
+
+		await expect(service.reconfigureInternal(() => Promise.reject(failure))).rejects.toBe(failure);
+
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.allowActivationInternal).not.toHaveBeenCalled();
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+	});
+
+	it('activates configured OAuth during startup', async () => {
+		await service.onApplicationBootstrap();
+
+		expect(runtime.activateInternal).toHaveBeenCalledTimes(1);
+		expect(routeGate.openInternal).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps OAuth closed during startup when either configuration switch is off', async () => {
+		config.oauthEnabled = false;
+
+		await service.onApplicationBootstrap();
+
+		expect(routeGate.closeInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.activateInternal).not.toHaveBeenCalled();
+	});
+
+	it('immediately closes and deactivates OAuth when global configuration is reset', () => {
+		service.onConfigReset();
+
+		expect(routeGate.closeInternal).toHaveBeenCalledTimes(1);
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+	});
+
+	it('fails closed without aborting application bootstrap when activation fails', async () => {
+		runtime.activateInternal.mockRejectedValue(new Error('provider activation failed'));
+
+		await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+
+		expect(routeGate.openInternal).not.toHaveBeenCalled();
+		expect(runtime.deactivateInternal).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-lifecycle.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-lifecycle.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { EventType } from '../../config/config.constants';
+import { ConfigService } from '../../config/services/config.service';
+import { MCP_MODULE_NAME } from '../mcp.constants';
+import { McpConfigModel } from '../models/config.model';
+
+import { McpOAuthReadinessService } from './mcp-oauth-readiness.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+
+export type McpOAuthLifecycleMutation = () => Promise<void> | void;
+
+@Injectable()
+export class McpOAuthLifecycleService implements OnApplicationBootstrap {
+	private readonly logger = createExtensionLogger(MCP_MODULE_NAME, 'McpOAuthLifecycleService');
+
+	constructor(
+		private readonly configService: ConfigService,
+		private readonly readiness: McpOAuthReadinessService,
+		private readonly routeGate: McpOAuthRouteGateService,
+		private readonly runtime: McpOAuthRuntimeService,
+	) {}
+
+	async onApplicationBootstrap(): Promise<void> {
+		const config = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
+
+		if (!config.enabled || !config.oauthEnabled) {
+			this.routeGate.closeInternal();
+			this.runtime.deactivateInternal();
+			return;
+		}
+
+		try {
+			await this.activateInternal();
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error('Unknown MCP OAuth startup activation error');
+			this.logger.error('MCP OAuth startup activation failed; the OAuth route gate remains closed', {
+				message: err.message,
+				stack: err.stack,
+			});
+		}
+	}
+
+	@OnEvent(EventType.CONFIG_RESET)
+	onConfigReset(): void {
+		this.routeGate.closeInternal();
+		this.runtime.deactivateInternal();
+	}
+
+	async activateInternal(): Promise<void> {
+		this.routeGate.closeInternal();
+		this.readiness.assertReady();
+		this.runtime.allowActivationInternal();
+
+		try {
+			await this.runtime.activateInternal();
+			this.readiness.assertReady();
+			this.routeGate.openInternal();
+		} catch (error) {
+			this.routeGate.closeInternal();
+			this.runtime.deactivateInternal();
+			throw error;
+		}
+	}
+
+	async reconfigureInternal(mutation: McpOAuthLifecycleMutation): Promise<void> {
+		this.routeGate.closeInternal();
+		this.runtime.deactivateInternal();
+
+		await mutation();
+		await this.activateInternal();
+	}
+}

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -10,7 +10,11 @@ import { McpConfigModel } from '../models/config.model';
 
 import { McpAuditService } from './mcp-audit.service';
 import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthLifecycleService } from './mcp-oauth-lifecycle.service';
 import { McpOAuthModuleConfigMutationService } from './mcp-oauth-module-config-mutation.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
+import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 import { McpOAuthSubscriptionBinding, McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 const deferred = <T = void>(): { promise: Promise<T>; resolve: (value: T) => void } => {
@@ -47,6 +51,8 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		recordSubscriptionClosed: jest.Mock;
 		recordSubscriptionOpened: jest.Mock;
 	};
+	let lifecycle: { reconfigureInternal: jest.Mock };
+	let switchOff: McpOAuthSwitchOffService;
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
 
@@ -70,13 +76,25 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			recordSubscriptionClosed: jest.fn(),
 			recordSubscriptionOpened: jest.fn(),
 		};
+		lifecycle = {
+			reconfigureInternal: jest.fn(async (mutation: () => Promise<void>) => mutation()),
+		};
 		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
+		switchOff = new McpOAuthSwitchOffService(
+			{ closeInternal: jest.fn() } as unknown as McpOAuthRouteGateService,
+			{ deactivateInternal: jest.fn() } as unknown as McpOAuthRuntimeService,
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
+			auditService as unknown as McpAuditService,
+		);
+		jest.spyOn(switchOff, 'disableInternal');
 		service = new McpOAuthModuleConfigMutationService(
 			configService as unknown as ConfigService,
 			serverState as unknown as Repository<McpOAuthServerStateEntity>,
 			subscriptions,
 			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 			auditService as unknown as McpAuditService,
+			lifecycle as unknown as McpOAuthLifecycleService,
+			switchOff,
 		);
 	});
 
@@ -228,6 +246,98 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			authorizationProfile: 'oauth',
 			outcome: 'completed',
 		});
+	});
+
+	it('reconciles generations and activates only after enabling OAuth commits', async () => {
+		config.oauthEnabled = false;
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn().mockImplementation(() => {
+			config.oauthEnabled = true;
+		});
+
+		await service.update({ type: MCP_MODULE_NAME, oauth_enabled: true } as UpdateMcpConfigDto, commit);
+
+		expect(lifecycle.reconfigureInternal).toHaveBeenCalledTimes(1);
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['oauth_enabled_reconciliation'],
+			authorizationProfile: 'oauth',
+			outcome: 'completed',
+		});
+	});
+
+	it('routes OAuth switch-off through awaited OAuth-only invalidation', async () => {
+		config.oauthEnabled = true;
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn().mockImplementation(() => {
+			config.oauthEnabled = false;
+		});
+
+		await service.update({ type: MCP_MODULE_NAME, oauth_enabled: false } as UpdateMcpConfigDto, commit);
+
+		expect(switchOff.disableInternal).toHaveBeenCalledWith(expect.any(Function), {
+			generations: ['oauthEnabledGeneration'],
+			reasons: ['oauth_disabled'],
+			authorizationProfile: 'oauth',
+		});
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
+		expect(lifecycle.reconfigureInternal).not.toHaveBeenCalled();
+	});
+
+	it('closes, invalidates, and reactivates around a live public identity change', async () => {
+		config.oauthEnabled = true;
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		const commit = jest.fn().mockImplementation(() => {
+			config.oauthPublicBaseUrl = 'https://new-panel.example.com';
+		});
+
+		await service.update(
+			{ type: MCP_MODULE_NAME, oauth_public_base_url: 'https://new-panel.example.com' } as UpdateMcpConfigDto,
+			commit,
+		);
+
+		expect(lifecycle.reconfigureInternal).toHaveBeenCalledTimes(1);
+		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['publicIdentityGeneration'], expect.any(Function));
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects OAuth enablement without an enabled module and explicit public identity', async () => {
+		config.enabled = false;
+		config.oauthEnabled = false;
+		const commit = jest.fn();
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, oauth_enabled: true } as UpdateMcpConfigDto, commit),
+		).rejects.toThrow('MCP OAuth cannot be enabled while the MCP module is disabled');
+
+		config.enabled = true;
+
+		await expect(
+			service.update({ type: MCP_MODULE_NAME, oauth_enabled: true } as UpdateMcpConfigDto, commit),
+		).rejects.toThrow('MCP OAuth requires an explicit public base URL before it can be enabled');
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('serializes concurrent configuration mutations before reading current state', async () => {
+		const firstStarted = deferred();
+		const releaseFirst = deferred();
+		const firstCommit = jest.fn(async () => {
+			firstStarted.resolve();
+			await releaseFirst.promise;
+		});
+		const secondCommit = jest.fn();
+		const first = service.update({ type: MCP_MODULE_NAME } as UpdateMcpConfigDto, firstCommit);
+
+		await firstStarted.promise;
+		const second = service.update({ type: MCP_MODULE_NAME } as UpdateMcpConfigDto, secondCommit);
+		await Promise.resolve();
+
+		expect(secondCommit).not.toHaveBeenCalled();
+		releaseFirst.resolve();
+		await Promise.all([first, second]);
+		expect(secondCommit).toHaveBeenCalledTimes(1);
 	});
 
 	it('routes module disable through global invalidation and all-stream closure', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.spec.ts
@@ -52,7 +52,9 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		recordSubscriptionOpened: jest.Mock;
 	};
 	let lifecycle: { reconfigureInternal: jest.Mock };
+	let routeGate: { isOpen: boolean };
 	let switchOff: McpOAuthSwitchOffService;
+	let switchOffDisableSpy: jest.SpyInstance;
 	let subscriptions: McpSubscriptionRegistryService;
 	let service: McpOAuthModuleConfigMutationService;
 
@@ -79,6 +81,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		lifecycle = {
 			reconfigureInternal: jest.fn(async (mutation: () => Promise<void>) => mutation()),
 		};
+		routeGate = { isOpen: true };
 		subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
 		switchOff = new McpOAuthSwitchOffService(
 			{ closeInternal: jest.fn() } as unknown as McpOAuthRouteGateService,
@@ -86,13 +89,14 @@ describe('McpOAuthModuleConfigMutationService', () => {
 			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 			auditService as unknown as McpAuditService,
 		);
-		jest.spyOn(switchOff, 'disableInternal');
+		switchOffDisableSpy = jest.spyOn(switchOff, 'disableInternal');
 		service = new McpOAuthModuleConfigMutationService(
 			configService as unknown as ConfigService,
 			serverState as unknown as Repository<McpOAuthServerStateEntity>,
 			subscriptions,
 			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 			auditService as unknown as McpAuditService,
+			routeGate as unknown as McpOAuthRouteGateService,
 			lifecycle as unknown as McpOAuthLifecycleService,
 			switchOff,
 		);
@@ -276,7 +280,7 @@ describe('McpOAuthModuleConfigMutationService', () => {
 
 		await service.update({ type: MCP_MODULE_NAME, oauth_enabled: false } as UpdateMcpConfigDto, commit);
 
-		expect(switchOff.disableInternal).toHaveBeenCalledWith(expect.any(Function), {
+		expect(switchOffDisableSpy).toHaveBeenCalledWith(expect.any(Function), {
 			generations: ['oauthEnabledGeneration'],
 			reasons: ['oauth_disabled'],
 			authorizationProfile: 'oauth',
@@ -284,6 +288,18 @@ describe('McpOAuthModuleConfigMutationService', () => {
 		expect(globalInvalidation.invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
 		expect(globalInvalidation.invalidateAll).not.toHaveBeenCalled();
 		expect(lifecycle.reconfigureInternal).not.toHaveBeenCalled();
+	});
+
+	it('retries activation when persisted OAuth configuration remains closed', async () => {
+		config.oauthEnabled = true;
+		config.oauthPublicBaseUrl = 'https://panel.example.com';
+		routeGate.isOpen = false;
+		const commit = jest.fn();
+
+		await service.update({ type: MCP_MODULE_NAME } as UpdateMcpConfigDto, commit);
+
+		expect(lifecycle.reconfigureInternal).toHaveBeenCalledWith(commit);
+		expect(commit).toHaveBeenCalledTimes(1);
 	});
 
 	it('closes, invalidates, and reactivates around a live public identity change', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -14,6 +14,7 @@ import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
 import { McpAuditOutcome, McpAuditService, McpOAuthInvalidationReason } from './mcp-audit.service';
 import { McpOAuthGlobalGeneration, McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthLifecycleService } from './mcp-oauth-lifecycle.service';
+import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
 import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
@@ -28,6 +29,7 @@ export class McpOAuthModuleConfigMutationService {
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
 		private readonly auditService: McpAuditService,
+		private readonly routeGate: McpOAuthRouteGateService,
 		private readonly lifecycle: McpOAuthLifecycleService,
 		private readonly switchOff: McpOAuthSwitchOffService,
 	) {}
@@ -57,6 +59,7 @@ export class McpOAuthModuleConfigMutationService {
 		const oauthDisabled = current.oauthEnabled && !nextOAuthEnabled;
 		const oauthEnabled = !current.oauthEnabled && nextOAuthEnabled;
 		const oauthShouldRun = nextEnabled && nextOAuthEnabled;
+		const oauthNeedsActivation = oauthShouldRun && !this.routeGate.isOpen;
 		const nextCapabilities = update.capabilities ?? current.capabilities;
 		const capabilitiesChanged = !this.sameCapabilities(current.capabilities, nextCapabilities);
 		const nextPublicBaseUrl =
@@ -174,36 +177,46 @@ export class McpOAuthModuleConfigMutationService {
 		}
 
 		if (!capabilitiesChanged) {
-			await commit();
+			if (oauthNeedsActivation) await this.lifecycle.reconfigureInternal(commit);
+			else await commit();
 			return;
 		}
 
-		let commitError: unknown;
-		let commitFailed = false;
+		const reconcileCapabilities = async (): Promise<void> => {
+			let commitError: unknown;
+			let commitFailed = false;
 
-		await this.subscriptions.closeOAuthScopeContractions(nextCapabilities.map(toMcpOAuthScope), async () => {
-			const result = await this.serverState.increment({ key: MCP_OAUTH_SERVER_STATE_KEY }, 'modulePolicyGeneration', 1);
+			await this.subscriptions.closeOAuthScopeContractions(nextCapabilities.map(toMcpOAuthScope), async () => {
+				const result = await this.serverState.increment(
+					{ key: MCP_OAUTH_SERVER_STATE_KEY },
+					'modulePolicyGeneration',
+					1,
+				);
 
-			if (result.affected !== 1) {
-				throw new ServiceUnavailableException('MCP OAuth module policy state is unavailable');
-			}
+				if (result.affected !== 1) {
+					throw new ServiceUnavailableException('MCP OAuth module policy state is unavailable');
+				}
 
-			try {
-				await commit();
-			} catch (error) {
-				this.configService.reload();
-				commitFailed = true;
-				commitError = error;
-			}
-		});
+				try {
+					await commit();
+				} catch (error) {
+					this.configService.reload();
+					commitFailed = true;
+					commitError = error;
+				}
+			});
 
-		this.auditService.recordOAuthAuthorizationInvalidation({
-			reasons: ['module_policy_changed'],
-			authorizationProfile: 'oauth',
-			outcome: commitFailed ? McpAuditOutcome.PARTIAL : McpAuditOutcome.COMPLETED,
-		});
+			this.auditService.recordOAuthAuthorizationInvalidation({
+				reasons: ['module_policy_changed'],
+				authorizationProfile: 'oauth',
+				outcome: commitFailed ? McpAuditOutcome.PARTIAL : McpAuditOutcome.COMPLETED,
+			});
 
-		if (commitFailed) throw commitError;
+			if (commitFailed) throw commitError;
+		};
+
+		if (oauthNeedsActivation) await this.lifecycle.reconfigureInternal(reconcileCapabilities);
+		else await reconcileCapabilities();
 	}
 
 	private async runSwitchOff(

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-module-config-mutation.service.ts
@@ -1,6 +1,6 @@
 import { Repository } from 'typeorm';
 
-import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { BadRequestException, Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { ConfigService } from '../../config/services/config.service';
@@ -13,10 +13,14 @@ import { toMcpOAuthScope } from '../oauth/mcp-oauth-scope.utils';
 
 import { McpAuditOutcome, McpAuditService, McpOAuthInvalidationReason } from './mcp-audit.service';
 import { McpOAuthGlobalGeneration, McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import { McpOAuthLifecycleService } from './mcp-oauth-lifecycle.service';
+import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 import { McpSubscriptionRegistryService } from './mcp-subscription-registry.service';
 
 @Injectable()
 export class McpOAuthModuleConfigMutationService {
+	private mutationTail = Promise.resolve();
+
 	constructor(
 		private readonly configService: ConfigService,
 		@InjectRepository(McpOAuthServerStateEntity)
@@ -24,18 +28,47 @@ export class McpOAuthModuleConfigMutationService {
 		private readonly subscriptions: McpSubscriptionRegistryService,
 		private readonly globalInvalidation: McpOAuthGlobalInvalidationService,
 		private readonly auditService: McpAuditService,
+		private readonly lifecycle: McpOAuthLifecycleService,
+		private readonly switchOff: McpOAuthSwitchOffService,
 	) {}
 
 	async update(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
+		const previousMutation = this.mutationTail;
+		let releaseMutation = (): void => undefined;
+		this.mutationTail = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+
+		await previousMutation;
+
+		try {
+			await this.updateInternal(update, commit);
+		} finally {
+			releaseMutation();
+		}
+	}
+
+	private async updateInternal(update: UpdateMcpConfigDto, commit: ModuleConfigCommit): Promise<void> {
 		const current = this.configService.getModuleConfig<McpConfigModel>(MCP_MODULE_NAME);
 		const nextEnabled = update.enabled ?? current.enabled;
 		const moduleDisabled = current.enabled && !nextEnabled;
 		const moduleEnabled = !current.enabled && nextEnabled;
+		const nextOAuthEnabled = update.oauth_enabled ?? current.oauthEnabled;
+		const oauthDisabled = current.oauthEnabled && !nextOAuthEnabled;
+		const oauthEnabled = !current.oauthEnabled && nextOAuthEnabled;
+		const oauthShouldRun = nextEnabled && nextOAuthEnabled;
 		const nextCapabilities = update.capabilities ?? current.capabilities;
 		const capabilitiesChanged = !this.sameCapabilities(current.capabilities, nextCapabilities);
 		const nextPublicBaseUrl =
 			update.oauth_public_base_url === undefined ? current.oauthPublicBaseUrl : update.oauth_public_base_url;
 		const publicIdentityChanged = current.oauthPublicBaseUrl !== nextPublicBaseUrl;
+
+		if (oauthEnabled && !nextEnabled) {
+			throw new BadRequestException('MCP OAuth cannot be enabled while the MCP module is disabled');
+		}
+		if (oauthShouldRun && nextPublicBaseUrl === null) {
+			throw new BadRequestException('MCP OAuth requires an explicit public base URL before it can be enabled');
+		}
 
 		if (moduleDisabled) {
 			const generations: McpOAuthGlobalGeneration[] = [
@@ -44,16 +77,34 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.runGlobalInvalidation(
+			await this.runSwitchOff(commit, {
 				generations,
-				[
+				reasons: [
 					'module_disabled',
 					...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
 					...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
 				],
-				'all',
-				commit,
-			);
+				authorizationProfile: 'all',
+			});
+			return;
+		}
+
+		if (oauthDisabled) {
+			const generations: McpOAuthGlobalGeneration[] = [
+				'oauthEnabledGeneration',
+				...(publicIdentityChanged ? (['publicIdentityGeneration'] as const) : []),
+				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
+			];
+
+			await this.runSwitchOff(commit, {
+				generations,
+				reasons: [
+					'oauth_disabled',
+					...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
+					...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
+				],
+				authorizationProfile: 'oauth',
+			});
 			return;
 		}
 
@@ -64,16 +115,42 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.runGlobalInvalidation(
-				generations,
-				[
-					'module_enabled_reconciliation',
-					...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
-					...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
-				],
-				'oauth',
-				commit,
-			);
+			const reconcile = (): Promise<void> =>
+				this.runGlobalInvalidation(
+					generations,
+					[
+						'module_enabled_reconciliation',
+						...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
+						...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
+					],
+					'oauth',
+					commit,
+				);
+
+			if (oauthShouldRun) await this.lifecycle.reconfigureInternal(reconcile);
+			else await reconcile();
+			return;
+		}
+
+		if (oauthEnabled) {
+			const generations: McpOAuthGlobalGeneration[] = [
+				'oauthEnabledGeneration',
+				...(publicIdentityChanged ? (['publicIdentityGeneration'] as const) : []),
+				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
+			];
+			const reconcile = (): Promise<void> =>
+				this.runGlobalInvalidation(
+					generations,
+					[
+						'oauth_enabled_reconciliation',
+						...(publicIdentityChanged ? (['public_identity_changed'] as const) : []),
+						...(capabilitiesChanged ? (['module_policy_changed'] as const) : []),
+					],
+					'oauth',
+					commit,
+				);
+
+			await this.lifecycle.reconfigureInternal(reconcile);
 			return;
 		}
 
@@ -83,12 +160,16 @@ export class McpOAuthModuleConfigMutationService {
 				...(capabilitiesChanged ? (['modulePolicyGeneration'] as const) : []),
 			];
 
-			await this.runGlobalInvalidation(
-				generations,
-				['public_identity_changed', ...(capabilitiesChanged ? (['module_policy_changed'] as const) : [])],
-				'oauth',
-				commit,
-			);
+			const reconcile = (): Promise<void> =>
+				this.runGlobalInvalidation(
+					generations,
+					['public_identity_changed', ...(capabilitiesChanged ? (['module_policy_changed'] as const) : [])],
+					'oauth',
+					commit,
+				);
+
+			if (oauthShouldRun) await this.lifecycle.reconfigureInternal(reconcile);
+			else await reconcile();
 			return;
 		}
 
@@ -123,6 +204,20 @@ export class McpOAuthModuleConfigMutationService {
 		});
 
 		if (commitFailed) throw commitError;
+	}
+
+	private async runSwitchOff(
+		commit: ModuleConfigCommit,
+		options: Parameters<McpOAuthSwitchOffService['disableInternal']>[1],
+	): Promise<void> {
+		await this.switchOff.disableInternal(async () => {
+			try {
+				await commit();
+			} catch (error) {
+				this.configService.reload();
+				throw error;
+			}
+		}, options);
 	}
 
 	private async runGlobalInvalidation(

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.spec.ts
@@ -35,4 +35,20 @@ describe('McpOAuthRouteGateService', () => {
 		expect(gate.isOpen).toBe(false);
 		expect(() => gate.assertOpen()).toThrow(ServiceUnavailableException);
 	});
+
+	it('rejects a request generation that crossed a close and reopen boundary', () => {
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+		readiness.onApplicationBootstrap();
+		const gate = new McpOAuthRouteGateService(readiness);
+		gate.openInternal();
+		const generation = gate.assertOpen();
+
+		gate.closeInternal();
+		gate.openInternal();
+
+		expect(() => gate.assertOpenGeneration(generation)).toThrow(
+			'The MCP OAuth route gate changed while the request was queued',
+		);
+	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-route-gate.service.ts
@@ -5,6 +5,7 @@ import { McpOAuthReadinessService } from './mcp-oauth-readiness.service';
 @Injectable()
 export class McpOAuthRouteGateService {
 	private open = false;
+	private generation = 0;
 
 	constructor(private readonly readiness: McpOAuthReadinessService) {}
 
@@ -15,14 +16,23 @@ export class McpOAuthRouteGateService {
 
 	closeInternal(): void {
 		this.open = false;
+		this.generation += 1;
 	}
 
-	assertOpen(): void {
+	assertOpen(): number {
 		if (!this.open) {
 			throw new ServiceUnavailableException('The MCP OAuth route gate is closed');
 		}
 
 		this.readiness.assertReady();
+
+		return this.generation;
+	}
+
+	assertOpenGeneration(generation: number): void {
+		if (this.assertOpen() !== generation) {
+			throw new ServiceUnavailableException('The MCP OAuth route gate changed while the request was queued');
+		}
 	}
 
 	get isOpen(): boolean {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.spec.ts
@@ -7,7 +7,7 @@ import { McpOAuthSwitchOffService } from './mcp-oauth-switch-off.service';
 describe('McpOAuthSwitchOffService', () => {
 	let routeGate: { closeInternal: jest.Mock; openInternal: jest.Mock };
 	let runtime: { deactivateInternal: jest.Mock };
-	let globalInvalidation: { invalidate: jest.Mock };
+	let globalInvalidation: { invalidate: jest.Mock; invalidateAll: jest.Mock };
 	let auditService: { recordOAuthAuthorizationInvalidation: jest.Mock };
 	let service: McpOAuthSwitchOffService;
 
@@ -16,6 +16,7 @@ describe('McpOAuthSwitchOffService', () => {
 		runtime = { deactivateInternal: jest.fn() };
 		globalInvalidation = {
 			invalidate: jest.fn(async (_generations: string[], commit: () => Promise<void>) => commit()),
+			invalidateAll: jest.fn(async (_generations: string[], commit: () => Promise<void>) => commit()),
 		};
 		auditService = { recordOAuthAuthorizationInvalidation: jest.fn() };
 		service = new McpOAuthSwitchOffService(
@@ -24,6 +25,27 @@ describe('McpOAuthSwitchOffService', () => {
 			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
 			auditService as unknown as McpAuditService,
 		);
+	});
+
+	it('can close both authorization profiles for a combined module-disable mutation', async () => {
+		const commit = jest.fn();
+
+		await service.disableInternal(commit, {
+			generations: ['oauthEnabledGeneration', 'publicIdentityGeneration'],
+			reasons: ['module_disabled', 'public_identity_changed'],
+			authorizationProfile: 'all',
+		});
+
+		expect(globalInvalidation.invalidateAll).toHaveBeenCalledWith(
+			['oauthEnabledGeneration', 'publicIdentityGeneration'],
+			expect.any(Function),
+		);
+		expect(globalInvalidation.invalidate).not.toHaveBeenCalled();
+		expect(auditService.recordOAuthAuthorizationInvalidation).toHaveBeenCalledWith({
+			reasons: ['module_disabled', 'public_identity_changed'],
+			authorizationProfile: 'all',
+			outcome: 'completed',
+		});
 	});
 
 	it('closes the shared gate before advancing OAuth enablement and preserves the static profile', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-switch-off.service.ts
@@ -1,11 +1,22 @@
 import { Injectable } from '@nestjs/common';
 
-import { McpAuditOutcome, McpAuditService } from './mcp-audit.service';
-import { McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
+import {
+	McpAuditOutcome,
+	McpAuditService,
+	McpOAuthAuthorizationProfile,
+	McpOAuthInvalidationReason,
+} from './mcp-audit.service';
+import { McpOAuthGlobalGeneration, McpOAuthGlobalInvalidationService } from './mcp-oauth-global-invalidation.service';
 import { McpOAuthRouteGateService } from './mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from './mcp-oauth-runtime.service';
 
 export type McpOAuthSwitchOffCommit = () => Promise<void> | void;
+
+export interface McpOAuthSwitchOffOptions {
+	generations?: McpOAuthGlobalGeneration[];
+	reasons?: McpOAuthInvalidationReason[];
+	authorizationProfile?: McpOAuthAuthorizationProfile;
+}
 
 @Injectable()
 export class McpOAuthSwitchOffService {
@@ -16,9 +27,12 @@ export class McpOAuthSwitchOffService {
 		private readonly auditService: McpAuditService,
 	) {}
 
-	async disableInternal(commit: McpOAuthSwitchOffCommit): Promise<void> {
+	async disableInternal(commit: McpOAuthSwitchOffCommit, options: McpOAuthSwitchOffOptions = {}): Promise<void> {
 		this.routeGate.closeInternal();
 		this.runtime.deactivateInternal();
+		const generations = options.generations ?? ['oauthEnabledGeneration'];
+		const reasons = options.reasons ?? ['oauth_disabled'];
+		const authorizationProfile = options.authorizationProfile ?? 'oauth';
 
 		let commitFailed = false;
 		const persist = async (): Promise<void> => {
@@ -31,12 +45,16 @@ export class McpOAuthSwitchOffService {
 		};
 
 		try {
-			await this.globalInvalidation.invalidate(['oauthEnabledGeneration'], persist);
+			if (authorizationProfile === 'all') {
+				await this.globalInvalidation.invalidateAll(generations, persist);
+			} else {
+				await this.globalInvalidation.invalidate(generations, persist);
+			}
 		} catch (error) {
 			if (commitFailed) {
 				this.auditService.recordOAuthAuthorizationInvalidation({
-					reasons: ['oauth_disabled'],
-					authorizationProfile: 'oauth',
+					reasons,
+					authorizationProfile,
 					outcome: McpAuditOutcome.PARTIAL,
 				});
 			}
@@ -45,8 +63,8 @@ export class McpOAuthSwitchOffService {
 		}
 
 		this.auditService.recordOAuthAuthorizationInvalidation({
-			reasons: ['oauth_disabled'],
-			authorizationProfile: 'oauth',
+			reasons,
+			authorizationProfile,
 			outcome: McpAuditOutcome.COMPLETED,
 		});
 	}

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -23,6 +23,7 @@ import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-cli
 import { McpOAuthEndpointRateLimitService } from '../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthProviderMaterialService } from '../src/modules/mcp/services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
 import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
@@ -235,6 +236,10 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			{
 				consume: () => Promise.resolve({ allowed: true, retryAfterSeconds: 60 }),
 			} as unknown as McpOAuthEndpointRateLimitService,
+			{
+				assertOpen: () => 0,
+				assertOpenGeneration: () => undefined,
+			} as unknown as McpOAuthRouteGateService,
 		);
 		const runtime = await factory.create({
 			allowTestInMemory: true,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -343,6 +343,20 @@ amend ADR 0002.
       isolated ephemeral test setup. Keep the user-facing switch absent until configuration lifecycle activation and
       invalidation are wired through the shared readiness and route gates.
 
+### Phase 5v — Readiness-gated OAuth configuration lifecycle
+
+- [x] Add the opt-in `oauth_enabled` configuration field and Admin control with an explicit canonical HTTPS public
+      identity prerequisite and deployment warning; keep the static MCP profile independently configurable.
+- [x] At startup, activate the persistent provider and open the complete pre-registered OAuth route set only after the
+      sealed readiness inventory passes twice; log activation failure and keep OAuth closed without aborting the rest
+      of the application. A global configuration reset also closes the gate and deactivates the provider immediately.
+- [x] Serialize authoritative MCP configuration mutations. On enable, advance the persistent OAuth generation and
+      revoke legacy artifacts before activating and opening; on switch-off or module disable, close/deactivate first,
+      advance every changed generation, persist, revoke, and close the correct OAuth-only or all-profile streams.
+- [x] Close/deactivate around a live public-identity change and reopen only after invalidation, persistence, readiness,
+      and provider reactivation succeed. Any failed mutation or activation remains fail-closed and never restores old
+      artifacts on a later retry.
+
 ### Remaining Phase 5 controls
 
 - [x] Bind OAuth subscriptions to client, grant, access-token, optional refresh-family IDs, and an authorization
@@ -365,7 +379,7 @@ amend ADR 0002.
       their authority generation before revoking every grant and token artifact they approved and closing matching
       subscriptions. A paused consent using the old generation must fail, role restoration must not revive old grants,
       invalidation failures propagate, and profile-only updates by an authorized approver preserve the generation.
-- [ ] Close all MCP subscriptions only when the MCP module is disabled. On public OAuth identity or server-secret
+- [x] Close all MCP subscriptions only when the MCP module is disabled. On public OAuth identity or server-secret
       rotation, advance the applicable artifact generation before revoke-all, revoke every OAuth artifact, and close
       every OAuth subscription while preserving static MCP credentials and streams.
 - [x] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
@@ -373,7 +387,7 @@ amend ADR 0002.
       coverage is complete; end-to-end audit verification remains in Phase 6.
 - [x] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
       invalidation failure, and never leave a demoted/deleted approver's grant usable.
-- [ ] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
+- [x] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted
       artifact and live-scope-reduction subscription aborts, awaited approver lifecycle invalidation,
       serialized subscription-open/invalidation and all-generation artifact-issuance gates,
       public-identity/server-secret rotation, OAuth switch-off invalidation, revoke controls, audit hooks, and rate
@@ -381,9 +395,9 @@ amend ADR 0002.
 - [x] Register the complete protected-resource metadata, authorization-server metadata,
       authorization/token/revocation, challenge, and OAuth MCP route set once during NestJS/Fastify bootstrap. Every
       route must check the same fail-closed gate before its handler; never mount or unmount routes after startup.
-- [ ] On enable, rerun readiness and open the shared gate for the complete pre-registered OAuth surface atomically;
+- [x] On enable, rerun readiness and open the shared gate for the complete pre-registered OAuth surface atomically;
       never expose a partial subset.
-- [ ] On switch-off, atomically close and increment the persistent OAuth generation before handlers can commit more
+- [x] On switch-off, atomically close and increment the persistent OAuth generation before handlers can commit more
       artifacts, revoke all OAuth artifacts, and abort all OAuth subscriptions before reporting success; preserve
       static MCP credentials and streams, remain fail-closed if invalidation fails, and require a new authorization
       flow after readiness-gated re-enable.


### PR DESCRIPTION
👍

## Summary

- add fail-closed MCP OAuth lifecycle orchestration for startup, configuration changes, enable/disable, and public identity changes
- serialize authoritative MCP configuration mutations and invalidate OAuth generations, grants, and subscriptions at the appropriate lifecycle boundaries
- add the admin OAuth opt-in and public HTTPS base URL controls, validation, API mapping, warnings, and translations
- mark Phase 5v and the remaining Phase 5 lifecycle work complete in the implementation plan

## Why

MCP OAuth configuration changes affect authorization state that can outlive a single request. The server must keep OAuth endpoints closed until configuration and provider readiness are confirmed, and it must revoke stale authorization artifacts whenever identity or security-sensitive settings change. Administrators also need a safe, validated way to configure and explicitly enable OAuth.

## Impact

- OAuth remains disabled by default and activates only when both MCP and OAuth are configured and ready.
- Startup or reconfiguration failures leave the OAuth gate closed.
- Disabling OAuth or MCP, resetting global configuration, and changing public identity invalidate the corresponding authorization state.
- Static authorization remains available when only OAuth is switched off.
- The admin UI accepts only public HTTPS base URLs and clears the value when OAuth is disabled.

## Checks

- backend focused lifecycle/config tests: 47 passed
- backend unit tests: 4,059 passed, 2 skipped across 322 suites
- backend E2E tests: 126 passed across 10 suites
- OAuth spike tests: 26 passed across 2 suites
- backend typecheck and lint
- admin schema tests: 14 passed
- full admin unit suite
- admin typecheck and lint (four pre-existing unrelated warnings only)
- OpenAPI generation and Spectral validation
- formatting and diff checks

## Next phase

Phase 6 covers end-to-end lifecycle/race testing and host compatibility validation.
