### PR TITLE
test(backend): cover OAuth global rotation races

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -31,7 +31,7 @@ import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-
 import { UserEntity } from '../src/modules/users/entities/users.entity';
 import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
 
-import { runMcpOAuthHandlerSwitchOffRace } from './support/mcp-oauth-handler-switch-off-race';
+import { runMcpOAuthHandlerInvalidationRaces } from './support/mcp-oauth-handler-invalidation-races';
 
 const CLIENT_ID = 'phase3-public-client';
 const ACCOUNT_ID = 'owner-1';
@@ -733,7 +733,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 	});
 
 	it(
-		'synchronizes authorization, code-exchange, and refresh commits with OAuth switch-off',
-		runMcpOAuthHandlerSwitchOffRace,
+		'synchronizes handler commits with OAuth switch-off and global security rotations',
+		runMcpOAuthHandlerInvalidationRaces,
 	);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -163,20 +163,10 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		server.listen(0, '127.0.0.1');
 		await once(server, 'listening');
 		const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
-		const urls: McpOAuthPublicUrls = {
-			publicBaseUrl: origin,
-			resource: `${origin}/api/v1/modules/mcp`,
-			protectedResourceMetadata: `${origin}/.well-known/oauth-protected-resource/api/v1/modules/mcp`,
-			issuer: `${origin}/api/v1/modules/mcp/oauth`,
-			authorizationServerMetadata: `${origin}/.well-known/oauth-authorization-server/api/v1/modules/mcp/oauth`,
-			authorizationEndpoint: `${origin}/api/v1/modules/mcp/oauth/authorize`,
-			tokenEndpoint: `${origin}/api/v1/modules/mcp/oauth/token`,
-			revocationEndpoint: `${origin}/api/v1/modules/mcp/oauth/token/revocation`,
-		};
 		const config = Object.assign(new McpConfigModel(), {
 			enabled: true,
 			oauthEnabled: true,
-			oauthPublicBaseUrl: urls.publicBaseUrl,
+			oauthPublicBaseUrl: origin,
 			capabilities: [McpCapability.READ],
 		});
 		const configService = {
@@ -186,6 +176,10 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			}),
 			reload: jest.fn(),
 		};
+		const publicUrlService = new McpOAuthPublicUrlService(configService as unknown as ConfigService);
+		const urls = publicUrlService.getUrls();
+
+		if (!urls) throw new Error('Expected initial MCP OAuth public URLs');
 		const clientsService = {
 			findActiveByIdentifier: jest.fn((clientIdentifier: string) =>
 				Promise.resolve(clientIdentifier === CLIENT_ID ? client : null),
@@ -201,7 +195,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		const providerFactory = new McpOAuthProviderFactory(
 			dataSource,
 			clientsService,
-			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			publicUrlService,
 			{} as McpOAuthProviderMaterialService,
 			subscriptions,
 			{
@@ -216,7 +210,13 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 						allowTestInMemory: true,
 						allowInsecureTestCookies: true,
 						beforeArtifactUpsert: (context) => beforeArtifactUpsert(context),
-						interactionUrl: (uid) => `${origin}/api/v1/modules/mcp/oauth/interaction/${uid}`,
+						interactionUrl: (uid) => {
+							const activeUrls = publicUrlService.getUrls();
+
+							if (!activeUrls) throw new Error('Expected active MCP OAuth public URLs');
+
+							return `${activeUrls.issuer}/interaction/${uid}`;
+						},
 					}),
 			} as unknown as McpOAuthProviderFactory,
 			routeGate,
@@ -273,14 +273,17 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			const state = await dataSource
 				.getRepository(McpOAuthServerStateEntity)
 				.findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY });
