### PR TITLE
fix(cross): complete Codex MCP OAuth compatibility

### DIFF
--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.spec.ts
@@ -206,7 +206,7 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
 	});
 
-	it('rejects an explicit offline-only scope after provider normalization', async () => {
+	it('rejects an explicit offline-only scope', async () => {
 		const findActiveByIdentifier = jest.fn(() =>
 			Promise.resolve({ maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS] }),
 		);
@@ -226,12 +226,45 @@ describe('McpOAuthProviderFactory artifact request gate', () => {
 			query: { scope: McpOAuthScope.OFFLINE_ACCESS },
 			oidc: {
 				route: 'authorization',
-				params: { client_id: 'codex-client', scope: undefined as string | undefined },
+				params: { client_id: 'codex-client', scope: McpOAuthScope.OFFLINE_ACCESS },
 			},
 		};
 
 		await expect(stateValidator(context, 'opaque-state')).rejects.toThrow();
 		expect(findActiveByIdentifier).toHaveBeenCalledWith('codex-client');
+	});
+
+	it('adds consent when renewable access is explicit and the client omitted prompt', async () => {
+		const request = createRequest();
+		request.url = `${request.url}?scope=mcp%3Aread+offline_access&state=opaque-state`;
+		let dispatchedRequest: IncomingMessage | undefined;
+		const providerCallback = jest.fn((candidate: IncomingMessage) => {
+			dispatchedRequest = candidate;
+			return Promise.resolve();
+		});
+
+		await dispatch(request, createResponse(), providerCallback, urls);
+
+		const dispatchedUrl = new URL(dispatchedRequest?.url ?? '/', urls.issuer);
+
+		expect(dispatchedUrl.searchParams.get('scope')).toBe('mcp:read offline_access');
+		expect(dispatchedUrl.searchParams.get('prompt')).toBe('consent');
+	});
+
+	it('preserves an explicit client prompt for renewable access', async () => {
+		const request = createRequest();
+		request.url = `${request.url}?scope=mcp%3Aread+offline_access&prompt=login`;
+		let dispatchedRequest: IncomingMessage | undefined;
+		const providerCallback = jest.fn((candidate: IncomingMessage) => {
+			dispatchedRequest = candidate;
+			return Promise.resolve();
+		});
+
+		await dispatch(request, createResponse(), providerCallback, urls);
+
+		const dispatchedUrl = new URL(dispatchedRequest?.url ?? '/', urls.issuer);
+
+		expect(dispatchedUrl.searchParams.get('prompt')).toBe('login');
 	});
 
 	it('rejects a blocked provider endpoint before entering the artifact mutation gate', async () => {

--- a/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
+++ b/apps/backend/src/modules/mcp/oauth/mcp-oauth-provider.factory.ts
@@ -133,9 +133,18 @@ export class McpOAuthProviderFactory {
 
 					if (typeof requestedScope !== 'string') return;
 
-					const disallowedScopes = requestedScope
-						.split(' ')
-						.filter((scope) => !registeredClient.maximumScopes.includes(scope as McpOAuthScope));
+					const requestedScopes = requestedScope.split(' ').filter(Boolean);
+
+					if (!requestedScopes.some((scope) => scope !== String(McpOAuthScope.OFFLINE_ACCESS))) {
+						throw new oidcProvider.errors.InvalidScope(
+							'requested scope contains no capability scope',
+							McpOAuthScope.OFFLINE_ACCESS,
+						);
+					}
+
+					const disallowedScopes = requestedScopes.filter(
+						(scope) => !registeredClient.maximumScopes.includes(scope as McpOAuthScope),
+					);
 
 					if (disallowedScopes.length > 0) {
 						throw new oidcProvider.errors.InvalidScope('requested scope is not allowed', disallowedScopes.join(' '));
@@ -306,6 +315,10 @@ export class McpOAuthProviderFactory {
 			}
 		}
 
+		if (request.method === 'GET' && pathname === new URL(urls.authorizationEndpoint).pathname) {
+			this.ensureOfflineAccessConsentPrompt(request, urls);
+		}
+
 		if (request.method === 'POST' && (pathname === tokenPathname || pathname === '/token')) {
 			const contentType = request.headers['content-type']?.split(';', 1)[0]?.trim().toLowerCase();
 
@@ -332,6 +345,19 @@ export class McpOAuthProviderFactory {
 
 			await providerCallback(request, response);
 		});
+	}
+
+	private ensureOfflineAccessConsentPrompt(request: IncomingMessage, urls: McpOAuthPublicUrls): void {
+		const authorizationUrl = new URL(request.url ?? '/', urls.issuer);
+		const requestedScopes = authorizationUrl.searchParams.get('scope')?.split(/\s+/).filter(Boolean) ?? [];
+
+		if (requestedScopes.includes(McpOAuthScope.OFFLINE_ACCESS) && !authorizationUrl.searchParams.has('prompt')) {
+			// Codex requests offline_access but does not expose an OAuth prompt option. Smart Panel always requires its
+			// owner/admin consent interaction, so make that existing consent explicit before oidc-provider applies the
+			// OIDC offline-access rule. Explicit client prompt choices remain untouched.
+			authorizationUrl.searchParams.set('prompt', 'consent');
+			request.url = `${authorizationUrl.pathname}${authorizationUrl.search}`;
+		}
 	}
 
 	private isDisconnected(request: IncomingMessage, response: ServerResponse): boolean {

--- a/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
+++ b/apps/backend/test/mcp-oauth-phase3-provider.oauth-spike.ts
@@ -535,6 +535,21 @@ describe('MCP OAuth Phase 3 provider runtime', () => {
 		expect(tokens.refresh_token).toBeUndefined();
 	});
 
+	it('issues renewable access when a host explicitly requests it without a prompt parameter', async () => {
+		const { callback, verifier } = await authorize(
+			REGISTERED_REDIRECT_URI,
+			'mcp:read offline_access',
+			new CookieBrowser(),
+			false,
+		);
+		const response = await exchangeCode(callback.searchParams.get('code'), verifier);
+		const tokens = (await response.json()) as TokenResponse;
+
+		expect(response.status).toBe(200);
+		expect(tokens.scope).toBe(McpOAuthScope.READ);
+		expect(tokens.refresh_token).toBeDefined();
+	});
+
 	it('rejects an explicitly requested resource scope above the client ceiling before consent', async () => {
 		const before = consentPromptCount;
 		const response = await fetch(

--- a/apps/website/app/docs/admin-management/mcp/page.mdx
+++ b/apps/website/app/docs/admin-management/mcp/page.mdx
@@ -211,7 +211,8 @@ To discover the full callback URI safely, pre-register the client initially with
 ```bash copy
 codex mcp add smart-panel \
   --url https://panel.example.com/api/v1/modules/mcp \
-  --oauth-client-id '<client-id>'
+  --oauth-client-id '<client-id>' \
+  --oauth-resource https://panel.example.com/api/v1/modules/mcp
 codex mcp login smart-panel --scopes mcp:read,offline_access
 ```
 
@@ -219,9 +220,16 @@ The first authorization request is rejected because Codex appends a callback ID.
 `redirect_uri` from the browser's authorization URL, edit the Smart Panel OAuth client, replace the temporary redirect
 with that exact URI, and run `codex mcp login` again. Never approve a redirect on another host or path.
 
-The `--scopes` option is available in current Codex CLI builds. The earlier Phase 6 smoke used a build that omitted the
-scope parameter even though it reported version `0.136.0`, so confirm `codex mcp login --help` lists `--scopes` before
-requesting `offline_access`; otherwise omit the option and use a finite access token without refresh.
+The completed Phase 6 profile passed on Codex CLI `0.147.0`. Use that release or a newer smoke-tested stable build and
+confirm `codex mcp login --help` lists `--scopes`. `--oauth-resource` is required for renewable access because it carries
+the canonical resource into refresh requests. The authorization URL may contain the same resource twice after discovery;
+Smart Panel accepts repeated identical indicators and still rejects any different resource. The older observed
+`0.136.0` client did not propagate the configured resource on refresh and received `invalid_target` from the strict
+token endpoint.
+
+When `offline_access` is explicit and Codex omits an OAuth prompt, Smart Panel sends the request through its existing
+owner/admin consent interaction as `prompt=consent`. This does not broaden the requested scopes or bypass the configured
+client, grant, and module ceilings.
 
 The ChatGPT desktop app, Codex CLI, and IDE extension on the same Codex host share this MCP configuration. Restart the
 app or extension after adding the server, then use `/mcp` or `codex mcp list` to verify it. See the

--- a/docs/mcp-oauth-compatibility-spike.md
+++ b/docs/mcp-oauth-compatibility-spike.md
@@ -18,19 +18,19 @@ exercise yet.
 Implementation must target the exact revisions below. OAuth 2.1 is still an IETF draft, so documentation and metadata
 must not describe it as a published RFC.
 
-| Concern | Revision used by this task |
-| --- | --- |
-| MCP authorization | MCP `2026-07-28` |
-| OAuth security profile | `draft-ietf-oauth-v2-1-13` plus OAuth 2.0 Security BCP, RFC 9700 |
-| Bearer challenges | RFC 6750 |
-| PKCE | RFC 7636, `S256` only |
-| Authorization-server metadata | RFC 8414 |
-| Resource indicators | RFC 8707 |
-| Authorization-response issuer | RFC 9207 |
-| Protected-resource metadata | RFC 9728 |
-| Token revocation | RFC 7009 |
-| Native loopback redirects | RFC 8252 |
-| Client registration | Pre-registration initially; CIMD draft support tracked separately |
+| Concern                       | Revision used by this task                                        |
+| ----------------------------- | ----------------------------------------------------------------- |
+| MCP authorization             | MCP `2026-07-28`                                                  |
+| OAuth security profile        | `draft-ietf-oauth-v2-1-13` plus OAuth 2.0 Security BCP, RFC 9700  |
+| Bearer challenges             | RFC 6750                                                          |
+| PKCE                          | RFC 7636, `S256` only                                             |
+| Authorization-server metadata | RFC 8414                                                          |
+| Resource indicators           | RFC 8707                                                          |
+| Authorization-response issuer | RFC 9207                                                          |
+| Protected-resource metadata   | RFC 9728                                                          |
+| Token revocation              | RFC 7009                                                          |
+| Native loopback redirects     | RFC 8252                                                          |
+| Client registration           | Pre-registration initially; CIMD draft support tracked separately |
 
 MCP `2026-07-28` requires protected-resource metadata and the `resource` parameter in authorization and token
 requests. It prefers Client ID Metadata Documents (CIMD), permits pre-registration, and deprecates Dynamic Client
@@ -53,12 +53,12 @@ the resource identifier.
 The matrix records documented capabilities as of the spike date. “Target” means it will receive a real smoke test once
 the endpoints exist.
 
-| Host | Documented registration paths | Relevant behavior | Release use |
-| --- | --- | --- | --- |
-| Codex CLI/app | Predefined client ID; OAuth discovery used by `codex mcp login`; ChatGPT connectors additionally support CIMD and DCR | Streamable HTTP OAuth, scopes, RFC 8707 resource override, fixed or ephemeral loopback callback, PKCE | Target 1 |
-| Claude Code | CIMD, DCR, or predefined public/confidential client | RFC 9728 discovery, HTTP OAuth, fixed loopback callback, automatic refresh, scope pinning | Target 2 |
-| MCP TypeScript client / Inspector | Programmatic provider or interactive inspector | Fine-grained discovery, PKCE, token and negative-path tests | Automated harness, not one of the two user hosts |
-| ChatGPT connector | CIMD preferred, DCR fallback, or predefined client | Cloud callback, authorization code plus PKCE, resource binding | Follow-up compatibility target |
+| Host                              | Documented registration paths                                                                                         | Relevant behavior                                                                                     | Release use                                      |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Codex CLI/app                     | Predefined client ID; OAuth discovery used by `codex mcp login`; ChatGPT connectors additionally support CIMD and DCR | Streamable HTTP OAuth, scopes, RFC 8707 resource override, fixed or ephemeral loopback callback, PKCE | Target 1                                         |
+| Claude Code                       | CIMD, DCR, or predefined public/confidential client                                                                   | RFC 9728 discovery, HTTP OAuth, fixed loopback callback, automatic refresh, scope pinning             | Target 2                                         |
+| MCP TypeScript client / Inspector | Programmatic provider or interactive inspector                                                                        | Fine-grained discovery, PKCE, token and negative-path tests                                           | Automated harness, not one of the two user hosts |
+| ChatGPT connector                 | CIMD preferred, DCR fallback, or predefined client                                                                    | Cloud callback, authorization code plus PKCE, resource binding                                        | Follow-up compatibility target                   |
 
 Both initial target hosts can use an owner-created public client ID and a registered loopback redirect. That means DCR
 is not required for the first supported profile. The live smoke test must record exact host versions, callback URIs,
@@ -213,32 +213,41 @@ combination closes the Inspector/TypeScript-client negative-case gate without de
 
 ## Live Codex evidence
 
-The Phase 6 smoke against Codex CLI `0.136.0` established the following current host profile:
+The completed Phase 6 smoke used current stable Codex CLI `0.147.0`. The CLI ran in an arm64 Debian container with the
+private smoke CA installed only in that container's OS trust store; the container changed certificate trust and network
+placement, not the Codex build or OAuth behavior. The supported host profile is:
 
-- pre-registration works with `codex mcp add --url <resource> --oauth-client-id <client-id>` followed by
-  `codex mcp login <name>`; the persisted client ID is stored under the server's nested `oauth.client_id` setting;
-- with `mcp_oauth_callback_port = 41456`, Codex uses a stable per-server callback path such as
-  `http://127.0.0.1:41456/callback/YCvSk6oijOs3`, so that exact path must be pre-registered while the loopback port may
-  vary under the RFC 8252 rule;
-- Codex discovers the resource and sends the RFC 8707 `resource` automatically. Configuring `--oauth-resource` to the
-  same URI duplicates the authorization parameter in `0.136.0`, so the explicit override must be omitted for this
-  server profile;
-- Codex omits `scope` from its authorization request. Smart Panel therefore defaults an omitted scope to the capability
-  scopes in the pre-registered client ceiling and still requires explicit owner/admin consent. It does not default
-  `offline_access`, because renewable access must be explicitly requested; and
-- the CLI build used for the live smoke omitted `scope` and did not expose a scope setting despite reporting version
-  `0.136.0`. Current builds reporting the same version expose `codex mcp login --scopes <SCOPE,SCOPE>`; operators must
-  confirm the option in their installed CLI before requesting `offline_access`. Smart Panel must not silently broaden
-  an omitted request merely to manufacture a refresh token; and
-- behind TLS termination, the proxy must be listed in `FB_MCP_OAUTH_TRUSTED_PROXIES` and must send
-  `X-Forwarded-Proto: https`. The finite bootstrap gate validates the immediate peer before the provider honors that
-  protocol for secure interaction cookies.
+- pre-register the public client, then use
+  `codex mcp add --url <resource> --oauth-client-id <client-id> --oauth-resource <resource>` and
+  `codex mcp login <name> --scopes mcp:read,offline_access`;
+- keep `mcp_oauth_callback_port = 41456` stable. Codex derives a stable path for the server profile; this run used
+  `http://127.0.0.1:41456/callback/ZaELrI6T7BVV`, and that exact path was pre-registered;
+- keep `--oauth-resource` even though the authorization URL contains the same canonical resource twice: once from
+  protected-resource discovery and once from the explicit override. The provider accepts repeated identical resource
+  indicators. More importantly, `0.147.0` carries the configured resource into refresh requests, satisfying the strict
+  token-endpoint boundary;
+- request `offline_access` explicitly with `--scopes`. Codex does not add `prompt=consent`, so Smart Panel makes consent
+  explicit only when the client explicitly requested `offline_access` and supplied no prompt. The owner/admin consent
+  interaction still controls the approved scopes and lifetime; and
+- behind TLS termination, list the immediate proxy in `FB_MCP_OAUTH_TRUSTED_PROXIES` and send
+  `X-Forwarded-Proto: https` so secure interaction cookies remain valid after the bootstrap trust check.
 
-Discovery, authorization, token exchange, tool listing, and a read-only `get_home_context` call succeeded with a client
-ceiling of `mcp:read offline_access`. Codex exposed only read tools under that ceiling and received no refresh token
-because its request omitted `offline_access`. Administrative revocation and the newer `--scopes` refresh path remain to
-be exercised with this host. Refresh rotation continues to be exercised through the protocol client and the Claude Code
-target instead of weakening the server's scope policy.
+Fresh discovery, authorization, code exchange, `tools/list`, and a read-only `get_home_context` call succeeded. Moving
+the stored Codex access expiry into the CLI's 30-second refresh window caused a refresh before tool discovery: the token
+endpoint returned `200`, the predecessor refresh artifact was consumed, exactly one successor remained live in the same
+family, and the read call succeeded with the successor access token. The old access token remained valid for the initial
+MCP handshake because Codex runs its proactive refresh hook after `initialize` and before `tools/list` and tool calls.
+
+Revoking that family through the production administrative API returned `204`, removed the live successor and linked
+access token, and made the next Codex connection fail with `AuthRequired` / `invalid_token` before any tool call. After
+the client ceiling was contracted to `mcp:read offline_access`, a fresh Codex request for
+`mcp:write offline_access` reached its validated callback with `error=invalid_scope`, the original state, and the
+provider issuer.
+
+Codex CLI `0.136.0` remains useful historical evidence for discovery, authorization, listing, and calling, but it did
+not propagate the configured resource on refresh and therefore received the intentional `invalid_target` response.
+`0.147.0` is the minimum release observed completing the strict Smart Panel refresh profile; deployments should repeat
+the smoke before lowering that supported version.
 
 ## Live Claude Code evidence
 

--- a/tasks/plans/plan-mcp-oauth-authorization.md
+++ b/tasks/plans/plan-mcp-oauth-authorization.md
@@ -1,6 +1,6 @@
 # Smart Panel MCP OAuth Authorization — Implementation Plan
 
-**Status:** Phase 6 in progress — security-profile E2E, external-host, and wire-level gates remain
+**Status:** Complete
 
 **Task:** [TECH-MCP-OAUTH-AUTHORIZATION](../technical/TECH-MCP-OAUTH-AUTHORIZATION.md)
 
@@ -487,8 +487,9 @@ amend ADR 0002.
 - [x] E2E: prove readiness-gated re-enable never makes OAuth artifacts issued before switch-off usable again.
 - [x] Reverse-proxy E2E: explicit external prefix, hostile forwarded headers, untrusted proxy, trusted proxy, public URL
       change, and rollback.
-- [ ] Codex smoke: discovery, authorization, list/call, refresh, scope failure, and revocation; record exact version and
-      callback profile.
+- [x] Codex smoke: Codex CLI `0.147.0` completed discovery, authorization, list/call, proactive refresh rotation,
+      administrative refresh-family revocation, and a validated `invalid_scope` callback. The exact fixed-port derived
+      callback and required explicit RFC 8707 resource override are recorded in the compatibility evidence.
 - [x] Claude Code smoke: discovery, authorization, list/call, forced-expiry refresh rotation, scope failure, and live
       refresh-family revocation passed with Claude Code `2.1.229`; both fixed-port loopback callback host forms are
       recorded in the compatibility evidence.
@@ -513,7 +514,8 @@ amend ADR 0002.
 - [x] Confirm no DCR/CIMD endpoints are advertised and create explicit follow-up tasks if the release gate justifies
       either feature. The bounded metadata snapshots advertise neither; pre-registration satisfies the current target
       profiles, so no implementation follow-up is justified without a named host failure.
-- [ ] Update task acceptance criteria and mark completion only after every deferred item has a named follow-up.
+- [x] Update task acceptance criteria and mark completion only after every deferred item has a named follow-up. Both
+      named host gates and every deferred implementation item are closed; no unnamed follow-up remains.
 
 ## Required verification cadence
 

--- a/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
+++ b/tasks/technical/TECH-MCP-OAUTH-AUTHORIZATION.md
@@ -5,7 +5,7 @@ Type: technical
 Scope: backend, admin
 Size: large
 Parent: Smart Panel MCP Module
-Status: in progress — Phase 6 security-profile E2E, external-host, and wire-level gates remain
+Status: complete
 
 ## 1. Business goal
 
@@ -92,8 +92,9 @@ upgrade consequences.
       concurrent refresh replay, revocation/listen and all invalidation/artifact-commit races, runtime-gated OAuth
       switch-off/re-enable, static-stream preservation, wrong issuer/resource/audience, cross-client isolation, stream
       closure, and log redaction.
-- [ ] At least two supported OAuth-capable MCP hosts complete discovery, authorization, tool listing, tool execution,
-      refresh, and revocation smoke tests.
+- [x] Codex CLI `0.147.0` and Claude Code `2.1.229` complete discovery, authorization, tool listing, tool execution,
+      refresh rotation, scope-failure, and administrative revocation smoke tests with their exact callback profiles
+      recorded in the compatibility evidence.
 - [x] Public deployment documentation requires HTTPS and provides reverse-proxy, key rotation, backup, incident
       response, and rollback guidance.
 


### PR DESCRIPTION
## Summary

- normalize explicit `offline_access` authorization requests that omit `prompt` to the existing owner/admin consent interaction
- preserve explicit client prompt choices and reject offline-only requests without a capability scope
- document the completed Codex CLI 0.147.0 compatibility profile, including the RFC 8707 resource override
- close the MCP OAuth implementation plan and technical task after both required host smokes completed

## Why

Codex CLI explicitly requests `offline_access` but does not send `prompt=consent`. The OAuth provider therefore correctly omitted refresh-token issuance under the OIDC offline-access rule. Smart Panel already requires owner/admin consent, so the authorization boundary now makes that consent explicit without broadening scopes or bypassing any configured ceiling.

## Impact

Codex CLI 0.147.0 can complete authorization, proactive refresh rotation, administrative family revocation, and scope-failure handling against Smart Panel's strict MCP OAuth profile.

## Validation

- provider-factory unit tests: 21 passed
- provider OAuth-spike tests: 17 passed
- backend type-check: passed
- backend lint: passed (two unrelated pre-existing warnings)
- website production build: passed
- full backend unit assertions: 346 suites / 4,278 tests passed; the process later exited during an unrelated pre-existing Home Assistant mock teardown