### PR TITLE
test(backend): cover OAuth grant revocation race

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -733,7 +733,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 	});
 
 	it(
-		'synchronizes handler commits with OAuth switch-off, security rotations, and client disable',
+		'synchronizes handler commits with OAuth switch-off, rotations, client disable, and grant revocation',
 		runMcpOAuthHandlerInvalidationRaces,
 	);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -268,6 +268,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			globalInvalidation,
 			auditService,
 		);
+		let latestGrantId: string | null = null;
 		const persistGrant = async (providerGrantId: string): Promise<void> => {
 			const state = await dataSource
 				.getRepository(McpOAuthServerStateEntity)
@@ -279,7 +280,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 
 			if (!activeUrls) throw new Error('Expected active MCP OAuth public URLs');
 
-			await dataSource.getRepository(McpOAuthGrantEntity).save({
+			const savedGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
 				providerGrantIdHash: hashToken(providerGrantId),
 				clientId: activeClient.id,
 				approvedById: user.id,
@@ -297,6 +298,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 				clientGeneration: activeClient.generation,
 				modulePolicyGeneration: state.modulePolicyGeneration,
 			});
+			latestGrantId = savedGrant.id;
 		};
 
 		server.on('request', (request, response) => {
@@ -519,6 +521,46 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			reenabledClientAuthorization.verifier,
 		);
 		expect(reenabledClientResponse.status).toBe(200);
+
+		const grantAuthorization = await authorize(urls);
+		const grantInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(grantAuthorization.callback),
+			grantAuthorization.verifier,
+		);
+		const grantInitialTokens = (await grantInitialResponse.json()) as TokenResponse;
+		const grantId = latestGrantId;
+
+		if (!grantId) throw new Error('Expected a persisted grant for the revocation race');
+		const grantRevocationResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(grantInitialTokens)),
+			async () => {
+				await management.revokeGrant(grantId, ACCOUNT_ID);
+			},
+			false,
+			false,
+		);
+		const revokedGrantTokens = (await grantRevocationResponse.json()) as TokenResponse;
+		const revokedGrant = await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantId });
+		expect(grantRevocationResponse.status).toBe(200);
+		expect(revokedGrant.revokedAt).not.toBeNull();
+		expect(revokedGrant.generation).toBe(1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(revokedGrantTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(revokedGrantTokens))).status).toBe(400);
+		const replacementGrantAuthorization = await authorize(urls);
+		const replacementGrantResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(replacementGrantAuthorization.callback),
+			replacementGrantAuthorization.verifier,
+		);
+		expect(replacementGrantResponse.status).toBe(200);
+		expect(latestGrantId).not.toBe(grantId);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(revokedGrantTokens.access_token),
+		).resolves.toBeUndefined();
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, global-rotation, and client-disable race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, global-rotation, client-disable, and grant-revocation race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -433,7 +433,9 @@ amend ADR 0002.
   - [x] Provider integration: disable a client against a paused token handler, then re-enable it; prove disable waits,
         revokes the returned artifacts before success, restoration never revives them, and a fresh authorization flow
         succeeds with the advanced client generation.
-  - [ ] Cover grant revocation, module/client/grant scope contraction/expansion, and approver demotion/restoration.
+  - [x] Provider integration: revoke a grant against a paused refresh handler; prove revocation waits, removes the
+        returned successor artifacts before success, and a replacement grant works without reviving the revoked one.
+  - [ ] Cover module/client/grant scope contraction/expansion and approver demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, switch-off, global-rotation, and client-disable race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, switch-off, global-rotation, client-disable, and grant-revocation race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- track the latest real-provider grant inside the handler invalidation-race harness
- issue an initial token family, pause refresh before successor access-token persistence, and revoke the matching grant
- prove grant revocation waits for the serialized refresh handler and removes the returned successor artifacts before success
- complete a replacement grant flow and prove the revoked grant's artifacts remain absent
- record grant-revocation coverage while leaving scope and approver races open

## Why

Grant revocation is a targeted authorization mutation with different scope from client disable and global rotation. Phase 6 needs proof that a refresh handler which wins the shared mutation gate cannot leave a successor artifact outside the subsequent grant revocation, and that a later replacement grant does not reactivate the revoked family.

## Impact

No production behavior or API schema changes. This expands the real-provider integration harness and task tracking only.

## Validation

- OAuth provider integration: 2 suites, 27 tests passed
- focused OAuth management and provider-adapter units: 2 suites, 24 tests passed
- backend type-check, focused lint, and formatting passed