### PR TITLE
test(backend): cover active OAuth client disable

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.spec.ts
@@ -681,6 +681,16 @@ describe('McpOAuthManagementService', () => {
 		expect(other.signal.aborted).toBe(false);
 		expect((await service.getGrant(grant.id)).active).toBe(false);
 		expect(await service.findAccessTokens()).toEqual([expect.objectContaining({ clientId: otherClient.id })]);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.existsBy({ model: 'Grant', idHash: grant.providerGrantIdHash }),
+		).toBe(false);
+		expect(
+			await dataSource
+				.getRepository(McpOAuthProviderArtifactEntity)
+				.existsBy({ model: 'Grant', idHash: otherGrant.providerGrantIdHash }),
+		).toBe(true);
 	});
 
 	it('preserves metadata updates when a client is disabled through PATCH', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-management.service.ts
@@ -183,7 +183,9 @@ export class McpOAuthManagementService {
 						grantHashes.map((grantIdHash) => ({ grantIdHash, revokedAt: revokedAt.getTime() })),
 						['grantIdHash'],
 					);
-					await manager.getRepository(McpOAuthProviderArtifactEntity).delete({ grantIdHash: In(grantHashes) });
+					const artifacts = manager.getRepository(McpOAuthProviderArtifactEntity);
+					await artifacts.delete({ grantIdHash: In(grantHashes) });
+					await artifacts.delete({ model: 'Grant', idHash: In(grantHashes) });
 				}
 			});
 		});

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -871,6 +871,12 @@ describe('MCP OAuth listen registration race', () => {
 				}),
 			).toBe(false);
 			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({
+					model: 'Grant',
+					idHash: hashToken(rawClientDisableGrantId),
+				}),
+			).toBe(false);
+			expect(
 				await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: preservedOAuthClientEntity.id }),
 			).toMatchObject({ enabled: true, generation: 0 });
 			expect(

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -122,6 +122,8 @@ describe('MCP OAuth listen registration race', () => {
 		let accessTokenSiblingClient: Client | undefined;
 		let refreshFamilyRevocationClient: Client | undefined;
 		let grantRevocationClient: Client | undefined;
+		let disabledOAuthClient: Client | undefined;
+		let preservedOAuthClient: Client | undefined;
 		const releaseListen = deferred();
 
 		try {
@@ -159,6 +161,24 @@ describe('MCP OAuth listen registration race', () => {
 				name: 'Listen refresh family client',
 				redirectUris: ['http://127.0.0.1:1457/callback'],
 				maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
+			const clientDisableOAuthClient = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'listen-client-disable-target',
+				name: 'Listen client disable target',
+				redirectUris: ['http://127.0.0.1:1458/callback'],
+				maximumScopes: [McpOAuthScope.READ],
+				enabled: true,
+				generation: 0,
+				createdById: user.id,
+			});
+			const preservedOAuthClientEntity = await dataSource.getRepository(McpOAuthClientEntity).save({
+				clientIdentifier: 'listen-client-disable-preserved',
+				name: 'Listen client disable preserved',
+				redirectUris: ['http://127.0.0.1:1459/callback'],
+				maximumScopes: [McpOAuthScope.READ],
 				enabled: true,
 				generation: 0,
 				createdById: user.id,
@@ -234,6 +254,44 @@ describe('MCP OAuth listen registration race', () => {
 				clientGeneration: 0,
 				modulePolicyGeneration: 0,
 			});
+			const rawClientDisableGrantId = 'listen-client-disable-grant';
+			const clientDisableGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawClientDisableGrantId),
+				clientId: clientDisableOAuthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const rawPreservedGrantId = 'listen-client-disable-preserved-grant';
+			const preservedGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawPreservedGrantId),
+				clientId: preservedOAuthClientEntity.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
 			const config = Object.assign(new McpConfigModel(), {
 				enabled: true,
 				oauthEnabled: true,
@@ -290,12 +348,16 @@ describe('MCP OAuth listen registration race', () => {
 				} as unknown as McpInstallationService,
 				{ getUrls: jest.fn(() => urls) } as unknown as McpOAuthPublicUrlService,
 			);
+			const oauthClientsService = new McpOAuthClientService(
+				dataSource.getRepository(McpOAuthClientEntity),
+				configService as unknown as ConfigService,
+			);
 			const management = new McpOAuthManagementService(
 				dataSource.getRepository(McpOAuthGrantEntity),
 				dataSource.getRepository(McpOAuthProviderArtifactEntity),
 				dataSource,
 				configService as unknown as ConfigService,
-				{} as McpOAuthClientService,
+				oauthClientsService,
 				subscriptions,
 				{} as McpOAuthGlobalInvalidationService,
 				auditService,
@@ -717,6 +779,119 @@ describe('MCP OAuth listen registration race', () => {
 			).toBeNull();
 			await grantRevocationClient.close();
 			grantRevocationClient = undefined;
+
+			const disabledAccessToken = 'listen-client-disable-access-token';
+			const preservedAccessToken = 'listen-client-disable-preserved-access-token';
+
+			await providerGrants.upsert(
+				rawClientDisableGrantId,
+				{ accountId: user.id, clientId: clientDisableOAuthClient.clientIdentifier },
+				600,
+			);
+			await providerGrants.upsert(
+				rawPreservedGrantId,
+				{ accountId: user.id, clientId: preservedOAuthClientEntity.clientIdentifier },
+				600,
+			);
+			await accessTokens.upsert(
+				disabledAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: clientDisableOAuthClient.clientIdentifier,
+					grantId: rawClientDisableGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			await accessTokens.upsert(
+				preservedAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: preservedOAuthClientEntity.clientIdentifier,
+					grantId: rawPreservedGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				600,
+			);
+			disabledOAuthClient = new Client(
+				{ name: 'listen-client-disable-target-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			preservedOAuthClient = new Client(
+				{ name: 'listen-client-disable-preserved-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			await disabledOAuthClient.connect(
+				new StreamableHTTPClientTransport(endpoint, {
+					requestInit: { headers: { Authorization: `Bearer ${disabledAccessToken}` } },
+				}),
+			);
+			await preservedOAuthClient.connect(
+				new StreamableHTTPClientTransport(endpoint, {
+					requestInit: { headers: { Authorization: `Bearer ${preservedAccessToken}` } },
+				}),
+			);
+			const disabledSubscription = await disabledOAuthClient.listen({ toolsListChanged: true });
+			const preservedSubscription = await preservedOAuthClient.listen({ toolsListChanged: true });
+
+			expect(subscriptions.activeCount).toBe(2);
+			await management.disableClient(clientDisableOAuthClient.id, 'owner-actor');
+			await expect(disabledSubscription.closed).resolves.toBe('remote');
+			expect(subscriptions.activeCount).toBe(1);
+			expect(auditLog).toHaveBeenCalledWith('MCP audit event', {
+				event: 'oauth_management',
+				request_id: 'administrative',
+				actor_id: 'owner-actor',
+				artifact: 'client',
+				artifact_id: clientDisableOAuthClient.id,
+				action: 'disabled',
+			});
+			await expect(resourceServer.verifyAccessToken(disabledAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await expect(resourceServer.verifyAccessToken(preservedAccessToken)).resolves.toMatchObject({
+				clientId: preservedOAuthClientEntity.clientIdentifier,
+			});
+			expect(
+				await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: clientDisableOAuthClient.id }),
+			).toMatchObject({ enabled: false, generation: 1 });
+			expect(
+				await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: clientDisableGrant.id }),
+			).toMatchObject({ generation: 1 });
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: clientDisableGrant.id })).revokedAt,
+			).toBeInstanceOf(Date);
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({
+					grantIdHash: hashToken(rawClientDisableGrantId),
+				}),
+			).toBe(false);
+			expect(
+				await dataSource.getRepository(McpOAuthClientEntity).findOneByOrFail({ id: preservedOAuthClientEntity.id }),
+			).toMatchObject({ enabled: true, generation: 0 });
+			expect(
+				(await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: preservedGrant.id })).revokedAt,
+			).toBeNull();
+			expect(
+				await dataSource.getRepository(McpOAuthProviderArtifactEntity).existsBy({
+					model: 'AccessToken',
+					idHash: hashToken(preservedAccessToken),
+				}),
+			).toBe(true);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(disabledAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(preservedAccessToken);
+			await disabledOAuthClient.close();
+			disabledOAuthClient = undefined;
+			await preservedSubscription.close();
+			await expect(preservedSubscription.closed).resolves.toBe('local');
+			await preservedOAuthClient.close();
+			preservedOAuthClient = undefined;
+			await subscriptions.closeAll();
+			expect(subscriptions.activeCount).toBe(0);
 		} finally {
 			releaseListen.resolve();
 			await expiryClient?.close();
@@ -725,6 +900,8 @@ describe('MCP OAuth listen registration race', () => {
 			await accessTokenSiblingClient?.close();
 			await refreshFamilyRevocationClient?.close();
 			await grantRevocationClient?.close();
+			await disabledOAuthClient?.close();
+			await preservedOAuthClient?.close();
 			await client?.close();
 			if (app) {
 				await app.get(McpServerService).closeAll();

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -429,6 +429,8 @@ amend ADR 0002.
 - [x] Provider-backed wire E2E: revoke an active refresh family through the management service, close its live
       subscription as `authorization_revoked`, delete every family artifact, reject subsequent bearer reuse, and
       preserve the grant.
+- [x] Provider-backed wire E2E: disable an active client, close only its live subscription, revoke its grants and
+      provider artifacts, reject subsequent bearer reuse, and preserve an unrelated client's stream and artifacts.
 - [x] E2E: submit the same refresh token concurrently behind a synchronization barrier; prove at most one successor is
       stored, the reuse loser revokes the entire family including that successor, and no fork remains usable.
 - [x] E2E: switch OAuth off with active OAuth and static subscriptions; prove new OAuth traffic is rejected and OAuth


### PR DESCRIPTION
## Summary

- add provider-backed wire E2E coverage for disabling an active MCP OAuth client
- verify only the target client's live subscription closes while an unrelated client remains connected
- verify the target grants and provider artifacts are revoked, bearer reuse is rejected, and unrelated artifacts remain valid
- update the Phase 6 implementation checklist

## Why

Phase 6 requires coverage that management-side client disabling propagates through the live MCP OAuth runtime without affecting unrelated clients. This closes that remaining provider-backed wire coverage gap.

## Impact

No production behavior changes. The new test protects targeted client-disable behavior, artifact cleanup, and cross-client isolation.

## Validation

- backend type-check
- focused ESLint for the changed E2E specification
- focused E2E repeated four times
- full backend E2E: 16 suites, 140 tests
- focused E2E rerun after rebasing onto latest `main`