+			const activeUrls = publicUrlService.getUrls();
+
+			if (!activeUrls) throw new Error('Expected active MCP OAuth public URLs');
 
 			await dataSource.getRepository(McpOAuthGrantEntity).save({
 				providerGrantIdHash: hashToken(providerGrantId),
 				clientId: client.id,
 				approvedById: user.id,
 				installationId: INSTALLATION_ID,
-				issuer: urls.issuer,
-				resource: urls.resource,
+				issuer: activeUrls.issuer,
+				resource: activeUrls.resource,
 				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
 				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
 				revokedAt: null,
@@ -295,7 +298,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		};
 
 		server.on('request', (request, response) => {
-			void dispatchRequest(request, response, runtime, subscriptions, persistGrant, urls).catch((error: unknown) => {
+			void dispatchRequest(request, response, runtime, subscriptions, persistGrant, origin).catch((error: unknown) => {
 				if (response.headersSent) {
 					response.destroy();
 					return;
@@ -456,8 +459,11 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			true,
 		);
 		const publicIdentityTokens = (await publicIdentityResponse.json()) as TokenResponse;
+		const rotatedUrls = runtime.getActive().urls;
 		expect(publicIdentityResponse.status).toBe(200);
 		expect(config.oauthPublicBaseUrl).toBe(rotatedPublicIdentity);
+		expect(rotatedUrls.publicBaseUrl).toBe(rotatedPublicIdentity);
+		expect(rotatedUrls.issuer).toBe(`${rotatedPublicIdentity}/api/v1/modules/mcp/oauth`);
 		expect(routeGate.isOpen).toBe(true);
 		expect(
 			(await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }))
@@ -466,9 +472,10 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		await expect(
 			runtime.getActive().provider.AccessToken.find(publicIdentityTokens.access_token),
 		).resolves.toBeUndefined();
-		expect((await refresh(urls, requireRefreshToken(publicIdentityTokens))).status).toBe(400);
+		expect((await refresh(rotatedUrls, requireRefreshToken(publicIdentityTokens))).status).toBe(400);
 		await updatePublicIdentity(origin);
 		expect(config.oauthPublicBaseUrl).toBe(origin);
+		expect(runtime.getActive().urls).toMatchObject({ publicBaseUrl: origin, issuer: urls.issuer });
 		await expect(
 			runtime.getActive().provider.AccessToken.find(publicIdentityTokens.access_token),
 		).resolves.toBeUndefined();
@@ -486,20 +493,21 @@ async function dispatchRequest(
 	runtime: McpOAuthRuntimeService,
 	subscriptions: McpSubscriptionRegistryService,
 	persistGrant: (providerGrantId: string) => Promise<void>,
-	urls: McpOAuthPublicUrls,
+	origin: string,
 ): Promise<void> {
-	const url = new URL(request.url ?? '/', urls.publicBaseUrl);
-	const interactionPrefix = '/api/v1/modules/mcp/oauth/interaction/';
+	const url = new URL(request.url ?? '/', origin);
+	const active = runtime.getActive();
+	const interactionPrefix = `${new URL(active.urls.issuer).pathname}/interaction/`;
 
 	if (url.pathname.startsWith(interactionPrefix)) {
-		const { provider } = runtime.getActive();
-
-		await subscriptions.runOAuthMutation(() => finishInteraction(provider, request, response, persistGrant, urls));
+		await subscriptions.runOAuthMutation(() =>
+			finishInteraction(active.provider, request, response, persistGrant, active.urls),
+		);
 		return;
 	}
 
 	request.url = `${url.pathname}${url.search}`;
-	runtime.getActive().callback(request, response);
+	active.callback(request, response);
 }
 
 async function finishInteraction(

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -38,6 +38,7 @@ import { McpOAuthClientService } from '../../src/modules/mcp/services/mcp-oauth-
 import { McpOAuthEndpointRateLimitService } from '../../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from '../../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
 import { McpOAuthLifecycleService } from '../../src/modules/mcp/services/mcp-oauth-lifecycle.service';
+import { McpOAuthManagementService } from '../../src/modules/mcp/services/mcp-oauth-management.service';
 import { McpOAuthModuleConfigMutationService } from '../../src/modules/mcp/services/mcp-oauth-module-config-mutation.service';
 import { McpOAuthProviderMaterialService } from '../../src/modules/mcp/services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../../src/modules/mcp/services/mcp-oauth-public-url.service';
@@ -96,7 +97,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isStringArray = (value: unknown): value is string[] =>
 	Array.isArray(value) && value.every((item) => typeof item === 'string');
 
-export async function runMcpOAuthHandlerSwitchOffRace(): Promise<void> {
+export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 	const dataSource = new DataSource({
 		type: 'sqlite',
 		database: ':memory:',
@@ -250,6 +251,24 @@ export async function runMcpOAuthHandlerSwitchOffRace(): Promise<void> {
 					config.oauthEnabled = oauthEnabled;
 				},
 			);
+		const updatePublicIdentity = (publicBaseUrl: string): Promise<void> =>
+			moduleConfigMutations.execute(
+				MCP_MODULE_NAME,
+				Object.assign(new UpdateMcpConfigDto(), { oauth_public_base_url: publicBaseUrl }),
+				() => {
+					config.oauthPublicBaseUrl = publicBaseUrl;
+				},
+			);
+		const management = new McpOAuthManagementService(
+			dataSource.getRepository(McpOAuthGrantEntity),
+			dataSource.getRepository(McpOAuthProviderArtifactEntity),
+			dataSource,
+			configService as unknown as ConfigService,
+			clientsService,
+			subscriptions,
+			globalInvalidation,
+			auditService,
+		);
 		const persistGrant = async (providerGrantId: string): Promise<void> => {
 			const state = await dataSource
 				.getRepository(McpOAuthServerStateEntity)
@@ -334,6 +353,32 @@ export async function runMcpOAuthHandlerSwitchOffRace(): Promise<void> {
 
 			return result;
 		};
+		const raceGlobalInvalidation = async <T>(
+			model: string,
+			startHandler: () => Promise<T>,
+			startInvalidation: () => Promise<void>,
+			closesRouteGate: boolean,
+		): Promise<T> => {
+			const pause = armPause(model);
+			const handler = startHandler();
+			await pause.entered;
+			let invalidationSettled = false;
+			const invalidation = startInvalidation().finally(() => {
+				invalidationSettled = true;
+			});
+
+			if (closesRouteGate) await waitFor(() => !routeGate.isOpen);
+			else expect(routeGate.isOpen).toBe(true);
+			expect(await settlesWithin(invalidation, 25)).toBe(false);
+			expect(invalidationSettled).toBe(false);
+			pause.release();
+			const result = await handler;
+			await invalidation;
+			beforeArtifactUpsert = () => Promise.resolve();
+			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+
+			return result;
+		};
 
 		const authorization = await raceSwitchOff('AuthorizationCode', () => authorize(urls));
 		const authorizationCode = requireAuthorizationCode(authorization.callback);
@@ -366,6 +411,68 @@ export async function runMcpOAuthHandlerSwitchOffRace(): Promise<void> {
 		await updateOAuth(true);
 		await expect(runtime.getActive().provider.AccessToken.find(refreshedTokens.access_token)).resolves.toBeUndefined();
 		expect((await refresh(urls, requireRefreshToken(refreshedTokens))).status).toBe(400);
+
+		const serverSecretBefore = (
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY })
+		).serverSecretVersion;
+		const serverSecretAuthorization = await authorize(urls);
+		const serverSecretResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() =>
+				exchangeCode(
+					urls,
+					requireAuthorizationCode(serverSecretAuthorization.callback),
+					serverSecretAuthorization.verifier,
+				),
+			() => management.revokeAll(ACCOUNT_ID),
+			false,
+		);
+		const serverSecretTokens = (await serverSecretResponse.json()) as TokenResponse;
+		expect(serverSecretResponse.status).toBe(200);
+		expect(
+			(await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }))
+				.serverSecretVersion,
+		).toBe(serverSecretBefore + 1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(serverSecretTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(serverSecretTokens))).status).toBe(400);
+
+		const publicIdentityBefore = (
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY })
+		).publicIdentityGeneration;
+		const publicIdentityAuthorization = await authorize(urls);
+		const publicIdentityInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(publicIdentityAuthorization.callback),
+			publicIdentityAuthorization.verifier,
+		);
+		const publicIdentityInitialTokens = (await publicIdentityInitialResponse.json()) as TokenResponse;
+		const rotatedPublicIdentity = `${origin}/rotated`;
+		const publicIdentityResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(publicIdentityInitialTokens)),
+			() => updatePublicIdentity(rotatedPublicIdentity),
+			true,
+		);
+		const publicIdentityTokens = (await publicIdentityResponse.json()) as TokenResponse;
+		expect(publicIdentityResponse.status).toBe(200);
+		expect(config.oauthPublicBaseUrl).toBe(rotatedPublicIdentity);
+		expect(routeGate.isOpen).toBe(true);
+		expect(
+			(await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }))
+				.publicIdentityGeneration,
+		).toBe(publicIdentityBefore + 1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(publicIdentityTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(publicIdentityTokens))).status).toBe(400);
+		await updatePublicIdentity(origin);
+		expect(config.oauthPublicBaseUrl).toBe(origin);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(publicIdentityTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(publicIdentityTokens))).status).toBe(400);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, and switch-off handler/adapter race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, and global-rotation race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -427,6 +427,11 @@ amend ADR 0002.
 - [ ] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,
       client disable/re-enable, grant revocation, module/client/grant scope contraction/expansion, and approver
       demotion/restoration; prove stale commits fail and later state restoration never revives an artifact.
