### PR TITLE
test(backend): cover OAuth client disable race

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -733,7 +733,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 	});
 
 	it(
-		'synchronizes handler commits with OAuth switch-off and global security rotations',
+		'synchronizes handler commits with OAuth switch-off, security rotations, and client disable',
 		runMcpOAuthHandlerInvalidationRaces,
 	);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -180,11 +180,10 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		const urls = publicUrlService.getUrls();
 
 		if (!urls) throw new Error('Expected initial MCP OAuth public URLs');
-		const clientsService = {
-			findActiveByIdentifier: jest.fn((clientIdentifier: string) =>
-				Promise.resolve(clientIdentifier === CLIENT_ID ? client : null),
-			),
-		} as unknown as McpOAuthClientService;
+		const clientsService = new McpOAuthClientService(
+			dataSource.getRepository(McpOAuthClientEntity),
+			configService as unknown as ConfigService,
+		);
 		const auditService = new McpAuditService();
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
 		const readiness = new McpOAuthReadinessService();
@@ -274,12 +273,15 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 				.getRepository(McpOAuthServerStateEntity)
 				.findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY });
 			const activeUrls = publicUrlService.getUrls();
+			const activeClient = await dataSource
+				.getRepository(McpOAuthClientEntity)
+				.findOneByOrFail({ clientIdentifier: CLIENT_ID });
 
 			if (!activeUrls) throw new Error('Expected active MCP OAuth public URLs');
 
 			await dataSource.getRepository(McpOAuthGrantEntity).save({
 				providerGrantIdHash: hashToken(providerGrantId),
-				clientId: client.id,
+				clientId: activeClient.id,
 				approvedById: user.id,
 				installationId: INSTALLATION_ID,
 				issuer: activeUrls.issuer,
@@ -292,7 +294,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 				oauthEnabledGeneration: state.oauthEnabledGeneration,
 				serverSecretVersion: state.serverSecretVersion,
 				publicIdentityGeneration: state.publicIdentityGeneration,
-				clientGeneration: client.generation,
+				clientGeneration: activeClient.generation,
 				modulePolicyGeneration: state.modulePolicyGeneration,
 			});
 		};
@@ -361,6 +363,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			startHandler: () => Promise<T>,
 			startInvalidation: () => Promise<void>,
 			closesRouteGate: boolean,
+			clearsAllArtifacts = true,
 		): Promise<T> => {
 			const pause = armPause(model);
 			const handler = startHandler();
@@ -378,7 +381,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			const result = await handler;
 			await invalidation;
 			beforeArtifactUpsert = () => Promise.resolve();
-			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+			if (clearsAllArtifacts) expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
 
 			return result;
 		};
@@ -480,6 +483,42 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			runtime.getActive().provider.AccessToken.find(publicIdentityTokens.access_token),
 		).resolves.toBeUndefined();
 		expect((await refresh(urls, requireRefreshToken(publicIdentityTokens))).status).toBe(400);
+
+		const clientAuthorization = await authorize(urls);
+		const clientDisableResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => exchangeCode(urls, requireAuthorizationCode(clientAuthorization.callback), clientAuthorization.verifier),
+			async () => {
+				await management.disableClient(client.id, ACCOUNT_ID);
+			},
+			false,
+			false,
+		);
+		const disabledClientTokens = (await clientDisableResponse.json()) as TokenResponse;
+		const disabledClient = await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: client.id });
+		expect(clientDisableResponse.status).toBe(200);
+		expect(disabledClient).toMatchObject({ enabled: false, generation: 1 });
+		await expect(
+			runtime.getActive().provider.AccessToken.find(disabledClientTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(disabledClientTokens))).status).toBe(401);
+
+		await management.updateClient(client.id, { enabled: true }, ACCOUNT_ID);
+		expect(await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: client.id })).toMatchObject({
+			enabled: true,
+			generation: 2,
+		});
+		await expect(
+			runtime.getActive().provider.AccessToken.find(disabledClientTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(disabledClientTokens))).status).toBe(400);
+		const reenabledClientAuthorization = await authorize(urls);
+		const reenabledClientResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(reenabledClientAuthorization.callback),
+			reenabledClientAuthorization.verifier,
+		);
+		expect(reenabledClientResponse.status).toBe(200);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, and global-rotation race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, global-rotation, and client-disable race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -430,8 +430,10 @@ amend ADR 0002.
   - [x] Provider integration: cover server-secret and public-identity rotation against paused token handlers; prove each
         rotation waits for the serialized commit, revokes its returned artifacts before success, and restoring the old
         public identity never revives them.
-  - [ ] Cover client disable/re-enable, grant revocation, module/client/grant scope contraction/expansion, and approver
-        demotion/restoration.
+  - [x] Provider integration: disable a client against a paused token handler, then re-enable it; prove disable waits,
+        revokes the returned artifacts before success, restoration never revives them, and a fresh authorization flow
+        succeeds with the advanced client generation.
+  - [ ] Cover grant revocation, module/client/grant scope contraction/expansion, and approver demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, switch-off, and global-rotation race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, switch-off, global-rotation, and client-disable race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- run the real OAuth client repository/service inside the provider invalidation-race harness
- pause authorization-code exchange before access-token persistence while disabling the registered client
- prove client disable waits for the serialized handler and revokes its returned access/refresh artifacts before success
- re-enable the same client, prove old artifacts remain invalid, and complete a fresh authorization flow with the advanced client generation
- record client disable/re-enable coverage while leaving grant, scope, and approver races open

## Why

Phase 6 requires targeted invalidation races in addition to global switch-off and security rotations. Client disable has distinct behavior: the token endpoint rejects the disabled public client immediately, targeted revocation removes only its grant artifacts, and later re-enable must permit fresh authorization without reviving anything issued before disable.

## Impact

No production behavior or API schema changes. This expands the real-provider integration harness and task tracking only.

## Validation

- OAuth provider integration: 2 suites, 27 tests passed
- focused OAuth client and management units: 2 suites, 27 tests passed
- backend type-check, focused lint, and formatting passed