### PR TITLE
test(backend): prove MCP OAuth listen revocation race

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -1,0 +1,287 @@
+import type { FastifyReply } from 'fastify';
+import { DataSource } from 'typeorm';
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { AuthInfo } from '@modelcontextprotocol/server';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+
+import { hashToken } from '../src/modules/auth/utils/token.utils';
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { McpController } from '../src/modules/mcp/controllers/mcp.controller';
+import {
+	McpOAuthAccessTokenEntity,
+	McpOAuthApproverAuthorityEntity,
+	McpOAuthAuthorizationCodeEntity,
+	McpOAuthClientEntity,
+	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
+	McpOAuthProviderArtifactEntity,
+	McpOAuthProviderRefreshFamilyLineageEntity,
+	McpOAuthProviderRevokedGrantEntity,
+	McpOAuthProviderRevokedRefreshFamilyEntity,
+	McpOAuthRefreshTokenEntity,
+	McpOAuthRefreshTokenFamilyEntity,
+	McpOAuthServerStateEntity,
+} from '../src/modules/mcp/entities/mcp-oauth.entity';
+import { McpClientGuard } from '../src/modules/mcp/guards/mcp-client.guard';
+import {
+	MCP_CATALOG_REGISTRAR,
+	MCP_OAUTH_SERVER_STATE_KEY,
+	McpCapability,
+	McpOAuthScope,
+} from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
+import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
+import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
+import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
+import { McpOAuthManagementService } from '../src/modules/mcp/services/mcp-oauth-management.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
+import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
+import { McpPolicyRequest, McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
+import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
+import { UserEntity } from '../src/modules/users/entities/users.entity';
+import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
+
+const urls: McpOAuthPublicUrls = {
+	publicBaseUrl: 'https://panel.example.com',
+	resource: 'https://panel.example.com/api/v1/modules/mcp',
+	protectedResourceMetadata: 'https://panel.example.com/.well-known/oauth-protected-resource/api/v1/modules/mcp',
+	issuer: 'https://panel.example.com/api/v1/modules/mcp/oauth',
+	authorizationServerMetadata:
+		'https://panel.example.com/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth',
+	authorizationEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/authorize',
+	tokenEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token',
+	revocationEndpoint: 'https://panel.example.com/api/v1/modules/mcp/oauth/token/revocation',
+};
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+	let resolve = (): void => undefined;
+	const promise = new Promise<void>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
+describe('MCP OAuth listen registration race', () => {
+	it('rejects a listen request resumed after matching access-token revocation succeeds', async () => {
+		const dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				McpOAuthAccessTokenEntity,
+				McpOAuthApproverAuthorityEntity,
+				McpOAuthAuthorizationCodeEntity,
+				McpOAuthClientEntity,
+				McpOAuthGrantEntity,
+				McpOAuthInteractionEntity,
+				McpOAuthProviderArtifactEntity,
+				McpOAuthProviderRefreshFamilyLineageEntity,
+				McpOAuthProviderRevokedGrantEntity,
+				McpOAuthProviderRevokedRefreshFamilyEntity,
+				McpOAuthRefreshTokenEntity,
+				McpOAuthRefreshTokenFamilyEntity,
+				McpOAuthServerStateEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+
+		const auditService = new McpAuditService();
+		const subscriptions = new McpSubscriptionRegistryService(auditService);
+		let app: NestFastifyApplication | undefined;
+		let client: Client | undefined;
+		const releaseListen = deferred();
+
+		try {
+			const user = await dataSource.getRepository(UserEntity).save({
+				id: 'listen-race-owner',
+				username: 'owner',
+				password: null,
+				email: null,
+				firstName: null,
+				lastName: null,
+				role: UserRole.OWNER,
+				language: UserLanguage.EN,
+				isHidden: false,
+			});
+			const oauthClient = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'listen-registration-race-client',
+				name: 'Listen registration race client',
+				redirectUris: ['http://127.0.0.1:1455/callback'],
+				maximumScopes: [McpOAuthScope.READ],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
+			await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({
+				approverId: user.id,
+				generation: 0,
+			});
+			await dataSource.getRepository(McpOAuthServerStateEntity).save({
+				key: MCP_OAUTH_SERVER_STATE_KEY,
+				serverSecretVersion: 1,
+				keyVersion: 1,
+				publicIdentityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				modulePolicyGeneration: 0,
+				createdAt: new Date(),
+				updatedAt: null,
+			});
+			const rawGrantId = 'listen-registration-race-grant';
+			const grant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawGrantId),
+				clientId: oauthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const config = Object.assign(new McpConfigModel(), {
+				enabled: true,
+				oauthEnabled: true,
+				oauthPublicBaseUrl: urls.publicBaseUrl,
+				capabilities: [McpCapability.READ],
+			});
+			const configService = {
+				getModuleConfig: jest.fn(() => config),
+			};
+			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+				allowTestInMemory: true,
+				artifactReuseError: () => new Error('The OAuth artifact is no longer active'),
+			});
+			const rawAccessToken = 'listen-registration-race-access-token';
+
+			await new Adapter('AccessToken').upsert(
+				rawAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			const accessArtifact = await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneByOrFail({
+				model: 'AccessToken',
+				idHash: hashToken(rawAccessToken),
+			});
+			const resourceServer = new McpOAuthResourceServerService(
+				dataSource.getRepository(McpOAuthProviderArtifactEntity),
+				dataSource.getRepository(McpOAuthProviderRevokedGrantEntity),
+				dataSource.getRepository(McpOAuthGrantEntity),
+				dataSource.getRepository(McpOAuthApproverAuthorityEntity),
+				dataSource.getRepository(McpOAuthServerStateEntity),
+				configService as unknown as ConfigService,
+				{
+					getInstallationId: jest.fn(() => Promise.resolve('listen-registration-race-installation')),
+				} as unknown as McpInstallationService,
+				{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			);
+			const management = new McpOAuthManagementService(
+				dataSource.getRepository(McpOAuthGrantEntity),
+				dataSource.getRepository(McpOAuthProviderArtifactEntity),
+				dataSource,
+				configService as unknown as ConfigService,
+				{} as McpOAuthClientService,
+				subscriptions,
+				{} as McpOAuthGlobalInvalidationService,
+				auditService,
+			);
+			const routeGate = {
+				isOpen: true,
+				assertOpen: jest.fn(),
+			};
+			const moduleRef = await Test.createTestingModule({
+				controllers: [McpController],
+				providers: [
+					{ provide: McpAuditService, useValue: auditService },
+					{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
+					{ provide: McpOAuthResourceServerService, useValue: resourceServer },
+					{ provide: McpOAuthRouteGateService, useValue: routeGate },
+					{ provide: McpPolicyService, useValue: { validateOAuthRequestOrigin: jest.fn() } },
+					McpServerService,
+					{ provide: McpSubscriptionRegistryService, useValue: subscriptions },
+					{ provide: MCP_CATALOG_REGISTRAR, useValue: { register: () => undefined } },
+				],
+			})
+				.overrideGuard(McpClientGuard)
+				.useValue({ canActivate: () => true })
+				.compile();
+
+			app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+			await app.listen(0, '127.0.0.1');
+			const serverService = app.get<McpServerService>(McpServerService);
+			const listenAuthenticated = deferred();
+
+			jest
+				.spyOn(serverService, 'handleOAuth')
+				.mockImplementation(
+					async (request: McpPolicyRequest, reply: FastifyReply, authInfo: AuthInfo): Promise<void> => {
+						if ((request.body as { method?: string } | undefined)?.method === 'subscriptions/listen') {
+							listenAuthenticated.resolve();
+							await releaseListen.promise;
+						}
+
+						await McpServerService.prototype.handleOAuth.call(serverService, request, reply, authInfo);
+					},
+				);
+			const endpoint = new URL('/', await app.getUrl());
+			client = new Client(
+				{ name: 'listen-registration-race-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const transport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${rawAccessToken}` } },
+			});
+
+			await client.connect(transport);
+			const rejectedListen = expect(client.listen({ toolsListChanged: true })).rejects.toThrow();
+
+			await listenAuthenticated.promise;
+			await management.revokeAccessToken(accessArtifact.managementId, 'owner-actor');
+
+			expect(subscriptions.activeCount).toBe(0);
+			await expect(resourceServer.verifyAccessToken(rawAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+
+			releaseListen.resolve();
+			await rejectedListen;
+			expect(subscriptions.activeCount).toBe(0);
+			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
+			).toBeNull();
+		} finally {
+			releaseListen.resolve();
+			await client?.close();
+			if (app) {
+				await app.get(McpServerService).closeAll();
+				await app.close();
+			}
+			await subscriptions.closeAll();
+			await dataSource.destroy();
+		}
+	});
+});

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime route-set, switch-off subscription, and stale-artifact lifecycle E2E implemented
+**Status:** Phase 6 in progress — runtime lifecycle and stale listen-registration E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -412,7 +412,7 @@ amend ADR 0002.
       grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
       invalidation, global server-secret rotation, and each module/client/grant scope reduction that removes a stream's
       effective read, write, or trigger scope.
-- [ ] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
+- [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [ ] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 switch-off subscription and stale-artifact lifecycle E2E underway
+Status: in progress — Phase 6 runtime lifecycle and stale listen-registration E2E underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- add a TypeORM-backed wire E2E for the OAuth listen-registration and access-token revocation race
- pause a real SDK `subscriptions/listen` request after controller authentication but before server registration
- complete revocation through `McpOAuthManagementService`, then resume the request and prove bearer revalidation rejects it without opening a stream
- update the MCP OAuth plan to mark the stale listen-registration Phase 6 criterion complete

## Why

An OAuth listen request can authenticate before a matching artifact is revoked. Phase 6 must prove that this stale in-flight request cannot register after the awaited invalidation has already reported success.

## Impact

- No production runtime, schema, API, or Admin behavior changes.
- Adds regression coverage across the real MCP controller/server, SDK HTTP transport, resource-server verifier, subscription gate, management revocation service, and TypeORM artifact persistence.
- Confirms the grant remains active while only the targeted access token is revoked.

## Checks

- focused MCP OAuth listen-registration race E2E: 1 passed
- backend E2E: 129 passed across 13 suites
- backend typecheck and lint (two pre-existing unrelated warnings only)
- backend unit assertions: 4,063 passed, 2 skipped across 322 suites; the local command subsequently hit the existing Home Assistant websocket teardown callback issue
- admin unit: 1,856 passed across 265 files
- admin typecheck and lint (four pre-existing unrelated warnings only)
- formatting and diff checks

## Next phase

Phase 6 continues with barrier-synchronized concurrent refresh-token replay and whole-family revocation coverage.
