### PR TITLE
docs(tasks): plan Homey device integration

### DIFF
--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -242,10 +242,11 @@ index.ts
 ### Task 2.3: Implement status and connection test APIs
 
 - [ ] Expand the status model with state, Homey identity/version, last sync/event timestamps, reconnect count, and sanitized error.
-- [ ] Add `POST test-connection` accepting saved configuration plus optional unsaved URL/key input through secret-safe DTO semantics.
+- [ ] Add `POST test-connection` with a discriminated request: `saved` accepts no endpoint/mode override and may resolve the persisted key; `candidate` requires a complete unsaved URL plus a newly entered key and must never resolve the persisted key.
+- [ ] Reject mixed requests, including an overridden URL with an omitted key, even when the candidate URL canonicalizes to the saved URL. Stored-secret reuse is authorized only by explicit `saved` mode.
 - [ ] Use a temporary connector for connection tests and always disconnect it.
 - [ ] Return categorized validation/auth/timeout/unavailable errors without raw response bodies.
-- [ ] Add controller/service tests for saved secret reuse and unsaved secret replacement.
+- [ ] Add controller/service tests for fully saved reuse, complete candidate URL/key, URL override without key, key-only candidate, mixed saved/override fields, canonical-equivalent candidate URL, and proof that candidate mode never reads or sends the stored secret.
 
 ### Task 2.4: Implement server discovery only from evidence
 
@@ -426,9 +427,9 @@ index.ts
 - [ ] Add URL, API-key replacement input, explicit clear action, bounded timeout/interval inputs, and enabled state.
 - [ ] Show only whether an API key is configured; never populate the key field from GET data.
 - [ ] Preserve the stored key when the field is untouched.
-- [ ] Add test-connection action supporting saved or newly entered key.
+- [ ] Add separate test actions/payloads for the fully saved configuration and a complete candidate URL/newly entered key pair; disable candidate testing until both fields are present.
 - [ ] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
-- [ ] Unit-test initial state, preserve/replace/clear payloads, validation, working state, successful test, and categorized failures.
+- [ ] Unit-test initial state, preserve/replace/clear payloads, saved-vs-candidate test payloads, candidate URL without a new key, validation, working state, successful test, and categorized failures.
 
 ### Task 5.3: Implement the generic wizard adapter
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -15,7 +15,7 @@
 - Do not edit generated files manually. Generate OpenAPI/admin/panel clients from backend Swagger sources and device specs from their generators.
 - Follow existing TypeScript tab indentation, naming, imports, Swagger response envelopes, tests, and plugin registration conventions.
 - Keep external calls bounded by timeouts and classify authentication, authorization, timeout, unavailable, protocol, validation, and unsupported failures.
-- Never pair, rename, remove, or otherwise mutate upstream Homey devices except an explicitly allowlisted harmless capability-write test.
+- Never mutate ordinary upstream Homey devices. Capability writes require an explicit device/capability allowlist; add/rename/zone-move/unavailable/remove lifecycle tests require a separate environment gate and an operation allowlist restricted to a designated disposable virtual/test device.
 - No database schema change is expected. If implementation evidence requires one, add an incremental migration and update this plan before proceeding.
 - Do not push to `main`. Use a feature branch and PR when implementation begins.
 
@@ -49,8 +49,10 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Give SHS a stable LAN address; prefer host networking or a dedicated address consistent with Homey guidance.
 - [ ] Create a least-privilege API key with only device read/control, zone read, and system read permissions required by the design.
 - [ ] Designate one harmless writable test capability; record only a synthetic alias in repository documents.
+- [ ] Designate one disposable virtual/test device for lifecycle mutations. It must not represent household equipment, and repository documents record only its synthetic alias.
 - [ ] Define environment variables for live tests. Do not store secret values in shell history, fixtures, `.env` files, or repository config.
 - [ ] Add an explicit live-write allowlist contract requiring both device ID and capability ID.
+- [ ] Add a separately enabled lifecycle-mutation allowlist containing the disposable device ID and the exact permitted operations: add, rename, zone move, availability change, and remove.
 
 **Verification:** Review the compatibility document for secret/private data before committing it.
 
