### PR TITLE
feat(backend): scaffold Homey device provider

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -85,6 +85,8 @@ import { DataSourcesDeviceChannelPlugin } from './plugins/data-sources-device-ch
 import { DataSourcesWeatherPlugin } from './plugins/data-sources-weather/data-sources-weather.plugin';
 import { DEVICES_HOME_ASSISTANT_PLUGIN_PREFIX } from './plugins/devices-home-assistant/devices-home-assistant.constants';
 import { DevicesHomeAssistantPlugin } from './plugins/devices-home-assistant/devices-home-assistant.plugin';
+import { DEVICES_HOMEY_PLUGIN_PREFIX } from './plugins/devices-homey/devices-homey.constants';
+import { DevicesHomeyPlugin } from './plugins/devices-homey/devices-homey.plugin';
 import { DEVICES_RETERMINAL_PLUGIN_PREFIX } from './plugins/devices-reterminal/devices-reterminal.constants';
 import { DevicesReTerminalPlugin } from './plugins/devices-reterminal/devices-reterminal.plugin';
 import { DEVICES_SHELLY_NG_PLUGIN_PREFIX } from './plugins/devices-shelly-ng/devices-shelly-ng.constants';
@@ -315,6 +317,10 @@ export class AppModule {
 								module: DevicesHomeAssistantPlugin,
 							},
 							{
+								path: DEVICES_HOMEY_PLUGIN_PREFIX,
+								module: DevicesHomeyPlugin,
+							},
+							{
 								path: DEVICES_THIRD_PARTY_PLUGIN_PREFIX,
 								module: DevicesThirdPartyPlugin,
 							},
@@ -440,6 +446,7 @@ export class AppModule {
 				DevicesReTerminalPlugin,
 				DevicesThirdPartyPlugin,
 				DevicesHomeAssistantPlugin,
+				DevicesHomeyPlugin,
 				DevicesShellyNgPlugin,
 				DevicesShellyV1Plugin,
 				DevicesWledPlugin,

--- a/apps/backend/src/modules/config/controllers/config.controller.spec.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.spec.ts
@@ -13,7 +13,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { ROLES_KEY } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
-import { ConfigException } from '../config.exceptions';
+import { ConfigException, ConfigValidationException } from '../config.exceptions';
 import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../dto/config.dto';
 import { AppConfigModel, ModuleConfigModel, PluginConfigModel } from '../models/config.model';
 import { ConfigSecretsService } from '../services/config-secrets.service';
@@ -172,6 +172,18 @@ describe('ConfigController', () => {
 			);
 			expect(response.data.errors).toEqual([{ field: 'api_key', message: 'Rejected [REDACTED]' }]);
 			expect(JSON.stringify(response)).not.toContain('stored-secret');
+		});
+	});
+
+	describe('updatePluginConfig', () => {
+		it('returns a bad request when the resolved stored configuration is invalid', async () => {
+			jest.spyOn(configService, 'setPluginConfig').mockImplementation(() => {
+				throw new ConfigValidationException('invalid resolved configuration');
+			});
+
+			await expect(
+				controller.updatePluginConfig('mock-plugin', { data: { type: 'mock-plugin', enabled: true } }),
+			).rejects.toThrow(BadRequestException);
 		});
 	});
 

