### PR TITLE
test(backend): cover OAuth client scope race

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -732,5 +732,5 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect((await refresh(tokens.refresh_token)).status).toBe(400);
 	});
 
-	it('synchronizes handlers with invalidation and module-scope contraction', runMcpOAuthHandlerInvalidationRaces);
+	it('synchronizes handlers with invalidation and policy-scope contraction', runMcpOAuthHandlerInvalidationRaces);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -621,6 +621,78 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		expect(
 			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: latestGrantId })).approvedScopes,
 		).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+
+		const clientGenerationBefore = (
+			await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: client.id })
+		).generation;
+		const clientScopeAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const clientScopeInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(clientScopeAuthorization.callback),
+			clientScopeAuthorization.verifier,
+		);
+		const clientScopeInitialTokens = (await clientScopeInitialResponse.json()) as TokenResponse;
+		expect(clientScopeInitialResponse.status).toBe(200);
+		expect(clientScopeInitialTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		const clientContractionResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(clientScopeInitialTokens)),
+			async () => {
+				await management.updateClient(
+					client.id,
+					{ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] },
+					ACCOUNT_ID,
+				);
+			},
+			false,
+			false,
+		);
+		const contractedClientTokens = (await clientContractionResponse.json()) as TokenResponse;
+		expect(clientContractionResponse.status).toBe(200);
+		expect(contractedClientTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: client.id })).toMatchObject({
+			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+			generation: clientGenerationBefore + 1,
+		});
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedClientTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedClientTokens))).status).toBe(400);
+
+		await management.updateClient(
+			client.id,
+			{ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS] },
+			ACCOUNT_ID,
+		);
+		expect(await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: client.id })).toMatchObject({
+			maximumScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS],
+			generation: clientGenerationBefore + 2,
+		});
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedClientTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedClientTokens))).status).toBe(400);
+		const expandedClientAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const expandedClientResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(expandedClientAuthorization.callback),
+			expandedClientAuthorization.verifier,
+		);
+		const expandedClientTokens = (await expandedClientResponse.json()) as TokenResponse;
+		expect(expandedClientResponse.status).toBe(200);
+		expect(expandedClientTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(latestGrantId).not.toBeNull();
+		const expandedClientGrant = await dataSource
+			.getRepository(McpOAuthGrantEntity)
+			.findOneByOrFail({ id: latestGrantId });
+		expect(expandedClientGrant.approvedScopes).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(expandedClientGrant.clientGeneration).toBe(clientGenerationBefore + 2);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, invalidation, and module-scope race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, invalidation, and policy-scope race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -438,7 +438,10 @@ amend ADR 0002.
   - [x] Provider integration: contract the module ceiling against a paused write-scoped refresh, then expand it; prove
         contraction waits, the committed successor is permanently invalid, and fresh write authorization works after
         expansion with the advanced policy generation.
-  - [ ] Cover client/grant scope contraction/expansion and approver demotion/restoration.
+  - [x] Provider integration: contract a client's scope ceiling against a paused write-scoped refresh, then expand it;
+        prove contraction waits, the committed successor is permanently invalid, and fresh write authorization works
+        with the advanced client generation.
+  - [ ] Cover grant scope contraction/replacement and approver demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, invalidation, and module-scope race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, invalidation, and policy-scope race coverage underway
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- exercise client scope contraction while a real OAuth provider refresh handler is paused
- verify contraction waits for the handler, advances the client generation, and permanently invalidates the committed successor artifacts
- expand the client scope ceiling and prove stale artifacts remain unusable
- verify a fresh authorization returns `mcp:write` and persists a write-approved grant at the advanced client generation
- update the Phase 6 implementation plan and task status

## Why

Phase 6 still needed provider-level proof that client scope policy changes serialize with in-flight OAuth handlers. This closes the client-ceiling portion of the remaining policy-race coverage.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- ESLint on the changed OAuth integration files
- Prettier check on all changed files
- 29 related management, client, and provider unit tests
- full OAuth spike suite: 27 tests
- focused real-provider suite: 12 tests