### PR TITLE
test(cross): add Homey SHS error probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -72,6 +72,7 @@
     "test:homey-spike": "jest --config ./test/jest-homey-spike.json --runInBand",
     "test:oauth-spike": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest --config ./test/jest-oauth-spike.json --runInBand",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
+    "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",

--- a/apps/backend/test/homey-shs-errors.homey-spike.ts
+++ b/apps/backend/test/homey-shs-errors.homey-spike.ts
@@ -1,0 +1,135 @@
+import {
+	type HomeyShsErrorReport,
+	type HomeyShsProbeFetch,
+	assertHomeyShsErrorReportSafe,
+	loadHomeyShsErrorProbeConfig,
+	probeHomeyShsErrors,
+	probeLocalNetworkFailures,
+} from './support/homey-shs-error-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'full-scope-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_DEVICE_ONLY_API_KEY: 'device-only-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const LOCAL_FAILURES: Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableHost'> = {
+	requestTimeout: { category: 'timeout', rejected: true },
+	unavailableHost: { category: 'unavailable', rejected: true },
+};
+
+const createLiveFetch = (): jest.MockedFunction<HomeyShsProbeFetch> =>
+	jest.fn<Promise<Response>, [URL, RequestInit]>((input, init) => {
+		const authorization = new Headers(init.headers).get('authorization');
+
+		if (authorization?.startsWith('Bearer invalid-homey-probe-') === true) {
+			return Promise.resolve(new Response(null, { status: 401 }));
+		}
+
+		if (authorization === `Bearer ${BASE_ENVIRONMENT.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY}`) {
+			return Promise.resolve(
+				new Response(null, { status: input.pathname === '/api/manager/devices/device' ? 200 : 403 }),
+			);
+		}
+
+		return Promise.reject(new Error('unexpected unsanitized test request'));
+	});
+
+describe('Homey SHS error compatibility probe', () => {
+	it('requires a distinct device-only key for missing-scope evidence', () => {
+		expect(() =>
+			loadHomeyShsErrorProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_DEVICE_ONLY_API_KEY: undefined,
+			}),
+		).toThrow('FB_HOMEY_SHS_DEVICE_ONLY_API_KEY is required');
+
+		expect(() =>
+			loadHomeyShsErrorProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_DEVICE_ONLY_API_KEY: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY,
+			}),
+		).toThrow('must differ from FB_HOMEY_SHS_API_KEY');
+	});
+
+	it('classifies all five failures without retaining endpoints, keys, or response bodies', async () => {
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-error-spike');
+		const fetchImplementation = createLiveFetch();
+		const report = await probeHomeyShsErrors(config, fetchImplementation, () => Promise.resolve(LOCAL_FAILURES));
+
+		expect(report).toEqual({
+			metadata: { probe: 'homey-shs-errors', schemaVersion: 1 },
+			scenarios: {
+				badUrl: { category: 'validation', rejected: true },
+				invalidKey: { category: 'authentication', rejected: true, statusCode: 401 },
+				missingScope: {
+					allowedRequestStatusCode: 200,
+					category: 'authorization',
+					rejected: true,
+					statusCode: 403,
+				},
+				...LOCAL_FAILURES,
+			},
+		});
+		expect(fetchImplementation).toHaveBeenCalledTimes(3);
+		expect(
+			fetchImplementation.mock.calls.every(([, init]) => init?.method === 'GET' && init.redirect === 'error'),
+		).toBe(true);
+		expect(() => assertHomeyShsErrorReportSafe(report, config)).not.toThrow();
+		expect(JSON.stringify(report)).not.toContain(config.apiKey);
+		expect(JSON.stringify(report)).not.toContain(config.deviceOnlyApiKey);
+	});
+
+	it('does not accept a successful request as invalid-key evidence', async () => {
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-error-spike');
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
+			Promise.resolve(new Response(null, { status: 200 })),
+		);
+
+		await expect(
+			probeHomeyShsErrors(config, fetchImplementation, () => Promise.resolve(LOCAL_FAILURES)),
+		).rejects.toThrow('invalid-key probe did not return an authentication rejection');
+	});
+
+	it('proves the restricted key is valid before accepting a denied scope', async () => {
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-error-spike');
+		const fetchImplementation = createLiveFetch();
+
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+
+		await expect(
+			probeHomeyShsErrors(config, fetchImplementation, () => Promise.resolve(LOCAL_FAILURES)),
+		).rejects.toThrow('device-only key did not authenticate for its allowed device read');
+	});
+
+	it('requires a forbidden system read to return an authorization rejection', async () => {
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-error-spike');
+		const fetchImplementation = createLiveFetch();
+
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 200 })));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+
+		await expect(
+			probeHomeyShsErrors(config, fetchImplementation, () => Promise.resolve(LOCAL_FAILURES)),
+		).rejects.toThrow('did not return an authorization rejection for system read');
+	});
+
+	it('classifies real bounded local connection refusal and timeout failures', async () => {
+		const result = await probeLocalNetworkFailures(20);
+
+		expect(result).toEqual(LOCAL_FAILURES);
+	});
+
+	it('rejects a report if a configured secret is inserted later', async () => {
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-error-spike');
+		const report = await probeHomeyShsErrors(config, createLiveFetch(), () => Promise.resolve(LOCAL_FAILURES));
+
+		report.metadata.probe = config.deviceOnlyApiKey as 'homey-shs-errors';
+
+		expect(() => assertHomeyShsErrorReportSafe(report, config)).toThrow('configured secret or private value');
+	});
+});

