### PR TITLE
test(cross): cover active grant scope contraction

### DIFF
--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -160,6 +160,7 @@ describe('MCP OAuth listen registration race', () => {
 		let grantRevocationClient: Client | undefined;
 		let disabledOAuthClient: Client | undefined;
 		let preservedOAuthClient: Client | undefined;
+		let grantScopeContractionClient: Client | undefined;
 		let scopeContractionClient: Client | undefined;
 		const releaseListen = deferred();
 
@@ -357,6 +358,25 @@ describe('MCP OAuth listen registration race', () => {
 				clientGeneration: 0,
 				modulePolicyGeneration: 0,
 			});
+			const rawGrantScopeContractionGrantId = 'listen-grant-scope-contraction-grant';
+			const grantScopeContractionGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawGrantScopeContractionGrantId),
+				clientId: scopeContractionOAuthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
 			const config = Object.assign(new McpConfigModel(), {
 				enabled: true,
 				oauthEnabled: true,
@@ -386,6 +406,14 @@ describe('MCP OAuth listen registration race', () => {
 			);
 			await providerGrants.upsert(
 				rawScopeContractionGrantId,
+				{
+					accountId: user.id,
+					clientId: scopeContractionOAuthClient.clientIdentifier,
+				},
+				600,
+			);
+			await providerGrants.upsert(
+				rawGrantScopeContractionGrantId,
 				{
 					accountId: user.id,
 					clientId: scopeContractionOAuthClient.clientIdentifier,
@@ -585,6 +613,56 @@ describe('MCP OAuth listen registration race', () => {
 			await expectOAuthConnectionRejected(endpoint, wireNegativeAccessToken);
 			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireNegativeAccessToken);
 			await artifactRepository.delete({ model: 'RefreshToken', idHash: wireNegativeArtifact.idHash });
+
+			const grantScopeContractionAccessToken = 'listen-grant-scope-contraction-access-token';
+
+			await accessTokens.upsert(
+				grantScopeContractionAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: scopeContractionOAuthClient.clientIdentifier,
+					grantId: rawGrantScopeContractionGrantId,
+					kind: 'AccessToken',
+					scope: `${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.TRIGGER}`,
+				},
+				600,
+			);
+			await expect(resourceServer.verifyAccessToken(grantScopeContractionAccessToken)).resolves.toMatchObject({
+				scopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+			});
+			grantScopeContractionClient = new Client(
+				{ name: 'listen-grant-scope-contraction-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			await grantScopeContractionClient.connect(
+				new StreamableHTTPClientTransport(endpoint, {
+					requestInit: { headers: { Authorization: `Bearer ${grantScopeContractionAccessToken}` } },
+				}),
+			);
+			const grantScopeContractionSubscription = await grantScopeContractionClient.listen({ toolsListChanged: true });
+
+			expect(subscriptions.activeCount).toBe(1);
+			let grantScopeContractionMutationSettled = false;
+			const grantScopeContractionMutation = management
+				.updateGrant(grantScopeContractionGrant.id, { approvedScopes: [] }, 'owner-actor')
+				.finally(() => {
+					grantScopeContractionMutationSettled = true;
+				});
+			await expect(grantScopeContractionSubscription.closed).resolves.toBe('remote');
+			expect(grantScopeContractionMutationSettled).toBe(false);
+			await grantScopeContractionMutation;
+			expect(subscriptions.activeCount).toBe(0);
+			await expect(resourceServer.verifyAccessToken(grantScopeContractionAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await expectOAuthConnectionRejected(endpoint, grantScopeContractionAccessToken);
+			expect(
+				await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantScopeContractionGrant.id }),
+			).toMatchObject({ approvedScopes: [], generation: 1, revokedAt: null });
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(grantScopeContractionAccessToken);
+			await grantScopeContractionClient.close();
+			grantScopeContractionClient = undefined;
 
 			const scopeContractionAccessToken = 'listen-client-scope-contraction-access-token';
 
@@ -1164,6 +1242,7 @@ describe('MCP OAuth listen registration race', () => {
 			await grantRevocationClient?.close();
 			await disabledOAuthClient?.close();
 			await preservedOAuthClient?.close();
+			await grantScopeContractionClient?.close();
 			await scopeContractionClient?.close();
 			await client?.close();
 			if (app) {

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -160,7 +160,8 @@ describe('MCP OAuth listen registration race', () => {
 		let grantRevocationClient: Client | undefined;
 		let disabledOAuthClient: Client | undefined;
 		let preservedOAuthClient: Client | undefined;
-		let grantScopeContractionClient: Client | undefined;
+		let grantWriteScopeContractionClient: Client | undefined;
+		let grantTriggerScopeContractionClient: Client | undefined;
 		let scopeContractionClient: Client | undefined;
 		const releaseListen = deferred();
 
@@ -358,9 +359,28 @@ describe('MCP OAuth listen registration race', () => {
 				clientGeneration: 0,
 				modulePolicyGeneration: 0,
 			});
-			const rawGrantScopeContractionGrantId = 'listen-grant-scope-contraction-grant';
-			const grantScopeContractionGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
-				providerGrantIdHash: hashToken(rawGrantScopeContractionGrantId),
+			const rawGrantWriteScopeContractionGrantId = 'listen-grant-write-scope-contraction-grant';
+			const grantWriteScopeContractionGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawGrantWriteScopeContractionGrantId),
+				clientId: scopeContractionOAuthClient.id,
+				approvedById: user.id,
+				installationId: 'listen-registration-race-installation',
+				issuer: urls.issuer,
+				resource: urls.resource,
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+				expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
+				revokedAt: null,
+				generation: 0,
+				approverAuthorityGeneration: 0,
+				oauthEnabledGeneration: 0,
+				serverSecretVersion: 1,
+				publicIdentityGeneration: 0,
+				clientGeneration: 0,
+				modulePolicyGeneration: 0,
+			});
+			const rawGrantTriggerScopeContractionGrantId = 'listen-grant-trigger-scope-contraction-grant';
+			const grantTriggerScopeContractionGrant = await dataSource.getRepository(McpOAuthGrantEntity).save({
+				providerGrantIdHash: hashToken(rawGrantTriggerScopeContractionGrantId),
 				clientId: scopeContractionOAuthClient.id,
 				approvedById: user.id,
 				installationId: 'listen-registration-race-installation',
@@ -413,7 +433,15 @@ describe('MCP OAuth listen registration race', () => {
 				600,
 			);
 			await providerGrants.upsert(
-				rawGrantScopeContractionGrantId,
+				rawGrantWriteScopeContractionGrantId,
+				{
+					accountId: user.id,
+					clientId: scopeContractionOAuthClient.clientIdentifier,
+				},
+				600,
+			);
+			await providerGrants.upsert(
+				rawGrantTriggerScopeContractionGrantId,
 				{
 					accountId: user.id,
 					clientId: scopeContractionOAuthClient.clientIdentifier,
@@ -614,55 +642,127 @@ describe('MCP OAuth listen registration race', () => {
 			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(wireNegativeAccessToken);
 			await artifactRepository.delete({ model: 'RefreshToken', idHash: wireNegativeArtifact.idHash });
 
-			const grantScopeContractionAccessToken = 'listen-grant-scope-contraction-access-token';
+			const grantWriteScopeContractionAccessToken = 'listen-grant-write-scope-contraction-access-token';
 
 			await accessTokens.upsert(
-				grantScopeContractionAccessToken,
+				grantWriteScopeContractionAccessToken,
 				{
 					accountId: user.id,
 					aud: urls.resource,
 					clientId: scopeContractionOAuthClient.clientIdentifier,
-					grantId: rawGrantScopeContractionGrantId,
+					grantId: rawGrantWriteScopeContractionGrantId,
 					kind: 'AccessToken',
 					scope: `${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.TRIGGER}`,
 				},
 				600,
 			);
-			await expect(resourceServer.verifyAccessToken(grantScopeContractionAccessToken)).resolves.toMatchObject({
+			await expect(resourceServer.verifyAccessToken(grantWriteScopeContractionAccessToken)).resolves.toMatchObject({
 				scopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
 			});
-			grantScopeContractionClient = new Client(
-				{ name: 'listen-grant-scope-contraction-e2e', version: '1.0.0' },
+			grantWriteScopeContractionClient = new Client(
+				{ name: 'listen-grant-write-scope-contraction-e2e', version: '1.0.0' },
 				{ versionNegotiation: { mode: 'auto' } },
 			);
-			await grantScopeContractionClient.connect(
+			await grantWriteScopeContractionClient.connect(
 				new StreamableHTTPClientTransport(endpoint, {
-					requestInit: { headers: { Authorization: `Bearer ${grantScopeContractionAccessToken}` } },
+					requestInit: { headers: { Authorization: `Bearer ${grantWriteScopeContractionAccessToken}` } },
 				}),
 			);
-			const grantScopeContractionSubscription = await grantScopeContractionClient.listen({ toolsListChanged: true });
+			const grantWriteScopeContractionSubscription = await grantWriteScopeContractionClient.listen({
+				toolsListChanged: true,
+			});
 
 			expect(subscriptions.activeCount).toBe(1);
-			let grantScopeContractionMutationSettled = false;
-			const grantScopeContractionMutation = management
-				.updateGrant(grantScopeContractionGrant.id, { approvedScopes: [] }, 'owner-actor')
+			let grantWriteScopeContractionMutationSettled = false;
+			const grantWriteScopeContractionMutation = management
+				.updateGrant(
+					grantWriteScopeContractionGrant.id,
+					{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER] },
+					'owner-actor',
+				)
 				.finally(() => {
-					grantScopeContractionMutationSettled = true;
+					grantWriteScopeContractionMutationSettled = true;
 				});
-			await expect(grantScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(grantScopeContractionMutationSettled).toBe(false);
-			await grantScopeContractionMutation;
+			await expect(grantWriteScopeContractionSubscription.closed).resolves.toBe('remote');
+			expect(grantWriteScopeContractionMutationSettled).toBe(false);
+			await grantWriteScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
-			await expect(resourceServer.verifyAccessToken(grantScopeContractionAccessToken)).rejects.toThrow(
+			await expect(resourceServer.verifyAccessToken(grantWriteScopeContractionAccessToken)).rejects.toThrow(
 				'The MCP OAuth access token is invalid or no longer active',
 			);
-			await expectOAuthConnectionRejected(endpoint, grantScopeContractionAccessToken);
+			await expectOAuthConnectionRejected(endpoint, grantWriteScopeContractionAccessToken);
 			expect(
-				await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantScopeContractionGrant.id }),
-			).toMatchObject({ approvedScopes: [], generation: 1, revokedAt: null });
-			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(grantScopeContractionAccessToken);
-			await grantScopeContractionClient.close();
-			grantScopeContractionClient = undefined;
+				await dataSource.getRepository(McpOAuthGrantEntity).findOneByOrFail({ id: grantWriteScopeContractionGrant.id }),
+			).toMatchObject({
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER],
+				generation: 1,
+				revokedAt: null,
+			});
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(grantWriteScopeContractionAccessToken);
+			await grantWriteScopeContractionClient.close();
+			grantWriteScopeContractionClient = undefined;
+
+			const grantTriggerScopeContractionAccessToken = 'listen-grant-trigger-scope-contraction-access-token';
+
+			await accessTokens.upsert(
+				grantTriggerScopeContractionAccessToken,
+				{
+					accountId: user.id,
+					aud: urls.resource,
+					clientId: scopeContractionOAuthClient.clientIdentifier,
+					grantId: rawGrantTriggerScopeContractionGrantId,
+					kind: 'AccessToken',
+					scope: `${McpOAuthScope.READ} ${McpOAuthScope.WRITE} ${McpOAuthScope.TRIGGER}`,
+				},
+				600,
+			);
+			await expect(resourceServer.verifyAccessToken(grantTriggerScopeContractionAccessToken)).resolves.toMatchObject({
+				scopes: [McpOAuthScope.READ, McpOAuthScope.WRITE, McpOAuthScope.TRIGGER],
+			});
+			grantTriggerScopeContractionClient = new Client(
+				{ name: 'listen-grant-trigger-scope-contraction-e2e', version: '1.0.0' },
+				{ versionNegotiation: { mode: 'auto' } },
+			);
+			await grantTriggerScopeContractionClient.connect(
+				new StreamableHTTPClientTransport(endpoint, {
+					requestInit: { headers: { Authorization: `Bearer ${grantTriggerScopeContractionAccessToken}` } },
+				}),
+			);
+			const grantTriggerScopeContractionSubscription = await grantTriggerScopeContractionClient.listen({
+				toolsListChanged: true,
+			});
+
+			expect(subscriptions.activeCount).toBe(1);
+			let grantTriggerScopeContractionMutationSettled = false;
+			const grantTriggerScopeContractionMutation = management
+				.updateGrant(
+					grantTriggerScopeContractionGrant.id,
+					{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] },
+					'owner-actor',
+				)
+				.finally(() => {
+					grantTriggerScopeContractionMutationSettled = true;
+				});
+			await expect(grantTriggerScopeContractionSubscription.closed).resolves.toBe('remote');
+			expect(grantTriggerScopeContractionMutationSettled).toBe(false);
+			await grantTriggerScopeContractionMutation;
+			expect(subscriptions.activeCount).toBe(0);
+			await expect(resourceServer.verifyAccessToken(grantTriggerScopeContractionAccessToken)).rejects.toThrow(
+				'The MCP OAuth access token is invalid or no longer active',
+			);
+			await expectOAuthConnectionRejected(endpoint, grantTriggerScopeContractionAccessToken);
+			expect(
+				await dataSource
+					.getRepository(McpOAuthGrantEntity)
+					.findOneByOrFail({ id: grantTriggerScopeContractionGrant.id }),
+			).toMatchObject({
+				approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE],
+				generation: 1,
+				revokedAt: null,
+			});
+			expect(JSON.stringify(auditLog.mock.calls)).not.toContain(grantTriggerScopeContractionAccessToken);
+			await grantTriggerScopeContractionClient.close();
+			grantTriggerScopeContractionClient = undefined;
 
 			const scopeContractionAccessToken = 'listen-client-scope-contraction-access-token';
 
@@ -1242,7 +1342,8 @@ describe('MCP OAuth listen registration race', () => {
 			await grantRevocationClient?.close();
 			await disabledOAuthClient?.close();
 			await preservedOAuthClient?.close();
-			await grantScopeContractionClient?.close();
+			await grantWriteScopeContractionClient?.close();
+			await grantTriggerScopeContractionClient?.close();
 			await scopeContractionClient?.close();
 			await client?.close();
 			if (app) {

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -423,6 +423,8 @@ amend ADR 0002.
       scope, or stored artifact model, preserve later valid authorization, and never log the raw bearer.
 - [x] Provider-backed wire E2E: contract a client's ceiling to remove effective read, write, and trigger scopes from
       an active subscription; close it before success, reject bearer reuse, preserve its grant, and redact the token.
+- [x] Provider-backed wire E2E: contract an active grant to remove effective read, write, and trigger scopes; close its
+      subscription before success, reject bearer reuse, preserve the reduced grant, and redact the token.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -423,8 +423,9 @@ amend ADR 0002.
       scope, or stored artifact model, preserve later valid authorization, and never log the raw bearer.
 - [x] Provider-backed wire E2E: contract a client's ceiling to remove effective read, write, and trigger scopes from
       an active subscription; close it before success, reject bearer reuse, preserve its grant, and redact the token.
-- [x] Provider-backed wire E2E: contract an active grant to remove effective read, write, and trigger scopes; close its
-      subscription before success, reject bearer reuse, preserve the reduced grant, and redact the token.
+- [x] Provider-backed wire E2E: independently contract active grants to remove effective write or trigger scope while
+      retaining read; close each subscription before success, reject bearer reuse, preserve each reduced grant, and
+      redact both tokens.
 - [x] E2E: pause a listen request after authentication, complete a matching artifact revocation or scope reduction,
       then resume registration and prove the stale request cannot open after invalidation success.
 - [x] Provider-backed wire E2E: close an active OAuth subscription at the access-token authorization deadline and


### PR DESCRIPTION
## Summary

- add provider-backed TypeScript MCP client coverage for active grant scope contraction
- independently remove write and trigger from active read/write/trigger grants while retaining read
- prove each remote SDK subscription closes before its grant mutation succeeds
- reject both old bearers through resource-server validation and fresh wire connections
- preserve each reduced grant as active while advancing its generation
- verify both raw bearers are absent from audit output
- update the Phase 6 implementation checklist

## Why

Phase 6 requires each module, client, and grant scope contraction to close affected active streams before reporting success, including removal of write or trigger while read remains. Client-ceiling contraction was already covered at the provider-backed wire boundary; the equivalent grant-management path only had service-level selection coverage.

## Impact

No production behavior changes. This adds regression coverage for the existing awaited grant-scope invalidation path and records the completed Phase 6 slice.

## Validation

- `pnpm --filter ./apps/backend run type-check`
- focused ESLint
- focused Prettier
- `pnpm --filter ./apps/backend exec jest --config ./test/jest-e2e.json --runInBand test/mcp-oauth-listen-registration-race.e2e-spec.ts`
