### PR TITLE
docs(cross): define MCP OAuth upgrade gate

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-oauth-resource-server.service.spec.ts
@@ -180,6 +180,9 @@ describe('McpOAuthResourceServerService', () => {
   },
 }
 `);
+
+		expect(service.getAuthorizationServerMetadata()).not.toHaveProperty('registration_endpoint');
+		expect(service.getProtectedResourceMetadata()).not.toHaveProperty('client_id_metadata_document_supported');
 	});
 
 	it('maps the four-way live scope intersection to MCP capabilities', async () => {

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -438,6 +438,8 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 			token_endpoint_auth_methods_supported: ['none'],
 			authorization_response_iss_parameter_supported: true,
 		});
+		expect(runtime.metadata).not.toHaveProperty('registration_endpoint');
+		expect(runtime.metadata).not.toHaveProperty('client_id_metadata_document_supported');
 	});
 
 	it('authorizes a dynamically pre-registered public client with PKCE S256', async () => {

--- a/apps/website/app/docs/updating/page.mdx
+++ b/apps/website/app/docs/updating/page.mdx
@@ -256,6 +256,14 @@ identity and MCP client tables without converting existing users or credentials.
 default: MCP is disabled, `read` is preselected as the enablement default, and the additional browser-origin allowlist
 is empty.
 
+MCP OAuth remains separately opt-in and uses exactly pinned authorization and protocol dependencies. Before deploying a
+release that changes `oidc-provider`, its type definitions, or the MCP server/client packages, review the bounded
+authorization-server and protected-resource metadata snapshots for newly advertised fields or changed defaults. The
+release must pass the complete OAuth negative/E2E suite plus the recorded Codex and Claude Code smoke profiles before
+OAuth is re-enabled. An upgraded dependency must never publish Dynamic Client Registration or Client ID Metadata
+Document support merely because it enables either feature internally; the supported profile continues to use
+owner/admin pre-registration.
+
 After updating, an owner or administrator must explicitly enable MCP and create finite-lived client credentials. Back
 up both the database and configuration first.
 
@@ -265,6 +273,18 @@ migration tooling. Do not only switch a symlink or container tag: application ro
 The migration's down step deletes MCP-owned tokens before older authentication code can load them.
 
 See [Model Context Protocol](/docs/admin-management/mcp) for setup, security guidance, and the exact curated catalog.
+
+### Rolling Back MCP OAuth
+
+If an upgrade changes OAuth metadata or breaks either supported host profile, use the Admin MCP settings to disable
+OAuth before rolling back. Disabling OAuth closes its public route gate, revokes its grants and provider artifacts, and
+closes OAuth subscriptions while preserving registered OAuth clients and the independent static bearer profile. Static
+LAN/VPN clients can therefore remain available during diagnosis.
+
+Do not attempt to convert, reissue, or reuse an OAuth token as a static credential. Restore the previous application
+version only after OAuth is disabled and the database schema is compatible with that version. After rollback, keep
+OAuth disabled until the previous version's metadata snapshots and target-host smoke profile have been verified, then
+require every OAuth client to complete a fresh authorization flow.
 
 ---
 

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -85,6 +85,37 @@ CIMD is deferred until the chosen authorization component supports the same draf
 specification and Smart Panel has a reviewed SSRF-safe metadata fetch policy. DCR is not implemented unless a supported
 host fails the pre-registration gate and the failure cannot be fixed with its documented client-ID/callback settings.
 
+### Release registration decision
+
+The bounded authorization-server metadata snapshots and provider integration tests assert that neither a
+`registration_endpoint` nor any CIMD capability is advertised. The documented Codex and Claude Code profiles both
+accept a predefined public client, so there is currently no host evidence that justifies DCR or CIMD and no
+implementation follow-up is opened. The live smoke gate remains responsible for validating both profiles end to end.
+
+Reconsider this decision only when a named supported host cannot complete the required smoke sequence with
+pre-registration. That evidence must identify the exact host version and failed callback/registration behavior. DCR
+would then require registration authentication, quotas, redirect-policy enforcement, abuse handling, and lifecycle
+administration; CIMD would require a draft-revision decision plus an SSRF-safe fetch policy covering DNS rebinding,
+redirects, address ranges, size/time limits, caching, and metadata validation.
+
+## Dependency and metadata upgrade gate
+
+The release profile pins `oidc-provider` `9.11.2`, `@types/oidc-provider` `9.11.1`, and the official MCP server and
+client packages at `2.0.0`. Any change to those versions must be treated as a security-profile change even when the
+package manager classifies it as minor or patch.
+
+Before merging an upgrade:
+
+1. Compare the bounded authorization-server and protected-resource metadata snapshots. Reject unreviewed endpoints,
+   grants, response types, authentication methods, algorithms, scopes, DCR, CIMD, or OIDC-only fields.
+2. Run the provider OAuth spike, focused metadata/resource-server tests, complete backend unit/E2E suites, and the
+   TypeScript client wire matrix, including PKCE, redirect, resource/audience, refresh replay, revocation, scope
+   contraction, stream closure, switch-off, and redaction cases.
+3. Repeat the exact Codex and Claude Code smoke profiles and record their versions, callback URIs, requested scopes,
+   refresh behavior, and revocation result. A successful automated TypeScript client run does not replace either host.
+4. Verify OAuth can be disabled while static bearer clients remain usable. Roll back with OAuth disabled, never map an
+   OAuth bearer into the static profile, and require fresh authorization after the previous version is restored.
+
 ## Authorization component survey
 
 Smart Panel must not implement OAuth protocol machinery ad hoc. The leading embedded candidate is `oidc-provider`

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -406,7 +406,7 @@ amend ADR 0002.
 
 **Goal:** Prove the complete security profile before documenting it as supported.
 
-- [ ] E2E: discovery, consent approval/denial, PKCE success/failure, RFC 8252 loopback port variation, strict redirect
+- [x] E2E: discovery, consent approval/denial, PKCE success/failure, RFC 8252 loopback port variation, strict redirect
       rejection otherwise, code replay, scope reduction, expiry, refresh rotation/reuse, revocation, wrong
       issuer/resource/audience, cross-client isolation, and redaction; cover open-stream abort on token expiry and
       grant expiry, client/grant/access-token/refresh-family revocation, awaited approver demotion/deletion
@@ -507,9 +507,10 @@ amend ADR 0002.
       Claude setup, consent, and migration from static credentials.
 - [x] Document backup sensitivity, clone handling, server-secret rotation, revoke-all, compromise response, and account
       recovery.
-- [ ] Document dependency upgrades, metadata diffs, smoke-test requirements, rollback, and static-profile retention.
-- [ ] Confirm no DCR/CIMD endpoints are advertised and create explicit follow-up tasks if the release gate justifies
-      either feature.
+- [x] Document dependency upgrades, metadata diffs, smoke-test requirements, rollback, and static-profile retention.
+- [x] Confirm no DCR/CIMD endpoints are advertised and create explicit follow-up tasks if the release gate justifies
+      either feature. The bounded metadata snapshots advertise neither; pre-registration satisfies the current target
+      profiles, so no implementation follow-up is justified without a named host failure.
 - [ ] Update task acceptance criteria and mark completion only after every deferred item has a named follow-up.
 
 ## Required verification cadence

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -51,19 +51,19 @@ upgrade consequences.
 ## 4. Acceptance criteria
 
 - [x] An ADR documents the authorization-server architecture and a threat model for internet-reachable MCP.
-- [ ] The MCP endpoint publishes standards-compliant protected-resource metadata with its canonical resource identifier
+- [x] The MCP endpoint publishes standards-compliant protected-resource metadata with its canonical resource identifier
       and authorization-server location.
-- [ ] Unauthenticated MCP responses include a protocol-correct bearer challenge pointing clients to protected-resource
+- [x] Unauthenticated MCP responses include a protocol-correct bearer challenge pointing clients to protected-resource
       metadata without leaking installation or credential secrets.
-- [ ] Authorization-server metadata is standards compliant and advertises only implemented endpoints, response types,
+- [x] Authorization-server metadata is standards compliant and advertises only implemented endpoints, response types,
       grant types, PKCE methods, scopes, and signing algorithms.
-- [ ] Authorization uses the code flow with PKCE `S256`, exact redirect-URI matching, state validation, short-lived
+- [x] Authorization uses the code flow with PKCE `S256`, exact redirect-URI matching, state validation, short-lived
       codes, and replay prevention.
-- [ ] Access tokens are finite, issuer/resource/audience bound, revocable, and rejected by ordinary REST, WebSocket,
+- [x] Access tokens are finite, issuer/resource/audience bound, revocable, and rejected by ordinary REST, WebSocket,
       display, and personal-access-token paths.
-- [ ] OAuth scopes map to the curated `read`, `write`, and `trigger` capabilities and remain bounded by the live module
+- [x] OAuth scopes map to the curated `read`, `write`, and `trigger` capabilities and remain bounded by the live module
       ceiling and approved grant.
-- [ ] Consent clearly names the installation, requesting client, redirect destination, expiry, and physical-device
+- [x] Consent clearly names the installation, requesting client, redirect destination, expiry, and physical-device
       impact of write/trigger scopes.
 - [x] Owners/admins can list and revoke OAuth clients, grants, access tokens, and refresh tokens; revocation closes the
       affected MCP subscriptions immediately.
@@ -82,19 +82,19 @@ upgrade consequences.
       runtime enable/disable never mounts or unmounts routes and never exposes a partial surface.
 - [x] Public OAuth identity and server-secret rotation revoke OAuth artifacts and close OAuth subscriptions while
       preserving static MCP streams; only MCP-module disable closes both authorization profiles.
-- [ ] Dynamic client registration is implemented only if required by supported target hosts and protected by an
+- [x] Dynamic client registration is implemented only if required by supported target hosts and protected by an
       explicit registration policy; otherwise the supported registration path is documented.
 - [x] Trusted reverse-proxy behavior is explicit and tested; forwarded headers are ignored unless the proxy is
       configured as trusted.
 - [x] Static bearer clients continue to work for trusted LAN/VPN deployments until a separately documented removal or
       migration policy is approved.
-- [ ] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
+- [x] E2E tests cover discovery, consent, PKCE success/failure, redirect validation, scope reduction, expiry, refresh,
       concurrent refresh replay, revocation/listen and all invalidation/artifact-commit races, runtime-gated OAuth
       switch-off/re-enable, static-stream preservation, wrong issuer/resource/audience, cross-client isolation, stream
       closure, and log redaction.
 - [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
       refresh, and revocation smoke tests.
-- [ ] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident
+- [x] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident
       response, and rollback guidance.
 
 ## 5. Example scenarios


### PR DESCRIPTION
## Summary

- define the security review gate for OAuth and MCP dependency upgrades
- document OAuth rollback while retaining the independent static bearer profile
- assert that authorization metadata does not advertise DCR or CIMD
- reconcile completed automated acceptance criteria while leaving real-host smoke tests open

## Why

The implementation now has broad automated coverage, but release operations still needed an explicit dependency-upgrade, metadata-diff, rollback, and client-registration policy. This keeps future package upgrades from silently expanding the public OAuth surface and makes the remaining Codex and Claude Code interoperability work visible.

## Impact

No production OAuth behavior or public API changes. Operators gain upgrade and rollback guidance, and tests pin the intended pre-registration-only metadata profile.

## Validation

- focused MCP OAuth resource-server unit tests
- provider-backed OAuth spike tests
- backend TypeScript type-check
- focused ESLint and formatting checks
- website production build
- `git diff --check`