### PR TITLE
fix(backend): complete MCP OAuth grant revocation

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
@@ -166,6 +166,30 @@ describe('McpOAuthManagementService', () => {
 		const artifacts = dataSource.getRepository(McpOAuthProviderArtifactEntity);
 		await artifacts.save([
 			artifacts.create({
+				model: 'Grant',
+				idHash: grant.providerGrantIdHash,
+				managementId: uuid(),
+				payload: JSON.stringify({ accountId: user.id, clientId: client.clientIdentifier }),
+				grantIdHash: null,
+				refreshFamilyId: null,
+				userCodeHash: null,
+				uidHash: null,
+				consumedAt: null,
+				expiresAt: Date.now() + 60_000,
+			}),
+			artifacts.create({
+				model: 'Grant',
+				idHash: otherGrant.providerGrantIdHash,
+				managementId: uuid(),
+				payload: JSON.stringify({ accountId: user.id, clientId: otherClient.clientIdentifier }),
+				grantIdHash: null,
+				refreshFamilyId: null,
+				userCodeHash: null,
+				uidHash: null,
+				consumedAt: null,
+				expiresAt: Date.now() + 60_000,
+			}),
+			artifacts.create({
 				model: 'AccessToken',
 				idHash: hashToken('access-one'),
 				managementId: accessId,
@@ -432,6 +456,21 @@ describe('McpOAuthManagementService', () => {
 			await dataSource
 				.getRepository(McpOAuthProviderRevokedGrantEntity)
 				.existsBy({ grantIdHash: grant.providerGrantIdHash }),
+		).toBe(true);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.existsBy({ grantIdHash: grant.providerGrantIdHash }),
+		).toBe(false);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.existsBy({ model: 'Grant', idHash: grant.providerGrantIdHash }),
+		).toBe(false);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.existsBy({ model: 'Grant', idHash: otherGrant.providerGrantIdHash }),
 		).toBe(true);
 	});
 

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
@@ -257,9 +257,9 @@ export class McpOAuthManagementService {
 					await manager
 						.getRepository(McpOAuthProviderRevokedGrantEntity)
 						.upsert({ grantIdHash: grant.providerGrantIdHash, revokedAt: revokedAt.getTime() }, ['grantIdHash']);
-					await manager
-						.getRepository(McpOAuthProviderArtifactEntity)
-						.delete({ grantIdHash: grant.providerGrantIdHash });
+					const artifacts = manager.getRepository(McpOAuthProviderArtifactEntity);
+					await artifacts.delete({ grantIdHash: grant.providerGrantIdHash });
+					await artifacts.delete({ model: 'Grant', idHash: grant.providerGrantIdHash });
 				}
 			});
 		});

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -363,6 +363,7 @@ describe('McpServerService policy revision', () => {
 	it('refreshes the idle deadline when subscription traffic is forwarded', async () => {
 		const touch = jest.fn();
 		const close = jest.fn();
+		const controller = new AbortController();
 		const upstream = new ReadableStream<Uint8Array>({
 			start(controller) {
 				controller.enqueue(new Uint8Array([1]));
@@ -370,7 +371,7 @@ describe('McpServerService policy revision', () => {
 			},
 		});
 		const response = new Response(upstream, { headers: { 'content-type': 'text/event-stream' } });
-		const subscription = { close, touch } as unknown as McpSubscriptionHandle;
+		const subscription = { close, signal: controller.signal, touch } as unknown as McpSubscriptionHandle;
 		const tracked = (
 			service as unknown as {
 				trackSubscriptionResponse(response: Response, subscription: McpSubscriptionHandle): Response;
@@ -384,5 +385,31 @@ describe('McpServerService policy revision', () => {
 
 		await expect(reader?.read()).resolves.toEqual({ done: true, value: undefined });
 		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it('terminates a forwarded subscription stream when its authorization signal aborts', async () => {
+		const cancelled = jest.fn();
+		const upstream = new ReadableStream<Uint8Array>({ cancel: cancelled });
+		const response = new Response(upstream, { headers: { 'content-type': 'text/event-stream' } });
+		const controller = new AbortController();
+		const close = jest.fn();
+		const subscription = {
+			close,
+			signal: controller.signal,
+			touch: jest.fn(),
+		} as unknown as McpSubscriptionHandle;
+		const tracked = (
+			service as unknown as {
+				trackSubscriptionResponse(response: Response, subscription: McpSubscriptionHandle): Response;
+			}
+		).trackSubscriptionResponse(response, subscription);
+		const reader = tracked.body?.getReader();
+		const pendingRead = reader?.read();
+
+		controller.abort(new Error('authorization expired'));
+
+		await expect(pendingRead).resolves.toEqual({ done: true, value: undefined });
+		expect(cancelled).toHaveBeenCalledWith(controller.signal.reason);
+		expect(close).toHaveBeenCalledWith('completed');
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -438,12 +438,17 @@ export class McpServerService implements OnApplicationShutdown {
 		}
 
 		const reader = response.body.getReader();
+		const cancelReader = (): void => {
+			void reader.cancel(subscription.signal.reason).catch(() => undefined);
+		};
+		const removeAbortListener = (): void => subscription.signal.removeEventListener('abort', cancelReader);
 		const stream = new ReadableStream<Uint8Array>({
 			pull: async (controller) => {
 				try {
 					const result = await reader.read();
 
 					if (result.done) {
+						removeAbortListener();
 						subscription.close('completed');
 						controller.close();
 						return;
@@ -452,15 +457,19 @@ export class McpServerService implements OnApplicationShutdown {
 					subscription.touch();
 					controller.enqueue(result.value);
 				} catch (error) {
+					removeAbortListener();
 					subscription.close('error');
 					controller.error(error);
 				}
 			},
 			cancel: async (reason) => {
+				removeAbortListener();
 				subscription.close('cancelled');
 				await reader.cancel(reason);
 			},
 		});
+		subscription.signal.addEventListener('abort', cancelReader, { once: true });
+		if (subscription.signal.aborted) cancelReader();
 
 		return new Response(stream, {
 			status: response.status,

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -71,7 +71,7 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 };
 
 describe('MCP OAuth listen registration race', () => {
-	it('expires live token and grant subscriptions and rejects a stale listen after revocation', async () => {
+	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',
@@ -103,6 +103,7 @@ describe('MCP OAuth listen registration race', () => {
 		let client: Client | undefined;
 		let expiryClient: Client | undefined;
 		let grantExpiryClient: Client | undefined;
+		let grantRevocationClient: Client | undefined;
 		const releaseListen = deferred();
 
 		try {
@@ -390,10 +391,58 @@ describe('MCP OAuth listen registration race', () => {
 			expect(
 				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
 			).toBeNull();
+
+			const grantRevocationAccessToken = 'listen-grant-revocation-access-token';
+
+			await accessTokens.upsert(
+				grantRevocationAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			grantRevocationClient = new Client(
+				{ name: 'listen-grant-revocation-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const grantRevocationTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${grantRevocationAccessToken}` } },
+			});
+
+			await grantRevocationClient.connect(grantRevocationTransport);
+			const grantRevokedSubscription = await grantRevocationClient.listen({ toolsListChanged: true });
+
+			expect(subscriptions.activeCount).toBe(1);
+			await management.revokeGrant(grant.id, 'owner-actor');
+			await expect(grantRevokedSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(0);
+			expect(auditLog).toHaveBeenCalledWith(
+				'MCP audit event',
+				expect.objectContaining({ event: 'subscription_close', reason: 'authorization_revoked' }),
+			);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_management',
+				request_id: 'administrative',
+				actor_id: 'owner-actor',
+				artifact: 'grant',
+				artifact_id: grant.id,
+				action: 'revoked',
+			});
+			await expect(resourceServer.verifyAccessToken(grantRevocationAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await grantRevocationClient.close();
+			grantRevocationClient = undefined;
 		} finally {
 			releaseListen.resolve();
 			await expiryClient?.close();
 			await grantExpiryClient?.close();
+			await grantRevocationClient?.close();
 			await client?.close();
 			if (app) {
 				await app.get(McpServerService).closeAll();

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -70,10 +70,20 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 	return { promise, resolve };
 };
 
-const waitForAuthorizationDeadline = (): Promise<void> =>
-	new Promise((resolve) => {
-		setTimeout(resolve, 5_500);
-	});
+const waitForRemoteClosure = async (closed: Promise<string>): Promise<string> => {
+	let timeout: NodeJS.Timeout | undefined;
+
+	try {
+		return await Promise.race([
+			closed,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error('The OAuth subscription did not close at its deadline')), 15_000);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+};
 
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
@@ -293,8 +303,7 @@ describe('MCP OAuth listen registration race', () => {
 				.update({ model: 'AccessToken', idHash: hashToken(shortLivedAccessToken) }, { expiresAt: Date.now() + 5_000 });
 			const expiringSubscription = await expiryClient.listen({ toolsListChanged: true });
 
-			await waitForAuthorizationDeadline();
-			await expect(expiringSubscription.closed).resolves.toBe('remote');
+			await expect(waitForRemoteClosure(expiringSubscription.closed)).resolves.toBe('remote');
 			expect(subscriptions.activeCount).toBe(0);
 			expect(auditLog).toHaveBeenCalledWith(
 				'MCP audit event',
@@ -331,8 +340,7 @@ describe('MCP OAuth listen registration race', () => {
 				.update({ id: expiringGrant.id }, { expiresAt: new Date(Date.now() + 5_000) });
 			const grantExpiringSubscription = await grantExpiryClient.listen({ toolsListChanged: true });
 
-			await waitForAuthorizationDeadline();
-			await expect(grantExpiringSubscription.closed).resolves.toBe('remote');
+			await expect(waitForRemoteClosure(grantExpiringSubscription.closed)).resolves.toBe('remote');
 			expect(subscriptions.activeCount).toBe(0);
 			expect(
 				auditLog.mock.calls.filter(

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -436,6 +436,12 @@ describe('MCP OAuth listen registration race', () => {
 			await expect(resourceServer.verifyAccessToken(grantRevocationAccessToken)).rejects.toThrow(
 				'The MCP OAuth access token is invalid or no longer active',
 			);
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
+					model: 'AccessToken',
+					idHash: hashToken(grantRevocationAccessToken),
+				}),
+			).toBeNull();
 			await grantRevocationClient.close();
 			grantRevocationClient = undefined;
 		} finally {

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -142,6 +142,15 @@ describe('MCP OAuth listen registration race', () => {
 				generation: 0,
 				createdById: user.id,
 			});
+			const grantExpiryOAuthClient = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'listen-grant-expiry-client',
+				name: 'Listen grant expiry client',
+				redirectUris: ['http://127.0.0.1:1456/callback'],
+				maximumScopes: [McpOAuthScope.READ],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
 			await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({
 				approverId: user.id,
 				generation: 0,
@@ -178,7 +187,7 @@ describe('MCP OAuth listen registration race', () => {
 			const rawExpiringGrantId = 'listen-expiring-grant';
 			const expiringGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
 				providerGrantIdHash: hashToken(rawExpiringGrantId),
-				clientId: oauthClient.id,
+				clientId: grantExpiryOAuthClient.id,
 				approvedById: user.id,
 				installationId: 'listen-registration-race-installation',
 				issuer: urls.issuer,
@@ -210,6 +219,16 @@ describe('MCP OAuth listen registration race', () => {
 			const rawAccessToken = 'listen-registration-race-access-token';
 
 			const accessTokens = new Adapter('AccessToken');
+			const providerGrants = new Adapter('Grant');
+
+			await providerGrants.upsert(
+				rawGrantId,
+				{
+					accountId: user.id,
+					clientId: oauthClient.clientIdentifier,
+				},
+				600,
+			);
 
 			await accessTokens.upsert(
 				rawAccessToken,
@@ -319,7 +338,7 @@ describe('MCP OAuth listen registration race', () => {
 				{
 					accountId: user.id,
 					aud: urls.resource,
-					clientId: oauthClient.clientIdentifier,
+					clientId: grantExpiryOAuthClient.clientIdentifier,
 					grantId: rawExpiringGrantId,
 					kind: 'AccessToken',
 					scope: McpOAuthScope.READ,
@@ -455,6 +474,12 @@ describe('MCP OAuth listen registration race', () => {
 				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
 					model: 'AccessToken',
 					idHash: hashToken(grantRevocationAccessToken),
+				}),
+			).toBeNull();
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
+					model: 'Grant',
+					idHash: hashToken(rawGrantId),
 				}),
 			).toBeNull();
 			await grantRevocationClient.close();

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -70,6 +70,11 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 	return { promise, resolve };
 };
 
+const waitForAuthorizationDeadline = (): Promise<void> =>
+	new Promise((resolve) => {
+		setTimeout(resolve, 5_500);
+	});
+
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
@@ -288,6 +293,7 @@ describe('MCP OAuth listen registration race', () => {
 				.update({ model: 'AccessToken', idHash: hashToken(shortLivedAccessToken) }, { expiresAt: Date.now() + 5_000 });
 			const expiringSubscription = await expiryClient.listen({ toolsListChanged: true });
 
+			await waitForAuthorizationDeadline();
 			await expect(expiringSubscription.closed).resolves.toBe('remote');
 			expect(subscriptions.activeCount).toBe(0);
 			expect(auditLog).toHaveBeenCalledWith(
@@ -325,6 +331,7 @@ describe('MCP OAuth listen registration race', () => {
 				.update({ id: expiringGrant.id }, { expiresAt: new Date(Date.now() + 5_000) });
 			const grantExpiringSubscription = await grantExpiryClient.listen({ toolsListChanged: true });
 
+			await waitForAuthorizationDeadline();
 			await expect(grantExpiringSubscription.closed).resolves.toBe('remote');
 			expect(subscriptions.activeCount).toBe(0);
 			expect(

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -418,6 +418,8 @@ amend ADR 0002.
       record `authorization_expired` rather than treating expiry as administrative revocation.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the grant authorization deadline and record
       `authorization_expired` rather than treating expiry as administrative revocation.
+- [x] Provider-backed wire E2E: revoke an active grant through the management service, close its live subscription as
+      `authorization_revoked`, delete its provider artifacts, and reject subsequent bearer reuse.
 - [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth


### PR DESCRIPTION
## Summary

- exercise active Streamable HTTP subscription closure when an OAuth grant is revoked
- delete both grant-linked provider artifacts and the provider Grant row itself
- terminate forwarded SSE streams when their authorization signal aborts
- assert revocation auditing, artifact cleanup, and subsequent bearer rejection
- update the Phase 6 verification checklist

## Why

Phase 6 requires production-wire proof for every OAuth invalidation boundary. This surfaced two production gaps: grant revocation left the provider Grant artifact behind, and an aborted authorization signal did not reliably end an already-established forwarded SSE response.

## Validation

- focused service unit tests: 38 passed
- OAuth registration-race E2E: passed three consecutive runs
- full backend E2E: 14 suites, 130 tests passed
- backend type-check
- focused backend ESLint
- git diff --check