--- a/apps/backend/test/homey-shs-errors.homey-spike.ts
+++ b/apps/backend/test/homey-shs-errors.homey-spike.ts
@@ -118,7 +118,7 @@ describe('Homey SHS error compatibility probe', () => {
 		).rejects.toThrow('did not return an authorization rejection for system read');
 	});
 
-	it('classifies real bounded local connection refusal and timeout failures', async () => {
+	it('keeps a short timeout simulation from racing real connection refusal', async () => {
 		const result = await probeLocalNetworkFailures(20);
 
 		expect(result).toEqual(LOCAL_FAILURES);

--- a/apps/backend/test/support/homey-shs-error-probe.ts
+++ b/apps/backend/test/support/homey-shs-error-probe.ts
@@ -1,0 +1,351 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { type Server, createServer } from 'node:http';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const DEVICE_PATH = '/api/manager/devices/device';
+const SYSTEM_PATH = '/api/manager/system/';
+const REPORT_SCHEMA_VERSION = 1;
+const MAX_LOCAL_SIMULATION_TIMEOUT_MS = 250;
+
+type FailureCategory = 'authentication' | 'authorization' | 'timeout' | 'unavailable' | 'validation';
+
+export type HomeyShsProbeFetch = (input: URL, init: RequestInit) => Promise<Response>;
+
+export interface HomeyShsErrorProbeConfig extends HomeyShsProbeConfig {
+	deviceOnlyApiKey: string;
+}
+
+export interface HomeyShsErrorReport {
+	metadata: {
+		probe: 'homey-shs-errors';
+		schemaVersion: 1;
+	};
+	scenarios: {
+		badUrl: { category: 'validation'; rejected: true };
+		invalidKey: { category: 'authentication'; rejected: true; statusCode: 401 | 403 };
+		missingScope: {
+			allowedRequestStatusCode: number;
+			category: 'authorization';
+			rejected: true;
+			statusCode: 403;
+		};
+		requestTimeout: { category: 'timeout'; rejected: true };
+		unavailableHost: { category: 'unavailable'; rejected: true };
+	};
+}
+
+interface ClassifiedFailure {
+	category: 'timeout' | 'unavailable';
+}
+
+export const loadHomeyShsErrorProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsErrorProbeConfig => {
+	const config = loadHomeyShsProbeConfig(environment, workingDirectory);
+	const deviceOnlyApiKey = environment.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
+
+	if (deviceOnlyApiKey === undefined || deviceOnlyApiKey.trim() === '') {
+		throw new Error('FB_HOMEY_SHS_DEVICE_ONLY_API_KEY is required');
+	}
+
+	if (deviceOnlyApiKey === config.apiKey) {
+		throw new Error('FB_HOMEY_SHS_DEVICE_ONLY_API_KEY must differ from FB_HOMEY_SHS_API_KEY');
+	}
+
+	return { ...config, deviceOnlyApiKey };
+};
+
+const discardResponse = async (response: Response): Promise<void> => {
+	try {
+		await response.body?.cancel();
+	} catch {
+		throw new Error('Homey error probe response cleanup failed');
+	}
+};
+
+const request = async (
+	url: URL,
+	timeoutMs: number,
+	fetchImplementation: HomeyShsProbeFetch,
+	token?: string,
+): Promise<Response | ClassifiedFailure> => {
+	const headers = new Headers({ accept: 'application/json' });
+
+	if (token !== undefined) {
+		headers.set('authorization', `Bearer ${token}`);
+	}
+
+	try {
+		return await fetchImplementation(url, {
+			headers,
+			method: 'GET',
+			redirect: 'error',
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+	} catch (error: unknown) {
+		return {
+			category:
+				error instanceof DOMException && ['AbortError', 'TimeoutError'].includes(error.name)
+					? 'timeout'
+					: 'unavailable',
+		};
+	}
+};
+
+const requireResponse = (result: Response | ClassifiedFailure, label: string): Response => {
+	if (result instanceof Response) {
+		return result;
+	}
+
+	throw new Error(`Homey ${label} request failed as ${result.category}`);
+};
+
+const verifyBadUrlValidation = (): HomeyShsErrorReport['scenarios']['badUrl'] => {
+	try {
+		loadHomeyShsProbeConfig({
+			FB_HOMEY_SHS_API_KEY: 'synthetic-invalid-url-key',
+			FB_HOMEY_SHS_EXPECTED_HOST: 'homey.invalid',
+			FB_HOMEY_SHS_URL: 'ftp://homey.invalid',
+		});
+	} catch (error: unknown) {
+		if (error instanceof Error && error.message === 'FB_HOMEY_SHS_URL must use HTTP or HTTPS') {
+			return { category: 'validation', rejected: true };
+		}
+	}
+
+	throw new Error('Homey bad-URL validation probe did not reject the candidate');
+};
+
+const verifyInvalidKey = async (
+	config: HomeyShsErrorProbeConfig,
+	fetchImplementation: HomeyShsProbeFetch,
+): Promise<HomeyShsErrorReport['scenarios']['invalidKey']> => {
+	const invalidKey = `invalid-homey-probe-${randomBytes(24).toString('hex')}`;
+	const response = requireResponse(
+		await request(new URL(SYSTEM_PATH, config.origin), config.timeoutMs, fetchImplementation, invalidKey),
+		'invalid-key',
+	);
+
+	try {
+		if (response.status !== 401 && response.status !== 403) {
+			throw new Error('Homey invalid-key probe did not return an authentication rejection');
+		}
+
+		return { category: 'authentication', rejected: true, statusCode: response.status };
+	} finally {
+		await discardResponse(response);
+	}
+};
+
+const verifyMissingScope = async (
+	config: HomeyShsErrorProbeConfig,
+	fetchImplementation: HomeyShsProbeFetch,
+): Promise<HomeyShsErrorReport['scenarios']['missingScope']> => {
+	const allowedResponse = requireResponse(
+		await request(new URL(DEVICE_PATH, config.origin), config.timeoutMs, fetchImplementation, config.deviceOnlyApiKey),
+		'device-only allowed-scope',
+	);
+	const allowedStatusCode = allowedResponse.status;
+
+	try {
+		if (!allowedResponse.ok) {
+			throw new Error('Homey device-only key did not authenticate for its allowed device read');
+		}
+	} finally {
+		await discardResponse(allowedResponse);
+	}
+
+	const deniedResponse = requireResponse(
+		await request(new URL(SYSTEM_PATH, config.origin), config.timeoutMs, fetchImplementation, config.deviceOnlyApiKey),
+		'device-only denied-scope',
+	);
+
+	try {
+		if (deniedResponse.status !== 403) {
+			throw new Error('Homey device-only key did not return an authorization rejection for system read');
+		}
+
+		return {
+			allowedRequestStatusCode: allowedStatusCode,
+			category: 'authorization',
+			rejected: true,
+			statusCode: 403,
+		};
+	} finally {
+		await discardResponse(deniedResponse);
+	}
+};
+
+const listen = async (server: Server): Promise<number> => {
+	try {
+		await new Promise<void>((resolvePromise, rejectPromise) => {
+			server.once('error', rejectPromise);
+			server.listen(0, '127.0.0.1', () => {
+				server.off('error', rejectPromise);
+				resolvePromise();
+			});
+		});
+	} catch {
+		throw new Error('Homey local failure simulator could not start');
+	}
+
+	const address = server.address();
+
+	if (address === null || typeof address === 'string') {
+		throw new Error('Homey local failure simulator did not allocate a TCP port');
+	}
+
+	return address.port;
+};
+
+const close = async (server: Server): Promise<void> => {
+	if (!server.listening) {
+		return;
+	}
+
+	try {
+		await new Promise<void>((resolvePromise, rejectPromise) => {
+			server.close((error) => (error === undefined ? resolvePromise() : rejectPromise(error)));
+		});
+	} catch {
+		throw new Error('Homey local failure simulator could not stop');
+	}
+};
+
+export const probeLocalNetworkFailures = async (
+	timeoutMs: number,
+	fetchImplementation: HomeyShsProbeFetch = fetch,
+): Promise<Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableHost'>> => {
+	const simulationTimeoutMs = Math.min(timeoutMs, MAX_LOCAL_SIMULATION_TIMEOUT_MS);
+	const unavailableServer = createServer();
+	const unavailablePort = await listen(unavailableServer);
+
+	await close(unavailableServer);
+
+	const unavailableResult = await request(
+		new URL(`http://127.0.0.1:${unavailablePort}/unavailable`),
+		simulationTimeoutMs,
+		fetchImplementation,
+	);
+
+	if (unavailableResult instanceof Response || unavailableResult.category !== 'unavailable') {
+		if (unavailableResult instanceof Response) {
+			await discardResponse(unavailableResult);
+		}
+
+		throw new Error('Homey unavailable-host simulator did not produce an unavailable failure');
+	}
+
+	const timeoutServer = createServer(() => undefined);
+	const timeoutPort = await listen(timeoutServer);
+	let timeoutResult: Response | ClassifiedFailure;
+
+	try {
+		timeoutResult = await request(
+			new URL(`http://127.0.0.1:${timeoutPort}/timeout`),
+			simulationTimeoutMs,
+			fetchImplementation,
+		);
+	} finally {
+		timeoutServer.closeAllConnections();
+		await close(timeoutServer);
+	}
+
+	if (timeoutResult instanceof Response || timeoutResult.category !== 'timeout') {
+		if (timeoutResult instanceof Response) {
+			await discardResponse(timeoutResult);
+		}
+
+		throw new Error('Homey timeout simulator did not produce a timeout failure');
+	}
+
+	return {
+		requestTimeout: { category: 'timeout', rejected: true },
+		unavailableHost: { category: 'unavailable', rejected: true },
+	};
+};
+
+export const probeHomeyShsErrors = async (
+	config: HomeyShsErrorProbeConfig,
+	fetchImplementation: HomeyShsProbeFetch = fetch,
+	localFailureProbe: typeof probeLocalNetworkFailures = probeLocalNetworkFailures,
+): Promise<HomeyShsErrorReport> => {
+	const localFailures = await localFailureProbe(config.timeoutMs);
+
+	return {
+		metadata: { probe: 'homey-shs-errors', schemaVersion: REPORT_SCHEMA_VERSION },
+		scenarios: {
+			badUrl: verifyBadUrlValidation(),
+			invalidKey: await verifyInvalidKey(config, fetchImplementation),
+			missingScope: await verifyMissingScope(config, fetchImplementation),
+			...localFailures,
+		},
+	};
+};
+
+export const assertHomeyShsErrorReportSafe = (report: HomeyShsErrorReport, config: HomeyShsErrorProbeConfig): void => {
+	const serialized = JSON.stringify(report).toLowerCase();
+	const forbidden = [config.apiKey, config.deviceOnlyApiKey, config.expectedHost, ...config.privateTerms]
+		.map((value) => value.trim().toLowerCase())
+		.filter((value) => value.length >= 3 && !['home', 'homey'].includes(value));
+
+	if (forbidden.some((value) => serialized.includes(value))) {
+		throw new Error('Sanitized Homey error report contains a configured secret or private value');
+	}
+
+	if (
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized)
+	) {
+		throw new Error('Sanitized Homey error report contains an address, email, or URL');
+	}
+
+	const categories = Object.values(report.scenarios).map(({ category }) => category as FailureCategory);
+
+	if (
+		!['validation', 'authentication', 'authorization', 'timeout', 'unavailable'].every((category) =>
+			categories.includes(category as FailureCategory),
+		)
+	) {
+		throw new Error('Homey error report does not contain every required failure category');
+	}
+};
+
+export const writeHomeyShsErrorReport = async (report: HomeyShsErrorReport, outputRoot: string): Promise<string> => {
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `errors-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsErrorProbeConfig(process.env);
+	const report = await probeHomeyShsErrors(config);
+
+	assertHomeyShsErrorReportSafe(report, config);
+
+	const outputDirectory = await writeHomeyShsErrorReport(report, config.outputRoot);
+
+	process.stdout.write(`Sanitized Homey error report written to ${outputDirectory} (5 scenarios).\n`);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS error probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/apps/backend/test/support/homey-shs-error-probe.ts
+++ b/apps/backend/test/support/homey-shs-error-probe.ts
@@ -9,6 +9,7 @@ const DEVICE_PATH = '/api/manager/devices/device';
 const SYSTEM_PATH = '/api/manager/system/';
 const REPORT_SCHEMA_VERSION = 1;
 const MAX_LOCAL_SIMULATION_TIMEOUT_MS = 250;
+const LOCAL_REFUSAL_TIMEOUT_MS = 250;
 
 type FailureCategory = 'authentication' | 'authorization' | 'timeout' | 'unavailable' | 'validation';
 
@@ -228,7 +229,7 @@ export const probeLocalNetworkFailures = async (
 
 	const unavailableResult = await request(
 		new URL(`http://127.0.0.1:${unavailablePort}/unavailable`),
-		simulationTimeoutMs,
+		LOCAL_REFUSAL_TIMEOUT_MS,
 		fetchImplementation,
 	);
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,6 +1,6 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory captured and realtime probe implemented, live realtime/write/recovery evidence pending
+**Status:** In progress; safe inventory captured and realtime/error probes implemented, live error/realtime/write/recovery evidence pending
 
 **Started:** 2026-08-12
 
@@ -24,6 +24,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read | Add allowlisted write and read-back evidence                                   |
 | Socket.IO events and reconnect                        | Probe implemented; live run pending          | Capture connect, subscribe, event, disconnect, restart, and reconnect ordering |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled       | Use only the designated harmless test capability                               |
+| Error classification                                  | Non-mutating probe implemented; live run pending | Verify invalid-key and missing-scope status behavior                         |
 | Disposable-device lifecycle                           | Contract defined, disabled                   | Use only the separately gated virtual/test device                              |
 | mDNS discovery                                        | Pending live access                          | Record stable service/TXT data or explicitly defer discovery                   |
 | SDK decision                                          | Provisional hold                             | Complete live Socket.IO and cleanup/reconnect comparison                       |
@@ -167,6 +168,31 @@ FB_HOMEY_SHS_LIFECYCLE_OPERATIONS=add,rename,zone-move,availability,remove
 The implementation must validate the exact operation list, require a synthetic test-device marker established during
 setup, and clean up only resources created by that run. It must never pair, rename, move, make unavailable, remove, or
 unpair ordinary household devices.
+
+## Non-mutating error-classification probe
+
+The error probe records only fixed category labels, rejection booleans, and HTTP status codes. It performs three live
+GET requests against the pinned SHS origin: a generated invalid key, an allowed device inventory read using a separate
+device-only key, and a system-information read using that same restricted key. The allowed read must succeed before a
+`403` system response can count as missing-scope evidence, so an invalid second token cannot be mislabeled as an
+authorization failure.
+
+Create a second least-privilege key with only `homey.device.readonly`, enter it without adding it to shell history, and
+run the probe from the same interactive shell as the read-only capture:
+
+```bash
+read -r -s FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
+export FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
+pnpm run homey:probe-errors
+unset FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
+```
+
+The probe also verifies the shared URL validator rejects a non-HTTP candidate. Unavailable-host and timeout categories
+are exercised against ephemeral loopback servers owned by the probe; it does not scan another LAN port or send the API
+keys anywhere except the configured SHS origin. Every request uses `GET`, blocks redirects, and is bounded by
+`FB_HOMEY_SHS_TIMEOUT_MS`; the local simulations use a shorter `250` ms cap. Response bodies, raw transport errors,
+URLs, addresses, keys, and private terms are never written. A report is created only after all five scenarios pass,
+under the same ignored capture root and restrictive directory/file modes as the inventory and realtime probes.
 
 ## SDK artifact review
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -17,18 +17,18 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                       | Evidence still required                                                        |
-| ----------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`      | Repeat over HTTPS `4860` if enabled                                            |
-| System, zone, device inventory, and individual device | Captured and sanitized                       | Add lifecycle delta evidence on the disposable test device                     |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read | Add allowlisted write and read-back evidence                                   |
-| Socket.IO events and reconnect                        | Probe implemented; live run pending          | Capture connect, subscribe, event, disconnect, restart, and reconnect ordering |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled       | Use only the designated harmless test capability                               |
-| Error classification                                  | Non-mutating probe implemented; live run pending | Verify invalid-key and missing-scope status behavior                         |
-| Disposable-device lifecycle                           | Contract defined, disabled                   | Use only the separately gated virtual/test device                              |
-| mDNS discovery                                        | Pending live access                          | Record stable service/TXT data or explicitly defer discovery                   |
-| SDK decision                                          | Provisional hold                             | Complete live Socket.IO and cleanup/reconnect comparison                       |
-| Sanitized fixture corpus                              | Nine representative live fixtures promoted   | Add event/reconnect fixtures and missing capability families/classes           |
+| Area                                                  | Status                                           | Evidence still required                                                        |
+| ----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`          | Repeat over HTTPS `4860` if enabled                                            |
+| System, zone, device inventory, and individual device | Captured and sanitized                           | Add lifecycle delta evidence on the disposable test device                     |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read     | Add allowlisted write and read-back evidence                                   |
+| Socket.IO events and reconnect                        | Probe implemented; live run pending              | Capture connect, subscribe, event, disconnect, restart, and reconnect ordering |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled           | Use only the designated harmless test capability                               |
+| Error classification                                  | Non-mutating probe implemented; live run pending | Verify invalid-key and missing-scope status behavior                           |
+| Disposable-device lifecycle                           | Contract defined, disabled                       | Use only the separately gated virtual/test device                              |
+| mDNS discovery                                        | Pending live access                              | Record stable service/TXT data or explicitly defer discovery                   |
+| SDK decision                                          | Provisional hold                                 | Complete live Socket.IO and cleanup/reconnect comparison                       |
+| Sanitized fixture corpus                              | Nine representative live fixtures promoted       | Add event/reconnect fixtures and missing capability families/classes           |
 
 ## Installation evidence
 
@@ -83,8 +83,10 @@ read -r -s FB_HOMEY_SHS_API_KEY
 read -r FB_HOMEY_SHS_PRIVATE_TERMS
 export FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
 pnpm run homey:probe
-unset FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
 ```
+
+Keep these base variables exported while running either optional probe below. Clear them only after the last probe you
+intend to run.
 
 `FB_HOMEY_SHS_PRIVATE_TERMS` is a comma-separated defense-in-depth list of household names or other strings that must
 not survive sanitization. Every nonempty entry must contain at least three characters; configuration fails instead of
@@ -184,7 +186,13 @@ run the probe from the same interactive shell as the read-only capture:
 read -r -s FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
 export FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
 pnpm run homey:probe-errors
-unset FB_HOMEY_SHS_DEVICE_ONLY_API_KEY
+```
+
+After the last probe you intend to run, clear every credential and private value from the interactive shell:
+
+```bash
+unset FB_HOMEY_SHS_DEVICE_ONLY_API_KEY FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY
+unset FB_HOMEY_SHS_PRIVATE_TERMS
 ```
 
 The probe also verifies the shared URL validator rejects a non-HTTP candidate. Unavailable-host and timeout categories


### PR DESCRIPTION
## Summary

- add a non-mutating Homey SHS error-classification probe
- verify validation, authentication, authorization, unavailable, and timeout categories
- require a proven-valid device-only key before accepting missing-scope evidence
- document the interactive live workflow and sanitized report contract

## Why

The Phase 0 compatibility gate still needs evidence for invalid keys, missing scopes, bad URLs, unavailable hosts, and request timeouts before the production connector can normalize these failures confidently.

## Safety

Only three read-only GET requests reach the pinned SHS origin. The generated invalid key is never persisted, and the restricted key must first succeed on device inventory before a denied system read counts as authorization evidence. Bad-URL validation and network failures are exercised locally; the probe does not scan LAN ports. Reports contain only fixed categories, booleans, and status codes and are written with restrictive modes after all safety assertions pass.

## Validation

- `pnpm run test:homey-spike` — 3 suites, 52 tests passed
- `pnpm run type-check` — passed
- targeted ESLint and Prettier for the changed TypeScript files — passed
- `git diff --check` — passed

## Baseline notes

Repository-wide `pnpm run lint:js` remains blocked by five unrelated Admin import-extension errors already present on `main`. Backend-wide `pretty:check` remains blocked by ten unrelated pre-existing migration files. No affected Homey file has a lint or formatting failure.

## Live validation

The live SHS run remains pending because it requires a separately created `homey.device.readonly` key in the interactive shell. No live error-matrix result is claimed by this PR.