### PR TITLE
test(cross): cover OAuth wire token bindings

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -516,8 +516,38 @@ describe('MCP OAuth listen registration race', () => {
 				},
 			);
 			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
-			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireNegativeAccessToken);
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{ payload: JSON.stringify({ ...wireNegativePayload, grantId: 'other-provider-grant' }) },
+			);
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{ payload: JSON.stringify({ ...wireNegativePayload, accountId: 'other-approver' }) },
+			);
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{ payload: JSON.stringify({ ...wireNegativePayload, scope: `${McpOAuthScope.READ} mcp:unknown` }) },
+			);
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+
+			await artifactRepository.update(
+				{ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash },
+				{ payload: JSON.stringify(wireNegativePayload) },
+			);
+			await grantRepository.update({ id: grant.id }, { installationId: 'other-installation' });
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+			await grantRepository.update({ id: grant.id }, { installationId: 'listen-registration-race-installation' });
+
 			await artifactRepository.delete({ model: wireNegativeArtifact.model, idHash: wireNegativeArtifact.idHash });
+			await artifactRepository.save(artifactRepository.create({ ...wireNegativeArtifact, model: 'RefreshToken' }));
+			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireNegativeAccessToken);
+			await artifactRepository.delete({ model: 'RefreshToken', idHash: wireNegativeArtifact.idHash });
 
 			const shortLivedAccessToken = 'listen-expiry-access-token';
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -419,6 +419,8 @@ amend ADR 0002.
       provider access token has the wrong audience or cross-client binding, without recording the raw bearer.
 - [x] TypeScript wire E2E: return bounded RFC 6750 discovery challenges for missing or malformed authorization and a
       valid token without effective read scope, using 401/403 correctly and never reflecting or logging credentials.
+- [x] TypeScript client wire E2E: reject provider access tokens with the wrong grant, account, installation, unknown
+      scope, or stored artifact model, preserve later valid authorization, and never log the raw bearer.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and


### PR DESCRIPTION
## Summary

- extend the TypeScript MCP client wire matrix for OAuth token binding failures
- reject provider tokens with the wrong grant or approver/account binding
- reject grants bound to another installation
- reject unknown OAuth scopes
- reject an access-token value whose provider artifact is stored under the refresh-token model
- prove later valid OAuth authorization still succeeds and raw bearer values remain absent from audit output
- update the Phase 6 implementation checklist

## Why

These resource-server rejection branches were covered only by focused unit tests. Phase 6 requires wire-level negative coverage for cases normal user hosts do not expose, so this slice exercises the remaining provider-token binding cases through the real MCP HTTP transport and TypeScript client.

## Impact

No production behavior changes. The new E2E assertions protect grant, approver, installation, scope, and provider-artifact type binding at the public MCP boundary.

## Validation

- backend type-check
- focused ESLint
- focused MCP OAuth E2E passed four consecutive runs
