### PR TITLE
feat(cross): add write-only configuration secrets

### DIFF
--- a/apps/backend/src/modules/config/config.module.ts
+++ b/apps/backend/src/modules/config/config.module.ts
@@ -19,6 +19,7 @@ import { CONFIG_SWAGGER_EXTRA_MODELS } from './config.openapi';
 import { ConfigController } from './controllers/config.controller';
 import { UpdateConfigModuleConfigDto } from './dto/update-module-config.dto';
 import { ConfigModuleConfigModel } from './models/module-config.model';
+import { ConfigSecretsService } from './services/config-secrets.service';
 import { ConfigService } from './services/config.service';
 import { ModuleConfigMutationRegistryService } from './services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './services/modules-type-mapper.service';
@@ -34,12 +35,13 @@ import { PluginConfigValidatorService } from './services/plugin-config-validator
 	imports: [NestConfigModule, PlatformModule, SwaggerModule],
 	providers: [
 		ConfigService,
+		ConfigSecretsService,
 		ModuleConfigMutationRegistryService,
 		PluginConfigValidatorService,
 		GenerateAdminExtensionsCommand,
 	],
 	controllers: [ConfigController],
-	exports: [ConfigService, ModuleConfigMutationRegistryService, PluginConfigValidatorService],
+	exports: [ConfigService, ConfigSecretsService, ModuleConfigMutationRegistryService, PluginConfigValidatorService],
 })
 export class ConfigModule implements OnModuleInit {
 	constructor(

--- a/apps/backend/src/modules/config/controllers/config.controller.spec.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.spec.ts
@@ -5,14 +5,18 @@ eslint-disable @typescript-eslint/unbound-method
 Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
+import { Expose } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { ROLES_KEY } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
 import { ConfigException } from '../config.exceptions';
-import { UpdateModuleConfigDto } from '../dto/config.dto';
-import { AppConfigModel, ModuleConfigModel } from '../models/config.model';
+import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto';
+import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
+import { ConfigSecretsService } from '../services/config-secrets.service';
 import { ConfigService } from '../services/config.service';
 import { ModulesTypeMapperService } from '../services/modules-type-mapper.service';
 import { PluginConfigValidatorService } from '../services/plugin-config-validator.service';
@@ -20,9 +24,28 @@ import { PluginsTypeMapperService } from '../services/plugins-type-mapper.servic
 
 import { ConfigController } from './config.controller';
 
+class MockPluginConfig extends PluginConfigModel {
+	type = 'mock-plugin';
+
+	@Expose({ name: 'api_key' })
+	@IsOptional()
+	@IsString()
+	apiKey: string | null = null;
+}
+
+class MockPluginConfigDto extends UpdatePluginConfigDto {
+	type = 'mock-plugin';
+
+	@Expose({ name: 'api_key' })
+	@IsOptional()
+	@IsString()
+	apiKey?: string | null;
+}
+
 describe('ConfigController', () => {
 	let controller: ConfigController;
 	let configService: ConfigService;
+	let pluginConfigValidator: PluginConfigValidatorService;
 
 	const mockConfig: AppConfigModel = {
 		path: '/var/smart-panel/config.yml',
@@ -43,16 +66,26 @@ describe('ConfigController', () => {
 				{
 					provide: ConfigService,
 					useValue: {
-						getConfig: jest.fn().mockReturnValue(mockConfig),
-						getModulesConfig: jest.fn().mockReturnValue(mockConfig.modules),
-						getModuleConfig: jest.fn((_module: string) => mockConfig.modules[0]),
+						getPublicConfig: jest.fn().mockReturnValue(mockConfig),
+						getPublicPluginsConfig: jest.fn().mockReturnValue(mockConfig.plugins),
+						getPublicPluginConfig: jest.fn(),
+						resolvePluginConfigUpdate: jest.fn((_plugin: string, value: MockPluginConfigDto) => value),
+						setPluginConfig: jest.fn(),
+						getPublicModulesConfig: jest.fn().mockReturnValue(mockConfig.modules),
+						getPublicModuleConfig: jest.fn((_module: string) => mockConfig.modules[0]),
 						updateModuleConfig: jest.fn(),
 					},
 				},
+				ConfigSecretsService,
 				{
 					provide: PluginsTypeMapperService,
 					useValue: {
-						getMapping: jest.fn(),
+						getMapping: jest.fn(() => ({
+							type: 'mock-plugin',
+							class: MockPluginConfig,
+							configDto: MockPluginConfigDto,
+							secretFields: [{ path: 'api_key', configuredPath: 'api_key_configured' }],
+						})),
 					},
 				},
 				{
@@ -77,6 +110,7 @@ describe('ConfigController', () => {
 
 		controller = testingModule.get<ConfigController>(ConfigController);
 		configService = testingModule.get<ConfigService>(ConfigService);
+		pluginConfigValidator = testingModule.get<PluginConfigValidatorService>(PluginConfigValidatorService);
 	});
 
 	afterEach(() => {
@@ -93,42 +127,73 @@ describe('ConfigController', () => {
 			const result = controller.getAllConfig();
 			expect(result).toHaveProperty('data');
 			expect(result.data).toEqual(mockConfig);
-			expect(configService.getConfig).toHaveBeenCalled();
+			expect(configService.getPublicConfig).toHaveBeenCalled();
 		});
 	});
 
 	describe('getModulesConfig', () => {
 		it('should return all module configurations', () => {
 			const mockModules = mockConfig.modules;
-			jest.spyOn(configService, 'getModulesConfig').mockReturnValue(mockModules);
+			jest.spyOn(configService, 'getPublicModulesConfig').mockReturnValue(mockModules);
 
 			const result = controller.getModulesConfig();
 
 			expect(result).toHaveProperty('data');
 			expect(result.data).toEqual(mockModules);
-			expect(configService.getModulesConfig).toHaveBeenCalled();
+			expect(configService.getPublicModulesConfig).toHaveBeenCalled();
+		});
+	});
+
+	describe('validatePluginConfig', () => {
+		it('validates with the resolved stored secret while keeping the response secret-free', async () => {
+			const resolved = Object.assign(new MockPluginConfigDto(), {
+				type: 'mock-plugin',
+				apiKey: 'stored-secret',
+			});
+
+			jest.spyOn(configService, 'resolvePluginConfigUpdate').mockReturnValue(resolved);
+			jest.spyOn(pluginConfigValidator, 'validate').mockResolvedValue({
+				valid: false,
+				errors: [{ field: 'api_key', message: 'Rejected stored-secret' }],
+			});
+
+			const response = await controller.validatePluginConfig('mock-plugin', {
+				data: { type: 'mock-plugin' },
+			});
+
+			expect(configService.resolvePluginConfigUpdate).toHaveBeenCalledWith(
+				'mock-plugin',
+				expect.any(MockPluginConfigDto),
+				{ type: 'mock-plugin' },
+			);
+			expect(pluginConfigValidator.validate).toHaveBeenCalledWith(
+				'mock-plugin',
+				expect.objectContaining({ apiKey: 'stored-secret' }),
+			);
+			expect(response.data.errors).toEqual([{ field: 'api_key', message: 'Rejected [REDACTED]' }]);
+			expect(JSON.stringify(response)).not.toContain('stored-secret');
 		});
 	});
 
 	describe('getModuleConfig', () => {
 		it('should return a specific module configuration', () => {
 			const mockModule = mockConfig.modules[0];
-			jest.spyOn(configService, 'getModuleConfig').mockReturnValue(mockModule);
+			jest.spyOn(configService, 'getPublicModuleConfig').mockReturnValue(mockModule);
 
 			const result = controller.getModuleConfig('mock-module');
 
 			expect(result).toHaveProperty('data');
 			expect(result.data).toEqual(mockModule);
-			expect(configService.getModuleConfig).toHaveBeenCalledWith('mock-module');
+			expect(configService.getPublicModuleConfig).toHaveBeenCalledWith('mock-module');
 		});
 
 		it('should throw ConfigNotFoundException for a non-existent module', () => {
-			(configService.getModuleConfig as jest.Mock).mockImplementation(() => {
+			(configService.getPublicModuleConfig as jest.Mock).mockImplementation(() => {
 				throw new ConfigException("Configuration module 'non-existent' not found.");
 			});
 
 			expect(() => controller.getModuleConfig('non-existent')).toThrow();
-			expect(configService.getModuleConfig).toHaveBeenCalledWith('non-existent');
+			expect(configService.getPublicModuleConfig).toHaveBeenCalledWith('non-existent');
 		});
 	});
 
@@ -141,7 +206,7 @@ describe('ConfigController', () => {
 			const updateDto: UpdateModuleConfigDto = { type: 'mock-module', enabled: false };
 			const updatedModule = { ...mockConfig.modules[0], enabled: false } as ModuleConfigModel;
 
-			jest.spyOn(configService, 'getModuleConfig').mockReturnValue(updatedModule);
+			jest.spyOn(configService, 'getPublicModuleConfig').mockReturnValue(updatedModule);
 			jest.spyOn(configService, 'updateModuleConfig').mockResolvedValue();
 
 			const result = await controller.updateModuleConfig('mock-module', { data: updateDto });
@@ -151,8 +216,8 @@ describe('ConfigController', () => {
 				type: 'mock-module',
 				enabled: false,
 			});
-			expect(configService.updateModuleConfig).toHaveBeenCalledWith('mock-module', updateDto);
-			expect(configService.getModuleConfig).toHaveBeenCalledWith('mock-module');
+			expect(configService.updateModuleConfig).toHaveBeenCalledWith('mock-module', updateDto, updateDto);
+			expect(configService.getPublicModuleConfig).toHaveBeenCalledWith('mock-module');
 		});
 
 		it('should throw BadRequestException for an unsupported module type', async () => {

--- a/apps/backend/src/modules/config/controllers/config.controller.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.ts
@@ -34,6 +34,7 @@ import {
 	ConfigValidationResultModel,
 } from '../models/config-validation-response.model';
 import { ModuleConfigModel, PluginConfigModel } from '../models/config.model';
+import { ConfigSecretsService } from '../services/config-secrets.service';
 import { ConfigService } from '../services/config.service';
 import { ModuleTypeMapping, ModulesTypeMapperService } from '../services/modules-type-mapper.service';
 import { PluginConfigValidatorService } from '../services/plugin-config-validator.service';
@@ -46,6 +47,7 @@ export class ConfigController {
 
 	constructor(
 		private readonly service: ConfigService,
+		private readonly configSecrets: ConfigSecretsService,
 		private readonly pluginsMapperService: PluginsTypeMapperService,
 		private readonly modulesMapperService: ModulesTypeMapperService,
 		private readonly pluginConfigValidator: PluginConfigValidatorService,
@@ -64,7 +66,7 @@ export class ConfigController {
 	getAllConfig(): ConfigModuleResAppConfig {
 		this.logger.debug('Fetching application configuration');
 
-		const config = this.service.getConfig();
+		const config = this.service.getPublicConfig();
 
 		this.logger.debug(`Retrieved application configuration`);
 
@@ -87,7 +89,7 @@ export class ConfigController {
 	getPluginsConfig(): ConfigModuleResPlugins {
 		this.logger.debug('Fetching configuration for all plugins');
 
-		const config: PluginConfigModel[] = this.service.getPluginsConfig();
+		const config: PluginConfigModel[] = this.service.getPublicPluginsConfig();
 
 		this.logger.debug('Found configuration for all plugins');
 
@@ -111,7 +113,7 @@ export class ConfigController {
 	getPluginConfig(@Param('plugin') plugin: string): ConfigModuleResPluginConfig {
 		this.logger.debug(`Fetching configuration plugin=${plugin}`);
 
-		const config: PluginConfigModel = this.service.getPluginConfig(plugin);
+		const config: PluginConfigModel = this.service.getPublicPluginConfig(plugin);
 
 		this.logger.debug(`Found configuration plugin=${plugin}`);
 
@@ -171,23 +173,26 @@ export class ConfigController {
 			whitelist: true,
 			forbidNonWhitelisted: true,
 			stopAtFirstError: false,
+			validationError: { target: false, value: false },
 		});
 
 		if (errors.length > 0) {
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, dtoInstance);
+
 			this.logger.error(
-				`[VALIDATION FAILED] Validation failed for plugin modification error=${JSON.stringify(errors)} plugin=${plugin} `,
+				`[VALIDATION FAILED] Validation failed for plugin modification error=${JSON.stringify(redactedErrors)} plugin=${plugin} `,
 			);
 
-			throw ValidationExceptionFactory.createException(errors);
+			throw ValidationExceptionFactory.createException(redactedErrors);
 		}
 
 		// Plugin-specific validation (connection tests) is NOT run here — it would
 		// block saves when the target service is temporarily unreachable. Users must
 		// be able to pre-configure credentials before the service is online.
 		// Use POST plugin/:plugin/validate for explicit validation.
-		this.service.setPluginConfig(plugin, dtoInstance);
+		this.service.setPluginConfig(plugin, dtoInstance, pluginConfig.data as Record<string, unknown>);
 
-		const config = this.service.getPluginConfig(plugin);
+		const config = this.service.getPublicPluginConfig(plugin);
 
 		this.logger.debug(`Successfully updated configuration plugin=${plugin}`);
 
@@ -248,21 +253,34 @@ export class ConfigController {
 			whitelist: true,
 			forbidNonWhitelisted: true,
 			stopAtFirstError: false,
+			validationError: { target: false, value: false },
 		});
 
 		if (errors.length > 0) {
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, dtoInstance);
+
 			this.logger.error(`[VALIDATION FAILED] Schema validation failed for plugin validation plugin=${plugin}`);
 
-			throw ValidationExceptionFactory.createException(errors);
+			throw ValidationExceptionFactory.createException(redactedErrors);
 		}
 
 		// Plugin-specific validation (connection tests, credential checks, etc.).
-		// Pass the DTO instance (not raw body) so validators get consistent property names.
-		const result = await this.pluginConfigValidator.validate(plugin, dtoInstance as unknown as Record<string, unknown>);
+		// Resolve omitted write-only fields from storage so a saved configuration can
+		// be validated without returning or re-entering its secret.
+		const resolvedConfig = this.service.resolvePluginConfigUpdate(
+			plugin,
+			dtoInstance,
+			pluginConfig.data as Record<string, unknown>,
+		);
+		const result = await this.pluginConfigValidator.validate(
+			plugin,
+			resolvedConfig as unknown as Record<string, unknown>,
+		);
+		const redactedResult = this.configSecrets.redactForLogging(result, mapping.secretFields, resolvedConfig);
 
 		const resultModel = new ConfigValidationResultModel();
-		resultModel.valid = result.valid;
-		resultModel.errors = result.errors;
+		resultModel.valid = redactedResult.valid;
+		resultModel.errors = redactedResult.errors;
 
 		const response = new ConfigModuleResPluginConfigValidation();
 		response.data = resultModel;
@@ -283,7 +301,7 @@ export class ConfigController {
 	getModulesConfig(): ConfigModuleResModules {
 		this.logger.debug('Fetching configuration for all modules');
 
-		const config: ModuleConfigModel[] = this.service.getModulesConfig();
+		const config: ModuleConfigModel[] = this.service.getPublicModulesConfig();
 
 		this.logger.debug('Found configuration for all modules');
 
@@ -307,7 +325,7 @@ export class ConfigController {
 	getModuleConfig(@Param('module') module: string): ConfigModuleResModuleConfig {
 		this.logger.debug(`Fetching configuration module=${module}`);
 
-		const config: ModuleConfigModel = this.service.getModuleConfig(module);
+		const config: ModuleConfigModel = this.service.getPublicModuleConfig(module);
 
 		this.logger.debug(`Found configuration module=${module}`);
 
@@ -368,19 +386,22 @@ export class ConfigController {
 			whitelist: true,
 			forbidNonWhitelisted: true,
 			stopAtFirstError: false,
+			validationError: { target: false, value: false },
 		});
 
 		if (errors.length > 0) {
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, dtoInstance);
+
 			this.logger.error(
-				`[VALIDATION FAILED] Validation failed for module modification error=${JSON.stringify(errors)} module=${module} `,
+				`[VALIDATION FAILED] Validation failed for module modification error=${JSON.stringify(redactedErrors)} module=${module} `,
 			);
 
-			throw ValidationExceptionFactory.createException(errors);
+			throw ValidationExceptionFactory.createException(redactedErrors);
 		}
 
-		await this.service.updateModuleConfig(module, dtoInstance);
+		await this.service.updateModuleConfig(module, dtoInstance, moduleConfig.data as Record<string, unknown>);
 
-		const config = this.service.getModuleConfig(module);
+		const config = this.service.getPublicModuleConfig(module);
 
 		this.logger.debug(`Successfully updated configuration module=${module}`);
 

--- a/apps/backend/src/modules/config/interfaces/config-secret.interface.ts
+++ b/apps/backend/src/modules/config/interfaces/config-secret.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * Declares a write-only field in a module or plugin configuration mapping.
+ *
+ * Paths use the serialized names produced by class-transformer (for example
+ * `api_key` or `mqtt.password`). `inputPaths` is only needed when callers may
+ * submit aliases that differ from the persisted/serialized field name.
+ */
+export interface ConfigSecretField {
+	path: string;
+	configuredPath: string;
+	inputPaths?: readonly string[];
+}

--- a/apps/backend/src/modules/config/services/config-secrets.service.spec.ts
+++ b/apps/backend/src/modules/config/services/config-secrets.service.spec.ts
@@ -1,0 +1,157 @@
+import { ConfigSecretField } from '../interfaces/config-secret.interface';
+
+import { ConfigSecretsService } from './config-secrets.service';
+
+describe('ConfigSecretsService', () => {
+	let service: ConfigSecretsService;
+
+	const fields: readonly ConfigSecretField[] = [
+		{
+			path: 'api_key',
+			configuredPath: 'api_key_configured',
+		},
+		{
+			path: 'mqtt.password',
+			configuredPath: 'mqtt.password_configured',
+		},
+	];
+
+	beforeEach(() => {
+		service = new ConfigSecretsService();
+	});
+
+	it('projects secret fields as configured indicators without mutating the source', () => {
+		const source = {
+			type: 'mock',
+			api_key: 'top-secret',
+			mqtt: { host: 'broker.local', password: 'nested-secret' },
+		};
+
+		expect(service.toPublic(source, fields)).toEqual({
+			type: 'mock',
+			api_key_configured: true,
+			mqtt: { host: 'broker.local', password_configured: true },
+		});
+		expect(source.api_key).toBe('top-secret');
+		expect(source.mqtt.password).toBe('nested-secret');
+	});
+
+	it('reports null and blank secrets as not configured', () => {
+		expect(service.toPublic({ api_key: null, mqtt: { password: '   ' } }, fields)).toEqual({
+			api_key_configured: false,
+			mqtt: { password_configured: false },
+		});
+	});
+
+	it('preserves an omitted secret while retaining other submitted fields', () => {
+		const resolved = service.resolveUpdate(
+			{ api_key: 'stored-secret', hostname: 'old.local' },
+			{ hostname: 'new.local' },
+			{ hostname: 'new.local' },
+			fields.slice(0, 1),
+		);
+
+		expect(resolved).toEqual({ hostname: 'new.local', api_key: 'stored-secret' });
+	});
+
+	it('does not treat a blank replacement field as an explicit clear', () => {
+		const resolved = service.resolveUpdate(
+			{ api_key: 'stored-secret' },
+			{ api_key: '   ' },
+			{ api_key: '   ' },
+			fields.slice(0, 1),
+		);
+
+		expect(resolved).toEqual({ api_key: 'stored-secret' });
+	});
+
+	it('replaces a submitted secret', () => {
+		const resolved = service.resolveUpdate(
+			{ api_key: 'stored-secret' },
+			{ api_key: 'replacement' },
+			{ api_key: 'replacement' },
+			fields.slice(0, 1),
+		);
+
+		expect(resolved).toEqual({ api_key: 'replacement' });
+	});
+
+	it('accepts registered input aliases from internal callers', () => {
+		const resolved = service.resolveUpdate(
+			{ api_key: 'stored-secret' },
+			{ api_key: 'replacement' },
+			{ apiKey: 'replacement' },
+			[{ ...fields[0], inputPaths: ['apiKey'] }],
+		);
+
+		expect(resolved).toEqual({ api_key: 'replacement' });
+	});
+
+	const camelCaseUpdates: ReadonlyArray<readonly [string | null, string | null]> = [
+		['replacement', 'replacement'],
+		[null, null],
+	];
+
+	it.each(camelCaseUpdates)(
+		'recognizes camel-case programmatic secret updates through serialized paths',
+		(submitted, expected) => {
+			const resolved = service.resolveUpdate(
+				{ api_key: 'stored-secret' },
+				{ api_key: submitted },
+				{ apiKey: submitted },
+				fields.slice(0, 1),
+			);
+
+			expect(resolved).toEqual({ api_key: expected });
+		},
+	);
+
+	it('clears a secret only when null is explicitly submitted', () => {
+		const resolved = service.resolveUpdate(
+			{ api_key: 'stored-secret' },
+			{ api_key: null },
+			{ api_key: null },
+			fields.slice(0, 1),
+		);
+
+		expect(resolved).toEqual({ api_key: null });
+	});
+
+	it('deep-merges a preserved nested secret without discarding sibling settings', () => {
+		const existing = {
+			mqtt: {
+				host: 'broker.local',
+				port: 1883,
+				username: 'panel',
+				password: 'stored-secret',
+			},
+		};
+		const update = service.resolveUpdate(existing, { mqtt: { host: 'new.local' } }, { mqtt: { host: 'new.local' } }, [
+			fields[1],
+		]);
+
+		expect(service.merge(existing, update)).toEqual({
+			mqtt: {
+				host: 'new.local',
+				port: 1883,
+				username: 'panel',
+				password: 'stored-secret',
+			},
+		});
+	});
+
+	it('redacts secret fields and occurrences from logging payloads', () => {
+		const secretSource = { api_key: 'sentinel-secret' };
+		const value = {
+			api_key: 'sentinel-secret',
+			message: 'Connection failed for sentinel-secret',
+			nested: ['sentinel-secret'],
+		};
+
+		expect(service.redactForLogging(value, fields.slice(0, 1), secretSource)).toEqual({
+			api_key: '[REDACTED]',
+			message: 'Connection failed for [REDACTED]',
+			nested: ['[REDACTED]'],
+		});
+	});
+});

--- a/apps/backend/src/modules/config/services/config-secrets.service.ts
+++ b/apps/backend/src/modules/config/services/config-secrets.service.ts
@@ -1,0 +1,220 @@
+import { instanceToPlain } from 'class-transformer';
+
+import { Injectable } from '@nestjs/common';
+
+import { toSnakeCaseKeys } from '../../../common/utils/transform.utils';
+import { ConfigSecretField } from '../interfaces/config-secret.interface';
+
+const REDACTED_VALUE = '[REDACTED]';
+
+type PlainConfig = Record<string, unknown>;
+
+@Injectable()
+export class ConfigSecretsService {
+	toPublic<TConfig>(config: TConfig, fields: readonly ConfigSecretField[] = []): TConfig {
+		const projected = this.toPlainConfig(config);
+
+		for (const field of fields) {
+			const configured = this.isConfigured(this.getPath(projected, field.path));
+
+			this.deletePath(projected, field.path);
+			this.setPath(projected, field.configuredPath, configured);
+		}
+
+		return projected as TConfig;
+	}
+
+	resolveUpdate<TUpdate>(
+		existing: unknown,
+		update: TUpdate,
+		submitted: Record<string, unknown>,
+		fields: readonly ConfigSecretField[] = [],
+	): TUpdate {
+		const existingPlain = this.toPlainConfig(existing);
+		const updatePlain = this.toPlainConfig(update);
+		const normalizedSubmitted = toSnakeCaseKeys<PlainConfig, PlainConfig>(this.toPlainConfig(submitted));
+
+		for (const field of fields) {
+			const inputPaths = [field.path, ...(field.inputPaths ?? [])];
+			const rawSubmittedPath = inputPaths.find((inputPath) => this.hasPath(submitted, inputPath));
+			const normalizedSubmittedPath = inputPaths.find((inputPath) => this.hasPath(normalizedSubmitted, inputPath));
+			const submittedSecret = rawSubmittedPath
+				? this.getPath(submitted, rawSubmittedPath)
+				: normalizedSubmittedPath
+					? this.getPath(normalizedSubmitted, normalizedSubmittedPath)
+					: undefined;
+			const preserveStoredSecret =
+				(rawSubmittedPath === undefined && normalizedSubmittedPath === undefined) ||
+				(typeof submittedSecret === 'string' && submittedSecret.trim().length === 0);
+
+			if (preserveStoredSecret) {
+				if (this.hasPath(existingPlain, field.path)) {
+					this.setPath(updatePlain, field.path, this.getPath(existingPlain, field.path));
+				}
+			} else if (!this.hasPath(updatePlain, field.path)) {
+				this.setPath(updatePlain, field.path, submittedSecret);
+			}
+
+			this.deletePath(updatePlain, field.configuredPath);
+		}
+
+		return updatePlain as TUpdate;
+	}
+
+	merge<TConfig>(existing: unknown, update: unknown): TConfig {
+		return this.mergePlain(this.toPlainConfig(existing), this.toPlainConfig(update)) as TConfig;
+	}
+
+	redactForLogging<TValue>(
+		value: TValue,
+		fields: readonly ConfigSecretField[] = [],
+		secretSource: unknown = value,
+	): TValue {
+		const redacted = this.toPlainValue(value);
+		const source = this.toPlainConfig(secretSource);
+		const secretValues: string[] = [];
+
+		for (const field of fields) {
+			const secretValue = this.getPath(source, field.path);
+
+			if (typeof secretValue === 'string' && secretValue.length > 0) {
+				secretValues.push(secretValue);
+			}
+
+			if (this.isPlainConfig(redacted) && this.hasPath(redacted, field.path)) {
+				this.setPath(redacted, field.path, REDACTED_VALUE);
+			}
+		}
+
+		return this.replaceSecretStrings(redacted, secretValues) as TValue;
+	}
+
+	private toPlainConfig(value: unknown): PlainConfig {
+		const plain = this.toPlainValue(value);
+
+		return this.isPlainConfig(plain) ? plain : {};
+	}
+
+	private toPlainValue(value: unknown): unknown {
+		return instanceToPlain(value, {
+			enableCircularCheck: true,
+			exposeUnsetFields: false,
+		});
+	}
+
+	private isPlainConfig(value: unknown): value is PlainConfig {
+		return value !== null && typeof value === 'object' && !Array.isArray(value);
+	}
+
+	private splitPath(path: string): string[] {
+		return path.split('.').filter((segment) => segment.length > 0);
+	}
+
+	private hasPath(value: PlainConfig, path: string): boolean {
+		const segments = this.splitPath(path);
+		let current: unknown = value;
+
+		for (const segment of segments) {
+			if (!this.isPlainConfig(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {
+				return false;
+			}
+
+			current = current[segment];
+		}
+
+		return segments.length > 0;
+	}
+
+	private getPath(value: PlainConfig, path: string): unknown {
+		let current: unknown = value;
+
+		for (const segment of this.splitPath(path)) {
+			if (!this.isPlainConfig(current)) {
+				return undefined;
+			}
+
+			current = current[segment];
+		}
+
+		return current;
+	}
+
+	private setPath(value: PlainConfig, path: string, nextValue: unknown): void {
+		const segments = this.splitPath(path);
+		const leaf = segments.pop();
+
+		if (!leaf) {
+			return;
+		}
+
+		let current = value;
+
+		for (const segment of segments) {
+			if (!this.isPlainConfig(current[segment])) {
+				current[segment] = {};
+			}
+
+			current = current[segment] as PlainConfig;
+		}
+
+		current[leaf] = nextValue;
+	}
+
+	private deletePath(value: PlainConfig, path: string): void {
+		const segments = this.splitPath(path);
+		const leaf = segments.pop();
+
+		if (!leaf) {
+			return;
+		}
+
+		let current: unknown = value;
+
+		for (const segment of segments) {
+			if (!this.isPlainConfig(current)) {
+				return;
+			}
+
+			current = current[segment];
+		}
+
+		if (this.isPlainConfig(current)) {
+			delete current[leaf];
+		}
+	}
+
+	private isConfigured(value: unknown): boolean {
+		return value !== null && value !== undefined && (typeof value !== 'string' || value.trim().length > 0);
+	}
+
+	private replaceSecretStrings(value: unknown, secretValues: readonly string[]): unknown {
+		if (typeof value === 'string') {
+			return secretValues.reduce((redacted, secret) => redacted.split(secret).join(REDACTED_VALUE), value);
+		}
+
+		if (Array.isArray(value)) {
+			return value.map((item) => this.replaceSecretStrings(item, secretValues));
+		}
+
+		if (this.isPlainConfig(value)) {
+			return Object.fromEntries(
+				Object.entries(value).map(([key, item]) => [key, this.replaceSecretStrings(item, secretValues)]),
+			);
+		}
+
+		return value;
+	}
+
+	private mergePlain(existing: PlainConfig, update: PlainConfig): PlainConfig {
+		const merged: PlainConfig = { ...existing };
+
+		for (const [key, value] of Object.entries(update)) {
+			const existingValue = merged[key];
+
+			merged[key] =
+				this.isPlainConfig(existingValue) && this.isPlainConfig(value) ? this.mergePlain(existingValue, value) : value;
+		}
+
+		return merged;
+	}
+}

--- a/apps/backend/src/modules/config/services/config.service.spec.ts
+++ b/apps/backend/src/modules/config/services/config.service.spec.ts
@@ -22,6 +22,7 @@ import { ConfigNotFoundException, ConfigValidationException } from '../config.ex
 import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto';
 import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
 
+import { ConfigSecretsService } from './config-secrets.service';
 import { ConfigService } from './config.service';
 import { ModuleConfigMutationRegistryService } from './module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './modules-type-mapper.service';
@@ -43,6 +44,11 @@ class MockPluginConfig extends PluginConfigModel {
 		toClassOnly: true,
 	})
 	mockValue: string = 'default value';
+
+	@Expose({ name: 'secret_value' })
+	@IsOptional()
+	@IsString()
+	secretValue: string | null = null;
 }
 
 class PluginConfigDto extends UpdatePluginConfigDto {
@@ -50,6 +56,11 @@ class PluginConfigDto extends UpdatePluginConfigDto {
 	@IsOptional()
 	@IsString()
 	mock_value?: string;
+
+	@Expose({ name: 'secret_value' })
+	@IsOptional()
+	@IsString()
+	secretValue?: string | null;
 }
 
 class MockModuleConfig extends ModuleConfigModel {
@@ -61,6 +72,11 @@ class MockModuleConfig extends ModuleConfigModel {
 		toClassOnly: true,
 	})
 	mockValue: string = 'default value';
+
+	@Expose({ name: 'secret_value' })
+	@IsOptional()
+	@IsString()
+	secretValue: string | null = null;
 }
 
 class ModuleConfigDto extends UpdateModuleConfigDto {
@@ -68,6 +84,11 @@ class ModuleConfigDto extends UpdateModuleConfigDto {
 	@IsOptional()
 	@IsString()
 	mock_value?: string;
+
+	@Expose({ name: 'secret_value' })
+	@IsOptional()
+	@IsString()
+	secretValue?: string | null;
 }
 
 describe('ConfigService', () => {
@@ -82,12 +103,14 @@ describe('ConfigService', () => {
 			mock: {
 				enabled: true,
 				mockValue: 'default value',
+				secret_value: 'stored-plugin-secret',
 			},
 		},
 		modules: {
 			'mock-module': {
 				enabled: true,
 				mockValue: 'default value',
+				secret_value: 'stored-module-secret',
 			},
 		},
 	};
@@ -100,6 +123,7 @@ describe('ConfigService', () => {
 				type: 'mock',
 				enabled: true,
 				mockValue: 'default value',
+				secretValue: 'stored-plugin-secret',
 			} as PluginConfigModel,
 		],
 		modules: [
@@ -107,6 +131,7 @@ describe('ConfigService', () => {
 				type: 'mock-module',
 				enabled: true,
 				mockValue: 'default value',
+				secretValue: 'stored-module-secret',
 			} as ModuleConfigModel,
 		],
 	};
@@ -116,6 +141,7 @@ describe('ConfigService', () => {
 			imports: [NestConfigModule],
 			providers: [
 				ConfigService,
+				ConfigSecretsService,
 				ModuleConfigMutationRegistryService,
 				{
 					provide: PlatformService,
@@ -135,12 +161,14 @@ describe('ConfigService', () => {
 							type: 'mock',
 							class: MockPluginConfig,
 							configDto: PluginConfigDto,
+							secretFields: [{ path: 'secret_value', configuredPath: 'secret_value_configured' }],
 						})),
 						getMappings: jest.fn(() => [
 							{
 								type: 'mock',
 								class: MockPluginConfig,
 								configDto: PluginConfigDto,
+								secretFields: [{ path: 'secret_value', configuredPath: 'secret_value_configured' }],
 							},
 						]),
 					},
@@ -154,12 +182,14 @@ describe('ConfigService', () => {
 							type: 'mock-module',
 							class: MockModuleConfig,
 							configDto: ModuleConfigDto,
+							secretFields: [{ path: 'secret_value', configuredPath: 'secret_value_configured' }],
 						})),
 						getMappings: jest.fn(() => [
 							{
 								type: 'mock-module',
 								class: MockModuleConfig,
 								configDto: ModuleConfigDto,
+								secretFields: [{ path: 'secret_value', configuredPath: 'secret_value_configured' }],
 							},
 						]),
 					},
@@ -241,6 +271,28 @@ describe('ConfigService', () => {
 			expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']), 'utf8');
 			expect(yaml.parse).toHaveBeenCalledWith(JSON.stringify(mockRawConfig));
 		});
+
+		it('returns a public configuration without plugin or module secrets', () => {
+			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockRawConfig));
+			jest.spyOn(yaml, 'parse').mockReturnValue(mockRawConfig);
+
+			const result = service.getPublicConfig() as unknown as {
+				plugins: Array<Record<string, unknown>>;
+				modules: Array<Record<string, unknown>>;
+			};
+
+			expect(result.plugins[0]).toMatchObject({
+				type: 'mock',
+				secret_value_configured: true,
+			});
+			expect(result.plugins[0]).not.toHaveProperty('secret_value');
+			expect(result.modules[0]).toMatchObject({
+				type: 'mock-module',
+				secret_value_configured: true,
+			});
+			expect(result.modules[0]).not.toHaveProperty('secret_value');
+		});
 	});
 
 	describe('getPluginConfig', () => {
@@ -256,6 +308,18 @@ describe('ConfigService', () => {
 			expect(fs.existsSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']));
 			expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']), 'utf8');
 			expect(yaml.parse).toHaveBeenCalledWith(JSON.stringify(mockRawConfig));
+		});
+
+		it('returns a configured indicator instead of the secret from the public getter', () => {
+			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockRawConfig));
+			jest.spyOn(yaml, 'parse').mockReturnValue(mockRawConfig);
+
+			const result = service.getPublicPluginConfig('mock') as unknown as Record<string, unknown>;
+
+			expect(result).toMatchObject({ secret_value_configured: true });
+			expect(result).not.toHaveProperty('secret_value');
+			expect(service.getPluginConfig<MockPluginConfig>('mock').secretValue).toBe('stored-plugin-secret');
 		});
 
 		it('should throw validation errors for an invalid plugin', () => {
@@ -281,7 +345,13 @@ describe('ConfigService', () => {
 
 			const updatedRawConfig = {
 				...mockRawConfig,
-				...{ plugins: { mock: { enabled: true, mock_value: 'Updated value' } } },
+				plugins: {
+					mock: {
+						enabled: true,
+						mock_value: 'Updated value',
+						secret_value: 'stored-plugin-secret',
+					},
+				},
 			};
 
 			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -309,6 +379,42 @@ describe('ConfigService', () => {
 				type: 'plugin',
 			});
 		});
+
+		const secretUpdates: ReadonlyArray<readonly [string | null, string | null]> = [
+			['replacement', 'replacement'],
+			[null, null],
+		];
+
+		it.each(secretUpdates)(
+			'persists an explicitly submitted secret value %p',
+			(submittedSecret: string | null, expectedSecret: string | null) => {
+				const updatedRawConfig = {
+					...mockRawConfig,
+					plugins: {
+						mock: {
+							enabled: true,
+							mock_value: 'default value',
+							secret_value: expectedSecret,
+						},
+					},
+				};
+
+				jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+				jest
+					.spyOn(fs, 'readFileSync')
+					.mockReturnValueOnce(JSON.stringify(mockRawConfig))
+					.mockReturnValueOnce(JSON.stringify(updatedRawConfig));
+				jest.spyOn(yaml, 'parse').mockReturnValueOnce(mockRawConfig).mockReturnValueOnce(updatedRawConfig);
+
+				service.setPluginConfig('mock', toInstance(PluginConfigDto, { type: 'mock', secret_value: submittedSecret }), {
+					type: 'mock',
+					secret_value: submittedSecret,
+				});
+
+				expect(service.getPluginConfig<MockPluginConfig>('mock').secretValue).toBe(expectedSecret);
+				expect(yaml.stringify).toHaveBeenCalled();
+			},
+		);
 
 		it('should throw validation errors for an invalid update', () => {
 			const invalidUpdateDto: PluginConfigDto & { invalidField: string } = {
@@ -406,7 +512,13 @@ describe('ConfigService', () => {
 
 			const updatedRawConfig = {
 				...mockRawConfig,
-				...{ modules: { 'mock-module': { enabled: true, mock_value: 'Updated value' } } },
+				modules: {
+					'mock-module': {
+						enabled: true,
+						mock_value: 'Updated value',
+						secret_value: 'stored-module-secret',
+					},
+				},
 			};
 
 			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -454,16 +566,33 @@ describe('ConfigService', () => {
 	});
 
 	describe('updateModuleConfig', () => {
-		it('runs registered module mutations around persistence', async () => {
+		it('runs registered module mutations with resolved secrets around persistence', async () => {
+			const loadedConfig = toInstance(AppConfigModel, mockConfig);
+			loadedConfig.plugins = [toInstance(MockPluginConfig, mockConfig.plugins[0])];
+			loadedConfig.modules = [toInstance(MockModuleConfig, mockConfig.modules[0])];
+			service['config'] = loadedConfig;
+
 			const commit = jest.spyOn(service, 'setModuleConfig').mockImplementation(() => {});
 			moduleConfigMutations.register('mock-module', async (update, persist) => {
-				expect(update).toMatchObject({ type: 'mock-module', enabled: false });
+				expect(update).toMatchObject({
+					type: 'mock-module',
+					enabled: false,
+					secretValue: 'stored-module-secret',
+				});
 				await persist();
 			});
 
-			await service.updateModuleConfig('mock-module', { type: 'mock-module', enabled: false });
+			await service.updateModuleConfig(
+				'mock-module',
+				{ type: 'mock-module', enabled: false },
+				{ type: 'mock-module', enabled: false },
+			);
 
-			expect(commit).toHaveBeenCalledWith('mock-module', { type: 'mock-module', enabled: false });
+			expect(commit).toHaveBeenCalledWith(
+				'mock-module',
+				expect.objectContaining({ secretValue: 'stored-module-secret' }),
+				expect.objectContaining({ secret_value: 'stored-module-secret' }),
+			);
 		});
 	});
 });

--- a/apps/backend/src/modules/config/services/config.service.ts
+++ b/apps/backend/src/modules/config/services/config.service.ts
@@ -1,5 +1,5 @@
 import { instanceToPlain } from 'class-transformer';
-import { validateSync } from 'class-validator';
+import { ValidatorOptions, validateSync } from 'class-validator';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
@@ -17,6 +17,7 @@ import { ConfigCorruptedException, ConfigNotFoundException, ConfigValidationExce
 import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto';
 import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
 
+import { ConfigSecretsService } from './config-secrets.service';
 import { ModuleConfigMutationRegistryService } from './module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from './modules-type-mapper.service';
 import { PluginsTypeMapperService } from './plugins-type-mapper.service';
@@ -27,11 +28,18 @@ export class ConfigService {
 	private readonly filename = 'config.yaml';
 	private config: AppConfigModel | null = null;
 	private isSaving = false;
+	private readonly validationOptions: ValidatorOptions = {
+		whitelist: true,
+		forbidNonWhitelisted: true,
+		stopAtFirstError: false,
+		validationError: { target: false, value: false },
+	};
 
 	constructor(
 		private readonly configService: NestConfigService,
 		private readonly pluginsMapperService: PluginsTypeMapperService,
 		private readonly modulesMapperService: ModulesTypeMapperService,
+		private readonly configSecrets: ConfigSecretsService,
 		private readonly moduleConfigMutations: ModuleConfigMutationRegistryService,
 		private readonly platform: PlatformService,
 		private readonly eventEmitter: EventEmitter2,
@@ -99,11 +107,7 @@ export class ConfigService {
 			appConfigInstance.modules = this.loadModules(parsedConfig);
 
 			// Validate the transformed configuration
-			const errors = validateSync(appConfigInstance, {
-				whitelist: true,
-				forbidNonWhitelisted: true,
-				stopAtFirstError: false,
-			});
+			const errors = validateSync(appConfigInstance, this.validationOptions);
 
 			if (errors.length > 0) {
 				this.logger.error(`[VALIDATION] Configuration validation failed error=${JSON.stringify(errors)}`);
@@ -219,11 +223,7 @@ export class ConfigService {
 					},
 				);
 
-				const errors = validateSync(instance, {
-					whitelist: true,
-					forbidNonWhitelisted: true,
-					stopAtFirstError: false,
-				});
+				const errors = validateSync(instance, this.validationOptions);
 
 				if (errors.length > 0) {
 					this.logger.warn(`[VALIDATION] Plugin '${pluginType}' is invalid, initializing with defaults`);
@@ -264,11 +264,7 @@ export class ConfigService {
 					},
 				);
 
-				const errors = validateSync(instance, {
-					whitelist: true,
-					forbidNonWhitelisted: true,
-					stopAtFirstError: false,
-				});
+				const errors = validateSync(instance, this.validationOptions);
 
 				if (errors.length > 0) {
 					this.logger.warn(`[VALIDATION] Module '${moduleType}' is invalid, initializing with defaults`);
@@ -294,6 +290,15 @@ export class ConfigService {
 		return this.appConfig;
 	}
 
+	getPublicConfig(): AppConfigModel {
+		const config = instanceToPlain(this.getConfig()) as AppConfigModel;
+
+		config.plugins = this.getPublicPluginsConfig();
+		config.modules = this.getPublicModulesConfig();
+
+		return config;
+	}
+
 	getPluginsConfig<TConfig extends PluginConfigModel>(): TConfig[] {
 		this.logger.debug('Fetching configuration for plugins');
 
@@ -314,11 +319,13 @@ export class ConfigService {
 				excludeExtraneousValues: false,
 			});
 
-			const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+			const errors = validateSync(instance, this.validationOptions);
 
 			if (errors.length > 0) {
+				const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
 				this.logger.error(
-					`[VALIDATION] Configuration plugin=${pluginConfig.type} is corrupted error=${JSON.stringify(errors)}`,
+					`[VALIDATION] Configuration plugin=${pluginConfig.type} is corrupted error=${JSON.stringify(redactedErrors)}`,
 				);
 
 				throw new ConfigCorruptedException(
@@ -332,6 +339,14 @@ export class ConfigService {
 		this.logger.log('Successfully retrieved configuration for all plugin');
 
 		return configs;
+	}
+
+	getPublicPluginsConfig<TConfig extends PluginConfigModel>(): TConfig[] {
+		return this.getPluginsConfig<TConfig>().map((config) => {
+			const mapping = this.pluginsMapperService.getMapping<TConfig, UpdatePluginConfigDto>(config.type);
+
+			return this.configSecrets.toPublic(config, mapping.secretFields);
+		});
 	}
 
 	getPluginConfig<TConfig extends PluginConfigModel>(plugin: string): TConfig {
@@ -359,10 +374,14 @@ export class ConfigService {
 			excludeExtraneousValues: false,
 		});
 
-		const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+		const errors = validateSync(instance, this.validationOptions);
 
 		if (errors.length > 0) {
-			this.logger.error(`[VALIDATION] Configuration plugin=${plugin} is corrupted error=${JSON.stringify(errors)}`);
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
+			this.logger.error(
+				`[VALIDATION] Configuration plugin=${plugin} is corrupted error=${JSON.stringify(redactedErrors)}`,
+			);
 
 			throw new ConfigCorruptedException(`Configuration plugin '${plugin}' is corrupted and can not be loaded.`);
 		}
@@ -372,7 +391,35 @@ export class ConfigService {
 		return instance;
 	}
 
-	setPluginConfig<TUpdateDto extends UpdatePluginConfigDto>(plugin: string, value: TUpdateDto): void {
+	getPublicPluginConfig<TConfig extends PluginConfigModel>(plugin: string): TConfig {
+		const config = this.getPluginConfig<TConfig>(plugin);
+		const mapping = this.pluginsMapperService.getMapping<TConfig, UpdatePluginConfigDto>(plugin);
+
+		return this.configSecrets.toPublic(config, mapping.secretFields);
+	}
+
+	resolvePluginConfigUpdate<TUpdateDto extends UpdatePluginConfigDto>(
+		plugin: string,
+		value: TUpdateDto,
+		submittedValue: Record<string, unknown> = value as unknown as Record<string, unknown>,
+	): TUpdateDto {
+		const mapping = this.pluginsMapperService.getMapping<PluginConfigModel, TUpdateDto>(plugin);
+		const existingPlugin = (this.appConfig.plugins ?? []).find((existingPlugin) => existingPlugin.type === plugin);
+		const resolvedUpdate = this.configSecrets.resolveUpdate(
+			existingPlugin,
+			value,
+			submittedValue,
+			mapping.secretFields,
+		);
+
+		return toInstance(mapping.configDto, resolvedUpdate, { excludeExtraneousValues: false });
+	}
+
+	setPluginConfig<TUpdateDto extends UpdatePluginConfigDto>(
+		plugin: string,
+		value: TUpdateDto,
+		submittedValue: Record<string, unknown> = value as unknown as Record<string, unknown>,
+	): void {
 		const mapping = this.pluginsMapperService.getMapping<PluginConfigModel, TUpdateDto>(plugin);
 
 		const existingPlugin = (this.appConfig.plugins ?? []).find((existingPlugin) => existingPlugin.type === plugin);
@@ -381,13 +428,17 @@ export class ConfigService {
 			excludeExtraneousValues: false,
 		});
 
-		const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+		const errors = validateSync(instance, this.validationOptions);
 
 		if (errors.length > 0) {
-			this.logger.error(`[VALIDATION] Validation failed for plugin=${plugin} error=${JSON.stringify(errors)}`);
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
+			this.logger.error(`[VALIDATION] Validation failed for plugin=${plugin} error=${JSON.stringify(redactedErrors)}`);
 
 			throw new ConfigValidationException(`New configuration for plugin '${plugin}' is invalid.`);
 		}
+
+		const resolvedUpdate = this.resolvePluginConfigUpdate(plugin, instance, submittedValue);
 
 		this.logger.log(`Updating configuration for plugin=${plugin}`);
 
@@ -397,11 +448,13 @@ export class ConfigService {
 		appConfig.plugins = (appConfig.plugins ?? []).filter((existingPlugin) => existingPlugin.type !== plugin);
 		// Add the new plugin config
 		appConfig.plugins.push(
-			toInstance(mapping.class, {
-				type: plugin,
-				...instanceToPlain(existingPlugin),
-				...instance,
-			}),
+			toInstance(
+				mapping.class,
+				this.configSecrets.merge(existingPlugin, {
+					type: plugin,
+					...resolvedUpdate,
+				}),
+			),
 		);
 
 		this.logger.log(`[SAVE] Saving updated configuration for plugin=${plugin}`);
@@ -436,11 +489,13 @@ export class ConfigService {
 				excludeExtraneousValues: false,
 			});
 
-			const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+			const errors = validateSync(instance, this.validationOptions);
 
 			if (errors.length > 0) {
+				const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
 				this.logger.error(
-					`[VALIDATION] Configuration module=${moduleConfig.type} is corrupted error=${JSON.stringify(errors)}`,
+					`[VALIDATION] Configuration module=${moduleConfig.type} is corrupted error=${JSON.stringify(redactedErrors)}`,
 				);
 
 				throw new ConfigCorruptedException(
@@ -454,6 +509,14 @@ export class ConfigService {
 		this.logger.log('Successfully retrieved configuration for all modules');
 
 		return configs;
+	}
+
+	getPublicModulesConfig<TConfig extends ModuleConfigModel>(): TConfig[] {
+		return this.getModulesConfig<TConfig>().map((config) => {
+			const mapping = this.modulesMapperService.getMapping<TConfig, UpdateModuleConfigDto>(config.type);
+
+			return this.configSecrets.toPublic(config, mapping.secretFields);
+		});
 	}
 
 	getModuleConfig<TConfig extends ModuleConfigModel>(module: string): TConfig {
@@ -481,10 +544,14 @@ export class ConfigService {
 			excludeExtraneousValues: false,
 		});
 
-		const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+		const errors = validateSync(instance, this.validationOptions);
 
 		if (errors.length > 0) {
-			this.logger.error(`[VALIDATION] Configuration module=${module} is corrupted error=${JSON.stringify(errors)}`);
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
+			this.logger.error(
+				`[VALIDATION] Configuration module=${module} is corrupted error=${JSON.stringify(redactedErrors)}`,
+			);
 
 			throw new ConfigCorruptedException(`Configuration module '${module}' is corrupted and can not be loaded.`);
 		}
@@ -494,7 +561,35 @@ export class ConfigService {
 		return instance;
 	}
 
-	setModuleConfig<TUpdateDto extends UpdateModuleConfigDto>(module: string, value: TUpdateDto): void {
+	getPublicModuleConfig<TConfig extends ModuleConfigModel>(module: string): TConfig {
+		const config = this.getModuleConfig<TConfig>(module);
+		const mapping = this.modulesMapperService.getMapping<TConfig, UpdateModuleConfigDto>(module);
+
+		return this.configSecrets.toPublic(config, mapping.secretFields);
+	}
+
+	resolveModuleConfigUpdate<TUpdateDto extends UpdateModuleConfigDto>(
+		module: string,
+		value: TUpdateDto,
+		submittedValue: Record<string, unknown> = value as unknown as Record<string, unknown>,
+	): TUpdateDto {
+		const mapping = this.modulesMapperService.getMapping<ModuleConfigModel, TUpdateDto>(module);
+		const existingModule = (this.appConfig.modules ?? []).find((existingModule) => existingModule.type === module);
+		const resolvedUpdate = this.configSecrets.resolveUpdate(
+			existingModule,
+			value,
+			submittedValue,
+			mapping.secretFields,
+		);
+
+		return toInstance(mapping.configDto, resolvedUpdate, { excludeExtraneousValues: false });
+	}
+
+	setModuleConfig<TUpdateDto extends UpdateModuleConfigDto>(
+		module: string,
+		value: TUpdateDto,
+		submittedValue: Record<string, unknown> = value as unknown as Record<string, unknown>,
+	): void {
 		const mapping = this.modulesMapperService.getMapping<ModuleConfigModel, TUpdateDto>(module);
 
 		const existingModule = (this.appConfig.modules ?? []).find((existingModule) => existingModule.type === module);
@@ -503,13 +598,17 @@ export class ConfigService {
 			excludeExtraneousValues: false,
 		});
 
-		const errors = validateSync(instance, { whitelist: true, forbidNonWhitelisted: true, stopAtFirstError: false });
+		const errors = validateSync(instance, this.validationOptions);
 
 		if (errors.length > 0) {
-			this.logger.error(`[VALIDATION] Validation failed for module=${module} error=${JSON.stringify(errors)}`);
+			const redactedErrors = this.configSecrets.redactForLogging(errors, mapping.secretFields, instance);
+
+			this.logger.error(`[VALIDATION] Validation failed for module=${module} error=${JSON.stringify(redactedErrors)}`);
 
 			throw new ConfigValidationException(`New configuration for module '${module}' is invalid.`);
 		}
+
+		const resolvedUpdate = this.resolveModuleConfigUpdate(module, instance, submittedValue);
 
 		this.logger.log(`Updating configuration for module=${module}`);
 
@@ -519,11 +618,13 @@ export class ConfigService {
 		appConfig.modules = (appConfig.modules ?? []).filter((existingModule) => existingModule.type !== module);
 		// Add the new module config
 		appConfig.modules.push(
-			toInstance(mapping.class, {
-				type: module,
-				...instanceToPlain(existingModule),
-				...instance,
-			}),
+			toInstance(
+				mapping.class,
+				this.configSecrets.merge(existingModule, {
+					type: module,
+					...resolvedUpdate,
+				}),
+			),
 		);
 
 		this.logger.log(`[SAVE] Saving updated configuration for module=${module}`);
@@ -538,8 +639,16 @@ export class ConfigService {
 		this.logger.log(`Configuration update for module=${module} completed successfully`);
 	}
 
-	async updateModuleConfig<TUpdateDto extends UpdateModuleConfigDto>(module: string, value: TUpdateDto): Promise<void> {
-		await this.moduleConfigMutations.execute(module, value, () => this.setModuleConfig(module, value));
+	async updateModuleConfig<TUpdateDto extends UpdateModuleConfigDto>(
+		module: string,
+		value: TUpdateDto,
+		submittedValue: Record<string, unknown> = value as unknown as Record<string, unknown>,
+	): Promise<void> {
+		const resolvedInstance = this.resolveModuleConfigUpdate(module, value, submittedValue);
+
+		await this.moduleConfigMutations.execute(module, resolvedInstance, () =>
+			this.setModuleConfig(module, resolvedInstance, instanceToPlain(resolvedInstance)),
+		);
 	}
 
 	async resetConfig(): Promise<void> {

--- a/apps/backend/src/modules/config/services/modules-type-mapper.service.ts
+++ b/apps/backend/src/modules/config/services/modules-type-mapper.service.ts
@@ -4,12 +4,14 @@ import { createExtensionLogger } from '../../../common/logger';
 import { CONFIG_MODULE_NAME } from '../config.constants';
 import { ConfigException } from '../config.exceptions';
 import { UpdateModuleConfigDto } from '../dto/config.dto';
+import { ConfigSecretField } from '../interfaces/config-secret.interface';
 import { ModuleConfigModel } from '../models/config.model';
 
 export interface ModuleTypeMapping<TModule extends ModuleConfigModel, TConfigDTO extends UpdateModuleConfigDto> {
 	type: string; // e.g., 'devices-module', 'dashboard-module'
 	class: new (...args: any[]) => TModule; // Constructor for the configuration class
 	configDto: new (...args: any[]) => TConfigDTO; // Constructor for the DTO
+	secretFields?: readonly ConfigSecretField[];
 }
 
 @Injectable()

--- a/apps/backend/src/modules/config/services/plugin-config-validator.service.spec.ts
+++ b/apps/backend/src/modules/config/services/plugin-config-validator.service.spec.ts
@@ -1,0 +1,17 @@
+import { PluginConfigValidatorService } from './plugin-config-validator.service';
+
+describe('PluginConfigValidatorService', () => {
+	it('does not expose an unexpected validator error message', async () => {
+		const service = new PluginConfigValidatorService();
+
+		service.register({
+			pluginType: 'mock',
+			validate: () => Promise.reject(new Error('validator leaked sentinel-secret')),
+		});
+
+		await expect(service.validate('mock', { api_key: 'sentinel-secret' })).resolves.toEqual({
+			valid: false,
+			errors: [{ message: 'Configuration validation failed unexpectedly' }],
+		});
+	});
+});

--- a/apps/backend/src/modules/config/services/plugin-config-validator.service.ts
+++ b/apps/backend/src/modules/config/services/plugin-config-validator.service.ts
@@ -43,14 +43,12 @@ export class PluginConfigValidatorService {
 
 		try {
 			return await validator.validate(config);
-		} catch (error) {
-			const err = error as Error;
-
-			this.logger.error(`Config validator for '${pluginType}' threw: ${err.message}`);
+		} catch {
+			this.logger.error(`Config validator for '${pluginType}' failed unexpectedly`);
 
 			return {
 				valid: false,
-				errors: [{ message: err.message }],
+				errors: [{ message: 'Configuration validation failed unexpectedly' }],
 			};
 		}
 	}

--- a/apps/backend/src/modules/config/services/plugins-type-mapper.service.ts
+++ b/apps/backend/src/modules/config/services/plugins-type-mapper.service.ts
@@ -4,12 +4,14 @@ import { createExtensionLogger } from '../../../common/logger';
 import { CONFIG_MODULE_NAME } from '../config.constants';
 import { ConfigException } from '../config.exceptions';
 import { UpdatePluginConfigDto } from '../dto/config.dto';
+import { ConfigSecretField } from '../interfaces/config-secret.interface';
 import { PluginConfigModel } from '../models/config.model';
 
 export interface PluginTypeMapping<TPlugin extends PluginConfigModel, TConfigDTO extends UpdatePluginConfigDto> {
 	type: string; // e.g., 'third-party', 'shelly'
 	class: new (...args: any[]) => TPlugin; // Constructor for the configuration class
 	configDto: new (...args: any[]) => TConfigDTO; // Constructor for the DTO
+	secretFields?: readonly ConfigSecretField[];
 }
 
 @Injectable()

--- a/apps/backend/test/config-authorization.e2e-spec.ts
+++ b/apps/backend/test/config-authorization.e2e-spec.ts
@@ -12,6 +12,7 @@ import { AuthenticatedEntity, AuthenticatedRequest } from '../src/modules/auth/g
 import { ConfigController } from '../src/modules/config/controllers/config.controller';
 import { UpdateModuleConfigDto } from '../src/modules/config/dto/config.dto';
 import { ModuleConfigModel } from '../src/modules/config/models/config.model';
+import { ConfigSecretsService } from '../src/modules/config/services/config-secrets.service';
 import { ConfigService } from '../src/modules/config/services/config.service';
 import { ModulesTypeMapperService } from '../src/modules/config/services/modules-type-mapper.service';
 import { PluginConfigValidatorService } from '../src/modules/config/services/plugin-config-validator.service';
@@ -72,11 +73,14 @@ class TestCredentialGuard implements CanActivate {
 
 describe('Module configuration authorization (e2e)', () => {
 	let app: INestApplication;
-	let configService: { getModuleConfig: jest.Mock; updateModuleConfig: jest.Mock };
+	let configService: { getPublicModuleConfig: jest.Mock; updateModuleConfig: jest.Mock };
 
 	beforeAll(async () => {
 		configService = {
-			getModuleConfig: jest.fn().mockReturnValue({ type: 'mock-module', enabled: false } as ModuleConfigModel),
+			getPublicModuleConfig: jest.fn().mockReturnValue({
+				type: 'mock-module',
+				enabled: false,
+			} as ModuleConfigModel),
 			updateModuleConfig: jest.fn().mockResolvedValue(undefined),
 		};
 
@@ -86,6 +90,7 @@ describe('Module configuration authorization (e2e)', () => {
 				{ provide: APP_GUARD, useClass: TestCredentialGuard },
 				{ provide: APP_GUARD, useClass: RolesGuard },
 				{ provide: ConfigService, useValue: configService },
+				ConfigSecretsService,
 				{ provide: PluginsTypeMapperService, useValue: { getMapping: jest.fn() } },
 				{
 					provide: ModulesTypeMapperService,

--- a/apps/backend/test/mcp-restart.e2e-spec.ts
+++ b/apps/backend/test/mcp-restart.e2e-spec.ts
@@ -12,6 +12,7 @@ import { Test } from '@nestjs/testing';
 
 import { TokenOwnerType } from '../src/modules/auth/auth.constants';
 import { AuthenticatedRequest } from '../src/modules/auth/guards/auth.guard';
+import { ConfigSecretsService } from '../src/modules/config/services/config-secrets.service';
 import { ConfigService } from '../src/modules/config/services/config.service';
 import { ModuleConfigMutationRegistryService } from '../src/modules/config/services/module-config-mutation-registry.service';
 import { ModulesTypeMapperService } from '../src/modules/config/services/modules-type-mapper.service';
@@ -130,6 +131,7 @@ describe('MCP disabled restart', () => {
 			nestConfigService,
 			pluginsMapper,
 			modulesMapper,
+			new ConfigSecretsService(),
 			new ModuleConfigMutationRegistryService(),
 			{} as PlatformService,
 			{ emit: jest.fn() } as unknown as EventEmitter2,

--- a/docs/config-secrets.md
+++ b/docs/config-secrets.md
@@ -1,0 +1,59 @@
+# Write-only configuration secrets
+
+Plugins and modules that store credentials in the shared configuration must register each credential as a write-only
+secret. The config module then keeps the resolved value available to backend services while removing it from every
+config API response.
+
+## Registering a secret
+
+Add `secretFields` to the owner's existing config type mapping:
+
+```typescript
+this.configMapper.registerMapping<HomeyConfigModel, UpdateHomeyConfigDto>({
+  type: DEVICES_HOMEY_PLUGIN_NAME,
+  class: HomeyConfigModel,
+  configDto: UpdateHomeyConfigDto,
+  secretFields: [
+    {
+      path: "api_key",
+      configuredPath: "api_key_configured",
+    },
+  ],
+});
+```
+
+Paths use the serialized names produced by `class-transformer`, including dot notation for nested values such as
+`mqtt.password`. Add `inputPaths` only when internal callers may submit aliases that differ from the persisted serialized
+path, for example `inputPaths: ['apiKey']` alongside `path: 'api_key'`.
+
+The concrete config response model should declare and expose the non-secret configured indicator so OpenAPI clients
+can use it. The secret remains optional and write-only in the update DTO; it must not be declared as a readable API
+property or included in examples.
+
+## Update semantics
+
+Secret updates have three states:
+
+- Omitted field: preserve the stored secret.
+- Empty or whitespace-only replacement field: preserve the stored secret.
+- Non-null field: replace the stored secret.
+- Explicit `null`: clear the stored secret.
+
+Admin forms therefore start replacement inputs as `undefined`, not `null`. They send `null` only from an explicit
+clear action. The configured indicator is read-only and must never be copied into an update request.
+
+The config controller passes the original request object to the merge layer. This is intentional: DTO default values
+cannot reliably distinguish an omitted field from an explicit clear.
+
+## Runtime and storage boundary
+
+Backend owners continue to use `ConfigService.getPluginConfig()` and `getModuleConfig()`; these internal getters return
+resolved secrets so managed services and config-change listeners can reconfigure safely. Config controllers use the
+corresponding `getPublic*` methods, which return only the configured indicator.
+
+Secrets are redacted from config validation logs and validation results. Do not log raw config DTOs or add credentials
+to config-change event payloads.
+
+Write-only API behavior is not encryption at rest. The current config file stores resolved values in `config.yaml`
+with restrictive file permissions, and backups include that file. Do not describe this mechanism as encrypted
+credential storage.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -131,14 +131,14 @@ apps/backend/src/plugins/devices-homey/__fixtures__/
 
 **Outcome:** Plugin config owners can mark fields as secret without Homey-specific controller hacks.
 
-- [ ] Define a registry/metadata contract for secret fields owned by module/plugin config DTOs.
-- [ ] Redact secret values from complete-config, plugin-config, validation-error, and serialization paths.
-- [ ] Expose a non-secret configured indicator suitable for admin forms.
-- [ ] Implement merge semantics: omitted secret preserves stored value; explicit clear removes it; provided value replaces it.
-- [ ] Ensure mutation events and plugin reload receive the resolved secret without exposing it to responses.
-- [ ] Ensure debug/error logs serialize redacted DTOs.
-- [ ] Add unit tests for get-all, get-one, update-preserve, update-replace, explicit-clear, validation failure, and logging helpers.
-- [ ] Document the registration convention for future secret-bearing plugins.
+- [x] Define a registry/metadata contract for secret fields owned by module/plugin config DTOs.
+- [x] Redact secret values from complete-config, plugin-config, validation-error, and serialization paths.
+- [x] Expose a non-secret configured indicator suitable for admin forms.
+- [x] Implement merge semantics: omitted secret preserves stored value; explicit clear removes it; provided value replaces it.
+- [x] Ensure mutation events and plugin reload receive the resolved secret without exposing it to responses.
+- [x] Ensure debug/error logs serialize redacted DTOs.
+- [x] Add unit tests for get-all, get-one, update-preserve, update-replace, explicit-clear, validation failure, and logging helpers.
+- [x] Document the registration convention for future secret-bearing plugins.
 
 **Verification:**
 


### PR DESCRIPTION
## Summary

- add opt-in write-only secret metadata to module and plugin config mappings
- keep internal runtime getters resolved while exposing redacted API projections with configured indicators
- support omitted/preserve, blank/preserve, replace, explicit-clear, nested secret, and programmatic alias semantics
- sanitize config validation results and logs, including unexpected validator failures
- document the registration and admin-form contract for Homey and future credential-bearing integrations

## Why

The Homey integration requires API keys to be accepted on write without ever being returned through generic config endpoints. This establishes that reusable boundary before the Homey plugin is scaffolded, while preserving credential access for backend lifecycle and reconfiguration services.

## Validation

- `pnpm --filter @fastybird/smart-panel-backend test:unit -- --runInBand src/modules/config` — 56 tests passed
- `pnpm --filter @fastybird/smart-panel-backend run type-check` — passed
- `pnpm --filter @fastybird/smart-panel-backend run lint:js` — passed with two pre-existing warnings
- `pnpm --filter @fastybird/smart-panel-backend run test:e2e -- --runInBand test/mcp-restart.e2e-spec.ts` — passed
- full backend Jest run completed 328/328 suites and 4,106 tests, then exited non-zero from an unrelated Home Assistant websocket mock cleanup (`terminate is not a function`)
- workspace lint remains blocked by existing admin `import/extensions` errors in generated/spec-facing imports

## Follow-up

The next Homey slice will register its API key through this contract while scaffolding the backend plugin and connector-domain interfaces. Live SHS connector and mDNS choices remain gated on the compatibility evidence program.
