### PR TITLE
test(cross): record Homey realtime evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -47,4 +47,10 @@ new raw fixture version, then review the complete diff. The connector transforme
 these outputs and add explicit assertions for source ordering, suffixed capability IDs, null/false/zero preservation,
 enum options, availability independence, and zone-cycle rejection.
 
+`evidence/` contains separately reviewed, minimal live behavior reports that do not belong to the immutable inventory
+corpus. The filename records the observation date and SHS version. Each report must retain only the probe's allowlisted
+labels, booleans, ordering numbers, public dependency versions, and non-sensitive status codes, and must have a focused
+test that re-applies the report safety assertions. The 2026-08-14 SDK session evidence records connection,
+subscription, cleanup, and invalid-key behavior only; it does not claim capability-event, write, or reconnect coverage.
+
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json
@@ -1,0 +1,53 @@
+{
+	"metadata": {
+		"probe": "homey-shs-realtime",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "socket.connect",
+				"order": 2
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 3
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 4
+			},
+			{
+				"event": "socket.disconnect",
+				"order": 5
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 6
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 7
+			}
+		],
+		"managerSubscribed": true
+	},
+	"invalidKey": {
+		"category": "authentication",
+		"rejected": true,
+		"statusCode": 401
+	},
+	"write": {
+		"attempted": false,
+		"eventObserved": false,
+		"readBackMatched": false,
+		"restoreReadBackMatched": false,
+		"restored": false
+	}
+}

