### PR TITLE
test(cross): add privacy-safe Homey mDNS probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -75,6 +75,7 @@
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",
     "homey:generate-normalized-fixtures": "ts-node --project tsconfig.json test/support/generate-homey-normalized-fixtures.ts",
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",
+    "homey:probe-mdns": "ts-node --project tsconfig.json test/support/homey-shs-mdns-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",
     "typeorm:migration:generate": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:generate -d ./src/dataSource.ts",

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-mdns-host-match.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-mdns-host-match.json
@@ -1,0 +1,18 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mdns",
+		"schemaVersion": 1
+	},
+	"observation": {
+		"durationMs": 5000,
+		"matchedServices": 1,
+		"services": [
+			{
+				"port": 80,
+				"protocol": "tcp",
+				"txtKeys": [],
+				"type": "http"
+			}
+		]
+	}
+}

--- a/apps/backend/test/homey-shs-mdns.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mdns.homey-spike.ts
@@ -32,10 +32,13 @@ interface FakeMdnsService {
 
 const createMdnsHarness = (options: { destroyFails?: boolean; stopFails?: boolean } = {}) => {
 	let onError: (() => void) | null = null;
-	let onUp: ((service: FakeMdnsService) => void) | null = null;
 	let destroyed = false;
+	let services: FakeMdnsService[] = [];
 	let stopped = false;
 	const browser: HomeyMdnsBrowser = {
+		get services() {
+			return services;
+		},
 		stop: () => {
 			stopped = true;
 
@@ -55,20 +58,19 @@ const createMdnsHarness = (options: { destroyFails?: boolean; stopFails?: boolea
 					throw new Error('raw client cleanup detail');
 				}
 			},
-			find: (_query, serviceListener) => {
-				onUp = serviceListener;
-
-				return browser;
-			},
+			find: () => browser,
 		};
 	};
 
 	return {
-		emit: (service: FakeMdnsService) => onUp?.(service),
+		emit: (service: FakeMdnsService) => services.push(service),
 		fail: () => onError?.(),
 		factory,
 		isDestroyed: () => destroyed,
 		isStopped: () => stopped,
+		replaceServices: (updatedServices: FakeMdnsService[]) => {
+			services = updatedServices;
+		},
 	};
 };
 
@@ -115,35 +117,38 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		);
 	});
 
