### PR TITLE
fix(cross): close OAuth streams for host compatibility

### DIFF
--- a/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.spec.ts
@@ -1,4 +1,6 @@
+import { EventEmitter } from 'events';
 import { FastifyReply } from 'fastify';
+import { ServerResponse } from 'http';
 
 import { AuthInfo, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
 import { UnauthorizedException } from '@nestjs/common';
@@ -418,30 +420,23 @@ describe('McpServerService policy revision', () => {
 
 	it('terminates a forwarded subscription stream when its authorization signal aborts', async () => {
 		const attachTransport = jest.fn();
-		const completeTransport = jest.fn();
 		const cancelled = jest.fn();
 		const upstream = new ReadableStream<Uint8Array>({ cancel: cancelled });
 		const response = new Response(upstream, { headers: { 'content-type': 'text/event-stream' } });
 		const controller = new AbortController();
-		const transportController = new AbortController();
 		const close = jest.fn();
 		const subscription = {
 			attachTransport,
 			close,
-			completeTransport,
 			wireRequestId: 'listen:1',
 			signal: controller.signal,
 			touch: jest.fn(),
 		} as unknown as McpSubscriptionHandle;
 		const tracked = (
 			service as unknown as {
-				trackSubscriptionResponse(
-					response: Response,
-					subscription: McpSubscriptionHandle,
-					transportSignal?: AbortSignal,
-				): Response;
+				trackSubscriptionResponse(response: Response, subscription: McpSubscriptionHandle): Response;
 			}
-		).trackSubscriptionResponse(response, subscription, transportController.signal);
+		).trackSubscriptionResponse(response, subscription);
 		const reader = tracked.body?.getReader();
 		const pendingRead = reader?.read();
 		expect(attachTransport).not.toHaveBeenCalled();
@@ -453,17 +448,30 @@ describe('McpServerService policy revision', () => {
 		expect(new TextDecoder().decode(cancellation?.value)).toContain(
 			'"method":"notifications/cancelled","params":{"requestId":"listen:1"}',
 		);
-		let nextReadSettled = false;
-		const nextRead = reader?.read().finally(() => {
-			nextReadSettled = true;
-		});
-		await Promise.resolve();
-		expect(nextReadSettled).toBe(false);
-
-		transportController.abort('remote client closed the request');
-		await expect(nextRead).resolves.toEqual({ done: true, value: undefined });
+		await expect(reader?.read()).resolves.toEqual({ done: true, value: undefined });
 		expect(cancelled).toHaveBeenCalledWith(controller.signal.reason);
-		expect(close).toHaveBeenCalledWith('cancelled');
-		expect(completeTransport).toHaveBeenCalledTimes(1);
+		expect(close).not.toHaveBeenCalled();
+	});
+
+	it('waits for the Node response to finish before completing transport teardown', async () => {
+		const response = new EventEmitter() as unknown as ServerResponse;
+		Object.defineProperties(response, {
+			destroyed: { configurable: true, value: false },
+			writableFinished: { configurable: true, value: false },
+		});
+		const completion = (
+			service as unknown as { waitForResponseCompletion(response: ServerResponse): Promise<void> }
+		).waitForResponseCompletion(response);
+		let settled = false;
+		void completion.then(() => {
+			settled = true;
+		});
+
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		response.emit('finish');
+		await completion;
+		expect(settled).toBe(true);
 	});
 });

--- a/apps/backend/src/modules/mcp/services/mcp-server.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-server.service.ts
@@ -1,6 +1,6 @@
 import { FastifyReply } from 'fastify';
 import { readFileSync } from 'fs';
-import { IncomingMessage } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 import { resolve } from 'path';
 
 import { toNodeHandler } from '@modelcontextprotocol/node';
@@ -33,7 +33,15 @@ const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../../../../pack
 	version: string;
 };
 
-type AuthenticatedIncomingMessage = IncomingMessage & { auth?: AuthInfo };
+const MCP_SUBSCRIPTION_CONTEXT = Symbol('mcp-subscription-context');
+
+interface McpSubscriptionRequestContext {
+	subscription?: McpSubscriptionHandle;
+}
+
+type McpRequestAuthInfo = AuthInfo & { [MCP_SUBSCRIPTION_CONTEXT]?: McpSubscriptionRequestContext };
+
+type AuthenticatedIncomingMessage = IncomingMessage & { auth?: McpRequestAuthInfo };
 
 interface ClientHandler {
 	handler: McpHttpHandler;
@@ -108,6 +116,7 @@ export class McpServerService implements OnApplicationShutdown {
 		const rawRequest = request.raw as AuthenticatedIncomingMessage;
 		const endpoint = new URL(request.url, `${request.protocol}://${request.headers.host ?? 'localhost'}`);
 
+		const subscriptionContext: McpSubscriptionRequestContext = {};
 		rawRequest.auth = {
 			token,
 			clientId: policy.client.id,
@@ -122,11 +131,12 @@ export class McpServerService implements OnApplicationShutdown {
 				clientName: policy.client.name,
 				tokenId: policy.tokenId,
 			},
-		};
+			[MCP_SUBSCRIPTION_CONTEXT]: subscriptionContext,
+		} as McpRequestAuthInfo;
 
 		reply.hijack();
 
-		await clientHandler.nodeHandler(rawRequest, reply.raw, request.body);
+		await this.handleNodeRequest(clientHandler, rawRequest, reply.raw, request.body, subscriptionContext);
 	}
 
 	async handleOAuth(request: McpPolicyRequest, reply: FastifyReply, authInfo: AuthInfo): Promise<void> {
@@ -135,10 +145,11 @@ export class McpServerService implements OnApplicationShutdown {
 		const clientHandler = this.getOrCreateHandler(`oauth:${authInfo.clientId}`);
 		const rawRequest = request.raw as AuthenticatedIncomingMessage;
 
-		rawRequest.auth = authInfo;
+		const subscriptionContext: McpSubscriptionRequestContext = {};
+		rawRequest.auth = { ...authInfo, [MCP_SUBSCRIPTION_CONTEXT]: subscriptionContext } as McpRequestAuthInfo;
 		reply.hijack();
 
-		await clientHandler.nodeHandler(rawRequest, reply.raw, request.body);
+		await this.handleNodeRequest(clientHandler, rawRequest, reply.raw, request.body, subscriptionContext);
 	}
 
 	notifyToolsChanged(clientId?: string): void {
@@ -263,8 +274,18 @@ export class McpServerService implements OnApplicationShutdown {
 
 					subscription = opened.handle;
 					if (opened.authInfo !== requestOptions?.authInfo) {
-						options = { ...requestOptions, authInfo: opened.authInfo };
+						options = {
+							...requestOptions,
+							authInfo: {
+								...opened.authInfo,
+								[MCP_SUBSCRIPTION_CONTEXT]: (requestOptions?.authInfo as McpRequestAuthInfo | undefined)?.[
+									MCP_SUBSCRIPTION_CONTEXT
+								],
+							} as McpRequestAuthInfo,
+						};
 					}
+					const context = (options?.authInfo as McpRequestAuthInfo | undefined)?.[MCP_SUBSCRIPTION_CONTEXT];
+					if (context) context.subscription = subscription;
 				} catch (error) {
 					if (error instanceof McpSubscriptionUnavailableError) {
 						return this.getSubscriptionErrorResponse(error, requestOptions?.parsedBody);
@@ -477,15 +498,13 @@ export class McpServerService implements OnApplicationShutdown {
 				abortStream = (): void => {
 					if (streamClosed || cancellationSent) return;
 
+					streamClosed = true;
 					cancellationSent = true;
 					removeAbortListener();
+					removeTransportAbortListener();
 					try {
 						controller.enqueue(this.subscriptionCancellationEvent(subscription.wireRequestId));
-						if (subscription.signal.reason !== 'authorization_revoked') {
-							streamClosed = true;
-							removeTransportAbortListener();
-							controller.close();
-						}
+						controller.close();
 					} catch {
 						// The response consumer already closed the stream.
 					} finally {
@@ -562,6 +581,39 @@ export class McpServerService implements OnApplicationShutdown {
 		const id = this.getRequestBody(body).id;
 
 		return typeof id === 'number' || typeof id === 'string' ? id : this.auditService.getRequestId(body);
+	}
+
+	private async handleNodeRequest(
+		clientHandler: ClientHandler,
+		request: AuthenticatedIncomingMessage,
+		response: ServerResponse,
+		body: unknown,
+		context: McpSubscriptionRequestContext,
+	): Promise<void> {
+		try {
+			await clientHandler.nodeHandler(request, response, body);
+		} finally {
+			if (context.subscription) {
+				await this.waitForResponseCompletion(response);
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				context.subscription.completeTransport();
+			}
+		}
+	}
+
+	private async waitForResponseCompletion(response: ServerResponse): Promise<void> {
+		if (response.writableFinished || response.destroyed) return;
+
+		await new Promise<void>((resolve) => {
+			const complete = (): void => {
+				response.off('close', complete);
+				response.off('finish', complete);
+				resolve();
+			};
+			response.once('close', complete);
+			response.once('finish', complete);
+			if (response.writableFinished || response.destroyed) complete();
+		});
 	}
 
 	private auditProtocolRequest(body: unknown, requestId: string, clientId: string): void {

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.spec.ts
@@ -210,7 +210,7 @@ describe('McpSubscriptionRegistryService', () => {
 		const subscription = await service.openOAuth('stalled-transport-close', () => Promise.resolve(oauthRegistration()));
 		subscription.attachTransport();
 		const mutation = service.closeOAuthAccessToken('access-one', () => Promise.resolve());
-		const rejection = expect(mutation).rejects.toThrow('MCP subscription transport did not acknowledge closure');
+		const rejection = expect(mutation).rejects.toThrow('MCP subscription transport did not complete closure');
 
 		await jest.advanceTimersByTimeAsync(MCP_SUBSCRIPTION_CLOSE_TIMEOUT_MS);
 		await rejection;
@@ -220,7 +220,7 @@ describe('McpSubscriptionRegistryService', () => {
 		expect(service.activeCount).toBe(1);
 
 		const retry = service.closeOAuthAccessToken('access-one', () => Promise.resolve());
-		const retryRejection = expect(retry).rejects.toThrow('MCP subscription transport did not acknowledge closure');
+		const retryRejection = expect(retry).rejects.toThrow('MCP subscription transport did not complete closure');
 		await jest.advanceTimersByTimeAsync(MCP_SUBSCRIPTION_CLOSE_TIMEOUT_MS);
 		await retryRejection;
 		expect(service.activeCount).toBe(1);

--- a/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-subscription-registry.service.ts
@@ -372,7 +372,7 @@ export class McpSubscriptionRegistryService implements OnApplicationShutdown {
 				closure,
 				new Promise<never>((_, reject) => {
 					timer = setTimeout(
-						() => reject(new Error('MCP subscription transport did not acknowledge closure')),
+						() => reject(new Error('MCP subscription transport did not complete closure')),
 						MCP_SUBSCRIPTION_CLOSE_TIMEOUT_MS,
 					);
 					timer.unref();

--- a/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth-listen-registration-race.e2e-spec.ts
@@ -747,18 +747,12 @@ describe('MCP OAuth listen registration race', () => {
 			});
 
 			expect(subscriptions.activeCount).toBe(1);
-			let grantWriteScopeContractionMutationSettled = false;
-			const grantWriteScopeContractionMutation = management
-				.updateGrant(
-					grantWriteScopeContractionGrant.id,
-					{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER] },
-					'owner-actor',
-				)
-				.finally(() => {
-					grantWriteScopeContractionMutationSettled = true;
-				});
+			const grantWriteScopeContractionMutation = management.updateGrant(
+				grantWriteScopeContractionGrant.id,
+				{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER] },
+				'owner-actor',
+			);
 			await expect(grantWriteScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(grantWriteScopeContractionMutationSettled).toBe(false);
 			await grantWriteScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			await expect(resourceServer.verifyAccessToken(grantWriteScopeContractionAccessToken)).rejects.toThrow(
@@ -807,18 +801,12 @@ describe('MCP OAuth listen registration race', () => {
 			});
 
 			expect(subscriptions.activeCount).toBe(1);
-			let grantTriggerScopeContractionMutationSettled = false;
-			const grantTriggerScopeContractionMutation = management
-				.updateGrant(
-					grantTriggerScopeContractionGrant.id,
-					{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] },
-					'owner-actor',
-				)
-				.finally(() => {
-					grantTriggerScopeContractionMutationSettled = true;
-				});
+			const grantTriggerScopeContractionMutation = management.updateGrant(
+				grantTriggerScopeContractionGrant.id,
+				{ approvedScopes: [McpOAuthScope.READ, McpOAuthScope.WRITE] },
+				'owner-actor',
+			);
 			await expect(grantTriggerScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(grantTriggerScopeContractionMutationSettled).toBe(false);
 			await grantTriggerScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			await expect(resourceServer.verifyAccessToken(grantTriggerScopeContractionAccessToken)).rejects.toThrow(
@@ -867,18 +855,12 @@ describe('MCP OAuth listen registration race', () => {
 			const scopeContractionSubscription = await scopeContractionClient.listen({ toolsListChanged: true });
 
 			expect(subscriptions.activeCount).toBe(1);
-			let scopeContractionMutationSettled = false;
-			const scopeContractionMutation = management
-				.updateClient(
-					scopeContractionOAuthClient.id,
-					{ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER] },
-					'owner-actor',
-				)
-				.finally(() => {
-					scopeContractionMutationSettled = true;
-				});
+			const scopeContractionMutation = management.updateClient(
+				scopeContractionOAuthClient.id,
+				{ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.TRIGGER] },
+				'owner-actor',
+			);
 			await expect(scopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(scopeContractionMutationSettled).toBe(false);
 			await scopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			expect(auditLog).toHaveBeenCalledWith(
@@ -955,14 +937,12 @@ describe('MCP OAuth listen registration race', () => {
 			});
 
 			expect(subscriptions.activeCount).toBe(1);
-			let clientTriggerScopeContractionMutationSettled = false;
-			const clientTriggerScopeContractionMutation = management
-				.updateClient(scopeContractionOAuthClient.id, { maximumScopes: [McpOAuthScope.READ] }, 'owner-actor')
-				.finally(() => {
-					clientTriggerScopeContractionMutationSettled = true;
-				});
+			const clientTriggerScopeContractionMutation = management.updateClient(
+				scopeContractionOAuthClient.id,
+				{ maximumScopes: [McpOAuthScope.READ] },
+				'owner-actor',
+			);
 			await expect(clientTriggerScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(clientTriggerScopeContractionMutationSettled).toBe(false);
 			await clientTriggerScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			await expect(resourceServer.verifyAccessToken(clientTriggerScopeContractionAccessToken)).rejects.toThrow(
@@ -1036,14 +1016,12 @@ describe('MCP OAuth listen registration race', () => {
 			const clientReadScopeContractionSubscription = await scopeContractionClient.listen({ toolsListChanged: true });
 
 			expect(subscriptions.activeCount).toBe(1);
-			let clientReadScopeContractionMutationSettled = false;
-			const clientReadScopeContractionMutation = management
-				.updateClient(scopeContractionOAuthClient.id, { maximumScopes: [] }, 'owner-actor')
-				.finally(() => {
-					clientReadScopeContractionMutationSettled = true;
-				});
+			const clientReadScopeContractionMutation = management.updateClient(
+				scopeContractionOAuthClient.id,
+				{ maximumScopes: [] },
+				'owner-actor',
+			);
 			await expect(clientReadScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(clientReadScopeContractionMutationSettled).toBe(false);
 			await clientReadScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			await expect(resourceServer.verifyAccessToken(clientReadScopeContractionAccessToken)).rejects.toThrow(
@@ -1636,22 +1614,16 @@ describe('MCP OAuth listen registration race', () => {
 			});
 
 			expect(subscriptions.activeCount).toBe(2);
-			let moduleWriteScopeContractionMutationSettled = false;
-			const moduleWriteScopeContractionMutation = moduleConfigMutation
-				.update(
-					Object.assign(new UpdateMcpConfigDto(), {
-						type: MCP_MODULE_NAME,
-						capabilities: [McpCapability.READ, McpCapability.TRIGGER],
-					}),
-					() => {
-						config.capabilities = [McpCapability.READ, McpCapability.TRIGGER];
-					},
-				)
-				.finally(() => {
-					moduleWriteScopeContractionMutationSettled = true;
-				});
+			const moduleWriteScopeContractionMutation = moduleConfigMutation.update(
+				Object.assign(new UpdateMcpConfigDto(), {
+					type: MCP_MODULE_NAME,
+					capabilities: [McpCapability.READ, McpCapability.TRIGGER],
+				}),
+				() => {
+					config.capabilities = [McpCapability.READ, McpCapability.TRIGGER];
+				},
+			);
 			await expect(moduleWriteScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(moduleWriteScopeContractionMutationSettled).toBe(false);
 			await moduleWriteScopeContractionMutation;
 			expect(moduleTriggerScopeSubscriptionClosed).toBe(false);
 			expect(subscriptions.activeCount).toBe(1);
@@ -1725,22 +1697,16 @@ describe('MCP OAuth listen registration race', () => {
 			});
 			expect(subscriptions.activeCount).toBe(1);
 
-			let moduleTriggerScopeContractionMutationSettled = false;
-			const moduleTriggerScopeContractionMutation = moduleConfigMutation
-				.update(
-					Object.assign(new UpdateMcpConfigDto(), {
-						type: MCP_MODULE_NAME,
-						capabilities: [McpCapability.READ],
-					}),
-					() => {
-						config.capabilities = [McpCapability.READ];
-					},
-				)
-				.finally(() => {
-					moduleTriggerScopeContractionMutationSettled = true;
-				});
+			const moduleTriggerScopeContractionMutation = moduleConfigMutation.update(
+				Object.assign(new UpdateMcpConfigDto(), {
+					type: MCP_MODULE_NAME,
+					capabilities: [McpCapability.READ],
+				}),
+				() => {
+					config.capabilities = [McpCapability.READ];
+				},
+			);
 			await expect(freshModuleTriggerScopeContractionSubscription.closed).resolves.toBe('remote');
-			expect(moduleTriggerScopeContractionMutationSettled).toBe(false);
 			await moduleTriggerScopeContractionMutation;
 			expect(subscriptions.activeCount).toBe(0);
 			await expect(resourceServer.verifyAccessToken(freshModuleTriggerScopeContractionAccessToken)).rejects.toThrow(

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -240,6 +240,27 @@ because its request omitted `offline_access`. Administrative revocation and the 
 be exercised with this host. Refresh rotation continues to be exercised through the protocol client and the Claude Code
 target instead of weakening the server's scope policy.
 
+## Live Claude Code evidence
+
+The Phase 6 smoke against Claude Code `2.1.229` exercised the production provider through a local HTTPS reverse proxy
+with a private test CA trusted only by the Claude Node.js process. The installed client used a pre-registered public
+client, discovered the protected-resource and authorization-server metadata, sent PKCE S256 and the RFC 8707 `resource`,
+and explicitly requested `mcp:read offline_access` with `prompt=consent`.
+
+Claude selected both `http://127.0.0.1:41457/callback` and `http://localhost:41457/callback` across fresh login attempts,
+so deployments using this fixed callback port must pre-register both exact loopback forms. Owner consent, authorization
+code exchange, `tools/list`, and a read-only `get_home_context` call succeeded. After the isolated provider access-token
+and mirror expiry were forced into the past, the next real Claude request succeeded and the persisted artifacts showed
+refresh-family rotation with exactly one live refresh successor.
+
+Revoking that refresh family through the production administrative API while Claude held live listen requests returned
+`204` and forced `claude mcp get` to report `Needs authentication`. This host check also established that invalidation
+must send `notifications/cancelled` and then end the server response: Claude does not send a separate acknowledgement for
+the cancelled listen request, so waiting for client-side cancellation would incorrectly turn a successful fail-closed
+revocation into a timeout. Finally, after contracting the client's ceiling to `mcp:read offline_access`, a fresh
+Claude-generated authorization request for `mcp:write offline_access` was redirected to its validated callback with
+`error=invalid_scope`, the original state, and the provider issuer.
+
 ## Primary references
 
 - [MCP authorization, revision 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -489,7 +489,9 @@ amend ADR 0002.
       change, and rollback.
 - [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and
       callback profile.
-- [ ] Claude Code smoke: the same sequence; record exact version and callback profile.
+- [x] Claude Code smoke: discovery, authorization, list/call, forced-expiry refresh rotation, scope failure, and live
+      refresh-family revocation passed with Claude Code `2.1.229`; both fixed-port loopback callback host forms are
+      recorded in the compatibility evidence.
 - [x] Repeat static bearer compatibility tests to prove coexistence. The static endpoint list/call suite and the
       simultaneous static-plus-OAuth lifecycle E2E exercise the production authentication and policy guards, including
       OAuth switch-off/re-enable while the static stream remains usable.


### PR DESCRIPTION
## Summary

- close invalidated MCP OAuth subscription streams from the server after sending `notifications/cancelled`
- wait for the local Node response to finish before completing the mutation transport barrier
- preserve per-request subscription correlation across OAuth revalidation
- record the completed Claude Code 2.1.229 compatibility smoke and its loopback callback behavior

## Root cause

Administrative refresh-family revocation waited for the remote client to cancel its listen request. Claude Code does not send a separate acknowledgement for a server-side cancellation notification, so the authorization was revoked fail-closed but the administrative request timed out and returned 500.

The server now ends the response itself and completes teardown after the Node response finishes. In a live Claude Code smoke, refresh-family revocation returned 204 in 23 ms and the client immediately reported that authentication was required.

## Validation

- `mcp-server.service.spec.ts` and `mcp-subscription-registry.service.spec.ts`: 37 tests passed
- `mcp-oauth-listen-registration-race.e2e-spec.ts`: passed
- backend TypeScript type-check
- focused ESLint and Prettier checks
- live Claude Code 2.1.229 OAuth authorization, refresh rotation, scope rejection, and revocation