--- a/apps/backend/test/homey-shs-realtime.homey-spike.ts
+++ b/apps/backend/test/homey-shs-realtime.homey-spike.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import {
 	type HomeySdkFactory,
+	type HomeyShsRealtimeReport,
 	assertHomeyShsRealtimeReportSafe,
 	loadHomeyShsRealtimeProbeConfig,
 	probeHomeyShsRealtime,
@@ -165,6 +168,35 @@ const createFactory = (
 };
 
 describe('Homey SHS realtime compatibility probe', () => {
+	it('preserves the sanitized live SHS SDK session evidence', () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json',
+		);
+		const report = JSON.parse(readFileSync(evidencePath, 'utf8')) as HomeyShsRealtimeReport;
+		const config = loadHomeyShsRealtimeProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-realtime-spike');
+
+		expect(report.session.events.map(({ event, order }) => ({ event, order }))).toStrictEqual([
+			{ event: 'sdk.create.resolved', order: 1 },
+			{ event: 'socket.connect', order: 2 },
+			{ event: 'manager.subscribe.resolved', order: 3 },
+			{ event: 'manager.unsubscribe.resolved', order: 4 },
+			{ event: 'socket.disconnect', order: 5 },
+			{ event: 'socket.disconnect.resolved', order: 6 },
+			{ event: 'sdk.destroyed', order: 7 },
+		]);
+		expect(report.session).toMatchObject({ cleanupCompleted: true, managerSubscribed: true });
+		expect(report.invalidKey).toStrictEqual({ category: 'authentication', rejected: true, statusCode: 401 });
+		expect(report.write).toStrictEqual({
+			attempted: false,
+			eventObserved: false,
+			readBackMatched: false,
+			restoreReadBackMatched: false,
+			restored: false,
+		});
+		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).not.toThrow();
+	});
+
 	it('keeps writes disabled when none of the four gate variables is present', () => {
 		const config = loadHomeyShsRealtimeProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-realtime-spike');
 

--- a/apps/backend/test/homey-shs-realtime.homey-spike.ts
+++ b/apps/backend/test/homey-shs-realtime.homey-spike.ts
@@ -6,6 +6,7 @@ import {
 	type HomeySdkFactory,
 	type HomeyShsRealtimeReport,
 	assertHomeyShsRealtimeReportSafe,
+	assertHomeyShsRealtimeReportSchema,
 	loadHomeyShsRealtimeProbeConfig,
 	probeHomeyShsRealtime,
 } from './support/homey-shs-realtime-probe';
@@ -16,6 +17,15 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
 	FB_HOMEY_SHS_REALTIME_OBSERVE_MS: '0',
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const loadLiveEvidence = (): unknown => {
+	const evidencePath = resolve(
+		__dirname,
+		'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json',
+	);
+
+	return JSON.parse(readFileSync(evidencePath, 'utf8')) as unknown;
 };
 
 class FakeDevice extends EventEmitter {
@@ -169,13 +179,10 @@ const createFactory = (
 
 describe('Homey SHS realtime compatibility probe', () => {
 	it('preserves the sanitized live SHS SDK session evidence', () => {
-		const evidencePath = resolve(
-			__dirname,
-			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json',
-		);
-		const report = JSON.parse(readFileSync(evidencePath, 'utf8')) as HomeyShsRealtimeReport;
+		const report = loadLiveEvidence();
 		const config = loadHomeyShsRealtimeProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-realtime-spike');
 
+		assertHomeyShsRealtimeReportSchema(report);
 		expect(report.session.events.map(({ event, order }) => ({ event, order }))).toStrictEqual([
 			{ event: 'sdk.create.resolved', order: 1 },
 			{ event: 'socket.connect', order: 2 },
@@ -195,6 +202,27 @@ describe('Homey SHS realtime compatibility probe', () => {
 			restored: false,
 		});
 		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).not.toThrow();
+	});
+
+	it('rejects extra fields and invalid scalar types in persisted evidence', () => {
+		const rootExtra = loadLiveEvidence() as Record<string, unknown>;
+		rootExtra.rawEndpoint = 'private-endpoint';
+
+		expect(() => assertHomeyShsRealtimeReportSchema(rootExtra)).toThrow('Homey realtime report root schema is invalid');
+
+		const nestedExtra = loadLiveEvidence() as HomeyShsRealtimeReport;
+		(nestedExtra.session.events[0] as unknown as Record<string, unknown>).rawPayload = 'private-payload';
+
+		expect(() => assertHomeyShsRealtimeReportSchema(nestedExtra)).toThrow(
+			'Homey realtime report event schema is invalid',
+		);
+
+		const invalidScalar = loadLiveEvidence() as HomeyShsRealtimeReport;
+		(invalidScalar.write as unknown as Record<string, unknown>).attempted = 'false';
+
+		expect(() => assertHomeyShsRealtimeReportSchema(invalidScalar)).toThrow(
+			'Homey realtime report write schema is invalid',
+		);
 	});
 
 	it('keeps writes disabled when none of the four gate variables is present', () => {
@@ -441,6 +469,8 @@ describe('Homey SHS realtime compatibility probe', () => {
 
 		report.session.events[0] = { event: 'private-device-id', order: 2 };
 
-		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).toThrow('unsafe or unordered event label');
+		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).toThrow(
+			'Homey realtime report event schema is invalid',
+		);
 	});
 });

--- a/apps/backend/test/support/homey-shs-realtime-probe.ts
+++ b/apps/backend/test/support/homey-shs-realtime-probe.ts
@@ -128,6 +128,81 @@ const sdkFactory: HomeySdkFactory = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey realtime report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey realtime report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+/** Validates every persisted key and scalar type before evidence is accepted or written. */
+export function assertHomeyShsRealtimeReportSchema(value: unknown): asserts value is HomeyShsRealtimeReport {
+	const report = requireExactKeys(value, ['metadata', 'session', 'invalidKey', 'write'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
+	const invalidKey = requireExactKeys(report.invalidKey, ['category', 'rejected', 'statusCode'], 'invalid-key');
+	const write = requireExactKeys(
+		report.write,
+		['attempted', 'eventObserved', 'readBackMatched', 'restoreReadBackMatched', 'restored'],
+		'write',
+	);
+
+	if (metadata.probe !== 'homey-shs-realtime' || metadata.schemaVersion !== 1 || metadata.sdkVersion !== SDK_VERSION) {
+		throw new Error('Homey realtime report metadata schema is invalid');
+	}
+
+	if (
+		typeof session.cleanupCompleted !== 'boolean' ||
+		typeof session.managerSubscribed !== 'boolean' ||
+		!Array.isArray(session.events)
+	) {
+		throw new Error('Homey realtime report session schema is invalid');
+	}
+
+	for (const eventValue of session.events) {
+		const event = requireExactKeys(eventValue, ['event', 'order'], 'event');
+
+		if (
+			typeof event.event !== 'string' ||
+			!SAFE_EVENT_LABELS.has(event.event) ||
+			typeof event.order !== 'number' ||
+			!Number.isInteger(event.order) ||
+			event.order < 1
+		) {
+			throw new Error('Homey realtime report event schema is invalid');
+		}
+	}
+
+	if (
+		invalidKey.category !== 'authentication' ||
+		invalidKey.rejected !== true ||
+		(invalidKey.statusCode !== 401 && invalidKey.statusCode !== 403)
+	) {
+		throw new Error('Homey realtime report invalid-key schema is invalid');
+	}
+
+	if (
+		typeof write.attempted !== 'boolean' ||
+		typeof write.eventObserved !== 'boolean' ||
+		typeof write.readBackMatched !== 'boolean' ||
+		typeof write.restoreReadBackMatched !== 'boolean' ||
+		typeof write.restored !== 'boolean'
+	) {
+		throw new Error('Homey realtime report write schema is invalid');
+	}
+}
+
 const parseObserveMs = (value: string | undefined): number => {
 	if (value === undefined) {
 		return DEFAULT_OBSERVE_MS;
@@ -640,10 +715,12 @@ export const probeHomeyShsRealtime = async (
 	return report;
 };
 
-export const assertHomeyShsRealtimeReportSafe = (
-	report: HomeyShsRealtimeReport,
+export function assertHomeyShsRealtimeReportSafe(
+	report: unknown,
 	config: HomeyShsRealtimeProbeConfig,
-): void => {
+): asserts report is HomeyShsRealtimeReport {
+	assertHomeyShsRealtimeReportSchema(report);
+
 	const serialized = JSON.stringify(report).toLowerCase();
 	const forbidden = [
 		config.apiKey,
@@ -676,12 +753,14 @@ export const assertHomeyShsRealtimeReportSafe = (
 	) {
 		throw new Error('Homey realtime probe did not verify the allowlisted write, event, read-back, and restoration');
 	}
-};
+}
 
 export const writeHomeyShsRealtimeReport = async (
 	report: HomeyShsRealtimeReport,
 	outputRoot: string,
 ): Promise<string> => {
+	assertHomeyShsRealtimeReportSchema(report);
+
 	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
 	const outputDirectory = resolve(outputRoot, `realtime-${suffix}`);
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,6 +1,7 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory captured and realtime/error probes implemented, live error/realtime/write/recovery evidence pending
+**Status:** In progress; safe inventory and SDK session/cleanup evidence captured, live capability-event, write, error-matrix,
+reconnect, and recovery evidence pending
 
 **Started:** 2026-08-12
 
@@ -17,18 +18,18 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                           | Evidence still required                                                        |
-| ----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`          | Repeat over HTTPS `4860` if enabled                                            |
-| System, zone, device inventory, and individual device | Captured and sanitized                           | Add lifecycle delta evidence on the disposable test device                     |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read     | Add allowlisted write and read-back evidence                                   |
-| Socket.IO events and reconnect                        | Probe implemented; live run pending              | Capture connect, subscribe, event, disconnect, restart, and reconnect ordering |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled           | Use only the designated harmless test capability                               |
-| Error classification                                  | Non-mutating probe implemented; live run pending | Verify invalid-key and missing-scope status behavior                           |
-| Disposable-device lifecycle                           | Contract defined, disabled                       | Use only the separately gated virtual/test device                              |
-| mDNS discovery                                        | Pending live access                              | Record stable service/TXT data or explicitly defer discovery                   |
-| SDK decision                                          | Provisional hold                                 | Complete live Socket.IO and cleanup/reconnect comparison                       |
-| Sanitized fixture corpus                              | Nine representative live fixtures promoted       | Add event/reconnect fixtures and missing capability families/classes           |
+| Area                                                  | Status                                         | Evidence still required                                                 |
+| ----------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`        | Repeat over HTTPS `4860` if enabled                                     |
+| System, zone, device inventory, and individual device | Captured and sanitized                         | Add lifecycle delta evidence on the disposable test device              |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read   | Add allowlisted write and read-back evidence                            |
+| Socket.IO events and reconnect                        | Connect/subscription/cleanup passed live       | Capture capability/availability events, restart, and reconnect ordering |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled         | Use only the designated harmless test capability                        |
+| Error classification                                  | SDK invalid key returned `401`; matrix pending | Verify missing-scope, bad-URL, unavailable, and timeout behavior        |
+| Disposable-device lifecycle                           | Contract defined, disabled                     | Use only the separately gated virtual/test device                       |
+| mDNS discovery                                        | Pending live access                            | Record stable service/TXT data or explicitly defer discovery            |
+| SDK decision                                          | Live session/cleanup passed; provisional hold  | Complete event, timeout, cleanup-failure, and reconnect comparison      |
+| Sanitized fixture corpus                              | Nine representative live fixtures promoted     | Add event/reconnect fixtures and missing capability families/classes    |
 
 ## Installation evidence
 
@@ -37,12 +38,13 @@ Complete this table after the live run. Values committed here must remain non-se
 | Field                                    | Recorded value                                                       |
 | ---------------------------------------- | -------------------------------------------------------------------- |
 | Capture date                             | `2026-08-13`                                                         |
+| Realtime SDK probe date                  | `2026-08-14`                                                         |
 | SHS version                              | `13.4.0`                                                             |
 | Container image tag and immutable digest | Pending                                                              |
 | Host operating system/architecture       | Pending                                                              |
 | Topology                                 | Pending; describe generically, for example `same LAN, separate host` |
 | Smart Panel to SHS network path          | Pending; do not record addresses                                     |
-| HTTP port `4859`                         | Confirmed for ping and authenticated system/zone/device reads        |
+| HTTP port `4859`                         | Confirmed for reads and the SDK Socket.IO session                    |
 | HTTPS port `4860`                        | Pending                                                              |
 | TLS certificate behavior                 | Pending                                                              |
 | Disposable capability alias              | Pending synthetic alias                                              |
@@ -133,6 +135,21 @@ mutation. Every SDK client, subscription, read, write, restoration, and disconne
 `FB_HOMEY_SHS_TIMEOUT_MS`. A failed or timed-out disconnect fails the probe and is never recorded as resolved, so no
 report can claim successful cleanup when the transport did not confirm it.
 
+The read-only live run on 2026-08-14 against SHS `13.4.0` and `homey-api` `3.19.2` recorded this sanitized order:
+
+1. SDK creation resolved;
+2. the Socket.IO connection opened;
+3. the devices manager subscription resolved;
+4. manager unsubscription resolved;
+5. the socket emitted disconnect;
+6. the explicit socket disconnect resolved; and
+7. the SDK client was destroyed.
+
+Cleanup completed and the write gate remained disabled. The same run proved that a generated invalid key was rejected
+with HTTP `401`. No capability or availability event occurred during the passive observation window, so this result
+does not close event-delivery, write-confirmation, restart, reconnect, timeout, or revoked-key evidence. The reviewed
+report is committed as `__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json`.
+
 Manager reads and writes also receive the SDK-native `$timeout`; that timeout is registered before the probe's outer
 watchdog. A timed-out write therefore settles inside the SDK before restoration is emitted afterward on the same
 ordered Socket.IO transport. Capability-event matching opens only immediately before the allowlisted write and closes
@@ -215,7 +232,7 @@ Artifact snapshot inspected on 2026-08-12:
 | Runtime dependencies | `engine.io-client ^3.5.5`, `socket.io-client ^2.5.0`, `node-fetch ^2.6.7`, `form-data ^4.0.0`              |
 | Local entry point    | `HomeyAPI.createLocalAPI({ address, token })`                                                              |
 | HTTP behavior        | Bearer authentication and generated manager paths described above                                          |
-| Realtime behavior    | WebSocket-only Socket.IO client; live session/auth/subscription behavior not yet verified against SHS      |
+| Realtime behavior    | WebSocket-only Socket.IO; live connect, subscribe, unsubscribe, disconnect, and destroy order verified     |
 
 ### Provisional dependency decision
 
@@ -243,13 +260,13 @@ Fill this matrix using synthetic aliases only.
 | ----------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | HTTP `4859` ping and authenticated reads  | Pass                                | Read-only system, zone, and device requests completed without redirects                                                                              |
 | HTTPS `4860` ping and authenticated reads | Pending                             |                                                                                                                                                      |
-| Invalid key                               | Pending                             |                                                                                                                                                      |
+| Invalid key                               | Partial pass                        | The SDK local factory rejected a generated invalid key with HTTP `401`; revocation and the restricted-scope matrix remain pending                    |
 | Missing system/zone/device scope          | Pending                             |                                                                                                                                                      |
 | Bad URL and unavailable host              | Pending                             |                                                                                                                                                      |
 | Request timeout                           | Pending                             |                                                                                                                                                      |
 | Complete inventory and individual read    | Pass                                | Complete inventory captured: 118 devices and 16 zones; the selected individual-device response matched its pseudonymized inventory identity          |
 | Suffixed capability IDs                   | Pass in inventory and explicit read | 1,142 capability entries, including 170 suffixed entries; 55 devices repeat a base ID; an explicit suffixed capability GET returned a numeric scalar |
-| Socket.IO connect and subscribe           | Pending                             |                                                                                                                                                      |
+| Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |
 | Capability and availability events        | Pending                             |                                                                                                                                                      |
 | Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
 | Network interruption and restoration      | Pending                             |                                                                                                                                                      |


### PR DESCRIPTION
## Summary

- record the sanitized live SDK session observed against Homey SHS `13.4.0`
- validate every persisted evidence key and scalar type before writing or accepting a fixture
- update the compatibility matrix with the exact behavior that passed
- keep capability events, writes, reconnects, timeout behavior, and the restricted-scope matrix explicitly pending

## Live observation

Using the reviewed `homey-api` `3.19.2` development-only probe over HTTP `4859`, the session completed in this order:

1. SDK creation resolved
2. Socket.IO connected
3. devices manager subscription resolved
4. manager unsubscription resolved
5. the socket emitted disconnect
6. explicit socket disconnect resolved
7. the SDK client was destroyed

Cleanup completed, the write gate remained disabled, and a generated invalid key was rejected with HTTP `401`.

## Safety

The committed evidence contains only allowlisted event labels, ordering numbers, booleans, the public SDK version, and the non-sensitive HTTP status. It contains no endpoint, address, Homey/device/zone identifier, capability value, API key, raw error, or household metadata. Exact runtime validation rejects unknown keys at every level, invalid fixed values, and incorrect scalar types before persistence. The offline test also re-runs `assertHomeyShsRealtimeReportSafe` against the committed report.

## Scope boundary

No capability or availability event occurred during the passive observation window. This PR therefore does not claim event delivery, write confirmation, restart/reconnect, timeout, cleanup-failure, revoked-key, or restricted-scope coverage, and it does not finalize the SDK-vs-direct-protocol decision.

## Validation

- `pnpm run test:homey-spike` — 3 suites, 54 tests passed
- targeted ESLint — passed
- `pnpm run type-check` — passed
- targeted Prettier — passed
- `git diff --check` — passed