### PR TITLE
chore(cross): enforce a strict PR title and commit convention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    target-branch: dev
+    # Emits `chore(deps): bump ...`, which satisfies the PR title convention
+    # enforced by .github/workflows/lint-pr.yml. See CONTRIBUTING.md.
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -43,24 +43,53 @@ jobs:
             tasks
             cross
           requireScope: true
-          # Mirrors commitlint's subject-first-char-lowercase and subject-full-stop.
-          # The header length rule is checked in the next step, because the action
-          # only exposes the subject, not the whole title.
-          subjectPattern: ^(?![A-Z])(?!.*\.$).+$
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character and doesn't end with a period.
+          # No subjectPattern here on purpose. The action builds a RegExp without the
+          # `u` flag, so it cannot express "not an uppercase letter" for non-ASCII
+          # scripts — `^(?![A-Z])` accepts "Čeština translations" while commitlint
+          # rejects it. Subject rules are checked in the next step instead, using
+          # commitlint's own predicate, so the two paths cannot disagree.
 
-      # commitlint applies @commitlint/config-conventional's header-max-length to
-      # local commits, but nothing sees the PR title — and the PR title is what
-      # becomes the commit on main and the release-note line. Check it here.
-      - name: Validate PR title length
+      # commitlint governs local commit messages but never sees the PR title — and the
+      # PR title is what squash-merge writes onto main and what release-drafter renders
+      # into the release notes. These checks mirror commitlint/config-conventional's
+      # header-max-length and this repo's subject-first-char-lowercase and
+      # subject-full-stop rules. Keep them in step with commitlint.config.js.
+      - name: Validate PR title subject
         env:
-          # Never interpolate the title into `run` directly — it is untrusted input.
+          # Untrusted input: pass it through the environment, never interpolate it
+          # into the script body.
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [ "${#PR_TITLE}" -gt 100 ]; then
-            echo "::error::PR title is ${#PR_TITLE} characters long; the limit is 100. See CONTRIBUTING.md."
-            exit 1
-          fi
+          node -e '
+          const title = process.env.PR_TITLE ?? "";
+          const errors = [];
+
+          if (title.length > 100) {
+            errors.push("header is " + title.length + " characters long; the limit is 100");
+          }
+
+          const match = /^[a-z]+(?:\([^)]+\))?!?: (.+)$/.exec(title);
+
+          if (match === null) {
+            errors.push("could not read a subject from the title");
+          } else {
+            const subject = match[1];
+
+            // Identical predicate to commitlint.config.js subject-first-char-lowercase.
+            // Not a character class: this way the two enforcement paths agree by
+            // construction, for every script, rather than by two regexes staying in sync.
+            if (subject[0] !== subject[0].toLowerCase()) {
+              errors.push("subject must not start with an uppercase letter");
+            }
+
+            if (subject.endsWith(".")) {
+              errors.push("subject must not end with a period");
+            }
+          }
+
+          for (const error of errors) {
+            console.log("::error::PR title: " + error + ". See CONTRIBUTING.md.");
+          }
+
+          process.exit(errors.length === 0 ? 0 : 1);
+          '

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -32,6 +32,7 @@ jobs:
             admin
             panel
             website
+            testing
             sdk
             installer
             spec

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -78,7 +78,11 @@ jobs:
             // Identical predicate to commitlint.config.js subject-first-char-lowercase.
             // Not a character class: this way the two enforcement paths agree by
             // construction, for every script, rather than by two regexes staying in sync.