-	it('keeps only exact host matches and only public service metadata', async () => {
+	it('uses the final browser state after late service updates and keeps only public metadata', async () => {
 		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
 		const harness = createMdnsHarness();
 		const report = await probeHomeyShsMdns(config, harness.factory, () => {
-			harness.emit({
-				addresses: ['192.0.2.99'],
-				host: 'unrelated.local',
-				name: 'Unrelated private service',
-				port: 1234,
-				protocol: 'tcp',
-				txt: { private: 'unrelated private value' },
-				type: 'unrelated',
-			});
 			harness.emit({
 				addresses: ['192.0.2.10'],
 				host: 'private-host.local.',
 				name: 'Private Room Homey',
 				port: 4859,
 				protocol: 'tcp',
-				txt: { id: 'private-id', version: '13.4.0' },
 				type: 'homey-shs',
 			});
-			harness.emit({
-				addresses: ['192.0.2.10'],
-				port: 4859,
-				protocol: 'tcp',
-				txt: { version: 'a different private value', id: 'another private id' },
-				type: 'homey-shs',
-			});
+			harness.replaceServices([
+				{
+					addresses: ['192.0.2.99'],
+					host: 'unrelated.local',
+					name: 'Unrelated private service',
+					port: 1234,
+					protocol: 'tcp',
+					txt: { private: 'unrelated private value' },
+					type: 'unrelated',
+				},
+				{
+					addresses: ['192.0.2.10'],
+					host: 'private-host.local.',
+					name: 'Private Room Homey',
+					port: 4860,
+					protocol: 'tcp',
+					txt: { id: 'private-id', version: '13.4.0' },
+					type: 'homey-shs',
+				},
+			]);
 
 			return Promise.resolve();
 		});
@@ -153,7 +158,7 @@ describe('Homey SHS mDNS compatibility probe', () => {
 			observation: {
 				durationMs: 1000,
 				matchedServices: 1,
-				services: [{ port: 4859, protocol: 'tcp', txtKeys: ['id', 'version'], type: 'homey-shs' }],
+				services: [{ port: 4860, protocol: 'tcp', txtKeys: ['id', 'version'], type: 'homey-shs' }],
 			},
 		});
 		expect(JSON.stringify(report)).not.toContain('Private Room');
@@ -256,7 +261,38 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		expect(() => assertHomeyShsMdnsReportSafe(privateReport, privateConfig)).toThrow(
 			'contains a secret, address, or email-like value',
 		);
+
+		const publicHomeyConfig = loadHomeyShsMdnsProbeConfig({
+			...BASE_ENVIRONMENT,
+			FB_HOMEY_SHS_EXPECTED_HOST: 'homey',
+			FB_HOMEY_SHS_PRIVATE_TERMS: 'homey',
+			FB_HOMEY_SHS_URL: 'http://homey:4859',
+		});
+		const zeroMatchReport: HomeyShsMdnsReport = {
+			metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+			observation: { durationMs: 1000, matchedServices: 0, services: [] },
+		};
+
+		expect(() => assertHomeyShsMdnsReportSafe(zeroMatchReport, publicHomeyConfig)).not.toThrow();
 	});
+
+	it.each(['aa-bb-cc-dd-ee-ff', 'aabb.ccdd.eeff', 'aabbccddeeff'])(
+		'rejects a MAC-derived public metadata identifier in %s format',
+		(identifier) => {
+			const report: HomeyShsMdnsReport = {
+				metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+				observation: {
+					durationMs: 1000,
+					matchedServices: 1,
+					services: [{ port: 4859, protocol: 'tcp', txtKeys: [identifier], type: 'homey-shs' }],
+				},
+			};
+
+			expect(() => assertHomeyShsMdnsReportSafe(report, loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT))).toThrow(
+				'contains a secret, address, or email-like value',
+			);
+		},
+	);
 
 	it('writes a new restrictive, schema-validated report directory', async () => {
 		const root = await mkdtemp(join(tmpdir(), 'homey-mdns-spike-'));

--- a/apps/backend/test/homey-shs-mdns.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mdns.homey-spike.ts
@@ -276,7 +276,7 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		expect(() => assertHomeyShsMdnsReportSafe(zeroMatchReport, publicHomeyConfig)).not.toThrow();
 	});
 
-	it.each(['aa-bb-cc-dd-ee-ff', 'aabb.ccdd.eeff', 'aabbccddeeff'])(
+	it.each(['aa-bb-cc-dd-ee-ff', 'aabb.ccdd.eeff', 'aabbccddeeff', 'macaabbccddeeff'])(
 		'rejects a MAC-derived public metadata identifier in %s format',
 		(identifier) => {
 			const report: HomeyShsMdnsReport = {

--- a/apps/backend/test/homey-shs-mdns.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mdns.homey-spike.ts
@@ -1,0 +1,281 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import {
+	type HomeyMdnsBrowser,
+	type HomeyMdnsClientFactory,
+	type HomeyShsMdnsReport,
+	assertHomeyShsMdnsReportSafe,
+	assertHomeyShsMdnsReportSchema,
+	loadHomeyShsMdnsProbeConfig,
+	probeHomeyShsMdns,
+	writeHomeyShsMdnsReport,
+} from './support/homey-shs-mdns-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_EXPECTED_HOST: '192.0.2.10',
+	FB_HOMEY_SHS_MDNS_OBSERVE_MS: '1000',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_URL: 'http://192.0.2.10:4859',
+};
+
+interface FakeMdnsService {
+	addresses?: string[];
+	host?: string;
+	name?: string;
+	port: number;
+	protocol: 'tcp' | 'udp';
+	txt?: unknown;
+	type: string;
+}
+
+const createMdnsHarness = (options: { destroyFails?: boolean; stopFails?: boolean } = {}) => {
+	let onError: (() => void) | null = null;
+	let onUp: ((service: FakeMdnsService) => void) | null = null;
+	let destroyed = false;
+	let stopped = false;
+	const browser: HomeyMdnsBrowser = {
+		stop: () => {
+			stopped = true;
+
+			if (options.stopFails === true) {
+				throw new Error('raw browser cleanup detail');
+			}
+		},
+	};
+	const factory: HomeyMdnsClientFactory = (errorListener) => {
+		onError = errorListener;
+
+		return {
+			destroy: () => {
+				destroyed = true;
+
+				if (options.destroyFails === true) {
+					throw new Error('raw client cleanup detail');
+				}
+			},
+			find: (_query, serviceListener) => {
+				onUp = serviceListener;
+
+				return browser;
+			},
+		};
+	};
+
+	return {
+		emit: (service: FakeMdnsService) => onUp?.(service),
+		fail: () => onError?.(),
+		factory,
+		isDestroyed: () => destroyed,
+		isStopped: () => stopped,
+	};
+};
+
+describe('Homey SHS mDNS compatibility probe', () => {
+	it('preserves the sanitized live pre-restart host-match evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-mdns-host-match.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+
+		assertHomeyShsMdnsReportSchema(evidence);
+		expect(evidence.observation).toStrictEqual({
+			durationMs: 5000,
+			matchedServices: 1,
+			services: [{ port: 80, protocol: 'tcp', txtKeys: [], type: 'http' }],
+		});
+		expect(() => assertHomeyShsMdnsReportSafe(evidence, config)).not.toThrow();
+	});
+
+	it('loads a key-free, exact-host configuration with bounded observation', () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-mdns-spike');
+
+		expect(config).toStrictEqual({
+			expectedHost: '192.0.2.10',
+			observeMs: 1000,
+			outputRoot: '/tmp/homey-mdns-spike/test/.homey-shs-captures',
+			privateTerms: ['Private Room', 'Private Device'],
+		});
+		expect(BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY).toBeUndefined();
+
+		expect(() =>
+			loadHomeyShsMdnsProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_EXPECTED_HOST: '192.0.2.11',
+			}),
+		).toThrow('does not match');
+		expect(() => loadHomeyShsMdnsProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_MDNS_OBSERVE_MS: '999' })).toThrow(
+			'between 1000 and 30000',
+		);
+		expect(() => loadHomeyShsMdnsProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_PRIVATE_TERMS: 'ab' })).toThrow(
+			'at least three characters',
+		);
+	});
+
+	it('keeps only exact host matches and only public service metadata', async () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+		const harness = createMdnsHarness();
+		const report = await probeHomeyShsMdns(config, harness.factory, () => {
+			harness.emit({
+				addresses: ['192.0.2.99'],
+				host: 'unrelated.local',
+				name: 'Unrelated private service',
+				port: 1234,
+				protocol: 'tcp',
+				txt: { private: 'unrelated private value' },
+				type: 'unrelated',
+			});
+			harness.emit({
+				addresses: ['192.0.2.10'],
+				host: 'private-host.local.',
+				name: 'Private Room Homey',
+				port: 4859,
+				protocol: 'tcp',
+				txt: { id: 'private-id', version: '13.4.0' },
+				type: 'homey-shs',
+			});
+			harness.emit({
+				addresses: ['192.0.2.10'],
+				port: 4859,
+				protocol: 'tcp',
+				txt: { version: 'a different private value', id: 'another private id' },
+				type: 'homey-shs',
+			});
+
+			return Promise.resolve();
+		});
+
+		expect(report).toStrictEqual({
+			metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+			observation: {
+				durationMs: 1000,
+				matchedServices: 1,
+				services: [{ port: 4859, protocol: 'tcp', txtKeys: ['id', 'version'], type: 'homey-shs' }],
+			},
+		});
+		expect(JSON.stringify(report)).not.toContain('Private Room');
+		expect(JSON.stringify(report)).not.toContain('192.0.2.10');
+		expect(JSON.stringify(report)).not.toContain('private-id');
+		expect(harness.isStopped()).toBe(true);
+		expect(harness.isDestroyed()).toBe(true);
+		expect(() => assertHomeyShsMdnsReportSafe(report, config)).not.toThrow();
+	});
+
+	it('accepts a zero-match observation without persisting unrelated LAN data', async () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+		const harness = createMdnsHarness();
+		const report = await probeHomeyShsMdns(config, harness.factory, () => {
+			harness.emit({
+				addresses: ['192.0.2.99'],
+				port: 8123,
+				protocol: 'tcp',
+				txt: { location: 'Private Room' },
+				type: 'home-assistant',
+			});
+
+			return Promise.resolve();
+		});
+
+		expect(report.observation).toStrictEqual({ durationMs: 1000, matchedServices: 0, services: [] });
+		expect(() => assertHomeyShsMdnsReportSafe(report, config)).not.toThrow();
+	});
+
+	it('rejects unsafe matched metadata with a fixed error and still cleans up', async () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+		const harness = createMdnsHarness();
+
+		await expect(
+			probeHomeyShsMdns(config, harness.factory, () => {
+				harness.emit({
+					addresses: ['192.0.2.10'],
+					port: 4859,
+					protocol: 'tcp',
+					txt: { 'unsafe private key': 'value' },
+					type: 'homey-shs',
+				});
+
+				return Promise.resolve();
+			}),
+		).rejects.toThrow('Homey mDNS service metadata was not safe to record');
+		expect(harness.isStopped()).toBe(true);
+		expect(harness.isDestroyed()).toBe(true);
+	});
+
+	it('sanitizes observer and cleanup errors while attempting all cleanup', async () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+		const observerHarness = createMdnsHarness();
+
+		await expect(
+			probeHomeyShsMdns(config, observerHarness.factory, () => {
+				observerHarness.fail();
+
+				return Promise.resolve();
+			}),
+		).rejects.toThrow('Homey mDNS observation failed');
+		expect(observerHarness.isStopped()).toBe(true);
+		expect(observerHarness.isDestroyed()).toBe(true);
+
+		const cleanupHarness = createMdnsHarness({ destroyFails: true, stopFails: true });
+
+		await expect(probeHomeyShsMdns(config, cleanupHarness.factory, () => Promise.resolve())).rejects.toThrow(
+			'Homey mDNS cleanup failed',
+		);
+		expect(cleanupHarness.isStopped()).toBe(true);
+		expect(cleanupHarness.isDestroyed()).toBe(true);
+	});
+
+	it('rejects extra report fields, invalid scalars, and configured private values', () => {
+		const report: HomeyShsMdnsReport = {
+			metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+			observation: {
+				durationMs: 1000,
+				matchedServices: 1,
+				services: [{ port: 4859, protocol: 'tcp', txtKeys: ['version'], type: 'homey-shs' }],
+			},
+		};
+		const extra = structuredClone(report) as unknown as Record<string, unknown>;
+		extra.rawHost = 'private-host';
+
+		expect(() => assertHomeyShsMdnsReportSchema(extra)).toThrow('root schema is invalid');
+
+		const invalidPort = structuredClone(report);
+		(invalidPort.observation.services[0] as unknown as Record<string, unknown>).port = '4859';
+
+		expect(() => assertHomeyShsMdnsReportSchema(invalidPort)).toThrow('service schema is invalid');
+
+		const privateReport = structuredClone(report);
+		privateReport.observation.services[0].txtKeys = ['Private_Device'];
+		const privateConfig = loadHomeyShsMdnsProbeConfig({
+			...BASE_ENVIRONMENT,
+			FB_HOMEY_SHS_PRIVATE_TERMS: 'Private_Device',
+		});
+
+		expect(() => assertHomeyShsMdnsReportSafe(privateReport, privateConfig)).toThrow(
+			'contains a secret, address, or email-like value',
+		);
+	});
+
+	it('writes a new restrictive, schema-validated report directory', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'homey-mdns-spike-'));
+		const report: HomeyShsMdnsReport = {
+			metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+			observation: { durationMs: 1000, matchedServices: 0, services: [] },
+		};
+
+		try {
+			const outputDirectory = await writeHomeyShsMdnsReport(report, root);
+			const outputStat = await stat(outputDirectory);
+			const reportStat = await stat(join(outputDirectory, 'report.json'));
+			const written = JSON.parse(await readFile(join(outputDirectory, 'report.json'), 'utf8')) as unknown;
+
+			expect(outputStat.mode & 0o777).toBe(0o700);
+			expect(reportStat.mode & 0o777).toBe(0o600);
+			expect(written).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/support/homey-shs-mdns-probe.ts
+++ b/apps/backend/test/support/homey-shs-mdns-probe.ts
@@ -10,8 +10,7 @@ const PUBLIC_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 const URL_PATTERN = /(?:https?|wss?):\/\//i;
 const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 const IPV4_PATTERN = /(?:^|[^\d])(?:\d{1,3}\.){3}\d{1,3}(?:$|[^\d])/;
-const MAC_PATTERN =
-	/(?:^|[^A-F0-9])(?:[0-9a-f]{2}(?:[:-][0-9a-f]{2}){5}|[0-9a-f]{4}(?:\.[0-9a-f]{4}){2}|[0-9a-f]{12})(?:$|[^A-F0-9])/i;
+const MAC_PATTERN = /(?:[0-9a-f]{2}(?:[:-][0-9a-f]{2}){5}|[0-9a-f]{4}(?:\.[0-9a-f]{4}){2}|[0-9a-f]{12})/i;
 const HOMEY_TOKEN_PATTERN = /(?:hpat|pat|homey)[_-][A-Za-z0-9_-]{16,}/i;
 const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
 

--- a/apps/backend/test/support/homey-shs-mdns-probe.ts
+++ b/apps/backend/test/support/homey-shs-mdns-probe.ts
@@ -1,0 +1,412 @@
+import Bonjour from 'bonjour-service';
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const DEFAULT_OBSERVE_MS = 5_000;
+const MIN_OBSERVE_MS = 1_000;
+const MAX_OBSERVE_MS = 30_000;
+const PUBLIC_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+const URL_PATTERN = /(?:https?|wss?):\/\//i;
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
+const IPV4_PATTERN = /(?:^|[^\d])(?:\d{1,3}\.){3}\d{1,3}(?:$|[^\d])/;
+const HOMEY_TOKEN_PATTERN = /(?:hpat|pat|homey)[_-][A-Za-z0-9_-]{16,}/i;
+
+export interface HomeyShsMdnsProbeConfig {
+	expectedHost: string;
+	observeMs: number;
+	outputRoot: string;
+	privateTerms: string[];
+}
+
+export interface HomeyShsMdnsServiceReport {
+	port: number;
+	protocol: 'tcp' | 'udp';
+	txtKeys: string[];
+	type: string;
+}
+
+export interface HomeyShsMdnsReport {
+	metadata: {
+		probe: 'homey-shs-mdns';
+		schemaVersion: 1;
+	};
+	observation: {
+		durationMs: number;
+		matchedServices: number;
+		services: HomeyShsMdnsServiceReport[];
+	};
+}
+
+interface HomeyMdnsService {
+	addresses?: string[];
+	host?: string;
+	port: number;
+	protocol: 'tcp' | 'udp';
+	txt?: unknown;
+	type: string;
+}
+
+export interface HomeyMdnsBrowser {
+	stop(): void;
+}
+
+export interface HomeyMdnsClient {
+	destroy(): void;
+	find(options: null, onUp: (service: HomeyMdnsService) => void): HomeyMdnsBrowser;
+}
+
+export type HomeyMdnsClientFactory = (onError: () => void) => HomeyMdnsClient;
+export type HomeyMdnsWait = (durationMs: number) => Promise<void>;
+
+const defaultClientFactory: HomeyMdnsClientFactory = (onError) => {
+	const bonjour = new Bonjour(undefined, onError);
+
+	return {
+		destroy: () => bonjour.destroy(),
+		find: (options, onUp) => bonjour.find(options, onUp),
+	};
+};
+
+const defaultWait: HomeyMdnsWait = async (durationMs) =>
+	new Promise((resolvePromise) => {
+		setTimeout(resolvePromise, durationMs);
+	});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey mDNS report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey mDNS report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+const parseObserveMs = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_OBSERVE_MS;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(`FB_HOMEY_SHS_MDNS_OBSERVE_MS must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`);
+	}
+
+	return parsed;
+};
+
+const normalizeHost = (value: string): string => {
+	const trimmed = value.trim().toLowerCase().replace(/\.$/, '');
+
+	return trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed.slice(1, -1) : trimmed;
+};
+
+export const loadHomeyShsMdnsProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsMdnsProbeConfig => {
+	const rawUrl = environment.FB_HOMEY_SHS_URL;
+	const expectedHost = environment.FB_HOMEY_SHS_EXPECTED_HOST;
+
+	if (rawUrl === undefined || expectedHost === undefined) {
+		throw new Error('FB_HOMEY_SHS_URL and FB_HOMEY_SHS_EXPECTED_HOST are required');
+	}
+
+	let origin: URL;
+
+	try {
+		origin = new URL(rawUrl);
+	} catch {
+		throw new Error('FB_HOMEY_SHS_URL must be a valid HTTP or HTTPS origin');
+	}
+
+	if (!['http:', 'https:'].includes(origin.protocol)) {
+		throw new Error('FB_HOMEY_SHS_URL must use HTTP or HTTPS');
+	}
+
+	if (
+		origin.username !== '' ||
+		origin.password !== '' ||
+		origin.search !== '' ||
+		origin.hash !== '' ||
+		(origin.pathname !== '/' && origin.pathname !== '')
+	) {
+		throw new Error('FB_HOMEY_SHS_URL must contain only the Homey origin');
+	}
+
+	const normalizedExpectedHost = normalizeHost(expectedHost);
+
+	if (normalizedExpectedHost === '' || normalizeHost(origin.hostname) !== normalizedExpectedHost) {
+		throw new Error('FB_HOMEY_SHS_EXPECTED_HOST does not match the configured URL host');
+	}
+
+	const configuredPrivateTerms = (environment.FB_HOMEY_SHS_PRIVATE_TERMS ?? '')
+		.split(',')
+		.map((term) => term.trim())
+		.filter((term) => term.length > 0);
+
+	if (configuredPrivateTerms.some((term) => term.length < 3)) {
+		throw new Error('Every FB_HOMEY_SHS_PRIVATE_TERMS entry must contain at least three characters');
+	}
+
+	return {
+		expectedHost: normalizedExpectedHost,
+		observeMs: parseObserveMs(environment.FB_HOMEY_SHS_MDNS_OBSERVE_MS),
+		outputRoot: resolve(workingDirectory, environment.FB_HOMEY_SHS_CAPTURE_DIR ?? 'test/.homey-shs-captures'),
+		privateTerms: [...new Set(configuredPrivateTerms)],
+	};
+};
+
+const serviceMatchesExpectedHost = (service: HomeyMdnsService, expectedHost: string): boolean =>
+	[service.host, ...(service.addresses ?? [])]
+		.filter((value): value is string => typeof value === 'string')
+		.some((value) => normalizeHost(value) === expectedHost);
+
+const toSafeServiceReport = (service: HomeyMdnsService): HomeyShsMdnsServiceReport => {
+	if (!PUBLIC_IDENTIFIER_PATTERN.test(service.type)) {
+		throw new Error('Homey mDNS service metadata was not safe to record');
+	}
+
+	if (
+		!['tcp', 'udp'].includes(service.protocol) ||
+		!Number.isInteger(service.port) ||
+		service.port < 1 ||
+		service.port > 65_535
+	) {
+		throw new Error('Homey mDNS service metadata was not safe to record');
+	}
+
+	if (service.txt !== undefined && !isRecord(service.txt)) {
+		throw new Error('Homey mDNS service metadata was not safe to record');
+	}
+
+	const txtKeys = Object.keys(service.txt ?? {}).sort();
+
+	if (txtKeys.some((key) => !PUBLIC_IDENTIFIER_PATTERN.test(key))) {
+		throw new Error('Homey mDNS service metadata was not safe to record');
+	}
+
+	return {
+		port: service.port,
+		protocol: service.protocol,
+		txtKeys,
+		type: service.type,
+	};
+};
+
+const serviceSignature = (service: HomeyShsMdnsServiceReport): string =>
+	`${service.protocol}/${service.type}/${service.port}/${service.txtKeys.join(',')}`;
+
+export const probeHomeyShsMdns = async (
+	config: HomeyShsMdnsProbeConfig,
+	clientFactory: HomeyMdnsClientFactory = defaultClientFactory,
+	wait: HomeyMdnsWait = defaultWait,
+): Promise<HomeyShsMdnsReport> => {
+	let observationFailure: Error | null = null;
+	let browser: HomeyMdnsBrowser | null = null;
+	let client: HomeyMdnsClient | null = null;
+	const services = new Map<string, HomeyShsMdnsServiceReport>();
+
+	try {
+		client = clientFactory(() => {
+			observationFailure = new Error('Homey mDNS observation failed');
+		});
+		browser = client.find(null, (service) => {
+			if (observationFailure !== null) {
+				return;
+			}
+
+			try {
+				if (!serviceMatchesExpectedHost(service, config.expectedHost)) {
+					return;
+				}
+
+				const report = toSafeServiceReport(service);
+
+				services.set(serviceSignature(report), report);
+			} catch {
+				observationFailure = new Error('Homey mDNS service metadata was not safe to record');
+			}
+		});
+
+		await wait(config.observeMs);
+	} catch {
+		observationFailure ??= new Error('Homey mDNS observation failed');
+	} finally {
+		try {
+			browser?.stop();
+		} catch {
+			observationFailure ??= new Error('Homey mDNS cleanup failed');
+		}
+
+		try {
+			client?.destroy();
+		} catch {
+			observationFailure ??= new Error('Homey mDNS cleanup failed');
+		}
+	}
+
+	if (observationFailure !== null) {
+		throw observationFailure;
+	}
+
+	const sortedServices = [...services.values()].sort((left, right) =>
+		serviceSignature(left).localeCompare(serviceSignature(right)),
+	);
+
+	return {
+		metadata: { probe: 'homey-shs-mdns', schemaVersion: 1 },
+		observation: {
+			durationMs: config.observeMs,
+			matchedServices: sortedServices.length,
+			services: sortedServices,
+		},
+	};
+};
+
+export function assertHomeyShsMdnsReportSchema(value: unknown): asserts value is HomeyShsMdnsReport {
+	const report = requireExactKeys(value, ['metadata', 'observation'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion'], 'metadata');
+	const observation = requireExactKeys(
+		report.observation,
+		['durationMs', 'matchedServices', 'services'],
+		'observation',
+	);
+
+	if (metadata.probe !== 'homey-shs-mdns' || metadata.schemaVersion !== 1) {
+		throw new Error('Homey mDNS report metadata schema is invalid');
+	}
+
+	if (
+		typeof observation.durationMs !== 'number' ||
+		!Number.isInteger(observation.durationMs) ||
+		observation.durationMs < MIN_OBSERVE_MS ||
+		observation.durationMs > MAX_OBSERVE_MS ||
+		typeof observation.matchedServices !== 'number' ||
+		!Number.isInteger(observation.matchedServices) ||
+		observation.matchedServices < 0 ||
+		!Array.isArray(observation.services) ||
+		observation.matchedServices !== observation.services.length
+	) {
+		throw new Error('Homey mDNS report observation schema is invalid');
+	}
+
+	let previousSignature: string | null = null;
+
+	for (const serviceValue of observation.services) {
+		const service = requireExactKeys(serviceValue, ['port', 'protocol', 'txtKeys', 'type'], 'service');
+
+		if (
+			typeof service.type !== 'string' ||
+			!PUBLIC_IDENTIFIER_PATTERN.test(service.type) ||
+			(service.protocol !== 'tcp' && service.protocol !== 'udp') ||
+			typeof service.port !== 'number' ||
+			!Number.isInteger(service.port) ||
+			service.port < 1 ||
+			service.port > 65_535 ||
+			!Array.isArray(service.txtKeys) ||
+			service.txtKeys.some((key) => typeof key !== 'string' || !PUBLIC_IDENTIFIER_PATTERN.test(key))
+		) {
+			throw new Error('Homey mDNS report service schema is invalid');
+		}
+
+		const txtKeys = service.txtKeys as string[];
+
+		if (txtKeys.some((key, index) => index > 0 && key <= txtKeys[index - 1])) {
+			throw new Error('Homey mDNS report service schema is invalid');
+		}
+
+		const signature = serviceSignature({
+			port: service.port,
+			protocol: service.protocol,
+			txtKeys,
+			type: service.type,
+		});
+
+		if (previousSignature !== null && signature.localeCompare(previousSignature) <= 0) {
+			throw new Error('Homey mDNS report service schema is invalid');
+		}
+
+		previousSignature = signature;
+	}
+}
+
+export function assertHomeyShsMdnsReportSafe(
+	value: unknown,
+	config: HomeyShsMdnsProbeConfig,
+): asserts value is HomeyShsMdnsReport {
+	assertHomeyShsMdnsReportSchema(value);
+
+	const serialized = JSON.stringify(value).toLowerCase();
+	const reportStrings = value.observation.services.flatMap(({ protocol, txtKeys, type }) => [
+		protocol,
+		type,
+		...txtKeys,
+	]);
+	const forbiddenValues = [config.expectedHost, ...config.privateTerms]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3);
+
+	if (
+		forbiddenValues.some((item) => serialized.includes(item)) ||
+		URL_PATTERN.test(serialized) ||
+		EMAIL_PATTERN.test(serialized) ||
+		IPV4_PATTERN.test(serialized) ||
+		reportStrings.some((item) => item.includes(':')) ||
+		HOMEY_TOKEN_PATTERN.test(serialized)
+	) {
+		throw new Error('Sanitized Homey mDNS report contains a secret, address, or email-like value');
+	}
+}
+
+export const writeHomeyShsMdnsReport = async (report: HomeyShsMdnsReport, outputRoot: string): Promise<string> => {
+	assertHomeyShsMdnsReportSchema(report);
+
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `mdns-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsMdnsProbeConfig(process.env);
+	const report = await probeHomeyShsMdns(config);
+
+	assertHomeyShsMdnsReportSafe(report, config);
+
+	const outputDirectory = await writeHomeyShsMdnsReport(report, config.outputRoot);
+
+	process.stdout.write(
+		`Sanitized Homey mDNS report written to ${outputDirectory} ` +
+			`(${report.observation.matchedServices} matched services).\n`,
+	);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS mDNS probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/apps/backend/test/support/homey-shs-mdns-probe.ts
+++ b/apps/backend/test/support/homey-shs-mdns-probe.ts
@@ -10,7 +10,10 @@ const PUBLIC_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 const URL_PATTERN = /(?:https?|wss?):\/\//i;
 const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 const IPV4_PATTERN = /(?:^|[^\d])(?:\d{1,3}\.){3}\d{1,3}(?:$|[^\d])/;
+const MAC_PATTERN =
+	/(?:^|[^A-F0-9])(?:[0-9a-f]{2}(?:[:-][0-9a-f]{2}){5}|[0-9a-f]{4}(?:\.[0-9a-f]{4}){2}|[0-9a-f]{12})(?:$|[^A-F0-9])/i;
 const HOMEY_TOKEN_PATTERN = /(?:hpat|pat|homey)[_-][A-Za-z0-9_-]{16,}/i;
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
 
 export interface HomeyShsMdnsProbeConfig {
 	expectedHost: string;
@@ -48,12 +51,13 @@ interface HomeyMdnsService {
 }
 
 export interface HomeyMdnsBrowser {
+	readonly services: HomeyMdnsService[];
 	stop(): void;
 }
 
 export interface HomeyMdnsClient {
 	destroy(): void;
-	find(options: null, onUp: (service: HomeyMdnsService) => void): HomeyMdnsBrowser;
+	find(options: null): HomeyMdnsBrowser;
 }
 
 export type HomeyMdnsClientFactory = (onError: () => void) => HomeyMdnsClient;
@@ -64,7 +68,7 @@ const defaultClientFactory: HomeyMdnsClientFactory = (onError) => {
 
 	return {
 		destroy: () => bonjour.destroy(),
-		find: (options, onUp) => bonjour.find(options, onUp),
+		find: (options) => bonjour.find(options),
 	};
 };
 
@@ -224,25 +228,26 @@ export const probeHomeyShsMdns = async (
 		client = clientFactory(() => {
 			observationFailure = new Error('Homey mDNS observation failed');
 		});
-		browser = client.find(null, (service) => {
-			if (observationFailure !== null) {
-				return;
-			}
-
-			try {
-				if (!serviceMatchesExpectedHost(service, config.expectedHost)) {
-					return;
-				}
-
-				const report = toSafeServiceReport(service);
-
-				services.set(serviceSignature(report), report);
-			} catch {
-				observationFailure = new Error('Homey mDNS service metadata was not safe to record');
-			}
-		});
+		browser = client.find(null);
 
 		await wait(config.observeMs);
+
+		if (observationFailure === null) {
+			for (const service of browser.services) {
+				if (!serviceMatchesExpectedHost(service, config.expectedHost)) {
+					continue;
+				}
+
+				try {
+					const report = toSafeServiceReport(service);
+
+					services.set(serviceSignature(report), report);
+				} catch {
+					observationFailure = new Error('Homey mDNS service metadata was not safe to record');
+					break;
+				}
+			}
+		}
 	} catch {
 		observationFailure ??= new Error('Homey mDNS observation failed');
 	} finally {
@@ -358,13 +363,14 @@ export function assertHomeyShsMdnsReportSafe(
 	]);
 	const forbiddenValues = [config.expectedHost, ...config.privateTerms]
 		.map((item) => item.trim().toLowerCase())
-		.filter((item) => item.length >= 3);
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
 
 	if (
 		forbiddenValues.some((item) => serialized.includes(item)) ||
 		URL_PATTERN.test(serialized) ||
 		EMAIL_PATTERN.test(serialized) ||
 		IPV4_PATTERN.test(serialized) ||
+		MAC_PATTERN.test(serialized) ||
 		reportStrings.some((item) => item.includes(':')) ||
 		HOMEY_TOKEN_PATTERN.test(serialized)
 	) {

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,7 +1,7 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory and SDK session/cleanup evidence captured, live capability-event, write, error-matrix,
-reconnect, and recovery evidence pending
+**Status:** In progress; safe inventory, SDK session/cleanup, and pre-restart mDNS host-match evidence captured; live
+capability-event, write, error-matrix, reconnect, and recovery evidence pending
 
 **Started:** 2026-08-12
 
@@ -27,7 +27,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled         | Use only the designated harmless test capability                        |
 | Error classification                                  | SDK invalid key returned `401`; matrix pending | Verify missing-scope, bad-URL, unavailable, and timeout behavior        |
 | Disposable-device lifecycle                           | Contract defined, disabled                     | Use only the separately gated virtual/test device                       |
-| mDNS discovery                                        | Pending live access                            | Record stable service/TXT data or explicitly defer discovery            |
+| mDNS discovery                                        | Partial pre-restart observation                | Attribute the generic host record and repeat after SHS restart          |
 | SDK decision                                          | Live session/cleanup passed; provisional hold  | Complete event, timeout, cleanup-failure, and reconnect comparison      |
 | Sanitized fixture corpus                              | Nine representative live fixtures promoted     | Add event/reconnect fixtures and missing capability families/classes    |
 
@@ -39,6 +39,7 @@ Complete this table after the live run. Values committed here must remain non-se
 | ---------------------------------------- | -------------------------------------------------------------------- |
 | Capture date                             | `2026-08-13`                                                         |
 | Realtime SDK probe date                  | `2026-08-14`                                                         |
+| mDNS observation date                    | `2026-08-14`                                                         |
 | SHS version                              | `13.4.0`                                                             |
 | Container image tag and immutable digest | Pending                                                              |
 | Host operating system/architecture       | Pending                                                              |
@@ -188,6 +189,33 @@ The implementation must validate the exact operation list, require a synthetic t
 setup, and clean up only resources created by that run. It must never pair, rename, move, make unavailable, remove, or
 unpair ordinary household devices.
 
+## Privacy-safe mDNS observation probe
+
+The mDNS probe performs a bounded wildcard DNS-SD observation because SHS's service type has not been established. It
+does not read or send `FB_HOMEY_SHS_API_KEY`. Although the browser necessarily receives other LAN advertisements in
+memory, the probe immediately discards every service whose hostname or address does not exactly match
+`FB_HOMEY_SHS_EXPECTED_HOST`. The persisted exact-schema report contains only the matched service type, protocol, port,
+and sorted TXT key names. Service names, hostnames, addresses, TXT values, referer data, FQDNs, URLs, credentials, and
+raw errors have no report fields.
+
+Run it from the same interactive shell as the read-only probe:
+
+```bash
+pnpm run homey:probe-mdns
+```
+
+`FB_HOMEY_SHS_MDNS_OBSERVE_MS` optionally controls the observation window from `1000` through `30000` milliseconds and
+defaults to `5000`. The report uses the shared `FB_HOMEY_SHS_CAPTURE_DIR` and the same non-overwriting `0700` directory
+and `0600` file modes as the other probes. A zero-match result is valid evidence that no matching advertisement was
+seen during that bounded window; it is not proof that SHS never advertises. Closing the discovery decision still
+requires stable observations before and after an SHS restart, or an explicit documented decision to defer mDNS.
+
+Two consecutive five-second observations on 2026-08-14 produced the same sanitized host match: `_http._tcp` on port
+`80` with no TXT keys. The reviewed report is committed as
+`__fixtures__/evidence/2026-08-14-shs-13.4.0-mdns-host-match.json`. Because the record is generic and the observed port
+is not either documented SHS API port, this does not establish that SHS owns the advertisement or provide a safe
+discovery discriminator. The discovery gate remains open pending attribution and an observation after SHS restart.
+
 ## Non-mutating error-classification probe
 
 The error probe records only fixed category labels, rejection booleans, and HTTP status codes. It performs three live
@@ -273,7 +301,7 @@ Fill this matrix using synthetic aliases only.
 | SHS restart and reconnect                 | Pending                             |                                                                                                                                                      |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
-| Stable mDNS service before/after restart  | Pending                             |                                                                                                                                                      |
+| Stable mDNS service before/after restart  | Partial pre-restart evidence        | Two identical windows matched generic `_http._tcp` port `80` with no TXT keys; SHS attribution and post-restart stability remain unproven            |
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- add a bounded, API-key-free wildcard DNS-SD observation probe for the Homey SHS compatibility spike
- persist only exact-schema service type, protocol, port, and TXT key names after exact host matching
- add offline coverage for privacy, configuration, cleanup, deduplication, schema validation, and restrictive file modes
- record two identical sanitized pre-restart observations and update the compatibility record

## Why

The Homey design requires mDNS behavior to be measured rather than inferred. SHS's service type is not established, so this probe safely observes wildcard DNS-SD records without shipping a guessed production discoverer or retaining unrelated LAN data.

The two live windows matched only a generic `_http._tcp` record on port `80` with no TXT keys. The documentation keeps discovery unresolved because SHS attribution and post-restart stability are still unproven.

## Impact

This adds compatibility-test tooling and reviewed evidence only. It does not add or enable production Homey discovery, does not read or send the Homey API key, and does not mutate the SHS instance.

## Validation

- `pnpm --dir apps/backend run test:homey-spike` — 4 suites, 62 tests
- targeted ESLint for the new probe and suite
- `pnpm --dir apps/backend run type-check`
- Prettier and `git diff --check`
- two live, read-only five-second mDNS observations with mutation gates absent