### PR TITLE
test(backend): cover MCP OAuth stream expiry

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -71,7 +71,7 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 };
 
 describe('MCP OAuth listen registration race', () => {
-	it('rejects a listen request resumed after matching access-token revocation succeeds', async () => {
+	it('expires a live access-token subscription and rejects a stale listen after revocation', async () => {
 		const dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',
@@ -101,6 +101,7 @@ describe('MCP OAuth listen registration race', () => {
 		const subscriptions = new McpSubscriptionRegistryService(auditService);
 		let app: NestFastifyApplication | undefined;
 		let client: Client | undefined;
+		let expiryClient: Client | undefined;
 		const releaseListen = deferred();
 
 		try {
@@ -172,7 +173,9 @@ describe('MCP OAuth listen registration race', () => {
 			});
 			const rawAccessToken = 'listen-registration-race-access-token';
 
-			await new Adapter('AccessToken').upsert(
+			const accessTokens = new Adapter('AccessToken');
+
+			await accessTokens.upsert(
 				rawAccessToken,
 				{
 					accountId: user.id,
@@ -235,6 +238,40 @@ describe('MCP OAuth listen registration race', () => {
 			await app.listen(0, '127.0.0.1');
 			const serverService = app.get<McpServerService>(McpServerService);
 			const listenAuthenticated = deferred();
+			const endpoint = new URL('/', await app.getUrl());
+			const shortLivedAccessToken = 'listen-expiry-access-token';
+
+			await accessTokens.upsert(
+				shortLivedAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				2,
+			);
+			expiryClient = new Client(
+				{ name: 'listen-expiry-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const expiryTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${shortLivedAccessToken}` } },
+			});
+
+			await expiryClient.connect(expiryTransport);
+			const expiringSubscription = await expiryClient.listen({ toolsListChanged: true });
+
+			await expect(expiringSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(0);
+			expect(auditLog).toHaveBeenCalledWith(
+				'MCP audit event',
+				expect.objectContaining({ event: 'subscription_close', reason: 'authorization_expired' }),
+			);
+			await expiryClient.close();
+			expiryClient = undefined;
 
 			jest
 				.spyOn(serverService, 'handleOAuth')
@@ -248,7 +285,7 @@ describe('MCP OAuth listen registration race', () => {
 						await McpServerService.prototype.handleOAuth.call(serverService, request, reply, authInfo);
 					},
 				);
-			const endpoint = new URL('/', await app.getUrl());
+
 			client = new Client(
 				{ name: 'listen-registration-race-e2e', version: '1.0.0' },
 				{ versionNegotiation: { mode: 'auto' } },
@@ -280,12 +317,18 @@ describe('MCP OAuth listen registration race', () => {
 			releaseListen.resolve();
 			await rejectedListen;
 			expect(subscriptions.activeCount).toBe(0);
-			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).count()).toBe(0);
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
+					model: 'AccessToken',
+					idHash: hashToken(rawAccessToken),
+				}),
+			).toBeNull();
 			expect(
 				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
 			).toBeNull();
 		} finally {
 			releaseListen.resolve();
+			await expiryClient?.close();
 			await client?.close();
 			if (app) {
 				await app.get(McpServerService).closeAll();
@@ -294,5 +337,5 @@ describe('MCP OAuth listen registration race', () => {
 			await subscriptions.closeAll();
 			await dataSource.destroy();
 		}
-	});
+	}, 15_000);
 });

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -251,7 +251,7 @@ describe('MCP OAuth listen registration race', () => {
 					kind: 'AccessToken',
 					scope: McpOAuthScope.READ,
 				},
-				2,
+				60,
 			);
 			expiryClient = new Client(
 				{ name: 'listen-expiry-e2e', version: '1.0.0' },
@@ -262,6 +262,9 @@ describe('MCP OAuth listen registration race', () => {
 			});
 
 			await expiryClient.connect(expiryTransport);
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.update({ model: 'AccessToken', idHash: hashToken(shortLivedAccessToken) }, { expiresAt: Date.now() + 5_000 });
 			const expiringSubscription = await expiryClient.listen({ toolsListChanged: true });
 
 			await expect(expiringSubscription.closed).resolves.toBe('remote');
@@ -337,5 +340,5 @@ describe('MCP OAuth listen registration race', () => {
 			await subscriptions.closeAll();
 			await dataSource.destroy();
 		}
-	}, 15_000);
+	}, 20_000);
 });

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -414,6 +414,8 @@ amend ADR 0002.
       effective read, write, or trigger scope.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
+- [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and
+      record `authorization_expired` rather than treating expiry as administrative revocation.
 - [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth


### PR DESCRIPTION
## Summary

- open a short-lived OAuth subscription through the provider-backed HTTP endpoint
- prove the remote MCP client observes closure at the access-token authorization deadline
- verify the closure is audited as `authorization_expired`
- retain the existing stale-listen versus access-token revocation race in the same E2E
- record the completed Phase 6 expiry sub-gate

## Why

Authorization-deadline timers had unit coverage, but Phase 6 still required provider-backed wire evidence that an already-open stream closes when its access token expires. This verifies the complete path from persisted OAuth artifact through resource-server authorization, subscription registration, timer closure, client observation, and audit classification.

## Validation

- `pnpm --filter ./apps/backend run test:e2e -- --runInBand test/mcp-oauth-listen-registration-race.e2e-spec.ts`
- `pnpm --filter ./apps/backend run type-check`
- `pnpm --filter ./apps/backend exec eslint test/mcp-oauth-listen-registration-race.e2e-spec.ts`
- `git diff --check`