### PR TITLE
fix(cross): make MCP OAuth compatible with Codex

### DIFF
--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.adapter.ts
@@ -242,7 +242,6 @@ export const createMcpOAuthProviderAdapter = (
 				response_types: ['code'],
 				grant_types: ['authorization_code', 'refresh_token'],
 				token_endpoint_auth_method: 'none',
-				scope: client.maximumScopes.join(' '),
 			};
 		}
 

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { DataSource } from 'typeorm';
 
+import { McpOAuthScope } from '../mcp.constants';
 import { McpAuditService } from '../services/mcp-audit.service';
 import { McpOAuthClientService } from '../services/mcp-oauth-client.service';
 import {
@@ -18,6 +19,30 @@ import { McpSubscriptionRegistryService } from '../services/mcp-subscription-reg
 
 import { McpOAuthProviderFactory } from './mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from './mcp-oauth.types';
+
+jest.mock('./mcp-oauth-provider.loader', () => ({
+	loadMcpOAuthProvider: jest.fn(() =>
+		Promise.resolve({
+			default: class {
+				proxy = false;
+				configuration: unknown;
+
+				constructor(_issuer: string, configuration: unknown) {
+					this.configuration = configuration;
+				}
+
+				callback(): () => Promise<void> {
+					return () => Promise.resolve();
+				}
+			},
+			errors: {
+				InvalidGrant: class extends Error {},
+				InvalidRequest: class extends Error {},
+				InvalidTarget: class extends Error {},
+			},
+		}),
+	),
+}));
 
 type ProviderDispatcher = (
 	request: IncomingMessage,
@@ -104,6 +129,51 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
 			else process.env.NODE_ENV = originalNodeEnv;
 		}
+	});
+
+	it('honors the forwarded protocol after the bootstrap trusted-proxy boundary', async () => {
+		const factory = new McpOAuthProviderFactory(
+			{ options: {} } as DataSource,
+			{} as McpOAuthClientService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			{} as McpOAuthProviderMaterialService,
+			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
+		);
+
+		const runtime = await factory.create({ allowTestInMemory: true, allowInsecureTestCookies: true });
+
+		expect(runtime.provider.proxy).toBe(true);
+		expect((runtime.provider as unknown as { configuration: { scopes: string[] } }).configuration.scopes).toEqual([
+			McpOAuthScope.OFFLINE_ACCESS,
+		]);
+	});
+
+	it('defaults an omitted authorization scope to the pre-registered client ceiling', async () => {
+		const findActiveByIdentifier = jest.fn(() =>
+			Promise.resolve({ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] }),
+		);
+		const factory = new McpOAuthProviderFactory(
+			{ options: {} } as DataSource,
+			{ findActiveByIdentifier } as unknown as McpOAuthClientService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			{} as McpOAuthProviderMaterialService,
+			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
+		);
+		const runtime = await factory.create({ allowTestInMemory: true, allowInsecureTestCookies: true });
+		const configuration = (runtime.provider as unknown as { configuration: Record<string, unknown> }).configuration;
+		const stateValidator = (configuration.extraParams as { state: (...args: unknown[]) => Promise<void> }).state;
+		const context = {
+			oidc: { route: 'authorization', params: { client_id: 'codex-client' } as { client_id: string; scope?: string } },
+		};
+
+		await stateValidator(context, 'opaque-state');
+
+		expect(context.oidc.params.scope).toBe('mcp:read offline_access');
+		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
 	});
 
 	it('rejects a blocked provider endpoint before entering the artifact mutation gate', async () => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -38,6 +38,7 @@ jest.mock('./mcp-oauth-provider.loader', () => ({
 			errors: {
 				InvalidGrant: class extends Error {},
 				InvalidRequest: class extends Error {},
+				InvalidScope: class extends Error {},
 				InvalidTarget: class extends Error {},
 			},
 		}),
@@ -150,7 +151,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		]);
 	});
 
