### PR TITLE
test(backend): cover OAuth approver race

### DIFF
--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -732,5 +732,5 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect((await refresh(tokens.refresh_token)).status).toBe(400);
 	});
 
-	it('synchronizes handlers with invalidation and policy-scope contraction', runMcpOAuthHandlerInvalidationRaces);
+	it('synchronizes handlers with policy and authority invalidation', runMcpOAuthHandlerInvalidationRaces);
 });

--- a/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
+++ b/apps/backend/test/support/mcp-oauth-handler-invalidation-races.ts
@@ -34,6 +34,7 @@ import { McpConfigModel } from '../../src/modules/mcp/models/config.model';
 import { McpOAuthProviderFactory } from '../../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpAuditService } from '../../src/modules/mcp/services/mcp-audit.service';
+import { McpOAuthApproverAuthorityService } from '../../src/modules/mcp/services/mcp-oauth-approver-authority.service';
 import { McpOAuthClientService } from '../../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthEndpointRateLimitService } from '../../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
 import { McpOAuthGlobalInvalidationService } from '../../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
@@ -187,6 +188,12 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 		);
 		const auditService = new McpAuditService();
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
+		const approverAuthority = new McpOAuthApproverAuthorityService(
+			dataSource.getRepository(McpOAuthApproverAuthorityEntity),
+			dataSource,
+			subscriptions,
+			auditService,
+		);
 		const readiness = new McpOAuthReadinessService();
 		readiness.register(...MCP_OAUTH_REQUIRED_READINESS_CONTROLS);
 		readiness.onApplicationBootstrap();
@@ -282,6 +289,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			const activeClient = await dataSource
 				.getRepository(McpOAuthClientEntity)
 				.findOneByOrFail({ clientIdentifier: CLIENT_ID });
+			const authorityGeneration = await approverAuthority.getGeneration(user.id);
 
 			if (!activeUrls) throw new Error('Expected active MCP OAuth public URLs');
 
@@ -296,7 +304,7 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
 				revokedAt: null,
 				generation: 0,
-				approverAuthorityGeneration: 0,
+				approverAuthorityGeneration: authorityGeneration,
 				oauthEnabledGeneration: state.oauthEnabledGeneration,
 				serverSecretVersion: state.serverSecretVersion,
 				publicIdentityGeneration: state.publicIdentityGeneration,
@@ -781,6 +789,87 @@ export async function runMcpOAuthHandlerInvalidationRaces(): Promise<void> {
 			runtime.getActive().provider.AccessToken.find(contractedGrantTokens.access_token),
 		).resolves.toBeUndefined();
 		expect((await refresh(urls, requireRefreshToken(contractedGrantTokens))).status).toBe(400);
