### PR TITLE
test(backend): cover OAuth module scope race

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -732,8 +732,5 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect((await refresh(tokens.refresh_token)).status).toBe(400);
 	});
 
-	it(
-		'synchronizes handler commits with OAuth switch-off, rotations, client disable, and grant revocation',
-		runMcpOAuthHandlerInvalidationRaces,
-	);
+	it('synchronizes handlers with invalidation and module-scope contraction', runMcpOAuthHandlerInvalidationRaces);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -140,7 +140,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			clientIdentifier: CLIENT_ID,
 			name: 'Handler race client',
 			redirectUris: [REDIRECT_URI],
-			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS],
 			enabled: true,
 			generation: 0,
 			createdById: user.id,
@@ -167,7 +167,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			enabled: true,
 			oauthEnabled: true,
 			oauthPublicBaseUrl: origin,
-			capabilities: [McpCapability.READ],
+			capabilities: [McpCapability.READ, McpCapability.WRITE],
 		});
 		const configService = {
 			getModuleConfig: jest.fn((moduleName: string) => {
@@ -258,6 +258,10 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 					config.oauthPublicBaseUrl = publicBaseUrl;
 				},
 			);
+		const updateCapabilities = (capabilities: McpCapability[]): Promise<void> =>
+			moduleConfigMutations.execute(MCP_MODULE_NAME, Object.assign(new UpdateMcpConfigDto(), { capabilities }), () => {
+				config.capabilities = [...capabilities];
+			});
 		const management = new McpOAuthManagementService(
 			dataSource.getRepository(McpOAuthGrantEntity),
 			dataSource.getRepository(McpOAuthProviderArtifactEntity),
@@ -269,7 +273,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			auditService,
 		);
 		let latestGrantId: string | null = null;
-		const persistGrant = async (providerGrantId: string): Promise<void> => {
+		const persistGrant = async (providerGrantId: string, approvedScopes: McpOAuthScope[]): Promise<void> => {
 			const state = await dataSource
 				.getRepository(McpOAuthServerStateEntity)
 				.findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY });
@@ -287,7 +291,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 				installationId: INSTALLATION_ID,
 				issuer: activeUrls.issuer,
 				resource: activeUrls.resource,
-				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				approvedScopes: [...approvedScopes],
 				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
 				revokedAt: null,
 				generation: 0,
@@ -561,6 +565,55 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		await expect(
 			runtime.getActive().provider.AccessToken.find(revokedGrantTokens.access_token),
 		).resolves.toBeUndefined();
+
+		const modulePolicyBefore = (
+			await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY })
+		).modulePolicyGeneration;
+		const writeAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const writeInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(writeAuthorization.callback),
+			writeAuthorization.verifier,
+		);
+		const writeInitialTokens = (await writeInitialResponse.json()) as TokenResponse;
+		const moduleContractionResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(writeInitialTokens)),
+			() => updateCapabilities([McpCapability.READ]),
+			false,
+			false,
+		);
+		const contractedModuleTokens = (await moduleContractionResponse.json()) as TokenResponse;
+		expect(moduleContractionResponse.status).toBe(200);
+		expect(config.capabilities).toEqual([McpCapability.READ]);
+		expect(
+			(await dataSource.getRepository(McpOAuthServerStateEntity).findOneByOrFail({ key: MCP_OAUTH_SERVER_STATE_KEY }))
+				.modulePolicyGeneration,
+		).toBe(modulePolicyBefore + 1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedModuleTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedModuleTokens))).status).toBe(400);
+
+		await updateCapabilities([McpCapability.READ, McpCapability.WRITE]);
+		expect(config.capabilities).toEqual([McpCapability.READ, McpCapability.WRITE]);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedModuleTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedModuleTokens))).status).toBe(400);
+		const expandedModuleAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const expandedModuleResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(expandedModuleAuthorization.callback),
+			expandedModuleAuthorization.verifier,
+		);
+		expect(expandedModuleResponse.status).toBe(200);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -573,7 +626,7 @@ async function dispatchRequest(
 	response: ServerResponse,
 	runtime: McpOAuthRuntimeService,
 	subscriptions: McpSubscriptionRegistryService,
-	persistGrant: (providerGrantId: string) => Promise<void>,
+	persistGrant: (providerGrantId: string, approvedScopes: McpOAuthScope[]) => Promise<void>,
 	origin: string,
 ): Promise<void> {
 	const url = new URL(request.url ?? '/', origin);
@@ -581,9 +634,7 @@ async function dispatchRequest(
 	const interactionPrefix = `${new URL(active.urls.issuer).pathname}/interaction/`;
 
 	if (url.pathname.startsWith(interactionPrefix)) {
-		await subscriptions.runOAuthMutation(() =>
-			finishInteraction(active.provider, request, response, persistGrant, active.urls),
-		);
+		await subscriptions.runOAuthMutation(() => finishInteraction(active.provider, request, response, persistGrant));
 		return;
 	}
 
@@ -595,8 +646,7 @@ async function finishInteraction(
 	provider: Provider,
 	request: IncomingMessage,
 	response: ServerResponse,
-	persistGrant: (providerGrantId: string) => Promise<void>,
-	urls: McpOAuthPublicUrls,
+	persistGrant: (providerGrantId: string, approvedScopes: McpOAuthScope[]) => Promise<void>,
 ): Promise<void> {
 	const details = await provider.interactionDetails(request, response);
 
@@ -615,26 +665,40 @@ async function finishInteraction(
 	}
 
 	const grant = new provider.Grant({ accountId: ACCOUNT_ID, clientId: details.params.client_id });
+	const approvedScopes = new Set<McpOAuthScope>();
 	const promptDetails = isRecord(details.prompt.details) ? details.prompt.details : {};
 	const missingResourceScopes = promptDetails.missingResourceScopes;
 
 	if (isRecord(missingResourceScopes)) {
 		for (const [resource, scopes] of Object.entries(missingResourceScopes)) {
-			if (isStringArray(scopes)) grant.addResourceScope(resource, scopes.join(' '));
+			if (isStringArray(scopes)) {
+				grant.addResourceScope(resource, scopes.join(' '));
+				for (const scope of scopes) {
+					if (Object.values(McpOAuthScope).includes(scope as McpOAuthScope)) {
+						approvedScopes.add(scope as McpOAuthScope);
+					}
+				}
+			}
 		}
 	}
 
 	const missingOidcScope = promptDetails.missingOIDCScope;
 
-	if (isStringArray(missingOidcScope)) grant.addOIDCScope(missingOidcScope.join(' '));
-	grant.addResourceScope(urls.resource, McpOAuthScope.READ);
-	grant.addOIDCScope(McpOAuthScope.OFFLINE_ACCESS);
+	if (isStringArray(missingOidcScope)) {
+		grant.addOIDCScope(missingOidcScope.join(' '));
+		if (missingOidcScope.includes(McpOAuthScope.OFFLINE_ACCESS)) {
+			approvedScopes.add(McpOAuthScope.OFFLINE_ACCESS);
+		}
+	}
 	const grantId = await grant.save();
-	await persistGrant(grantId);
+	await persistGrant(grantId, [...approvedScopes]);
 	await provider.interactionFinished(request, response, { consent: { grantId } }, { mergeWithLastSubmission: true });
 }
 
-async function authorize(urls: McpOAuthPublicUrls): Promise<{ callback: URL; verifier: string }> {
+async function authorize(
+	urls: McpOAuthPublicUrls,
+	scope = `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
+): Promise<{ callback: URL; verifier: string }> {
 	const verifier = randomBytes(32).toString('base64url');
 	const challenge = createHash('sha256').update(verifier).digest('base64url');
 	const browser = new CookieBrowser();
@@ -643,7 +707,7 @@ async function authorize(urls: McpOAuthPublicUrls): Promise<{ callback: URL; ver
 		client_id: CLIENT_ID,
 		redirect_uri: REDIRECT_URI,
 		response_type: 'code',
-		scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		scope,
 		code_challenge: challenge,
 		code_challenge_method: 'S256',
 		resource: urls.resource,

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -61,6 +61,7 @@ const REDIRECT_URI = 'http://127.0.0.1:1455/callback';
 interface TokenResponse {
 	access_token: string;
 	refresh_token?: string;
+	scope: string;
 }
 
 interface ArtifactPause {
@@ -613,7 +614,13 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			requireAuthorizationCode(expandedModuleAuthorization.callback),
 			expandedModuleAuthorization.verifier,
 		);
+		const expandedModuleTokens = (await expandedModuleResponse.json()) as TokenResponse;
 		expect(expandedModuleResponse.status).toBe(200);
+		expect(expandedModuleTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(latestGrantId).not.toBeNull();
+		expect(
+			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: latestGrantId })).approvedScopes,
+		).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, switch-off, global-rotation, client-disable, and grant-revocation race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, invalidation, and module-scope race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -435,7 +435,10 @@ amend ADR 0002.
         succeeds with the advanced client generation.
   - [x] Provider integration: revoke a grant against a paused refresh handler; prove revocation waits, removes the
         returned successor artifacts before success, and a replacement grant works without reviving the revoked one.
-  - [ ] Cover module/client/grant scope contraction/expansion and approver demotion/restoration.
+  - [x] Provider integration: contract the module ceiling against a paused write-scoped refresh, then expand it; prove
+        contraction waits, the committed successor is permanently invalid, and fresh write authorization works after
+        expansion with the advanced policy generation.
+  - [ ] Cover client/grant scope contraction/expansion and approver demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, switch-off, global-rotation, client-disable, and grant-revocation race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, invalidation, and module-scope race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- exercise module capability contraction while a real OAuth provider refresh handler is paused
- verify the mutation waits for the handler, advances the module policy generation, and permanently invalidates the committed successor artifacts
- verify expanding the module scope does not revive stale artifacts and permits a fresh write-scoped authorization
- derive persisted grant scopes from the provider consent prompt so the integration harness accurately models requested access
- update the Phase 6 implementation plan and task status

## Why

Phase 6 still needed provider-level proof that module scope policy changes serialize with in-flight OAuth handlers. This closes the module-ceiling portion of the remaining policy-race coverage.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- ESLint on the changed OAuth integration files
- Prettier check on all changed files
- 24 focused module-config/provider unit tests
- full OAuth spike suite: 27 tests