### PR TITLE
test(backend): cover OAuth proxy boundary

### DIFF
--- a/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
@@ -1,0 +1,160 @@
+import fastify, { FastifyInstance } from 'fastify';
+import { RequestListener } from 'node:http';
+
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, MCP_OAUTH_TOKEN_PATH } from '../src/modules/mcp/mcp.constants';
+import { McpConfigModel } from '../src/modules/mcp/models/config.model';
+import { McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
+import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
+import { McpOAuthBootstrapService } from '../src/modules/mcp/services/mcp-oauth-bootstrap.service';
+import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
+import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
+import {
+	MCP_OAUTH_REQUIRED_READINESS_CONTROLS,
+	McpOAuthReadinessControl,
+	McpOAuthReadinessService,
+} from '../src/modules/mcp/services/mcp-oauth-readiness.service';
+import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-oauth-resource-server.service';
+import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
+
+describe('MCP OAuth reverse-proxy boundary', () => {
+	let server: FastifyInstance;
+
+	afterEach(async () => {
+		await server?.close();
+	});
+
+	it('uses only stored prefixed identity across untrusted, trusted, changed, and rolled-back proxy requests', async () => {
+		const originalPublicBaseUrl = 'https://panel.example.com/smart-panel';
+		const changedPublicBaseUrl = 'https://new-panel.example.com/edge/panel';
+		const config = Object.assign(new McpConfigModel(), {
+			enabled: true,
+			oauthEnabled: true,
+			oauthPublicBaseUrl: originalPublicBaseUrl,
+		});
+		const configService = { getModuleConfig: jest.fn(() => config) };
+		const publicUrls = new McpOAuthPublicUrlService(configService as unknown as ConfigService);
+		let trustedProxies = '';
+		const env = { get: jest.fn(() => trustedProxies) };
+		const proxyPolicy = new McpOAuthProxyPolicyService(env as unknown as NestConfigService);
+		const readiness = new McpOAuthReadinessService();
+		readiness.register(
+			...MCP_OAUTH_REQUIRED_READINESS_CONTROLS.filter(
+				(control) => control !== McpOAuthReadinessControl.COMPLETE_ROUTE_SET,
+			),
+		);
+		const routeGate = new McpOAuthRouteGateService(readiness);
+		const providerRequests: string[] = [];
+		const callback: RequestListener = (request, response) => {
+			providerRequests.push(request.url ?? '');
+			response.statusCode = 200;
+			response.setHeader('content-type', 'application/json');
+			response.end(JSON.stringify({ path: request.url }));
+		};
+		const runtime = {
+			getActive: jest.fn(
+				() =>
+					({
+						provider: {} as McpOAuthProviderRuntime['provider'],
+						callback,
+						urls: requireUrls(publicUrls),
+						metadata: {} as McpOAuthProviderRuntime['metadata'],
+					}) satisfies McpOAuthProviderRuntime,
+			),
+		};
+		const resourceServer = {
+			getProtectedResourceMetadata: jest.fn(() => {
+				const urls = requireUrls(publicUrls);
+
+				return { resource: urls.resource, authorization_servers: [urls.issuer] };
+			}),
+			getAuthorizationServerMetadata: jest.fn(() => ({ issuer: requireUrls(publicUrls).issuer })),
+		};
+		const bootstrap = new McpOAuthBootstrapService(
+			readiness,
+			routeGate,
+			proxyPolicy,
+			resourceServer as unknown as McpOAuthResourceServerService,
+			runtime as unknown as McpOAuthRuntimeService,
+		);
+
+		server = fastify();
+		bootstrap.register(server);
+		readiness.onApplicationBootstrap();
+		routeGate.openInternal();
+		const origin = await server.listen({ host: '127.0.0.1', port: 0 });
+
+		const direct = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, {
+			host: 'host-header-attacker.example',
+		});
+		expect(direct.status).toBe(200);
+		expect(await direct.json()).toEqual({
+			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
+			authorization_servers: ['https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth'],
+		});
+
+		const rejected = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, {
+			forwarded: 'for=203.0.113.9;host=forwarded-attacker.example;proto=http',
+			'x-forwarded-host': 'forwarded-attacker.example',
+			'x-forwarded-proto': 'http',
+		});
+		expect(rejected.status).toBe(403);
+		expect(await rejected.json()).toEqual({ error: 'access_denied' });
+
+		trustedProxies = '127.0.0.1';
+		const trusted = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, {
+			forwarded: 'for=203.0.113.9;host=forwarded-attacker.example;proto=http',
+			'x-forwarded-host': 'forwarded-attacker.example',
+			'x-forwarded-proto': 'http',
+		});
+		expect(trusted.status).toBe(200);
+		expect(await trusted.json()).toEqual({
+			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
+			authorization_servers: ['https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth'],
+		});
+
+		const provider = await request(origin, MCP_OAUTH_TOKEN_PATH, {
+			'x-forwarded-host': 'forwarded-attacker.example',
+			'x-forwarded-prefix': '/attacker-prefix',
+			'x-forwarded-proto': 'http',
+		});
+		expect(provider.status).toBe(200);
+		expect(await provider.json()).toEqual({ path: '/smart-panel/api/v1/modules/mcp/oauth/token' });
+
+		config.oauthPublicBaseUrl = changedPublicBaseUrl;
+		const changed = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH);
+		expect(changed.status).toBe(200);
+		expect(await changed.json()).toEqual({
+			resource: 'https://new-panel.example.com/edge/panel/api/v1/modules/mcp',
+			authorization_servers: ['https://new-panel.example.com/edge/panel/api/v1/modules/mcp/oauth'],
+		});
+		const changedProvider = await request(origin, MCP_OAUTH_TOKEN_PATH);
+		expect(await changedProvider.json()).toEqual({ path: '/edge/panel/api/v1/modules/mcp/oauth/token' });
+
+		config.oauthPublicBaseUrl = originalPublicBaseUrl;
+		const rolledBack = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH);
+		expect(await rolledBack.json()).toEqual({
+			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
+			authorization_servers: ['https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth'],
+		});
+		expect(providerRequests).toEqual([
+			'/smart-panel/api/v1/modules/mcp/oauth/token',
+			'/edge/panel/api/v1/modules/mcp/oauth/token',
+		]);
+	});
+});
+
+function requireUrls(service: McpOAuthPublicUrlService): McpOAuthPublicUrls {
+	const urls = service.getUrls();
+
+	if (!urls) throw new Error('Expected configured MCP OAuth public URLs');
+
+	return urls;
+}
+
+function request(origin: string, path: string, headers: Record<string, string> = {}): Promise<Response> {
+	return fetch(new URL(path, origin), { method: path === MCP_OAUTH_TOKEN_PATH ? 'POST' : 'GET', headers });
+}

