### PR TITLE
test(backend): cover OAuth grant scope race

### DIFF
--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -693,6 +693,84 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			.findOneByOrFail({ id: latestGrantId });
 		expect(expandedClientGrant.approvedScopes).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
 		expect(expandedClientGrant.clientGeneration).toBe(clientGenerationBefore + 2);
+
+		const grantScopeAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const grantScopeInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(grantScopeAuthorization.callback),
+			grantScopeAuthorization.verifier,
+		);
+		const grantScopeInitialTokens = (await grantScopeInitialResponse.json()) as TokenResponse;
+		expect(grantScopeInitialResponse.status).toBe(200);
+		expect(grantScopeInitialTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		const grantScopeId = latestGrantId;
+
+		if (!grantScopeId) throw new Error('Expected a persisted grant for the scope-contraction race');
+
+		const grantContractionResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(grantScopeInitialTokens)),
+			async () => {
+				await management.updateGrant(
+					grantScopeId,
+					{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] },
+					ACCOUNT_ID,
+				);
+			},
+			false,
+			false,
+		);
+		const contractedGrantTokens = (await grantContractionResponse.json()) as TokenResponse;
+		expect(grantContractionResponse.status).toBe(200);
+		expect(contractedGrantTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantScopeId })).toMatchObject({
+			approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+			generation: 1,
+		});
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedGrantTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedGrantTokens))).status).toBe(400);
+		await expect(
+			management.updateGrant(
+				grantScopeId,
+				{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.OFFLINE_ACCESS] },
+				ACCOUNT_ID,
+			),
+		).rejects.toThrow('can only be reduced');
+		expect((await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantScopeId })).generation).toBe(
+			1,
+		);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedGrantTokens.access_token),
+		).resolves.toBeUndefined();
+
+		const replacementScopeAuthorization = await authorize(
+			urls,
+			`${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.OFFLINE_ACCESS}`,
+		);
+		const replacementScopeResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(replacementScopeAuthorization.callback),
+			replacementScopeAuthorization.verifier,
+		);
+		const replacementScopeTokens = (await replacementScopeResponse.json()) as TokenResponse;
+		expect(replacementScopeResponse.status).toBe(200);
+		expect(replacementScopeTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(latestGrantId).not.toBe(grantScopeId);
+		expect(latestGrantId).not.toBeNull();
+		const replacementScopeGrant = await dataSource
+			.getRepository(McpOAuthGrantEntity)
+			.findOneByOrFail({ id: latestGrantId });
+		expect(replacementScopeGrant.approvedScopes).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		expect(replacementScopeGrant.generation).toBe(0);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(contractedGrantTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(contractedGrantTokens))).status).toBe(400);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -768,6 +768,16 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		expect(replacementScopeGrant.approvedScopes).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
 		expect(replacementScopeGrant.generation).toBe(0);
 		await expect(
+			runtime.getActive().provider.AccessToken.find(replacementScopeTokens.access_token),
+		).resolves.toBeDefined();
+		const replacementScopeRefreshResponse = await refresh(urls, requireRefreshToken(replacementScopeTokens));
+		const refreshedReplacementScopeTokens = (await replacementScopeRefreshResponse.json()) as TokenResponse;
+		expect(replacementScopeRefreshResponse.status).toBe(200);
+		expect(refreshedReplacementScopeTokens.scope.split(' ')).toEqual(expect.arrayContaining([McpOAuthScope.WRITE]));
+		await expect(
+			runtime.getActive().provider.AccessToken.find(refreshedReplacementScopeTokens.access_token),
+		).resolves.toBeDefined();
+		await expect(
 			runtime.getActive().provider.AccessToken.find(contractedGrantTokens.access_token),
 		).resolves.toBeUndefined();
 		expect((await refresh(urls, requireRefreshToken(contractedGrantTokens))).status).toBe(400);

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -441,7 +441,10 @@ amend ADR 0002.
   - [x] Provider integration: contract a client's scope ceiling against a paused write-scoped refresh, then expand it;
         prove contraction waits, the committed successor is permanently invalid, and fresh write authorization works
         with the advanced client generation.
-  - [ ] Cover grant scope contraction/replacement and approver demotion/restoration.
+  - [x] Provider integration: contract a grant against a paused write-scoped refresh; prove contraction waits, the
+        committed successor is permanently invalid, in-place scope expansion is rejected, and fresh write consent
+        creates a replacement grant without reviving the contracted artifacts.
+  - [ ] Cover approver demotion/restoration.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.


### PR DESCRIPTION
## Summary

- contract a write-approved grant while a real OAuth provider refresh handler is paused
- verify contraction waits for the handler, advances the grant generation, and permanently invalidates the committed successor artifacts
- prove in-place grant scope expansion is rejected without changing the contracted generation
- verify fresh consent creates a separate write-capable replacement grant without reviving stale artifacts
- update the Phase 6 implementation plan

## Why

Phase 6 still needed provider-level proof that grant scope reduction serializes with in-flight OAuth handlers and that restored write access requires fresh consent rather than mutating or reviving the contracted grant.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- ESLint on the changed OAuth integration files
- Prettier check on all changed files
- 24 related management and provider unit tests
- full OAuth spike suite: 27 tests
- focused real-provider suite: 12 tests