### PR TITLE
test(cross): cover OAuth wire challenges

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -101,6 +101,26 @@ const expectOAuthConnectionRejected = async (endpoint: URL, accessToken: string)
 	}
 };
 
+const requestOAuthChallenge = (endpoint: URL, authorization?: string): Promise<Response> =>
+	fetch(endpoint, {
+		method: 'POST',
+		headers: {
+			accept: 'application/json, text/event-stream',
+			'content-type': 'application/json',
+			...(authorization ? { authorization } : {}),
+		},
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			id: 'oauth-wire-challenge',
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'oauth-wire-challenge-e2e', version: '1.0.0' },
+			},
+		}),
+	});
+
 describe('MCP OAuth listen registration race', () => {
 	it('expires live subscriptions and closes matching streams during revocation', async () => {
 		const dataSource = new DataSource({
@@ -405,8 +425,54 @@ describe('MCP OAuth listen registration race', () => {
 			const listenAuthenticated = deferred();
 			const endpoint = new URL('/', await app.getUrl());
 			const wireNegativeAccessToken = 'listen-wire-negative-access-token';
+			const wireMalformedAccessToken = 'listen-wire-malformed-access-token';
+			const wireInsufficientScopeAccessToken = 'listen-wire-insufficient-scope-access-token';
 			const grantRepository = dataSource.getRepository(McpOAuthGrantEntity);
 			const artifactRepository = dataSource.getRepository(McpOAuthProviderArtifactEntity);
+			const expectedResourceMetadata = `resource_metadata="${urls.protectedResourceMetadata}"`;
+
+			const missingBearerResponse = await requestOAuthChallenge(endpoint);
+			const missingBearerChallenge = missingBearerResponse.headers.get('www-authenticate');
+
+			expect(missingBearerResponse.status).toBe(401);
+			expect(missingBearerChallenge).toContain('error="invalid_token"');
+			expect(missingBearerChallenge).toContain('scope="mcp:read"');
+			expect(missingBearerChallenge).toContain(expectedResourceMetadata);
+
+			const malformedBearerResponse = await requestOAuthChallenge(endpoint, `Basic ${wireMalformedAccessToken}`);
+			const malformedBearerChallenge = malformedBearerResponse.headers.get('www-authenticate');
+
+			expect(malformedBearerResponse.status).toBe(401);
+			expect(malformedBearerChallenge).toContain('error="invalid_token"');
+			expect(malformedBearerChallenge).toContain('scope="mcp:read"');
+			expect(malformedBearerChallenge).toContain(expectedResourceMetadata);
+			expect(malformedBearerChallenge).not.toContain(wireMalformedAccessToken);
+
+			await accessTokens.upsert(
+				wireInsufficientScopeAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: oauthClient.clientIdentifier,
+					grantId: rawGrantId,
+					kind: 'AccessToken',
+					scope: McpOAuthScope.WRITE,
+				},
+				60,
+			);
+			const insufficientScopeResponse = await requestOAuthChallenge(
+				endpoint,
+				`Bearer ${wireInsufficientScopeAccessToken}`,
+			);
+			const insufficientScopeChallenge = insufficientScopeResponse.headers.get('www-authenticate');
+
+			expect(insufficientScopeResponse.status).toBe(403);
+			expect(insufficientScopeChallenge).toContain('error="insufficient_scope"');
+			expect(insufficientScopeChallenge).toContain('scope="mcp:read"');
+			expect(insufficientScopeChallenge).toContain(expectedResourceMetadata);
+			expect(insufficientScopeChallenge).not.toContain(wireInsufficientScopeAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireMalformedAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireInsufficientScopeAccessToken);
 
 			await accessTokens.upsert(
 				wireNegativeAccessToken,

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -417,6 +417,8 @@ amend ADR 0002.
       authorization code, access token, or refresh token.
 - [x] TypeScript client wire E2E: reject access when the persisted grant has the wrong issuer or resource, or the
       provider access token has the wrong audience or cross-client binding, without recording the raw bearer.
+- [x] TypeScript wire E2E: return bounded RFC 6750 discovery challenges for missing or malformed authorization and a
+      valid token without effective read scope, using 401/403 correctly and never reflecting or logging credentials.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and


### PR DESCRIPTION
## Summary

- add wire-level RFC 6750 challenge coverage at the MCP HTTP endpoint
- verify missing and malformed authorization return bounded `401 invalid_token` challenges
- verify a valid OAuth token without effective read scope returns `403 insufficient_scope`
- verify required scope and protected-resource discovery metadata are included
- verify credential values are neither reflected in challenge headers nor recorded in audit output
- update the Phase 6 implementation checklist

## Why

The resource-server and controller layers already had focused unit coverage for these challenges, but Phase 6 still lacked proof through the real MCP endpoint. This closes that wire-level negative-case gap while keeping the existing valid OAuth lifecycle scenario intact.

## Impact

No production behavior changes. The new E2E assertions protect RFC 6750 status/header behavior, discovery routing, scope enforcement, and credential redaction at the public wire boundary.

## Validation

- backend type-check
- focused ESLint
- focused MCP OAuth E2E passed four consecutive runs