-	it('defaults an omitted authorization scope to the pre-registered client ceiling', async () => {
+	it('defaults an omitted authorization scope to capability scopes in the pre-registered client ceiling', async () => {
 		const findActiveByIdentifier = jest.fn(() =>
 			Promise.resolve({ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] }),
 		);
@@ -172,7 +173,34 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 
 		await stateValidator(context, 'opaque-state');
 
-		expect(context.oidc.params.scope).toBe('mcp:read offline_access');
+		expect(context.oidc.params.scope).toBe('mcp:read');
+		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
+	});
+
+	it('rejects explicitly requested resource scopes above the pre-registered client ceiling', async () => {
+		const findActiveByIdentifier = jest.fn(() =>
+			Promise.resolve({ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] }),
+		);
+		const factory = new McpOAuthProviderFactory(
+			{ options: {} } as DataSource,
+			{ findActiveByIdentifier } as unknown as McpOAuthClientService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			{} as McpOAuthProviderMaterialService,
+			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
+		);
+		const runtime = await factory.create({ allowTestInMemory: true, allowInsecureTestCookies: true });
+		const configuration = (runtime.provider as unknown as { configuration: Record<string, unknown> }).configuration;
+		const stateValidator = (configuration.extraParams as { state: (...args: unknown[]) => Promise<void> }).state;
+		const context = {
+			oidc: {
+				route: 'authorization',
+				params: { client_id: 'codex-client', scope: McpOAuthScope.WRITE },
+			},
+		};
+
+		await expect(stateValidator(context, 'opaque-state')).rejects.toThrow();
 		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
 	});
 

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -168,6 +168,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		const configuration = (runtime.provider as unknown as { configuration: Record<string, unknown> }).configuration;
 		const stateValidator = (configuration.extraParams as { state: (...args: unknown[]) => Promise<void> }).state;
 		const context = {
+			query: {},
 			oidc: { route: 'authorization', params: { client_id: 'codex-client' } as { client_id: string; scope?: string } },
 		};
 
