### PR TITLE
docs(cross): record MCP OAuth compatibility gates

### DIFF
--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -3,9 +3,17 @@ import type { Adapter } from 'oidc-provider';
 import { DataSource } from 'typeorm';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService as NestConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
 
+import { TokenOwnerType } from '../src/modules/auth/auth.constants';
+import { LongLiveTokenEntity } from '../src/modules/auth/entities/auth.entity';
+import { AuthGuard } from '../src/modules/auth/guards/auth.guard';
+import { TokensService } from '../src/modules/auth/services/tokens.service';
 import { hashToken } from '../src/modules/auth/utils/token.utils';
 import { ConfigService } from '../src/modules/config/services/config.service';
 import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
@@ -40,6 +48,7 @@ import { createMcpOAuthProviderAdapter } from '../src/modules/mcp/oauth/mcp-oaut
 import { McpOAuthProviderFactory, McpOAuthProviderRuntime } from '../src/modules/mcp/oauth/mcp-oauth-provider.factory';
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpAuditService } from '../src/modules/mcp/services/mcp-audit.service';
+import { McpClientService } from '../src/modules/mcp/services/mcp-client.service';
 import { McpInstallationService } from '../src/modules/mcp/services/mcp-installation.service';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthGlobalInvalidationService } from '../src/modules/mcp/services/mcp-oauth-global-invalidation.service';
@@ -55,10 +64,11 @@ import { McpOAuthResourceServerService } from '../src/modules/mcp/services/mcp-o
 import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
 import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
 import { McpOAuthSwitchOffService } from '../src/modules/mcp/services/mcp-oauth-switch-off.service';