--- a/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
@@ -6,9 +6,10 @@ import { ConfigService as NestConfigService } from '@nestjs/config';
 import { ConfigService } from '../src/modules/config/services/config.service';
 import { MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, MCP_OAUTH_TOKEN_PATH } from '../src/modules/mcp/mcp.constants';
 import { McpConfigModel } from '../src/modules/mcp/models/config.model';
-import { McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
+import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthBootstrapService } from '../src/modules/mcp/services/mcp-oauth-bootstrap.service';
+import { McpOAuthLifecycleService } from '../src/modules/mcp/services/mcp-oauth-lifecycle.service';
 import { McpOAuthProxyPolicyService } from '../src/modules/mcp/services/mcp-oauth-proxy-policy.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import {
@@ -54,17 +55,24 @@ describe('MCP OAuth reverse-proxy boundary', () => {
 			response.setHeader('content-type', 'application/json');
 			response.end(JSON.stringify({ path: request.url }));
 		};
-		const runtime = {
-			getActive: jest.fn(
-				() =>
-					({
-						provider: {} as McpOAuthProviderRuntime['provider'],
-						callback,
-						urls: requireUrls(publicUrls),
-						metadata: {} as McpOAuthProviderRuntime['metadata'],
-					}) satisfies McpOAuthProviderRuntime,
-			),
-		};
+		const createRuntime = jest.fn(() =>
+			Promise.resolve({
+				provider: {} as McpOAuthProviderRuntime['provider'],
+				callback,
+				urls: requireUrls(publicUrls),
+				metadata: {} as McpOAuthProviderRuntime['metadata'],
+			} satisfies McpOAuthProviderRuntime),
+		);
+		const runtime = new McpOAuthRuntimeService(
+			{ create: createRuntime } as unknown as McpOAuthProviderFactory,
+			routeGate,
+		);
+		const lifecycle = new McpOAuthLifecycleService(
+			configService as unknown as ConfigService,
+			readiness,
+			routeGate,
+			runtime,
+		);
 		const resourceServer = {
 			getProtectedResourceMetadata: jest.fn(() => {
 				const urls = requireUrls(publicUrls);
@@ -78,14 +86,15 @@ describe('MCP OAuth reverse-proxy boundary', () => {
 			routeGate,
 			proxyPolicy,
 			resourceServer as unknown as McpOAuthResourceServerService,
-			runtime as unknown as McpOAuthRuntimeService,
+			runtime,
 		);
 
 		server = fastify();
 		bootstrap.register(server);
 		readiness.onApplicationBootstrap();
-		routeGate.openInternal();
+		await lifecycle.activateInternal();
 		const origin = await server.listen({ host: '127.0.0.1', port: 0 });
+		expect(createRuntime).toHaveBeenCalledTimes(1);
 
 		const direct = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH, {
 			host: 'host-header-attacker.example',
@@ -124,7 +133,10 @@ describe('MCP OAuth reverse-proxy boundary', () => {
 		expect(provider.status).toBe(200);
 		expect(await provider.json()).toEqual({ path: '/smart-panel/api/v1/modules/mcp/oauth/token' });
 
-		config.oauthPublicBaseUrl = changedPublicBaseUrl;
+		await lifecycle.reconfigureInternal(() => {
+			config.oauthPublicBaseUrl = changedPublicBaseUrl;
+		});
+		expect(createRuntime).toHaveBeenCalledTimes(2);
 		const changed = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH);
 		expect(changed.status).toBe(200);
 		expect(await changed.json()).toEqual({
@@ -134,7 +146,10 @@ describe('MCP OAuth reverse-proxy boundary', () => {
 		const changedProvider = await request(origin, MCP_OAUTH_TOKEN_PATH);
 		expect(await changedProvider.json()).toEqual({ path: '/edge/panel/api/v1/modules/mcp/oauth/token' });
 
-		config.oauthPublicBaseUrl = originalPublicBaseUrl;
+		await lifecycle.reconfigureInternal(() => {
+			config.oauthPublicBaseUrl = originalPublicBaseUrl;
+		});
+		expect(createRuntime).toHaveBeenCalledTimes(3);
 		const rolledBack = await request(origin, MCP_OAUTH_PROTECTED_RESOURCE_METADATA_PATH);
 		expect(await rolledBack.json()).toEqual({
 			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',

--- a/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-reverse-proxy.e2e-spec.ts
@@ -140,9 +140,12 @@ describe('MCP OAuth reverse-proxy boundary', () => {
 			resource: 'https://panel.example.com/smart-panel/api/v1/modules/mcp',
 			authorization_servers: ['https://panel.example.com/smart-panel/api/v1/modules/mcp/oauth'],
 		});
+		const rolledBackProvider = await request(origin, MCP_OAUTH_TOKEN_PATH);
+		expect(await rolledBackProvider.json()).toEqual({ path: '/smart-panel/api/v1/modules/mcp/oauth/token' });
 		expect(providerRequests).toEqual([
 			'/smart-panel/api/v1/modules/mcp/oauth/token',
 			'/edge/panel/api/v1/modules/mcp/oauth/token',
+			'/smart-panel/api/v1/modules/mcp/oauth/token',
 		]);
 	});
 });

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -454,7 +454,7 @@ amend ADR 0002.
       bootstrap-registered route set is uniformly unreachable/reachable behind one gate, never partially exposed, and
       replaces the deactivated provider runtime before reopening.
 - [x] E2E: prove readiness-gated re-enable never makes OAuth artifacts issued before switch-off usable again.
-- [ ] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
+- [x] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and
       callback profile.

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -80,11 +80,11 @@ upgrade consequences.
       success while leaving static MCP subscriptions active; re-enable does not reactivate old OAuth artifacts.
 - [x] The complete OAuth route set is registered once at NestJS/Fastify bootstrap behind one shared fail-closed gate;
       runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.
-- [ ] Public OAuth identity and server-secret rotation revoke OAuth artifacts and close OAuth subscriptions while
+- [x] Public OAuth identity and server-secret rotation revoke OAuth artifacts and close OAuth subscriptions while
       preserving static MCP streams; only MCP-module disable closes both authorization profiles.
 - [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
       explicit registration policy; otherwise the supported registration path is documented.
-- [ ] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
+- [x] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
       configured as trusted.
 - [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.


### PR DESCRIPTION
## Summary

- add a Fastify E2E for the MCP OAuth reverse-proxy security boundary
- prove public identifiers and provider routing use only the explicitly stored external URL and path prefix
- reject hostile forwarded headers from an untrusted immediate peer
- permit forwarded headers from an explicitly trusted peer without allowing them to rewrite OAuth identity or paths
- verify configured public URL changes and rollback remap metadata and provider paths deterministically
- update the Phase 6 and technical-task acceptance criteria

## Why

The proxy and public-URL services had focused unit coverage, but Phase 6 still needed an HTTP-boundary test proving that request Host and forwarded headers cannot select OAuth identity, including deployments behind a trusted proxy with an external path prefix.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- ESLint on the new reverse-proxy E2E
- Prettier check on all changed files
- reverse-proxy E2E: 1 test
- proxy-policy, public-URL, and bootstrap unit suites: 22 tests
- full OAuth spike suite: 27 tests