### PR TITLE
test(backend): prove MCP OAuth switch-off stream isolation

### DIFF
--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -30,7 +30,7 @@ import {
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
 import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
-import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpOAuthPrincipal, McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
@@ -269,9 +269,36 @@ describe('MCP OAuth artifact lifecycle', () => {
 				{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
 			);
 
-			await expect(resourceServer.verifyAccessToken(rawAccessToken)).resolves.toMatchObject({
+			const authInfo = await resourceServer.verifyAccessToken(rawAccessToken);
+			expect(authInfo).toMatchObject({
 				clientId: client.clientIdentifier,
 			});
+			const principal = authInfo.extra?.principal as McpOAuthPrincipal;
+			const staticSubscription = subscriptions.open('static-lifecycle-client', 'static-lifecycle-stream');
+			const oauthSubscription = await subscriptions.openOAuth('oauth-lifecycle-stream', () =>
+				Promise.resolve({
+					clientId: principal.clientId,
+					binding: {
+						accessTokenId: principal.accessTokenId,
+						approverAuthorityGeneration: principal.approverAuthorityGeneration,
+						approverId: principal.approverId,
+						authorizationDeadline: new Date(principal.authorizationDeadline),
+						clientGeneration: principal.clientGeneration,
+						effectiveScopes: principal.effectiveScopes,
+						grantGeneration: principal.grantGeneration,
+						grantId: principal.grantId,
+						modulePolicyGeneration: principal.modulePolicyGeneration,
+						oauthEnabledGeneration: principal.oauthEnabledGeneration,
+						publicIdentityGeneration: principal.publicIdentityGeneration,
+						...(principal.refreshFamilyId ? { refreshFamilyId: principal.refreshFamilyId } : {}),
+						serverSecretVersion: principal.serverSecretVersion,
+					},
+				}),
+			);
+
+			expect(staticSubscription.signal.aborted).toBe(false);
+			expect(oauthSubscription.signal.aborted).toBe(false);
+			expect(subscriptions.activeCount).toBe(2);
 			await expect(initialProvider.authorizationCodes.find(rawAuthorizationCode)).resolves.toBeDefined();
 			await expect(initialProvider.accessTokens.find(rawAccessToken)).resolves.toBeDefined();
 			await expect(initialProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeDefined();
@@ -280,7 +307,11 @@ describe('MCP OAuth artifact lifecycle', () => {
 
 			expect(config.oauthEnabled).toBe(false);
 			expect(routeGate.isOpen).toBe(false);
+			expect(() => routeGate.assertOpen()).toThrow('The MCP OAuth route gate is closed');
 			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
+			expect(oauthSubscription.signal.aborted).toBe(true);
+			expect(staticSubscription.signal.aborted).toBe(false);
+			expect(subscriptions.activeCount).toBe(1);
 			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
 			expect(
 				await dataSource
@@ -293,6 +324,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(config.oauthEnabled).toBe(true);
 			expect(routeGate.isOpen).toBe(true);
 			expect(createRuntime).toHaveBeenCalledTimes(2);
+			expect(oauthSubscription.signal.aborted).toBe(true);
+			expect(staticSubscription.signal.aborted).toBe(false);
+			expect(subscriptions.activeCount).toBe(1);
 			const replacementProvider = getArtifactProvider(runtime.getActive().provider);
 
 			expect(replacementProvider).not.toBe(initialProvider);

--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -80,6 +80,7 @@ interface ArtifactProvider {
 }
 
 interface WireSubscriptions {
+	endpoint: URL;
 	oauthClient: Client;
 	oauthSubscription: Awaited<ReturnType<Client['listen']>>;
 	staticClient: Client;
@@ -305,7 +306,7 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(() => routeGate.assertOpen()).toThrow('The MCP OAuth route gate is closed');
 			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
 			await expect(wireSubscriptions.oauthSubscription.closed).resolves.toBe('remote');
-			await expect(wireSubscriptions.oauthClient.listTools()).rejects.toThrow();
+			await expectOAuthConnectionRejected(wireSubscriptions.endpoint, rawAccessToken);
 			await expect(wireSubscriptions.staticClient.listTools()).resolves.toMatchObject({ tools: [] });
 			await expectSubscriptionOpen(wireSubscriptions.staticSubscription.closed);
 			expect(subscriptions.activeCount).toBe(1);
@@ -321,7 +322,7 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(config.oauthEnabled).toBe(true);
 			expect(routeGate.isOpen).toBe(true);
 			expect(createRuntime).toHaveBeenCalledTimes(2);
-			await expect(wireSubscriptions.oauthClient.listTools()).rejects.toThrow();
+			await expectOAuthConnectionRejected(wireSubscriptions.endpoint, rawAccessToken);
 			await expect(wireSubscriptions.staticClient.listTools()).resolves.toMatchObject({ tools: [] });
 			await expectSubscriptionOpen(wireSubscriptions.staticSubscription.closed);
 			expect(subscriptions.activeCount).toBe(1);
@@ -429,6 +430,7 @@ async function openWireSubscriptions(
 		const oauthSubscription = await oauthClient.listen({ toolsListChanged: true });
 
 		return {
+			endpoint,
 			oauthClient,
 			oauthSubscription,
 			staticClient,
@@ -443,6 +445,22 @@ async function openWireSubscriptions(
 		await Promise.allSettled([oauthClient.close(), staticClient.close()]);
 		await app.close();
 		throw error;
+	}
+}
+
+async function expectOAuthConnectionRejected(endpoint: URL, accessToken: string): Promise<void> {
+	const client = new Client(
+		{ name: 'fresh-oauth-lifecycle-probe', version: '1.0.0' },
+		{ versionNegotiation: { mode: 'auto' } },
+	);
+	const transport = new StreamableHTTPClientTransport(endpoint, {
+		requestInit: { headers: { Authorization: `Bearer ${accessToken}` } },
+	});
+
+	try {
+		await expect(client.connect(transport)).rejects.toThrow();
+	} finally {
+		await client.close();
 	}
 }
 

--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -2,10 +2,16 @@ import { RequestListener } from 'node:http';
 import type { Adapter } from 'oidc-provider';
 import { DataSource } from 'typeorm';
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+
 import { hashToken } from '../src/modules/auth/utils/token.utils';
 import { ConfigService } from '../src/modules/config/services/config.service';
 import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
+import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
 import { UpdateMcpConfigDto } from '../src/modules/mcp/dto/update-config.dto';
+import { McpClientEntity } from '../src/modules/mcp/entities/mcp-client.entity';
 import {
 	McpOAuthAccessTokenEntity,
 	McpOAuthApproverAuthorityEntity,
@@ -21,7 +27,9 @@ import {
 	McpOAuthRefreshTokenFamilyEntity,
 	McpOAuthServerStateEntity,
 } from '../src/modules/mcp/entities/mcp-oauth.entity';
+import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
 import {
+	MCP_CATALOG_REGISTRAR,
 	MCP_MODULE_NAME,
 	MCP_OAUTH_SERVER_STATE_KEY,
 	McpCapability,
@@ -30,13 +38,14 @@ import {
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
 import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
 import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
-import { McpOAuthPrincipal, McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
 import { McpOAuthLifecycleService } from '../src/modules/mcp/services/mcp-oauth-lifecycle.service';
 import { McpOAuthModuleConfigMutationService } from '../src/modules/mcp/services/mcp-oauth-module-config-mutation.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import {
 	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
@@ -46,6 +55,8 @@ import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-o
 import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
 import { McpOAuthSwitchOffService } from '../src/modules/mcp/services/mcp-oauth-switch-off.service';
+import { McpPolicyRequest, McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
 import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
@@ -66,6 +77,14 @@ interface ArtifactProvider {
 	authorizationCodes: Adapter;
 	accessTokens: Adapter;
 	refreshTokens: Adapter;
+}
+
+interface WireSubscriptions {
+	oauthClient: Client;
+	oauthSubscription: Awaited<ReturnType<Client['listen']>>;
+	staticClient: Client;
+	staticSubscription: Awaited<ReturnType<Client['listen']>>;
+	close: () => Promise<void>;
 }
 
 const getArtifactProvider = (provider: McpOAuthProviderRuntime['provider']): ArtifactProvider =>
@@ -96,12 +115,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 		});
 		await dataSource.initialize();
 
-		const auditService = {
-			recordOAuthAuthorizationInvalidation: jest.fn(),
-			recordSubscriptionClosed: jest.fn(),
-			recordSubscriptionOpened: jest.fn(),
-		};
-		const subscriptions = new McpSubscriptionRegistryService(auditService as unknown as McpAuditService);
+		const auditService = new McpAuditService();
+		const subscriptions = new McpSubscriptionRegistryService(auditService);
+		let wireSubscriptions: WireSubscriptions | undefined;
 
 		try {
 			const user = await dataSource.getRepository(UserEntity).save({
@@ -199,18 +215,13 @@ describe('MCP OAuth artifact lifecycle', () => {
 				runtime,
 			);
 			const globalInvalidation = new McpOAuthGlobalInvalidationService(dataSource, subscriptions);
-			const switchOff = new McpOAuthSwitchOffService(
-				routeGate,
-				runtime,
-				globalInvalidation,
-				auditService as unknown as McpAuditService,
-			);
+			const switchOff = new McpOAuthSwitchOffService(routeGate, runtime, globalInvalidation, auditService);
 			const moduleConfigMutation = new McpOAuthModuleConfigMutationService(
 				configService as unknown as ConfigService,
 				dataSource.getRepository(McpOAuthServerStateEntity),
 				subscriptions,
 				globalInvalidation,
-				auditService as unknown as McpAuditService,
+				auditService,
 				routeGate,
 				lifecycle,
 				switchOff,
@@ -273,31 +284,15 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(authInfo).toMatchObject({
 				clientId: client.clientIdentifier,
 			});
-			const principal = authInfo.extra?.principal as McpOAuthPrincipal;
-			const staticSubscription = subscriptions.open('static-lifecycle-client', 'static-lifecycle-stream');
-			const oauthSubscription = await subscriptions.openOAuth('oauth-lifecycle-stream', () =>
-				Promise.resolve({
-					clientId: principal.clientId,
-					binding: {
-						accessTokenId: principal.accessTokenId,
-						approverAuthorityGeneration: principal.approverAuthorityGeneration,
-						approverId: principal.approverId,
-						authorizationDeadline: new Date(principal.authorizationDeadline),
-						clientGeneration: principal.clientGeneration,
-						effectiveScopes: principal.effectiveScopes,
-						grantGeneration: principal.grantGeneration,
-						grantId: principal.grantId,
-						modulePolicyGeneration: principal.modulePolicyGeneration,
-						oauthEnabledGeneration: principal.oauthEnabledGeneration,
-						publicIdentityGeneration: principal.publicIdentityGeneration,
-						...(principal.refreshFamilyId ? { refreshFamilyId: principal.refreshFamilyId } : {}),
-						serverSecretVersion: principal.serverSecretVersion,
-					},
-				}),
+			wireSubscriptions = await openWireSubscriptions(
+				config,
+				routeGate,
+				resourceServer,
+				subscriptions,
+				auditService,
+				rawAccessToken,
 			);
 
-			expect(staticSubscription.signal.aborted).toBe(false);
-			expect(oauthSubscription.signal.aborted).toBe(false);
 			expect(subscriptions.activeCount).toBe(2);
 			await expect(initialProvider.authorizationCodes.find(rawAuthorizationCode)).resolves.toBeDefined();
 			await expect(initialProvider.accessTokens.find(rawAccessToken)).resolves.toBeDefined();
@@ -309,8 +304,10 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(routeGate.isOpen).toBe(false);
 			expect(() => routeGate.assertOpen()).toThrow('The MCP OAuth route gate is closed');
 			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
-			expect(oauthSubscription.signal.aborted).toBe(true);
-			expect(staticSubscription.signal.aborted).toBe(false);
+			await expect(wireSubscriptions.oauthSubscription.closed).resolves.toBe('remote');
+			await expect(wireSubscriptions.oauthClient.listTools()).rejects.toThrow();
+			await expect(wireSubscriptions.staticClient.listTools()).resolves.toMatchObject({ tools: [] });
+			await expectSubscriptionOpen(wireSubscriptions.staticSubscription.closed);
 			expect(subscriptions.activeCount).toBe(1);
 			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
 			expect(
@@ -324,8 +321,9 @@ describe('MCP OAuth artifact lifecycle', () => {
 			expect(config.oauthEnabled).toBe(true);
 			expect(routeGate.isOpen).toBe(true);
 			expect(createRuntime).toHaveBeenCalledTimes(2);
-			expect(oauthSubscription.signal.aborted).toBe(true);
-			expect(staticSubscription.signal.aborted).toBe(false);
+			await expect(wireSubscriptions.oauthClient.listTools()).rejects.toThrow();
+			await expect(wireSubscriptions.staticClient.listTools()).resolves.toMatchObject({ tools: [] });
+			await expectSubscriptionOpen(wireSubscriptions.staticSubscription.closed);
 			expect(subscriptions.activeCount).toBe(1);
 			const replacementProvider = getArtifactProvider(runtime.getActive().provider);
 
@@ -347,8 +345,114 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(replacementProvider.accessTokens.find(rawAccessToken)).resolves.toBeUndefined();
 			await expect(replacementProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeUndefined();
 		} finally {
+			await wireSubscriptions?.close();
 			await subscriptions.closeAll();
 			await dataSource.destroy();
 		}
 	});
 });
+
+async function openWireSubscriptions(
+	config: McpConfigModel,
+	routeGate: McpOAuthRouteGateService,
+	resourceServer: McpOAuthResourceServerService,
+	subscriptions: McpSubscriptionRegistryService,
+	auditService: McpAuditService,
+	oauthAccessToken: string,
+): Promise<WireSubscriptions> {
+	const staticClientId = 'static-lifecycle-client';
+	const staticToken = 'static-lifecycle-token';
+	const moduleRef = await Test.createTestingModule({
+		controllers: [McpController],
+		providers: [
+			{ provide: McpAuditService, useValue: auditService },
+			{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
+			{ provide: McpOAuthResourceServerService, useValue: resourceServer },
+			{ provide: McpOAuthRouteGateService, useValue: routeGate },
+			{ provide: McpPolicyService, useValue: { validateOAuthRequestOrigin: jest.fn() } },
+			McpServerService,
+			{ provide: McpSubscriptionRegistryService, useValue: subscriptions },
+			{ provide: MCP_CATALOG_REGISTRAR, useValue: { register: () => undefined } },
+		],
+	})
+		.overrideGuard(McpClientGuard)
+		.useValue({
+			canActivate: (context: { switchToHttp: () => { getRequest: () => McpPolicyRequest } }): boolean => {
+				const request = context.switchToHttp().getRequest();
+
+				if (request.headers.authorization !== `Bearer ${staticToken}`) return true;
+
+				request.mcpPolicy = {
+					client: {
+						id: staticClientId,
+						name: 'Static lifecycle client',
+						enabled: true,
+						capabilities: [McpCapability.READ],
+						tokenId: staticToken,
+						token: { id: staticToken, revoked: false, expiresAt: new Date(Date.now() + 60_000) },
+					} as McpClientEntity,
+					config,
+					clientPolicyRevision: 0,
+					effectiveCapabilities: [McpCapability.READ],
+					installationId: 'artifact-lifecycle-installation',
+					policyRevision: 0,
+					tokenId: staticToken,
+				};
+
+				return true;
+			},
+		})
+		.compile();
+	const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+	await app.listen(0, '127.0.0.1');
+	const endpoint = new URL('/', await app.getUrl());
+	const staticClient = new Client(
+		{ name: 'static-lifecycle-e2e', version: '1.0.0' },
+		{ versionNegotiation: { mode: 'auto' } },
+	);
+	const oauthClient = new Client(
+		{ name: 'oauth-lifecycle-e2e', version: '1.0.0' },
+		{ versionNegotiation: { mode: 'auto' } },
+	);
+	const staticTransport = new StreamableHTTPClientTransport(endpoint, {
+		requestInit: { headers: { Authorization: `Bearer ${staticToken}` } },
+	});
+	const oauthTransport = new StreamableHTTPClientTransport(endpoint, {
+		requestInit: { headers: { Authorization: `Bearer ${oauthAccessToken}` } },
+	});
+
+	try {
+		await staticClient.connect(staticTransport);
+		await oauthClient.connect(oauthTransport);
+		const staticSubscription = await staticClient.listen({ toolsListChanged: true });
+		const oauthSubscription = await oauthClient.listen({ toolsListChanged: true });
+
+		return {
+			oauthClient,
+			oauthSubscription,
+			staticClient,
+			staticSubscription,
+			close: async () => {
+				await Promise.allSettled([oauthClient.close(), staticClient.close()]);
+				await app.get(McpServerService).closeAll();
+				await app.close();
+			},
+		};
+	} catch (error) {
+		await Promise.allSettled([oauthClient.close(), staticClient.close()]);
+		await app.close();
+		throw error;
+	}
+}
+
+async function expectSubscriptionOpen(closed: Promise<unknown>): Promise<void> {
+	const closedEarly = await Promise.race([
+		closed.then(() => true),
+		new Promise<boolean>((resolve) => {
+			setTimeout(() => resolve(false), 50);
+		}),
+	]);
+
+	expect(closedEarly).toBe(false);
+}

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime route-set and stale-artifact lifecycle E2E implemented
+**Status:** Phase 6 in progress — runtime route-set, switch-off subscription, and stale-artifact lifecycle E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -416,7 +416,7 @@ amend ADR 0002.
       then resume registration and prove the stale request cannot open after invalidation success.
 - [ ] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
-- [ ] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
+- [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
       reruns readiness and old OAuth artifacts remain unusable.
 - [ ] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 runtime and stale-artifact lifecycle E2E underway
+Status: in progress — Phase 6 switch-off subscription and stale-artifact lifecycle E2E underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- extend the TypeORM-backed MCP OAuth lifecycle E2E with simultaneous static and OAuth subscriptions
- prove switch-off closes the OAuth route gate, provider runtime, OAuth stream, and persisted artifacts before the configuration mutation returns
- prove the independently authorized static MCP stream remains active through OAuth switch-off and readiness-gated re-enable
- update the MCP OAuth plan to mark the combined switch-off subscription lifecycle criterion complete

## Why

Phase 6 must prove that OAuth switch-off is profile-scoped: new OAuth traffic must fail closed and active OAuth authorization state must be invalidated synchronously, without interrupting the separately authorized static MCP profile.

## Impact

- No production runtime behavior, schema, or API changes.
- Adds regression coverage for OAuth/static stream isolation across disable and re-enable.
- Confirms the validated OAuth principal is bound into the real subscription registry before global invalidation closes only the matching profile.

## Checks

- focused MCP OAuth lifecycle E2E: 1 passed
- backend unit: 4,063 passed, 2 skipped across 322 suites
- backend E2E: 128 passed across 12 suites
- backend typecheck and lint (two pre-existing unrelated warnings only)
- admin unit: 1,856 passed across 265 files
- admin typecheck and lint (four pre-existing unrelated warnings only)
- formatting and diff checks

## Next phase

Phase 6 continues with synchronized listen-registration and artifact-commit invalidation races, server-secret/public-identity rotation profiles, reverse-proxy behavior, and external host compatibility tests.
