### PR TITLE
test(backend): prove MCP OAuth artifacts stay revoked

### DIFF
--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -1,0 +1,294 @@
+import { RequestListener } from 'node:http';
+import { DataSource } from 'typeorm';
+
+import { hashToken } from '../src/modules/auth/utils/token.utils';
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
+import { UpdateMcpConfigDto } from '../src/modules/mcp/dto/update-config.dto';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRefreshFamilyLineageEntity,
+	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
+} from '../src/modules/mcp/entities/mcp-oauth.entity';
+import {
+	MCP_MODULE_NAME,
+	MCP_OAUTH_SERVER_STATE_KEY,
+	McpCapability,
+	McpOAuthScope,
+} from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
+import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
+import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
+import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
+import { McpOAuthLifecycleService } from '../src/modules/mcp/services/mcp-oauth-lifecycle.service';
+import { McpOAuthModuleConfigMutationService } from '../src/modules/mcp/services/mcp-oauth-module-config-mutation.service';
+import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessService,
+} from '../src/modules/mcp/services/mcp-oauth-readiness.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
+import { McpOAuthSwitchOffService } from '../src/modules/mcp/services/mcp-oauth-switch-off.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+import { UserEntity } from '../src/modules/users/entities/users.entity';
+import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
+
+const urls: McpOAuthPublicUrls = {
+	publicBaseUrl: 'https://panel.example.com',
+	resource: 'https://panel.example.com/api/v1/modules/mcp',
+	protectedResourceMetadata: 'https://panel.example.com/.well-known/oauth-protected-resource/api/v1/modules/mcp',
+	issuer: 'https://panel.example.com/api/v1/modules/mcp/oauth',
+	authorizationServerMetadata:
+		'https://panel.example.com/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth',
+	authorizationEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/authorize',
+	tokenEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token',
+	revocationEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token/revocation',
+};
+
+describe('MCP OAuth artifact lifecycle', () => {
+	it('never reactivates artifacts issued before readiness-gated switch-off and re-enable', async () => {
+		const dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				McpOAuthAccessTokenEntity,
+				McpOAuthApproverAuthorityEntity,
+				McpOAuthAuthorizationCodeEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
+				McpOAuthInteractionEntity,
+				McpOAuthProviderArtifactEntity,
+				McpOAuthProviderRefreshFamilyLineageEntity,
+				McpOAuthProviderRevokedGrantEntity,
+				McpOAuthProviderRevokedRefreshFamilyEntity,
+				McpOAuthRefreshTokenEntity,
+				McpOAuthRefreshTokenFamilyEntity,
+				McpOAuthServerStateEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+
+		const auditService = {
+			recordOAuthAuthorizationInvalidation: jest.fn(),
+			recordSubscriptionClosed: jest.fn(),
+			recordSubscriptionOpened: jest.fn(),
+		};
+		const subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
+
+		try {
+			const user = await dataSource.getRepository(UserEntity).save({
+				id: 'owner-one',
+				username: 'owner',
+				password: null,
+				email: null,
+				firstName: null,
+				lastName: null,
+				role: UserRole.OWNER,
+				language: UserLanguage.EN,
+				isHidden: false,
+			});
+			const client = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'artifact-lifecycle-client',
+				name: 'Artifact lifecycle client',
+				redirectUris: ['http://127.0.0.1:1455/callback'],
+				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
+			await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({ approverId: user.id, generation: 0 });
+			await dataSource.getRepository(McpOAuthServerStateEntity).save({
+				key: MCP_OAUTH_SERVER_STATE_KEY,
+				serverSecretVersion: 1,
+				keyVersion: 1,
+				publicIdentityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				modulePolicyGeneration: 0,
+				createdAt: new Date(),
+				updatedAt: null,
+			});
+			const rawGrantId = 'provider-grant-before-switch-off';
+			const grant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawGrantId),
+				clientId: client.id,
+				approvedById: user.id,
+				installationId: 'artifact-lifecycle-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const config = Object.assign(new McpConfigModel(), {
+				enabled: true,
+				oauthEnabled: true,
+				oauthPublicBaseUrl: urls.publicBaseUrl,
+				capabilities: [McpCapability.READ],
+			});
+			const configService = {
+				getModuleConfig: jest.fn(() => config),
+				reload: jest.fn(),
+			};
+			const readiness = new McpOAuthReadinessService();
+			readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
+			readiness.onApplicationBootstrap();
+			const routeGate = new McpOAuthRouteGateService(readiness);
+			const createRuntime = jest.fn(() => {
+				const callback: RequestListener = (_request, response) => response.end();
+				const runtime: McpOAuthProviderRuntime = {
+					provider: {} as McpOAuthProviderRuntime['provider'],
+					callback,
+					urls,
+					metadata: { issuer: urls.issuer } as McpOAuthProviderRuntime['metadata'],
+				};
+
+				return Promise.resolve(runtime);
+			});
+			const runtime = new McpOAuthRuntimeService(
+				{ create: createRuntime } as unknown as McpOAuthProviderFactory,
+				routeGate,
+			);
+			const lifecycle = new McpOAuthLifecycleService(
+				configService as unknown as ConfigService,
+				readiness,
+				routeGate,
+				runtime,
+			);
+			const globalInvalidation = new McpOAuthGlobalInvalidationService(dataSource, subscriptions);
+			const switchOff = new McpOAuthSwitchOffService(
+				routeGate,
+				runtime,
+				globalInvalidation,
+				auditService as unknown as McpAuditService,
+			);
+			const moduleConfigMutation = new McpOAuthModuleConfigMutationService(
+				configService as unknown as ConfigService,
+				dataSource.getRepository(McpOAuthServerStateEntity),
+				subscriptions,
+				globalInvalidation,
+				auditService as unknown as McpAuditService,
+				routeGate,
+				lifecycle,
+				switchOff,
+			);
+			const moduleConfigMutations = new ModuleConfigMutationRegistryService();
+			moduleConfigMutations.register<UpdateMcpConfigDto>(MCP_MODULE_NAME, (update, commit) =>
+				moduleConfigMutation.update(update, commit),
+			);
+			const updateOAuth = (oauthEnabled: boolean): Promise<void> =>
+				moduleConfigMutations.execute(
+					MCP_MODULE_NAME,
+					Object.assign(new UpdateMcpConfigDto(), { oauth_enabled: oauthEnabled }),
+					() => {
+						config.oauthEnabled = oauthEnabled;
+					},
+				);
+
+			await lifecycle.onApplicationBootstrap();
+			expect(routeGate.isOpen).toBe(true);
+			expect(createRuntime).toHaveBeenCalledTimes(1);
+
+			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+				allowTestInMemory: true,
+				artifactReuseError: () => new Error('The OAuth artifact is no longer active'),
+			});
+			const authorizationCodes = new Adapter('AuthorizationCode');
+			const accessTokens = new Adapter('AccessToken');
+			const refreshTokens = new Adapter('RefreshToken');
+			const rawAuthorizationCode = 'authorization-code-before-switch-off';
+			const rawAccessToken = 'access-token-before-switch-off';
+			const rawRefreshToken = 'refresh-token-before-switch-off';
+			const basePayload = {
+				accountId: user.id,
+				aud: urls.resource,
+				clientId: client.clientIdentifier,
+				grantId: rawGrantId,
+				scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
+			};
+
+			await authorizationCodes.upsert(rawAuthorizationCode, { ...basePayload, kind: 'AuthorizationCode' }, 60);
+			await refreshTokens.upsert(rawRefreshToken, { ...basePayload, kind: 'RefreshToken' }, 3_600);
+			await accessTokens.upsert(rawAccessToken, { ...basePayload, gty: 'refresh_token', kind: 'AccessToken' }, 600);
+
+			const resourceServer = new McpOAuthResourceServerService(
+				dataSource.getRepository(McpOAuthProviderArtifactEntity),
+				dataSource.getRepository(McpOAuthProviderRevokedGrantEntity),
+				dataSource.getRepository(McpOAuthGrantEntity),
+				dataSource.getRepository(McpOAuthApproverAuthorityEntity),
+				dataSource.getRepository(McpOAuthServerStateEntity),
+				configService as unknown as ConfigService,
+				{
+					getInstallationId: jest.fn(() => Promise.resolve('artifact-lifecycle-installation')),
+				} as unknown as McpInstallationService,
+				{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			);
+
+			await expect(resourceServer.verifyAccessToken(rawAccessToken)).resolves.toMatchObject({
+				clientId: client.clientIdentifier,
+			});
+			await expect(authorizationCodes.find(rawAuthorizationCode)).resolves.toBeDefined();
+			await expect(refreshTokens.find(rawRefreshToken)).resolves.toBeDefined();
+
+			await updateOAuth(false);
+
+			expect(config.oauthEnabled).toBe(false);
+			expect(routeGate.isOpen).toBe(false);
+			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
+			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+			expect(
+				await dataSource
+					.getRepository(McpOAuthProviderRevokedGrantEntity)
+					.existsBy({ grantIdHash: hashToken(rawGrantId) }),
+			).toBe(true);
+
+			await updateOAuth(true);
+
+			expect(config.oauthEnabled).toBe(true);
+			expect(routeGate.isOpen).toBe(true);
+			expect(createRuntime).toHaveBeenCalledTimes(2);
+			expect(
+				(
+					await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({
+						key: MCP_OAUTH_SERVER_STATE_KEY,
+					})
+				).oauthEnabledGeneration,
+			).toBe(2);
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
+			).not.toBeNull();
+			await expect(resourceServer.verifyAccessToken(rawAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await expect(authorizationCodes.find(rawAuthorizationCode)).resolves.toBeUndefined();
+			await expect(refreshTokens.find(rawRefreshToken)).resolves.toBeUndefined();
+		} finally {
+			await subscriptions.closeAll();
+			await dataSource.destroy();
+		}
+	});
+});