+  - [x] Provider integration: cover server-secret and public-identity rotation against paused token handlers; prove each
+        rotation waits for the serialized commit, revokes its returned artifacts before success, and restoring the old
+        public identity never revives them.
+  - [ ] Cover client disable/re-enable, grant revocation, module/client/grant scope contraction/expansion, and approver
+        demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, and switch-off handler/adapter race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, switch-off, and global-rotation race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- extend the real-provider race harness from OAuth switch-off to global security rotations
- pause code exchange before access-token persistence while owner revoke-all advances the server-secret epoch
- pause refresh before successor persistence while a public-identity change closes and rebuilds the OAuth runtime
- prove both rotations wait for the serialized handler, revoke every returned artifact before success, and keep artifacts invalid after restoring the previous public identity
- record the completed global-rotation slice while leaving client, grant, scope, and approver races open

## Why

The switch-off coverage exercised the shared handler/invalidation gate, but the Phase 6 matrix also requires proof for the independent server-secret and public-identity generation paths. These tests exercise those production mutation services against real provider HTTP flows.

## Impact

No production behavior or API schema changes. This expands the provider integration harness and task tracking only.

## Validation

- OAuth provider integration: 2 suites, 27 tests passed
- focused management, module-config mutation, and global-invalidation units: 3 suites, 53 tests passed
- backend type-check, focused lint, and formatting passed