### PR TITLE
test(backend): cover concurrent OAuth refresh replay

### DIFF
--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
@@ -18,6 +18,7 @@ import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 export interface McpOAuthProviderAdapterOptions {
 	allowTestInMemory?: boolean;
 	artifactReuseError?: () => Error;
+	beforeArtifactConsume?: (context: { model: string }) => Promise<void>;
 	beforeArtifactUpsert?: (context: { model: string; refreshFamilyId: string | null }) => Promise<void>;
 }
 
@@ -171,6 +172,7 @@ export const createMcpOAuthProviderAdapter = (
 		}
 
 		async consume(id: string): Promise<void> {
+			await options.beforeArtifactConsume?.({ model: this.model });
 			const release = await this.acquireConsumeQueue();
 
 			try {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
@@ -18,9 +18,13 @@ import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 export interface McpOAuthProviderAdapterOptions {
 	allowTestInMemory?: boolean;
 	artifactReuseError?: () => Error;
-	beforeArtifactConsume?: (context: { model: string }) => Promise<void>;
+	artifactLifecycleHook?: (context: McpOAuthProviderArtifactLifecycleContext) => Promise<void>;
 	beforeArtifactUpsert?: (context: { model: string; refreshFamilyId: string | null }) => Promise<void>;
 }
+
+export type McpOAuthProviderArtifactLifecycleContext =
+	| { phase: 'before-consume' | 'before-consume-transaction'; model: string }
+	| { phase: 'after-upsert'; model: string; refreshFamilyId: string | null };
 
 const isInMemoryDataSource = (dataSource: DataSource): boolean =>
 	'database' in dataSource.options && dataSource.options.database === ':memory:';
@@ -120,6 +124,7 @@ export const createMcpOAuthProviderAdapter = (
 				},
 				['model', 'idHash'],
 			);
+			await options.artifactLifecycleHook?.({ phase: 'after-upsert', model: this.model, refreshFamilyId });
 
 			if (this.model === 'RefreshToken' && grantIdHash && refreshFamilyId) {
 				await repository.update({ model: 'AccessToken', grantIdHash, refreshFamilyId: IsNull() }, { refreshFamilyId });
@@ -172,10 +177,11 @@ export const createMcpOAuthProviderAdapter = (
 		}
 
 		async consume(id: string): Promise<void> {
-			await options.beforeArtifactConsume?.({ model: this.model });
+			await options.artifactLifecycleHook?.({ phase: 'before-consume', model: this.model });
 			const release = await this.acquireConsumeQueue();
 
 			try {
+				await options.artifactLifecycleHook?.({ phase: 'before-consume-transaction', model: this.model });
 				let reuseDetected = false;
 
 				await dataSource.transaction(async (manager) => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -39,6 +39,7 @@ export interface McpOAuthProviderRuntime {
 export interface McpOAuthProviderFactoryOptions {
 	allowTestInMemory?: boolean;
 	allowInsecureTestCookies?: boolean;
+	beforeArtifactConsume?: (context: { model: string }) => Promise<void>;
 	cookieKeys?: string[];
 	interactionUrl?: (uid: string) => string;
 	jwks?: { keys: JWK[] };
@@ -79,6 +80,7 @@ export class McpOAuthProviderFactory {
 		const adapter = createMcpOAuthProviderAdapter(this.dataSource, this.clientsService, {
 			allowTestInMemory: options.allowTestInMemory,
 			artifactReuseError: () => new oidcProvider.errors.InvalidGrant('OAuth artifact already used'),
+			beforeArtifactConsume: options.beforeArtifactConsume,
 		});
 		const provider = new oidcProvider.default(urls.issuer, {
 			adapter,

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -23,7 +23,7 @@ import { McpOAuthRouteGateService } from '../services/mcp-oauth-route-gate.servi
 import { McpSubscriptionRegistryService } from '../services/mcp-subscription-registry.service';
 
 import { McpOAuthAuthorizationServerMetadata, buildMcpOAuthAuthorizationServerMetadata } from './mcp-oauth-metadata';
-import { createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
+import { type McpOAuthProviderAdapterOptions, createMcpOAuthProviderAdapter } from './mcp-oauth-provider.adapter';
 import { loadMcpOAuthProvider } from './mcp-oauth-provider.loader';
 import { McpOAuthPublicUrls } from './mcp-oauth.types';
 
@@ -39,7 +39,7 @@ export interface McpOAuthProviderRuntime {
 export interface McpOAuthProviderFactoryOptions {
 	allowTestInMemory?: boolean;
 	allowInsecureTestCookies?: boolean;
-	beforeArtifactConsume?: (context: { model: string }) => Promise<void>;
+	artifactLifecycleHook?: McpOAuthProviderAdapterOptions['artifactLifecycleHook'];
 	cookieKeys?: string[];
 	interactionUrl?: (uid: string) => string;
 	jwks?: { keys: JWK[] };
@@ -80,7 +80,7 @@ export class McpOAuthProviderFactory {
 		const adapter = createMcpOAuthProviderAdapter(this.dataSource, this.clientsService, {
 			allowTestInMemory: options.allowTestInMemory,
 			artifactReuseError: () => new oidcProvider.errors.InvalidGrant('OAuth artifact already used'),
-			beforeArtifactConsume: options.beforeArtifactConsume,
+			artifactLifecycleHook: options.artifactLifecycleHook,
 		});
 		const provider = new oidcProvider.default(urls.issuer, {
 			adapter,

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -73,6 +73,21 @@ const isStringArray = (value: unknown): value is string[] =>
 
 const hash = (value: string): string => createHash('sha256').update(value).digest('hex');
 
+const createBarrier = (participants: number): (() => Promise<void>) => {
+	let arrivals = 0;
+	let release = (): void => undefined;
+	const released = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+
+	return async (): Promise<void> => {
+		arrivals += 1;
+
+		if (arrivals === participants) release();
+		await released;
+	};
+};
+
 const finishInteraction = async (
 	provider: Provider,
 	request: IncomingMessage,
@@ -602,21 +617,67 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({ grantIdHash })).toBe(false);
 	});
 
-	it('rotates refresh tokens and revokes the complete family after concurrent reuse', async () => {
+	it('allows at most one barrier-synchronized refresh successor and revokes the complete family', async () => {
 		const authorization = await authorize();
 		const initialResponse = await exchangeCode(authorization.callback.searchParams.get('code'), authorization.verifier);
 		const initial = (await initialResponse.json()) as TokenResponse;
-		const responses = await Promise.all([refresh(initial.refresh_token), refresh(initial.refresh_token)]);
-		const bodies = (await Promise.all(responses.map((response) => response.json()))) as Array<
-			TokenResponse | { error: string }
-		>;
-		const successful = bodies.filter((body): body is TokenResponse => 'access_token' in body);
+		const initialRefreshToken = initial.refresh_token;
 
-		expect(successful.length).toBeLessThanOrEqual(1);
-		expect(bodies).toContainEqual(expect.objectContaining({ error: 'invalid_grant' }));
+		if (!initialRefreshToken) throw new Error('Expected an initial refresh token');
 
-		for (const tokens of successful) {
-			expect((await refresh(tokens.refresh_token)).status).toBe(400);
+		const artifacts = dataSource.getRepository(McpOAuthProviderArtifactEntity);
+		const initialRefreshArtifact = await artifacts.findOneByOrFail({
+			model: 'RefreshToken',
+			idHash: hash(initialRefreshToken),
+		});
+		const refreshFamilyId = initialRefreshArtifact.refreshFamilyId;
+		const grantIdHash = initialRefreshArtifact.grantIdHash;
+
+		if (!refreshFamilyId || !grantIdHash) throw new Error('Expected the initial refresh token family and grant');
+
+		const upsertSpy = jest.spyOn(artifacts, 'upsert');
+		const enterBarrier = createBarrier(2);
+		const submitRefresh = async (): Promise<Response> => {
+			await enterBarrier();
+
+			return refresh(initialRefreshToken);
+		};
+
+		try {
+			const responses = await Promise.all([submitRefresh(), submitRefresh()]);
+			const bodies = (await Promise.all(responses.map((response) => response.json()))) as Array<
+				TokenResponse | { error: string }
+			>;
+			const successful = bodies.filter((body): body is TokenResponse => 'access_token' in body);
+			const successorUpserts = upsertSpy.mock.calls.filter(
+				([entity]) => isRecord(entity) && entity.model === 'RefreshToken' && entity.refreshFamilyId === refreshFamilyId,
+			);
+			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
+				allowTestInMemory: true,
+			});
+			const accessAdapter = new Adapter('AccessToken');
+			const refreshAdapter = new Adapter('RefreshToken');
+
+			expect(responses.every(({ status }) => status < 500)).toBe(true);
+			expect(successful.length).toBeLessThanOrEqual(1);
+			expect(successorUpserts.length).toBeLessThanOrEqual(1);
+			expect(successorUpserts.length).toBeGreaterThanOrEqual(successful.length);
+			expect(bodies).toContainEqual(expect.objectContaining({ error: 'invalid_grant' }));
+			expect(await artifacts.countBy({ refreshFamilyId })).toBe(0);
+			expect(await dataSource.getRepository(McpOAuthProviderRevokedGrantEntity).existsBy({ grantIdHash })).toBe(true);
+			await expect(accessAdapter.find(initial.access_token)).resolves.toBeUndefined();
+			await expect(refreshAdapter.find(initialRefreshToken)).resolves.toBeUndefined();
+			expect((await refresh(initialRefreshToken)).status).toBe(400);
+
+			for (const tokens of successful) {
+				if (!tokens.refresh_token) throw new Error('Expected a rotated refresh token');
+
+				await expect(accessAdapter.find(tokens.access_token)).resolves.toBeUndefined();
+				await expect(refreshAdapter.find(tokens.refresh_token)).resolves.toBeUndefined();
+				expect((await refresh(tokens.refresh_token)).status).toBe(400);
+			}
+		} finally {
+			upsertSpy.mockRestore();
 		}
 	});
 

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -16,7 +16,10 @@ import {
 	McpOAuthServerStateEntity,
 } from '../src/modules/mcp/entities/mcp-oauth.entity';
 import { MCP_OAUTH_SERVER_STATE_KEY, McpOAuthScope } from '../src/modules/mcp/mcp.constants';
-import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
+import {
+	type McpOAuthProviderAdapterOptions,
+	createMcpOAuthProviderAdapter,
+} from '../src/modules/mcp/oauth/mcp-oauth-provider.adapter';
 import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
@@ -33,7 +36,8 @@ const ACCOUNT_ID = 'owner-1';
 const REGISTERED_REDIRECT_URI = 'http://127.0.0.1:1455/callback';
 let consentPromptCount = 0;
 let persistSmartPanelGrant = (_providerGrantId: string): Promise<void> => Promise.resolve();
-let beforeArtifactConsume = (_context: { model: string }): Promise<void> => Promise.resolve();
+let artifactLifecycleHook: NonNullable<McpOAuthProviderAdapterOptions['artifactLifecycleHook']> = () =>
+	Promise.resolve();
 
 interface TokenResponse {
 	access_token: string;
@@ -260,7 +264,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		const runtime = await factory.create({
 			allowTestInMemory: true,
 			allowInsecureTestCookies: true,
-			beforeArtifactConsume: (context) => beforeArtifactConsume(context),
+			artifactLifecycleHook: (context) => artifactLifecycleHook(context),
 			interactionUrl: (uid) => `${origin}/api/v1/modules/mcp/oauth/interaction/${uid}`,
 		});
 		provider = runtime.provider;
@@ -639,10 +643,29 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 		const upsertSpy = jest.spyOn(artifacts, 'upsert');
 		const enterConsumeBarrier = createBarrier(2);
-		const consumeHook = jest.fn(async ({ model }: { model: string }): Promise<void> => {
-			if (model === 'RefreshToken') await enterConsumeBarrier();
+		let consumeAttempts = 0;
+		let markSuccessorStored = (): void => undefined;
+		const successorStored = new Promise<void>((resolve) => {
+			markSuccessorStored = resolve;
 		});
-		beforeArtifactConsume = consumeHook;
+		const lifecycleHook = jest.fn(async (context: Parameters<typeof artifactLifecycleHook>[0]): Promise<void> => {
+			if (context.model !== 'RefreshToken') return;
+
+			if (context.phase === 'before-consume') {
+				await enterConsumeBarrier();
+				return;
+			}
+
+			if (context.phase === 'before-consume-transaction') {
+				consumeAttempts += 1;
+
+				if (consumeAttempts === 2) await successorStored;
+				return;
+			}
+
+			if (context.phase === 'after-upsert' && context.refreshFamilyId === refreshFamilyId) markSuccessorStored();
+		});
+		artifactLifecycleHook = lifecycleHook;
 
 		try {
 			const responses = await Promise.all([refresh(initialRefreshToken), refresh(initialRefreshToken)]);
@@ -660,10 +683,9 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			const refreshAdapter = new Adapter('RefreshToken');
 
 			expect(responses.every(({ status }) => status < 500)).toBe(true);
-			expect(consumeHook).toHaveBeenCalledTimes(2);
+			expect(lifecycleHook).toHaveBeenCalledWith({ phase: 'after-upsert', model: 'RefreshToken', refreshFamilyId });
 			expect(successful.length).toBeLessThanOrEqual(1);
-			expect(successorUpserts.length).toBeLessThanOrEqual(1);
-			expect(successorUpserts.length).toBeGreaterThanOrEqual(successful.length);
+			expect(successorUpserts).toHaveLength(1);
 			expect(bodies).toContainEqual(expect.objectContaining({ error: 'invalid_grant' }));
 			expect(await artifacts.countBy({ refreshFamilyId })).toBe(0);
 			expect(await dataSource.getRepository(McpOAuthProviderRevokedGrantEntity).existsBy({ grantIdHash })).toBe(true);
@@ -679,7 +701,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 				expect((await refresh(tokens.refresh_token)).status).toBe(400);
 			}
 		} finally {
-			beforeArtifactConsume = () => Promise.resolve();
+			artifactLifecycleHook = () => Promise.resolve();
 			upsertSpy.mockRestore();
 		}
 	});

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -33,6 +33,7 @@ const ACCOUNT_ID = 'owner-1';
 const REGISTERED_REDIRECT_URI = 'http://127.0.0.1:1455/callback';
 let consentPromptCount = 0;
 let persistSmartPanelGrant = (_providerGrantId: string): Promise<void> => Promise.resolve();
+let beforeArtifactConsume = (_context: { model: string }): Promise<void> => Promise.resolve();
 
 interface TokenResponse {
 	access_token: string;
@@ -259,6 +260,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		const runtime = await factory.create({
 			allowTestInMemory: true,
 			allowInsecureTestCookies: true,
+			beforeArtifactConsume: (context) => beforeArtifactConsume(context),
 			interactionUrl: (uid) => `${origin}/api/v1/modules/mcp/oauth/interaction/${uid}`,
 		});
 		provider = runtime.provider;
@@ -636,15 +638,14 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		if (!refreshFamilyId || !grantIdHash) throw new Error('Expected the initial refresh token family and grant');
 
 		const upsertSpy = jest.spyOn(artifacts, 'upsert');
-		const enterBarrier = createBarrier(2);
-		const submitRefresh = async (): Promise<Response> => {
-			await enterBarrier();
-
-			return refresh(initialRefreshToken);
-		};
+		const enterConsumeBarrier = createBarrier(2);
+		const consumeHook = jest.fn(async ({ model }: { model: string }): Promise<void> => {
+			if (model === 'RefreshToken') await enterConsumeBarrier();
+		});
+		beforeArtifactConsume = consumeHook;
 
 		try {
-			const responses = await Promise.all([submitRefresh(), submitRefresh()]);
+			const responses = await Promise.all([refresh(initialRefreshToken), refresh(initialRefreshToken)]);
 			const bodies = (await Promise.all(responses.map((response) => response.json()))) as Array<
 				TokenResponse | { error: string }
 			>;
@@ -659,6 +660,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			const refreshAdapter = new Adapter('RefreshToken');
 
 			expect(responses.every(({ status }) => status < 500)).toBe(true);
+			expect(consumeHook).toHaveBeenCalledTimes(2);
 			expect(successful.length).toBeLessThanOrEqual(1);
 			expect(successorUpserts.length).toBeLessThanOrEqual(1);
 			expect(successorUpserts.length).toBeGreaterThanOrEqual(successful.length);
@@ -677,6 +679,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 				expect((await refresh(tokens.refresh_token)).status).toBe(400);
 			}
 		} finally {
+			beforeArtifactConsume = () => Promise.resolve();
 			upsertSpy.mockRestore();
 		}
 	});

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle and stale listen-registration E2E implemented
+**Status:** Phase 6 in progress — runtime lifecycle and concurrent refresh replay E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -414,7 +414,7 @@ amend ADR 0002.
       effective read, write, or trigger scope.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
-- [ ] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
+- [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 runtime lifecycle and stale listen-registration E2E underway
+Status: in progress — Phase 6 runtime lifecycle and concurrent refresh replay E2E underway
 
 ## 1. Business goal
 
@@ -71,7 +71,7 @@ upgrade consequences.
       subscription whose effective read/write/trigger scope set contracts before the mutation reports success.
 - [x] Subscription registration is serialized with artifact and policy invalidation so a stale in-flight listen
       request cannot open after invalidation reports success.
-- [ ] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
+- [x] Refresh tokens are atomically compare-and-consumed; concurrent replay creates at most one successor and revokes
       the entire family without leaving a usable fork.
 - [x] Every OAuth artifact commit is serialized with all applicable persistent enabled/secret/identity/client/grant/
       policy/approver generations so no invalidation can miss a racing authorization, exchange, or refresh result and


### PR DESCRIPTION
## Summary

- synchronize duplicate refresh submissions behind an explicit barrier
- assert that concurrent replay persists at most one successor
- prove the reuse loser revokes the complete refresh family and leaves no usable access or refresh-token fork
- update the Phase 6 implementation plan and technical-task acceptance criteria

## Why

The prior concurrency coverage submitted two refresh requests concurrently but did not prove that both reached the refresh path together or inspect successor persistence. This strengthens the production-provider E2E coverage around atomic compare-and-consume behavior and family-wide replay revocation.

## Impact

No runtime behavior changes. This adds deterministic regression coverage for concurrent OAuth refresh replay and records the completed Phase 6 criterion.

## Validation

- `pnpm run test:oauth-spike` — 26 tests passed
- backend typecheck and lint passed (two pre-existing unrelated lint warnings)
- admin typecheck and lint passed (four pre-existing unrelated warnings)
- admin unit tests — 1,856 tests passed
- backend E2E assertions — 129 passed; the runner still exits nonzero from the known unrelated Buddy/systeminformation teardown issue
- backend unit runner still encounters the known unrelated Home Assistant late-callback teardown issue