-            if (subject[0] !== subject[0].toLowerCase()) {
+            // Destructuring iterates by code point — `subject[0]` would yield a lone high
+            // surrogate for a non-BMP letter such as `𐐀`, which lowercases to itself.
+            const [first] = subject;
+
+            if (first !== first.toLowerCase()) {
               errors.push("subject must not start with an uppercase letter");
             }
 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -42,8 +42,24 @@ jobs:
             tasks
             cross
           requireScope: true
-          subjectPattern: ^(?![A-Z]).+$
+          # Mirrors commitlint's subject-first-char-lowercase and subject-full-stop.
+          # The header length rule is checked in the next step, because the action
+          # only exposes the subject, not the whole title.
+          subjectPattern: ^(?![A-Z])(?!.*\.$).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
+            doesn't start with an uppercase character and doesn't end with a period.
+
+      # commitlint applies @commitlint/config-conventional's header-max-length to
+      # local commits, but nothing sees the PR title — and the PR title is what
+      # becomes the commit on main and the release-note line. Check it here.
+      - name: Validate PR title length
+        env:
+          # Never interpolate the title into `run` directly — it is untrusted input.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "${#PR_TITLE}" -gt 100 ]; then
+            echo "::error::PR title is ${#PR_TITLE} characters long; the limit is 100. See CONTRIBUTING.md."
+            exit 1
+          fi

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,49 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            perf
+            ci
+            build
+            revert
+          scopes: |
+            backend
+            admin
+            panel
+            website
+            sdk
+            installer
+            spec
+            infra
+            ci
+            deps
+            docs
+            tasks
+            cross
+          requireScope: true
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,12 +153,18 @@ apps/
 │   ├── plugins/     # Plugin implementations
 │   ├── api/         # Generated API client (DO NOT EDIT)
 │   └── spec/        # Generated device/channel specs (DO NOT EDIT)
-└── website/         # Next.js documentation site
+├── website/         # Next.js documentation site
+├── testing/         # Testing app (@fastybird/smart-panel-testing)
+└── get-script/      # Cloudflare Pages site serving get.smart-panel.fastybird.com
 
 packages/
 ├── extension-sdk/       # SDK for building extensions
 └── example-extension/   # Example extension
 
+build/                   # Installer package, raspbian image, service scripts
+scripts/                 # install-server.sh, install-display.sh
+docker/                  # Dev and prod compose setups
+spec/                    # OpenAPI + device/channel/display/weather specs
 docs/                    # Architecture reference documents
 tasks/                   # Feature and technical task specifications
 ```
@@ -204,8 +210,9 @@ When implementing features:
 | `admin` | `apps/admin/**` |
 | `panel` | `apps/panel/**` |
 | `website` | `apps/website/**` |
+| `testing` | `apps/testing/**` |
 | `sdk` | `packages/**` |
-| `installer` | `build/**` |
+| `installer` | `build/**`, `scripts/**`, `apps/get-script/**` |
 | `spec` | `spec/**` |
 | `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, root workspace tooling |
 | `ci` | `.github/**` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,8 +181,48 @@ When implementing features:
 ## Key Rules
 
 1. **NEVER push directly to main.** All changes must go through a feature branch and Pull Request — no exceptions, not even for "quick fixes" or lint fixes. Only push to main if the user explicitly requests it.
-2. Respect modular architecture — avoid "god services" mixing multiple concerns.
-3. Prefer existing patterns, helpers, and abstractions over inventing new ones.
-4. Do not introduce new dependencies without a strong reason.
-5. Pay special attention to: auth, error handling, timeouts on external calls, data validation.
-6. Migration policy: always create incremental migration files for schema changes (e.g., `1000000000002-AddTokenLastUsedAt.ts`). Never modify the initial migration — alpha releases are deployed and existing installations have already run it.
+2. **Commit messages and PR titles are `<type>(<scope>): <subject>`, with the scope required.** Enforced by `commitlint` locally and `lint-pr.yml` in CI. The PR title becomes the squash commit on `main` and is rendered verbatim into release notes, so it has to be right. See [Commit and PR titles](#commit-and-pr-titles) below and [CONTRIBUTING.md](CONTRIBUTING.md).
+3. Respect modular architecture — avoid "god services" mixing multiple concerns.
+4. Prefer existing patterns, helpers, and abstractions over inventing new ones.
+5. Do not introduce new dependencies without a strong reason.
+6. Pay special attention to: auth, error handling, timeouts on external calls, data validation.
+7. Migration policy: always create incremental migration files for schema changes (e.g., `1000000000002-AddTokenLastUsedAt.ts`). Never modify the initial migration — alpha releases are deployed and existing installations have already run it.
+
+## Commit and PR titles
+
+```
+<type>(<scope>): <subject>
+```
+
+**Types:** `feat` `fix` `docs` `style` `refactor` `test` `chore` `perf` `ci` `build` `revert`
+
+**Scopes** — required, closed list. The scope is the *surface* changed, not the feature domain:
+
+| Scope | Covers |
+|---|---|
+| `backend` | `apps/backend/**` |
+| `admin` | `apps/admin/**` |
+| `panel` | `apps/panel/**` |
+| `website` | `apps/website/**` |
+| `sdk` | `packages/**` |
+| `installer` | `build/**` |
+| `spec` | `spec/**` |
+| `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, root workspace tooling |
+| `ci` | `.github/**` |
+| `deps` | Dependency bumps |
+| `docs` | `docs/**`, root `*.md` |
+| `tasks` | `tasks/**` |
+| `cross` | Genuinely cross-cutting |
+
+**Subject:** starts lowercase (acronyms later are fine — `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
+
+**Breaking changes:** `feat(backend)!: …`, and add the `breaking change` label — release-drafter categorises by label, not by the `!` marker.
+
+```
+feat(backend): add MCP OAuth artifact administration
+fix(admin): recover the websocket after the machine wakes from sleep
+docs(tasks): close the virtual devices epic
+chore(cross): align PR workflow docs and automation
+```
+
+Common mistakes: omitting the scope; using a domain (`mcp`, `energy`, `devices`) instead of a surface; starting the subject with a capital; using `security`, `feature` or `doc` as a type. Adding a scope means editing `commitlint.config.js`, `.github/workflows/lint-pr.yml` and `CONTRIBUTING.md` together.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ When implementing features:
 | `tasks` | `tasks/**` |
 | `cross` | Genuinely cross-cutting |
 
-**Subject:** starts lowercase (acronyms later are fine — `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
+**Subject:** must not start with an uppercase letter in any script (`Add …`, `Čeština …` and `Überarbeiten …` are all rejected; acronyms later are fine, so `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
 
 **Breaking changes:** `feat(backend)!: …`, and add the `breaking change` label — release-drafter categorises by label, not by the `!` marker.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,12 +153,18 @@ apps/
 │   ├── plugins/     # Plugin implementations
 │   ├── api/         # Generated API client (DO NOT EDIT)
 │   └── spec/        # Generated device/channel specs (DO NOT EDIT)
-└── website/         # Next.js documentation site
+├── website/         # Next.js documentation site
+├── testing/         # Testing app (@fastybird/smart-panel-testing)
+└── get-script/      # Cloudflare Pages site serving get.smart-panel.fastybird.com
 
 packages/
 ├── extension-sdk/       # SDK for building extensions
 └── example-extension/   # Example extension
 
+build/                   # Installer package, raspbian image, service scripts
+scripts/                 # install-server.sh, install-display.sh
+docker/                  # Dev and prod compose setups
+spec/                    # OpenAPI + device/channel/display/weather specs
 docs/                    # Architecture reference documents
 tasks/                   # Feature and technical task specifications
 ```
@@ -204,8 +210,9 @@ When implementing features:
 | `admin` | `apps/admin/**` |
 | `panel` | `apps/panel/**` |
 | `website` | `apps/website/**` |
+| `testing` | `apps/testing/**` |
 | `sdk` | `packages/**` |
-| `installer` | `build/**` |
+| `installer` | `build/**`, `scripts/**`, `apps/get-script/**` |
 | `spec` | `spec/**` |
 | `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, root workspace tooling |
 | `ci` | `.github/**` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,8 +181,48 @@ When implementing features:
 ## Key Rules
 
 1. **NEVER push directly to main.** All changes must go through a feature branch and Pull Request — no exceptions, not even for "quick fixes" or lint fixes. Only push to main if the user explicitly requests it.
-2. Respect modular architecture — avoid "god services" mixing multiple concerns.
-3. Prefer existing patterns, helpers, and abstractions over inventing new ones.
-4. Do not introduce new dependencies without a strong reason.
-5. Pay special attention to: auth, error handling, timeouts on external calls, data validation.
-6. Migration policy: always create incremental migration files for schema changes (e.g., `1000000000002-AddTokenLastUsedAt.ts`). Never modify the initial migration — alpha releases are deployed and existing installations have already run it.
+2. **Commit messages and PR titles are `<type>(<scope>): <subject>`, with the scope required.** Enforced by `commitlint` locally and `lint-pr.yml` in CI. The PR title becomes the squash commit on `main` and is rendered verbatim into release notes, so it has to be right. See [Commit and PR titles](#commit-and-pr-titles) below and [CONTRIBUTING.md](CONTRIBUTING.md).
+3. Respect modular architecture — avoid "god services" mixing multiple concerns.
+4. Prefer existing patterns, helpers, and abstractions over inventing new ones.
+5. Do not introduce new dependencies without a strong reason.
+6. Pay special attention to: auth, error handling, timeouts on external calls, data validation.
+7. Migration policy: always create incremental migration files for schema changes (e.g., `1000000000002-AddTokenLastUsedAt.ts`). Never modify the initial migration — alpha releases are deployed and existing installations have already run it.
+
+## Commit and PR titles
+
+```
+<type>(<scope>): <subject>
+```
+
+**Types:** `feat` `fix` `docs` `style` `refactor` `test` `chore` `perf` `ci` `build` `revert`
+
+**Scopes** — required, closed list. The scope is the *surface* changed, not the feature domain:
+
+| Scope | Covers |
+|---|---|
+| `backend` | `apps/backend/**` |
+| `admin` | `apps/admin/**` |
+| `panel` | `apps/panel/**` |
+| `website` | `apps/website/**` |
+| `sdk` | `packages/**` |
+| `installer` | `build/**` |
+| `spec` | `spec/**` |
+| `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, root workspace tooling |
+| `ci` | `.github/**` |
+| `deps` | Dependency bumps |
+| `docs` | `docs/**`, root `*.md` |
+| `tasks` | `tasks/**` |
+| `cross` | Genuinely cross-cutting |
+
+**Subject:** starts lowercase (acronyms later are fine — `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
+
+**Breaking changes:** `feat(backend)!: …`, and add the `breaking change` label — release-drafter categorises by label, not by the `!` marker.
+
+```
+feat(backend): add MCP OAuth artifact administration
+fix(admin): recover the websocket after the machine wakes from sleep
+docs(tasks): close the virtual devices epic
+chore(cross): align PR workflow docs and automation
+```
+
+Common mistakes: omitting the scope; using a domain (`mcp`, `energy`, `devices`) instead of a surface; starting the subject with a capital; using `security`, `feature` or `doc` as a type. Adding a scope means editing `commitlint.config.js`, `.github/workflows/lint-pr.yml` and `CONTRIBUTING.md` together.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ When implementing features:
 | `tasks` | `tasks/**` |
 | `cross` | Genuinely cross-cutting |
 
-**Subject:** starts lowercase (acronyms later are fine — `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
+**Subject:** must not start with an uppercase letter in any script (`Add …`, `Čeština …` and `Überarbeiten …` are all rejected; acronyms later are fine, so `add MCP OAuth …` is valid), no trailing period, imperative mood, whole header ≤ 100 characters.
 
 **Breaking changes:** `feat(backend)!: …`, and add the `breaking change` label — release-drafter categorises by label, not by the `!` marker.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to FastyBird Smart Panel
+
+Thanks for contributing. This document covers the conventions that are enforced automatically — commit messages, PR titles, and the PR flow.
+
+For development setup, see [README.md](./README.md). For architecture, see [docs/](./docs/).
+
+## Commit messages and PR titles
+
+Conventional commits. One logical change per commit.
+
+```
+<type>(<scope>): <subject>
+```
+
+The scope is **required** on both local commit messages and PR titles. `commitlint` enforces this on every commit via the husky `commit-msg` hook, and [`lint-pr.yml`](./.github/workflows/lint-pr.yml) enforces it again on the PR title.
+
+This matters more than usual here. The repository squash-merges with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so **the PR title becomes the commit subject on `main`**, and [`release-drafter.yml`](./.github/release-drafter.yml) renders `$TITLE` verbatim into published release notes. Every title ships to users.
+
+### Types
+
+| Type | Use for |
+|---|---|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, whitespace — no behaviour change |
+| `refactor` | Restructuring that neither fixes a bug nor adds a feature |
+| `test` | Adding or correcting tests |
+| `chore` | Maintenance, tooling, dependency bumps |
+| `perf` | A performance improvement |
+| `ci` | CI configuration and workflows |
+| `build` | Build system, packaging, toolchain |
+| `revert` | Reverting a previous commit |
+
+### Scopes
+
+The scope is the **surface** you changed, not the feature domain. The domain belongs in the subject.
+
+| Scope | Covers |
+|---|---|
+| `backend` | `apps/backend/**` |
+| `admin` | `apps/admin/**` |
+| `panel` | `apps/panel/**` |
+| `website` | `apps/website/**` |
+| `sdk` | `packages/**` — extension SDK and the example extension |
+| `installer` | `build/**` — installer package, raspbian image, service scripts |
+| `spec` | `spec/**` — OpenAPI plus device, channel, display and weather specs |
+| `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, and root workspace tooling (`package.json`, `pnpm-workspace.yaml`, `melos.yaml`, `tsconfig*`, linter and formatter config) |
+| `ci` | `.github/**` |
+| `deps` | Dependency bumps |
+| `docs` | `docs/**` and root `*.md` |
+| `tasks` | `tasks/**` |
+| `cross` | Genuinely cross-cutting changes |
+
+Use `cross` for changes that genuinely span several surfaces — never omit the scope instead.
+
+The scope list is deliberately closed and derived from the directory layout, so it changes only when the monorepo gains a top-level surface, not when a module or plugin is added. Adding a scope means editing three files together: [`commitlint.config.js`](./commitlint.config.js), [`.github/workflows/lint-pr.yml`](./.github/workflows/lint-pr.yml), and this table.
+
+### Subject
+
+- Must start with a **lowercase** character. Acronyms later in the subject are fine — `add MCP OAuth artifact administration` is valid.
+- No trailing period.
+- Imperative mood — "add", "fix", "drop", not "added" or "adds".
+- Keep the whole header at 100 characters or fewer, including the `type(scope): ` prefix.
+
+### Breaking changes
+
+Mark them with `!` before the colon:
+
+```
+feat(backend)!: require authentication during the websocket handshake
+```
+
+The `!` alone does not file the change under **Breaking Changes** in the release notes — `release-drafter.yml` categorises by label, so add the `breaking change` label as well.
+
+### Examples
+
+```
+feat(backend): add MCP OAuth artifact administration
+fix(admin): recover the websocket after the machine wakes from sleep
+build(panel): upgrade Flutter toolchain
+refactor(admin): let stores declare their own refresh contract
+docs(tasks): close the virtual devices epic
+chore(deps): bump actions/checkout from 4 to 5
+chore(cross): align PR workflow docs and automation
+feat(backend)!: require authentication during the websocket handshake
+```
+
+Rejected, with the fix:
+
+| Rejected | Why | Instead |
+|---|---|---|
+| `Add MCP OAuth bootstrap route set` | No type, no scope | `feat(backend): add MCP OAuth bootstrap route set` |
+| `fix: ignore build metadata when comparing versions` | Missing scope | `fix(backend): ignore build metadata when comparing versions` |
+| `feat(mcp): add OAuth resource validation` | `mcp` is not a scope — it is a domain | `feat(backend): add MCP OAuth resource validation` |
+| `feat(panel): Add device hardware control service` | Subject starts uppercase | `feat(panel): add device hardware control service` |
+| `security(backend): harden auth and headers` | `security` is not a type | `fix(backend): harden auth and headers` |
+| `doc(zigbee): add task definition` | `doc` is not a type; `zigbee` is not a scope | `docs(tasks): add Zigbee integration task definition` |
+
+## Before opening a PR
+
+Run these locally and make sure they pass:
+
+```bash
+pnpm run lint:js                # Lint TypeScript
+pnpm run pretty:check           # Formatting
+pnpm run test:unit              # Backend unit tests
+pnpm run test:e2e               # Backend E2E tests
+
+pnpm --filter ./apps/admin run test:unit   # Admin unit tests
+
+melos analyze                   # Dart / Flutter analysis
+```
+
+If you changed backend Swagger decorators or device/channel specs, regenerate rather than hand-editing:
+
+```bash
+pnpm run generate:openapi
+pnpm run generate:spec
+melos rebuild-all               # Flutter API client and specs
+```
+
+Never edit generated files directly — see the "Generated Code" section in [CLAUDE.md](./CLAUDE.md).
+
+## Pull request flow
+
+1. **Never push directly to `main`.** Branch first — `feature/…`, `fix/…` or `chore/…`, which is also what [`labeler.yml`](./.github/labeler.yml) uses to apply labels.
+2. Push the branch and open a PR against `main`.
+3. The PR title must follow the convention above — it becomes the squash commit message.
+4. Link the GitHub issue the PR resolves.
+5. Check the labels. `actions/labeler` applies branch- and path-based labels automatically; add anything missing, especially `breaking change`, which drives release-note categorisation.
+6. Summarise the change, note the regression surface, and record how you verified it.
+7. Add tests for new business logic. If you skipped tests, explain why in the PR description.
+8. Merge with **Squash and merge**.
+
+## Database changes
+
+Always create an incremental migration file for a schema change, for example `1000000000002-AddTokenLastUsedAt.ts`. Never modify the initial migration — alpha releases are deployed and existing installations have already run it.
+
+```bash
+cd apps/backend
+pnpm run typeorm:migration:run
+```
+
+## Getting help
+
+Open an issue on the [issue tracker](https://github.com/FastyBird/smart-panel/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,9 @@ The scope is the **surface** you changed, not the feature domain. The domain bel
 | `admin` | `apps/admin/**` |
 | `panel` | `apps/panel/**` |
 | `website` | `apps/website/**` |
+| `testing` | `apps/testing/**` — the testing app |
 | `sdk` | `packages/**` — extension SDK and the example extension |
-| `installer` | `build/**` — installer package, raspbian image, service scripts |
+| `installer` | `build/**` (installer package, raspbian image, service scripts), `scripts/**` (`install-server.sh`, `install-display.sh`), `apps/get-script/**` (the site serving `get.smart-panel.fastybird.com`) |
 | `spec` | `spec/**` — OpenAPI plus device, channel, display and weather specs |
 | `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, and root workspace tooling (`package.json`, `pnpm-workspace.yaml`, `melos.yaml`, `tsconfig*`, linter and formatter config) |
 | `ci` | `.github/**` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The scope list is deliberately closed and derived from the directory layout, so 
 
 ### Subject
 
-- Must start with a **lowercase** character. Acronyms later in the subject are fine — `add MCP OAuth artifact administration` is valid.
+- Must **not start with an uppercase letter**, in any script — `Add …`, `Čeština …` and `Überarbeiten …` are all rejected. Acronyms later in the subject are fine: `add MCP OAuth artifact administration` is valid. Digits and punctuation are allowed as the first character.
 - No trailing period.
 - Imperative mood — "add", "fix", "drop", not "added" or "adds".
 - Keep the whole header at 100 characters or fewer, including the `type(scope): ` prefix.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -33,6 +33,7 @@ module.exports = {
 				'admin',
 				'panel',
 				'website',
+				'testing',
 				'sdk',
 				'installer',
 				'spec',

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,8 +6,10 @@ module.exports = {
 	plugins: [
 		{
 			rules: {
-				// Mirrors lint-pr.yml's subjectPattern: ^(?![A-Z]).+$
-				// — the first character of the subject must not be uppercase.
+				// The PR-title workflow runs this exact predicate (see the
+				// "Validate PR title subject" step in .github/workflows/lint-pr.yml)
+				// rather than an equivalent regex, so the two enforcement paths agree
+				// for every script, including non-ASCII uppercase such as "Č" or "Ü".
 				// Acronyms later in the subject (MCP, OAuth, API, UI, JSON, ...) are fine.
 				'subject-first-char-lowercase': ({ subject }) => {
 					if (!subject) return [true];

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,9 +14,12 @@ module.exports = {
 				'subject-first-char-lowercase': ({ subject }) => {
 					if (!subject) return [true];
 
-					const first = subject[0];
+					// Destructuring iterates by code point, not UTF-16 code unit. `subject[0]`
+					// would yield a lone high surrogate for a non-BMP letter such as `𐐀`, and a
+					// surrogate lowercases to itself, so the check would silently accept it.
+					const [first] = subject;
 
-					return [first === first.toLowerCase(), 'subject must start with a lowercase character'];
+					return [first === first.toLowerCase(), 'subject must not start with an uppercase letter'];
 				},
 			},
 		},

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,56 @@
+// Enforces conventional commits on every local commit (via the husky commit-msg hook).
+// Shares the same type and scope vocabulary as .github/workflows/lint-pr.yml and
+// CONTRIBUTING.md — keep all three in sync when a scope is added or removed.
+module.exports = {
+	extends: ['@commitlint/config-conventional'],
+	plugins: [
+		{
+			rules: {
+				// Mirrors lint-pr.yml's subjectPattern: ^(?![A-Z]).+$
+				// — the first character of the subject must not be uppercase.
+				// Acronyms later in the subject (MCP, OAuth, API, UI, JSON, ...) are fine.
+				'subject-first-char-lowercase': ({ subject }) => {
+					if (!subject) return [true];
+
+					const first = subject[0];
+
+					return [first === first.toLowerCase(), 'subject must start with a lowercase character'];
+				},
+			},
+		},
+	],
+	rules: {
+		'type-enum': [
+			2,
+			'always',
+			['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore', 'perf', 'ci', 'build', 'revert'],
+		],
+		'scope-enum': [
+			2,
+			'always',
+			[
+				'backend',
+				'admin',
+				'panel',
+				'website',
+				'sdk',
+				'installer',
+				'spec',
+				'infra',
+				'ci',
+				'deps',
+				'docs',
+				'tasks',
+				'cross',
+			],
+		],
+		'scope-empty': [2, 'never'],
+		// Disable the strict all-lowercase rule (it rejects legitimate acronyms
+		// like MCP, API, UI, JSON) and use the custom rule above to mirror
+		// lint-pr.yml's leading-lowercase check exactly.
+		'subject-case': [0],
+		'subject-first-char-lowercase': [2, 'always'],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+	},
+};

--- a/docs/superpowers/specs/2026-08-11-pr-title-convention-design.md
+++ b/docs/superpowers/specs/2026-08-11-pr-title-convention-design.md
@@ -1,0 +1,176 @@
+# PR Title Convention — Design
+
+**Status:** Approved
+**Date:** 2026-08-11
+**Author:** Adam Kadlec
+**Related:** `.github/release-drafter.yml`, `.github/labeler.yml`, `.github/dependabot.yml`, `tasks/_template.md`
+
+## Problem
+
+PR titles in this repository have no stated convention. There is no `CONTRIBUTING.md`, no PR template, no commitlint, no husky, and neither `CLAUDE.md` nor `AGENTS.md` mentions title format. The result is measurable drift across 680 pull requests.
+
+Conformance to `type(scope): subject`, by PR number window:
+
+| Window | Matches the shape | Fully strict (scope present, lowercase subject) |
+|---|---|---|
+| #1–100 | 100% | 0% |
+| #101–200 | 97% | 1% |
+| #201–300 | 95% | 7% |
+| #301–400 | 95% | 8% |
+| #401–500 | 91% | 12% |
+| #501–600 | 85% | 71% |
+| #601–650 | 69% | 52% |
+| #651–682 | 38% | 38% |
+
+The most recent ~20 PRs (the MCP OAuth series) are uniformly imperative-sentence style — `Prove MCP OAuth switch-off stream isolation`, `Await MCP module disable invalidation`. Internally consistent, but a different convention.
+
+Scope usage is the worse half of the problem. 90+ distinct scopes have been used, from an unbounded vocabulary:
+
+- **Near-duplicates:** `security` / `security-module` / `security-domain`, `buddy` / `ai-buddy`, `media` / `media-domain`, `doc` / `docs` / `documentation`, `zigbee` / `zigbee2mqtt` / `z2m-plugin`, `simulator` / `devices-simulator` / `real-simulator`, `covers-domain` / `cover-domain`, `tests` / `testing`, `localization` / `localizations` / `translations`
+- **Typos, shipped:** `ligting-domain`, `circular-dependnecny`
+- **Two competing axes:** app (`panel` 42, `admin` 37, `backend` 14) against domain (`ai-buddy` 31, `energy` 17, `media-domain` 17, `mcp` 15). The same change could plausibly take either, so it took both.
+
+### Why this costs more here than in a normal repo
+
+Two pipelines consume PR titles verbatim:
+
+1. **Squash merge.** The repository sets `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so the PR title becomes the commit subject on `main`. Confirmed in history: `ec483eb5f Prove MCP OAuth switch-off stream isolation (#682)`.
+2. **Release notes.** `release-drafter.yml` sets `change-template: '- $TITLE @$AUTHOR [#$NUMBER]'`. Every title ships to users in the published release body.
+
+`squash_merge_commit_message` is `COMMIT_MESSAGES`, so individual commit messages are concatenated into the squash body. Local commit hygiene therefore also reaches `main`.
+
+## Goal
+
+One enforced title format, drawn from the conventions already in use in the `nexcue` and `tarmoto` repositories, applied to both PR titles and local commit messages, and documented where humans *and* agents will read it.
+
+## Non-Goals
+
+- **Rewriting history.** 680 existing titles stay as they are. Rewriting them would rewrite `main`.
+- **Domain-level scopes.** Considered and rejected — see [Scope axis](#scope-axis).
+- **Enabling branch protection.** Recommended separately, out of scope here — see [Open follow-up](#open-follow-up).
+
+## The rule
+
+```
+<type>(<scope>): <subject>
+```
+
+### Types
+
+`feat` `fix` `docs` `style` `refactor` `test` `chore` `perf` `ci` `build` `revert`
+
+The same 11 used by `nexcue` and `tarmoto`. Three historical forms become invalid and have direct replacements:
+
+| Was | Becomes |
+|---|---|
+| `security(backend): …` | `fix(backend):` or `chore(backend):` |
+| `doc(zigbee): …` | `docs(…):` |
+| `feature(storage): …` | `feat(…):` |
+
+### Scope — required
+
+Required on every PR title and every local commit. `cross` is the escape hatch for genuinely cross-cutting changes; omitting the scope is never the answer.
+
+| Scope | Covers |
+|---|---|
+| `backend` | `apps/backend/**` |
+| `admin` | `apps/admin/**` |
+| `panel` | `apps/panel/**` |
+| `website` | `apps/website/**` |
+| `sdk` | `packages/**` — `extension-sdk`, `example-extension` |
+| `installer` | `build/**` — installer package, raspbian image, service scripts |
+| `spec` | `spec/**` — OpenAPI plus device/channel/display/weather specs |
+| `infra` | `docker/**`, `docker-compose.yml`, `Makefile`, `bin/**`, and root workspace tooling — `package.json`, `pnpm-workspace.yaml`, `melos.yaml`, `tsconfig*`, linter and formatter config |
+| `ci` | `.github/**` |
+| `deps` | Dependency bumps |
+| `docs` | `docs/**`, root `*.md` |
+| `tasks` | `tasks/**` |
+| `cross` | Genuinely cross-cutting |
+
+Thirteen entries, closed. The vocabulary is derived from directory layout, so it only changes when the monorepo gains a top-level surface — not when a module or plugin is added.
+
+`installer` is deliberately not named `build`, because `build(build): …` reads badly when type and scope collide.
+
+### Subject
+
+- Must start with a **lowercase** character. Acronyms later in the subject are fine — `add MCP OAuth artifact administration` is valid.
+- No trailing period.
+- Imperative mood.
+- Header ≤ 100 characters including the `type(scope): ` prefix (commitlint's `header-max-length` default).
+
+### Breaking changes
+
+`feat(backend)!: …`. The `!` marker alone does **not** file the change under "Breaking Changes" in the release notes — `release-drafter.yml` categorises by label, so the `breaking change` label is still required.
+
+### Examples
+
+```
+feat(backend): add MCP OAuth artifact administration
+fix(admin): recover the websocket after the machine wakes from sleep
+build(panel): upgrade Flutter toolchain
+docs(tasks): close the virtual devices epic
+chore(deps): bump actions/checkout from 4 to 5
+chore(cross): align PR workflow docs and automation
+feat(backend)!: require authentication during the websocket handshake
+```
+
+## Design decisions
+
+### Scope axis
+
+Scope is the **surface** changed, not the feature domain. Three inputs converged on this:
+
+1. Both reference repositories scope by surface and neither uses feature names. `nexcue`: `backend`, `mobile`, `marketing`, `openapi`, `infra`, `ci`, `deps`, `docs`. `tarmoto` adds `companion`, `admin`, `shared`, `cross`, `ingest`, `poc-sensor`.
+2. This repository's own `tasks/_template.md` already declares `Scope: backend | admin | panel | backend, admin | …` — surface-scoped, predating this design.
+3. A surface enum is closed and derivable from the directory tree. A domain enum needs an edit every time a module or plugin lands, and an unmaintained enum is what produced `ligting-domain`.
+
+**Accepted tradeoff:** release-note lines lose the domain signal — `feat(backend): add MCP OAuth artifact administration` rather than `feat(mcp): …`. The subject carries it instead. This is a real loss in exchange for a vocabulary that cannot rot.
+
+### Enforcement surface
+
+Both the PR title and every local commit, matching `tarmoto` exactly. Title-only enforcement would cover everything users see, since the title is what becomes the `main` commit subject and the release-note line. Local enforcement is added on top because `squash_merge_commit_message: COMMIT_MESSAGES` puts every commit message into the squash body, so unconstrained local commits still reach `main`.
+
+### `subject-case` and acronyms
+
+commitlint's `subject-case: [2, "always", "lower-case"]` rejects any uppercase character anywhere in the subject, which would reject `add MCP OAuth …`. `tarmoto` solved this with a custom `subject-first-char-lowercase` plugin rule that mirrors the CI `subjectPattern: ^(?![A-Z]).+$` exactly. That config is adopted verbatim rather than re-derived.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `.github/workflows/lint-pr.yml` | New. `amannn/action-semantic-pull-request` pinned to `48f256284bd46cdaab1048c3721360e808335d50` (v6.1.1), the same SHA the other repositories use. `requireScope: true`, `subjectPattern: ^(?![A-Z]).+$`, triggered on `pull_request_target` for `opened`/`reopened`/`edited`/`synchronize` with `pull-requests: read`. |
+| `commitlint.config.js` | New. `tarmoto`'s config, with this repository's scope enum: `type-enum` (11 types), `scope-enum` (13 scopes), `scope-empty: [2, "never"]`, `subject-case: [0]` disabled in favour of the custom `subject-first-char-lowercase` rule, `subject-empty: [2, "never"]`, `subject-full-stop: [2, "never", "."]`. |
+| `.husky/commit-msg` | New. Runs commitlint on the message file. |
+| `package.json` | Add `prepare: husky`, and devDependencies `@commitlint/cli` + `@commitlint/config-conventional`. |
+| `.github/dependabot.yml` | Add `commit-message: { prefix: "chore", include: "scope" }` so Dependabot emits `chore(deps): bump …`. Also remove `target-branch: dev` — see below. |
+| `CONTRIBUTING.md` | New. Documents the convention, the type and scope tables, and the PR flow. |
+| `CLAUDE.md`, `AGENTS.md` | Add a Key Rules entry stating the format and the scope enum. |
+
+### Incidental fix: Dependabot targets a branch that does not exist
+
+`.github/dependabot.yml` sets `target-branch: dev`. The remote has only `main`, `docs/followups-count` and one `claude/*` branch — there is no `dev`. Dependabot has therefore been opening nothing. Removing the line restores it to `main`.
+
+This is unrelated to the title convention, but it lands in the same file for the `commit-message` prefix, and leaving a known-dead config in a file being edited would be worse than fixing it. Called out separately in the PR description.
+
+### Why the agent-facing docs matter most
+
+Most PRs in this repository are agent-authored. The convention has never been stated in `CLAUDE.md` or `AGENTS.md`, which is the direct cause of the recent drift to imperative-sentence titles — nothing told the agent otherwise. CI alone would turn that into a red check on every PR rather than a correct title on the first try. The docs change is the part that actually prevents the failure; CI is the backstop.
+
+## Rollout
+
+The check applies to new pull requests only. No existing title changes, no history rewrite.
+
+`docs/followups-count` is the one open branch without a PR; it will need a conforming title when opened.
+
+Local enforcement takes effect for a contributor after their next `pnpm install` runs the `prepare` script.
+
+## Open follow-up
+
+`main` has no branch protection (`GET /branches/main/protection` → 404). The `lint-pr` check will report status but cannot block a merge until it is added as a required status check. Enabling branch protection is recommended and would also give teeth to the existing "never push directly to main" rule, which is currently policy-only. Left out of this change because it is a repository-admin decision with consequences beyond PR titles.
+
+## Verification
+
+- `commitlint` accepts each example in this document and rejects: a missing scope, a scope outside the enum, an uppercase first subject character, a trailing period, and an invalid type.
+- `lint-pr.yml` is valid workflow YAML and its scope list matches `commitlint.config.js` exactly.
+- `pnpm install` installs the husky hook; a non-conforming `git commit` is rejected locally.
+- This PR's own title conforms.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,13 @@
     "admin:build": "pnpm --filter @fastybird/smart-panel-admin build",
     "admin:postinstall": "node -e \"process.exit(process.env.FB_NO_ADMIN_BUILD ? 0 : 1)\" || pnpm run admin:extensions && pnpm run admin:build",
     "testing:dev": "pnpm --filter @fastybird/smart-panel-testing start:dev",
-    "testing:build": "pnpm --filter @fastybird/smart-panel-testing build"
+    "testing:build": "pnpm --filter @fastybird/smart-panel-testing build",
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
+    "husky": "^9.1.7"
   },
   "engines": {
     "node": ">=20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,17 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@commitlint/cli':
+        specifier: ^20.5.0
+        version: 20.5.3(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+      '@commitlint/config-conventional':
+        specifier: ^20.5.0
+        version: 20.5.3
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
 
   apps/admin:
     dependencies:
@@ -1223,6 +1233,87 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@commitlint/cli@20.5.3':
+    resolution: {integrity: sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-conventional@20.5.3':
+    resolution: {integrity: sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@20.5.3':
+    resolution: {integrity: sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@20.0.0':
+    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@20.5.3':
+    resolution: {integrity: sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@20.5.3':
+    resolution: {integrity: sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@20.5.3':
+    resolution: {integrity: sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@20.5.3':
+    resolution: {integrity: sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@20.0.0':
+    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
+    engines: {node: '>=v18'}
+
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3674,6 +3765,14 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
@@ -5394,6 +5493,9 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
@@ -5989,6 +6091,9 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
@@ -6046,6 +6151,19 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
+  conventional-changelog-angular@8.3.1:
+    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.4.0:
+    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
     engines: {node: '>=12'}
@@ -6086,6 +6204,14 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': ^24.12.0
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -6101,6 +6227,15 @@ packages:
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -6528,6 +6663,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -7363,6 +7502,12 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    hasBin: true
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -7392,6 +7537,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -7640,6 +7789,11 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   i18n-iso-countries@7.14.0:
     resolution: {integrity: sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==}
     engines: {node: '>= 12'}
@@ -7715,6 +7869,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
@@ -7869,6 +8027,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
 
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
@@ -8792,6 +8954,10 @@ packages:
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -12476,6 +12642,124 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@commitlint/cli@20.5.3(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.3
+      '@commitlint/load': 20.5.3(@types/node@24.12.2)(typescript@5.9.3)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.0.2
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@20.5.3':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-conventionalcommits: 9.3.1
+
+  '@commitlint/config-validator@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      ajv: 8.18.0
+
+  '@commitlint/ensure@20.5.3':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.50.0
+
+  '@commitlint/execute-rule@20.0.0': {}
+
+  '@commitlint/format@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      semver: 7.8.5
+
+  '@commitlint/lint@20.5.3':
+    dependencies:
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.3
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/load@20.5.3(@types/node@24.12.2)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/execute-rule': 20.0.0
+      '@commitlint/resolve-extends': 20.5.3
+      '@commitlint/types': 20.5.0
+      cosmiconfig: 9.0.2(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.12.2)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3)
+      es-toolkit: 1.50.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@20.4.3': {}
+
+  '@commitlint/parse@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
+
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      minimist: 1.2.8
+      tinyexec: 1.0.2
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@20.5.3':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.50.0
+      global-directory: 5.0.0
+      import-meta-resolve: 4.2.0
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@20.5.3':
+    dependencies:
+      '@commitlint/ensure': 20.5.3
+      '@commitlint/message': 20.4.3
+      '@commitlint/to-lines': 20.0.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/to-lines@20.0.0': {}
+
+  '@commitlint/top-level@20.4.3':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@20.5.0':
+    dependencies:
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.8.5
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -14693,6 +14977,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
 
   '@sinclair/typebox@0.34.48': {}
 
@@ -16941,6 +17231,8 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
+  array-ify@1.0.0: {}
+
   array-includes@3.1.9:
     dependencies:
       call-bind: 1.0.8
@@ -17594,6 +17886,11 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   component-emitter@1.3.1: {}
 
   compressible@2.0.18:
@@ -17647,6 +17944,19 @@ snapshots:
 
   content-type@2.0.0: {}
 
+  conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.4.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
@@ -17684,6 +17994,13 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.12.2)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 24.12.2
+      cosmiconfig: 9.0.2(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -17703,6 +18020,15 @@ snapshots:
       typescript: 5.9.3
 
   cosmiconfig@9.0.0(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  cosmiconfig@9.0.2(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
@@ -18148,6 +18474,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dotenv-expand@12.0.3:
     dependencies:
@@ -19295,6 +19625,14 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
@@ -19332,6 +19670,10 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  global-directory@5.0.0:
+    dependencies:
+      ini: 6.0.0
 
   global-modules@2.0.0:
     dependencies:
@@ -19689,6 +20031,8 @@ snapshots:
       ms: 2.1.3
     optional: true
 
+  husky@9.1.7: {}
+
   i18n-iso-countries@7.14.0:
     dependencies:
       diacritics: 1.3.0
@@ -19749,6 +20093,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@6.0.0: {}
 
   inline-style-parser@0.2.4: {}
 
@@ -19903,6 +20249,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
 
   is-path-inside@4.0.0: {}
 
@@ -21119,6 +21467,8 @@ snapshots:
   memoize-one@6.0.0: {}
 
   memorystream@0.3.1: {}
+
+  meow@13.2.0: {}
 
   meow@14.1.0: {}
 


### PR DESCRIPTION
## Why

680 PRs in, conformance to `type(scope): subject` has collapsed:

| PR window | Matches the shape | Fully strict (scope + lowercase subject) |
|---|---|---|
| #1–100 | 100% | 0% |
| #301–400 | 95% | 8% |
| #501–600 | 85% | 71% |
| #601–650 | 69% | 52% |
| **#651–682** | **38%** | **38%** |

The scope vocabulary is the worse half. 90+ distinct scopes have been used, unbounded — including typos that shipped (`ligting-domain`, `circular-dependnecny`) and four-way near-duplicates (`security` / `security-module` / `security-domain`, `buddy` / `ai-buddy`, `doc` / `docs` / `documentation`).

This costs more here than in a typical repo. `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, so **the PR title becomes the commit subject on `main`**, and `release-drafter.yml` uses `change-template: '- $TITLE @$AUTHOR [#$NUMBER]'` — every title is rendered verbatim into published release notes.

**Root cause:** nothing in this repo states the convention. No `CONTRIBUTING.md`, no PR template, no commitlint, and no mention in `CLAUDE.md` or `AGENTS.md`. Since most PRs here are agent-authored, that omission *is* the cause of the recent drift to imperative-sentence titles.

## What

Adopts the convention already used in the nexcue and tarmoto repos, with a scope enum fitted to this monorepo.

```
<type>(<scope>): <subject>
```

- **Types** — the same 11 as the other repos.
- **Scope — required**, closed 13-item list, **surface-based** (`backend`, `admin`, `panel`, `website`, `sdk`, `installer`, `spec`, `infra`, `ci`, `deps`, `docs`, `tasks`, `cross`). Both reference repos scope by surface rather than feature domain, and this repo's own `tasks/_template.md` already declared `Scope: backend | admin | panel | …`. The enum derives from the directory tree, so it only changes when the monorepo gains a top-level surface — not when a module or plugin lands.
- **Subject** — lowercase first character (acronyms later are fine: `add MCP OAuth …` is valid), no trailing period, imperative, ≤100 chars.

**Accepted tradeoff:** release-note lines lose the domain signal — `feat(backend): add MCP OAuth artifact administration` rather than `feat(mcp): …`. The subject carries it instead, in exchange for a vocabulary that cannot rot.

| File | Change |
|---|---|
| `.github/workflows/lint-pr.yml` | New. `amannn/action-semantic-pull-request` pinned to the same SHA the other repos use, `requireScope: true` |
| `commitlint.config.js` | New. Includes tarmoto's custom `subject-first-char-lowercase` rule, which exists because `subject-case: lower-case` wrongly rejects acronyms |
| `.husky/commit-msg` | New |
| `package.json` | `prepare: husky`, plus `@commitlint/cli`, `@commitlint/config-conventional`, `husky` |
| `CONTRIBUTING.md` | New — full convention, including a rejected-with-the-fix table |
| `CLAUDE.md`, `AGENTS.md` | New Key Rule + a `Commit and PR titles` section. **This is the part that actually prevents recurrence** — CI alone would just turn agent-authored titles red instead of correct. |

## Incidental fix

`.github/dependabot.yml` had `target-branch: dev`. **That branch does not exist** — the remote has only `main`, `docs/followups-count` and one `claude/*` branch, so Dependabot has been opening nothing. Removed, restoring it to `main`. It also gains `commit-message: {prefix: chore, include: scope}` so its PRs emit `chore(deps): bump …` and satisfy the new check.

Unrelated to titles, but it is the same file that needed the prefix, and leaving known-dead config in a file being edited would be worse.

## Verification

- **30/30 message cases** behave correctly against the real `commitlint` — 16 accepted (one per type, plus `!` breaking-change form), 14 rejected (missing scope, domain-as-scope, uppercase subject, trailing period, `security`/`feature`/`doc` as type, the historical typo scopes, empty subject, empty scope).
- **husky hook blocks a real commit** end to end: `git commit -m "Add a thing"` is refused and no commit is created.
- **Scope and type lists verified identical** across `lint-pr.yml`, `commitlint.config.js`, `CONTRIBUTING.md`, `CLAUDE.md` and `AGENTS.md` — checked programmatically, not by eye.
- **Both YAML files parse**; `dependabot.yml` resolves to `target-branch: (none → main)`.
- **Every install site audited** for the new `prepare` script: husky 9.1.7 exits `0` when `.git` is absent (Docker ignores `.git`); the `npm install --omit=dev` release steps operate on a synthesized `build-arm64/package.json`, not the repo root; `release.yml:335` runs in `build/`, which has no `prepare`; the raspbian chroot uses `--ignore-scripts`. No workspace package has a competing `prepare`.

## Note on rollout

`lint-pr.yml` uses `pull_request_target`, which always runs the workflow from the **base** branch — so the check will not appear on this PR. It starts enforcing on PRs opened after this merges.

`main` also has **no branch protection** (`GET /branches/main/protection` → 404), so the check will report status but cannot block a merge until it is added as a required status check. Enabling that is a repo-admin decision left out of this PR; it would also give teeth to the existing "never push directly to main" rule, which is currently policy-only.

History is untouched — 680 existing titles stay as they are.

Design: `docs/superpowers/specs/2026-08-11-pr-title-convention-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)