### PR TITLE
docs(cross): add MCP OAuth recovery runbook

### DIFF
--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -180,7 +180,7 @@ Handles user authentication, JWT issuing and session management for the Smart Pa
 ## CLI Commands
 
 - \`pnpm run cli auth:onboarding\` — create the initial owner account
-- \`pnpm run cli auth:reset\` — reset the owner password`,
+- \`pnpm run cli auth:reset\` — reset an owner or administrator password and revoke its active credentials`,
 			links: {
 				documentation: 'https://smart-panel.fastybird.com/docs',
 				repository: 'https://github.com/FastyBird/smart-panel',

--- a/apps/backend/src/modules/auth/commands/reset-password.command.spec.ts
+++ b/apps/backend/src/modules/auth/commands/reset-password.command.spec.ts
@@ -1,9 +1,16 @@
+import inquirer from 'inquirer';
+
 import { UserEntity } from '../../users/entities/users.entity';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
 import { TokensService } from '../services/tokens.service';
 
 import { ResetPasswordCommand } from './reset-password.command';
+
+jest.mock('inquirer', () => ({
+	__esModule: true,
+	default: { prompt: jest.fn() },
+}));
 
 describe('ResetPasswordCommand', () => {
 	afterEach(() => {
@@ -13,6 +20,7 @@ describe('ResetPasswordCommand', () => {
 	it.each([UserRole.OWNER, UserRole.ADMIN])(
 		'should reset a %s password and revoke every user credential',
 		async (role) => {
+			jest.mocked(inquirer.prompt).mockResolvedValue({ password: 'replacement-password' });
 			const update = jest.fn().mockResolvedValue(undefined);
 			const revokeUserCredentials = jest.fn().mockResolvedValue(undefined);
 			const user = {
@@ -31,7 +39,7 @@ describe('ResetPasswordCommand', () => {
 
 			jest.spyOn(console, 'log').mockImplementation(() => undefined);
 
-			await command.run(['privileged-user', 'replacement-password']);
+			await command.run(['privileged-user']);
 
 			expect(update).toHaveBeenCalledWith(user.id, { password: 'replacement-password' });
 			expect(revokeUserCredentials).toHaveBeenCalledWith(user.id);

--- a/apps/backend/src/modules/auth/commands/reset-password.command.spec.ts
+++ b/apps/backend/src/modules/auth/commands/reset-password.command.spec.ts
@@ -1,0 +1,40 @@
+import { UserEntity } from '../../users/entities/users.entity';
+import { UsersService } from '../../users/services/users.service';
+import { UserRole } from '../../users/users.constants';
+import { TokensService } from '../services/tokens.service';
+
+import { ResetPasswordCommand } from './reset-password.command';
+
+describe('ResetPasswordCommand', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it.each([UserRole.OWNER, UserRole.ADMIN])(
+		'should reset a %s password and revoke every user credential',
+		async (role) => {
+			const update = jest.fn().mockResolvedValue(undefined);
+			const revokeUserCredentials = jest.fn().mockResolvedValue(undefined);
+			const user = {
+				id: 'e9b1b3fb-f813-42b8-985f-2cb068baf1a8',
+				username: 'privileged-user',
+				role,
+			} as UserEntity;
+			const usersService = {
+				findByUsername: jest.fn().mockResolvedValue(user),
+				update,
+			} as unknown as UsersService;
+			const tokensService = {
+				revokeUserCredentials,
+			} as unknown as TokensService;
+			const command = new ResetPasswordCommand(usersService, tokensService);
+
+			jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+			await command.run(['privileged-user', 'replacement-password']);
+
+			expect(update).toHaveBeenCalledWith(user.id, { password: 'replacement-password' });
+			expect(revokeUserCredentials).toHaveBeenCalledWith(user.id);
+		},
+	);
+});

--- a/apps/backend/src/modules/auth/commands/reset-password.command.ts
+++ b/apps/backend/src/modules/auth/commands/reset-password.command.ts
@@ -6,17 +6,21 @@ import { createExtensionLogger } from '../../../common/logger';
 import { UsersService } from '../../users/services/users.service';
 import { UserRole } from '../../users/users.constants';
 import { AUTH_MODULE_NAME } from '../auth.constants';
+import { TokensService } from '../services/tokens.service';
 
 @Command({
 	name: 'auth:reset',
-	description: 'Reset application owner password',
+	description: 'Reset an application owner or administrator password and revoke its credentials',
 	arguments: '<username> <password>',
 })
 @Injectable()
 export class ResetPasswordCommand extends CommandRunner {
 	private readonly logger = createExtensionLogger(AUTH_MODULE_NAME, 'ResetPasswordCommand');
 
-	constructor(private readonly service: UsersService) {
+	constructor(
+		private readonly service: UsersService,
+		private readonly tokensService: TokensService,
+	) {
 		super();
 	}
 
@@ -31,22 +35,25 @@ export class ResetPasswordCommand extends CommandRunner {
 		}
 		const user = await this.service.findByUsername(username);
 
-		if (user === null || user.role !== UserRole.OWNER) {
-			this.logger.warn('No owner account found.');
+		if (user === null || (user.role !== UserRole.OWNER && user.role !== UserRole.ADMIN)) {
+			this.logger.warn('No owner or administrator account found.');
 
-			console.log('\n\x1b[31m🚨 No owner account found. Cannot reset password.\n');
+			console.log('\n\x1b[31m🚨 No owner or administrator account found. Cannot reset password.\n');
 
 			return;
 		}
 
-		console.log(`\n\x1b[33m🔹 Resetting password for owner: \x1b[1m${user.username}\x1b[0m\n`);
+		console.log(`\n\x1b[33m🔹 Resetting password for privileged account: \x1b[1m${user.username}\x1b[0m\n`);
 
 		await this.service.update(user.id, {
 			password,
 		});
+		await this.tokensService.revokeUserCredentials(user.id);
 
-		console.log(`\n\x1b[32m✅ Successfully reset password for: \x1b[1m${user.username}\x1b[0m\n`);
+		console.log(
+			`\n\x1b[32m✅ Successfully reset password and revoked active sessions and personal tokens for: \x1b[1m${user.username}\x1b[0m\n`,
+		);
 
-		this.logger.log(`Password reset successfully for owner=${user.username}`);
+		this.logger.log(`Password reset and user credentials revoked successfully for user=${user.username}`);
 	}
 }

--- a/apps/backend/src/modules/auth/commands/reset-password.command.ts
+++ b/apps/backend/src/modules/auth/commands/reset-password.command.ts
@@ -1,3 +1,4 @@
+import inquirer from 'inquirer';
 import { Command, CommandRunner } from 'nest-commander';
 
 import { Injectable } from '@nestjs/common';
@@ -11,7 +12,7 @@ import { TokensService } from '../services/tokens.service';
 @Command({
 	name: 'auth:reset',
 	description: 'Reset an application owner or administrator password and revoke its credentials',
-	arguments: '<username> <password>',
+	arguments: '<username>',
 })
 @Injectable()
 export class ResetPasswordCommand extends CommandRunner {
@@ -26,11 +27,10 @@ export class ResetPasswordCommand extends CommandRunner {
 
 	async run(passedParams: string[], _options?: Record<string, any>): Promise<void> {
 		const username = passedParams[0];
-		const password = passedParams[1];
 
-		if (!username || !password) {
-			console.error('\x1b[31m❌ Error: username and password are required\n');
-			console.error('Usage: auth:reset <username> <password>');
+		if (!username) {
+			console.error('\x1b[31m❌ Error: username is required\n');
+			console.error('Usage: auth:reset <username>');
 			process.exit(1);
 		}
 		const user = await this.service.findByUsername(username);
@@ -44,6 +44,15 @@ export class ResetPasswordCommand extends CommandRunner {
 		}
 
 		console.log(`\n\x1b[33m🔹 Resetting password for privileged account: \x1b[1m${user.username}\x1b[0m\n`);
+		const { password } = await inquirer.prompt<{ password: string }>([
+			{
+				type: 'password',
+				name: 'password',
+				message: 'New password:',
+				mask: '*',
+				validate: (value: string) => value.length > 0 || 'Password is required',
+			},
+		]);
 
 		await this.service.update(user.id, {
 			password,

--- a/apps/backend/src/modules/auth/services/tokens.service.spec.ts
+++ b/apps/backend/src/modules/auth/services/tokens.service.spec.ts
@@ -8,7 +8,7 @@ Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
 import bcrypt from 'bcrypt';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { Test, TestingModule } from '@nestjs/testing';
@@ -19,7 +19,7 @@ import { TokenOwnerType, TokenType } from '../auth.constants';
 import { AuthException, AuthNotFoundException } from '../auth.exceptions';
 import { CreateLongLiveTokenDto, CreateTokenDto } from '../dto/create-token.dto';
 import { UpdateLongLiveTokenDto, UpdateTokenDto } from '../dto/update-token.dto';
-import { LongLiveTokenEntity, TokenEntity } from '../entities/auth.entity';
+import { AccessTokenEntity, LongLiveTokenEntity, RefreshTokenEntity, TokenEntity } from '../entities/auth.entity';
 
 import { TokensTypeMapperService } from './tokens-type-mapper.service';
 import { TokensService } from './tokens.service';
@@ -38,6 +38,7 @@ describe('TokensService', () => {
 	let repository: Repository<TokenEntity>;
 	let mapper: TokensTypeMapperService;
 	let dataSource: DataSource;
+	let transaction: jest.Mock;
 
 	const mockToken = {
 		id: uuid().toString(),
@@ -54,6 +55,8 @@ describe('TokensService', () => {
 	} as unknown as LongLiveTokenEntity;
 
 	beforeEach(async () => {
+		transaction = jest.fn();
+
 		const mockRepository = () => ({
 			find: jest.fn(),
 			findOne: jest.fn(),
@@ -90,6 +93,7 @@ describe('TokensService', () => {
 					provide: DataSource,
 					useValue: {
 						getRepository: jest.fn(() => {}),
+						transaction,
 					},
 				},
 			],
@@ -403,6 +407,43 @@ describe('TokensService', () => {
 			// Uses tokenOwnerId column for LongLiveTokenEntity to avoid FK conflict
 			expect(mockRepo.update).toHaveBeenCalledWith(
 				{ tokenOwnerId: ownerId, ownerType: TokenOwnerType.DISPLAY },
+				{ revoked: true },
+			);
+		});
+	});
+
+	describe('revokeUserCredentials', () => {
+		it('should revoke login pairs and personal tokens in one transaction', async () => {
+			const userId = uuid().toString();
+			const accessRepository = { update: jest.fn().mockResolvedValue({ affected: 2 }) };
+			const refreshRepository = { update: jest.fn().mockResolvedValue({ affected: 2 }) };
+			const personalRepository = { update: jest.fn().mockResolvedValue({ affected: 1 }) };
+			const manager = {
+				getRepository: jest.fn((entity) => {
+					if (entity === AccessTokenEntity) {
+						return accessRepository;
+					}
+
+					if (entity === RefreshTokenEntity) {
+						return refreshRepository;
+					}
+
+					return personalRepository;
+				}),
+			};
+
+			transaction.mockImplementation(
+				async (callback: (entityManager: EntityManager) => Promise<void>): Promise<void> => {
+					await callback(manager as unknown as EntityManager);
+				},
+			);
+
+			await service.revokeUserCredentials(userId);
+
+			expect(accessRepository.update).toHaveBeenCalledWith({ ownerId: userId }, { revoked: true });
+			expect(refreshRepository.update).toHaveBeenCalledWith({ ownerId: userId }, { revoked: true });
+			expect(personalRepository.update).toHaveBeenCalledWith(
+				{ tokenOwnerId: userId, ownerType: TokenOwnerType.USER },
 				{ revoked: true },
 			);
 		});

--- a/apps/backend/src/modules/auth/services/tokens.service.ts
+++ b/apps/backend/src/modules/auth/services/tokens.service.ts
@@ -134,6 +134,20 @@ export class TokensService {
 		this.logger.debug(`Successfully revoked tokens for ownerId=${ownerId}`);
 	}
 
+	async revokeUserCredentials(userId: string): Promise<void> {
+		this.logger.debug(`Revoking all authentication credentials for userId=${userId}`);
+
+		await this.dataSource.transaction(async (manager) => {
+			await manager.getRepository(AccessTokenEntity).update({ ownerId: userId }, { revoked: true });
+			await manager.getRepository(RefreshTokenEntity).update({ ownerId: userId }, { revoked: true });
+			await manager
+				.getRepository(LongLiveTokenEntity)
+				.update({ tokenOwnerId: userId, ownerType: TokenOwnerType.USER }, { revoked: true });
+		});
+
+		this.logger.debug(`Successfully revoked all authentication credentials for userId=${userId}`);
+	}
+
 	async revoke(id: string, manager?: EntityManager): Promise<void> {
 		const repository = (manager ?? this.dataSource).getRepository(LongLiveTokenEntity);
 		const result = await repository.update(id, { revoked: true });

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -350,12 +350,13 @@ Preserve backend logs before cleanup. MCP audit events such as `oauth_management
 `oauth_authorization_invalidation`, and `tool_execution` identify actors, affected management IDs, and outcomes without
 recording raw bearer material.
 
-### Recover an owner account
+### Recover an owner or administrator account
 
-Use the existing backend CLI to reset an owner password when the Admin login is unavailable. On a pre-built image:
+Use the existing backend CLI to reset a privileged account when its Admin login cannot be trusted. On a pre-built
+image:
 
 ```bash copy
-read -rsp 'New owner password: ' SMART_PANEL_RECOVERY_PASSWORD && printf '\n'
+read -rsp 'New privileged-account password: ' SMART_PANEL_RECOVERY_PASSWORD && printf '\n'
 sudo smart-panel-cli auth:reset <username> "$SMART_PANEL_RECOVERY_PASSWORD"
 unset SMART_PANEL_RECOVERY_PASSWORD
 ```
@@ -364,7 +365,8 @@ Other installation methods must invoke the same `auth:reset` command through the
 normal environment and database permissions. Use the same silent-prompt pattern on a trusted local console so the
 recovery password is not written to shell history, and clear the variable immediately after the command.
 
-A password reset restores login access but deliberately does **not** revoke OAuth grants, access tokens, refresh
+The recovery command changes the password and revokes every active Admin login session and personal access token owned
+by that account before reporting success. It deliberately does **not** revoke MCP OAuth grants, access tokens, refresh
 families, or static MCP credentials. After signing in, select **Revoke all OAuth access**, rotate every static client
 that the compromised account could have created or copied, review the registered clients and grants, and remove or
 demote unknown users. Demoting or deleting an approving owner/administrator automatically revokes grants that user

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -356,21 +356,24 @@ Use the existing backend CLI to reset a privileged account when its Admin login 
 image:
 
 ```bash copy
-read -rsp 'New privileged-account password: ' SMART_PANEL_RECOVERY_PASSWORD && printf '\n'
-sudo smart-panel-cli auth:reset <username> "$SMART_PANEL_RECOVERY_PASSWORD"
-unset SMART_PANEL_RECOVERY_PASSWORD
+sudo smart-panel-service stop \
+  && sudo smart-panel-cli auth:reset <username> \
+  && sudo smart-panel-service start
 ```
 
 Other installation methods must invoke the same `auth:reset` command through their backend CLI with the installation's
-normal environment and database permissions. Use the same silent-prompt pattern on a trusted local console so the
-recovery password is not written to shell history, and clear the variable immediately after the command.
+normal environment and database permissions. Stop every backend instance before invoking it and keep them stopped until
+the command reports success; this immediately closes live WebSocket sessions and prevents a concurrent login from
+creating new credentials during recovery. The command reads the replacement password from its masked terminal prompt;
+it never accepts the password as a command-line argument. Run it on a trusted local console.
 
 The recovery command changes the password and revokes every active Admin login session and personal access token owned
-by that account before reporting success. It deliberately does **not** revoke MCP OAuth grants, access tokens, refresh
-families, or static MCP credentials. After signing in, select **Revoke all OAuth access**, rotate every static client
-that the compromised account could have created or copied, review the registered clients and grants, and remove or
-demote unknown users. Demoting or deleting an approving owner/administrator automatically revokes grants that user
-approved, but it is not a substitute for global revocation when the exposure is uncertain.
+by that account before reporting success. Restarting the backend after that success cannot restore the disconnected
+sessions. The command deliberately does **not** revoke MCP OAuth grants, access tokens, refresh families, or static MCP
+credentials. After signing in, select **Revoke all OAuth access**, rotate every static client that the compromised
+account could have created or copied, review the registered clients and grants, and remove or demote unknown users.
+Demoting or deleting an approving owner/administrator automatically revokes grants that user approved, but it is not a
+substitute for global revocation when the exposure is uncertain.
 
 ## Connect an Agent
 

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -355,11 +355,14 @@ recording raw bearer material.
 Use the existing backend CLI to reset an owner password when the Admin login is unavailable. On a pre-built image:
 
 ```bash copy
-sudo smart-panel-cli auth:reset <username> '<new-password>'
+read -rsp 'New owner password: ' SMART_PANEL_RECOVERY_PASSWORD && printf '\n'
+sudo smart-panel-cli auth:reset <username> "$SMART_PANEL_RECOVERY_PASSWORD"
+unset SMART_PANEL_RECOVERY_PASSWORD
 ```
 
 Other installation methods must invoke the same `auth:reset` command through their backend CLI with the installation's
-normal environment and database permissions. Avoid leaving the recovery password in shared terminal history.
+normal environment and database permissions. Use the same silent-prompt pattern on a trusted local console so the
+recovery password is not written to shell history, and clear the variable immediately after the command.
 
 A password reset restores login access but deliberately does **not** revoke OAuth grants, access tokens, refresh
 families, or static MCP credentials. After signing in, select **Revoke all OAuth access**, rotate every static client

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -268,6 +268,105 @@ Keep static credentials for trusted LAN/VPN agents if desired. Disabling OAuth r
 OAuth streams; it is the supported rollback when remote authorization must be withdrawn without interrupting static
 agents.
 
+## Protect Backups and Restored Installations
+
+<Callout type="warning">
+  Smart Panel backups are not encrypted. Store and transfer them as credentials,
+  restrict access, and securely remove obsolete copies after the retention
+  period.
+</Callout>
+
+A complete backup contains the installation database and configuration directory. For MCP, that includes:
+
+- the installation UUID, static-client records and token hashes, and OAuth clients, grants, and artifact metadata in
+  the database;
+- resolved write-only configuration secrets in `config.yaml`; and
+- `.mcp-oauth-provider.json`, containing the private OAuth signing key and interaction-cookie keys, after OAuth has
+  first been activated.
+
+Raw static and OAuth bearer values are stored only as hashes and cannot be recovered from the backup. The remaining
+identity, authorization, private-key, and configuration data is still security-sensitive.
+
+### Restore a replacement or create a clone
+
+Decide whether the restored host replaces a failed installation or becomes a separate installation:
+
+- **Replacement:** Permanently retire or isolate the old host. A trusted backup preserves the installation identity and
+  can preserve existing client access. Verify the public URL, TLS certificate, proxy trust, and known clients before
+  reopening ingress. If the old host or backup may have been exposed, follow the compromise procedure below instead.
+- **Separate clone:** Keep the clone isolated from public ingress and MCP agent networks while recovering it. A database
+  restore preserves the original installation UUID; do not run the original and clone concurrently with copied
+  credentials.
+
+Before exposing a separate clone:
+
+1. Assign its dedicated public origin and change **OAuth public base URL**. The identity change revokes copied OAuth
+   grants and tokens and closes OAuth subscriptions.
+2. In **MCP clients**, rotate, revoke, or delete every copied static client. Copy replacement credentials only to agents
+   intended for the clone.
+3. In **MCP OAuth access**, select **Revoke all OAuth access**, then disable copied OAuth clients that the clone should
+   not accept.
+4. Complete fresh consent for every retained OAuth client and verify one minimum-scope tool call.
+5. Open public ingress only after old credentials fail against the clone and the original host can no longer answer for
+   the clone's public identity.
+
+### Revoke all and rotate OAuth server material
+
+**Revoke all OAuth access** is the supported logical server-secret rotation. It advances the persistent
+authorization-server security epoch, revokes every grant, authorization code, access token, and refresh family, and
+closes every OAuth subscription before reporting success. Pre-registered public clients remain available for fresh
+consent, and static MCP credentials and streams remain active.
+
+Use it after an unknown OAuth leak, owner/administrator compromise, risky restore, or before transferring an
+installation. Disabling OAuth also performs global OAuth invalidation, but leaves the remote profile closed until it is
+explicitly enabled again.
+
+If the backup, Smart Panel host, or `.mcp-oauth-provider.json` itself was disclosed, also replace the cryptographic
+provider material:
+
+1. Isolate the host, revoke all OAuth access, and disable OAuth.
+2. Stop the backend. Never edit, remove, or replace provider material while it is running.
+3. Move `.mcp-oauth-provider.json` out of `FB_CONFIG_PATH` into access-controlled incident evidence, or securely remove
+   it after evidence retention. Do not restore that file from a potentially exposed backup.
+4. Start the backend. Smart Panel creates new owner-only provider material when OAuth is next activated. It tightens
+   permissions to `0600`; malformed, incomplete, or symlinked material keeps OAuth fail-closed.
+5. Verify the public identity and proxy, enable OAuth, and require fresh browser consent. Rotate every other secret
+   contained in the exposed configuration backup separately.
+
+## Respond to Credential or Account Compromise
+
+Use the narrowest control that contains the known exposure:
+
+| Exposure                                   | Immediate action                                                                                                       |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| One static bearer                          | Rotate that client credential; revoke or delete the client if it is no longer trusted                                  |
+| One OAuth access token                     | Revoke that access token; it expires after at most 10 minutes                                                          |
+| OAuth refresh token or one agent host      | Revoke its refresh family and grant, or disable the OAuth client if all of its access is suspect                       |
+| Unknown or installation-wide OAuth access  | Select **Revoke all OAuth access**                                                                                     |
+| Backup, provider material, or backend host | Isolate the host, revoke all, replace provider material, rotate every static client and other copied configuration key |
+| Owner or administrator account             | Recover the account, revoke all OAuth access, rotate static clients, and remove or demote unknown administrative users |
+
+Preserve backend logs before cleanup. MCP audit events such as `oauth_management`, `oauth_global_revocation`,
+`oauth_authorization_invalidation`, and `tool_execution` identify actors, affected management IDs, and outcomes without
+recording raw bearer material.
+
+### Recover an owner account
+
+Use the existing backend CLI to reset an owner password when the Admin login is unavailable. On a pre-built image:
+
+```bash copy
+sudo smart-panel-cli auth:reset <username> '<new-password>'
+```
+
+Other installation methods must invoke the same `auth:reset` command through their backend CLI with the installation's
+normal environment and database permissions. Avoid leaving the recovery password in shared terminal history.
+
+A password reset restores login access but deliberately does **not** revoke OAuth grants, access tokens, refresh
+families, or static MCP credentials. After signing in, select **Revoke all OAuth access**, rotate every static client
+that the compromised account could have created or copied, review the registered clients and grants, and remove or
+demote unknown users. Demoting or deleting an approving owner/administrator automatically revokes grants that user
+approved, but it is not a substitute for global revocation when the exposure is uncertain.
+
 ## Connect an Agent
 
 The client must support **Streamable HTTP** and either a preconfigured bearer token or standards-based OAuth.

--- a/apps/website/app/docs/updating/page.mdx
+++ b/apps/website/app/docs/updating/page.mdx
@@ -18,10 +18,16 @@ covers how to safely update your installation and back up your data.
 
 ## Backup
 
-Your Smart Panel stores two important files:
+Your Smart Panel stores its database and an owner-only configuration directory. Important contents include:
 
 - `config/config.yaml` — system configuration (plugins, weather, display settings)
 - `data/database.sqlite` — all devices, dashboards, users, and scenes
+- `config/.mcp-oauth-provider.json` — private OAuth signing and cookie material after MCP OAuth is first activated
+
+<Callout type="warning">
+	Backups are not encrypted. The configuration can contain resolved write-only secrets, and the database contains
+	installation identity and authorization metadata. Restrict backup access and securely remove obsolete copies.
+</Callout>
 
 The location depends on your installation method:
 
@@ -92,8 +98,10 @@ docker compose up -d
 
 <Callout type="warning">
 	If you restore a backup into a second or cloned installation, the database also copies the installation UUID, MCP
-	clients, and token hashes. Before allowing access to the clone, immediately rotate or revoke every copied MCP
-	credential; otherwise, existing bearer tokens remain valid against both installations under the same audience.
+	clients, OAuth grants, and token hashes, while the configuration copies the OAuth provider's private material. Keep
+	the clone isolated, assign a dedicated public origin, revoke all OAuth access, and rotate or revoke every copied
+	static MCP credential before allowing access. Follow the complete
+	[MCP restore and compromise runbook](/docs/admin-management/mcp#protect-backups-and-restored-installations).
 </Callout>
 
 ---

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -505,7 +505,7 @@ amend ADR 0002.
 
 - [x] Document HTTPS and explicit public URL requirements, supported proxy layouts, client pre-registration, Codex and
       Claude setup, consent, and migration from static credentials.
-- [ ] Document backup sensitivity, clone handling, server-secret rotation, revoke-all, compromise response, and account
+- [x] Document backup sensitivity, clone handling, server-secret rotation, revoke-all, compromise response, and account
       recovery.
 - [ ] Document dependency upgrades, metadata diffs, smoke-test requirements, rollback, and static-profile retention.
 - [ ] Confirm no DCR/CIMD endpoints are advertised and create explicit follow-up tasks if the release gate justifies


### PR DESCRIPTION
## Summary

- document MCP-sensitive backup contents and storage precautions
- distinguish replacement restores from independently operated clones
- add OAuth revoke-all, logical server-secret rotation, and cryptographic provider-material replacement procedures
- add credential, host, backup, and owner-account compromise response guidance
- link the general backup guide to the MCP recovery runbook
- mark the corresponding Phase 7 rollout task complete

## Why

Remote OAuth makes backups and restored installations part of the authorization boundary. Operators need an explicit procedure that preserves a trusted replacement while preventing copied credentials, grants, signing material, or a compromised administrator from retaining access.

## Impact

This is documentation-only. It explains the existing fail-closed lifecycle controls and recovery commands without changing runtime behavior.

## Validation

- `pnpm --filter ./apps/website run build`
- `pnpm --filter ./apps/website exec prettier --check app/docs/admin-management/mcp/page.mdx ../../tasks/plans/plan-mcp-oauth-authorization.md`
- `git diff --check`