--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { RequestListener } from 'node:http';
+import type { Adapter } from 'oidc-provider';
 import { DataSource } from 'typeorm';
 
 import { hashToken } from '../src/modules/auth/utils/token.utils';
@@ -60,6 +61,15 @@ const urls: McpOAuthPublicUrls = {
 	tokenEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token',
 	revocationEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token/revocation',
 };
+
+interface ArtifactProvider {
+	authorizationCodes: Adapter;
+	accessTokens: Adapter;
+	refreshTokens: Adapter;
+}
+
+const getArtifactProvider = (provider: McpOAuthProviderRuntime['provider']): ArtifactProvider =>
+	provider as unknown as ArtifactProvider;
 
 describe('MCP OAuth artifact lifecycle', () => {
 	it('never reactivates artifacts issued before readiness-gated switch-off and re-enable', async () => {
@@ -154,14 +164,23 @@ describe('MCP OAuth artifact lifecycle', () => {
 				getModuleConfig: jest.fn(() => config),
 				reload: jest.fn(),
 			};
+			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+				allowTestInMemory: true,
+				artifactReuseError: () => new Error('The OAuth artifact is no longer active'),
+			});
 			const readiness = new McpOAuthReadinessService();
 			readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
 			readiness.onApplicationBootstrap();
 			const routeGate = new McpOAuthRouteGateService(readiness);
 			const createRuntime = jest.fn(() => {
 				const callback: RequestListener = (_request, response) => response.end();
+				const provider: ArtifactProvider = {
+					authorizationCodes: new Adapter('AuthorizationCode'),
+					accessTokens: new Adapter('AccessToken'),
+					refreshTokens: new Adapter('RefreshToken'),
+				};
 				const runtime: McpOAuthProviderRuntime = {
-					provider: {} as McpOAuthProviderRuntime['provider'],
+					provider: provider as unknown as McpOAuthProviderRuntime['provider'],
 					callback,
 					urls,
 					metadata: { issuer: urls.issuer } as McpOAuthProviderRuntime['metadata'],
@@ -213,13 +232,7 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(routeGate.isOpen).toBe(true);
 			expect(createRuntime).toHaveBeenCalledTimes(1);
 
-			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
-				allowTestInMemory: true,
-				artifactReuseError: () => new Error('The OAuth artifact is no longer active'),
-			});
-			const authorizationCodes = new Adapter('AuthorizationCode');
-			const accessTokens = new Adapter('AccessToken');
-			const refreshTokens = new Adapter('RefreshToken');
+			const initialProvider = getArtifactProvider(runtime.getActive().provider);
 			const rawAuthorizationCode = 'authorization-code-before-switch-off';
 			const rawAccessToken = 'access-token-before-switch-off';
 			const rawRefreshToken = 'refresh-token-before-switch-off';
@@ -231,9 +244,17 @@ describe('MCP OAuth artifact lifecycle', () => {
 				scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
 			};
 
-			await authorizationCodes.upsert(rawAuthorizationCode, { ...basePayload, kind: 'AuthorizationCode' }, 60);
-			await refreshTokens.upsert(rawRefreshToken, { ...basePayload, kind: 'RefreshToken' }, 3_600);
-			await accessTokens.upsert(rawAccessToken, { ...basePayload, gty: 'refresh_token', kind: 'AccessToken' }, 600);
+			await initialProvider.authorizationCodes.upsert(
+				rawAuthorizationCode,
+				{ ...basePayload, kind: 'AuthorizationCode' },
+				60,
+			);
+			await initialProvider.refreshTokens.upsert(rawRefreshToken, { ...basePayload, kind: 'RefreshToken' }, 3_600);
+			await initialProvider.accessTokens.upsert(
+				rawAccessToken,
+				{ ...basePayload, gty: 'refresh_token', kind: 'AccessToken' },
+				600,
+			);
 
 			const resourceServer = new McpOAuthResourceServerService(
 				dataSource.getRepository(McpOAuthProviderArtifactEntity),
@@ -251,8 +272,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(resourceServer.verifyAccessToken(rawAccessToken)).resolves.toMatchObject({
 				clientId: client.clientIdentifier,
 			});
-			await expect(authorizationCodes.find(rawAuthorizationCode)).resolves.toBeDefined();
-			await expect(refreshTokens.find(rawRefreshToken)).resolves.toBeDefined();
+			await expect(initialProvider.authorizationCodes.find(rawAuthorizationCode)).resolves.toBeDefined();
+			await expect(initialProvider.accessTokens.find(rawAccessToken)).resolves.toBeDefined();
+			await expect(initialProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeDefined();
 
 			await updateOAuth(false);
 
@@ -271,6 +293,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(config.oauthEnabled).toBe(true);
 			expect(routeGate.isOpen).toBe(true);
 			expect(createRuntime).toHaveBeenCalledTimes(2);
+			const replacementProvider = getArtifactProvider(runtime.getActive().provider);
+
+			expect(replacementProvider).not.toBe(initialProvider);
 			expect(
 				(
 					await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({
@@ -284,8 +309,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(resourceServer.verifyAccessToken(rawAccessToken)).rejects.toThrow(
 				'The MCP OAuth access token is invalid or no longer active',
 			);
-			await expect(authorizationCodes.find(rawAuthorizationCode)).resolves.toBeUndefined();
-			await expect(refreshTokens.find(rawRefreshToken)).resolves.toBeUndefined();
+			await expect(replacementProvider.authorizationCodes.find(rawAuthorizationCode)).resolves.toBeUndefined();
+			await expect(replacementProvider.accessTokens.find(rawAccessToken)).resolves.toBeUndefined();
+			await expect(replacementProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeUndefined();
 		} finally {
 			await subscriptions.closeAll();
 			await dataSource.destroy();

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime route-set lifecycle E2E implemented
+**Status:** Phase 6 in progress — runtime route-set and stale-artifact lifecycle E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -431,7 +431,7 @@ amend ADR 0002.
 - [x] E2E: start disabled, enable without restarting, disable without restarting, and re-enable; prove the
       bootstrap-registered route set is uniformly unreachable/reachable behind one gate, never partially exposed, and
       replaces the deactivated provider runtime before reopening.
-- [ ] E2E: prove readiness-gated re-enable never makes OAuth artifacts issued before switch-off usable again.
+- [x] E2E: prove readiness-gated re-enable never makes OAuth artifacts issued before switch-off usable again.
 - [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 runtime lifecycle E2E underway
+Status: in progress — Phase 6 runtime and stale-artifact lifecycle E2E underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add a TypeORM-backed E2E profile for MCP OAuth switch-off and readiness-gated re-enable
- prove an access token, refresh token, and authorization code are usable before switch-off and remain unusable afterward
- exercise the production configuration mutation, switch-off coordinator, global invalidation, route gate, runtime lifecycle, provider adapter, and resource-server verifier together
- update the MCP OAuth task plan to mark stale-artifact reactivation coverage complete

## Why

Runtime route-gate coverage alone does not prove that authorization state issued by the previous provider remains invalid after OAuth is enabled again. Phase 6 requires persistent generation advancement, grant revocation, provider-artifact deletion, and a fresh readiness-gated runtime to prevent restored configuration from reviving old credentials.

## Impact

- No production runtime behavior, schema, or API changes.
- Adds regression coverage for the switch-off security boundary using real in-memory TypeORM persistence.
- Confirms the OAuth-enabled generation advances across disable and re-enable, the previous grant remains revoked, and the replacement runtime cannot validate old artifacts.

## Checks

- focused stale-artifact lifecycle E2E: 1 passed
- backend unit: 4,063 passed, 2 skipped across 322 suites
- backend E2E: 128 passed across 12 suites
- backend typecheck and lint (two pre-existing unrelated warnings only)
- admin unit: 1,856 passed across 265 files
- admin typecheck and lint (four pre-existing unrelated warnings only)
- formatting and diff checks

## Next phase

Phase 6 continues with the remaining switch-off subscription profile, synchronized artifact-commit and invalidation races, proxy behavior, and external host compatibility tests.
