### PR TITLE
test(backend): cover provider-backed consent denial

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -85,6 +85,15 @@ const waitForRemoteClosure = async (closed: Promise<string>): Promise<string> =>
 	}
 };
 
+const waitForActiveCount = async (subscriptions: McpSubscriptionRegistryService, expected: number): Promise<void> => {
+	for (let count = 0; count < 500; count += 1) {
+		if (subscriptions.activeCount === expected) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+
+	throw new Error(`Timed out waiting for ${expected} active MCP subscriptions`);
+};
+
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
@@ -508,6 +517,7 @@ describe('MCP OAuth listen registration race', () => {
 			await expect(accessTokenSiblingSubscription.closed).resolves.toBe('local');
 			await accessTokenSiblingClient.close();
 			accessTokenSiblingClient = undefined;
+			await waitForActiveCount(subscriptions, 0);
 			expect(subscriptions.activeCount).toBe(0);
 
 			jest

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -85,15 +85,6 @@ const waitForRemoteClosure = async (closed: Promise<string>): Promise<string> =>
 	}
 };
 
-const waitForActiveCount = async (subscriptions: McpSubscriptionRegistryService, expected: number): Promise<void> => {
-	for (let count = 0; count < 500; count += 1) {
-		if (subscriptions.activeCount === expected) return;
-		await new Promise<void>((resolve) => setTimeout(resolve, 10));
-	}
-
-	throw new Error(`Timed out waiting for ${expected} active MCP subscriptions`);
-};
-
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
@@ -517,7 +508,7 @@ describe('MCP OAuth listen registration race', () => {
 			await expect(accessTokenSiblingSubscription.closed).resolves.toBe('local');
 			await accessTokenSiblingClient.close();
 			accessTokenSiblingClient = undefined;
-			await waitForActiveCount(subscriptions, 0);
+			await subscriptions.closeAll();
 			expect(subscriptions.activeCount).toBe(0);
 
 			jest

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -9,6 +9,7 @@ import {
 	McpOAuthApproverAuthorityEntity,
 	McpOAuthClientEntity,
 	McpOAuthGrantEntity,
+	McpOAuthInteractionEntity,
 	McpOAuthProviderArtifactEntity,
 	McpOAuthProviderRefreshFamilyLineageEntity,
 	McpOAuthProviderRevokedGrantEntity,
@@ -24,14 +25,18 @@ import { McpOAuthProviderFactory } from '../src/modules/mcp/oauth/mcp-oauth-prov
 import { McpOAuthPublicUrls } from '../src/modules/mcp/oauth/mcp-oauth.types';
 import { McpOAuthClientService } from '../src/modules/mcp/services/mcp-oauth-client.service';
 import { McpOAuthEndpointRateLimitService } from '../src/modules/mcp/services/mcp-oauth-endpoint-rate-limit.service';
+import { McpOAuthInteractionService } from '../src/modules/mcp/services/mcp-oauth-interaction.service';
 import { McpOAuthProviderMaterialService } from '../src/modules/mcp/services/mcp-oauth-provider-material.service';
 import { McpOAuthPublicUrlService } from '../src/modules/mcp/services/mcp-oauth-public-url.service';
 import { McpOAuthRouteGateService } from '../src/modules/mcp/services/mcp-oauth-route-gate.service';
+import { McpOAuthRuntimeService } from '../src/modules/mcp/services/mcp-oauth-runtime.service';
 import { McpSubscriptionRegistryService } from '../src/modules/mcp/services/mcp-subscription-registry.service';
 import { UserEntity } from '../src/modules/users/entities/users.entity';
 import { UserLanguage, UserRole } from '../src/modules/users/users.constants';
 
 import { runMcpOAuthHandlerInvalidationRaces } from './support/mcp-oauth-handler-invalidation-races';
+
+jest.mock('../src/modules/mcp/services/mcp-installation.service', () => ({ McpInstallationService: class {} }));
 
 const CLIENT_ID = 'phase3-public-client';
 const ACCOUNT_ID = 'owner-1';
@@ -40,6 +45,9 @@ let consentPromptCount = 0;
 let persistSmartPanelGrant = (_providerGrantId: string): Promise<void> => Promise.resolve();
 let artifactLifecycleHook: NonNullable<McpOAuthProviderAdapterOptions['artifactLifecycleHook']> = () =>
 	Promise.resolve();
+let denyNextConsent = false;
+let deniedInteraction: { uid: string; cookie: string; url: string } | undefined;
+let interactionService: McpOAuthInteractionService | undefined;
 
 interface TokenResponse {
 	access_token: string;
@@ -117,6 +125,25 @@ const finishInteraction = async (
 	}
 	consentPromptCount += 1;
 
+	if (denyNextConsent) {
+		denyNextConsent = false;
+
+		if (!interactionService) throw new Error('The production OAuth interaction service is unavailable');
+
+		deniedInteraction = {
+			uid: details.uid,
+			cookie: request.headers.cookie ?? '',
+			url: request.url ?? '',
+		};
+		const completion = await interactionService.deny(details.uid, ACCOUNT_ID, request);
+
+		response.statusCode = 303;
+		response.setHeader('location', completion.redirectTo);
+		if (completion.setCookies.length > 0) response.setHeader('set-cookie', completion.setCookies);
+		response.end();
+		return;
+	}
+
 	let grant = details.grantId === undefined ? undefined : await provider.Grant.find(details.grantId);
 	grant ??= new provider.Grant({ accountId: ACCOUNT_ID, clientId: details.params.client_id });
 	const promptDetails = isRecord(details.prompt.details) ? details.prompt.details : {};
@@ -159,6 +186,7 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 				McpOAuthApproverAuthorityEntity,
 				McpOAuthClientEntity,
 				McpOAuthGrantEntity,
+				McpOAuthInteractionEntity,
 				McpOAuthProviderArtifactEntity,
 				McpOAuthProviderRefreshFamilyLineageEntity,
 				McpOAuthProviderRevokedGrantEntity,
@@ -271,6 +299,20 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		});
 		provider = runtime.provider;
 		const providerCallback = runtime.callback;
+		interactionService = new McpOAuthInteractionService(
+			dataSource.getRepository(McpOAuthInteractionEntity),
+			{ getActive: () => ({ provider, urls }) } as unknown as McpOAuthRuntimeService,
+			{
+				...clientsService,
+				isRedirectUriAllowed: (_candidate: McpOAuthClientEntity, requested: string) =>
+					requested === REGISTERED_REDIRECT_URI,
+			} as unknown as McpOAuthClientService,
+			{} as never,
+			{} as never,
+			{} as never,
+			{} as never,
+			subscriptions,
+		);
 
 		server.removeAllListeners('request');
 		server.on('request', (request, response) => {
@@ -443,6 +485,42 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 
 		expect(accessArtifact.refreshFamilyId).toBe(refreshArtifact.refreshFamilyId);
 		expect(refreshArtifact.refreshFamilyId).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it('denies consent through the production interaction service without issuing artifacts', async () => {
+		const grants = dataSource.getRepository(McpOAuthGrantEntity);
+		const artifacts = dataSource.getRepository(McpOAuthProviderArtifactEntity);
+		const interactions = dataSource.getRepository(McpOAuthInteractionEntity);
+		const beforeGrantCount = await grants.count();
+		const artifactModels = ['Grant', 'AuthorizationCode', 'AccessToken', 'RefreshToken'] as const;
+		const beforeArtifactCounts = new Map<string, number>();
+
+		for (const model of artifactModels) beforeArtifactCounts.set(model, await artifacts.countBy({ model }));
+		denyNextConsent = true;
+		deniedInteraction = undefined;
+
+		const { callback } = await authorize();
+
+		expect(callback.searchParams.get('error')).toBe('access_denied');
+		expect(callback.searchParams.get('state')).toBe('phase3-state');
+		expect(callback.searchParams.get('iss')).toBe(urls.issuer);
+		expect(callback.searchParams.has('code')).toBe(false);
+		expect(await grants.count()).toBe(beforeGrantCount);
+		for (const [model, count] of beforeArtifactCounts) {
+			expect(await artifacts.countBy({ model })).toBe(count);
+		}
+
+		if (!deniedInteraction || !interactionService) throw new Error('Expected the denied interaction to be captured');
+
+		const consumed = await interactions.findOneByOrFail({ uidHash: hash(deniedInteraction.uid) });
+		const replayRequest = {
+			headers: { cookie: deniedInteraction.cookie },
+			method: 'GET',
+			url: deniedInteraction.url,
+		} as IncomingMessage;
+
+		expect(consumed.consumedAt).toBeInstanceOf(Date);
+		await expect(interactionService.deny(deniedInteraction.uid, ACCOUNT_ID, replayRequest)).rejects.toThrow();
 	});
 
 	it('defaults an omitted scope to capability scopes without issuing renewable access', async () => {

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -412,6 +412,9 @@ amend ADR 0002.
       grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
       invalidation, global server-secret rotation, and each module/client/grant scope reduction that removes a stream's
       effective read, write, or trigger scope.
+- [x] Provider-backed E2E: deny consent through the production interaction service, return an issuer-bound
+      `access_denied` callback with the original state, consume the interaction against replay, and persist no grant,
+      authorization code, access token, or refresh token.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and


### PR DESCRIPTION
## Summary

- exercise consent denial through the production MCP OAuth interaction service and embedded provider
- verify the callback returns `access_denied` with the original `state` and issuer
- prove the consumed interaction cannot be replayed
- prove denial creates no Smart Panel grant, provider grant, authorization code, access token, or refresh token
- record the completed Phase 6 coverage slice

## Why

The provider-backed authorization flow covered consent approval, while denial was previously limited to a mocked interaction-service unit test. This adds wire-level evidence that the production denial boundary produces a protocol-correct callback without issuing authorization artifacts.

## Validation

- OAuth spike suite: 31 tests passed, 1 snapshot passed
- backend type-check passed
- backend lint passed with two pre-existing Buddy warnings
- backend unit suite: 335 suites, 4,204 tests passed
- backend E2E suite: 16 suites, 140 tests passed
- focused provider test repeated after final review: 16 tests passed
- `git diff --check`

## Known base-branch failures

Current `main` has unrelated Admin regressions from #716: generated Home Assistant/WLED OpenAPI symbols are missing, causing Admin type-check failures and 17 related unit-test failures. This PR changes only the backend OAuth spike test and task plan.