### PR TITLE
test(backend): cover active access-token revocation

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -118,6 +118,8 @@ describe('MCP OAuth listen registration race', () => {
 		let client: Client | undefined;
 		let expiryClient: Client | undefined;
 		let grantExpiryClient: Client | undefined;
+		let accessTokenRevocationClient: Client | undefined;
+		let accessTokenSiblingClient: Client | undefined;
 		let refreshFamilyRevocationClient: Client | undefined;
 		let grantRevocationClient: Client | undefined;
 		const releaseListen = deferred();
@@ -402,6 +404,112 @@ describe('MCP OAuth listen registration race', () => {
 			await grantExpiryClient.close();
 			grantExpiryClient = undefined;
 
+			const activeRevocationAccessToken = 'listen-active-revocation-access-token';
+			const siblingAccessToken = 'listen-active-revocation-sibling-access-token';
+
+			await accessTokens.upsert(
+				activeRevocationAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			await accessTokens.upsert(
+				siblingAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			const activeRevocationAccessArtifact = await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.findOneByOrFail({ model: 'AccessToken', idHash: hashToken(activeRevocationAccessToken) });
+			const siblingAccessArtifact = await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.findOneByOrFail({ model: 'AccessToken', idHash: hashToken(siblingAccessToken) });
+			accessTokenRevocationClient = new Client(
+				{ name: 'listen-access-token-revocation-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const accessTokenRevocationTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${activeRevocationAccessToken}` } },
+			});
+			accessTokenSiblingClient = new Client(
+				{ name: 'listen-access-token-sibling-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			const accessTokenSiblingTransport = new StreamableHTTPClientTransport(endpoint, {
+				requestInit: { headers: { Authorization: `Bearer ${siblingAccessToken}` } },
+			});
+
+			await accessTokenRevocationClient.connect(accessTokenRevocationTransport);
+			await accessTokenSiblingClient.connect(accessTokenSiblingTransport);
+			const accessTokenRevokedSubscription = await accessTokenRevocationClient.listen({ toolsListChanged: true });
+			const accessTokenSiblingSubscription = await accessTokenSiblingClient.listen({ toolsListChanged: true });
+
+			expect(subscriptions.activeCount).toBe(2);
+			await management.revokeAccessToken(activeRevocationAccessArtifact.managementId, 'owner-actor');
+			await expect(accessTokenRevokedSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(1);
+			expect(auditLog).toHaveBeenCalledWith(
+				'MCP audit event',
+				expect.objectContaining({ event: 'subscription_close', reason: 'authorization_revoked' }),
+			);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_management',
+				request_id: 'administrative',
+				actor_id: 'owner-actor',
+				artifact: 'access_token',
+				artifact_id: activeRevocationAccessArtifact.managementId,
+				action: 'revoked',
+			});
+			await expect(resourceServer.verifyAccessToken(activeRevocationAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await expect(resourceServer.verifyAccessToken(siblingAccessToken)).resolves.toMatchObject({
+				clientId: oauthClient.clientIdentifier,
+			});
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
+					model: 'AccessToken',
+					idHash: hashToken(activeRevocationAccessToken),
+				}),
+			).toBeNull();
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).findOneBy({
+					model: 'AccessToken',
+					managementId: siblingAccessArtifact.managementId,
+				}),
+			).not.toBeNull();
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grant.id })).revokedAt,
+			).toBeNull();
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({
+					model: 'Grant',
+					idHash: hashToken(rawGrantId),
+				}),
+			).toBe(true);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(activeRevocationAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(siblingAccessToken);
+			await accessTokenRevocationClient.close();
+			accessTokenRevocationClient = undefined;
+			await accessTokenSiblingSubscription.close();
+			await expect(accessTokenSiblingSubscription.closed).resolves.toBe('local');
+			await accessTokenSiblingClient.close();
+			accessTokenSiblingClient = undefined;
+			expect(subscriptions.activeCount).toBe(0);
+
 			jest
 				.spyOn(serverService, 'handleOAuth')
 				.mockImplementation(
@@ -612,6 +720,8 @@ describe('MCP OAuth listen registration race', () => {
 			releaseListen.resolve();
 			await expiryClient?.close();
 			await grantExpiryClient?.close();
+			await accessTokenRevocationClient?.close();
+			await accessTokenSiblingClient?.close();
 			await refreshFamilyRevocationClient?.close();
 			await grantRevocationClient?.close();
 			await client?.close();

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -418,6 +418,9 @@ amend ADR 0002.
       record `authorization_expired` rather than treating expiry as administrative revocation.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the grant authorization deadline and record
       `authorization_expired` rather than treating expiry as administrative revocation.
+- [x] Provider-backed wire E2E: revoke an active access token through the management service, close its live
+      subscription as `authorization_revoked`, delete only that token artifact, reject subsequent bearer reuse, and
+      preserve a sibling token's live stream and the grant.
 - [x] Provider-backed wire E2E: revoke an active grant through the management service, close its live subscription as
       `authorization_revoked`, delete its provider artifacts, and reject subsequent bearer reuse.
 - [x] Provider-backed wire E2E: revoke an active refresh family through the management service, close its live


### PR DESCRIPTION
## Summary

- add provider-backed wire E2E coverage for revoking an active MCP OAuth access token
- prove token-level isolation by keeping a sibling token stream and grant active
- verify remote stream closure, bearer rejection, artifact deletion, audit identity, and raw-token redaction
- record the completed Phase 6 coverage slice in the implementation plan

## Why

Phase 6 already covered active grant and refresh-family revocation, while access-token revocation was only exercised against an in-flight registration. This closes the remaining wire-level gap for an already-active subscription and proves revocation remains scoped to the selected token.

## Validation

- focused E2E repeated three times
- backend type-check
- focused backend ESLint
- full backend E2E: 15 suites, 134 tests passed
- git diff --check