### PR TITLE
test(backend): cover OAuth switch-off adapter races

### DIFF
--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -92,7 +92,7 @@ const getArtifactProvider = (provider: McpOAuthProviderRuntime['provider']): Art
 	provider as unknown as ArtifactProvider;
 
 describe('MCP OAuth artifact lifecycle', () => {
-	it('rejects paused artifact commits and never reactivates pre-switch-off artifacts after re-enable', async () => {
+	it('rejects paused provider-adapter commits and never reactivates pre-switch-off artifacts after re-enable', async () => {
 		const dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',

--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -92,7 +92,7 @@ const getArtifactProvider = (provider: McpOAuthProviderRuntime['provider']): Art
 	provider as unknown as ArtifactProvider;
 
 describe('MCP OAuth artifact lifecycle', () => {
-	it('never reactivates artifacts issued before readiness-gated switch-off and re-enable', async () => {
+	it('rejects paused artifact commits and never reactivates pre-switch-off artifacts after re-enable', async () => {
 		const dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',
@@ -119,6 +119,8 @@ describe('MCP OAuth artifact lifecycle', () => {
 		const auditService = new McpAuditService();
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
 		let wireSubscriptions: WireSubscriptions | undefined;
+		let releasePausedArtifacts = (): void => undefined;
+		let pendingArtifactCommits: Promise<PromiseSettledResult<void>[]> | undefined;
 
 		try {
 			const user = await dataSource.getRepository(UserEntity).save({
@@ -181,9 +183,12 @@ describe('MCP OAuth artifact lifecycle', () => {
 				getModuleConfig: jest.fn(() => config),
 				reload: jest.fn(),
 			};
+			let beforeArtifactUpsert = (_context: { model: string; refreshFamilyId: string | null }): Promise<void> =>
+				Promise.resolve();
 			const Adapter = createMcpOAuthProviderAdapter(dataSource, {} as McpOAuthClientService, {
 				allowTestInMemory: true,
 				artifactReuseError: () => new Error('The OAuth artifact is no longer active'),
+				beforeArtifactUpsert: (context) => beforeArtifactUpsert(context),
 			});
 			const readiness = new McpOAuthReadinessService();
 			readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
@@ -299,7 +304,67 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(initialProvider.accessTokens.find(rawAccessToken)).resolves.toBeDefined();
 			await expect(initialProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeDefined();
 
+			const lateAuthorizationCode = 'authorization-code-racing-switch-off';
+			const lateAccessToken = 'access-token-racing-switch-off';
+			const lateRefreshToken = 'refresh-token-racing-switch-off';
+			const pausedModels = new Set<string>();
+			let signalAllArtifactsPaused = (): void => undefined;
+			const allArtifactsPaused = new Promise<void>((resolve) => {
+				signalAllArtifactsPaused = resolve;
+			});
+			const allowArtifactCommits = new Promise<void>((resolve) => {
+				releasePausedArtifacts = resolve;
+			});
+			beforeArtifactUpsert = async ({ model }): Promise<void> => {
+				if (!['AuthorizationCode', 'AccessToken', 'RefreshToken'].includes(model)) return;
+
+				pausedModels.add(model);
+
+				if (pausedModels.size === 3) signalAllArtifactsPaused();
+				await allowArtifactCommits;
+			};
+			pendingArtifactCommits = Promise.allSettled([
+				initialProvider.authorizationCodes.upsert(
+					lateAuthorizationCode,
+					{ ...basePayload, kind: 'AuthorizationCode' },
+					60,
+				),
+				initialProvider.accessTokens.upsert(
+					lateAccessToken,
+					{ ...basePayload, gty: 'authorization_code', kind: 'AccessToken' },
+					600,
+				),
+				initialProvider.refreshTokens.upsert(
+					lateRefreshToken,
+					{
+						...basePayload,
+						gty: 'authorization_code refresh_token',
+						kind: 'RefreshToken',
+						rotations: 1,
+					},
+					3_600,
+				),
+			]);
+
+			await allArtifactsPaused;
+			expect(pausedModels).toEqual(new Set(['AuthorizationCode', 'AccessToken', 'RefreshToken']));
 			await updateOAuth(false);
+			releasePausedArtifacts();
+			beforeArtifactUpsert = () => Promise.resolve();
+			const staleCommits = await pendingArtifactCommits;
+
+			expect(staleCommits).toHaveLength(3);
+			for (const result of staleCommits) {
+				expect(result.status).toBe('rejected');
+
+				if (result.status !== 'rejected') throw new Error('Expected the stale artifact commit to fail');
+
+				const reason: unknown = result.reason;
+
+				expect(reason).toBeInstanceOf(Error);
+				if (!(reason instanceof Error)) throw new Error('Expected the stale artifact failure to be an Error');
+				expect(reason.message).toBe('The OAuth artifact is no longer active');
+			}
 
 			expect(config.oauthEnabled).toBe(false);
 			expect(routeGate.isOpen).toBe(false);
@@ -345,7 +410,15 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(replacementProvider.authorizationCodes.find(rawAuthorizationCode)).resolves.toBeUndefined();
 			await expect(replacementProvider.accessTokens.find(rawAccessToken)).resolves.toBeUndefined();
 			await expect(replacementProvider.refreshTokens.find(rawRefreshToken)).resolves.toBeUndefined();
+			await expect(replacementProvider.authorizationCodes.find(lateAuthorizationCode)).resolves.toBeUndefined();
+			await expect(replacementProvider.accessTokens.find(lateAccessToken)).resolves.toBeUndefined();
+			await expect(replacementProvider.refreshTokens.find(lateRefreshToken)).resolves.toBeUndefined();
+			await expect(resourceServer.verifyAccessToken(lateAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
 		} finally {
+			releasePausedArtifacts();
+			if (pendingArtifactCommits !== undefined) await pendingArtifactCommits;
 			await wireSubscriptions?.close();
 			await subscriptions.closeAll();
 			await dataSource.destroy();

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, concurrent refresh replay, and switch-off commit-race E2E implemented
+**Status:** Phase 6 in progress — runtime lifecycle and refresh replay E2E plus switch-off adapter-race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -419,7 +419,7 @@ amend ADR 0002.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
       reruns readiness and old OAuth artifacts remain unusable.
-- [x] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
+- [ ] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
       off, then resume them; prove each stale-generation commit fails, no late artifact escapes revoke-all, and none
       becomes usable after re-enable.
 - [ ] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle and concurrent refresh replay E2E implemented
+**Status:** Phase 6 in progress — runtime lifecycle, concurrent refresh replay, and switch-off commit-race E2E implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -419,7 +419,7 @@ amend ADR 0002.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth
       streams and artifacts are invalidated before success while static streams remain open, then prove re-enable
       reruns readiness and old OAuth artifacts remain unusable.
-- [ ] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
+- [x] E2E: pause authorization, code-exchange, and refresh handlers immediately before artifact commit, switch OAuth
       off, then resume them; prove each stale-generation commit fails, no late artifact escapes revoke-all, and none
       becomes usable after re-enable.
 - [ ] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 runtime lifecycle and concurrent refresh replay E2E underway
+Status: in progress — Phase 6 runtime lifecycle, refresh replay, and switch-off commit-race E2E underway
 
 ## 1. Business goal
 
@@ -76,7 +76,7 @@ upgrade consequences.
 - [x] Every OAuth artifact commit is serialized with all applicable persistent enabled/secret/identity/client/grant/
       policy/approver generations so no invalidation can miss a racing authorization, exchange, or refresh result and
       later state restoration cannot make it usable.
-- [ ] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
+- [x] Switching OAuth off rejects all OAuth traffic, revokes OAuth artifacts, and closes OAuth subscriptions before
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
 - [x] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
       runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 runtime lifecycle, refresh replay, and switch-off commit-race E2E underway
+Status: in progress — Phase 6 lifecycle and refresh E2E plus switch-off adapter-race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- pause authorization-code, access-token, and rotated refresh-token provider-adapter persistence immediately before upsert
- complete readiness-gated OAuth switch-off while those stale adapter commits are paused
- prove every resumed commit fails, leaves no artifact behind, and remains unusable after re-enable
- record the adapter-level coverage while keeping the separate HTTP-handler race E2E item open

## Why

The existing lifecycle E2E proved that artifacts issued before switch-off were revoked and stayed invalid after re-enable, but it did not exercise provider artifacts that had captured the old authorization generation and were paused immediately before persistence. This adds deterministic defense-in-depth coverage for that adapter boundary without claiming endpoint-handler coverage.

## Impact

No production behavior or API schema changes. The route-level authorization, code-exchange, and refresh handler race remains an explicit unfinished Phase 6 item.

## Validation

- focused artifact-lifecycle E2E — 1/1 passed
- backend E2E — 13 suites, 129 tests passed
- backend unit — 322 suites, 4,063 passed and 2 skipped; after completion the runner hit the known unrelated Home Assistant late-callback teardown error
- backend typecheck and lint passed (two pre-existing unrelated lint warnings)
- admin typecheck and lint passed (four pre-existing unrelated lint warnings)
- admin unit — 265 files, 1,856 tests passed