### PR TITLE
test(backend): add MCP OAuth route lifecycle E2E

### DIFF
--- a/apps/backend/test/mcp-oauth-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-lifecycle.e2e-spec.ts
@@ -1,0 +1,187 @@
+import fastify, { FastifyInstance } from 'fastify';
+import { RequestListener } from 'node:http';
+
+import { ConfigService } from '../src/modules/config/services/config.service';
+import {
+	MCP_OAUTH_AUTHORIZATION_PATH,
+	MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
+	MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
+	MCP_OAUTH_REVOCATION_PATH,
+	MCP_OAUTH_TOKEN_PATH,
+} from '../src/modules/mcp/mcp.constants';
+import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
+import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpOAuthBootstrapService } from '../src/modules/mcp/services/mcp-oauth-bootstrap.service';
+import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
+import { McpOAuthLifecycleService } from '../src/modules/mcp/services/mcp-oauth-lifecycle.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessControl,
+	McpOAuthReadinessService,
+} from '../src/modules/mcp/services/mcp-oauth-readiness.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
+import { McpOAuthSwitchOffService } from '../src/modules/mcp/services/mcp-oauth-switch-off.service';
+
+type RouteMethod = 'GET' | 'OPTIONS' | 'POST';
+
+interface OAuthRouteCase {
+	method: RouteMethod;
+	path: string;
+	provider: boolean;
+}
+
+const ROUTE_SET: readonly OAuthRouteCase[] = [
+	{ method: 'GET', path: MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, provider: false },
+	{ method: 'GET', path: MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH, provider: false },
+	{ method: 'GET', path: MCP_OAUTH_AUTHORIZATION_PATH, provider: true },
+	{ method: 'GET', path: `${MCP_OAUTH_AUTHORIZATION_PATH}/interaction-one`, provider: true },
+	{ method: 'POST', path: MCP_OAUTH_TOKEN_PATH, provider: true },
+	{ method: 'OPTIONS', path: MCP_OAUTH_TOKEN_PATH, provider: true },
+	{ method: 'POST', path: MCP_OAUTH_REVOCATION_PATH, provider: true },
+	{ method: 'OPTIONS', path: MCP_OAUTH_REVOCATION_PATH, provider: true },
+];
+
+const urls: McpOAuthPublicUrls = {
+	publicBaseUrl: 'https://panel.example.com',
+	resource: 'https://panel.example.com/api/v1/modules/mcp',
+	protectedResourceMetadata: `https://panel.example.com${MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH}`,
+	issuer: 'https://panel.example.com/api/v1/modules/mcp/oauth',
+	authorizationServerMetadata: `https://panel.example.com${MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH}`,
+	authorizationEndpoint: `https://panel.example.com${MCP_OAUTH_AUTHORIZATION_PATH}`,
+	tokenEndpoint: `https://panel.example.com${MCP_OAUTH_TOKEN_PATH}`,
+	revocationEndpoint: `https://panel.example.com${MCP_OAUTH_REVOCATION_PATH}`,
+};
+
+describe('MCP OAuth runtime route lifecycle', () => {
+	let server: FastifyInstance;
+
+	afterEach(async () => {
+		await server?.close();
+	});
+
+	it('transitions the complete bootstrap route set together without restarting', async () => {
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(
+			...MCP_OAUTH_REQUIRED_READINESS_CONTROLS.filter(
+				(control) => control !== McpOAuthReadinessControl.COMPLETE_ROUTE_SET,
+			),
+		);
+		const routeGate = new McpOAuthRouteGateService(readiness);
+		const providerRequests: string[] = [];
+		let runtimeVersion = 0;
+		const createRuntime = jest.fn(() => {
+			runtimeVersion += 1;
+			const version = runtimeVersion;
+			const callback: RequestListener = (request, response) => {
+				providerRequests.push(request.url ?? '');
+				response.statusCode = 200;
+				response.setHeader('content-type', 'application/json');
+				response.setHeader('cache-control', 'no-store');
+				response.end(JSON.stringify({ runtimeVersion: version }));
+			};
+			const runtime: McpOAuthProviderRuntime = {
+				provider: {} as McpOAuthProviderRuntime['provider'],
+				callback,
+				urls,
+				metadata: { issuer: urls.issuer } as McpOAuthProviderRuntime['metadata'],
+			};
+
+			return Promise.resolve(runtime);
+		});
+		const runtime = new McpOAuthRuntimeService(
+			{ create: createRuntime } as unknown as McpOAuthProviderFactory,
+			routeGate,
+		);
+		const config = { enabled: true, oauthEnabled: false };
+		const lifecycle = new McpOAuthLifecycleService(
+			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
+			readiness,
+			routeGate,
+			runtime,
+		);
+		const bootstrap = new McpOAuthBootstrapService(
+			readiness,
+			routeGate,
+			{ assertForwardedHeadersTrusted: jest.fn() } as unknown as McpOAuthProxyPolicyService,
+			{
+				getProtectedResourceMetadata: jest.fn(() => ({
+					resource: urls.resource,
+					authorization_servers: [urls.issuer],
+				})),
+				getAuthorizationServerMetadata: jest.fn(() => ({ issuer: urls.issuer })),
+			} as unknown as McpOAuthResourceServerService,
+			runtime,
+		);
+		const invalidate = jest.fn(async (_generations: string[], persist: () => Promise<void>): Promise<void> => {
+			expect(routeGate.isOpen).toBe(false);
+			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
+			await persist();
+		});
+		const switchOff = new McpOAuthSwitchOffService(
+			routeGate,
+			runtime,
+			{ invalidate } as unknown as McpOAuthGlobalInvalidationService,
+			{ recordOAuthAuthorizationInvalidation: jest.fn() } as unknown as McpAuditService,
+		);
+
+		server = fastify();
+		bootstrap.register(server);
+		readiness.onApplicationBootstrap();
+		await lifecycle.onApplicationBootstrap();
+		const origin = await server.listen({ host: '127.0.0.1', port: 0 });
+
+		await expectRouteSet(origin, 503);
+		expect(providerRequests).toEqual([]);
+
+		await lifecycle.reconfigureInternal(() => {
+			config.oauthEnabled = true;
+		});
+
+		await expectRouteSet(origin, 200, 1);
+		expect(createRuntime).toHaveBeenCalledTimes(1);
+
+		await switchOff.disableInternal(() => {
+			config.oauthEnabled = false;
+		});
+
+		await expectRouteSet(origin, 503);
+		expect(invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
+		expect(createRuntime).toHaveBeenCalledTimes(1);
+
+		await lifecycle.reconfigureInternal(() => {
+			config.oauthEnabled = true;
+		});
+
+		await expectRouteSet(origin, 200, 2);
+		expect(createRuntime).toHaveBeenCalledTimes(2);
+	});
+});
+
+async function expectRouteSet(origin: string, status: number, runtimeVersion?: number): Promise<void> {
+	for (const route of ROUTE_SET) {
+		const response = await fetch(new URL(route.path, origin), {
+			method: route.method,
+			...(route.method === 'POST'
+				? {
+						body: 'resource=https%3A%2F%2Fpanel.example.com%2Fapi%2Fv1%2Fmodules%2Fmcp',
+						headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					}
+				: {}),
+		});
+		const body = (await response.json()) as { error?: string; runtimeVersion?: number };
+
+		expect({ method: route.method, path: route.path, status: response.status }).toMatchObject({ status });
+		expect(response.headers.get('cache-control')).toBe('no-store');
+
+		if (status === 503) {
+			expect(body).toEqual({ error: 'temporarily_unavailable' });
+			expect(response.headers.get('pragma')).toBe('no-cache');
+		} else if (route.provider) {
+			expect(body.runtimeVersion).toBe(runtimeVersion);
+		}
+	}
+}

--- a/apps/backend/test/mcp-oauth-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-lifecycle.e2e-spec.ts
@@ -1,20 +1,27 @@
 import fastify, { FastifyInstance } from 'fastify';
 import { RequestListener } from 'node:http';
+import { Repository } from 'typeorm';
 
 import { ConfigService } from '../src/modules/config/services/config.service';
+import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
+import { UpdateMcpConfigDto } from '../src/modules/mcp/dto/update-config.dto';
+import { McpOAuthServerStateEntity } from '../src/modules/mcp/entities/mcp-oauth.entity';
 import {
+	MCP_MODULE_NAME,
 	MCP_OAUTH_AUTHORIZATION_PATH,
 	MCP_OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
 	MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
 	MCP_OAUTH_REVOCATION_PATH,
 	MCP_OAUTH_TOKEN_PATH,
 } from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpOAuthBootstrapService } from '../src/modules/mcp/services/mcp-oauth-bootstrap.service';
 import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
 import { McpOAuthLifecycleService } from '../src/modules/mcp/services/mcp-oauth-lifecycle.service';