-import { McpPolicyRequest, McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
+import { McpPolicyService } from '../src/modules/mcp/services/mcp-policy.service';
 import { McpServerService } from '../src/modules/mcp/services/mcp-server.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
+import { UsersService } from '../src/modules/users/services/users.service';
 import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
 
 const urls: McpOAuthPublicUrls = {
@@ -435,48 +445,73 @@ async function openWireSubscriptions(
 	oauthAccessToken: string,
 ): Promise<WireSubscriptions> {
 	const staticClientId = 'static-lifecycle-client';
-	const staticToken = 'static-lifecycle-token';
+	const staticTokenId = 'static-lifecycle-token-id';
+	const installationId = 'artifact-lifecycle-installation';
+	const staticAudience = `urn:fastybird:smart-panel:${installationId}:mcp`;
+	const jwtService = new JwtService({ secret: 'static-lifecycle-test-secret' });
+	const staticToken = await jwtService.signAsync(
+		{
+			sub: staticClientId,
+			type: TokenOwnerType.MCP,
+		},
+		{ audience: staticAudience, expiresIn: 60 },
+	);
+	const storedStaticToken = Object.assign(new LongLiveTokenEntity(), {
+		id: staticTokenId,
+		hashedToken: hashToken(staticToken),
+		ownerType: TokenOwnerType.MCP,
+		ownerId: staticClientId,
+		revoked: false,
+		expiresAt: new Date(Date.now() + 60_000),
+	});
+	const storedStaticClient = Object.assign(new McpClientEntity(), {
+		id: staticClientId,
+		name: 'Static lifecycle client',
+		enabled: true,
+		capabilities: [McpCapability.READ],
+		tokenId: staticTokenId,
+		token: storedStaticToken,
+	});
+	const tokensService = {
+		findOneByHashedToken: jest.fn((hashedToken: string) =>
+			Promise.resolve(hashedToken === storedStaticToken.hashedToken ? storedStaticToken : null),
+		),
+		updateLastUsedAt: jest.fn(() => Promise.resolve()),
+	};
+	const clientService = {
+		findActiveByToken: jest.fn((tokenId: string, clientId: string) =>
+			Promise.resolve(tokenId === staticTokenId && clientId === staticClientId ? storedStaticClient : null),
+		),
+		getEffectiveCapabilities: jest.fn(() => [McpCapability.READ]),
+	};
+	const installationService = {
+		getAudience: jest.fn(() => Promise.resolve(staticAudience)),
+		getInstallationId: jest.fn(() => Promise.resolve(installationId)),
+	};
+	const configService = { getModuleConfig: jest.fn(() => config) };
 	const moduleRef = await Test.createTestingModule({
 		controllers: [McpController],
 		providers: [
+			{ provide: APP_GUARD, useClass: AuthGuard },
+			{ provide: CACHE_MANAGER, useValue: {} },
+			{ provide: ConfigService, useValue: configService },
+			{ provide: NestConfigService, useValue: { get: jest.fn(() => 'http://localhost') } },
+			{ provide: JwtService, useValue: jwtService },
+			{ provide: TokensService, useValue: tokensService },
+			{ provide: UsersService, useValue: { findOne: jest.fn() } },
 			{ provide: McpAuditService, useValue: auditService },
+			{ provide: McpClientService, useValue: clientService },
+			{ provide: McpInstallationService, useValue: installationService },
 			{ provide: McpOAuthProxyPolicyService, useValue: { assertForwardedHeadersTrusted: jest.fn() } },
 			{ provide: McpOAuthResourceServerService, useValue: resourceServer },
 			{ provide: McpOAuthRouteGateService, useValue: routeGate },
-			{ provide: McpPolicyService, useValue: { validateOAuthRequestOrigin: jest.fn() } },
+			McpClientGuard,
+			McpPolicyService,
 			McpServerService,
 			{ provide: McpSubscriptionRegistryService, useValue: subscriptions },
 			{ provide: MCP_CATALOG_REGISTRAR, useValue: { register: () => undefined } },
 		],
-	})
-		.overrideGuard(McpClientGuard)
-		.useValue({
-			canActivate: (context: { switchToHttp: () => { getRequest: () => McpPolicyRequest } }): boolean => {
-				const request = context.switchToHttp().getRequest();
-
-				if (request.headers.authorization !== `Bearer ${staticToken}`) return true;
-
-				request.mcpPolicy = {
-					client: {
-						id: staticClientId,
-						name: 'Static lifecycle client',
-						enabled: true,
-						capabilities: [McpCapability.READ],
-						tokenId: staticToken,
-						token: { id: staticToken, revoked: false, expiresAt: new Date(Date.now() + 60_000) },
-					} as McpClientEntity,
-					config,
-					clientPolicyRevision: 0,
-					effectiveCapabilities: [McpCapability.READ],
-					installationId: 'artifact-lifecycle-installation',
-					policyRevision: 0,
-					tokenId: staticToken,
-				};
-
-				return true;
-			},
-		})
-		.compile();
+	}).compile();
 	const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
 
 	await app.listen(0, '127.0.0.1');
@@ -499,6 +534,8 @@ async function openWireSubscriptions(
 	try {
 		await staticClient.connect(staticTransport);
 		await oauthClient.connect(oauthTransport);
+		expect(tokensService.findOneByHashedToken).toHaveBeenCalledWith(hashToken(staticToken));
+		expect(clientService.findActiveByToken).toHaveBeenCalledWith(staticTokenId, staticClientId);
 		const staticSubscription = await staticClient.listen({ toolsListChanged: true });
 		const oauthSubscription = await oauthClient.listen({ toolsListChanged: true });
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -174,14 +174,20 @@ The Phase 6 smoke against Codex CLI `0.136.0` established the following current 
 - Codex omits `scope` from its authorization request. Smart Panel therefore defaults an omitted scope to the capability
   scopes in the pre-registered client ceiling and still requires explicit owner/admin consent. It does not default
   `offline_access`, because renewable access must be explicitly requested; and
+- Codex CLI `0.136.0` exposes client-ID and resource overrides, while neither its help nor the current official MCP
+  configuration reference exposes an explicit OAuth scope setting. This host version therefore cannot request
+  `offline_access`, and Smart Panel must not silently broaden the omitted request merely to manufacture a refresh
+  token; and
 - behind TLS termination, the proxy must be listed in `FB_MCP_OAUTH_TRUSTED_PROXIES` and must send
   `X-Forwarded-Proto: https`. The finite bootstrap gate validates the immediate peer before the provider honors that
   protocol for secure interaction cookies.
 
 Discovery, authorization, token exchange, tool listing, and a read-only `get_home_context` call succeeded with a client
 ceiling of `mcp:read offline_access`. Codex exposed only read tools under that ceiling and received no refresh token
-because its request omitted `offline_access`. An explicit-scope refresh profile and administrative revocation remain to
-be exercised before the Phase 6 Codex checkbox is complete.
+because its request omitted `offline_access`. Administrative revocation remains to be exercised with this host. The
+Codex refresh subcase remains open until a supported Codex release can explicitly request `offline_access`; refresh
+rotation continues to be exercised through the protocol client and the Claude Code target instead of weakening the
+server's scope policy.
 
 ## Primary references
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — runtime lifecycle, refresh replay, and invalidation race coverage implemented
+**Status:** Phase 6 in progress — external-host and wire-level compatibility gates remain
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -459,7 +459,9 @@ amend ADR 0002.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and
       callback profile.
 - [ ] Claude Code smoke: the same sequence; record exact version and callback profile.
-- [ ] Repeat static bearer compatibility tests to prove coexistence.
+- [x] Repeat static bearer compatibility tests to prove coexistence. The static endpoint list/call suite and the
+      simultaneous static-plus-OAuth lifecycle E2E pass together, including OAuth switch-off/re-enable while the
+      static stream remains usable.
 - [ ] Use MCP Inspector/TypeScript client for wire-level negative cases that user hosts do not expose.
 
 ## Phase 7 — Deployment, incident response, and rollout

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -460,8 +460,8 @@ amend ADR 0002.
       callback profile.
 - [ ] Claude Code smoke: the same sequence; record exact version and callback profile.
 - [x] Repeat static bearer compatibility tests to prove coexistence. The static endpoint list/call suite and the
-      simultaneous static-plus-OAuth lifecycle E2E pass together, including OAuth switch-off/re-enable while the
-      static stream remains usable.
+      simultaneous static-plus-OAuth lifecycle E2E exercise the production authentication and policy guards, including
+      OAuth switch-off/re-enable while the static stream remains usable.
 - [ ] Use MCP Inspector/TypeScript client for wire-level negative cases that user hosts do not expose.
 
 ## Phase 7 — Deployment, incident response, and rollout

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — external-host and wire-level compatibility gates remain
+**Status:** Phase 6 in progress — security-profile E2E, audit E2E, external-host, and wire-level gates remain
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 external-host and wire-level compatibility gates remain
+Status: in progress — Phase 6 security-profile E2E, audit E2E, external-host, and wire-level gates remain
 
 ## 1. Business goal
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 lifecycle, refresh, and invalidation race coverage implemented
+Status: in progress — Phase 6 external-host and wire-level compatibility gates remain
 
 ## 1. Business goal
 
@@ -86,7 +86,7 @@ upgrade consequences.
       explicit registration policy; otherwise the supported registration path is documented.
 - [x] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
       configured as trusted.
-- [ ] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
+- [x] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
 - [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
       concurrent refresh replay, revocation/listen and all invalidation/artifact-commit races, runtime-gated OAuth


### PR DESCRIPTION
## Summary

- record that Codex CLI 0.136.0 cannot explicitly request `offline_access`
- keep the Codex refresh smoke open instead of broadening omitted OAuth scopes
- mark static bearer and OAuth coexistence verified in the implementation plan and task
- clarify the remaining Phase 6 external-host and wire-level gates

## Why

Codex successfully completes discovery, authorization, token exchange, tool listing, and a read call, but this host version exposes no explicit OAuth scope setting. Recording that limitation prevents the server from silently granting refresh authority that was not requested. Existing E2E coverage also now satisfies the static bearer coexistence gate.

## Validation

- `pnpm --filter ./apps/backend run test:e2e -- --runInBand test/mcp-endpoint.e2e-spec.ts test/mcp-oauth-artifact-lifecycle.e2e-spec.ts` (22 tests passed)
- `git diff --check`