### PR TITLE
test(backend): cover refresh-family revocation streams

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -152,6 +152,15 @@ describe('MCP OAuth listen registration race', () => {
 				generation: 0,
 				createdById: user.id,
 			});
+			const refreshFamilyOAuthClient = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'listen-refresh-family-client',
+				name: 'Listen refresh family client',
+				redirectUris: ['http://127.0.0.1:1457/callback'],
+				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
 			await dataSource.getRepository(McpOAuthApproverAuthorityEntity).save({
 				approverId: user.id,
 				generation: 0,
@@ -194,6 +203,25 @@ describe('MCP OAuth listen registration race', () => {
 				issuer: urls.issuer,
 				resource: urls.resource,
 				approvedScopes: [McpOAuthScope.READ],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const rawRefreshFamilyGrantId = 'listen-refresh-family-grant';
+			const refreshFamilyGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawRefreshFamilyGrantId),
+				clientId: refreshFamilyOAuthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
 				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
 				revokedAt: null,
 				generation: 0,
@@ -431,13 +459,21 @@ describe('MCP OAuth listen registration race', () => {
 			const refreshFamilyAccessToken = 'listen-refresh-family-revocation-access-token';
 			const refreshFamilyRefreshToken = 'listen-refresh-family-revocation-refresh-token';
 
+			await providerGrants.upsert(
+				rawRefreshFamilyGrantId,
+				{
+					accountId: user.id,
+					clientId: refreshFamilyOAuthClient.clientIdentifier,
+				},
+				600,
+			);
 			await accessTokens.upsert(
 				refreshFamilyAccessToken,
 				{
 					accountId: user.id,
 					aud: urls.resource,
-					clientId: oauthClient.clientIdentifier,
-					grantId: rawGrantId,
+					clientId: refreshFamilyOAuthClient.clientIdentifier,
+					grantId: rawRefreshFamilyGrantId,
 					gty: 'authorization_code',
 					kind: 'AccessToken',
 					scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
@@ -448,8 +484,8 @@ describe('MCP OAuth listen registration race', () => {
 				refreshFamilyRefreshToken,
 				{
 					accountId: user.id,
-					clientId: oauthClient.clientIdentifier,
-					grantId: rawGrantId,
+					clientId: refreshFamilyOAuthClient.clientIdentifier,
+					grantId: rawRefreshFamilyGrantId,
 					gty: 'authorization_code refresh_token',
 					rotations: 0,
 					scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
@@ -467,9 +503,7 @@ describe('MCP OAuth listen registration race', () => {
 			expect(refreshFamilyId).not.toBeNull();
 			if (!refreshFamilyId) throw new Error('Expected the access token to be linked to a refresh family');
 			expect(refreshFamilyRefreshArtifact.refreshFamilyId).toBe(refreshFamilyId);
-			expect(
-				await dataSource.getRepository(McpOAuthProviderArtifactEntity).countBy({ refreshFamilyId }),
-			).toBeGreaterThanOrEqual(2);
+			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).countBy({ refreshFamilyId })).toBe(2);
 			refreshFamilyRevocationClient = new Client(
 				{ name: 'listen-refresh-family-revocation-e2e', version: '1.0.0' },
 				{ versionNegotiation: { mode: 'auto' } },
@@ -505,8 +539,14 @@ describe('MCP OAuth listen registration race', () => {
 				await dataSource.getRepository(McpOAuthProviderRevokedRefreshFamilyEntity).existsBy({ refreshFamilyId }),
 			).toBe(true);
 			expect(
-				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: refreshFamilyGrant.id })).revokedAt,
 			).toBeNull();
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({
+					model: 'Grant',
+					idHash: hashToken(rawRefreshFamilyGrantId),
+				}),
+			).toBe(true);
 			await refreshFamilyRevocationClient.close();
 			refreshFamilyRevocationClient = undefined;
 

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -118,6 +118,7 @@ describe('MCP OAuth listen registration race', () => {
 		let client: Client | undefined;
 		let expiryClient: Client | undefined;
 		let grantExpiryClient: Client | undefined;
+		let refreshFamilyRevocationClient: Client | undefined;
 		let grantRevocationClient: Client | undefined;
 		const releaseListen = deferred();
 
@@ -220,6 +221,7 @@ describe('MCP OAuth listen registration race', () => {
 
 			const accessTokens = new Adapter('AccessToken');
 			const providerGrants = new Adapter('Grant');
+			const refreshTokens = new Adapter('RefreshToken');
 
 			await providerGrants.upsert(
 				rawGrantId,
@@ -426,6 +428,88 @@ describe('MCP OAuth listen registration race', () => {
 				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
 			).toBeNull();
 
+			const refreshFamilyAccessToken = 'listen-refresh-family-revocation-access-token';
+			const refreshFamilyRefreshToken = 'listen-refresh-family-revocation-refresh-token';
+
+			await accessTokens.upsert(
+				refreshFamilyAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					gty: 'authorization_code',
+					kind: 'AccessToken',
+					scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
+				},
+				600,
+			);
+			await refreshTokens.upsert(
+				refreshFamilyRefreshToken,
+				{
+					accountId: user.id,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					gty: 'authorization_code refresh_token',
+					rotations: 0,
+					scope: `${McpOAuthScope.READ} ${McpOAuthScope.OFFLINE_ACCESS}`,
+				},
+				600,
+			);
+			const refreshFamilyAccessArtifact = await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.findOneByOrFail({ model: 'AccessToken', idHash: hashToken(refreshFamilyAccessToken) });
+			const refreshFamilyRefreshArtifact = await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.findOneByOrFail({ model: 'RefreshToken', idHash: hashToken(refreshFamilyRefreshToken) });
+			const refreshFamilyId = refreshFamilyAccessArtifact.refreshFamilyId;
+
+			expect(refreshFamilyId).not.toBeNull();
+			if (!refreshFamilyId) throw new Error('Expected the access token to be linked to a refresh family');
+			expect(refreshFamilyRefreshArtifact.refreshFamilyId).toBe(refreshFamilyId);
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).countBy({ refreshFamilyId }),
+			).toBeGreaterThanOrEqual(2);
+			refreshFamilyRevocationClient = new Client(
+				{ name: 'listen-refresh-family-revocation-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const refreshFamilyRevocationTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${refreshFamilyAccessToken}` } },
+			});
+
+			await refreshFamilyRevocationClient.connect(refreshFamilyRevocationTransport);
+			const refreshFamilyRevokedSubscription = await refreshFamilyRevocationClient.listen({ toolsListChanged: true });
+
+			expect(subscriptions.activeCount).toBe(1);
+			await management.revokeRefreshFamily(refreshFamilyId, 'owner-actor');
+			await expect(refreshFamilyRevokedSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(0);
+			expect(auditLog).toHaveBeenCalledWith(
+				'MCP audit event',
+				expect.objectContaining({ event: 'subscription_close', reason: 'authorization_revoked' }),
+			);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_management',
+				request_id: 'administrative',
+				actor_id: 'owner-actor',
+				artifact: 'refresh_family',
+				artifact_id: refreshFamilyId,
+				action: 'revoked',
+			});
+			await expect(resourceServer.verifyAccessToken(refreshFamilyAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			expect(await dataSource.getRepository(McpOAuthProviderArtifactEntity).countBy({ refreshFamilyId })).toBe(0);
+			expect(
+				await dataSource.getRepository(McpOAuthProviderRevokedRefreshFamilyEntity).existsBy({ refreshFamilyId }),
+			).toBe(true);
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
+			).toBeNull();
+			await refreshFamilyRevocationClient.close();
+			refreshFamilyRevocationClient = undefined;
+
 			const grantRevocationAccessToken = 'listen-grant-revocation-access-token';
 
 			await accessTokens.upsert(
@@ -488,6 +572,7 @@ describe('MCP OAuth listen registration race', () => {
 			releaseListen.resolve();
 			await expiryClient?.close();
 			await grantExpiryClient?.close();
+			await refreshFamilyRevocationClient?.close();
 			await grantRevocationClient?.close();
 			await client?.close();
 			if (app) {

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -420,6 +420,9 @@ amend ADR 0002.
       `authorization_expired` rather than treating expiry as administrative revocation.
 - [x] Provider-backed wire E2E: revoke an active grant through the management service, close its live subscription as
       `authorization_revoked`, delete its provider artifacts, and reject subsequent bearer reuse.
+- [x] Provider-backed wire E2E: revoke an active refresh family through the management service, close its live
+      subscription as `authorization_revoked`, delete every family artifact, reject subsequent bearer reuse, and
+      preserve the grant.
 - [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth


### PR DESCRIPTION
## Summary

- open a provider-backed Streamable HTTP subscription with an access token linked to a refresh family
- revoke the refresh family through the OAuth management service and prove the live stream closes remotely
- assert `authorization_revoked` auditing, complete family-artifact deletion, bearer rejection, and grant preservation
- update the Phase 6 verification checklist

## Why

Phase 6 requires production-wire proof for every OAuth invalidation boundary. Refresh-family revocation already had service-level coverage, but no active Streamable HTTP subscription exercised the complete management-to-stream-closure path.

## Impact

This adds regression evidence that administrative refresh-family revocation immediately terminates affected MCP streams and invalidates every family credential without revoking the underlying grant.

## Validation

- focused OAuth registration-race E2E passed after rebase
- focused E2E passed three consecutive runs during implementation
- full backend E2E: 14 suites and 130 tests passed
- backend type-check
- focused backend ESLint
- `git diff --check`
