### PR TITLE
feat(cross): add Home Assistant bulk adoption wizard

### DIFF
--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -214,4 +214,22 @@ describe('DeviceWizardConfirmStep', () => {
 
 		expect(wrapper.emitted('toggle-rows')?.[0]).toEqual([['kitchen.local'], true]);
 	});
+
+	it('filters by the rendered fallback status label', async () => {
+		const wrapper = mountStep([row(), row({ key: 'registered', identifier: 'registered', status: 'already_registered', willUpdate: true })], {
+			selected: { 'shelly-1.local': true, registered: true },
+			nameByKey: { 'shelly-1.local': 'Living room switch', registered: 'Registered switch' },
+			categoryByKey: {
+				'shelly-1.local': DevicesModuleDeviceCategory.lighting,
+				registered: DevicesModuleDeviceCategory.lighting,
+			},
+		});
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-confirm-search"] input').setValue('already_registered');
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+		expect(wrapper.text()).toContain('registered');
+	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -37,8 +37,7 @@ const mountStep = (rows: IWizardRow[] = [row()], props: Record<string, unknown> 
 			nameByKey: { 'shelly-1.local': 'Living room switch' },
 			categoryByKey: { 'shelly-1.local': DevicesModuleDeviceCategory.lighting },
 			identifierLabel: 'Hostname',
-			allSelected: true,
-			someSelected: true,
+			confirmationMode: 'editable',
 			...props,
 		},
 	});
@@ -62,14 +61,14 @@ describe('DeviceWizardConfirmStep', () => {
 		expect(wrapper.emitted('toggle-row')?.[0]).toEqual(['shelly-1.local', false]);
 	});
 