+import { McpOAuthModuleConfigMutationService } from '../src/modules/mcp/services/mcp-oauth-module-config-mutation.service';
 import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import {
 	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
@@ -25,6 +32,7 @@ import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-o
 import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
 import { McpOAuthSwitchOffService } from '../src/modules/mcp/services/mcp-oauth-switch-off.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 
 type RouteMethod = 'GET' | 'OPTIONS' | 'POST';
 
@@ -96,9 +104,17 @@ describe('MCP OAuth runtime route lifecycle', () => {
 			{ create: createRuntime } as unknown as McpOAuthProviderFactory,
 			routeGate,
 		);
-		const config = { enabled: true, oauthEnabled: false };
+		const config = Object.assign(new McpConfigModel(), {
+			enabled: true,
+			oauthEnabled: false,
+			oauthPublicBaseUrl: urls.publicBaseUrl,
+		});
+		const configService = {
+			getModuleConfig: jest.fn(() => config),
+			reload: jest.fn(),
+		};
 		const lifecycle = new McpOAuthLifecycleService(
-			{ getModuleConfig: jest.fn(() => config) } as unknown as ConfigService,
+			configService as unknown as ConfigService,
 			readiness,
 			routeGate,
 			runtime,
@@ -121,12 +137,43 @@ describe('MCP OAuth runtime route lifecycle', () => {
 			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
 			await persist();
 		});
+		const auditService = {
+			recordOAuthAuthorizationInvalidation: jest.fn(),
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		const globalInvalidation = {
+			invalidate,
+			invalidateAll: jest.fn(),
+		};
 		const switchOff = new McpOAuthSwitchOffService(
 			routeGate,
 			runtime,
-			{ invalidate } as unknown as McpOAuthGlobalInvalidationService,
-			{ recordOAuthAuthorizationInvalidation: jest.fn() } as unknown as McpAuditService,
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
+			auditService as unknown as McpAuditService,
 		);
+		const moduleConfigMutation = new McpOAuthModuleConfigMutationService(
+			configService as unknown as ConfigService,
+			{} as Repository<McpOAuthServerStateEntity>,
+			new McpSubscriptionRegistryService(auditService as unknown as McpAuditService),
+			globalInvalidation as unknown as McpOAuthGlobalInvalidationService,
+			auditService as unknown as McpAuditService,
+			routeGate,
+			lifecycle,
+			switchOff,
+		);
+		const moduleConfigMutations = new ModuleConfigMutationRegistryService();
+		moduleConfigMutations.register<UpdateMcpConfigDto>(MCP_MODULE_NAME, (update, commit) =>
+			moduleConfigMutation.update(update, commit),
+		);
+		const updateOAuth = (oauthEnabled: boolean): Promise<void> =>
+			moduleConfigMutations.execute(
+				MCP_MODULE_NAME,
+				Object.assign(new UpdateMcpConfigDto(), { oauth_enabled: oauthEnabled }),
+				() => {
+					config.oauthEnabled = oauthEnabled;
+				},
+			);
 
 		server = fastify();
 		bootstrap.register(server);
@@ -137,24 +184,18 @@ describe('MCP OAuth runtime route lifecycle', () => {
 		await expectRouteSet(origin, 503);
 		expect(providerRequests).toEqual([]);
 
-		await lifecycle.reconfigureInternal(() => {
-			config.oauthEnabled = true;
-		});
+		await updateOAuth(true);
 
 		await expectRouteSet(origin, 200, 1);
 		expect(createRuntime).toHaveBeenCalledTimes(1);
 
-		await switchOff.disableInternal(() => {
-			config.oauthEnabled = false;
-		});
+		await updateOAuth(false);
 
 		await expectRouteSet(origin, 503);
 		expect(invalidate).toHaveBeenCalledWith(['oauthEnabledGeneration'], expect.any(Function));
 		expect(createRuntime).toHaveBeenCalledTimes(1);
 
-		await lifecycle.reconfigureInternal(() => {
-			config.oauthEnabled = true;
-		});
+		await updateOAuth(true);
 
 		await expectRouteSet(origin, 200, 2);
 		expect(createRuntime).toHaveBeenCalledTimes(2);

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 5 in progress — complete bootstrap OAuth route-set foundation implemented
+**Status:** Phase 6 in progress — runtime route-set lifecycle E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -428,8 +428,10 @@ amend ADR 0002.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.
-- [ ] E2E: start disabled, enable without restarting, disable without restarting, and re-enable; prove the
-      bootstrap-registered route set is uniformly unreachable/reachable behind one gate and never partially exposed.
+- [x] E2E: start disabled, enable without restarting, disable without restarting, and re-enable; prove the
+      bootstrap-registered route set is uniformly unreachable/reachable behind one gate, never partially exposed, and
+      replaces the deactivated provider runtime before reopening.
+- [ ] E2E: prove readiness-gated re-enable never makes OAuth artifacts issued before switch-off usable again.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 5 complete bootstrap OAuth route-set foundation implemented
+Status: in progress — Phase 6 runtime lifecycle E2E underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add HTTP-boundary E2E coverage for the complete finite MCP OAuth bootstrap route set
- prove disabled, enabled, switched-off, and re-enabled transitions occur without server restart
- prove switch-off closes the route gate and provider before invalidation, and re-enable creates a fresh provider runtime
- update the MCP OAuth task and plan to mark the runtime lifecycle slice complete while keeping artifact-replay validation pending

## Why

Phase 6 must prove the Phase 5 lifecycle behavior through the actual HTTP boundary before the OAuth profile is documented as supported. The route set is registered once and must never expose a partial surface during runtime configuration transitions.

## Impact

- No production runtime behavior or API schema changes.
- Adds regression protection around uniform route-gate behavior and provider replacement.
- Narrows remaining Phase 6 work by keeping old-artifact invalidation, races, proxy, and host compatibility tests explicitly pending.

## Checks

- focused MCP OAuth lifecycle E2E: 1 passed
- backend unit: 4,063 passed, 2 skipped across 322 suites
- backend E2E: 127 passed across 11 suites
- backend typecheck and lint (two pre-existing unrelated warnings only)
- admin unit: 1,856 passed across 265 files
- admin typecheck and lint (four pre-existing unrelated warnings only)
- formatting and diff checks

## Next phase

Phase 6 continues with proof that OAuth artifacts issued before switch-off remain unusable after readiness-gated re-enable, followed by barrier race, proxy, and host compatibility profiles.