@@ -67,7 +69,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
 - [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
-- [ ] Test device add, rename, zone move, unavailable, and removal events or inventory deltas.
+- [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [ ] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
 - [ ] If Homey Pro hardware is available, repeat the minimum inventory/event/write suite against its local API.
 
@@ -227,7 +229,8 @@ index.ts
 **Proposed service:** `services/homey.service.ts`
 
 - [ ] Start only when enabled and minimally configured.
-- [ ] Connect, load metadata/inventory, establish subscriptions, then publish healthy state.
+- [ ] Connect, load system/zone metadata, establish event subscriptions, perform the authoritative inventory reconciliation behind a startup event barrier, merge buffered events, then publish healthy state.
+- [ ] Use Homey ordering metadata verified in Phase 0 to merge snapshot/events. If none is reliable, perform a final targeted reconciliation for capabilities touched while the startup snapshot was in flight before releasing the barrier.
 - [ ] Stop subscriptions/timers/connector on disable, config change, module shutdown, or failed startup cleanup.
 - [ ] Reconfigure safely when URL/key/timeouts change; never overlap old/new connectors.
 - [ ] Use exponential reconnect backoff with jitter and a maximum delay.
@@ -346,13 +349,13 @@ index.ts
 **Proposed service:** `services/homey-synchronizer.service.ts`
 
 - [ ] Maintain an index from adopted Homey device/full capability IDs to Smart Panel properties.
-- [ ] Subscribe through the active connector after initial inventory is available.
+- [ ] Subscribe through the active connector before the authoritative initial inventory reconciliation; buffer/serialize events through the startup barrier so a snapshot cannot overwrite a newer event.
 - [ ] Validate/filter events and ignore unadopted or unmapped capabilities.
 - [ ] Transform values and update properties through the standard Devices service path.
 - [ ] Update whole-device/capability availability when corresponding events arrive.
 - [ ] Coalesce bursts per property while preserving the final order/value.
 - [ ] Avoid feedback loops when a command confirmation event returns.
-- [ ] Add tests for unknown devices, unknown capabilities, duplicate/out-of-order events, bursts, invalid values, and unsubscribe.
+- [ ] Add tests for unknown devices, unknown capabilities, duplicate/out-of-order events, bursts, invalid values, unsubscribe, and a capability change during the startup snapshot/subscription boundary.
 
 ### Task 4.2: Implement reconciliation fallback
 
@@ -484,7 +487,7 @@ pnpm run lint:js
 - [ ] SHS restart during event flow.
 - [ ] Network interruption/restoration.
 - [ ] API key revoked, replaced, and insufficiently scoped.
-- [ ] Device add/rename/zone move/unavailable/removal.
+- [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [ ] Physical/Homey/flow-originated state changes.
 - [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -1,0 +1,573 @@
+# Homey Device Integration — Implementation Plan
+
+**Goal:** Deliver a secure local Homey SHS/Homey Pro provider with discovery, mapping preview, adoption, real-time synchronization, and control, then add Homey Cloud as a second connector.
+
+**Architecture:** One `devices-homey` plugin owns provider-domain behavior. A transport-independent `HomeyConnector` produces normalized devices/capabilities/events. Mapping, preview, adoption, synchronization, and control depend only on that contract. Admin uses the shared device wizard; Flutter uses the normal Devices API and state stream.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-homey-integration-design.md`
+
+**Task:** `tasks/features/FEATURE-PLUGIN-HOMEY.md`
+
+## Global constraints
+
+- Complete the live compatibility spike and fixture capture while the one-month SHS subscription is active.
+- Never commit or print a real API key, OAuth token, household device name, private address, or unsanitized payload.
+- Do not edit generated files manually. Generate OpenAPI/admin/panel clients from backend Swagger sources and device specs from their generators.
+- Follow existing TypeScript tab indentation, naming, imports, Swagger response envelopes, tests, and plugin registration conventions.
+- Keep external calls bounded by timeouts and classify authentication, authorization, timeout, unavailable, protocol, validation, and unsupported failures.
+- Never pair, rename, remove, or otherwise mutate upstream Homey devices except an explicitly allowlisted harmless capability-write test.
+- No database schema change is expected. If implementation evidence requires one, add an incremental migration and update this plan before proceeding.
+- Do not push to `main`. Use a feature branch and PR when implementation begins.
+
+## Delivery map
+
+| Milestone | Outcome | Estimate |
+|---|---|---:|
+| 0 | Verified SHS contract and sanitized fixture corpus | 2–3 days |
+| 1 | Secret-safe config foundation and backend plugin shell | 3–4 days |
+| 2 | Local connector, lifecycle, normalization, and health | 4–6 days |
+| 3 | Mapping, preview, discovery, and adoption | 6–8 days |
+| 4 | Real-time sync, reconciliation, and control | 4–6 days |
+| 5 | Admin wizard/config and panel integration | 4–6 days |
+| 6 | Hardening, live matrix, docs, and release gate | 2–3 days |
+| 7 | Homey Cloud connector | 7–12 additional days |
+
+Local MVP total: approximately 25–36 engineering days. Backend and admin tasks can overlap after Milestone 3 stabilizes the API contract.
+
+---
+
+## Milestone 0: SHS compatibility spike and fixtures
+
+### Task 0.1: Establish a safe live test environment
+
+**Deliverables:**
+
+- Create: `docs/homey-shs-compatibility.md`
+- Create: `apps/backend/src/plugins/devices-homey/__fixtures__/README.md` when the plugin directory is introduced
+
+- [ ] Record SHS version, container image digest, installation topology, exposed ports, capture date, and Smart Panel runtime network path.
+- [ ] Give SHS a stable LAN address; prefer host networking or a dedicated address consistent with Homey guidance.
+- [ ] Create a least-privilege API key with only device read/control, zone read, and system read permissions required by the design.
+- [ ] Designate one harmless writable test capability; record only a synthetic alias in repository documents.
+- [ ] Define environment variables for live tests. Do not store secret values in shell history, fixtures, `.env` files, or repository config.
+- [ ] Add an explicit live-write allowlist contract requiring both device ID and capability ID.
+
+**Verification:** Review the compatibility document for secret/private data before committing it.
+
+### Task 0.2: Probe the local API contract
+
+**Reference:** Official local API factory, ManagerDevices, Device capability/event documentation, and SHS port documentation linked by the design.
+
+- [ ] Verify connection with the documented SDK against HTTP `4859` and HTTPS `4860` where the installation supports them.
+- [ ] Capture sanitized system information and manager state.
+- [ ] Capture zones and zone hierarchy.
+- [ ] Capture the complete device inventory and individual device objects.
+- [ ] Capture capabilities with values, types, units, ranges, enums, readable/writable flags, and repeated/suffixed IDs.
+- [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
+- [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
+- [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
+- [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
+- [ ] Test device add, rename, zone move, unavailable, and removal events or inventory deltas.
+- [ ] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
+- [ ] If Homey Pro hardware is available, repeat the minimum inventory/event/write suite against its local API.
+
+### Task 0.3: Decide SDK vs. direct protocol
+
+- [ ] Review the exact `homey-api` package version, license text, transitive dependencies, Node 24 support, release activity, and bundle/runtime implications.
+- [ ] Exercise connect/disconnect, timeouts, subscription cleanup, and reconnect behavior in a disposable spike.
+- [ ] Record one decision: `use SDK behind connector` or `use documented HTTP/Socket.IO directly`.
+- [ ] Record replacement considerations so the rest of the plugin does not depend on SDK-specific objects.
+- [ ] Do not add the dependency to production packages until this decision is reviewed.
+
+### Task 0.4: Build the sanitized fixture corpus
+
+**Proposed files:**
+
+```text
+apps/backend/src/plugins/devices-homey/__fixtures__/
+  README.md
+  system-info.json
+  zones.json
+  devices/
+    light.json
+    switch.json
+    climate.json
+    cover.json
+    lock.json
+    sensor-air-quality.json
+    sensor-safety.json
+    energy-meter.json
+    repeated-capabilities.json
+    unavailable.json
+  events/
+    capability-updates.json
+    availability.json
+    reconnect.json
+    lifecycle.json
+```
+
+- [ ] Replace IDs, names, zones, addresses, and sensitive driver metadata with deterministic synthetic values.
+- [ ] Preserve field shape, ordering where relevant, types, units, ranges, enum values, and capability suffix behavior.
+- [ ] Add expected normalized output fixtures for representative devices.
+- [ ] Add forbidden-token assertions or a fixture-safety test covering key prefixes, original host/address, and known private names.
+- [ ] Confirm the corpus can drive connector/domain tests after live SHS access ends.
+
+**Gate:** Milestone 1 may scaffold interfaces in parallel, but no production connector or mDNS implementation is finalized until Tasks 0.2–0.4 are complete.
+
+---
+
+## Milestone 1: Secret-safe config and plugin foundation
+
+### Task 1.1: Add generic write-only secret semantics to config
+
+**Inspect first:**
+
+- `apps/backend/src/modules/config/services/config.service.ts`
+- `apps/backend/src/modules/config/controllers/config.controller.ts`
+- Config type mapper/registry services and plugin config DTO/model conventions
+- Existing token/password configuration implementations, if any
+
+**Outcome:** Plugin config owners can mark fields as secret without Homey-specific controller hacks.
+
+- [ ] Define a registry/metadata contract for secret fields owned by module/plugin config DTOs.
+- [ ] Redact secret values from complete-config, plugin-config, validation-error, and serialization paths.
+- [ ] Expose a non-secret configured indicator suitable for admin forms.
+- [ ] Implement merge semantics: omitted secret preserves stored value; explicit clear removes it; provided value replaces it.
+- [ ] Ensure mutation events and plugin reload receive the resolved secret without exposing it to responses.
+- [ ] Ensure debug/error logs serialize redacted DTOs.
+- [ ] Add unit tests for get-all, get-one, update-preserve, update-replace, explicit-clear, validation failure, and logging helpers.
+- [ ] Document the registration convention for future secret-bearing plugins.
+
+**Verification:**
+
+```bash
+pnpm run test:unit -- config
+pnpm run lint:js
+```
+
+### Task 1.2: Scaffold the backend plugin
+
+**Create under:** `apps/backend/src/plugins/devices-homey/`
+
+Proposed initial structure:
+
+```text
+connectors/
+controllers/
+dto/
+entities/
+errors/
+mappings/
+models/
+platforms/
+services/
+__fixtures__/
+devices-homey.constants.ts
+devices-homey.openapi.ts
+devices-homey.plugin.ts
+index.ts
+```
+
+- [ ] Define plugin name/type, API tag, config keys, injection tokens, default timeouts/intervals, and health states.
+- [ ] Add Homey device entity discriminator by following the closest provider entity pattern.
+- [ ] Register the plugin through the repository's backend plugin mechanism.
+- [ ] Extend the managed plugin lifecycle base used by current providers.
+- [ ] Add local config DTO/model with URL, write-only API key mutation fields, timeout, reconciliation interval, and disabled/enabled state.
+- [ ] Register config validation/mutation and secret metadata.
+- [ ] Add a placeholder status response and controller using standard response envelopes.
+- [ ] Add plugin bootstrap/config tests, including disabled and incomplete configuration states.
+
+**Verification:** Targeted Jest tests and `pnpm run lint:js`.
+
+### Task 1.3: Define connector and normalized model contracts
+
+**Proposed files:**
+
+- `connectors/homey-connector.interface.ts`
+- `connectors/homey-connector.types.ts`
+- `models/homey-system-info.model.ts`
+- `models/homey-zone.model.ts`
+- `models/homey-device.model.ts`
+- `models/homey-capability.model.ts`
+- `models/homey-event.model.ts`
+- `errors/homey-connector.error.ts`
+
+- [ ] Define connect/disconnect, inventory, device read, write, and subscribe semantics.
+- [ ] Define idempotent cleanup/unsubscribe semantics.
+- [ ] Define system, zone, device, capability, and event plain-data models.
+- [ ] Preserve full capability IDs; expose separately derived base IDs for matching.
+- [ ] Define normalized error categories and retryability.
+- [ ] Define connector contract tests reusable by local and cloud implementations.
+- [ ] Add model/ID derivation unit tests, especially repeated capabilities such as `measure_temperature.inside`.
+
+---
+
+## Milestone 2: Local connector, lifecycle, normalization, and health
+
+### Task 2.1: Implement the local connector
+
+**Proposed files:**
+
+- `connectors/homey-local.connector.ts`
+- `connectors/homey-local.transformer.ts`
+- Corresponding specs using captured fixtures/fakes
+
+- [ ] Add the reviewed dependency only if Milestone 0 selected the SDK.
+- [ ] Construct a local API client from validated address/token without logging either.
+- [ ] Apply explicit connect/read/write/subscription timeouts.
+- [ ] Transform SDK/protocol objects into normalized models.
+- [ ] Convert raw errors into normalized categories.
+- [ ] Implement inventory, zones, system info, device lookup, capability writes, subscriptions, and cleanup.
+- [ ] Ensure one connector instance owns one transport connection.
+- [ ] Add fixture-backed tests for every operation and error category.
+- [ ] Add environment-gated contract tests against live SHS.
+
+### Task 2.2: Implement plugin lifecycle and connection state machine
+
+**Proposed service:** `services/homey.service.ts`
+
+- [ ] Start only when enabled and minimally configured.
+- [ ] Connect, load metadata/inventory, establish subscriptions, then publish healthy state.
+- [ ] Stop subscriptions/timers/connector on disable, config change, module shutdown, or failed startup cleanup.
+- [ ] Reconfigure safely when URL/key/timeouts change; never overlap old/new connectors.
+- [ ] Use exponential reconnect backoff with jitter and a maximum delay.
+- [ ] Treat authentication/authorization failures differently from transient network failures.
+- [ ] Prevent concurrent reconnect and reconciliation loops.
+- [ ] Track last successful connection, inventory sync, event, error category, reconnect count, and degraded state.
+- [ ] Unit-test all state transitions with fake timers.
+
+### Task 2.3: Implement status and connection test APIs
+
+- [ ] Expand the status model with state, Homey identity/version, last sync/event timestamps, reconnect count, and sanitized error.
+- [ ] Add `POST test-connection` accepting saved configuration plus optional unsaved URL/key input through secret-safe DTO semantics.
+- [ ] Use a temporary connector for connection tests and always disconnect it.
+- [ ] Return categorized validation/auth/timeout/unavailable errors without raw response bodies.
+- [ ] Add controller/service tests for saved secret reuse and unsaved secret replacement.
+
+### Task 2.4: Implement server discovery only from evidence
+
+- [ ] If Milestone 0 found a stable mDNS service, implement a Homey discoverer using the existing mDNS module.
+- [ ] Deduplicate by stable server identity and retain manual URL as fallback.
+- [ ] Expose start/restart/results endpoints following existing discovery patterns.
+- [ ] Test expiry, duplicate records, restart, and malformed TXT records.
+- [ ] If no stable record exists, document manual-only setup and mark automatic discovery deferred; do not ship guessed records.
+
+---
+
+## Milestone 3: Mapping, preview, discovery, and adoption
+
+### Task 3.1: Implement mapping loader and override storage
+
+**Inspect first:** Home Assistant mapping/adoption services and Shelly mapping loader/storage patterns.
+
+**Proposed files:**
+
+- `mappings/definitions/devices.yaml`
+- `mappings/definitions/channels.yaml`
+- `mappings/definitions/properties.yaml`
+- `mappings/mapping-loader.service.ts`
+- `mappings/property-mapping-storage.service.ts`
+- Mapping schemas/types/specs
+
+- [ ] Define strict schemas for device, channel, and property descriptors.
+- [ ] Match on Homey class plus capability base ID; permit driver/vendor restrictions only where necessary.
+- [ ] Define priority, exclusivity/conflict, read/write direction, unit/range, and transformations.
+- [ ] Load built-ins and deterministic user overrides from `var/data/plugin.devices-homey.*.yaml` or the closest established naming scheme.
+- [ ] Validate mappings at startup and fail the plugin clearly on invalid built-ins while isolating invalid user overrides with actionable errors.
+- [ ] Add tests for precedence, duplicates, invalid schemas, ambiguous matches, and suffix/base-ID handling.
+
+### Task 3.2: Add MVP mapping definitions
+
+- [ ] Power: `onoff`.
+- [ ] Lighting: `dim`, hue, saturation, and temperature.
+- [ ] Climate: measured temperature, target temperature, and verified thermostat modes.
+- [ ] Environment: humidity, pressure, luminance, and CO2.
+- [ ] Safety/contact: motion, contact, smoke, carbon monoxide.
+- [ ] Energy: instantaneous power and accumulated energy.
+- [ ] Battery: level and low-battery alarm.
+- [ ] Lock: state/control when writable.
+- [ ] Covers: state, position, tilt, open/close/stop behavior after fixture validation.
+- [ ] Add representative fixture tests for each mapping family and inverse transformation.
+
+### Task 3.3: Implement device inventory/discovery service and API
+
+**Proposed files:**
+
+- `services/homey-device-inventory.service.ts`
+- `controllers/homey-devices.controller.ts`
+- Inventory models/response models/specs
+
+- [ ] Return normalized devices with resolved zone path, capabilities summary, availability, support state, and adoption state.
+- [ ] Determine adoption by plugin discriminator plus Homey device identifier.
+- [ ] Keep unsupported devices visible with reasons.
+- [ ] Support stable sorting/filtering without exposing raw SDK data.
+- [ ] Add list and single-device endpoints with authorization, standard response envelopes, and tests.
+
+### Task 3.4: Implement mapping preview
+
+**Proposed service:** `services/mapping-preview.service.ts`
+
+- [ ] Fetch a fresh normalized device snapshot.
+- [ ] Infer suggested category and valid alternatives.
+- [ ] Produce proposed channels/properties with identifiers, transformed values, access, and conversion metadata.
+- [ ] Warn for unsupported capabilities, unavailable values, conflicting descriptors, and lossy/ambiguous conversions.
+- [ ] Keep output deterministic for identical snapshot/mapping versions.
+- [ ] Add request/response models and `POST mapping-preview` endpoint.
+- [ ] Add comprehensive fixture-backed tests.
+
+### Task 3.5: Implement idempotent adoption
+
+**Proposed service:** `services/device-adoption.service.ts`
+
+- [ ] Re-fetch the device and recompute/validate mapping immediately before mutation.
+- [ ] Create/update the plugin-specific device by full Homey device ID.
+- [ ] Create/reconcile channels by stable mapping key.
+- [ ] Create/reconcile properties by full Homey capability ID.
+- [ ] Apply current transformed values through normal Devices service paths.
+- [ ] Isolate each batch selection in its own transaction where repository transaction patterns permit.
+- [ ] Return created/updated/skipped/failed per device with sanitized errors.
+- [ ] Make retry idempotent and prevent duplicates under concurrent requests.
+- [ ] Never mutate or delete anything in Homey.
+- [ ] Add single and batch adoption endpoints and tests for partial success, stale preview, duplicate request, unknown device, unsupported mapping, and rollback.
+
+### Task 3.6: Verify persistence assumptions
+
+- [ ] Prove device uniqueness is scoped by provider/entity type plus identifier.
+- [ ] Prove channel and property lookup/reconciliation use the appropriate parent/type scope.
+- [ ] Document that no migration is required.
+- [ ] If proof fails, design the minimum new entity metadata and add an incremental TypeORM migration with upgrade/rollback tests.
+
+---
+
+## Milestone 4: Real-time synchronization, reconciliation, and control
+
+### Task 4.1: Implement event synchronization
+
+**Proposed service:** `services/homey-synchronizer.service.ts`
+
+- [ ] Maintain an index from adopted Homey device/full capability IDs to Smart Panel properties.
+- [ ] Subscribe through the active connector after initial inventory is available.
+- [ ] Validate/filter events and ignore unadopted or unmapped capabilities.
+- [ ] Transform values and update properties through the standard Devices service path.
+- [ ] Update whole-device/capability availability when corresponding events arrive.
+- [ ] Coalesce bursts per property while preserving the final order/value.
+- [ ] Avoid feedback loops when a command confirmation event returns.
+- [ ] Add tests for unknown devices, unknown capabilities, duplicate/out-of-order events, bursts, invalid values, and unsubscribe.
+
+### Task 4.2: Implement reconciliation fallback
+
+- [ ] Reconcile all adopted devices immediately after every successful reconnect.
+- [ ] Reconcile inventory periodically at a conservative bounded interval.
+- [ ] Update current values, availability, renamed metadata where policy permits, and missing-upstream status.
+- [ ] Never delete orphaned Smart Panel devices automatically.
+- [ ] Prevent overlapping reconciliation runs and cap per-device errors.
+- [ ] Transition to `degraded_polling` when events are unavailable but reads succeed.
+- [ ] Expose reconciliation duration/count/failure metrics in status/logging.
+- [ ] Add fake-timer tests for scheduling, overlap prevention, reconnect, and shutdown.
+
+### Task 4.3: Implement Homey device control platform
+
+**Proposed files:**
+
+- `platforms/homey-device.platform.ts`
+- Command transformation/confirmation helpers and specs
+
+- [ ] Register a device platform for Homey-backed devices.
+- [ ] Resolve the property mapping and full capability ID.
+- [ ] Validate writable access, value type, enum/range, and device availability.
+- [ ] Apply the inverse transformation.
+- [ ] Serialize writes per device/capability.
+- [ ] Send the command through the connector with a bounded timeout.
+- [ ] Await a matching event as authoritative confirmation.
+- [ ] Perform at most one targeted read when confirmation times out.
+- [ ] Return a rejected/timeout result without treating an unconfirmed optimistic value as final.
+- [ ] Test on/off, dim normalization, temperature/range conversion, enums, covers, lock, concurrent commands, disconnect mid-command, rejection, event confirmation, and read fallback.
+
+### Task 4.4: Add observability and operational diagnostics
+
+- [ ] Add structured sanitized logs for state transitions, inventory/reconciliation summaries, and command failures.
+- [ ] Keep routine value payloads at trace/debug and rate-limit repetitive failures.
+- [ ] Expose adopted, missing, unsupported, and unavailable counts.
+- [ ] Add last-event age so a silent broken subscription is visible.
+- [ ] Stop aggressive retries on authentication failure until configuration changes or slow retry policy permits.
+
+---
+
+## Milestone 5: Admin and panel integration
+
+### Task 5.1: Scaffold the admin plugin
+
+**Create under:** `apps/admin/src/plugins/devices-homey/`
+
+Proposed structure:
+
+```text
+components/
+composables/
+locales/
+schemas/
+store/
+devices-homey.constants.ts
+devices-homey.plugin.ts
+index.ts
+```
+
+- [ ] Register the plugin, config component, add/edit components only where needed, and wizard adapter.
+- [ ] Add stores/schemas/transformers for config, status, inventory, preview, and adoption results.
+- [ ] Follow generated OpenAPI types after backend generation; do not create shadow API types without need.
+- [ ] Add all required locale files and update locale consistency tests.
+
+### Task 5.2: Implement secret-safe configuration UI
+
+- [ ] Add mode selection with local mode active and cloud mode marked unavailable until Phase 7.
+- [ ] Add URL, API-key replacement input, explicit clear action, bounded timeout/interval inputs, and enabled state.
+- [ ] Show only whether an API key is configured; never populate the key field from GET data.
+- [ ] Preserve the stored key when the field is untouched.
+- [ ] Add test-connection action supporting saved or newly entered key.
+- [ ] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
+- [ ] Unit-test initial state, preserve/replace/clear payloads, validation, working state, successful test, and categorized failures.
+
+### Task 5.3: Implement the generic wizard adapter
+
+**Reference:** `apps/admin/src/modules/devices/components/wizard/device-wizard.types.ts` and current Shelly/Z2M factories.
+
+- [ ] Start/load Homey inventory and expose normalized wizard rows.
+- [ ] Map name, model/class, zone, capability count, availability, and support/adoption status into built-in/extra cells.
+- [ ] Provide stable device ID keys, suggested name/category, and category options.
+- [ ] Fetch or derive read-only mapping summaries for confirmation.
+- [ ] Submit batch adoption and translate per-device results.
+- [ ] Clean up polling/subscriptions on wizard disposal.
+- [ ] Handle offline, empty, loading, reconnect, unsupported, already adopted, and partial-success states.
+- [ ] Add adapter/store/component tests using generated API mocks.
+
+### Task 5.4: Generate OpenAPI clients and verify the admin app
+
+- [ ] Run `pnpm run generate:openapi` after Swagger models/controllers stabilize.
+- [ ] Update manually maintained `apps/admin/src/openapi.constants.ts` exports only if needed.
+- [ ] Fix admin compile/test issues against generated types without editing `apps/admin/src/openapi.ts`.
+- [ ] Run admin unit tests, build, and JS lint/type checks.
+
+**Verification:**
+
+```bash
+pnpm run generate:openapi
+pnpm --filter ./apps/admin run test:unit
+pnpm run admin:build
+pnpm run lint:js
+```
+
+### Task 5.5: Integrate and verify the panel
+
+- [ ] Determine whether the new backend entity discriminator needs plugin-specific Dart model mappers.
+- [ ] If required, add minimal mappers/registration under `apps/panel/lib/plugins/devices-homey/` following current provider patterns.
+- [ ] Do not add a Homey HTTP/Socket.IO client or credentials to Flutter.
+- [ ] Regenerate API/spec clients with `melos rebuild-all` after backend generation.
+- [ ] Add/extend tests for representative Homey-backed lighting, sensor, thermostat, cover, lock, and energy device rendering/control.
+- [ ] Run `melos analyze` and relevant Flutter tests.
+
+---
+
+## Milestone 6: Hardening and local release gate
+
+### Task 6.1: Complete automated verification
+
+- [ ] Backend normalization, connector, mapping, preview, adoption, sync, reconciliation, control, config-secret, controller, and lifecycle suites pass.
+- [ ] Admin config, status, inventory, wizard adapter, results, and locale suites pass.
+- [ ] Panel representative widget/control tests pass.
+- [ ] OpenAPI/spec generation is clean and generated diffs are intentional.
+- [ ] Default CI requires no live Homey/SHS access.
+
+### Task 6.2: Run the live lifecycle matrix
+
+- [ ] Fresh startup with SHS online.
+- [ ] Startup with SHS offline, then recovery.
+- [ ] SHS restart during event flow.
+- [ ] Network interruption/restoration.
+- [ ] API key revoked, replaced, and insufficiently scoped.
+- [ ] Device add/rename/zone move/unavailable/removal.
+- [ ] Physical/Homey/flow-originated state changes.
+- [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
+- [ ] Burst updates and concurrent commands.
+- [ ] Plugin disable/enable and backend shutdown with no leaked connections/timers.
+
+### Task 6.3: Validate performance and security
+
+- [ ] Measure inventory/normalization with up to 250 fixture-generated devices and on supported panel/backend hardware where available.
+- [ ] Measure capability event handoff and command-start latency against design targets.
+- [ ] Confirm no full inventory call occurs per event.
+- [ ] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
+- [ ] Verify all external calls have timeouts and reconnect loops have upper bounds.
+- [ ] Verify no route or service can delete/pair/rename an upstream Homey device.
+
+### Task 6.4: Documentation and release checklist
+
+**Proposed documentation updates:**
+
+- `apps/website/` integration guide in the website's current content structure
+- Root/project feature listing where providers are enumerated
+- `docs/homey-shs-compatibility.md`
+- Plugin README or module documentation if current plugins use one
+
+- [ ] Document SHS installation/network/port assumptions and least-privilege API-key creation.
+- [ ] Document local configuration, discovery/manual URL, adoption, supported capability families, limitations, and troubleshooting.
+- [ ] Document backups/secret behavior without revealing storage internals unnecessarily.
+- [ ] Document fixture refresh procedure for future SHS/Homey versions.
+- [ ] Update `FEATURE-PLUGIN-HOMEY` acceptance checkboxes and status to `review` only when evidence is recorded.
+
+**Local MVP gate:** All Phase 0 and Phase 1 acceptance criteria in `tasks/features/FEATURE-PLUGIN-HOMEY.md` are checked or carry an approved, explicit deferral. Cloud criteria remain unchecked.
+
+---
+
+## Milestone 7: Homey Cloud connector
+
+This milestone starts only after the local MVP is stable. It should be a separate PR series because OAuth/client registration and external approval can move independently.
+
+### Task 7.1: Register and document the Athom API client
+
+- [ ] Register the OAuth client and production/development redirect URIs.
+- [ ] Confirm current user limits, approval requirements, scopes, and branding/legal requirements with Athom.
+- [ ] Record client configuration as deployment secrets, not repository values.
+
+### Task 7.2: Implement cloud authorization
+
+- [ ] Add authorization start/callback/disconnect/reconnect endpoints using repository OAuth/state/PKCE patterns where applicable.
+- [ ] Store access/refresh tokens through the generic secret mechanism or established encrypted credential store.
+- [ ] Handle expiry, refresh rotation, revocation, invalid state, callback errors, and account reauthorization.
+- [ ] List/select a Homey when an account has more than one.
+- [ ] Add security-focused controller/service tests.
+
+### Task 7.3: Implement `HomeyCloudConnector`
+
+- [ ] Implement the same connector contract and normalized error categories.
+- [ ] Run the shared connector contract suite.
+- [ ] Verify inventory, subscriptions, writes, reconnect, rate limits, and cloud-specific latency behavior.
+- [ ] Keep mapping, preview, adoption, synchronizer, and control code unchanged.
+
+### Task 7.4: Extend admin configuration and release docs
+
+- [ ] Enable cloud mode and OAuth connect/disconnect/status UI.
+- [ ] Add Homey selection when required.
+- [ ] Explain local vs. cloud latency, reachability, and credential tradeoffs.
+- [ ] Run the full common acceptance suite against cloud mode.
+
+---
+
+## Final verification commands
+
+Use targeted suites during development, then run the repository-appropriate full checks before review:
+
+```bash
+pnpm run test:unit
+pnpm --filter ./apps/admin run test:unit
+pnpm run lint:js
+pnpm run generate:openapi
+pnpm run admin:build
+melos rebuild-all
+melos analyze
+```
+
+Run backend E2E and relevant Flutter widget tests if the implementation adds or changes their covered paths. Record any skipped command with the concrete environment reason in the feature task/PR.
+
+## Definition of done
+
+The local integration is done when a new administrator can configure a scoped SHS key without secret exposure, discover and batch-adopt supported logical Homey devices, see initial and live state, issue confirmed controls, survive network/SHS restarts, understand unsupported and degraded states, disable the plugin cleanly, and run the automated suite after the SHS subscription has expired.

--- a/docs/superpowers/specs/2026-08-12-homey-integration-design.md
+++ b/docs/superpowers/specs/2026-08-12-homey-integration-design.md
@@ -80,6 +80,13 @@ Local configuration contains:
 
 An omitted API key preserves the configured secret. An explicit clear action removes it. The response exposes only `apiKeyConfigured: boolean`.
 
+Connection tests have two mutually exclusive request modes:
+
+- `saved`: test the fully persisted connector identity and its stored secret; endpoint/mode overrides are rejected.
+- `candidate`: test an unsaved local configuration; the request must provide both the complete URL and a newly entered API key, and the backend must not resolve or reuse the stored key.
+
+This boundary prevents an administrator-supplied URL from receiving a credential associated with the saved Homey endpoint. Canonical URL equality must not silently convert a `candidate` request into stored-secret reuse; only the explicit `saved` mode may access the stored key.
+
 ### Discover and adopt
 
 The existing generic device wizard presents Homey devices that are available for adoption:
@@ -370,7 +377,7 @@ The backend remains the OpenAPI source of truth. Proposed plugin routes, under t
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/plugins/devices-homey/status` | Connection and synchronization health |
-| `POST` | `/plugins/devices-homey/test-connection` | Validate unsaved or saved local configuration without exposing the key |
+| `POST` | `/plugins/devices-homey/test-connection` | Validate either the fully saved configuration or a complete candidate URL/key pair without exposing the key |
 | `GET` | `/plugins/devices-homey/discovery` | Discover local Homey/SHS endpoints if supported |
 | `POST` | `/plugins/devices-homey/discovery` | Restart server discovery |
 | `GET` | `/plugins/devices-homey/devices` | List Homey devices with adoption status |
@@ -388,6 +395,7 @@ Credential safety is a release blocker, not an optional hardening task.
 - Add a generic config-secret redaction and merge mechanism if the config module still returns registered plugin DTOs verbatim.
 - API keys and OAuth tokens are write-only fields.
 - Omitted secret values preserve existing secrets; explicit clear is intentional and separately represented.
+- Test-connection requests may reuse a stored secret only in explicit `saved` mode with no connector identity override. Candidate mode requires a complete new endpoint/secret pair and never falls back to persistence.
 - Logs, exceptions, telemetry, fixtures, snapshots, and OpenAPI examples never contain real credentials.
 - Use the narrowest Homey permissions that support inventory, zones, state reads, and device control.
 - Connection tests use short timeouts and return categorized, sanitized errors.

--- a/docs/superpowers/specs/2026-08-12-homey-integration-design.md
+++ b/docs/superpowers/specs/2026-08-12-homey-integration-design.md
@@ -1,0 +1,557 @@
+# Homey Device Integration — Design
+
+**Status:** Approved
+
+**Date:** 2026-08-12
+
+**Author:** Adam Kadlec
+
+**Related task:** `tasks/features/FEATURE-PLUGIN-HOMEY.md`
+
+**Implementation plan:** `docs/superpowers/plans/2026-08-12-homey-integration.md`
+
+## Goal
+
+Add Homey as a native Smart Panel device provider. Users connect a Homey instance, inspect the logical devices that Homey already manages, adopt selected devices into Smart Panel, receive live capability updates, and control supported capabilities from the existing Smart Panel interfaces.
+
+The first release targets Homey Self-Hosted Server (SHS) and compatible Homey Pro local APIs. A later connector adds Homey Cloud without duplicating mapping, adoption, synchronization, or control logic.
+
+## Product Decision
+
+Homey is a provider integration, comparable to Home Assistant, Shelly, and Zigbee2MQTT:
+
+- Homey remains responsible for radio pairing, drivers, apps, and device ownership.
+- Smart Panel discovers the logical devices exposed by Homey, not unpaired Zigbee, Z-Wave, Matter, BLE, or infrared hardware.
+- Adoption creates Smart Panel devices, channels, and properties that reference Homey device and capability identifiers.
+- Homey capability events update adopted Smart Panel properties in real time.
+- Smart Panel control requests are translated into Homey capability writes.
+- Deleting or disabling the Smart Panel integration never deletes or unpairs anything in Homey.
+
+Local and cloud access are transport variants of one plugin, not separate provider plugins.
+
+## Release Boundaries
+
+### Phase 1 — Local MVP
+
+- Homey Self-Hosted Server using its LAN address and an API key.
+- Homey Pro local API where the same authentication and API behavior is verified.
+- Manual address configuration is guaranteed.
+- Automatic server discovery is included only if the compatibility spike confirms a stable advertised service.
+- Device inventory, zones, capability metadata and current values.
+- Mapping preview and batch adoption through the generic device wizard.
+- Initial reconciliation, real-time updates, reconnect handling, and bounded polling fallback.
+- Control of mapped writable capabilities.
+- Admin configuration and health/status surfaces.
+- Fixture-backed tests that remain usable after the one-month SHS subscription ends.
+
+### Phase 2 — Homey Cloud
+
+- Athom OAuth client registration and authorization-code flow.
+- Home selection for accounts with more than one Homey.
+- Cloud connector using the same normalized models and downstream services.
+- Token refresh, revocation, and reconnect behavior.
+- Deployment documentation for redirect URIs and Athom approval or user-limit requirements.
+
+Cloud support must not delay the local MVP.
+
+## Non-Goals
+
+- Pairing, interviewing, commissioning, or removing physical devices in Homey.
+- Managing Homey apps, drivers, users, flows, alarms, insights, firmware, backups, or system updates.
+- Mirroring every vendor-specific capability in the first release.
+- Presenting Homey-specific UI on the Flutter panel.
+- Controlling Homey directly from the panel client.
+- Replacing Homey's own interface.
+- Using Matter Bridge as the primary integration path. It can remain a simpler future alternative with less metadata and control coverage.
+
+## User Experience
+
+### Configure
+
+The admin plugin form lets an administrator choose `Local` or, after Phase 2, `Cloud`.
+
+Local configuration contains:
+
+- Base URL, for example `http://192.168.1.20:4859`.
+- API key, accepted only on write and never returned in plaintext.
+- Optional connection timeout and polling fallback interval within safe bounds.
+- `Test connection` action.
+- Read-only connection state, Homey identity/version where available, last successful synchronization, and last sanitized error.
+
+An omitted API key preserves the configured secret. An explicit clear action removes it. The response exposes only `apiKeyConfigured: boolean`.
+
+### Discover and adopt
+
+The existing generic device wizard presents Homey devices that are available for adoption:
+
+1. Discover: list devices with name, class, zone, availability, and capability count.
+2. Confirm: select devices, edit Smart Panel names, confirm suggested categories, and inspect the proposed channel count.
+3. Results: show created, updated, skipped, or failed outcomes per Homey device.
+
+The first release uses automatic mappings and a read-only mapping preview. Fine-grained per-property customization can follow after real device fixtures show that users need it.
+
+Already adopted devices remain visible with an `already_registered` status. Unsupported devices remain visible with a reason rather than disappearing.
+
+### Operate
+
+Once adopted, a Homey device behaves like any other Smart Panel device:
+
+- Its current values are visible in admin and on the panel.
+- Live changes made in Homey, by physical controls, or by Homey flows appear in Smart Panel.
+- Supported commands from Smart Panel are sent to Homey.
+- Offline or unavailable states are shown without deleting stored devices or last-known values.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    HL["Homey Local / SHS"] --> CL["Local connector"]
+    HC["Homey Cloud"] --> CC["Cloud connector (Phase 2)"]
+    CL --> NC["HomeyConnector contract"]
+    CC --> NC
+    NC --> NM["Normalized device/capability model"]
+    NM --> MP["YAML mapping registry"]
+    MP --> PW["Preview + generic adoption wizard"]
+    PW --> SP["Smart Panel device/channel/property entities"]
+    NC --> SY["Realtime synchronizer + reconciliation"]
+    SY --> SP
+    SP --> CP["Homey device platform"]
+    CP --> NC
+```
+
+### Plugin ownership
+
+Create one plugin in each application layer:
+
+- Backend: `apps/backend/src/plugins/devices-homey/`
+- Admin: `apps/admin/src/plugins/devices-homey/`
+- Panel: minimal registration/mappers under `apps/panel/lib/plugins/devices-homey/` only if plugin-specific entity types require it.
+
+The backend plugin owns connection management, normalized Homey models, mappings, discovery, adoption, synchronization, and command transport. The panel consumes the normal Devices API and WebSocket state stream; it never receives Homey credentials.
+
+### Connector contract
+
+All transport-specific behavior is hidden behind a narrow interface. The exact TypeScript shape may adapt to repository conventions, but it must provide these semantics:
+
+```typescript
+interface HomeyConnector {
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+	getSystemInfo(): Promise<HomeySystemInfo>;
+	getZones(): Promise<HomeyZone[]>;
+	getDevices(): Promise<HomeyDevice[]>;
+	getDevice(deviceId: string): Promise<HomeyDevice | null>;
+	setCapabilityValue(deviceId: string, capabilityId: string, value: unknown): Promise<void>;
+	subscribe(listener: HomeyEventListener): Promise<() => Promise<void> | void>;
+}
+```
+
+Rules:
+
+- Downstream services depend on `HomeyConnector`, never on the Homey SDK directly.
+- SDK response objects and event emitters must not leak into controllers, persistence, or mapping definitions.
+- Errors are normalized into authentication, authorization, timeout, unavailable, protocol, validation, and unsupported categories.
+- The connector owns SDK-specific reconnect and subscription details, but plugin lifecycle remains controlled by the managed plugin service.
+
+### Local connector
+
+Use the official `homey-api` package if the compatibility and license spikes pass. The documented local entry point is `HomeyAPI.createLocalAPI({ address, token })`. SHS documents HTTP and Socket.IO on port `4859`, and HTTPS and Socket.IO on `4860`.
+
+The package currently declares a Node.js version compatible with this repository, but it is Athom proprietary software licensed for use with Homey products. Before merging the dependency:
+
+- Record the exact package version and integrity in the lockfile.
+- Confirm distribution within Smart Panel is acceptable under the package license.
+- Wrap it entirely inside the local connector so it can be replaced without changing the plugin domain.
+- Verify timeout and cleanup behavior rather than relying on undocumented SDK defaults.
+
+If the SDK is unsuitable, implement the same connector contract against the documented local HTTP and Socket.IO APIs. This fallback is a Phase 0 decision, not a mid-implementation rewrite.
+
+### Cloud connector
+
+The cloud connector uses Athom OAuth and Web API endpoints. It must be added after the local connector passes acceptance tests because it introduces external client registration, redirect URI deployment, token storage, token refresh, and possible Athom approval/user limits.
+
+Cloud OAuth tokens use the same secret-handling rules as the local API key.
+
+## Normalized Domain Model
+
+The connector converts Homey data into plain internal models.
+
+### Homey device
+
+Required normalized fields:
+
+- `id`: stable Homey device identifier.
+- `name`.
+- `class`: Homey device class.
+- `zoneId` and resolved zone name/path where available.
+- `available` and optional sanitized availability message.
+- `driverId`, manufacturer, model, and energy metadata when present.
+- `capabilities`: ordered list of normalized capabilities.
+
+Unknown fields are ignored by default. Sanitized raw fixture payloads may be retained only in tests.
+
+### Homey capability
+
+Required normalized fields:
+
+- Full `id`, including sub-capability suffixes such as `measure_temperature.inside`.
+- Base ID used for descriptor matching, obtained by removing only the instance suffix.
+- Display title.
+- Current value.
+- Type, unit, minimum, maximum, step, enum values, readable, writable, and last-updated metadata when available.
+- Capability availability independent of whole-device availability when Homey exposes it.
+
+The full capability ID is always persisted and used for reads, events, and commands. Base IDs are only mapping lookup keys.
+
+## Persistence
+
+Reuse the generic Devices entities wherever possible:
+
+- Smart Panel device `identifier` = full Homey device ID.
+- Channel `identifier` = stable mapping/channel key within that Homey device.
+- Channel property `identifier` = full Homey capability ID.
+
+Existing type-scoped uniqueness should make this sufficient without a database migration. Phase 0 must verify that the plugin discriminator participates in every relevant uniqueness lookup. If additional queryable Homey metadata is truly required, add an incremental migration; never modify the initial migration.
+
+Do not persist:
+
+- API keys or OAuth tokens in device entities.
+- Raw SDK objects.
+- Socket connection identifiers.
+- Transient subscription state.
+
+## Mapping System
+
+### Mapping definitions
+
+Store built-in mappings as YAML under the backend plugin, following the existing mapping loader/storage patterns. Allow user overrides in:
+
+- `var/data/plugin.devices-homey.devices.yaml`
+- `var/data/plugin.devices-homey.channels.yaml`
+- `var/data/plugin.devices-homey.properties.yaml`
+
+Exact filenames may be consolidated if an existing plugin pattern is a better fit. User files override built-ins deterministically and survive application upgrades.
+
+Descriptors match primarily on Homey class and capability base IDs. Vendor/driver matching is an optional narrowing mechanism, not the default, because it would make mappings unnecessarily device-specific.
+
+### Initial capability coverage
+
+The MVP mapping catalog targets:
+
+| Homey capabilities | Smart Panel behavior |
+|---|---|
+| `onoff` | switch/light/outlet power state and command |
+| `dim` | normalized brightness |
+| `light_hue`, `light_saturation` | color control |
+| `light_temperature` | color-temperature control with verified range conversion |
+| `measure_temperature`, `target_temperature` | temperature sensor/setpoint |
+| `measure_humidity` | humidity sensor |
+| `alarm_motion`, `alarm_contact` | motion/contact sensor |
+| `alarm_smoke`, `alarm_co`, `measure_co2` | safety/air-quality sensor |
+| `measure_power`, `meter_power` | instantaneous power and accumulated energy |
+| `measure_battery`, `alarm_battery` | battery level/low-battery state |
+| `locked` | lock state and command where writable |
+| `windowcoverings_state`, `windowcoverings_set`, `windowcoverings_tilt_set` | cover state, position, tilt, and commands |
+| thermostat mode capabilities | supported enum modes after fixture verification |
+| `measure_pressure`, `measure_luminance` | pressure and illuminance sensors |
+
+Every mapping declares:
+
+- Eligible Homey class/capability pattern.
+- Smart Panel device category, channel category, and property category.
+- Read/write direction.
+- Value transformation and inverse transformation when writable.
+- Unit and range expectations.
+- Priority and conflict behavior.
+
+Unknown capabilities are ignored with a preview warning. They must not cause the whole device to fail adoption.
+
+### Mapping preview
+
+Preview is deterministic for the same normalized device and mapping versions. It returns:
+
+- Suggested device category and alternatives.
+- Proposed channels and properties.
+- Homey device/capability identifiers.
+- Current transformed values.
+- Read/write access.
+- Warnings for unsupported capabilities, conversion ambiguity, duplicate matches, and unavailable values.
+
+Adoption revalidates against a fresh device snapshot to avoid using stale preview data.
+
+## Discovery
+
+There are two distinct meanings of discovery:
+
+1. Server discovery: finding a Homey/SHS endpoint on the LAN.
+2. Device discovery: listing logical devices already registered in that Homey.
+
+Manual server URL entry is always supported. mDNS discovery is implemented only after the one-month compatibility spike identifies a stable service type and verifies behavior across SHS restarts. No guessed service record is shipped.
+
+Device discovery is an authenticated inventory request through the active connector. It does not start radio pairing mode and must remain read-only.
+
+## Adoption
+
+Adoption is transactional per selected device:
+
+1. Fetch the latest Homey device snapshot.
+2. Validate the selected category and proposed mappings.
+3. Find an existing Smart Panel device by plugin type plus Homey device ID.
+4. Create or update the Smart Panel device.
+5. Reconcile channels and properties by stable identifiers.
+6. Apply initial transformed values.
+7. Register the adopted identifiers with the synchronizer.
+8. Return a per-device result.
+
+A batch may partially succeed; failures are isolated per device and returned with sanitized messages. Retrying the same selection is idempotent and updates the existing adopted device rather than duplicating it.
+
+Upstream removal behavior:
+
+- If a Homey device disappears, mark the Smart Panel device unavailable and report the missing upstream reference.
+- Never automatically delete the Smart Panel device.
+- A later explicit cleanup action may let an administrator remove orphaned Smart Panel records.
+
+## Synchronization and Reconciliation
+
+### Initial synchronization
+
+After connecting:
+
+- Load system and zone metadata.
+- Load the complete Homey device inventory.
+- Reconcile availability and current values for adopted devices.
+- Subscribe to manager/device/capability events.
+- Mark the plugin healthy only after inventory and subscription setup succeed.
+
+### Real-time updates
+
+Subscribe only as broadly as required by the SDK. Filter downstream processing to adopted device IDs and mapped full capability IDs.
+
+For each accepted event:
+
+- Validate device ID, capability ID, and value shape.
+- Apply the mapping's read transformation.
+- Update the corresponding property through the normal Devices service path.
+- Coalesce bursts for the same property without reordering the final value.
+- Never log raw event payloads at normal log levels.
+
+### Reconciliation fallback
+
+Socket.IO events are the primary state path. A bounded reconciliation loop repairs missed events and supports degraded operation:
+
+- Full reconciliation immediately after reconnect.
+- Periodic inventory reconciliation at a conservative configurable interval.
+- Optional targeted read after a command when no matching event arrives within the confirmation timeout.
+- Exponential reconnect backoff with jitter and a maximum delay.
+- One connection/reconnect owner; no overlapping loops.
+
+Polling must not conceal a permanently broken event subscription. Health status distinguishes `connected`, `degraded_polling`, `reconnecting`, `authentication_failed`, and `stopped`.
+
+## Control Semantics
+
+The Homey device platform handles writable mapped properties:
+
+1. Validate that the property is mapped and writable.
+2. Validate and normalize the Smart Panel input.
+3. Apply the inverse mapping transformation.
+4. Send `setCapabilityValue(deviceId, fullCapabilityId, value)` through the connector.
+5. Wait for the matching Homey event as authoritative confirmation.
+6. If the event does not arrive in time, perform one targeted read where supported.
+7. Report timeout or rejection without presenting an unconfirmed value as final state.
+
+Concurrent commands to the same device/capability are serialized. A later command supersedes an earlier pending confirmation for display purposes, while both transport outcomes remain observable in logs/metrics.
+
+## API Surface
+
+The backend remains the OpenAPI source of truth. Proposed plugin routes, under the repository's actual API prefix, are:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/plugins/devices-homey/status` | Connection and synchronization health |
+| `POST` | `/plugins/devices-homey/test-connection` | Validate unsaved or saved local configuration without exposing the key |
+| `GET` | `/plugins/devices-homey/discovery` | Discover local Homey/SHS endpoints if supported |
+| `POST` | `/plugins/devices-homey/discovery` | Restart server discovery |
+| `GET` | `/plugins/devices-homey/devices` | List Homey devices with adoption status |
+| `GET` | `/plugins/devices-homey/devices/:deviceId` | Read one normalized device |
+| `POST` | `/plugins/devices-homey/mapping-preview` | Preview mapping for a device/category request |
+| `POST` | `/plugins/devices-homey/adopt` | Adopt one device |
+| `POST` | `/plugins/devices-homey/adopt/batch` | Adopt selected devices with per-device results |
+
+Exact path naming should follow the closest current controller convention at implementation time. All actions require the standard tags, operations, response envelopes, validation, and authorization decorators.
+
+## Security
+
+Credential safety is a release blocker, not an optional hardening task.
+
+- Add a generic config-secret redaction and merge mechanism if the config module still returns registered plugin DTOs verbatim.
+- API keys and OAuth tokens are write-only fields.
+- Omitted secret values preserve existing secrets; explicit clear is intentional and separately represented.
+- Logs, exceptions, telemetry, fixtures, snapshots, and OpenAPI examples never contain real credentials.
+- Use the narrowest Homey permissions that support inventory, zones, state reads, and device control.
+- Connection tests use short timeouts and return categorized, sanitized errors.
+- URL validation rejects unsupported schemes and credentials embedded in URLs.
+- TLS verification is enabled by default. Any development-only override must be explicit, warned, and excluded from production builds/configuration.
+- Configuration file permissions remain restrictive; secrets are never sent to the panel.
+
+Recommended local scopes to verify during the spike are `homey.device.readonly`, `homey.device.control`, `homey.zone.readonly`, and `homey.system.readonly`.
+
+## Admin Integration
+
+Create `apps/admin/src/plugins/devices-homey/` following existing plugin conventions:
+
+- Plugin registration and routes.
+- Configuration model/store/form.
+- Status and connection-test composables.
+- Device inventory and mapping-preview stores.
+- A `deviceWizardAdapter` factory for the shared wizard.
+- Locale files for all languages required by repository tests.
+- Unit tests for transformers, stores/composables, adapter reconciliation, and secret-preserving form submission.
+
+Wizard rows include:
+
+- Stable key: Homey device ID.
+- Label: Homey device name.
+- Sub-label: manufacturer/model or class.
+- Identifier: Homey device ID.
+- Extra cells: zone, class, capability count, and availability as useful.
+- Status: checking, ready, already registered, unsupported, or failed.
+- Suggested name/category and valid category options.
+
+## Panel Integration
+
+No Homey transport exists in Flutter. Adopted devices flow through the generic Devices API, WebSocket updates, specs, and existing device-detail widgets.
+
+Panel work is limited to:
+
+- Registering plugin-specific entity mappers only if the backend introduces a Homey-specific entity discriminator that generic mappers cannot instantiate.
+- Regenerating the API/spec clients after backend Swagger/spec changes.
+- Verifying representative lighting, sensor, thermostat, cover, lock, and energy devices render and control correctly.
+
+## One-Month SHS Compatibility Program
+
+The subscription is time-limited, so live verification and fixture capture happen before broad implementation.
+
+### Days 1–3: establish the contract
+
+- Install SHS with a stable LAN address using host networking or an equivalent dedicated address.
+- Record SHS version, container image digest, exposed ports, and Smart Panel runtime topology.
+- Create a narrowly scoped API key.
+- Populate representative devices, using virtual devices where physical coverage is unavailable.
+- Verify authentication against HTTP `4859` and HTTPS `4860` where configured.
+- Capture sanitized responses for system info, zones, device inventory, individual devices, capability metadata, and current values.
+- Capture sanitized Socket.IO connection and capability-event sequences.
+- Verify writable capability calls on an explicitly designated harmless test device.
+
+### Failure and lifecycle matrix
+
+Test and record:
+
+- SHS unavailable at startup.
+- SHS restart while connected.
+- API key revoked or insufficiently scoped.
+- Network interruption and restoration.
+- Device added, renamed, moved between zones, made unavailable, and removed.
+- Capability value changed physically, through Homey, through a flow, and through Smart Panel.
+- Repeated capability instances with suffixes.
+- Multiple fast updates and multiple fast commands.
+- Whether SHS advertises a stable mDNS record.
+- Whether Homey Pro local mode is behaviorally equivalent when hardware is available.
+
+### Fixture policy
+
+Store fixtures under `apps/backend/src/plugins/devices-homey/__fixtures__/` or the nearest established test convention.
+
+- Replace device IDs, names, zone names, IP addresses, driver identifiers where sensitive, and all credentials.
+- Retain data shapes, types, capability suffixes, units, ranges, and enum values.
+- Include expected normalized outputs beside representative raw inputs.
+- Add a fixture provenance README with SHS version and capture date, but no household details.
+- Validate fixtures with a secret scanner or explicit forbidden-token assertions.
+
+The plugin must be testable after the subscription expires. Live tests remain optional and environment-gated.
+
+## Observability
+
+Expose and log enough information to diagnose the provider without leaking payloads:
+
+- Connector state and transition reason.
+- Last successful inventory synchronization.
+- Last event timestamp.
+- Reconnect attempt count and next retry delay.
+- Adopted/missing/unsupported device counts.
+- Event processing and command failures by normalized category.
+- Reconciliation duration and changed-property count.
+
+Routine capability updates should be trace/debug-level and rate-limited. Authentication failures should stop aggressive retrying until configuration changes.
+
+## Testing Strategy
+
+### Unit tests
+
+- SDK-to-normalized-model transformation.
+- Base vs. full capability ID handling.
+- Mapping selection, priority, conflicts, transformations, and inverse transformations.
+- Preview warnings.
+- Adoption idempotency and per-device rollback behavior.
+- Event filtering/coalescing and reconnect state machine.
+- Command confirmation, timeout, and targeted-read fallback.
+- Secret redaction and secret-preserving config merge.
+
+### Fixture integration tests
+
+- Inventory and zone loading from captured SHS fixtures.
+- Initial reconciliation of adopted devices.
+- Socket event sequences including reconnect and duplicate events.
+- Representative devices for every MVP mapping family.
+- Missing device and unknown capability behavior.
+
+### Live SHS tests
+
+- Environment-gated and excluded from default CI.
+- Read-only tests run against all configured representative devices.
+- Write tests require an explicit device ID/capability allowlist.
+- No test may pair, remove, rename, or otherwise mutate upstream devices unless separately and explicitly enabled.
+
+### Admin and panel tests
+
+- Config form never repopulates a secret.
+- Wizard handles online, offline, empty, mixed-support, partial-success, and reconnect cases.
+- Adopted device state updates reach the standard admin/panel stores.
+- Representative panel widgets preserve their existing optimistic/confirmation semantics.
+
+## Performance Targets
+
+Targets for a typical local installation of up to 250 Homey devices:
+
+- Initial device inventory and normalization completes within 10 seconds on the supported Smart Panel hardware, excluding an unavailable network timeout.
+- A received capability event is handed to the Devices state path within 250 ms at p95 under normal load.
+- Control transport begins within 250 ms at p95 after validation.
+- The event path performs no full inventory scan per capability update.
+- Reconnect backoff prevents request storms.
+
+These are engineering targets to validate, not contractual Homey latency guarantees.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| SHS API-key behavior differs from Homey Pro documentation | Compatibility spike before committing architecture; preserve sanitized fixtures |
+| SDK license or behavior is unsuitable | License review and strict connector boundary; documented HTTP/Socket.IO fallback |
+| Capability vocabulary is broad and vendor-extensible | Base-ID descriptors, full-ID persistence, warnings for unknown capabilities, iterative fixture catalog |
+| Socket events are missed during reconnect | Full reconciliation after reconnect and conservative periodic reconciliation |
+| API key leaks through generic config endpoints | Generic write-only secret handling is a Phase 1 release gate |
+| Cloud OAuth approval delays release | Ship local MVP independently; cloud is a second connector |
+| Upstream device removal causes destructive sync | Mark unavailable/orphaned; never automatically delete |
+| Expiring SHS subscription removes test access | Front-load lifecycle tests and sanitized fixture capture in the first three days |
+
+## Acceptance Summary
+
+The local MVP is complete when an administrator can securely configure SHS, list and adopt supported Homey devices, observe initial and real-time states, control mapped writable properties, survive SHS/network restarts, understand unsupported/degraded states, and run the full automated suite without a live subscription.
+
+## External References
+
+- [Homey Self-Hosted Server installation and ports](https://support.homey.app/hc/en-us/articles/24010537261980-How-to-install-Homey-Self-Hosted-Server-with-Docker-on-Linux)
+- [Homey local API factory](https://athombv.github.io/node-homey-api/HomeyAPI.html)
+- [Homey local ManagerDevices API](https://athombv.github.io/node-homey-api/HomeyAPIV3Local.ManagerDevices.html)
+- [Homey local device capability and event API](https://athombv.github.io/node-homey-api/HomeyAPIV3Local.ManagerDevices.Device.html)
+- [Homey Web API](https://api.developer.homey.app/)
+- [Community SHS integration field report](https://community.homey.app/t/homey-integration-for-home-assistant-now-available/148786) — useful field evidence only; not a substitute for verification against the subscribed SHS instance.

--- a/docs/superpowers/specs/2026-08-12-homey-integration-design.md
+++ b/docs/superpowers/specs/2026-08-12-homey-integration-design.md
@@ -318,10 +318,12 @@ Upstream removal behavior:
 After connecting:
 
 - Load system and zone metadata.
-- Load the complete Homey device inventory.
-- Reconcile availability and current values for adopted devices.
-- Subscribe to manager/device/capability events.
+- Establish manager/device/capability subscriptions before taking the authoritative state snapshot.
+- Buffer events behind a startup barrier while loading the complete Homey device inventory and reconciling adopted devices.
+- Merge buffered events with the snapshot using the ordering metadata verified in Phase 0, then atomically switch to live event processing. If Homey exposes no reliable ordering metadata, use a subscription-first reconciliation barrier plus a final targeted reconciliation for capabilities touched while the snapshot was in flight.
 - Mark the plugin healthy only after inventory and subscription setup succeed.
+
+This order is mandatory: reading state before subscribing creates a gap in which a Homey change can be missed until periodic reconciliation. Startup and reconnect tests must exercise a capability change during the snapshot/subscription boundary and prove that the final Smart Panel value is the newest authoritative value.
 
 ### Real-time updates
 
@@ -437,6 +439,7 @@ The subscription is time-limited, so live verification and fixture capture happe
 - Record SHS version, container image digest, exposed ports, and Smart Panel runtime topology.
 - Create a narrowly scoped API key.
 - Populate representative devices, using virtual devices where physical coverage is unavailable.
+- Designate a disposable virtual/test device for lifecycle mutation tests. It must not represent household equipment and its synthetic alias, rather than its live identifier, is recorded in repository documents.
 - Verify authentication against HTTP `4859` and HTTPS `4860` where configured.
 - Capture sanitized responses for system info, zones, device inventory, individual devices, capability metadata, and current values.
 - Capture sanitized Socket.IO connection and capability-event sequences.
@@ -450,7 +453,7 @@ Test and record:
 - SHS restart while connected.
 - API key revoked or insufficiently scoped.
 - Network interruption and restoration.
-- Device added, renamed, moved between zones, made unavailable, and removed.
+- Disposable test device added, renamed, moved between zones, made unavailable, and removed.
 - Capability value changed physically, through Homey, through a flow, and through Smart Panel.
 - Repeated capability instances with suffixes.
 - Multiple fast updates and multiple fast commands.
@@ -509,7 +512,8 @@ Routine capability updates should be trace/debug-level and rate-limited. Authent
 - Environment-gated and excluded from default CI.
 - Read-only tests run against all configured representative devices.
 - Write tests require an explicit device ID/capability allowlist.
-- No test may pair, remove, rename, or otherwise mutate upstream devices unless separately and explicitly enabled.
+- Lifecycle mutation tests require a separate explicit environment gate plus an allowlist naming the disposable virtual/test device and permitted operations.
+- Pairing, renaming, moving, making unavailable, or removing ordinary household devices is always forbidden. The lifecycle exception applies only to the designated disposable device and is cleaned up after capture.
 
 ### Admin and panel tests
 

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -229,8 +229,9 @@ Build a device from properties of other devices — splitting one physical devic
 | 2 | [FEATURE-PLUGIN-MATTER](features/FEATURE-PLUGIN-MATTER.md) | backend, admin | :clipboard: Planned |
 | 3 | [FEATURE-PLUGIN-ZIGBEE-HERDSMAN](features/FEATURE-PLUGIN-ZIGBEE-HERDSMAN.md) | backend, admin | :clipboard: Planned |
 | 4 | [FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS](features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md) | backend, admin, spec | :construction: In Progress |
+| 5 | [FEATURE-PLUGIN-HOMEY](features/FEATURE-PLUGIN-HOMEY.md) | backend, admin, panel | :clipboard: Planned |
 
-**Remaining work:** WLED adoption wizard and remaining cross-plugin QA; Matter plugin implementation; direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management).
+**Remaining work:** WLED adoption wizard and remaining cross-plugin QA; Homey local integration (SHS/Homey Pro) followed by Homey Cloud; Matter plugin implementation; and direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management). Homey's [approved design](../docs/superpowers/specs/2026-08-12-homey-integration-design.md) and [implementation plan](../docs/superpowers/plans/2026-08-12-homey-integration.md) front-load compatibility testing and sanitized fixture capture during the one-month SHS subscription.
 
 ---
 
@@ -382,10 +383,10 @@ ESP32-based knob with round LCD as a companion peripheral to the main panel disp
 | Security | 1 | 0 | 0 | 1 |
 | Virtual Devices | 0 | 1 | 0 | 1 |
 | Companion Display | 0 | 0 | 9 | 9 |
-| Plugins | 1 | 0 | 2 | 3 |
+| Plugins | 1 | 1 | 3 | 5 |
 | Extension Actions | 3 | 0 | 5 | 8 |
 | Device & Infrastructure | 5 | 0 | 1 | 6 |
 | Technical | 6 | 0 | 0 | 6 |
 | Other Features | 4 | 0 | 1 | 5 |
 | Plans | 2 | 0 | 1 | 3 |
-| **Total** | **72** | **1** | **30** | **103** |
+| **Total** | **72** | **2** | **31** | **105** |

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -67,7 +67,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 ### Out of scope
 
-- Pairing, commissioning, interviewing, renaming, or removing physical devices in Homey.
+- Product support for pairing, commissioning, interviewing, renaming, or removing physical devices in Homey. Phase 0 may exercise lifecycle mutations only on a separately gated, explicitly allowlisted disposable virtual/test device.
 - Homey apps, drivers, flows, alarms, insights, firmware, backups, or user administration.
 - Automatic deletion of Smart Panel devices when upstream Homey devices disappear.
 - Direct Homey credentials or transport in the Flutter panel.
@@ -82,7 +82,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] A least-privilege API key can read devices, zones, system information, and current capability values.
 - [ ] A designated harmless writable capability can be controlled and its resulting event observed.
 - [ ] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
-- [ ] Device add, rename, zone move, unavailable, removal, and suffixed-capability behavior are captured.
+- [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
 - [ ] mDNS behavior is verified; discovery is either specified from evidence or explicitly deferred.
 - [ ] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
 - [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.
@@ -112,6 +112,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] Single and batch adoption are idempotent and return per-device outcomes.
 - [ ] Adoption reuses generic device/channel/property identifiers without a migration, or an incremental migration is added if evidence shows one is required.
 - [ ] Initial reconciliation populates current values and availability for adopted devices.
+- [ ] Subscriptions are established before the authoritative initial reconciliation, and a tested startup barrier prevents snapshot/event races from losing the newest value.
 - [ ] Real-time Homey events update only adopted, mapped properties.
 - [ ] Reconnect performs a full reconciliation and bounded periodic reconciliation repairs missed events.
 - [ ] A missing upstream device is marked unavailable/orphaned but never automatically deleted.

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -93,6 +93,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] Homey API keys and OAuth tokens are write-only through every config endpoint.
 - [ ] Config responses expose only a configured/not-configured indicator for secrets.
 - [ ] Omitting a secret during update preserves it; explicit clear removes it.
+- [ ] Connection testing reuses the stored key only for an explicit fully saved configuration request; every candidate/overridden URL requires a newly supplied key and can never fall back to the stored secret.
 - [ ] Secrets are absent from logs, exceptions, telemetry, OpenAPI examples, tests, and fixtures.
 - [ ] URLs, schemes, timeouts, intervals, and permission errors are validated and sanitized.
 - [ ] Disabling the plugin closes subscriptions, stops timers, and disconnects the connector cleanly.
@@ -130,6 +131,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 - [ ] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
 - [ ] The form never repopulates or displays a stored API key.
+- [ ] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
 - [ ] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
 - [ ] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
 - [ ] Confirm rows provide sensible names/categories and a read-only mapping summary.

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -1,0 +1,255 @@
+# Task: Homey Device Provider Integration
+ID: FEATURE-PLUGIN-HOMEY
+Type: feature
+Scope: backend, admin, panel
+Size: large
+Parent: (none)
+Status: planned
+Created: 2026-08-12
+
+## 1. Business goal
+
+In order to use Smart Panel as a unified display and control interface
+
+As a user whose devices are managed by Homey
+
+I want to connect Homey, adopt its devices, receive live state updates, and control supported capabilities from Smart Panel
+
+## 2. Context
+
+- Approved design: `docs/superpowers/specs/2026-08-12-homey-integration-design.md`
+- Detailed execution plan: `docs/superpowers/plans/2026-08-12-homey-integration.md`
+- The first release targets Homey Self-Hosted Server (SHS) and compatible Homey Pro local APIs.
+- Homey Cloud is a subsequent connector behind the same plugin contract.
+- The current one-month SHS subscription must be used first for compatibility validation and sanitized fixture capture.
+- Home Assistant provides the closest backend reference for discovery, mapping preview, adoption, synchronization, and command routing:
+  - `apps/backend/src/plugins/devices-home-assistant/`
+  - `apps/admin/src/plugins/devices-home-assistant/`
+- The shared admin adoption wizard is the required UI foundation:
+  - `apps/admin/src/modules/devices/components/wizard/`
+- The panel consumes normal Smart Panel device APIs and state updates. It must not connect directly to Homey.
+
+## 3. Scope
+
+### In scope — Phase 0 compatibility and fixtures
+
+- Install/configure the subscribed SHS instance on a stable LAN address.
+- Verify API-key authentication, required permissions, HTTP/HTTPS ports, inventory, zones, capability metadata, events, commands, reconnects, and upstream lifecycle changes.
+- Determine whether SHS publishes a stable mDNS service suitable for discovery.
+- Review the `homey-api` package license and runtime behavior before adding it.
+- Capture sanitized, versioned fixtures and event sequences for offline automated tests.
+
+### In scope — Phase 1 local MVP
+
+- One backend `devices-homey` plugin with a transport-independent connector contract.
+- Local SHS/Homey Pro connector using URL and API key.
+- Generic write-only config-secret handling so credentials cannot be returned by config endpoints.
+- Plugin lifecycle, health states, timeouts, reconnect backoff, event subscriptions, and reconciliation fallback.
+- Normalized Homey device, zone, capability, and event models.
+- Server discovery when verified, with manual URL configuration always available.
+- Authenticated discovery of logical devices already managed by Homey.
+- YAML-based category/channel/property mappings with upgrade-safe user overrides.
+- Mapping preview and batch adoption using stable Homey identifiers.
+- Initial state synchronization, real-time updates, missing-device handling, and periodic reconciliation.
+- Commands for supported writable capabilities with event-based confirmation and targeted-read fallback.
+- Admin configuration, connection testing, health display, and generic wizard adapter.
+- Minimal panel registration/mapping plus regenerated clients/specs where required.
+- Backend, admin, and representative panel tests.
+- Operator/developer documentation.
+
+### In scope — Phase 2 cloud connector
+
+- Athom OAuth/Web API client registration and authorization flow.
+- Homey selection for multi-Homey accounts.
+- Secure access/refresh-token persistence and revocation behavior.
+- Cloud connector implementing the same normalized connector contract.
+- Cloud-specific deployment and approval/limit documentation.
+
+### Out of scope
+
+- Pairing, commissioning, interviewing, renaming, or removing physical devices in Homey.
+- Homey apps, drivers, flows, alarms, insights, firmware, backups, or user administration.
+- Automatic deletion of Smart Panel devices when upstream Homey devices disappear.
+- Direct Homey credentials or transport in the Flutter panel.
+- Exhaustive support for all vendor-specific capabilities in the first release.
+- Matter Bridge as the primary implementation.
+
+## 4. Acceptance criteria
+
+### Phase 0 — compatibility gate
+
+- [ ] SHS version, image digest, network topology, ports, and test date are recorded.
+- [ ] A least-privilege API key can read devices, zones, system information, and current capability values.
+- [ ] A designated harmless writable capability can be controlled and its resulting event observed.
+- [ ] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
+- [ ] Device add, rename, zone move, unavailable, removal, and suffixed-capability behavior are captured.
+- [ ] mDNS behavior is verified; discovery is either specified from evidence or explicitly deferred.
+- [ ] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
+- [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.
+- [ ] Fixture-backed tests can run without live SHS access.
+
+### Security and configuration
+
+- [ ] Homey API keys and OAuth tokens are write-only through every config endpoint.
+- [ ] Config responses expose only a configured/not-configured indicator for secrets.
+- [ ] Omitting a secret during update preserves it; explicit clear removes it.
+- [ ] Secrets are absent from logs, exceptions, telemetry, OpenAPI examples, tests, and fixtures.
+- [ ] URLs, schemes, timeouts, intervals, and permission errors are validated and sanitized.
+- [ ] Disabling the plugin closes subscriptions, stops timers, and disconnects the connector cleanly.
+
+### Backend local provider
+
+- [ ] `devices-homey` is registered as a managed backend plugin.
+- [ ] A `HomeyConnector` abstraction prevents SDK/transport objects from leaking into domain services.
+- [ ] The local connector supports connection testing, inventory, zones, device reads, events, and capability writes.
+- [ ] Health exposes connected, degraded polling, reconnecting, authentication failed, and stopped states.
+- [ ] Manual URL setup works without mDNS.
+- [ ] Authenticated device discovery lists all logical Homey devices with adoption/support status.
+- [ ] Normalization preserves full device and capability IDs, including capability suffixes.
+- [ ] Mapping definitions cover the agreed MVP light, switch, sensor, climate, cover, lock, battery, and energy capabilities.
+- [ ] Unknown capabilities create preview warnings without failing otherwise supported devices.
+- [ ] Mapping preview returns category, channels, properties, identifiers, values, access, conversions, and warnings.
+- [ ] Single and batch adoption are idempotent and return per-device outcomes.
+- [ ] Adoption reuses generic device/channel/property identifiers without a migration, or an incremental migration is added if evidence shows one is required.
+- [ ] Initial reconciliation populates current values and availability for adopted devices.
+- [ ] Real-time Homey events update only adopted, mapped properties.
+- [ ] Reconnect performs a full reconciliation and bounded periodic reconciliation repairs missed events.
+- [ ] A missing upstream device is marked unavailable/orphaned but never automatically deleted.
+- [ ] Writable property commands validate and transform values, use the full capability ID, and await authoritative confirmation.
+- [ ] A missing confirmation triggers at most one targeted read before returning a timeout/error.
+
+### Backend API and OpenAPI
+
+- [ ] Status, test-connection, discovery, device inventory, mapping-preview, and adoption endpoints follow repository controller conventions.
+- [ ] Every controller action has the required Swagger tags, operation metadata, response envelope, validation, authorization, and error responses.
+- [ ] `pnpm run generate:openapi` succeeds after backend Swagger changes.
+- [ ] No generated OpenAPI, admin API type, panel API client, or generated spec file is edited manually.
+
+### Admin
+
+- [ ] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
+- [ ] The form never repopulates or displays a stored API key.
+- [ ] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
+- [ ] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
+- [ ] Confirm rows provide sensible names/categories and a read-only mapping summary.
+- [ ] Batch results show created, updated, skipped, and failed outcomes with sanitized errors.
+- [ ] Stores/composables handle offline, empty, mixed-support, partial-success, and reconnect states.
+- [ ] All required locale files and locale schema tests are updated.
+
+### Panel
+
+- [ ] Adopted Homey devices load through the normal Devices API without Homey credentials.
+- [ ] Real-time property changes use the existing Smart Panel WebSocket/state path.
+- [ ] Representative lighting, sensor, thermostat, cover, lock, and energy devices render in existing detail widgets.
+- [ ] Supported commands follow existing panel optimistic/confirmation behavior.
+- [ ] `melos rebuild-all` and `melos analyze` succeed after generated API/spec changes.
+
+### Tests and quality
+
+- [ ] Unit tests cover normalization, mappings, transformations, preview, adoption, event processing, reconnects, command confirmation, and secret handling.
+- [ ] Fixture integration tests cover every MVP capability family and representative lifecycle failures.
+- [ ] Live SHS tests are environment-gated; write tests require an explicit device/capability allowlist.
+- [ ] Backend unit tests, admin unit tests, JS lint/type checks, OpenAPI generation, and relevant panel tests pass.
+- [ ] The plugin remains fully testable after the one-month SHS subscription expires.
+- [ ] No new dependency is merged without its license, maintenance, runtime, and replacement implications being documented.
+
+### Phase 2 cloud
+
+- [ ] Cloud authorization uses Athom OAuth and never asks users to paste account credentials.
+- [ ] Refresh, expiry, revocation, reauthorization, and multi-Homey selection are handled.
+- [ ] The cloud connector passes the same connector contract suite as the local connector.
+- [ ] Mapping, adoption, state sync, and control services contain no cloud-specific forks outside connector/authorization boundaries.
+- [ ] User limits, approval requirements, redirect URIs, and deployment steps are documented.
+
+## 5. Example scenarios
+
+### Scenario: Adopt a Homey lighting device
+
+Given the administrator has configured a reachable SHS instance with a valid scoped API key,
+and Homey manages a dimmable color light, when the administrator opens the Homey device wizard,
+then the light appears with its Homey name, zone, class, capabilities, and suggested lighting category.
+When the administrator adopts it, Smart Panel creates the mapped lighting channels and properties,
+the initial power, brightness, color, and temperature values are visible,
+and physical or Homey-originated changes appear in Smart Panel in real time.
+
+### Scenario: Control and confirm a cover
+
+Given an adopted Homey cover exposes writable position and state capabilities,
+when the user changes its position from Smart Panel, Smart Panel sends the transformed value to the full Homey capability identifier
+and treats the resulting Homey event as confirmation.
+It shows a timeout/error instead of a false final value if confirmation and the targeted read both fail.
+
+### Scenario: SHS restarts
+
+Given adopted devices are receiving capability events, when SHS restarts,
+then Smart Panel enters reconnecting state with bounded backoff
+and does not create duplicate connections or polling loops.
+When SHS returns, Smart Panel reconnects, restores subscriptions, performs full reconciliation, and resumes live updates.
+
+### Scenario: API key is revoked
+
+Given the integration is connected, when its API key is revoked,
+then the plugin reports authentication failure with a sanitized message,
+avoids aggressive retries, and no key appears in logs or API responses.
+When the administrator saves a new key, the plugin reconnects without requiring a Smart Panel restart.
+
+### Scenario: Homey device is removed upstream
+
+Given a Homey device has been adopted into Smart Panel, when it is removed from Homey,
+then its Smart Panel device is marked unavailable/orphaned,
+it is not automatically deleted, and no deletion or unpairing request is sent to Homey.
+
+## 6. Technical constraints
+
+- Follow the approved design and detailed implementation plan linked above.
+- Use `apps/backend/src/plugins/devices-home-assistant/` as the main backend reference and the shared device wizard as the admin reference.
+- Keep connector, mapping, adoption, synchronization, and platform/control responsibilities in separate services.
+- Prefer existing managed plugin, devices, mapping storage, mDNS, config, WebSocket, and platform abstractions.
+- Do not introduce a database migration unless the generic identifiers are proven insufficient; if needed, create an incremental migration.
+- Do not edit generated code manually.
+- The backend Swagger decorators are the OpenAPI source of truth.
+- Add external-call timeouts, categorized errors, cleanup, and reconnect limits from the start.
+- Never perform destructive upstream Homey actions.
+- Never commit credentials or unsanitized live payloads.
+
+## 7. Implementation hints
+
+- Complete Phase 0 while SHS access is available; fixture capture is on the critical path.
+- Make normalized models plain data and write contract tests that both local and cloud connectors must pass.
+- Match descriptors using Homey class plus capability base IDs, but persist and command full capability IDs.
+- Revalidate a device immediately before adoption.
+- Treat Homey events as authoritative command confirmation; use targeted reads only as a fallback.
+- Authentication failures should wait for configuration changes or a slow retry policy rather than use normal reconnect cadence.
+- Keep manual URL configuration even if mDNS discovery proves reliable.
+
+## 8. Delivery estimate and sequencing
+
+- Local MVP: approximately 25–36 engineering days.
+- A four-week calendar target is plausible if backend and admin work overlap after the connector and API contracts stabilize.
+- A single implementation stream should budget approximately 5–7 weeks.
+- Homey Cloud: approximately 7–12 additional engineering days, excluding Athom approval/client-registration lead time.
+
+Implementation order:
+
+1. SHS compatibility spike and sanitized fixtures.
+2. Generic secret-safe configuration support.
+3. Backend plugin foundation and connector contract.
+4. Local connector and lifecycle/reconnect service.
+5. Normalization and mapping catalog.
+6. Discovery, preview, and adoption APIs.
+7. Real-time synchronization and control platform.
+8. Admin configuration and wizard adapter.
+9. Panel/OpenAPI/spec integration.
+10. Hardening, live verification, documentation, and release gate.
+11. Cloud OAuth and cloud connector.
+
+## 9. AI instructions
+
+- Read this task, the approved design, and the detailed plan entirely before changing code.
+- Inspect the current Home Assistant and generic wizard implementations before choosing exact files/types.
+- Begin with Phase 0; do not infer SHS behavior that can be measured during the subscription.
+- Keep work scoped to the current plan task and update its checkbox when verified.
+- Preserve unrelated worktree changes.
+- For every acceptance criterion, implement it, leave it unchecked, or record a concrete reason for deferral.
+- Run the verification commands specified by the detailed plan after each milestone.
+- Never include a real API key or unsanitized Homey fixture in a tool call, patch, test snapshot, commit, or response.


### PR DESCRIPTION
## Summary

- define the approved architecture for a native Homey device provider
- add an execution-ready plan covering the time-limited SHS compatibility spike, local MVP, and later Homey Cloud connector
- add `FEATURE-PLUGIN-HOMEY` with detailed scope and acceptance criteria
- register the planned feature in the project roadmap

## Why

Smart Panel needs a concrete, reviewable path for using Homey as a display and control provider. The one-month Homey Self-Hosted Server subscription makes early compatibility verification and sanitized fixture capture time-sensitive, so the plan puts that work before implementation.

## Impact

Documentation and planning only. No application source, generated files, dependencies, database schema, or runtime behavior changes.

## Validation

- `git diff --cached --check`
- reviewed the staged scope and roadmap totals
- application tests and code generation were not run because this PR changes Markdown documentation only