### PR TITLE
test(backend): cover MCP OAuth grant stream expiry

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -402,5 +402,5 @@ describe('MCP OAuth listen registration race', () => {
 			await subscriptions.closeAll();
 			await dataSource.destroy();
 		}
-	}, 30_000);
+	}, 90_000);
 });

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -71,7 +71,7 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 };
 
 describe('MCP OAuth listen registration race', () => {
-	it('expires a live access-token subscription and rejects a stale listen after revocation', async () => {
+	it('expires live token and grant subscriptions and rejects a stale listen after revocation', async () => {
 		const dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',
@@ -102,6 +102,7 @@ describe('MCP OAuth listen registration race', () => {
 		let app: NestFastifyApplication | undefined;
 		let client: Client | undefined;
 		let expiryClient: Client | undefined;
+		let grantExpiryClient: Client | undefined;
 		const releaseListen = deferred();
 
 		try {
@@ -142,6 +143,25 @@ describe('MCP OAuth listen registration race', () => {
 			const rawGrantId = 'listen-registration-race-grant';
 			const grant = await dataSource.getRepository(McpOAuthGrantEntity).save({
 				providerGrantIdHash: hashToken(rawGrantId),
+				clientId: oauthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const rawExpiringGrantId = 'listen-expiring-grant';
+			const expiringGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawExpiringGrantId),
 				clientId: oauthClient.id,
 				approvedById: user.id,
 				installationId: 'listen-registration-race-installation',
@@ -276,6 +296,47 @@ describe('MCP OAuth listen registration race', () => {
 			await expiryClient.close();
 			expiryClient = undefined;
 
+			const grantExpiryAccessToken = 'listen-grant-expiry-access-token';
+
+			await accessTokens.upsert(
+				grantExpiryAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawExpiringGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				60,
+			);
+			grantExpiryClient = new Client(
+				{ name: 'listen-grant-expiry-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const grantExpiryTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${grantExpiryAccessToken}` } },
+			});
+
+			await grantExpiryClient.connect(grantExpiryTransport);
+			await dataSource
+				.getRepository(McpOAuthGrantEntity)
+				.update({ id: expiringGrant.id }, { expiresAt: new Date(Date.now() + 5_000) });
+			const grantExpiringSubscription = await grantExpiryClient.listen({ toolsListChanged: true });
+
+			await expect(grantExpiringSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(0);
+			expect(
+				auditLog.mock.calls.filter(
+					([message, event]) =>
+						message === 'MCP audit event' &&
+						(event as { event?: string; reason?: string }).event === 'subscription_close' &&
+						(event as { event?: string; reason?: string }).reason === 'authorization_expired',
+				),
+			).toHaveLength(2);
+			await grantExpiryClient.close();
+			grantExpiryClient = undefined;
+
 			jest
 				.spyOn(serverService, 'handleOAuth')
 				.mockImplementation(
@@ -332,6 +393,7 @@ describe('MCP OAuth listen registration race', () => {
 		} finally {
 			releaseListen.resolve();
 			await expiryClient?.close();
+			await grantExpiryClient?.close();
 			await client?.close();
 			if (app) {
 				await app.get(McpServerService).closeAll();
@@ -340,5 +402,5 @@ describe('MCP OAuth listen registration race', () => {
 			await subscriptions.closeAll();
 			await dataSource.destroy();
 		}
-	}, 20_000);
+	}, 30_000);
 });

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -416,6 +416,8 @@ amend ADR 0002.
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and
       record `authorization_expired` rather than treating expiry as administrative revocation.
+- [x] Provider-backed wire E2E: close an active OAuth subscription at the grant authorization deadline and record
+      `authorization_expired` rather than treating expiry as administrative revocation.
 - [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth


### PR DESCRIPTION
## Summary

- add a separate provider-backed grant and access token to the Streamable HTTP listen E2E
- prove an active subscription closes at the grant authorization deadline
- assert the close is audited as `authorization_expired` and update the Phase 6 checklist

## Why

Phase 6 requires wire-level proof that grant expiry aborts an already-open OAuth stream. Existing coverage proved access-token expiry and unit-level deadline selection, but did not exercise grant expiry through the production MCP transport path.

## Validation

- `pnpm --filter ./apps/backend run test:e2e --runInBand test/mcp-oauth-listen-registration-race.e2e-spec.ts`
- `pnpm --filter ./apps/backend run type-check`
- `pnpm --filter ./apps/backend exec eslint test/mcp-oauth-listen-registration-race.e2e-spec.ts`
- `git diff --check`