-	it('emits toggle-all when the header checkbox changes', async () => {
+	it('emits toggle-rows for the filtered rows when the header checkbox changes', async () => {
 		const wrapper = mountStep();
 
 		await flushPromises();
 
 		await wrapper.find('thead input[type="checkbox"]').setValue(false);
 
-		expect(wrapper.emitted('toggle-all')?.[0]).toEqual([false]);
+		expect(wrapper.emitted('toggle-rows')?.[0]).toEqual([['shelly-1.local'], false]);
 	});
 
 	it('emits update-name when the name input changes', async () => {
@@ -145,8 +144,10 @@ describe('DeviceWizardConfirmStep', () => {
 		expect(order).toEqual(['a', 'b']);
 	});
 
-	it('marks the header checkbox indeterminate when some but not all rows are selected', async () => {
-		const wrapper = mountStep([row(), row({ key: 'b', identifier: 'b' })], { allSelected: false, someSelected: true });
+	it('marks the header checkbox indeterminate when some but not all filtered rows are selected', async () => {
+		const wrapper = mountStep([row(), row({ key: 'b', identifier: 'b' })], {
+			selected: { 'shelly-1.local': true, b: false },
+		});
 
 		await flushPromises();
 
@@ -155,7 +156,9 @@ describe('DeviceWizardConfirmStep', () => {
 	});
 
 	it('does not mark the header checkbox indeterminate once every row is selected', async () => {
-		const wrapper = mountStep([row(), row({ key: 'b', identifier: 'b' })], { allSelected: true, someSelected: true });
+		const wrapper = mountStep([row(), row({ key: 'b', identifier: 'b' })], {
+			selected: { 'shelly-1.local': true, b: true },
+		});
 
 		await flushPromises();
 
@@ -183,5 +186,32 @@ describe('DeviceWizardConfirmStep', () => {
 		await wrapper.findComponent(ElSelect).setValue(DevicesModuleDeviceCategory.switcher);
 
 		expect(wrapper.emitted('update-category')?.[0]).toEqual(['shelly-1.local', DevicesModuleDeviceCategory.switcher]);
+	});
+
+	it('renders automatic names and categories read-only in selection-only mode', async () => {
+		const wrapper = mountStep([row()], { confirmationMode: 'selection-only' });
+
+		await flushPromises();
+
+		expect(wrapper.find('tbody input[type="text"]').exists()).toBe(false);
+		expect(wrapper.findComponent(ElSelect).exists()).toBe(false);
+		expect(wrapper.text()).toContain('Living room switch');
+		expect(wrapper.text()).toContain('Lighting');
+	});
+
+	it('filters rows and applies the header toggle only to visible matches', async () => {
+		const wrapper = mountStep([
+			row(),
+			row({ key: 'kitchen.local', identifier: 'kitchen.local', label: 'Kitchen light', suggestedName: 'Kitchen light' }),
+		]);
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-confirm-search"] input').setValue('kitchen');
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+		await wrapper.find('thead input[type="checkbox"]').setValue(true);
+
+		expect(wrapper.emitted('toggle-rows')?.[0]).toEqual([['kitchen.local'], true]);
 	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -1,7 +1,18 @@
 <template>
 	<div class="flex flex-col gap-3 h-full overflow-hidden">
+		<div
+			data-test-id="wizard-confirm-search"
+			class="shrink-0"
+		>
+			<el-input
+				v-model="search"
+				:placeholder="t('devicesModule.fields.devices.search.placeholder')"
+				clearable
+			/>
+		</div>
+
 		<el-table
-			:data="rows"
+			:data="filteredRows"
 			class="h-full w-full flex-grow"
 			table-layout="fixed"
 			:empty-text="t('devicesModule.wizard.texts.noSelection')"
@@ -10,10 +21,17 @@
 			<el-table-column width="60">
 				<template #header>
 					<el-checkbox
-						:model-value="allSelected"
-						:indeterminate="someSelected && !allSelected"
-						:disabled="rows.length === 0"
-						@change="(value: boolean | string | number) => emit('toggle-all', value === true)"
+						:model-value="allFilteredSelected"
+						:indeterminate="someFilteredSelected && !allFilteredSelected"
+						:disabled="filteredRows.length === 0"
+						@change="
+							(value: boolean | string | number) =>
+								emit(
+									'toggle-rows',
+									filteredRows.map((row) => row.key),
+									value === true
+								)
+						"
 					/>
 				</template>
 				<template #default="{ row }: { row: IWizardRow }">
@@ -33,9 +51,16 @@
 			>
 				<template #default="{ row }: { row: IWizardRow }">
 					<el-input
+						v-if="confirmationMode === 'editable'"
 						:model-value="nameByKey[row.key] ?? ''"
 						@update:model-value="(value: string) => emit('update-name', row.key, value)"
 					/>
+					<span
+						v-else
+						class="font-medium"
+					>
+						{{ nameByKey[row.key] ?? row.suggestedName }}
+					</span>
 				</template>
 			</el-table-column>
 
@@ -75,6 +100,7 @@
 			>
 				<template #default="{ row }: { row: IWizardRow }">
 					<el-select
+						v-if="confirmationMode === 'editable'"
 						:model-value="categoryByKey[row.key] ?? null"
 						filterable
 						@update:model-value="(value: DevicesModuleDeviceCategory | null) => emit('update-category', row.key, value)"
@@ -86,6 +112,9 @@
 							:value="option.value"
 						/>
 					</el-select>
+					<span v-else>
+						{{ categoryLabel(row) }}
+					</span>
 				</template>
 			</el-table-column>
 
@@ -107,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { ElCheckbox, ElInput, ElOption, ElSelect, ElTable, ElTableColumn, ElTag } from 'element-plus';
@@ -129,20 +158,55 @@ interface IProps {
 	nameByKey: Record<string, string>;
 	categoryByKey: Record<string, DevicesModuleDeviceCategory | null>;
 	identifierLabel: string;
-	allSelected: boolean;
-	someSelected: boolean;
+	confirmationMode: 'editable' | 'selection-only';
 }
 
 const props = defineProps<IProps>();
 
 const emit = defineEmits<{
-	(e: 'toggle-all', value: boolean): void;
 	(e: 'toggle-row', key: string, value: boolean): void;
+	(e: 'toggle-rows', keys: string[], value: boolean): void;
 	(e: 'update-name', key: string, value: string): void;
 	(e: 'update-category', key: string, value: DevicesModuleDeviceCategory | null): void;
 }>();
 
 const { t } = useI18n();
+
+const search = ref<string>('');
+
+const categoryLabel = (row: IWizardRow): string => {
+	const category = props.categoryByKey[row.key] ?? row.suggestedCategory;
+
+	return row.categoryOptions.find((option) => option.value === category)?.label ?? '';
+};
+
+const filteredRows = computed<IWizardRow[]>(() => {
+	const query = search.value.trim().toLocaleLowerCase();
+
+	if (query.length === 0) {
+		return props.rows;
+	}
+
+	return props.rows.filter((row) => {
+		const values = [
+			row.label,
+			row.subLabel,
+			row.identifier,
+			row.statusLabel,
+			props.nameByKey[row.key],
+			categoryLabel(row),
+			...Object.values(row.cells ?? {}).map((cell) => cell.value),
+		];
+
+		return values.some((value) => value?.toLocaleLowerCase().includes(query));
+	});
+});
+
+const allFilteredSelected = computed<boolean>(
+	() => filteredRows.value.length > 0 && filteredRows.value.every((row) => props.selected[row.key] === true)
+);
+
+const someFilteredSelected = computed<boolean>(() => filteredRows.value.some((row) => props.selected[row.key] === true));
 
 const extraColumns = computed<IWizardColumn[]>(() => props.columns.filter((column) => column.steps.includes('confirm')));
 
@@ -161,13 +225,7 @@ const sortByChange = (a: IWizardRow, b: IWizardRow): number => {
 };
 
 const sortByCategory = (a: IWizardRow, b: IWizardRow): number => {
-	const label = (row: IWizardRow): string => {
-		const category = props.categoryByKey[row.key];
-
-		return row.categoryOptions.find((option) => option.value === category)?.label ?? '';
-	};
-
-	return compareLocale(label(a), label(b));
+	return compareLocale(categoryLabel(a), categoryLabel(b));
 };
 
 const sortByCell = (key: string, a: IWizardRow, b: IWizardRow): number => compareLocale(a.cells?.[key]?.value, b.cells?.[key]?.value);

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -192,7 +192,7 @@ const filteredRows = computed<IWizardRow[]>(() => {
 			row.label,
 			row.subLabel,
 			row.identifier,
-			row.statusLabel,
+			row.statusLabel ?? t(`devicesModule.wizard.statuses.${row.status}`),
 			props.nameByKey[row.key],
 			categoryLabel(row),
 			...Object.values(row.cells ?? {}).map((cell) => cell.value),

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -162,4 +162,15 @@ describe('DeviceWizardDiscoverStep', () => {
 		expect(wrapper.text()).toContain('Kitchen light');
 		expect(wrapper.text()).not.toContain('Living room switch');
 	});
+
+	it('filters by the rendered fallback status label', async () => {
+		const wrapper = mountStep([], [row(), row({ key: 'registered', identifier: 'registered', status: 'already_registered' })]);
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-discover-search"] input').setValue('already_registered');
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+		expect(wrapper.text()).toContain('registered');
+	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -139,4 +139,27 @@ describe('DeviceWizardDiscoverStep', () => {
 		expect(wrapper.text()).toContain('Shelly Plus 1');
 		expect(wrapper.text()).toContain('shelly-1.local');
 	});
+
+	it('filters discovered rows by label, identifier, and extra-cell value', async () => {
+		const wrapper = mountStep(
+			[],
+			[
+				row(),
+				row({
+					key: 'kitchen.local',
+					identifier: 'kitchen.local',
+					label: 'Kitchen light',
+					cells: { kind: { render: 'text', value: 'helper' } },
+				}),
+			]
+		);
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-discover-search"] input').setValue('helper');
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+		expect(wrapper.text()).toContain('Kitchen light');
+		expect(wrapper.text()).not.toContain('Living room switch');
+	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -227,7 +227,13 @@ const filteredRows = computed<IWizardRow[]>(() => {
 	}
 
 	return props.rows.filter((row) => {
-		const values = [row.label, row.subLabel, row.identifier, row.statusLabel, ...Object.values(row.cells ?? {}).map((cell) => cell.value)];
+		const values = [
+			row.label,
+			row.subLabel,
+			row.identifier,
+			row.statusLabel ?? t(`devicesModule.wizard.statuses.${row.status}`),
+			...Object.values(row.cells ?? {}).map((cell) => cell.value),
+		];
 
 		return values.some((value) => value?.toLocaleLowerCase().includes(query));
 	});

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -103,8 +103,19 @@
 			</el-form>
 		</div>
 
+		<div
+			data-test-id="wizard-discover-search"
+			class="shrink-0"
+		>
+			<el-input
+				v-model="search"
+				:placeholder="t('devicesModule.fields.devices.search.placeholder')"
+				clearable
+			/>
+		</div>
+
 		<el-table
-			:data="rows"
+			:data="filteredRows"
 			class="h-full w-full flex-grow"
 			table-layout="fixed"
 			:empty-text="t('devicesModule.wizard.texts.empty')"
@@ -171,7 +182,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue';
+import { computed, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElProgress, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
@@ -205,6 +216,22 @@ interface IProps {
 const props = defineProps<IProps>();
 
 const { t } = useI18n();
+
+const search = ref<string>('');
+
+const filteredRows = computed<IWizardRow[]>(() => {
+	const query = search.value.trim().toLocaleLowerCase();
+
+	if (query.length === 0) {
+		return props.rows;
+	}
+
+	return props.rows.filter((row) => {
+		const values = [row.label, row.subLabel, row.identifier, row.statusLabel, ...Object.values(row.cells ?? {}).map((cell) => cell.value)];
+
+		return values.some((value) => value?.toLocaleLowerCase().includes(query));
+	});
+});
 
 const banners = computed<IWizardBannerControl[]>(() => props.controls.filter((item): item is IWizardBannerControl => item.type === 'banner'));
 

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard.types.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard.types.ts
@@ -5,7 +5,7 @@ import type { DevicesModuleDeviceCategory } from '../../../../openapi.constants'
 
 export type IWizardStep = 'discover' | 'confirm' | 'results';
 
-export type IWizardRowStatus = 'checking' | 'ready' | 'needs_credentials' | 'already_registered' | 'unsupported' | 'failed';
+export type IWizardRowStatus = 'checking' | 'ready' | 'needs_credentials' | 'needs_attention' | 'already_registered' | 'unsupported' | 'failed';
 
 export type IWizardCell =
 	| { render: 'text'; value: string; muted?: boolean }
@@ -33,6 +33,8 @@ export interface IWizardRow {
 	statusLabel?: string;
 	/** The adapter decides; the shell never infers adoptability from status. */
 	adoptable: boolean;
+	/** Defaults to `status === 'ready'`. Set false for explicit-selection bulk inventories. */
+	selectedByDefault?: boolean;
 	willUpdate: boolean;
 	suggestedName: string;
 	suggestedCategory: DevicesModuleDeviceCategory | null;
@@ -117,6 +119,8 @@ interface IDeviceWizardAdapterBase {
 	/** Breadcrumb route param, e.g. 'devices-shelly-ng-plugin'. */
 	pluginType: string;
 	identifierLabel: string;
+	/** Defaults to editable. Selection-only keeps automatic names/categories read-only. */
+	confirmationMode?: 'editable' | 'selection-only';
 
 	rows: ComputedRef<IWizardRow[]>;
 	results: ComputedRef<IWizardResult[]>;
@@ -183,7 +187,7 @@ export const wizardStatusTagType = (status: IWizardRowStatus): 'success' | 'info
 		return 'info';
 	}
 
-	if (status === 'needs_credentials' || status === 'unsupported') {
+	if (status === 'needs_credentials' || status === 'needs_attention' || status === 'unsupported') {
 		return 'warning';
 	}
 

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard.vue
@@ -106,10 +106,9 @@
 					:name-by-key="nameByKey"
 					:category-by-key="categoryByKey"
 					:identifier-label="adapter.identifierLabel"
-					:all-selected="allSelected"
-					:some-selected="someSelected"
-					@toggle-all="toggleAll"
+					:confirmation-mode="adapter.confirmationMode ?? 'editable'"
 					@toggle-row="onToggleRow"
+					@toggle-rows="toggleRows"
 					@update-name="onUpdateName"
 					@update-category="onUpdateCategory"
 				/>
@@ -184,21 +183,8 @@ const { isMDDevice, isLGDevice } = useBreakpoints();
 // useI18n / useBackend / inject internally, which are only valid in an injection context.
 const adapter = props.adapterFactory();
 
-const {
-	activeStep,
-	activeStepIndex,
-	selected,
-	nameByKey,
-	categoryByKey,
-	adoptableRows,
-	canContinue,
-	allSelected,
-	someSelected,
-	toggleAll,
-	reconcile,
-	reset,
-	buildSelection,
-} = useDeviceWizardState(adapter.rows);
+const { activeStep, activeStepIndex, selected, nameByKey, categoryByKey, adoptableRows, canContinue, toggleRows, reconcile, reset, buildSelection } =
+	useDeviceWizardState(adapter.rows);
 
 // A rescan opens a brand new discovery session, and the previous session's selections must not
 // survive into it: a device that was `ready` last time may come back as `already_registered`,

--- a/apps/admin/src/modules/devices/composables/useDeviceWizardState.spec.ts
+++ b/apps/admin/src/modules/devices/composables/useDeviceWizardState.spec.ts
@@ -38,6 +38,14 @@ describe('useDeviceWizardState — reconciliation', () => {
 		expect(state.selected['shelly-1.local']).toBe(false);
 	});
 
+	it('lets an adapter require explicit selection for a ready row', () => {
+		const state = useDeviceWizardState();
+
+		state.reconcile([row({ selectedByDefault: false })]);
+
+		expect(state.selected['shelly-1.local']).toBe(false);
+	});
+
 	it('selects a row on its first transition to ready', () => {
 		const state = useDeviceWizardState();
 
@@ -227,6 +235,21 @@ describe('useDeviceWizardState — derived state', () => {
 
 		state.toggleAll(true);
 		expect(state.allSelected.value).toBe(true);
+		expect(state.selected['c']).toBeUndefined();
+	});
+
+	it('toggleRows changes only the requested adoptable rows', () => {
+		const rows = ref<IWizardRow[]>([
+			row(),
+			row({ key: 'b', identifier: 'b' }),
+			row({ key: 'c', identifier: 'c', adoptable: false, status: 'failed' }),
+		]);
+		const state = useDeviceWizardState(rows);
+
+		state.toggleRows(['b', 'c'], true);
+
+		expect(state.selected['shelly-1.local']).toBeUndefined();
+		expect(state.selected['b']).toBe(true);
 		expect(state.selected['c']).toBeUndefined();
 	});
 

--- a/apps/admin/src/modules/devices/composables/useDeviceWizardState.ts
+++ b/apps/admin/src/modules/devices/composables/useDeviceWizardState.ts
@@ -15,6 +15,7 @@ export interface IUseDeviceWizardState {
 	allSelected: ComputedRef<boolean>;
 	someSelected: ComputedRef<boolean>;
 	toggleAll: (value: boolean) => void;
+	toggleRows: (keys: string[], value: boolean) => void;
 	reconcile: (rows: IWizardRow[]) => void;
 	reset: () => void;
 	buildSelection: () => IWizardAdoptSelection[];
@@ -68,10 +69,21 @@ export const useDeviceWizardState = (rows: Ref<IWizardRow[]> | ComputedRef<IWiza
 
 	const someSelected = computed<boolean>(() => adoptableRows.value.some((item) => selected[item.key] === true));
 
-	const toggleAll = (value: boolean): void => {
-		for (const item of adoptableRows.value) {
-			selected[item.key] = value;
+	const toggleRows = (keys: string[], value: boolean): void => {
+		const adoptableKeys = new Set(adoptableRows.value.map((item) => item.key));
+
+		for (const key of keys) {
+			if (adoptableKeys.has(key)) {
+				selected[key] = value;
+			}
 		}
+	};
+
+	const toggleAll = (value: boolean): void => {
+		toggleRows(
+			adoptableRows.value.map((item) => item.key),
+			value
+		);
 	};
 
 	const buildSelection = (): IWizardAdoptSelection[] =>
@@ -85,14 +97,15 @@ export const useDeviceWizardState = (rows: Ref<IWizardRow[]> | ComputedRef<IWiza
 		for (const row of rows) {
 			const previous = previousRows.value.find((item) => item.key === row.key);
 
-			const firstTimeReady = row.status === 'ready' && !everReady.has(row.key);
+			const selectedByDefault = row.selectedByDefault ?? row.status === 'ready';
+			const firstTimeReady = row.status === 'ready' && selectedByDefault && !everReady.has(row.key);
 			const becameAlreadyRegistered = previous !== undefined && previous.status !== 'already_registered' && row.status === 'already_registered';
 			const becameAdoptable = previous !== undefined && !previous.adoptable && row.adoptable;
 
 			// Pre-select ready devices on first sight and on their first transition to ready,
 			// but never resurrect a selection the user cleared.
 			if (selected[row.key] === undefined || firstTimeReady) {
-				selected[row.key] = row.status === 'ready';
+				selected[row.key] = selectedByDefault;
 			} else if (becameAlreadyRegistered) {
 				// The background connector adopted this device mid-session. Updating it is now
 				// an explicit opt-in rather than the default.
@@ -149,6 +162,7 @@ export const useDeviceWizardState = (rows: Ref<IWizardRow[]> | ComputedRef<IWiza
 		allSelected,
 		someSelected,
 		toggleAll,
+		toggleRows,
 		reconcile,
 		reset,
 		buildSelection,

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -7,7 +7,6 @@
  *
  * @module openapi.constants
  */
-
 // Core OpenAPI Types
 // ==================
 import type { components, operations, paths } from './openapi';
@@ -143,11 +142,22 @@ export type DevicesHomeAssistantPluginAdoptHelperRequestSchema = components['sch
 export type DevicesHomeAssistantPluginStateSchema = components['schemas']['DevicesHomeAssistantPluginDataState'];
 export type DevicesHomeAssistantPluginUpdateConfigSchema = components['schemas']['DevicesHomeAssistantPluginUpdateConfig'];
 export type DevicesHomeAssistantPluginConfigSchema = components['schemas']['DevicesHomeAssistantPluginDataConfig'];
+export type DevicesHomeAssistantPluginWizardCandidateSchema = components['schemas']['DevicesHomeAssistantPluginDataWizardCandidate'];
+export type DevicesHomeAssistantPluginWizardSessionSchema = components['schemas']['DevicesHomeAssistantPluginDataWizardSession'];
+export type DevicesHomeAssistantPluginWizardAdoptionSchema = components['schemas']['DevicesHomeAssistantPluginDataWizardAdoption'];
+export {
+	DevicesHomeAssistantPluginDataWizardAdoptionResultStatus,
+	DevicesHomeAssistantPluginDataWizardCandidateKind,
+	DevicesHomeAssistantPluginDataWizardCandidateStatus,
+} from './openapi';
 
 // Data Sources Device Channel Plugin Schemas
-export type DataSourcesDeviceChannelPluginCreateDeviceChannelDataSourceSchema = components['schemas']['DataSourcesDeviceChannelPluginCreateDeviceChannelDataSource'];
-export type DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSourceSchema = components['schemas']['DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSource'];
-export type DataSourcesDeviceChannelPluginDeviceChannelDataSourceSchema = components['schemas']['DataSourcesDeviceChannelPluginDataDeviceChannelDataSource'];
+export type DataSourcesDeviceChannelPluginCreateDeviceChannelDataSourceSchema =
+	components['schemas']['DataSourcesDeviceChannelPluginCreateDeviceChannelDataSource'];
+export type DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSourceSchema =
+	components['schemas']['DataSourcesDeviceChannelPluginUpdateDeviceChannelDataSource'];
+export type DataSourcesDeviceChannelPluginDeviceChannelDataSourceSchema =
+	components['schemas']['DataSourcesDeviceChannelPluginDataDeviceChannelDataSource'];
 
 // Devices Shelly V1 Plugin Schemas
 export type DevicesShellyV1PluginDeviceSchema = components['schemas']['DevicesShellyV1PluginDataDevice'];
@@ -421,6 +431,10 @@ export type DevicesHomeAssistantPluginGetHelpersOperation = operations['get-devi
 export type DevicesHomeAssistantPluginGetHelperOperation = operations['get-devices-home-assistant-plugin-helper'];
 export type DevicesHomeAssistantPluginPreviewHelperMappingOperation = operations['preview-devices-home-assistant-plugin-helper-mapping'];
 export type DevicesHomeAssistantPluginAdoptHelperOperation = operations['adopt-devices-home-assistant-plugin-helper'];
+export type DevicesHomeAssistantPluginCreateWizardOperation = operations['create-devices-home-assistant-plugin-wizard'];
+export type DevicesHomeAssistantPluginGetWizardOperation = operations['get-devices-home-assistant-plugin-wizard'];
+export type DevicesHomeAssistantPluginDeleteWizardOperation = operations['delete-devices-home-assistant-plugin-wizard'];
+export type DevicesHomeAssistantPluginAdoptWizardOperation = operations['adopt-devices-home-assistant-plugin-wizard'];
 
 // Devices Virtual Plugin Operations
 export type DevicesVirtualPluginCheckCompatibilityOperation = operations['check-devices-virtual-plugin-devices-compatibility'];

--- a/apps/admin/src/plugins/devices-home-assistant/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/composables.ts
@@ -11,5 +11,6 @@ export * from './useEntitiesOptions';
 export * from './useAttributesOptions';
 export { useMappingPreview, type IUseMappingPreview } from './useMappingPreview';
 export { useDeviceAdoption, type IUseDeviceAdoption } from './useDeviceAdoption';
+export * from './useDevicesWizard';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -23,6 +23,11 @@ const flashMessage = {
 	warning: vi.fn(),
 };
 
+const devicesStore = { fetch: vi.fn() };
+const discoveredDevicesStore = { fetch: vi.fn() };
+const discoveredHelpersStore = { fetch: vi.fn() };
+const stores = [devicesStore, discoveredDevicesStore, discoveredHelpersStore];
+
 vi.mock('vue-i18n', () => ({
 	createI18n: () => ({
 		global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => undefined },
@@ -37,6 +42,7 @@ vi.mock('../../../common', async () => {
 
 	return {
 		...actual,
+		injectStoresManager: () => ({ getStore: vi.fn(() => stores.shift()) }),
 		useBackend: () => ({ client: backendClient }),
 		useFlashMessage: () => flashMessage,
 		useLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
@@ -67,6 +73,10 @@ const wizardSession: DevicesHomeAssistantPluginWizardSessionSchema = {
 describe('useDevicesWizard', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		stores.splice(0, stores.length, devicesStore, discoveredDevicesStore, discoveredHelpersStore);
+		devicesStore.fetch.mockResolvedValue([]);
+		discoveredDevicesStore.fetch.mockResolvedValue([]);
+		discoveredHelpersStore.fetch.mockResolvedValue([]);
 	});
 
 	it('starts a selection-only bulk session and maps ready candidates', async () => {
@@ -144,6 +154,34 @@ describe('useDevicesWizard', () => {
 				error: null,
 			},
 		]);
+		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
+		expect(discoveredDevicesStore.fetch).toHaveBeenCalledTimes(1);
+		expect(discoveredHelpersStore.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces an isolated candidate mapping error in its status and tooltip', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: {
+					...wizardSession,
+					candidates: [
+						{
+							...readyCandidate,
+							status: DevicesHomeAssistantPluginDataWizardCandidateStatus.failed,
+							warningCount: 1,
+							error: 'Home Assistant registry entry disappeared',
+						},
+					],
+				},
+			},
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		expect(adapter.rows.value[0].statusLabel).toBe('Home Assistant registry entry disappeared');
+		expect(adapter.rows.value[0].cells?.channels).toEqual(expect.objectContaining({ tooltip: 'Home Assistant registry entry disappeared' }));
 	});
 
 	it('shows an actionable configuration banner when the inventory cannot be loaded', async () => {

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -211,6 +211,30 @@ describe('useDevicesWizard', () => {
 		});
 	});
 
+	it('clears the busy state and shows a retry banner when session transport rejects', async () => {
+		backendClient.POST.mockRejectedValueOnce(new Error('Backend unreachable'));
+		const adapter = useDevicesWizard();
+
+		await expect(adapter.start()).rejects.toThrow('Backend unreachable');
+
+		expect(adapter.busy.value).toBe(false);
+		expect(adapter.ready.value).toBe(true);
+		expect((adapter.controls.value[0] as IWizardBannerControl).message).toBe('Backend unreachable');
+	});
+
+	it('clears the busy state when adoption transport rejects', async () => {
+		backendClient.POST.mockResolvedValueOnce({ data: { data: wizardSession }, response: { status: 201 } });
+		backendClient.POST.mockRejectedValueOnce(new Error('Connection dropped'));
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		await expect(
+			adapter.adopt([{ key: readyCandidate.key, name: readyCandidate.name, category: DevicesModuleDeviceCategory.generic }])
+		).rejects.toThrow('Connection dropped');
+
+		expect(adapter.busy.value).toBe(false);
+	});
+
 	it('rescans by replacing the server-side snapshot', async () => {
 		backendClient.POST.mockResolvedValueOnce({ data: { data: wizardSession }, response: { status: 201 } }).mockResolvedValueOnce({
 			data: { data: { ...wizardSession, id: 'session-2' } },

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IWizardBannerControl } from '../../../modules/devices';
 import {
@@ -12,6 +12,7 @@ import { DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX } from '../devices-home-assistant.
 import { useDevicesWizard } from './useDevicesWizard';
 
 const backendClient = {
+	GET: vi.fn(),
 	POST: vi.fn(),
 	DELETE: vi.fn(),
 };
@@ -72,11 +73,18 @@ const wizardSession: DevicesHomeAssistantPluginWizardSessionSchema = {
 
 describe('useDevicesWizard', () => {
 	beforeEach(() => {
+		vi.useFakeTimers();
 		vi.clearAllMocks();
 		stores.splice(0, stores.length, devicesStore, discoveredDevicesStore, discoveredHelpersStore);
 		devicesStore.fetch.mockResolvedValue([]);
 		discoveredDevicesStore.fetch.mockResolvedValue([]);
 		discoveredHelpersStore.fetch.mockResolvedValue([]);
+		backendClient.GET.mockResolvedValue({ data: { data: wizardSession }, response: { status: 200 } });
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
 	});
 
 	it('starts a selection-only bulk session and maps ready candidates', async () => {
@@ -216,7 +224,7 @@ describe('useDevicesWizard', () => {
 		const refresh = adapter.controls.value.find((control) => control.type === 'action' && control.id === 'refresh');
 		expect(refresh?.type).toBe('action');
 		if (refresh?.type === 'action') {
-			await refresh.handler();
+			await Promise.all([refresh.handler(), refresh.handler()]);
 		}
 
 		expect(backendClient.DELETE).toHaveBeenCalledWith(`/plugins/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
@@ -224,5 +232,18 @@ describe('useDevicesWizard', () => {
 		});
 		expect(backendClient.POST).toHaveBeenCalledTimes(2);
 		expect(adapter.sessionKey?.value).toBe('session-2');
+	});
+
+	it('keeps an open wizard session active while the administrator reviews candidates', async () => {
+		backendClient.POST.mockResolvedValue({ data: { data: wizardSession }, response: { status: 201 } });
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		await vi.advanceTimersByTimeAsync(4 * 60_000);
+
+		expect(backendClient.GET).toHaveBeenCalledWith(`/plugins/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+			params: { path: { id: 'session-1' } },
+		});
+		await adapter.dispose?.();
 	});
 });

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IWizardBannerControl } from '../../../modules/devices';
+import {
+	DevicesHomeAssistantPluginDataWizardCandidateKind,
+	DevicesHomeAssistantPluginDataWizardCandidateStatus,
+	type DevicesHomeAssistantPluginWizardSessionSchema,
+	DevicesModuleDeviceCategory,
+} from '../../../openapi.constants';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX } from '../devices-home-assistant.constants';
+
+import { useDevicesWizard } from './useDevicesWizard';
+
+const backendClient = {
+	POST: vi.fn(),
+	DELETE: vi.fn(),
+};
+
+const flashMessage = {
+	error: vi.fn(),
+	info: vi.fn(),
+	success: vi.fn(),
+	warning: vi.fn(),
+};
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({
+		global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => undefined },
+	}),
+	useI18n: () => ({
+		t: (key: string, params?: Record<string, unknown>) => (params === undefined ? key : `${key}:${JSON.stringify(params)}`),
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: () => ({ client: backendClient }),
+		useFlashMessage: () => flashMessage,
+		useLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+	};
+});
+
+const readyCandidate = {
+	key: 'device:ha-device-1',
+	kind: DevicesHomeAssistantPluginDataWizardCandidateKind.device,
+	sourceId: 'ha-device-1',
+	name: 'Living room lamp',
+	manufacturer: 'Philips',
+	model: 'Hue',
+	status: DevicesHomeAssistantPluginDataWizardCandidateStatus.ready,
+	suggestedCategory: DevicesModuleDeviceCategory.lighting,
+	previewChannelCount: 2,
+	warningCount: 0,
+	adoptedDeviceId: null,
+	error: null,
+};
+
+const wizardSession: DevicesHomeAssistantPluginWizardSessionSchema = {
+	id: 'session-1',
+	startedAt: '2026-08-12T10:00:00.000Z',
+	candidates: [readyCandidate],
+};
+
+describe('useDevicesWizard', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('starts a selection-only bulk session and maps ready candidates', async () => {
+		backendClient.POST.mockResolvedValue({ data: { data: wizardSession }, response: { status: 201 } });
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		expect(adapter.confirmationMode).toBe('selection-only');
+		expect(adapter.ready.value).toBe(true);
+		expect(adapter.rows.value[0]).toEqual(
+			expect.objectContaining({
+				key: 'device:ha-device-1',
+				label: 'Living room lamp',
+				identifier: 'ha-device-1',
+				status: 'ready',
+				adoptable: true,
+				selectedByDefault: false,
+				suggestedCategory: DevicesModuleDeviceCategory.lighting,
+			})
+		);
+	});
+
+	it('keeps candidates requiring review unavailable and links to controlled adoption', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: {
+					...wizardSession,
+					candidates: [
+						{
+							...readyCandidate,
+							status: DevicesHomeAssistantPluginDataWizardCandidateStatus.needs_attention,
+							warningCount: 1,
+						},
+					],
+				},
+			},
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ status: 'needs_attention', adoptable: false, selectedByDefault: false }));
+		const banner = adapter.controls.value[0] as IWizardBannerControl;
+		expect(banner.id).toBe('manual-review');
+		expect(banner.link?.to).toEqual({ name: 'devices_module-devices_add' });
+	});
+
+	it('sends only selected candidate keys to bulk adoption', async () => {
+		backendClient.POST.mockResolvedValueOnce({ data: { data: wizardSession }, response: { status: 201 } });
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
+				data: {
+					results: [{ key: readyCandidate.key, name: readyCandidate.name, status: 'created', error: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: readyCandidate.key, name: 'Ignored override', category: DevicesModuleDeviceCategory.generic }]);
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(`/plugins/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
+			params: { path: { id: 'session-1' } },
+			body: { data: { keys: ['device:ha-device-1'] } },
+		});
+		expect(results).toEqual([
+			{
+				key: readyCandidate.key,
+				name: readyCandidate.name,
+				identifier: readyCandidate.sourceId,
+				status: 'created',
+				error: null,
+			},
+		]);
+	});
+
+	it('shows an actionable configuration banner when the inventory cannot be loaded', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: undefined,
+			error: { message: 'Home Assistant is offline' },
+			response: { status: 503 },
+		});
+		const adapter = useDevicesWizard();
+
+		await expect(adapter.start()).rejects.toThrow();
+
+		expect(adapter.ready.value).toBe(true);
+		const banner = adapter.controls.value[0] as IWizardBannerControl;
+		expect(banner.id).toBe('connection-error');
+		expect(banner.link?.to).toEqual({
+			name: 'config_module-config_plugin_edit',
+			params: { plugin: 'devices-home-assistant-plugin' },
+		});
+	});
+
+	it('rescans by replacing the server-side snapshot', async () => {
+		backendClient.POST.mockResolvedValue({ data: { data: wizardSession }, response: { status: 201 } });
+		backendClient.DELETE.mockResolvedValue({ response: { status: 204 } });
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+		const refresh = adapter.controls.value.find((control) => control.type === 'action' && control.id === 'refresh');
+		expect(refresh?.type).toBe('action');
+		if (refresh?.type === 'action') {
+			await refresh.handler();
+		}
+
+		expect(backendClient.DELETE).toHaveBeenCalledWith(`/plugins/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+			params: { path: { id: 'session-1' } },
+		});
+		expect(backendClient.POST).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -166,11 +166,15 @@ describe('useDevicesWizard', () => {
 	});
 
 	it('rescans by replacing the server-side snapshot', async () => {
-		backendClient.POST.mockResolvedValue({ data: { data: wizardSession }, response: { status: 201 } });
+		backendClient.POST.mockResolvedValueOnce({ data: { data: wizardSession }, response: { status: 201 } }).mockResolvedValueOnce({
+			data: { data: { ...wizardSession, id: 'session-2' } },
+			response: { status: 201 },
+		});
 		backendClient.DELETE.mockResolvedValue({ response: { status: 204 } });
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
+		expect(adapter.sessionKey?.value).toBe('session-1');
 		const refresh = adapter.controls.value.find((control) => control.type === 'action' && control.id === 'refresh');
 		expect(refresh?.type).toBe('action');
 		if (refresh?.type === 'action') {
@@ -181,5 +185,6 @@ describe('useDevicesWizard', () => {
 			params: { path: { id: 'session-1' } },
 		});
 		expect(backendClient.POST).toHaveBeenCalledTimes(2);
+		expect(adapter.sessionKey?.value).toBe('session-2');
 	});
 });

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -270,4 +270,27 @@ describe('useDevicesWizard', () => {
 		});
 		await adapter.dispose?.();
 	});
+
+	it('deletes a session that arrives after the wizard has been disposed', async () => {
+		let resolveStart: ((value: unknown) => void) | undefined;
+		backendClient.POST.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveStart = resolve;
+				})
+		);
+		backendClient.DELETE.mockResolvedValue({ response: { status: 204 } });
+		const adapter = useDevicesWizard();
+
+		const starting = adapter.start();
+		await adapter.dispose?.();
+		resolveStart?.({ data: { data: wizardSession }, response: { status: 201 } });
+		await starting;
+		await vi.advanceTimersByTimeAsync(4 * 60_000);
+
+		expect(backendClient.DELETE).toHaveBeenCalledWith(`/plugins/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+			params: { path: { id: 'session-1' } },
+		});
+		expect(backendClient.GET).not.toHaveBeenCalled();
+	});
 });

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -192,7 +192,20 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const startSession = async (): Promise<void> => {
 		formResult.value = FormResult.WORKING;
 		sessionError.value = null;
-		const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard`);
+		let started;
+
+		try {
+			started = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard`);
+		} catch (transportError: unknown) {
+			const fallback = t('devicesHomeAssistantPlugin.wizard.messages.sessionNotStarted');
+			const reason = transportError instanceof Error && transportError.message ? transportError.message : fallback;
+			formResult.value = FormResult.ERROR;
+			sessionError.value = reason;
+			flashMessage.error(reason);
+			throw new DevicesHomeAssistantApiException(reason, null, transportError instanceof Error ? transportError : null);
+		}
+
+		const { data, error, response } = started;
 
 		if (typeof data !== 'undefined') {
 			const nextSession = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
@@ -257,10 +270,22 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}
 
 		formResult.value = FormResult.WORKING;
-		const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
-			params: { path: { id: session.value.id } },
-			body: transformWizardAdoptRequest(selection.map((item) => item.key)),
-		});
+		let adopted;
+
+		try {
+			adopted = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
+				params: { path: { id: session.value.id } },
+				body: transformWizardAdoptRequest(selection.map((item) => item.key)),
+			});
+		} catch (transportError: unknown) {
+			const fallback = t('devicesHomeAssistantPlugin.wizard.messages.adoptionFailed');
+			const reason = transportError instanceof Error && transportError.message ? transportError.message : fallback;
+			formResult.value = FormResult.ERROR;
+			flashMessage.error(reason);
+			throw new DevicesHomeAssistantApiException(reason, null, transportError instanceof Error ? transportError : null);
+		}
+
+		const { data, error, response } = adopted;
 
 		if (typeof data !== 'undefined') {
 			adoptionResults.value = transformWizardAdoptionResponse((data as { data: DevicesHomeAssistantPluginWizardAdoptionSchema }).data);

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -21,6 +21,7 @@ import type {
 	DevicesHomeAssistantPluginAdoptWizardOperation,
 	DevicesHomeAssistantPluginCreateWizardOperation,
 	DevicesHomeAssistantPluginDeleteWizardOperation,
+	DevicesHomeAssistantPluginGetWizardOperation,
 	DevicesHomeAssistantPluginWizardAdoptionSchema,
 	DevicesHomeAssistantPluginWizardSessionSchema,
 } from '../../../openapi.constants';
@@ -31,6 +32,7 @@ import { discoveredDevicesStoreKey, discoveredHelpersStoreKey } from '../store/k
 import { transformWizardAdoptRequest, transformWizardAdoptionResponse, transformWizardSessionResponse } from '../utils/wizard.transformers';
 
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
+	const sessionKeepaliveMs = 4 * 60_000;
 	const { t } = useI18n();
 	const backend = useBackend();
 	const flashMessage = useFlashMessage();
@@ -46,6 +48,33 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const adoptionResults = ref<IHomeAssistantWizardAdoptionResult[]>([]);
 	const formResult = ref<FormResultType>(FormResult.NONE);
 	const sessionError = ref<string | null>(null);
+	let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+	let restartPromise: Promise<void> | null = null;
+
+	const stopKeepalive = (): void => {
+		if (keepaliveTimer !== null) {
+			clearInterval(keepaliveTimer);
+			keepaliveTimer = null;
+		}
+	};
+
+	const startKeepalive = (id: string): void => {
+		stopKeepalive();
+		keepaliveTimer = setInterval(() => {
+			void backend.client
+				.GET(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+					params: { path: { id } },
+				})
+				.then(({ error }) => {
+					if (error) {
+						logger.warn(
+							getErrorReason<DevicesHomeAssistantPluginGetWizardOperation>(error, 'Failed to keep the Home Assistant wizard session active')
+						);
+					}
+				})
+				.catch((error: unknown) => logger.warn('Failed to keep the Home Assistant wizard session active', error));
+		}, sessionKeepaliveMs);
+	};
 
 	const candidates = computed<IHomeAssistantWizardCandidate[]>(() =>
 		orderBy(session.value?.candidates ?? [], [(candidate) => (candidate.status === 'ready' ? 0 : 1), (candidate) => candidate.name], ['asc', 'asc'])
@@ -115,10 +144,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			variant: 'default',
 			disabled: formResult.value === FormResult.WORKING,
 			loading: formResult.value === FormResult.WORKING,
-			handler: async (): Promise<void> => {
-				await endSession();
-				await startSession();
-			},
+			handler: restartSession,
 		};
 
 		if (sessionError.value !== null) {
@@ -172,6 +198,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			const nextSession = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
 			session.value = nextSession;
 			sessionKey.value = nextSession.id;
+			startKeepalive(nextSession.id);
 			adoptionResults.value = [];
 			formResult.value = FormResult.OK;
 			return;
@@ -186,6 +213,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	};
 
 	const endSession = async (): Promise<void> => {
+		stopKeepalive();
 		const currentSession = session.value;
 		session.value = null;
 		sessionError.value = null;
@@ -205,6 +233,22 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		} catch (error: unknown) {
 			logger.warn('Failed to cleanly end Home Assistant wizard session', error);
 		}
+	};
+
+	const restartSession = (): Promise<void> => {
+		if (restartPromise !== null) {
+			return restartPromise;
+		}
+
+		formResult.value = FormResult.WORKING;
+		restartPromise = (async (): Promise<void> => {
+			await endSession();
+			await startSession();
+		})().finally(() => {
+			restartPromise = null;
+		});
+
+		return restartPromise;
 	};
 
 	const adopt = async (selection: IWizardAdoptSelection[]): Promise<IWizardResult[]> => {
@@ -264,10 +308,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		capabilities: { addMore: true },
 		start: startSession,
 		adopt,
-		restart: async (): Promise<void> => {
-			await endSession();
-			await startSession();
-		},
+		restart: restartSession,
 		dispose: endSession,
 	};
 };

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { orderBy } from 'natural-orderby';
 
 import { PLUGINS_PREFIX } from '../../../app.constants';
-import { getErrorReason, useBackend, useFlashMessage, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, useBackend, useFlashMessage, useLogger } from '../../../common';
 import { RouteNames as ConfigRouteNames } from '../../../modules/config';
 import {
 	RouteNames as DevicesRouteNames,
@@ -15,6 +15,7 @@ import {
 	type IWizardControl,
 	type IWizardResult,
 	type IWizardRow,
+	devicesStoreKey,
 } from '../../../modules/devices';
 import type {
 	DevicesHomeAssistantPluginAdoptWizardOperation,
@@ -26,6 +27,7 @@ import type {
 import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME, DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX } from '../devices-home-assistant.constants';
 import { DevicesHomeAssistantApiException } from '../devices-home-assistant.exceptions';
 import type { IHomeAssistantWizardAdoptionResult, IHomeAssistantWizardCandidate, IHomeAssistantWizardSession } from '../schemas/wizard.types';
+import { discoveredDevicesStoreKey, discoveredHelpersStoreKey } from '../store/keys';
 import { transformWizardAdoptRequest, transformWizardAdoptionResponse, transformWizardSessionResponse } from '../utils/wizard.transformers';
 
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
@@ -33,6 +35,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const backend = useBackend();
 	const flashMessage = useFlashMessage();
 	const logger = useLogger();
+	const storesManager = injectStoresManager();
+	const devicesStore = storesManager.getStore(devicesStoreKey);
+	const discoveredDevicesStore = storesManager.getStore(discoveredDevicesStoreKey);
+	const discoveredHelpersStore = storesManager.getStore(discoveredHelpersStoreKey);
 	const session = ref<IHomeAssistantWizardSession | null>(null);
 	// Keep the last non-null session identity across DELETE so a refresh produces a direct
 	// old-id -> new-id transition. The shared shell uses that transition to clear row state.
@@ -52,7 +58,8 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			subLabel: [candidate.manufacturer, candidate.model].filter(Boolean).join(' · ') || null,
 			identifier: candidate.sourceId,
 			status: candidate.status,
-			statusLabel: candidate.status === 'needs_attention' ? t('devicesHomeAssistantPlugin.wizard.statuses.needsAttention') : undefined,
+			statusLabel:
+				candidate.error ?? (candidate.status === 'needs_attention' ? t('devicesHomeAssistantPlugin.wizard.statuses.needsAttention') : undefined),
 			adoptable: candidate.status === 'ready',
 			selectedByDefault: false,
 			willUpdate: false,
@@ -80,7 +87,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 					}),
 					variant: candidate.warningCount > 0 ? 'warning' : 'success',
 					tooltip:
-						candidate.warningCount > 0 ? t('devicesHomeAssistantPlugin.wizard.columns.warningsCount', { count: candidate.warningCount }) : undefined,
+						candidate.error ??
+						(candidate.warningCount > 0
+							? t('devicesHomeAssistantPlugin.wizard.columns.warningsCount', { count: candidate.warningCount })
+							: undefined),
 				},
 			},
 		}))
@@ -210,6 +220,14 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 		if (typeof data !== 'undefined') {
 			adoptionResults.value = transformWizardAdoptionResponse((data as { data: DevicesHomeAssistantPluginWizardAdoptionSchema }).data);
+			if (adoptionResults.value.some((result) => result.status === 'created')) {
+				const refreshes = await Promise.allSettled([devicesStore.fetch(), discoveredDevicesStore.fetch(), discoveredHelpersStore.fetch()]);
+				for (const refresh of refreshes) {
+					if (refresh.status === 'rejected') {
+						logger.warn('Failed to refresh a device store after Home Assistant bulk adoption', refresh.reason);
+					}
+				}
+			}
 			formResult.value = adoptionResults.value.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
 			return results.value;
 		}

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -50,6 +50,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const sessionError = ref<string | null>(null);
 	let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 	let restartPromise: Promise<void> | null = null;
+	let disposed = false;
 
 	const stopKeepalive = (): void => {
 		if (keepaliveTimer !== null) {
@@ -74,6 +75,20 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				})
 				.catch((error: unknown) => logger.warn('Failed to keep the Home Assistant wizard session active', error));
 		}, sessionKeepaliveMs);
+	};
+
+	const deleteSession = async (id: string): Promise<void> => {
+		try {
+			const { error } = await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+				params: { path: { id } },
+			});
+
+			if (error) {
+				logger.warn(getErrorReason<DevicesHomeAssistantPluginDeleteWizardOperation>(error, 'Failed to cleanly end Home Assistant wizard session'));
+			}
+		} catch (error: unknown) {
+			logger.warn('Failed to cleanly end Home Assistant wizard session', error);
+		}
 	};
 
 	const candidates = computed<IHomeAssistantWizardCandidate[]>(() =>
@@ -209,6 +224,10 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 		if (typeof data !== 'undefined') {
 			const nextSession = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
+			if (disposed) {
+				await deleteSession(nextSession.id);
+				return;
+			}
 			session.value = nextSession;
 			sessionKey.value = nextSession.id;
 			startKeepalive(nextSession.id);
@@ -235,17 +254,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			return;
 		}
 
-		try {
-			const { error } = await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
-				params: { path: { id: currentSession.id } },
-			});
+		await deleteSession(currentSession.id);
+	};
 
-			if (error) {
-				logger.warn(getErrorReason<DevicesHomeAssistantPluginDeleteWizardOperation>(error, 'Failed to cleanly end Home Assistant wizard session'));
-			}
-		} catch (error: unknown) {
-			logger.warn('Failed to cleanly end Home Assistant wizard session', error);
-		}
+	const disposeSession = async (): Promise<void> => {
+		disposed = true;
+		await endSession();
 	};
 
 	const restartSession = (): Promise<void> => {
@@ -334,6 +348,6 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		start: startSession,
 		adopt,
 		restart: restartSession,
-		dispose: endSession,
+		dispose: disposeSession,
 	};
 };

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -34,6 +34,9 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const flashMessage = useFlashMessage();
 	const logger = useLogger();
 	const session = ref<IHomeAssistantWizardSession | null>(null);
+	// Keep the last non-null session identity across DELETE so a refresh produces a direct
+	// old-id -> new-id transition. The shared shell uses that transition to clear row state.
+	const sessionKey = ref<string | null>(null);
 	const adoptionResults = ref<IHomeAssistantWizardAdoptionResult[]>([]);
 	const formResult = ref<FormResultType>(FormResult.NONE);
 	const sessionError = ref<string | null>(null);
@@ -156,7 +159,9 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard`);
 
 		if (typeof data !== 'undefined') {
-			session.value = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
+			const nextSession = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
+			session.value = nextSession;
+			sessionKey.value = nextSession.id;
 			adoptionResults.value = [];
 			formResult.value = FormResult.OK;
 			return;
@@ -235,7 +240,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			},
 		],
 		controls,
-		sessionKey: computed(() => session.value?.id ?? null),
+		sessionKey: computed(() => sessionKey.value),
 		ready: computed(() => session.value !== null || sessionError.value !== null),
 		busy: computed(() => formResult.value === FormResult.WORKING),
 		capabilities: { addMore: true },

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -1,0 +1,250 @@
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { orderBy } from 'natural-orderby';
+
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { getErrorReason, useBackend, useFlashMessage, useLogger } from '../../../common';
+import { RouteNames as ConfigRouteNames } from '../../../modules/config';
+import {
+	RouteNames as DevicesRouteNames,
+	FormResult,
+	type FormResultType,
+	type IDeviceWizardAdapter,
+	type IWizardAdoptSelection,
+	type IWizardControl,
+	type IWizardResult,
+	type IWizardRow,
+} from '../../../modules/devices';
+import type {
+	DevicesHomeAssistantPluginAdoptWizardOperation,
+	DevicesHomeAssistantPluginCreateWizardOperation,
+	DevicesHomeAssistantPluginDeleteWizardOperation,
+	DevicesHomeAssistantPluginWizardAdoptionSchema,
+	DevicesHomeAssistantPluginWizardSessionSchema,
+} from '../../../openapi.constants';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME, DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX } from '../devices-home-assistant.constants';
+import { DevicesHomeAssistantApiException } from '../devices-home-assistant.exceptions';
+import type { IHomeAssistantWizardAdoptionResult, IHomeAssistantWizardCandidate, IHomeAssistantWizardSession } from '../schemas/wizard.types';
+import { transformWizardAdoptRequest, transformWizardAdoptionResponse, transformWizardSessionResponse } from '../utils/wizard.transformers';
+
+export const useDevicesWizard = (): IDeviceWizardAdapter => {
+	const { t } = useI18n();
+	const backend = useBackend();
+	const flashMessage = useFlashMessage();
+	const logger = useLogger();
+	const session = ref<IHomeAssistantWizardSession | null>(null);
+	const adoptionResults = ref<IHomeAssistantWizardAdoptionResult[]>([]);
+	const formResult = ref<FormResultType>(FormResult.NONE);
+	const sessionError = ref<string | null>(null);
+
+	const candidates = computed<IHomeAssistantWizardCandidate[]>(() =>
+		orderBy(session.value?.candidates ?? [], [(candidate) => (candidate.status === 'ready' ? 0 : 1), (candidate) => candidate.name], ['asc', 'asc'])
+	);
+
+	const rows = computed<IWizardRow[]>(() =>
+		candidates.value.map((candidate) => ({
+			key: candidate.key,
+			label: candidate.name,
+			subLabel: [candidate.manufacturer, candidate.model].filter(Boolean).join(' · ') || null,
+			identifier: candidate.sourceId,
+			status: candidate.status,
+			statusLabel: candidate.status === 'needs_attention' ? t('devicesHomeAssistantPlugin.wizard.statuses.needsAttention') : undefined,
+			adoptable: candidate.status === 'ready',
+			selectedByDefault: false,
+			willUpdate: false,
+			suggestedName: candidate.name,
+			suggestedCategory: candidate.suggestedCategory,
+			categoryOptions:
+				candidate.suggestedCategory === null
+					? []
+					: [
+							{
+								value: candidate.suggestedCategory,
+								label: t(`devicesModule.categories.devices.${candidate.suggestedCategory}`),
+							},
+						],
+			cells: {
+				kind: {
+					render: 'tag',
+					value: t(`devicesHomeAssistantPlugin.wizard.kinds.${candidate.kind}`),
+					variant: 'info',
+				},
+				channels: {
+					render: 'tag',
+					value: t('devicesHomeAssistantPlugin.wizard.columns.channelsCount', {
+						count: candidate.previewChannelCount,
+					}),
+					variant: candidate.warningCount > 0 ? 'warning' : 'success',
+					tooltip:
+						candidate.warningCount > 0 ? t('devicesHomeAssistantPlugin.wizard.columns.warningsCount', { count: candidate.warningCount }) : undefined,
+				},
+			},
+		}))
+	);
+
+	const results = computed<IWizardResult[]>(() =>
+		adoptionResults.value.map((result) => ({
+			key: result.key,
+			name: result.name,
+			identifier: session.value?.candidates.find((candidate) => candidate.key === result.key)?.sourceId ?? result.key,
+			status: result.status,
+			error: result.error,
+		}))
+	);
+
+	const controls = computed<IWizardControl[]>(() => {
+		const refreshControl: IWizardControl = {
+			type: 'action',
+			id: 'refresh',
+			label: t('devicesHomeAssistantPlugin.wizard.actions.refresh'),
+			icon: 'mdi:refresh',
+			variant: 'default',
+			disabled: formResult.value === FormResult.WORKING,
+			loading: formResult.value === FormResult.WORKING,
+			handler: async (): Promise<void> => {
+				await endSession();
+				await startSession();
+			},
+		};
+
+		if (sessionError.value !== null) {
+			return [
+				{
+					type: 'banner',
+					id: 'connection-error',
+					severity: 'warning',
+					title: t('devicesHomeAssistantPlugin.wizard.connectionError.title'),
+					message: sessionError.value,
+					link: {
+						label: t('devicesHomeAssistantPlugin.wizard.connectionError.openConfig'),
+						to: {
+							name: ConfigRouteNames.CONFIG_PLUGIN_EDIT,
+							params: { plugin: DEVICES_HOME_ASSISTANT_PLUGIN_NAME },
+						},
+					},
+				},
+				refreshControl,
+			];
+		}
+
+		const reviewCount = candidates.value.filter((candidate) => candidate.status === 'needs_attention').length;
+
+		if (reviewCount === 0) {
+			return [refreshControl];
+		}
+
+		return [
+			{
+				type: 'banner',
+				id: 'manual-review',
+				severity: 'info',
+				title: t('devicesHomeAssistantPlugin.wizard.manualReview.title', { count: reviewCount }),
+				message: t('devicesHomeAssistantPlugin.wizard.manualReview.message'),
+				link: {
+					label: t('devicesHomeAssistantPlugin.wizard.manualReview.open'),
+					to: { name: DevicesRouteNames.DEVICES_ADD },
+				},
+			},
+			refreshControl,
+		];
+	});
+
+	const startSession = async (): Promise<void> => {
+		formResult.value = FormResult.WORKING;
+		sessionError.value = null;
+		const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard`);
+
+		if (typeof data !== 'undefined') {
+			session.value = transformWizardSessionResponse((data as { data: DevicesHomeAssistantPluginWizardSessionSchema }).data);
+			adoptionResults.value = [];
+			formResult.value = FormResult.OK;
+			return;
+		}
+
+		const fallback = t('devicesHomeAssistantPlugin.wizard.messages.sessionNotStarted');
+		const reason = error ? getErrorReason<DevicesHomeAssistantPluginCreateWizardOperation>(error, fallback) : fallback;
+		formResult.value = FormResult.ERROR;
+		sessionError.value = reason;
+		flashMessage.error(reason);
+		throw new DevicesHomeAssistantApiException(reason, response.status);
+	};
+
+	const endSession = async (): Promise<void> => {
+		const currentSession = session.value;
+		session.value = null;
+		sessionError.value = null;
+
+		if (!currentSession) {
+			return;
+		}
+
+		try {
+			const { error } = await backend.client.DELETE(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}`, {
+				params: { path: { id: currentSession.id } },
+			});
+
+			if (error) {
+				logger.warn(getErrorReason<DevicesHomeAssistantPluginDeleteWizardOperation>(error, 'Failed to cleanly end Home Assistant wizard session'));
+			}
+		} catch (error: unknown) {
+			logger.warn('Failed to cleanly end Home Assistant wizard session', error);
+		}
+	};
+
+	const adopt = async (selection: IWizardAdoptSelection[]): Promise<IWizardResult[]> => {
+		if (!session.value) {
+			return [];
+		}
+
+		formResult.value = FormResult.WORKING;
+		const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX}/wizard/{id}/adopt`, {
+			params: { path: { id: session.value.id } },
+			body: transformWizardAdoptRequest(selection.map((item) => item.key)),
+		});
+
+		if (typeof data !== 'undefined') {
+			adoptionResults.value = transformWizardAdoptionResponse((data as { data: DevicesHomeAssistantPluginWizardAdoptionSchema }).data);
+			formResult.value = adoptionResults.value.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
+			return results.value;
+		}
+
+		const fallback = t('devicesHomeAssistantPlugin.wizard.messages.adoptionFailed');
+		const reason = error ? getErrorReason<DevicesHomeAssistantPluginAdoptWizardOperation>(error, fallback) : fallback;
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(reason);
+		throw new DevicesHomeAssistantApiException(reason, response.status);
+	};
+
+	return {
+		title: t('devicesHomeAssistantPlugin.wizard.title'),
+		subtitle: t('devicesHomeAssistantPlugin.wizard.subtitle'),
+		breadcrumbLabel: t('devicesHomeAssistantPlugin.wizard.breadcrumb'),
+		pluginType: DEVICES_HOME_ASSISTANT_PLUGIN_NAME,
+		identifierLabel: t('devicesHomeAssistantPlugin.wizard.columns.identifier'),
+		confirmationMode: 'selection-only',
+		rows,
+		results,
+		columns: [
+			{ key: 'kind', label: t('devicesHomeAssistantPlugin.wizard.columns.kind'), steps: ['discover'], width: 120 },
+			{
+				key: 'channels',
+				label: t('devicesHomeAssistantPlugin.wizard.columns.channels'),
+				steps: ['discover', 'confirm'],
+				width: 130,
+			},
+		],
+		controls,
+		sessionKey: computed(() => session.value?.id ?? null),
+		ready: computed(() => session.value !== null || sessionError.value !== null),
+		busy: computed(() => formResult.value === FormResult.WORKING),
+		capabilities: { addMore: true },
+		start: startSession,
+		adopt,
+		restart: async (): Promise<void> => {
+			await endSession();
+			await startSession();
+		},
+		dispose: endSession,
+	};
+};

--- a/apps/admin/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
@@ -22,6 +22,7 @@ import {
 	HomeAssistantDeviceAddForm,
 	HomeAssistantDeviceEditForm,
 } from './components/components';
+import { useDevicesWizard } from './composables/composables';
 import { DEVICES_HOME_ASSISTANT_PLUGIN_NAME, DEVICES_HOME_ASSISTANT_TYPE } from './devices-home-assistant.constants';
 import { locales } from './locales';
 import { HomeAssistantChannelPropertyAddFormSchema, HomeAssistantChannelPropertyEditFormSchema } from './schemas/channels.properties.schemas';
@@ -106,6 +107,7 @@ export default {
 					components: {
 						deviceAddForm: HomeAssistantDeviceAddForm,
 						deviceEditForm: HomeAssistantDeviceEditForm,
+						deviceWizardAdapter: useDevicesWizard,
 						channelPropertyAddForm: HomeAssistantChannelPropertyAddForm,
 						channelPropertyEditForm: HomeAssistantChannelPropertyEditForm,
 					},

--- a/apps/admin/src/plugins/devices-home-assistant/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/cs-CZ.json
@@ -249,5 +249,33 @@
 		"mapping": {
 			"customizationDescription": "Můžete přizpůsobit mapování změnou kategorií kanálů pro entity nebo povolením/zakázáním entit. Ve výchozím nastavení jsou všechny entity s navrženou kategorií kanálu povoleny. Klikněte na 'Další' pro pokračování s vybranou konfigurací."
 		}
+	},
+	"wizard": {
+		"title": "Hromadně přidat zařízení Home Assistant",
+		"subtitle": "Zkontrolujte automaticky namapovaná zařízení a přidejte vybrané položky bez další konfigurace.",
+		"breadcrumb": "Hromadný import Home Assistant",
+		"columns": {
+			"identifier": "ID Home Assistant",
+			"kind": "Typ",
+			"channels": "Kanály",
+			"channelsCount": "Počet kanálů: {count}",
+			"warningsCount": "Počet upozornění mapování: {count}"
+		},
+		"kinds": { "device": "Zařízení", "helper": "Pomocná entita" },
+		"statuses": { "needsAttention": "Ruční kontrola" },
+		"actions": { "refresh": "Obnovit inventář" },
+		"manualReview": {
+			"title": "Položky vyžadující ruční kontrolu: {count}",
+			"message": "Tyto položky nejsou vybrány pro hromadný import. Pro kontrolu kategorie, kanálů a vlastností použijte stávající řízené přidání.",
+			"open": "Otevřít ruční přidání zařízení"
+		},
+		"connectionError": {
+			"title": "Inventář Home Assistant není dostupný",
+			"openConfig": "Otevřít konfiguraci Home Assistant"
+		},
+		"messages": {
+			"sessionNotStarted": "Zařízení Home Assistant se nepodařilo připravit pro hromadný import.",
+			"adoptionFailed": "Vybraná zařízení Home Assistant se nepodařilo přidat."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-home-assistant/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/de-DE.json
@@ -249,5 +249,33 @@
     "mapping": {
       "customizationDescription": "Sie können die Zuordnung anpassen, indem Sie Kanalkategorien für Entitäten ändern oder Entitäten aktivieren/deaktivieren. Standardmäßig sind alle Entitäten mit einer vorgeschlagenen Kanalkategorie aktiviert. Klicken Sie auf 'Weiter', um mit der ausgewählten Konfiguration fortzufahren."
     }
+  },
+  "wizard": {
+    "title": "Home Assistant-Geräte gesammelt hinzufügen",
+    "subtitle": "Prüfen Sie die automatisch zugeordneten Geräte und fügen Sie die ausgewählten Einträge ohne weitere Konfiguration hinzu.",
+    "breadcrumb": "Home Assistant-Sammelimport",
+    "columns": {
+      "identifier": "Home Assistant-ID",
+      "kind": "Typ",
+      "channels": "Kanäle",
+      "channelsCount": "{count} Kanäle",
+      "warningsCount": "{count} Zuordnungswarnungen"
+    },
+    "kinds": { "device": "Gerät", "helper": "Helfer" },
+    "statuses": { "needsAttention": "Manuelle Prüfung" },
+    "actions": { "refresh": "Inventar aktualisieren" },
+    "manualReview": {
+      "title": "{count} Einträge müssen manuell geprüft werden",
+      "message": "Diese Einträge sind nicht für den Sammelimport ausgewählt. Verwenden Sie das vorhandene kontrollierte Formular, um Kategorie, Kanäle und Eigenschaften zu prüfen.",
+      "open": "Manuelle Geräteübernahme öffnen"
+    },
+    "connectionError": {
+      "title": "Home Assistant-Inventar ist nicht verfügbar",
+      "openConfig": "Home Assistant-Konfiguration öffnen"
+    },
+    "messages": {
+      "sessionNotStarted": "Home Assistant-Geräte konnten nicht für den Sammelimport vorbereitet werden.",
+      "adoptionFailed": "Die ausgewählten Home Assistant-Geräte konnten nicht hinzugefügt werden."
+    }
   }
 }

--- a/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
@@ -249,5 +249,40 @@
     "mapping": {
       "customizationDescription": "You can customize the mapping by changing channel categories for entities or enabling/disabling entities. By default, all entities with a suggested channel category are enabled. Click 'Next' to proceed with the selected configuration."
     }
+  },
+  "wizard": {
+    "title": "Add Home Assistant devices in bulk",
+    "subtitle": "Review the automatically mapped devices and add the selected items without additional configuration.",
+    "breadcrumb": "Home Assistant bulk import",
+    "columns": {
+      "identifier": "Home Assistant ID",
+      "kind": "Type",
+      "channels": "Channels",
+      "channelsCount": "{count} channels",
+      "warningsCount": "{count} mapping warnings"
+    },
+    "kinds": {
+      "device": "Device",
+      "helper": "Helper"
+    },
+    "statuses": {
+      "needsAttention": "Manual review"
+    },
+    "actions": {
+      "refresh": "Refresh inventory"
+    },
+    "manualReview": {
+      "title": "{count} items need manual review",
+      "message": "These items are not selected for bulk import. Use the existing controlled add form to review their category, channels, and properties.",
+      "open": "Open manual device adoption"
+    },
+    "connectionError": {
+      "title": "Home Assistant inventory is unavailable",
+      "openConfig": "Open Home Assistant configuration"
+    },
+    "messages": {
+      "sessionNotStarted": "Home Assistant devices could not be prepared for bulk import.",
+      "adoptionFailed": "The selected Home Assistant devices could not be added."
+    }
   }
 }

--- a/apps/admin/src/plugins/devices-home-assistant/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/es-ES.json
@@ -249,5 +249,33 @@
     "mapping": {
       "customizationDescription": "Puede personalizar el mapeo cambiando las categorías de canal para las entidades o habilitando/deshabilitando entidades. Por defecto, todas las entidades con una categoría de canal sugerida están habilitadas. Haga clic en 'Siguiente' para continuar con la configuración seleccionada."
     }
+  },
+  "wizard": {
+    "title": "Añadir dispositivos de Home Assistant en lote",
+    "subtitle": "Revise los dispositivos asignados automáticamente y añada los elementos seleccionados sin más configuración.",
+    "breadcrumb": "Importación masiva de Home Assistant",
+    "columns": {
+      "identifier": "ID de Home Assistant",
+      "kind": "Tipo",
+      "channels": "Canales",
+      "channelsCount": "{count} canales",
+      "warningsCount": "{count} avisos de mapeo"
+    },
+    "kinds": { "device": "Dispositivo", "helper": "Ayudante" },
+    "statuses": { "needsAttention": "Revisión manual" },
+    "actions": { "refresh": "Actualizar inventario" },
+    "manualReview": {
+      "title": "{count} elementos necesitan revisión manual",
+      "message": "Estos elementos no están seleccionados para la importación masiva. Use el formulario controlado existente para revisar su categoría, canales y propiedades.",
+      "open": "Abrir adopción manual de dispositivos"
+    },
+    "connectionError": {
+      "title": "El inventario de Home Assistant no está disponible",
+      "openConfig": "Abrir configuración de Home Assistant"
+    },
+    "messages": {
+      "sessionNotStarted": "No se pudieron preparar los dispositivos de Home Assistant para la importación masiva.",
+      "adoptionFailed": "No se pudieron añadir los dispositivos de Home Assistant seleccionados."
+    }
   }
 }

--- a/apps/admin/src/plugins/devices-home-assistant/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/pl-PL.json
@@ -249,5 +249,33 @@
 		"mapping": {
 			"customizationDescription": "Mozesz dostosowac mapowanie zmieniajac kategorie kanalow dla encji lub wlaczajac/wylaczajac encje. Domyslnie wszystkie encje z sugerowana kategoria kanalu sa wlaczone. Kliknij 'Dalej', aby kontynuowac z wybrana konfiguracja."
 		}
+	},
+	"wizard": {
+		"title": "Dodaj zbiorczo urządzenia Home Assistant",
+		"subtitle": "Sprawdź automatycznie zmapowane urządzenia i dodaj wybrane pozycje bez dodatkowej konfiguracji.",
+		"breadcrumb": "Import zbiorczy Home Assistant",
+		"columns": {
+			"identifier": "ID Home Assistant",
+			"kind": "Typ",
+			"channels": "Kanały",
+			"channelsCount": "Liczba kanałów: {count}",
+			"warningsCount": "Liczba ostrzeżeń mapowania: {count}"
+		},
+		"kinds": { "device": "Urządzenie", "helper": "Pomocnik" },
+		"statuses": { "needsAttention": "Kontrola ręczna" },
+		"actions": { "refresh": "Odśwież inwentarz" },
+		"manualReview": {
+			"title": "Pozycje wymagające kontroli ręcznej: {count}",
+			"message": "Te pozycje nie są wybrane do importu zbiorczego. Użyj istniejącego kontrolowanego formularza, aby sprawdzić kategorię, kanały i właściwości.",
+			"open": "Otwórz ręczne dodawanie urządzenia"
+		},
+		"connectionError": {
+			"title": "Inwentarz Home Assistant jest niedostępny",
+			"openConfig": "Otwórz konfigurację Home Assistant"
+		},
+		"messages": {
+			"sessionNotStarted": "Nie udało się przygotować urządzeń Home Assistant do importu zbiorczego.",
+			"adoptionFailed": "Nie udało się dodać wybranych urządzeń Home Assistant."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-home-assistant/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/sk-SK.json
@@ -249,5 +249,33 @@
 		"mapping": {
 			"customizationDescription": "Môžete prispôsobiť mapovanie zmenou kategórií kanálov pre entity alebo povolením/zakázaním entít. Predvolene sú všetky entity s navrhovanou kategóriou kanála povolené. Kliknite na 'Ďalej' pre pokračovanie s vybranou konfiguráciou."
 		}
+	},
+	"wizard": {
+		"title": "Hromadne pridať zariadenia Home Assistant",
+		"subtitle": "Skontrolujte automaticky namapované zariadenia a pridajte vybrané položky bez ďalšej konfigurácie.",
+		"breadcrumb": "Hromadný import Home Assistant",
+		"columns": {
+			"identifier": "ID Home Assistant",
+			"kind": "Typ",
+			"channels": "Kanály",
+			"channelsCount": "Počet kanálov: {count}",
+			"warningsCount": "Počet upozornení mapovania: {count}"
+		},
+		"kinds": { "device": "Zariadenie", "helper": "Pomocná entita" },
+		"statuses": { "needsAttention": "Ručná kontrola" },
+		"actions": { "refresh": "Obnoviť inventár" },
+		"manualReview": {
+			"title": "Položky vyžadujúce ručnú kontrolu: {count}",
+			"message": "Tieto položky nie sú vybrané na hromadný import. Na kontrolu kategórie, kanálov a vlastností použite existujúce riadené pridanie.",
+			"open": "Otvoriť ručné pridanie zariadenia"
+		},
+		"connectionError": {
+			"title": "Inventár Home Assistant nie je dostupný",
+			"openConfig": "Otvoriť konfiguráciu Home Assistant"
+		},
+		"messages": {
+			"sessionNotStarted": "Zariadenia Home Assistant sa nepodarilo pripraviť na hromadný import.",
+			"adoptionFailed": "Vybrané zariadenia Home Assistant sa nepodarilo pridať."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-home-assistant/schemas/wizard.types.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/schemas/wizard.types.ts
@@ -1,0 +1,31 @@
+import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+
+export type IHomeAssistantWizardCandidateStatus = 'ready' | 'needs_attention' | 'already_registered' | 'failed';
+
+export interface IHomeAssistantWizardCandidate {
+	key: string;
+	kind: 'device' | 'helper';
+	sourceId: string;
+	name: string;
+	manufacturer: string | null;
+	model: string | null;
+	status: IHomeAssistantWizardCandidateStatus;
+	suggestedCategory: DevicesModuleDeviceCategory | null;
+	previewChannelCount: number;
+	warningCount: number;
+	adoptedDeviceId: string | null;
+	error: string | null;
+}
+
+export interface IHomeAssistantWizardSession {
+	id: string;
+	startedAt: string;
+	candidates: IHomeAssistantWizardCandidate[];
+}
+
+export interface IHomeAssistantWizardAdoptionResult {
+	key: string;
+	name: string;
+	status: 'created' | 'failed';
+	error: string | null;
+}

--- a/apps/admin/src/plugins/devices-home-assistant/utils/wizard.transformers.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/utils/wizard.transformers.ts
@@ -1,0 +1,39 @@
+import type {
+	DevicesHomeAssistantPluginWizardAdoptionSchema,
+	DevicesHomeAssistantPluginWizardSessionSchema,
+	DevicesModuleDeviceCategory,
+} from '../../../openapi.constants';
+import type { IHomeAssistantWizardAdoptionResult, IHomeAssistantWizardCandidate, IHomeAssistantWizardSession } from '../schemas/wizard.types';
+
+export const transformWizardSessionResponse = (raw: DevicesHomeAssistantPluginWizardSessionSchema): IHomeAssistantWizardSession => ({
+	id: raw.id,
+	startedAt: raw.startedAt,
+	candidates: raw.candidates.map(
+		(candidate): IHomeAssistantWizardCandidate => ({
+			key: candidate.key,
+			kind: candidate.kind,
+			sourceId: candidate.sourceId,
+			name: candidate.name,
+			manufacturer: candidate.manufacturer ?? null,
+			model: candidate.model ?? null,
+			status: candidate.status,
+			suggestedCategory: (candidate.suggestedCategory ?? null) as DevicesModuleDeviceCategory | null,
+			previewChannelCount: candidate.previewChannelCount,
+			warningCount: candidate.warningCount,
+			adoptedDeviceId: candidate.adoptedDeviceId ?? null,
+			error: candidate.error ?? null,
+		})
+	),
+});
+
+export const transformWizardAdoptionResponse = (raw: DevicesHomeAssistantPluginWizardAdoptionSchema): IHomeAssistantWizardAdoptionResult[] =>
+	raw.results.map((result) => ({
+		key: result.key,
+		name: result.name,
+		status: result.status,
+		error: result.error ?? null,
+	}));
+
+export const transformWizardAdoptRequest = (keys: string[]): { data: { keys: string[] } } => ({
+	data: { keys },
+});

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
@@ -1,0 +1,63 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { HomeAssistantWizardService } from '../services/wizard.service';
+
+import { HomeAssistantWizardController } from './home-assistant-wizard.controller';
+
+describe('HomeAssistantWizardController', () => {
+	let controller: HomeAssistantWizardController;
+	let wizardService: jest.Mocked<HomeAssistantWizardService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [HomeAssistantWizardController],
+			providers: [
+				{
+					provide: HomeAssistantWizardService,
+					useValue: {
+						start: jest.fn(),
+						get: jest.fn(),
+						end: jest.fn(),
+						adopt: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get(HomeAssistantWizardController);
+		wizardService = module.get(HomeAssistantWizardService);
+	});
+
+	it('starts a bulk wizard session', async () => {
+		const session = { id: 'session-1', startedAt: '2026-08-12T10:00:00.000Z', candidates: [] };
+		wizardService.start.mockResolvedValueOnce(session);
+
+		await expect(controller.startSession()).resolves.toEqual(expect.objectContaining({ data: session }));
+	});
+
+	it('returns not found for an unknown session', () => {
+		wizardService.get.mockReturnValueOnce(null);
+
+		expect(() => controller.getSession('missing')).toThrow(NotFoundException);
+	});
+
+	it('passes only selected candidate keys to adoption', async () => {
+		wizardService.adopt.mockResolvedValueOnce([
+			{ key: 'device:ha-device-1', name: 'Lamp', status: 'created', error: null },
+		]);
+
+		const response = await controller.adopt('session-1', {
+			data: { keys: ['device:ha-device-1'] },
+		});
+
+		expect(wizardService.adopt.mock.calls).toEqual([['session-1', ['device:ha-device-1']]]);
+		expect(response.data.results[0]?.status).toBe('created');
+	});
+
+	it('ends a wizard session', () => {
+		controller.endSession('session-1');
+
+		expect(wizardService.end.mock.calls).toEqual([['session-1']]);
+	});
+});

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
@@ -1,6 +1,10 @@
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import {
+	DevicesHomeAssistantNotFoundException,
+	DevicesHomeAssistantValidationException,
+} from '../devices-home-assistant.exceptions';
 import { HomeAssistantWizardService } from '../services/wizard.service';
 
 import { HomeAssistantWizardController } from './home-assistant-wizard.controller';
@@ -34,6 +38,22 @@ describe('HomeAssistantWizardController', () => {
 		wizardService.start.mockResolvedValueOnce(session);
 
 		await expect(controller.startSession()).resolves.toEqual(expect.objectContaining({ data: session }));
+	});
+
+	it('returns unprocessable entity when the plugin is not configured', async () => {
+		wizardService.start.mockRejectedValueOnce(
+			new DevicesHomeAssistantValidationException('Home Assistant API key is not configured'),
+		);
+
+		await expect(controller.startSession()).rejects.toBeInstanceOf(UnprocessableEntityException);
+	});
+
+	it('returns not found when the Home Assistant inventory cannot be loaded', async () => {
+		wizardService.start.mockRejectedValueOnce(
+			new DevicesHomeAssistantNotFoundException('Home Assistant discovered inventory could not be loaded'),
+		);
+
+		await expect(controller.startSession()).rejects.toBeInstanceOf(NotFoundException);
 	});
 
 	it('returns not found for an unknown session', () => {

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException, UnprocessableEntityException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing';
 
 import {
+	DevicesHomeAssistantException,
 	DevicesHomeAssistantNotFoundException,
 	DevicesHomeAssistantValidationException,
 } from '../devices-home-assistant.exceptions';
@@ -54,6 +55,14 @@ describe('HomeAssistantWizardController', () => {
 		);
 
 		await expect(controller.startSession()).rejects.toBeInstanceOf(NotFoundException);
+	});
+
+	it('returns unprocessable entity when a Home Assistant connection request fails', async () => {
+		wizardService.start.mockRejectedValueOnce(
+			new DevicesHomeAssistantException('Home Assistant registry request timed out'),
+		);
+
+		await expect(controller.startSession()).rejects.toBeInstanceOf(UnprocessableEntityException);
 	});
 
 	it('returns not found for an unknown session', () => {

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, HttpCode, NotFoundException, Param, Post } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Delete,
+	Get,
+	HttpCode,
+	NotFoundException,
+	Param,
+	Post,
+	UnprocessableEntityException,
+} from '@nestjs/common';
 import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import {
@@ -7,8 +17,13 @@ import {
 	ApiInternalServerErrorResponse,
 	ApiNotFoundResponse,
 	ApiSuccessResponse,
+	ApiUnprocessableEntityResponse,
 } from '../../../modules/swagger/decorators/api-documentation.decorator';
 import { DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME } from '../devices-home-assistant.constants';
+import {
+	DevicesHomeAssistantNotFoundException,
+	DevicesHomeAssistantValidationException,
+} from '../devices-home-assistant.exceptions';
 import { ReqHomeAssistantWizardAdoptDto } from '../dto/wizard-adopt.dto';
 import {
 	HomeAssistantWizardAdoptionResponseModel,
@@ -28,12 +43,18 @@ export class HomeAssistantWizardController {
 		operationId: 'create-devices-home-assistant-plugin-wizard',
 	})
 	@ApiCreatedSuccessResponse(HomeAssistantWizardSessionResponseModel, 'Wizard session was started successfully')
+	@ApiNotFoundResponse('Home Assistant inventory could not be loaded')
+	@ApiUnprocessableEntityResponse('Devices Home Assistant plugin is not properly configured')
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Post()
 	async startSession(): Promise<HomeAssistantWizardSessionResponseModel> {
-		const response = new HomeAssistantWizardSessionResponseModel();
-		response.data = await this.wizardService.start();
-		return response;
+		try {
+			const response = new HomeAssistantWizardSessionResponseModel();
+			response.data = await this.wizardService.start();
+			return response;
+		} catch (error) {
+			this.translatePluginError(error);
+		}
 	}
 
 	@ApiOperation({
@@ -99,5 +120,17 @@ export class HomeAssistantWizardController {
 		const response = new HomeAssistantWizardAdoptionResponseModel();
 		response.data = { results };
 		return response;
+	}
+
+	private translatePluginError(error: unknown): never {
+		if (error instanceof DevicesHomeAssistantValidationException) {
+			throw new UnprocessableEntityException(error.message);
+		}
+
+		if (error instanceof DevicesHomeAssistantNotFoundException) {
+			throw new NotFoundException(error.message);
+		}
+
+		throw error;
 	}
 }

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../modules/swagger/decorators/api-documentation.decorator';
 import { DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME } from '../devices-home-assistant.constants';
 import {
+	DevicesHomeAssistantException,
 	DevicesHomeAssistantNotFoundException,
 	DevicesHomeAssistantValidationException,
 } from '../devices-home-assistant.exceptions';
@@ -129,6 +130,10 @@ export class HomeAssistantWizardController {
 
 		if (error instanceof DevicesHomeAssistantNotFoundException) {
 			throw new NotFoundException(error.message);
+		}
+
+		if (error instanceof DevicesHomeAssistantException) {
+			throw new UnprocessableEntityException(error.message);
 		}
 
 		throw error;

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
@@ -1,0 +1,103 @@
+import { Body, Controller, Delete, Get, HttpCode, NotFoundException, Param, Post } from '@nestjs/common';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import {
+	ApiBadRequestResponse,
+	ApiCreatedSuccessResponse,
+	ApiInternalServerErrorResponse,
+	ApiNotFoundResponse,
+	ApiSuccessResponse,
+} from '../../../modules/swagger/decorators/api-documentation.decorator';
+import { DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME } from '../devices-home-assistant.constants';
+import { ReqHomeAssistantWizardAdoptDto } from '../dto/wizard-adopt.dto';
+import {
+	HomeAssistantWizardAdoptionResponseModel,
+	HomeAssistantWizardSessionResponseModel,
+} from '../models/wizard.model';
+import { HomeAssistantWizardService } from '../services/wizard.service';
+
+@ApiTags(DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME)
+@Controller('wizard')
+export class HomeAssistantWizardController {
+	constructor(private readonly wizardService: HomeAssistantWizardService) {}
+
+	@ApiOperation({
+		tags: [DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME],
+		summary: 'Start Home Assistant bulk adoption wizard session',
+		description: 'Creates one automatic mapping snapshot for all discoverable Home Assistant devices and helpers.',
+		operationId: 'create-devices-home-assistant-plugin-wizard',
+	})
+	@ApiCreatedSuccessResponse(HomeAssistantWizardSessionResponseModel, 'Wizard session was started successfully')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post()
+	async startSession(): Promise<HomeAssistantWizardSessionResponseModel> {
+		const response = new HomeAssistantWizardSessionResponseModel();
+		response.data = await this.wizardService.start();
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME],
+		summary: 'Get Home Assistant bulk adoption wizard session',
+		description: 'Returns the immutable discovery and mapping snapshot for the session.',
+		operationId: 'get-devices-home-assistant-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiSuccessResponse(HomeAssistantWizardSessionResponseModel, 'Wizard session was successfully retrieved')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@Get(':id')
+	getSession(@Param('id') id: string): HomeAssistantWizardSessionResponseModel {
+		const session = this.wizardService.get(id);
+
+		if (!session) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
+		const response = new HomeAssistantWizardSessionResponseModel();
+		response.data = session;
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME],
+		summary: 'End Home Assistant bulk adoption wizard session',
+		description: 'Deletes the server-side discovery and mapping snapshot.',
+		operationId: 'delete-devices-home-assistant-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiNoContentResponse({ description: 'Wizard session ended' })
+	@Delete(':id')
+	@HttpCode(204)
+	endSession(@Param('id') id: string): void {
+		this.wizardService.end(id);
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME],
+		summary: 'Adopt selected Home Assistant wizard candidates',
+		description:
+			'Adopts candidates using the automatic mappings stored in the session. Candidates requiring review are rejected.',
+		operationId: 'adopt-devices-home-assistant-plugin-wizard',
+	})
+	@ApiParam({ name: 'id', type: 'string' })
+	@ApiBody({ type: ReqHomeAssistantWizardAdoptDto })
+	@ApiSuccessResponse(HomeAssistantWizardAdoptionResponseModel, 'Adoption results returned')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiNotFoundResponse('Wizard session could not be found')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post(':id/adopt')
+	async adopt(
+		@Param('id') id: string,
+		@Body() body: ReqHomeAssistantWizardAdoptDto,
+	): Promise<HomeAssistantWizardAdoptionResponseModel> {
+		const results = await this.wizardService.adopt(id, body.data.keys);
+
+		if (results === null) {
+			throw new NotFoundException('Wizard session could not be found');
+		}
+
+		const response = new HomeAssistantWizardAdoptionResponseModel();
+		response.data = { results };
+		return response;
+	}
+}

--- a/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.openapi.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.openapi.ts
@@ -28,6 +28,7 @@ import { UpdateHomeAssistantChannelPropertyDto } from './dto/update-channel-prop
 import { UpdateHomeAssistantChannelDto } from './dto/update-channel.dto';
 import { HomeAssistantUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateHomeAssistantDeviceDto } from './dto/update-device.dto';
+import { HomeAssistantWizardAdoptDto, ReqHomeAssistantWizardAdoptDto } from './dto/wizard-adopt.dto';
 import {
 	HomeAssistantChannelEntity,
 	HomeAssistantChannelPropertyEntity,
@@ -73,6 +74,14 @@ import {
 	SuggestedChannelModel,
 	SuggestedDeviceModel,
 } from './models/mapping-preview.model';
+import {
+	HomeAssistantWizardAdoptionModel,
+	HomeAssistantWizardAdoptionResponseModel,
+	HomeAssistantWizardAdoptionResultModel,
+	HomeAssistantWizardCandidateModel,
+	HomeAssistantWizardSessionModel,
+	HomeAssistantWizardSessionResponseModel,
+} from './models/wizard.model';
 
 export const DEVICES_HOME_ASSISTANT_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	// DTOs
@@ -99,6 +108,8 @@ export const DEVICES_HOME_ASSISTANT_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	AdoptHelperRequestDto,
 	AdoptHelperChannelDefinitionDto,
 	AdoptHelperPropertyDefinitionDto,
+	HomeAssistantWizardAdoptDto,
+	ReqHomeAssistantWizardAdoptDto,
 	// Response models
 	HomeAssistantDiscoveredDeviceResponseModel,
 	HomeAssistantDiscoveredDevicesResponseModel,
@@ -134,6 +145,12 @@ export const DEVICES_HOME_ASSISTANT_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	HelperInfoModel,
 	SuggestedHelperDeviceModel,
 	HelperMappingWarningModel,
+	HomeAssistantWizardCandidateModel,
+	HomeAssistantWizardSessionModel,
+	HomeAssistantWizardSessionResponseModel,
+	HomeAssistantWizardAdoptionResultModel,
+	HomeAssistantWizardAdoptionModel,
+	HomeAssistantWizardAdoptionResponseModel,
 	// Entities
 	HomeAssistantDeviceEntity,
 	HomeAssistantChannelEntity,

--- a/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
@@ -28,6 +28,7 @@ import { HomeAssistantDiscoveredHelpersController } from './controllers/home-ass
 import { HomeAssistantDiscoveryController } from './controllers/home-assistant-discovery.controller';
 import { HomeAssistantRegistryController } from './controllers/home-assistant-registry.controller';
 import { HomeAssistantStatesController } from './controllers/home-assistant-states.controller';
+import { HomeAssistantWizardController } from './controllers/home-assistant-wizard.controller';
 import {
 	DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_DESCRIPTION,
 	DEVICES_HOME_ASSISTANT_PLUGIN_API_TAG_NAME,
@@ -70,6 +71,7 @@ import { LightCapabilityAnalyzer } from './services/light-capability.analyzer';
 import { MappingPreviewService } from './services/mapping-preview.service';
 import { StateChangedEventService } from './services/state-changed.event.service';
 import { VirtualPropertyService } from './services/virtual-property.service';
+import { HomeAssistantWizardService } from './services/wizard.service';
 import { DevicesServiceSubscriber } from './subscribers/devices-service.subscriber';
 
 @ApiTag({
@@ -116,6 +118,7 @@ import { DevicesServiceSubscriber } from './subscribers/devices-service.subscrib
 		LightCapabilityAnalyzer,
 		HaMdnsDiscovererService,
 		VirtualPropertyService,
+		HomeAssistantWizardService,
 	],
 	controllers: [
 		HomeAssistantDiscoveredDevicesController,
@@ -123,6 +126,7 @@ import { DevicesServiceSubscriber } from './subscribers/devices-service.subscrib
 		HomeAssistantDiscoveryController,
 		HomeAssistantStatesController,
 		HomeAssistantRegistryController,
+		HomeAssistantWizardController,
 	],
 	exports: [HomeAssistantHttpService],
 })

--- a/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.spec.ts
@@ -1,0 +1,15 @@
+import { validate } from 'class-validator';
+
+import { toInstance } from '../../../common/utils/transform.utils';
+
+import { ReqHomeAssistantWizardAdoptDto } from './wizard-adopt.dto';
+
+describe('ReqHomeAssistantWizardAdoptDto', () => {
+	it('rejects a missing adoption payload wrapper', async () => {
+		const dto = toInstance(ReqHomeAssistantWizardAdoptDto, {});
+
+		const errors = await validate(dto);
+
+		expect(errors.some((error) => error.property === 'data')).toBe(true);
+	});
+});

--- a/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayNotEmpty, IsArray, IsString, ValidateNested } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsDefined, IsObject, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -21,6 +21,8 @@ export class HomeAssistantWizardAdoptDto {
 export class ReqHomeAssistantWizardAdoptDto {
 	@ApiProperty({ description: 'Wizard adoption payload', type: () => HomeAssistantWizardAdoptDto })
 	@Expose()
+	@IsDefined()
+	@IsObject()
 	@ValidateNested()
 	@Type(() => HomeAssistantWizardAdoptDto)
 	data: HomeAssistantWizardAdoptDto;

--- a/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/dto/wizard-adopt.dto.ts
@@ -1,0 +1,27 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginReqWizardAdopt' })
+export class HomeAssistantWizardAdoptDto {
+	@ApiProperty({
+		description: 'Candidate keys selected from the wizard session',
+		type: [String],
+		example: ['device:abcd1234', 'helper:input_boolean.guest_mode'],
+	})
+	@Expose()
+	@IsArray()
+	@ArrayNotEmpty()
+	@IsString({ each: true })
+	keys: string[];
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginReqWizardAdoptWrap' })
+export class ReqHomeAssistantWizardAdoptDto {
+	@ApiProperty({ description: 'Wizard adoption payload', type: () => HomeAssistantWizardAdoptDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => HomeAssistantWizardAdoptDto)
+	data: HomeAssistantWizardAdoptDto;
+}

--- a/apps/backend/src/plugins/devices-home-assistant/models/helper-mapping-preview.model.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/models/helper-mapping-preview.model.ts
@@ -93,6 +93,17 @@ export class HelperPropertyMappingPreviewModel {
 	@Expose({ name: 'current_value' })
 	@IsOptional()
 	currentValue: string | number | boolean | null;
+
+	@ApiPropertyOptional({
+		description: 'Transformer name for value conversion',
+		type: 'string',
+		nullable: true,
+		name: 'ha_transformer',
+	})
+	@Expose({ name: 'ha_transformer' })
+	@IsOptional()
+	@IsString()
+	haTransformer?: string | null;
 }
 
 @ApiSchema({ name: 'DevicesHomeAssistantPluginDataHelperChannelMappingPreview' })

--- a/apps/backend/src/plugins/devices-home-assistant/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/models/wizard.model.ts
@@ -1,0 +1,166 @@
+import { Expose, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsIn, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
+
+import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+export const HOME_ASSISTANT_WIZARD_CANDIDATE_STATUSES = [
+	'ready',
+	'needs_attention',
+	'already_registered',
+	'failed',
+] as const;
+
+export type HomeAssistantWizardCandidateStatus = (typeof HOME_ASSISTANT_WIZARD_CANDIDATE_STATUSES)[number];
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginDataWizardCandidate' })
+export class HomeAssistantWizardCandidateModel {
+	@ApiProperty({ description: 'Stable candidate key for this session', example: 'device:abcd1234' })
+	@Expose()
+	@IsString()
+	key: string;
+
+	@ApiProperty({ description: 'Home Assistant candidate kind', enum: ['device', 'helper'], example: 'device' })
+	@Expose()
+	@IsIn(['device', 'helper'])
+	kind: 'device' | 'helper';
+
+	@ApiProperty({ description: 'Home Assistant device or entity identifier', example: 'abcd1234' })
+	@Expose()
+	@IsString()
+	sourceId: string;
+
+	@ApiProperty({ description: 'Suggested device name', example: 'Living room lamp' })
+	@Expose()
+	@IsString()
+	name: string;
+
+	@ApiPropertyOptional({ description: 'Manufacturer', nullable: true, example: 'Philips' })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	manufacturer: string | null;
+
+	@ApiPropertyOptional({ description: 'Model or helper domain', nullable: true, example: 'Hue bulb' })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	model: string | null;
+
+	@ApiProperty({ description: 'Automatic adoption status', enum: HOME_ASSISTANT_WIZARD_CANDIDATE_STATUSES })
+	@Expose()
+	@IsIn(HOME_ASSISTANT_WIZARD_CANDIDATE_STATUSES)
+	status: HomeAssistantWizardCandidateStatus;
+
+	@ApiPropertyOptional({ description: 'Automatically suggested category', enum: DeviceCategory, nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsEnum(DeviceCategory)
+	suggestedCategory: DeviceCategory | null;
+
+	@ApiProperty({ description: 'Number of channels in the automatic mapping', example: 2 })
+	@Expose()
+	@IsInt()
+	previewChannelCount: number;
+
+	@ApiProperty({ description: 'Number of mapping warnings requiring manual review', example: 0 })
+	@Expose()
+	@IsInt()
+	warningCount: number;
+
+	@ApiPropertyOptional({ description: 'Existing Smart Panel device identifier', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	adoptedDeviceId: string | null;
+
+	@ApiPropertyOptional({ description: 'Discovery or mapping failure', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	error: string | null;
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginDataWizardSession' })
+export class HomeAssistantWizardSessionModel {
+	@ApiProperty({ description: 'Wizard session id' })
+	@Expose()
+	@IsString()
+	id: string;
+
+	@ApiProperty({ description: 'Wizard session start timestamp' })
+	@Expose()
+	@IsString()
+	startedAt: string;
+
+	@ApiProperty({
+		description: 'Home Assistant device and helper adoption candidates',
+		type: 'array',
+		items: { $ref: getSchemaPath(HomeAssistantWizardCandidateModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => HomeAssistantWizardCandidateModel)
+	candidates: HomeAssistantWizardCandidateModel[];
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginDataWizardAdoptionResult' })
+export class HomeAssistantWizardAdoptionResultModel {
+	@ApiProperty({ description: 'Candidate key from the wizard session' })
+	@Expose()
+	@IsString()
+	key: string;
+
+	@ApiProperty({ description: 'Resolved Smart Panel device name' })
+	@Expose()
+	@IsString()
+	name: string;
+
+	@ApiProperty({ description: 'Adoption outcome', enum: ['created', 'failed'] })
+	@Expose()
+	@IsIn(['created', 'failed'])
+	status: 'created' | 'failed';
+
+	@ApiPropertyOptional({ description: 'Failure message', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	error: string | null;
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginDataWizardAdoption' })
+export class HomeAssistantWizardAdoptionModel {
+	@ApiProperty({
+		description: 'Per-candidate adoption results',
+		type: 'array',
+		items: { $ref: getSchemaPath(HomeAssistantWizardAdoptionResultModel) },
+	})
+	@Expose()
+	@IsArray()
+	@ValidateNested({ each: true })
+	@Type(() => HomeAssistantWizardAdoptionResultModel)
+	results: HomeAssistantWizardAdoptionResultModel[];
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginResWizardSession' })
+export class HomeAssistantWizardSessionResponseModel extends BaseSuccessResponseModel<HomeAssistantWizardSessionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => HomeAssistantWizardSessionModel,
+	})
+	@Expose()
+	declare data: HomeAssistantWizardSessionModel;
+}
+
+@ApiSchema({ name: 'DevicesHomeAssistantPluginResWizardAdoption' })
+export class HomeAssistantWizardAdoptionResponseModel extends BaseSuccessResponseModel<HomeAssistantWizardAdoptionModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => HomeAssistantWizardAdoptionModel,
+	})
+	@Expose()
+	declare data: HomeAssistantWizardAdoptionModel;
+}

--- a/apps/backend/src/plugins/devices-home-assistant/services/device-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/device-adoption.service.ts
@@ -21,7 +21,10 @@ import { CreateHomeAssistantChannelDto } from '../dto/create-channel.dto';
 import { CreateHomeAssistantDeviceDto } from '../dto/create-device.dto';
 import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { HomeAssistantDeviceEntity } from '../entities/devices-home-assistant.entity';
-import { HomeAssistantDeviceRegistryResultModel } from '../models/home-assistant.model';
+import {
+	HomeAssistantDeviceRegistryResultModel,
+	HomeAssistantDiscoveredDeviceModel,
+} from '../models/home-assistant.model';
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
 import { HomeAssistantWsService } from './home-assistant.ws.service';
@@ -60,6 +63,7 @@ export class DeviceAdoptionService {
 	async adoptDevice(
 		request: AdoptDeviceRequestDto,
 		registryDevice?: HomeAssistantDeviceRegistryResultModel,
+		discoveredDevice?: HomeAssistantDiscoveredDeviceModel,
 	): Promise<HomeAssistantDeviceEntity> {
 		// Validate HA device exists
 		const haDevice =
@@ -155,7 +159,7 @@ export class DeviceAdoptionService {
 
 			// Sync initial states from Home Assistant to populate property values
 			// This also updates virtual property values and sets device connection state
-			await this.homeAssistantHttpService.syncDeviceStates(device.id);
+			await this.homeAssistantHttpService.syncDeviceStates(device.id, discoveredDevice);
 
 			// Return the fully loaded device
 			return await this.devicesService.findOne<HomeAssistantDeviceEntity>(device.id, DEVICES_HOME_ASSISTANT_TYPE);

--- a/apps/backend/src/plugins/devices-home-assistant/services/device-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/device-adoption.service.ts
@@ -21,6 +21,7 @@ import { CreateHomeAssistantChannelDto } from '../dto/create-channel.dto';
 import { CreateHomeAssistantDeviceDto } from '../dto/create-device.dto';
 import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { HomeAssistantDeviceEntity } from '../entities/devices-home-assistant.entity';
+import { HomeAssistantDeviceRegistryResultModel } from '../models/home-assistant.model';
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
 import { HomeAssistantWsService } from './home-assistant.ws.service';
@@ -56,10 +57,15 @@ export class DeviceAdoptionService {
 	/**
 	 * Adopt a Home Assistant device into the Smart Panel system
 	 */
-	async adoptDevice(request: AdoptDeviceRequestDto): Promise<HomeAssistantDeviceEntity> {
+	async adoptDevice(
+		request: AdoptDeviceRequestDto,
+		registryDevice?: HomeAssistantDeviceRegistryResultModel,
+	): Promise<HomeAssistantDeviceEntity> {
 		// Validate HA device exists
-		const devicesRegistry = await this.homeAssistantWsService.getDevicesRegistry();
-		const haDevice = devicesRegistry.find((d) => d.id === request.haDeviceId);
+		const haDevice =
+			registryDevice?.id === request.haDeviceId
+				? registryDevice
+				: (await this.homeAssistantWsService.getDevicesRegistry()).find((device) => device.id === request.haDeviceId);
 
 		if (!haDevice) {
 			throw new DevicesHomeAssistantNotFoundException(

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.spec.ts
@@ -1,0 +1,56 @@
+import { DataTypeType, PropertyCategory } from '../../../modules/devices/devices.constants';
+import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
+import { ChannelsService } from '../../../modules/devices/services/channels.service';
+import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
+import { DeviceValidationService } from '../../../modules/devices/services/device-validation.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import {
+	HomeAssistantChannelEntity,
+	HomeAssistantChannelPropertyEntity,
+	HomeAssistantDeviceEntity,
+} from '../entities/devices-home-assistant.entity';
+import { BUILTIN_TRANSFORMERS, TransformerRegistry } from '../mappings/transformers/transformer.registry';
+
+import { HelperAdoptionService } from './helper-adoption.service';
+import { HomeAssistantHttpService } from './home-assistant.http.service';
+
+describe('HelperAdoptionService', () => {
+	it('applies the configured transformer while syncing a discovered helper state', async () => {
+		const getState = jest.fn();
+		const update = jest.fn().mockResolvedValue(undefined);
+		const panelDevice = Object.assign(new HomeAssistantDeviceEntity(), { id: 'device-1' });
+		const channel = Object.assign(new HomeAssistantChannelEntity(), { device: panelDevice });
+		const property = Object.assign(new HomeAssistantChannelPropertyEntity(), {
+			id: 'property-1',
+			category: PropertyCategory.BRIGHTNESS,
+			dataType: DataTypeType.UCHAR,
+			haEntityId: 'light.desk',
+			haAttribute: 'brightness',
+			haTransformer: 'brightness_to_percent',
+			channel,
+		});
+		const transformerRegistry = new TransformerRegistry();
+		transformerRegistry.registerAll(BUILTIN_TRANSFORMERS);
+		const service = new HelperAdoptionService(
+			{ getState } as unknown as HomeAssistantHttpService,
+			{} as DevicesService,
+			{} as ChannelsService,
+			{ findAll: jest.fn().mockResolvedValue([property]), update } as unknown as ChannelsPropertiesService,
+			{} as DeviceConnectivityService,
+			{} as DeviceValidationService,
+			transformerRegistry,
+		);
+
+		await service['syncHelperState']('device-1', 'light.desk', {
+			entityId: 'light.desk',
+			state: 'on',
+			attributes: { brightness: 255 },
+			lastChanged: new Date(),
+			lastReported: new Date(),
+			lastUpdated: new Date(),
+		});
+
+		expect(getState).not.toHaveBeenCalled();
+		expect(update).toHaveBeenCalledWith('property-1', expect.objectContaining({ value: 100 }));
+	});
+});

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
@@ -36,6 +36,7 @@ import {
 	HomeAssistantChannelPropertyEntity,
 	HomeAssistantDeviceEntity,
 } from '../entities/devices-home-assistant.entity';
+import { HomeAssistantDiscoveredHelperModel } from '../models/home-assistant.model';
 import { buildHelperDeviceStructure } from '../utils/helper-structure.utils';
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
@@ -62,9 +63,15 @@ export class HelperAdoptionService {
 	/**
 	 * Adopt a Home Assistant helper into the Smart Panel system
 	 */
-	async adoptHelper(request: AdoptHelperRequestDto): Promise<HomeAssistantDeviceEntity> {
+	async adoptHelper(
+		request: AdoptHelperRequestDto,
+		discoveredHelper?: HomeAssistantDiscoveredHelperModel,
+	): Promise<HomeAssistantDeviceEntity> {
 		// Validate helper exists
-		const helper = await this.homeAssistantHttpService.getDiscoveredHelper(request.entityId);
+		const helper =
+			discoveredHelper?.entityId === request.entityId
+				? discoveredHelper
+				: await this.homeAssistantHttpService.getDiscoveredHelper(request.entityId);
 
 		if (!helper) {
 			throw new DevicesHomeAssistantNotFoundException(

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
@@ -36,7 +36,8 @@ import {
 	HomeAssistantChannelPropertyEntity,
 	HomeAssistantDeviceEntity,
 } from '../entities/devices-home-assistant.entity';
-import { HomeAssistantDiscoveredHelperModel } from '../models/home-assistant.model';
+import { TransformerRegistry } from '../mappings/transformers/transformer.registry';
+import { HomeAssistantDiscoveredHelperModel, HomeAssistantStateModel } from '../models/home-assistant.model';
 import { buildHelperDeviceStructure } from '../utils/helper-structure.utils';
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
@@ -58,6 +59,7 @@ export class HelperAdoptionService {
 		private readonly channelsPropertiesService: ChannelsPropertiesService,
 		private readonly deviceConnectivityService: DeviceConnectivityService,
 		private readonly deviceValidationService: DeviceValidationService,
+		private readonly transformerRegistry: TransformerRegistry,
 	) {}
 
 	/**
@@ -149,7 +151,7 @@ export class HelperAdoptionService {
 			}
 
 			// Sync initial state
-			await this.syncHelperState(device.id, request.entityId);
+			await this.syncHelperState(device.id, request.entityId, helper.state);
 
 			// Set device connection state to connected (helper is available if we got here)
 			await this.deviceConnectivityService.setConnectionState(device.id, {
@@ -294,9 +296,13 @@ export class HelperAdoptionService {
 	 * Sync the initial state from Home Assistant
 	 * This method fetches the helper's state and updates all matching property values
 	 */
-	private async syncHelperState(deviceId: string, entityId: string): Promise<void> {
+	private async syncHelperState(
+		deviceId: string,
+		entityId: string,
+		discoveredState?: HomeAssistantStateModel | null,
+	): Promise<void> {
 		try {
-			const state = await this.homeAssistantHttpService.getState(entityId);
+			const state = discoveredState ?? (await this.homeAssistantHttpService.getState(entityId));
 
 			// Load all properties for this device's channels
 			const allProperties = await this.channelsPropertiesService.findAll<HomeAssistantChannelPropertyEntity>(
@@ -329,6 +335,21 @@ export class HelperAdoptionService {
 					const attrValue = state.attributes[property.haAttribute];
 					if (attrValue !== undefined) {
 						newValue = attrValue as string | number | boolean;
+					}
+				}
+
+				if (newValue !== null && property.haTransformer) {
+					const transformer = this.transformerRegistry.getOrCreateMonitored(property.haTransformer);
+					if (transformer.canRead()) {
+						const transformedValue = transformer.read(newValue);
+						if (
+							typeof transformedValue === 'string' ||
+							typeof transformedValue === 'number' ||
+							typeof transformedValue === 'boolean' ||
+							transformedValue === null
+						) {
+							newValue = transformedValue as string | number | boolean | null;
+						}
 					}
 				}
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-adoption.service.ts
@@ -15,6 +15,7 @@ import {
 import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
 import { ChannelsService } from '../../../modules/devices/services/channels.service';
 import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
+import { DeviceValidationService } from '../../../modules/devices/services/device-validation.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import {
 	DEVICES_HOME_ASSISTANT_PLUGIN_NAME,
@@ -35,6 +36,7 @@ import {
 	HomeAssistantChannelPropertyEntity,
 	HomeAssistantDeviceEntity,
 } from '../entities/devices-home-assistant.entity';
+import { buildHelperDeviceStructure } from '../utils/helper-structure.utils';
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
 
@@ -54,6 +56,7 @@ export class HelperAdoptionService {
 		private readonly channelsService: ChannelsService,
 		private readonly channelsPropertiesService: ChannelsPropertiesService,
 		private readonly deviceConnectivityService: DeviceConnectivityService,
+		private readonly deviceValidationService: DeviceValidationService,
 	) {}
 
 	/**
@@ -114,6 +117,14 @@ export class HelperAdoptionService {
 		if (errors.length) {
 			this.logger.error(`[HELPER ADOPTION] Device validation failed: ${JSON.stringify(errors)}`);
 			throw new DevicesHomeAssistantValidationException('Device validation failed');
+		}
+
+		const structureValidation = this.deviceValidationService.validateDeviceStructure(
+			buildHelperDeviceStructure(request),
+		);
+		if (!structureValidation.isValid) {
+			const reasons = structureValidation.issues.map((issue) => issue.message).join('; ');
+			throw new DevicesHomeAssistantValidationException(`Device structure validation failed: ${reasons}`);
 		}
 
 		// Create the device

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.spec.ts
@@ -1,0 +1,48 @@
+import { ChannelCategory, DeviceCategory, PropertyCategory } from '../../../modules/devices/devices.constants';
+import { HomeAssistantDomain } from '../devices-home-assistant.constants';
+import { MappingLoaderService } from '../mappings';
+import { HomeAssistantDiscoveredHelperModel, HomeAssistantStateModel } from '../models/home-assistant.model';
+
+import { HelperMappingPreviewService } from './helper-mapping-preview.service';
+import { HomeAssistantHttpService } from './home-assistant.http.service';
+
+describe('HelperMappingPreviewService', () => {
+	it('carries mapping transformers into helper property previews', async () => {
+		const mappingLoaderService = {
+			findMatchingMapping: jest.fn().mockReturnValue({
+				channel: { category: ChannelCategory.LIGHT },
+				deviceCategory: DeviceCategory.LIGHTING,
+				propertyBindings: [
+					{
+						haAttribute: 'brightness',
+						propertyCategory: PropertyCategory.BRIGHTNESS,
+						transformerName: 'brightness_to_percent',
+					},
+				],
+			}),
+		};
+		const service = new HelperMappingPreviewService(
+			{} as HomeAssistantHttpService,
+			mappingLoaderService as unknown as MappingLoaderService,
+		);
+		const state = Object.assign(new HomeAssistantStateModel(), {
+			entityId: 'light.desk',
+			state: 'on',
+			attributes: { brightness: 128 },
+			lastChanged: null,
+			lastReported: null,
+			lastUpdated: null,
+		});
+		const helper = Object.assign(new HomeAssistantDiscoveredHelperModel(), {
+			entityId: 'light.desk',
+			name: 'Desk light',
+			domain: HomeAssistantDomain.LIGHT,
+			adoptedDeviceId: null,
+			state,
+		});
+
+		const previews = await service.generatePreviews([helper]);
+
+		expect(previews[0].suggestedChannels[0].suggestedProperties[0].haTransformer).toBe('brightness_to_percent');
+	});
+});

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
@@ -353,6 +353,7 @@ export class HelperMappingPreviewService {
 					null,
 				required: propertyMetadata?.required ?? false,
 				currentValue,
+				haTransformer: binding.transformerName ?? null,
 			});
 		}
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
@@ -51,9 +51,27 @@ export class HelperMappingPreviewService {
 		entityId: string,
 		options?: HelperMappingPreviewRequestDto,
 	): Promise<HelperMappingPreviewModel> {
-		// Fetch helper information
 		const helper = await this.homeAssistantHttpService.getDiscoveredHelper(entityId);
 
+		return this.generatePreviewFromSnapshot(entityId, helper, options);
+	}
+
+	/**
+	 * Generate automatic previews for all discoverable helpers from one Home Assistant snapshot.
+	 */
+	async generatePreviews(
+		discoveredHelpers?: HomeAssistantDiscoveredHelperModel[],
+	): Promise<HelperMappingPreviewModel[]> {
+		const helpers = discoveredHelpers ?? (await this.homeAssistantHttpService.getDiscoveredHelpers());
+
+		return helpers.map((helper) => this.generatePreviewFromSnapshot(helper.entityId, helper));
+	}
+
+	private generatePreviewFromSnapshot(
+		entityId: string,
+		helper: HomeAssistantDiscoveredHelperModel,
+		options?: HelperMappingPreviewRequestDto,
+	): HelperMappingPreviewModel {
 		if (!helper) {
 			throw new DevicesHomeAssistantNotFoundException(`Home Assistant helper with entity_id ${entityId} not found`);
 		}

--- a/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/helper-mapping-preview.service.ts
@@ -29,6 +29,12 @@ import { HomeAssistantDiscoveredHelperModel } from '../models/home-assistant.mod
 
 import { HomeAssistantHttpService } from './home-assistant.http.service';
 
+export interface HelperMappingPreviewResult {
+	source: HomeAssistantDiscoveredHelperModel;
+	preview: HelperMappingPreviewModel | null;
+	error: string | null;
+}
+
 /**
  * Service for generating mapping previews for Home Assistant helpers
  */
@@ -62,9 +68,30 @@ export class HelperMappingPreviewService {
 	async generatePreviews(
 		discoveredHelpers?: HomeAssistantDiscoveredHelperModel[],
 	): Promise<HelperMappingPreviewModel[]> {
+		const results = await this.generateSettledPreviews(discoveredHelpers);
+
+		return results.flatMap((result) => (result.preview ? [result.preview] : []));
+	}
+
+	/**
+	 * Generate helper previews while preserving other candidates if one mapping fails.
+	 */
+	async generateSettledPreviews(
+		discoveredHelpers?: HomeAssistantDiscoveredHelperModel[],
+	): Promise<HelperMappingPreviewResult[]> {
 		const helpers = discoveredHelpers ?? (await this.homeAssistantHttpService.getDiscoveredHelpers());
 
-		return helpers.map((helper) => this.generatePreviewFromSnapshot(helper.entityId, helper));
+		return helpers.map((helper) => {
+			try {
+				return {
+					source: helper,
+					preview: this.generatePreviewFromSnapshot(helper.entityId, helper),
+					error: null,
+				};
+			} catch (error) {
+				return { source: helper, preview: null, error: (error as Error).message };
+			}
+		});
 	}
 
 	private generatePreviewFromSnapshot(

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
@@ -28,6 +28,7 @@ const mockConfigService = {
 
 const mockDevicesService = {
 	findAll: jest.fn(),
+	findOne: jest.fn(),
 };
 
 const mockChannelsPropertiesService = {
@@ -80,6 +81,7 @@ describe('HomeAssistantHttpService', () => {
 
 		mockConfigService.getPluginConfig.mockReturnValue({
 			apiKey: 'test-api-key',
+			enabled: true,
 			hostname: 'localhost',
 		});
 		mockDevicesService.findAll.mockResolvedValue([]);
@@ -321,6 +323,40 @@ describe('HomeAssistantHttpService', () => {
 			jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchSingleHaState').mockResolvedValue(null);
 
 			await expect(service.getState('sensor.temp')).rejects.toThrow(DevicesHomeAssistantNotFoundException);
+		});
+	});
+
+	describe('syncDeviceStates', () => {
+		it('reuses a discovered device snapshot without refetching Home Assistant inventory', async () => {
+			mockDevicesService.findOne.mockResolvedValue(
+				Object.assign(new HomeAssistantDeviceEntity(), {
+					id: 'panel-device-1',
+					haDeviceId: 'device_1',
+					name: 'Test device',
+				}),
+			);
+			const fetchDevices = jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaDevices');
+			const fetchStates = jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaStates');
+
+			await service.syncDeviceStates('panel-device-1', {
+				id: 'device_1',
+				name: 'Test device',
+				entities: ['sensor.temp'],
+				adoptedDeviceId: null,
+				states: [
+					{
+						entityId: 'sensor.temp',
+						state: '22',
+						attributes: {},
+						lastChanged: new Date(),
+						lastReported: new Date(),
+						lastUpdated: new Date(),
+					},
+				],
+			});
+
+			expect(fetchDevices).not.toHaveBeenCalled();
+			expect(fetchStates).not.toHaveBeenCalled();
 		});
 	});
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
@@ -11,7 +11,11 @@ import {
 import { HomeAssistantDiscoveredDeviceDto } from '../dto/home-assistant-discovered-device.dto';
 import { HomeAssistantDiscoveredHelperDto } from '../dto/home-assistant-discovered-helper.dto';
 import { HomeAssistantStateDto } from '../dto/home-assistant-state.dto';
-import { HomeAssistantDeviceEntity } from '../entities/devices-home-assistant.entity';
+import {
+	HomeAssistantChannelEntity,
+	HomeAssistantChannelPropertyEntity,
+	HomeAssistantDeviceEntity,
+} from '../entities/devices-home-assistant.entity';
 import { MapperService } from '../mappers/mapper.service';
 
 import { HaSupervisorService } from './ha-supervisor.service';
@@ -78,6 +82,8 @@ describe('HomeAssistantHttpService', () => {
 			apiKey: 'test-api-key',
 			hostname: 'localhost',
 		});
+		mockDevicesService.findAll.mockResolvedValue([]);
+		mockChannelsPropertiesService.findAll.mockResolvedValue([]);
 	});
 
 	afterEach(() => {
@@ -244,8 +250,6 @@ describe('HomeAssistantHttpService', () => {
 			const fetchStates = jest
 				.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaStates')
 				.mockResolvedValue(states);
-			mockDevicesService.findAll.mockResolvedValue([]);
-
 			const result = await service.getDiscoveredInventory();
 
 			expect(result.devices[0].states[0].entityId).toBe('sensor.temp');
@@ -254,6 +258,34 @@ describe('HomeAssistantHttpService', () => {
 			expect(fetchHelpers.mock.calls).toHaveLength(1);
 			expect(fetchStates.mock.calls).toHaveLength(1);
 			expect(mockDevicesService.findAll.mock.calls).toHaveLength(1);
+			expect(mockChannelsPropertiesService.findAll.mock.calls).toHaveLength(1);
+		});
+
+		it('marks a helper adopted when it is mapped to a property of a physical device', async () => {
+			const helper: HomeAssistantDiscoveredHelperDto = {
+				entity_id: 'climate.living_room',
+				name: 'Living room thermostat',
+				domain: 'climate',
+			};
+			const panelDevice = Object.assign(new HomeAssistantDeviceEntity(), {
+				id: 'panel-device-1',
+				haDeviceId: 'ha-physical-device-1',
+			});
+			const channel = Object.assign(new HomeAssistantChannelEntity(), { device: panelDevice });
+			const property = Object.assign(new HomeAssistantChannelPropertyEntity(), {
+				haEntityId: helper.entity_id,
+				channel,
+			});
+
+			jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaDevices').mockResolvedValue([]);
+			jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaHelpers').mockResolvedValue([helper]);
+			jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaStates').mockResolvedValue([]);
+			mockDevicesService.findAll.mockResolvedValue([panelDevice]);
+			mockChannelsPropertiesService.findAll.mockResolvedValue([property]);
+
+			const result = await service.getDiscoveredInventory();
+
+			expect(result.helpers[0].adoptedDeviceId).toBe(panelDevice.id);
 		});
 	});
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.spec.ts
@@ -9,6 +9,7 @@ import {
 	DevicesHomeAssistantValidationException,
 } from '../devices-home-assistant.exceptions';
 import { HomeAssistantDiscoveredDeviceDto } from '../dto/home-assistant-discovered-device.dto';
+import { HomeAssistantDiscoveredHelperDto } from '../dto/home-assistant-discovered-helper.dto';
 import { HomeAssistantStateDto } from '../dto/home-assistant-state.dto';
 import { HomeAssistantDeviceEntity } from '../entities/devices-home-assistant.entity';
 import { MapperService } from '../mappers/mapper.service';
@@ -199,6 +200,60 @@ describe('HomeAssistantHttpService', () => {
 			jest.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaStates').mockResolvedValue(null);
 
 			await expect(service.getDiscoveredDevices()).rejects.toThrow(DevicesHomeAssistantNotFoundException);
+		});
+	});
+
+	describe('getDiscoveredInventory', () => {
+		it('shares one states response across physical devices and helpers', async () => {
+			const mockDevice: HomeAssistantDiscoveredDeviceDto = {
+				id: 'device_1',
+				name: 'Test Device',
+				entities: ['sensor.temp'],
+			};
+			const mockHelper: HomeAssistantDiscoveredHelperDto = {
+				entity_id: 'input_boolean.guest_mode',
+				name: 'Guest mode',
+				domain: 'input_boolean',
+			};
+			const states: HomeAssistantStateDto[] = [
+				{
+					entity_id: 'sensor.temp',
+					state: '22',
+					attributes: {},
+					last_changed: new Date(),
+					last_updated: new Date(),
+					last_reported: new Date(),
+					context: { id: 'device-state', parent_id: null, user_id: null },
+				},
+				{
+					entity_id: 'input_boolean.guest_mode',
+					state: 'off',
+					attributes: {},
+					last_changed: new Date(),
+					last_updated: new Date(),
+					last_reported: new Date(),
+					context: { id: 'helper-state', parent_id: null, user_id: null },
+				},
+			];
+			const fetchDevices = jest
+				.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaDevices')
+				.mockResolvedValue([mockDevice]);
+			const fetchHelpers = jest
+				.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaHelpers')
+				.mockResolvedValue([mockHelper]);
+			const fetchStates = jest
+				.spyOn<HomeAssistantHttpService, any>(service, 'fetchListHaStates')
+				.mockResolvedValue(states);
+			mockDevicesService.findAll.mockResolvedValue([]);
+
+			const result = await service.getDiscoveredInventory();
+
+			expect(result.devices[0].states[0].entityId).toBe('sensor.temp');
+			expect(result.helpers[0].state?.entityId).toBe('input_boolean.guest_mode');
+			expect(fetchDevices.mock.calls).toHaveLength(1);
+			expect(fetchHelpers.mock.calls).toHaveLength(1);
+			expect(fetchStates.mock.calls).toHaveLength(1);
+			expect(mockDevicesService.findAll.mock.calls).toHaveLength(1);
 		});
 	});
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
@@ -168,11 +168,15 @@ export class HomeAssistantHttpService {
 		this.ensureApiKey();
 
 		try {
-			const [devices, helpers, states, panelDevices] = await Promise.all([
+			const [devices, helpers, states, panelDevices, properties] = await Promise.all([
 				this.fetchListHaDevices(),
 				this.fetchListHaHelpers(),
 				this.fetchListHaStates(),
 				this.devicesService.findAll<HomeAssistantDeviceEntity>(DEVICES_HOME_ASSISTANT_TYPE),
+				this.channelsPropertiesService.findAll<HomeAssistantChannelPropertyEntity>(
+					undefined,
+					DEVICES_HOME_ASSISTANT_TYPE,
+				),
 			]);
 
 			if (!devices || !helpers || !states) {
@@ -190,7 +194,14 @@ export class HomeAssistantHttpService {
 				}),
 				helpers: helpers.map((helper) => {
 					const model = this.toDiscoveredHelperModel(helper);
-					model.adoptedDeviceId = panelDevices.find((item) => item.haDeviceId === helper.entity_id)?.id ?? null;
+					const directlyAdoptedDeviceId = panelDevices.find((item) => item.haDeviceId === helper.entity_id)?.id ?? null;
+					const mappedProperty = properties.find((property) => property.haEntityId === helper.entity_id);
+					const mappedDeviceId =
+						mappedProperty?.channel instanceof HomeAssistantChannelEntity &&
+						mappedProperty.channel.device instanceof HomeAssistantDeviceEntity
+							? mappedProperty.channel.device.id
+							: null;
+					model.adoptedDeviceId = directlyAdoptedDeviceId ?? mappedDeviceId;
 					const state = states.find((item) => item.entity_id === helper.entity_id);
 					if (state) {
 						model.state = this.toStateModel(state);

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
@@ -59,6 +59,11 @@ const DISCOVERED_DEVICE_TEMPLATE =
 const DISCOVERED_HELPERS_TEMPLATE =
 	"{% set helper_domains = ['input_boolean', 'input_number', 'input_select', 'input_text', 'input_datetime', 'input_button', 'timer', 'climate', 'sensor', 'binary_sensor', 'switch', 'light', 'fan', 'cover', 'lock', 'humidifier', 'water_heater', 'vacuum'] %}{% set virtual_device_domains = ['climate', 'humidifier', 'water_heater'] %}{% set ns = namespace(list=[]) %}{% for state in states %}{% set domain = state.entity_id.split('.')[0] %}{% if domain in helper_domains %}{% set dev_id = device_id(state.entity_id) %}{% if dev_id is none or dev_id == '' or domain in virtual_device_domains %}{% set ns.list = ns.list + [{'entity_id': state.entity_id, 'name': state.attributes.friendly_name | default(state.entity_id), 'domain': domain}] %}{% endif %}{% endif %}{% endfor %}{{ ns.list | tojson }}";
 
+export interface HomeAssistantDiscoveredInventory {
+	devices: HomeAssistantDiscoveredDeviceModel[];
+	helpers: HomeAssistantDiscoveredHelperModel[];
+}
+
 @Injectable()
 export class HomeAssistantHttpService {
 	private readonly logger: ExtensionLoggerService = createExtensionLogger(
@@ -154,6 +159,57 @@ export class HomeAssistantHttpService {
 		}
 
 		throw new DevicesHomeAssistantNotFoundException('Home Assistant discovered devices list could not be loaded');
+	}
+
+	/**
+	 * Fetch the complete wizard inventory with one shared states response and one adopted-devices lookup.
+	 */
+	async getDiscoveredInventory(): Promise<HomeAssistantDiscoveredInventory> {
+		this.ensureApiKey();
+
+		try {
+			const [devices, helpers, states, panelDevices] = await Promise.all([
+				this.fetchListHaDevices(),
+				this.fetchListHaHelpers(),
+				this.fetchListHaStates(),
+				this.devicesService.findAll<HomeAssistantDeviceEntity>(DEVICES_HOME_ASSISTANT_TYPE),
+			]);
+
+			if (!devices || !helpers || !states) {
+				throw new DevicesHomeAssistantNotFoundException('Home Assistant discovered inventory could not be loaded');
+			}
+
+			return {
+				devices: devices.map((device) => {
+					const model = this.toDiscoveredDeviceModel(device);
+					model.adoptedDeviceId = panelDevices.find((item) => item.haDeviceId === device.id)?.id ?? null;
+					model.states = states
+						.filter((state) => device.entities.includes(state.entity_id))
+						.map((state) => this.toStateModel(state));
+					return model;
+				}),
+				helpers: helpers.map((helper) => {
+					const model = this.toDiscoveredHelperModel(helper);
+					model.adoptedDeviceId = panelDevices.find((item) => item.haDeviceId === helper.entity_id)?.id ?? null;
+					const state = states.find((item) => item.entity_id === helper.entity_id);
+					if (state) {
+						model.state = this.toStateModel(state);
+					}
+					return model;
+				}),
+			};
+		} catch (error) {
+			if (error instanceof DevicesHomeAssistantNotFoundException) {
+				throw error;
+			}
+
+			const err = error as Error;
+			this.logger.error('Failed to fetch Home Assistant discovered inventory', {
+				message: err.message,
+				stack: err.stack,
+			});
+			throw new DevicesHomeAssistantException('Home Assistant discovered inventory could not be loaded');
+		}
 	}
 
 	async getDiscoveredHelper(entityId: string): Promise<HomeAssistantDiscoveredHelperModel> {

--- a/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/home-assistant.http.service.ts
@@ -490,7 +490,7 @@ export class HomeAssistantHttpService {
 	 * Sync states for a specific device from Home Assistant
 	 * This is called after device adoption to immediately populate property values
 	 */
-	async syncDeviceStates(deviceId: string): Promise<void> {
+	async syncDeviceStates(deviceId: string, discoveredDevice?: HomeAssistantDiscoveredDeviceModel): Promise<void> {
 		if (this.apiKey === null || this.enabled !== true) {
 			this.logger.debug(`[SYNC] Skipping sync for device ${deviceId} - HA not configured`, { resource: deviceId });
 			return;
@@ -510,23 +510,37 @@ export class HomeAssistantHttpService {
 				return;
 			}
 
-			// Fetch HA device info and states
-			const [haDevices, states] = await Promise.all([this.fetchListHaDevices(), this.fetchListHaStates()]);
+			let deviceStates: HomeAssistantStateDto[];
 
-			if (!haDevices?.length || !states?.length) {
-				this.logger.debug(`[SYNC] Missing HA data for device ${deviceId}`, { resource: deviceId });
-				return;
+			if (discoveredDevice?.id === device.haDeviceId) {
+				deviceStates = discoveredDevice.states.map((state) =>
+					toInstance(HomeAssistantStateDto, {
+						entity_id: state.entityId,
+						state: String(state.state ?? ''),
+						attributes: state.attributes,
+						last_changed: state.lastChanged ?? new Date(0),
+						last_reported: state.lastReported ?? new Date(0),
+						last_updated: state.lastUpdated ?? new Date(0),
+						context: { id: '', parent_id: null, user_id: null },
+					}),
+				);
+			} else {
+				// Manual adoption has no shared discovery snapshot, so retain the existing fetch path.
+				const [haDevices, states] = await Promise.all([this.fetchListHaDevices(), this.fetchListHaStates()]);
+
+				if (!haDevices?.length || !states?.length) {
+					this.logger.debug(`[SYNC] Missing HA data for device ${deviceId}`, { resource: deviceId });
+					return;
+				}
+
+				const haDevice = haDevices.find((candidate) => candidate.id === device.haDeviceId);
+				if (!haDevice) {
+					this.logger.warn(`[SYNC] HA device ${device.haDeviceId} not found in registry`, { resource: deviceId });
+					return;
+				}
+
+				deviceStates = states.filter((state) => haDevice.entities.includes(state.entity_id));
 			}
-
-			// Find the HA device
-			const haDevice = haDevices.find((d) => d.id === device.haDeviceId);
-			if (!haDevice) {
-				this.logger.warn(`[SYNC] HA device ${device.haDeviceId} not found in registry`, { resource: deviceId });
-				return;
-			}
-
-			// Get states for this device's entities
-			const deviceStates = states.filter((s) => haDevice.entities.includes(s.entity_id));
 
 			if (!deviceStates.length) {
 				this.logger.debug(`[SYNC] No states found for device ${deviceId}`, { resource: deviceId });

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
@@ -83,6 +83,7 @@ describe('MappingPreviewService', () => {
 	beforeEach(async () => {
 		const homeAssistantHttpServiceMock: Partial<jest.Mocked<HomeAssistantHttpService>> = {
 			getDiscoveredDevice: jest.fn(),
+			getDiscoveredDevices: jest.fn(),
 		};
 
 		const homeAssistantWsServiceMock: Partial<jest.Mocked<HomeAssistantWsService>> = {
@@ -154,6 +155,23 @@ describe('MappingPreviewService', () => {
 
 	it('should be defined', () => {
 		expect(service).toBeDefined();
+	});
+
+	describe('generatePreviews', () => {
+		it('uses one registry and discovery snapshot for the complete inventory', async () => {
+			homeAssistantWsService.getDevicesRegistry.mockResolvedValue(mockDeviceRegistry);
+			homeAssistantWsService.getEntitiesRegistry.mockResolvedValue(mockEntityRegistry);
+			homeAssistantHttpService.getDiscoveredDevices.mockResolvedValue([mockDiscoveredDevice]);
+
+			const result = await service.generatePreviews();
+
+			expect(result).toHaveLength(1);
+			expect(result[0].haDevice.id).toBe('device123');
+			expect(homeAssistantWsService.getDevicesRegistry.mock.calls).toHaveLength(1);
+			expect(homeAssistantWsService.getEntitiesRegistry.mock.calls).toHaveLength(1);
+			expect(homeAssistantHttpService.getDiscoveredDevices.mock.calls).toHaveLength(1);
+			expect(homeAssistantHttpService.getDiscoveredDevice.mock.calls).toHaveLength(0);
+		});
 	});
 
 	describe('generatePreview', () => {

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
@@ -181,10 +181,12 @@ describe('MappingPreviewService', () => {
 			const results = await service.generateSettledPreviews([mockDiscoveredDevice, missingDevice]);
 
 			expect(results[0].source).toBe(mockDiscoveredDevice);
+			expect(results[0].registryDevice).toBe(mockDeviceRegistry[0]);
 			expect(results[0].preview?.haDevice.id).toBe('device123');
 			expect(results[0].error).toBeNull();
 			expect(results[1]).toEqual({
 				source: missingDevice,
+				registryDevice: null,
 				preview: null,
 				error: 'Home Assistant device with ID removed-device not found',
 			});

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.spec.ts
@@ -172,6 +172,23 @@ describe('MappingPreviewService', () => {
 			expect(homeAssistantHttpService.getDiscoveredDevices.mock.calls).toHaveLength(1);
 			expect(homeAssistantHttpService.getDiscoveredDevice.mock.calls).toHaveLength(0);
 		});
+
+		it('isolates a device missing from the registry snapshot', async () => {
+			homeAssistantWsService.getDevicesRegistry.mockResolvedValue(mockDeviceRegistry);
+			homeAssistantWsService.getEntitiesRegistry.mockResolvedValue(mockEntityRegistry);
+			const missingDevice = { ...mockDiscoveredDevice, id: 'removed-device', name: 'Removed device' };
+
+			const results = await service.generateSettledPreviews([mockDiscoveredDevice, missingDevice]);
+
+			expect(results[0].source).toBe(mockDiscoveredDevice);
+			expect(results[0].preview?.haDevice.id).toBe('device123');
+			expect(results[0].error).toBeNull();
+			expect(results[1]).toEqual({
+				source: missingDevice,
+				preview: null,
+				error: 'Home Assistant device with ID removed-device not found',
+			});
+		});
 	});
 
 	describe('generatePreview', () => {

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
@@ -51,6 +51,7 @@ import { VirtualPropertyContext } from './virtual-property.types';
 
 export interface DeviceMappingPreviewResult {
 	source: HomeAssistantDiscoveredDeviceModel;
+	registryDevice: HomeAssistantDeviceRegistryResultModel | null;
 	preview: MappingPreviewModel | null;
 	error: string | null;
 }
@@ -114,13 +115,15 @@ export class MappingPreviewService {
 
 		return inventory.map((device) => {
 			try {
+				const registryDevice = devicesRegistry.find((item) => item.id === device.id) ?? null;
 				return {
 					source: device,
+					registryDevice,
 					preview: this.generatePreviewFromSnapshot(device.id, devicesRegistry, entitiesRegistry, device),
 					error: null,
 				};
 			} catch (error) {
-				return { source: device, preview: null, error: (error as Error).message };
+				return { source: device, registryDevice: null, preview: null, error: (error as Error).message };
 			}
 		});
 	}

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
@@ -49,6 +49,12 @@ import { LightCapabilityAnalyzer } from './light-capability.analyzer';
 import { VirtualPropertyService } from './virtual-property.service';
 import { VirtualPropertyContext } from './virtual-property.types';
 
+export interface DeviceMappingPreviewResult {
+	source: HomeAssistantDiscoveredDeviceModel;
+	preview: MappingPreviewModel | null;
+	error: string | null;
+}
+
 /**
  * Service for generating mapping previews for Home Assistant devices
  *
@@ -89,15 +95,34 @@ export class MappingPreviewService {
 	 * Generate automatic previews for all discoverable devices from one Home Assistant snapshot.
 	 */
 	async generatePreviews(discoveredDevices?: HomeAssistantDiscoveredDeviceModel[]): Promise<MappingPreviewModel[]> {
+		const results = await this.generateSettledPreviews(discoveredDevices);
+
+		return results.flatMap((result) => (result.preview ? [result.preview] : []));
+	}
+
+	/**
+	 * Generate previews from one registry snapshot while keeping a failure scoped to its source device.
+	 */
+	async generateSettledPreviews(
+		discoveredDevices?: HomeAssistantDiscoveredDeviceModel[],
+	): Promise<DeviceMappingPreviewResult[]> {
 		const [devicesRegistry, entitiesRegistry, inventory] = await Promise.all([
 			this.homeAssistantWsService.getDevicesRegistry(),
 			this.homeAssistantWsService.getEntitiesRegistry(),
 			discoveredDevices ?? this.homeAssistantHttpService.getDiscoveredDevices(),
 		]);
 
-		return inventory.map((device) =>
-			this.generatePreviewFromSnapshot(device.id, devicesRegistry, entitiesRegistry, device),
-		);
+		return inventory.map((device) => {
+			try {
+				return {
+					source: device,
+					preview: this.generatePreviewFromSnapshot(device.id, devicesRegistry, entitiesRegistry, device),
+					error: null,
+				};
+			} catch (error) {
+				return { source: device, preview: null, error: (error as Error).message };
+			}
+		});
 	}
 
 	private generatePreviewFromSnapshot(

--- a/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/mapping-preview.service.ts
@@ -27,7 +27,12 @@ import { DevicesHomeAssistantNotFoundException } from '../devices-home-assistant
 import { MappingPreviewRequestDto } from '../dto/mapping-preview.dto';
 import { EntityRole, MappingLoaderService, ResolvedHaMapping, ResolvedPropertyBinding } from '../mappings';
 import { TransformerRegistry } from '../mappings/transformers/transformer.registry';
-import { HomeAssistantDeviceRegistryResultModel, HomeAssistantStateModel } from '../models/home-assistant.model';
+import {
+	HomeAssistantDeviceRegistryResultModel,
+	HomeAssistantDiscoveredDeviceModel,
+	HomeAssistantEntityRegistryResultModel,
+	HomeAssistantStateModel,
+} from '../models/home-assistant.model';
 import {
 	EntityMappingPreviewModel,
 	HaDeviceInfoModel,
@@ -71,13 +76,37 @@ export class MappingPreviewService {
 	 * Generate a mapping preview for a Home Assistant device
 	 */
 	async generatePreview(haDeviceId: string, options?: MappingPreviewRequestDto): Promise<MappingPreviewModel> {
-		// Fetch device information and states
 		const [devicesRegistry, entitiesRegistry, discoveredDevice] = await Promise.all([
 			this.homeAssistantWsService.getDevicesRegistry(),
 			this.homeAssistantWsService.getEntitiesRegistry(),
 			this.homeAssistantHttpService.getDiscoveredDevice(haDeviceId),
 		]);
 
+		return this.generatePreviewFromSnapshot(haDeviceId, devicesRegistry, entitiesRegistry, discoveredDevice, options);
+	}
+
+	/**
+	 * Generate automatic previews for all discoverable devices from one Home Assistant snapshot.
+	 */
+	async generatePreviews(discoveredDevices?: HomeAssistantDiscoveredDeviceModel[]): Promise<MappingPreviewModel[]> {
+		const [devicesRegistry, entitiesRegistry, inventory] = await Promise.all([
+			this.homeAssistantWsService.getDevicesRegistry(),
+			this.homeAssistantWsService.getEntitiesRegistry(),
+			discoveredDevices ?? this.homeAssistantHttpService.getDiscoveredDevices(),
+		]);
+
+		return inventory.map((device) =>
+			this.generatePreviewFromSnapshot(device.id, devicesRegistry, entitiesRegistry, device),
+		);
+	}
+
+	private generatePreviewFromSnapshot(
+		haDeviceId: string,
+		devicesRegistry: HomeAssistantDeviceRegistryResultModel[],
+		entitiesRegistry: HomeAssistantEntityRegistryResultModel[],
+		discoveredDevice: HomeAssistantDiscoveredDeviceModel,
+		options?: MappingPreviewRequestDto,
+	): MappingPreviewModel {
 		// Find device in registry
 		const deviceRegistry = devicesRegistry.find((d) => d.id === haDeviceId);
 		if (!deviceRegistry) {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -185,6 +185,7 @@ describe('HomeAssistantWizardService', () => {
 		const snapshot = await service.start();
 
 		expect(snapshot.candidates.find((candidate) => candidate.kind === 'device')?.status).toBe('needs_attention');
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'device')?.error).toBe('Review mapping');
 		const results = await service.adopt(snapshot.id, ['device:ha-device-1']);
 
 		expect(results?.[0]).toEqual(
@@ -209,6 +210,7 @@ describe('HomeAssistantWizardService', () => {
 				channels: [expect.objectContaining({ entityId: 'light.living_room', category: ChannelCategory.LIGHT })],
 			}),
 			undefined,
+			expect.objectContaining({ id: 'ha-device-1' }),
 		);
 		expect(homeAssistantHttpService.getDiscoveredInventory).toHaveBeenCalledTimes(2);
 		expect(mappingPreviewService.generateSettledPreviews).toHaveBeenLastCalledWith([
@@ -413,7 +415,7 @@ describe('HomeAssistantWizardService', () => {
 		const snapshot = await service.start();
 
 		expect(snapshot.candidates.find((candidate) => candidate.kind === 'helper')).toEqual(
-			expect.objectContaining({ status: 'needs_attention' }),
+			expect.objectContaining({ status: 'needs_attention', error: 'Automatic mapping requires manual review' }),
 		);
 		expect(helperAdoptionService.adoptHelper).not.toHaveBeenCalled();
 	});

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -208,8 +208,12 @@ describe('HomeAssistantWizardService', () => {
 				category: DeviceCategory.LIGHTING,
 				channels: [expect.objectContaining({ entityId: 'light.living_room', category: ChannelCategory.LIGHT })],
 			}),
+			undefined,
 		);
-		expect(mappingPreviewService.generatePreview).toHaveBeenCalledWith('ha-device-1');
+		expect(homeAssistantHttpService.getDiscoveredInventory).toHaveBeenCalledTimes(2);
+		expect(mappingPreviewService.generateSettledPreviews).toHaveBeenLastCalledWith([
+			expect.objectContaining({ id: 'ha-device-1' }),
+		]);
 		expect(helperAdoptionService.adoptHelper).not.toHaveBeenCalled();
 		expect(service.get(snapshot.id)?.candidates.find((candidate) => candidate.key === 'device:ha-device-1')).toEqual(
 			expect.objectContaining({ status: 'already_registered', adoptedDeviceId: 'device-1' }),
@@ -226,8 +230,14 @@ describe('HomeAssistantWizardService', () => {
 				error: null,
 			},
 		]);
-		helperMappingPreviewService.generatePreview.mockResolvedValueOnce(transformedPreview);
 		const snapshot = await service.start();
+		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { entityId: 'input_boolean.guest_mode', name: 'Guest mode', domain: 'input_boolean' },
+				preview: transformedPreview,
+				error: null,
+			},
+		]);
 
 		await service.adopt(snapshot.id, ['helper:input_boolean.guest_mode']);
 
@@ -239,14 +249,21 @@ describe('HomeAssistantWizardService', () => {
 					}),
 				],
 			}),
+			expect.objectContaining({ entityId: 'input_boolean.guest_mode' }),
 		);
 	});
 
 	it('revalidates automatic mapping immediately before persistence', async () => {
 		const snapshot = await service.start();
-		mappingPreviewService.generatePreview.mockResolvedValueOnce(
-			createDevicePreview([{ type: 'unsupported_entity', entityId: 'sensor.changed', message: 'Mapping changed' }]),
-		);
+		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				preview: createDevicePreview([
+					{ type: 'unsupported_entity', entityId: 'sensor.changed', message: 'Mapping changed' },
+				]),
+				error: null,
+			},
+		]);
 
 		const results = await service.adopt(snapshot.id, ['device:ha-device-1']);
 
@@ -270,6 +287,9 @@ describe('HomeAssistantWizardService', () => {
 			{ key: 'device:ha-device-1', name: 'Living room lamp', status: 'created', error: null },
 			{ key: 'helper:input_boolean.guest_mode', name: 'Guest mode', status: 'failed', error: 'Helper disappeared' },
 		]);
+		expect(homeAssistantHttpService.getDiscoveredInventory).toHaveBeenCalledTimes(2);
+		expect(mappingPreviewService.generateSettledPreviews).toHaveBeenCalledTimes(2);
+		expect(helperMappingPreviewService.generateSettledPreviews).toHaveBeenCalledTimes(2);
 	});
 
 	it('marks candidates already adopted outside the wizard as unavailable', async () => {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -5,6 +5,8 @@ import {
 	PermissionType,
 	PropertyCategory,
 } from '../../../modules/devices/devices.constants';
+import { DeviceValidationService } from '../../../modules/devices/services/device-validation.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
 import { MappingPreviewModel } from '../models/mapping-preview.model';
 
@@ -97,21 +99,34 @@ const createHelperPreview = (): HelperMappingPreviewModel =>
 
 describe('HomeAssistantWizardService', () => {
 	let service: HomeAssistantWizardService;
-	let mappingPreviewService: { generatePreview: jest.Mock; generatePreviews: jest.Mock };
-	let helperMappingPreviewService: { generatePreview: jest.Mock; generatePreviews: jest.Mock };
+	let mappingPreviewService: { generatePreview: jest.Mock; generateSettledPreviews: jest.Mock };
+	let helperMappingPreviewService: { generatePreview: jest.Mock; generateSettledPreviews: jest.Mock };
 	let deviceAdoptionService: { adoptDevice: jest.Mock };
 	let helperAdoptionService: { adoptHelper: jest.Mock };
 	let homeAssistantHttpService: { getDiscoveredInventory: jest.Mock };
+	let deviceValidationService: DeviceValidationService;
 
 	beforeEach(() => {
 		jest.useFakeTimers();
 		mappingPreviewService = {
 			generatePreview: jest.fn().mockResolvedValue(createDevicePreview()),
-			generatePreviews: jest.fn().mockResolvedValue([createDevicePreview()]),
+			generateSettledPreviews: jest.fn().mockResolvedValue([
+				{
+					source: { id: 'ha-device-1', name: 'Living room lamp' },
+					preview: createDevicePreview(),
+					error: null,
+				},
+			]),
 		};
 		helperMappingPreviewService = {
 			generatePreview: jest.fn().mockResolvedValue(createHelperPreview()),
-			generatePreviews: jest.fn().mockResolvedValue([createHelperPreview()]),
+			generateSettledPreviews: jest.fn().mockResolvedValue([
+				{
+					source: { entityId: 'input_boolean.guest_mode', name: 'Guest mode', domain: 'input_boolean' },
+					preview: createHelperPreview(),
+					error: null,
+				},
+			]),
 		};
 		deviceAdoptionService = { adoptDevice: jest.fn().mockResolvedValue({ id: 'device-1' }) };
 		helperAdoptionService = { adoptHelper: jest.fn().mockResolvedValue({ id: 'helper-1' }) };
@@ -121,12 +136,14 @@ describe('HomeAssistantWizardService', () => {
 				helpers: [{ entityId: 'input_boolean.guest_mode', adoptedDeviceId: null }],
 			}),
 		};
+		deviceValidationService = new DeviceValidationService({} as DevicesService);
 		service = new HomeAssistantWizardService(
 			mappingPreviewService as unknown as MappingPreviewService,
 			helperMappingPreviewService as unknown as HelperMappingPreviewService,
 			deviceAdoptionService as unknown as DeviceAdoptionService,
 			helperAdoptionService as unknown as HelperAdoptionService,
 			homeAssistantHttpService as unknown as HomeAssistantHttpService,
+			deviceValidationService,
 		);
 	});
 
@@ -145,18 +162,24 @@ describe('HomeAssistantWizardService', () => {
 				expect.objectContaining({ key: 'helper:input_boolean.guest_mode', status: 'ready', previewChannelCount: 1 }),
 			]),
 		);
-		expect(mappingPreviewService.generatePreviews).toHaveBeenCalledWith(
+		expect(mappingPreviewService.generateSettledPreviews).toHaveBeenCalledWith(
 			expect.arrayContaining([expect.objectContaining({ id: 'ha-device-1' })]),
 		);
-		expect(helperMappingPreviewService.generatePreviews).toHaveBeenCalledWith(
+		expect(helperMappingPreviewService.generateSettledPreviews).toHaveBeenCalledWith(
 			expect.arrayContaining([expect.objectContaining({ entityId: 'input_boolean.guest_mode' })]),
 		);
 		expect(homeAssistantHttpService.getDiscoveredInventory).toHaveBeenCalledTimes(1);
 	});
 
 	it('keeps ambiguous candidates out of automatic adoption', async () => {
-		mappingPreviewService.generatePreviews.mockResolvedValueOnce([
-			createDevicePreview([{ type: 'unsupported_entity', entityId: 'sensor.unknown', message: 'Review mapping' }]),
+		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				preview: createDevicePreview([
+					{ type: 'unsupported_entity', entityId: 'sensor.unknown', message: 'Review mapping' },
+				]),
+				error: null,
+			},
 		]);
 		const snapshot = await service.start();
 
@@ -232,6 +255,89 @@ describe('HomeAssistantWizardService', () => {
 		expect(snapshot.candidates.find((candidate) => candidate.key === 'device:ha-device-1')).toEqual(
 			expect.objectContaining({ status: 'already_registered', adoptedDeviceId: 'existing-1' }),
 		);
+	});
+
+	it('keeps valid candidates when another mapping preview fails', async () => {
+		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				preview: null,
+				error: 'Home Assistant device with ID ha-device-1 not found',
+			},
+		]);
+
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: 'device:ha-device-1',
+					status: 'failed',
+					error: 'Home Assistant device with ID ha-device-1 not found',
+				}),
+				expect.objectContaining({ key: 'helper:input_boolean.guest_mode', status: 'ready' }),
+			]),
+		);
+	});
+
+	it('does not offer a helper that is already represented by a ready physical device mapping', async () => {
+		const overlappingHelper = createHelperPreview();
+		overlappingHelper.helper.entityId = 'light.living_room';
+		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { entityId: 'light.living_room', name: 'Living room lamp', domain: 'light' },
+				preview: overlappingHelper,
+				error: null,
+			},
+		]);
+
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'helper')).toBeUndefined();
+	});
+
+	it('requires helper mappings to satisfy the complete device specification', async () => {
+		const incompleteClimatePreview = createHelperPreview();
+		incompleteClimatePreview.helper = {
+			entityId: 'climate.living_room',
+			name: 'Living room thermostat',
+			domain: 'climate',
+		};
+		incompleteClimatePreview.suggestedDevice.category = DeviceCategory.THERMOSTAT;
+		incompleteClimatePreview.suggestedChannels = [
+			{
+				category: ChannelCategory.THERMOSTAT,
+				name: 'Thermostat',
+				confidence: 'high',
+				suggestedProperties: [
+					{
+						category: PropertyCategory.LOCKED,
+						name: 'Locked',
+						haAttribute: 'locked',
+						dataType: DataTypeType.BOOL,
+						permissions: [PermissionType.READ_WRITE],
+						unit: null,
+						format: null,
+						required: false,
+						currentValue: false,
+					},
+				],
+			},
+		];
+		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { entityId: 'climate.living_room', name: 'Living room thermostat', domain: 'climate' },
+				preview: incompleteClimatePreview,
+				error: null,
+			},
+		]);
+
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'helper')).toEqual(
+			expect.objectContaining({ status: 'needs_attention' }),
+		);
+		expect(helperAdoptionService.adoptHelper).not.toHaveBeenCalled();
 	});
 
 	it('returns null for an unknown session', async () => {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -41,6 +41,7 @@ const createDevicePreview = (warnings: MappingPreviewModel['warnings'] = []): Ma
 						format: null,
 						required: true,
 						currentValue: false,
+						haTransformer: null,
 					},
 				],
 				unmappedAttributes: [],
@@ -215,6 +216,32 @@ describe('HomeAssistantWizardService', () => {
 		);
 	});
 
+	it('preserves helper mapping transformers during bulk adoption', async () => {
+		const transformedPreview = createHelperPreview();
+		transformedPreview.suggestedChannels[0].suggestedProperties[0].haTransformer = 'brightness_to_percent';
+		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: { entityId: 'input_boolean.guest_mode', name: 'Guest mode', domain: 'input_boolean' },
+				preview: transformedPreview,
+				error: null,
+			},
+		]);
+		helperMappingPreviewService.generatePreview.mockResolvedValueOnce(transformedPreview);
+		const snapshot = await service.start();
+
+		await service.adopt(snapshot.id, ['helper:input_boolean.guest_mode']);
+
+		expect(helperAdoptionService.adoptHelper).toHaveBeenCalledWith(
+			expect.objectContaining({
+				channels: [
+					expect.objectContaining({
+						properties: [expect.objectContaining({ haTransformer: 'brightness_to_percent' })],
+					}),
+				],
+			}),
+		);
+	});
+
 	it('revalidates automatic mapping immediately before persistence', async () => {
 		const snapshot = await service.start();
 		mappingPreviewService.generatePreview.mockResolvedValueOnce(
@@ -320,6 +347,7 @@ describe('HomeAssistantWizardService', () => {
 						format: null,
 						required: false,
 						currentValue: false,
+						haTransformer: null,
 					},
 				],
 			},

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -343,6 +343,36 @@ describe('HomeAssistantWizardService', () => {
 		expect(snapshot.candidates.find((candidate) => candidate.kind === 'helper')).toBeUndefined();
 	});
 
+	it('keeps an adopted helper visible and blocks a conflicting physical device candidate', async () => {
+		const overlappingHelper = createHelperPreview();
+		overlappingHelper.helper.entityId = 'light.living_room';
+		homeAssistantHttpService.getDiscoveredInventory.mockResolvedValueOnce({
+			devices: [{ id: 'ha-device-1', adoptedDeviceId: null }],
+			helpers: [{ entityId: 'light.living_room', adoptedDeviceId: 'helper-device-1' }],
+		});
+		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
+			{
+				source: {
+					entityId: 'light.living_room',
+					name: 'Living room lamp',
+					domain: 'light',
+					adoptedDeviceId: 'helper-device-1',
+				},
+				preview: overlappingHelper,
+				error: null,
+			},
+		]);
+
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'device')).toEqual(
+			expect.objectContaining({ status: 'needs_attention' }),
+		);
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'helper')).toEqual(
+			expect.objectContaining({ status: 'already_registered', adoptedDeviceId: 'helper-device-1' }),
+		);
+	});
+
 	it('requires helper mappings to satisfy the complete device specification', async () => {
 		const incompleteClimatePreview = createHelperPreview();
 		incompleteClimatePreview.helper = {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -1,0 +1,241 @@
+import {
+	ChannelCategory,
+	DataTypeType,
+	DeviceCategory,
+	PermissionType,
+	PropertyCategory,
+} from '../../../modules/devices/devices.constants';
+import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
+import { MappingPreviewModel } from '../models/mapping-preview.model';
+
+import { DeviceAdoptionService } from './device-adoption.service';
+import { HelperAdoptionService } from './helper-adoption.service';
+import { HelperMappingPreviewService } from './helper-mapping-preview.service';
+import { HomeAssistantHttpService } from './home-assistant.http.service';
+import { MappingPreviewService } from './mapping-preview.service';
+import { HomeAssistantWizardService } from './wizard.service';
+
+const createDevicePreview = (warnings: MappingPreviewModel['warnings'] = []): MappingPreviewModel =>
+	({
+		haDevice: { id: 'ha-device-1', name: 'Living room lamp', manufacturer: 'Philips', model: 'Hue' },
+		suggestedDevice: { category: DeviceCategory.LIGHTING, name: 'Living room lamp', confidence: 'high' },
+		entities: [
+			{
+				entityId: 'light.living_room',
+				domain: 'light',
+				deviceClass: null,
+				currentState: 'off',
+				attributes: {},
+				status: 'mapped',
+				suggestedChannel: { category: ChannelCategory.LIGHT, name: 'Light', confidence: 'high' },
+				suggestedProperties: [
+					{
+						category: PropertyCategory.ON,
+						name: 'On',
+						haAttribute: 'fb.main_state',
+						dataType: DataTypeType.BOOL,
+						permissions: [PermissionType.READ_WRITE],
+						unit: null,
+						format: null,
+						required: true,
+						currentValue: false,
+					},
+				],
+				unmappedAttributes: [],
+				missingRequiredProperties: [],
+			},
+		],
+		warnings,
+		readyToAdopt: true,
+		validation: {
+			isValid: true,
+			missingChannelsCount: 0,
+			missingPropertiesCount: 0,
+			fillableWithVirtualCount: 0,
+			missingChannels: [],
+			missingProperties: {},
+			unknownChannels: [],
+			duplicateChannels: [],
+			constraintViolations: [],
+			autoFilledVirtual: {},
+		},
+	}) as MappingPreviewModel;
+
+const createHelperPreview = (): HelperMappingPreviewModel =>
+	({
+		helper: { entityId: 'input_boolean.guest_mode', name: 'Guest mode', domain: 'input_boolean' },
+		suggestedDevice: { category: DeviceCategory.SWITCHER, name: 'Guest mode', confidence: 'medium' },
+		suggestedChannel: {
+			category: ChannelCategory.SWITCHER,
+			name: 'Guest mode',
+			confidence: 'medium',
+			suggestedProperties: [],
+		},
+		suggestedChannels: [
+			{
+				category: ChannelCategory.SWITCHER,
+				name: 'Guest mode',
+				confidence: 'medium',
+				suggestedProperties: [
+					{
+						category: PropertyCategory.ON,
+						name: 'On',
+						haAttribute: 'fb.main_state',
+						dataType: DataTypeType.BOOL,
+						permissions: [PermissionType.READ_WRITE],
+						unit: null,
+						format: null,
+						required: true,
+						currentValue: false,
+					},
+				],
+			},
+		],
+		warnings: [],
+		readyToAdopt: true,
+	}) as HelperMappingPreviewModel;
+
+describe('HomeAssistantWizardService', () => {
+	let service: HomeAssistantWizardService;
+	let mappingPreviewService: { generatePreview: jest.Mock; generatePreviews: jest.Mock };
+	let helperMappingPreviewService: { generatePreview: jest.Mock; generatePreviews: jest.Mock };
+	let deviceAdoptionService: { adoptDevice: jest.Mock };
+	let helperAdoptionService: { adoptHelper: jest.Mock };
+	let homeAssistantHttpService: { getDiscoveredInventory: jest.Mock };
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		mappingPreviewService = {
+			generatePreview: jest.fn().mockResolvedValue(createDevicePreview()),
+			generatePreviews: jest.fn().mockResolvedValue([createDevicePreview()]),
+		};
+		helperMappingPreviewService = {
+			generatePreview: jest.fn().mockResolvedValue(createHelperPreview()),
+			generatePreviews: jest.fn().mockResolvedValue([createHelperPreview()]),
+		};
+		deviceAdoptionService = { adoptDevice: jest.fn().mockResolvedValue({ id: 'device-1' }) };
+		helperAdoptionService = { adoptHelper: jest.fn().mockResolvedValue({ id: 'helper-1' }) };
+		homeAssistantHttpService = {
+			getDiscoveredInventory: jest.fn().mockResolvedValue({
+				devices: [{ id: 'ha-device-1', adoptedDeviceId: null }],
+				helpers: [{ entityId: 'input_boolean.guest_mode', adoptedDeviceId: null }],
+			}),
+		};
+		service = new HomeAssistantWizardService(
+			mappingPreviewService as unknown as MappingPreviewService,
+			helperMappingPreviewService as unknown as HelperMappingPreviewService,
+			deviceAdoptionService as unknown as DeviceAdoptionService,
+			helperAdoptionService as unknown as HelperAdoptionService,
+			homeAssistantHttpService as unknown as HomeAssistantHttpService,
+		);
+	});
+
+	afterEach(() => {
+		service.onModuleDestroy();
+		jest.useRealTimers();
+	});
+
+	it('creates one bulk snapshot containing automatically mapped devices and helpers', async () => {
+		const snapshot = await service.start();
+
+		expect(snapshot.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(snapshot.candidates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ key: 'device:ha-device-1', status: 'ready', previewChannelCount: 1 }),
+				expect.objectContaining({ key: 'helper:input_boolean.guest_mode', status: 'ready', previewChannelCount: 1 }),
+			]),
+		);
+		expect(mappingPreviewService.generatePreviews).toHaveBeenCalledWith(
+			expect.arrayContaining([expect.objectContaining({ id: 'ha-device-1' })]),
+		);
+		expect(helperMappingPreviewService.generatePreviews).toHaveBeenCalledWith(
+			expect.arrayContaining([expect.objectContaining({ entityId: 'input_boolean.guest_mode' })]),
+		);
+		expect(homeAssistantHttpService.getDiscoveredInventory).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps ambiguous candidates out of automatic adoption', async () => {
+		mappingPreviewService.generatePreviews.mockResolvedValueOnce([
+			createDevicePreview([{ type: 'unsupported_entity', entityId: 'sensor.unknown', message: 'Review mapping' }]),
+		]);
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates.find((candidate) => candidate.kind === 'device')?.status).toBe('needs_attention');
+		const results = await service.adopt(snapshot.id, ['device:ha-device-1']);
+
+		expect(results?.[0]).toEqual(
+			expect.objectContaining({
+				status: 'failed',
+				error: 'Candidate requires manual mapping or is no longer adoptable',
+			}),
+		);
+		expect(deviceAdoptionService.adoptDevice).not.toHaveBeenCalled();
+	});
+
+	it('accepts only selected keys and adopts with the stored automatic mapping', async () => {
+		const snapshot = await service.start();
+		const results = await service.adopt(snapshot.id, ['device:ha-device-1']);
+
+		expect(results).toEqual([{ key: 'device:ha-device-1', name: 'Living room lamp', status: 'created', error: null }]);
+		expect(deviceAdoptionService.adoptDevice).toHaveBeenCalledWith(
+			expect.objectContaining({
+				haDeviceId: 'ha-device-1',
+				name: 'Living room lamp',
+				category: DeviceCategory.LIGHTING,
+				channels: [expect.objectContaining({ entityId: 'light.living_room', category: ChannelCategory.LIGHT })],
+			}),
+		);
+		expect(mappingPreviewService.generatePreview).toHaveBeenCalledWith('ha-device-1');
+		expect(helperAdoptionService.adoptHelper).not.toHaveBeenCalled();
+		expect(service.get(snapshot.id)?.candidates.find((candidate) => candidate.key === 'device:ha-device-1')).toEqual(
+			expect.objectContaining({ status: 'already_registered', adoptedDeviceId: 'device-1' }),
+		);
+	});
+
+	it('revalidates automatic mapping immediately before persistence', async () => {
+		const snapshot = await service.start();
+		mappingPreviewService.generatePreview.mockResolvedValueOnce(
+			createDevicePreview([{ type: 'unsupported_entity', entityId: 'sensor.changed', message: 'Mapping changed' }]),
+		);
+
+		const results = await service.adopt(snapshot.id, ['device:ha-device-1']);
+
+		expect(results).toEqual([
+			expect.objectContaining({
+				key: 'device:ha-device-1',
+				status: 'failed',
+				error: 'Automatic mapping changed and now requires manual review',
+			}),
+		]);
+		expect(deviceAdoptionService.adoptDevice).not.toHaveBeenCalled();
+	});
+
+	it('keeps successful siblings when one selected candidate fails', async () => {
+		const snapshot = await service.start();
+		helperAdoptionService.adoptHelper.mockRejectedValueOnce(new Error('Helper disappeared'));
+
+		const results = await service.adopt(snapshot.id, ['device:ha-device-1', 'helper:input_boolean.guest_mode']);
+
+		expect(results).toEqual([
+			{ key: 'device:ha-device-1', name: 'Living room lamp', status: 'created', error: null },
+			{ key: 'helper:input_boolean.guest_mode', name: 'Guest mode', status: 'failed', error: 'Helper disappeared' },
+		]);
+	});
+
+	it('marks candidates already adopted outside the wizard as unavailable', async () => {
+		homeAssistantHttpService.getDiscoveredInventory.mockResolvedValueOnce({
+			devices: [{ id: 'ha-device-1', adoptedDeviceId: 'existing-1' }],
+			helpers: [{ entityId: 'input_boolean.guest_mode', adoptedDeviceId: null }],
+		});
+		const snapshot = await service.start();
+
+		expect(snapshot.candidates.find((candidate) => candidate.key === 'device:ha-device-1')).toEqual(
+			expect.objectContaining({ status: 'already_registered', adoptedDeviceId: 'existing-1' }),
+		);
+	});
+
+	it('returns null for an unknown session', async () => {
+		expect(service.get('missing')).toBeNull();
+		await expect(service.adopt('missing', ['device:ha-device-1'])).resolves.toBeNull();
+	});
+});

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -9,6 +9,7 @@ import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
 import {
 	HomeAssistantDeviceRegistryResultModel,
+	HomeAssistantDiscoveredDeviceModel,
 	HomeAssistantDiscoveredHelperModel,
 } from '../models/home-assistant.model';
 import { MappingPreviewModel } from '../models/mapping-preview.model';
@@ -40,6 +41,7 @@ interface HomeAssistantWizardSession {
 interface ResolvedAdoptionRequest {
 	request: AdoptDeviceRequestDto | AdoptHelperRequestDto;
 	registryDevice?: HomeAssistantDeviceRegistryResultModel;
+	discoveredDevice?: HomeAssistantDiscoveredDeviceModel;
 	discoveredHelper?: HomeAssistantDiscoveredHelperModel;
 }
 
@@ -216,7 +218,11 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				const request = resolved.request;
 				const device =
 					candidate.snapshot.kind === 'device'
-						? await this.deviceAdoptionService.adoptDevice(request as AdoptDeviceRequestDto, resolved.registryDevice)
+						? await this.deviceAdoptionService.adoptDevice(
+								request as AdoptDeviceRequestDto,
+								resolved.registryDevice,
+								resolved.discoveredDevice,
+							)
 						: await this.helperAdoptionService.adoptHelper(request as AdoptHelperRequestDto, resolved.discoveredHelper);
 
 				candidate.snapshot.status = 'already_registered';
@@ -269,7 +275,11 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				requests.set(
 					candidate.snapshot.key,
 					result.preview.readyToAdopt && result.preview.warnings.length === 0 && request.channels.length > 0
-						? { request, registryDevice: result.registryDevice ?? undefined }
+						? {
+								request,
+								registryDevice: result.registryDevice ?? undefined,
+								discoveredDevice: result.source,
+							}
 						: new Error('Automatic mapping changed and now requires manual review'),
 				);
 				continue;
@@ -317,7 +327,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				previewChannelCount: request.channels.length,
 				warningCount: preview.warnings.length,
 				adoptedDeviceId,
-				error: null,
+				error: status === 'needs_attention' ? this.mappingReviewReason(preview.warnings) : null,
 			},
 			request: status === 'ready' ? request : null,
 		};
@@ -349,10 +359,19 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				previewChannelCount: request.channels.length,
 				warningCount: preview.warnings.length,
 				adoptedDeviceId,
-				error: null,
+				error: status === 'needs_attention' ? this.mappingReviewReason(preview.warnings) : null,
 			},
 			request: status === 'ready' ? request : null,
 		};
+	}
+
+	private mappingReviewReason(warnings: Array<{ message: string }>): string {
+		return (
+			warnings
+				.map((warning) => warning.message)
+				.filter(Boolean)
+				.join('; ') || 'Automatic mapping requires manual review'
+		);
 	}
 
 	private buildDeviceRequest(preview: MappingPreviewModel): AdoptDeviceRequestDto {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -72,6 +72,9 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 			}
 		}
 		const id = randomUUID();
+		const adoptedHelperIds = new Set(
+			inventory.helpers.filter((helper) => helper.adoptedDeviceId !== null).map((helper) => helper.entityId),
+		);
 		const session: HomeAssistantWizardSession = {
 			id,
 			startedAt: new Date(),
@@ -82,6 +85,16 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 			const candidate = result.preview
 				? this.createDeviceCandidate(result.preview, adoptedBySourceId.get(result.source.id) ?? null)
 				: this.createFailedCandidate('device', result.source.id, result.source.name, null, null, result.error);
+			if (
+				candidate.snapshot.status === 'ready' &&
+				candidate.request &&
+				(candidate.request as AdoptDeviceRequestDto).channels.some((channel) => adoptedHelperIds.has(channel.entityId))
+			) {
+				candidate.snapshot.status = 'needs_attention';
+				candidate.snapshot.warningCount += 1;
+				candidate.snapshot.error = 'One or more entities are already adopted as standalone helpers';
+				candidate.request = null;
+			}
 			session.candidates.set(candidate.snapshot.key, candidate);
 		}
 
@@ -94,7 +107,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 		);
 
 		for (const result of helperPreviewResults) {
-			if (representedEntityIds.has(result.source.entityId)) {
+			if (representedEntityIds.has(result.source.entityId) && !result.source.adoptedDeviceId) {
 				continue;
 			}
 

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 
 import { ChannelCategory } from '../../../modules/devices/devices.constants';
+import { DeviceValidationService } from '../../../modules/devices/services/device-validation.service';
 import { AdoptHelperRequestDto } from '../dto/helper-mapping-preview.dto';
 import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
@@ -12,6 +13,7 @@ import {
 	HomeAssistantWizardCandidateModel,
 	HomeAssistantWizardSessionModel,
 } from '../models/wizard.model';
+import { buildHelperDeviceStructure } from '../utils/helper-structure.utils';
 
 import { DeviceAdoptionService } from './device-adoption.service';
 import { HelperAdoptionService } from './helper-adoption.service';
@@ -43,13 +45,14 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 		private readonly deviceAdoptionService: DeviceAdoptionService,
 		private readonly helperAdoptionService: HelperAdoptionService,
 		private readonly homeAssistantHttpService: HomeAssistantHttpService,
+		private readonly deviceValidationService: DeviceValidationService,
 	) {}
 
 	async start(): Promise<HomeAssistantWizardSessionModel> {
 		const inventory = await this.homeAssistantHttpService.getDiscoveredInventory();
-		const [devicePreviews, helperPreviews] = await Promise.all([
-			this.mappingPreviewService.generatePreviews(inventory.devices),
-			this.helperMappingPreviewService.generatePreviews(inventory.helpers),
+		const [devicePreviewResults, helperPreviewResults] = await Promise.all([
+			this.mappingPreviewService.generateSettledPreviews(inventory.devices),
+			this.helperMappingPreviewService.generateSettledPreviews(inventory.helpers),
 		]);
 		const adoptedBySourceId = new Map<string, string>();
 		for (const item of [...inventory.devices, ...inventory.helpers]) {
@@ -65,13 +68,36 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 			candidates: new Map(),
 		};
 
-		for (const preview of devicePreviews) {
-			const candidate = this.createDeviceCandidate(preview, adoptedBySourceId.get(preview.haDevice.id) ?? null);
+		for (const result of devicePreviewResults) {
+			const candidate = result.preview
+				? this.createDeviceCandidate(result.preview, adoptedBySourceId.get(result.source.id) ?? null)
+				: this.createFailedCandidate('device', result.source.id, result.source.name, null, null, result.error);
 			session.candidates.set(candidate.snapshot.key, candidate);
 		}
 
-		for (const preview of helperPreviews) {
-			const candidate = this.createHelperCandidate(preview, adoptedBySourceId.get(preview.helper.entityId) ?? null);
+		const representedEntityIds = new Set(
+			Array.from(session.candidates.values()).flatMap((candidate) =>
+				candidate.snapshot.kind === 'device' && candidate.snapshot.status === 'ready' && candidate.request
+					? (candidate.request as AdoptDeviceRequestDto).channels.map((channel) => channel.entityId)
+					: [],
+			),
+		);
+
+		for (const result of helperPreviewResults) {
+			if (representedEntityIds.has(result.source.entityId)) {
+				continue;
+			}
+
+			const candidate = result.preview
+				? this.createHelperCandidate(result.preview, adoptedBySourceId.get(result.source.entityId) ?? null)
+				: this.createFailedCandidate(
+						'helper',
+						result.source.entityId,
+						result.source.name,
+						'Home Assistant',
+						`Helper (${result.source.domain})`,
+						result.error,
+					);
 			session.candidates.set(candidate.snapshot.key, candidate);
 		}
 
@@ -177,7 +203,12 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 		const preview = await this.helperMappingPreviewService.generatePreview(candidate.sourceId);
 		const request = this.buildHelperRequest(preview);
 
-		if (!preview.readyToAdopt || preview.warnings.length > 0 || request.channels.length === 0) {
+		if (
+			!preview.readyToAdopt ||
+			preview.warnings.length > 0 ||
+			request.channels.length === 0 ||
+			!this.isHelperRequestValid(request)
+		) {
 			throw new Error('Automatic mapping changed and now requires manual review');
 		}
 
@@ -218,7 +249,11 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 	): HomeAssistantWizardCandidate {
 		const key = `helper:${preview.helper.entityId}`;
 		const request = this.buildHelperRequest(preview);
-		const ready = preview.readyToAdopt && preview.warnings.length === 0 && request.channels.length > 0;
+		const ready =
+			preview.readyToAdopt &&
+			preview.warnings.length === 0 &&
+			request.channels.length > 0 &&
+			this.isHelperRequestValid(request);
 		const status = adoptedDeviceId ? 'already_registered' : ready ? 'ready' : 'needs_attention';
 
 		return {
@@ -295,6 +330,37 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 					})),
 				})),
 		};
+	}
+
+	private createFailedCandidate(
+		kind: 'device' | 'helper',
+		sourceId: string,
+		name: string,
+		manufacturer: string | null,
+		model: string | null,
+		error: string | null,
+	): HomeAssistantWizardCandidate {
+		return {
+			snapshot: {
+				key: `${kind}:${sourceId}`,
+				kind,
+				sourceId,
+				name,
+				manufacturer,
+				model,
+				status: 'failed',
+				suggestedCategory: null,
+				previewChannelCount: 0,
+				warningCount: 1,
+				adoptedDeviceId: null,
+				error: error ?? 'Automatic mapping could not be generated',
+			},
+			request: null,
+		};
+	}
+
+	private isHelperRequestValid(request: AdoptHelperRequestDto): boolean {
+		return this.deviceValidationService.validateDeviceStructure(buildHelperDeviceStructure(request)).isValid;
 	}
 
 	private toSnapshot(session: HomeAssistantWizardSession): HomeAssistantWizardSessionModel {

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -7,6 +7,10 @@ import { DeviceValidationService } from '../../../modules/devices/services/devic
 import { AdoptHelperRequestDto } from '../dto/helper-mapping-preview.dto';
 import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
 import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
+import {
+	HomeAssistantDeviceRegistryResultModel,
+	HomeAssistantDiscoveredHelperModel,
+} from '../models/home-assistant.model';
 import { MappingPreviewModel } from '../models/mapping-preview.model';
 import {
 	HomeAssistantWizardAdoptionResultModel,
@@ -31,6 +35,12 @@ interface HomeAssistantWizardSession {
 	startedAt: Date;
 	candidates: Map<string, HomeAssistantWizardCandidate>;
 	idleTimer?: NodeJS.Timeout;
+}
+
+interface ResolvedAdoptionRequest {
+	request: AdoptDeviceRequestDto | AdoptHelperRequestDto;
+	registryDevice?: HomeAssistantDeviceRegistryResultModel;
+	discoveredHelper?: HomeAssistantDiscoveredHelperModel;
 }
 
 @Injectable()
@@ -152,8 +162,24 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 
 		this.refreshIdleTimer(session);
 		const results: HomeAssistantWizardAdoptionResultModel[] = [];
+		const uniqueKeys = [...new Set(keys)];
+		const adoptableCandidates = uniqueKeys.flatMap((key) => {
+			const candidate = session.candidates.get(key);
+			return candidate?.snapshot.status === 'ready' && candidate.request ? [candidate] : [];
+		});
+		let currentRequests = new Map<string, ResolvedAdoptionRequest | Error>();
 
-		for (const key of [...new Set(keys)]) {
+		if (adoptableCandidates.length > 0) {
+			try {
+				currentRequests = await this.resolveCurrentRequests(adoptableCandidates);
+			} catch (error) {
+				for (const candidate of adoptableCandidates) {
+					currentRequests.set(candidate.snapshot.key, error as Error);
+				}
+			}
+		}
+
+		for (const key of uniqueKeys) {
 			const candidate = session.candidates.get(key);
 
 			if (!candidate || candidate.snapshot.status !== 'ready' || !candidate.request) {
@@ -167,11 +193,18 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 			}
 
 			try {
-				const request = await this.resolveCurrentRequest(candidate.snapshot);
+				const resolved = currentRequests.get(key);
+				if (!resolved) {
+					throw new Error('Automatic mapping is no longer available');
+				}
+				if (resolved instanceof Error) {
+					throw resolved;
+				}
+				const request = resolved.request;
 				const device =
 					candidate.snapshot.kind === 'device'
-						? await this.deviceAdoptionService.adoptDevice(request as AdoptDeviceRequestDto)
-						: await this.helperAdoptionService.adoptHelper(request as AdoptHelperRequestDto);
+						? await this.deviceAdoptionService.adoptDevice(request as AdoptDeviceRequestDto, resolved.registryDevice)
+						: await this.helperAdoptionService.adoptHelper(request as AdoptHelperRequestDto, resolved.discoveredHelper);
 
 				candidate.snapshot.status = 'already_registered';
 				candidate.snapshot.adoptedDeviceId = device.id;
@@ -186,33 +219,67 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 		return results;
 	}
 
-	private async resolveCurrentRequest(
-		candidate: HomeAssistantWizardCandidateModel,
-	): Promise<AdoptDeviceRequestDto | AdoptHelperRequestDto> {
-		if (candidate.kind === 'device') {
-			const preview = await this.mappingPreviewService.generatePreview(candidate.sourceId);
-			const request = this.buildDeviceRequest(preview);
+	private async resolveCurrentRequests(
+		candidates: HomeAssistantWizardCandidate[],
+	): Promise<Map<string, ResolvedAdoptionRequest | Error>> {
+		const inventory = await this.homeAssistantHttpService.getDiscoveredInventory();
+		const deviceIds = new Set(
+			candidates
+				.filter((candidate) => candidate.snapshot.kind === 'device')
+				.map((candidate) => candidate.snapshot.sourceId),
+		);
+		const helperIds = new Set(
+			candidates
+				.filter((candidate) => candidate.snapshot.kind === 'helper')
+				.map((candidate) => candidate.snapshot.sourceId),
+		);
+		const [deviceResults, helperResults] = await Promise.all([
+			this.mappingPreviewService.generateSettledPreviews(
+				inventory.devices.filter((device) => deviceIds.has(device.id)),
+			),
+			this.helperMappingPreviewService.generateSettledPreviews(
+				inventory.helpers.filter((helper) => helperIds.has(helper.entityId)),
+			),
+		]);
+		const deviceResultsById = new Map(deviceResults.map((result) => [result.source.id, result]));
+		const helperResultsById = new Map(helperResults.map((result) => [result.source.entityId, result]));
+		const requests = new Map<string, ResolvedAdoptionRequest | Error>();
 
-			if (!preview.readyToAdopt || preview.warnings.length > 0 || request.channels.length === 0) {
-				throw new Error('Automatic mapping changed and now requires manual review');
+		for (const candidate of candidates) {
+			if (candidate.snapshot.kind === 'device') {
+				const result = deviceResultsById.get(candidate.snapshot.sourceId);
+				if (!result?.preview) {
+					requests.set(candidate.snapshot.key, new Error(result?.error ?? 'Automatic mapping is no longer available'));
+					continue;
+				}
+				const request = this.buildDeviceRequest(result.preview);
+				requests.set(
+					candidate.snapshot.key,
+					result.preview.readyToAdopt && result.preview.warnings.length === 0 && request.channels.length > 0
+						? { request, registryDevice: result.registryDevice ?? undefined }
+						: new Error('Automatic mapping changed and now requires manual review'),
+				);
+				continue;
 			}
 
-			return request;
+			const result = helperResultsById.get(candidate.snapshot.sourceId);
+			if (!result?.preview) {
+				requests.set(candidate.snapshot.key, new Error(result?.error ?? 'Automatic mapping is no longer available'));
+				continue;
+			}
+			const request = this.buildHelperRequest(result.preview);
+			requests.set(
+				candidate.snapshot.key,
+				result.preview.readyToAdopt &&
+					result.preview.warnings.length === 0 &&
+					request.channels.length > 0 &&
+					this.isHelperRequestValid(request)
+					? { request, discoveredHelper: result.source }
+					: new Error('Automatic mapping changed and now requires manual review'),
+			);
 		}
 
-		const preview = await this.helperMappingPreviewService.generatePreview(candidate.sourceId);
-		const request = this.buildHelperRequest(preview);
-
-		if (
-			!preview.readyToAdopt ||
-			preview.warnings.length > 0 ||
-			request.channels.length === 0 ||
-			!this.isHelperRequestValid(request)
-		) {
-			throw new Error('Automatic mapping changed and now requires manual review');
-		}
-
-		return request;
+		return requests;
 	}
 
 	private createDeviceCandidate(

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -326,7 +326,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 						dataType: property.dataType,
 						permissions: property.permissions,
 						format: property.format,
-						haTransformer: null,
+						haTransformer: property.haTransformer,
 					})),
 				})),
 		};

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -1,0 +1,315 @@
+import { randomUUID } from 'crypto';
+
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+
+import { ChannelCategory } from '../../../modules/devices/devices.constants';
+import { AdoptHelperRequestDto } from '../dto/helper-mapping-preview.dto';
+import { AdoptDeviceRequestDto } from '../dto/mapping-preview.dto';
+import { HelperMappingPreviewModel } from '../models/helper-mapping-preview.model';
+import { MappingPreviewModel } from '../models/mapping-preview.model';
+import {
+	HomeAssistantWizardAdoptionResultModel,
+	HomeAssistantWizardCandidateModel,
+	HomeAssistantWizardSessionModel,
+} from '../models/wizard.model';
+
+import { DeviceAdoptionService } from './device-adoption.service';
+import { HelperAdoptionService } from './helper-adoption.service';
+import { HelperMappingPreviewService } from './helper-mapping-preview.service';
+import { HomeAssistantHttpService } from './home-assistant.http.service';
+import { MappingPreviewService } from './mapping-preview.service';
+
+interface HomeAssistantWizardCandidate {
+	snapshot: HomeAssistantWizardCandidateModel;
+	request: AdoptDeviceRequestDto | AdoptHelperRequestDto | null;
+}
+
+interface HomeAssistantWizardSession {
+	id: string;
+	startedAt: Date;
+	candidates: Map<string, HomeAssistantWizardCandidate>;
+	idleTimer?: NodeJS.Timeout;
+}
+
+@Injectable()
+export class HomeAssistantWizardService implements OnModuleDestroy {
+	private static readonly IDLE_TTL_MS = 10 * 60_000;
+
+	private readonly sessions = new Map<string, HomeAssistantWizardSession>();
+
+	constructor(
+		private readonly mappingPreviewService: MappingPreviewService,
+		private readonly helperMappingPreviewService: HelperMappingPreviewService,
+		private readonly deviceAdoptionService: DeviceAdoptionService,
+		private readonly helperAdoptionService: HelperAdoptionService,
+		private readonly homeAssistantHttpService: HomeAssistantHttpService,
+	) {}
+
+	async start(): Promise<HomeAssistantWizardSessionModel> {
+		const inventory = await this.homeAssistantHttpService.getDiscoveredInventory();
+		const [devicePreviews, helperPreviews] = await Promise.all([
+			this.mappingPreviewService.generatePreviews(inventory.devices),
+			this.helperMappingPreviewService.generatePreviews(inventory.helpers),
+		]);
+		const adoptedBySourceId = new Map<string, string>();
+		for (const item of [...inventory.devices, ...inventory.helpers]) {
+			const sourceId = 'id' in item ? item.id : item.entityId;
+			if (item.adoptedDeviceId) {
+				adoptedBySourceId.set(sourceId, item.adoptedDeviceId);
+			}
+		}
+		const id = randomUUID();
+		const session: HomeAssistantWizardSession = {
+			id,
+			startedAt: new Date(),
+			candidates: new Map(),
+		};
+
+		for (const preview of devicePreviews) {
+			const candidate = this.createDeviceCandidate(preview, adoptedBySourceId.get(preview.haDevice.id) ?? null);
+			session.candidates.set(candidate.snapshot.key, candidate);
+		}
+
+		for (const preview of helperPreviews) {
+			const candidate = this.createHelperCandidate(preview, adoptedBySourceId.get(preview.helper.entityId) ?? null);
+			session.candidates.set(candidate.snapshot.key, candidate);
+		}
+
+		this.sessions.set(id, session);
+		this.refreshIdleTimer(session);
+
+		return this.toSnapshot(session);
+	}
+
+	get(id: string): HomeAssistantWizardSessionModel | null {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return null;
+		}
+
+		this.refreshIdleTimer(session);
+
+		return this.toSnapshot(session);
+	}
+
+	end(id: string): void {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return;
+		}
+
+		if (session.idleTimer) {
+			clearTimeout(session.idleTimer);
+		}
+
+		this.sessions.delete(id);
+	}
+
+	onModuleDestroy(): void {
+		for (const session of this.sessions.values()) {
+			if (session.idleTimer) {
+				clearTimeout(session.idleTimer);
+			}
+		}
+
+		this.sessions.clear();
+	}
+
+	async adopt(id: string, keys: string[]): Promise<HomeAssistantWizardAdoptionResultModel[] | null> {
+		const session = this.sessions.get(id);
+
+		if (!session) {
+			return null;
+		}
+
+		this.refreshIdleTimer(session);
+		const results: HomeAssistantWizardAdoptionResultModel[] = [];
+
+		for (const key of [...new Set(keys)]) {
+			const candidate = session.candidates.get(key);
+
+			if (!candidate || candidate.snapshot.status !== 'ready' || !candidate.request) {
+				results.push({
+					key,
+					name: candidate?.snapshot.name ?? key,
+					status: 'failed',
+					error: candidate ? 'Candidate requires manual mapping or is no longer adoptable' : 'Unknown candidate',
+				});
+				continue;
+			}
+
+			try {
+				const request = await this.resolveCurrentRequest(candidate.snapshot);
+				const device =
+					candidate.snapshot.kind === 'device'
+						? await this.deviceAdoptionService.adoptDevice(request as AdoptDeviceRequestDto)
+						: await this.helperAdoptionService.adoptHelper(request as AdoptHelperRequestDto);
+
+				candidate.snapshot.status = 'already_registered';
+				candidate.snapshot.adoptedDeviceId = device.id;
+				candidate.snapshot.name = request.name;
+				candidate.request = null;
+				results.push({ key, name: request.name, status: 'created', error: null });
+			} catch (error) {
+				results.push({ key, name: candidate.snapshot.name, status: 'failed', error: (error as Error).message });
+			}
+		}
+
+		return results;
+	}
+
+	private async resolveCurrentRequest(
+		candidate: HomeAssistantWizardCandidateModel,
+	): Promise<AdoptDeviceRequestDto | AdoptHelperRequestDto> {
+		if (candidate.kind === 'device') {
+			const preview = await this.mappingPreviewService.generatePreview(candidate.sourceId);
+			const request = this.buildDeviceRequest(preview);
+
+			if (!preview.readyToAdopt || preview.warnings.length > 0 || request.channels.length === 0) {
+				throw new Error('Automatic mapping changed and now requires manual review');
+			}
+
+			return request;
+		}
+
+		const preview = await this.helperMappingPreviewService.generatePreview(candidate.sourceId);
+		const request = this.buildHelperRequest(preview);
+
+		if (!preview.readyToAdopt || preview.warnings.length > 0 || request.channels.length === 0) {
+			throw new Error('Automatic mapping changed and now requires manual review');
+		}
+
+		return request;
+	}
+
+	private createDeviceCandidate(
+		preview: MappingPreviewModel,
+		adoptedDeviceId: string | null,
+	): HomeAssistantWizardCandidate {
+		const key = `device:${preview.haDevice.id}`;
+		const request = this.buildDeviceRequest(preview);
+		const ready = preview.readyToAdopt && preview.warnings.length === 0 && request.channels.length > 0;
+		const status = adoptedDeviceId ? 'already_registered' : ready ? 'ready' : 'needs_attention';
+
+		return {
+			snapshot: {
+				key,
+				kind: 'device',
+				sourceId: preview.haDevice.id,
+				name: preview.suggestedDevice.name,
+				manufacturer: preview.haDevice.manufacturer,
+				model: preview.haDevice.model,
+				status,
+				suggestedCategory: preview.suggestedDevice.category,
+				previewChannelCount: request.channels.length,
+				warningCount: preview.warnings.length,
+				adoptedDeviceId,
+				error: null,
+			},
+			request: status === 'ready' ? request : null,
+		};
+	}
+
+	private createHelperCandidate(
+		preview: HelperMappingPreviewModel,
+		adoptedDeviceId: string | null,
+	): HomeAssistantWizardCandidate {
+		const key = `helper:${preview.helper.entityId}`;
+		const request = this.buildHelperRequest(preview);
+		const ready = preview.readyToAdopt && preview.warnings.length === 0 && request.channels.length > 0;
+		const status = adoptedDeviceId ? 'already_registered' : ready ? 'ready' : 'needs_attention';
+
+		return {
+			snapshot: {
+				key,
+				kind: 'helper',
+				sourceId: preview.helper.entityId,
+				name: preview.suggestedDevice.name,
+				manufacturer: 'Home Assistant',
+				model: `Helper (${preview.helper.domain})`,
+				status,
+				suggestedCategory: preview.suggestedDevice.category,
+				previewChannelCount: request.channels.length,
+				warningCount: preview.warnings.length,
+				adoptedDeviceId,
+				error: null,
+			},
+			request: status === 'ready' ? request : null,
+		};
+	}
+
+	private buildDeviceRequest(preview: MappingPreviewModel): AdoptDeviceRequestDto {
+		return {
+			haDeviceId: preview.haDevice.id,
+			name: preview.suggestedDevice.name,
+			category: preview.suggestedDevice.category,
+			description: null,
+			enabled: true,
+			channels: preview.entities
+				.filter(
+					(entity) =>
+						entity.status !== 'skipped' &&
+						entity.status !== 'incompatible' &&
+						entity.suggestedChannel &&
+						entity.suggestedChannel.category !== ChannelCategory.GENERIC &&
+						entity.suggestedProperties.length > 0,
+				)
+				.map((entity) => ({
+					entityId: entity.entityId,
+					category: entity.suggestedChannel.category,
+					name: entity.suggestedChannel.name,
+					properties: entity.suggestedProperties.map((property) => ({
+						category: property.category,
+						haAttribute: property.haAttribute,
+						dataType: property.dataType,
+						permissions: property.permissions,
+						format: property.format,
+						haEntityId: property.haEntityId ?? entity.entityId,
+						haTransformer: property.haTransformer ?? null,
+					})),
+				})),
+		};
+	}
+
+	private buildHelperRequest(preview: HelperMappingPreviewModel): AdoptHelperRequestDto {
+		return {
+			entityId: preview.helper.entityId,
+			name: preview.suggestedDevice.name,
+			category: preview.suggestedDevice.category,
+			description: null,
+			enabled: true,
+			channels: preview.suggestedChannels
+				.filter((channel) => channel.category !== ChannelCategory.GENERIC && channel.suggestedProperties.length > 0)
+				.map((channel) => ({
+					category: channel.category,
+					name: channel.name,
+					properties: channel.suggestedProperties.map((property) => ({
+						category: property.category,
+						haAttribute: property.haAttribute,
+						dataType: property.dataType,
+						permissions: property.permissions,
+						format: property.format,
+						haTransformer: null,
+					})),
+				})),
+		};
+	}
+
+	private toSnapshot(session: HomeAssistantWizardSession): HomeAssistantWizardSessionModel {
+		return {
+			id: session.id,
+			startedAt: session.startedAt.toISOString(),
+			candidates: Array.from(session.candidates.values(), (candidate) => candidate.snapshot),
+		};
+	}
+
+	private refreshIdleTimer(session: HomeAssistantWizardSession): void {
+		if (session.idleTimer) {
+			clearTimeout(session.idleTimer);
+		}
+
+		session.idleTimer = setTimeout(() => this.end(session.id), HomeAssistantWizardService.IDLE_TTL_MS);
+	}
+}

--- a/apps/backend/src/plugins/devices-home-assistant/utils/helper-structure.utils.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/utils/helper-structure.utils.ts
@@ -1,0 +1,47 @@
+import {
+	ChannelCategory,
+	DataTypeType,
+	PermissionType,
+	PropertyCategory,
+} from '../../../modules/devices/devices.constants';
+import { DeviceDataInput } from '../../../modules/devices/services/device-validation.service';
+import { AdoptHelperRequestDto } from '../dto/helper-mapping-preview.dto';
+
+export const buildHelperDeviceStructure = (request: AdoptHelperRequestDto): DeviceDataInput => ({
+	category: request.category,
+	channels: [
+		...request.channels.map((channel) => ({
+			category: channel.category,
+			properties: channel.properties.map((property) => ({
+				category: property.category,
+				dataType: property.dataType,
+				permissions: property.permissions,
+			})),
+		})),
+		{
+			category: ChannelCategory.DEVICE_INFORMATION,
+			properties: [
+				{
+					category: PropertyCategory.MANUFACTURER,
+					dataType: DataTypeType.STRING,
+					permissions: [PermissionType.READ_ONLY],
+				},
+				{
+					category: PropertyCategory.MODEL,
+					dataType: DataTypeType.STRING,
+					permissions: [PermissionType.READ_ONLY],
+				},
+				{
+					category: PropertyCategory.SERIAL_NUMBER,
+					dataType: DataTypeType.STRING,
+					permissions: [PermissionType.READ_ONLY],
+				},
+				{
+					category: PropertyCategory.STATUS,
+					dataType: DataTypeType.ENUM,
+					permissions: [PermissionType.READ_ONLY],
+				},
+			],
+		},
+	],
+});

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -1,6 +1,6 @@
 # Smart Panel — Task Roadmap
 
-> Last updated: 2026-08-01. Reflects actual codebase state.
+> Last updated: 2026-08-12. Reflects actual codebase state.
 
 ---
 
@@ -228,8 +228,9 @@ Build a device from properties of other devices — splitting one physical devic
 | 1 | [FEATURE-PLUGIN-Z2M-ADOPTION-IMPROVEMENTS](features/FEATURE-PLUGIN-Z2M-ADOPTION-IMPROVEMENTS.md) | backend, admin | :white_check_mark: Done |
 | 2 | [FEATURE-PLUGIN-MATTER](features/FEATURE-PLUGIN-MATTER.md) | backend, admin | :clipboard: Planned |
 | 3 | [FEATURE-PLUGIN-ZIGBEE-HERDSMAN](features/FEATURE-PLUGIN-ZIGBEE-HERDSMAN.md) | backend, admin | :clipboard: Planned |
+| 4 | [FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS](features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md) | backend, admin, spec | :construction: In Progress |
 
-**Remaining work:** Matter plugin implementation. Direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management).
+**Remaining work:** WLED adoption wizard and remaining cross-plugin QA; Matter plugin implementation; direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management).
 
 ---
 

--- a/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
+++ b/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
@@ -1,0 +1,317 @@
+# Task: Device plugin adoption wizards
+ID: FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS
+Type: feature
+Scope: backend, admin, spec
+Size: large
+Parent: (none)
+Status: in-progress
+Created: 2026-08-12
+
+## 1. Business goal
+
+In order to bring existing devices into Smart Panel without manually reproducing their configuration,
+as a Smart Panel administrator,
+I want each discoverable/importable device integration to offer a guided adoption wizard that discovers candidates,
+lets me select many devices at once, applies safe automatic defaults, and reports a result for every selected device.
+
+## 2. Current-state audit
+
+The devices module already owns a shared three-step adoption shell (`discover -> confirm -> results`) through
+`IDeviceWizardAdapter`. Shelly v1, Shelly NG, and Zigbee2MQTT register adapters. The shell owns selection, names,
+categories, actions, and result rendering; plugins own discovery, mapping, transport, and adoption.
+
+The remaining device-capable plugins do not all represent the same workflow. Only integrations with an external
+inventory should be added to the shared adoption wizard.
+
+| Plugin | Current setup path | Decision |
+|---|---|---|
+| Shelly v1 | Shared discovery wizard, mDNS/manual host | Already covered |
+| Shelly NG | Shared discovery wizard, mDNS/manual host | Already covered |
+| Zigbee2MQTT | Shared pairing/adoption wizard | Already covered |
+| Home Assistant | Five-step, one-device-at-a-time controlled adoption form backed by discovery, mapping-preview, customization, and adoption APIs | **P0: add a question-free bulk-import wizard while retaining the current controlled adoption form unchanged** |
+| WLED | mDNS discovery API plus a manual device form; auto-add is the only path that invokes the full mapper | **P1: add a shared discovery/adoption wizard and a backend adoption API** |
+| reTerminal | The connector detects local hardware and provisions the single host device automatically | No adoption wizard; expose automatic-detection status instead of pretending there is a device inventory |
+| Third Party | Manually configured outbound service address; no discovery provider or import inventory | Keep the focused manual form; no wizard until the plugin gains a real discovery contract |
+| Virtual Devices | Bespoke construction wizard that composes existing properties | Already covered by the correct non-discovery wizard |
+| Simulator | Generates synthetic devices from specifications; it does not adopt external devices | Separate generation wizard candidate; do not force it into `IDeviceWizardAdapter` |
+
+### Important findings
+
+1. The shared shell preselects every first-seen `ready` row. That is suitable for a small Shelly/Zigbee session but
+   unsafe for a Home Assistant instance containing hundreds of devices and helpers.
+2. The shared tables have sorting but no search/filter support. A large Home Assistant inventory would be difficult to
+   review.
+3. Home Assistant already has mature mapping preview and adoption services, but its add-form composable constructs the
+   final channel request client-side and handles one item at a time.
+4. Calling the existing Home Assistant preview endpoint once per inventory row would repeatedly fetch HA registries and
+   states. A bulk wizard needs one upstream snapshot, not an N+1 request loop.
+5. WLED's discovery endpoint returns only unadded mDNS records. The backend has no explicit adopt/probe endpoint, and a
+   raw device created by the current manual form does not run `WledDeviceMapperService.mapDevice()`, so it can remain
+   without its generated channels and properties.
+
+## 3. Product rules
+
+- The shared wizard is for **discover/import/adopt** flows only.
+- Home Assistant intentionally has two complementary adoption paths:
+  - **Bulk wizard:** select many automatically mapped items and adopt them without per-device questions.
+  - **Controlled adoption:** keep the existing one-device-at-a-time form for category selection, mapping preview,
+    mapping customization, naming, description, and final review.
+- The Home Assistant bulk wizard must never replace, hide, or reduce the capabilities of the controlled adoption form.
+- The Home Assistant bulk wizard derives name, category, channels, and properties automatically. It does not ask the
+  administrator to edit them during the bulk flow.
+- An already-adopted Home Assistant item is informational and non-selectable. Updating/remapping it is not silently
+  folded into bulk adoption.
+- One failed device must not roll back successful siblings; results are reported per item.
+- Device identity is derived and validated by the backend integration (HA ID, WLED MAC), never trusted from an editable
+  browser field.
+- Discovery/probing must not create persistent devices or leak connections. Persistence begins only on adoption.
+
+## 4. Scope
+
+### In scope
+
+- Shared-wizard hardening for large inventories.
+- Home Assistant bulk inventory, mapping summary, and adoption wizard.
+- WLED discovery, manual probe, and adoption wizard.
+- Reuse of existing mapping/adoption services and plugin registration through `deviceWizardAdapter`.
+- OpenAPI regeneration after backend endpoint/model changes.
+- Admin translations in all supported locales.
+- Unit/component tests and focused backend E2E coverage.
+- A small setup-capability cleanup so only real adoption wizards appear in the device wizard chooser.
+
+### Out of scope
+
+- Replacing, simplifying, or removing the existing Home Assistant controlled adoption form.
+- Adding per-device name, category, description, or mapping questions to the Home Assistant bulk wizard.
+- Bulk remapping or deletion of already-adopted Home Assistant devices.
+- A discovery wizard for Third Party without a provider-side inventory API.
+- A reTerminal adoption wizard (the plugin is a singleton local-hardware detector).
+- Reworking the existing Virtual Devices wizard.
+- A Simulator generation wizard; track that separately if desired.
+- Unifying every plugin's backend endpoints into a common REST contract.
+- Panel/Flutter changes.
+
+## 5. Proposed architecture
+
+### 5.1 Shared wizard hardening
+
+Extend the shell without moving plugin transport logic into the devices module:
+
+- Add an optional adapter-owned default-selection hint to `IWizardRow` (for example `selectedByDefault?: boolean`).
+  Existing adapters retain current behavior when it is omitted; Home Assistant sets it to `false`.
+- Add an adapter confirmation mode (for example `confirmationMode: 'editable' | 'selection-only'`). Existing adapters
+  default to `editable`. Home Assistant uses `selection-only`, which shows the automatically resolved name/category as
+  read-only context and asks only which rows to adopt.
+- Add search to discover and confirm tables. Match label, sub-label, identifier, status label, and textual extra-cell
+  values. Keep selection/name/category state for rows hidden by the current query.
+- Define select-all semantics over the currently filtered adoptable rows and cover the indeterminate state.
+- Show compact totals (found, adoptable, already added, unsupported) so a filtered large inventory remains legible.
+- Keep the adapter contract declarative. If a new presentation primitive is required, add a typed cell/control variant;
+  do not add a plugin-rendered slot.
+
+Primary files:
+
+- `apps/admin/src/modules/devices/components/wizard/device-wizard.types.ts`
+- `apps/admin/src/modules/devices/composables/useDeviceWizardState.ts`
+- `apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue`
+- `apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue`
+- related specs under the same module
+
+### 5.2 Home Assistant wizard backend
+
+Add a plugin-owned wizard service/controller that builds a bulk inventory snapshot and performs server-side default
+adoption. Use a bounded, expiring wizard session, matching the existing plugin wizard lifecycle:
+
+- `POST /plugins/devices-home-assistant/wizard` creates a session and returns its inventory snapshot.
+- `GET /plugins/devices-home-assistant/wizard/{id}` returns the current session snapshot.
+- `POST /plugins/devices-home-assistant/wizard/{id}/adopt` adopts a batch and returns per-item outcomes.
+- `DELETE /plugins/devices-home-assistant/wizard/{id}` disposes the snapshot; expired sessions are cleaned up
+  automatically.
+
+The implementation must meet these behavioral requirements:
+
+- Fetch HA device registry, entity registry, device/helper lists, and states once per inventory refresh.
+- Refactor mapping-preview logic so the existing single-item endpoints and the bulk inventory can use the same pure
+  mapping functions with a supplied snapshot/context.
+- Return one normalized summary for each physical device and helper:
+  - namespaced stable key (`device:<ha-id>` / `helper:<entity-id>`), item kind, label, identifier;
+  - adopted Smart Panel device ID when present;
+  - entity/channel counts, warning count, suggested name/category, and `readyToAdopt`;
+  - a reason when automatic adoption is unsupported or requires the controlled adoption path.
+- Accept a batch containing only selected item keys. Revalidate each selected item against current HA data, resolve the
+  name/category automatically, build channels/properties from the shared preview-to-adoption builder, and delegate
+  persistence to the existing `DeviceAdoptionService` / `HelperAdoptionService`.
+- Return `created` or `failed` per item; do not fail the whole response because one item became stale or unsupported.
+- Bound inventory/session lifetime and cleanup. Never retain HA access tokens or raw secret config in session models.
+- Preserve the existing single-device discovery, preview, customization, and adoption endpoints and their UI behavior.
+
+Likely files:
+
+- new `controllers/home-assistant-wizard.controller.ts`
+- new `services/home-assistant-wizard.service.ts`
+- new wizard DTOs/models and Swagger registration
+- refactors in `mapping-preview.service.ts`, `helper-mapping-preview.service.ts`, and adoption request construction
+- backend unit tests plus controller/E2E coverage
+
+### 5.3 Home Assistant admin adapter
+
+Create `apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts` and register it as
+`deviceWizardAdapter`.
+
+Behavior:
+
+- Start/refresh the HA inventory and map summaries to shared rows.
+- Do not preselect rows by default; the administrator explicitly chooses devices, with search and filtered select-all
+  making large batches practical.
+- Use the shell's selection-only confirmation mode. Display automatic name/category/mapping summaries as read-only;
+  do not render editable name or category controls and do not introduce additional per-device steps.
+- Render devices and helpers together with a type column; show entity/channel counts and mapping readiness/warnings.
+- Map inferred, valid previews to `ready`; adopted items to `already_registered`; automatic-mapping failures to
+  `unsupported`; transport/config failures to `failed` plus a banner.
+- When HA is unconfigured or offline, show a clear banner linking to the plugin configuration page.
+- Provide a refresh action. If sessions are used, dispose them on unmount and restart them for “Add more”.
+- Batch-adopt the shell selection and refresh the local devices/discovery stores from the returned results.
+- Show a link and explanatory copy to the controlled adoption path when an item needs category or entity-level mapping
+  decisions. Keep `HomeAssistantDeviceAddForm` unchanged as that path.
+
+### 5.4 WLED backend adoption path
+
+Build explicit discovery/probe/adoption operations around existing WLED services:
+
+- Return discovered candidates with a stable MAC identity where available, host, port, advertised name, and adoption
+  state. Do not hide already-adopted records from the wizard response.
+- Add a manual-host probe operation that retrieves WLED info with the configured timeout but does not persist the
+  device or leave a registered WebSocket/client connection behind.
+- Add a refresh operation for the mDNS browser or otherwise expose a deterministic rescan trigger.
+- Add batch adoption accepting host plus confirmed name/category. The backend probes again, derives identity from the
+  actual WLED response, rejects duplicates, then calls `WledDeviceMapperService.mapDevice()` so device, channels, and
+  properties are provisioned together.
+- Restrict the category to the categories genuinely supported by the mapper (currently `lighting`).
+- Return per-device outcomes and tolerate partial failure.
+- Route the existing manual WLED add form through the same probe/adoption service (or remove it from the selectable
+  manual path) so it cannot create an incomplete raw device.
+
+Primary files:
+
+- `apps/backend/src/plugins/devices-wled/controllers/wled-discovery.controller.ts`
+- new WLED discovery/adoption DTOs and response models
+- `apps/backend/src/plugins/devices-wled/services/wled.service.ts`
+- `apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts`
+- focused service/controller tests
+
+### 5.5 WLED admin adapter
+
+Create and register `apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts`.
+
+Behavior:
+
+- Poll the discovery inventory while the wizard is open and stop polling on dispose.
+- Show mDNS candidates with name, host, MAC, and registered status.
+- Provide a rescan action and a manual host/IP form; manual probe failures retain the entered value for correction.
+- Suggest `lighting` and preselect newly discovered ready devices (WLED inventories are normally small).
+- Adopt selected candidates through the new backend batch endpoint and present partial results.
+- Support “Add more” by clearing UI state and starting a fresh discovery pass.
+- Work when mDNS is disabled by leaving the manual-host probe available and explaining why automatic discovery is off.
+
+## 6. Delivery sequence
+
+Each phase should be independently reviewable and keep the branch green.
+
+1. **Shared shell hardening (admin)**
+   - adapter-controlled default selection;
+   - selection-only confirmation mode;
+   - search/filter and filtered select-all;
+   - inventory totals and regression tests for Shelly/Zigbee behavior.
+2. **Home Assistant bulk backend (backend + spec source)**
+   - snapshot/context refactor;
+   - summary/session endpoint;
+   - batch default-adoption endpoint and tests.
+3. **Regenerate OpenAPI after the HA endpoints (spec/admin/panel generated outputs)**
+   - run `pnpm run generate:openapi`; do not hand-edit generated files.
+4. **Home Assistant adapter (admin)**
+   - rows, controls, config/offline handling, results, registration, locales, tests.
+5. **WLED backend adoption path (backend + spec source)**
+   - enriched discovery, manual probe, rescan, mapper-backed batch adoption, tests.
+6. **Regenerate OpenAPI after the WLED endpoints (spec/admin/panel generated outputs)**
+   - run `pnpm run generate:openapi`; do not hand-edit generated files.
+7. **WLED adapter and manual-form correction (admin)**
+   - wizard registration, polling/manual controls, locales, tests;
+   - ensure the old manual path uses the same mapper-backed adoption operation.
+8. **Integration QA and documentation**
+   - permission/config/offline/large-inventory/partial-failure passes;
+   - verify chooser only lists enabled plugins with registered adapters;
+   - verify current Shelly and Zigbee wizards are unchanged.
+
+Recommended implementation order is Home Assistant before WLED despite WLED being smaller: the shared-shell changes
+should be driven by the largest real inventory, and Home Assistant delivers the highest administrator value.
+
+## 7. Acceptance criteria
+
+### Shared shell
+
+- [x] Existing Shelly v1, Shelly NG, and Zigbee2MQTT wizard behavior and tests remain green.
+- [x] An adapter can opt out of default row selection without abusing row status.
+- [x] An adapter can use selection-only confirmation while existing adapters retain editable name/category confirmation.
+- [x] Discover and confirm inventories can be searched without losing edits or selection state.
+- [x] Select-all acts on the documented filtered set and has correct checked/indeterminate states.
+- [ ] Large inventories remain usable on desktop and mobile layouts.
+
+### Home Assistant
+
+- [x] Home Assistant appears in the device wizard chooser only when its plugin is enabled.
+- [x] A configured instance lists physical devices and helpers with adoption and automatic-mapping status.
+- [x] Inventory loading avoids one HA registry/state round trip per item.
+- [x] No HA item is selected automatically on first load.
+- [x] The administrator can select multiple ready items and adopt them in one operation without answering name,
+  category, description, or mapping questions.
+- [x] Bulk adoption derives names, categories, channels, and properties from the automatic mapping preview and
+  revalidates those decisions on the backend before persistence.
+- [x] Successful items create spec-valid devices/channels/properties through existing adoption services.
+- [x] Already-adopted items are visible but not selectable for bulk adoption.
+- [x] Items requiring category or mapping decisions are not bulk-adoptable and clearly direct the administrator to the
+  existing controlled adoption form.
+- [x] The existing controlled adoption form remains available and behaviorally unchanged for one-device-at-a-time
+  category selection, mapping preview/customization, naming, description, and final review.
+- [x] Unconfigured/offline HA produces an actionable configuration banner, not an empty table or raw API error.
+- [x] Partial batch failure leaves successful devices adopted and reports a reason for each failed item.
+
+### WLED
+
+- [ ] WLED appears in the device wizard chooser only when its plugin is enabled.
+- [ ] mDNS devices appear without being auto-created.
+- [ ] An administrator can probe a manual hostname/IP when mDNS is disabled or unavailable.
+- [ ] Probe-only operations do not persist devices or leak client connections.
+- [ ] Adoption derives identity from WLED data and provisions the full mapped device structure.
+- [ ] Duplicate/already-adopted devices are not created twice.
+- [ ] The existing manual WLED path cannot create an incomplete device.
+- [ ] Rescan, add-more, offline, timeout, and partial-failure flows are covered.
+
+### Quality
+
+- [x] Backend unit tests cover snapshot reuse, identity/deduplication, mapping delegation, and partial outcomes.
+- [x] Admin unit/component tests cover adapter row mapping, controls, lifecycle cleanup, and adoption payloads.
+- [ ] Relevant authenticated E2E endpoints are covered.
+- [x] OpenAPI is regenerated from backend Swagger decorators.
+- [ ] `pnpm --filter ./apps/admin run test:unit`, relevant backend Jest suites, and `pnpm run lint:js` pass.
+- [x] All six admin locales have parity for new user-visible keys.
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| HA inventories are large and expensive to preview | Build one upstream snapshot, separate summary from full detail, and bound any CPU concurrency/session lifetime |
+| HA data changes between preview and adoption | Revalidate selected items server-side immediately before persistence and report stale items individually |
+| Bulk adoption overwhelms HA/backend | Use bounded concurrency or sequential persistence; expose progress through busy state and per-item results |
+| Automatic HA mapping would require an administrator decision | Mark the row non-bulk-adoptable and direct it to the unchanged controlled adoption form |
+| WLED host/IP changes cause duplicates | Derive canonical identity from probed MAC/device info, treating host as a mutable address |
+| Probes leave temporary sockets/connections | Use a stateless probe client or explicit `finally` cleanup; cover it in tests |
+| Shared-shell changes regress current adapters | Preserve fallback behavior and land shell tests before registering new adapters |
+| A non-discoverable plugin is forced into the shared shell | Keep explicit eligibility rules from the audit; construction/generation/manual plugins use their own UX |
+
+## 9. Follow-ups (separate tasks)
+
+- A Simulator generation wizard using `GET /plugins/simulator/categories` and `POST /plugins/simulator/generate`.
+- A reTerminal integration-status card showing detected variant and automatic provisioning state.
+- A formal provider-discovery contract for Third Party integrations, if that plugin becomes more than the current demo/
+  manually-addressed proxy.
+- Bulk remap/update for already-adopted Home Assistant devices.


### PR DESCRIPTION
## Summary

- harden the shared device wizard for large inventories with search, filtered selection, explicit default selection, and read-only confirmation
- add Home Assistant bulk discovery sessions for physical devices and helpers using one shared state snapshot
- adopt selected candidate keys with server-derived mappings, pre-persistence revalidation, and per-item partial-failure results
- register the Home Assistant admin adapter while retaining the existing controlled single-device adoption form unchanged
- add all supported locale strings and document the wider device-plugin wizard roadmap

## Why

Home Assistant administrators currently have to adopt devices one at a time through the controlled mapping form. This adds a complementary bulk path for automatically mapped devices without reducing the control available in the existing manual workflow. Ambiguous candidates remain non-selectable and are directed to manual adoption.

## Validation

- Admin unit tests: 266 files, 1,866 tests passed
- Focused Home Assistant backend/controller tests: 4 suites, 33 tests passed
- Backend and admin type checks passed
- Full backend and admin ESLint runs completed without errors
- OpenAPI regenerated from backend Swagger decorators
- Six-locale wizard key parity verified
