### PR TITLE
feat(cross): add WLED adoption wizard

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -436,6 +436,13 @@ export type DevicesHomeAssistantPluginGetWizardOperation = operations['get-devic
 export type DevicesHomeAssistantPluginDeleteWizardOperation = operations['delete-devices-home-assistant-plugin-wizard'];
 export type DevicesHomeAssistantPluginAdoptWizardOperation = operations['adopt-devices-home-assistant-plugin-wizard'];
 
+// Devices WLED Plugin Operations
+export type DevicesWledPluginGetDiscoveryOperation = operations['get-devices-wled-plugin-discovery'];
+export type DevicesWledPluginRescanDiscoveryOperation = operations['rescan-devices-wled-plugin-discovery'];
+export type DevicesWledPluginProbeDiscoveryOperation = operations['probe-devices-wled-plugin-discovery'];
+export type DevicesWledPluginAdoptDiscoveryOperation = operations['adopt-devices-wled-plugin-discovery'];
+export { DevicesWledPluginAdoptDeviceCategory } from './openapi';
+
 // Devices Virtual Plugin Operations
 export type DevicesVirtualPluginCheckCompatibilityOperation = operations['check-devices-virtual-plugin-devices-compatibility'];
 export type DevicesVirtualPluginGetDeviceSourceDevicesOperation = operations['get-devices-virtual-plugin-device-source-devices'];

--- a/apps/admin/src/plugins/devices-wled/composables/composables.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/composables.ts
@@ -1,4 +1,5 @@
 export * from './useDeviceAddForm';
 export * from './useDeviceEditForm';
+export * from './useDevicesWizard';
 
 export * from './types';

--- a/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.spec.ts
@@ -23,7 +23,7 @@ vi.mock('../../../common', async () => {
 		injectStoresManager: () => ({ getStore: vi.fn(() => devicesStore) }),
 		useBackend: () => ({ client: backendClient }),
 		useFlashMessage: () => flashMessage,
-		useLogger: () => ({ error: vi.fn() }),
+		useLogger: () => ({ error: vi.fn(), warn: vi.fn() }),
 	};
 });
 
@@ -66,5 +66,19 @@ describe('useDeviceAddForm', () => {
 			},
 		});
 		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('completes successfully when the post-adoption store refresh fails', async () => {
+		devicesStore.fetch.mockRejectedValueOnce(new Error('Refresh failed'));
+		const form = useDeviceAddForm({ id: '6ce8b8e8-c15c-4f10-86dc-50d342c7ec35' });
+		form.formEl.value = { clearValidate: vi.fn(), validate: vi.fn().mockResolvedValue(true) } as never;
+		form.model.name = 'Desk strip';
+		form.model.category = DevicesModuleDeviceCategory.lighting;
+		form.model.hostname = '192.168.1.100';
+
+		await expect(form.submit()).resolves.toBe('added');
+
+		expect(flashMessage.success).toHaveBeenCalled();
+		expect(flashMessage.error).not.toHaveBeenCalled();
 	});
 });

--- a/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DevicesModuleDeviceCategory, DevicesWledPluginAdoptDeviceCategory } from '../../../openapi.constants';
+import { DEVICES_WLED_PLUGIN_PREFIX } from '../devices-wled.constants';
+
+import { useDeviceAddForm } from './useDeviceAddForm';
+
+const backendClient = { POST: vi.fn() };
+const devicesStore = { fetch: vi.fn() };
+const flashMessage = { error: vi.fn(), success: vi.fn() };
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({
+		global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => undefined },
+	}),
+	useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+	return {
+		...actual,
+		injectStoresManager: () => ({ getStore: vi.fn(() => devicesStore) }),
+		useBackend: () => ({ client: backendClient }),
+		useFlashMessage: () => flashMessage,
+		useLogger: () => ({ error: vi.fn() }),
+	};
+});
+
+describe('useDeviceAddForm', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		devicesStore.fetch.mockResolvedValue([]);
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: [{ host: '192.168.1.100', name: 'Desk strip', status: 'created', error: null, deviceId: 'device-1' }],
+			},
+			response: { status: 200 },
+		});
+	});
+
+	it('uses mapper-backed adoption instead of creating a raw generic device', async () => {
+		const form = useDeviceAddForm({ id: '6ce8b8e8-c15c-4f10-86dc-50d342c7ec35' });
+		form.formEl.value = { clearValidate: vi.fn(), validate: vi.fn().mockResolvedValue(true) } as never;
+		form.model.name = 'Desk strip';
+		form.model.category = DevicesModuleDeviceCategory.lighting;
+		form.model.hostname = '192.168.1.100';
+		form.model.description = 'Behind the desk';
+		form.model.enabled = false;
+
+		await form.submit();
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`, {
+			body: {
+				data: {
+					devices: [
+						{
+							host: '192.168.1.100',
+							name: 'Desk strip',
+							category: DevicesWledPluginAdoptDeviceCategory.lighting,
+							description: 'Behind the desk',
+							enabled: false,
+						},
+					],
+				},
+			},
+		});
+		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.ts
@@ -114,7 +114,13 @@ export const useDeviceAddForm = ({ id }: IUseDeviceAddFormProps): IUseDeviceAddF
 				throw new DevicesWledApiException(result?.error ?? errorMessage, 422);
 			}
 
-			await devicesStore.fetch();
+			try {
+				await devicesStore.fetch();
+			} catch (error: unknown) {
+				logger.warn('WLED device was created, but the device store could not be refreshed', {
+					message: error instanceof Error ? error.message : String(error),
+				});
+			}
 		} catch (error: unknown) {
 			formResult.value = FormResult.ERROR;
 

--- a/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDeviceAddForm.ts
@@ -5,11 +5,16 @@ import type { FormInstance } from 'element-plus';
 import { isEqual } from 'lodash';
 import { orderBy } from 'natural-orderby';
 
-import { deepClone, getSchemaDefaults, injectStoresManager, useFlashMessage, useLogger } from '../../../common';
-import { DevicesApiException, FormResult, type FormResultType, type IDevice, devicesStoreKey } from '../../../modules/devices';
-import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
-import { DEVICES_WLED_TYPE } from '../devices-wled.constants';
-import { DevicesWledValidationException } from '../devices-wled.exceptions';
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { deepClone, getErrorReason, getSchemaDefaults, injectStoresManager, useBackend, useFlashMessage, useLogger } from '../../../common';
+import { FormResult, type FormResultType, type IDevice, devicesStoreKey } from '../../../modules/devices';
+import {
+	DevicesModuleDeviceCategory,
+	DevicesWledPluginAdoptDeviceCategory,
+	type DevicesWledPluginAdoptDiscoveryOperation,
+} from '../../../openapi.constants';
+import { DEVICES_WLED_PLUGIN_PREFIX, DEVICES_WLED_TYPE } from '../devices-wled.constants';
+import { DevicesWledApiException, DevicesWledValidationException } from '../devices-wled.exceptions';
 import { WledDeviceAddFormSchema } from '../schemas/devices.schemas';
 import type { IWledDeviceAddForm } from '../schemas/devices.types';
 
@@ -20,12 +25,11 @@ interface IUseDeviceAddFormProps {
 }
 
 // WLED LED controllers typically fall into these categories
-const WLED_CATEGORIES = [
-	DevicesModuleDeviceCategory.lighting,
-];
+const WLED_CATEGORIES = [DevicesModuleDeviceCategory.lighting];
 
 export const useDeviceAddForm = ({ id }: IUseDeviceAddFormProps): IUseDeviceAddForm => {
 	const storesManager = injectStoresManager();
+	const backend = useBackend();
 
 	const devicesStore = storesManager.getStore(devicesStoreKey);
 
@@ -40,12 +44,10 @@ export const useDeviceAddForm = ({ id }: IUseDeviceAddFormProps): IUseDeviceAddF
 
 	const categoriesOptions = computed<{ value: DevicesModuleDeviceCategory; label: string }[]>(
 		(): { value: DevicesModuleDeviceCategory; label: string }[] => {
-			return orderBy(WLED_CATEGORIES, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map(
-				(value) => ({
-					value,
-					label: t(`devicesModule.categories.devices.${value}`),
-				})
-			);
+			return orderBy(WLED_CATEGORIES, [(category: string) => t(`devicesModule.categories.devices.${category}`)], ['asc']).map((value) => ({
+				value,
+				label: t(`devicesModule.categories.devices.${value}`),
+			}));
 		}
 	);
 
@@ -86,20 +88,39 @@ export const useDeviceAddForm = ({ id }: IUseDeviceAddFormProps): IUseDeviceAddF
 		const errorMessage = t('devicesWledPlugin.messages.devices.notCreated', { device: model.name });
 
 		try {
-			await devicesStore.add({
-				id,
-				draft: false,
-				data: {
-					...parsedModel.data,
-					type: DEVICES_WLED_TYPE,
+			const { data, error, response } = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`, {
+				body: {
+					data: {
+						devices: [
+							{
+								host: parsedModel.data.hostname,
+								name: parsedModel.data.name,
+								category: DevicesWledPluginAdoptDeviceCategory.lighting,
+								description: parsedModel.data.description || null,
+								enabled: parsedModel.data.enabled,
+							},
+						],
+					},
 				},
 			});
+
+			if (typeof data === 'undefined') {
+				const reason = error ? getErrorReason<DevicesWledPluginAdoptDiscoveryOperation>(error, errorMessage) : errorMessage;
+				throw new DevicesWledApiException(reason, response.status);
+			}
+
+			const result = data.data[0];
+			if (!result || result.status === 'failed') {
+				throw new DevicesWledApiException(result?.error ?? errorMessage, 422);
+			}
+
+			await devicesStore.fetch();
 		} catch (error: unknown) {
 			formResult.value = FormResult.ERROR;
 
 			timer = window.setTimeout(clear, 2000);
 
-			if (error instanceof DevicesApiException && error.code === 422) {
+			if (error instanceof DevicesWledApiException && error.code === 422) {
 				flashMessage.error(error.message);
 			} else {
 				flashMessage.error(errorMessage);

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -138,6 +138,38 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('includes a discovered non-default port in the adoption host', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], port: 8080 }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: [{ host: '192.168.1.100:8080', name: 'Strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(backendClient.POST).toHaveBeenCalledWith(
+			`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
+			expect.objectContaining({
+				body: expect.objectContaining({
+					data: expect.objectContaining({
+						devices: [expect.objectContaining({ host: '192.168.1.100:8080' })],
+					}),
+				}),
+			})
+		);
+		await adapter.dispose?.();
+	});
+
 	it('stops polling when disposed', async () => {
 		const adapter = useDevicesWizard();
 		await adapter.start();

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -138,6 +138,23 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('refreshes the device store after updating an adopted device', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: [{ host: '192.168.1.100', name: 'Renamed strip', status: 'updated', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		const results = await adapter.adopt([
+			{ key: 'mac:aabbccddeeff', name: 'Renamed strip', category: DevicesModuleDeviceCategory.lighting },
+		]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'updated' }));
+		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
+		await adapter.dispose?.();
+	});
+
 	it('includes a discovered non-default port in the adoption host', async () => {
 		backendClient.GET.mockResolvedValue({
 			data: {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -220,6 +220,41 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])(
+		'preserves an explicit default port from a manual probe: %s',
+		async (host) => {
+			backendClient.GET.mockResolvedValue({
+				data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },
+				response: { status: 200 },
+			});
+			backendClient.POST.mockResolvedValueOnce({
+				data: { data: { ...inventory.devices[0], host, port: 80 } },
+				response: { status: 201 },
+			}).mockResolvedValueOnce({
+				data: { data: [{ host, name: 'Strip', status: 'created', error: null }] },
+				response: { status: 200 },
+			});
+			const adapter = useDevicesWizard();
+			await adapter.start();
+			const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+			await form.handler({ host });
+
+			await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+			expect(backendClient.POST).toHaveBeenLastCalledWith(
+				`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
+				expect.objectContaining({
+					body: expect.objectContaining({
+						data: expect.objectContaining({
+							devices: [expect.objectContaining({ host })],
+						}),
+					}),
+				}),
+			);
+			await adapter.dispose?.();
+		},
+	);
+
 	it('brackets an IPv6 discovery host on the default port', async () => {
 		backendClient.GET.mockResolvedValue({
 			data: {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -110,6 +110,28 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('keeps cache clearing available when mDNS is disabled', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: { data: { ...inventory, mdnsEnabled: false } },
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory, mdnsEnabled: false, discoveryRunning: false, devices: [] } },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const action = adapter.controls.value.find((control) => control.type === 'action');
+		if (action?.type !== 'action') throw new Error('Rescan action not found');
+
+		expect(action.disabled).toBe(false);
+		await action.handler();
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/rescan`);
+		expect(adapter.rows.value).toHaveLength(0);
+		await adapter.dispose?.();
+	});
+
 	it('adopts selected devices in one mapper-backed batch and refreshes the device store', async () => {
 		backendClient.POST.mockResolvedValue({
 			data: { data: [{ host: '192.168.1.100', name: 'Renamed strip', status: 'created', error: null }] },
@@ -409,6 +431,40 @@ describe('useDevicesWizard', () => {
 		await Promise.all(rescans);
 
 		expect(backendClient.POST).toHaveBeenCalledTimes(1);
+		await adapter.dispose?.();
+	});
+
+	it('ignores an in-flight poll response that predates a completed rescan', async () => {
+		let resolvePoll: ((value: unknown) => void) | undefined;
+		backendClient.GET.mockResolvedValueOnce({
+			data: { data: inventory },
+			response: { status: 200 },
+		}).mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolvePoll = resolve;
+				})
+		);
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory, devices: [] } },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		vi.advanceTimersByTime(2_000);
+		await Promise.resolve();
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+		const action = adapter.controls.value.find((control) => control.type === 'action');
+		if (action?.type !== 'action') throw new Error('Rescan action not found');
+		await action.handler();
+		expect(adapter.rows.value).toHaveLength(0);
+
+		resolvePoll?.({ data: { data: inventory }, response: { status: 200 } });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(adapter.rows.value).toHaveLength(0);
 		await adapter.dispose?.();
 	});
 

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -203,6 +203,38 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('brackets an IPv6 discovery host on the default port', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: 'fe80::1234', port: 80 }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: [{ host: '[fe80::1234]', name: 'Strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(backendClient.POST).toHaveBeenCalledWith(
+			`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
+			expect.objectContaining({
+				body: expect.objectContaining({
+					data: expect.objectContaining({
+						devices: [expect.objectContaining({ host: '[fe80::1234]' })],
+					}),
+				}),
+			})
+		);
+		await adapter.dispose?.();
+	});
+
 	it('stops polling when disposed', async () => {
 		const adapter = useDevicesWizard();
 		await adapter.start();

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type IWizardBannerControl, type IWizardFormControl } from '../../../modules/devices';
+import { DevicesModuleDeviceCategory, DevicesWledPluginAdoptDeviceCategory } from '../../../openapi.constants';
+import { DEVICES_WLED_PLUGIN_PREFIX } from '../devices-wled.constants';
+
+import { useDevicesWizard } from './useDevicesWizard';
+
+const backendClient = {
+	GET: vi.fn(),
+	POST: vi.fn(),
+};
+
+const flashMessage = { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() };
+const devicesStore = { fetch: vi.fn() };
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({
+		global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => undefined },
+	}),
+	useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+	return {
+		...actual,
+		injectStoresManager: () => ({ getStore: vi.fn(() => devicesStore) }),
+		useBackend: () => ({ client: backendClient }),
+		useFlashMessage: () => flashMessage,
+		useLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+	};
+});
+
+const inventory = {
+	mdnsEnabled: true,
+	discoveryRunning: true,
+	devices: [
+		{
+			host: '192.168.1.100',
+			name: 'Living room strip',
+			mac: 'AA:BB:CC:DD:EE:FF',
+			port: 80,
+			adoptedDeviceId: null,
+		},
+	],
+};
+
+describe('useDevicesWizard', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		devicesStore.fetch.mockResolvedValue([]);
+		backendClient.GET.mockResolvedValue({ data: { data: inventory }, response: { status: 200 } });
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('maps discovered and already adopted WLED devices to shared rows', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [
+						...inventory.devices,
+						{
+							...inventory.devices[0],
+							host: '192.168.1.101',
+							mac: '11:22:33:44:55:66',
+							adoptedDeviceId: 'device-1',
+						},
+					],
+				},
+			},
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		expect(adapter.rows.value).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'ready', adoptable: true }),
+				expect.objectContaining({ status: 'already_registered', adoptable: false }),
+			])
+		);
+		await adapter.dispose?.();
+	});
+
+	it('keeps manual probing available when mDNS is disabled', async () => {
+		backendClient.GET.mockResolvedValue({ data: { data: { ...inventory, mdnsEnabled: false, devices: [] } }, response: { status: 200 } });
+		backendClient.POST.mockResolvedValue({
+			data: { data: inventory.devices[0] },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		expect((adapter.controls.value[0] as IWizardBannerControl).id).toBe('mdns-disabled');
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+		await form.handler({ host: '192.168.1.100' });
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/probe`, {
+			body: { data: { host: '192.168.1.100' } },
+		});
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ label: 'Living room strip', adoptable: true }));
+		await adapter.dispose?.();
+	});
+
+	it('adopts selected devices in one mapper-backed batch and refreshes the device store', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: [{ host: '192.168.1.100', name: 'Renamed strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Renamed strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(backendClient.POST).toHaveBeenCalledWith(`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`, {
+			body: {
+				data: {
+					devices: [
+						{
+							host: '192.168.1.100',
+							name: 'Renamed strip',
+							category: DevicesWledPluginAdoptDeviceCategory.lighting,
+						},
+					],
+				},
+			},
+		});
+		expect(results[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'created' }));
+		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
+		await adapter.dispose?.();
+	});
+
+	it('stops polling when disposed', async () => {
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		await adapter.dispose?.();
+		await vi.advanceTimersByTimeAsync(4_000);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(1);
+	});
+
+	it('serializes repeated rescan actions', async () => {
+		let resolveRescan: ((value: unknown) => void) | undefined;
+		backendClient.POST.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveRescan = resolve;
+				})
+		);
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const action = adapter.controls.value.find((control) => control.type === 'action');
+		if (action?.type !== 'action') throw new Error('Rescan action not found');
+
+		const rescans = [action.handler(), action.handler()];
+		resolveRescan?.({ data: { data: inventory }, response: { status: 200 } });
+		await Promise.all(rescans);
+
+		expect(backendClient.POST).toHaveBeenCalledTimes(1);
+		await adapter.dispose?.();
+	});
+
+	it('clears the busy state when adoption transport fails', async () => {
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		backendClient.POST.mockRejectedValueOnce(new Error('Connection dropped'));
+
+		await expect(adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }])).rejects.toThrow(
+			'Connection dropped'
+		);
+		expect(adapter.busy.value).toBe(false);
+		await adapter.dispose?.();
+	});
+});

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -293,6 +293,31 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('replaces a MAC-less IPv6 discovery row when the manual probe uses an equivalent expanded address', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: '2001:db8::1', port: 80, mac: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], host: '[2001:0db8::1]', port: 80 } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: '[2001:0db8::1]' });
+
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff' }));
+		await adapter.dispose?.();
+	});
+
 	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])('preserves an explicit default port from a manual probe: %s', async (host) => {
 		backendClient.GET.mockResolvedValue({
 			data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -367,8 +367,50 @@ describe('useDevicesWizard', () => {
 		await vi.advanceTimersByTimeAsync(2_000);
 
 		expect(adapter.rows.value).toHaveLength(1);
-		expect(adapter.rows.value[0]).toEqual(
-			expect.objectContaining({ label: 'Administrator name', status: 'already_registered', willUpdate: true })
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ label: 'Administrator name', status: 'already_registered', willUpdate: true }));
+		await adapter.dispose?.();
+	});
+
+	it('keeps a manual probe when an adopted endpoint reports a contradictory MAC', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [
+						{
+							...inventory.devices[0],
+							name: 'Cached controller',
+							mac: 'AA:BB:CC:DD:EE:FF',
+							adoptedDeviceId: 'device-1',
+						},
+					],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: {
+				data: {
+					...inventory.devices[0],
+					name: 'Live replacement',
+					mac: '11:22:33:44:55:66',
+					adoptedDeviceId: null,
+				},
+			},
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: '192.168.1.100' });
+
+		expect(adapter.rows.value).toHaveLength(2);
+		expect(adapter.rows.value).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: 'Live replacement', status: 'ready', key: 'mac:112233445566' }),
+				expect.objectContaining({ label: 'Cached controller', status: 'already_registered', key: 'mac:aabbccddeeff' }),
+			])
 		);
 		await adapter.dispose?.();
 	});

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -371,6 +371,78 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('adopts a moved controller through its freshly probed endpoint while retaining adoption metadata', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [
+						{
+							...inventory.devices[0],
+							name: 'Administrator name',
+							adoptedDeviceId: 'device-1',
+						},
+					],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
+				data: {
+					...inventory.devices[0],
+					host: '192.168.1.200',
+					name: 'Probed name',
+					adoptedDeviceId: null,
+				},
+			},
+			response: { status: 201 },
+		}).mockResolvedValueOnce({
+			data: {
+				data: [{ host: '192.168.1.200', name: 'Administrator name', status: 'updated', error: null }],
+			},
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: '192.168.1.200' });
+
+		expect(adapter.rows.value).toEqual([
+			expect.objectContaining({
+				key: 'mac:aabbccddeeff',
+				label: 'Administrator name',
+				status: 'already_registered',
+				willUpdate: true,
+				cells: { host: { render: 'code', value: '192.168.1.200' } },
+			}),
+		]);
+
+		await adapter.adopt([
+			{
+				key: 'mac:aabbccddeeff',
+				name: 'Administrator name',
+				category: DevicesModuleDeviceCategory.lighting,
+			},
+		]);
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`, {
+			body: {
+				data: {
+					devices: [
+						{
+							host: '192.168.1.200',
+							name: 'Administrator name',
+							category: DevicesWledPluginAdoptDeviceCategory.lighting,
+						},
+					],
+				},
+			},
+		});
+		await adapter.dispose?.();
+	});
+
 	it('keeps a manual probe when an adopted endpoint reports a contradictory MAC', async () => {
 		backendClient.GET.mockResolvedValue({
 			data: {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -146,9 +146,7 @@ describe('useDevicesWizard', () => {
 		const adapter = useDevicesWizard();
 		await adapter.start();
 
-		const results = await adapter.adopt([
-			{ key: 'mac:aabbccddeeff', name: 'Renamed strip', category: DevicesModuleDeviceCategory.lighting },
-		]);
+		const results = await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Renamed strip', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(results[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'updated' }));
 		expect(devicesStore.fetch).toHaveBeenCalledTimes(1);
@@ -245,40 +243,62 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
-	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])(
-		'preserves an explicit default port from a manual probe: %s',
-		async (host) => {
-			backendClient.GET.mockResolvedValue({
-				data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },
-				response: { status: 200 },
-			});
-			backendClient.POST.mockResolvedValueOnce({
-				data: { data: { ...inventory.devices[0], host, port: 80 } },
-				response: { status: 201 },
-			}).mockResolvedValueOnce({
-				data: { data: [{ host, name: 'Strip', status: 'created', error: null }] },
-				response: { status: 200 },
-			});
-			const adapter = useDevicesWizard();
-			await adapter.start();
-			const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
-			await form.handler({ host });
+	it('replaces a MAC-less default-port discovery row with an explicit port 80 probe', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: 'wled.local', port: 80, mac: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], host: 'wled.local:80', port: 80 } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
 
-			await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+		await form.handler({ host: 'wled.local:80' });
 
-			expect(backendClient.POST).toHaveBeenLastCalledWith(
-				`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
-				expect.objectContaining({
-					body: expect.objectContaining({
-						data: expect.objectContaining({
-							devices: [expect.objectContaining({ host })],
-						}),
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff' }));
+		await adapter.dispose?.();
+	});
+
+	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])('preserves an explicit default port from a manual probe: %s', async (host) => {
+		backendClient.GET.mockResolvedValue({
+			data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: { ...inventory.devices[0], host, port: 80 } },
+			response: { status: 201 },
+		}).mockResolvedValueOnce({
+			data: { data: [{ host, name: 'Strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+		await form.handler({ host });
+
+		await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(
+			`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
+			expect.objectContaining({
+				body: expect.objectContaining({
+					data: expect.objectContaining({
+						devices: [expect.objectContaining({ host })],
 					}),
 				}),
-			);
-			await adapter.dispose?.();
-		},
-	);
+			})
+		);
+		await adapter.dispose?.();
+	});
 
 	it('brackets an IPv6 discovery host on the default port', async () => {
 		backendClient.GET.mockResolvedValue({

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -220,6 +220,31 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('replaces a MAC-less discovery row with a manual probe at the same normalized endpoint', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: 'wled.local', port: 8080, mac: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], host: 'wled.local:8080', port: 8080 } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: 'wled.local:8080' });
+
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff' }));
+		await adapter.dispose?.();
+	});
+
 	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])(
 		'preserves an explicit default port from a manual probe: %s',
 		async (host) => {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -84,7 +84,7 @@ describe('useDevicesWizard', () => {
 		expect(adapter.rows.value).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'ready', adoptable: true }),
-				expect.objectContaining({ status: 'already_registered', adoptable: false }),
+				expect.objectContaining({ status: 'already_registered', adoptable: true, willUpdate: true }),
 			])
 		);
 		await adapter.dispose?.();

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -244,4 +244,20 @@ describe('useDevicesWizard', () => {
 		expect(adapter.busy.value).toBe(false);
 		await adapter.dispose?.();
 	});
+
+	it('returns successful adoption results when the device-store refresh fails', async () => {
+		backendClient.POST.mockResolvedValue({
+			data: { data: [{ host: '192.168.1.100', name: 'Strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		devicesStore.fetch.mockRejectedValueOnce(new Error('Refresh failed'));
+		const adapter = useDevicesWizard();
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff', status: 'created' }));
+		expect(adapter.busy.value).toBe(false);
+		await adapter.dispose?.();
+	});
 });

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -155,9 +155,42 @@ describe('useDevicesWizard', () => {
 		const adapter = useDevicesWizard();
 		await adapter.start();
 
-		await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(backendClient.POST).toHaveBeenCalledWith(
+			`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
+			expect.objectContaining({
+				body: expect.objectContaining({
+					data: expect.objectContaining({
+						devices: [expect.objectContaining({ host: '192.168.1.100:8080' })],
+					}),
+				}),
+			})
+		);
+		expect(results[0].key).toBe('mac:aabbccddeeff');
+		await adapter.dispose?.();
+	});
+
+	it('does not append the port twice after a manual probe', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValueOnce({
+			data: { data: { ...inventory.devices[0], host: '192.168.1.100:8080', port: 8080 } },
+			response: { status: 201 },
+		}).mockResolvedValueOnce({
+			data: { data: [{ host: '192.168.1.100:8080', name: 'Strip', status: 'created', error: null }] },
+			response: { status: 200 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+		await form.handler({ host: '192.168.1.100:8080' });
+
+		await adapter.adopt([{ key: 'mac:aabbccddeeff', name: 'Strip', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(backendClient.POST).toHaveBeenLastCalledWith(
 			`/plugins/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`,
 			expect.objectContaining({
 				body: expect.objectContaining({

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -315,6 +315,64 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('replaces a DNS discovery row when the manual hostname has a terminal root dot', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: 'wled.local', port: 80, mac: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], host: 'wled.local.', port: 80 } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: 'wled.local.' });
+
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff' }));
+		await adapter.dispose?.();
+	});
+
+	it('uses fresh adopted inventory state instead of a stale manual probe overlay', async () => {
+		backendClient.GET.mockResolvedValueOnce({
+			data: { data: { ...inventory, devices: [] } },
+			response: { status: 200 },
+		}).mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], name: 'Administrator name', adoptedDeviceId: 'device-1' }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], name: 'Stale probed name' } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+		await form.handler({ host: '192.168.1.100' });
+
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ label: 'Stale probed name', status: 'ready' }));
+
+		await vi.advanceTimersByTimeAsync(2_000);
+
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(
+			expect.objectContaining({ label: 'Administrator name', status: 'already_registered', willUpdate: true })
+		);
+		await adapter.dispose?.();
+	});
+
 	it('replaces a MAC-less IPv6 discovery row when the manual probe uses an equivalent expanded address', async () => {
 		backendClient.GET.mockResolvedValue({
 			data: {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.spec.ts
@@ -268,6 +268,31 @@ describe('useDevicesWizard', () => {
 		await adapter.dispose?.();
 	});
 
+	it('replaces a MAC-less discovery row when the manual hostname differs only by case', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: {
+				data: {
+					...inventory,
+					devices: [{ ...inventory.devices[0], host: 'WLED.local', port: 80, mac: null }],
+				},
+			},
+			response: { status: 200 },
+		});
+		backendClient.POST.mockResolvedValue({
+			data: { data: { ...inventory.devices[0], host: 'wled.local', port: 80 } },
+			response: { status: 201 },
+		});
+		const adapter = useDevicesWizard();
+		await adapter.start();
+		const form = adapter.controls.value.find((control) => control.type === 'form') as IWizardFormControl;
+
+		await form.handler({ host: 'wled.local' });
+
+		expect(adapter.rows.value).toHaveLength(1);
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ key: 'mac:aabbccddeeff' }));
+		await adapter.dispose?.();
+	});
+
 	it.each(['192.168.1.100:80', 'wled.local:80', '[fe80::1234]:80'])('preserves an explicit default port from a manual probe: %s', async (host) => {
 		backendClient.GET.mockResolvedValue({
 			data: { data: { ...inventory, mdnsEnabled: false, devices: [] } },

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -322,7 +322,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				body: {
 					data: {
 						devices: selectedDevices.map(({ item, device }) => ({
-							host: device.host,
+							host: device.port === 80 ? device.host : `${device.host}:${device.port}`,
 							name: item.name,
 							category: DevicesWledPluginAdoptDeviceCategory.lighting,
 						})),

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -159,9 +159,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	};
 
 	const loadDiscovery = async (): Promise<void> => {
+		const requestedGeneration = generation.value;
 		const { data, error, response } = await backend.client.GET(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery`);
 		if (typeof data !== 'undefined') {
-			applyInventory(data.data);
+			if (requestedGeneration === generation.value) {
+				applyInventory(data.data);
+			}
 			return;
 		}
 
@@ -308,7 +311,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				id: 'rescan',
 				label: t('devicesWledPlugin.wizard.actions.rescan'),
 				icon: 'mdi:radar',
-				disabled: inventory.value?.mdnsEnabled === false || formResult.value === FormResult.WORKING,
+				disabled: formResult.value === FormResult.WORKING,
 				loading: formResult.value === FormResult.WORKING,
 				handler: rescan,
 			},

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -87,7 +87,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}
 		for (const device of manualDevices.value) {
 			for (const [key, candidate] of merged) {
-				if (candidate.host === device.host) merged.delete(key);
+				if (adoptionHost(candidate) === adoptionHost(device)) merged.delete(key);
 			}
 			merged.set(deviceKey(device), device);
 		}

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -43,7 +43,7 @@ interface IWledWizardInventory {
 interface IWledWizardAdoptionResult {
 	host: string;
 	name: string;
-	status: 'created' | 'failed';
+	status: 'created' | 'updated' | 'failed';
 	error: string | null;
 }
 
@@ -103,8 +103,8 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			subLabel: device.mac,
 			identifier: device.mac ?? device.host,
 			status: device.adoptedDeviceId ? 'already_registered' : 'ready',
-			adoptable: device.adoptedDeviceId === null,
-			willUpdate: false,
+			adoptable: true,
+			willUpdate: device.adoptedDeviceId !== null,
 			suggestedName: device.name || device.host,
 			suggestedCategory: DevicesModuleDeviceCategory.lighting,
 			categoryOptions: [

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -63,6 +63,8 @@ const adoptionHost = (device: IWledWizardDevice): string => {
 	return `${normalizedHost}:${device.port}`;
 };
 
+const adoptionEndpointKey = (device: IWledWizardDevice): string => adoptionHost(device).replace(/:80$/, '');
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -87,7 +89,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		}
 		for (const device of manualDevices.value) {
 			for (const [key, candidate] of merged) {
-				if (adoptionHost(candidate) === adoptionHost(device)) merged.delete(key);
+				if (adoptionEndpointKey(candidate) === adoptionEndpointKey(device)) merged.delete(key);
 			}
 			merged.set(deviceKey(device), device);
 		}

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -122,9 +122,16 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				}
 			}
 
-			// Once the live inventory recognizes an adopted controller it is authoritative:
-			// retaining the older manual probe would hide its registration and current name.
-			const resolvedDevice = inventoryMatch && inventoryMatch.adoptedDeviceId !== null ? inventoryMatch : device;
+			// Preserve the freshly verified manual endpoint while carrying forward the
+			// administrator-owned name and adoption state from a matching inventory row.
+			const resolvedDevice =
+				inventoryMatch && inventoryMatch.adoptedDeviceId !== null
+					? {
+							...device,
+							name: inventoryMatch.name,
+							adoptedDeviceId: inventoryMatch.adoptedDeviceId,
+						}
+					: device;
 			merged.set(deviceKey(resolvedDevice), resolvedDevice);
 		}
 		return orderBy(Array.from(merged.values()), [(device) => (device.adoptedDeviceId ? 1 : 0), 'name'], ['asc', 'asc']);

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -1,0 +1,384 @@
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { orderBy } from 'natural-orderby';
+
+import { PLUGINS_PREFIX } from '../../../app.constants';
+import { getErrorReason, injectStoresManager, useBackend, useFlashMessage, useLogger } from '../../../common';
+import {
+	FormResult,
+	type FormResultType,
+	type IDeviceWizardAdapter,
+	type IWizardAdoptSelection,
+	type IWizardControl,
+	type IWizardResult,
+	type IWizardRow,
+	devicesStoreKey,
+} from '../../../modules/devices';
+import {
+	DevicesModuleDeviceCategory,
+	DevicesWledPluginAdoptDeviceCategory,
+	type DevicesWledPluginAdoptDiscoveryOperation,
+	type DevicesWledPluginGetDiscoveryOperation,
+	type DevicesWledPluginProbeDiscoveryOperation,
+	type DevicesWledPluginRescanDiscoveryOperation,
+} from '../../../openapi.constants';
+import { DEVICES_WLED_PLUGIN_NAME, DEVICES_WLED_PLUGIN_PREFIX } from '../devices-wled.constants';
+import { DevicesWledApiException, DevicesWledValidationException } from '../devices-wled.exceptions';
+
+interface IWledWizardDevice {
+	host: string;
+	name: string;
+	mac: string | null;
+	port: number;
+	adoptedDeviceId: string | null;
+}
+
+interface IWledWizardInventory {
+	mdnsEnabled: boolean;
+	discoveryRunning: boolean;
+	devices: IWledWizardDevice[];
+}
+
+interface IWledWizardAdoptionResult {
+	host: string;
+	name: string;
+	status: 'created' | 'failed';
+	error: string | null;
+}
+
+const POLL_INTERVAL_MS = 2_000;
+
+const deviceKey = (device: IWledWizardDevice): string =>
+	device.mac ? `mac:${device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase()}` : `host:${device.host}`;
+
+export const useDevicesWizard = (): IDeviceWizardAdapter => {
+	const { t } = useI18n();
+	const backend = useBackend();
+	const flashMessage = useFlashMessage();
+	const logger = useLogger();
+	const storesManager = injectStoresManager();
+	const devicesStore = storesManager.getStore(devicesStoreKey);
+	const inventory = ref<IWledWizardInventory | null>(null);
+	const manualDevices = ref<IWledWizardDevice[]>([]);
+	const adoptionResults = ref<IWledWizardAdoptionResult[]>([]);
+	const formResult = ref<FormResultType>(FormResult.NONE);
+	const discoveryError = ref<string | null>(null);
+	const generation = ref(0);
+	let pollTimer: ReturnType<typeof setTimeout> | null = null;
+	let rescanPromise: Promise<void> | null = null;
+	let disposed = false;
+
+	const devices = computed<IWledWizardDevice[]>(() => {
+		const merged = new Map<string, IWledWizardDevice>();
+		for (const device of inventory.value?.devices ?? []) {
+			merged.set(deviceKey(device), device);
+		}
+		for (const device of manualDevices.value) {
+			for (const [key, candidate] of merged) {
+				if (candidate.host === device.host) merged.delete(key);
+			}
+			merged.set(deviceKey(device), device);
+		}
+		return orderBy(Array.from(merged.values()), [(device) => (device.adoptedDeviceId ? 1 : 0), 'name'], ['asc', 'asc']);
+	});
+
+	const rows = computed<IWizardRow[]>(() =>
+		devices.value.map((device) => ({
+			key: deviceKey(device),
+			label: device.name || device.host,
+			subLabel: device.mac,
+			identifier: device.mac ?? device.host,
+			status: device.adoptedDeviceId ? 'already_registered' : 'ready',
+			adoptable: device.adoptedDeviceId === null,
+			willUpdate: false,
+			suggestedName: device.name || device.host,
+			suggestedCategory: DevicesModuleDeviceCategory.lighting,
+			categoryOptions: [
+				{
+					value: DevicesModuleDeviceCategory.lighting,
+					label: t(`devicesModule.categories.devices.${DevicesModuleDeviceCategory.lighting}`),
+				},
+			],
+			cells: {
+				host: { render: 'code', value: device.host },
+			},
+		}))
+	);
+
+	const results = computed<IWizardResult[]>(() =>
+		adoptionResults.value.map((result) => {
+			const device = devices.value.find((candidate) => candidate.host === result.host);
+			return {
+				key: device ? deviceKey(device) : `host:${result.host}`,
+				name: result.name,
+				identifier: device?.mac ?? result.host,
+				status: result.status,
+				error: result.error,
+			};
+		})
+	);
+
+	const applyInventory = (data: {
+		mdnsEnabled: boolean;
+		discoveryRunning: boolean;
+		devices: Array<{ host: string; name: string; mac?: string | null; port: number; adoptedDeviceId?: string | null }>;
+	}): void => {
+		inventory.value = {
+			mdnsEnabled: data.mdnsEnabled,
+			discoveryRunning: data.discoveryRunning,
+			devices: data.devices.map((device) => ({
+				...device,
+				mac: device.mac ?? null,
+				adoptedDeviceId: device.adoptedDeviceId ?? null,
+			})),
+		};
+		discoveryError.value = null;
+	};
+
+	const loadDiscovery = async (): Promise<void> => {
+		const { data, error, response } = await backend.client.GET(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery`);
+		if (typeof data !== 'undefined') {
+			applyInventory(data.data);
+			return;
+		}
+
+		const reason = error
+			? getErrorReason<DevicesWledPluginGetDiscoveryOperation>(error, t('devicesWledPlugin.wizard.messages.discoveryFailed'))
+			: t('devicesWledPlugin.wizard.messages.discoveryFailed');
+		throw new DevicesWledApiException(reason, response.status);
+	};
+
+	const stopPolling = (): void => {
+		if (pollTimer !== null) {
+			clearTimeout(pollTimer);
+			pollTimer = null;
+		}
+	};
+
+	const schedulePoll = (): void => {
+		stopPolling();
+		pollTimer = setTimeout(async () => {
+			pollTimer = null;
+			if (disposed) return;
+			try {
+				await loadDiscovery();
+			} catch (error: unknown) {
+				logger.warn('Failed to refresh WLED discovery inventory', error);
+			}
+			if (!disposed) schedulePoll();
+		}, POLL_INTERVAL_MS);
+	};
+
+	const start = async (): Promise<void> => {
+		disposed = false;
+		formResult.value = FormResult.WORKING;
+		try {
+			await loadDiscovery();
+			formResult.value = FormResult.NONE;
+			if (disposed) return;
+			schedulePoll();
+		} catch (error: unknown) {
+			const reason = error instanceof Error ? error.message : t('devicesWledPlugin.wizard.messages.discoveryFailed');
+			formResult.value = FormResult.ERROR;
+			discoveryError.value = reason;
+			flashMessage.error(reason);
+			throw error;
+		}
+	};
+
+	const performRescan = async (): Promise<void> => {
+		formResult.value = FormResult.WORKING;
+		let rescanned;
+		try {
+			rescanned = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/rescan`);
+		} catch (error: unknown) {
+			const reason = error instanceof Error ? error.message : t('devicesWledPlugin.wizard.messages.rescanFailed');
+			formResult.value = FormResult.ERROR;
+			flashMessage.error(reason);
+			throw new DevicesWledApiException(reason, 0);
+		}
+		const { data, error, response } = rescanned;
+		if (typeof data !== 'undefined') {
+			generation.value += 1;
+			manualDevices.value = [];
+			adoptionResults.value = [];
+			applyInventory(data.data);
+			formResult.value = FormResult.NONE;
+			return;
+		}
+		const reason = error
+			? getErrorReason<DevicesWledPluginRescanDiscoveryOperation>(error, t('devicesWledPlugin.wizard.messages.rescanFailed'))
+			: t('devicesWledPlugin.wizard.messages.rescanFailed');
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(reason);
+		throw new DevicesWledApiException(reason, response.status);
+	};
+
+	const rescan = (): Promise<void> => {
+		if (rescanPromise !== null) return rescanPromise;
+		rescanPromise = performRescan().finally(() => {
+			rescanPromise = null;
+		});
+		return rescanPromise;
+	};
+
+	const probeManual = async (values: Record<string, string>): Promise<void> => {
+		const host = (values.host ?? '').trim();
+		if (!host) {
+			const reason = t('devicesWledPlugin.fields.devices.hostname.validation.required');
+			flashMessage.error(reason);
+			throw new DevicesWledValidationException(reason);
+		}
+
+		formResult.value = FormResult.WORKING;
+		let probed;
+		try {
+			probed = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/probe`, {
+				body: { data: { host } },
+			});
+		} catch (error: unknown) {
+			const reason = error instanceof Error ? error.message : t('devicesWledPlugin.wizard.messages.probeFailed');
+			formResult.value = FormResult.ERROR;
+			flashMessage.error(reason);
+			throw new DevicesWledApiException(reason, 0);
+		}
+		const { data, error, response } = probed;
+		if (typeof data !== 'undefined') {
+			const device = data.data;
+			manualDevices.value = [
+				...manualDevices.value.filter((candidate) => candidate.host !== device.host),
+				{
+					host: device.host,
+					name: device.name,
+					mac: device.mac ?? null,
+					port: device.port,
+					adoptedDeviceId: device.adoptedDeviceId ?? null,
+				},
+			];
+			formResult.value = FormResult.NONE;
+			return;
+		}
+		const reason = error
+			? getErrorReason<DevicesWledPluginProbeDiscoveryOperation>(error, t('devicesWledPlugin.wizard.messages.probeFailed'))
+			: t('devicesWledPlugin.wizard.messages.probeFailed');
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(reason);
+		throw new DevicesWledApiException(reason, response.status);
+	};
+
+	const controls = computed<IWizardControl[]>(() => {
+		const items: IWizardControl[] = [];
+		if (discoveryError.value) {
+			items.push({ type: 'banner', id: 'error', severity: 'error', title: discoveryError.value });
+		} else if (inventory.value?.mdnsEnabled === false) {
+			items.push({
+				type: 'banner',
+				id: 'mdns-disabled',
+				severity: 'info',
+				title: t('devicesWledPlugin.wizard.mdnsDisabled.title'),
+				message: t('devicesWledPlugin.wizard.mdnsDisabled.message'),
+			});
+		}
+		items.push(
+			{
+				type: 'action',
+				id: 'rescan',
+				label: t('devicesWledPlugin.wizard.actions.rescan'),
+				icon: 'mdi:radar',
+				disabled: inventory.value?.mdnsEnabled === false || formResult.value === FormResult.WORKING,
+				loading: formResult.value === FormResult.WORKING,
+				handler: rescan,
+			},
+			{
+				type: 'form',
+				id: 'manual',
+				fields: [
+					{
+						key: 'host',
+						label: t('devicesWledPlugin.fields.devices.hostname.title'),
+						placeholder: t('devicesWledPlugin.fields.devices.hostname.placeholder'),
+					},
+				],
+				submitLabel: t('devicesWledPlugin.wizard.actions.probe'),
+				submitIcon: 'mdi:lan-connect',
+				submitDisabled: formResult.value === FormResult.WORKING,
+				loading: formResult.value === FormResult.WORKING,
+				handler: probeManual,
+			}
+		);
+		return items;
+	});
+
+	const adopt = async (selection: IWizardAdoptSelection[]): Promise<IWizardResult[]> => {
+		formResult.value = FormResult.WORKING;
+		const selectedDevices = selection.flatMap((item) => {
+			const device = devices.value.find((candidate) => deviceKey(candidate) === item.key);
+			return device ? [{ item, device }] : [];
+		});
+		let adopted;
+		try {
+			adopted = await backend.client.POST(`/${PLUGINS_PREFIX}/${DEVICES_WLED_PLUGIN_PREFIX}/discovery/adopt`, {
+				body: {
+					data: {
+						devices: selectedDevices.map(({ item, device }) => ({
+							host: device.host,
+							name: item.name,
+							category: DevicesWledPluginAdoptDeviceCategory.lighting,
+						})),
+					},
+				},
+			});
+		} catch (error: unknown) {
+			const reason = error instanceof Error ? error.message : t('devicesWledPlugin.wizard.messages.adoptionFailed');
+			formResult.value = FormResult.ERROR;
+			flashMessage.error(reason);
+			throw new DevicesWledApiException(reason, 0);
+		}
+		const { data, error, response } = adopted;
+		if (typeof data !== 'undefined') {
+			adoptionResults.value = data.data.map((result) => ({
+				host: result.host,
+				name: result.name,
+				status: result.status,
+				error: result.error ?? null,
+			}));
+			if (adoptionResults.value.some((result) => result.status === 'created')) {
+				await devicesStore.fetch();
+			}
+			formResult.value = adoptionResults.value.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
+			return results.value;
+		}
+		const reason = error
+			? getErrorReason<DevicesWledPluginAdoptDiscoveryOperation>(error, t('devicesWledPlugin.wizard.messages.adoptionFailed'))
+			: t('devicesWledPlugin.wizard.messages.adoptionFailed');
+		formResult.value = FormResult.ERROR;
+		flashMessage.error(reason);
+		throw new DevicesWledApiException(reason, response.status);
+	};
+
+	const dispose = async (): Promise<void> => {
+		disposed = true;
+		stopPolling();
+	};
+
+	return {
+		title: t('devicesWledPlugin.wizard.title'),
+		subtitle: t('devicesWledPlugin.wizard.subtitle'),
+		breadcrumbLabel: t('devicesWledPlugin.wizard.breadcrumb'),
+		pluginType: DEVICES_WLED_PLUGIN_NAME,
+		identifierLabel: t('devicesWledPlugin.wizard.columns.identifier'),
+		rows,
+		results,
+		columns: [{ key: 'host', label: t('devicesWledPlugin.wizard.columns.host'), steps: ['discover'], minWidth: 160 }],
+		controls,
+		sessionKey: computed(() => String(generation.value)),
+		ready: computed(() => inventory.value !== null || discoveryError.value !== null),
+		busy: computed(() => formResult.value === FormResult.WORKING),
+		capabilities: { addMore: true },
+		start,
+		adopt,
+		restart: rescan,
+		dispose,
+	};
+};

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -52,6 +52,20 @@ const POLL_INTERVAL_MS = 2_000;
 const deviceKey = (device: IWledWizardDevice): string =>
 	device.mac ? `mac:${device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase()}` : `host:${device.host}`;
 
+const normalizedMac = (device: IWledWizardDevice): string | null => {
+	if (!device.mac) return null;
+
+	const normalized = device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+	return normalized.length === 12 ? normalized : null;
+};
+
+const identitiesAreCompatible = (first: IWledWizardDevice, second: IWledWizardDevice): boolean => {
+	const firstMac = normalizedMac(first);
+	const secondMac = normalizedMac(second);
+
+	return firstMac === null || secondMac === null || firstMac === secondMac;
+};
+
 const adoptionHost = (device: IWledWizardDevice): string => {
 	const host = device.host.trim();
 	const hasExplicitPort = /^\[[^\]]+\]:\d+$/.test(host) || /^[^:]+:\d+$/.test(host);
@@ -70,7 +84,10 @@ const adoptionEndpointKey = (device: IWledWizardDevice): string => {
 		const url = new URL(`http://${endpoint}`);
 		return `${url.hostname.toLowerCase().replace(/\.$/, '')}${url.port ? `:${url.port}` : ''}`;
 	} catch {
-		return endpoint.toLowerCase().replace(/\.(?=:\d+$|$)/, '').replace(/:80$/, '');
+		return endpoint
+			.toLowerCase()
+			.replace(/\.(?=:\d+$|$)/, '')
+			.replace(/:80$/, '');
 	}
 };
 
@@ -99,7 +116,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		for (const device of manualDevices.value) {
 			let inventoryMatch = merged.get(deviceKey(device));
 			for (const [key, candidate] of merged) {
-				if (adoptionEndpointKey(candidate) === adoptionEndpointKey(device)) {
+				if (adoptionEndpointKey(candidate) === adoptionEndpointKey(device) && identitiesAreCompatible(candidate, device)) {
 					if (!inventoryMatch || candidate.adoptedDeviceId !== null) inventoryMatch = candidate;
 					merged.delete(key);
 				}

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -357,7 +357,13 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				error: result.error ?? null,
 			}));
 			if (adoptionResults.value.some((result) => result.status === 'created')) {
-				await devicesStore.fetch();
+				try {
+					await devicesStore.fetch();
+				} catch (error: unknown) {
+					logger.warn('WLED devices were adopted, but the device store could not be refreshed', {
+						message: error instanceof Error ? error.message : String(error),
+					});
+				}
 			}
 			formResult.value = adoptionResults.value.some((result) => result.status === 'failed') ? FormResult.ERROR : FormResult.OK;
 			return results.value;

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -63,7 +63,16 @@ const adoptionHost = (device: IWledWizardDevice): string => {
 	return `${normalizedHost}:${device.port}`;
 };
 
-const adoptionEndpointKey = (device: IWledWizardDevice): string => adoptionHost(device).toLowerCase().replace(/:80$/, '');
+const adoptionEndpointKey = (device: IWledWizardDevice): string => {
+	const endpoint = adoptionHost(device);
+
+	try {
+		const url = new URL(`http://${endpoint}`);
+		return `${url.hostname.toLowerCase()}${url.port ? `:${url.port}` : ''}`;
+	} catch {
+		return endpoint.toLowerCase().replace(/:80$/, '');
+	}
+};
 
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -63,7 +63,7 @@ const adoptionHost = (device: IWledWizardDevice): string => {
 	return `${normalizedHost}:${device.port}`;
 };
 
-const adoptionEndpointKey = (device: IWledWizardDevice): string => adoptionHost(device).replace(/:80$/, '');
+const adoptionEndpointKey = (device: IWledWizardDevice): string => adoptionHost(device).toLowerCase().replace(/:80$/, '');
 
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -53,16 +53,14 @@ const deviceKey = (device: IWledWizardDevice): string =>
 	device.mac ? `mac:${device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase()}` : `host:${device.host}`;
 
 const adoptionHost = (device: IWledWizardDevice): string => {
-	try {
-		if (new URL(`http://${device.host}`).port) return device.host;
-	} catch {
-		// The backend will return a scoped validation error for malformed hosts.
-	}
+	const host = device.host.trim();
+	const hasExplicitPort = /^\[[^\]]+\]:\d+$/.test(host) || /^[^:]+:\d+$/.test(host);
+	if (hasExplicitPort) return host;
 
-	const host = device.host.includes(':') && !device.host.startsWith('[') ? `[${device.host}]` : device.host;
-	if (device.port === 80) return host;
+	const normalizedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+	if (device.port === 80) return normalizedHost;
 
-	return `${host}:${device.port}`;
+	return `${normalizedHost}:${device.port}`;
 };
 
 export const useDevicesWizard = (): IDeviceWizardAdapter => {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -68,9 +68,9 @@ const adoptionEndpointKey = (device: IWledWizardDevice): string => {
 
 	try {
 		const url = new URL(`http://${endpoint}`);
-		return `${url.hostname.toLowerCase()}${url.port ? `:${url.port}` : ''}`;
+		return `${url.hostname.toLowerCase().replace(/\.$/, '')}${url.port ? `:${url.port}` : ''}`;
 	} catch {
-		return endpoint.toLowerCase().replace(/:80$/, '');
+		return endpoint.toLowerCase().replace(/\.(?=:\d+$|$)/, '').replace(/:80$/, '');
 	}
 };
 
@@ -97,10 +97,18 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			merged.set(deviceKey(device), device);
 		}
 		for (const device of manualDevices.value) {
+			let inventoryMatch = merged.get(deviceKey(device));
 			for (const [key, candidate] of merged) {
-				if (adoptionEndpointKey(candidate) === adoptionEndpointKey(device)) merged.delete(key);
+				if (adoptionEndpointKey(candidate) === adoptionEndpointKey(device)) {
+					if (!inventoryMatch || candidate.adoptedDeviceId !== null) inventoryMatch = candidate;
+					merged.delete(key);
+				}
 			}
-			merged.set(deviceKey(device), device);
+
+			// Once the live inventory recognizes an adopted controller it is authoritative:
+			// retaining the older manual probe would hide its registration and current name.
+			const resolvedDevice = inventoryMatch && inventoryMatch.adoptedDeviceId !== null ? inventoryMatch : device;
+			merged.set(deviceKey(resolvedDevice), resolvedDevice);
 		}
 		return orderBy(Array.from(merged.values()), [(device) => (device.adoptedDeviceId ? 1 : 0), 'name'], ['asc', 'asc']);
 	});

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -53,8 +53,6 @@ const deviceKey = (device: IWledWizardDevice): string =>
 	device.mac ? `mac:${device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase()}` : `host:${device.host}`;
 
 const adoptionHost = (device: IWledWizardDevice): string => {
-	if (device.port === 80) return device.host;
-
 	try {
 		if (new URL(`http://${device.host}`).port) return device.host;
 	} catch {
@@ -62,6 +60,8 @@ const adoptionHost = (device: IWledWizardDevice): string => {
 	}
 
 	const host = device.host.includes(':') && !device.host.startsWith('[') ? `[${device.host}]` : device.host;
+	if (device.port === 80) return host;
+
 	return `${host}:${device.port}`;
 };
 

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -356,7 +356,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				status: result.status,
 				error: result.error ?? null,
 			}));
-			if (adoptionResults.value.some((result) => result.status === 'created')) {
+			if (adoptionResults.value.some((result) => result.status === 'created' || result.status === 'updated')) {
 				try {
 					await devicesStore.fetch();
 				} catch (error: unknown) {

--- a/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-wled/composables/useDevicesWizard.ts
@@ -52,6 +52,19 @@ const POLL_INTERVAL_MS = 2_000;
 const deviceKey = (device: IWledWizardDevice): string =>
 	device.mac ? `mac:${device.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase()}` : `host:${device.host}`;
 
+const adoptionHost = (device: IWledWizardDevice): string => {
+	if (device.port === 80) return device.host;
+
+	try {
+		if (new URL(`http://${device.host}`).port) return device.host;
+	} catch {
+		// The backend will return a scoped validation error for malformed hosts.
+	}
+
+	const host = device.host.includes(':') && !device.host.startsWith('[') ? `[${device.host}]` : device.host;
+	return `${host}:${device.port}`;
+};
+
 export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	const { t } = useI18n();
 	const backend = useBackend();
@@ -108,7 +121,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 
 	const results = computed<IWizardResult[]>(() =>
 		adoptionResults.value.map((result) => {
-			const device = devices.value.find((candidate) => candidate.host === result.host);
+			const device = devices.value.find((candidate) => adoptionHost(candidate) === result.host);
 			return {
 				key: device ? deviceKey(device) : `host:${result.host}`,
 				name: result.name,
@@ -322,7 +335,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				body: {
 					data: {
 						devices: selectedDevices.map(({ item, device }) => ({
-							host: device.port === 80 ? device.host : `${device.host}:${device.port}`,
+							host: adoptionHost(device),
 							name: item.name,
 							category: DevicesWledPluginAdoptDeviceCategory.lighting,
 						})),

--- a/apps/admin/src/plugins/devices-wled/devices-wled.plugin.ts
+++ b/apps/admin/src/plugins/devices-wled/devices-wled.plugin.ts
@@ -16,6 +16,7 @@ import {
 } from '../../modules/devices';
 
 import { WledConfigForm, WledDeviceAddForm, WledDeviceEditForm } from './components/components';
+import { useDevicesWizard } from './composables/composables';
 import { DEVICES_WLED_PLUGIN_NAME, DEVICES_WLED_TYPE } from './devices-wled.constants';
 import { locales } from './locales';
 import { WledConfigEditFormSchema } from './schemas/config.schemas';
@@ -75,6 +76,7 @@ export default {
 					components: {
 						deviceAddForm: WledDeviceAddForm,
 						deviceEditForm: WledDeviceEditForm,
+						deviceWizardAdapter: useDevicesWizard,
 					},
 					schemas: {
 						deviceSchema: WledDeviceSchema,

--- a/apps/admin/src/plugins/devices-wled/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-wled/locales/cs-CZ.json
@@ -114,5 +114,28 @@
 			"edited": "Zařízení WLED '{device}' bylo aktualizováno",
 			"notEdited": "Nepodařilo se aktualizovat zařízení WLED '{device}'"
 		}
+	},
+	"wizard": {
+		"title": "Přidat zařízení WLED",
+		"subtitle": "Vyhledejte řadiče WLED nebo přidejte zařízení podle adresy a přijměte jich více najednou.",
+		"breadcrumb": "Průvodce přijetím WLED",
+		"columns": {
+			"identifier": "MAC adresa nebo název hostitele",
+			"host": "Hostitel"
+		},
+		"actions": {
+			"rescan": "Znovu prohledat síť",
+			"probe": "Ověřit zařízení"
+		},
+		"mdnsDisabled": {
+			"title": "Automatické vyhledávání je vypnuté",
+			"message": "Řadič WLED můžete přesto přidat zadáním názvu hostitele nebo IP adresy níže."
+		},
+		"messages": {
+			"discoveryFailed": "Nepodařilo se načíst vyhledávání WLED.",
+			"rescanFailed": "Nepodařilo se znovu spustit vyhledávání WLED.",
+			"probeFailed": "Nepodařilo se připojit k zařízení WLED.",
+			"adoptionFailed": "Nepodařilo se přijmout vybraná zařízení WLED."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-wled/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-wled/locales/de-DE.json
@@ -114,5 +114,28 @@
 			"edited": "WLED-Gerät '{device}' wurde aktualisiert",
 			"notEdited": "Aktualisierung des WLED-Geräts '{device}' fehlgeschlagen"
 		}
+	},
+	"wizard": {
+		"title": "WLED-Geräte hinzufügen",
+		"subtitle": "WLED-Controller erkennen oder per Hostname hinzufügen und mehrere Geräte gemeinsam übernehmen.",
+		"breadcrumb": "WLED-Übernahmeassistent",
+		"columns": {
+			"identifier": "MAC-Adresse oder Hostname",
+			"host": "Host"
+		},
+		"actions": {
+			"rescan": "Netzwerk erneut durchsuchen",
+			"probe": "Gerät prüfen"
+		},
+		"mdnsDisabled": {
+			"title": "Automatische Erkennung ist deaktiviert",
+			"message": "Ein WLED-Controller kann weiterhin über Hostname oder IP-Adresse hinzugefügt werden."
+		},
+		"messages": {
+			"discoveryFailed": "WLED-Erkennung konnte nicht geladen werden.",
+			"rescanFailed": "WLED-Erkennung konnte nicht neu gestartet werden.",
+			"probeFailed": "Verbindung zum WLED-Gerät fehlgeschlagen.",
+			"adoptionFailed": "Die ausgewählten WLED-Geräte konnten nicht übernommen werden."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-wled/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-wled/locales/en-US.json
@@ -114,5 +114,28 @@
 			"edited": "WLED device '{device}' has been updated",
 			"notEdited": "Failed to update WLED device '{device}'"
 		}
+	},
+	"wizard": {
+		"title": "Add WLED devices",
+		"subtitle": "Discover WLED controllers or add one by hostname, then adopt several devices at once.",
+		"breadcrumb": "WLED adoption wizard",
+		"columns": {
+			"identifier": "MAC address or hostname",
+			"host": "Host"
+		},
+		"actions": {
+			"rescan": "Rescan network",
+			"probe": "Check device"
+		},
+		"mdnsDisabled": {
+			"title": "Automatic discovery is disabled",
+			"message": "You can still add a WLED controller by entering its hostname or IP address below."
+		},
+		"messages": {
+			"discoveryFailed": "Failed to load WLED discovery.",
+			"rescanFailed": "Failed to restart WLED discovery.",
+			"probeFailed": "Failed to connect to the WLED device.",
+			"adoptionFailed": "Failed to adopt the selected WLED devices."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-wled/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-wled/locales/es-ES.json
@@ -114,5 +114,28 @@
 			"edited": "El dispositivo WLED '{device}' ha sido actualizado",
 			"notEdited": "Error al actualizar el dispositivo WLED '{device}'"
 		}
+	},
+	"wizard": {
+		"title": "Añadir dispositivos WLED",
+		"subtitle": "Descubre controladores WLED o añade uno por nombre de host y adopta varios dispositivos a la vez.",
+		"breadcrumb": "Asistente de adopción WLED",
+		"columns": {
+			"identifier": "Dirección MAC o nombre de host",
+			"host": "Host"
+		},
+		"actions": {
+			"rescan": "Volver a explorar la red",
+			"probe": "Comprobar dispositivo"
+		},
+		"mdnsDisabled": {
+			"title": "El descubrimiento automático está desactivado",
+			"message": "Aún puedes añadir un controlador WLED indicando su nombre de host o dirección IP."
+		},
+		"messages": {
+			"discoveryFailed": "No se pudo cargar el descubrimiento WLED.",
+			"rescanFailed": "No se pudo reiniciar el descubrimiento WLED.",
+			"probeFailed": "No se pudo conectar con el dispositivo WLED.",
+			"adoptionFailed": "No se pudieron adoptar los dispositivos WLED seleccionados."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-wled/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-wled/locales/pl-PL.json
@@ -114,5 +114,28 @@
 			"edited": "Urzadzenie WLED '{device}' zostalo zaktualizowane",
 			"notEdited": "Nie udalo sie zaktualizowac urzadzenia WLED '{device}'"
 		}
+	},
+	"wizard": {
+		"title": "Dodaj urządzenia WLED",
+		"subtitle": "Wykryj sterowniki WLED lub dodaj urządzenie po nazwie hosta i przyjmij wiele urządzeń naraz.",
+		"breadcrumb": "Kreator przyjmowania WLED",
+		"columns": {
+			"identifier": "Adres MAC lub nazwa hosta",
+			"host": "Host"
+		},
+		"actions": {
+			"rescan": "Skanuj sieć ponownie",
+			"probe": "Sprawdź urządzenie"
+		},
+		"mdnsDisabled": {
+			"title": "Automatyczne wykrywanie jest wyłączone",
+			"message": "Nadal możesz dodać sterownik WLED, podając poniżej nazwę hosta lub adres IP."
+		},
+		"messages": {
+			"discoveryFailed": "Nie udało się wczytać wykrywania WLED.",
+			"rescanFailed": "Nie udało się ponownie uruchomić wykrywania WLED.",
+			"probeFailed": "Nie udało się połączyć z urządzeniem WLED.",
+			"adoptionFailed": "Nie udało się przyjąć wybranych urządzeń WLED."
+		}
 	}
 }

--- a/apps/admin/src/plugins/devices-wled/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-wled/locales/sk-SK.json
@@ -114,5 +114,28 @@
 			"edited": "Zariadenie WLED '{device}' bolo aktualizované",
 			"notEdited": "Nepodarilo sa aktualizovať zariadenie WLED '{device}'"
 		}
+	},
+	"wizard": {
+		"title": "Pridať zariadenia WLED",
+		"subtitle": "Vyhľadajte radiče WLED alebo pridajte zariadenie podľa adresy a prijmite viac zariadení naraz.",
+		"breadcrumb": "Sprievodca prijatím WLED",
+		"columns": {
+			"identifier": "MAC adresa alebo názov hostiteľa",
+			"host": "Hostiteľ"
+		},
+		"actions": {
+			"rescan": "Znova prehľadať sieť",
+			"probe": "Overiť zariadenie"
+		},
+		"mdnsDisabled": {
+			"title": "Automatické vyhľadávanie je vypnuté",
+			"message": "Radič WLED môžete napriek tomu pridať zadaním názvu hostiteľa alebo IP adresy nižšie."
+		},
+		"messages": {
+			"discoveryFailed": "Nepodarilo sa načítať vyhľadávanie WLED.",
+			"rescanFailed": "Nepodarilo sa znova spustiť vyhľadávanie WLED.",
+			"probeFailed": "Nepodarilo sa pripojiť k zariadeniu WLED.",
+			"adoptionFailed": "Nepodarilo sa prijať vybrané zariadenia WLED."
+		}
 	}
 }

--- a/apps/backend/src/migrations/1000000000018-AddWledHardwareIdentity.ts
+++ b/apps/backend/src/migrations/1000000000018-AddWledHardwareIdentity.ts
@@ -5,9 +5,7 @@ export class AddWledHardwareIdentity1000000000018 implements MigrationInterface 
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(`ALTER TABLE "devices_module_devices" ADD COLUMN "mac" varchar`);
-		await queryRunner.query(
-			`CREATE UNIQUE INDEX "IDX_devices_wled_mac_type" ON "devices_module_devices" ("mac", "type") WHERE "mac" IS NOT NULL`,
-		);
+		await queryRunner.query(`CREATE INDEX "IDX_devices_wled_mac_type" ON "devices_module_devices" ("mac", "type")`);
 		await queryRunner.query(
 			`UPDATE "devices_module_devices"
 			 SET "mac" = substr(lower("identifier"), 6)

--- a/apps/backend/src/migrations/1000000000018-AddWledHardwareIdentity.ts
+++ b/apps/backend/src/migrations/1000000000018-AddWledHardwareIdentity.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWledHardwareIdentity1000000000018 implements MigrationInterface {
+	name = 'AddWledHardwareIdentity1000000000018';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "devices_module_devices" ADD COLUMN "mac" varchar`);
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "IDX_devices_wled_mac_type" ON "devices_module_devices" ("mac", "type") WHERE "mac" IS NOT NULL`,
+		);
+		await queryRunner.query(
+			`UPDATE "devices_module_devices"
+			 SET "mac" = substr(lower("identifier"), 6)
+			 WHERE "type" = 'devices-wled'
+			   AND length("identifier") = 17
+			   AND lower("identifier") GLOB 'wled-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]'`,
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_devices_wled_mac_type"`);
+		await queryRunner.query(`ALTER TABLE "devices_module_devices" DROP COLUMN "mac"`);
+	}
+}

--- a/apps/backend/src/migrations/1000000000019-EnforceUniqueWledHardwareIdentity.ts
+++ b/apps/backend/src/migrations/1000000000019-EnforceUniqueWledHardwareIdentity.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EnforceUniqueWledHardwareIdentity1000000000019 implements MigrationInterface {
+	name = 'EnforceUniqueWledHardwareIdentity1000000000019';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		// Keep one deterministic owner for identities duplicated before the constraint
+		// existed. Cleared rows can be reconciled safely on their next verified probe.
+		await queryRunner.query(
+			`UPDATE "devices_module_devices" AS "duplicate"
+			 SET "mac" = NULL
+			 WHERE "duplicate"."type" = 'devices-wled'
+			   AND "duplicate"."mac" IS NOT NULL
+			   AND EXISTS (
+			     SELECT 1
+			     FROM "devices_module_devices" AS "keeper"
+			     WHERE "keeper"."type" = 'devices-wled'
+			       AND "keeper"."mac" = "duplicate"."mac"
+			       AND "keeper"."id" < "duplicate"."id"
+			   )`,
+		);
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_devices_wled_mac_type"`);
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "UQ_devices_wled_mac_type"
+			 ON "devices_module_devices" ("mac", "type")
+			 WHERE "mac" IS NOT NULL AND "type" = 'devices-wled'`,
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "UQ_devices_wled_mac_type"`);
+		await queryRunner.query(`CREATE INDEX "IDX_devices_wled_mac_type" ON "devices_module_devices" ("mac", "type")`);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000018-AddWledHardwareIdentity.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000018-AddWledHardwareIdentity.spec.ts
@@ -22,7 +22,7 @@ describe('AddWledHardwareIdentity1000000000018', () => {
 		await dataSource.destroy();
 	});
 
-	it('persists one hardware identity per device type', async () => {
+	it('indexes hardware identity without rejecting pre-existing duplicate owners', async () => {
 		await migration.up(queryRunner);
 		await queryRunner.query(
 			`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES ('wled-1', 'devices-wled', 'aabbccddeeff')`,
@@ -32,7 +32,7 @@ describe('AddWledHardwareIdentity1000000000018', () => {
 			queryRunner.query(
 				`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES ('wled-2', 'devices-wled', 'aabbccddeeff')`,
 			),
-		).rejects.toThrow();
+		).resolves.toBeDefined();
 
 		await expect(
 			queryRunner.query(

--- a/apps/backend/src/migrations/__tests__/1000000000018-AddWledHardwareIdentity.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000018-AddWledHardwareIdentity.spec.ts
@@ -1,0 +1,68 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddWledHardwareIdentity1000000000018 } from '../1000000000018-AddWledHardwareIdentity';
+
+describe('AddWledHardwareIdentity1000000000018', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+
+	const migration = new AddWledHardwareIdentity1000000000018();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(
+			`CREATE TABLE "devices_module_devices" ("id" varchar PRIMARY KEY NOT NULL, "type" varchar NOT NULL)`,
+		);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('persists one hardware identity per device type', async () => {
+		await migration.up(queryRunner);
+		await queryRunner.query(
+			`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES ('wled-1', 'devices-wled', 'aabbccddeeff')`,
+		);
+
+		await expect(
+			queryRunner.query(
+				`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES ('wled-2', 'devices-wled', 'aabbccddeeff')`,
+			),
+		).rejects.toThrow();
+
+		await expect(
+			queryRunner.query(
+				`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES ('other-1', 'other', 'aabbccddeeff')`,
+			),
+		).resolves.toBeDefined();
+	});
+
+	it('backfills canonical WLED identifiers without guessing custom identities', async () => {
+		await queryRunner.query(
+			`INSERT INTO "devices_module_devices" ("id", "type") VALUES
+			 ('canonical', 'devices-wled'), ('custom', 'devices-wled'), ('other', 'other')`,
+		);
+		await queryRunner.query(`ALTER TABLE "devices_module_devices" ADD COLUMN "identifier" varchar`);
+		await queryRunner.query(
+			`UPDATE "devices_module_devices" SET "identifier" = CASE "id"
+			 WHEN 'canonical' THEN 'wled-aabbccddeeff'
+			 WHEN 'custom' THEN 'living-room-strip'
+			 ELSE 'wled-112233445566' END`,
+		);
+
+		await migration.up(queryRunner);
+
+		const rows = (await queryRunner.query(
+			`SELECT "id", "mac" FROM "devices_module_devices" ORDER BY "id"`,
+		)) as Array<{ id: string; mac: string | null }>;
+		expect(rows).toEqual([
+			{ id: 'canonical', mac: 'aabbccddeeff' },
+			{ id: 'custom', mac: null },
+			{ id: 'other', mac: null },
+		]);
+	});
+});

--- a/apps/backend/src/migrations/__tests__/1000000000019-EnforceUniqueWledHardwareIdentity.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000019-EnforceUniqueWledHardwareIdentity.spec.ts
@@ -1,0 +1,63 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { EnforceUniqueWledHardwareIdentity1000000000019 } from '../1000000000019-EnforceUniqueWledHardwareIdentity';
+
+describe('EnforceUniqueWledHardwareIdentity1000000000019', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+
+	const migration = new EnforceUniqueWledHardwareIdentity1000000000019();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await queryRunner.query(
+			`CREATE TABLE "devices_module_devices" (
+			 "id" varchar PRIMARY KEY NOT NULL,
+			 "type" varchar NOT NULL,
+			 "mac" varchar
+			)`,
+		);
+		await queryRunner.query(`CREATE INDEX "IDX_devices_wled_mac_type" ON "devices_module_devices" ("mac", "type")`);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('reconciles existing duplicates and rejects racing WLED owners', async () => {
+		await queryRunner.query(
+			`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES
+			 ('wled-2', 'devices-wled', 'aabbccddeeff'),
+			 ('wled-1', 'devices-wled', 'aabbccddeeff'),
+			 ('other-1', 'other', 'aabbccddeeff')`,
+		);
+
+		await migration.up(queryRunner);
+
+		const rows = (await queryRunner.query(`SELECT "id", "mac" FROM "devices_module_devices" ORDER BY "id"`)) as Array<{
+			id: string;
+			mac: string | null;
+		}>;
+		expect(rows).toEqual([
+			{ id: 'other-1', mac: 'aabbccddeeff' },
+			{ id: 'wled-1', mac: 'aabbccddeeff' },
+			{ id: 'wled-2', mac: null },
+		]);
+
+		await expect(
+			queryRunner.query(
+				`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES
+				 ('wled-3', 'devices-wled', 'aabbccddeeff')`,
+			),
+		).rejects.toThrow();
+		await expect(
+			queryRunner.query(
+				`INSERT INTO "devices_module_devices" ("id", "type", "mac") VALUES
+				 ('other-2', 'other', 'aabbccddeeff')`,
+			),
+		).resolves.toBeDefined();
+	});
+});

--- a/apps/backend/src/modules/devices/devices.module.ts
+++ b/apps/backend/src/modules/devices/devices.module.ts
@@ -166,6 +166,7 @@ import { DeviceNotHiddenConstraintValidator } from './validators/device-not-hidd
 		DevicesSeederService,
 		PlatformRegistryService,
 		PropertyValueSourceRegistryService,
+		PropertyValueService,
 		PropertyTimeseriesService,
 		PropertyCommandService,
 		DeviceExistsConstraintValidator,

--- a/apps/backend/src/modules/devices/services/property-value.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.spec.ts
@@ -208,6 +208,21 @@ describe('PropertyValueService', () => {
 				"DELETE FROM property_value WHERE propertyId = 'test-property-id'",
 			);
 		});
+
+		it('strictly deletes only measurements written since a rollback snapshot and clears caches', async () => {
+			const property = { id: 'test-property-id' } as ChannelPropertyEntity;
+			const since = new Date('2026-08-12T20:00:00.000Z');
+			service['valuesMap'].set(property.id, new PropertyValueState(42));
+			service['recentValuesMap'].set(property.id, [40, 42]);
+
+			await service.deleteSinceStrict(property, since);
+
+			expect(storageService.queryStrict).toHaveBeenCalledWith(
+				"DELETE FROM property_value WHERE propertyId = 'test-property-id' AND time >= '2026-08-12T20:00:00.001Z'",
+			);
+			expect(service['valuesMap'].has(property.id)).toBe(false);
+			expect(service['recentValuesMap'].has(property.id)).toBe(false);
+		});
 	});
 
 	describe('validation', () => {

--- a/apps/backend/src/modules/devices/services/property-value.service.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.ts
@@ -416,6 +416,23 @@ export class PropertyValueService {
 		}
 	}
 
+	async deleteSinceStrict(property: ChannelPropertyEntity, since: Date): Promise<void> {
+		const key = this.valueSourceRegistry.resolve(property);
+		if (key !== property.id) {
+			return;
+		}
+		if (!this.storageService.isConnected()) {
+			throw new Error('Property value storage is unavailable');
+		}
+
+		this.valuesMap.delete(key);
+		this.recentValuesMap.delete(key);
+		const firstTransientMillisecond = new Date(since.getTime() + 1);
+		await this.storageService.queryStrict(
+			`DELETE FROM property_value WHERE propertyId = '${this.escapeTagValue(key)}' AND time >= '${firstTransientMillisecond.toISOString()}'`,
+		);
+	}
+
 	/**
 	 * Compute trend direction from recent cached values.
 	 * Returns null for non-numeric types or insufficient data.

--- a/apps/backend/src/plugins/devices-wled/controllers/wled-discovery.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/controllers/wled-discovery.controller.spec.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { WledService } from '../services/wled.service';
+
+import { WledDiscoveryController } from './wled-discovery.controller';
+
+describe('WledDiscoveryController', () => {
+	let controller: WledDiscoveryController;
+	let service: jest.Mocked<WledService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [WledDiscoveryController],
+			providers: [
+				{
+					provide: WledService,
+					useValue: {
+						getDiscoveryInventory: jest.fn(),
+						rescanDiscovery: jest.fn(),
+						probeDevice: jest.fn(),
+						adoptDevices: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		controller = module.get(WledDiscoveryController);
+		service = module.get(WledService);
+	});
+
+	it('returns the enriched discovery inventory', async () => {
+		service.getDiscoveryInventory.mockResolvedValue({ mdnsEnabled: true, discoveryRunning: true, devices: [] });
+
+		const response = await controller.getDiscovery();
+
+		expect(response.data).toEqual({ mdnsEnabled: true, discoveryRunning: true, devices: [] });
+	});
+
+	it('delegates a stateless manual probe', async () => {
+		service.probeDevice.mockResolvedValue({
+			host: '192.168.1.100',
+			name: 'WLED',
+			mac: 'AA:BB:CC:DD:EE:FF',
+			port: 80,
+			adoptedDeviceId: null,
+		});
+
+		const response = await controller.probeDevice({ data: { host: '192.168.1.100' } });
+
+		expect(service.probeDevice).toHaveBeenCalledWith('192.168.1.100');
+		expect(response.data.mac).toBe('AA:BB:CC:DD:EE:FF');
+	});
+
+	it('returns independent batch adoption results', async () => {
+		service.adoptDevices.mockResolvedValue([
+			{ host: '192.168.1.100', name: 'WLED', status: 'created', error: null, deviceId: 'device-1' },
+		]);
+		const devices = [
+			{ host: '192.168.1.100', name: 'WLED', category: DeviceCategory.LIGHTING as DeviceCategory.LIGHTING },
+		];
+
+		const response = await controller.adoptDevices({ data: { devices } });
+
+		expect(service.adoptDevices).toHaveBeenCalledWith(devices);
+		expect(response.data[0].status).toBe('created');
+	});
+});

--- a/apps/backend/src/plugins/devices-wled/controllers/wled-discovery.controller.ts
+++ b/apps/backend/src/plugins/devices-wled/controllers/wled-discovery.controller.ts
@@ -1,57 +1,91 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, HttpCode, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 
-import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger/extension-logger.service';
-import { toInstance } from '../../../common/utils/transform.utils';
 import {
 	ApiBadRequestResponse,
+	ApiCreatedSuccessResponse,
 	ApiInternalServerErrorResponse,
+	ApiServiceUnavailableResponse,
 	ApiSuccessResponse,
 } from '../../../modules/swagger/decorators/api-documentation.decorator';
-import { DEVICES_WLED_API_TAG_NAME, DEVICES_WLED_PLUGIN_NAME } from '../devices-wled.constants';
-import { WledDiscoveredDeviceModel, WledDiscoveredDevicesResponseModel } from '../models/wled-discovery.model';
+import { DEVICES_WLED_API_TAG_NAME } from '../devices-wled.constants';
+import { WledAdoptRequestDto, WledProbeRequestDto } from '../dto/wled-adoption.dto';
+import {
+	WledAdoptionResultsResponseModel,
+	WledDiscoveryResponseModel,
+	WledProbedDeviceResponseModel,
+} from '../models/wled-discovery.model';
 import { WledService } from '../services/wled.service';
 
 @ApiTags(DEVICES_WLED_API_TAG_NAME)
 @Controller('discovery')
 export class WledDiscoveryController {
-	private readonly logger: ExtensionLoggerService = createExtensionLogger(
-		DEVICES_WLED_PLUGIN_NAME,
-		'WledDiscoveryController',
-	);
-
 	constructor(private readonly wledService: WledService) {}
 
 	@ApiOperation({
 		tags: [DEVICES_WLED_API_TAG_NAME],
-		summary: 'Get discovered WLED devices',
-		description:
-			'Returns a list of WLED devices discovered via mDNS that have not yet been added to the system. ' +
-			'These devices can be manually added through the device creation endpoint.',
-		operationId: 'get-devices-wled-plugin-discovered',
+		summary: 'Get WLED adoption inventory',
+		description: 'Returns all mDNS candidates with their current Smart Panel adoption state.',
+		operationId: 'get-devices-wled-plugin-discovery',
 	})
-	@ApiSuccessResponse(
-		WledDiscoveredDevicesResponseModel,
-		'List of discovered WLED devices not yet added to the system.',
-	)
-	@ApiBadRequestResponse('Invalid request parameters')
+	@ApiSuccessResponse(WledDiscoveryResponseModel, 'WLED discovery inventory')
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Get()
-	async getDiscoveredDevices(): Promise<WledDiscoveredDevicesResponseModel> {
-		const discoveredDevices = await this.wledService.getUnadedDiscoveredDevices();
+	async getDiscovery(): Promise<WledDiscoveryResponseModel> {
+		const response = new WledDiscoveryResponseModel();
+		response.data = await this.wledService.getDiscoveryInventory();
+		return response;
+	}
 
-		const devices: WledDiscoveredDeviceModel[] = discoveredDevices.map((device) =>
-			toInstance(WledDiscoveredDeviceModel, {
-				host: device.host,
-				name: device.name,
-				mac: device.mac ?? null,
-				port: device.port,
-			}),
-		);
+	@ApiOperation({
+		tags: [DEVICES_WLED_API_TAG_NAME],
+		summary: 'Rescan for WLED devices',
+		description: 'Restarts mDNS discovery and clears stale discovery candidates.',
+		operationId: 'rescan-devices-wled-plugin-discovery',
+	})
+	@ApiSuccessResponse(WledDiscoveryResponseModel, 'WLED discovery was restarted')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('rescan')
+	@HttpCode(200)
+	async rescanDiscovery(): Promise<WledDiscoveryResponseModel> {
+		const response = new WledDiscoveryResponseModel();
+		response.data = await this.wledService.rescanDiscovery();
+		return response;
+	}
 
-		const response = new WledDiscoveredDevicesResponseModel();
-		response.data = devices;
+	@ApiOperation({
+		tags: [DEVICES_WLED_API_TAG_NAME],
+		summary: 'Probe a WLED device',
+		description: 'Loads WLED identity and metadata without persisting or registering a device connection.',
+		operationId: 'probe-devices-wled-plugin-discovery',
+	})
+	@ApiBody({ type: WledProbeRequestDto })
+	@ApiCreatedSuccessResponse(WledProbedDeviceResponseModel, 'WLED device was probed successfully')
+	@ApiBadRequestResponse('Invalid hostname or IP address')
+	@ApiServiceUnavailableResponse('WLED device is unavailable')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('probe')
+	async probeDevice(@Body() body: WledProbeRequestDto): Promise<WledProbedDeviceResponseModel> {
+		const response = new WledProbedDeviceResponseModel();
+		response.data = await this.wledService.probeDevice(body.data.host);
+		return response;
+	}
 
+	@ApiOperation({
+		tags: [DEVICES_WLED_API_TAG_NAME],
+		summary: 'Adopt WLED devices',
+		description: 'Probes and provisions each selected WLED device, returning an independent result for every item.',
+		operationId: 'adopt-devices-wled-plugin-discovery',
+	})
+	@ApiBody({ type: WledAdoptRequestDto })
+	@ApiSuccessResponse(WledAdoptionResultsResponseModel, 'WLED adoption results')
+	@ApiBadRequestResponse('Invalid adoption request')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('adopt')
+	@HttpCode(200)
+	async adoptDevices(@Body() body: WledAdoptRequestDto): Promise<WledAdoptionResultsResponseModel> {
+		const response = new WledAdoptionResultsResponseModel();
+		response.data = await this.wledService.adoptDevices(body.data.devices);
 		return response;
 	}
 }

--- a/apps/backend/src/plugins/devices-wled/devices-wled.exceptions.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.exceptions.ts
@@ -26,3 +26,9 @@ export class WledDeviceNotFoundException extends DevicesWledException {
 		super(`WLED device not found: ${identifier}`, HttpStatus.NOT_FOUND);
 	}
 }
+
+export class WledValidationException extends DevicesWledException {
+	constructor(message: string) {
+		super(message, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/apps/backend/src/plugins/devices-wled/devices-wled.openapi.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.openapi.ts
@@ -8,9 +8,23 @@ import { UpdateWledChannelPropertyDto } from './dto/update-channel-property.dto'
 import { UpdateWledChannelDto } from './dto/update-channel.dto';
 import { WledUpdatePluginConfigDto, WledUpdatePollingDto, WledUpdateTimeoutsDto } from './dto/update-config.dto';
 import { UpdateWledDeviceDto } from './dto/update-device.dto';
+import {
+	WledAdoptDeviceDto,
+	WledAdoptDto,
+	WledAdoptRequestDto,
+	WledProbeDto,
+	WledProbeRequestDto,
+} from './dto/wled-adoption.dto';
 import { WledChannelEntity, WledChannelPropertyEntity, WledDeviceEntity } from './entities/devices-wled.entity';
 import { WledConfigModel, WledPollingConfigModel, WledTimeoutsConfigModel } from './models/config.model';
-import { WledDiscoveredDeviceModel, WledDiscoveredDevicesResponseModel } from './models/wled-discovery.model';
+import {
+	WledAdoptionResultModel,
+	WledAdoptionResultsResponseModel,
+	WledDiscoveredDeviceModel,
+	WledDiscoveryModel,
+	WledDiscoveryResponseModel,
+	WledProbedDeviceResponseModel,
+} from './models/wled-discovery.model';
 
 export const DEVICES_WLED_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	// DTOs
@@ -23,13 +37,22 @@ export const DEVICES_WLED_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	WledUpdatePluginConfigDto,
 	WledUpdateTimeoutsDto,
 	WledUpdatePollingDto,
+	WledProbeDto,
+	WledProbeRequestDto,
+	WledAdoptDeviceDto,
+	WledAdoptDto,
+	WledAdoptRequestDto,
 	// Config models
 	WledConfigModel,
 	WledTimeoutsConfigModel,
 	WledPollingConfigModel,
 	// Discovery models
 	WledDiscoveredDeviceModel,
-	WledDiscoveredDevicesResponseModel,
+	WledDiscoveryModel,
+	WledAdoptionResultModel,
+	WledDiscoveryResponseModel,
+	WledProbedDeviceResponseModel,
+	WledAdoptionResultsResponseModel,
 	// Entities
 	WledDeviceEntity,
 	WledChannelEntity,

--- a/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
@@ -231,7 +231,7 @@ Any ESP8266 / ESP32 controller running WLED firmware **0.13** or later.
 |--------|-------------|---------|
 | \`mdns.enabled\` | Run mDNS discovery for WLED devices | \`true\` |
 | \`mdns.interface\` | Network interface to bind discovery to | all |
-| \`mdns.auto_add\` | Auto-add discovered devices | \`true\` |
+| \`mdns.auto_add\` | Auto-add discovered devices | \`false\` |
 | \`websocket.enabled\` | Use WebSocket for real-time updates | \`true\` |
 | \`websocket.reconnect_interval\` | WebSocket reconnect interval (ms, min 1000) | \`5000\` |
 | \`polling.interval\` | State polling interval (ms, min 5000) | \`30000\` |

--- a/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
@@ -41,6 +41,7 @@ import { UpdateWledDeviceDto } from './dto/update-device.dto';
 import { WledChannelEntity, WledChannelPropertyEntity, WledDeviceEntity } from './entities/devices-wled.entity';
 import { WledConfigModel } from './models/config.model';
 import { WledDevicePlatform } from './platforms/wled.device.platform';
+import { WledAdoptionSnapshotService } from './services/adoption-snapshot.service';
 import { WledDeviceMapperService } from './services/device-mapper.service';
 import { WledClientAdapterService } from './services/wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './services/wled-mdns-discoverer.service';
@@ -62,6 +63,7 @@ import { WledService } from './services/wled.service';
 	providers: [
 		WledClientAdapterService,
 		WledMdnsDiscovererService,
+		WledAdoptionSnapshotService,
 		WledDeviceMapperService,
 		WledDevicePlatform,
 		WledService,

--- a/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
+++ b/apps/backend/src/plugins/devices-wled/devices-wled.plugin.ts
@@ -43,6 +43,7 @@ import { WledConfigModel } from './models/config.model';
 import { WledDevicePlatform } from './platforms/wled.device.platform';
 import { WledAdoptionSnapshotService } from './services/adoption-snapshot.service';
 import { WledDeviceMapperService } from './services/device-mapper.service';
+import { WledHardwareIdentityService } from './services/hardware-identity.service';
 import { WledClientAdapterService } from './services/wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './services/wled-mdns-discoverer.service';
 import { WledService } from './services/wled.service';
@@ -64,6 +65,7 @@ import { WledService } from './services/wled.service';
 		WledClientAdapterService,
 		WledMdnsDiscovererService,
 		WledAdoptionSnapshotService,
+		WledHardwareIdentityService,
 		WledDeviceMapperService,
 		WledDevicePlatform,
 		WledService,

--- a/apps/backend/src/plugins/devices-wled/dto/create-device.dto.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/create-device.dto.ts
@@ -30,11 +30,4 @@ export class CreateWledDeviceDto extends CreateDeviceDto {
 	})
 	@ValidateIf((_, value) => value !== null)
 	hostname?: string | null;
-
-	@ApiPropertyOptional({ description: 'Verified WLED hardware MAC identity', example: 'aabbccddeeff', nullable: true })
-	@Expose()
-	@IsOptional()
-	@IsString()
-	@ValidateIf((_, value) => value !== null)
-	mac?: string | null;
 }

--- a/apps/backend/src/plugins/devices-wled/dto/create-device.dto.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/create-device.dto.ts
@@ -30,4 +30,11 @@ export class CreateWledDeviceDto extends CreateDeviceDto {
 	})
 	@ValidateIf((_, value) => value !== null)
 	hostname?: string | null;
+
+	@ApiPropertyOptional({ description: 'Verified WLED hardware MAC identity', example: 'aabbccddeeff', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@ValidateIf((_, value) => value !== null)
+	mac?: string | null;
 }

--- a/apps/backend/src/plugins/devices-wled/dto/update-device.dto.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/update-device.dto.ts
@@ -28,11 +28,4 @@ export class UpdateWledDeviceDto extends UpdateDeviceDto {
 	@IsString()
 	@ValidateIf((_, value) => value !== null)
 	hostname?: string | null;
-
-	@ApiPropertyOptional({ description: 'Verified WLED hardware MAC identity', example: 'aabbccddeeff', nullable: true })
-	@Expose()
-	@IsOptional()
-	@IsString()
-	@ValidateIf((_, value) => value !== null)
-	mac?: string | null;
 }

--- a/apps/backend/src/plugins/devices-wled/dto/update-device.dto.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/update-device.dto.ts
@@ -28,4 +28,11 @@ export class UpdateWledDeviceDto extends UpdateDeviceDto {
 	@IsString()
 	@ValidateIf((_, value) => value !== null)
 	hostname?: string | null;
+
+	@ApiPropertyOptional({ description: 'Verified WLED hardware MAC identity', example: 'aabbccddeeff', nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@ValidateIf((_, value) => value !== null)
+	mac?: string | null;
 }

--- a/apps/backend/src/plugins/devices-wled/dto/wled-adoption.dto.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/wled-adoption.dto.spec.ts
@@ -1,0 +1,27 @@
+import { validate } from 'class-validator';
+
+import { toInstance } from '../../../common/utils/transform.utils';
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+import { WledAdoptRequestDto, WledProbeRequestDto } from './wled-adoption.dto';
+
+describe('WLED adoption DTOs', () => {
+	it('requires the probe wrapper data', async () => {
+		const errors = await validate(toInstance(WledProbeRequestDto, {}));
+
+		expect(errors.some((error) => error.property === 'data')).toBe(true);
+	});
+
+	it('accepts only lighting adoption requests', async () => {
+		const valid = toInstance(WledAdoptRequestDto, {
+			data: { devices: [{ host: '192.168.1.100', name: 'Strip', category: DeviceCategory.LIGHTING }] },
+		});
+		const invalid = toInstance(WledAdoptRequestDto, {
+			data: { devices: [{ host: '192.168.1.100', name: 'Strip', category: DeviceCategory.SWITCHER }] },
+		});
+
+		await expect(validate(valid)).resolves.toHaveLength(0);
+		const errors = await validate(invalid);
+		expect(errors).not.toHaveLength(0);
+	});
+});

--- a/apps/backend/src/plugins/devices-wled/dto/wled-adoption.dto.ts
+++ b/apps/backend/src/plugins/devices-wled/dto/wled-adoption.dto.ts
@@ -1,0 +1,85 @@
+import { Expose, Type } from 'class-transformer';
+import {
+	ArrayMinSize,
+	IsArray,
+	IsBoolean,
+	IsDefined,
+	IsIn,
+	IsNotEmpty,
+	IsObject,
+	IsOptional,
+	IsString,
+	ValidateNested,
+} from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+@ApiSchema({ name: 'DevicesWledPluginProbe' })
+export class WledProbeDto {
+	@ApiProperty({ description: 'WLED hostname or IP address', example: '192.168.1.100' })
+	@Expose()
+	@IsString()
+	@IsNotEmpty()
+	host: string;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginReqProbe' })
+export class WledProbeRequestDto {
+	@ApiProperty({ type: WledProbeDto })
+	@Expose()
+	@IsDefined()
+	@IsObject()
+	@ValidateNested()
+	@Type(() => WledProbeDto)
+	data: WledProbeDto;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginAdoptDevice' })
+export class WledAdoptDeviceDto extends WledProbeDto {
+	@ApiProperty({ description: 'Device name', example: 'Living room strip' })
+	@Expose()
+	@IsString()
+	@IsNotEmpty()
+	name: string;
+
+	@ApiProperty({ enum: [DeviceCategory.LIGHTING], example: DeviceCategory.LIGHTING })
+	@Expose()
+	@IsIn([DeviceCategory.LIGHTING])
+	category: DeviceCategory.LIGHTING;
+
+	@ApiProperty({ description: 'Optional device description', nullable: true, required: false })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	description?: string | null;
+
+	@ApiProperty({ description: 'Whether the adopted device is enabled', default: true, required: false })
+	@Expose()
+	@IsOptional()
+	@IsBoolean()
+	enabled?: boolean;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginAdopt' })
+export class WledAdoptDto {
+	@ApiProperty({ type: [WledAdoptDeviceDto] })
+	@Expose()
+	@IsArray()
+	@ArrayMinSize(1)
+	@ValidateNested({ each: true })
+	@Type(() => WledAdoptDeviceDto)
+	devices: WledAdoptDeviceDto[];
+}
+
+@ApiSchema({ name: 'DevicesWledPluginReqAdopt' })
+export class WledAdoptRequestDto {
+	@ApiProperty({ type: WledAdoptDto })
+	@Expose()
+	@IsDefined()
+	@IsObject()
+	@ValidateNested()
+	@Type(() => WledAdoptDto)
+	data: WledAdoptDto;
+}

--- a/apps/backend/src/plugins/devices-wled/entities/devices-wled.entity.ts
+++ b/apps/backend/src/plugins/devices-wled/entities/devices-wled.entity.ts
@@ -33,6 +33,18 @@ export class WledDeviceEntity extends DeviceEntity {
 	@Column({ nullable: true, default: null })
 	hostname: string | null = null;
 
+	@ApiPropertyOptional({
+		description: 'Verified WLED hardware MAC identity',
+		type: 'string',
+		example: 'aabbccddeeff',
+		nullable: true,
+	})
+	@Expose()
+	@IsOptional()
+	@IsString()
+	@Column({ nullable: true, default: null })
+	mac: string | null = null;
+
 	toString(): string {
 		return `WLED Device [${this.identifier}] -> Device [${this.id}]`;
 	}

--- a/apps/backend/src/plugins/devices-wled/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-wled/models/config.model.ts
@@ -83,9 +83,9 @@ export class WledMdnsConfigModel {
 	@ApiProperty({
 		name: 'auto_add',
 		description: 'Automatically add discovered devices to the system',
-		example: true,
+		example: false,
 	})
-	autoAdd: boolean = true;
+	autoAdd: boolean = false;
 }
 
 /**

--- a/apps/backend/src/plugins/devices-wled/models/wled-discovery.model.ts
+++ b/apps/backend/src/plugins/devices-wled/models/wled-discovery.model.ts
@@ -1,60 +1,106 @@
-import { Expose } from 'class-transformer';
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { Expose, Type } from 'class-transformer';
+import { IsBoolean, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 
-/**
- * Model representing a discovered WLED device that hasn't been added yet
- */
 @ApiSchema({ name: 'DevicesWledPluginDataDiscoveredDevice' })
 export class WledDiscoveredDeviceModel {
-	@ApiProperty({
-		description: 'Device hostname or IP address',
-		example: '192.168.1.100',
-	})
+	@ApiProperty({ description: 'Device hostname or IP address', example: '192.168.1.100' })
 	@Expose()
 	@IsString()
 	host: string;
 
-	@ApiProperty({
-		description: 'Device name advertised via mDNS',
-		example: 'WLED-Living-Room',
-	})
+	@ApiProperty({ description: 'Device name', example: 'WLED-Living-Room' })
 	@Expose()
 	@IsString()
 	name: string;
 
-	@ApiPropertyOptional({
-		description: 'Device MAC address (if available)',
-		example: 'AA:BB:CC:DD:EE:FF',
-		nullable: true,
-	})
+	@ApiPropertyOptional({ description: 'Device MAC address', example: 'AA:BB:CC:DD:EE:FF', nullable: true })
 	@Expose()
 	@IsOptional()
 	@IsString()
-	mac?: string | null;
+	mac: string | null;
 
-	@ApiProperty({
-		description: 'Device port',
-		example: 80,
-	})
+	@ApiProperty({ description: 'Device port', example: 80 })
 	@Expose()
 	@IsNumber()
 	port: number;
+
+	@ApiPropertyOptional({ description: 'Adopted Smart Panel device ID', nullable: true })
+	@Expose({ name: 'adopted_device_id' })
+	@IsOptional()
+	@IsString()
+	adoptedDeviceId: string | null;
 }
 
-/**
- * Response wrapper for array of discovered WLED devices
- */
-@ApiSchema({ name: 'DevicesWledPluginResDiscoveredDevices' })
-export class WledDiscoveredDevicesResponseModel extends BaseSuccessResponseModel<WledDiscoveredDeviceModel[]> {
-	@ApiProperty({
-		description: 'List of discovered WLED devices not yet added to the system',
-		type: 'array',
-		items: { $ref: getSchemaPath(WledDiscoveredDeviceModel) },
-	})
+@ApiSchema({ name: 'DevicesWledPluginDataDiscovery' })
+export class WledDiscoveryModel {
+	@ApiProperty({ description: 'Whether mDNS discovery is enabled' })
+	@Expose({ name: 'mdns_enabled' })
+	@IsBoolean()
+	mdnsEnabled: boolean;
+
+	@ApiProperty({ description: 'Whether the mDNS browser is running' })
+	@Expose({ name: 'discovery_running' })
+	@IsBoolean()
+	discoveryRunning: boolean;
+
+	@ApiProperty({ type: 'array', items: { $ref: getSchemaPath(WledDiscoveredDeviceModel) } })
 	@Expose()
-	declare data: WledDiscoveredDeviceModel[];
+	@ValidateNested({ each: true })
+	@Type(() => WledDiscoveredDeviceModel)
+	devices: WledDiscoveredDeviceModel[];
+}
+
+@ApiSchema({ name: 'DevicesWledPluginDataAdoptionResult' })
+export class WledAdoptionResultModel {
+	@ApiProperty({ example: '192.168.1.100' })
+	@Expose()
+	@IsString()
+	host: string;
+
+	@ApiProperty({ example: 'Living room strip' })
+	@Expose()
+	@IsString()
+	name: string;
+
+	@ApiProperty({ enum: ['created', 'failed'] })
+	@Expose()
+	@IsIn(['created', 'failed'])
+	status: 'created' | 'failed';
+
+	@ApiPropertyOptional({ nullable: true })
+	@Expose()
+	@IsOptional()
+	@IsString()
+	error: string | null;
+
+	@ApiPropertyOptional({ description: 'Created Smart Panel device ID', nullable: true })
+	@Expose({ name: 'device_id' })
+	@IsOptional()
+	@IsString()
+	deviceId: string | null;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginResDiscovery' })
+export class WledDiscoveryResponseModel extends BaseSuccessResponseModel<WledDiscoveryModel> {
+	@ApiProperty({ type: WledDiscoveryModel })
+	@Expose()
+	declare data: WledDiscoveryModel;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginResProbedDevice' })
+export class WledProbedDeviceResponseModel extends BaseSuccessResponseModel<WledDiscoveredDeviceModel> {
+	@ApiProperty({ type: WledDiscoveredDeviceModel })
+	@Expose()
+	declare data: WledDiscoveredDeviceModel;
+}
+
+@ApiSchema({ name: 'DevicesWledPluginResAdoptionResults' })
+export class WledAdoptionResultsResponseModel extends BaseSuccessResponseModel<WledAdoptionResultModel[]> {
+	@ApiProperty({ type: 'array', items: { $ref: getSchemaPath(WledAdoptionResultModel) } })
+	@Expose()
+	declare data: WledAdoptionResultModel[];
 }

--- a/apps/backend/src/plugins/devices-wled/models/wled-discovery.model.ts
+++ b/apps/backend/src/plugins/devices-wled/models/wled-discovery.model.ts
@@ -66,10 +66,10 @@ export class WledAdoptionResultModel {
 	@IsString()
 	name: string;
 
-	@ApiProperty({ enum: ['created', 'failed'] })
+	@ApiProperty({ enum: ['created', 'updated', 'failed'] })
 	@Expose()
-	@IsIn(['created', 'failed'])
-	status: 'created' | 'failed';
+	@IsIn(['created', 'updated', 'failed'])
+	status: 'created' | 'updated' | 'failed';
 
 	@ApiPropertyOptional({ nullable: true })
 	@Expose()

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
@@ -6,6 +6,25 @@ import { WledChannelEntity, WledChannelPropertyEntity } from '../entities/device
 import { WledAdoptionSnapshotService } from './adoption-snapshot.service';
 
 describe('WledAdoptionSnapshotService', () => {
+	it('rejects capture when original property values cannot be read strictly', async () => {
+		const channel = { id: 'channel-1', device: { id: 'device-1' } } as WledChannelEntity;
+		const property = { id: 'property-1', channel, value: undefined } as WledChannelPropertyEntity;
+		const channelRepository = { find: jest.fn().mockResolvedValue([channel]) };
+		const propertyRepository = { find: jest.fn().mockResolvedValue([property]) };
+		const dataSource = {
+			getRepository: jest.fn((entity) => (entity === WledChannelEntity ? channelRepository : propertyRepository)),
+		} as unknown as DataSource;
+		const readLatestManyStrict = jest.fn().mockRejectedValue(new Error('Property value storage is unavailable'));
+		const propertyValueService = {
+			readLatestManyStrict,
+		} as unknown as PropertyValueService;
+		const service = new WledAdoptionSnapshotService(dataSource, propertyValueService);
+
+		await expect(service.capture('device-1')).rejects.toThrow('Property value storage is unavailable');
+
+		expect(readLatestManyStrict).toHaveBeenCalledWith([property]);
+	});
+
 	it('restores captured latest values through the property value service', async () => {
 		const channel = { id: 'channel-1', device: { id: 'device-1' } } as WledChannelEntity;
 		const valuedProperty = {

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
@@ -18,13 +18,18 @@ describe('WledAdoptionSnapshotService', () => {
 			channel,
 			value: null,
 		} as WledChannelPropertyEntity;
+		const extraProperty = {
+			id: 'property-extra',
+			channel,
+			value: { value: 'orphaned' },
+		} as WledChannelPropertyEntity;
 		const channelRepository = {
 			find: jest.fn().mockResolvedValue([channel]),
 			delete: jest.fn(),
 			save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
 		};
 		const propertyRepository = {
-			find: jest.fn().mockResolvedValue([valuedProperty, emptyProperty]),
+			find: jest.fn().mockResolvedValue([valuedProperty, emptyProperty, extraProperty]),
 			delete: jest.fn(),
 			save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
 		};
@@ -52,5 +57,6 @@ describe('WledAdoptionSnapshotService', () => {
 
 		expect(write).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-1' }), 'original');
 		expect(deleteValue).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-2' }));
+		expect(deleteValue).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-extra' }));
 	});
 });

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
@@ -1,0 +1,56 @@
+import { DataSource } from 'typeorm';
+
+import { PropertyValueService } from '../../../modules/devices/services/property-value.service';
+import { WledChannelEntity, WledChannelPropertyEntity } from '../entities/devices-wled.entity';
+
+import { WledAdoptionSnapshotService } from './adoption-snapshot.service';
+
+describe('WledAdoptionSnapshotService', () => {
+	it('restores captured latest values through the property value service', async () => {
+		const channel = { id: 'channel-1', device: { id: 'device-1' } } as WledChannelEntity;
+		const valuedProperty = {
+			id: 'property-1',
+			channel,
+			value: { value: 'original' },
+		} as WledChannelPropertyEntity;
+		const emptyProperty = {
+			id: 'property-2',
+			channel,
+			value: null,
+		} as WledChannelPropertyEntity;
+		const channelRepository = {
+			find: jest.fn().mockResolvedValue([channel]),
+			delete: jest.fn(),
+			save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
+		};
+		const propertyRepository = {
+			find: jest.fn().mockResolvedValue([valuedProperty, emptyProperty]),
+			delete: jest.fn(),
+			save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
+		};
+		const manager = {
+			getRepository: jest.fn((entity) => (entity === WledChannelEntity ? channelRepository : propertyRepository)),
+		};
+		const dataSource = {
+			transaction: jest.fn(async (handler: (transactionManager: typeof manager) => Promise<void>): Promise<void> => {
+				await handler(manager);
+			}),
+		} as unknown as DataSource;
+		const write = jest.fn().mockResolvedValue(true);
+		const deleteValue = jest.fn().mockResolvedValue(undefined);
+		const propertyValueService = {
+			write,
+			delete: deleteValue,
+		} as unknown as PropertyValueService;
+		const service = new WledAdoptionSnapshotService(dataSource, propertyValueService);
+
+		await service.restore({
+			deviceId: 'device-1',
+			channels: [channel],
+			properties: [valuedProperty, emptyProperty],
+		});
+
+		expect(write).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-1' }), 'original');
+		expect(deleteValue).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-2' }));
+	});
+});

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.spec.ts
@@ -62,19 +62,26 @@ describe('WledAdoptionSnapshotService', () => {
 		} as unknown as DataSource;
 		const write = jest.fn().mockResolvedValue(true);
 		const deleteValue = jest.fn().mockResolvedValue(undefined);
+		const deleteSinceStrict = jest.fn().mockResolvedValue(undefined);
 		const propertyValueService = {
 			write,
 			delete: deleteValue,
+			deleteSinceStrict,
 		} as unknown as PropertyValueService;
 		const service = new WledAdoptionSnapshotService(dataSource, propertyValueService);
 
 		await service.restore({
 			deviceId: 'device-1',
+			capturedAt: new Date('2026-08-12T20:00:00.000Z'),
 			channels: [channel],
 			properties: [valuedProperty, emptyProperty],
 		});
 
 		expect(write).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-1' }), 'original');
+		expect(deleteSinceStrict).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'property-1' }),
+			new Date('2026-08-12T20:00:00.000Z'),
+		);
 		expect(deleteValue).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-2' }));
 		expect(deleteValue).toHaveBeenCalledWith(expect.objectContaining({ id: 'property-extra' }));
 	});

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 
 import { Injectable } from '@nestjs/common';
 
+import { PropertyValueService } from '../../../modules/devices/services/property-value.service';
 import { WledChannelEntity, WledChannelPropertyEntity } from '../entities/devices-wled.entity';
 
 export interface WledAdoptionStructureSnapshot {
@@ -13,7 +14,10 @@ export interface WledAdoptionStructureSnapshot {
 
 @Injectable()
 export class WledAdoptionSnapshotService {
-	constructor(private readonly dataSource: DataSource) {}
+	constructor(
+		private readonly dataSource: DataSource,
+		private readonly propertyValueService: PropertyValueService,
+	) {}
 
 	async capture(deviceId: string): Promise<WledAdoptionStructureSnapshot> {
 		const channels = await this.dataSource.getRepository(WledChannelEntity).find({
@@ -33,6 +37,8 @@ export class WledAdoptionSnapshotService {
 	}
 
 	async restore(snapshot: WledAdoptionStructureSnapshot): Promise<void> {
+		const restoredProperties: WledChannelPropertyEntity[] = [];
+
 		await this.dataSource.transaction(async (manager) => {
 			const channelRepository = manager.getRepository(WledChannelEntity);
 			const propertyRepository = manager.getRepository(WledChannelPropertyEntity);
@@ -73,8 +79,23 @@ export class WledAdoptionSnapshotService {
 
 			for (const property of snapshot.properties) {
 				const channelId = typeof property.channel === 'string' ? property.channel : property.channel.id;
-				await propertyRepository.save({ ...property, channel: channelId });
+				restoredProperties.push(await propertyRepository.save({ ...property, channel: channelId }));
 			}
 		});
+
+		for (const property of restoredProperties) {
+			const snapshotProperty = snapshot.properties.find(({ id }) => id === property.id);
+			if (snapshotProperty?.value === undefined) {
+				continue;
+			}
+
+			const value = snapshotProperty.value?.value ?? null;
+
+			if (value === null) {
+				await this.propertyValueService.delete(property);
+			} else {
+				await this.propertyValueService.write(property, value);
+			}
+		}
 	}
 }

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
@@ -32,6 +32,11 @@ export class WledAdoptionSnapshotService {
 						where: { channel: { id: In(channelIds) } },
 						relations: ['channel'],
 					});
+		const values = await this.propertyValueService.readLatestManyStrict(properties);
+
+		for (const property of properties) {
+			property.value = values.get(property.id) ?? null;
+		}
 
 		return { deviceId, channels, properties };
 	}
@@ -97,11 +102,7 @@ export class WledAdoptionSnapshotService {
 
 		for (const property of restoredProperties) {
 			const snapshotProperty = snapshot.properties.find(({ id }) => id === property.id);
-			if (snapshotProperty?.value === undefined) {
-				continue;
-			}
-
-			const value = snapshotProperty.value?.value ?? null;
+			const value = snapshotProperty?.value?.value ?? null;
 
 			if (value === null) {
 				await this.propertyValueService.delete(property);

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
@@ -38,6 +38,7 @@ export class WledAdoptionSnapshotService {
 
 	async restore(snapshot: WledAdoptionStructureSnapshot): Promise<void> {
 		const restoredProperties: WledChannelPropertyEntity[] = [];
+		const removedProperties: WledChannelPropertyEntity[] = [];
 
 		await this.dataSource.transaction(async (manager) => {
 			const channelRepository = manager.getRepository(WledChannelEntity);
@@ -48,6 +49,12 @@ export class WledAdoptionSnapshotService {
 			const extraChannelIds = currentChannelIds.filter((id) => !snapshotChannelIds.has(id));
 
 			if (extraChannelIds.length > 0) {
+				removedProperties.push(
+					...(await propertyRepository.find({
+						where: { channel: { id: In(extraChannelIds) } },
+						relations: ['channel'],
+					})),
+				);
 				await channelRepository.delete({ id: In(extraChannelIds) });
 			}
 
@@ -74,6 +81,7 @@ export class WledAdoptionSnapshotService {
 			const extraPropertyIds = currentProperties.map(({ id }) => id).filter((id) => !snapshotPropertyIds.has(id));
 
 			if (extraPropertyIds.length > 0) {
+				removedProperties.push(...currentProperties.filter(({ id }) => extraPropertyIds.includes(id)));
 				await propertyRepository.delete({ id: In(extraPropertyIds) });
 			}
 
@@ -82,6 +90,10 @@ export class WledAdoptionSnapshotService {
 				restoredProperties.push(await propertyRepository.save({ ...property, channel: channelId }));
 			}
 		});
+
+		for (const property of removedProperties) {
+			await this.propertyValueService.delete(property);
+		}
 
 		for (const property of restoredProperties) {
 			const snapshotProperty = snapshot.properties.find(({ id }) => id === property.id);

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
@@ -1,0 +1,80 @@
+import { In } from 'typeorm';
+import { DataSource } from 'typeorm';
+
+import { Injectable } from '@nestjs/common';
+
+import { WledChannelEntity, WledChannelPropertyEntity } from '../entities/devices-wled.entity';
+
+export interface WledAdoptionStructureSnapshot {
+	deviceId: string;
+	channels: WledChannelEntity[];
+	properties: WledChannelPropertyEntity[];
+}
+
+@Injectable()
+export class WledAdoptionSnapshotService {
+	constructor(private readonly dataSource: DataSource) {}
+
+	async capture(deviceId: string): Promise<WledAdoptionStructureSnapshot> {
+		const channels = await this.dataSource.getRepository(WledChannelEntity).find({
+			where: { device: { id: deviceId } },
+			relations: ['device'],
+		});
+		const channelIds = channels.map(({ id }) => id);
+		const properties =
+			channelIds.length === 0
+				? []
+				: await this.dataSource.getRepository(WledChannelPropertyEntity).find({
+						where: { channel: { id: In(channelIds) } },
+						relations: ['channel'],
+					});
+
+		return { deviceId, channels, properties };
+	}
+
+	async restore(snapshot: WledAdoptionStructureSnapshot): Promise<void> {
+		await this.dataSource.transaction(async (manager) => {
+			const channelRepository = manager.getRepository(WledChannelEntity);
+			const propertyRepository = manager.getRepository(WledChannelPropertyEntity);
+			const currentChannels = await channelRepository.find({ where: { device: { id: snapshot.deviceId } } });
+			const currentChannelIds = currentChannels.map(({ id }) => id);
+			const snapshotChannelIds = new Set(snapshot.channels.map(({ id }) => id));
+			const extraChannelIds = currentChannelIds.filter((id) => !snapshotChannelIds.has(id));
+
+			if (extraChannelIds.length > 0) {
+				await channelRepository.delete({ id: In(extraChannelIds) });
+			}
+
+			for (const channel of snapshot.channels) {
+				await channelRepository.save({
+					...channel,
+					device: snapshot.deviceId,
+					properties: undefined,
+					controls: undefined,
+					children: undefined,
+					parent: undefined,
+				});
+			}
+
+			const restoredChannelIds = snapshot.channels.map(({ id }) => id);
+			if (restoredChannelIds.length === 0) {
+				return;
+			}
+
+			const currentProperties = await propertyRepository.find({
+				where: { channel: { id: In(restoredChannelIds) } },
+			});
+			const snapshotPropertyIds = new Set(snapshot.properties.map(({ id }) => id));
+			const extraPropertyIds = currentProperties.map(({ id }) => id).filter((id) => !snapshotPropertyIds.has(id));
+
+			if (extraPropertyIds.length > 0) {
+				await propertyRepository.delete({ id: In(extraPropertyIds) });
+			}
+
+			for (const property of snapshot.properties) {
+				const channelId = typeof property.channel === 'string' ? property.channel : property.channel.id;
+				await propertyRepository.save({ ...property, channel: channelId });
+			}
+		});
+	}
+}

--- a/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/adoption-snapshot.service.ts
@@ -8,6 +8,7 @@ import { WledChannelEntity, WledChannelPropertyEntity } from '../entities/device
 
 export interface WledAdoptionStructureSnapshot {
 	deviceId: string;
+	capturedAt: Date;
 	channels: WledChannelEntity[];
 	properties: WledChannelPropertyEntity[];
 }
@@ -20,6 +21,7 @@ export class WledAdoptionSnapshotService {
 	) {}
 
 	async capture(deviceId: string): Promise<WledAdoptionStructureSnapshot> {
+		const capturedAt = new Date();
 		const channels = await this.dataSource.getRepository(WledChannelEntity).find({
 			where: { device: { id: deviceId } },
 			relations: ['device'],
@@ -38,7 +40,7 @@ export class WledAdoptionSnapshotService {
 			property.value = values.get(property.id) ?? null;
 		}
 
-		return { deviceId, channels, properties };
+		return { deviceId, capturedAt, channels, properties };
 	}
 
 	async restore(snapshot: WledAdoptionStructureSnapshot): Promise<void> {
@@ -107,6 +109,7 @@ export class WledAdoptionSnapshotService {
 			if (value === null) {
 				await this.propertyValueService.delete(property);
 			} else {
+				await this.propertyValueService.deleteSinceStrict(property, snapshot.capturedAt);
 				await this.propertyValueService.write(property, value);
 			}
 		}

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -306,6 +306,21 @@ describe('WledDeviceMapperService', () => {
 			expect(channelsService.remove).toHaveBeenCalledWith('segment-obsolete');
 		});
 
+		it('does not prune segment history when current segment mapping fails', async () => {
+			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
+			const obsoleteSegment = createMockChannel('segment-obsolete', 'segment_1', mockDevice.id);
+			devicesService.findOneBy.mockResolvedValue(mockDevice);
+			channelsService.findAll.mockResolvedValue([obsoleteSegment]);
+			channelsService.findOneBy.mockResolvedValue(null);
+			channelsService.create.mockRejectedValueOnce(new Error('Current segment mapping failed'));
+
+			await expect(service.mapDevice('192.168.1.100', mockDeviceContext)).rejects.toThrow(
+				'Current segment mapping failed',
+			);
+
+			expect(channelsService.remove).not.toHaveBeenCalled();
+		});
+
 		it('should apply confirmed adoption fields when updating an existing device', async () => {
 			const mockDevice = {
 				...createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100', false),

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -263,6 +263,42 @@ describe('WledDeviceMapperService', () => {
 			);
 		});
 
+		it('should apply confirmed adoption fields when updating an existing device', async () => {
+			const mockDevice = {
+				...createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100', false),
+				name: 'Old strip',
+				description: 'Old description',
+			} as WledDeviceEntity;
+			const updatedDevice = {
+				...mockDevice,
+				name: 'Renamed strip',
+				description: null,
+				enabled: true,
+			};
+
+			devicesService.findOneBy.mockResolvedValue(mockDevice);
+			devicesService.update.mockResolvedValue(updatedDevice as WledDeviceEntity);
+			channelsService.findOneBy.mockResolvedValue(null);
+			channelsService.create.mockResolvedValue(createMockChannel('channel-1', 'device_information', 'device-1'));
+			channelsPropertiesService.findOneBy.mockResolvedValue(null);
+			channelsPropertiesService.create.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+			channelsPropertiesService.update.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+			deviceConnectivityService.setConnectionState.mockResolvedValue(undefined);
+
+			await service.mapDevice('192.168.1.100', mockDeviceContext, 'Renamed strip', 'wled-ddeeff', null, true);
+
+			expect(devicesService.update).toHaveBeenCalledWith(mockDevice.id, {
+				type: DEVICES_WLED_TYPE,
+				hostname: '192.168.1.100',
+				name: 'Renamed strip',
+				description: null,
+				enabled: true,
+			});
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith(mockDevice.id, {
+				state: ConnectionState.CONNECTED,
+			});
+		});
+
 		it('should resume idempotent provisioning for an existing disabled device', async () => {
 			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100', false);
 

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -300,25 +300,10 @@ describe('WledDeviceMapperService', () => {
 			channelsPropertiesService.create.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
 			channelsPropertiesService.update.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
 
-			await service.mapDevice('192.168.1.100', mockDeviceContext);
+			await service.pruneObsoleteSegmentChannels(mockDevice, mockDeviceContext.state);
 
 			expect(channelsService.remove).toHaveBeenCalledTimes(1);
 			expect(channelsService.remove).toHaveBeenCalledWith('segment-obsolete');
-		});
-
-		it('does not prune segment history when current segment mapping fails', async () => {
-			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
-			const obsoleteSegment = createMockChannel('segment-obsolete', 'segment_1', mockDevice.id);
-			devicesService.findOneBy.mockResolvedValue(mockDevice);
-			channelsService.findAll.mockResolvedValue([obsoleteSegment]);
-			channelsService.findOneBy.mockResolvedValue(null);
-			channelsService.create.mockRejectedValueOnce(new Error('Current segment mapping failed'));
-
-			await expect(service.mapDevice('192.168.1.100', mockDeviceContext)).rejects.toThrow(
-				'Current segment mapping failed',
-			);
-
-			expect(channelsService.remove).not.toHaveBeenCalled();
 		});
 
 		it('should apply confirmed adoption fields when updating an existing device', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -123,6 +123,7 @@ describe('WledDeviceMapperService', () => {
 			category: DeviceCategory.LIGHTING,
 			enabled,
 			hostname,
+			mac: 'aabbccddeeff',
 			description: null,
 			icon: null,
 			draft: false,
@@ -229,6 +230,7 @@ describe('WledDeviceMapperService', () => {
 					type: DEVICES_WLED_TYPE,
 					category: DeviceCategory.LIGHTING,
 					hostname: '192.168.1.100',
+					mac: 'aabbccddeeff',
 				}),
 			);
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith(mockDevice.id, {
@@ -290,6 +292,7 @@ describe('WledDeviceMapperService', () => {
 			expect(devicesService.update).toHaveBeenCalledWith(mockDevice.id, {
 				type: DEVICES_WLED_TYPE,
 				hostname: '192.168.1.100',
+				mac: 'aabbccddeeff',
 				name: 'Renamed strip',
 				description: null,
 				enabled: true,

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -26,6 +26,7 @@ describe('WledDeviceMapperService', () => {
 	let channelsService: jest.Mocked<ChannelsService>;
 	let channelsPropertiesService: jest.Mocked<ChannelsPropertiesService>;
 	let deviceConnectivityService: jest.Mocked<DeviceConnectivityService>;
+	let hardwareIdentity: jest.Mocked<WledHardwareIdentityService>;
 
 	// Quiet logger noise
 
@@ -208,9 +209,23 @@ describe('WledDeviceMapperService', () => {
 		channelsService = module.get(ChannelsService);
 		channelsPropertiesService = module.get(ChannelsPropertiesService);
 		deviceConnectivityService = module.get(DeviceConnectivityService);
+		hardwareIdentity = module.get(WledHardwareIdentityService);
 	});
 
 	describe('mapDevice', () => {
+		it('rejects mapping when the verified hardware identity conflicts', async () => {
+			const mockDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			devicesService.findOneBy.mockResolvedValue(mockDevice);
+			hardwareIdentity.persist.mockResolvedValueOnce('conflict');
+
+			await expect(
+				service.mapDevice('192.168.1.100', mockDeviceContext, undefined, 'wled-aabbccddeeff'),
+			).rejects.toThrow('WLED hardware identity conflicts with the stored device device-1');
+
+			expect(channelsService.create).not.toHaveBeenCalled();
+			expect(deviceConnectivityService.setConnectionState).not.toHaveBeenCalled();
+		});
+
 		it('should create a new device when it does not exist', async () => {
 			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
 

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -178,8 +178,10 @@ describe('WledDeviceMapperService', () => {
 				{
 					provide: ChannelsService,
 					useValue: {
+						findAll: jest.fn().mockResolvedValue([]),
 						findOneBy: jest.fn(),
 						create: jest.fn(),
+						remove: jest.fn(),
 					},
 				},
 				{
@@ -282,6 +284,26 @@ describe('WledDeviceMapperService', () => {
 					hostname: '192.168.1.100',
 				}),
 			);
+		});
+
+		it('removes obsolete mapper-owned segment channels during re-adoption', async () => {
+			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
+			const currentSegment = createMockChannel('segment-current', 'segment_0', mockDevice.id);
+			const obsoleteSegment = createMockChannel('segment-obsolete', 'segment_1', mockDevice.id);
+			const customChannel = createMockChannel('custom-channel', 'segment_custom', mockDevice.id);
+
+			devicesService.findOneBy.mockResolvedValue(mockDevice);
+			channelsService.findAll.mockResolvedValue([currentSegment, obsoleteSegment, customChannel]);
+			channelsService.findOneBy.mockResolvedValue(null);
+			channelsService.create.mockResolvedValue(createMockChannel('channel-1', 'device_information', mockDevice.id));
+			channelsPropertiesService.findOneBy.mockResolvedValue(null);
+			channelsPropertiesService.create.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+			channelsPropertiesService.update.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+
+			await service.mapDevice('192.168.1.100', mockDeviceContext);
+
+			expect(channelsService.remove).toHaveBeenCalledTimes(1);
+			expect(channelsService.remove).toHaveBeenCalledWith('segment-obsolete');
 		});
 
 		it('should apply confirmed adoption fields when updating an existing device', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -18,6 +18,7 @@ import { WledChannelEntity, WledChannelPropertyEntity, WledDeviceEntity } from '
 import { WledDeviceContext, WledInfo, WledState } from '../interfaces/wled.interface';
 
 import { WledDeviceMapperService } from './device-mapper.service';
+import { WledHardwareIdentityService } from './hardware-identity.service';
 
 describe('WledDeviceMapperService', () => {
 	let service: WledDeviceMapperService;
@@ -195,6 +196,10 @@ describe('WledDeviceMapperService', () => {
 					},
 				},
 				DeviceProvisionQueueService,
+				{
+					provide: WledHardwareIdentityService,
+					useValue: { persist: jest.fn().mockResolvedValue('persisted') },
+				},
 			],
 		}).compile();
 
@@ -230,7 +235,6 @@ describe('WledDeviceMapperService', () => {
 					type: DEVICES_WLED_TYPE,
 					category: DeviceCategory.LIGHTING,
 					hostname: '192.168.1.100',
-					mac: 'aabbccddeeff',
 				}),
 			);
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith(mockDevice.id, {
@@ -292,7 +296,6 @@ describe('WledDeviceMapperService', () => {
 			expect(devicesService.update).toHaveBeenCalledWith(mockDevice.id, {
 				type: DEVICES_WLED_TYPE,
 				hostname: '192.168.1.100',
-				mac: 'aabbccddeeff',
 				name: 'Renamed strip',
 				description: null,
 				enabled: true,

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -351,6 +351,38 @@ describe('WledDeviceMapperService', () => {
 				}),
 			);
 		});
+
+		it('preserves manual description and disabled state while provisioning channels', async () => {
+			const mockDevice = {
+				...createMockDevice('device-1', 'custom-wled', '192.168.1.100', false),
+				description: 'Behind the desk',
+			};
+
+			devicesService.findOneBy.mockResolvedValue(null);
+			devicesService.create.mockResolvedValue(mockDevice as WledDeviceEntity);
+			channelsService.findOneBy.mockResolvedValue(null);
+			channelsService.create.mockResolvedValue(createMockChannel('channel-1', 'device_information', 'device-1'));
+			channelsPropertiesService.findOneBy.mockResolvedValue(null);
+			channelsPropertiesService.create.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+			channelsPropertiesService.update.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+
+			await service.mapDevice(
+				'192.168.1.100',
+				mockDeviceContext,
+				'Desk strip',
+				'custom-wled',
+				'Behind the desk',
+				false,
+			);
+
+			expect(devicesService.create).toHaveBeenCalledWith(
+				expect.objectContaining({ description: 'Behind the desk', enabled: false }),
+			);
+			expect(channelsService.create).toHaveBeenCalled();
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-1', {
+				state: ConnectionState.UNKNOWN,
+			});
+		});
 	});
 
 	describe('updateDeviceState', () => {

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.spec.ts
@@ -263,10 +263,15 @@ describe('WledDeviceMapperService', () => {
 			);
 		});
 
-		it('should skip updates for disabled device and set connection to UNKNOWN', async () => {
+		it('should resume idempotent provisioning for an existing disabled device', async () => {
 			const mockDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100', false);
 
 			devicesService.findOneBy.mockResolvedValue(mockDevice);
+			channelsService.findOneBy.mockResolvedValue(null);
+			channelsService.create.mockResolvedValue(createMockChannel('channel-1', 'device_information', 'device-1'));
+			channelsPropertiesService.findOneBy.mockResolvedValue(null);
+			channelsPropertiesService.create.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
+			channelsPropertiesService.update.mockResolvedValue(createMockProperty('prop-1', 'test', 'channel-1'));
 			deviceConnectivityService.setConnectionState.mockResolvedValue(undefined);
 
 			const result = await service.mapDevice('192.168.1.100', mockDeviceContext);
@@ -275,7 +280,7 @@ describe('WledDeviceMapperService', () => {
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith(mockDevice.id, {
 				state: ConnectionState.UNKNOWN,
 			});
-			expect(channelsService.findOneBy).not.toHaveBeenCalled();
+			expect(channelsService.create).toHaveBeenCalled();
 		});
 
 		it('should create device_information channel with correct property identifiers', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -133,16 +133,6 @@ export class WledDeviceMapperService {
 		const lightChannel = await this.createLightChannel(device, context.state);
 		await this.createElectricalPowerChannel(device, context.info, lightChannel?.id);
 		await this.createSegmentChannels(device, context.state, lightChannel?.id);
-		try {
-			await this.pruneObsoleteSegmentChannels(device, context.state);
-		} catch (error) {
-			// Current device structure is already fully mapped. Treat obsolete-channel cleanup as
-			// best effort so a delete failure cannot trigger rollback after history was pruned.
-			this.logger.warn(`Could not prune obsolete WLED segment channels for device ${device.id}`, {
-				resource: device.id,
-				message: error instanceof Error ? error.message : String(error),
-			});
-		}
 
 		// Set connection state to CONNECTED
 		await this.deviceConnectivityService.setConnectionState(device.id, {
@@ -428,20 +418,26 @@ export class WledDeviceMapperService {
 		}
 	}
 
-	private async pruneObsoleteSegmentChannels(device: WledDeviceEntity, state: WledState): Promise<void> {
-		const segmentPrefix = `${WLED_CHANNEL_IDENTIFIERS.SEGMENT}_`;
-		const desiredIdentifiers = new Set(state.segments.map((_, index) => `${segmentPrefix}${index}`));
-		const channels = await this.channelsService.findAll<WledChannelEntity>(device.id, DEVICES_WLED_TYPE);
+	async pruneObsoleteSegmentChannels(device: WledDeviceEntity, state: WledState): Promise<void> {
+		try {
+			const segmentPrefix = `${WLED_CHANNEL_IDENTIFIERS.SEGMENT}_`;
+			const desiredIdentifiers = new Set(state.segments.map((_, index) => `${segmentPrefix}${index}`));
+			const channels = await this.channelsService.findAll<WledChannelEntity>(device.id, DEVICES_WLED_TYPE);
 
-		for (const channel of channels) {
-			if (
-				/^\d+$/.test(channel.identifier.slice(segmentPrefix.length)) &&
-				channel.identifier.startsWith(segmentPrefix)
-			) {
-				if (!desiredIdentifiers.has(channel.identifier)) {
+			for (const channel of channels) {
+				if (
+					/^\d+$/.test(channel.identifier.slice(segmentPrefix.length)) &&
+					channel.identifier.startsWith(segmentPrefix) &&
+					!desiredIdentifiers.has(channel.identifier)
+				) {
 					await this.channelsService.remove(channel.id);
 				}
 			}
+		} catch (error) {
+			this.logger.warn(`Could not prune obsolete WLED segment channels for device ${device.id}`, {
+				resource: device.id,
+				message: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -59,10 +59,14 @@ export class WledDeviceMapperService {
 		context: WledDeviceContext,
 		configName?: string | null,
 		configIdentifier?: string | null,
+		configDescription?: string | null,
+		configEnabled?: boolean,
 	): Promise<WledDeviceEntity> {
 		const identifier = configIdentifier || this.generateIdentifier(context.info.mac);
 
-		return this.provisionQueue.enqueue(identifier, () => this.doMapDevice(host, context, identifier, configName));
+		return this.provisionQueue.enqueue(identifier, () =>
+			this.doMapDevice(host, context, identifier, configName, configDescription, configEnabled),
+		);
 	}
 
 	private async doMapDevice(
@@ -70,6 +74,8 @@ export class WledDeviceMapperService {
 		context: WledDeviceContext,
 		identifier: string,
 		configName?: string | null,
+		configDescription?: string | null,
+		configEnabled?: boolean,
 	): Promise<WledDeviceEntity> {
 		const name = configName || context.info.name || `WLED ${identifier}`;
 
@@ -83,8 +89,9 @@ export class WledDeviceMapperService {
 				type: DEVICES_WLED_TYPE,
 				identifier,
 				name,
+				description: configDescription ?? null,
 				category: DeviceCategory.LIGHTING,
-				enabled: true,
+				enabled: configEnabled ?? true,
 				hostname: host,
 			};
 
@@ -122,7 +129,7 @@ export class WledDeviceMapperService {
 
 		// Set connection state to CONNECTED
 		await this.deviceConnectivityService.setConnectionState(device.id, {
-			state: ConnectionState.CONNECTED,
+			state: device.enabled ? ConnectionState.CONNECTED : ConnectionState.UNKNOWN,
 		});
 
 		return device;

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -78,6 +78,7 @@ export class WledDeviceMapperService {
 		configEnabled?: boolean,
 	): Promise<WledDeviceEntity> {
 		const name = configName || context.info.name || `WLED ${identifier}`;
+		const mac = context.info.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
 
 		// Create or update the device entity
 		let device = await this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE);
@@ -93,6 +94,7 @@ export class WledDeviceMapperService {
 				category: DeviceCategory.LIGHTING,
 				enabled: configEnabled ?? true,
 				hostname: host,
+				mac,
 			};
 
 			device = await this.devicesService.create<WledDeviceEntity, CreateWledDeviceDto>(createDto);
@@ -100,12 +102,14 @@ export class WledDeviceMapperService {
 			const updateDto: UpdateWledDeviceDto = {
 				type: DEVICES_WLED_TYPE,
 				hostname: host,
+				mac,
 				...(configName !== undefined && configName !== null ? { name: configName } : {}),
 				...(configDescription !== undefined ? { description: configDescription } : {}),
 				...(configEnabled !== undefined ? { enabled: configEnabled } : {}),
 			};
 			const shouldUpdate =
 				device.hostname !== host ||
+				device.mac !== mac ||
 				(configName !== undefined && configName !== null && device.name !== configName) ||
 				(configDescription !== undefined && device.description !== configDescription) ||
 				(configEnabled !== undefined && device.enabled !== configEnabled);

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -132,8 +132,17 @@ export class WledDeviceMapperService {
 		await this.createDeviceInformationChannel(device, context.info);
 		const lightChannel = await this.createLightChannel(device, context.state);
 		await this.createElectricalPowerChannel(device, context.info, lightChannel?.id);
-		await this.pruneObsoleteSegmentChannels(device, context.state);
 		await this.createSegmentChannels(device, context.state, lightChannel?.id);
+		try {
+			await this.pruneObsoleteSegmentChannels(device, context.state);
+		} catch (error) {
+			// Current device structure is already fully mapped. Treat obsolete-channel cleanup as
+			// best effort so a delete failure cannot trigger rollback after history was pruned.
+			this.logger.warn(`Could not prune obsolete WLED segment channels for device ${device.id}`, {
+				resource: device.id,
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
 
 		// Set connection state to CONNECTED
 		await this.deviceConnectivityService.setConnectionState(device.id, {

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -34,6 +34,8 @@ import { UpdateWledDeviceDto } from '../dto/update-device.dto';
 import { WledChannelEntity, WledChannelPropertyEntity, WledDeviceEntity } from '../entities/devices-wled.entity';
 import { WledDeviceContext, WledInfo, WledState } from '../interfaces/wled.interface';
 
+import { WledHardwareIdentityService } from './hardware-identity.service';
+
 /**
  * WLED Device Mapper Service
  *
@@ -49,6 +51,7 @@ export class WledDeviceMapperService {
 		private readonly channelsPropertiesService: ChannelsPropertiesService,
 		private readonly deviceConnectivityService: DeviceConnectivityService,
 		private readonly provisionQueue: DeviceProvisionQueueService,
+		private readonly hardwareIdentity: WledHardwareIdentityService,
 	) {}
 
 	/**
@@ -78,7 +81,6 @@ export class WledDeviceMapperService {
 		configEnabled?: boolean,
 	): Promise<WledDeviceEntity> {
 		const name = configName || context.info.name || `WLED ${identifier}`;
-		const mac = context.info.mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
 
 		// Create or update the device entity
 		let device = await this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE);
@@ -94,7 +96,6 @@ export class WledDeviceMapperService {
 				category: DeviceCategory.LIGHTING,
 				enabled: configEnabled ?? true,
 				hostname: host,
-				mac,
 			};
 
 			device = await this.devicesService.create<WledDeviceEntity, CreateWledDeviceDto>(createDto);
@@ -102,14 +103,12 @@ export class WledDeviceMapperService {
 			const updateDto: UpdateWledDeviceDto = {
 				type: DEVICES_WLED_TYPE,
 				hostname: host,
-				mac,
 				...(configName !== undefined && configName !== null ? { name: configName } : {}),
 				...(configDescription !== undefined ? { description: configDescription } : {}),
 				...(configEnabled !== undefined ? { enabled: configEnabled } : {}),
 			};
 			const shouldUpdate =
 				device.hostname !== host ||
-				device.mac !== mac ||
 				(configName !== undefined && configName !== null && device.name !== configName) ||
 				(configDescription !== undefined && device.description !== configDescription) ||
 				(configEnabled !== undefined && device.enabled !== configEnabled);
@@ -122,6 +121,8 @@ export class WledDeviceMapperService {
 				device = await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(device.id, updateDto);
 			}
 		}
+
+		await this.hardwareIdentity.persist(device, context.info.mac);
 
 		// Create channels and properties
 		await this.createDeviceInformationChannel(device, context.info);

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -25,6 +25,7 @@ import {
 	wledCurrentToAmps,
 	wledPowerToWatts,
 } from '../devices-wled.constants';
+import { WledValidationException } from '../devices-wled.exceptions';
 import { CreateWledChannelPropertyDto } from '../dto/create-channel-property.dto';
 import { CreateWledChannelDto } from '../dto/create-channel.dto';
 import { CreateWledDeviceDto } from '../dto/create-device.dto';
@@ -122,7 +123,10 @@ export class WledDeviceMapperService {
 			}
 		}
 
-		await this.hardwareIdentity.persist(device, context.info.mac);
+		const identityResult = await this.hardwareIdentity.persist(device, context.info.mac);
+		if (identityResult === 'conflict') {
+			throw new WledValidationException(`WLED hardware identity conflicts with the stored device ${device.id}`);
+		}
 
 		// Create channels and properties
 		await this.createDeviceInformationChannel(device, context.info);

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -132,6 +132,7 @@ export class WledDeviceMapperService {
 		await this.createDeviceInformationChannel(device, context.info);
 		const lightChannel = await this.createLightChannel(device, context.state);
 		await this.createElectricalPowerChannel(device, context.info, lightChannel?.id);
+		await this.pruneObsoleteSegmentChannels(device, context.state);
 		await this.createSegmentChannels(device, context.state, lightChannel?.id);
 
 		// Set connection state to CONNECTED
@@ -414,6 +415,23 @@ export class WledDeviceMapperService {
 			// Create/update properties
 			for (const binding of segmentBindings) {
 				await this.createOrUpdateProperty(channel, binding, propertyValues[binding.propertyIdentifier]);
+			}
+		}
+	}
+
+	private async pruneObsoleteSegmentChannels(device: WledDeviceEntity, state: WledState): Promise<void> {
+		const segmentPrefix = `${WLED_CHANNEL_IDENTIFIERS.SEGMENT}_`;
+		const desiredIdentifiers = new Set(state.segments.map((_, index) => `${segmentPrefix}${index}`));
+		const channels = await this.channelsService.findAll<WledChannelEntity>(device.id, DEVICES_WLED_TYPE);
+
+		for (const channel of channels) {
+			if (
+				/^\d+$/.test(channel.identifier.slice(segmentPrefix.length)) &&
+				channel.identifier.startsWith(segmentPrefix)
+			) {
+				if (!desiredIdentifiers.has(channel.identifier)) {
+					await this.channelsService.remove(channel.id);
+				}
 			}
 		}
 	}

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -97,16 +97,23 @@ export class WledDeviceMapperService {
 
 			device = await this.devicesService.create<WledDeviceEntity, CreateWledDeviceDto>(createDto);
 		} else {
-			// Update hostname if it changed
-			if (device.hostname !== host) {
-				this.logger.log(`Updating hostname for device ${identifier}: ${device.hostname} -> ${host}`, {
+			const updateDto: UpdateWledDeviceDto = {
+				type: DEVICES_WLED_TYPE,
+				hostname: host,
+				...(configName !== undefined && configName !== null ? { name: configName } : {}),
+				...(configDescription !== undefined ? { description: configDescription } : {}),
+				...(configEnabled !== undefined ? { enabled: configEnabled } : {}),
+			};
+			const shouldUpdate =
+				device.hostname !== host ||
+				(configName !== undefined && configName !== null && device.name !== configName) ||
+				(configDescription !== undefined && device.description !== configDescription) ||
+				(configEnabled !== undefined && device.enabled !== configEnabled);
+
+			if (shouldUpdate) {
+				this.logger.log(`Updating device ${identifier} from confirmed adoption data`, {
 					resource: device.id,
 				});
-
-				const updateDto: UpdateWledDeviceDto = {
-					type: DEVICES_WLED_TYPE,
-					hostname: host,
-				};
 
 				device = await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(device.id, updateDto);
 			}

--- a/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/device-mapper.service.ts
@@ -97,15 +97,6 @@ export class WledDeviceMapperService {
 
 			device = await this.devicesService.create<WledDeviceEntity, CreateWledDeviceDto>(createDto);
 		} else {
-			// Device exists - check if enabled
-			if (!device.enabled) {
-				await this.deviceConnectivityService.setConnectionState(device.id, {
-					state: ConnectionState.UNKNOWN,
-				});
-
-				return device;
-			}
-
 			// Update hostname if it changed
 			if (device.hostname !== host) {
 				this.logger.log(`Updating hostname for device ${identifier}: ${device.hostname} -> ${host}`, {

--- a/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.spec.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+
+import { WledDeviceEntity } from '../entities/devices-wled.entity';
+
+import { WledHardwareIdentityService } from './hardware-identity.service';
+
+describe('WledHardwareIdentityService', () => {
+	it('persists a verified normalized identity through the internal repository path', async () => {
+		const device = { id: 'device-1', mac: null } as WledDeviceEntity;
+		const update = jest.fn().mockResolvedValue(undefined);
+		const repository = { findOne: jest.fn().mockResolvedValue(null), update };
+		const dataSource = { getRepository: jest.fn().mockReturnValue(repository) } as unknown as DataSource;
+		const service = new WledHardwareIdentityService(dataSource);
+
+		await expect(service.persist(device, 'AA:BB:CC:DD:EE:FF')).resolves.toBe('persisted');
+
+		expect(update).toHaveBeenCalledWith('device-1', { mac: 'aabbccddeeff' });
+		expect(device.mac).toBe('aabbccddeeff');
+	});
+
+	it('rejects a hardware identity owned by another device', async () => {
+		const device = { id: 'device-legacy', mac: null } as WledDeviceEntity;
+		const update = jest.fn();
+		const repository = {
+			findOne: jest.fn().mockResolvedValue({ id: 'device-canonical', mac: 'aabbccddeeff' }),
+			update,
+		};
+		const dataSource = { getRepository: jest.fn().mockReturnValue(repository) } as unknown as DataSource;
+		const service = new WledHardwareIdentityService(dataSource);
+
+		await expect(service.persist(device, 'AA:BB:CC:DD:EE:FF')).resolves.toBe('conflict');
+
+		expect(update).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.spec.ts
@@ -32,4 +32,16 @@ describe('WledHardwareIdentityService', () => {
 
 		expect(update).not.toHaveBeenCalled();
 	});
+
+	it('rejects replacing an identity already verified for the device', async () => {
+		const device = { id: 'device-1', mac: 'aabbccddeeff' } as WledDeviceEntity;
+		const getRepository = jest.fn();
+		const dataSource = { getRepository } as unknown as DataSource;
+		const service = new WledHardwareIdentityService(dataSource);
+
+		await expect(service.persist(device, '11:22:33:44:55:66')).resolves.toBe('conflict');
+
+		expect(getRepository).not.toHaveBeenCalled();
+		expect(device.mac).toBe('aabbccddeeff');
+	});
 });

--- a/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.ts
@@ -1,0 +1,36 @@
+import { DataSource } from 'typeorm';
+
+import { Injectable } from '@nestjs/common';
+
+import { WledDeviceEntity } from '../entities/devices-wled.entity';
+
+@Injectable()
+export class WledHardwareIdentityService {
+	constructor(private readonly dataSource: DataSource) {}
+
+	async persist(device: WledDeviceEntity, reportedMac: string): Promise<'persisted' | 'unchanged' | 'conflict'> {
+		const mac = this.normalize(reportedMac);
+		if (!mac || device.mac === mac) {
+			return 'unchanged';
+		}
+
+		const repository = this.dataSource.getRepository(WledDeviceEntity);
+		const existingOwner = await repository.findOne({ where: { mac } });
+		if (existingOwner && existingOwner.id !== device.id) {
+			return 'conflict';
+		}
+
+		await repository.update(device.id, { mac });
+		device.mac = mac;
+		return 'persisted';
+	}
+
+	async restore(deviceId: string, mac: string | null): Promise<void> {
+		await this.dataSource.getRepository(WledDeviceEntity).update(deviceId, { mac });
+	}
+
+	private normalize(mac: string): string | null {
+		const normalized = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+		return normalized.length === 12 ? normalized : null;
+	}
+}

--- a/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/hardware-identity.service.ts
@@ -13,6 +13,9 @@ export class WledHardwareIdentityService {
 		if (!mac || device.mac === mac) {
 			return 'unchanged';
 		}
+		if (device.mac !== null) {
+			return 'conflict';
+		}
 
 		const repository = this.dataSource.getRepository(WledDeviceEntity);
 		const existingOwner = await repository.findOne({ where: { mac } });

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
@@ -5,12 +5,15 @@ eslint-disable @typescript-eslint/require-await
 Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
-import { WledAdapterCallbacks } from '../interfaces/wled.interface';
+import WebSocket from 'ws';
+
+import { WledAdapterCallbacks, WledDeviceContext } from '../interfaces/wled.interface';
 
 import { WledClientAdapterService } from './wled-client-adapter.service';
 
 // Mock global fetch
 global.fetch = jest.fn();
+jest.mock('ws');
 
 describe('WledClientAdapterService', () => {
 	let service: WledClientAdapterService;
@@ -204,6 +207,49 @@ describe('WledClientAdapterService', () => {
 			service.disconnect('192.168.1.100');
 
 			expect(callbacks.onDeviceDisconnected).not.toHaveBeenCalled();
+		});
+
+		it('ignores a stale socket close after a replacement is registered at the same host', () => {
+			jest.useFakeTimers();
+			const sockets: Array<{
+				on: jest.Mock;
+				close: jest.Mock;
+				handlers: Map<string, (...args: unknown[]) => void>;
+			}> = [];
+			(WebSocket as unknown as jest.Mock).mockImplementation(() => {
+				const handlers = new Map<string, (...args: unknown[]) => void>();
+				const socket = {
+					on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+						handlers.set(event, handler);
+					}),
+					close: jest.fn(),
+					handlers,
+				};
+				sockets.push(socket);
+
+				return socket;
+			});
+			const context = {
+				state: { on: true, brightness: 128, segments: [] },
+				info: { name: 'WLED', mac: 'AA:BB:CC:DD:EE:FF' },
+				effects: [],
+				palettes: [],
+			} as WledDeviceContext;
+			service.configureWebSocket(true, 5000);
+
+			service.connectWithContext('192.168.1.100', 'wled-old', context);
+			sockets[0].handlers.get('open')?.();
+			service.disconnect('192.168.1.100');
+			service.connectWithContext('192.168.1.100', 'wled-new', context);
+			sockets[1].handlers.get('open')?.();
+			sockets[0].handlers.get('close')?.();
+			jest.advanceTimersByTime(5000);
+
+			expect(service.getDevice('192.168.1.100')).toEqual(
+				expect.objectContaining({ identifier: 'wled-new', websocket: sockets[1] }),
+			);
+			expect(WebSocket).toHaveBeenCalledTimes(2);
+			jest.useRealTimers();
 		});
 	});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
@@ -209,6 +209,17 @@ describe('WledClientAdapterService', () => {
 			expect(callbacks.onDeviceDisconnected).not.toHaveBeenCalled();
 		});
 
+		it('can suppress the disconnected callback during controlled replacement', async () => {
+			mockFetchMultiple([{ data: mockWledState }, { data: mockWledInfo }, { data: ['Solid'] }, { data: ['Default'] }]);
+			await service.connect('192.168.1.100', 'wled-test');
+			jest.clearAllMocks();
+
+			service.disconnect('192.168.1.100', false);
+
+			expect(service.getDevice('192.168.1.100')).toBeUndefined();
+			expect(callbacks.onDeviceDisconnected).not.toHaveBeenCalled();
+		});
+
 		it('ignores a stale socket close after a replacement is registered at the same host', () => {
 			jest.useFakeTimers();
 			const sockets: Array<{

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.spec.ts
@@ -141,6 +141,16 @@ describe('WledClientAdapterService', () => {
 	};
 
 	describe('connect', () => {
+		it('probes without registering the device or emitting connection events', async () => {
+			mockFetchMultiple([{ data: mockWledState }, { data: mockWledInfo }, { data: ['Solid'] }, { data: ['Default'] }]);
+
+			const context = await service.probe('192.168.1.100');
+
+			expect(context.info.mac).toBe(mockWledInfo.mac);
+			expect(service.getDevice('192.168.1.100')).toBeUndefined();
+			expect(callbacks.onDeviceConnected).not.toHaveBeenCalled();
+		});
+
 		it('should connect to a WLED device and invoke connected callback', async () => {
 			mockFetchMultiple([
 				{ data: mockWledState },

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
@@ -197,7 +197,7 @@ export class WledClientAdapterService {
 	/**
 	 * Disconnect from a WLED device
 	 */
-	disconnect(host: string): void {
+	disconnect(host: string, emitEvent = true): void {
 		const device = this.devices.get(host);
 
 		if (device) {
@@ -230,12 +230,13 @@ export class WledClientAdapterService {
 
 			this.logger.log(`Disconnected from WLED device at ${host}`);
 
-			// Invoke disconnected callback
-			void this.callbacks.onDeviceDisconnected?.({
-				host,
-				identifier,
-				reason: 'manual disconnect',
-			});
+			if (emitEvent) {
+				void this.callbacks.onDeviceDisconnected?.({
+					host,
+					identifier,
+					reason: 'manual disconnect',
+				});
+			}
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
@@ -641,10 +641,14 @@ export class WledClientAdapterService {
 
 		try {
 			const ws = new WebSocket(wsUrl);
+			this.websockets.set(host, ws);
 
 			ws.on('open', () => {
+				if (this.websockets.get(host) !== ws) {
+					return;
+				}
+
 				this.logger.log(`WebSocket connected to ${host}`);
-				this.websockets.set(host, ws);
 
 				const device = this.devices.get(host);
 				if (device) {
@@ -653,6 +657,10 @@ export class WledClientAdapterService {
 			});
 
 			ws.on('message', (data: WebSocket.Data) => {
+				if (this.websockets.get(host) !== ws) {
+					return;
+				}
+
 				try {
 					let dataStr: string;
 
@@ -693,6 +701,10 @@ export class WledClientAdapterService {
 			});
 
 			ws.on('close', () => {
+				if (this.websockets.get(host) !== ws) {
+					return;
+				}
+
 				this.logger.debug(`WebSocket disconnected from ${host}`);
 				this.websockets.delete(host);
 

--- a/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-client-adapter.service.ts
@@ -154,39 +154,43 @@ export class WledClientAdapterService {
 		this.logger.log(`Connecting to WLED device at ${host}`);
 
 		try {
-			// Fetch device context
 			const context = await this.fetchDeviceContext(host, timeout);
-
-			// Register the device
-			const device: RegisteredWledDevice = {
-				host,
-				identifier,
-				connected: true,
-				enabled: true,
-				context,
-				lastSeen: new Date(),
-			};
-
-			this.devices.set(host, device);
-
-			this.logger.log(`Successfully connected to WLED device at ${host} (${context.info.name})`);
-
-			// Invoke connected callback
-			void this.callbacks.onDeviceConnected?.({
-				host,
-				info: context.info,
-			});
-
-			// Connect WebSocket if enabled
-			if (this.wsEnabled) {
-				this.connectWebSocket(host);
-			}
+			this.connectWithContext(host, identifier, context);
 		} catch (error) {
 			this.logger.error(`Failed to connect to WLED device at ${host}`, {
 				message: error instanceof Error ? error.message : String(error),
 			});
 
 			throw new WledConnectionException(host, error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	/** Fetch device information without registering a persistent connection. */
+	async probe(host: string, timeout: number = DEFAULT_CONNECTION_TIMEOUT_MS): Promise<WledDeviceContext> {
+		try {
+			return await this.fetchDeviceContext(host, timeout);
+		} catch (error) {
+			throw new WledConnectionException(host, error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	/** Register an already-probed device without repeating the HTTP requests. */
+	connectWithContext(host: string, identifier: string, context: WledDeviceContext): void {
+		const device: RegisteredWledDevice = {
+			host,
+			identifier,
+			connected: true,
+			enabled: true,
+			context,
+			lastSeen: new Date(),
+		};
+
+		this.devices.set(host, device);
+		this.logger.log(`Successfully connected to WLED device at ${host} (${context.info.name})`);
+		void this.callbacks.onDeviceConnected?.({ host, info: context.info });
+
+		if (this.wsEnabled) {
+			this.connectWebSocket(host);
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled-mdns-discoverer.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-mdns-discoverer.service.ts
@@ -98,6 +98,10 @@ export class WledMdnsDiscovererService implements OnModuleDestroy {
 		return Array.from(this.discoveredDevices.values());
 	}
 
+	clearDiscoveredDevices(): void {
+		this.discoveredDevices.clear();
+	}
+
 	/**
 	 * Check if a device has been discovered
 	 */

--- a/apps/backend/src/plugins/devices-wled/services/wled-mdns-discoverer.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled-mdns-discoverer.service.ts
@@ -102,6 +102,10 @@ export class WledMdnsDiscovererService implements OnModuleDestroy {
 		this.discoveredDevices.clear();
 	}
 
+	forgetDiscoveredDevice(host: string): void {
+		this.discoveredDevices.delete(host);
+	}
+
 	/**
 	 * Check if a device has been discovered
 	 */

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -749,6 +749,9 @@ describe('WledService', () => {
 			]);
 
 			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(deviceMapper.mapDevice.mock.invocationCallOrder[0]).toBeLessThan(
+				wledAdapter.disconnect.mock.invocationCallOrder[0],
+			);
 			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
 				type: DEVICES_WLED_TYPE,
 				enabled: false,
@@ -783,6 +786,7 @@ describe('WledService', () => {
 			]);
 
 			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -950,6 +950,53 @@ describe('WledService', () => {
 			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
 		});
 
+		it('serializes mDNS auto-add before an overlapping adoption snapshot', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const autoAddedDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Discovered WLED',
+				host: '192.168.1.100',
+				port: 80,
+				mac: 'AA:BB:CC:DD:EE:FF',
+			};
+			let finishAutoAdd: ((device: WledDeviceEntity) => void) | undefined;
+			const autoAddMapping = new Promise<WledDeviceEntity>((resolve) => {
+				finishAutoAdd = resolve;
+			});
+			devicesService.findAll.mockResolvedValueOnce([]).mockResolvedValueOnce([autoAddedDevice]);
+			wledAdapter.connect.mockResolvedValue(undefined);
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+				context: mockContext,
+			} as RegisteredWledDevice);
+			deviceMapper.mapDevice.mockReturnValueOnce(autoAddMapping).mockResolvedValueOnce(autoAddedDevice);
+
+			const autoAdd = mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+			await Promise.resolve();
+			await Promise.resolve();
+			const adoption = service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Adopted WLED', category: DeviceCategory.LIGHTING },
+			]);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(devicesService.findAll).toHaveBeenCalledTimes(1);
+			finishAutoAdd?.(autoAddedDevice);
+
+			await autoAdd;
+			const results = await adoption;
+
+			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+			expect(devicesService.remove).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
 		it('retires a stale hostname owner after provisioning a different MAC', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {
@@ -1062,6 +1109,41 @@ describe('WledService', () => {
 			});
 			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', 5000);
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
+		});
+
+		it('restores an unselected stale owner when a dependent move group fails', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			const staleDevice = {
+				...createMockDevice('device-stale', 'wled-778899aabbcc', '192.168.1.200'),
+				name: 'Stale original',
+				description: 'Restore me',
+			} as WledDeviceEntity;
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice, staleDevice]);
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200' } as WledDeviceEntity)
+				.mockRejectedValueOnce(new Error('Second mapping failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second moved', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'failed']);
+			expect(devicesService.update).toHaveBeenCalledWith('device-stale', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-778899aabbcc',
+				name: 'Stale original',
+				description: 'Restore me',
+				enabled: true,
+				hostname: '192.168.1.200',
+			});
+			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.200', 'wled-778899aabbcc', 5000);
 		});
 
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -567,6 +567,27 @@ describe('WledService', () => {
 			expect(results.map((result) => result.status)).toEqual(['failed', 'created']);
 		});
 
+		it('resumes mapper provisioning for an existing device after a partial failure', async () => {
+			const partialDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([partialDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(partialDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Living room', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Living room',
+				'wled-ddeeff',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-1' })]);
+		});
+
 		it('marks discovered devices as already adopted by MAC identity', async () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: '192.168.1.200', name: 'Moved WLED', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -18,6 +18,7 @@ import {
 	RegisteredWledDevice,
 	WledAdapterCallbacks,
 	WledDeviceConnectedEvent,
+	WledDeviceContext,
 	WledDeviceDisconnectedEvent,
 	WledDeviceStateChangedEvent,
 	WledInfo,
@@ -88,6 +89,13 @@ describe('WledService', () => {
 			updated_at: new Date(),
 		}) as unknown as WledDeviceEntity;
 
+	const mockContext = {
+		state: { on: true, brightness: 128, segments: [] },
+		info: { name: 'Probed WLED', mac: 'AA:BB:CC:DD:EE:FF' },
+		effects: [],
+		palettes: [],
+	} as WledDeviceContext;
+
 	beforeEach(async () => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
@@ -105,6 +113,8 @@ describe('WledService', () => {
 					provide: WledClientAdapterService,
 					useValue: {
 						connect: jest.fn(),
+						probe: jest.fn(),
+						connectWithContext: jest.fn(),
 						disconnect: jest.fn(),
 						disconnectAll: jest.fn(),
 						getDevice: jest.fn(),
@@ -139,6 +149,8 @@ describe('WledService', () => {
 						start: jest.fn(),
 						stop: jest.fn(),
 						getDiscoveredDevices: jest.fn().mockReturnValue([]),
+						isDiscoveryRunning: jest.fn().mockReturnValue(true),
+						clearDiscoveredDevices: jest.fn(),
 						setCallbacks: jest.fn().mockImplementation((callbacks: WledMdnsCallbacks) => {
 							mdnsCallbacks = callbacks;
 						}),
@@ -486,6 +498,84 @@ describe('WledService', () => {
 			const result = service.getDiscoveredDevices();
 
 			expect(result).toEqual(mockDiscoveredDevices);
+		});
+	});
+
+	describe('adoption flow', () => {
+		it('restarts and clears mDNS discovery during a rescan', async () => {
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([]);
+
+			await service.rescanDiscovery();
+
+			expect(mdnsDiscoverer.stop).toHaveBeenCalled();
+			expect(mdnsDiscoverer.clearDiscoveredDevices).toHaveBeenCalled();
+			expect(mdnsDiscoverer.start).toHaveBeenCalled();
+		});
+
+		it('probes without registering a connection', async () => {
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([]);
+
+			const result = await service.probeDevice('http://192.168.1.100');
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					host: '192.168.1.100',
+					name: 'Probed WLED',
+					mac: 'AA:BB:CC:DD:EE:FF',
+					adoptedDeviceId: null,
+				}),
+			);
+			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+		});
+
+		it('provisions each device through the mapper and retains partial failures', async () => {
+			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockRejectedValueOnce(new Error('Device offline'));
+			devicesService.findAll.mockResolvedValue([]);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Living room', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.101', name: 'Kitchen', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Living room',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', mockContext);
+			expect(results).toEqual([
+				expect.objectContaining({ status: 'created', deviceId: 'device-1' }),
+				expect.objectContaining({ status: 'failed', error: 'Device offline' }),
+			]);
+		});
+
+		it('keeps an invalid host scoped to its batch item', async () => {
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([]);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'));
+
+			const results = await service.adoptDevices([
+				{ host: 'not/a/host', name: 'Invalid', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Valid', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'created']);
+		});
+
+		it('marks discovered devices as already adopted by MAC identity', async () => {
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: '192.168.1.200', name: 'Moved WLED', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100')]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0].adoptedDeviceId).toBe('device-1');
 		});
 	});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -141,6 +141,7 @@ describe('WledService', () => {
 					provide: WledDeviceMapperService,
 					useValue: {
 						mapDevice: jest.fn(),
+						pruneObsoleteSegmentChannels: jest.fn(),
 						updateDeviceState: jest.fn(),
 						setDeviceConnectionState: jest.fn(),
 					},
@@ -1023,6 +1024,10 @@ describe('WledService', () => {
 				undefined,
 			);
 			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', mockContext);
+			expect(deviceMapper.pruneObsoleteSegmentChannels).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'device-1' }),
+				mockContext.state,
+			);
 			expect(results).toEqual([
 				expect.objectContaining({ status: 'created', deviceId: 'device-1' }),
 				expect.objectContaining({ status: 'failed', error: 'Device offline' }),
@@ -1047,6 +1052,7 @@ describe('WledService', () => {
 
 			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
 			expect(devicesService.remove).toHaveBeenCalledWith('device-1');
+			expect(deviceMapper.pruneObsoleteSegmentChannels).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
 		});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -535,6 +535,24 @@ describe('WledService', () => {
 			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
 		});
 
+		it('preserves an adopted device name when probing its current MAC', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.50'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+
+			const result = await service.probeDevice('192.168.1.100');
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					name: 'Administrator name',
+					adoptedDeviceId: 'device-1',
+				}),
+			);
+		});
+
 		it('brackets a bare IPv6 host before probing', async () => {
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([]);
@@ -786,6 +804,26 @@ describe('WledService', () => {
 			const inventory = await service.getDiscoveryInventory();
 
 			expect(inventory.devices[0].adoptedDeviceId).toBe('device-1');
+		});
+
+		it('preserves an adopted device name in discovery inventory', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: '192.168.1.200', name: 'Advertised name', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0]).toEqual(
+				expect.objectContaining({
+					name: 'Administrator name',
+					adoptedDeviceId: 'device-1',
+				}),
+			);
 		});
 
 		it('does not match a reused hostname when the probed MAC belongs to another device', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -30,6 +30,7 @@ import { WledConfigModel } from '../models/config.model';
 
 import { WledAdoptionSnapshotService } from './adoption-snapshot.service';
 import { WledDeviceMapperService } from './device-mapper.service';
+import { WledHardwareIdentityService } from './hardware-identity.service';
 import { WledClientAdapterService } from './wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './wled-mdns-discoverer.service';
 import { WledService } from './wled.service';
@@ -40,6 +41,7 @@ describe('WledService', () => {
 	let wledAdapter: jest.Mocked<WledClientAdapterService>;
 	let deviceMapper: jest.Mocked<WledDeviceMapperService>;
 	let adoptionSnapshot: jest.Mocked<WledAdoptionSnapshotService>;
+	let hardwareIdentity: jest.Mocked<WledHardwareIdentityService>;
 	let devicesService: jest.Mocked<DevicesService>;
 	let mdnsDiscoverer: jest.Mocked<WledMdnsDiscovererService>;
 	let deviceConnectivityService: jest.Mocked<DeviceConnectivityService>;
@@ -157,6 +159,10 @@ describe('WledService', () => {
 					},
 				},
 				{
+					provide: WledHardwareIdentityService,
+					useValue: { persist: jest.fn().mockResolvedValue('persisted'), restore: jest.fn() },
+				},
+				{
 					provide: DevicesService,
 					useValue: {
 						findAll: jest.fn().mockResolvedValue([]),
@@ -199,6 +205,7 @@ describe('WledService', () => {
 		wledAdapter = module.get(WledClientAdapterService);
 		deviceMapper = module.get(WledDeviceMapperService);
 		adoptionSnapshot = module.get(WledAdoptionSnapshotService);
+		hardwareIdentity = module.get(WledHardwareIdentityService);
 		devicesService = module.get(DevicesService);
 		mdnsDiscoverer = module.get(WledMdnsDiscovererService);
 		deviceConnectivityService = module.get(DeviceConnectivityService);
@@ -406,22 +413,14 @@ describe('WledService', () => {
 				enabled: true,
 			} as RegisteredWledDevice);
 			devicesService.findOneBy.mockResolvedValue(storedDevice);
-			devicesService.update.mockResolvedValue({ ...storedDevice, mac: 'aabbccddeeff' } as WledDeviceEntity);
 
 			await adapterCallbacks.onDeviceConnected?.(event);
 
-			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
-				type: DEVICES_WLED_TYPE,
-				mac: 'aabbccddeeff',
-			});
+			expect(hardwareIdentity.persist).toHaveBeenCalledWith(storedDevice, 'aabbccddeeff');
 		});
 
 		it('should skip duplicate hardware identity persistence without rejecting the connected callback', async () => {
 			const storedDevice = createMockDevice('device-legacy', 'custom-strip', '192.168.1.100');
-			const existingOwner = {
-				...createMockDevice('device-canonical', 'wled-aabbccddeeff', '192.168.1.200'),
-				mac: 'aabbccddeeff',
-			} as WledDeviceEntity;
 			const event: WledDeviceConnectedEvent = {
 				host: '192.168.1.100',
 				info: { name: 'Test WLED', mac: 'AA:BB:CC:DD:EE:FF' } as WledInfo,
@@ -433,11 +432,11 @@ describe('WledService', () => {
 				enabled: true,
 			} as RegisteredWledDevice);
 			devicesService.findOneBy.mockResolvedValue(storedDevice);
-			devicesService.findAll.mockResolvedValue([storedDevice, existingOwner]);
+			hardwareIdentity.persist.mockResolvedValueOnce('conflict');
 
 			await expect(adapterCallbacks.onDeviceConnected?.(event)).resolves.toBeUndefined();
 
-			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(hardwareIdentity.persist).toHaveBeenCalledWith(storedDevice, 'aabbccddeeff');
 			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.CONNECTED);
 		});
 
@@ -2097,6 +2096,18 @@ describe('WledService', () => {
 			const inventory = await service.getDiscoveryInventory();
 
 			expect(inventory.devices[0].adoptedDeviceId).toBe('device-1');
+		});
+
+		it('returns null identities for malformed advertised MAC addresses', async () => {
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: '192.168.1.100', name: 'Malformed one', mac: 'not-a-mac', port: 80 },
+				{ host: '192.168.1.101', name: 'Malformed two', mac: 'also-bad', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices.map((device) => device.mac)).toEqual([null, null]);
 		});
 
 		it('preserves an adopted device name in discovery inventory', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -158,6 +158,7 @@ describe('WledService', () => {
 						getDiscoveredDevices: jest.fn().mockReturnValue([]),
 						isDiscoveryRunning: jest.fn().mockReturnValue(true),
 						clearDiscoveredDevices: jest.fn(),
+						forgetDiscoveredDevice: jest.fn(),
 						setCallbacks: jest.fn().mockImplementation((callbacks: WledMdnsCallbacks) => {
 							mdnsCallbacks = callbacks;
 						}),
@@ -475,6 +476,24 @@ describe('WledService', () => {
 				undefined,
 				undefined,
 			);
+		});
+
+		it('should make a failed auto-add discovery retryable', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Offline WLED',
+				host: '192.168.1.200',
+				port: 80,
+			};
+			devicesService.findAll.mockResolvedValue([]);
+			wledAdapter.probe.mockRejectedValue(new Error('Device offline'));
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
 		});
 
 		it('should reconcile a known MAC at its newly advertised endpoint', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -496,6 +496,23 @@ describe('WledService', () => {
 			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
 		});
 
+		it('should make a thrown auto-add setup failure retryable', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Unknown WLED',
+				host: '192.168.1.200',
+				port: 80,
+			};
+			devicesService.findAll.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('Database unavailable'));
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
+		});
+
 		it('should reconcile a known MAC at its newly advertised endpoint', async () => {
 			configService.getPluginConfig.mockReturnValue({
 				...mockConfig,
@@ -905,6 +922,10 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			wledAdapter.getDevice.mockImplementation((host) => {
+				const device = [firstDevice, secondDevice].find(({ hostname }) => hostname === host);
+				return device ? ({ host, identifier: device.identifier, connected: true } as RegisteredWledDevice) : null;
+			});
 			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
 			deviceMapper.mapDevice
 				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200' } as WledDeviceEntity)
@@ -1351,6 +1372,11 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
 			devicesService.findAll.mockResolvedValue([staleDevice]);
 			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-2', 'wled-112233445566', '192.168.1.100'));
 
@@ -1381,6 +1407,38 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-2' })]);
 		});
 
+		it('disconnects a stale owner using its explicit default-port registration', async () => {
+			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', 'wled.local:80');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockImplementation((host) =>
+				host === 'wled.local:80'
+					? ({
+							host,
+							identifier: 'wled-aabbccddeeff',
+							connected: true,
+						} as RegisteredWledDevice)
+					: null,
+			);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-2', 'wled-112233445566', 'wled.local'));
+
+			const results = await service.adoptDevices([
+				{ host: 'wled.local', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('wled.local:80', false);
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				enabled: false,
+				hostname: null,
+			});
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-2' })]);
+		});
+
 		it('does not retire a stale hostname owner when replacement provisioning fails', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {
@@ -1388,6 +1446,11 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
 			devicesService.findAll.mockResolvedValue([staleDevice]);
 			deviceMapper.mapDevice.mockRejectedValue(new Error('Provisioning failed'));
 
@@ -1408,6 +1471,11 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
 			devicesService.findAll.mockResolvedValue([staleDevice]);
 			deviceMapper.mapDevice.mockResolvedValue(replacementDevice);
 			devicesService.update.mockRejectedValueOnce(new Error('Retirement failed'));
@@ -1436,6 +1504,11 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
 			devicesService.findAll.mockResolvedValue([staleDevice]);
 			deviceMapper.mapDevice.mockResolvedValue(replacementDevice);
 			devicesService.update.mockResolvedValue(staleDevice);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -547,11 +547,7 @@ describe('WledService', () => {
 			expect(wledAdapter.probe).not.toHaveBeenCalled();
 		});
 
-		it('should reconcile a known MAC at its newly advertised endpoint', async () => {
-			configService.getPluginConfig.mockReturnValue({
-				...mockConfig,
-				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
-			} as WledConfigModel);
+		it('should reconcile a known MAC at its newly advertised endpoint when auto-add is disabled', async () => {
 			const existingDevice = {
 				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
 				name: 'Administrator name',
@@ -833,6 +829,32 @@ describe('WledService', () => {
 				undefined,
 			);
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('does not reuse a moved legacy short-MAC row for a different full MAC', async () => {
+			const legacyDevice = createMockDevice('device-legacy', 'wled-aabbcc', '192.168.1.100');
+			const collidingContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:AA:BB:CC' },
+			};
+			const createdDevice = createMockDevice('device-new', 'wled-112233aabbcc', '192.168.1.200');
+			wledAdapter.probe.mockResolvedValue(collidingContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(createdDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Different strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				collidingContext,
+				'Different strip',
+				'wled-112233aabbcc',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-new' })]);
 		});
 
 		it('updates an adopted MAC when it is discovered at a new host', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -640,6 +640,37 @@ describe('WledService', () => {
 			expect(result.host).toBe('[fe80::1234]');
 		});
 
+		it('adopts a legacy bare IPv6 row without creating a duplicate', async () => {
+			const legacyDevice = createMockDevice('device-1', 'wled-2001:db8::1', '2001:db8::1');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '[2001:db8::1]',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '[2001:db8::1]',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: '2001:db8::1', name: 'Legacy IPv6 strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'[2001:db8::1]',
+				mockContext,
+				'Legacy IPv6 strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.remove).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
 		it('provisions each device through the mapper and retains partial failures', async () => {
 			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockRejectedValueOnce(new Error('Device offline'));
 			devicesService.findAll.mockResolvedValue([]);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -584,6 +584,44 @@ describe('WledService', () => {
 			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.200', 'wled-aabbccddeeff', mockContext);
 		});
 
+		it('should upgrade a same-endpoint null identity discovered with a MAC', async () => {
+			const legacyDevice = {
+				...createMockDevice('device-1', null, '192.168.1.100'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			const upgradedDevice = {
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity;
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Advertised name',
+				host: '192.168.1.100',
+				port: 80,
+				mac: 'AA:BB:CC:DD:EE:FF',
+			};
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue(upgradedDevice);
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			deviceMapper.mapDevice.mockResolvedValue(upgradedDevice);
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '192.168.1.100',
+			});
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Administrator name',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(wledAdapter.connect).not.toHaveBeenCalled();
+		});
+
 		it('should probe and reconcile a known MAC-less announcement when auto-add is disabled', async () => {
 			const existingDevice = {
 				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -648,12 +648,15 @@ describe('WledService', () => {
 
 		it('reuses an existing connection when an enabled device keeps its host', async () => {
 			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
-			wledAdapter.probe.mockResolvedValue(mockContext);
-			wledAdapter.getDevice.mockReturnValue({
+			const registeredDevice = {
 				host: '192.168.1.100',
 				identifier: 'wled-aabbccddeeff',
 				connected: true,
-			} as RegisteredWledDevice);
+				context: { ...mockContext, state: { ...mockContext.state, brightness: 1 } },
+				lastSeen: new Date(0),
+			} as RegisteredWledDevice;
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue(registeredDevice);
 			devicesService.findAll.mockResolvedValue([existingDevice]);
 			deviceMapper.mapDevice.mockResolvedValue(existingDevice);
 
@@ -663,6 +666,8 @@ describe('WledService', () => {
 
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+			expect(registeredDevice.context).toBe(mockContext);
+			expect(registeredDevice.lastSeen?.getTime()).toBeGreaterThan(0);
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -764,6 +764,79 @@ describe('WledService', () => {
 			]);
 		});
 
+		it('rolls back every selected device when one address-swap mapping fails', async () => {
+			const firstDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'First original',
+			} as WledDeviceEntity;
+			const secondDevice = {
+				...createMockDevice('device-2', 'wled-112233445566', '192.168.1.200'),
+				name: 'Second original',
+			} as WledDeviceEntity;
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200', name: 'First moved' } as WledDeviceEntity)
+				.mockRejectedValueOnce(new Error('Second mapping failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second moved', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'failed']);
+			expect(results[0].error).toContain('Second mapping failed');
+			expect(results[1].error).toContain('Second mapping failed');
+			expect(devicesService.update).toHaveBeenCalledWith(
+				'device-1',
+				expect.objectContaining({
+					identifier: 'wled-aabbccddeeff',
+					name: 'First original',
+					hostname: '192.168.1.100',
+					enabled: true,
+				}),
+			);
+			expect(devicesService.update).toHaveBeenCalledWith(
+				'device-2',
+				expect.objectContaining({
+					identifier: 'wled-112233445566',
+					name: 'Second original',
+					hostname: '192.168.1.200',
+					enabled: true,
+				}),
+			);
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-1', {
+				state: ConnectionState.DISCONNECTED,
+			});
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-2', {
+				state: ConnectionState.DISCONNECTED,
+			});
+		});
+
+		it('rejects a duplicate controller identity within one adoption batch', async () => {
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([]);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'mDNS alias', category: DeviceCategory.LIGHTING },
+				{ host: 'wled.local', name: 'Manual alias', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledTimes(1);
+			expect(results).toEqual([
+				expect.objectContaining({ status: 'created', deviceId: 'device-1' }),
+				expect.objectContaining({
+					status: 'failed',
+					error: 'The same WLED controller was selected more than once',
+				}),
+			]);
+		});
+
 		it('retires a stale hostname owner after provisioning a different MAC', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -970,6 +970,42 @@ describe('WledService', () => {
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 		});
 
+		it('blocks an entire move chain when its closing selection probe fails', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			const thirdDevice = createMockDevice('device-3', 'wled-778899aabbcc', '192.168.1.30');
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe
+				.mockResolvedValueOnce(mockContext)
+				.mockResolvedValueOnce(secondContext)
+				.mockRejectedValueOnce(new Error('Third controller offline'));
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice, thirdDevice]);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.30', name: 'Second moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Third moved', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results).toEqual([
+				expect.objectContaining({
+					status: 'failed',
+					error: 'A related selected WLED controller could not be probed',
+				}),
+				expect.objectContaining({
+					status: 'failed',
+					error: 'A related selected WLED controller could not be probed',
+				}),
+				expect.objectContaining({ status: 'failed', error: 'Third controller offline' }),
+			]);
+			expect(deviceMapper.mapDevice).not.toHaveBeenCalled();
+			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+		});
+
 		it('continues independent adoption after a dependent rollback write fails', async () => {
 			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -584,6 +584,42 @@ describe('WledService', () => {
 			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.200', 'wled-aabbccddeeff', mockContext);
 		});
 
+		it('should probe and reconcile a known MAC-less announcement when auto-add is disabled', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Advertised name',
+				host: '192.168.1.200',
+				port: 80,
+			};
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValueOnce({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...existingDevice,
+				hostname: '192.168.1.200',
+			} as WledDeviceEntity);
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(wledAdapter.probe).toHaveBeenCalledWith('192.168.1.200', 5000);
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				mockContext,
+				'Administrator name',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+		});
+
 		it('should not auto-add device when autoAdd is disabled', async () => {
 			const discoveredDevice: WledMdnsDiscoveredDevice = {
 				name: 'Discovered WLED',
@@ -743,6 +779,37 @@ describe('WledService', () => {
 				'[2001:db8::1]',
 				mockContext,
 				'Legacy IPv6 strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.remove).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('adopts an equivalent expanded IPv6 endpoint over a compressed null-identifier row', async () => {
+			const legacyDevice = createMockDevice('device-1', null, '[2001:db8::1]');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '[2001:0db8::1]',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '[2001:0db8::1]',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: '2001:0db8::1', name: 'Expanded IPv6 strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'[2001:0db8::1]',
+				mockContext,
+				'Expanded IPv6 strip',
 				'wled-aabbccddeeff',
 				undefined,
 				undefined,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -622,6 +622,25 @@ describe('WledService', () => {
 			expect(wledAdapter.connect).not.toHaveBeenCalled();
 		});
 
+		it('should treat a malformed advertised MAC as unavailable without rejecting the discovery callback', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-existing', '192.168.1.100');
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Existing WLED',
+				host: '192.168.1.100',
+				port: 80,
+				mac: 'not-a-mac',
+			};
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			wledAdapter.isConnected.mockReturnValue(false);
+			wledAdapter.connect.mockResolvedValue(undefined);
+			wledAdapter.getDevice.mockReturnValue(null);
+
+			await expect(mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice)).resolves.toBeUndefined();
+
+			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-existing', 5000);
+			expect(deviceMapper.mapDevice).not.toHaveBeenCalled();
+		});
+
 		it('should probe and reconcile a known MAC-less announcement when auto-add is disabled', async () => {
 			const existingDevice = {
 				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -886,6 +886,27 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 
+		it('preserves a healthy same-host connection when provisioning fails', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockRejectedValue(new Error('Provisioning failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Living room', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+			expect(wledAdapter.connect).not.toHaveBeenCalled();
+			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
+		});
+
 		it('disconnects a failed move target before restoring the source connection', async () => {
 			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -626,6 +626,91 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
+		it('disconnects an existing same-host device when adoption disables it', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockResolvedValue({ ...existingDevice, enabled: false } as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{
+					host: '192.168.1.100',
+					name: 'Disabled strip',
+					category: DeviceCategory.LIGHTING,
+					enabled: false,
+				},
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('reuses an existing connection when an enabled device keeps its host', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(existingDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Living room', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('preserves both selected devices when adopted controllers exchange hosts', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200' } as WledDeviceEntity)
+				.mockResolvedValueOnce({ ...secondDevice, hostname: '192.168.1.100' } as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First strip', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.200');
+			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(deviceMapper.mapDevice).toHaveBeenNthCalledWith(
+				1,
+				'192.168.1.200',
+				mockContext,
+				'First strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(deviceMapper.mapDevice).toHaveBeenNthCalledWith(
+				2,
+				'192.168.1.100',
+				secondContext,
+				'Second strip',
+				'wled-112233445566',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([
+				expect.objectContaining({ status: 'updated', deviceId: 'device-1' }),
+				expect.objectContaining({ status: 'updated', deviceId: 'device-2' }),
+			]);
+		});
+
 		it('retires a stale hostname owner before provisioning a different MAC', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -843,6 +843,29 @@ describe('WledService', () => {
 			);
 		});
 
+		it('removes a partial new device when its mapper rejects inside a dependent group', async () => {
+			const existingDevice = createMockDevice('device-existing', 'wled-aabbccddeeff', '192.168.1.100');
+			const partialDevice = createMockDevice('device-partial', 'wled-778899aabbcc', '192.168.1.100');
+			const newContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '77:88:99:AA:BB:CC' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(newContext).mockResolvedValueOnce(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			devicesService.findOneBy.mockResolvedValue(partialDevice);
+			deviceMapper.mapDevice.mockRejectedValueOnce(new Error('Channel provisioning failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Partial controller', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.200', name: 'Existing controller', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'failed']);
+			expect(devicesService.findOneBy).toHaveBeenCalledWith('identifier', 'wled-778899aabbcc', DEVICES_WLED_TYPE);
+			expect(devicesService.remove).toHaveBeenCalledWith('device-partial');
+			expect(deviceMapper.mapDevice).toHaveBeenCalledTimes(1);
+		});
+
 		it('rolls back only the failed connected address-move group', async () => {
 			const devices = [
 				createMockDevice('device-1', 'wled-000000000001', '192.168.1.1'),
@@ -1001,6 +1024,26 @@ describe('WledService', () => {
 			} as WledDeviceEntity;
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: '192.168.1.200', name: 'Advertised name', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0]).toEqual(
+				expect.objectContaining({
+					name: 'Administrator name',
+					adoptedDeviceId: 'device-1',
+				}),
+			);
+		});
+
+		it('matches a MAC-less discovery record using its non-default port', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', 'wled.local:8080'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: 'wled.local', name: 'Advertised name', port: 8080 },
 			]);
 			devicesService.findAll.mockResolvedValue([existingDevice]);
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -589,6 +589,27 @@ describe('WledService', () => {
 			]);
 		});
 
+		it('disconnects a newly registered host when final adoption persistence fails', async () => {
+			const createdDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValueOnce(null).mockReturnValueOnce({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			devicesService.findAll.mockResolvedValue([]);
+			deviceMapper.mapDevice.mockResolvedValue(createdDevice);
+			deviceConnectivityService.setConnectionState.mockRejectedValueOnce(new Error('Connectivity write failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Living room', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(devicesService.remove).toHaveBeenCalledWith('device-1');
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
+		});
+
 		it('keeps an invalid host scoped to its batch item', async () => {
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([]);
@@ -671,6 +692,35 @@ describe('WledService', () => {
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 			expect(deviceConnectivityService.setConnectionState).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
+		});
+
+		it('disconnects a failed move target before restoring the source connection', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice
+				.mockReturnValueOnce({
+					host: '192.168.1.100',
+					identifier: 'wled-aabbccddeeff',
+					connected: true,
+				} as RegisteredWledDevice)
+				.mockReturnValueOnce(null)
+				.mockReturnValueOnce({
+					host: '192.168.1.200',
+					identifier: 'wled-aabbccddeeff',
+					connected: true,
+				} as RegisteredWledDevice);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockResolvedValue({ ...existingDevice, hostname: '192.168.1.200' } as WledDeviceEntity);
+			deviceConnectivityService.setConnectionState.mockRejectedValueOnce(new Error('Connectivity write failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Moved strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.200', false);
+			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', 5000);
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
 		});
 
 		it('disconnects an existing same-host device when adoption disables it', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -625,6 +625,11 @@ describe('WledService', () => {
 		it('updates an adopted MAC when it is discovered at a new host', async () => {
 			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
 			devicesService.findAll.mockResolvedValue([existingDevice]);
 			deviceMapper.mapDevice.mockResolvedValue({ ...existingDevice, hostname: '192.168.1.200' } as WledDeviceEntity);
 
@@ -642,6 +647,25 @@ describe('WledService', () => {
 				undefined,
 			);
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('keeps the source connection when moved-device provisioning fails', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockRejectedValue(new Error('Provisioning failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Moved strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 
 		it('disconnects an existing same-host device when adoption disables it', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1477,7 +1477,14 @@ describe('WledService', () => {
 			const legacyDevice = createMockDevice('device-1', 'wled-192-168-1-100', '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([legacyDevice]);
-			deviceMapper.mapDevice.mockResolvedValue(legacyDevice);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
 
 			const results = await service.adoptDevices([
 				{ host: '192.168.1.100', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
@@ -1487,10 +1494,15 @@ describe('WledService', () => {
 				'192.168.1.100',
 				mockContext,
 				'Legacy strip',
-				'wled-192-168-1-100',
+				'wled-aabbccddeeff',
 				undefined,
 				undefined,
 			);
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '192.168.1.100',
+			});
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
@@ -1498,7 +1510,14 @@ describe('WledService', () => {
 			const legacyDevice = createMockDevice('device-1', 'wled-wled-local', 'wled.local:8080');
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([legacyDevice]);
-			deviceMapper.mapDevice.mockResolvedValue(legacyDevice);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
 
 			const results = await service.adoptDevices([
 				{ host: 'wled.local:8080', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
@@ -1508,7 +1527,7 @@ describe('WledService', () => {
 				'wled.local:8080',
 				mockContext,
 				'Legacy strip',
-				'wled-wled-local',
+				'wled-aabbccddeeff',
 				undefined,
 				undefined,
 			);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -393,6 +393,29 @@ describe('WledService', () => {
 			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('wled-test', ConnectionState.CONNECTED);
 		});
 
+		it('should persist verified hardware identity when a configured device reconnects', async () => {
+			const storedDevice = createMockDevice('device-1', 'custom-strip', '192.168.1.100');
+			const event: WledDeviceConnectedEvent = {
+				host: '192.168.1.100',
+				info: { name: 'Test WLED', mac: 'AA:BB:CC:DD:EE:FF' } as WledInfo,
+			};
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'custom-strip',
+				connected: true,
+				enabled: true,
+			} as RegisteredWledDevice);
+			devicesService.findOneBy.mockResolvedValue(storedDevice);
+			devicesService.update.mockResolvedValue({ ...storedDevice, mac: 'aabbccddeeff' } as WledDeviceEntity);
+
+			await adapterCallbacks.onDeviceConnected?.(event);
+
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				mac: 'aabbccddeeff',
+			});
+		});
+
 		it('should set connection state to DISCONNECTED on device disconnected', async () => {
 			const event: WledDeviceDisconnectedEvent = {
 				host: '192.168.1.100',

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -637,7 +637,7 @@ describe('WledService', () => {
 				{ host: '192.168.1.200', name: 'Moved strip', category: DeviceCategory.LIGHTING },
 			]);
 
-			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
 			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
 				'192.168.1.200',
 				mockContext,
@@ -646,6 +646,9 @@ describe('WledService', () => {
 				undefined,
 				undefined,
 			);
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenLastCalledWith('device-1', {
+				state: ConnectionState.CONNECTED,
+			});
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
@@ -683,8 +686,11 @@ describe('WledService', () => {
 				},
 			]);
 
-			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
 			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenLastCalledWith('device-1', {
+				state: ConnectionState.DISCONNECTED,
+			});
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
@@ -731,8 +737,8 @@ describe('WledService', () => {
 				{ host: '192.168.1.100', name: 'Second strip', category: DeviceCategory.LIGHTING },
 			]);
 
-			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
-			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.200');
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.200', false);
 			expect(devicesService.update).not.toHaveBeenCalled();
 			expect(deviceMapper.mapDevice).toHaveBeenNthCalledWith(
 				1,
@@ -772,7 +778,7 @@ describe('WledService', () => {
 				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
 			]);
 
-			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
 			expect(deviceMapper.mapDevice.mock.invocationCallOrder[0]).toBeLessThan(
 				wledAdapter.disconnect.mock.invocationCallOrder[0],
 			);
@@ -871,6 +877,34 @@ describe('WledService', () => {
 				expect.objectContaining({
 					name: 'Administrator name',
 					adoptedDeviceId: 'device-1',
+				}),
+			);
+		});
+
+		it('prefers the canonical MAC device over legacy rows at the same host', async () => {
+			const nullIdentifierDevice = {
+				...createMockDevice('device-null', null, '192.168.1.200'),
+				name: 'Null identifier',
+			} as WledDeviceEntity;
+			const legacyDevice = {
+				...createMockDevice('device-legacy', 'wled-ddeeff', '192.168.1.200'),
+				name: 'Legacy identifier',
+			} as WledDeviceEntity;
+			const canonicalDevice = {
+				...createMockDevice('device-canonical', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Canonical identifier',
+			} as WledDeviceEntity;
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: '192.168.1.200', name: 'Advertised name', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([nullIdentifierDevice, legacyDevice, canonicalDevice]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0]).toEqual(
+				expect.objectContaining({
+					name: 'Canonical identifier',
+					adoptedDeviceId: 'device-canonical',
 				}),
 			);
 		});

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -577,6 +577,17 @@ describe('WledService', () => {
 
 			expect(inventory.devices[0].adoptedDeviceId).toBe('device-1');
 		});
+
+		it('does not match a reused hostname when the probed MAC belongs to another device', async () => {
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
+				{ host: '192.168.1.100', name: 'Replacement WLED', mac: '11:22:33:44:55:66', port: 80 },
+			]);
+			devicesService.findAll.mockResolvedValue([createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100')]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0].adoptedDeviceId).toBeNull();
+		});
 	});
 
 	describe('polling', () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1142,6 +1142,30 @@ describe('WledService', () => {
 			]);
 		});
 
+		it('does not propagate a duplicate alias as a failed move probe', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...existingDevice,
+				hostname: 'wled.local',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: 'wled.local', name: 'Moved strip', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Duplicate alias', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results).toEqual([
+				expect.objectContaining({ status: 'updated', deviceId: 'device-1' }),
+				expect.objectContaining({
+					status: 'failed',
+					error: 'The same WLED controller was selected more than once',
+				}),
+			]);
+			expect(deviceMapper.mapDevice).toHaveBeenCalledTimes(1);
+		});
+
 		it('serializes overlapping adoption batches before taking their database snapshots', async () => {
 			const createdDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			let finishFirstMapping: ((device: WledDeviceEntity) => void) | undefined;
@@ -1530,6 +1554,24 @@ describe('WledService', () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: 'wled.local', name: 'Advertised name', port: 8080 },
 			]);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0]).toEqual(
+				expect.objectContaining({
+					name: 'Administrator name',
+					adoptedDeviceId: 'device-1',
+				}),
+			);
+		});
+
+		it('matches a MAC-less default-port record to an explicit port 80 endpoint', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', 'wled.local:80'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([{ host: 'wled.local', name: 'Advertised name', port: 80 }]);
 			devicesService.findAll.mockResolvedValue([existingDevice]);
 
 			const inventory = await service.getDiscoveryInventory();

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1030,6 +1030,40 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Retirement failed' })]);
 		});
 
+		it('restores a retired owner snapshot when a later connectivity write fails', async () => {
+			const staleDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Original strip',
+				description: 'Original description',
+			} as WledDeviceEntity;
+			const replacementDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.100');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(replacementDevice);
+			devicesService.update.mockResolvedValue(staleDevice);
+			deviceConnectivityService.setConnectionState.mockRejectedValueOnce(new Error('Connectivity write failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.remove).toHaveBeenCalledWith('device-2');
+			expect(devicesService.update).toHaveBeenLastCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				name: 'Original strip',
+				description: 'Original description',
+				enabled: true,
+				hostname: '192.168.1.100',
+			});
+			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', 5000);
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
+		});
+
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {
 			const legacyDevice = createMockDevice('device-1', null, '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -419,7 +419,7 @@ describe('WledService', () => {
 			expect(hardwareIdentity.persist).toHaveBeenCalledWith(storedDevice, 'aabbccddeeff');
 		});
 
-		it('should skip duplicate hardware identity persistence without rejecting the connected callback', async () => {
+		it('should disconnect a registration whose hardware identity conflicts', async () => {
 			const storedDevice = createMockDevice('device-legacy', 'custom-strip', '192.168.1.100');
 			const event: WledDeviceConnectedEvent = {
 				host: '192.168.1.100',
@@ -437,7 +437,8 @@ describe('WledService', () => {
 			await expect(adapterCallbacks.onDeviceConnected?.(event)).resolves.toBeUndefined();
 
 			expect(hardwareIdentity.persist).toHaveBeenCalledWith(storedDevice, 'aabbccddeeff');
-			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.CONNECTED);
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.DISCONNECTED);
 		});
 
 		it('should set connection state to DISCONNECTED on device disconnected', async () => {
@@ -1342,6 +1343,22 @@ describe('WledService', () => {
 				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
 			};
 			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			wledAdapter.getRegisteredDevices.mockReturnValue([
+				{
+					host: firstDevice.hostname,
+					identifier: firstDevice.identifier,
+					connected: true,
+					enabled: true,
+					context: mockContext,
+				},
+				{
+					host: secondDevice.hostname,
+					identifier: secondDevice.identifier,
+					connected: true,
+					enabled: true,
+					context: secondContext,
+				},
+			] as RegisteredWledDevice[]);
 			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
 			deviceMapper.mapDevice
 				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200', name: 'First moved' } as WledDeviceEntity)
@@ -1380,6 +1397,55 @@ describe('WledService', () => {
 				state: ConnectionState.CONNECTED,
 			});
 			expect(adoptionSnapshot.restore).toHaveBeenCalledTimes(2);
+		});
+
+		it('restores an unselected registration when an address-swap group fails before stale-owner tracking', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			const staleDevice = createMockDevice('device-stale', 'custom-stale-strip', '192.168.1.200');
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			const staleContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '77:88:99:AA:BB:CC' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockResolvedValueOnce(secondContext);
+			wledAdapter.getRegisteredDevices.mockReturnValue([
+				{
+					host: firstDevice.hostname,
+					identifier: firstDevice.identifier,
+					connected: true,
+					enabled: true,
+					context: mockContext,
+				},
+				{
+					host: staleDevice.hostname,
+					identifier: staleDevice.identifier,
+					connected: true,
+					enabled: true,
+					context: staleContext,
+				},
+			] as RegisteredWledDevice[]);
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice, staleDevice]);
+			deviceMapper.mapDevice.mockRejectedValueOnce(new Error('First mapping failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second moved', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map(({ status }) => status)).toEqual(['failed', 'failed']);
+			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.200', 'custom-stale-strip', staleContext);
+			expect(wledAdapter.connectWithContext).not.toHaveBeenCalledWith(
+				'192.168.1.200',
+				'wled-112233445566',
+				secondContext,
+			);
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-stale', {
+				state: ConnectionState.CONNECTED,
+			});
 		});
 
 		it('does not retire a selected address owner when its swap probe fails', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -669,6 +669,7 @@ describe('WledService', () => {
 			]);
 
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+			expect(deviceConnectivityService.setConnectionState).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 
@@ -811,10 +812,10 @@ describe('WledService', () => {
 				}),
 			);
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-1', {
-				state: ConnectionState.DISCONNECTED,
+				state: ConnectionState.CONNECTED,
 			});
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-2', {
-				state: ConnectionState.DISCONNECTED,
+				state: ConnectionState.CONNECTED,
 			});
 		});
 
@@ -1022,6 +1023,10 @@ describe('WledService', () => {
 			]);
 
 			expect(devicesService.remove).toHaveBeenCalledWith('device-2');
+			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', 5000);
+			expect(deviceConnectivityService.setConnectionState).toHaveBeenLastCalledWith('device-1', {
+				state: ConnectionState.CONNECTED,
+			});
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Retirement failed' })]);
 		});
 
@@ -1049,6 +1054,27 @@ describe('WledService', () => {
 				mockContext,
 				'Legacy strip',
 				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('adopts a legacy host-derived identifier without creating a duplicate', async () => {
+			const legacyDevice = createMockDevice('device-1', 'wled-192-168-1-100', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(legacyDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Legacy strip',
+				'wled-192-168-1-100',
 				undefined,
 				undefined,
 			);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1049,6 +1049,40 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-legacy' })]);
 		});
 
+		it('reuses a moved custom-identifier row when its stored serial matches the full MAC', async () => {
+			const customDevice = {
+				...createMockDevice('device-custom', 'custom-living-room-strip', '192.168.1.100'),
+				channels: [
+					{
+						identifier: 'device_information',
+						properties: [{ identifier: 'serial_number', value: { value: 'AA:BB:CC:DD:EE:FF' } }],
+					},
+				],
+			} as WledDeviceEntity;
+			const movedDevice = { ...customDevice, hostname: '192.168.1.200' } as WledDeviceEntity;
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([customDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(movedDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Moved custom strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				mockContext,
+				'Moved custom strip',
+				'custom-living-room-strip',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.update).not.toHaveBeenCalledWith(
+				'device-custom',
+				expect.objectContaining({ identifier: 'wled-aabbccddeeff' }),
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-custom' })]);
+		});
+
 		it('updates an adopted MAC when it is discovered at a new host', async () => {
 			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1435,6 +1435,19 @@ describe('WledService', () => {
 				expect.objectContaining({ status: 'updated', deviceId: 'device-1' }),
 				expect.objectContaining({ status: 'updated', deviceId: 'device-2' }),
 			]);
+			expect(deviceMapper.pruneObsoleteSegmentChannels).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({ id: 'device-1' }),
+				mockContext.state,
+			);
+			expect(deviceMapper.pruneObsoleteSegmentChannels).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({ id: 'device-2' }),
+				secondContext.state,
+			);
+			expect(deviceMapper.pruneObsoleteSegmentChannels.mock.invocationCallOrder[0]).toBeGreaterThan(
+				deviceConnectivityService.setConnectionState.mock.invocationCallOrder.at(-1) ?? 0,
+			);
 		});
 
 		it('rolls back every selected device when one address-swap mapping fails', async () => {
@@ -1505,6 +1518,7 @@ describe('WledService', () => {
 				state: ConnectionState.CONNECTED,
 			});
 			expect(adoptionSnapshot.restore).toHaveBeenCalledTimes(2);
+			expect(deviceMapper.pruneObsoleteSegmentChannels).not.toHaveBeenCalled();
 		});
 
 		it('restores an unselected registration when an address-swap group fails before stale-owner tracking', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -147,6 +147,7 @@ describe('WledService', () => {
 						findAll: jest.fn().mockResolvedValue([]),
 						findOneBy: jest.fn(),
 						update: jest.fn(),
+						remove: jest.fn(),
 					},
 				},
 				{
@@ -815,6 +816,65 @@ describe('WledService', () => {
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-2', {
 				state: ConnectionState.DISCONNECTED,
 			});
+		});
+
+		it('removes a newly created device when its dependent move group fails', async () => {
+			const existingDevice = createMockDevice('device-existing', 'wled-aabbccddeeff', '192.168.1.100');
+			const newContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '77:88:99:AA:BB:CC' },
+			};
+			wledAdapter.probe.mockResolvedValueOnce(newContext).mockResolvedValueOnce(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce(createMockDevice('device-new', 'wled-778899aabbcc', '192.168.1.100'))
+				.mockRejectedValueOnce(new Error('Existing move failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'New controller', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.200', name: 'Existing controller', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'failed']);
+			expect(devicesService.remove).toHaveBeenCalledWith('device-new');
+			expect(devicesService.update).toHaveBeenCalledWith(
+				'device-existing',
+				expect.objectContaining({ hostname: '192.168.1.100', enabled: true }),
+			);
+		});
+
+		it('rolls back only the failed connected address-move group', async () => {
+			const devices = [
+				createMockDevice('device-1', 'wled-000000000001', '192.168.1.1'),
+				createMockDevice('device-2', 'wled-000000000002', '192.168.1.2'),
+				createMockDevice('device-3', 'wled-000000000003', '192.168.1.3'),
+				createMockDevice('device-4', 'wled-000000000004', '192.168.1.4'),
+			];
+			const contexts = devices.map((device, index) => ({
+				...mockContext,
+				info: { ...mockContext.info, mac: `00:00:00:00:00:0${index + 1}` },
+			}));
+			wledAdapter.probe
+				.mockResolvedValueOnce(contexts[0])
+				.mockResolvedValueOnce(contexts[1])
+				.mockResolvedValueOnce(contexts[2])
+				.mockResolvedValueOnce(contexts[3]);
+			devicesService.findAll.mockResolvedValue(devices);
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce({ ...devices[0], hostname: '192.168.1.2' } as WledDeviceEntity)
+				.mockResolvedValueOnce({ ...devices[1], hostname: '192.168.1.1' } as WledDeviceEntity)
+				.mockResolvedValueOnce({ ...devices[2], hostname: '192.168.1.4' } as WledDeviceEntity)
+				.mockRejectedValueOnce(new Error('Second group failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.2', name: 'First A', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.1', name: 'First B', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.4', name: 'Second A', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.3', name: 'Second B', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['updated', 'updated', 'failed', 'failed']);
+			expect(devicesService.update.mock.calls.map(([id]) => id)).toEqual(['device-3', 'device-4']);
 		});
 
 		it('rejects a duplicate controller identity within one adoption batch', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -513,6 +513,24 @@ describe('WledService', () => {
 			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
 		});
 
+		it('should make the initial mDNS database lookup failure retryable', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Unknown WLED',
+				host: '192.168.1.200',
+				port: 80,
+			};
+			devicesService.findAll.mockRejectedValueOnce(new Error('Database unavailable'));
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
+			expect(wledAdapter.probe).not.toHaveBeenCalled();
+		});
+
 		it('should reconcile a known MAC at its newly advertised endpoint', async () => {
 			configService.getPluginConfig.mockReturnValue({
 				...mockConfig,
@@ -1528,6 +1546,39 @@ describe('WledService', () => {
 				hostname: '192.168.1.100',
 			});
 			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.100', 'wled-aabbccddeeff', 5000);
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
+		});
+
+		it('restores an offline stale owner snapshot after replacement failure', async () => {
+			const staleDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Offline original',
+			} as WledDeviceEntity;
+			const replacementDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.100');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			wledAdapter.getDevice.mockReturnValue(null);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			devicesService.update.mockResolvedValue(staleDevice);
+			deviceMapper.mapDevice.mockResolvedValue(replacementDevice);
+			deviceConnectivityService.setConnectionState.mockRejectedValueOnce(new Error('Connectivity write failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.update).toHaveBeenLastCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				name: 'Offline original',
+				description: null,
+				enabled: true,
+				hostname: '192.168.1.100',
+			});
+			expect(wledAdapter.connect).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Connectivity write failed' })]);
 		});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -2087,6 +2087,37 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
+		it('adopts a terminal-dot DNS endpoint over its equivalent legacy row', async () => {
+			const legacyDevice = createMockDevice('device-1', null, 'wled.local');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: 'wled.local.',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: 'wled.local.',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: 'wled.local.', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'wled.local.',
+				mockContext,
+				'Legacy strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.remove).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
 		it('marks discovered devices as already adopted by MAC identity', async () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: '192.168.1.200', name: 'Moved WLED', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -73,7 +73,12 @@ describe('WledService', () => {
 		},
 	} as unknown as WledConfigModel;
 
-	const createMockDevice = (id: string, identifier: string, hostname: string, enabled = true): WledDeviceEntity =>
+	const createMockDevice = (
+		id: string,
+		identifier: string | null,
+		hostname: string,
+		enabled = true,
+	): WledDeviceEntity =>
 		({
 			id,
 			type: DEVICES_WLED_TYPE,
@@ -141,6 +146,7 @@ describe('WledService', () => {
 					useValue: {
 						findAll: jest.fn().mockResolvedValue([]),
 						findOneBy: jest.fn(),
+						update: jest.fn(),
 					},
 				},
 				{
@@ -529,6 +535,16 @@ describe('WledService', () => {
 			expect(wledAdapter.connectWithContext).not.toHaveBeenCalled();
 		});
 
+		it('brackets a bare IPv6 host before probing', async () => {
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([]);
+
+			const result = await service.probeDevice('fe80::1234');
+
+			expect(wledAdapter.probe).toHaveBeenCalledWith('[fe80::1234]', 5000);
+			expect(result.host).toBe('[fe80::1234]');
+		});
+
 		it('provisions each device through the mapper and retains partial failures', async () => {
 			wledAdapter.probe.mockResolvedValueOnce(mockContext).mockRejectedValueOnce(new Error('Device offline'));
 			devicesService.findAll.mockResolvedValue([]);
@@ -582,6 +598,36 @@ describe('WledService', () => {
 				mockContext,
 				'Living room',
 				'wled-ddeeff',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-1' })]);
+		});
+
+		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {
+			const legacyDevice = createMockDevice('device-1', null, '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({ ...legacyDevice, identifier: 'wled-aabbccddeeff' } as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '192.168.1.100',
+			});
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Legacy strip',
+				'wled-aabbccddeeff',
 				undefined,
 				undefined,
 			);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1722,6 +1722,37 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
+		it('adopts a mixed-case legacy host-derived identifier in place', async () => {
+			const legacyDevice = createMockDevice('device-1', 'wled-WLED-local', 'WLED.local');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: 'wled.local',
+			} as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...legacyDevice,
+				identifier: 'wled-aabbccddeeff',
+				hostname: 'wled.local',
+			} as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: 'wled.local', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'wled.local',
+				mockContext,
+				'Legacy strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.remove).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
 		it('marks discovered devices as already adopted by MAC identity', async () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: '192.168.1.200', name: 'Moved WLED', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -869,6 +869,40 @@ describe('WledService', () => {
 			});
 		});
 
+		it('continues independent adoption after a dependent rollback write fails', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			const secondContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			const independentContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '77:88:99:AA:BB:CC' },
+			};
+			const independentDevice = createMockDevice('device-3', 'wled-778899aabbcc', '192.168.1.30');
+			wledAdapter.probe
+				.mockResolvedValueOnce(mockContext)
+				.mockResolvedValueOnce(secondContext)
+				.mockResolvedValueOnce(independentContext);
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
+			devicesService.update.mockRejectedValue(new Error('Rollback write failed'));
+			deviceMapper.mapDevice
+				.mockResolvedValueOnce({ ...firstDevice, hostname: '192.168.1.200' } as WledDeviceEntity)
+				.mockRejectedValueOnce(new Error('Second mapping failed'))
+				.mockResolvedValueOnce(independentDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.30', name: 'Independent', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results.map((result) => result.status)).toEqual(['failed', 'failed', 'created']);
+			expect(deviceMapper.mapDevice).toHaveBeenCalledTimes(3);
+			expect(results[2]).toEqual(expect.objectContaining({ deviceId: 'device-3' }));
+		});
+
 		it('removes a newly created device when its dependent move group fails', async () => {
 			const existingDevice = createMockDevice('device-existing', 'wled-aabbccddeeff', '192.168.1.100');
 			const newContext = {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -814,6 +814,10 @@ describe('WledService', () => {
 			const partialDevice = createMockDevice('device-1', 'wled-ddeeff', '192.168.1.100');
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([partialDevice]);
+			devicesService.update.mockResolvedValue({
+				...partialDevice,
+				identifier: 'wled-aabbccddeeff',
+			} as WledDeviceEntity);
 			deviceMapper.mapDevice.mockResolvedValue(partialDevice);
 
 			const results = await service.adoptDevices([
@@ -824,15 +828,28 @@ describe('WledService', () => {
 				'192.168.1.100',
 				mockContext,
 				'Living room',
-				'wled-ddeeff',
+				'wled-aabbccddeeff',
 				undefined,
 				undefined,
 			);
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '192.168.1.100',
+			});
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
 		it('does not reuse a moved legacy short-MAC row for a different full MAC', async () => {
-			const legacyDevice = createMockDevice('device-legacy', 'wled-aabbcc', '192.168.1.100');
+			const legacyDevice = {
+				...createMockDevice('device-legacy', 'wled-aabbcc', '192.168.1.100'),
+				channels: [
+					{
+						identifier: 'device_information',
+						properties: [{ identifier: 'serial_number', value: { value: '77:88:99:AA:BB:CC' } }],
+					},
+				],
+			} as WledDeviceEntity;
 			const collidingContext = {
 				...mockContext,
 				info: { ...mockContext.info, mac: '11:22:33:AA:BB:CC' },
@@ -855,6 +872,42 @@ describe('WledService', () => {
 				undefined,
 			);
 			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-new' })]);
+		});
+
+		it('reuses a moved legacy short-MAC row when its stored serial matches the full MAC', async () => {
+			const legacyDevice = {
+				...createMockDevice('device-legacy', 'wled-ddeeff', '192.168.1.100'),
+				channels: [
+					{
+						identifier: 'device_information',
+						properties: [{ identifier: 'serial_number', value: { value: 'AA:BB:CC:DD:EE:FF' } }],
+					},
+				],
+			} as WledDeviceEntity;
+			const movedDevice = { ...legacyDevice, hostname: '192.168.1.200' } as WledDeviceEntity;
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			devicesService.update.mockResolvedValue({ ...legacyDevice, identifier: 'wled-aabbccddeeff' } as WledDeviceEntity);
+			deviceMapper.mapDevice.mockResolvedValue(movedDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Moved legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.update).toHaveBeenCalledWith('device-legacy', {
+				type: DEVICES_WLED_TYPE,
+				identifier: 'wled-aabbccddeeff',
+				hostname: '192.168.1.200',
+			});
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				mockContext,
+				'Moved legacy strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-legacy' })]);
 		});
 
 		it('updates an adopted MAC when it is discovered at a new host', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -920,6 +920,35 @@ describe('WledService', () => {
 			]);
 		});
 
+		it('serializes overlapping adoption batches before taking their database snapshots', async () => {
+			const createdDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			let finishFirstMapping: ((device: WledDeviceEntity) => void) | undefined;
+			const firstMapping = new Promise<WledDeviceEntity>((resolve) => {
+				finishFirstMapping = resolve;
+			});
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValueOnce([]).mockResolvedValueOnce([createdDevice]);
+			deviceMapper.mapDevice.mockReturnValueOnce(firstMapping).mockResolvedValueOnce(createdDevice);
+
+			const firstAdoption = service.adoptDevices([
+				{ host: '192.168.1.100', name: 'First request', category: DeviceCategory.LIGHTING },
+			]);
+			const secondAdoption = service.adoptDevices([
+				{ host: 'wled.local', name: 'Second request', category: DeviceCategory.LIGHTING },
+			]);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(devicesService.findAll).toHaveBeenCalledTimes(1);
+			finishFirstMapping?.(createdDevice);
+
+			const [firstResults, secondResults] = await Promise.all([firstAdoption, secondAdoption]);
+
+			expect(firstResults[0].status).toBe('created');
+			expect(secondResults[0].status).toBe('updated');
+			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+		});
+
 		it('retires a stale hostname owner after provisioning a different MAC', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {
@@ -974,6 +1003,26 @@ describe('WledService', () => {
 			expect(devicesService.update).not.toHaveBeenCalled();
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
+		});
+
+		it('removes a replacement when stale-owner retirement fails', async () => {
+			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const replacementDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.100');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(replacementDevice);
+			devicesService.update.mockRejectedValueOnce(new Error('Retirement failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.remove).toHaveBeenCalledWith('device-2');
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Retirement failed' })]);
 		});
 
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -649,6 +649,20 @@ describe('WledService', () => {
 			expect(mdnsDiscoverer.start).toHaveBeenCalled();
 		});
 
+		it('clears stale discovery candidates during a rescan when mDNS is disabled', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, enabled: false },
+			} as WledConfigModel);
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([]);
+
+			await service.rescanDiscovery();
+
+			expect(mdnsDiscoverer.clearDiscoveredDevices).toHaveBeenCalled();
+			expect(mdnsDiscoverer.stop).not.toHaveBeenCalled();
+			expect(mdnsDiscoverer.start).not.toHaveBeenCalled();
+		});
+
 		it('probes without registering a connection', async () => {
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			devicesService.findAll.mockResolvedValue([]);
@@ -1747,6 +1761,24 @@ describe('WledService', () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: 'wled.local', name: 'Advertised name', port: 8080 },
 			]);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+
+			const inventory = await service.getDiscoveryInventory();
+
+			expect(inventory.devices[0]).toEqual(
+				expect.objectContaining({
+					name: 'Administrator name',
+					adoptedDeviceId: 'device-1',
+				}),
+			);
+		});
+
+		it('matches a MAC-less discovery hostname case-insensitively', async () => {
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', 'wled.local'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([{ host: 'WLED.local', name: 'Advertised name', port: 80 }]);
 			devicesService.findAll.mockResolvedValue([existingDevice]);
 
 			const inventory = await service.getDiscoveryInventory();

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -442,6 +442,40 @@ describe('WledService', () => {
 			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.200', 'wled-ffeeddccbbaa', 5000);
 		});
 
+		it('should auto-add a device through its advertised non-default port', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Port-qualified WLED',
+				host: 'wled.local',
+				port: 8080,
+				mac: 'FF:EE:DD:CC:BB:AA',
+			};
+			const registeredDevice = {
+				host: 'wled.local:8080',
+				identifier: 'wled-ffeeddccbbaa',
+				connected: true,
+				context: mockContext,
+			} as RegisteredWledDevice;
+			devicesService.findAll.mockResolvedValue([]);
+			wledAdapter.connect.mockResolvedValue(undefined);
+			wledAdapter.getDevice.mockReturnValue(registeredDevice);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-ffeeddccbbaa', 'wled.local:8080'));
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(wledAdapter.connect).toHaveBeenCalledWith('wled.local:8080', 'wled-ffeeddccbbaa', 5000);
+			expect(wledAdapter.getDevice).toHaveBeenCalledWith('wled.local:8080');
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'wled.local:8080',
+				mockContext,
+				'Port-qualified WLED',
+				'wled-ffeeddccbbaa',
+			);
+		});
+
 		it('should not auto-add device when autoAdd is disabled', async () => {
 			const discoveredDevice: WledMdnsDiscoveredDevice = {
 				name: 'Discovered WLED',
@@ -1050,7 +1084,10 @@ describe('WledService', () => {
 			const autoAddMapping = new Promise<WledDeviceEntity>((resolve) => {
 				finishAutoAdd = resolve;
 			});
-			devicesService.findAll.mockResolvedValueOnce([]).mockResolvedValueOnce([autoAddedDevice]);
+			devicesService.findAll
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([autoAddedDevice]);
 			wledAdapter.connect.mockResolvedValue(undefined);
 			wledAdapter.probe.mockResolvedValue(mockContext);
 			wledAdapter.getDevice.mockReturnValue({
@@ -1070,15 +1107,63 @@ describe('WledService', () => {
 			await Promise.resolve();
 			await Promise.resolve();
 
-			expect(devicesService.findAll).toHaveBeenCalledTimes(1);
+			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
 			finishAutoAdd?.(autoAddedDevice);
 
 			await autoAdd;
 			const results = await adoption;
 
-			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+			expect(devicesService.findAll).toHaveBeenCalledTimes(3);
 			expect(devicesService.remove).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('rechecks mDNS auto-add eligibility after a queued adoption finishes', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const adoptedDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Advertised name',
+				host: '192.168.1.100',
+				port: 80,
+				mac: 'AA:BB:CC:DD:EE:FF',
+			};
+			let finishProbe: ((context: WledDeviceContext) => void) | undefined;
+			const pendingProbe = new Promise<WledDeviceContext>((resolve) => {
+				finishProbe = resolve;
+			});
+			wledAdapter.probe.mockReturnValue(pendingProbe);
+			wledAdapter.isConnected.mockReturnValue(true);
+			devicesService.findAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([adoptedDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(adoptedDevice);
+
+			const adoption = service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Administrator name', category: DeviceCategory.LIGHTING },
+			]);
+			await Promise.resolve();
+			await Promise.resolve();
+			const autoAdd = mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			finishProbe?.(mockContext);
+			const [results] = await Promise.all([adoption, autoAdd]);
+
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-1' })]);
+			expect(deviceMapper.mapDevice).toHaveBeenCalledTimes(1);
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Administrator name',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
 		});
 
 		it('retires a stale hostname owner after provisioning a different MAC', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -894,7 +894,7 @@ describe('WledService', () => {
 				expect.objectContaining({
 					host: '192.168.1.100',
 					name: 'Probed WLED',
-					mac: 'AA:BB:CC:DD:EE:FF',
+					mac: 'aabbccddeeff',
 					adoptedDeviceId: null,
 				}),
 			);
@@ -917,6 +917,19 @@ describe('WledService', () => {
 					adoptedDeviceId: 'device-1',
 				}),
 			);
+		});
+
+		it('rejects a manual probe whose controller reports a malformed MAC', async () => {
+			wledAdapter.probe.mockResolvedValue({
+				...mockContext,
+				info: { ...mockContext.info, mac: 'not-a-mac' },
+			});
+
+			await expect(service.probeDevice('192.168.1.100')).rejects.toThrow(
+				'WLED device did not report a valid MAC address',
+			);
+
+			expect(devicesService.findAll).not.toHaveBeenCalled();
 		});
 
 		it('brackets a bare IPv6 host before probing', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -620,6 +620,21 @@ describe('WledService', () => {
 			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
 		});
 
+		it('should make a failed MAC-less identity probe retryable when auto-add is disabled', async () => {
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Temporarily offline WLED',
+				host: '192.168.1.200',
+				port: 80,
+			};
+			devicesService.findAll.mockResolvedValue([]);
+			wledAdapter.probe.mockRejectedValue(new Error('Device offline'));
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(mdnsDiscoverer.forgetDiscoveredDevice).toHaveBeenCalledWith('192.168.1.200');
+			expect(deviceMapper.mapDevice).not.toHaveBeenCalled();
+		});
+
 		it('should not auto-add device when autoAdd is disabled', async () => {
 			const discoveredDevice: WledMdnsDiscoveredDevice = {
 				name: 'Discovered WLED',

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -601,7 +601,60 @@ describe('WledService', () => {
 				undefined,
 				undefined,
 			);
-			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-1' })]);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('updates an adopted MAC when it is discovered at a new host', async () => {
+			const existingDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			deviceMapper.mapDevice.mockResolvedValue({ ...existingDevice, hostname: '192.168.1.200' } as WledDeviceEntity);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'Moved strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				mockContext,
+				'Moved strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
+		it('retires a stale hostname owner before provisioning a different MAC', async () => {
+			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-2', 'wled-112233445566', '192.168.1.100'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100');
+			expect(devicesService.update).toHaveBeenCalledWith('device-1', {
+				type: DEVICES_WLED_TYPE,
+				enabled: false,
+				hostname: null,
+			});
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				replacementContext,
+				'Replacement strip',
+				'wled-112233445566',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-2' })]);
 		});
 
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {
@@ -631,7 +684,7 @@ describe('WledService', () => {
 				undefined,
 				undefined,
 			);
-			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-1' })]);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
 		it('marks discovered devices as already adopted by MAC identity', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1366,6 +1366,27 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});
 
+		it('adopts a raw host-derived identifier stored with a non-default port', async () => {
+			const legacyDevice = createMockDevice('device-1', 'wled-wled-local', 'wled.local:8080');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([legacyDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(legacyDevice);
+
+			const results = await service.adoptDevices([
+				{ host: 'wled.local:8080', name: 'Legacy strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'wled.local:8080',
+				mockContext,
+				'Legacy strip',
+				'wled-wled-local',
+				undefined,
+				undefined,
+			);
+			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
+		});
+
 		it('marks discovered devices as already adopted by MAC identity', async () => {
 			mdnsDiscoverer.getDiscoveredDevices.mockReturnValue([
 				{ host: '192.168.1.200', name: 'Moved WLED', mac: 'AA:BB:CC:DD:EE:FF', port: 80 },

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -280,6 +280,35 @@ describe('WledService', () => {
 			});
 		});
 
+		it('should disconnect and skip state sync when startup identity conflicts', async () => {
+			const mockDevice = {
+				...createMockDevice('device-1', 'wled-test', '192.168.1.100'),
+				mac: 'aabbccddeeff',
+			} as WledDeviceEntity;
+			devicesService.findAll.mockResolvedValue([mockDevice]);
+			wledAdapter.connect.mockResolvedValue(undefined);
+			wledAdapter.getDevice.mockReturnValue({
+				host: mockDevice.hostname,
+				identifier: mockDevice.identifier,
+				connected: true,
+				enabled: true,
+				context: {
+					...mockContext,
+					info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+				},
+			} as RegisteredWledDevice);
+			hardwareIdentity.persist.mockResolvedValueOnce('conflict');
+
+			await service.start();
+
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith(mockDevice.hostname, false);
+			expect(deviceMapper.updateDeviceState).not.toHaveBeenCalled();
+			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith(
+				mockDevice.identifier,
+				ConnectionState.DISCONNECTED,
+			);
+		});
+
 		it('should not start if already started', async () => {
 			wledAdapter.connect.mockResolvedValue(undefined);
 			wledAdapter.getDevice.mockReturnValue(null);
@@ -438,6 +467,30 @@ describe('WledService', () => {
 
 			expect(hardwareIdentity.persist).toHaveBeenCalledWith(storedDevice, 'aabbccddeeff');
 			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.DISCONNECTED);
+		});
+
+		it('should disconnect a durable device when reconnect reports a malformed hardware identity', async () => {
+			const storedDevice = {
+				...createMockDevice('device-1', 'custom-strip', '192.168.1.100'),
+				mac: 'aabbccddeeff',
+			} as WledDeviceEntity;
+			const event: WledDeviceConnectedEvent = {
+				host: '192.168.1.100',
+				info: { name: 'Replacement WLED', mac: 'not-a-mac' } as WledInfo,
+			};
+			wledAdapter.getDevice.mockReturnValue({
+				host: event.host,
+				identifier: 'custom-strip',
+				connected: true,
+				enabled: true,
+			} as RegisteredWledDevice);
+			devicesService.findOneBy.mockResolvedValue(storedDevice);
+
+			await adapterCallbacks.onDeviceConnected?.(event);
+
+			expect(hardwareIdentity.persist).not.toHaveBeenCalled();
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith(event.host, false);
 			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.DISCONNECTED);
 		});
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -416,6 +416,31 @@ describe('WledService', () => {
 			});
 		});
 
+		it('should skip duplicate hardware identity persistence without rejecting the connected callback', async () => {
+			const storedDevice = createMockDevice('device-legacy', 'custom-strip', '192.168.1.100');
+			const existingOwner = {
+				...createMockDevice('device-canonical', 'wled-aabbccddeeff', '192.168.1.200'),
+				mac: 'aabbccddeeff',
+			} as WledDeviceEntity;
+			const event: WledDeviceConnectedEvent = {
+				host: '192.168.1.100',
+				info: { name: 'Test WLED', mac: 'AA:BB:CC:DD:EE:FF' } as WledInfo,
+			};
+			wledAdapter.getDevice.mockReturnValue({
+				host: '192.168.1.100',
+				identifier: 'custom-strip',
+				connected: true,
+				enabled: true,
+			} as RegisteredWledDevice);
+			devicesService.findOneBy.mockResolvedValue(storedDevice);
+			devicesService.findAll.mockResolvedValue([storedDevice, existingOwner]);
+
+			await expect(adapterCallbacks.onDeviceConnected?.(event)).resolves.toBeUndefined();
+
+			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(deviceMapper.setDeviceConnectionState).toHaveBeenCalledWith('custom-strip', ConnectionState.CONNECTED);
+		});
+
 		it('should set connection state to DISCONNECTED on device disconnected', async () => {
 			const event: WledDeviceDisconnectedEvent = {
 				host: '192.168.1.100',

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -421,25 +421,23 @@ describe('WledService', () => {
 				port: 80,
 				mac: 'FF:EE:DD:CC:BB:AA',
 			};
+			const discoveredContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: 'FF:EE:DD:CC:BB:AA' },
+			};
 
 			devicesService.findAll.mockResolvedValue([]);
-			wledAdapter.connect.mockResolvedValue(undefined);
-			wledAdapter.getDevice.mockReturnValue({
-				host: '192.168.1.200',
-				identifier: 'wled-ffeeddccbbaa',
-				connected: true,
-				enabled: true,
-				context: {
-					state: { on: true, brightness: 128, segments: [] },
-					info: { mac: 'FF:EE:DD:CC:BB:AA' },
-					effects: [],
-					palettes: [],
-				},
-			} as RegisteredWledDevice);
+			wledAdapter.probe.mockResolvedValue(discoveredContext);
+			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-ffeeddccbbaa', '192.168.1.200'));
 
 			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
 
-			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.200', 'wled-ffeeddccbbaa', 5000);
+			expect(wledAdapter.probe).toHaveBeenCalledWith('192.168.1.200', 5000);
+			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith(
+				'192.168.1.200',
+				'wled-ffeeddccbbaa',
+				discoveredContext,
+			);
 		});
 
 		it('should auto-add a device through its advertised non-default port', async () => {
@@ -453,27 +451,71 @@ describe('WledService', () => {
 				port: 8080,
 				mac: 'FF:EE:DD:CC:BB:AA',
 			};
-			const registeredDevice = {
-				host: 'wled.local:8080',
-				identifier: 'wled-ffeeddccbbaa',
-				connected: true,
-				context: mockContext,
-			} as RegisteredWledDevice;
+			const discoveredContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: 'FF:EE:DD:CC:BB:AA' },
+			};
 			devicesService.findAll.mockResolvedValue([]);
-			wledAdapter.connect.mockResolvedValue(undefined);
-			wledAdapter.getDevice.mockReturnValue(registeredDevice);
+			wledAdapter.probe.mockResolvedValue(discoveredContext);
 			deviceMapper.mapDevice.mockResolvedValue(createMockDevice('device-1', 'wled-ffeeddccbbaa', 'wled.local:8080'));
 
 			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
 
-			expect(wledAdapter.connect).toHaveBeenCalledWith('wled.local:8080', 'wled-ffeeddccbbaa', 5000);
-			expect(wledAdapter.getDevice).toHaveBeenCalledWith('wled.local:8080');
+			expect(wledAdapter.probe).toHaveBeenCalledWith('wled.local:8080', 5000);
+			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith(
+				'wled.local:8080',
+				'wled-ffeeddccbbaa',
+				discoveredContext,
+			);
 			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
 				'wled.local:8080',
-				mockContext,
+				discoveredContext,
 				'Port-qualified WLED',
 				'wled-ffeeddccbbaa',
+				undefined,
+				undefined,
 			);
+		});
+
+		it('should reconcile a known MAC at its newly advertised endpoint', async () => {
+			configService.getPluginConfig.mockReturnValue({
+				...mockConfig,
+				mdns: { ...(mockConfig as WledConfigModel).mdns, autoAdd: true },
+			} as WledConfigModel);
+			const existingDevice = {
+				...createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100'),
+				name: 'Administrator name',
+			} as WledDeviceEntity;
+			const discoveredDevice: WledMdnsDiscoveredDevice = {
+				name: 'Advertised name',
+				host: '192.168.1.200',
+				port: 80,
+				mac: 'AA:BB:CC:DD:EE:FF',
+			};
+			devicesService.findAll.mockResolvedValue([existingDevice]);
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			wledAdapter.getDevice.mockReturnValueOnce({
+				host: '192.168.1.100',
+				identifier: 'wled-aabbccddeeff',
+				connected: true,
+			} as RegisteredWledDevice);
+			deviceMapper.mapDevice.mockResolvedValue({
+				...existingDevice,
+				hostname: '192.168.1.200',
+			} as WledDeviceEntity);
+
+			await mdnsCallbacks.onDeviceDiscovered?.(discoveredDevice);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.200',
+				mockContext,
+				'Administrator name',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(wledAdapter.disconnect).toHaveBeenCalledWith('192.168.1.100', false);
+			expect(wledAdapter.connectWithContext).toHaveBeenCalledWith('192.168.1.200', 'wled-aabbccddeeff', mockContext);
 		});
 
 		it('should not auto-add device when autoAdd is disabled', async () => {
@@ -903,6 +945,31 @@ describe('WledService', () => {
 			});
 		});
 
+		it('does not retire a selected address owner when its swap probe fails', async () => {
+			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
+			wledAdapter.probe
+				.mockResolvedValueOnce(mockContext)
+				.mockRejectedValueOnce(new Error('Second controller offline'));
+			devicesService.findAll.mockResolvedValue([firstDevice, secondDevice]);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.200', name: 'First moved', category: DeviceCategory.LIGHTING },
+				{ host: '192.168.1.100', name: 'Second moved', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(results).toEqual([
+				expect.objectContaining({
+					status: 'failed',
+					error: 'A related selected WLED controller could not be probed',
+				}),
+				expect.objectContaining({ status: 'failed', error: 'Second controller offline' }),
+			]);
+			expect(deviceMapper.mapDevice).not.toHaveBeenCalled();
+			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
+		});
+
 		it('continues independent adoption after a dependent rollback write fails', async () => {
 			const firstDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const secondDevice = createMockDevice('device-2', 'wled-112233445566', '192.168.1.200');
@@ -1087,6 +1154,7 @@ describe('WledService', () => {
 			devicesService.findAll
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([autoAddedDevice]);
 			wledAdapter.connect.mockResolvedValue(undefined);
 			wledAdapter.probe.mockResolvedValue(mockContext);
@@ -1107,13 +1175,13 @@ describe('WledService', () => {
 			await Promise.resolve();
 			await Promise.resolve();
 
-			expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+			expect(devicesService.findAll).toHaveBeenCalledTimes(3);
 			finishAutoAdd?.(autoAddedDevice);
 
 			await autoAdd;
 			const results = await adoption;
 
-			expect(devicesService.findAll).toHaveBeenCalledTimes(3);
+			expect(devicesService.findAll).toHaveBeenCalledTimes(4);
 			expect(devicesService.remove).not.toHaveBeenCalled();
 			expect(results).toEqual([expect.objectContaining({ status: 'updated', deviceId: 'device-1' })]);
 		});

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -734,7 +734,7 @@ describe('WledService', () => {
 			]);
 		});
 
-		it('retires a stale hostname owner before provisioning a different MAC', async () => {
+		it('retires a stale hostname owner after provisioning a different MAC', async () => {
 			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
 			const replacementContext = {
 				...mockContext,
@@ -754,6 +754,9 @@ describe('WledService', () => {
 				enabled: false,
 				hostname: null,
 			});
+			expect(deviceMapper.mapDevice.mock.invocationCallOrder[0]).toBeLessThan(
+				devicesService.update.mock.invocationCallOrder[0],
+			);
 			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
 				'192.168.1.100',
 				replacementContext,
@@ -763,6 +766,24 @@ describe('WledService', () => {
 				undefined,
 			);
 			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-2' })]);
+		});
+
+		it('does not retire a stale hostname owner when replacement provisioning fails', async () => {
+			const staleDevice = createMockDevice('device-1', 'wled-aabbccddeeff', '192.168.1.100');
+			const replacementContext = {
+				...mockContext,
+				info: { ...mockContext.info, mac: '11:22:33:44:55:66' },
+			};
+			wledAdapter.probe.mockResolvedValue(replacementContext);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockRejectedValue(new Error('Provisioning failed'));
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(devicesService.update).not.toHaveBeenCalled();
+			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -1061,6 +1061,42 @@ describe('WledService', () => {
 			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-new' })]);
 		});
 
+		it('does not reuse a null-identifier endpoint whose stored serial contradicts the probed MAC', async () => {
+			const staleDevice = {
+				...createMockDevice('device-stale', null, '192.168.1.100'),
+				mac: null,
+				channels: [
+					{
+						identifier: 'device_information',
+						properties: [{ identifier: 'serial_number', value: { value: '77:88:99:AA:BB:CC' } }],
+					},
+				],
+			} as WledDeviceEntity;
+			const createdDevice = createMockDevice('device-new', 'wled-aabbccddeeff', '192.168.1.100');
+			wledAdapter.probe.mockResolvedValue(mockContext);
+			devicesService.findAll.mockResolvedValue([staleDevice]);
+			deviceMapper.mapDevice.mockResolvedValue(createdDevice);
+
+			const results = await service.adoptDevices([
+				{ host: '192.168.1.100', name: 'Replacement strip', category: DeviceCategory.LIGHTING },
+			]);
+
+			expect(deviceMapper.mapDevice).toHaveBeenCalledWith(
+				'192.168.1.100',
+				mockContext,
+				'Replacement strip',
+				'wled-aabbccddeeff',
+				undefined,
+				undefined,
+			);
+			expect(devicesService.update).toHaveBeenCalledWith('device-stale', {
+				type: DEVICES_WLED_TYPE,
+				enabled: false,
+				hostname: null,
+			});
+			expect(results).toEqual([expect.objectContaining({ status: 'created', deviceId: 'device-new' })]);
+		});
+
 		it('reuses a moved legacy short-MAC row when its stored serial matches the full MAC', async () => {
 			const legacyDevice = {
 				...createMockDevice('device-legacy', 'wled-ddeeff', '192.168.1.100'),

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '../interfaces/wled.interface';
 import { WledConfigModel } from '../models/config.model';
 
+import { WledAdoptionSnapshotService } from './adoption-snapshot.service';
 import { WledDeviceMapperService } from './device-mapper.service';
 import { WledClientAdapterService } from './wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './wled-mdns-discoverer.service';
@@ -38,6 +39,7 @@ describe('WledService', () => {
 	let configService: jest.Mocked<ConfigService>;
 	let wledAdapter: jest.Mocked<WledClientAdapterService>;
 	let deviceMapper: jest.Mocked<WledDeviceMapperService>;
+	let adoptionSnapshot: jest.Mocked<WledAdoptionSnapshotService>;
 	let devicesService: jest.Mocked<DevicesService>;
 	let mdnsDiscoverer: jest.Mocked<WledMdnsDiscovererService>;
 	let deviceConnectivityService: jest.Mocked<DeviceConnectivityService>;
@@ -142,6 +144,19 @@ describe('WledService', () => {
 					},
 				},
 				{
+					provide: WledAdoptionSnapshotService,
+					useValue: {
+						capture: jest.fn().mockImplementation((deviceId: string) =>
+							Promise.resolve({
+								deviceId,
+								channels: [],
+								properties: [],
+							}),
+						),
+						restore: jest.fn(),
+					},
+				},
+				{
 					provide: DevicesService,
 					useValue: {
 						findAll: jest.fn().mockResolvedValue([]),
@@ -183,6 +198,7 @@ describe('WledService', () => {
 		configService = module.get(ConfigService);
 		wledAdapter = module.get(WledClientAdapterService);
 		deviceMapper = module.get(WledDeviceMapperService);
+		adoptionSnapshot = module.get(WledAdoptionSnapshotService);
 		devicesService = module.get(DevicesService);
 		mdnsDiscoverer = module.get(WledMdnsDiscovererService);
 		deviceConnectivityService = module.get(DeviceConnectivityService);
@@ -866,6 +882,7 @@ describe('WledService', () => {
 
 			expect(wledAdapter.disconnect).not.toHaveBeenCalled();
 			expect(deviceConnectivityService.setConnectionState).not.toHaveBeenCalled();
+			expect(adoptionSnapshot.restore).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'device-1' }));
 			expect(results).toEqual([expect.objectContaining({ status: 'failed', error: 'Provisioning failed' })]);
 		});
 
@@ -1046,6 +1063,7 @@ describe('WledService', () => {
 			expect(deviceConnectivityService.setConnectionState).toHaveBeenCalledWith('device-2', {
 				state: ConnectionState.CONNECTED,
 			});
+			expect(adoptionSnapshot.restore).toHaveBeenCalledTimes(2);
 		});
 
 		it('does not retire a selected address owner when its swap probe fails', async () => {
@@ -1628,7 +1646,7 @@ describe('WledService', () => {
 				enabled: true,
 				hostname: '192.168.1.200',
 			});
-			expect(wledAdapter.connect).toHaveBeenCalledWith('192.168.1.200', 'wled-778899aabbcc', 5000);
+			expect(wledAdapter.connect).not.toHaveBeenCalledWith('192.168.1.200', 'wled-778899aabbcc', 5000);
 		});
 
 		it('upgrades a legacy same-host device without an identifier before provisioning', async () => {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -564,9 +564,10 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	async rescanDiscovery(): Promise<WledDiscoveryModel> {
+		this.mdnsDiscoverer.clearDiscoveredDevices();
+
 		if (this.config.mdns.enabled) {
 			this.mdnsDiscoverer.stop();
-			this.mdnsDiscoverer.clearDiscoveredDevices();
 			this.mdnsDiscoverer.start(this.config.mdns.interface ?? undefined);
 		}
 
@@ -1151,7 +1152,7 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	private canonicalEndpoint(endpoint: string): string {
-		const trimmed = endpoint.trim();
+		const trimmed = endpoint.trim().toLowerCase();
 		const bracketedIpv6 = trimmed.match(/^\[([^\]]+)](?::(\d+))?$/);
 		if (bracketedIpv6) {
 			const [, address, port] = bracketedIpv6;

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -459,11 +459,7 @@ export class WledService extends BaseManagedPluginService {
 
 			// Reconcile a known MAC at a new endpoint through the same guarded
 			// provisioning path as administrator adoption.
-			if (
-				existingDevice.hostname &&
-				!this.endpointsEquivalent(existingDevice.hostname, endpoint) &&
-				this.config.mdns.autoAdd
-			) {
+			if (existingDevice.hostname && !this.endpointsEquivalent(existingDevice.hostname, endpoint)) {
 				await this.connectAndMapDiscoveredDevice(device);
 			} else if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 				this.logger.debug(`Connecting to existing device at ${endpoint}`);
@@ -1155,7 +1151,12 @@ export class WledService extends BaseManagedPluginService {
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
-					devices.find((device) => device.identifier === legacyIdentifier) ??
+					devices.find(
+						(device) =>
+							device.identifier === legacyIdentifier &&
+							device.hostname !== null &&
+							this.endpointsEquivalent(device.hostname, host),
+					) ??
 					devices.find(
 						(device) =>
 							device.identifier !== null &&

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -752,6 +752,7 @@ export class WledService extends BaseManagedPluginService {
 
 			let mappedDevice: WledDeviceEntity | null = null;
 			let existingDeviceDisconnected = false;
+			let attemptedRegistrationCreated = false;
 			const retiredStaleOwners: WledDeviceEntity[] = [];
 			const disconnectedStaleOwners: WledDeviceEntity[] = [];
 
@@ -852,6 +853,7 @@ export class WledService extends BaseManagedPluginService {
 					} else {
 						try {
 							this.wledAdapter.connectWithContext(host, identifier, context);
+							attemptedRegistrationCreated = true;
 							connectionState = ConnectionState.CONNECTED;
 						} catch (error) {
 							this.logger.warn(
@@ -961,10 +963,7 @@ export class WledService extends BaseManagedPluginService {
 						}
 					}
 				} else {
-					const attemptedRegistration = this.wledAdapter.getDevice(host);
-					const attemptedHostDisconnected =
-						attemptedRegistration?.host === host && attemptedRegistration.identifier === identifier;
-					if (attemptedHostDisconnected) {
+					if (attemptedRegistrationCreated) {
 						await this.tryRollback(`disconnect ${host}`, () =>
 							Promise.resolve(this.wledAdapter.disconnect(host, false)),
 						);
@@ -994,7 +993,7 @@ export class WledService extends BaseManagedPluginService {
 								hostname: existingDevice.hostname,
 							}),
 						);
-						if (existingDeviceDisconnected || attemptedHostDisconnected) {
+						if (existingDeviceDisconnected || attemptedRegistrationCreated) {
 							await this.tryRollback(`reconnect device ${existingDevice.id}`, () =>
 								this.restoreDeviceConnection(existingDevice),
 							);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -1022,18 +1022,28 @@ export class WledService extends BaseManagedPluginService {
 			if (normalizedMac.length === 12) {
 				const canonicalIdentifier = `wled-${normalizedMac}`;
 				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
-				const legacyHostIdentifier = `wled-${host.replace(/\./g, '-')}`;
+				const legacyHostIdentifiers = this.legacyHostIdentifiers(host);
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
 					devices.find((device) => device.identifier === legacyIdentifier) ??
-					devices.find((device) => device.identifier === legacyHostIdentifier && device.hostname === host) ??
+					devices.find(
+						(device) =>
+							device.identifier !== null && legacyHostIdentifiers.has(device.identifier) && device.hostname === host,
+					) ??
 					devices.find((device) => device.identifier === null && device.hostname === host)
 				);
 			}
 		}
 
 		return devices.find((device) => device.hostname === host);
+	}
+
+	private legacyHostIdentifiers(endpoint: string): Set<string> {
+		const bracketedHost = endpoint.match(/^\[([^\]]+)](?::\d+)?$/)?.[1];
+		const rawHost = bracketedHost ?? endpoint.replace(/:\d+$/, '');
+
+		return new Set([endpoint, rawHost].map((host) => `wled-${host.replace(/\./g, '-')}`));
 	}
 
 	private portFromHost(host: string): number {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -13,6 +13,8 @@ import {
 } from '../../../modules/extensions/services/managed-plugin-service.interface';
 import { PluginServiceManagerService } from '../../../modules/extensions/services/plugin-service-manager.service';
 import { DEVICES_WLED_PLUGIN_NAME, DEVICES_WLED_TYPE } from '../devices-wled.constants';
+import { WledValidationException } from '../devices-wled.exceptions';
+import { WledAdoptDeviceDto } from '../dto/wled-adoption.dto';
 import { WledDeviceEntity } from '../entities/devices-wled.entity';
 import {
 	WledDeviceConnectedEvent,
@@ -22,6 +24,7 @@ import {
 	WledMdnsDiscoveredDevice,
 } from '../interfaces/wled.interface';
 import { WledConfigModel } from '../models/config.model';
+import { WledAdoptionResultModel, WledDiscoveredDeviceModel, WledDiscoveryModel } from '../models/wled-discovery.model';
 
 import { WledDeviceMapperService } from './device-mapper.service';
 import { WledClientAdapterService } from './wled-client-adapter.service';
@@ -460,11 +463,8 @@ export class WledService extends BaseManagedPluginService {
 	 * Connect to a newly discovered device and map it to the database
 	 */
 	private async connectAndMapDiscoveredDevice(device: WledMdnsDiscoveredDevice): Promise<void> {
-		const identifier = device.mac
-			? `wled-${device.mac.replace(/:/g, '').toLowerCase()}`
-			: `wled-${device.host.replace(/\./g, '-')}`;
-
 		try {
+			const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
 			await this.wledAdapter.connect(device.host, identifier, this.config.timeouts.connectionTimeout);
 
 			const registeredDevice = this.wledAdapter.getDevice(device.host);
@@ -486,6 +486,99 @@ export class WledService extends BaseManagedPluginService {
 		return this.mdnsDiscoverer.getDiscoveredDevices();
 	}
 
+	async getDiscoveryInventory(): Promise<WledDiscoveryModel> {
+		const [discoveredDevices, databaseDevices] = await Promise.all([
+			Promise.resolve(this.mdnsDiscoverer.getDiscoveredDevices()),
+			this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE),
+		]);
+
+		return {
+			mdnsEnabled: this.config.mdns.enabled,
+			discoveryRunning: this.mdnsDiscoverer.isDiscoveryRunning(),
+			devices: discoveredDevices.map((device) => ({
+				host: device.host,
+				name: device.name,
+				mac: device.mac ?? null,
+				port: device.port,
+				adoptedDeviceId: this.findExistingDevice(databaseDevices, device.host, device.mac)?.id ?? null,
+			})),
+		};
+	}
+
+	async probeDevice(host: string): Promise<WledDiscoveredDeviceModel> {
+		const normalizedHost = this.normalizeHost(host);
+		const context = await this.wledAdapter.probe(normalizedHost, this.config.timeouts.connectionTimeout);
+		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+
+		return {
+			host: normalizedHost,
+			name: context.info.name || `WLED ${context.info.mac}`,
+			mac: context.info.mac,
+			port: this.portFromHost(normalizedHost),
+			adoptedDeviceId: this.findExistingDevice(databaseDevices, normalizedHost, context.info.mac)?.id ?? null,
+		};
+	}
+
+	async rescanDiscovery(): Promise<WledDiscoveryModel> {
+		if (this.config.mdns.enabled) {
+			this.mdnsDiscoverer.stop();
+			this.mdnsDiscoverer.clearDiscoveredDevices();
+			this.mdnsDiscoverer.start(this.config.mdns.interface ?? undefined);
+		}
+
+		return this.getDiscoveryInventory();
+	}
+
+	async adoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
+		const results: WledAdoptionResultModel[] = [];
+
+		for (const request of requests) {
+			let host = request.host.trim();
+
+			try {
+				host = this.normalizeHost(request.host);
+				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
+				const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
+
+				if (existingDevice) {
+					throw new Error(`WLED device is already adopted as ${existingDevice.name}`);
+				}
+
+				const identifier = this.identifierFromMac(context.info.mac);
+				const device = await this.deviceMapper.mapDevice(
+					host,
+					context,
+					request.name,
+					identifier,
+					request.description,
+					request.enabled,
+				);
+				if (device.enabled) {
+					try {
+						this.wledAdapter.connectWithContext(host, identifier, context);
+					} catch (error) {
+						this.logger.warn(`WLED device ${identifier} was adopted but its live connection could not be registered`, {
+							resource: device.id,
+							message: error instanceof Error ? error.message : String(error),
+						});
+					}
+				}
+				results.push({ host, name: request.name, status: 'created', error: null, deviceId: device.id });
+			} catch (error) {
+				results.push({
+					host,
+					name: request.name,
+					status: 'failed',
+					error: error instanceof Error ? error.message : String(error),
+					deviceId: null,
+				});
+			}
+		}
+
+		return results;
+	}
+
 	/**
 	 * Get discovered devices that haven't been added to the database yet
 	 */
@@ -498,6 +591,61 @@ export class WledService extends BaseManagedPluginService {
 
 		// Filter out devices that are already in the database
 		return discoveredDevices.filter((device) => !existingHostnames.has(device.host));
+	}
+
+	private normalizeHost(host: string): string {
+		const trimmed = host.trim();
+		if (!trimmed) {
+			throw new WledValidationException('WLED hostname or IP address is required');
+		}
+
+		if (/^https?:\/\//i.test(trimmed)) {
+			let url: URL;
+			try {
+				url = new URL(trimmed);
+			} catch {
+				throw new WledValidationException('WLED address must be a valid hostname or IP address');
+			}
+			if (url.pathname !== '/' || url.search || url.hash) {
+				throw new WledValidationException('WLED address must not include a path, query, or fragment');
+			}
+			return url.host;
+		}
+
+		if (trimmed.includes('/') || trimmed.includes('?') || trimmed.includes('#')) {
+			throw new WledValidationException('WLED address must be a hostname or IP address');
+		}
+
+		return trimmed;
+	}
+
+	private identifierFromMac(mac: string): string {
+		const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+		if (!normalizedMac) {
+			throw new WledValidationException('WLED device did not report a valid MAC address');
+		}
+
+		return `wled-${normalizedMac}`;
+	}
+
+	private findExistingDevice(
+		devices: WledDeviceEntity[],
+		host: string,
+		mac?: string | null,
+	): WledDeviceEntity | undefined {
+		const identifiers = new Set<string>();
+		if (mac) {
+			const fullIdentifier = this.identifierFromMac(mac);
+			identifiers.add(fullIdentifier);
+			identifiers.add(`wled-${fullIdentifier.slice(-6)}`);
+		}
+
+		return devices.find((device) => device.hostname === host || identifiers.has(device.identifier));
+	}
+
+	private portFromHost(host: string): number {
+		const port = Number(host.match(/:(\d+)$/)?.[1] ?? 80);
+		return Number.isInteger(port) && port > 0 && port <= 65535 ? port : 80;
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -620,6 +620,8 @@ export class WledService extends BaseManagedPluginService {
 					const registeredDevice = this.wledAdapter.getDevice(host);
 
 					if (registeredDevice?.identifier === identifier && registeredDevice.connected) {
+						registeredDevice.context = context;
+						registeredDevice.lastSeen = new Date();
 						results[index] = {
 							host,
 							name: request.name,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -35,6 +35,7 @@ import { WledAdoptionResultModel, WledDiscoveredDeviceModel, WledDiscoveryModel 
 
 import { WledAdoptionSnapshotService, WledAdoptionStructureSnapshot } from './adoption-snapshot.service';
 import { WledDeviceMapperService } from './device-mapper.service';
+import { WledHardwareIdentityService } from './hardware-identity.service';
 import { WledClientAdapterService } from './wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './wled-mdns-discoverer.service';
 
@@ -61,6 +62,7 @@ export class WledService extends BaseManagedPluginService {
 		private readonly wledAdapter: WledClientAdapterService,
 		private readonly deviceMapper: WledDeviceMapperService,
 		private readonly adoptionSnapshot: WledAdoptionSnapshotService,
+		private readonly hardwareIdentity: WledHardwareIdentityService,
 		private readonly devicesService: DevicesService,
 		private readonly mdnsDiscoverer: WledMdnsDiscovererService,
 		private readonly deviceConnectivityService: DeviceConnectivityService,
@@ -345,19 +347,12 @@ export class WledService extends BaseManagedPluginService {
 		if (!mac || device.mac === mac) {
 			return;
 		}
-		const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
-		const existingOwner = devices.find((candidate) => candidate.id !== device.id && candidate.mac === mac);
-		if (existingOwner) {
-			this.logger.warn(`WLED hardware identity ${mac} is already owned by device ${existingOwner.id}`, {
+		const result = await this.hardwareIdentity.persist(device, mac);
+		if (result === 'conflict') {
+			this.logger.warn(`WLED hardware identity ${mac} is already owned by another device`, {
 				resource: device.id,
 			});
-			return;
 		}
-
-		await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(device.id, {
-			type: DEVICES_WLED_TYPE,
-			mac,
-		});
 	}
 
 	/**
@@ -605,7 +600,7 @@ export class WledService extends BaseManagedPluginService {
 				return {
 					host: device.host,
 					name: existingDevice?.name ?? device.name,
-					mac: device.mac ?? null,
+					mac: this.normalizeMac(device.mac),
 					port: device.port,
 					adoptedDeviceId: existingDevice?.id ?? null,
 				};
@@ -976,8 +971,10 @@ export class WledService extends BaseManagedPluginService {
 									description: original.description,
 									enabled: original.enabled,
 									hostname: original.hostname,
-									mac: original.mac,
 								}),
+							);
+							await this.tryRollback(`restore hardware identity ${original.id}`, () =>
+								this.hardwareIdentity.restore(original.id, original.mac),
 							);
 							await this.tryRollback(`reconnect device ${original.id}`, () => this.restoreDeviceConnection(original));
 						} else {
@@ -1018,8 +1015,10 @@ export class WledService extends BaseManagedPluginService {
 								description: staleHostOwner.description,
 								enabled: staleHostOwner.enabled,
 								hostname: staleHostOwner.hostname,
-								mac: staleHostOwner.mac,
 							}),
+						);
+						await this.tryRollback(`restore stale owner hardware identity ${staleHostOwner.id}`, () =>
+							this.hardwareIdentity.restore(staleHostOwner.id, staleHostOwner.mac),
 						);
 						retiredDeviceIds.delete(staleHostOwner.id);
 						if (disconnectedStaleOwnerIdsByDependencyGroup.get(dependencyGroup)?.has(staleHostOwner.id)) {
@@ -1057,8 +1056,10 @@ export class WledService extends BaseManagedPluginService {
 								description: existingDevice.description,
 								enabled: existingDevice.enabled,
 								hostname: existingDevice.hostname,
-								mac: existingDevice.mac,
 							}),
+						);
+						await this.tryRollback(`restore hardware identity ${existingDevice.id}`, () =>
+							this.hardwareIdentity.restore(existingDevice.id, existingDevice.mac),
 						);
 						if (existingDeviceDisconnected || attemptedRegistrationCreated) {
 							await this.tryRollback(`reconnect device ${existingDevice.id}`, () =>
@@ -1080,8 +1081,10 @@ export class WledService extends BaseManagedPluginService {
 								description: staleHostOwner.description,
 								enabled: staleHostOwner.enabled,
 								hostname: staleHostOwner.hostname,
-								mac: staleHostOwner.mac,
 							}),
+						);
+						await this.tryRollback(`restore stale owner hardware identity ${staleHostOwner.id}`, () =>
+							this.hardwareIdentity.restore(staleHostOwner.id, staleHostOwner.mac),
 						);
 						if (disconnectedStaleOwners.some(({ id }) => id === staleHostOwner.id)) {
 							await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -820,6 +820,14 @@ export class WledService extends BaseManagedPluginService {
 					}
 
 					for (const staleHostOwner of disconnectedStaleOwners) {
+						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
+							type: DEVICES_WLED_TYPE,
+							identifier: staleHostOwner.identifier,
+							name: staleHostOwner.name,
+							description: staleHostOwner.description,
+							enabled: staleHostOwner.enabled,
+							hostname: staleHostOwner.hostname,
+						});
 						await this.restoreDeviceConnection(staleHostOwner);
 					}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -817,6 +817,12 @@ export class WledService extends BaseManagedPluginService {
 						await this.restoreDeviceConnection(staleHostOwner);
 					}
 				} else {
+					const attemptedRegistration = this.wledAdapter.getDevice(host);
+					const attemptedHostDisconnected =
+						attemptedRegistration?.host === host && attemptedRegistration.identifier === identifier;
+					if (attemptedHostDisconnected) {
+						this.wledAdapter.disconnect(host, false);
+					}
 					const partialDevice =
 						mappedDevice ??
 						(await this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE));
@@ -830,7 +836,7 @@ export class WledService extends BaseManagedPluginService {
 							enabled: existingDevice.enabled,
 							hostname: existingDevice.hostname,
 						});
-						if (existingDeviceDisconnected) {
+						if (existingDeviceDisconnected || attemptedHostDisconnected) {
 							await this.restoreDeviceConnection(existingDevice);
 						}
 					} else if (partialDevice) {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -466,20 +466,22 @@ export class WledService extends BaseManagedPluginService {
 	 * Connect to a newly discovered device and map it to the database
 	 */
 	private async connectAndMapDiscoveredDevice(device: WledMdnsDiscoveredDevice): Promise<void> {
-		try {
-			const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
-			await this.wledAdapter.connect(device.host, identifier, this.config.timeouts.connectionTimeout);
+		await this.enqueueProvisioning(async () => {
+			try {
+				const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
+				await this.wledAdapter.connect(device.host, identifier, this.config.timeouts.connectionTimeout);
 
-			const registeredDevice = this.wledAdapter.getDevice(device.host);
+				const registeredDevice = this.wledAdapter.getDevice(device.host);
 
-			if (registeredDevice?.context) {
-				await this.deviceMapper.mapDevice(device.host, registeredDevice.context, device.name, identifier);
+				if (registeredDevice?.context) {
+					await this.deviceMapper.mapDevice(device.host, registeredDevice.context, device.name, identifier);
+				}
+			} catch (error) {
+				this.logger.error(`Failed to connect to discovered device at ${device.host}`, {
+					message: error instanceof Error ? error.message : String(error),
+				});
 			}
-		} catch (error) {
-			this.logger.error(`Failed to connect to discovered device at ${device.host}`, {
-				message: error instanceof Error ? error.message : String(error),
-			});
-		}
+		});
 	}
 
 	/**
@@ -539,13 +541,7 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	async adoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
-		const operation: Promise<WledAdoptionResultModel[]> = this.adoptionQueue.then(() => this.doAdoptDevices(requests));
-		this.adoptionQueue = operation.then<void>(
-			() => undefined,
-			() => undefined,
-		);
-
-		return operation;
+		return this.enqueueProvisioning(() => this.doAdoptDevices(requests));
 	}
 
 	private async doAdoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
@@ -641,6 +637,7 @@ export class WledService extends BaseManagedPluginService {
 		const retiredDeviceIds = new Set<string>();
 		const failedDependencyGroups = new Map<Set<number>, string>();
 		const createdDeviceIdsByPlan = new Map<number, string>();
+		const retiredStaleOwnersByDependencyGroup = new Map<Set<number>, Map<string, WledDeviceEntity>>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
 			const dependencyGroup = dependencyGroupByIndex.get(index);
@@ -697,6 +694,14 @@ export class WledService extends BaseManagedPluginService {
 				const retiringHostOwners = staleHostOwners.filter(
 					(staleHostOwner) => !selectedDeviceIds.has(staleHostOwner.id) && !retiredDeviceIds.has(staleHostOwner.id),
 				);
+				if (dependencyGroup && retiringHostOwners.length > 0) {
+					const groupOwners =
+						retiredStaleOwnersByDependencyGroup.get(dependencyGroup) ?? new Map<string, WledDeviceEntity>();
+					for (const staleHostOwner of retiringHostOwners) {
+						groupOwners.set(staleHostOwner.id, staleHostOwner);
+					}
+					retiredStaleOwnersByDependencyGroup.set(dependencyGroup, groupOwners);
+				}
 				if (staleHostOwners.length > 0) {
 					this.wledAdapter.disconnect(host, false);
 					disconnectedStaleOwners.push(...retiringHostOwners);
@@ -798,6 +803,19 @@ export class WledService extends BaseManagedPluginService {
 							deviceId: dependentPlan.existingDevice?.id ?? null,
 						};
 					}
+
+					for (const staleHostOwner of retiredStaleOwnersByDependencyGroup.get(dependencyGroup)?.values() ?? []) {
+						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
+							type: DEVICES_WLED_TYPE,
+							identifier: staleHostOwner.identifier,
+							name: staleHostOwner.name,
+							description: staleHostOwner.description,
+							enabled: staleHostOwner.enabled,
+							hostname: staleHostOwner.hostname,
+						});
+						retiredDeviceIds.delete(staleHostOwner.id);
+						await this.restoreDeviceConnection(staleHostOwner);
+					}
 				} else {
 					const partialDevice =
 						mappedDevice ??
@@ -843,6 +861,16 @@ export class WledService extends BaseManagedPluginService {
 		}
 
 		return results.filter((result): result is WledAdoptionResultModel => result !== undefined);
+	}
+
+	private enqueueProvisioning<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.adoptionQueue.then(operation);
+		this.adoptionQueue = result.then<void>(
+			() => undefined,
+			() => undefined,
+		);
+
+		return result;
 	}
 
 	private async restoreDeviceConnection(device: WledDeviceEntity): Promise<void> {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -23,6 +23,7 @@ import { UpdateWledDeviceDto } from '../dto/update-device.dto';
 import { WledAdoptDeviceDto } from '../dto/wled-adoption.dto';
 import { WledDeviceEntity } from '../entities/devices-wled.entity';
 import {
+	RegisteredWledDevice,
 	WledDeviceConnectedEvent,
 	WledDeviceContext,
 	WledDeviceDisconnectedEvent,
@@ -336,23 +337,31 @@ export class WledService extends BaseManagedPluginService {
 				DEVICES_WLED_TYPE,
 			);
 			if (storedDevice) {
-				await this.persistHardwareIdentity(storedDevice, event.info.mac);
+				const identityVerified = await this.persistHardwareIdentity(storedDevice, event.info.mac);
+				if (!identityVerified) {
+					this.wledAdapter.disconnect(event.host, false);
+					await this.deviceMapper.setDeviceConnectionState(device.identifier, ConnectionState.DISCONNECTED);
+					return;
+				}
 			}
 			await this.deviceMapper.setDeviceConnectionState(device.identifier, ConnectionState.CONNECTED);
 		}
 	}
 
-	private async persistHardwareIdentity(device: WledDeviceEntity, reportedMac: string): Promise<void> {
+	private async persistHardwareIdentity(device: WledDeviceEntity, reportedMac: string): Promise<boolean> {
 		const mac = this.normalizeMac(reportedMac);
 		if (!mac || device.mac === mac) {
-			return;
+			return true;
 		}
 		const result = await this.hardwareIdentity.persist(device, mac);
 		if (result === 'conflict') {
-			this.logger.warn(`WLED hardware identity ${mac} is already owned by another device`, {
+			this.logger.warn(`WLED hardware identity ${mac} conflicts with the configured device`, {
 				resource: device.id,
 			});
+			return false;
 		}
+
+		return true;
 	}
 
 	/**
@@ -783,13 +792,23 @@ export class WledService extends BaseManagedPluginService {
 				dependencyGroupByIndex.set(member, group);
 			}
 		}
+		const registrationSnapshotsByDependencyGroup = new Map<Set<number>, RegisteredWledDevice[]>();
+		for (const dependencyGroup of new Set(dependencyGroupByIndex.values())) {
+			const involvedHosts = plans
+				.filter((plan) => dependencyGroup.has(plan.index))
+				.flatMap((plan) => [plan.host, plan.existingDevice?.hostname].filter((host): host is string => !!host));
+			const registrations = this.wledAdapter
+				.getRegisteredDevices()
+				.filter((registration) => involvedHosts.some((host) => this.endpointsEquivalent(registration.host, host)))
+				.map((registration) => ({ ...registration }));
+			registrationSnapshotsByDependencyGroup.set(dependencyGroup, registrations);
+		}
 
 		const retiredDeviceIds = new Set<string>();
 		const failedDependencyGroups = new Map<Set<number>, string>();
 		const createdDeviceIdsByPlan = new Map<number, string>();
 		const structureSnapshotsByPlan = new Map<number, WledAdoptionStructureSnapshot>();
 		const retiredStaleOwnersByDependencyGroup = new Map<Set<number>, Map<string, WledDeviceEntity>>();
-		const disconnectedStaleOwnerIdsByDependencyGroup = new Map<Set<number>, Set<string>>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
 			if (blockedPlanIndices.has(index)) {
@@ -876,12 +895,6 @@ export class WledService extends BaseManagedPluginService {
 							this.wledAdapter.disconnect(staleHostOwner.hostname, false);
 							if (retiringHostOwners.some(({ id }) => id === staleHostOwner.id)) {
 								disconnectedStaleOwners.push(staleHostOwner);
-								if (dependencyGroup) {
-									const disconnectedIds =
-										disconnectedStaleOwnerIdsByDependencyGroup.get(dependencyGroup) ?? new Set<string>();
-									disconnectedIds.add(staleHostOwner.id);
-									disconnectedStaleOwnerIdsByDependencyGroup.set(dependencyGroup, disconnectedIds);
-								}
 							}
 						}
 					}
@@ -976,7 +989,6 @@ export class WledService extends BaseManagedPluginService {
 							await this.tryRollback(`restore hardware identity ${original.id}`, () =>
 								this.hardwareIdentity.restore(original.id, original.mac),
 							);
-							await this.tryRollback(`reconnect device ${original.id}`, () => this.restoreDeviceConnection(original));
 						} else {
 							const partialDevice = await this.tryRollback(
 								`find partial device ${dependentPlan.identifier}`,
@@ -1021,12 +1033,22 @@ export class WledService extends BaseManagedPluginService {
 							this.hardwareIdentity.restore(staleHostOwner.id, staleHostOwner.mac),
 						);
 						retiredDeviceIds.delete(staleHostOwner.id);
-						if (disconnectedStaleOwnerIdsByDependencyGroup.get(dependencyGroup)?.has(staleHostOwner.id)) {
-							await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
-								this.restoreDeviceConnection(staleHostOwner),
-							);
-						}
 					}
+
+					const snapshotDevices = databaseDevices.filter((device) => {
+						const deviceHost = device.hostname;
+						return (
+							deviceHost !== null &&
+							[...involvedHosts].some((involvedHost) => this.endpointsEquivalent(deviceHost, involvedHost))
+						);
+					});
+					await this.tryRollback('restore dependency group registrations', () =>
+						this.restoreDependencyGroupRegistrations(
+							involvedHosts,
+							registrationSnapshotsByDependencyGroup.get(dependencyGroup) ?? [],
+							snapshotDevices,
+						),
+					);
 				} else {
 					if (attemptedRegistrationCreated) {
 						await this.tryRollback(`disconnect ${host}`, () =>
@@ -1144,6 +1166,51 @@ export class WledService extends BaseManagedPluginService {
 		}
 
 		await this.deviceConnectivityService.setConnectionState(device.id, { state });
+	}
+
+	private async restoreDependencyGroupRegistrations(
+		involvedHosts: Set<string>,
+		registrations: RegisteredWledDevice[],
+		devices: WledDeviceEntity[],
+	): Promise<void> {
+		const belongsToGroup = (host: string): boolean =>
+			[...involvedHosts].some((involvedHost) => this.endpointsEquivalent(host, involvedHost));
+
+		for (const registration of this.wledAdapter.getRegisteredDevices().filter(({ host }) => belongsToGroup(host))) {
+			this.wledAdapter.disconnect(registration.host, false);
+		}
+
+		for (const registration of registrations.filter(({ connected }) => connected)) {
+			if (registration.context) {
+				this.wledAdapter.connectWithContext(registration.host, registration.identifier, registration.context);
+			} else {
+				await this.wledAdapter.connect(
+					registration.host,
+					registration.identifier,
+					this.config.timeouts.connectionTimeout,
+				);
+			}
+
+			const restored = this.wledAdapter.getDevice(registration.host);
+			if (restored) {
+				restored.enabled = registration.enabled;
+				restored.lastSeen = registration.lastSeen;
+			}
+		}
+
+		const uniqueDevices = new Map(devices.map((device) => [device.id, device]));
+		for (const device of uniqueDevices.values()) {
+			const connected = registrations.some(
+				(registration) =>
+					registration.connected &&
+					registration.identifier === device.identifier &&
+					device.hostname !== null &&
+					this.endpointsEquivalent(registration.host, device.hostname),
+			);
+			await this.deviceConnectivityService.setConnectionState(device.id, {
+				state: connected ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
+			});
+		}
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -476,10 +476,15 @@ export class WledService extends BaseManagedPluginService {
 
 		if (existingDevice) {
 			this.logger.debug(`Device at ${endpoint} already exists in database`);
+			const identityUpgradeRequired = this.requiresCanonicalIdentity(existingDevice, endpoint, identifiedDevice.mac);
 
 			// Reconcile a known MAC at a new endpoint through the same guarded
-			// provisioning path as administrator adoption.
-			if (existingDevice.hostname && !this.endpointsEquivalent(existingDevice.hostname, endpoint)) {
+			// provisioning path as administrator adoption. Legacy same-endpoint
+			// identities use it too so a later address move remains recognizable.
+			if (
+				identityUpgradeRequired ||
+				(existingDevice.hostname && !this.endpointsEquivalent(existingDevice.hostname, endpoint))
+			) {
 				await this.connectAndMapDiscoveredDevice(identifiedDevice);
 			} else if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 				this.logger.debug(`Connecting to existing device at ${endpoint}`);
@@ -506,7 +511,11 @@ export class WledService extends BaseManagedPluginService {
 				const endpoint = this.discoveryEndpoint(device.host, device.port);
 				const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
-				if (existingDevice?.hostname && this.endpointsEquivalent(existingDevice.hostname, endpoint)) {
+				if (
+					existingDevice?.hostname &&
+					this.endpointsEquivalent(existingDevice.hostname, endpoint) &&
+					!this.requiresCanonicalIdentity(existingDevice, endpoint, device.mac)
+				) {
 					if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 						await this.connectToDevice(existingDevice);
 					}
@@ -1205,6 +1214,21 @@ export class WledService extends BaseManagedPluginService {
 
 		const normalized = serial.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
 		return normalized.length === 12 ? normalized : null;
+	}
+
+	private requiresCanonicalIdentity(device: WledDeviceEntity, host: string, mac?: string | null): boolean {
+		if (!mac) {
+			return false;
+		}
+
+		const canonicalIdentifier = this.identifierFromMac(mac);
+		const identifier = device.identifier?.toLowerCase() ?? null;
+
+		return (
+			identifier === null ||
+			identifier === `wled-${canonicalIdentifier.slice(-6)}` ||
+			this.legacyHostIdentifiers(device.hostname ?? host).has(identifier)
+		);
 	}
 
 	private endpointsEquivalent(first: string, second: string): boolean {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -597,6 +597,14 @@ export class WledService extends BaseManagedPluginService {
 						hostname: host,
 					});
 				}
+				const device = await this.deviceMapper.mapDevice(
+					host,
+					context,
+					request.name,
+					identifier,
+					request.description,
+					request.enabled,
+				);
 				for (const staleHostOwner of databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
 				)) {
@@ -611,14 +619,6 @@ export class WledService extends BaseManagedPluginService {
 					});
 					retiredDeviceIds.add(staleHostOwner.id);
 				}
-				const device = await this.deviceMapper.mapDevice(
-					host,
-					context,
-					request.name,
-					identifier,
-					request.description,
-					request.enabled,
-				);
 				if (!device.enabled) {
 					this.wledAdapter.disconnect(host);
 				} else {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -602,7 +602,8 @@ export class WledService extends BaseManagedPluginService {
 				const canonicalIdentity = this.identifierFromMac(context.info.mac);
 				const existingIdentifier = existingDevice?.identifier;
 				const identifier =
-					existingIdentifier && !this.legacyHostIdentifiers(existingDevice.hostname ?? host).has(existingIdentifier)
+					existingIdentifier &&
+					!this.legacyHostIdentifiers(existingDevice.hostname ?? host).has(existingIdentifier.toLowerCase())
 						? existingIdentifier
 						: canonicalIdentity;
 
@@ -1132,7 +1133,7 @@ export class WledService extends BaseManagedPluginService {
 					devices.find(
 						(device) =>
 							device.identifier !== null &&
-							legacyHostIdentifiers.has(device.identifier) &&
+							legacyHostIdentifiers.has(device.identifier.toLowerCase()) &&
 							device.hostname !== null &&
 							this.endpointsEquivalent(device.hostname, host),
 					) ??
@@ -1170,7 +1171,7 @@ export class WledService extends BaseManagedPluginService {
 		const bracketedHost = endpoint.match(/^\[([^\]]+)](?::\d+)?$/)?.[1];
 		const rawHost = bracketedHost ?? endpoint.replace(/:\d+$/, '');
 
-		return new Set([endpoint, rawHost].map((host) => `wled-${host.replace(/\./g, '-')}`));
+		return new Set([endpoint, rawHost].map((host) => `wled-${host.replace(/\./g, '-')}`.toLowerCase()));
 	}
 
 	private portFromHost(host: string): number {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -615,19 +615,38 @@ export class WledService extends BaseManagedPluginService {
 			[...normalizedHostsByIndex].flatMap(([index, host]) => (!plannedIndices.has(index) ? [host] : [])),
 		);
 		const selectedDeviceIds = plannedExistingDeviceIds;
+		const moveHostEdges = new Map<string, Set<string>>();
+		for (const plan of plans) {
+			const sourceHost = plan.existingDevice?.hostname;
+			if (!sourceHost || sourceHost === plan.host) {
+				continue;
+			}
+
+			const sourceEdges = moveHostEdges.get(sourceHost) ?? new Set<string>();
+			sourceEdges.add(plan.host);
+			moveHostEdges.set(sourceHost, sourceEdges);
+			const targetEdges = moveHostEdges.get(plan.host) ?? new Set<string>();
+			targetEdges.add(sourceHost);
+			moveHostEdges.set(plan.host, targetEdges);
+		}
+		const failedMoveHosts = new Set<string>();
+		const pendingFailedHosts = [...failedSelectionHosts];
+		while (pendingFailedHosts.length > 0) {
+			const currentHost = pendingFailedHosts.pop();
+			if (!currentHost || failedMoveHosts.has(currentHost)) {
+				continue;
+			}
+
+			failedMoveHosts.add(currentHost);
+			pendingFailedHosts.push(...(moveHostEdges.get(currentHost) ?? []));
+		}
 		const blockedPlanIndices = new Set<number>();
 		for (const plan of plans) {
-			const unplannedSelectedTargetOwner = databaseDevices.find(
-				(device) =>
-					device.hostname === plan.host &&
-					device.id !== plan.existingDevice?.id &&
-					!plannedExistingDeviceIds.has(device.id),
-			);
-
 			if (
-				unplannedSelectedTargetOwner &&
-				plan.existingDevice?.hostname &&
-				failedSelectionHosts.has(plan.existingDevice.hostname)
+				failedMoveHosts.has(plan.host) ||
+				(plan.existingDevice?.hostname !== null &&
+					plan.existingDevice?.hostname !== undefined &&
+					failedMoveHosts.has(plan.existingDevice.hostname))
 			) {
 				blockedPlanIndices.add(plan.index);
 				results[plan.index] = {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -1183,7 +1183,7 @@ export class WledService extends BaseManagedPluginService {
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
-					legacyDevices.find((device) => this.deviceSerialMac(device) === normalizedMac) ??
+					devices.find((device) => this.deviceSerialMac(device) === normalizedMac) ??
 					legacyDevices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host)) ??
 					devices.find(
 						(device) =>

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -30,6 +30,7 @@ import {
 	WledDeviceErrorEvent,
 	WledDeviceStateChangedEvent,
 	WledMdnsDiscoveredDevice,
+	WledState,
 } from '../interfaces/wled.interface';
 import { WledConfigModel } from '../models/config.model';
 import { WledAdoptionResultModel, WledDiscoveredDeviceModel, WledDiscoveryModel } from '../models/wled-discovery.model';
@@ -828,6 +829,10 @@ export class WledService extends BaseManagedPluginService {
 		const createdDeviceIdsByPlan = new Map<number, string>();
 		const structureSnapshotsByPlan = new Map<number, WledAdoptionStructureSnapshot>();
 		const retiredStaleOwnersByDependencyGroup = new Map<Set<number>, Map<string, WledDeviceEntity>>();
+		const deferredPruningByDependencyGroup = new Map<
+			Set<number>,
+			Array<{ device: WledDeviceEntity; state: WledState }>
+		>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
 			if (blockedPlanIndices.has(index)) {
@@ -960,9 +965,14 @@ export class WledService extends BaseManagedPluginService {
 				await this.deviceConnectivityService.setConnectionState(device.id, {
 					state: connectionState,
 				});
-				// This destructive cleanup intentionally runs after every rollback-capable adoption
-				// step. It is best-effort and cannot turn a mapped device into a failed adoption.
-				await this.deviceMapper.pruneObsoleteSegmentChannels(device, context.state);
+				if (dependencyGroup) {
+					const deferredPruning = deferredPruningByDependencyGroup.get(dependencyGroup) ?? [];
+					deferredPruning.push({ device, state: context.state });
+					deferredPruningByDependencyGroup.set(dependencyGroup, deferredPruning);
+				} else {
+					// Independent plans cannot be rolled back by a later batch item.
+					await this.deviceMapper.pruneObsoleteSegmentChannels(device, context.state);
+				}
 				results[index] = {
 					host,
 					name: request.name,
@@ -1145,6 +1155,21 @@ export class WledService extends BaseManagedPluginService {
 						deviceId: null,
 					};
 				}
+			}
+		}
+
+		// A dependency group commits atomically: no destructive history cleanup may run
+		// until every member has succeeded and the group can no longer roll back.
+		for (const [dependencyGroup, deferredPruning] of deferredPruningByDependencyGroup) {
+			if (
+				failedDependencyGroups.has(dependencyGroup) ||
+				[...dependencyGroup].some((index) => results[index]?.status === 'failed')
+			) {
+				continue;
+			}
+
+			for (const { device, state } of deferredPruning) {
+				await this.deviceMapper.pruneObsoleteSegmentChannels(device, state);
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -14,6 +14,7 @@ import {
 import { PluginServiceManagerService } from '../../../modules/extensions/services/plugin-service-manager.service';
 import { DEVICES_WLED_PLUGIN_NAME, DEVICES_WLED_TYPE } from '../devices-wled.constants';
 import { WledValidationException } from '../devices-wled.exceptions';
+import { UpdateWledDeviceDto } from '../dto/update-device.dto';
 import { WledAdoptDeviceDto } from '../dto/wled-adoption.dto';
 import { WledDeviceEntity } from '../entities/devices-wled.entity';
 import {
@@ -541,6 +542,13 @@ export class WledService extends BaseManagedPluginService {
 				const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
 				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
+				if (existingDevice && !existingDevice.identifier) {
+					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
+						type: DEVICES_WLED_TYPE,
+						identifier,
+						hostname: host,
+					});
+				}
 				const device = await this.deviceMapper.mapDevice(
 					host,
 					context,
@@ -611,6 +619,10 @@ export class WledService extends BaseManagedPluginService {
 			throw new WledValidationException('WLED address must be a hostname or IP address');
 		}
 
+		if (!trimmed.startsWith('[') && (trimmed.match(/:/g)?.length ?? 0) > 1) {
+			return `[${trimmed}]`;
+		}
+
 		return trimmed;
 	}
 
@@ -632,7 +644,9 @@ export class WledService extends BaseManagedPluginService {
 			const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
 			if (normalizedMac.length === 12) {
 				const identifiers = new Set([`wled-${normalizedMac}`, `wled-${normalizedMac.slice(-6)}`]);
-				return devices.find((device) => identifiers.has(device.identifier));
+				return devices.find(
+					(device) => identifiers.has(device.identifier) || (device.identifier === null && device.hostname === host),
+				);
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -582,8 +582,12 @@ export class WledService extends BaseManagedPluginService {
 				host = this.normalizeHost(request.host);
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
-				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
 				const canonicalIdentity = this.identifierFromMac(context.info.mac);
+				const existingIdentifier = existingDevice?.identifier;
+				const identifier =
+					existingIdentifier && !this.legacyHostIdentifiers(existingDevice.hostname ?? host).has(existingIdentifier)
+						? existingIdentifier
+						: canonicalIdentity;
 
 				if (plannedIdentities.has(canonicalIdentity)) {
 					results[index] = {
@@ -729,7 +733,7 @@ export class WledService extends BaseManagedPluginService {
 			const disconnectedStaleOwners: WledDeviceEntity[] = [];
 
 			try {
-				if (existingDevice && !existingDevice.identifier) {
+				if (existingDevice && existingDevice.identifier !== identifier) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
 						type: DEVICES_WLED_TYPE,
 						identifier,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -960,6 +960,9 @@ export class WledService extends BaseManagedPluginService {
 				await this.deviceConnectivityService.setConnectionState(device.id, {
 					state: connectionState,
 				});
+				// This destructive cleanup intentionally runs after every rollback-capable adoption
+				// step. It is best-effort and cannot turn a mapped device into a failed adoption.
+				await this.deviceMapper.pruneObsoleteSegmentChannels(device, context.state);
 				results[index] = {
 					host,
 					name: request.name,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -457,7 +457,21 @@ export class WledService extends BaseManagedPluginService {
 			});
 			return;
 		}
-		const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
+		let identifiedDevice = device;
+		let existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
+
+		if (!existingDevice && !device.mac && !this.config.mdns.autoAdd) {
+			try {
+				const context = await this.wledAdapter.probe(endpoint, this.config.timeouts.connectionTimeout);
+				identifiedDevice = { ...device, mac: context.info.mac };
+				existingDevice = this.findExistingDevice(devices, endpoint, context.info.mac);
+			} catch (error) {
+				this.logger.debug(`Could not identify MAC-less WLED device at ${endpoint}`, {
+					message: error instanceof Error ? error.message : String(error),
+				});
+				return;
+			}
+		}
 
 		if (existingDevice) {
 			this.logger.debug(`Device at ${endpoint} already exists in database`);
@@ -465,7 +479,7 @@ export class WledService extends BaseManagedPluginService {
 			// Reconcile a known MAC at a new endpoint through the same guarded
 			// provisioning path as administrator adoption.
 			if (existingDevice.hostname && !this.endpointsEquivalent(existingDevice.hostname, endpoint)) {
-				await this.connectAndMapDiscoveredDevice(device);
+				await this.connectAndMapDiscoveredDevice(identifiedDevice);
 			} else if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 				this.logger.debug(`Connecting to existing device at ${endpoint}`);
 				await this.connectToDevice(existingDevice);
@@ -1198,6 +1212,16 @@ export class WledService extends BaseManagedPluginService {
 
 	private canonicalEndpoint(endpoint: string): string {
 		const trimmed = endpoint.trim().toLowerCase();
+		const urlHost = !trimmed.startsWith('[') && (trimmed.match(/:/g)?.length ?? 0) > 1 ? `[${trimmed}]` : trimmed;
+
+		try {
+			const url = new URL(`http://${urlHost}`);
+			return `${url.hostname}${url.port ? `:${url.port}` : ''}`;
+		} catch {
+			// Fall through for unusual host spellings (for example scoped IPv6 literals)
+			// that URL cannot parse but the WLED client may still support.
+		}
+
 		const bracketedIpv6 = trimmed.match(/^\[([^\]]+)](?::(\d+))?$/);
 		if (bracketedIpv6) {
 			const [, address, port] = bracketedIpv6;

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -19,6 +19,7 @@ import { WledAdoptDeviceDto } from '../dto/wled-adoption.dto';
 import { WledDeviceEntity } from '../entities/devices-wled.entity';
 import {
 	WledDeviceConnectedEvent,
+	WledDeviceContext,
 	WledDeviceDisconnectedEvent,
 	WledDeviceErrorEvent,
 	WledDeviceStateChangedEvent,
@@ -531,17 +532,59 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	async adoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
-		const results: WledAdoptionResultModel[] = [];
+		const results = requests.map<WledAdoptionResultModel | undefined>(() => undefined);
+		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		const plans: Array<{
+			index: number;
+			request: WledAdoptDeviceDto;
+			host: string;
+			context: WledDeviceContext;
+			existingDevice: WledDeviceEntity | null;
+			identifier: string;
+		}> = [];
 
-		for (const request of requests) {
+		for (const [index, request] of requests.entries()) {
 			let host = request.host.trim();
 
 			try {
 				host = this.normalizeHost(request.host);
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
-				const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
 				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
+
+				plans.push({ index, request, host, context, existingDevice, identifier });
+			} catch (error) {
+				results[index] = {
+					host,
+					name: request.name,
+					status: 'failed',
+					error: error instanceof Error ? error.message : String(error),
+					deviceId: null,
+				};
+			}
+		}
+
+		const selectedDeviceIds = new Set(
+			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
+		);
+
+		// Tear down every connection involved in an address move before registering any
+		// replacement. This makes address swaps safe: processing the first item cannot
+		// disconnect the second item after it has already been moved to its new host.
+		for (const { host, existingDevice } of plans) {
+			if (existingDevice?.hostname && existingDevice.hostname !== host) {
+				this.wledAdapter.disconnect(existingDevice.hostname);
+			}
+
+			if (databaseDevices.some((device) => device.hostname === host && device.id !== existingDevice?.id)) {
+				this.wledAdapter.disconnect(host);
+			}
+		}
+
+		const retiredDeviceIds = new Set<string>();
+
+		for (const { index, request, host, context, existingDevice, identifier } of plans) {
+			try {
 				if (existingDevice && !existingDevice.identifier) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
 						type: DEVICES_WLED_TYPE,
@@ -549,18 +592,19 @@ export class WledService extends BaseManagedPluginService {
 						hostname: host,
 					});
 				}
-				if (existingDevice?.hostname && existingDevice.hostname !== host) {
-					this.wledAdapter.disconnect(existingDevice.hostname);
-				}
 				for (const staleHostOwner of databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
 				)) {
-					this.wledAdapter.disconnect(host);
+					if (selectedDeviceIds.has(staleHostOwner.id) || retiredDeviceIds.has(staleHostOwner.id)) {
+						continue;
+					}
+
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
 						type: DEVICES_WLED_TYPE,
 						enabled: false,
 						hostname: null,
 					});
+					retiredDeviceIds.add(staleHostOwner.id);
 				}
 				const device = await this.deviceMapper.mapDevice(
 					host,
@@ -570,7 +614,22 @@ export class WledService extends BaseManagedPluginService {
 					request.description,
 					request.enabled,
 				);
-				if (device.enabled) {
+				if (!device.enabled) {
+					this.wledAdapter.disconnect(host);
+				} else {
+					const registeredDevice = this.wledAdapter.getDevice(host);
+
+					if (registeredDevice?.identifier === identifier && registeredDevice.connected) {
+						results[index] = {
+							host,
+							name: request.name,
+							status: existingDevice ? 'updated' : 'created',
+							error: null,
+							deviceId: device.id,
+						};
+						continue;
+					}
+
 					try {
 						this.wledAdapter.connectWithContext(host, identifier, context);
 					} catch (error) {
@@ -580,25 +639,25 @@ export class WledService extends BaseManagedPluginService {
 						});
 					}
 				}
-				results.push({
+				results[index] = {
 					host,
 					name: request.name,
 					status: existingDevice ? 'updated' : 'created',
 					error: null,
 					deviceId: device.id,
-				});
+				};
 			} catch (error) {
-				results.push({
+				results[index] = {
 					host,
 					name: request.name,
 					status: 'failed',
 					error: error instanceof Error ? error.message : String(error),
 					deviceId: null,
-				});
+				};
 			}
 		}
 
-		return results;
+		return results.filter((result): result is WledAdoptionResultModel => result !== undefined);
 	}
 
 	/**

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -621,7 +621,7 @@ export class WledService extends BaseManagedPluginService {
 
 	private identifierFromMac(mac: string): string {
 		const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-		if (!normalizedMac) {
+		if (normalizedMac.length !== 12) {
 			throw new WledValidationException('WLED device did not report a valid MAC address');
 		}
 
@@ -633,14 +633,15 @@ export class WledService extends BaseManagedPluginService {
 		host: string,
 		mac?: string | null,
 	): WledDeviceEntity | undefined {
-		const identifiers = new Set<string>();
 		if (mac) {
-			const fullIdentifier = this.identifierFromMac(mac);
-			identifiers.add(fullIdentifier);
-			identifiers.add(`wled-${fullIdentifier.slice(-6)}`);
+			const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+			if (normalizedMac.length === 12) {
+				const identifiers = new Set([`wled-${normalizedMac}`, `wled-${normalizedMac.slice(-6)}`]);
+				return devices.find((device) => identifiers.has(device.identifier));
+			}
 		}
 
-		return devices.find((device) => device.hostname === host || identifiers.has(device.identifier));
+		return devices.find((device) => device.hostname === host);
 	}
 
 	private portFromHost(host: string): number {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -498,7 +498,8 @@ export class WledService extends BaseManagedPluginService {
 			mdnsEnabled: this.config.mdns.enabled,
 			discoveryRunning: this.mdnsDiscoverer.isDiscoveryRunning(),
 			devices: discoveredDevices.map((device) => {
-				const existingDevice = this.findExistingDevice(databaseDevices, device.host, device.mac);
+				const discoveryEndpoint = this.discoveryEndpoint(device.host, device.port);
+				const existingDevice = this.findExistingDevice(databaseDevices, discoveryEndpoint, device.mac);
 
 				return {
 					host: device.host,
@@ -761,7 +762,12 @@ export class WledService extends BaseManagedPluginService {
 								state: ConnectionState.DISCONNECTED,
 							});
 						} else {
-							const createdDeviceId = createdDeviceIdsByPlan.get(dependentPlan.index);
+							const partialDevice = await this.devicesService.findOneBy<WledDeviceEntity>(
+								'identifier',
+								dependentPlan.identifier,
+								DEVICES_WLED_TYPE,
+							);
+							const createdDeviceId = createdDeviceIdsByPlan.get(dependentPlan.index) ?? partialDevice?.id;
 							if (createdDeviceId) {
 								await this.devicesService.remove(createdDeviceId);
 								createdDeviceIdsByPlan.delete(dependentPlan.index);
@@ -802,7 +808,16 @@ export class WledService extends BaseManagedPluginService {
 		const existingHostnames = new Set(databaseDevices.map((d) => d.hostname));
 
 		// Filter out devices that are already in the database
-		return discoveredDevices.filter((device) => !existingHostnames.has(device.host));
+		return discoveredDevices.filter(
+			(device) => !existingHostnames.has(this.discoveryEndpoint(device.host, device.port)),
+		);
+	}
+
+	private discoveryEndpoint(host: string, port: number): string {
+		const normalizedHost = this.normalizeHost(host);
+		const hasExplicitPort = /^\[[^\]]+\]:\d+$/.test(normalizedHost) || /^[^:]+:\d+$/.test(normalizedHost);
+
+		return port === 80 || hasExplicitPort ? normalizedHost : `${normalizedHost}:${port}`;
 	}
 
 	private normalizeHost(host: string): string {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -599,14 +599,14 @@ export class WledService extends BaseManagedPluginService {
 					// another successfully moved controller. Disconnect only the registration
 					// that actually belongs to this device.
 					if (sourceRegistration?.identifier === existingDevice.identifier) {
-						this.wledAdapter.disconnect(existingDevice.hostname);
+						this.wledAdapter.disconnect(existingDevice.hostname, false);
 					}
 				}
 				const staleHostOwners = databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
 				);
 				if (staleHostOwners.length > 0) {
-					this.wledAdapter.disconnect(host);
+					this.wledAdapter.disconnect(host, false);
 				}
 				for (const staleHostOwner of staleHostOwners) {
 					if (selectedDeviceIds.has(staleHostOwner.id) || retiredDeviceIds.has(staleHostOwner.id)) {
@@ -618,35 +618,39 @@ export class WledService extends BaseManagedPluginService {
 						enabled: false,
 						hostname: null,
 					});
+					await this.deviceConnectivityService.setConnectionState(staleHostOwner.id, {
+						state: ConnectionState.DISCONNECTED,
+					});
 					retiredDeviceIds.add(staleHostOwner.id);
 				}
+				let connectionState = ConnectionState.DISCONNECTED;
 				if (!device.enabled) {
-					this.wledAdapter.disconnect(host);
+					this.wledAdapter.disconnect(host, false);
 				} else {
 					const registeredDevice = this.wledAdapter.getDevice(host);
 
 					if (registeredDevice?.identifier === identifier && registeredDevice.connected) {
 						registeredDevice.context = context;
 						registeredDevice.lastSeen = new Date();
-						results[index] = {
-							host,
-							name: request.name,
-							status: existingDevice ? 'updated' : 'created',
-							error: null,
-							deviceId: device.id,
-						};
-						continue;
-					}
-
-					try {
-						this.wledAdapter.connectWithContext(host, identifier, context);
-					} catch (error) {
-						this.logger.warn(`WLED device ${identifier} was adopted but its live connection could not be registered`, {
-							resource: device.id,
-							message: error instanceof Error ? error.message : String(error),
-						});
+						connectionState = ConnectionState.CONNECTED;
+					} else {
+						try {
+							this.wledAdapter.connectWithContext(host, identifier, context);
+							connectionState = ConnectionState.CONNECTED;
+						} catch (error) {
+							this.logger.warn(
+								`WLED device ${identifier} was adopted but its live connection could not be registered`,
+								{
+									resource: device.id,
+									message: error instanceof Error ? error.message : String(error),
+								},
+							);
+						}
 					}
 				}
+				await this.deviceConnectivityService.setConnectionState(device.id, {
+					state: connectionState,
+				});
 				results[index] = {
 					host,
 					name: request.name,
@@ -729,9 +733,13 @@ export class WledService extends BaseManagedPluginService {
 		if (mac) {
 			const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
 			if (normalizedMac.length === 12) {
-				const identifiers = new Set([`wled-${normalizedMac}`, `wled-${normalizedMac.slice(-6)}`]);
-				return devices.find(
-					(device) => identifiers.has(device.identifier) || (device.identifier === null && device.hostname === host),
+				const canonicalIdentifier = `wled-${normalizedMac}`;
+				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
+
+				return (
+					devices.find((device) => device.identifier === canonicalIdentifier) ??
+					devices.find((device) => device.identifier === legacyIdentifier) ??
+					devices.find((device) => device.identifier === null && device.hostname === host)
 				);
 			}
 		}

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -500,6 +500,7 @@ export class WledService extends BaseManagedPluginService {
 					});
 				}
 			} catch (error) {
+				this.mdnsDiscoverer.forgetDiscoveredDevice(device.host);
 				this.logger.error(`Failed to connect to discovered device at ${device.host}`, {
 					message: error instanceof Error ? error.message : String(error),
 				});
@@ -781,14 +782,24 @@ export class WledService extends BaseManagedPluginService {
 				if (dependencyGroup && retiringHostOwners.length > 0) {
 					const groupOwners =
 						retiredStaleOwnersByDependencyGroup.get(dependencyGroup) ?? new Map<string, WledDeviceEntity>();
-					for (const staleHostOwner of retiringHostOwners) {
+					for (const staleHostOwner of staleHostOwners) {
 						groupOwners.set(staleHostOwner.id, staleHostOwner);
 					}
 					retiredStaleOwnersByDependencyGroup.set(dependencyGroup, groupOwners);
 				}
 				if (staleHostOwners.length > 0) {
-					this.wledAdapter.disconnect(host, false);
-					disconnectedStaleOwners.push(...retiringHostOwners);
+					for (const staleHostOwner of retiringHostOwners) {
+						if (!staleHostOwner.hostname) {
+							continue;
+						}
+						const staleRegistration = this.wledAdapter.getDevice(staleHostOwner.hostname);
+						if (staleRegistration?.identifier === staleHostOwner.identifier) {
+							this.wledAdapter.disconnect(staleHostOwner.hostname, false);
+							if (retiringHostOwners.some(({ id }) => id === staleHostOwner.id)) {
+								disconnectedStaleOwners.push(staleHostOwner);
+							}
+						}
+					}
 				}
 				for (const staleHostOwner of retiringHostOwners) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -547,6 +547,7 @@ export class WledService extends BaseManagedPluginService {
 			existingDevice: WledDeviceEntity | null;
 			identifier: string;
 		}> = [];
+		const plannedIdentities = new Set<string>();
 
 		for (const [index, request] of requests.entries()) {
 			let host = request.host.trim();
@@ -556,6 +557,20 @@ export class WledService extends BaseManagedPluginService {
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
 				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
+				const canonicalIdentity = this.identifierFromMac(context.info.mac);
+
+				if (plannedIdentities.has(canonicalIdentity)) {
+					results[index] = {
+						host,
+						name: request.name,
+						status: 'failed',
+						error: 'The same WLED controller was selected more than once',
+						deviceId: existingDevice?.id ?? null,
+					};
+					continue;
+				}
+
+				plannedIdentities.add(canonicalIdentity);
 
 				plans.push({ index, request, host, context, existingDevice, identifier });
 			} catch (error) {
@@ -572,10 +587,34 @@ export class WledService extends BaseManagedPluginService {
 		const selectedDeviceIds = new Set(
 			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
 		);
+		const dependentPlanIndexes = new Set<number>();
+		for (const plan of plans) {
+			const selectedTargetOwner = plans.find(
+				(candidate) =>
+					candidate.existingDevice?.hostname === plan.host && candidate.existingDevice.id !== plan.existingDevice?.id,
+			);
+
+			if (selectedTargetOwner) {
+				dependentPlanIndexes.add(plan.index);
+				dependentPlanIndexes.add(selectedTargetOwner.index);
+			}
+		}
 
 		const retiredDeviceIds = new Set<string>();
+		let dependentFailure: string | null = null;
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
+			if (dependentPlanIndexes.has(index) && dependentFailure) {
+				results[index] = {
+					host,
+					name: request.name,
+					status: 'failed',
+					error: dependentFailure,
+					deviceId: existingDevice?.id ?? null,
+				};
+				continue;
+			}
+
 			try {
 				if (existingDevice && !existingDevice.identifier) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
@@ -659,13 +698,54 @@ export class WledService extends BaseManagedPluginService {
 					deviceId: device.id,
 				};
 			} catch (error) {
-				results[index] = {
-					host,
-					name: request.name,
-					status: 'failed',
-					error: error instanceof Error ? error.message : String(error),
-					deviceId: null,
-				};
+				const reason = error instanceof Error ? error.message : String(error);
+
+				if (dependentPlanIndexes.has(index)) {
+					dependentFailure = `A related WLED address move failed: ${reason}`;
+					const dependentPlans = plans.filter((plan) => dependentPlanIndexes.has(plan.index));
+					const involvedHosts = new Set(
+						dependentPlans.flatMap((plan) =>
+							[plan.host, plan.existingDevice?.hostname].filter((item): item is string => !!item),
+						),
+					);
+
+					for (const involvedHost of involvedHosts) {
+						this.wledAdapter.disconnect(involvedHost, false);
+					}
+
+					for (const dependentPlan of dependentPlans) {
+						if (dependentPlan.existingDevice) {
+							const original = dependentPlan.existingDevice;
+							await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(original.id, {
+								type: DEVICES_WLED_TYPE,
+								identifier: original.identifier,
+								name: original.name,
+								description: original.description,
+								enabled: original.enabled,
+								hostname: original.hostname,
+							});
+							await this.deviceConnectivityService.setConnectionState(original.id, {
+								state: ConnectionState.DISCONNECTED,
+							});
+						}
+
+						results[dependentPlan.index] = {
+							host: dependentPlan.host,
+							name: dependentPlan.request.name,
+							status: 'failed',
+							error: dependentFailure,
+							deviceId: dependentPlan.existingDevice?.id ?? null,
+						};
+					}
+				} else {
+					results[index] = {
+						host,
+						name: request.name,
+						status: 'failed',
+						error: reason,
+						deviceId: null,
+					};
+				}
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -1290,7 +1290,11 @@ export class WledService extends BaseManagedPluginService {
 				const canonicalIdentifier = `wled-${normalizedMac}`;
 				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
 				const legacyHostIdentifiers = this.legacyHostIdentifiers(host);
-				const legacyDevices = devices.filter((device) => device.identifier === legacyIdentifier);
+				const identityCompatible = (device: WledDeviceEntity): boolean =>
+					!this.hasContradictoryIdentity(device, normalizedMac);
+				const legacyDevices = devices.filter(
+					(device) => device.identifier === legacyIdentifier && identityCompatible(device),
+				);
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
@@ -1299,6 +1303,7 @@ export class WledService extends BaseManagedPluginService {
 					legacyDevices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host)) ??
 					devices.find(
 						(device) =>
+							identityCompatible(device) &&
 							device.identifier !== null &&
 							legacyHostIdentifiers.has(device.identifier.toLowerCase()) &&
 							device.hostname !== null &&
@@ -1306,7 +1311,10 @@ export class WledService extends BaseManagedPluginService {
 					) ??
 					devices.find(
 						(device) =>
-							device.identifier === null && device.hostname !== null && this.endpointsEquivalent(device.hostname, host),
+							identityCompatible(device) &&
+							device.identifier === null &&
+							device.hostname !== null &&
+							this.endpointsEquivalent(device.hostname, host),
 					)
 				);
 			}
@@ -1335,6 +1343,14 @@ export class WledService extends BaseManagedPluginService {
 		}
 
 		return this.normalizeMac(serial);
+	}
+
+	private hasContradictoryIdentity(device: WledDeviceEntity, reportedMac: string): boolean {
+		const knownIdentities = [this.normalizeMac(device.mac), this.deviceSerialMac(device)].filter(
+			(identity): identity is string => identity !== null,
+		);
+
+		return knownIdentities.some((identity) => identity !== reportedMac);
 	}
 
 	private requiresCanonicalIdentity(device: WledDeviceEntity, host: string, mac?: string | null): boolean {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -573,15 +573,6 @@ export class WledService extends BaseManagedPluginService {
 			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
 		);
 
-		// Tear down every connection involved in an address move before registering any
-		// replacement. This makes address swaps safe: processing the first item cannot
-		// disconnect the second item after it has already been moved to its new host.
-		for (const { host, existingDevice } of plans) {
-			if (existingDevice?.hostname && existingDevice.hostname !== host) {
-				this.wledAdapter.disconnect(existingDevice.hostname);
-			}
-		}
-
 		const retiredDeviceIds = new Set<string>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
@@ -601,6 +592,16 @@ export class WledService extends BaseManagedPluginService {
 					request.description,
 					request.enabled,
 				);
+				if (existingDevice?.hostname && existingDevice.hostname !== host) {
+					const sourceRegistration = this.wledAdapter.getDevice(existingDevice.hostname);
+
+					// During a batch address swap, the previous source host may already hold
+					// another successfully moved controller. Disconnect only the registration
+					// that actually belongs to this device.
+					if (sourceRegistration?.identifier === existingDevice.identifier) {
+						this.wledAdapter.disconnect(existingDevice.hostname);
+					}
+				}
 				const staleHostOwners = databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
 				);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -497,13 +497,17 @@ export class WledService extends BaseManagedPluginService {
 		return {
 			mdnsEnabled: this.config.mdns.enabled,
 			discoveryRunning: this.mdnsDiscoverer.isDiscoveryRunning(),
-			devices: discoveredDevices.map((device) => ({
-				host: device.host,
-				name: device.name,
-				mac: device.mac ?? null,
-				port: device.port,
-				adoptedDeviceId: this.findExistingDevice(databaseDevices, device.host, device.mac)?.id ?? null,
-			})),
+			devices: discoveredDevices.map((device) => {
+				const existingDevice = this.findExistingDevice(databaseDevices, device.host, device.mac);
+
+				return {
+					host: device.host,
+					name: existingDevice?.name ?? device.name,
+					mac: device.mac ?? null,
+					port: device.port,
+					adoptedDeviceId: existingDevice?.id ?? null,
+				};
+			}),
 		};
 	}
 
@@ -511,13 +515,14 @@ export class WledService extends BaseManagedPluginService {
 		const normalizedHost = this.normalizeHost(host);
 		const context = await this.wledAdapter.probe(normalizedHost, this.config.timeouts.connectionTimeout);
 		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		const existingDevice = this.findExistingDevice(databaseDevices, normalizedHost, context.info.mac);
 
 		return {
 			host: normalizedHost,
-			name: context.info.name || `WLED ${context.info.mac}`,
+			name: existingDevice?.name || context.info.name || `WLED ${context.info.mac}`,
 			mac: context.info.mac,
 			port: this.portFromHost(normalizedHost),
-			adoptedDeviceId: this.findExistingDevice(databaseDevices, normalizedHost, context.info.mac)?.id ?? null,
+			adoptedDeviceId: existingDevice?.id ?? null,
 		};
 	}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -540,12 +540,7 @@ export class WledService extends BaseManagedPluginService {
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
 				const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
-
-				if (existingDevice) {
-					throw new Error(`WLED device is already adopted as ${existingDevice.name}`);
-				}
-
-				const identifier = this.identifierFromMac(context.info.mac);
+				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
 				const device = await this.deviceMapper.mapDevice(
 					host,
 					context,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -549,6 +549,19 @@ export class WledService extends BaseManagedPluginService {
 						hostname: host,
 					});
 				}
+				if (existingDevice?.hostname && existingDevice.hostname !== host) {
+					this.wledAdapter.disconnect(existingDevice.hostname);
+				}
+				for (const staleHostOwner of databaseDevices.filter(
+					(device) => device.hostname === host && device.id !== existingDevice?.id,
+				)) {
+					this.wledAdapter.disconnect(host);
+					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
+						type: DEVICES_WLED_TYPE,
+						enabled: false,
+						hostname: null,
+					});
+				}
 				const device = await this.deviceMapper.mapDevice(
 					host,
 					context,
@@ -567,7 +580,13 @@ export class WledService extends BaseManagedPluginService {
 						});
 					}
 				}
-				results.push({ host, name: request.name, status: 'created', error: null, deviceId: device.id });
+				results.push({
+					host,
+					name: request.name,
+					status: existingDevice ? 'updated' : 'created',
+					error: null,
+					deviceId: device.id,
+				});
 			} catch (error) {
 				results.push({
 					host,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -1295,7 +1295,7 @@ export class WledService extends BaseManagedPluginService {
 
 		try {
 			const url = new URL(`http://${urlHost}`);
-			return `${url.hostname}${url.port ? `:${url.port}` : ''}`;
+			return `${url.hostname.replace(/\.$/, '')}${url.port ? `:${url.port}` : ''}`;
 		} catch {
 			// Fall through for unusual host spellings (for example scoped IPv6 literals)
 			// that URL cannot parse but the WLED client may still support.
@@ -1311,7 +1311,7 @@ export class WledService extends BaseManagedPluginService {
 			return `[${trimmed}]`;
 		}
 
-		return trimmed.replace(/:80$/, '');
+		return trimmed.replace(/\.(?=:\d+$|$)/, '').replace(/:80$/, '');
 	}
 
 	private legacyHostIdentifiers(endpoint: string): Set<string> {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -635,13 +635,17 @@ export class WledService extends BaseManagedPluginService {
 	async probeDevice(host: string): Promise<WledDiscoveredDeviceModel> {
 		const normalizedHost = this.normalizeHost(host);
 		const context = await this.wledAdapter.probe(normalizedHost, this.config.timeouts.connectionTimeout);
+		const mac = this.normalizeMac(context.info.mac);
+		if (!mac) {
+			throw new WledValidationException('WLED device did not report a valid MAC address');
+		}
 		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
-		const existingDevice = this.findExistingDevice(databaseDevices, normalizedHost, context.info.mac);
+		const existingDevice = this.findExistingDevice(databaseDevices, normalizedHost, mac);
 
 		return {
 			host: normalizedHost,
-			name: existingDevice?.name || context.info.name || `WLED ${context.info.mac}`,
-			mac: context.info.mac,
+			name: existingDevice?.name || context.info.name || `WLED ${mac}`,
+			mac,
 			port: this.portFromHost(normalizedHost),
 			adoptedDeviceId: existingDevice?.id ?? null,
 		};

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -657,6 +657,8 @@ export class WledService extends BaseManagedPluginService {
 			}
 
 			let mappedDevice: WledDeviceEntity | null = null;
+			let existingDeviceDisconnected = false;
+			const disconnectedStaleOwners: WledDeviceEntity[] = [];
 
 			try {
 				if (existingDevice && !existingDevice.identifier) {
@@ -686,19 +688,20 @@ export class WledService extends BaseManagedPluginService {
 					// that actually belongs to this device.
 					if (sourceRegistration?.identifier === existingDevice.identifier) {
 						this.wledAdapter.disconnect(existingDevice.hostname, false);
+						existingDeviceDisconnected = true;
 					}
 				}
 				const staleHostOwners = databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
 				);
+				const retiringHostOwners = staleHostOwners.filter(
+					(staleHostOwner) => !selectedDeviceIds.has(staleHostOwner.id) && !retiredDeviceIds.has(staleHostOwner.id),
+				);
 				if (staleHostOwners.length > 0) {
 					this.wledAdapter.disconnect(host, false);
+					disconnectedStaleOwners.push(...retiringHostOwners);
 				}
-				for (const staleHostOwner of staleHostOwners) {
-					if (selectedDeviceIds.has(staleHostOwner.id) || retiredDeviceIds.has(staleHostOwner.id)) {
-						continue;
-					}
-
+				for (const staleHostOwner of retiringHostOwners) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
 						type: DEVICES_WLED_TYPE,
 						enabled: false,
@@ -712,6 +715,7 @@ export class WledService extends BaseManagedPluginService {
 				let connectionState = ConnectionState.DISCONNECTED;
 				if (!device.enabled) {
 					this.wledAdapter.disconnect(host, false);
+					existingDeviceDisconnected = existingDevice !== null;
 				} else {
 					const registeredDevice = this.wledAdapter.getDevice(host);
 
@@ -772,9 +776,7 @@ export class WledService extends BaseManagedPluginService {
 								enabled: original.enabled,
 								hostname: original.hostname,
 							});
-							await this.deviceConnectivityService.setConnectionState(original.id, {
-								state: ConnectionState.DISCONNECTED,
-							});
+							await this.restoreDeviceConnection(original);
 						} else {
 							const partialDevice = await this.devicesService.findOneBy<WledDeviceEntity>(
 								'identifier',
@@ -810,11 +812,15 @@ export class WledService extends BaseManagedPluginService {
 							enabled: existingDevice.enabled,
 							hostname: existingDevice.hostname,
 						});
-						await this.deviceConnectivityService.setConnectionState(existingDevice.id, {
-							state: ConnectionState.DISCONNECTED,
-						});
+						if (existingDeviceDisconnected) {
+							await this.restoreDeviceConnection(existingDevice);
+						}
 					} else if (partialDevice) {
 						await this.devicesService.remove(partialDevice.id);
+					}
+
+					for (const staleHostOwner of disconnectedStaleOwners) {
+						await this.restoreDeviceConnection(staleHostOwner);
 					}
 
 					results[index] = {
@@ -829,6 +835,24 @@ export class WledService extends BaseManagedPluginService {
 		}
 
 		return results.filter((result): result is WledAdoptionResultModel => result !== undefined);
+	}
+
+	private async restoreDeviceConnection(device: WledDeviceEntity): Promise<void> {
+		let state = ConnectionState.DISCONNECTED;
+
+		if (device.enabled && device.hostname && device.identifier) {
+			try {
+				await this.wledAdapter.connect(device.hostname, device.identifier, this.config.timeouts.connectionTimeout);
+				state = ConnectionState.CONNECTED;
+			} catch (error) {
+				this.logger.warn(`Could not restore the WLED connection for ${device.identifier}`, {
+					resource: device.id,
+					message: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+
+		await this.deviceConnectivityService.setConnectionState(device.id, { state });
 	}
 
 	/**
@@ -903,10 +927,12 @@ export class WledService extends BaseManagedPluginService {
 			if (normalizedMac.length === 12) {
 				const canonicalIdentifier = `wled-${normalizedMac}`;
 				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
+				const legacyHostIdentifier = `wled-${host.replace(/\./g, '-')}`;
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
 					devices.find((device) => device.identifier === legacyIdentifier) ??
+					devices.find((device) => device.identifier === legacyHostIdentifier && device.hostname === host) ??
 					devices.find((device) => device.identifier === null && device.hostname === host)
 				);
 			}

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -440,7 +440,16 @@ export class WledService extends BaseManagedPluginService {
 		const endpoint = this.discoveryEndpoint(device.host, device.port);
 
 		// Check if we already have this device configured by hostname
-		const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		let devices: WledDeviceEntity[];
+		try {
+			devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		} catch (error) {
+			this.mdnsDiscoverer.forgetDiscoveredDevice(device.host);
+			this.logger.error(`Could not inspect discovered WLED device at ${endpoint}`, {
+				message: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
 		const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
 
 		if (existingDevice) {
@@ -737,6 +746,7 @@ export class WledService extends BaseManagedPluginService {
 
 			let mappedDevice: WledDeviceEntity | null = null;
 			let existingDeviceDisconnected = false;
+			const retiredStaleOwners: WledDeviceEntity[] = [];
 			const disconnectedStaleOwners: WledDeviceEntity[] = [];
 
 			try {
@@ -802,6 +812,7 @@ export class WledService extends BaseManagedPluginService {
 					}
 				}
 				for (const staleHostOwner of retiringHostOwners) {
+					retiredStaleOwners.push(staleHostOwner);
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
 						type: DEVICES_WLED_TYPE,
 						enabled: false,
@@ -965,7 +976,7 @@ export class WledService extends BaseManagedPluginService {
 						);
 					}
 
-					for (const staleHostOwner of disconnectedStaleOwners) {
+					for (const staleHostOwner of retiredStaleOwners) {
 						await this.tryRollback(`restore stale owner ${staleHostOwner.id}`, () =>
 							this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
 								type: DEVICES_WLED_TYPE,
@@ -976,9 +987,11 @@ export class WledService extends BaseManagedPluginService {
 								hostname: staleHostOwner.hostname,
 							}),
 						);
-						await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
-							this.restoreDeviceConnection(staleHostOwner),
-						);
+						if (disconnectedStaleOwners.some(({ id }) => id === staleHostOwner.id)) {
+							await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
+								this.restoreDeviceConnection(staleHostOwner),
+							);
+						}
 					}
 
 					results[index] = {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -448,7 +448,11 @@ export class WledService extends BaseManagedPluginService {
 
 			// Reconcile a known MAC at a new endpoint through the same guarded
 			// provisioning path as administrator adoption.
-			if (existingDevice.hostname !== endpoint && this.config.mdns.autoAdd) {
+			if (
+				existingDevice.hostname &&
+				!this.endpointsEquivalent(existingDevice.hostname, endpoint) &&
+				this.config.mdns.autoAdd
+			) {
 				await this.connectAndMapDiscoveredDevice(device);
 			} else if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 				this.logger.debug(`Connecting to existing device at ${endpoint}`);
@@ -475,7 +479,7 @@ export class WledService extends BaseManagedPluginService {
 				const endpoint = this.discoveryEndpoint(device.host, device.port);
 				const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
-				if (existingDevice?.hostname === endpoint) {
+				if (existingDevice?.hostname && this.endpointsEquivalent(existingDevice.hostname, endpoint)) {
 					if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 						await this.connectToDevice(existingDevice);
 					}
@@ -560,7 +564,7 @@ export class WledService extends BaseManagedPluginService {
 	private async doAdoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
 		const results = requests.map<WledAdoptionResultModel | undefined>(() => undefined);
 		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
-		const normalizedHostsByIndex = new Map<number, string>();
+		const failedSelectionHosts = new Set<string>();
 		const plans: Array<{
 			index: number;
 			request: WledAdoptDeviceDto;
@@ -576,7 +580,6 @@ export class WledService extends BaseManagedPluginService {
 
 			try {
 				host = this.normalizeHost(request.host);
-				normalizedHostsByIndex.set(index, host);
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
 				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
@@ -597,6 +600,7 @@ export class WledService extends BaseManagedPluginService {
 
 				plans.push({ index, request, host, context, existingDevice, identifier });
 			} catch (error) {
+				failedSelectionHosts.add(host);
 				results[index] = {
 					host,
 					name: request.name,
@@ -610,27 +614,24 @@ export class WledService extends BaseManagedPluginService {
 		const plannedExistingDeviceIds = new Set(
 			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
 		);
-		const plannedIndices = new Set(plans.map(({ index }) => index));
-		const failedSelectionHosts = new Set(
-			[...normalizedHostsByIndex].flatMap(([index, host]) => (!plannedIndices.has(index) ? [host] : [])),
-		);
 		const selectedDeviceIds = plannedExistingDeviceIds;
 		const moveHostEdges = new Map<string, Set<string>>();
 		for (const plan of plans) {
-			const sourceHost = plan.existingDevice?.hostname;
-			if (!sourceHost || sourceHost === plan.host) {
+			const sourceHost = plan.existingDevice?.hostname ? this.canonicalEndpoint(plan.existingDevice.hostname) : null;
+			const targetHost = this.canonicalEndpoint(plan.host);
+			if (!sourceHost || sourceHost === targetHost) {
 				continue;
 			}
 
 			const sourceEdges = moveHostEdges.get(sourceHost) ?? new Set<string>();
-			sourceEdges.add(plan.host);
+			sourceEdges.add(targetHost);
 			moveHostEdges.set(sourceHost, sourceEdges);
-			const targetEdges = moveHostEdges.get(plan.host) ?? new Set<string>();
+			const targetEdges = moveHostEdges.get(targetHost) ?? new Set<string>();
 			targetEdges.add(sourceHost);
-			moveHostEdges.set(plan.host, targetEdges);
+			moveHostEdges.set(targetHost, targetEdges);
 		}
 		const failedMoveHosts = new Set<string>();
-		const pendingFailedHosts = [...failedSelectionHosts];
+		const pendingFailedHosts = [...failedSelectionHosts].map((host) => this.canonicalEndpoint(host));
 		while (pendingFailedHosts.length > 0) {
 			const currentHost = pendingFailedHosts.pop();
 			if (!currentHost || failedMoveHosts.has(currentHost)) {
@@ -643,10 +644,10 @@ export class WledService extends BaseManagedPluginService {
 		const blockedPlanIndices = new Set<number>();
 		for (const plan of plans) {
 			if (
-				failedMoveHosts.has(plan.host) ||
+				failedMoveHosts.has(this.canonicalEndpoint(plan.host)) ||
 				(plan.existingDevice?.hostname !== null &&
 					plan.existingDevice?.hostname !== undefined &&
-					failedMoveHosts.has(plan.existingDevice.hostname))
+					failedMoveHosts.has(this.canonicalEndpoint(plan.existingDevice.hostname)))
 			) {
 				blockedPlanIndices.add(plan.index);
 				results[plan.index] = {
@@ -662,7 +663,10 @@ export class WledService extends BaseManagedPluginService {
 		for (const plan of plans.filter(({ index }) => !blockedPlanIndices.has(index))) {
 			const selectedTargetOwner = plans.find(
 				(candidate) =>
-					candidate.existingDevice?.hostname === plan.host && candidate.existingDevice.id !== plan.existingDevice?.id,
+					candidate.existingDevice?.hostname !== null &&
+					candidate.existingDevice?.hostname !== undefined &&
+					this.endpointsEquivalent(candidate.existingDevice.hostname, plan.host) &&
+					candidate.existingDevice.id !== plan.existingDevice?.id,
 			);
 
 			if (selectedTargetOwner) {
@@ -756,7 +760,10 @@ export class WledService extends BaseManagedPluginService {
 					}
 				}
 				const staleHostOwners = databaseDevices.filter(
-					(device) => device.hostname === host && device.id !== existingDevice?.id,
+					(device) =>
+						device.hostname !== null &&
+						this.endpointsEquivalent(device.hostname, host) &&
+						device.id !== existingDevice?.id,
 				);
 				const retiringHostOwners = staleHostOwners.filter(
 					(staleHostOwner) => !selectedDeviceIds.has(staleHostOwner.id) && !retiredDeviceIds.has(staleHostOwner.id),
@@ -1018,7 +1025,11 @@ export class WledService extends BaseManagedPluginService {
 
 		// Filter out devices that are already in the database
 		return discoveredDevices.filter(
-			(device) => !existingHostnames.has(this.discoveryEndpoint(device.host, device.port)),
+			(device) =>
+				![...existingHostnames].some(
+					(hostname) =>
+						hostname !== null && this.endpointsEquivalent(hostname, this.discoveryEndpoint(device.host, device.port)),
+				),
 		);
 	}
 
@@ -1085,14 +1096,28 @@ export class WledService extends BaseManagedPluginService {
 					devices.find((device) => device.identifier === legacyIdentifier) ??
 					devices.find(
 						(device) =>
-							device.identifier !== null && legacyHostIdentifiers.has(device.identifier) && device.hostname === host,
+							device.identifier !== null &&
+							legacyHostIdentifiers.has(device.identifier) &&
+							device.hostname !== null &&
+							this.endpointsEquivalent(device.hostname, host),
 					) ??
-					devices.find((device) => device.identifier === null && device.hostname === host)
+					devices.find(
+						(device) =>
+							device.identifier === null && device.hostname !== null && this.endpointsEquivalent(device.hostname, host),
+					)
 				);
 			}
 		}
 
-		return devices.find((device) => device.hostname === host);
+		return devices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host));
+	}
+
+	private endpointsEquivalent(first: string, second: string): boolean {
+		return this.canonicalEndpoint(first) === this.canonicalEndpoint(second);
+	}
+
+	private canonicalEndpoint(endpoint: string): string {
+		return endpoint.replace(/:80$/, '');
 	}
 
 	private legacyHostIdentifiers(endpoint: string): Set<string> {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -28,6 +28,7 @@ import {
 import { WledConfigModel } from '../models/config.model';
 import { WledAdoptionResultModel, WledDiscoveredDeviceModel, WledDiscoveryModel } from '../models/wled-discovery.model';
 
+import { WledAdoptionSnapshotService, WledAdoptionStructureSnapshot } from './adoption-snapshot.service';
 import { WledDeviceMapperService } from './device-mapper.service';
 import { WledClientAdapterService } from './wled-client-adapter.service';
 import { WledMdnsDiscovererService } from './wled-mdns-discoverer.service';
@@ -54,6 +55,7 @@ export class WledService extends BaseManagedPluginService {
 		private readonly configService: ConfigService,
 		private readonly wledAdapter: WledClientAdapterService,
 		private readonly deviceMapper: WledDeviceMapperService,
+		private readonly adoptionSnapshot: WledAdoptionSnapshotService,
 		private readonly devicesService: DevicesService,
 		private readonly mdnsDiscoverer: WledMdnsDiscovererService,
 		private readonly deviceConnectivityService: DeviceConnectivityService,
@@ -726,7 +728,9 @@ export class WledService extends BaseManagedPluginService {
 		const retiredDeviceIds = new Set<string>();
 		const failedDependencyGroups = new Map<Set<number>, string>();
 		const createdDeviceIdsByPlan = new Map<number, string>();
+		const structureSnapshotsByPlan = new Map<number, WledAdoptionStructureSnapshot>();
 		const retiredStaleOwnersByDependencyGroup = new Map<Set<number>, Map<string, WledDeviceEntity>>();
+		const disconnectedStaleOwnerIdsByDependencyGroup = new Map<Set<number>, Set<string>>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
 			if (blockedPlanIndices.has(index)) {
@@ -752,6 +756,9 @@ export class WledService extends BaseManagedPluginService {
 			const disconnectedStaleOwners: WledDeviceEntity[] = [];
 
 			try {
+				if (existingDevice) {
+					structureSnapshotsByPlan.set(index, await this.adoptionSnapshot.capture(existingDevice.id));
+				}
 				if (existingDevice && existingDevice.identifier !== identifier) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
 						type: DEVICES_WLED_TYPE,
@@ -809,6 +816,12 @@ export class WledService extends BaseManagedPluginService {
 							this.wledAdapter.disconnect(staleHostOwner.hostname, false);
 							if (retiringHostOwners.some(({ id }) => id === staleHostOwner.id)) {
 								disconnectedStaleOwners.push(staleHostOwner);
+								if (dependencyGroup) {
+									const disconnectedIds =
+										disconnectedStaleOwnerIdsByDependencyGroup.get(dependencyGroup) ?? new Set<string>();
+									disconnectedIds.add(staleHostOwner.id);
+									disconnectedStaleOwnerIdsByDependencyGroup.set(dependencyGroup, disconnectedIds);
+								}
 							}
 						}
 					}
@@ -883,6 +896,12 @@ export class WledService extends BaseManagedPluginService {
 					for (const dependentPlan of dependentPlans) {
 						if (dependentPlan.existingDevice) {
 							const original = dependentPlan.existingDevice;
+							const structureSnapshot = structureSnapshotsByPlan.get(dependentPlan.index);
+							if (structureSnapshot) {
+								await this.tryRollback(`restore device structure ${original.id}`, () =>
+									this.adoptionSnapshot.restore(structureSnapshot),
+								);
+							}
 							await this.tryRollback(`restore device ${original.id}`, () =>
 								this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(original.id, {
 									type: DEVICES_WLED_TYPE,
@@ -935,9 +954,11 @@ export class WledService extends BaseManagedPluginService {
 							}),
 						);
 						retiredDeviceIds.delete(staleHostOwner.id);
-						await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
-							this.restoreDeviceConnection(staleHostOwner),
-						);
+						if (disconnectedStaleOwnerIdsByDependencyGroup.get(dependencyGroup)?.has(staleHostOwner.id)) {
+							await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
+								this.restoreDeviceConnection(staleHostOwner),
+							);
+						}
 					}
 				} else {
 					const attemptedRegistration = this.wledAdapter.getDevice(host);
@@ -957,6 +978,12 @@ export class WledService extends BaseManagedPluginService {
 						));
 
 					if (existingDevice) {
+						const structureSnapshot = structureSnapshotsByPlan.get(index);
+						if (structureSnapshot) {
+							await this.tryRollback(`restore device structure ${existingDevice.id}`, () =>
+								this.adoptionSnapshot.restore(structureSnapshot),
+							);
+						}
 						await this.tryRollback(`restore device ${existingDevice.id}`, () =>
 							this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
 								type: DEVICES_WLED_TYPE,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -486,13 +486,19 @@ export class WledService extends BaseManagedPluginService {
 					return;
 				}
 
-				await this.doAdoptDevices([
+				const [result] = await this.doAdoptDevices([
 					{
 						host: endpoint,
 						name: existingDevice?.name ?? device.name,
 						category: DeviceCategory.LIGHTING,
 					},
 				]);
+				if (!result || result.status === 'failed') {
+					this.mdnsDiscoverer.forgetDiscoveredDevice(device.host);
+					this.logger.warn(`Auto-add failed for discovered WLED device at ${endpoint}`, {
+						message: result?.error ?? 'No adoption result was returned',
+					});
+				}
 			} catch (error) {
 				this.logger.error(`Failed to connect to discovered device at ${device.host}`, {
 					message: error instanceof Error ? error.message : String(error),

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -767,30 +767,41 @@ export class WledService extends BaseManagedPluginService {
 					);
 
 					for (const involvedHost of involvedHosts) {
-						this.wledAdapter.disconnect(involvedHost, false);
+						await this.tryRollback(`disconnect ${involvedHost}`, () =>
+							Promise.resolve(this.wledAdapter.disconnect(involvedHost, false)),
+						);
 					}
 
 					for (const dependentPlan of dependentPlans) {
 						if (dependentPlan.existingDevice) {
 							const original = dependentPlan.existingDevice;
-							await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(original.id, {
-								type: DEVICES_WLED_TYPE,
-								identifier: original.identifier,
-								name: original.name,
-								description: original.description,
-								enabled: original.enabled,
-								hostname: original.hostname,
-							});
-							await this.restoreDeviceConnection(original);
+							await this.tryRollback(`restore device ${original.id}`, () =>
+								this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(original.id, {
+									type: DEVICES_WLED_TYPE,
+									identifier: original.identifier,
+									name: original.name,
+									description: original.description,
+									enabled: original.enabled,
+									hostname: original.hostname,
+								}),
+							);
+							await this.tryRollback(`reconnect device ${original.id}`, () => this.restoreDeviceConnection(original));
 						} else {
-							const partialDevice = await this.devicesService.findOneBy<WledDeviceEntity>(
-								'identifier',
-								dependentPlan.identifier,
-								DEVICES_WLED_TYPE,
+							const partialDevice = await this.tryRollback(
+								`find partial device ${dependentPlan.identifier}`,
+								() =>
+									this.devicesService.findOneBy<WledDeviceEntity>(
+										'identifier',
+										dependentPlan.identifier,
+										DEVICES_WLED_TYPE,
+									),
+								null,
 							);
 							const createdDeviceId = createdDeviceIdsByPlan.get(dependentPlan.index) ?? partialDevice?.id;
 							if (createdDeviceId) {
-								await this.devicesService.remove(createdDeviceId);
+								await this.tryRollback(`remove partial device ${createdDeviceId}`, () =>
+									this.devicesService.remove(createdDeviceId),
+								);
 								createdDeviceIdsByPlan.delete(dependentPlan.index);
 							}
 						}
@@ -805,54 +816,74 @@ export class WledService extends BaseManagedPluginService {
 					}
 
 					for (const staleHostOwner of retiredStaleOwnersByDependencyGroup.get(dependencyGroup)?.values() ?? []) {
-						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
-							type: DEVICES_WLED_TYPE,
-							identifier: staleHostOwner.identifier,
-							name: staleHostOwner.name,
-							description: staleHostOwner.description,
-							enabled: staleHostOwner.enabled,
-							hostname: staleHostOwner.hostname,
-						});
+						await this.tryRollback(`restore stale owner ${staleHostOwner.id}`, () =>
+							this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
+								type: DEVICES_WLED_TYPE,
+								identifier: staleHostOwner.identifier,
+								name: staleHostOwner.name,
+								description: staleHostOwner.description,
+								enabled: staleHostOwner.enabled,
+								hostname: staleHostOwner.hostname,
+							}),
+						);
 						retiredDeviceIds.delete(staleHostOwner.id);
-						await this.restoreDeviceConnection(staleHostOwner);
+						await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
+							this.restoreDeviceConnection(staleHostOwner),
+						);
 					}
 				} else {
 					const attemptedRegistration = this.wledAdapter.getDevice(host);
 					const attemptedHostDisconnected =
 						attemptedRegistration?.host === host && attemptedRegistration.identifier === identifier;
 					if (attemptedHostDisconnected) {
-						this.wledAdapter.disconnect(host, false);
+						await this.tryRollback(`disconnect ${host}`, () =>
+							Promise.resolve(this.wledAdapter.disconnect(host, false)),
+						);
 					}
 					const partialDevice =
 						mappedDevice ??
-						(await this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE));
+						(await this.tryRollback(
+							`find partial device ${identifier}`,
+							() => this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE),
+							null,
+						));
 
 					if (existingDevice) {
-						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
-							type: DEVICES_WLED_TYPE,
-							identifier: existingDevice.identifier,
-							name: existingDevice.name,
-							description: existingDevice.description,
-							enabled: existingDevice.enabled,
-							hostname: existingDevice.hostname,
-						});
+						await this.tryRollback(`restore device ${existingDevice.id}`, () =>
+							this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
+								type: DEVICES_WLED_TYPE,
+								identifier: existingDevice.identifier,
+								name: existingDevice.name,
+								description: existingDevice.description,
+								enabled: existingDevice.enabled,
+								hostname: existingDevice.hostname,
+							}),
+						);
 						if (existingDeviceDisconnected || attemptedHostDisconnected) {
-							await this.restoreDeviceConnection(existingDevice);
+							await this.tryRollback(`reconnect device ${existingDevice.id}`, () =>
+								this.restoreDeviceConnection(existingDevice),
+							);
 						}
 					} else if (partialDevice) {
-						await this.devicesService.remove(partialDevice.id);
+						await this.tryRollback(`remove partial device ${partialDevice.id}`, () =>
+							this.devicesService.remove(partialDevice.id),
+						);
 					}
 
 					for (const staleHostOwner of disconnectedStaleOwners) {
-						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
-							type: DEVICES_WLED_TYPE,
-							identifier: staleHostOwner.identifier,
-							name: staleHostOwner.name,
-							description: staleHostOwner.description,
-							enabled: staleHostOwner.enabled,
-							hostname: staleHostOwner.hostname,
-						});
-						await this.restoreDeviceConnection(staleHostOwner);
+						await this.tryRollback(`restore stale owner ${staleHostOwner.id}`, () =>
+							this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(staleHostOwner.id, {
+								type: DEVICES_WLED_TYPE,
+								identifier: staleHostOwner.identifier,
+								name: staleHostOwner.name,
+								description: staleHostOwner.description,
+								enabled: staleHostOwner.enabled,
+								hostname: staleHostOwner.hostname,
+							}),
+						);
+						await this.tryRollback(`reconnect stale owner ${staleHostOwner.id}`, () =>
+							this.restoreDeviceConnection(staleHostOwner),
+						);
 					}
 
 					results[index] = {
@@ -877,6 +908,17 @@ export class WledService extends BaseManagedPluginService {
 		);
 
 		return result;
+	}
+
+	private async tryRollback<T>(description: string, operation: () => Promise<T>, fallback?: T): Promise<T | undefined> {
+		try {
+			return await operation();
+		} catch (error) {
+			this.logger.error(`WLED adoption rollback could not ${description}`, {
+				message: error instanceof Error ? error.message : String(error),
+			});
+			return fallback;
+		}
 	}
 
 	private async restoreDeviceConnection(device: WledDeviceEntity): Promise<void> {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -466,6 +466,7 @@ export class WledService extends BaseManagedPluginService {
 				identifiedDevice = { ...device, mac: context.info.mac };
 				existingDevice = this.findExistingDevice(devices, endpoint, context.info.mac);
 			} catch (error) {
+				this.mdnsDiscoverer.forgetDiscoveredDevice(device.host);
 				this.logger.debug(`Could not identify MAC-less WLED device at ${endpoint}`, {
 					message: error instanceof Error ? error.message : String(error),
 				});

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -311,7 +311,12 @@ export class WledService extends BaseManagedPluginService {
 			const registeredDevice = this.wledAdapter.getDevice(device.hostname);
 
 			if (registeredDevice?.context) {
-				await this.persistHardwareIdentity(device, registeredDevice.context.info.mac);
+				const identityVerified = await this.persistHardwareIdentity(device, registeredDevice.context.info.mac);
+				if (!identityVerified) {
+					this.wledAdapter.disconnect(device.hostname, false);
+					await this.deviceMapper.setDeviceConnectionState(device.identifier, ConnectionState.DISCONNECTED);
+					return;
+				}
 				await this.deviceMapper.updateDeviceState(device.identifier, registeredDevice.context.state);
 			}
 		} catch (error) {
@@ -350,7 +355,17 @@ export class WledService extends BaseManagedPluginService {
 
 	private async persistHardwareIdentity(device: WledDeviceEntity, reportedMac: string): Promise<boolean> {
 		const mac = this.normalizeMac(reportedMac);
-		if (!mac || device.mac === mac) {
+		if (!mac) {
+			if (device.mac) {
+				this.logger.warn('WLED did not report a valid hardware identity for the configured device', {
+					resource: device.id,
+				});
+				return false;
+			}
+
+			return true;
+		}
+		if (device.mac === mac) {
 			return true;
 		}
 		const result = await this.hardwareIdentity.persist(device, mac);

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -48,6 +48,7 @@ export class WledService extends BaseManagedPluginService {
 
 	private pluginConfig: WledConfigModel | null = null;
 	private pollingInterval: NodeJS.Timeout | null = null;
+	private adoptionQueue: Promise<void> = Promise.resolve();
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -538,6 +539,16 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	async adoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
+		const operation: Promise<WledAdoptionResultModel[]> = this.adoptionQueue.then(() => this.doAdoptDevices(requests));
+		this.adoptionQueue = operation.then<void>(
+			() => undefined,
+			() => undefined,
+		);
+
+		return operation;
+	}
+
+	private async doAdoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
 		const results = requests.map<WledAdoptionResultModel | undefined>(() => undefined);
 		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 		const plans: Array<{
@@ -645,6 +656,8 @@ export class WledService extends BaseManagedPluginService {
 				continue;
 			}
 
+			let mappedDevice: WledDeviceEntity | null = null;
+
 			try {
 				if (existingDevice && !existingDevice.identifier) {
 					await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
@@ -661,6 +674,7 @@ export class WledService extends BaseManagedPluginService {
 					request.description,
 					request.enabled,
 				);
+				mappedDevice = device;
 				if (!existingDevice) {
 					createdDeviceIdsByPlan.set(index, device.id);
 				}
@@ -783,6 +797,26 @@ export class WledService extends BaseManagedPluginService {
 						};
 					}
 				} else {
+					const partialDevice =
+						mappedDevice ??
+						(await this.devicesService.findOneBy<WledDeviceEntity>('identifier', identifier, DEVICES_WLED_TYPE));
+
+					if (existingDevice) {
+						await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(existingDevice.id, {
+							type: DEVICES_WLED_TYPE,
+							identifier: existingDevice.identifier,
+							name: existingDevice.name,
+							description: existingDevice.description,
+							enabled: existingDevice.enabled,
+							hostname: existingDevice.hostname,
+						});
+						await this.deviceConnectivityService.setConnectionState(existingDevice.id, {
+							state: ConnectionState.DISCONNECTED,
+						});
+					} else if (partialDevice) {
+						await this.devicesService.remove(partialDevice.id);
+					}
+
 					results[index] = {
 						host,
 						name: request.name,

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -580,10 +580,6 @@ export class WledService extends BaseManagedPluginService {
 			if (existingDevice?.hostname && existingDevice.hostname !== host) {
 				this.wledAdapter.disconnect(existingDevice.hostname);
 			}
-
-			if (databaseDevices.some((device) => device.hostname === host && device.id !== existingDevice?.id)) {
-				this.wledAdapter.disconnect(host);
-			}
 		}
 
 		const retiredDeviceIds = new Set<string>();
@@ -605,9 +601,13 @@ export class WledService extends BaseManagedPluginService {
 					request.description,
 					request.enabled,
 				);
-				for (const staleHostOwner of databaseDevices.filter(
+				const staleHostOwners = databaseDevices.filter(
 					(device) => device.hostname === host && device.id !== existingDevice?.id,
-				)) {
+				);
+				if (staleHostOwners.length > 0) {
+					this.wledAdapter.disconnect(host);
+				}
+				for (const staleHostOwner of staleHostOwners) {
 					if (selectedDeviceIds.has(staleHostOwner.id) || retiredDeviceIds.has(staleHostOwner.id)) {
 						continue;
 					}

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -300,6 +300,7 @@ export class WledService extends BaseManagedPluginService {
 			const registeredDevice = this.wledAdapter.getDevice(device.hostname);
 
 			if (registeredDevice?.context) {
+				await this.persistHardwareIdentity(device, registeredDevice.context.info.mac);
 				await this.deviceMapper.updateDeviceState(device.identifier, registeredDevice.context.state);
 			}
 		} catch (error) {
@@ -319,8 +320,28 @@ export class WledService extends BaseManagedPluginService {
 		const device = this.wledAdapter.getDevice(event.host);
 
 		if (device) {
+			const storedDevice = await this.devicesService.findOneBy<WledDeviceEntity>(
+				'identifier',
+				device.identifier,
+				DEVICES_WLED_TYPE,
+			);
+			if (storedDevice) {
+				await this.persistHardwareIdentity(storedDevice, event.info.mac);
+			}
 			await this.deviceMapper.setDeviceConnectionState(device.identifier, ConnectionState.CONNECTED);
 		}
+	}
+
+	private async persistHardwareIdentity(device: WledDeviceEntity, reportedMac: string): Promise<void> {
+		const mac = this.normalizeMac(reportedMac);
+		if (!mac || device.mac === mac) {
+			return;
+		}
+
+		await this.devicesService.update<WledDeviceEntity, UpdateWledDeviceDto>(device.id, {
+			type: DEVICES_WLED_TYPE,
+			mac,
+		});
 	}
 
 	/**
@@ -939,6 +960,7 @@ export class WledService extends BaseManagedPluginService {
 									description: original.description,
 									enabled: original.enabled,
 									hostname: original.hostname,
+									mac: original.mac,
 								}),
 							);
 							await this.tryRollback(`reconnect device ${original.id}`, () => this.restoreDeviceConnection(original));
@@ -980,6 +1002,7 @@ export class WledService extends BaseManagedPluginService {
 								description: staleHostOwner.description,
 								enabled: staleHostOwner.enabled,
 								hostname: staleHostOwner.hostname,
+								mac: staleHostOwner.mac,
 							}),
 						);
 						retiredDeviceIds.delete(staleHostOwner.id);
@@ -1018,6 +1041,7 @@ export class WledService extends BaseManagedPluginService {
 								description: existingDevice.description,
 								enabled: existingDevice.enabled,
 								hostname: existingDevice.hostname,
+								mac: existingDevice.mac,
 							}),
 						);
 						if (existingDeviceDisconnected || attemptedRegistrationCreated) {
@@ -1040,6 +1064,7 @@ export class WledService extends BaseManagedPluginService {
 								description: staleHostOwner.description,
 								enabled: staleHostOwner.enabled,
 								hostname: staleHostOwner.hostname,
+								mac: staleHostOwner.mac,
 							}),
 						);
 						if (disconnectedStaleOwners.some(({ id }) => id === staleHostOwner.id)) {
@@ -1183,6 +1208,7 @@ export class WledService extends BaseManagedPluginService {
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
+					devices.find((device) => device.mac === normalizedMac) ??
 					devices.find((device) => this.deviceSerialMac(device) === normalizedMac) ??
 					legacyDevices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host)) ??
 					devices.find(

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -445,6 +445,7 @@ export class WledService extends BaseManagedPluginService {
 	private async handleMdnsDeviceDiscovered(device: WledMdnsDiscoveredDevice): Promise<void> {
 		this.logger.log(`mDNS discovered device: ${device.name} at ${device.host}`);
 		const endpoint = this.discoveryEndpoint(device.host, device.port);
+		const advertisedMac = this.normalizeMac(device.mac) ? device.mac : undefined;
 
 		// Check if we already have this device configured by hostname
 		let devices: WledDeviceEntity[];
@@ -457,10 +458,10 @@ export class WledService extends BaseManagedPluginService {
 			});
 			return;
 		}
-		let identifiedDevice = device;
-		let existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
+		let identifiedDevice = { ...device, mac: advertisedMac };
+		let existingDevice = this.findExistingDevice(devices, endpoint, advertisedMac);
 
-		if (!existingDevice && !device.mac && !this.config.mdns.autoAdd) {
+		if (!existingDevice && !advertisedMac && !this.config.mdns.autoAdd) {
 			try {
 				const context = await this.wledAdapter.probe(endpoint, this.config.timeouts.connectionTimeout);
 				identifiedDevice = { ...device, mac: context.info.mac };
@@ -1159,8 +1160,8 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	private identifierFromMac(mac: string): string {
-		const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-		if (normalizedMac.length !== 12) {
+		const normalizedMac = this.normalizeMac(mac);
+		if (!normalizedMac) {
 			throw new WledValidationException('WLED device did not report a valid MAC address');
 		}
 
@@ -1173,8 +1174,8 @@ export class WledService extends BaseManagedPluginService {
 		mac?: string | null,
 	): WledDeviceEntity | undefined {
 		if (mac) {
-			const normalizedMac = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-			if (normalizedMac.length === 12) {
+			const normalizedMac = this.normalizeMac(mac);
+			if (normalizedMac) {
 				const canonicalIdentifier = `wled-${normalizedMac}`;
 				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
 				const legacyHostIdentifiers = this.legacyHostIdentifiers(host);
@@ -1202,6 +1203,15 @@ export class WledService extends BaseManagedPluginService {
 		return devices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host));
 	}
 
+	private normalizeMac(mac?: string | null): string | null {
+		if (!mac) {
+			return null;
+		}
+
+		const normalized = mac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+		return normalized.length === 12 ? normalized : null;
+	}
+
 	private deviceSerialMac(device: WledDeviceEntity): string | null {
 		const serial = device.channels
 			?.find((channel) => channel.identifier === WLED_CHANNEL_IDENTIFIERS.DEVICE_INFORMATION)
@@ -1212,8 +1222,7 @@ export class WledService extends BaseManagedPluginService {
 			return null;
 		}
 
-		const normalized = serial.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-		return normalized.length === 12 ? normalized : null;
+		return this.normalizeMac(serial);
 	}
 
 	private requiresCanonicalIdentity(device: WledDeviceEntity, host: string, mac?: string | null): boolean {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -437,17 +437,18 @@ export class WledService extends BaseManagedPluginService {
 	 */
 	private async handleMdnsDeviceDiscovered(device: WledMdnsDiscoveredDevice): Promise<void> {
 		this.logger.log(`mDNS discovered device: ${device.name} at ${device.host}`);
+		const endpoint = this.discoveryEndpoint(device.host, device.port);
 
 		// Check if we already have this device configured by hostname
 		const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
-		const existingDevice = devices.find((d) => d.hostname === device.host);
+		const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
 
 		if (existingDevice) {
-			this.logger.debug(`Device at ${device.host} already exists in database`);
+			this.logger.debug(`Device at ${endpoint} already exists in database`);
 
 			// If device is enabled and not connected, try to connect
-			if (existingDevice.enabled && !this.wledAdapter.isConnected(device.host)) {
-				this.logger.debug(`Connecting to existing device at ${device.host}`);
+			if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
+				this.logger.debug(`Connecting to existing device at ${endpoint}`);
 				await this.connectToDevice(existingDevice);
 			}
 			return;
@@ -468,13 +469,23 @@ export class WledService extends BaseManagedPluginService {
 	private async connectAndMapDiscoveredDevice(device: WledMdnsDiscoveredDevice): Promise<void> {
 		await this.enqueueProvisioning(async () => {
 			try {
-				const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
-				await this.wledAdapter.connect(device.host, identifier, this.config.timeouts.connectionTimeout);
+				const endpoint = this.discoveryEndpoint(device.host, device.port);
+				const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+				const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
+				if (existingDevice) {
+					if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
+						await this.connectToDevice(existingDevice);
+					}
+					return;
+				}
 
-				const registeredDevice = this.wledAdapter.getDevice(device.host);
+				const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
+				await this.wledAdapter.connect(endpoint, identifier, this.config.timeouts.connectionTimeout);
+
+				const registeredDevice = this.wledAdapter.getDevice(endpoint);
 
 				if (registeredDevice?.context) {
-					await this.deviceMapper.mapDevice(device.host, registeredDevice.context, device.name, identifier);
+					await this.deviceMapper.mapDevice(endpoint, registeredDevice.context, device.name, identifier);
 				}
 			} catch (error) {
 				this.logger.error(`Failed to connect to discovered device at ${device.host}`, {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -12,7 +12,12 @@ import {
 	ServiceState,
 } from '../../../modules/extensions/services/managed-plugin-service.interface';
 import { PluginServiceManagerService } from '../../../modules/extensions/services/plugin-service-manager.service';
-import { DEVICES_WLED_PLUGIN_NAME, DEVICES_WLED_TYPE } from '../devices-wled.constants';
+import {
+	DEVICES_WLED_PLUGIN_NAME,
+	DEVICES_WLED_TYPE,
+	WLED_CHANNEL_IDENTIFIERS,
+	WLED_DEVICE_INFO_PROPERTY_IDENTIFIERS,
+} from '../devices-wled.constants';
 import { WledValidationException } from '../devices-wled.exceptions';
 import { UpdateWledDeviceDto } from '../dto/update-device.dto';
 import { WledAdoptDeviceDto } from '../dto/wled-adoption.dto';
@@ -601,7 +606,8 @@ export class WledService extends BaseManagedPluginService {
 				const existingIdentifier = existingDevice?.identifier;
 				const identifier =
 					existingIdentifier &&
-					!this.legacyHostIdentifiers(existingDevice.hostname ?? host).has(existingIdentifier.toLowerCase())
+					!this.legacyHostIdentifiers(existingDevice.hostname ?? host).has(existingIdentifier.toLowerCase()) &&
+					existingIdentifier.toLowerCase() !== `wled-${canonicalIdentity.slice(-6)}`
 						? existingIdentifier
 						: canonicalIdentity;
 
@@ -1148,15 +1154,12 @@ export class WledService extends BaseManagedPluginService {
 				const canonicalIdentifier = `wled-${normalizedMac}`;
 				const legacyIdentifier = `wled-${normalizedMac.slice(-6)}`;
 				const legacyHostIdentifiers = this.legacyHostIdentifiers(host);
+				const legacyDevices = devices.filter((device) => device.identifier === legacyIdentifier);
 
 				return (
 					devices.find((device) => device.identifier === canonicalIdentifier) ??
-					devices.find(
-						(device) =>
-							device.identifier === legacyIdentifier &&
-							device.hostname !== null &&
-							this.endpointsEquivalent(device.hostname, host),
-					) ??
+					legacyDevices.find((device) => this.deviceSerialMac(device) === normalizedMac) ??
+					legacyDevices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host)) ??
 					devices.find(
 						(device) =>
 							device.identifier !== null &&
@@ -1173,6 +1176,20 @@ export class WledService extends BaseManagedPluginService {
 		}
 
 		return devices.find((device) => device.hostname !== null && this.endpointsEquivalent(device.hostname, host));
+	}
+
+	private deviceSerialMac(device: WledDeviceEntity): string | null {
+		const serial = device.channels
+			?.find((channel) => channel.identifier === WLED_CHANNEL_IDENTIFIERS.DEVICE_INFORMATION)
+			?.properties?.find((property) => property.identifier === WLED_DEVICE_INFO_PROPERTY_IDENTIFIERS.SERIAL_NUMBER)
+			?.value?.value;
+
+		if (typeof serial !== 'string') {
+			return null;
+		}
+
+		const normalized = serial.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+		return normalized.length === 12 ? normalized : null;
 	}
 
 	private endpointsEquivalent(first: string, second: string): boolean {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -70,7 +70,15 @@ export class WledService extends BaseManagedPluginService {
 
 		// Set up adapter callbacks
 		this.wledAdapter.setCallbacks({
-			onDeviceConnected: (event) => this.handleDeviceConnected(event),
+			onDeviceConnected: async (event) => {
+				try {
+					await this.handleDeviceConnected(event);
+				} catch (error) {
+					this.logger.error(`Failed to process WLED connected event for ${event.host}`, {
+						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+			},
 			onDeviceDisconnected: (event) => this.handleDeviceDisconnected(event),
 			onDeviceStateChanged: (event) => this.handleDeviceStateChanged(event),
 			onDeviceError: (event) => this.handleDeviceError(event),
@@ -335,6 +343,14 @@ export class WledService extends BaseManagedPluginService {
 	private async persistHardwareIdentity(device: WledDeviceEntity, reportedMac: string): Promise<void> {
 		const mac = this.normalizeMac(reportedMac);
 		if (!mac || device.mac === mac) {
+			return;
+		}
+		const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		const existingOwner = devices.find((candidate) => candidate.id !== device.id && candidate.mac === mac);
+		if (existingOwner) {
+			this.logger.warn(`WLED hardware identity ${mac} is already owned by device ${existingOwner.id}`, {
+				resource: device.id,
+			});
 			return;
 		}
 

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -3,7 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
 import { ConfigService } from '../../../modules/config/services/config.service';
-import { ConnectionState } from '../../../modules/devices/devices.constants';
+import { ConnectionState, DeviceCategory } from '../../../modules/devices/devices.constants';
 import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { BaseManagedPluginService } from '../../../modules/extensions/services/base-managed-plugin.service';
@@ -446,8 +446,11 @@ export class WledService extends BaseManagedPluginService {
 		if (existingDevice) {
 			this.logger.debug(`Device at ${endpoint} already exists in database`);
 
-			// If device is enabled and not connected, try to connect
-			if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
+			// Reconcile a known MAC at a new endpoint through the same guarded
+			// provisioning path as administrator adoption.
+			if (existingDevice.hostname !== endpoint && this.config.mdns.autoAdd) {
+				await this.connectAndMapDiscoveredDevice(device);
+			} else if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 				this.logger.debug(`Connecting to existing device at ${endpoint}`);
 				await this.connectToDevice(existingDevice);
 			}
@@ -472,21 +475,20 @@ export class WledService extends BaseManagedPluginService {
 				const endpoint = this.discoveryEndpoint(device.host, device.port);
 				const devices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
 				const existingDevice = this.findExistingDevice(devices, endpoint, device.mac);
-				if (existingDevice) {
+				if (existingDevice?.hostname === endpoint) {
 					if (existingDevice.enabled && !this.wledAdapter.isConnected(endpoint)) {
 						await this.connectToDevice(existingDevice);
 					}
 					return;
 				}
 
-				const identifier = device.mac ? this.identifierFromMac(device.mac) : `wled-${device.host.replace(/\./g, '-')}`;
-				await this.wledAdapter.connect(endpoint, identifier, this.config.timeouts.connectionTimeout);
-
-				const registeredDevice = this.wledAdapter.getDevice(endpoint);
-
-				if (registeredDevice?.context) {
-					await this.deviceMapper.mapDevice(endpoint, registeredDevice.context, device.name, identifier);
-				}
+				await this.doAdoptDevices([
+					{
+						host: endpoint,
+						name: existingDevice?.name ?? device.name,
+						category: DeviceCategory.LIGHTING,
+					},
+				]);
 			} catch (error) {
 				this.logger.error(`Failed to connect to discovered device at ${device.host}`, {
 					message: error instanceof Error ? error.message : String(error),
@@ -558,6 +560,7 @@ export class WledService extends BaseManagedPluginService {
 	private async doAdoptDevices(requests: WledAdoptDeviceDto[]): Promise<WledAdoptionResultModel[]> {
 		const results = requests.map<WledAdoptionResultModel | undefined>(() => undefined);
 		const databaseDevices = await this.devicesService.findAll<WledDeviceEntity>(DEVICES_WLED_TYPE);
+		const normalizedHostsByIndex = new Map<number, string>();
 		const plans: Array<{
 			index: number;
 			request: WledAdoptDeviceDto;
@@ -573,6 +576,7 @@ export class WledService extends BaseManagedPluginService {
 
 			try {
 				host = this.normalizeHost(request.host);
+				normalizedHostsByIndex.set(index, host);
 				const context = await this.wledAdapter.probe(host, this.config.timeouts.connectionTimeout);
 				const existingDevice = this.findExistingDevice(databaseDevices, host, context.info.mac);
 				const identifier = existingDevice?.identifier || this.identifierFromMac(context.info.mac);
@@ -603,11 +607,40 @@ export class WledService extends BaseManagedPluginService {
 			}
 		}
 
-		const selectedDeviceIds = new Set(
+		const plannedExistingDeviceIds = new Set(
 			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
 		);
-		const dependencyEdges = new Map<number, Set<number>>();
+		const plannedIndices = new Set(plans.map(({ index }) => index));
+		const failedSelectionHosts = new Set(
+			[...normalizedHostsByIndex].flatMap(([index, host]) => (!plannedIndices.has(index) ? [host] : [])),
+		);
+		const selectedDeviceIds = plannedExistingDeviceIds;
+		const blockedPlanIndices = new Set<number>();
 		for (const plan of plans) {
+			const unplannedSelectedTargetOwner = databaseDevices.find(
+				(device) =>
+					device.hostname === plan.host &&
+					device.id !== plan.existingDevice?.id &&
+					!plannedExistingDeviceIds.has(device.id),
+			);
+
+			if (
+				unplannedSelectedTargetOwner &&
+				plan.existingDevice?.hostname &&
+				failedSelectionHosts.has(plan.existingDevice.hostname)
+			) {
+				blockedPlanIndices.add(plan.index);
+				results[plan.index] = {
+					host: plan.host,
+					name: plan.request.name,
+					status: 'failed',
+					error: 'A related selected WLED controller could not be probed',
+					deviceId: plan.existingDevice?.id ?? null,
+				};
+			}
+		}
+		const dependencyEdges = new Map<number, Set<number>>();
+		for (const plan of plans.filter(({ index }) => !blockedPlanIndices.has(index))) {
 			const selectedTargetOwner = plans.find(
 				(candidate) =>
 					candidate.existingDevice?.hostname === plan.host && candidate.existingDevice.id !== plan.existingDevice?.id,
@@ -651,6 +684,10 @@ export class WledService extends BaseManagedPluginService {
 		const retiredStaleOwnersByDependencyGroup = new Map<Set<number>, Map<string, WledDeviceEntity>>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
+			if (blockedPlanIndices.has(index)) {
+				continue;
+			}
+
 			const dependencyGroup = dependencyGroupByIndex.get(index);
 			const dependencyFailure = dependencyGroup ? failedDependencyGroups.get(dependencyGroup) : undefined;
 			if (dependencyFailure) {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -1121,7 +1121,18 @@ export class WledService extends BaseManagedPluginService {
 	}
 
 	private canonicalEndpoint(endpoint: string): string {
-		return endpoint.replace(/:80$/, '');
+		const trimmed = endpoint.trim();
+		const bracketedIpv6 = trimmed.match(/^\[([^\]]+)](?::(\d+))?$/);
+		if (bracketedIpv6) {
+			const [, address, port] = bracketedIpv6;
+			return port && port !== '80' ? `[${address}]:${port}` : `[${address}]`;
+		}
+
+		if ((trimmed.match(/:/g)?.length ?? 0) > 1) {
+			return `[${trimmed}]`;
+		}
+
+		return trimmed.replace(/:80$/, '');
 	}
 
 	private legacyHostIdentifiers(endpoint: string): Set<string> {

--- a/apps/backend/src/plugins/devices-wled/services/wled.service.ts
+++ b/apps/backend/src/plugins/devices-wled/services/wled.service.ts
@@ -587,7 +587,7 @@ export class WledService extends BaseManagedPluginService {
 		const selectedDeviceIds = new Set(
 			plans.flatMap(({ existingDevice }) => (existingDevice ? [existingDevice.id] : [])),
 		);
-		const dependentPlanIndexes = new Set<number>();
+		const dependencyEdges = new Map<number, Set<number>>();
 		for (const plan of plans) {
 			const selectedTargetOwner = plans.find(
 				(candidate) =>
@@ -595,21 +595,50 @@ export class WledService extends BaseManagedPluginService {
 			);
 
 			if (selectedTargetOwner) {
-				dependentPlanIndexes.add(plan.index);
-				dependentPlanIndexes.add(selectedTargetOwner.index);
+				const planEdges = dependencyEdges.get(plan.index) ?? new Set<number>();
+				planEdges.add(selectedTargetOwner.index);
+				dependencyEdges.set(plan.index, planEdges);
+				const ownerEdges = dependencyEdges.get(selectedTargetOwner.index) ?? new Set<number>();
+				ownerEdges.add(plan.index);
+				dependencyEdges.set(selectedTargetOwner.index, ownerEdges);
+			}
+		}
+		const dependencyGroupByIndex = new Map<number, Set<number>>();
+		for (const start of dependencyEdges.keys()) {
+			if (dependencyGroupByIndex.has(start)) {
+				continue;
+			}
+
+			const group = new Set<number>();
+			const pending = [start];
+			while (pending.length > 0) {
+				const current = pending.pop();
+				if (current === undefined || group.has(current)) {
+					continue;
+				}
+
+				group.add(current);
+				pending.push(...(dependencyEdges.get(current) ?? []));
+			}
+
+			for (const member of group) {
+				dependencyGroupByIndex.set(member, group);
 			}
 		}
 
 		const retiredDeviceIds = new Set<string>();
-		let dependentFailure: string | null = null;
+		const failedDependencyGroups = new Map<Set<number>, string>();
+		const createdDeviceIdsByPlan = new Map<number, string>();
 
 		for (const { index, request, host, context, existingDevice, identifier } of plans) {
-			if (dependentPlanIndexes.has(index) && dependentFailure) {
+			const dependencyGroup = dependencyGroupByIndex.get(index);
+			const dependencyFailure = dependencyGroup ? failedDependencyGroups.get(dependencyGroup) : undefined;
+			if (dependencyFailure) {
 				results[index] = {
 					host,
 					name: request.name,
 					status: 'failed',
-					error: dependentFailure,
+					error: dependencyFailure,
 					deviceId: existingDevice?.id ?? null,
 				};
 				continue;
@@ -631,6 +660,9 @@ export class WledService extends BaseManagedPluginService {
 					request.description,
 					request.enabled,
 				);
+				if (!existingDevice) {
+					createdDeviceIdsByPlan.set(index, device.id);
+				}
 				if (existingDevice?.hostname && existingDevice.hostname !== host) {
 					const sourceRegistration = this.wledAdapter.getDevice(existingDevice.hostname);
 
@@ -700,9 +732,10 @@ export class WledService extends BaseManagedPluginService {
 			} catch (error) {
 				const reason = error instanceof Error ? error.message : String(error);
 
-				if (dependentPlanIndexes.has(index)) {
-					dependentFailure = `A related WLED address move failed: ${reason}`;
-					const dependentPlans = plans.filter((plan) => dependentPlanIndexes.has(plan.index));
+				if (dependencyGroup) {
+					const dependentFailure = `A related WLED address move failed: ${reason}`;
+					failedDependencyGroups.set(dependencyGroup, dependentFailure);
+					const dependentPlans = plans.filter((plan) => dependencyGroup.has(plan.index));
 					const involvedHosts = new Set(
 						dependentPlans.flatMap((plan) =>
 							[plan.host, plan.existingDevice?.hostname].filter((item): item is string => !!item),
@@ -727,6 +760,12 @@ export class WledService extends BaseManagedPluginService {
 							await this.deviceConnectivityService.setConnectionState(original.id, {
 								state: ConnectionState.DISCONNECTED,
 							});
+						} else {
+							const createdDeviceId = createdDeviceIdsByPlan.get(dependentPlan.index);
+							if (createdDeviceId) {
+								await this.devicesService.remove(createdDeviceId);
+								createdDeviceIdsByPlan.delete(dependentPlan.index);
+							}
 						}
 
 						results[dependentPlan.index] = {

--- a/apps/backend/src/plugins/memory-storage/services/in-memory-timeseries.store.ts
+++ b/apps/backend/src/plugins/memory-storage/services/in-memory-timeseries.store.ts
@@ -362,8 +362,8 @@ export class InMemoryTimeSeriesStore {
 		return results;
 	}
 
-	delete(measurement: string, where?: Record<string, string | string[]>): void {
-		if (!where || Object.keys(where).length === 0) {
+	delete(measurement: string, where?: Record<string, string | string[]>, timeFrom?: Date, timeTo?: Date): void {
+		if ((!where || Object.keys(where).length === 0) && !timeFrom && !timeTo) {
 			this.data.delete(measurement);
 			return;
 		}
@@ -375,7 +375,7 @@ export class InMemoryTimeSeriesStore {
 		}
 
 		const remaining = arr.filter((p) => {
-			return !Object.entries(where).every(([key, value]) => {
+			const matchesTags = Object.entries(where ?? {}).every(([key, value]) => {
 				const pointValue = key in p.tags ? p.tags[key] : key in p.fields ? String(p.fields[key]) : undefined;
 
 				if (pointValue === undefined) {
@@ -388,6 +388,9 @@ export class InMemoryTimeSeriesStore {
 
 				return pointValue === value;
 			});
+			const matchesTime = (!timeFrom || p.timestamp >= timeFrom) && (!timeTo || p.timestamp <= timeTo);
+
+			return !(matchesTags && matchesTime);
 		});
 
 		if (remaining.length === 0) {

--- a/apps/backend/src/plugins/memory-storage/services/influxql-parser.spec.ts
+++ b/apps/backend/src/plugins/memory-storage/services/influxql-parser.spec.ts
@@ -50,4 +50,37 @@ describe('InfluxQLParser', () => {
 		);
 		expect(rows).toHaveLength(2);
 	});
+
+	it('deletes only matching measurements inside the requested time range', () => {
+		store.writePoints([
+			{
+				measurement: 'property_value',
+				tags: { propertyId: 'property-a' },
+				fields: { numberValue: 1 },
+				timestamp: new Date('2026-08-12T20:00:00.000Z'),
+			},
+			{
+				measurement: 'property_value',
+				tags: { propertyId: 'property-a' },
+				fields: { numberValue: 2 },
+				timestamp: new Date('2026-08-12T20:00:00.001Z'),
+			},
+			{
+				measurement: 'property_value',
+				tags: { propertyId: 'property-b' },
+				fields: { numberValue: 3 },
+				timestamp: new Date('2026-08-12T20:00:00.002Z'),
+			},
+		]);
+
+		parser.execute("DELETE FROM property_value WHERE propertyId = 'property-a' AND time >= '2026-08-12T20:00:00.001Z'");
+
+		expect(parser.execute<{ propertyId: string; numberValue: number }>('SELECT * FROM property_value')).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ propertyId: 'property-a', numberValue: 1 }),
+				expect.objectContaining({ propertyId: 'property-b', numberValue: 3 }),
+			]),
+		);
+		expect(parser.execute('SELECT * FROM property_value')).toHaveLength(2);
+	});
 });

--- a/apps/backend/src/plugins/memory-storage/services/influxql-parser.ts
+++ b/apps/backend/src/plugins/memory-storage/services/influxql-parser.ts
@@ -367,8 +367,9 @@ export class InfluxQLParser {
 
 	private executeDelete(parsed: ParsedDelete): unknown[] {
 		const tagFilters = this.buildTagFilters(parsed.where);
+		const { timeFrom, timeTo } = this.buildTimeRange(parsed.where);
 
-		this.store.delete(parsed.measurement, tagFilters);
+		this.store.delete(parsed.measurement, tagFilters, timeFrom, timeTo);
 
 		return [];
 	}

--- a/apps/backend/test/wled-adoption.e2e-spec.ts
+++ b/apps/backend/test/wled-adoption.e2e-spec.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment */
+import { useContainer } from 'class-validator';
+import request from 'supertest';
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { DeviceCategory } from '../src/modules/devices/devices.constants';
+import { DEVICES_WLED_PLUGIN_PREFIX } from '../src/plugins/devices-wled/devices-wled.constants';
+import { DevicesWledPlugin } from '../src/plugins/devices-wled/devices-wled.plugin';
+import { WledService } from '../src/plugins/devices-wled/services/wled.service';
+
+describe('WLED adoption endpoints (e2e)', () => {
+	let app: INestApplication;
+	let accessToken: string;
+	const wledService = {
+		pluginName: 'devices-wled-plugin',
+		serviceId: 'connector',
+		getState: jest.fn().mockReturnValue('stopped'),
+		start: jest.fn().mockResolvedValue(undefined),
+		stop: jest.fn().mockResolvedValue(undefined),
+		onConfigChanged: jest.fn().mockResolvedValue({ restartRequired: false }),
+		getDiscoveryInventory: jest.fn().mockResolvedValue({ mdnsEnabled: true, discoveryRunning: true, devices: [] }),
+		rescanDiscovery: jest.fn().mockResolvedValue({ mdnsEnabled: true, discoveryRunning: true, devices: [] }),
+		probeDevice: jest.fn().mockResolvedValue({
+			host: '192.168.1.100',
+			name: 'WLED',
+			mac: 'AA:BB:CC:DD:EE:FF',
+			port: 80,
+			adoptedDeviceId: null,
+		}),
+		adoptDevices: jest
+			.fn()
+			.mockResolvedValue([
+				{ host: '192.168.1.100', name: 'WLED', status: 'created', error: null, deviceId: 'device-1' },
+			]),
+	};
+
+	beforeAll(async () => {
+		const dynamicAppModule = AppModule.register({
+			moduleExtensions: [],
+			pluginExtensions: [{ routePrefix: DEVICES_WLED_PLUGIN_PREFIX, extensionClass: DevicesWledPlugin }],
+		});
+		const moduleFixture = await Test.createTestingModule({ imports: [dynamicAppModule] })
+			.overrideProvider(WledService)
+			.useValue(wledService)
+			.compile();
+
+		app = moduleFixture.createNestApplication();
+		app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));
+		useContainer(moduleFixture, { fallbackOnErrors: true });
+		await app.init();
+
+		await request(app.getHttpServer())
+			.post('/modules/auth/auth/register')
+			.send({
+				data: { username: 'wledtest', password: 'securePassword123!', email: 'wledtest@example.com' },
+			});
+		const login = await request(app.getHttpServer())
+			.post('/modules/auth/auth/login')
+			.send({
+				data: { username: 'wledtest', password: 'securePassword123!' },
+			});
+		accessToken = (login.body as { data: { access_token: string } }).data.access_token;
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	it('requires authentication for discovery inventory', async () => {
+		await request(app.getHttpServer()).get('/plugins/devices-wled/discovery').expect(401);
+	});
+
+	it('returns the authenticated discovery envelope', async () => {
+		const response = await request(app.getHttpServer())
+			.get('/plugins/devices-wled/discovery')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(200);
+
+		expect(response.body).toEqual(expect.objectContaining({ data: expect.objectContaining({ mdnsEnabled: true }) }));
+	});
+
+	it('validates and executes a manual probe', async () => {
+		await request(app.getHttpServer())
+			.post('/plugins/devices-wled/discovery/probe')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({})
+			.expect(400);
+
+		await request(app.getHttpServer())
+			.post('/plugins/devices-wled/discovery/probe')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { host: '192.168.1.100' } })
+			.expect(201);
+	});
+
+	it('rejects unsupported categories before batch adoption', async () => {
+		await request(app.getHttpServer())
+			.post('/plugins/devices-wled/discovery/adopt')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { devices: [{ host: '192.168.1.100', name: 'WLED', category: DeviceCategory.SWITCHER }] } })
+			.expect(400);
+
+		await request(app.getHttpServer())
+			.post('/plugins/devices-wled/discovery/adopt')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { devices: [{ host: '192.168.1.100', name: 'WLED', category: DeviceCategory.LIGHTING }] } })
+			.expect(200);
+	});
+});

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -230,7 +230,7 @@ Build a device from properties of other devices — splitting one physical devic
 | 3 | [FEATURE-PLUGIN-ZIGBEE-HERDSMAN](features/FEATURE-PLUGIN-ZIGBEE-HERDSMAN.md) | backend, admin | :clipboard: Planned |
 | 4 | [FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS](features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md) | backend, admin, spec | :construction: In Progress |
 
-**Remaining work:** WLED adoption wizard and remaining cross-plugin QA; Matter plugin implementation; direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management).
+**Remaining work:** Adoption-wizard cross-plugin QA; Matter plugin implementation; direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management).
 
 ---
 

--- a/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
+++ b/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
@@ -277,22 +277,22 @@ should be driven by the largest real inventory, and Home Assistant delivers the 
 
 ### WLED
 
-- [ ] WLED appears in the device wizard chooser only when its plugin is enabled.
-- [ ] mDNS devices appear without being auto-created.
-- [ ] An administrator can probe a manual hostname/IP when mDNS is disabled or unavailable.
-- [ ] Probe-only operations do not persist devices or leak client connections.
-- [ ] Adoption derives identity from WLED data and provisions the full mapped device structure.
-- [ ] Duplicate/already-adopted devices are not created twice.
-- [ ] The existing manual WLED path cannot create an incomplete device.
-- [ ] Rescan, add-more, offline, timeout, and partial-failure flows are covered.
+- [x] WLED appears in the device wizard chooser only when its plugin is enabled.
+- [x] mDNS devices appear without being auto-created.
+- [x] An administrator can probe a manual hostname/IP when mDNS is disabled or unavailable.
+- [x] Probe-only operations do not persist devices or leak client connections.
+- [x] Adoption derives identity from WLED data and provisions the full mapped device structure.
+- [x] Duplicate/already-adopted devices are not created twice.
+- [x] The existing manual WLED path cannot create an incomplete device.
+- [x] Rescan, add-more, offline, timeout, and partial-failure flows are covered.
 
 ### Quality
 
 - [x] Backend unit tests cover snapshot reuse, identity/deduplication, mapping delegation, and partial outcomes.
 - [x] Admin unit/component tests cover adapter row mapping, controls, lifecycle cleanup, and adoption payloads.
-- [ ] Relevant authenticated E2E endpoints are covered.
+- [x] Relevant authenticated E2E endpoints are covered.
 - [x] OpenAPI is regenerated from backend Swagger decorators.
-- [ ] `pnpm --filter ./apps/admin run test:unit`, relevant backend Jest suites, and `pnpm run lint:js` pass.
+- [x] `pnpm --filter ./apps/admin run test:unit`, relevant backend Jest suites, and `pnpm run lint:js` pass.
 - [x] All six admin locales have parity for new user-visible keys.
 
 ## 8. Risks and mitigations


### PR DESCRIPTION
## Summary

- add WLED discovery inventory, rescan, stateless probe, and partial-success bulk adoption endpoints
- add the shared admin device-wizard adapter with mDNS discovery, manual probing, polling, add-more, and retryable per-device results
- retain the existing manual device form while routing it through the same mapper-backed adoption path for controlled name, description, and enabled-state setup
- make automatic mDNS adoption opt-in so discovered devices remain under administrator control
- update the adoption-wizard task and roadmap progress

## Administrator impact

Administrators can now discover and adopt multiple WLED controllers from the shared wizard. When mDNS is unavailable, they can probe hosts manually and add the verified devices in bulk. The original one-device form remains available for advanced, deliberate setup.

## Validation

- WLED backend unit/controller/DTO suites: 72 tests passed
- authenticated WLED adoption E2E suite: 4 tests passed
- WLED admin composable suites: 14 tests passed
- full admin suite: 1,880 tests passed
- backend ESLint and TypeScript checks
- admin ESLint, Vue TypeScript checks, and generated OpenAPI client validation
- workspace JavaScript lint (pre-existing warnings only)