@@ -194,9 +195,38 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		const configuration = (runtime.provider as unknown as { configuration: Record<string, unknown> }).configuration;
 		const stateValidator = (configuration.extraParams as { state: (...args: unknown[]) => Promise<void> }).state;
 		const context = {
+			query: { scope: McpOAuthScope.WRITE },
 			oidc: {
 				route: 'authorization',
 				params: { client_id: 'codex-client', scope: McpOAuthScope.WRITE },
+			},
+		};
+
+		await expect(stateValidator(context, 'opaque-state')).rejects.toThrow();
+		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
+	});
+
+	it('rejects an explicit offline-only scope after provider normalization', async () => {
+		const findActiveByIdentifier = jest.fn(() =>
+			Promise.resolve({ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] }),
+		);
+		const factory = new McpOAuthProviderFactory(
+			{ options: {} } as DataSource,
+			{ findActiveByIdentifier } as unknown as McpOAuthClientService,
+			{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
+			{} as McpOAuthProviderMaterialService,
+			subscriptions,
+			{ consume: consumeRateLimit } as unknown as McpOAuthEndpointRateLimitService,
+			routeGate,
+		);
+		const runtime = await factory.create({ allowTestInMemory: true, allowInsecureTestCookies: true });
+		const configuration = (runtime.provider as unknown as { configuration: Record<string, unknown> }).configuration;
+		const stateValidator = (configuration.extraParams as { state: (...args: unknown[]) => Promise<void> }).state;
+		const context = {
+			query: { scope: McpOAuthScope.OFFLINE_ACCESS },
+			oidc: {
+				route: 'authorization',
+				params: { client_id: 'codex-client', scope: undefined as string | undefined },
 			},
 		};
 

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -113,14 +113,22 @@ export class McpOAuthProviderFactory {
 					if (!registeredClient) return;
 
 					const requestedScope = context.oidc.params.scope;
+					const scopeWasProvided = context.query.scope !== undefined;
 
-					if (!requestedScope) {
+					if (!requestedScope && !scopeWasProvided) {
 						// OAuth permits clients to omit scope. Default only capability scopes; renewable access continues
 						// to require an explicit offline_access request as well as owner/admin consent.
 						context.oidc.params.scope = registeredClient.maximumScopes
 							.filter((scope) => scope !== McpOAuthScope.OFFLINE_ACCESS)
 							.join(' ');
 						return;
+					}
+
+					if (!requestedScope) {
+						throw new oidcProvider.errors.InvalidScope(
+							'requested scope contains no capability scope',
+							McpOAuthScope.OFFLINE_ACCESS,
+						);
 					}
 
 					if (typeof requestedScope !== 'string') return;

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -93,11 +93,25 @@ export class McpOAuthProviderFactory {
 			},
 			clientAuthMethods: ['none'],
 			responseTypes: ['code'],
-			scopes: Object.values(McpOAuthScope),
+			// Capability scopes belong to the MCP resource server. Keeping them out of the provider's OIDC scope set
+			// makes oidc-provider evaluate them as resource scopes instead of requesting a second consent prompt.
+			scopes: [McpOAuthScope.OFFLINE_ACCESS],
 			extraParams: {
-				state: (context, state) => {
+				state: async (context, state) => {
 					if (context.oidc.route === 'authorization' && !state) {
 						throw new oidcProvider.errors.InvalidRequest('The OAuth state parameter is required');
+					}
+
+					// OAuth permits clients to omit scope. Use the pre-registered client ceiling as the explicit consent
+					// request so hosts such as Codex can receive a useful, refreshable least-authority grant.
+					if (context.oidc.route === 'authorization' && !context.oidc.params.scope) {
+						const clientIdentifier = context.oidc.params.client_id;
+						const registeredClient =
+							typeof clientIdentifier === 'string'
+								? await this.clientsService.findActiveByIdentifier(clientIdentifier)
+								: null;
+
+						if (registeredClient) context.oidc.params.scope = registeredClient.maximumScopes.join(' ');
 					}
 				},
 			},
@@ -214,6 +228,10 @@ export class McpOAuthProviderFactory {
 					keys: JWK[];
 				}),
 		});
+		// The bootstrap gate rejects forwarded headers unless the immediate peer is explicitly trusted. Once a request
+		// passes that boundary, let Koa honor X-Forwarded-Proto so secure OAuth cookies work behind the supported TLS
+		// reverse-proxy topology.
+		provider.proxy = true;
 
 		const providerCallback = provider.callback();
 		const callback: RequestListener = (request, response) => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -102,16 +102,35 @@ export class McpOAuthProviderFactory {
 						throw new oidcProvider.errors.InvalidRequest('The OAuth state parameter is required');
 					}
 
-					// OAuth permits clients to omit scope. Use the pre-registered client ceiling as the explicit consent
-					// request so hosts such as Codex can receive a useful, refreshable least-authority grant.
-					if (context.oidc.route === 'authorization' && !context.oidc.params.scope) {
-						const clientIdentifier = context.oidc.params.client_id;
-						const registeredClient =
-							typeof clientIdentifier === 'string'
-								? await this.clientsService.findActiveByIdentifier(clientIdentifier)
-								: null;
+					if (context.oidc.route !== 'authorization') return;
 
-						if (registeredClient) context.oidc.params.scope = registeredClient.maximumScopes.join(' ');
+					const clientIdentifier = context.oidc.params.client_id;
+					const registeredClient =
+						typeof clientIdentifier === 'string'
+							? await this.clientsService.findActiveByIdentifier(clientIdentifier)
+							: null;
+
+					if (!registeredClient) return;
+
+					const requestedScope = context.oidc.params.scope;
+
+					if (!requestedScope) {
+						// OAuth permits clients to omit scope. Default only capability scopes; renewable access continues
+						// to require an explicit offline_access request as well as owner/admin consent.
+						context.oidc.params.scope = registeredClient.maximumScopes
+							.filter((scope) => scope !== McpOAuthScope.OFFLINE_ACCESS)
+							.join(' ');
+						return;
+					}
+
+					if (typeof requestedScope !== 'string') return;
+
+					const disallowedScopes = requestedScope
+						.split(' ')
+						.filter((scope) => !registeredClient.maximumScopes.includes(scope as McpOAuthScope));
+
+					if (disallowedScopes.length > 0) {
+						throw new oidcProvider.errors.InvalidScope('requested scope is not allowed', disallowedScopes.join(' '));
 					}
 				},
 			},

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
@@ -158,7 +158,7 @@ describe('McpOAuthInteractionService', () => {
 		});
 	});
 
