### PR TITLE
test(backend): verify MCP OAuth invalidation audits

### DIFF
--- a/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-artifact-lifecycle.e2e-spec.ts
@@ -127,6 +127,8 @@ describe('MCP OAuth artifact lifecycle', () => {
 		await dataSource.initialize();
 
 		const auditService = new McpAuditService();
+		const auditLogger = (auditService as unknown as { logger: { log: (...args: unknown[]) => void } }).logger;
+		const auditLog = jest.spyOn(auditLogger, 'log').mockImplementation(() => undefined);
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
 		let wireSubscriptions: WireSubscriptions | undefined;
 		let releasePausedArtifacts = (): void => undefined;
@@ -378,6 +380,13 @@ describe('MCP OAuth artifact lifecycle', () => {
 
 			expect(config.oauthEnabled).toBe(false);
 			expect(routeGate.isOpen).toBe(false);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_authorization_invalidation',
+				request_id: 'administrative',
+				reasons: ['oauth_disabled'],
+				authorization_profile: 'oauth',
+				outcome: 'completed',
+			});
 			expect(() => routeGate.assertOpen()).toThrow('The MCP OAuth route gate is closed');
 			expect(() => runtime.getActive()).toThrow('The MCP OAuth route gate is closed');
 			await expect(wireSubscriptions.oauthSubscription.closed).resolves.toBe('remote');
@@ -426,6 +435,14 @@ describe('MCP OAuth artifact lifecycle', () => {
 			await expect(resourceServer.verifyAccessToken(lateAccessToken)).rejects.toThrow(
 				'The MCP OAuth access token is invalid or no longer active',
 			);
+			const capturedAudit = JSON.stringify(auditLog.mock.calls);
+
+			expect(capturedAudit).not.toContain(rawAuthorizationCode);
+			expect(capturedAudit).not.toContain(rawAccessToken);
+			expect(capturedAudit).not.toContain(rawRefreshToken);
+			expect(capturedAudit).not.toContain(lateAuthorizationCode);
+			expect(capturedAudit).not.toContain(lateAccessToken);
+			expect(capturedAudit).not.toContain(lateRefreshToken);
 		} finally {
 			releasePausedArtifacts();
 			if (pendingArtifactCommits !== undefined) await pendingArtifactCommits;

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -96,6 +96,8 @@ describe('MCP OAuth listen registration race', () => {
 		await dataSource.initialize();
 
 		const auditService = new McpAuditService();
+		const auditLogger = (auditService as unknown as { logger: { log: (...args: unknown[]) => void } }).logger;
+		const auditLog = jest.spyOn(auditLogger, 'log').mockImplementation(() => undefined);
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
 		let app: NestFastifyApplication | undefined;
 		let client: Client | undefined;
@@ -262,6 +264,15 @@ describe('MCP OAuth listen registration race', () => {
 			await management.revokeAccessToken(accessArtifact.managementId, 'owner-actor');
 
 			expect(subscriptions.activeCount).toBe(0);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_management',
+				request_id: 'administrative',
+				actor_id: 'owner-actor',
+				artifact: 'access_token',
+				artifact_id: accessArtifact.managementId,
+				action: 'revoked',
+			});
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(rawAccessToken);
 			await expect(resourceServer.verifyAccessToken(rawAccessToken)).rejects.toThrow(
 				'The MCP OAuth access token is invalid or no longer active',
 			);

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — security-profile E2E, audit E2E, external-host, and wire-level gates remain
+**Status:** Phase 6 in progress — security-profile E2E, external-host, and wire-level gates remain
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -383,8 +383,8 @@ amend ADR 0002.
       rotation, advance the applicable artifact generation before revoke-all, revoke every OAuth artifact, and close
       every OAuth subscription while preserving static MCP credentials and streams.
 - [x] Add revoke-all recovery action and document password-reset versus OAuth-revocation semantics.
-- [ ] Add audit events and unit/e2e coverage for targeted and global invalidation. Automatic and owner/admin unit
-      coverage is complete; end-to-end audit verification remains in Phase 6.
+- [x] Add audit events and unit/e2e coverage for targeted and global invalidation, including structured provider-backed
+      E2E assertions that raw authorization codes, access tokens, and refresh tokens are never recorded.
 - [x] Prove user update/delete promises remain pending until approver invalidation and stream closure finish, propagate
       invalidation failure, and never leave a demoted/deleted approver's grant usable.
 - [x] Add the user-facing OAuth enable switch only after startup verifies authorization-deadline timers, targeted

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 security-profile E2E, audit E2E, external-host, and wire-level gates remain
+Status: in progress — Phase 6 security-profile E2E, external-host, and wire-level gates remain
 
 ## 1. Business goal
 


### PR DESCRIPTION
## Summary

- assert the structured audit event emitted by targeted OAuth access-token revocation
- assert the structured global OAuth switch-off invalidation event
- prove provider authorization codes, access tokens, and refresh tokens never enter captured audit records
- close the Phase 6 targeted/global invalidation audit E2E gate

## Why

The audit event shapes and management hooks had unit coverage, while Phase 6 still required provider-backed end-to-end verification. These assertions exercise the real invalidation flows and confirm their security-sensitive artifacts remain redacted.

## Validation

- `pnpm --filter ./apps/backend run test:e2e -- --runInBand test/mcp-oauth-artifact-lifecycle.e2e-spec.ts test/mcp-oauth-listen-registration-race.e2e-spec.ts` (2 tests passed)
- `pnpm --filter ./apps/backend run type-check`
- `pnpm --filter ./apps/backend exec eslint test/mcp-oauth-artifact-lifecycle.e2e-spec.ts test/mcp-oauth-listen-registration-race.e2e-spec.ts`
- `git diff --check`