### PR TITLE
test(backend): cover OAuth wire claim mismatches

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -85,6 +85,22 @@ const waitForRemoteClosure = async (closed: Promise<string>): Promise<string> =>
 	}
 };
 
+const expectOAuthConnectionRejected = async (endpoint: URL, accessToken: string): Promise<void> => {
+	const rejectedClient = new Client(
+		{ name: 'oauth-wire-negative-e2e', version: '1.0.0' },
+		{ versionNegotiation: { mode: 'auto' } },
+	);
+	const transport = new StreamableHTTPClientTransport(endpoint, {
+		requestInit: { headers: { Authorization: `Bearer ${accessToken}` } },
+	});
+
+	try {
+		await expect(rejectedClient.connect(transport)).rejects.toThrow();
+	} finally {
+		await rejectedClient.close();
+	}
+};
+
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
@@ -388,6 +404,55 @@ describe('MCP OAuth listen registration race', () => {
 			const serverService = app.get<McpServerService>(McpServerService);
 			const listenAuthenticated = deferred();
 			const endpoint = new URL('/', await app.getUrl());
+			const wireNegativeAccessToken = 'listen-wire-negative-access-token';
+			const grantRepository = dataSource.getRepository(McpOAuthGrantEntity);
+			const artifactRepository = dataSource.getRepository(McpOAuthProviderArtifactEntity);
+
+			await accessTokens.upsert(
+				wireNegativeAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.READ,
+				},
+				60,
+			);
+			const wireNegativeArtifact = await artifactRepository.findOneByOrFail({
+				model: 'AccessToken',
+				idHash: hashToken(wireNegativeAccessToken),
+			});
+			const wireNegativePayload = JSON.parse(wireNegativeArtifact.payload) as Record<string, unknown>;
+
+			await grantRepository.update({ id: grant.id }, { issuer: 'https://other.example.com/oauth' });
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+			await grantRepository.update({ id: grant.id }, { issuer: urls.issuer });
+
+			await grantRepository.update({ id: grant.id }, { resource: 'https://other.example.com/mcp' });
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+			await grantRepository.update({ id: grant.id }, { resource: urls.resource });
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{ payload: JSON.stringify({ ...wireNegativePayload, aud: 'https://other.example.com/mcp' }) },
+			);
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{
+					payload: JSON.stringify({
+						...wireNegativePayload,
+						clientId: preservedOAuthClientEntity.clientIdentifier,
+					}),
+				},
+			);
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireNegativeAccessToken);
+			await artifactRepository.delete({ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash });
+
 			const shortLivedAccessToken = 'listen-expiry-access-token';
 
 			await accessTokens.upsert(

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -415,6 +415,8 @@ amend ADR 0002.
 - [x] Provider-backed E2E: deny consent through the production interaction service, return an issuer-bound
       `access_denied` callback with the original state, consume the interaction against replay, and persist no grant,
       authorization code, access token, or refresh token.
+- [x] TypeScript client wire E2E: reject access when the persisted grant has the wrong issuer or resource, or the
+      provider access token has the wrong audience or cross-client binding, without recording the raw bearer.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and


### PR DESCRIPTION
## Summary

- add TypeScript MCP client wire coverage for OAuth access-token claim mismatches
- reject connections when the persisted grant has a wrong issuer or resource
- reject connections when the provider token has a wrong audience or cross-client binding
- verify raw bearer values are not recorded in MCP audit output
- update the Phase 6 implementation checklist

## Why

The resource server already validates these bindings, but the Phase 6 compatibility gate still lacked proof through the real MCP HTTP transport and TypeScript client. This closes that wire-level negative-case gap while preserving the existing valid-client lifecycle scenario.

## Impact

No production behavior changes. The new E2E assertions protect issuer, resource, audience, client isolation, and bearer-redaction behavior at the wire boundary.

## Validation

- backend type-check
- focused ESLint
- focused MCP OAuth E2E passed four consecutive runs
- WLED adoption E2E passed independently: 4/4
- Home Assistant wizard E2E passed independently: 6/6

The full local parallel backend E2E run hit unrelated 5-second bootstrap timeouts in the WLED and Home Assistant suites under load; both passed independently. A serial run reproduced the pre-existing macOS `systeminformation` teardown race from `app.e2e-spec.ts`.