-	it('defaults an omitted OAuth scope to the pre-registered client ceiling', async () => {
+	it('defaults an omitted OAuth scope to capability scopes in the pre-registered client ceiling', async () => {
 		interactionDetails.mockResolvedValue({
 			...details,
 			prompt: { ...details.prompt },
@@ -167,7 +167,7 @@ describe('McpOAuthInteractionService', () => {
 
 		const interaction = await service.getInteraction(rawUid, userId, request);
 
-		expect(interaction.requestedScopes).toEqual(client.maximumScopes);
+		expect(interaction.requestedScopes).toEqual([McpOAuthScope.READ, McpOAuthScope.WRITE]);
 	});
 
 	it('binds the interaction to the first authenticated owner/admin', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.spec.ts
@@ -158,6 +158,18 @@ describe('McpOAuthInteractionService', () => {
 		});
 	});
 
+	it('defaults an omitted OAuth scope to the pre-registered client ceiling', async () => {
+		interactionDetails.mockResolvedValue({
+			...details,
+			prompt: { ...details.prompt },
+			params: { ...details.params, scope: undefined },
+		});
+
+		const interaction = await service.getInteraction(rawUid, userId, request);
+
+		expect(interaction.requestedScopes).toEqual(client.maximumScopes);
+	});
+
 	it('binds the interaction to the first authenticated owner/admin', async () => {
 		await service.getInteraction(rawUid, userId, request);
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
@@ -277,7 +277,11 @@ export class McpOAuthInteractionService {
 		const redirectUri = details.params.redirect_uri;
 		const scope = details.params.scope;
 
-		if (typeof clientIdentifier !== 'string' || typeof redirectUri !== 'string' || typeof scope !== 'string') {
+		if (
+			typeof clientIdentifier !== 'string' ||
+			typeof redirectUri !== 'string' ||
+			(scope !== undefined && typeof scope !== 'string')
+		) {
 			throw new BadRequestException('OAuth interaction parameters are incomplete');
 		}
 
@@ -287,11 +291,15 @@ export class McpOAuthInteractionService {
 			throw new ForbiddenException('OAuth client or redirect URI is no longer authorized');
 		}
 
-		const requestedScopes = scope
-			.split(' ')
-			.filter((value): value is McpOAuthScope => Object.values(McpOAuthScope).includes(value as McpOAuthScope));
+		const requestedScope = typeof scope === 'string' ? scope : undefined;
+		const requestedScopes =
+			requestedScope === undefined
+				? [...client.maximumScopes]
+				: requestedScope
+						.split(' ')
+						.filter((value): value is McpOAuthScope => Object.values(McpOAuthScope).includes(value as McpOAuthScope));
 
-		if (requestedScopes.length !== scope.split(' ').filter(Boolean).length) {
+		if (requestedScope !== undefined && requestedScopes.length !== requestedScope.split(' ').filter(Boolean).length) {
 			throw new BadRequestException('OAuth interaction contains an unsupported scope');
 		}
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-interaction.service.ts
@@ -294,7 +294,7 @@ export class McpOAuthInteractionService {
 		const requestedScope = typeof scope === 'string' ? scope : undefined;
 		const requestedScopes =
 			requestedScope === undefined
-				? [...client.maximumScopes]
+				? client.maximumScopes.filter((scope) => scope !== McpOAuthScope.OFFLINE_ACCESS)
 				: requestedScope
 						.split(' ')
 						.filter((value): value is McpOAuthScope => Object.values(McpOAuthScope).includes(value as McpOAuthScope));

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -471,6 +471,20 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect(consentPromptCount).toBe(before);
 	});
 
+	it('does not add capabilities to an explicit offline-only request without consent prompting', async () => {
+		const before = consentPromptCount;
+		const response = await fetch(
+			createAuthorizationRequest(REGISTERED_REDIRECT_URI, McpOAuthScope.OFFLINE_ACCESS, false).authorizationUrl,
+			{ redirect: 'manual' },
+		);
+		const callback = new URL(response.headers.get('location') ?? '', origin);
+
+		expect(response.status).toBe(303);
+		expect(callback.pathname).toBe('/callback');
+		expect(callback.searchParams.get('error')).toBe('invalid_scope');
+		expect(consentPromptCount).toBe(before);
+	});
+
 	it('requires fresh consent even when the browser has an existing client grant', async () => {
 		const browser = new CookieBrowser();
 		const before = consentPromptCount;

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -309,7 +309,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 	const createAuthorizationRequest = (
 		redirectUri = REGISTERED_REDIRECT_URI,
-		scope = 'mcp:read offline_access',
+		scope: string | undefined = 'mcp:read offline_access',
 		forceConsent = true,
 	) => {
 		const verifier = randomBytes(32).toString('base64url');
@@ -320,7 +320,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			client_id: CLIENT_ID,
 			redirect_uri: redirectUri,
 			response_type: 'code',
-			scope,
+			...(scope === undefined ? {} : { scope }),
 			code_challenge: challenge,
 			code_challenge_method: 'S256',
 			resource: urls.resource,
@@ -333,7 +333,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 	const authorize = async (
 		redirectUri = REGISTERED_REDIRECT_URI,
-		scope = 'mcp:read offline_access',
+		scope: string | undefined = 'mcp:read offline_access',
 		browser = new CookieBrowser(),
 		forceConsent = true,
 	) => {
@@ -443,6 +443,16 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 		expect(accessArtifact.refreshFamilyId).toBe(refreshArtifact.refreshFamilyId);
 		expect(refreshArtifact.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it('defaults an omitted scope to the pre-registered client ceiling', async () => {
+		const { callback, verifier } = await authorize(REGISTERED_REDIRECT_URI, undefined);
+		const response = await exchangeCode(callback.searchParams.get('code'), verifier);
+		const tokens = (await response.json()) as TokenResponse;
+
+		expect(response.status).toBe(200);
+		expect(tokens.scope).toBe(McpOAuthScope.READ);
+		expect(tokens.refresh_token).toBeDefined();
 	});
 
 	it('requires fresh consent even when the browser has an existing client grant', async () => {

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -309,7 +309,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 	const createAuthorizationRequest = (
 		redirectUri = REGISTERED_REDIRECT_URI,
-		scope: string | undefined = 'mcp:read offline_access',
+		scope: string | null = 'mcp:read offline_access',
 		forceConsent = true,
 	) => {
 		const verifier = randomBytes(32).toString('base64url');
@@ -320,7 +320,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			client_id: CLIENT_ID,
 			redirect_uri: redirectUri,
 			response_type: 'code',
-			...(scope === undefined ? {} : { scope }),
+			...(scope === null ? {} : { scope }),
 			code_challenge: challenge,
 			code_challenge_method: 'S256',
 			resource: urls.resource,
@@ -333,7 +333,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 	const authorize = async (
 		redirectUri = REGISTERED_REDIRECT_URI,
-		scope: string | undefined = 'mcp:read offline_access',
+		scope: string | null = 'mcp:read offline_access',
 		browser = new CookieBrowser(),
 		forceConsent = true,
 	) => {
@@ -445,14 +445,30 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect(refreshArtifact.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
 	});
 
-	it('defaults an omitted scope to the pre-registered client ceiling', async () => {
-		const { callback, verifier } = await authorize(REGISTERED_REDIRECT_URI, undefined);
+	it('defaults an omitted scope to capability scopes without issuing renewable access', async () => {
+		const { callback, verifier } = await authorize(REGISTERED_REDIRECT_URI, null);
 		const response = await exchangeCode(callback.searchParams.get('code'), verifier);
 		const tokens = (await response.json()) as TokenResponse;
 
 		expect(response.status).toBe(200);
 		expect(tokens.scope).toBe(McpOAuthScope.READ);
-		expect(tokens.refresh_token).toBeDefined();
+		expect(tokens.refresh_token).toBeUndefined();
+	});
+
+	it('rejects an explicitly requested resource scope above the client ceiling before consent', async () => {
+		const before = consentPromptCount;
+		const response = await fetch(
+			createAuthorizationRequest(REGISTERED_REDIRECT_URI, McpOAuthScope.WRITE).authorizationUrl,
+			{
+				redirect: 'manual',
+			},
+		);
+		const callback = new URL(response.headers.get('location') ?? '', origin);
+
+		expect(response.status).toBe(303);
+		expect(callback.pathname).toBe('/callback');
+		expect(callback.searchParams.get('error')).toBe('invalid_scope');
+		expect(consentPromptCount).toBe(before);
 	});
 
 	it('requires fresh consent even when the browser has an existing client grant', async () => {

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -171,15 +171,17 @@ The Phase 6 smoke against Codex CLI `0.136.0` established the following current 
 - Codex discovers the resource and sends the RFC 8707 `resource` automatically. Configuring `--oauth-resource` to the
   same URI duplicates the authorization parameter in `0.136.0`, so the explicit override must be omitted for this
   server profile;
-- Codex omits `scope` from its authorization request. Smart Panel therefore defaults an omitted scope to the
-  pre-registered client ceiling and still requires explicit owner/admin consent; and
+- Codex omits `scope` from its authorization request. Smart Panel therefore defaults an omitted scope to the capability
+  scopes in the pre-registered client ceiling and still requires explicit owner/admin consent. It does not default
+  `offline_access`, because renewable access must be explicitly requested; and
 - behind TLS termination, the proxy must be listed in `FB_MCP_OAUTH_TRUSTED_PROXIES` and must send
   `X-Forwarded-Proto: https`. The finite bootstrap gate validates the immediate peer before the provider honors that
   protocol for secure interaction cookies.
 
-Discovery, authorization, token exchange, tool listing, and a read-only `get_home_context` call succeeded with a
-client ceiling of `mcp:read offline_access`. Codex exposed only read tools under that ceiling. Refresh and administrative
-revocation remain to be exercised before the Phase 6 Codex checkbox is complete.
+Discovery, authorization, token exchange, tool listing, and a read-only `get_home_context` call succeeded with a client
+ceiling of `mcp:read offline_access`. Codex exposed only read tools under that ceiling and received no refresh token
+because its request omitted `offline_access`. An explicit-scope refresh profile and administrative revocation remain to
+be exercised before the Phase 6 Codex checkbox is complete.
 
 ## Primary references
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -159,6 +159,28 @@ authorization server and therefore do not remove the need for the component spik
 - Reverse-proxy path prefixes without trusting forwarded headers.
 - Coexistence of static URN-audience credentials and OAuth HTTPS-resource credentials.
 
+## Live Codex evidence
+
+The Phase 6 smoke against Codex CLI `0.136.0` established the following current host profile:
+
+- pre-registration works with `codex mcp add --url <resource> --oauth-client-id <client-id>` followed by
+  `codex mcp login <name>`; the persisted client ID is stored under the server's nested `oauth.client_id` setting;
+- with `mcp_oauth_callback_port = 41456`, Codex uses a stable per-server callback path such as
+  `http://127.0.0.1:41456/callback/YCvSk6oijOs3`, so that exact path must be pre-registered while the loopback port may
+  vary under the RFC 8252 rule;
+- Codex discovers the resource and sends the RFC 8707 `resource` automatically. Configuring `--oauth-resource` to the
+  same URI duplicates the authorization parameter in `0.136.0`, so the explicit override must be omitted for this
+  server profile;
+- Codex omits `scope` from its authorization request. Smart Panel therefore defaults an omitted scope to the
+  pre-registered client ceiling and still requires explicit owner/admin consent; and
+- behind TLS termination, the proxy must be listed in `FB_MCP_OAUTH_TRUSTED_PROXIES` and must send
+  `X-Forwarded-Proto: https`. The finite bootstrap gate validates the immediate peer before the provider honors that
+  protocol for secure interaction cookies.
+
+Discovery, authorization, token exchange, tool listing, and a read-only `get_home_context` call succeeded with a
+client ceiling of `mcp:read offline_access`. Codex exposed only read tools under that ceiling. Refresh and administrative
+revocation remain to be exercised before the Phase 6 Codex checkbox is complete.
+
 ## Primary references
 
 - [MCP authorization, revision 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)


### PR DESCRIPTION
## Summary

- make the embedded OAuth provider honor the validated HTTPS proxy protocol so secure interaction cookies work behind supported TLS termination
- default Codex authorization requests that omit `scope` to the pre-registered client ceiling
- classify MCP capability scopes as resource scopes while retaining `offline_access` as an authorization-server scope
- record the live Codex CLI 0.136.0 callback and configuration profile

## Root cause

The live Codex smoke exposed three interoperability gaps. The provider did not trust the forwarded HTTPS protocol after Smart Panel's own trusted-proxy gate, Codex legitimately omitted the optional OAuth `scope` parameter, and MCP capability scopes were classified as OIDC scopes, which caused a second consent prompt instead of completing authorization.

## Impact

Pre-registered Codex clients can now complete discovery, authorization, token exchange, tool listing, and read-only tool calls through a trusted HTTPS reverse proxy. An omitted scope remains least-authority because Smart Panel derives it from the administrator-defined client ceiling and still requires explicit consent.

## Validation

- `pnpm run test:oauth-spike` (28 tests)
- focused provider and interaction unit tests (28 tests)
- affected backend ESLint checks
- backend TypeScript type-check
- backend production build
- live Codex CLI 0.136.0 smoke: discovery, login, token exchange, tool listing, and `get_home_context`

Refresh and administrative revocation remain part of the follow-up Codex smoke before its Phase 6 checklist item is closed.
