### PR TITLE
fix(cross): complete the Home Assistant wizard contract

### DIFF
--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.spec.ts
@@ -60,6 +60,7 @@ const readyCandidate = {
 	status: DevicesHomeAssistantPluginDataWizardCandidateStatus.ready,
 	suggestedCategory: DevicesModuleDeviceCategory.lighting,
 	previewChannelCount: 2,
+	entityCount: 3,
 	warningCount: 0,
 	adoptedDeviceId: null,
 	error: null,
@@ -175,7 +176,7 @@ describe('useDevicesWizard', () => {
 					candidates: [
 						{
 							...readyCandidate,
-							status: DevicesHomeAssistantPluginDataWizardCandidateStatus.failed,
+							status: DevicesHomeAssistantPluginDataWizardCandidateStatus.unsupported,
 							warningCount: 1,
 							error: 'Home Assistant registry entry disappeared',
 						},
@@ -189,6 +190,10 @@ describe('useDevicesWizard', () => {
 		await adapter.start();
 
 		expect(adapter.rows.value[0].statusLabel).toBe('Home Assistant registry entry disappeared');
+		expect(adapter.rows.value[0]).toEqual(expect.objectContaining({ status: 'unsupported', adoptable: false }));
+		expect(adapter.rows.value[0].cells?.entities).toEqual(
+			expect.objectContaining({ value: 'devicesHomeAssistantPlugin.wizard.columns.entitiesCount:{"count":3}' })
+		);
 		expect(adapter.rows.value[0].cells?.channels).toEqual(expect.objectContaining({ tooltip: 'Home Assistant registry entry disappeared' }));
 	});
 

--- a/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/composables/useDevicesWizard.ts
@@ -124,6 +124,13 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 					value: t(`devicesHomeAssistantPlugin.wizard.kinds.${candidate.kind}`),
 					variant: 'info',
 				},
+				entities: {
+					render: 'tag',
+					value: t('devicesHomeAssistantPlugin.wizard.columns.entitiesCount', {
+						count: candidate.entityCount,
+					}),
+					variant: 'info',
+				},
 				channels: {
 					render: 'tag',
 					value: t('devicesHomeAssistantPlugin.wizard.columns.channelsCount', {
@@ -333,6 +340,12 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		results,
 		columns: [
 			{ key: 'kind', label: t('devicesHomeAssistantPlugin.wizard.columns.kind'), steps: ['discover'], width: 120 },
+			{
+				key: 'entities',
+				label: t('devicesHomeAssistantPlugin.wizard.columns.entities'),
+				steps: ['discover', 'confirm'],
+				width: 120,
+			},
 			{
 				key: 'channels',
 				label: t('devicesHomeAssistantPlugin.wizard.columns.channels'),

--- a/apps/admin/src/plugins/devices-home-assistant/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/cs-CZ.json
@@ -257,6 +257,8 @@
 		"columns": {
 			"identifier": "ID Home Assistant",
 			"kind": "Typ",
+			"entities": "Entity",
+			"entitiesCount": "Počet entit: {count}",
 			"channels": "Kanály",
 			"channelsCount": "Počet kanálů: {count}",
 			"warningsCount": "Počet upozornění mapování: {count}"

--- a/apps/admin/src/plugins/devices-home-assistant/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/de-DE.json
@@ -257,6 +257,8 @@
     "columns": {
       "identifier": "Home Assistant-ID",
       "kind": "Typ",
+      "entities": "Entitäten",
+      "entitiesCount": "{count} Entitäten",
       "channels": "Kanäle",
       "channelsCount": "{count} Kanäle",
       "warningsCount": "{count} Zuordnungswarnungen"

--- a/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/en-US.json
@@ -257,6 +257,8 @@
     "columns": {
       "identifier": "Home Assistant ID",
       "kind": "Type",
+      "entities": "Entities",
+      "entitiesCount": "{count} entities",
       "channels": "Channels",
       "channelsCount": "{count} channels",
       "warningsCount": "{count} mapping warnings"

--- a/apps/admin/src/plugins/devices-home-assistant/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/es-ES.json
@@ -257,6 +257,8 @@
     "columns": {
       "identifier": "ID de Home Assistant",
       "kind": "Tipo",
+      "entities": "Entidades",
+      "entitiesCount": "{count} entidades",
       "channels": "Canales",
       "channelsCount": "{count} canales",
       "warningsCount": "{count} avisos de mapeo"

--- a/apps/admin/src/plugins/devices-home-assistant/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/pl-PL.json
@@ -257,6 +257,8 @@
 		"columns": {
 			"identifier": "ID Home Assistant",
 			"kind": "Typ",
+			"entities": "Encje",
+			"entitiesCount": "Liczba encji: {count}",
 			"channels": "Kanały",
 			"channelsCount": "Liczba kanałów: {count}",
 			"warningsCount": "Liczba ostrzeżeń mapowania: {count}"

--- a/apps/admin/src/plugins/devices-home-assistant/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-home-assistant/locales/sk-SK.json
@@ -257,6 +257,8 @@
 		"columns": {
 			"identifier": "ID Home Assistant",
 			"kind": "Typ",
+			"entities": "Entity",
+			"entitiesCount": "Počet entít: {count}",
 			"channels": "Kanály",
 			"channelsCount": "Počet kanálov: {count}",
 			"warningsCount": "Počet upozornení mapovania: {count}"

--- a/apps/admin/src/plugins/devices-home-assistant/schemas/wizard.types.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/schemas/wizard.types.ts
@@ -1,6 +1,6 @@
 import type { DevicesModuleDeviceCategory } from '../../../openapi.constants';
 
-export type IHomeAssistantWizardCandidateStatus = 'ready' | 'needs_attention' | 'already_registered' | 'failed';
+export type IHomeAssistantWizardCandidateStatus = 'ready' | 'needs_attention' | 'already_registered' | 'unsupported' | 'failed';
 
 export interface IHomeAssistantWizardCandidate {
 	key: string;
@@ -12,6 +12,7 @@ export interface IHomeAssistantWizardCandidate {
 	status: IHomeAssistantWizardCandidateStatus;
 	suggestedCategory: DevicesModuleDeviceCategory | null;
 	previewChannelCount: number;
+	entityCount: number;
 	warningCount: number;
 	adoptedDeviceId: string | null;
 	error: string | null;

--- a/apps/admin/src/plugins/devices-home-assistant/utils/wizard.transformers.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/utils/wizard.transformers.ts
@@ -19,6 +19,7 @@ export const transformWizardSessionResponse = (raw: DevicesHomeAssistantPluginWi
 			status: candidate.status,
 			suggestedCategory: (candidate.suggestedCategory ?? null) as DevicesModuleDeviceCategory | null,
 			previewChannelCount: candidate.previewChannelCount,
+			entityCount: candidate.entityCount,
 			warningCount: candidate.warningCount,
 			adoptedDeviceId: candidate.adoptedDeviceId ?? null,
 			error: candidate.error ?? null,

--- a/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/controllers/home-assistant-wizard.controller.ts
@@ -108,6 +108,7 @@ export class HomeAssistantWizardController {
 	@ApiNotFoundResponse('Wizard session could not be found')
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Post(':id/adopt')
+	@HttpCode(200)
 	async adopt(
 		@Param('id') id: string,
 		@Body() body: ReqHomeAssistantWizardAdoptDto,

--- a/apps/backend/src/plugins/devices-home-assistant/models/wizard.model.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/models/wizard.model.ts
@@ -10,6 +10,7 @@ export const HOME_ASSISTANT_WIZARD_CANDIDATE_STATUSES = [
 	'ready',
 	'needs_attention',
 	'already_registered',
+	'unsupported',
 	'failed',
 ] as const;
 
@@ -64,6 +65,11 @@ export class HomeAssistantWizardCandidateModel {
 	@Expose()
 	@IsInt()
 	previewChannelCount: number;
+
+	@ApiProperty({ description: 'Number of Home Assistant entities represented by this candidate', example: 3 })
+	@Expose()
+	@IsInt()
+	entityCount: number;
 
 	@ApiProperty({ description: 'Number of mapping warnings requiring manual review', example: 0 })
 	@Expose()

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.spec.ts
@@ -113,7 +113,7 @@ describe('HomeAssistantWizardService', () => {
 			generatePreview: jest.fn().mockResolvedValue(createDevicePreview()),
 			generateSettledPreviews: jest.fn().mockResolvedValue([
 				{
-					source: { id: 'ha-device-1', name: 'Living room lamp' },
+					source: { id: 'ha-device-1', name: 'Living room lamp', entities: ['light.living_room'] },
 					preview: createDevicePreview(),
 					error: null,
 				},
@@ -133,7 +133,7 @@ describe('HomeAssistantWizardService', () => {
 		helperAdoptionService = { adoptHelper: jest.fn().mockResolvedValue({ id: 'helper-1' }) };
 		homeAssistantHttpService = {
 			getDiscoveredInventory: jest.fn().mockResolvedValue({
-				devices: [{ id: 'ha-device-1', adoptedDeviceId: null }],
+				devices: [{ id: 'ha-device-1', entities: ['light.living_room'], adoptedDeviceId: null }],
 				helpers: [{ entityId: 'input_boolean.guest_mode', adoptedDeviceId: null }],
 			}),
 		};
@@ -159,8 +159,13 @@ describe('HomeAssistantWizardService', () => {
 		expect(snapshot.id).toMatch(/^[0-9a-f-]{36}$/);
 		expect(snapshot.candidates).toEqual(
 			expect.arrayContaining([
-				expect.objectContaining({ key: 'device:ha-device-1', status: 'ready', previewChannelCount: 1 }),
-				expect.objectContaining({ key: 'helper:input_boolean.guest_mode', status: 'ready', previewChannelCount: 1 }),
+				expect.objectContaining({ key: 'device:ha-device-1', status: 'ready', previewChannelCount: 1, entityCount: 1 }),
+				expect.objectContaining({
+					key: 'helper:input_boolean.guest_mode',
+					status: 'ready',
+					previewChannelCount: 1,
+					entityCount: 1,
+				}),
 			]),
 		);
 		expect(mappingPreviewService.generateSettledPreviews).toHaveBeenCalledWith(
@@ -175,7 +180,7 @@ describe('HomeAssistantWizardService', () => {
 	it('keeps ambiguous candidates out of automatic adoption', async () => {
 		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
 			{
-				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				source: { id: 'ha-device-1', name: 'Living room lamp', entities: ['light.living_room'] },
 				preview: createDevicePreview([
 					{ type: 'unsupported_entity', entityId: 'sensor.unknown', message: 'Review mapping' },
 				]),
@@ -259,7 +264,7 @@ describe('HomeAssistantWizardService', () => {
 		const snapshot = await service.start();
 		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
 			{
-				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				source: { id: 'ha-device-1', name: 'Living room lamp', entities: ['light.living_room'] },
 				preview: createDevicePreview([
 					{ type: 'unsupported_entity', entityId: 'sensor.changed', message: 'Mapping changed' },
 				]),
@@ -296,7 +301,7 @@ describe('HomeAssistantWizardService', () => {
 
 	it('marks candidates already adopted outside the wizard as unavailable', async () => {
 		homeAssistantHttpService.getDiscoveredInventory.mockResolvedValueOnce({
-			devices: [{ id: 'ha-device-1', adoptedDeviceId: 'existing-1' }],
+			devices: [{ id: 'ha-device-1', entities: ['light.living_room'], adoptedDeviceId: 'existing-1' }],
 			helpers: [{ entityId: 'input_boolean.guest_mode', adoptedDeviceId: null }],
 		});
 		const snapshot = await service.start();
@@ -309,7 +314,7 @@ describe('HomeAssistantWizardService', () => {
 	it('keeps valid candidates when another mapping preview fails', async () => {
 		mappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([
 			{
-				source: { id: 'ha-device-1', name: 'Living room lamp' },
+				source: { id: 'ha-device-1', name: 'Living room lamp', entities: ['light.living_room'] },
 				preview: null,
 				error: 'Home Assistant device with ID ha-device-1 not found',
 			},
@@ -321,7 +326,8 @@ describe('HomeAssistantWizardService', () => {
 			expect.arrayContaining([
 				expect.objectContaining({
 					key: 'device:ha-device-1',
-					status: 'failed',
+					status: 'unsupported',
+					entityCount: 1,
 					error: 'Home Assistant device with ID ha-device-1 not found',
 				}),
 				expect.objectContaining({ key: 'helper:input_boolean.guest_mode', status: 'ready' }),
@@ -349,7 +355,7 @@ describe('HomeAssistantWizardService', () => {
 		const overlappingHelper = createHelperPreview();
 		overlappingHelper.helper.entityId = 'light.living_room';
 		homeAssistantHttpService.getDiscoveredInventory.mockResolvedValueOnce({
-			devices: [{ id: 'ha-device-1', adoptedDeviceId: null }],
+			devices: [{ id: 'ha-device-1', entities: ['light.living_room'], adoptedDeviceId: null }],
 			helpers: [{ entityId: 'light.living_room', adoptedDeviceId: 'helper-device-1' }],
 		});
 		helperMappingPreviewService.generateSettledPreviews.mockResolvedValueOnce([

--- a/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/services/wizard.service.ts
@@ -85,8 +85,20 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 
 		for (const result of devicePreviewResults) {
 			const candidate = result.preview
-				? this.createDeviceCandidate(result.preview, adoptedBySourceId.get(result.source.id) ?? null)
-				: this.createFailedCandidate('device', result.source.id, result.source.name, null, null, result.error);
+				? this.createDeviceCandidate(
+						result.preview,
+						adoptedBySourceId.get(result.source.id) ?? null,
+						result.source.entities.length,
+					)
+				: this.createUnsupportedCandidate(
+						'device',
+						result.source.id,
+						result.source.name,
+						null,
+						null,
+						result.source.entities.length,
+						result.error,
+					);
 			if (
 				candidate.snapshot.status === 'ready' &&
 				candidate.request &&
@@ -115,12 +127,13 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 
 			const candidate = result.preview
 				? this.createHelperCandidate(result.preview, adoptedBySourceId.get(result.source.entityId) ?? null)
-				: this.createFailedCandidate(
+				: this.createUnsupportedCandidate(
 						'helper',
 						result.source.entityId,
 						result.source.name,
 						'Home Assistant',
 						`Helper (${result.source.domain})`,
+						1,
 						result.error,
 					);
 			session.candidates.set(candidate.snapshot.key, candidate);
@@ -308,6 +321,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 	private createDeviceCandidate(
 		preview: MappingPreviewModel,
 		adoptedDeviceId: string | null,
+		entityCount: number,
 	): HomeAssistantWizardCandidate {
 		const key = `device:${preview.haDevice.id}`;
 		const request = this.buildDeviceRequest(preview);
@@ -325,6 +339,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				status,
 				suggestedCategory: preview.suggestedDevice.category,
 				previewChannelCount: request.channels.length,
+				entityCount,
 				warningCount: preview.warnings.length,
 				adoptedDeviceId,
 				error: status === 'needs_attention' ? this.mappingReviewReason(preview.warnings) : null,
@@ -357,6 +372,7 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				status,
 				suggestedCategory: preview.suggestedDevice.category,
 				previewChannelCount: request.channels.length,
+				entityCount: 1,
 				warningCount: preview.warnings.length,
 				adoptedDeviceId,
 				error: status === 'needs_attention' ? this.mappingReviewReason(preview.warnings) : null,
@@ -431,12 +447,13 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 		};
 	}
 
-	private createFailedCandidate(
+	private createUnsupportedCandidate(
 		kind: 'device' | 'helper',
 		sourceId: string,
 		name: string,
 		manufacturer: string | null,
 		model: string | null,
+		entityCount: number,
 		error: string | null,
 	): HomeAssistantWizardCandidate {
 		return {
@@ -447,9 +464,10 @@ export class HomeAssistantWizardService implements OnModuleDestroy {
 				name,
 				manufacturer,
 				model,
-				status: 'failed',
+				status: 'unsupported',
 				suggestedCategory: null,
 				previewChannelCount: 0,
+				entityCount,
 				warningCount: 1,
 				adoptedDeviceId: null,
 				error: error ?? 'Automatic mapping could not be generated',

--- a/apps/backend/test/home-assistant-wizard.e2e-spec.ts
+++ b/apps/backend/test/home-assistant-wizard.e2e-spec.ts
@@ -1,0 +1,184 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { useContainer } from 'class-validator';
+import request from 'supertest';
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { DevicesHomeAssistantValidationException } from '../src/plugins/devices-home-assistant/devices-home-assistant.exceptions';
+import { HomeAssistantWizardService } from '../src/plugins/devices-home-assistant/services/wizard.service';
+
+describe('Home Assistant wizard endpoints (e2e)', () => {
+	let app: INestApplication;
+	let accessToken: string;
+	const session = {
+		id: 'session-1',
+		startedAt: '2026-08-13T00:00:00.000Z',
+		candidates: [
+			{
+				key: 'device:ha-device-1',
+				kind: 'device',
+				sourceId: 'ha-device-1',
+				name: 'Living room lamp',
+				manufacturer: 'Philips',
+				model: 'Hue',
+				status: 'ready',
+				suggestedCategory: 'lighting',
+				previewChannelCount: 2,
+				entityCount: 3,
+				warningCount: 0,
+				adoptedDeviceId: null,
+				error: null,
+			},
+			{
+				key: 'helper:input_text.unsupported',
+				kind: 'helper',
+				sourceId: 'input_text.unsupported',
+				name: 'Unsupported helper',
+				manufacturer: 'Home Assistant',
+				model: 'Helper (input_text)',
+				status: 'unsupported',
+				suggestedCategory: null,
+				previewChannelCount: 0,
+				entityCount: 1,
+				warningCount: 1,
+				adoptedDeviceId: null,
+				error: 'Automatic mapping could not be generated',
+			},
+		],
+	};
+	const wizardService = {
+		start: jest.fn().mockResolvedValue(session),
+		get: jest.fn((id: string) => (id === session.id ? session : null)),
+		end: jest.fn(),
+		adopt: jest.fn((id: string) =>
+			id === session.id
+				? Promise.resolve([
+						{ key: 'device:ha-device-1', name: 'Living room lamp', status: 'created', error: null },
+						{
+							key: 'helper:input_text.unsupported',
+							name: 'Unsupported helper',
+							status: 'failed',
+							error: 'Candidate requires manual mapping or is no longer adoptable',
+						},
+					])
+				: Promise.resolve(null),
+		),
+	};
+
+	beforeAll(async () => {
+		const dynamicAppModule = AppModule.register({ moduleExtensions: [], pluginExtensions: [] });
+		const moduleFixture = await Test.createTestingModule({ imports: [dynamicAppModule] })
+			.overrideProvider(HomeAssistantWizardService)
+			.useValue(wizardService)
+			.compile();
+
+		app = moduleFixture.createNestApplication();
+		app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));
+		useContainer(moduleFixture, { fallbackOnErrors: true });
+		await app.init();
+
+		await request(app.getHttpServer())
+			.post('/modules/auth/auth/register')
+			.send({
+				data: { username: 'hawizardtest', password: 'securePassword123!', email: 'hawizardtest@example.com' },
+			});
+		const login = await request(app.getHttpServer())
+			.post('/modules/auth/auth/login')
+			.send({ data: { username: 'hawizardtest', password: 'securePassword123!' } });
+		accessToken = (login.body as { data: { access_token: string } }).data.access_token;
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('requires authentication before starting a session', async () => {
+		await request(app.getHttpServer()).post('/plugins/devices-home-assistant/wizard').expect(401);
+
+		expect(wizardService.start).not.toHaveBeenCalled();
+	});
+
+	it('starts and retrieves an authenticated inventory session', async () => {
+		const started = await request(app.getHttpServer())
+			.post('/plugins/devices-home-assistant/wizard')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(201);
+		const startedBody = started.body as { data: typeof session };
+
+		expect(startedBody).toEqual(expect.objectContaining({ data: session }));
+		expect(startedBody.data.candidates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ key: 'device:ha-device-1', entityCount: 3, previewChannelCount: 2 }),
+				expect.objectContaining({ key: 'helper:input_text.unsupported', status: 'unsupported', entityCount: 1 }),
+			]),
+		);
+
+		const retrieved = await request(app.getHttpServer())
+			.get('/plugins/devices-home-assistant/wizard/session-1')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(200);
+
+		expect(retrieved.body).toEqual(expect.objectContaining({ data: session }));
+	});
+
+	it('validates selected keys and returns partial adoption results with HTTP 200', async () => {
+		await request(app.getHttpServer())
+			.post('/plugins/devices-home-assistant/wizard/session-1/adopt')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { keys: [] } })
+			.expect(400);
+
+		expect(wizardService.adopt).not.toHaveBeenCalled();
+
+		const adopted = await request(app.getHttpServer())
+			.post('/plugins/devices-home-assistant/wizard/session-1/adopt')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { keys: ['device:ha-device-1', 'helper:input_text.unsupported'] } })
+			.expect(200);
+		const adoptedBody = adopted.body as { data: { results: Array<{ key: string; status: string }> } };
+
+		expect(adoptedBody.data.results).toEqual([
+			expect.objectContaining({ key: 'device:ha-device-1', status: 'created' }),
+			expect.objectContaining({ key: 'helper:input_text.unsupported', status: 'failed' }),
+		]);
+	});
+
+	it('returns not found for unknown sessions', async () => {
+		await request(app.getHttpServer())
+			.get('/plugins/devices-home-assistant/wizard/missing')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(404);
+
+		await request(app.getHttpServer())
+			.post('/plugins/devices-home-assistant/wizard/missing/adopt')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.send({ data: { keys: ['device:ha-device-1'] } })
+			.expect(404);
+	});
+
+	it('ends an authenticated session', async () => {
+		await request(app.getHttpServer())
+			.delete('/plugins/devices-home-assistant/wizard/session-1')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(204);
+
+		expect(wizardService.end).toHaveBeenCalledWith('session-1');
+	});
+
+	it('translates plugin configuration failures', async () => {
+		wizardService.start.mockRejectedValueOnce(
+			new DevicesHomeAssistantValidationException('Home Assistant API key is not configured'),
+		);
+
+		await request(app.getHttpServer())
+			.post('/plugins/devices-home-assistant/wizard')
+			.set('Authorization', `Bearer ${accessToken}`)
+			.expect(422);
+	});
+});

--- a/tasks/ROADMAP.md
+++ b/tasks/ROADMAP.md
@@ -228,10 +228,10 @@ Build a device from properties of other devices — splitting one physical devic
 | 1 | [FEATURE-PLUGIN-Z2M-ADOPTION-IMPROVEMENTS](features/FEATURE-PLUGIN-Z2M-ADOPTION-IMPROVEMENTS.md) | backend, admin | :white_check_mark: Done |
 | 2 | [FEATURE-PLUGIN-MATTER](features/FEATURE-PLUGIN-MATTER.md) | backend, admin | :clipboard: Planned |
 | 3 | [FEATURE-PLUGIN-ZIGBEE-HERDSMAN](features/FEATURE-PLUGIN-ZIGBEE-HERDSMAN.md) | backend, admin | :clipboard: Planned |
-| 4 | [FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS](features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md) | backend, admin, spec | :construction: In Progress |
+| 4 | [FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS](features/FEATURE-DEVICE-PLUGIN-ADOPTION-WIZARDS.md) | backend, admin, spec | :white_check_mark: Done |
 | 5 | [FEATURE-PLUGIN-HOMEY](features/FEATURE-PLUGIN-HOMEY.md) | backend, admin, panel | :construction: In Progress |
 
-**Remaining work:** Adoption-wizard cross-plugin QA; Homey local integration (SHS/Homey Pro) followed by Homey Cloud; Matter plugin implementation; and direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management). Homey's [approved design](../docs/superpowers/specs/2026-08-12-homey-integration-design.md) and [implementation plan](../docs/superpowers/plans/2026-08-12-homey-integration.md) front-load compatibility testing and sanitized fixture capture during the one-month SHS subscription.
+**Remaining work:** Homey local integration (SHS/Homey Pro) followed by Homey Cloud; Matter plugin implementation; and direct Zigbee integration via zigbee-herdsman (6 phases: coordinator service, converters, device platform, adoption flow, admin UI, network management). Homey's [approved design](../docs/superpowers/specs/2026-08-12-homey-integration-design.md) and [implementation plan](../docs/superpowers/plans/2026-08-12-homey-integration.md) front-load compatibility testing and sanitized fixture capture during the one-month SHS subscription.
 
 ---
 


### PR DESCRIPTION
## Summary

- expose entity and channel counts plus unsupported mapping outcomes in the Home Assistant bulk wizard
- align the batch-adopt endpoint with its documented HTTP 200 response
- add authenticated wizard E2E coverage and mark the completed roadmap item done

## Why

The adoption-wizard task marked these contracts and authenticated endpoint coverage complete, but the Home Assistant adapter omitted entity counts, classified per-item automatic mapping failures as failed instead of unsupported, and had no authenticated route-level E2E suite. The existing manual device mapping flow remains unchanged for advanced administrator control.

## Validation

- 19 focused backend unit and controller tests
- 6 Home Assistant wizard E2E tests
- 34 focused admin tests
- backend and admin type-checks
- OpenAPI generation and Spectral validation
- pnpm run lint:js
- pnpm run admin:build