### PR TITLE
feat(cross): harden adoption wizard inventories

### DIFF
--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -236,6 +236,7 @@ describe('DeviceWizardConfirmStep', () => {
 	it('keeps a large confirmation inventory inside a mobile horizontal scroller', async () => {
 		const rows = Array.from({ length: 100 }, (_, index) => row({ key: `device-${index}`, identifier: `device-${index}`, label: `Device ${index}` }));
 		const wrapper = mountStep(rows, {
+			columns: [{ key: 'channels', label: 'Channels', steps: ['confirm'], width: 130 }],
 			selected: {},
 			nameByKey: {},
 			categoryByKey: {},
@@ -248,6 +249,6 @@ describe('DeviceWizardConfirmStep', () => {
 		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"]').classes()).toEqual(
 			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
 		);
-		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"] .el-table').classes()).toContain('min-w-[900px]');
+		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"] .el-table').attributes('style')).toContain('min-width: 1030px');
 	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -1,4 +1,4 @@
-import { ElSelect } from 'element-plus';
+import { ElPagination, ElSelect } from 'element-plus';
 import { describe, expect, it, vi } from 'vitest';
 
 import { flushPromises, mount } from '@vue/test-utils';
@@ -136,6 +136,35 @@ describe('DeviceWizardConfirmStep', () => {
 
 		expect(wrapper.findAll('tbody tr')).toHaveLength(25);
 		expect(wrapper.find('tbody tr code').text()).toBe('device-25');
+	});
+
+	it('clamps the current page when edited names shrink the filtered inventory', async () => {
+		const rows = Array.from({ length: 30 }, (_, index) =>
+			row({ key: `device-${index}`, identifier: `device-${index}`, suggestedName: `Device ${index}` })
+		);
+		const wrapper = mountStep(rows, {
+			confirmationMode: 'selection-only',
+			selected: {},
+			nameByKey: Object.fromEntries(rows.map((item) => [item.key, `Match ${item.identifier}`])),
+			categoryByKey: {},
+		});
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-confirm-search"] input').setValue('match');
+		await flushPromises();
+		wrapper.findComponent(ElPagination).vm.$emit('update:current-page', 2);
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(5);
+
+		await wrapper.setProps({
+			nameByKey: Object.fromEntries(rows.map((item, index) => [item.key, `${index < 10 ? 'Match' : 'Other'} ${item.identifier}`])),
+		});
+		await flushPromises();
+
+		expect(wrapper.find('[data-test-id="wizard-confirm-pagination"]').exists()).toBe(false);
+		expect(wrapper.findAll('tbody tr')).toHaveLength(10);
+		expect(wrapper.text()).toContain('device-0');
 	});
 
 	it('sorts by the translated category label rather than the raw category value', async () => {

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -257,9 +257,7 @@ describe('DeviceWizardConfirmStep', () => {
 		const rows = Array.from({ length: 100 }, (_, index) => row({ key: `device-${index}`, identifier: `device-${index}`, label: `Device ${index}` }));
 		const wrapper = mountStep(rows, {
 			columns: [{ key: 'channels', label: 'Channels', steps: ['confirm'], width: 130 }],
-			selected: {},
-			nameByKey: {},
-			categoryByKey: {},
+			confirmationMode: 'selection-only',
 		});
 
 		await flushPromises();

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -10,7 +10,7 @@ import type { IWizardColumn, IWizardRow } from './device-wizard.types';
 
 vi.mock('vue-i18n', () => ({
 	useI18n: () => ({
-		t: (key: string) => key,
+		t: (key: string, params?: { count?: number }) => (params?.count === undefined ? key : `${key}:${params.count}`),
 	}),
 }));
 
@@ -231,5 +231,23 @@ describe('DeviceWizardConfirmStep', () => {
 
 		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
 		expect(wrapper.text()).toContain('registered');
+	});
+
+	it('keeps a large confirmation inventory inside a mobile horizontal scroller', async () => {
+		const rows = Array.from({ length: 100 }, (_, index) => row({ key: `device-${index}`, identifier: `device-${index}`, label: `Device ${index}` }));
+		const wrapper = mountStep(rows, {
+			selected: {},
+			nameByKey: {},
+			categoryByKey: {},
+		});
+
+		await flushPromises();
+
+		expect(wrapper.find('[data-test-id="wizard-inventory-found"]').text()).toBe('devicesModule.wizard.totals.found:100');
+		expect(wrapper.find('[data-test-id="wizard-inventory-visible"]').text()).toBe('devicesModule.wizard.totals.visible:100');
+		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"]').classes()).toEqual(
+			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
+		);
+		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"] .el-table').classes()).toContain('min-w-[900px]');
 	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -32,6 +32,7 @@ const mountStep = (rows: IWizardRow[] = [row()], props: Record<string, unknown> 
 	mount(DeviceWizardConfirmStep, {
 		props: {
 			rows,
+			summaryRows: rows,
 			columns: [],
 			selected: { 'shelly-1.local': true },
 			nameByKey: { 'shelly-1.local': 'Living room switch' },
@@ -231,6 +232,25 @@ describe('DeviceWizardConfirmStep', () => {
 
 		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
 		expect(wrapper.text()).toContain('registered');
+	});
+
+	it('keeps full discovery totals while the confirmation table contains only adoptable rows', async () => {
+		const adoptable = row();
+		const wrapper = mountStep([adoptable], {
+			summaryRows: [
+				adoptable,
+				row({ key: 'registered', identifier: 'registered', status: 'already_registered', adoptable: false }),
+				row({ key: 'unsupported', identifier: 'unsupported', status: 'unsupported', adoptable: false }),
+			],
+		});
+
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+		expect(wrapper.find('[data-test-id="wizard-inventory-found"]').text()).toBe('devicesModule.wizard.totals.found:3');
+		expect(wrapper.find('[data-test-id="wizard-inventory-alreadyAdded"]').text()).toBe('devicesModule.wizard.totals.alreadyAdded:1');
+		expect(wrapper.find('[data-test-id="wizard-inventory-unsupported"]').text()).toBe('devicesModule.wizard.totals.unsupported:1');
+		expect(wrapper.find('[data-test-id="wizard-inventory-visible"]').text()).toBe('devicesModule.wizard.totals.visible:1');
 	});
 
 	it('keeps a large confirmation inventory inside a mobile horizontal scroller', async () => {

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -250,5 +250,5 @@ describe('DeviceWizardConfirmStep', () => {
 			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
 		);
 		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"] .el-table').attributes('style')).toContain('min-width: 1030px');
-	});
+	}, 10_000);
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -117,6 +117,27 @@ describe('DeviceWizardConfirmStep', () => {
 		expect(order).toEqual(['a', 'b']);
 	});
 
+	it('sorts the full confirmation inventory before slicing it into pages', async () => {
+		const rows = Array.from({ length: 26 }, (_, index) =>
+			row({
+				key: `device-${index}`,
+				identifier: `device-${index}`,
+				suggestedName: `Device ${String(25 - index).padStart(2, '0')}`,
+			})
+		);
+		const wrapper = mountStep(rows, {
+			confirmationMode: 'selection-only',
+			selected: {},
+			nameByKey: {},
+			categoryByKey: {},
+		});
+
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(25);
+		expect(wrapper.find('tbody tr code').text()).toBe('device-25');
+	});
+
 	it('sorts by the translated category label rather than the raw category value', async () => {
 		// Labels are deliberately inverted relative to the raw enum values ('lighting' <
 		// 'switcher' alphabetically, but 'Zzz' > 'Aaa'): a regression back to comparing

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.spec.ts
@@ -266,9 +266,11 @@ describe('DeviceWizardConfirmStep', () => {
 
 		expect(wrapper.find('[data-test-id="wizard-inventory-found"]').text()).toBe('devicesModule.wizard.totals.found:100');
 		expect(wrapper.find('[data-test-id="wizard-inventory-visible"]').text()).toBe('devicesModule.wizard.totals.visible:100');
+		expect(wrapper.findAll('tbody tr')).toHaveLength(25);
+		expect(wrapper.find('[data-test-id="wizard-confirm-pagination"]').exists()).toBe(true);
 		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"]').classes()).toEqual(
 			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
 		);
 		expect(wrapper.find('[data-test-id="wizard-confirm-table-scroll"] .el-table').attributes('style')).toContain('min-width: 1030px');
-	}, 10_000);
+	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -12,7 +12,7 @@
 		</div>
 
 		<device-wizard-inventory-summary
-			:rows="rows"
+			:rows="summaryRows"
 			:visible-count="filteredRows.length"
 		/>
 
@@ -165,6 +165,7 @@ defineOptions({
 
 interface IProps {
 	rows: IWizardRow[];
+	summaryRows: IWizardRow[];
 	columns: IWizardColumn[];
 	selected: Record<string, boolean>;
 	nameByKey: Record<string, string>;

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -21,7 +21,7 @@
 			class="min-h-0 flex-1 overflow-x-auto overscroll-x-contain"
 		>
 			<el-table
-				:data="filteredRows"
+				:data="pageRows"
 				class="h-full w-full"
 				:style="{ minWidth: `${tableMinWidth}px` }"
 				table-layout="fixed"
@@ -143,14 +143,25 @@
 				</el-table-column>
 			</el-table>
 		</div>
+
+		<el-pagination
+			v-if="filteredRows.length > PAGE_SIZE"
+			v-model:current-page="currentPage"
+			data-test-id="wizard-confirm-pagination"
+			class="shrink-0 justify-center"
+			layout="prev, pager, next"
+			:page-size="PAGE_SIZE"
+			:pager-count="5"
+			:total="filteredRows.length"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElCheckbox, ElInput, ElOption, ElSelect, ElTable, ElTableColumn, ElTag } from 'element-plus';
+import { ElCheckbox, ElInput, ElOption, ElPagination, ElSelect, ElTable, ElTableColumn, ElTag } from 'element-plus';
 
 import type { DevicesModuleDeviceCategory } from '../../../../openapi.constants';
 
@@ -185,7 +196,10 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
+const PAGE_SIZE = 25;
+
 const search = ref<string>('');
+const currentPage = ref<number>(1);
 
 const categoryLabel = (row: IWizardRow): string => {
 	const category = props.categoryByKey[row.key] ?? row.suggestedCategory;
@@ -213,6 +227,16 @@ const filteredRows = computed<IWizardRow[]>(() => {
 
 		return values.some((value) => value?.toLocaleLowerCase().includes(query));
 	});
+});
+
+const pageRows = computed<IWizardRow[]>(() => {
+	const start = (currentPage.value - 1) * PAGE_SIZE;
+
+	return filteredRows.value.slice(start, start + PAGE_SIZE);
+});
+
+watch([search, () => props.rows.length], () => {
+	currentPage.value = 1;
 });
 
 const allFilteredSelected = computed<boolean>(

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -27,6 +27,7 @@
 				table-layout="fixed"
 				:empty-text="t('devicesModule.wizard.texts.noSelection')"
 				:default-sort="{ prop: 'name', order: 'ascending' }"
+				@sort-change="onSortChange"
 			>
 				<el-table-column width="60">
 					<template #header>
@@ -56,8 +57,7 @@
 					prop="name"
 					:label="t('devicesModule.wizard.columns.name')"
 					min-width="220"
-					sortable
-					:sort-method="sortByName"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<el-input
@@ -78,8 +78,7 @@
 					prop="identifier"
 					:label="identifierLabel"
 					min-width="150"
-					sortable
-					:sort-method="sortByIdentifier"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<code class="text-sm">{{ row.identifier }}</code>
@@ -87,10 +86,10 @@
 				</el-table-column>
 
 				<el-table-column
+					prop="change"
 					:label="t('devicesModule.wizard.columns.change')"
 					width="170"
-					sortable
-					:sort-method="sortByChange"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<el-tag
@@ -103,10 +102,10 @@
 				</el-table-column>
 
 				<el-table-column
+					prop="category"
 					:label="t('devicesModule.wizard.columns.category')"
 					min-width="240"
-					sortable
-					:sort-method="sortByCategory"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<el-select
@@ -131,11 +130,11 @@
 				<el-table-column
 					v-for="column in extraColumns"
 					:key="column.key"
+					:prop="column.key"
 					:label="column.label"
 					:width="column.width"
 					:min-width="column.minWidth"
-					:sortable="column.sortable"
-					:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
+					:sortable="column.sortable ? 'custom' : false"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<device-wizard-cell :cell="row.cells?.[column.key]" />
@@ -200,6 +199,8 @@ const PAGE_SIZE = 25;
 
 const search = ref<string>('');
 const currentPage = ref<number>(1);
+const sortKey = ref<string | null>('name');
+const sortOrder = ref<'ascending' | 'descending' | null>('ascending');
 
 const categoryLabel = (row: IWizardRow): string => {
 	const category = props.categoryByKey[row.key] ?? row.suggestedCategory;
@@ -227,16 +228,6 @@ const filteredRows = computed<IWizardRow[]>(() => {
 
 		return values.some((value) => value?.toLocaleLowerCase().includes(query));
 	});
-});
-
-const pageRows = computed<IWizardRow[]>(() => {
-	const start = (currentPage.value - 1) * PAGE_SIZE;
-
-	return filteredRows.value.slice(start, start + PAGE_SIZE);
-});
-
-watch([search, () => props.rows.length], () => {
-	currentPage.value = 1;
 });
 
 const allFilteredSelected = computed<boolean>(
@@ -268,4 +259,50 @@ const sortByCategory = (a: IWizardRow, b: IWizardRow): number => {
 };
 
 const sortByCell = (key: string, a: IWizardRow, b: IWizardRow): number => compareLocale(a.cells?.[key]?.value, b.cells?.[key]?.value);
+
+const compareRows = (a: IWizardRow, b: IWizardRow): number => {
+	if (sortKey.value === 'name') {
+		return sortByName(a, b);
+	}
+
+	if (sortKey.value === 'identifier') {
+		return sortByIdentifier(a, b);
+	}
+
+	if (sortKey.value === 'change') {
+		return sortByChange(a, b);
+	}
+
+	if (sortKey.value === 'category') {
+		return sortByCategory(a, b);
+	}
+
+	return sortKey.value === null ? 0 : sortByCell(sortKey.value, a, b);
+};
+
+const sortedRows = computed<IWizardRow[]>(() => {
+	if (sortKey.value === null || sortOrder.value === null) {
+		return filteredRows.value;
+	}
+
+	const direction = sortOrder.value === 'ascending' ? 1 : -1;
+
+	return [...filteredRows.value].sort((a, b) => direction * compareRows(a, b));
+});
+
+const pageRows = computed<IWizardRow[]>(() => {
+	const start = (currentPage.value - 1) * PAGE_SIZE;
+
+	return sortedRows.value.slice(start, start + PAGE_SIZE);
+});
+
+watch([search, () => filteredRows.value.length], () => {
+	currentPage.value = 1;
+});
+
+const onSortChange = ({ prop, order }: { prop: string | null; order: 'ascending' | 'descending' | null }): void => {
+	sortKey.value = prop;
+	sortOrder.value = order;
+	currentPage.value = 1;
+};
 </script>

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -296,9 +296,16 @@ const pageRows = computed<IWizardRow[]>(() => {
 	return sortedRows.value.slice(start, start + PAGE_SIZE);
 });
 
-watch([search, () => filteredRows.value.length], () => {
+watch(search, () => {
 	currentPage.value = 1;
 });
+
+watch(
+	() => filteredRows.value.length,
+	(count) => {
+		currentPage.value = Math.min(currentPage.value, Math.max(1, Math.ceil(count / PAGE_SIZE)));
+	}
+);
 
 const onSortChange = ({ prop, order }: { prop: string | null; order: 'ascending' | 'descending' | null }): void => {
 	sortKey.value = prop;

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -11,127 +11,137 @@
 			/>
 		</div>
 
-		<el-table
-			:data="filteredRows"
-			class="h-full w-full flex-grow"
-			table-layout="fixed"
-			:empty-text="t('devicesModule.wizard.texts.noSelection')"
-			:default-sort="{ prop: 'name', order: 'ascending' }"
+		<device-wizard-inventory-summary
+			:rows="rows"
+			:visible-count="filteredRows.length"
+		/>
+
+		<div
+			data-test-id="wizard-confirm-table-scroll"
+			class="min-h-0 flex-1 overflow-x-auto overscroll-x-contain"
 		>
-			<el-table-column width="60">
-				<template #header>
-					<el-checkbox
-						:model-value="allFilteredSelected"
-						:indeterminate="someFilteredSelected && !allFilteredSelected"
-						:disabled="filteredRows.length === 0"
-						@change="
-							(value: boolean | string | number) =>
-								emit(
-									'toggle-rows',
-									filteredRows.map((row) => row.key),
-									value === true
-								)
-						"
-					/>
-				</template>
-				<template #default="{ row }: { row: IWizardRow }">
-					<el-checkbox
-						:model-value="selected[row.key] === true"
-						@change="(value: boolean | string | number) => emit('toggle-row', row.key, value === true)"
-					/>
-				</template>
-			</el-table-column>
-
-			<el-table-column
-				prop="name"
-				:label="t('devicesModule.wizard.columns.name')"
-				min-width="220"
-				sortable
-				:sort-method="sortByName"
+			<el-table
+				:data="filteredRows"
+				class="h-full w-full min-w-[900px]"
+				table-layout="fixed"
+				:empty-text="t('devicesModule.wizard.texts.noSelection')"
+				:default-sort="{ prop: 'name', order: 'ascending' }"
 			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<el-input
-						v-if="confirmationMode === 'editable'"
-						:model-value="nameByKey[row.key] ?? ''"
-						@update:model-value="(value: string) => emit('update-name', row.key, value)"
-					/>
-					<span
-						v-else
-						class="font-medium"
-					>
-						{{ nameByKey[row.key] ?? row.suggestedName }}
-					</span>
-				</template>
-			</el-table-column>
-
-			<el-table-column
-				prop="identifier"
-				:label="identifierLabel"
-				min-width="150"
-				sortable
-				:sort-method="sortByIdentifier"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<code class="text-sm">{{ row.identifier }}</code>
-				</template>
-			</el-table-column>
-
-			<el-table-column
-				:label="t('devicesModule.wizard.columns.change')"
-				width="170"
-				sortable
-				:sort-method="sortByChange"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<el-tag
-						size="small"
-						:type="row.willUpdate ? 'warning' : 'success'"
-					>
-						{{ row.willUpdate ? t('devicesModule.wizard.statuses.willUpdate') : t('devicesModule.wizard.statuses.willCreate') }}
-					</el-tag>
-				</template>
-			</el-table-column>
-
-			<el-table-column
-				:label="t('devicesModule.wizard.columns.category')"
-				min-width="240"
-				sortable
-				:sort-method="sortByCategory"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<el-select
-						v-if="confirmationMode === 'editable'"
-						:model-value="categoryByKey[row.key] ?? null"
-						filterable
-						@update:model-value="(value: DevicesModuleDeviceCategory | null) => emit('update-category', row.key, value)"
-					>
-						<el-option
-							v-for="option in row.categoryOptions"
-							:key="option.value"
-							:label="option.label"
-							:value="option.value"
+				<el-table-column width="60">
+					<template #header>
+						<el-checkbox
+							:model-value="allFilteredSelected"
+							:indeterminate="someFilteredSelected && !allFilteredSelected"
+							:disabled="filteredRows.length === 0"
+							@change="
+								(value: boolean | string | number) =>
+									emit(
+										'toggle-rows',
+										filteredRows.map((row) => row.key),
+										value === true
+									)
+							"
 						/>
-					</el-select>
-					<span v-else>
-						{{ categoryLabel(row) }}
-					</span>
-				</template>
-			</el-table-column>
+					</template>
+					<template #default="{ row }: { row: IWizardRow }">
+						<el-checkbox
+							:model-value="selected[row.key] === true"
+							@change="(value: boolean | string | number) => emit('toggle-row', row.key, value === true)"
+						/>
+					</template>
+				</el-table-column>
 
-			<el-table-column
-				v-for="column in extraColumns"
-				:key="column.key"
-				:label="column.label"
-				:width="column.width"
-				:min-width="column.minWidth"
-				:sortable="column.sortable"
-				:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<device-wizard-cell :cell="row.cells?.[column.key]" />
-				</template>
-			</el-table-column>
-		</el-table>
+				<el-table-column
+					prop="name"
+					:label="t('devicesModule.wizard.columns.name')"
+					min-width="220"
+					sortable
+					:sort-method="sortByName"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<el-input
+							v-if="confirmationMode === 'editable'"
+							:model-value="nameByKey[row.key] ?? ''"
+							@update:model-value="(value: string) => emit('update-name', row.key, value)"
+						/>
+						<span
+							v-else
+							class="font-medium"
+						>
+							{{ nameByKey[row.key] ?? row.suggestedName }}
+						</span>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					prop="identifier"
+					:label="identifierLabel"
+					min-width="150"
+					sortable
+					:sort-method="sortByIdentifier"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<code class="text-sm">{{ row.identifier }}</code>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					:label="t('devicesModule.wizard.columns.change')"
+					width="170"
+					sortable
+					:sort-method="sortByChange"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<el-tag
+							size="small"
+							:type="row.willUpdate ? 'warning' : 'success'"
+						>
+							{{ row.willUpdate ? t('devicesModule.wizard.statuses.willUpdate') : t('devicesModule.wizard.statuses.willCreate') }}
+						</el-tag>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					:label="t('devicesModule.wizard.columns.category')"
+					min-width="240"
+					sortable
+					:sort-method="sortByCategory"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<el-select
+							v-if="confirmationMode === 'editable'"
+							:model-value="categoryByKey[row.key] ?? null"
+							filterable
+							@update:model-value="(value: DevicesModuleDeviceCategory | null) => emit('update-category', row.key, value)"
+						>
+							<el-option
+								v-for="option in row.categoryOptions"
+								:key="option.value"
+								:label="option.label"
+								:value="option.value"
+							/>
+						</el-select>
+						<span v-else>
+							{{ categoryLabel(row) }}
+						</span>
+					</template>
+				</el-table-column>
+
+				<el-table-column
+					v-for="column in extraColumns"
+					:key="column.key"
+					:label="column.label"
+					:width="column.width"
+					:min-width="column.minWidth"
+					:sortable="column.sortable"
+					:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<device-wizard-cell :cell="row.cells?.[column.key]" />
+					</template>
+				</el-table-column>
+			</el-table>
+		</div>
 	</div>
 </template>
 
@@ -144,6 +154,7 @@ import { ElCheckbox, ElInput, ElOption, ElSelect, ElTable, ElTableColumn, ElTag 
 import type { DevicesModuleDeviceCategory } from '../../../../openapi.constants';
 
 import DeviceWizardCell from './device-wizard-cell.vue';
+import DeviceWizardInventorySummary from './device-wizard-inventory-summary.vue';
 import { compareLocale } from './device-wizard.sort';
 import type { IWizardColumn, IWizardRow } from './device-wizard.types';
 

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-confirm-step.vue
@@ -22,7 +22,8 @@
 		>
 			<el-table
 				:data="filteredRows"
-				class="h-full w-full min-w-[900px]"
+				class="h-full w-full"
+				:style="{ minWidth: `${tableMinWidth}px` }"
 				table-layout="fixed"
 				:empty-text="t('devicesModule.wizard.texts.noSelection')"
 				:default-sort="{ prop: 'name', order: 'ascending' }"
@@ -220,6 +221,8 @@ const allFilteredSelected = computed<boolean>(
 const someFilteredSelected = computed<boolean>(() => filteredRows.value.some((row) => props.selected[row.key] === true));
 
 const extraColumns = computed<IWizardColumn[]>(() => props.columns.filter((column) => column.steps.includes('confirm')));
+
+const tableMinWidth = computed<number>(() => extraColumns.value.reduce((width, column) => width + (column.width ?? column.minWidth ?? 150), 900));
 
 // `prop`-based sorting can't reach into the parent-owned name / category records, so each
 // editable column gets a comparator that reads the current value rather than the row field.

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -196,6 +196,6 @@ describe('DeviceWizardDiscoverStep', () => {
 		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"]').classes()).toEqual(
 			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
 		);
-		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"] .el-table').classes()).toContain('min-w-[680px]');
+		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"] .el-table').attributes('style')).toContain('min-width: 680px');
 	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -193,6 +193,8 @@ describe('DeviceWizardDiscoverStep', () => {
 		expect(wrapper.find('[data-test-id="wizard-inventory-alreadyAdded"]').text()).toBe('devicesModule.wizard.totals.alreadyAdded:10');
 		expect(wrapper.find('[data-test-id="wizard-inventory-unsupported"]').text()).toBe('devicesModule.wizard.totals.unsupported:10');
 		expect(wrapper.find('[data-test-id="wizard-inventory-visible"]').text()).toBe('devicesModule.wizard.totals.visible:100');
+		expect(wrapper.findAll('tbody tr')).toHaveLength(25);
+		expect(wrapper.find('[data-test-id="wizard-discover-pagination"]').exists()).toBe(true);
 		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"]').classes()).toEqual(
 			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
 		);

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -9,7 +9,7 @@ import type { IWizardControl, IWizardRow } from './device-wizard.types';
 
 vi.mock('vue-i18n', () => ({
 	useI18n: () => ({
-		t: (key: string) => key,
+		t: (key: string, params?: { count?: number }) => (params?.count === undefined ? key : `${key}:${params.count}`),
 	}),
 }));
 
@@ -172,5 +172,30 @@ describe('DeviceWizardDiscoverStep', () => {
 
 		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
 		expect(wrapper.text()).toContain('registered');
+	});
+
+	it('summarizes and horizontally contains a large responsive inventory', async () => {
+		const rows = Array.from({ length: 100 }, (_, index) =>
+			row({
+				key: `device-${index}`,
+				identifier: `device-${index}`,
+				label: `Device ${index}`,
+				status: index < 80 ? 'ready' : index < 90 ? 'already_registered' : 'unsupported',
+				adoptable: index < 80,
+			})
+		);
+		const wrapper = mountStep([], rows);
+
+		await flushPromises();
+
+		expect(wrapper.find('[data-test-id="wizard-inventory-found"]').text()).toBe('devicesModule.wizard.totals.found:100');
+		expect(wrapper.find('[data-test-id="wizard-inventory-adoptable"]').text()).toBe('devicesModule.wizard.totals.adoptable:80');
+		expect(wrapper.find('[data-test-id="wizard-inventory-alreadyAdded"]').text()).toBe('devicesModule.wizard.totals.alreadyAdded:10');
+		expect(wrapper.find('[data-test-id="wizard-inventory-unsupported"]').text()).toBe('devicesModule.wizard.totals.unsupported:10');
+		expect(wrapper.find('[data-test-id="wizard-inventory-visible"]').text()).toBe('devicesModule.wizard.totals.visible:100');
+		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"]').classes()).toEqual(
+			expect.arrayContaining(['min-h-0', 'overflow-x-auto', 'overscroll-x-contain'])
+		);
+		expect(wrapper.find('[data-test-id="wizard-discover-table-scroll"] .el-table').classes()).toContain('min-w-[680px]');
 	});
 });

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -1,3 +1,4 @@
+import { ElPagination } from 'element-plus';
 import { describe, expect, it, vi } from 'vitest';
 
 import { flushPromises, mount } from '@vue/test-utils';
@@ -172,6 +173,52 @@ describe('DeviceWizardDiscoverStep', () => {
 
 		expect(wrapper.findAll('tbody tr')).toHaveLength(1);
 		expect(wrapper.text()).toContain('registered');
+	});
+
+	it('sorts the full discovery inventory before slicing it into pages', async () => {
+		const rows = Array.from({ length: 26 }, (_, index) =>
+			row({
+				key: `device-${index}`,
+				identifier: `device-${index}`,
+				label: `Device ${String(25 - index).padStart(2, '0')}`,
+			})
+		);
+		const wrapper = mountStep([], rows);
+
+		await flushPromises();
+
+		const nameHeader = wrapper.findAll('th').find((header) => header.text().includes('devicesModule.wizard.columns.name'));
+		expect(nameHeader).toBeDefined();
+
+		await nameHeader!.find('.caret-wrapper').trigger('click');
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(25);
+		expect(wrapper.find('tbody tr code').text()).toBe('device-25');
+	});
+
+	it('returns to the first page when live row updates shrink the filtered inventory', async () => {
+		const rows = Array.from({ length: 30 }, (_, index) =>
+			row({ key: `device-${index}`, identifier: `device-${index}`, label: `Device ${index}`, status: 'checking' })
+		);
+		const wrapper = mountStep([], rows);
+
+		await flushPromises();
+		await wrapper.find('[data-test-id="wizard-discover-search"] input').setValue('checking');
+		await flushPromises();
+		wrapper.findComponent(ElPagination).vm.$emit('update:current-page', 2);
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(5);
+
+		await wrapper.setProps({
+			rows: rows.map((item, index) => ({ ...item, status: index < 10 ? ('checking' as const) : ('ready' as const) })),
+		});
+		await flushPromises();
+
+		expect(wrapper.find('[data-test-id="wizard-discover-pagination"]').exists()).toBe(false);
+		expect(wrapper.findAll('tbody tr')).toHaveLength(10);
+		expect(wrapper.text()).toContain('device-0');
 	});
 
 	it('summarizes and horizontally contains a large responsive inventory', async () => {

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.spec.ts
@@ -221,6 +221,34 @@ describe('DeviceWizardDiscoverStep', () => {
 		expect(wrapper.text()).toContain('device-0');
 	});
 
+	it('preserves the current page when live discovery grows', async () => {
+		const rows = Array.from({ length: 30 }, (_, index) =>
+			row({ key: `device-${index}`, identifier: `device-${index}`, label: `Device ${index}` })
+		);
+		const wrapper = mountStep([], rows);
+
+		await flushPromises();
+		wrapper.findComponent(ElPagination).vm.$emit('update:current-page', 2);
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(5);
+		expect(wrapper.text()).toContain('device-25');
+
+		await wrapper.setProps({
+			rows: [
+				...rows,
+				...Array.from({ length: 10 }, (_, index) =>
+					row({ key: `device-${index + 30}`, identifier: `device-${index + 30}`, label: `Device ${index + 30}` })
+				),
+			],
+		});
+		await flushPromises();
+
+		expect(wrapper.findAll('tbody tr')).toHaveLength(15);
+		expect(wrapper.text()).toContain('device-25');
+		expect(wrapper.text()).not.toContain('device-0');
+	});
+
 	it('summarizes and horizontally contains a large responsive inventory', async () => {
 		const rows = Array.from({ length: 100 }, (_, index) =>
 			row({

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -124,7 +124,7 @@
 			class="min-h-0 flex-1 overflow-x-auto overscroll-x-contain"
 		>
 			<el-table
-				:data="filteredRows"
+				:data="pageRows"
 				class="h-full w-full"
 				:style="{ minWidth: `${tableMinWidth}px` }"
 				table-layout="fixed"
@@ -189,6 +189,17 @@
 				</el-table-column>
 			</el-table>
 		</div>
+
+		<el-pagination
+			v-if="filteredRows.length > PAGE_SIZE"
+			v-model:current-page="currentPage"
+			data-test-id="wizard-discover-pagination"
+			class="shrink-0 justify-center"
+			layout="prev, pager, next"
+			:page-size="PAGE_SIZE"
+			:pager-count="5"
+			:total="filteredRows.length"
+		/>
 	</div>
 </template>
 
@@ -196,7 +207,20 @@
 import { computed, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElProgress, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
+import {
+	ElAlert,
+	ElButton,
+	ElForm,
+	ElFormItem,
+	ElInput,
+	ElPagination,
+	ElProgress,
+	ElTable,
+	ElTableColumn,
+	ElTag,
+	ElText,
+	vLoading,
+} from 'element-plus';
 
 import { Icon } from '@iconify/vue';
 
@@ -229,7 +253,10 @@ const props = defineProps<IProps>();
 
 const { t } = useI18n();
 
+const PAGE_SIZE = 25;
+
 const search = ref<string>('');
+const currentPage = ref<number>(1);
 
 const filteredRows = computed<IWizardRow[]>(() => {
 	const query = search.value.trim().toLocaleLowerCase();
@@ -249,6 +276,16 @@ const filteredRows = computed<IWizardRow[]>(() => {
 
 		return values.some((value) => value?.toLocaleLowerCase().includes(query));
 	});
+});
+
+const pageRows = computed<IWizardRow[]>(() => {
+	const start = (currentPage.value - 1) * PAGE_SIZE;
+
+	return filteredRows.value.slice(start, start + PAGE_SIZE);
+});
+
+watch([search, () => props.rows.length], () => {
+	currentPage.value = 1;
 });
 
 const banners = computed<IWizardBannerControl[]>(() => props.controls.filter((item): item is IWizardBannerControl => item.type === 'banner'));

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -366,9 +366,16 @@ const pageRows = computed<IWizardRow[]>(() => {
 	return sortedRows.value.slice(start, start + PAGE_SIZE);
 });
 
-watch([search, () => filteredRows.value.length], () => {
+watch(search, () => {
 	currentPage.value = 1;
 });
+
+watch(
+	() => filteredRows.value.length,
+	(count) => {
+		currentPage.value = Math.min(currentPage.value, Math.max(1, Math.ceil(count / PAGE_SIZE)));
+	}
+);
 
 const onSortChange = ({ prop, order }: { prop: string | null; order: 'ascending' | 'descending' | null }): void => {
 	sortKey.value = prop;

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -129,12 +129,13 @@
 				:style="{ minWidth: `${tableMinWidth}px` }"
 				table-layout="fixed"
 				:empty-text="t('devicesModule.wizard.texts.empty')"
+				@sort-change="onSortChange"
 			>
 				<el-table-column
+					prop="name"
 					:label="t('devicesModule.wizard.columns.name')"
 					min-width="200"
-					sortable
-					:sort-method="sortByLabel"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<div class="flex flex-col">
@@ -153,8 +154,7 @@
 					prop="identifier"
 					:label="identifierLabel"
 					min-width="150"
-					sortable
-					:sort-method="sortByIdentifier"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<code class="text-sm">{{ row.identifier }}</code>
@@ -162,10 +162,10 @@
 				</el-table-column>
 
 				<el-table-column
+					prop="status"
 					:label="t('devicesModule.wizard.columns.status')"
 					width="180"
-					sortable
-					:sort-method="sortByStatus"
+					sortable="custom"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<el-tag :type="wizardStatusTagType(row.status)">
@@ -177,11 +177,11 @@
 				<el-table-column
 					v-for="column in extraColumns"
 					:key="column.key"
+					:prop="column.key"
 					:label="column.label"
 					:width="column.width"
 					:min-width="column.minWidth"
-					:sortable="column.sortable"
-					:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
+					:sortable="column.sortable ? 'custom' : false"
 				>
 					<template #default="{ row }: { row: IWizardRow }">
 						<device-wizard-cell :cell="row.cells?.[column.key]" />
@@ -257,6 +257,8 @@ const PAGE_SIZE = 25;
 
 const search = ref<string>('');
 const currentPage = ref<number>(1);
+const sortKey = ref<string | null>(null);
+const sortOrder = ref<'ascending' | 'descending' | null>(null);
 
 const filteredRows = computed<IWizardRow[]>(() => {
 	const query = search.value.trim().toLocaleLowerCase();
@@ -276,16 +278,6 @@ const filteredRows = computed<IWizardRow[]>(() => {
 
 		return values.some((value) => value?.toLocaleLowerCase().includes(query));
 	});
-});
-
-const pageRows = computed<IWizardRow[]>(() => {
-	const start = (currentPage.value - 1) * PAGE_SIZE;
-
-	return filteredRows.value.slice(start, start + PAGE_SIZE);
-});
-
-watch([search, () => props.rows.length], () => {
-	currentPage.value = 1;
 });
 
 const banners = computed<IWizardBannerControl[]>(() => props.controls.filter((item): item is IWizardBannerControl => item.type === 'banner'));
@@ -341,4 +333,46 @@ const sortByStatus = (a: IWizardRow, b: IWizardRow): number => {
 };
 
 const sortByCell = (key: string, a: IWizardRow, b: IWizardRow): number => compareLocale(a.cells?.[key]?.value, b.cells?.[key]?.value);
+
+const compareRows = (a: IWizardRow, b: IWizardRow): number => {
+	if (sortKey.value === 'name') {
+		return sortByLabel(a, b);
+	}
+
+	if (sortKey.value === 'identifier') {
+		return sortByIdentifier(a, b);
+	}
+
+	if (sortKey.value === 'status') {
+		return sortByStatus(a, b);
+	}
+
+	return sortKey.value === null ? 0 : sortByCell(sortKey.value, a, b);
+};
+
+const sortedRows = computed<IWizardRow[]>(() => {
+	if (sortKey.value === null || sortOrder.value === null) {
+		return filteredRows.value;
+	}
+
+	const direction = sortOrder.value === 'ascending' ? 1 : -1;
+
+	return [...filteredRows.value].sort((a, b) => direction * compareRows(a, b));
+});
+
+const pageRows = computed<IWizardRow[]>(() => {
+	const start = (currentPage.value - 1) * PAGE_SIZE;
+
+	return sortedRows.value.slice(start, start + PAGE_SIZE);
+});
+
+watch([search, () => filteredRows.value.length], () => {
+	currentPage.value = 1;
+});
+
+const onSortChange = ({ prop, order }: { prop: string | null; order: 'ascending' | 'descending' | null }): void => {
+	sortKey.value = prop;
+	sortOrder.value = order;
+	currentPage.value = 1;
+};
 </script>

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -125,7 +125,8 @@
 		>
 			<el-table
 				:data="filteredRows"
-				class="h-full w-full min-w-[680px]"
+				class="h-full w-full"
+				:style="{ minWidth: `${tableMinWidth}px` }"
 				table-layout="fixed"
 				:empty-text="t('devicesModule.wizard.texts.empty')"
 			>
@@ -259,6 +260,8 @@ const progressBars = computed<IWizardProgressControl[]>(() =>
 const forms = computed<IWizardFormControl[]>(() => props.controls.filter((item): item is IWizardFormControl => item.type === 'form'));
 
 const extraColumns = computed<IWizardColumn[]>(() => props.columns.filter((column) => column.steps.includes('discover')));
+
+const tableMinWidth = computed<number>(() => extraColumns.value.reduce((width, column) => width + (column.width ?? column.minWidth ?? 150), 680));
 
 // Field values are keyed by control id so several forms can coexist. Rebuilt whenever the
 // set of form controls changes so a newly-declared form always has a backing record.

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-discover-step.vue
@@ -114,70 +114,80 @@
 			/>
 		</div>
 
-		<el-table
-			:data="filteredRows"
-			class="h-full w-full flex-grow"
-			table-layout="fixed"
-			:empty-text="t('devicesModule.wizard.texts.empty')"
+		<device-wizard-inventory-summary
+			:rows="rows"
+			:visible-count="filteredRows.length"
+		/>
+
+		<div
+			data-test-id="wizard-discover-table-scroll"
+			class="min-h-0 flex-1 overflow-x-auto overscroll-x-contain"
 		>
-			<el-table-column
-				:label="t('devicesModule.wizard.columns.name')"
-				min-width="200"
-				sortable
-				:sort-method="sortByLabel"
+			<el-table
+				:data="filteredRows"
+				class="h-full w-full min-w-[680px]"
+				table-layout="fixed"
+				:empty-text="t('devicesModule.wizard.texts.empty')"
 			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<div class="flex flex-col">
-						<span class="font-medium">{{ row.label }}</span>
-						<span
-							v-if="row.subLabel"
-							class="text-xs text-gray-500"
-						>
-							{{ row.subLabel }}
-						</span>
-					</div>
-				</template>
-			</el-table-column>
+				<el-table-column
+					:label="t('devicesModule.wizard.columns.name')"
+					min-width="200"
+					sortable
+					:sort-method="sortByLabel"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<div class="flex flex-col">
+							<span class="font-medium">{{ row.label }}</span>
+							<span
+								v-if="row.subLabel"
+								class="text-xs text-gray-500"
+							>
+								{{ row.subLabel }}
+							</span>
+						</div>
+					</template>
+				</el-table-column>
 
-			<el-table-column
-				prop="identifier"
-				:label="identifierLabel"
-				min-width="150"
-				sortable
-				:sort-method="sortByIdentifier"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<code class="text-sm">{{ row.identifier }}</code>
-				</template>
-			</el-table-column>
+				<el-table-column
+					prop="identifier"
+					:label="identifierLabel"
+					min-width="150"
+					sortable
+					:sort-method="sortByIdentifier"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<code class="text-sm">{{ row.identifier }}</code>
+					</template>
+				</el-table-column>
 
-			<el-table-column
-				:label="t('devicesModule.wizard.columns.status')"
-				width="180"
-				sortable
-				:sort-method="sortByStatus"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<el-tag :type="wizardStatusTagType(row.status)">
-						{{ row.statusLabel ?? t(`devicesModule.wizard.statuses.${row.status}`) }}
-					</el-tag>
-				</template>
-			</el-table-column>
+				<el-table-column
+					:label="t('devicesModule.wizard.columns.status')"
+					width="180"
+					sortable
+					:sort-method="sortByStatus"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<el-tag :type="wizardStatusTagType(row.status)">
+							{{ row.statusLabel ?? t(`devicesModule.wizard.statuses.${row.status}`) }}
+						</el-tag>
+					</template>
+				</el-table-column>
 
-			<el-table-column
-				v-for="column in extraColumns"
-				:key="column.key"
-				:label="column.label"
-				:width="column.width"
-				:min-width="column.minWidth"
-				:sortable="column.sortable"
-				:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
-			>
-				<template #default="{ row }: { row: IWizardRow }">
-					<device-wizard-cell :cell="row.cells?.[column.key]" />
-				</template>
-			</el-table-column>
-		</el-table>
+				<el-table-column
+					v-for="column in extraColumns"
+					:key="column.key"
+					:label="column.label"
+					:width="column.width"
+					:min-width="column.minWidth"
+					:sortable="column.sortable"
+					:sort-method="(a: IWizardRow, b: IWizardRow) => sortByCell(column.key, a, b)"
+				>
+					<template #default="{ row }: { row: IWizardRow }">
+						<device-wizard-cell :cell="row.cells?.[column.key]" />
+					</template>
+				</el-table-column>
+			</el-table>
+		</div>
 	</div>
 </template>
 
@@ -190,6 +200,7 @@ import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElProgress, ElTable, El
 import { Icon } from '@iconify/vue';
 
 import DeviceWizardCell from './device-wizard-cell.vue';
+import DeviceWizardInventorySummary from './device-wizard-inventory-summary.vue';
 import { compareLocale } from './device-wizard.sort';
 import {
 	type IWizardBannerControl,

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard-inventory-summary.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard-inventory-summary.vue
@@ -1,0 +1,46 @@
+<template>
+	<div
+		data-test-id="wizard-inventory-summary"
+		class="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs"
+		aria-live="polite"
+	>
+		<el-text
+			v-for="item in summary"
+			:key="item.key"
+			:data-test-id="`wizard-inventory-${item.key}`"
+			size="small"
+		>
+			{{ t(`devicesModule.wizard.totals.${item.key}`, { count: item.count }) }}
+		</el-text>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElText } from 'element-plus';
+
+import type { IWizardRow } from './device-wizard.types';
+
+defineOptions({
+	name: 'DeviceWizardInventorySummary',
+});
+
+interface IProps {
+	rows: IWizardRow[];
+	visibleCount: number;
+}
+
+const props = defineProps<IProps>();
+
+const { t } = useI18n();
+
+const summary = computed(() => [
+	{ key: 'found', count: props.rows.length },
+	{ key: 'adoptable', count: props.rows.filter((row) => row.adoptable).length },
+	{ key: 'alreadyAdded', count: props.rows.filter((row) => row.status === 'already_registered').length },
+	{ key: 'unsupported', count: props.rows.filter((row) => row.status === 'unsupported').length },
+	{ key: 'visible', count: props.visibleCount },
+]);
+</script>

--- a/apps/admin/src/modules/devices/components/wizard/device-wizard.vue
+++ b/apps/admin/src/modules/devices/components/wizard/device-wizard.vue
@@ -101,6 +101,7 @@
 					v-else-if="activeStep === 'confirm'"
 					data-test-id="wizard-step-confirm"
 					:rows="adoptableRows"
+					:summary-rows="adapter.rows.value"
 					:columns="adapter.columns"
 					:selected="selected"
 					:name-by-key="nameByKey"

--- a/apps/admin/src/modules/devices/locales/cs-CZ.json
+++ b/apps/admin/src/modules/devices/locales/cs-CZ.json
@@ -998,6 +998,13 @@
 			"change": "Akce",
 			"error": "Chyba"
 		},
+		"totals": {
+			"found": "Nalezeno: {count}",
+			"adoptable": "Lze přidat: {count}",
+			"alreadyAdded": "Již přidáno: {count}",
+			"unsupported": "Nepodporováno: {count}",
+			"visible": "Zobrazeno: {count}"
+		},
 		"texts": {
 			"loading": "Načítání vyhledávací relace...",
 			"empty": "Zatím nebyla nalezena žádná zařízení",

--- a/apps/admin/src/modules/devices/locales/de-DE.json
+++ b/apps/admin/src/modules/devices/locales/de-DE.json
@@ -998,6 +998,13 @@
 			"change": "Aktion",
 			"error": "Fehler"
 		},
+		"totals": {
+			"found": "Gefunden: {count}",
+			"adoptable": "Hinzufügbar: {count}",
+			"alreadyAdded": "Bereits hinzugefügt: {count}",
+			"unsupported": "Nicht unterstützt: {count}",
+			"visible": "Sichtbar: {count}"
+		},
 		"texts": {
 			"loading": "Suchsitzung wird geladen...",
 			"empty": "Noch keine Geräte gefunden",

--- a/apps/admin/src/modules/devices/locales/en-US.json
+++ b/apps/admin/src/modules/devices/locales/en-US.json
@@ -999,6 +999,13 @@
 			"change": "Action",
 			"error": "Error"
 		},
+		"totals": {
+			"found": "Found: {count}",
+			"adoptable": "Adoptable: {count}",
+			"alreadyAdded": "Already added: {count}",
+			"unsupported": "Unsupported: {count}",
+			"visible": "Visible: {count}"
+		},
 		"texts": {
 			"loading": "Loading discovery session...",
 			"empty": "No devices found yet",

--- a/apps/admin/src/modules/devices/locales/es-ES.json
+++ b/apps/admin/src/modules/devices/locales/es-ES.json
@@ -998,6 +998,13 @@
 			"change": "Acción",
 			"error": "Error"
 		},
+		"totals": {
+			"found": "Encontrados: {count}",
+			"adoptable": "Adoptables: {count}",
+			"alreadyAdded": "Ya añadidos: {count}",
+			"unsupported": "No compatibles: {count}",
+			"visible": "Visibles: {count}"
+		},
 		"texts": {
 			"loading": "Cargando sesión de búsqueda...",
 			"empty": "Todavía no se han encontrado dispositivos",

--- a/apps/admin/src/modules/devices/locales/pl-PL.json
+++ b/apps/admin/src/modules/devices/locales/pl-PL.json
@@ -998,6 +998,13 @@
 			"change": "Akcja",
 			"error": "Błąd"
 		},
+		"totals": {
+			"found": "Znaleziono: {count}",
+			"adoptable": "Możliwe do dodania: {count}",
+			"alreadyAdded": "Już dodano: {count}",
+			"unsupported": "Nieobsługiwane: {count}",
+			"visible": "Widoczne: {count}"
+		},
 		"texts": {
 			"loading": "Ładowanie sesji wyszukiwania...",
 			"empty": "Nie znaleziono jeszcze żadnych urządzeń",

--- a/apps/admin/src/modules/devices/locales/sk-SK.json
+++ b/apps/admin/src/modules/devices/locales/sk-SK.json
@@ -998,6 +998,13 @@
 			"change": "Akcia",
 			"error": "Chyba"
 		},
+		"totals": {
+			"found": "Nájdené: {count}",
+			"adoptable": "Možno pridať: {count}",
+			"alreadyAdded": "Už pridané: {count}",
+			"unsupported": "Nepodporované: {count}",
+			"visible": "Zobrazené: {count}"
+		},
 		"texts": {
 			"loading": "Načítavanie relácie vyhľadávania...",
 			"empty": "Zatiaľ neboli nájdené žiadne zariadenia",

--- a/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
+++ b/tasks/features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md
@@ -4,7 +4,7 @@ Type: feature
 Scope: backend, admin, spec
 Size: large
 Parent: (none)
-Status: in-progress
+Status: done
 Created: 2026-08-12
 
 ## 1. Business goal
@@ -254,7 +254,7 @@ should be driven by the largest real inventory, and Home Assistant delivers the 
 - [x] An adapter can use selection-only confirmation while existing adapters retain editable name/category confirmation.
 - [x] Discover and confirm inventories can be searched without losing edits or selection state.
 - [x] Select-all acts on the documented filtered set and has correct checked/indeterminate states.
-- [ ] Large inventories remain usable on desktop and mobile layouts.
+- [x] Large inventories remain usable on desktop and mobile layouts.
 
 ### Home Assistant
 


### PR DESCRIPTION
## Summary
- add compact found, adoptable, already-added, unsupported, and visible inventory totals
- keep discover and confirm tables usable on narrow screens through bounded horizontal scrolling
- cover 100-row inventories and responsive overflow behavior in shared wizard tests
- complete the device plugin adoption wizard task

## Verification
- pnpm exec vitest run src/modules/devices/components/wizard src/modules/devices/composables/useDeviceWizardState.spec.ts
- pnpm run type-check
- pnpm run build
- locale key validation for all six device-module locales

## Visual QA
- the isolated admin server reached sign-in, but the wizard itself requires a configured backend and plugin inventory; responsive behavior is covered at the real component level and verified in the production CSS output.