+
+		const approverAuthorization = await authorize(urls);
+		const approverInitialResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(approverAuthorization.callback),
+			approverAuthorization.verifier,
+		);
+		const approverInitialTokens = (await approverInitialResponse.json()) as TokenResponse;
+		expect(approverInitialResponse.status).toBe(200);
+		const approverGrantId = latestGrantId;
+
+		if (!approverGrantId) throw new Error('Expected a persisted grant for the approver-demotion race');
+		expect(
+			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: approverGrantId }))
+				.approverAuthorityGeneration,
+		).toBe(0);
+
+		const demotedApproverResponse = await raceGlobalInvalidation(
+			'AccessToken',
+			() => refresh(urls, requireRefreshToken(approverInitialTokens)),
+			async () => {
+				const demoted = Object.assign(new UserEntity(), user, { role: UserRole.USER });
+				await approverAuthority.update(user, demoted, async (manager) => {
+					if (!manager) throw new Error('Expected transactional user lifecycle commit');
+					await manager.getRepository(UserEntity).update({ id: user.id }, { role: UserRole.USER });
+				});
+			},
+			false,
+			false,
+		);
+		const demotedApproverTokens = (await demotedApproverResponse.json()) as TokenResponse;
+		expect(demotedApproverResponse.status).toBe(200);
+		expect((await dataSource.getRepository(UserEntity).findOneByOrFail({ id: user.id })).role).toBe(UserRole.USER);
+		expect(await approverAuthority.getGeneration(user.id)).toBe(1);
+		expect(
+			(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: approverGrantId })).revokedAt,
+		).not.toBeNull();
+		await expect(
+			runtime.getActive().provider.AccessToken.find(demotedApproverTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(demotedApproverTokens))).status).toBe(400);
+
+		const demotedUser = await dataSource.getRepository(UserEntity).findOneByOrFail({ id: user.id });
+		const restoredUser = Object.assign(new UserEntity(), demotedUser, { role: UserRole.OWNER });
+		await approverAuthority.update(demotedUser, restoredUser, async (manager) => {
+			await (manager ?? dataSource.manager).getRepository(UserEntity).update({ id: user.id }, { role: UserRole.OWNER });
+		});
+		expect((await dataSource.getRepository(UserEntity).findOneByOrFail({ id: user.id })).role).toBe(UserRole.OWNER);
+		expect(await approverAuthority.getGeneration(user.id)).toBe(1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(demotedApproverTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(demotedApproverTokens))).status).toBe(400);
+
+		const restoredApproverAuthorization = await authorize(urls);
+		const restoredApproverResponse = await exchangeCode(
+			urls,
+			requireAuthorizationCode(restoredApproverAuthorization.callback),
+			restoredApproverAuthorization.verifier,
+		);
+		const restoredApproverTokens = (await restoredApproverResponse.json()) as TokenResponse;
+		expect(restoredApproverResponse.status).toBe(200);
+		expect(latestGrantId).not.toBe(approverGrantId);
+		expect(latestGrantId).not.toBeNull();
+		const restoredApproverGrant = await dataSource
+			.getRepository(McpOAuthGrantEntity)
+			.findOneByOrFail({ id: latestGrantId });
+		expect(restoredApproverGrant.approverAuthorityGeneration).toBe(1);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(restoredApproverTokens.access_token),
+		).resolves.toBeDefined();
+		const restoredApproverRefreshResponse = await refresh(urls, requireRefreshToken(restoredApproverTokens));
+		const refreshedRestoredApproverTokens = (await restoredApproverRefreshResponse.json()) as TokenResponse;
+		expect(restoredApproverRefreshResponse.status).toBe(200);
+		await expect(
+			runtime.getActive().provider.AccessToken.find(refreshedRestoredApproverTokens.access_token),
+		).resolves.toBeDefined();
+		await expect(
+			runtime.getActive().provider.AccessToken.find(demotedApproverTokens.access_token),
+		).resolves.toBeUndefined();
+		expect((await refresh(urls, requireRefreshToken(demotedApproverTokens))).status).toBe(400);
 	} finally {
 		releaseActivePause();
 		await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, invalidation, and policy-scope race coverage implemented
+**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, and invalidation race coverage implemented
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -424,7 +424,7 @@ amend ADR 0002.
       serialized handler; after resume, prove revoke-all removes every returned artifact before reporting success and
       none becomes usable after re-enable. Complement this commit-first branch with adapter-level stale-generation
       rejection coverage so both allowed serialization outcomes are exercised.
-- [ ] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,
+- [x] E2E: repeat the barrier-synchronized artifact-commit race for server-secret rotation, public-identity rotation,
       client disable/re-enable, grant revocation, module/client/grant scope contraction/expansion, and approver
       demotion/restoration; prove stale commits fail and later state restoration never revives an artifact.
   - [x] Provider integration: cover server-secret and public-identity rotation against paused token handlers; prove each
@@ -444,7 +444,9 @@ amend ADR 0002.
   - [x] Provider integration: contract a grant against a paused write-scoped refresh; prove contraction waits, the
         committed successor is permanently invalid, in-place scope expansion is rejected, and fresh write consent
         creates a replacement grant without reviving the contracted artifacts.
-  - [ ] Cover approver demotion/restoration.
+  - [x] Provider integration: demote an approver against a paused refresh, then restore the role; prove demotion waits,
+        advances authority and revokes the grant and committed successor, restoration never revives stale artifacts,
+        and fresh authorization binds a usable grant to the advanced authority generation.
 - [ ] E2E: rotate the public OAuth identity and server secret with simultaneous OAuth and static subscriptions; prove
       only OAuth artifacts/streams are invalidated and static streams remain open. Separately prove MCP-module disable
       closes both kinds.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, invalidation, and policy-scope race coverage underway
+Status: in progress — Phase 6 lifecycle, refresh, and invalidation race coverage implemented
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- demote an OAuth grant approver while a real provider refresh handler is paused
- verify demotion waits for the handler, advances approver authority, revokes the grant, and invalidates the committed successor artifacts
- restore the approver role through the lifecycle handler and prove stale artifacts remain unusable
- verify fresh authorization binds a new grant to the advanced authority generation and both issued and refreshed tokens remain usable
- mark the complete barrier-synchronized invalidation-race criterion finished in the Phase 6 plan

## Why

Phase 6 still needed provider-level proof that approver lifecycle changes serialize with in-flight OAuth handlers and that restoring an authorized role never restores grants or tokens from the previous authority generation.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- ESLint on the changed OAuth integration files
- Prettier check on all changed files
- 9 focused approver-authority and provider tests
- full OAuth spike suite: 27 tests
- focused real-provider suite: 12 tests