--- a/apps/backend/src/modules/config/controllers/config.controller.ts
+++ b/apps/backend/src/modules/config/controllers/config.controller.ts
@@ -15,7 +15,7 @@ import {
 import { Roles } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
 import { CONFIG_MODULE_API_TAG_NAME, CONFIG_MODULE_NAME } from '../config.constants';
-import { ConfigException } from '../config.exceptions';
+import { ConfigException, ConfigValidationException } from '../config.exceptions';
 import {
 	ReqUpdateModuleDto,
 	ReqUpdatePluginDto,
@@ -190,7 +190,17 @@ export class ConfigController {
 		// block saves when the target service is temporarily unreachable. Users must
 		// be able to pre-configure credentials before the service is online.
 		// Use POST plugin/:plugin/validate for explicit validation.
-		this.service.setPluginConfig(plugin, dtoInstance, pluginConfig.data as Record<string, unknown>);
+		try {
+			this.service.setPluginConfig(plugin, dtoInstance, pluginConfig.data as Record<string, unknown>);
+		} catch (error) {
+			if (error instanceof ConfigValidationException) {
+				throw new BadRequestException([
+					JSON.stringify({ field: 'config', reason: 'The resolved plugin configuration is invalid.' }),
+				]);
+			}
+
+			throw error;
+		}
 
 		const config = this.service.getPublicPluginConfig(plugin);
 

--- a/apps/backend/src/modules/config/services/config.service.spec.ts
+++ b/apps/backend/src/modules/config/services/config.service.spec.ts
@@ -6,7 +6,7 @@ Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
 import { Expose, Transform } from 'class-transformer';
-import { IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import * as fs from 'fs';
 import path from 'path';
 import * as yaml from 'yaml';
@@ -40,10 +40,15 @@ class MockPluginConfig extends PluginConfigModel {
 
 	@Expose({ name: 'mock_value' })
 	@IsString()
-	@Transform(({ obj }: { obj: { mock_value?: string; mockValue?: string } }) => obj.mock_value || obj.mockValue, {
-		toClassOnly: true,
-	})
-	mockValue: string = 'default value';
+	@IsNotEmpty()
+	@Transform(
+		({ obj }: { obj: { mock_value?: string | null; mockValue?: string | null } }) =>
+			Object.prototype.hasOwnProperty.call(obj, 'mock_value') ? obj.mock_value : obj.mockValue,
+		{
+			toClassOnly: true,
+		},
+	)
+	mockValue: string | null = 'default value';
 
 	@Expose({ name: 'secret_value' })
 	@IsOptional()
@@ -55,7 +60,7 @@ class PluginConfigDto extends UpdatePluginConfigDto {
 	@Expose()
 	@IsOptional()
 	@IsString()
-	mock_value?: string;
+	mock_value?: string | null;
 
 	@Expose({ name: 'secret_value' })
 	@IsOptional()
@@ -431,6 +436,20 @@ describe('ConfigService', () => {
 			expect(fs.existsSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']));
 			expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(service['configPath'], service['filename']), 'utf8');
 			expect(yaml.parse).toHaveBeenCalledWith(JSON.stringify(mockRawConfig));
+		});
+
+		it('validates the resolved persisted model before saving', () => {
+			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockRawConfig));
+			jest.spyOn(yaml, 'parse').mockReturnValue(mockRawConfig);
+
+			expect(() =>
+				service.setPluginConfig('mock', toInstance(PluginConfigDto, { type: 'mock', mock_value: null }), {
+					type: 'mock',
+					mock_value: null,
+				}),
+			).toThrow(ConfigValidationException);
+			expect(yaml.stringify).not.toHaveBeenCalled();
 		});
 	});
 

--- a/apps/backend/src/modules/config/services/config.service.ts
+++ b/apps/backend/src/modules/config/services/config.service.ts
@@ -439,6 +439,24 @@ export class ConfigService {
 		}
 
 		const resolvedUpdate = this.resolvePluginConfigUpdate(plugin, instance, submittedValue);
+		const candidate = toInstance(
+			mapping.class,
+			this.configSecrets.merge(existingPlugin, {
+				type: plugin,
+				...resolvedUpdate,
+			}),
+		);
+		const candidateErrors = validateSync(candidate, this.validationOptions);
+
+		if (candidateErrors.length > 0) {
+			const redactedErrors = this.configSecrets.redactForLogging(candidateErrors, mapping.secretFields, candidate);
+
+			this.logger.error(
+				`[VALIDATION] Resolved configuration is invalid for plugin=${plugin} error=${JSON.stringify(redactedErrors)}`,
+			);
+
+			throw new ConfigValidationException(`New configuration for plugin '${plugin}' is invalid.`);
+		}
 
 		this.logger.log(`Updating configuration for plugin=${plugin}`);
 
@@ -447,15 +465,7 @@ export class ConfigService {
 		// Remove the old plugin if it exists
 		appConfig.plugins = (appConfig.plugins ?? []).filter((existingPlugin) => existingPlugin.type !== plugin);
 		// Add the new plugin config
-		appConfig.plugins.push(
-			toInstance(
-				mapping.class,
-				this.configSecrets.merge(existingPlugin, {
-					type: plugin,
-					...resolvedUpdate,
-				}),
-			),
-		);
+		appConfig.plugins.push(candidate);
 
 		this.logger.log(`[SAVE] Saving updated configuration for plugin=${plugin}`);
 		this.saveConfig(appConfig);

--- a/apps/backend/src/modules/extensions/extensions.exceptions.ts
+++ b/apps/backend/src/modules/extensions/extensions.exceptions.ts
@@ -11,3 +11,9 @@ export class ExtensionNotConfigurableException extends BadRequestException {
 		super(`Extension '${type}' does not support enable/disable configuration.`);
 	}
 }
+
+export class ExtensionConfigValidationException extends BadRequestException {
+	constructor(type: string) {
+		super(`Extension '${type}' can not be enabled because its configuration is incomplete or invalid.`);
+	}
+}

--- a/apps/backend/src/modules/extensions/services/extensions.service.spec.ts
+++ b/apps/backend/src/modules/extensions/services/extensions.service.spec.ts
@@ -7,12 +7,17 @@ handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { ConfigValidationException } from '../../config/config.exceptions';
 import { UpdatePluginConfigDto } from '../../config/dto/config.dto';
 import { ConfigService } from '../../config/services/config.service';
 import { ModulesTypeMapperService } from '../../config/services/modules-type-mapper.service';
 import { PluginsTypeMapperService } from '../../config/services/plugins-type-mapper.service';
 import { ExtensionKind } from '../extensions.constants';
-import { ExtensionNotConfigurableException, ExtensionNotFoundException } from '../extensions.exceptions';
+import {
+	ExtensionConfigValidationException,
+	ExtensionNotConfigurableException,
+	ExtensionNotFoundException,
+} from '../extensions.exceptions';
 
 import { ExtensionsBundledService } from './extensions-bundled.service';
 import { ExtensionsService } from './extensions.service';
@@ -228,6 +233,22 @@ describe('ExtensionsService', () => {
 				type: 'pages-tiles-plugin',
 				enabled: false,
 			});
+		});
+
+		it('maps invalid resolved plugin configuration to a client error', async () => {
+			jest.spyOn(configService, 'setPluginConfig').mockImplementation(() => {
+				throw new ConfigValidationException('sensitive provider detail');
+			});
+
+			await expect(service.updateEnabled('pages-tiles-plugin', true)).rejects.toThrow(
+				ExtensionConfigValidationException,
+			);
+
+			try {
+				await service.updateEnabled('pages-tiles-plugin', true);
+			} catch (error) {
+				expect(JSON.stringify(error)).not.toContain('sensitive provider detail');
+			}
 		});
 
 		it('should throw ExtensionNotConfigurableException when plugin DTO has no enabled property', async () => {

--- a/apps/backend/src/modules/extensions/services/extensions.service.ts
+++ b/apps/backend/src/modules/extensions/services/extensions.service.ts
@@ -1,12 +1,17 @@
 import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { ConfigValidationException } from '../../config/config.exceptions';
 import { UpdateModuleConfigDto, UpdatePluginConfigDto } from '../../config/dto/config.dto';
 import { ConfigService } from '../../config/services/config.service';
 import { ModulesTypeMapperService } from '../../config/services/modules-type-mapper.service';
 import { PluginsTypeMapperService } from '../../config/services/plugins-type-mapper.service';
 import { EXTENSIONS_MODULE_NAME, ExtensionKind, NON_TOGGLEABLE_MODULES } from '../extensions.constants';
-import { ExtensionNotConfigurableException, ExtensionNotFoundException } from '../extensions.exceptions';
+import {
+	ExtensionConfigValidationException,
+	ExtensionNotConfigurableException,
+	ExtensionNotFoundException,
+} from '../extensions.exceptions';
 import { ExtensionLinksModel, ExtensionModel } from '../models/extension.model';
 
 import { ExtensionsBundledService } from './extensions-bundled.service';
@@ -151,10 +156,18 @@ export class ExtensionsService {
 
 		// Update the config based on extension kind
 		// Note: type is required in the DTO validation
-		if (extension.kind === ExtensionKind.MODULE) {
-			await this.configService.updateModuleConfig(type, { type, enabled } as UpdateModuleConfigDto);
-		} else {
-			this.configService.setPluginConfig(type, { type, enabled } as UpdatePluginConfigDto);
+		try {
+			if (extension.kind === ExtensionKind.MODULE) {
+				await this.configService.updateModuleConfig(type, { type, enabled } as UpdateModuleConfigDto);
+			} else {
+				this.configService.setPluginConfig(type, { type, enabled } as UpdatePluginConfigDto);
+			}
+		} catch (error) {
+			if (error instanceof ConfigValidationException) {
+				throw new ExtensionConfigValidationException(type);
+			}
+
+			throw error;
 		}
 
 		// Return updated extension

--- a/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
@@ -1,0 +1,27 @@
+import { HomeyConnectionState } from '../devices-homey.constants';
+import { HomeyStatusModel } from '../models/status.model';
+import { HomeyService } from '../services/homey.service';
+
+import { HomeyStatusController } from './homey-status.controller';
+
+describe('HomeyStatusController', () => {
+	it('wraps the secret-free provider status in the standard response envelope', () => {
+		const status = Object.assign(new HomeyStatusModel(), {
+			serviceState: 'started',
+			connectionState: HomeyConnectionState.STOPPED,
+			enabled: true,
+			configured: true,
+			healthy: false,
+			lastError: null,
+		});
+		const service = { getStatus: jest.fn().mockReturnValue(status) };
+		const controller = new HomeyStatusController(service as unknown as HomeyService);
+
+		const response = controller.getStatus();
+
+		expect(response.data).toBe(status);
+		expect(service.getStatus).toHaveBeenCalledTimes(1);
+		expect(JSON.stringify(response)).not.toContain('api_key');
+		expect(JSON.stringify(response)).not.toContain('configured-secret');
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.ts
+++ b/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import {
+	ApiInternalServerErrorResponse,
+	ApiSuccessResponse,
+} from '../../../modules/swagger/decorators/api-documentation.decorator';
+import { Roles } from '../../../modules/users/guards/roles.guard';
+import { UserRole } from '../../../modules/users/users.constants';
+import { DEVICES_HOMEY_PLUGIN_API_TAG_NAME } from '../devices-homey.constants';
+import { HomeyStatusResponseModel } from '../models/status.model';
+import { HomeyService } from '../services/homey.service';
+
+@ApiTags(DEVICES_HOMEY_PLUGIN_API_TAG_NAME)
+@Controller('status')
+export class HomeyStatusController {
+	constructor(private readonly homeyService: HomeyService) {}
+
+	@ApiOperation({
+		tags: [DEVICES_HOMEY_PLUGIN_API_TAG_NAME],
+		summary: 'Get Homey provider status',
+		description: 'Returns the managed service and transport state without exposing connector credentials.',
+		operationId: 'get-devices-homey-plugin-status',
+	})
+	@ApiSuccessResponse(HomeyStatusResponseModel, 'Homey provider status retrieved successfully')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Get()
+	@Roles(UserRole.OWNER, UserRole.ADMIN, UserRole.USER)
+	getStatus(): HomeyStatusResponseModel {
+		const response = new HomeyStatusResponseModel();
+		response.data = this.homeyService.getStatus();
+
+		return response;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -1,0 +1,36 @@
+export const DEVICES_HOMEY_PLUGIN_PREFIX = 'devices-homey';
+
+export const DEVICES_HOMEY_PLUGIN_NAME = 'devices-homey-plugin';
+
+export const DEVICES_HOMEY_TYPE = 'devices-homey';
+
+export const DEVICES_HOMEY_CONNECTOR_SERVICE_ID = 'connector';
+
+export const HOMEY_CONNECTOR = Symbol('HOMEY_CONNECTOR');
+
+export const DEVICES_HOMEY_PLUGIN_API_TAG_NAME = 'Devices Homey plugin';
+
+export const DEVICES_HOMEY_PLUGIN_API_TAG_DESCRIPTION =
+	'Endpoints for configuring and monitoring the Homey device provider integration.';
+
+export const DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS = 10000;
+
+export const MIN_HOMEY_CONNECTION_TIMEOUT_MS = 1000;
+
+export const MAX_HOMEY_CONNECTION_TIMEOUT_MS = 60000;
+
+export const DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS = 300000;
+
+export const MIN_HOMEY_RECONCILIATION_INTERVAL_MS = 30000;
+
+export const MAX_HOMEY_RECONCILIATION_INTERVAL_MS = 3600000;
+
+export enum HomeyConnectionState {
+	STOPPED = 'stopped',
+	CONNECTING = 'connecting',
+	CONNECTED = 'connected',
+	DEGRADED_POLLING = 'degraded_polling',
+	RECONNECTING = 'reconnecting',
+	AUTHENTICATION_FAILED = 'authentication_failed',
+	ERROR = 'error',
+}

--- a/apps/backend/src/plugins/devices-homey/devices-homey.openapi.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.openapi.ts
@@ -1,0 +1,26 @@
+import { CreateHomeyChannelPropertyDto } from './dto/create-channel-property.dto';
+import { CreateHomeyChannelDto } from './dto/create-channel.dto';
+import { CreateHomeyDeviceDto } from './dto/create-device.dto';
+import { UpdateHomeyChannelPropertyDto } from './dto/update-channel-property.dto';
+import { UpdateHomeyChannelDto } from './dto/update-channel.dto';
+import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
+import { UpdateHomeyDeviceDto } from './dto/update-device.dto';
+import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './entities/devices-homey.entity';
+import { HomeyConfigModel } from './models/config.model';
+import { HomeyStatusModel, HomeyStatusResponseModel } from './models/status.model';
+
+export const DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS = [
+	HomeyConfigModel,
+	HomeyUpdatePluginConfigDto,
+	HomeyStatusModel,
+	HomeyStatusResponseModel,
+	HomeyDeviceEntity,
+	HomeyChannelEntity,
+	HomeyChannelPropertyEntity,
+	CreateHomeyDeviceDto,
+	UpdateHomeyDeviceDto,
+	CreateHomeyChannelDto,
+	UpdateHomeyChannelDto,
+	CreateHomeyChannelPropertyDto,
+	UpdateHomeyChannelPropertyDto,
+];

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -63,7 +63,7 @@ describe('DevicesHomeyPlugin', () => {
 		);
 		expect(swaggerRegistry.register).toHaveBeenCalledTimes(DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS.length);
 		expect(extensionsService.registerPluginMetadata).toHaveBeenCalledWith(
-			expect.objectContaining({ type: DEVICES_HOMEY_PLUGIN_NAME, name: 'Homey' }),
+			expect.objectContaining({ type: DEVICES_HOMEY_PLUGIN_NAME, name: 'Homey', defaultEnabled: false }),
 		);
 		expect(pluginServiceManager.register).toHaveBeenCalledWith(homeyService);
 	});

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -1,0 +1,70 @@
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
+import { ChannelsTypeMapperService } from '../../modules/devices/services/channels-type-mapper.service';
+import { ChannelsPropertiesTypeMapperService } from '../../modules/devices/services/channels.properties-type-mapper.service';
+import { DevicesTypeMapperService } from '../../modules/devices/services/devices-type-mapper.service';
+import { ExtensionsService } from '../../modules/extensions/services/extensions.service';
+import { PluginServiceManagerService } from '../../modules/extensions/services/plugin-service-manager.service';
+import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
+import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
+
+import { DEVICES_HOMEY_PLUGIN_NAME, DEVICES_HOMEY_TYPE } from './devices-homey.constants';
+import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.openapi';
+import { DevicesHomeyPlugin } from './devices-homey.plugin';
+import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
+import { HomeyConfigModel } from './models/config.model';
+import { HomeyService } from './services/homey.service';
+
+describe('DevicesHomeyPlugin', () => {
+	it('registers config, entities, discriminators, metadata, Swagger models, and managed lifecycle', () => {
+		const configMapper = { registerMapping: jest.fn() };
+		const devicesMapper = { registerMapping: jest.fn() };
+		const channelsMapper = { registerMapping: jest.fn() };
+		const propertiesMapper = { registerMapping: jest.fn() };
+		const swaggerRegistry = { register: jest.fn() };
+		const discriminatorRegistry = { register: jest.fn() };
+		const extensionsService = { registerPluginMetadata: jest.fn() };
+		const pluginServiceManager = { register: jest.fn() };
+		const homeyService = { pluginName: DEVICES_HOMEY_PLUGIN_NAME, serviceId: 'connector' };
+
+		const plugin = new DevicesHomeyPlugin(
+			configMapper as unknown as PluginsTypeMapperService,
+			devicesMapper as unknown as DevicesTypeMapperService,
+			channelsMapper as unknown as ChannelsTypeMapperService,
+			propertiesMapper as unknown as ChannelsPropertiesTypeMapperService,
+			swaggerRegistry as unknown as SwaggerModelsRegistryService,
+			discriminatorRegistry as unknown as ExtendedDiscriminatorService,
+			extensionsService as unknown as ExtensionsService,
+			pluginServiceManager as unknown as PluginServiceManagerService,
+			homeyService as unknown as HomeyService,
+		);
+
+		plugin.onModuleInit();
+
+		expect(configMapper.registerMapping).toHaveBeenCalledWith({
+			type: DEVICES_HOMEY_PLUGIN_NAME,
+			class: HomeyConfigModel,
+			configDto: HomeyUpdatePluginConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
+		});
+		expect(devicesMapper.registerMapping).toHaveBeenCalledWith(expect.objectContaining({ type: DEVICES_HOMEY_TYPE }));
+		expect(channelsMapper.registerMapping).toHaveBeenCalledWith(expect.objectContaining({ type: DEVICES_HOMEY_TYPE }));
+		expect(propertiesMapper.registerMapping).toHaveBeenCalledWith(
+			expect.objectContaining({ type: DEVICES_HOMEY_TYPE }),
+		);
+		expect(discriminatorRegistry.register).toHaveBeenCalledTimes(9);
+		expect(discriminatorRegistry.register).toHaveBeenCalledWith(
+			expect.objectContaining({ discriminatorProperty: 'type', discriminatorValue: DEVICES_HOMEY_TYPE }),
+		);
+		expect(swaggerRegistry.register).toHaveBeenCalledTimes(DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS.length);
+		expect(extensionsService.registerPluginMetadata).toHaveBeenCalledWith(
+			expect.objectContaining({ type: DEVICES_HOMEY_PLUGIN_NAME, name: 'Homey' }),
+		);
+		expect(pluginServiceManager.register).toHaveBeenCalledWith(homeyService);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -1,0 +1,160 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ConfigModule } from '../../modules/config/config.module';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
+import { DevicesModule } from '../../modules/devices/devices.module';
+import { CreateChannelPropertyDto } from '../../modules/devices/dto/create-channel-property.dto';
+import { CreateChannelDto } from '../../modules/devices/dto/create-channel.dto';
+import { CreateDeviceDto } from '../../modules/devices/dto/create-device.dto';
+import { UpdateChannelPropertyDto } from '../../modules/devices/dto/update-channel-property.dto';
+import { UpdateChannelDto } from '../../modules/devices/dto/update-channel.dto';
+import { UpdateDeviceDto } from '../../modules/devices/dto/update-device.dto';
+import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../modules/devices/entities/devices.entity';
+import { ChannelsTypeMapperService } from '../../modules/devices/services/channels-type-mapper.service';
+import { ChannelsPropertiesTypeMapperService } from '../../modules/devices/services/channels.properties-type-mapper.service';
+import { DevicesTypeMapperService } from '../../modules/devices/services/devices-type-mapper.service';
+import { ExtensionsModule } from '../../modules/extensions/extensions.module';
+import { ExtensionsService } from '../../modules/extensions/services/extensions.service';
+import { PluginServiceManagerService } from '../../modules/extensions/services/plugin-service-manager.service';
+import { ApiTag } from '../../modules/swagger/decorators/api-tag.decorator';
+import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
+import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
+import { SwaggerModule } from '../../modules/swagger/swagger.module';
+
+import { HomeyStatusController } from './controllers/homey-status.controller';
+import {
+	DEVICES_HOMEY_PLUGIN_API_TAG_DESCRIPTION,
+	DEVICES_HOMEY_PLUGIN_API_TAG_NAME,
+	DEVICES_HOMEY_PLUGIN_NAME,
+	DEVICES_HOMEY_TYPE,
+} from './devices-homey.constants';
+import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.openapi';
+import { CreateHomeyChannelPropertyDto } from './dto/create-channel-property.dto';
+import { CreateHomeyChannelDto } from './dto/create-channel.dto';
+import { CreateHomeyDeviceDto } from './dto/create-device.dto';
+import { UpdateHomeyChannelPropertyDto } from './dto/update-channel-property.dto';
+import { UpdateHomeyChannelDto } from './dto/update-channel.dto';
+import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
+import { UpdateHomeyDeviceDto } from './dto/update-device.dto';
+import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './entities/devices-homey.entity';
+import { HomeyConfigModel } from './models/config.model';
+import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
+import { HomeyService } from './services/homey.service';
+
+@ApiTag({
+	tagName: DEVICES_HOMEY_PLUGIN_NAME,
+	displayName: DEVICES_HOMEY_PLUGIN_API_TAG_NAME,
+	description: DEVICES_HOMEY_PLUGIN_API_TAG_DESCRIPTION,
+})
+@Module({
+	imports: [
+		TypeOrmModule.forFeature([HomeyDeviceEntity, HomeyChannelEntity, HomeyChannelPropertyEntity]),
+		DevicesModule,
+		ConfigModule,
+		ExtensionsModule,
+		SwaggerModule,
+	],
+	providers: [HomeyConfigValidatorService, HomeyService],
+	controllers: [HomeyStatusController],
+	exports: [HomeyService],
+})
+export class DevicesHomeyPlugin implements OnModuleInit {
+	constructor(
+		private readonly configMapper: PluginsTypeMapperService,
+		private readonly devicesMapper: DevicesTypeMapperService,
+		private readonly channelsMapper: ChannelsTypeMapperService,
+		private readonly channelsPropertiesMapper: ChannelsPropertiesTypeMapperService,
+		private readonly swaggerRegistry: SwaggerModelsRegistryService,
+		private readonly discriminatorRegistry: ExtendedDiscriminatorService,
+		private readonly extensionsService: ExtensionsService,
+		private readonly pluginServiceManager: PluginServiceManagerService,
+		private readonly homeyService: HomeyService,
+	) {}
+
+	onModuleInit(): void {
+		this.configMapper.registerMapping<HomeyConfigModel, HomeyUpdatePluginConfigDto>({
+			type: DEVICES_HOMEY_PLUGIN_NAME,
+			class: HomeyConfigModel,
+			configDto: HomeyUpdatePluginConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
+		});
+
+		this.devicesMapper.registerMapping<HomeyDeviceEntity, CreateHomeyDeviceDto, UpdateHomeyDeviceDto>({
+			type: DEVICES_HOMEY_TYPE,
+			class: HomeyDeviceEntity,
+			createDto: CreateHomeyDeviceDto,
+			updateDto: UpdateHomeyDeviceDto,
+		});
+
+		this.channelsMapper.registerMapping<HomeyChannelEntity, CreateHomeyChannelDto, UpdateHomeyChannelDto>({
+			type: DEVICES_HOMEY_TYPE,
+			class: HomeyChannelEntity,
+			createDto: CreateHomeyChannelDto,
+			updateDto: UpdateHomeyChannelDto,
+		});
+
+		this.channelsPropertiesMapper.registerMapping<
+			HomeyChannelPropertyEntity,
+			CreateHomeyChannelPropertyDto,
+			UpdateHomeyChannelPropertyDto
+		>({
+			type: DEVICES_HOMEY_TYPE,
+			class: HomeyChannelPropertyEntity,
+			createDto: CreateHomeyChannelPropertyDto,
+			updateDto: UpdateHomeyChannelPropertyDto,
+		});
+
+		for (const model of DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS) {
+			this.swaggerRegistry.register(model);
+		}
+
+		this.registerDiscriminator(DeviceEntity, HomeyDeviceEntity);
+		this.registerDiscriminator(CreateDeviceDto, CreateHomeyDeviceDto);
+		this.registerDiscriminator(UpdateDeviceDto, UpdateHomeyDeviceDto);
+		this.registerDiscriminator(ChannelEntity, HomeyChannelEntity);
+		this.registerDiscriminator(CreateChannelDto, CreateHomeyChannelDto);
+		this.registerDiscriminator(UpdateChannelDto, UpdateHomeyChannelDto);
+		this.registerDiscriminator(ChannelPropertyEntity, HomeyChannelPropertyEntity);
+		this.registerDiscriminator(CreateChannelPropertyDto, CreateHomeyChannelPropertyDto);
+		this.registerDiscriminator(UpdateChannelPropertyDto, UpdateHomeyChannelPropertyDto);
+
+		this.extensionsService.registerPluginMetadata({
+			type: DEVICES_HOMEY_PLUGIN_NAME,
+			name: 'Homey',
+			description: 'Imports and synchronizes logical devices managed by Homey',
+			author: 'FastyBird',
+			readme: `# Homey
+
+> Plugin · by FastyBird · platform: devices
+
+Connects Smart Panel to Homey Self-Hosted Server and compatible Homey Pro local APIs. Homey remains responsible for pairing, radio networks, drivers and apps; Smart Panel adopts selected logical devices for display and control.
+
+The local connector is under development. Configuration credentials are write-only and are never returned by the API.`,
+			links: {
+				documentation: 'https://smart-panel.fastybird.com/docs',
+				repository: 'https://github.com/FastyBird/smart-panel',
+			},
+		});
+
+		this.pluginServiceManager.register(this.homeyService);
+	}
+
+	private registerDiscriminator(
+		parentClass: new (...args: any[]) => unknown,
+		modelClass: new (...args: any[]) => unknown,
+	) {
+		this.discriminatorRegistry.register({
+			parentClass,
+			discriminatorProperty: 'type',
+			discriminatorValue: DEVICES_HOMEY_TYPE,
+			modelClass,
+		});
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -130,6 +130,7 @@ export class DevicesHomeyPlugin implements OnModuleInit {
 			name: 'Homey',
 			description: 'Imports and synchronizes logical devices managed by Homey',
 			author: 'FastyBird',
+			defaultEnabled: false,
 			readme: `# Homey
 
 > Plugin · by FastyBird · platform: devices

--- a/apps/backend/src/plugins/devices-homey/dto/create-channel-property.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/create-channel-property.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { CreateChannelPropertyDto } from '../../../modules/devices/dto/create-channel-property.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginCreateChannelProperty' })
+export class CreateHomeyChannelPropertyDto extends CreateChannelPropertyDto {
+	@ApiProperty({
+		description: 'Channel property type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid channel property type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/create-channel.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/create-channel.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { CreateChannelDto } from '../../../modules/devices/dto/create-channel.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginCreateChannel' })
+export class CreateHomeyChannelDto extends CreateChannelDto {
+	@ApiProperty({
+		description: 'Channel type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid channel type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/create-device.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/create-device.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { CreateDeviceDto } from '../../../modules/devices/dto/create-device.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginCreateDevice' })
+export class CreateHomeyDeviceDto extends CreateDeviceDto {
+	@ApiProperty({
+		description: 'Device type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid device type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/update-channel-property.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-channel-property.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { UpdateChannelPropertyDto } from '../../../modules/devices/dto/update-channel-property.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginUpdateChannelProperty' })
+export class UpdateHomeyChannelPropertyDto extends UpdateChannelPropertyDto {
+	@ApiProperty({
+		description: 'Channel property type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid channel property type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/update-channel.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-channel.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { UpdateChannelDto } from '../../../modules/devices/dto/update-channel.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginUpdateChannel' })
+export class UpdateHomeyChannelDto extends UpdateChannelDto {
+	@ApiProperty({
+		description: 'Channel type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid channel type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Transform } from 'class-transformer';
-import { IsInt, IsOptional, IsString, IsUrl, Max, Min } from 'class-validator';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -13,6 +13,7 @@ import {
 	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
 	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
 } from '../devices-homey.constants';
+import { IsSafeHomeyUrl } from '../validators/homey-url.validator';
 
 @ApiSchema({ name: 'DevicesHomeyPluginUpdateConfig' })
 export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
@@ -31,10 +32,9 @@ export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
 	})
 	@Expose()
 	@IsOptional()
-	@IsUrl(
-		{ protocols: ['http', 'https'], require_protocol: true, require_tld: false },
-		{ message: '[{"field":"url","reason":"URL must use HTTP or HTTPS and include a protocol."}]' },
-	)
+	@IsSafeHomeyUrl({
+		message: '[{"field":"url","reason":"URL must use HTTP or HTTPS without embedded credentials."}]',
+	})
 	url?: string | null;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Transform } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -46,6 +46,7 @@ export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
 	@Expose({ name: 'api_key' })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a valid string."}]' })
+	@Matches(/\S/, { message: '[{"field":"api_key","reason":"API key must contain a non-whitespace character."}]' })
 	apiKey?: string | null;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
@@ -1,0 +1,90 @@
+import { Expose, Transform } from 'class-transformer';
+import { IsInt, IsOptional, IsString, IsUrl, Max, Min } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
+import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+	DEVICES_HOMEY_PLUGIN_NAME,
+	MAX_HOMEY_CONNECTION_TIMEOUT_MS,
+	MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
+	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+} from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginUpdateConfig' })
+export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
+	@ApiProperty({
+		description: 'Plugin type identifier',
+		example: DEVICES_HOMEY_PLUGIN_NAME,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid string."}]' })
+	type: typeof DEVICES_HOMEY_PLUGIN_NAME;
+
+	@ApiPropertyOptional({
+		description: 'Homey local API base URL',
+		example: 'http://homey.local:4859',
+		nullable: true,
+	})
+	@Expose()
+	@IsOptional()
+	@IsUrl(
+		{ protocols: ['http', 'https'], require_protocol: true, require_tld: false },
+		{ message: '[{"field":"url","reason":"URL must use HTTP or HTTPS and include a protocol."}]' },
+	)
+	url?: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Replacement Homey local API key. Omit to preserve the stored key or send null to clear it.',
+		writeOnly: true,
+		nullable: true,
+		name: 'api_key',
+	})
+	@Expose({ name: 'api_key' })
+	@IsOptional()
+	@IsString({ message: '[{"field":"api_key","reason":"API key must be a valid string."}]' })
+	apiKey?: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Connection timeout in milliseconds',
+		example: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+		minimum: MIN_HOMEY_CONNECTION_TIMEOUT_MS,
+		maximum: MAX_HOMEY_CONNECTION_TIMEOUT_MS,
+		name: 'connection_timeout',
+	})
+	@Expose({ name: 'connection_timeout' })
+	@Transform(({ value }: { value: unknown }) => (value === null ? undefined : value))
+	@IsOptional()
+	@IsInt({ message: '[{"field":"connection_timeout","reason":"Connection timeout must be a whole number."}]' })
+	@Min(MIN_HOMEY_CONNECTION_TIMEOUT_MS, {
+		message: `[{"field":"connection_timeout","reason":"Connection timeout must be at least ${MIN_HOMEY_CONNECTION_TIMEOUT_MS}ms."}]`,
+	})
+	@Max(MAX_HOMEY_CONNECTION_TIMEOUT_MS, {
+		message: `[{"field":"connection_timeout","reason":"Connection timeout must be at most ${MAX_HOMEY_CONNECTION_TIMEOUT_MS}ms."}]`,
+	})
+	connectionTimeout?: number;
+
+	@ApiPropertyOptional({
+		description: 'Authoritative inventory reconciliation interval in milliseconds',
+		example: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		minimum: MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+		maximum: MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+		name: 'reconciliation_interval',
+	})
+	@Expose({ name: 'reconciliation_interval' })
+	@Transform(({ value }: { value: unknown }) => (value === null ? undefined : value))
+	@IsOptional()
+	@IsInt({
+		message: '[{"field":"reconciliation_interval","reason":"Reconciliation interval must be a whole number."}]',
+	})
+	@Min(MIN_HOMEY_RECONCILIATION_INTERVAL_MS, {
+		message: `[{"field":"reconciliation_interval","reason":"Reconciliation interval must be at least ${MIN_HOMEY_RECONCILIATION_INTERVAL_MS}ms."}]`,
+	})
+	@Max(MAX_HOMEY_RECONCILIATION_INTERVAL_MS, {
+		message: `[{"field":"reconciliation_interval","reason":"Reconciliation interval must be at most ${MAX_HOMEY_RECONCILIATION_INTERVAL_MS}ms."}]`,
+	})
+	reconciliationInterval?: number;
+}

--- a/apps/backend/src/plugins/devices-homey/dto/update-device.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-device.dto.ts
@@ -1,0 +1,20 @@
+import { Expose } from 'class-transformer';
+import { IsString } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { UpdateDeviceDto } from '../../../modules/devices/dto/update-device.dto';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginUpdateDevice' })
+export class UpdateHomeyDeviceDto extends UpdateDeviceDto {
+	@ApiProperty({
+		description: 'Device type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"type","reason":"Type must be a valid device type string."}]' })
+	readonly type: typeof DEVICES_HOMEY_TYPE;
+}

--- a/apps/backend/src/plugins/devices-homey/entities/devices-homey.entity.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/entities/devices-homey.entity.spec.ts
@@ -1,0 +1,21 @@
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './devices-homey.entity';
+
+describe('Homey entities', () => {
+	it('use the Homey discriminator while retaining generic identifiers', () => {
+		const device = Object.assign(new HomeyDeviceEntity(), { id: 'device-id', identifier: 'homey-device-id' });
+		const channel = Object.assign(new HomeyChannelEntity(), { id: 'channel-id', identifier: 'lighting' });
+		const property = Object.assign(new HomeyChannelPropertyEntity(), {
+			id: 'property-id',
+			identifier: 'measure_temperature.inside',
+		});
+
+		expect(device.type).toBe(DEVICES_HOMEY_TYPE);
+		expect(device.identifier).toBe('homey-device-id');
+		expect(channel.type).toBe(DEVICES_HOMEY_TYPE);
+		expect(channel.identifier).toBe('lighting');
+		expect(property.type).toBe(DEVICES_HOMEY_TYPE);
+		expect(property.identifier).toBe('measure_temperature.inside');
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/entities/devices-homey.entity.ts
+++ b/apps/backend/src/plugins/devices-homey/entities/devices-homey.entity.ts
@@ -1,0 +1,64 @@
+import { Expose } from 'class-transformer';
+import { ChildEntity } from 'typeorm';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../../modules/devices/entities/devices.entity';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginDataDevice' })
+@ChildEntity()
+export class HomeyDeviceEntity extends DeviceEntity {
+	@ApiProperty({
+		description: 'Device type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	get type(): string {
+		return DEVICES_HOMEY_TYPE;
+	}
+
+	toString(): string {
+		return `Homey Device [${this.identifier}] -> Device [${this.id}]`;
+	}
+}
+
+@ApiSchema({ name: 'DevicesHomeyPluginDataChannel' })
+@ChildEntity()
+export class HomeyChannelEntity extends ChannelEntity {
+	@ApiProperty({
+		description: 'Channel type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	get type(): string {
+		return DEVICES_HOMEY_TYPE;
+	}
+
+	toString(): string {
+		return `Homey Channel [${this.identifier}] -> Channel [${this.id}]`;
+	}
+}
+
+@ApiSchema({ name: 'DevicesHomeyPluginDataChannelProperty' })
+@ChildEntity()
+export class HomeyChannelPropertyEntity extends ChannelPropertyEntity {
+	@ApiProperty({
+		description: 'Channel property type',
+		type: 'string',
+		default: DEVICES_HOMEY_TYPE,
+		example: DEVICES_HOMEY_TYPE,
+	})
+	@Expose()
+	get type(): string {
+		return DEVICES_HOMEY_TYPE;
+	}
+
+	toString(): string {
+		return `Homey Capability [${this.identifier}] -> Property [${this.id}]`;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/index.ts
+++ b/apps/backend/src/plugins/devices-homey/index.ts
@@ -1,0 +1,6 @@
+export * from './devices-homey.constants';
+export * from './devices-homey.plugin';
+export * from './dto/update-config.dto';
+export * from './entities/devices-homey.entity';
+export * from './models/config.model';
+export * from './models/status.model';

--- a/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
@@ -64,4 +64,19 @@ describe('Homey configuration', () => {
 		expect(validateSync(config)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
 		expect(validateSync(update)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
 	});
+
+	it('rejects whitespace-only API keys in stored and update configuration', () => {
+		const config = Object.assign(new HomeyConfigModel(), {
+			enabled: true,
+			url: 'http://homey.local:4859',
+			apiKey: '   ',
+		});
+		const update = plainToInstance(HomeyUpdatePluginConfigDto, {
+			type: 'devices-homey-plugin',
+			api_key: '   ',
+		});
+
+		expect(validateSync(config)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'apiKey' })]));
+		expect(validateSync(update)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'apiKey' })]));
+	});
 });

--- a/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
@@ -41,4 +41,16 @@ describe('Homey configuration', () => {
 		expect(update.reconciliationInterval).toBe(60000);
 		expect(validateSync(update)).toEqual([]);
 	});
+
+	it('rejects embedded URL credentials in stored and update configuration', () => {
+		const url = 'http://owner:credential@homey.local:4859';
+		const config = Object.assign(new HomeyConfigModel(), { url });
+		const update = plainToInstance(HomeyUpdatePluginConfigDto, {
+			type: 'devices-homey-plugin',
+			url,
+		});
+
+		expect(validateSync(config)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
+		expect(validateSync(update)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
+	});
 });

--- a/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
@@ -11,6 +11,17 @@ describe('Homey configuration', () => {
 		expect(validateSync(new HomeyConfigModel())).toEqual([]);
 	});
 
+	it('rejects an enabled stored configuration without a URL and API key', () => {
+		const errors = validateSync(Object.assign(new HomeyConfigModel(), { enabled: true }));
+
+		expect(errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ property: 'url' }),
+				expect.objectContaining({ property: 'apiKey' }),
+			]),
+		);
+	});
+
 	it('projects the API key as a configured indicator', () => {
 		const secrets = new ConfigSecretsService();
 		const config = Object.assign(new HomeyConfigModel(), {

--- a/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
@@ -1,0 +1,44 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { ConfigSecretsService } from '../../../modules/config/services/config-secrets.service';
+import { HomeyUpdatePluginConfigDto } from '../dto/update-config.dto';
+
+import { HomeyConfigModel } from './config.model';
+
+describe('Homey configuration', () => {
+	it('keeps the disabled defaults structurally valid', () => {
+		expect(validateSync(new HomeyConfigModel())).toEqual([]);
+	});
+
+	it('projects the API key as a configured indicator', () => {
+		const secrets = new ConfigSecretsService();
+		const config = Object.assign(new HomeyConfigModel(), {
+			url: 'http://homey.local:4859',
+			apiKey: 'configured-secret',
+		});
+
+		const projected = secrets.toPublic(config, [
+			{ path: 'api_key', configuredPath: 'api_key_configured', inputPaths: ['apiKey'] },
+		]) as unknown as Record<string, unknown>;
+
+		expect(projected).not.toHaveProperty('api_key');
+		expect(projected).not.toHaveProperty('apiKey');
+		expect(projected).toHaveProperty('api_key_configured', true);
+		expect(JSON.stringify(projected)).not.toContain('configured-secret');
+	});
+
+	it('accepts snake-case update fields while keeping the API key optional', () => {
+		const update = plainToInstance(HomeyUpdatePluginConfigDto, {
+			type: 'devices-homey-plugin',
+			api_key: 'replacement-secret',
+			connection_timeout: 5000,
+			reconciliation_interval: 60000,
+		});
+
+		expect(update.apiKey).toBe('replacement-secret');
+		expect(update.connectionTimeout).toBe(5000);
+		expect(update.reconciliationInterval).toBe(60000);
+		expect(validateSync(update)).toEqual([]);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateIf } from 'class-validator';
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Matches, Max, Min, ValidateIf } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -46,6 +46,7 @@ export class HomeyConfigModel extends PluginConfigModel {
 	@ValidateIf((config: HomeyConfigModel) => config.enabled || config.apiKey !== null)
 	@IsNotEmpty()
 	@IsString()
+	@Matches(/\S/)
 	apiKey: string | null = null;
 
 	@ApiProperty({

--- a/apps/backend/src/plugins/devices-homey/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.ts
@@ -1,0 +1,82 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional, IsString, IsUrl, Max, Min } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { PluginConfigModel } from '../../../modules/config/models/config.model';
+import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+	DEVICES_HOMEY_PLUGIN_NAME,
+	MAX_HOMEY_CONNECTION_TIMEOUT_MS,
+	MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
+	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+} from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginDataConfig' })
+export class HomeyConfigModel extends PluginConfigModel {
+	@ApiProperty({
+		description: 'Plugin type identifier',
+		example: DEVICES_HOMEY_PLUGIN_NAME,
+	})
+	@Expose()
+	@IsString()
+	type: string = DEVICES_HOMEY_PLUGIN_NAME;
+
+	@ApiPropertyOptional({
+		description: 'Homey local API base URL',
+		example: 'http://homey.local:4859',
+		nullable: true,
+	})
+	@Expose()
+	@IsOptional()
+	@IsUrl({ protocols: ['http', 'https'], require_protocol: true, require_tld: false })
+	url: string | null = null;
+
+	@ApiPropertyOptional({
+		description: 'Homey local API key. This value is accepted on write and never returned.',
+		writeOnly: true,
+		nullable: true,
+		name: 'api_key',
+	})
+	@Expose({ name: 'api_key' })
+	@IsOptional()
+	@IsString()
+	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Homey local API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
+
+	@ApiProperty({
+		description: 'Connection timeout in milliseconds',
+		example: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+		minimum: MIN_HOMEY_CONNECTION_TIMEOUT_MS,
+		maximum: MAX_HOMEY_CONNECTION_TIMEOUT_MS,
+		name: 'connection_timeout',
+	})
+	@Expose({ name: 'connection_timeout' })
+	@IsInt()
+	@Min(MIN_HOMEY_CONNECTION_TIMEOUT_MS)
+	@Max(MAX_HOMEY_CONNECTION_TIMEOUT_MS)
+	connectionTimeout: number = DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS;
+
+	@ApiProperty({
+		description: 'Authoritative inventory reconciliation interval in milliseconds',
+		example: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		minimum: MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+		maximum: MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+		name: 'reconciliation_interval',
+	})
+	@Expose({ name: 'reconciliation_interval' })
+	@IsInt()
+	@Min(MIN_HOMEY_RECONCILIATION_INTERVAL_MS)
+	@Max(MAX_HOMEY_RECONCILIATION_INTERVAL_MS)
+	reconciliationInterval: number = DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS;
+}

--- a/apps/backend/src/plugins/devices-homey/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsBoolean, IsInt, IsOptional, IsString, IsUrl, Max, Min } from 'class-validator';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -13,6 +13,7 @@ import {
 	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
 	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
 } from '../devices-homey.constants';
+import { IsSafeHomeyUrl } from '../validators/homey-url.validator';
 
 @ApiSchema({ name: 'DevicesHomeyPluginDataConfig' })
 export class HomeyConfigModel extends PluginConfigModel {
@@ -31,7 +32,7 @@ export class HomeyConfigModel extends PluginConfigModel {
 	})
 	@Expose()
 	@IsOptional()
-	@IsUrl({ protocols: ['http', 'https'], require_protocol: true, require_tld: false })
+	@IsSafeHomeyUrl()
 	url: string | null = null;
 
 	@ApiPropertyOptional({

--- a/apps/backend/src/plugins/devices-homey/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateIf } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -31,7 +31,8 @@ export class HomeyConfigModel extends PluginConfigModel {
 		nullable: true,
 	})
 	@Expose()
-	@IsOptional()
+	@ValidateIf((config: HomeyConfigModel) => config.enabled || config.url !== null)
+	@IsNotEmpty()
 	@IsSafeHomeyUrl()
 	url: string | null = null;
 
@@ -42,7 +43,8 @@ export class HomeyConfigModel extends PluginConfigModel {
 		name: 'api_key',
 	})
 	@Expose({ name: 'api_key' })
-	@IsOptional()
+	@ValidateIf((config: HomeyConfigModel) => config.enabled || config.apiKey !== null)
+	@IsNotEmpty()
 	@IsString()
 	apiKey: string | null = null;
 

--- a/apps/backend/src/plugins/devices-homey/models/status.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/status.model.ts
@@ -1,0 +1,61 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
+import { ServiceState } from '../../../modules/extensions/services/managed-plugin-service.interface';
+import { HomeyConnectionState } from '../devices-homey.constants';
+
+@ApiSchema({ name: 'DevicesHomeyPluginDataStatus' })
+export class HomeyStatusModel {
+	@ApiProperty({
+		description: 'Managed plugin service lifecycle state',
+		enum: ['stopped', 'starting', 'started', 'stopping', 'error'],
+		name: 'service_state',
+	})
+	@Expose({ name: 'service_state' })
+	@IsString()
+	serviceState: ServiceState;
+
+	@ApiProperty({
+		description: 'Homey transport connection state',
+		enum: HomeyConnectionState,
+		name: 'connection_state',
+	})
+	@Expose({ name: 'connection_state' })
+	@IsEnum(HomeyConnectionState)
+	connectionState: HomeyConnectionState;
+
+	@ApiProperty({ description: 'Whether the plugin is enabled' })
+	@Expose()
+	@IsBoolean()
+	enabled: boolean;
+
+	@ApiProperty({ description: 'Whether the saved local URL and API key are both configured' })
+	@Expose()
+	@IsBoolean()
+	configured: boolean;
+
+	@ApiProperty({ description: 'Whether an active Homey connector is healthy' })
+	@Expose()
+	@IsBoolean()
+	healthy: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Sanitized service error summary',
+		nullable: true,
+		name: 'last_error',
+	})
+	@Expose({ name: 'last_error' })
+	@IsOptional()
+	@IsString()
+	lastError: string | null;
+}
+
+@ApiSchema({ name: 'DevicesHomeyPluginResStatus' })
+export class HomeyStatusResponseModel extends BaseSuccessResponseModel<HomeyStatusModel> {
+	@ApiProperty({ type: HomeyStatusModel })
+	@Expose()
+	declare data: HomeyStatusModel;
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.spec.ts
@@ -1,0 +1,84 @@
+import { PluginConfigValidatorService } from '../../../modules/config/services/plugin-config-validator.service';
+import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+	DEVICES_HOMEY_PLUGIN_NAME,
+} from '../devices-homey.constants';
+
+import { HomeyConfigValidatorService } from './homey-config-validator.service';
+
+describe('HomeyConfigValidatorService', () => {
+	let registry: jest.Mocked<Pick<PluginConfigValidatorService, 'register'>>;
+	let service: HomeyConfigValidatorService;
+
+	beforeEach(() => {
+		registry = { register: jest.fn() };
+		service = new HomeyConfigValidatorService(registry as unknown as PluginConfigValidatorService);
+	});
+
+	it('registers itself for the Homey plugin', () => {
+		service.onModuleInit();
+
+		expect(service.pluginType).toBe(DEVICES_HOMEY_PLUGIN_NAME);
+		expect(registry.register).toHaveBeenCalledWith(service);
+	});
+
+	it('accepts an incomplete disabled configuration without a network request', async () => {
+		await expect(service.validate({ enabled: false })).resolves.toEqual({ valid: true });
+	});
+
+	it('requires a URL when enabled', async () => {
+		await expect(service.validate({ enabled: true, apiKey: 'configured-secret' })).resolves.toEqual({
+			valid: false,
+			errors: [{ message: 'Homey URL is required', field: 'url' }],
+		});
+	});
+
+	it('rejects embedded URL credentials without echoing them', async () => {
+		const result = await service.validate({
+			enabled: true,
+			url: 'http://user:password@homey.local:4859',
+			apiKey: 'configured-secret',
+		});
+
+		expect(result.valid).toBe(false);
+		expect(JSON.stringify(result)).not.toContain('configured-secret');
+		expect(JSON.stringify(result)).not.toContain('password');
+	});
+
+	it('requires an API key when enabled', async () => {
+		const result = await service.validate({ enabled: true, url: 'http://homey.local:4859' });
+
+		expect(result).toEqual({
+			valid: false,
+			errors: [{ message: 'Homey API key is required', field: 'api_key' }],
+		});
+	});
+
+	it('accepts a complete local configuration without connecting', async () => {
+		await expect(
+			service.validate({
+				enabled: true,
+				url: 'http://homey.local:4859',
+				api_key: 'configured-secret',
+				connection_timeout: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+				reconciliation_interval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+			}),
+		).resolves.toEqual({ valid: true });
+	});
+
+	it('rejects timeout and reconciliation values outside their supported ranges', async () => {
+		const base = {
+			enabled: true,
+			url: 'https://homey.local:4860',
+			apiKey: 'configured-secret',
+			connectionTimeout: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+			reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		};
+
+		await expect(service.validate({ ...base, connectionTimeout: 999 })).resolves.toMatchObject({ valid: false });
+		await expect(service.validate({ ...base, reconciliationInterval: 1000 })).resolves.toMatchObject({
+			valid: false,
+		});
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.spec.ts
@@ -55,6 +55,16 @@ describe('HomeyConfigValidatorService', () => {
 		});
 	});
 
+	it('applies interval defaults to a minimal enabled candidate', async () => {
+		await expect(
+			service.validate({
+				enabled: true,
+				url: 'http://homey.local:4859',
+				apiKey: 'configured-secret',
+			}),
+		).resolves.toEqual({ valid: true });
+	});
+
 	it('accepts a complete local configuration without connecting', async () => {
 		await expect(
 			service.validate({

--- a/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
@@ -12,6 +12,7 @@ import {
 	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
 	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
 } from '../devices-homey.constants';
+import { isSafeHomeyUrl } from '../validators/homey-url.validator';
 
 @Injectable()
 export class HomeyConfigValidatorService implements IPluginConfigValidator, OnModuleInit {
@@ -35,7 +36,7 @@ export class HomeyConfigValidatorService implements IPluginConfigValidator, OnMo
 			return Promise.resolve({ valid: false, errors: [{ message: 'Homey URL is required', field: 'url' }] });
 		}
 
-		if (!this.isSafeUrl(url)) {
+		if (!isSafeHomeyUrl(url)) {
 			return Promise.resolve({
 				valid: false,
 				errors: [{ message: 'Homey URL must use HTTP or HTTPS without embedded credentials', field: 'url' }],
@@ -79,16 +80,6 @@ export class HomeyConfigValidatorService implements IPluginConfigValidator, OnMo
 		}
 
 		return Promise.resolve({ valid: true });
-	}
-
-	private isSafeUrl(value: string): boolean {
-		try {
-			const url = new URL(value);
-
-			return ['http:', 'https:'].includes(url.protocol) && url.username.length === 0 && url.password.length === 0;
-		} catch {
-			return false;
-		}
 	}
 
 	private isIntegerInRange(value: unknown, minimum: number, maximum: number): boolean {

--- a/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+
+import type {
+	IConfigValidationResult,
+	IPluginConfigValidator,
+} from '../../../modules/config/services/plugin-config-validator.service';
+import { PluginConfigValidatorService } from '../../../modules/config/services/plugin-config-validator.service';
+import {
+	DEVICES_HOMEY_PLUGIN_NAME,
+	MAX_HOMEY_CONNECTION_TIMEOUT_MS,
+	MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
+	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+} from '../devices-homey.constants';
+
+@Injectable()
+export class HomeyConfigValidatorService implements IPluginConfigValidator, OnModuleInit {
+	readonly pluginType = DEVICES_HOMEY_PLUGIN_NAME;
+
+	constructor(private readonly pluginConfigValidator: PluginConfigValidatorService) {}
+
+	onModuleInit(): void {
+		this.pluginConfigValidator.register(this);
+	}
+
+	validate(config: Record<string, unknown>): Promise<IConfigValidationResult> {
+		if (config['enabled'] !== true) {
+			return Promise.resolve({ valid: true });
+		}
+
+		const url = config['url'];
+		const apiKey = config['apiKey'] ?? config['api_key'];
+
+		if (typeof url !== 'string' || url.trim().length === 0) {
+			return Promise.resolve({ valid: false, errors: [{ message: 'Homey URL is required', field: 'url' }] });
+		}
+
+		if (!this.isSafeUrl(url)) {
+			return Promise.resolve({
+				valid: false,
+				errors: [{ message: 'Homey URL must use HTTP or HTTPS without embedded credentials', field: 'url' }],
+			});
+		}
+
+		if (typeof apiKey !== 'string' || apiKey.trim().length === 0) {
+			return Promise.resolve({
+				valid: false,
+				errors: [{ message: 'Homey API key is required', field: 'api_key' }],
+			});
+		}
+
+		const connectionTimeout = config['connectionTimeout'] ?? config['connection_timeout'];
+
+		if (!this.isIntegerInRange(connectionTimeout, MIN_HOMEY_CONNECTION_TIMEOUT_MS, MAX_HOMEY_CONNECTION_TIMEOUT_MS)) {
+			return Promise.resolve({
+				valid: false,
+				errors: [{ message: 'Homey connection timeout is outside the supported range', field: 'connection_timeout' }],
+			});
+		}
+
+		const reconciliationInterval = config['reconciliationInterval'] ?? config['reconciliation_interval'];
+
+		if (
+			!this.isIntegerInRange(
+				reconciliationInterval,
+				MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
+				MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
+			)
+		) {
+			return Promise.resolve({
+				valid: false,
+				errors: [
+					{
+						message: 'Homey reconciliation interval is outside the supported range',
+						field: 'reconciliation_interval',
+					},
+				],
+			});
+		}
+
+		return Promise.resolve({ valid: true });
+	}
+
+	private isSafeUrl(value: string): boolean {
+		try {
+			const url = new URL(value);
+
+			return ['http:', 'https:'].includes(url.protocol) && url.username.length === 0 && url.password.length === 0;
+		} catch {
+			return false;
+		}
+	}
+
+	private isIntegerInRange(value: unknown, minimum: number, maximum: number): boolean {
+		return typeof value === 'number' && Number.isInteger(value) && value >= minimum && value <= maximum;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-config-validator.service.ts
@@ -6,6 +6,8 @@ import type {
 } from '../../../modules/config/services/plugin-config-validator.service';
 import { PluginConfigValidatorService } from '../../../modules/config/services/plugin-config-validator.service';
 import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
 	DEVICES_HOMEY_PLUGIN_NAME,
 	MAX_HOMEY_CONNECTION_TIMEOUT_MS,
 	MAX_HOMEY_RECONCILIATION_INTERVAL_MS,
@@ -50,7 +52,8 @@ export class HomeyConfigValidatorService implements IPluginConfigValidator, OnMo
 			});
 		}
 
-		const connectionTimeout = config['connectionTimeout'] ?? config['connection_timeout'];
+		const connectionTimeout =
+			config['connectionTimeout'] ?? config['connection_timeout'] ?? DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS;
 
 		if (!this.isIntegerInRange(connectionTimeout, MIN_HOMEY_CONNECTION_TIMEOUT_MS, MAX_HOMEY_CONNECTION_TIMEOUT_MS)) {
 			return Promise.resolve({
@@ -59,7 +62,8 @@ export class HomeyConfigValidatorService implements IPluginConfigValidator, OnMo
 			});
 		}
 
-		const reconciliationInterval = config['reconciliationInterval'] ?? config['reconciliation_interval'];
+		const reconciliationInterval =
+			config['reconciliationInterval'] ?? config['reconciliation_interval'] ?? DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS;
 
 		if (
 			!this.isIntegerInRange(

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -52,7 +52,7 @@ describe('HomeyService', () => {
 			throw new Error('raw configuration detail');
 		});
 
-		await expect(service.start()).rejects.toThrow('raw configuration detail');
+		await expect(service.start()).rejects.toThrow('Homey service failed to start');
 		expect(service.getState()).toBe('error');
 		expect(service.getStatus().lastError).toBe('Homey service failed to start');
 	});

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -72,6 +72,21 @@ describe('HomeyService', () => {
 		expect(status).not.toHaveProperty('url');
 	});
 
+	it('reads current configuration for each status snapshot while stopped', () => {
+		expect(service.getStatus()).toMatchObject({ enabled: true, configured: true });
+
+		configService.getPluginConfig.mockReturnValue(
+			Object.assign(new HomeyConfigModel(), {
+				enabled: false,
+				url: null,
+				apiKey: null,
+			}),
+		);
+
+		expect(service.getStatus()).toMatchObject({ enabled: false, configured: false });
+		expect(configService.getPluginConfig).toHaveBeenCalledTimes(2);
+	});
+
 	it('requests a restart only when connector configuration changes', async () => {
 		await service.start();
 

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -1,0 +1,86 @@
+import { ConfigService } from '../../../modules/config/services/config.service';
+import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+	DEVICES_HOMEY_CONNECTOR_SERVICE_ID,
+	DEVICES_HOMEY_PLUGIN_NAME,
+	HomeyConnectionState,
+} from '../devices-homey.constants';
+import { HomeyConfigModel } from '../models/config.model';
+
+import { HomeyService } from './homey.service';
+
+describe('HomeyService', () => {
+	let config: HomeyConfigModel;
+	let configService: jest.Mocked<Pick<ConfigService, 'getPluginConfig'>>;
+	let service: HomeyService;
+
+	beforeEach(() => {
+		config = Object.assign(new HomeyConfigModel(), {
+			enabled: true,
+			url: 'http://homey.local:4859',
+			apiKey: 'configured-secret',
+			connectionTimeout: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+			reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		});
+		configService = { getPluginConfig: jest.fn().mockReturnValue(config) };
+		service = new HomeyService(configService as unknown as ConfigService);
+	});
+
+	it('exposes the managed connector identity and starts stopped', () => {
+		expect(service.pluginName).toBe(DEVICES_HOMEY_PLUGIN_NAME);
+		expect(service.serviceId).toBe(DEVICES_HOMEY_CONNECTOR_SERVICE_ID);
+		expect(service.getState()).toBe('stopped');
+	});
+
+	it('starts and stops idempotently without opening a transport', async () => {
+		await service.start();
+		await service.start();
+
+		expect(service.getState()).toBe('started');
+		expect(configService.getPluginConfig).toHaveBeenCalledTimes(1);
+		expect(await service.isHealthy()).toBe(false);
+
+		await service.stop();
+		await service.stop();
+
+		expect(service.getState()).toBe('stopped');
+	});
+
+	it('enters error state with a sanitized status if configuration loading fails', async () => {
+		configService.getPluginConfig.mockImplementation(() => {
+			throw new Error('raw configuration detail');
+		});
+
+		await expect(service.start()).rejects.toThrow('raw configuration detail');
+		expect(service.getState()).toBe('error');
+		expect(service.getStatus().lastError).toBe('Homey service failed to start');
+	});
+
+	it('reports configuration without exposing its URL or API key', () => {
+		const status = service.getStatus();
+
+		expect(status).toMatchObject({
+			serviceState: 'stopped',
+			connectionState: HomeyConnectionState.STOPPED,
+			enabled: true,
+			configured: true,
+			healthy: false,
+			lastError: null,
+		});
+		expect(status).not.toHaveProperty('apiKey');
+		expect(status).not.toHaveProperty('url');
+	});
+
+	it('requests a restart only when connector configuration changes', async () => {
+		await service.start();
+
+		expect(await service.onConfigChanged()).toEqual({ restartRequired: false });
+
+		configService.getPluginConfig.mockReturnValue(
+			Object.assign(new HomeyConfigModel(), config, { apiKey: 'next-key' }),
+		);
+
+		expect(await service.onConfigChanged()).toEqual({ restartRequired: true });
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -1,0 +1,133 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { ConfigService } from '../../../modules/config/services/config.service';
+import { BaseManagedPluginService } from '../../../modules/extensions/services/base-managed-plugin.service';
+import { ConfigChangeResult } from '../../../modules/extensions/services/managed-plugin-service.interface';
+import {
+	DEVICES_HOMEY_CONNECTOR_SERVICE_ID,
+	DEVICES_HOMEY_PLUGIN_NAME,
+	HomeyConnectionState,
+} from '../devices-homey.constants';
+import { HomeyConfigModel } from '../models/config.model';
+import { HomeyStatusModel } from '../models/status.model';
+
+@Injectable()
+export class HomeyService extends BaseManagedPluginService {
+	private readonly logger = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'HomeyService');
+
+	readonly pluginName = DEVICES_HOMEY_PLUGIN_NAME;
+	readonly serviceId = DEVICES_HOMEY_CONNECTOR_SERVICE_ID;
+
+	private pluginConfig: HomeyConfigModel | null = null;
+	private lastError: string | null = null;
+
+	constructor(private readonly configService: ConfigService) {
+		super();
+	}
+
+	async start(): Promise<void> {
+		await this.withLock(() => {
+			if (this.state === 'started') {
+				return Promise.resolve();
+			}
+
+			this.state = 'starting';
+			this.pluginConfig = null;
+			this.lastError = null;
+
+			try {
+				this.getPluginConfig();
+
+				// The live connector is introduced by Task 2.1. Until then the
+				// managed shell deliberately performs no network activity.
+				this.state = 'started';
+				this.logger.log('Homey plugin shell started; connector is not initialized yet');
+			} catch (error) {
+				this.state = 'error';
+				this.lastError = 'Homey service failed to start';
+				this.logger.error(this.lastError);
+
+				throw error;
+			}
+
+			return Promise.resolve();
+		});
+	}
+
+	async stop(): Promise<void> {
+		await this.withLock(() => {
+			if (this.state === 'stopped') {
+				return Promise.resolve();
+			}
+
+			this.state = 'stopping';
+			this.pluginConfig = null;
+			this.state = 'stopped';
+			this.logger.log('Homey plugin shell stopped');
+
+			return Promise.resolve();
+		});
+	}
+
+	onConfigChanged(): Promise<ConfigChangeResult> {
+		if (this.state === 'started' && this.pluginConfig) {
+			const previous = this.pluginConfig;
+			const next = this.configService.getPluginConfig<HomeyConfigModel>(DEVICES_HOMEY_PLUGIN_NAME);
+			const restartRequired =
+				previous.url !== next.url ||
+				previous.apiKey !== next.apiKey ||
+				previous.connectionTimeout !== next.connectionTimeout ||
+				previous.reconciliationInterval !== next.reconciliationInterval;
+
+			return Promise.resolve({ restartRequired });
+		}
+
+		this.pluginConfig = null;
+
+		return Promise.resolve({ restartRequired: false });
+	}
+
+	isHealthy(): Promise<boolean> {
+		return Promise.resolve(false);
+	}
+
+	getStatus(): HomeyStatusModel {
+		const config = this.getPluginConfigOrDefault();
+		const status = new HomeyStatusModel();
+
+		status.serviceState = this.getState();
+		status.connectionState = HomeyConnectionState.STOPPED;
+		status.enabled = config.enabled;
+		status.configured = this.isConfigured(config);
+		status.healthy = false;
+		status.lastError = this.lastError;
+
+		return status;
+	}
+
+	private getPluginConfig(): HomeyConfigModel {
+		if (!this.pluginConfig) {
+			this.pluginConfig = this.configService.getPluginConfig<HomeyConfigModel>(DEVICES_HOMEY_PLUGIN_NAME);
+		}
+
+		return this.pluginConfig;
+	}
+
+	private getPluginConfigOrDefault(): HomeyConfigModel {
+		try {
+			return this.getPluginConfig();
+		} catch {
+			return new HomeyConfigModel();
+		}
+	}
+
+	private isConfigured(config: HomeyConfigModel): boolean {
+		return (
+			typeof config.url === 'string' &&
+			config.url.trim().length > 0 &&
+			typeof config.apiKey === 'string' &&
+			config.apiKey.trim().length > 0
+		);
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -93,7 +93,7 @@ export class HomeyService extends BaseManagedPluginService {
 	}
 
 	getStatus(): HomeyStatusModel {
-		const config = this.getPluginConfigOrDefault();
+		const config = this.getCurrentPluginConfigOrDefault();
 		const status = new HomeyStatusModel();
 
 		status.serviceState = this.getState();
@@ -114,9 +114,9 @@ export class HomeyService extends BaseManagedPluginService {
 		return this.pluginConfig;
 	}
 
-	private getPluginConfigOrDefault(): HomeyConfigModel {
+	private getCurrentPluginConfigOrDefault(): HomeyConfigModel {
 		try {
-			return this.getPluginConfig();
+			return this.configService.getPluginConfig<HomeyConfigModel>(DEVICES_HOMEY_PLUGIN_NAME);
 		} catch {
 			return new HomeyConfigModel();
 		}

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -43,12 +43,12 @@ export class HomeyService extends BaseManagedPluginService {
 				// managed shell deliberately performs no network activity.
 				this.state = 'started';
 				this.logger.log('Homey plugin shell started; connector is not initialized yet');
-			} catch (error) {
+			} catch {
 				this.state = 'error';
 				this.lastError = 'Homey service failed to start';
 				this.logger.error(this.lastError);
 
-				throw error;
+				throw new Error(this.lastError);
 			}
 
 			return Promise.resolve();

--- a/apps/backend/src/plugins/devices-homey/validators/homey-url.validator.ts
+++ b/apps/backend/src/plugins/devices-homey/validators/homey-url.validator.ts
@@ -1,0 +1,27 @@
+import { ValidateBy, ValidationOptions } from 'class-validator';
+
+export const isSafeHomeyUrl = (value: unknown): value is string => {
+	if (typeof value !== 'string') {
+		return false;
+	}
+
+	try {
+		const url = new URL(value);
+
+		return ['http:', 'https:'].includes(url.protocol) && url.username.length === 0 && url.password.length === 0;
+	} catch {
+		return false;
+	}
+};
+
+export const IsSafeHomeyUrl = (validationOptions?: ValidationOptions): PropertyDecorator =>
+	ValidateBy(
+		{
+			name: 'isSafeHomeyUrl',
+			validator: {
+				validate: isSafeHomeyUrl,
+				defaultMessage: () => 'Homey URL must use HTTP or HTTPS without embedded credentials',
+			},
+		},
+		validationOptions,
+	);

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -170,14 +170,14 @@ devices-homey.plugin.ts
 index.ts
 ```
 
-- [ ] Define plugin name/type, API tag, config keys, injection tokens, default timeouts/intervals, and health states.
-- [ ] Add Homey device entity discriminator by following the closest provider entity pattern.
-- [ ] Register the plugin through the repository's backend plugin mechanism.
-- [ ] Extend the managed plugin lifecycle base used by current providers.
-- [ ] Add local config DTO/model with URL, write-only API key mutation fields, timeout, reconciliation interval, and disabled/enabled state.
-- [ ] Register config validation/mutation and secret metadata.
-- [ ] Add a placeholder status response and controller using standard response envelopes.
-- [ ] Add plugin bootstrap/config tests, including disabled and incomplete configuration states.
+- [x] Define plugin name/type, API tag, config keys, injection tokens, default timeouts/intervals, and health states.
+- [x] Add Homey device entity discriminator by following the closest provider entity pattern.
+- [x] Register the plugin through the repository's backend plugin mechanism.
+- [x] Extend the managed plugin lifecycle base used by current providers.
+- [x] Add local config DTO/model with URL, write-only API key mutation fields, timeout, reconciliation interval, and disabled/enabled state.
+- [x] Register config validation/mutation and secret metadata.
+- [x] Add a placeholder status response and controller using standard response envelopes.
+- [x] Add plugin bootstrap/config tests, including disabled and incomplete configuration states.
 
 **Verification:** Targeted Jest tests and `pnpm run lint:js`.
 


### PR DESCRIPTION
Establishes the backend foundation for Homey as a native Smart Panel device provider.

## What changed

- register the `devices-homey` plugin in the backend application and plugin router
- add Homey device, channel, and property discriminators using the generic scoped identifiers
- add local configuration for URL, write-only API key, bounded connection timeout, and reconciliation interval
- register generic secret metadata so API responses expose only `api_key_configured`
- add structural configuration validation without performing network requests
- add a managed plugin lifecycle shell and secret-free status endpoint
- register Swagger/OpenAPI models and extension metadata
- mark implementation-plan Task 1.2 complete

## Why

The Homey integration needs a secure, transport-independent plugin boundary before the live SHS connector, discovery, mapping, adoption, synchronization, and control layers can be implemented. This slice deliberately performs no Homey network activity and adds no SDK dependency; those decisions remain gated by the live compatibility spike and sanitized fixture capture.

## Impact

When disabled, the incomplete default configuration remains valid and does not start the managed service. When enabled, a safe HTTP/HTTPS URL and API key are required. The placeholder status endpoint reports lifecycle/configuration state without returning the URL or API key, and adopted-device persistence can later reuse the existing provider-scoped generic identifiers without a migration.

## Validation

- `pnpm --filter @fastybird/smart-panel-backend exec jest src/plugins/devices-homey --runInBand` — 6 suites, 21 tests passed
- `pnpm --filter @fastybird/smart-panel-backend type-check` — passed
- `pnpm --filter @fastybird/smart-panel-backend lint:js` — passed with 2 pre-existing unrelated warnings
- `pnpm --filter @fastybird/smart-panel-backend exec jest --config ./test/jest-e2e.json test/app.e2e-spec.ts --runInBand` — 7 tests passed
- `pnpm run generate:openapi` — generated 263 endpoints and admin types successfully


