### PR TITLE
test(cross): add guarded Homey recovery probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,6 +76,7 @@
     "homey:generate-normalized-fixtures": "ts-node --project tsconfig.json test/support/generate-homey-normalized-fixtures.ts",
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",
     "homey:probe-mdns": "ts-node --project tsconfig.json test/support/homey-shs-mdns-probe.ts",
+    "homey:probe-recovery": "ts-node --project tsconfig.json test/support/homey-shs-recovery-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",
     "typeorm:migration:generate": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:generate -d ./src/dataSource.ts",

--- a/apps/backend/test/homey-shs-recovery.homey-spike.ts
+++ b/apps/backend/test/homey-shs-recovery.homey-spike.ts
@@ -1,0 +1,359 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	type HomeyRecoverySdkFactory,
+	type HomeyShsRecoveryProbeConfig,
+	type HomeyShsRecoveryReport,
+	assertHomeyShsRecoveryReportSafe,
+	assertHomeyShsRecoveryReportSchema,
+	loadHomeyShsRecoveryProbeConfig,
+	probeHomeyShsRecovery,
+	writeHomeyShsRecoveryReport,
+} from './support/homey-shs-recovery-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'test-api-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_RECOVERY_ENABLE: 'I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE',
+	FB_HOMEY_SHS_RECOVERY_OBSERVE_MS: '10000',
+	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+type RecoveryScenario = 'inventory-failure' | 'manager-offline' | 'no-recovery' | 'success';
+
+class FakeRecoveryDevicesManager {
+	connectCount = 0;
+	connected = false;
+	disconnectCount = 0;
+	failDisconnect = false;
+	inventoryReadCount = 0;
+
+	constructor(
+		private readonly client: FakeRecoveryClient,
+		private readonly scenario: RecoveryScenario,
+	) {}
+
+	connect(): Promise<void> {
+		this.connectCount += 1;
+		this.connected = true;
+		this.client.emit('connect');
+
+		if (this.scenario !== 'no-recovery') {
+			setTimeout(() => {
+				this.connected = false;
+				this.client.emit('disconnect', 'raw private disconnect reason');
+				this.client.emit('reconnect_attempt', 1);
+				this.client.emit('reconnecting', 1);
+				this.connected = this.scenario !== 'manager-offline';
+				this.client.emit('reconnect');
+			}, 0);
+		}
+
+		return Promise.resolve();
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+		this.connected = false;
+
+		return this.failDisconnect ? Promise.reject(new Error('raw manager cleanup detail')) : Promise.resolve();
+	}
+
+	getDevices(): Promise<Record<string, unknown>> {
+		this.inventoryReadCount += 1;
+
+		return this.scenario === 'inventory-failure'
+			? Promise.reject(new Error('raw inventory detail with endpoint and key'))
+			: Promise.resolve({ 'private-device-id': { name: 'Private Device' } });
+	}
+
+	isConnected(): boolean {
+		return this.connected;
+	}
+}
+
+class FakeRecoveryClient extends EventEmitter {
+	destroyCount = 0;
+	disconnectCount = 0;
+	failDestroy = false;
+	failDisconnect = false;
+	readonly devices: FakeRecoveryDevicesManager;
+
+	constructor(scenario: RecoveryScenario) {
+		super();
+		this.devices = new FakeRecoveryDevicesManager(this, scenario);
+	}
+
+	destroy(): void {
+		this.destroyCount += 1;
+		this.removeAllListeners();
+
+		if (this.failDestroy) {
+			throw new Error('raw destroy detail');
+		}
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+
+		return this.failDisconnect ? Promise.reject(new Error('raw socket cleanup detail')) : Promise.resolve();
+	}
+}
+
+const createFactory = (
+	scenario: RecoveryScenario,
+	configure?: (client: FakeRecoveryClient) => void,
+): {
+	clients: FakeRecoveryClient[];
+	factory: HomeyRecoverySdkFactory;
+	requests: Array<{ address: string; token: string }>;
+} => {
+	const clients: FakeRecoveryClient[] = [];
+	const requests: Array<{ address: string; token: string }> = [];
+	const factory: HomeyRecoverySdkFactory = {
+		createLocalApi: ({ address, token }) => {
+			const client = new FakeRecoveryClient(scenario);
+
+			configure?.(client);
+			clients.push(client);
+			requests.push({ address, token });
+
+			return Promise.resolve(client);
+		},
+	};
+
+	return { clients, factory, requests };
+};
+
+const fastConfig = (overrides: Partial<HomeyShsRecoveryProbeConfig> = {}): HomeyShsRecoveryProbeConfig => ({
+	...loadHomeyShsRecoveryProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-recovery-spike'),
+	observeMs: 100,
+	timeoutMs: 50,
+	...overrides,
+});
+
+describe('Homey SHS recovery compatibility probe', () => {
+	it('requires the exact operator acknowledgement and refuses mutation gates', () => {
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_ENABLE: undefined,
+			}),
+		).toThrow('required operator acknowledgement');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_ENABLE: 'yes',
+			}),
+		).toThrow('required operator acknowledgement');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_WRITE_ENABLE: '',
+			}),
+		).toThrow('mutation gates must be unset');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID: 'private-device',
+			}),
+		).toThrow('mutation gates must be unset');
+	});
+
+	it('loads bounded recovery configuration without changing the shared endpoint contract', () => {
+		const config = loadHomeyShsRecoveryProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-recovery-spike');
+
+		expect(config).toMatchObject({
+			apiKey: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY,
+			expectedHost: '127.0.0.1',
+			observeMs: 10_000,
+			outputRoot: '/tmp/homey-recovery-spike/test/.homey-shs-captures',
+			timeoutMs: 1000,
+		});
+		expect(config.origin.origin).toBe('http://127.0.0.1:4859');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_RECOVERY_OBSERVE_MS: '9999' }),
+		).toThrow('between 10000 and 300000');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_RECOVERY_OBSERVE_MS: '300001' }),
+		).toThrow('between 10000 and 300000');
+	});
+
+	it('verifies disconnect, reconnect, resubscription, inventory, and cleanup in order', async () => {
+		const config = fastConfig();
+		const harness = createFactory('success');
+		let windowOpenCount = 0;
+		const report = await probeHomeyShsRecovery(config, harness.factory, undefined, () => {
+			windowOpenCount += 1;
+		});
+
+		expect(report).toStrictEqual({
+			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			recovery: {
+				disconnectObserved: true,
+				inventoryReadSucceeded: true,
+				managerResubscribed: true,
+				transportReconnected: true,
+			},
+			session: {
+				cleanupCompleted: true,
+				events: [
+					{ event: 'sdk.create.resolved', order: 1 },
+					{ event: 'manager.subscribe.resolved', order: 2 },
+					{ event: 'recovery.window.open', order: 3 },
+					{ event: 'socket.disconnect', order: 4 },
+					{ event: 'socket.reconnect_attempt', order: 5 },
+					{ event: 'socket.reconnecting', order: 6 },
+					{ event: 'socket.reconnect', order: 7 },
+					{ event: 'manager.resubscribe.observed', order: 8 },
+					{ event: 'inventory.read.resolved', order: 9 },
+					{ event: 'manager.unsubscribe.resolved', order: 10 },
+					{ event: 'socket.disconnect.resolved', order: 11 },
+					{ event: 'sdk.destroyed', order: 12 },
+				],
+				managerSubscribed: true,
+			},
+		});
+		expect(harness.requests).toStrictEqual([
+			{ address: 'http://127.0.0.1:4859', token: 'test-api-key-that-must-not-leak' },
+		]);
+		expect(harness.clients[0].devices.inventoryReadCount).toBe(1);
+		expect(harness.clients[0].devices.disconnectCount).toBe(1);
+		expect(harness.clients[0].disconnectCount).toBe(1);
+		expect(harness.clients[0].destroyCount).toBe(1);
+		expect(windowOpenCount).toBe(1);
+		expect(() => assertHomeyShsRecoveryReportSafe(report, config)).not.toThrow();
+		expect(JSON.stringify(report)).not.toContain('test-api-key-that-must-not-leak');
+		expect(JSON.stringify(report)).not.toContain('Private Device');
+	});
+
+	it('fails safely when no operator restart occurs and still cleans up', async () => {
+		const config = fastConfig({ observeMs: 10 });
+		const harness = createFactory('no-recovery');
+
+		await expect(probeHomeyShsRecovery(config, harness.factory)).rejects.toThrow(
+			'Homey recovery operator restart observation timed out after 10 ms',
+		);
+		expect(harness.clients[0].devices.disconnectCount).toBe(1);
+		expect(harness.clients[0].disconnectCount).toBe(1);
+		expect(harness.clients[0].destroyCount).toBe(1);
+	});
+
+	it('requires manager restoration after transport reconnect and sanitizes failures', async () => {
+		const offlineConfig = fastConfig({ timeoutMs: 10 });
+		const offlineHarness = createFactory('manager-offline');
+
+		await expect(probeHomeyShsRecovery(offlineConfig, offlineHarness.factory)).rejects.toThrow(
+			'Homey recovery manager resubscription timed out after 10 ms',
+		);
+		expect(offlineHarness.clients[0].destroyCount).toBe(1);
+
+		const inventoryHarness = createFactory('inventory-failure');
+
+		await expect(probeHomeyShsRecovery(fastConfig(), inventoryHarness.factory)).rejects.toThrow(
+			'Homey recovery post-reconnect inventory read failed',
+		);
+		expect(inventoryHarness.clients[0].destroyCount).toBe(1);
+	});
+
+	it('reports fixed cleanup failures after attempting every cleanup step', async () => {
+		const harness = createFactory('success', (client) => {
+			client.devices.failDisconnect = true;
+			client.failDisconnect = true;
+			client.failDestroy = true;
+		});
+
+		await expect(probeHomeyShsRecovery(fastConfig(), harness.factory)).rejects.toThrow(
+			'Homey recovery cleanup failed: manager unsubscribe, socket disconnect, client destroy',
+		);
+		expect(harness.clients[0].devices.disconnectCount).toBe(1);
+		expect(harness.clients[0].disconnectCount).toBe(1);
+		expect(harness.clients[0].destroyCount).toBe(1);
+	});
+
+	it('rejects extra fields, invalid state, unsafe values, and unordered evidence', () => {
+		const report: HomeyShsRecoveryReport = {
+			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			recovery: {
+				disconnectObserved: true,
+				inventoryReadSucceeded: true,
+				managerResubscribed: true,
+				transportReconnected: true,
+			},
+			session: {
+				cleanupCompleted: true,
+				events: [
+					{ event: 'manager.subscribe.resolved', order: 1 },
+					{ event: 'recovery.window.open', order: 2 },
+					{ event: 'socket.disconnect', order: 3 },
+					{ event: 'socket.reconnect', order: 4 },
+					{ event: 'manager.resubscribe.observed', order: 5 },
+					{ event: 'inventory.read.resolved', order: 6 },
+				],
+				managerSubscribed: true,
+			},
+		};
+		const extra = structuredClone(report) as unknown as Record<string, unknown>;
+		extra.rawEndpoint = 'private-endpoint';
+
+		expect(() => assertHomeyShsRecoveryReportSchema(extra)).toThrow('root schema is invalid');
+
+		const invalidState = structuredClone(report);
+		(invalidState.recovery as unknown as Record<string, unknown>).managerResubscribed = 'true';
+
+		expect(() => assertHomeyShsRecoveryReportSchema(invalidState)).toThrow('state schema is invalid');
+
+		const incomplete = structuredClone(report);
+		incomplete.recovery.inventoryReadSucceeded = false;
+
+		expect(() => assertHomeyShsRecoveryReportSafe(incomplete, fastConfig())).toThrow(
+			'did not verify restart recovery and cleanup',
+		);
+
+		const unordered = structuredClone(report);
+		unordered.session.events = [
+			{ event: 'socket.disconnect', order: 1 },
+			{ event: 'manager.subscribe.resolved', order: 2 },
+			{ event: 'recovery.window.open', order: 3 },
+			{ event: 'socket.reconnect', order: 4 },
+			{ event: 'manager.resubscribe.observed', order: 5 },
+			{ event: 'inventory.read.resolved', order: 6 },
+		];
+
+		expect(() => assertHomeyShsRecoveryReportSafe(unordered, fastConfig())).toThrow(
+			'does not contain the required restart ordering',
+		);
+	});
+
+	it('writes a new restrictive, schema-validated report directory', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'homey-recovery-spike-'));
+		const report: HomeyShsRecoveryReport = {
+			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			recovery: {
+				disconnectObserved: true,
+				inventoryReadSucceeded: true,
+				managerResubscribed: true,
+				transportReconnected: true,
+			},
+			session: { cleanupCompleted: true, events: [], managerSubscribed: true },
+		};
+
+		try {
+			const outputDirectory = await writeHomeyShsRecoveryReport(report, root);
+			const outputStat = await stat(outputDirectory);
+			const reportStat = await stat(join(outputDirectory, 'report.json'));
+			const written = JSON.parse(await readFile(join(outputDirectory, 'report.json'), 'utf8')) as unknown;
+
+			expect(outputStat.mode & 0o777).toBe(0o700);
+			expect(reportStat.mode & 0o777).toBe(0o600);
+			expect(written).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/homey-shs-recovery.homey-spike.ts
+++ b/apps/backend/test/homey-shs-recovery.homey-spike.ts
@@ -24,7 +24,13 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
 };
 
-type RecoveryScenario = 'inventory-failure' | 'manager-offline' | 'no-recovery' | 'success';
+type RecoveryScenario =
+	| 'connect-recovery'
+	| 'inventory-failure'
+	| 'late-success'
+	| 'manager-offline'
+	| 'no-recovery'
+	| 'success';
 
 class FakeRecoveryDevicesManager {
 	connectCount = 0;
@@ -44,14 +50,25 @@ class FakeRecoveryDevicesManager {
 		this.client.emit('connect');
 
 		if (this.scenario !== 'no-recovery') {
-			setTimeout(() => {
-				this.connected = false;
-				this.client.emit('disconnect', 'raw private disconnect reason');
-				this.client.emit('reconnect_attempt', 1);
-				this.client.emit('reconnecting', 1);
-				this.connected = this.scenario !== 'manager-offline';
-				this.client.emit('reconnect');
-			}, 0);
+			setTimeout(
+				() => {
+					this.connected = false;
+					this.client.emit('disconnect', 'raw private disconnect reason');
+					this.client.emit('reconnect_attempt', 1);
+					this.client.emit('reconnecting', 1);
+
+					if (this.scenario === 'late-success') {
+						this.client.emit('reconnect');
+						setTimeout(() => {
+							this.connected = true;
+						}, 20);
+					} else {
+						this.connected = this.scenario !== 'manager-offline';
+						this.client.emit(this.scenario === 'connect-recovery' ? 'connect' : 'reconnect');
+					}
+				},
+				this.scenario === 'late-success' ? 90 : 0,
+			);
 		}
 
 		return Promise.resolve();
@@ -230,6 +247,43 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(() => assertHomeyShsRecoveryReportSafe(report, config)).not.toThrow();
 		expect(JSON.stringify(report)).not.toContain('test-api-key-that-must-not-leak');
 		expect(JSON.stringify(report)).not.toContain('Private Device');
+	});
+
+	it('accepts a post-disconnect connect event as transport recovery', async () => {
+		const config = fastConfig();
+		const report = await probeHomeyShsRecovery(config, createFactory('connect-recovery').factory);
+		const eventNames = report.session.events.map(({ event }) => event);
+
+		expect(eventNames).toContain('socket.connect');
+		expect(eventNames).not.toContain('socket.reconnect');
+		expect(report.recovery).toStrictEqual({
+			disconnectObserved: true,
+			inventoryReadSucceeded: true,
+			managerResubscribed: true,
+			transportReconnected: true,
+		});
+		expect(() => assertHomeyShsRecoveryReportSafe(report, config)).not.toThrow();
+	});
+
+	it('gives verification a fresh timeout budget after late transport recovery', async () => {
+		jest.useFakeTimers();
+
+		try {
+			const config = fastConfig({ observeMs: 100, timeoutMs: 50 });
+			const recovery = probeHomeyShsRecovery(config, createFactory('late-success').factory);
+			const assertion = expect(recovery).resolves.toMatchObject({
+				recovery: {
+					inventoryReadSucceeded: true,
+					managerResubscribed: true,
+					transportReconnected: true,
+				},
+			});
+
+			await jest.advanceTimersByTimeAsync(200);
+			await assertion;
+		} finally {
+			jest.useRealTimers();
+		}
 	});
 
 	it('fails safely when no operator restart occurs and still cleans up', async () => {

--- a/apps/backend/test/support/homey-shs-recovery-probe.ts
+++ b/apps/backend/test/support/homey-shs-recovery-probe.ts
@@ -1,0 +1,535 @@
+import { HomeyAPI } from 'homey-api';
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const SDK_VERSION = '3.19.2';
+const RECOVERY_ACKNOWLEDGEMENT = 'I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE';
+const DEFAULT_OBSERVE_MS = 90_000;
+const MIN_OBSERVE_MS = 10_000;
+const MAX_OBSERVE_MS = 300_000;
+const RESUBSCRIBE_POLL_MS = 100;
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
+const MUTATION_GATE_PREFIXES = ['FB_HOMEY_SHS_WRITE_', 'FB_HOMEY_SHS_LIFECYCLE_'];
+const SAFE_EVENT_LABELS = new Set([
+	'inventory.read.resolved',
+	'manager.resubscribe.observed',
+	'manager.subscribe.resolved',
+	'manager.unsubscribe.failed',
+	'manager.unsubscribe.resolved',
+	'recovery.window.open',
+	'sdk.create.resolved',
+	'sdk.destroy.failed',
+	'sdk.destroyed',
+	'socket.connect',
+	'socket.disconnect',
+	'socket.disconnect.failed',
+	'socket.disconnect.resolved',
+	'socket.reconnect',
+	'socket.reconnect_attempt',
+	'socket.reconnect_error',
+	'socket.reconnecting',
+]);
+
+type EventListener = (...arguments_: unknown[]) => void;
+
+class HomeyShsRecoveryTimeoutError extends Error {
+	constructor(label: string, timeoutMs: number) {
+		super(`Homey recovery ${label} timed out after ${timeoutMs} ms`);
+		this.name = 'HomeyShsRecoveryTimeoutError';
+	}
+}
+
+interface EventSource {
+	off?(event: string, listener: EventListener): unknown;
+	on(event: string, listener: EventListener): unknown;
+}
+
+interface HomeyRecoveryDevicesManager {
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+	getDevices(options?: { $timeout?: number }): Promise<Record<string, unknown>>;
+	isConnected(): boolean;
+}
+
+interface HomeyRecoveryClient extends EventSource {
+	destroy(): void;
+	disconnect(): Promise<void>;
+	devices: HomeyRecoveryDevicesManager;
+}
+
+export interface HomeyRecoverySdkFactory {
+	createLocalApi(options: { address: string; token: string }): Promise<HomeyRecoveryClient>;
+}
+
+export interface HomeyShsRecoveryProbeConfig extends HomeyShsProbeConfig {
+	observeMs: number;
+}
+
+export interface HomeyShsRecoveryReport {
+	metadata: {
+		probe: 'homey-shs-recovery';
+		schemaVersion: 1;
+		sdkVersion: string;
+	};
+	recovery: {
+		disconnectObserved: boolean;
+		inventoryReadSucceeded: boolean;
+		managerResubscribed: boolean;
+		transportReconnected: boolean;
+	};
+	session: {
+		cleanupCompleted: boolean;
+		events: Array<{ event: string; order: number }>;
+		managerSubscribed: boolean;
+	};
+}
+
+export type HomeyRecoveryWait = (milliseconds: number) => Promise<void>;
+
+const sdkFactory: HomeyRecoverySdkFactory = {
+	createLocalApi: async ({ address, token }) =>
+		(await HomeyAPI.createLocalAPI({ address, token, debug: null })) as HomeyRecoveryClient,
+};
+
+const sleep: HomeyRecoveryWait = async (milliseconds) =>
+	new Promise((resolvePromise) => {
+		setTimeout(resolvePromise, milliseconds);
+	});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey recovery report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey recovery report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+const parseObserveMs = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_OBSERVE_MS;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(
+			`FB_HOMEY_SHS_RECOVERY_OBSERVE_MS must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`,
+		);
+	}
+
+	return parsed;
+};
+
+export const loadHomeyShsRecoveryProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsRecoveryProbeConfig => {
+	if (environment.FB_HOMEY_SHS_RECOVERY_ENABLE !== RECOVERY_ACKNOWLEDGEMENT) {
+		throw new Error('FB_HOMEY_SHS_RECOVERY_ENABLE does not contain the required operator acknowledgement');
+	}
+
+	const mutationGate = Object.keys(environment).find((name) =>
+		MUTATION_GATE_PREFIXES.some((prefix) => name.startsWith(prefix)),
+	);
+
+	if (mutationGate !== undefined) {
+		throw new Error('Homey write and lifecycle mutation gates must be unset during the recovery probe');
+	}
+
+	return {
+		...loadHomeyShsProbeConfig(environment, workingDirectory),
+		observeMs: parseObserveMs(environment.FB_HOMEY_SHS_RECOVERY_OBSERVE_MS),
+	};
+};
+
+const settleOperation = async <T>(label: string, timeoutMs: number, operation: () => Promise<T>): Promise<T> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const operationPromise = operation();
+	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
+		timeout = setTimeout(() => rejectPromise(new HomeyShsRecoveryTimeoutError(label, timeoutMs)), timeoutMs);
+	});
+
+	try {
+		return await Promise.race([operationPromise, timeoutPromise]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
+};
+
+const runOperation = async <T>(label: string, timeoutMs: number, operation: () => Promise<T>): Promise<T> => {
+	try {
+		return await settleOperation(label, timeoutMs, operation);
+	} catch (error: unknown) {
+		if (error instanceof HomeyShsRecoveryTimeoutError) {
+			throw error;
+		}
+
+		// eslint-disable-next-line preserve-caught-error -- SDK causes may expose endpoint or credential-bearing detail.
+		throw new Error(`Homey recovery ${label} failed`);
+	}
+};
+
+const createClient = async (
+	config: HomeyShsRecoveryProbeConfig,
+	factory: HomeyRecoverySdkFactory,
+): Promise<HomeyRecoveryClient> => {
+	const creationPromise = factory.createLocalApi({ address: config.origin.origin, token: config.apiKey });
+
+	try {
+		return await runOperation('client creation', config.timeoutMs, () => creationPromise);
+	} catch (error: unknown) {
+		if (error instanceof HomeyShsRecoveryTimeoutError) {
+			void creationPromise.then(
+				(lateClient) => {
+					try {
+						lateClient.destroy();
+					} catch {
+						// The caller already receives the fixed, sanitized creation timeout.
+					}
+				},
+				() => undefined,
+			);
+		}
+
+		throw error;
+	}
+};
+
+const appendEvent = (report: HomeyShsRecoveryReport, event: string): void => {
+	report.session.events.push({ event, order: report.session.events.length + 1 });
+};
+
+const attachListener = (source: EventSource, event: string, listener: EventListener): (() => void) => {
+	source.on(event, listener);
+
+	return () => source.off?.(event, listener);
+};
+
+const waitForManagerResubscription = async (
+	client: HomeyRecoveryClient,
+	config: HomeyShsRecoveryProbeConfig,
+	wait: HomeyRecoveryWait,
+): Promise<void> => {
+	const deadline = Date.now() + config.timeoutMs;
+
+	while (!client.devices.isConnected()) {
+		if (Date.now() >= deadline) {
+			throw new HomeyShsRecoveryTimeoutError('manager resubscription', config.timeoutMs);
+		}
+
+		await wait(Math.min(RESUBSCRIBE_POLL_MS, Math.max(1, deadline - Date.now())));
+	}
+};
+
+const waitForRecoveryCompletion = async (completion: Promise<void>, observeMs: number): Promise<void> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
+		timeout = setTimeout(
+			() => rejectPromise(new HomeyShsRecoveryTimeoutError('operator restart observation', observeMs)),
+			observeMs,
+		);
+	});
+
+	try {
+		await Promise.race([completion, timeoutPromise]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
+};
+
+export const probeHomeyShsRecovery = async (
+	config: HomeyShsRecoveryProbeConfig,
+	factory: HomeyRecoverySdkFactory = sdkFactory,
+	wait: HomeyRecoveryWait = sleep,
+	onWindowOpen: () => void = () => undefined,
+): Promise<HomeyShsRecoveryReport> => {
+	const report: HomeyShsRecoveryReport = {
+		metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: SDK_VERSION },
+		recovery: {
+			disconnectObserved: false,
+			inventoryReadSucceeded: false,
+			managerResubscribed: false,
+			transportReconnected: false,
+		},
+		session: { cleanupCompleted: false, events: [], managerSubscribed: false },
+	};
+	const client = await createClient(config, factory);
+	appendEvent(report, 'sdk.create.resolved');
+	let recoveryWindowOpen = false;
+	let resolveRecovery: (() => void) | undefined;
+	let rejectRecovery: ((error: Error) => void) | undefined;
+	const recoveryCompletion = new Promise<void>((resolvePromise, rejectPromise) => {
+		resolveRecovery = resolvePromise;
+		rejectRecovery = rejectPromise;
+	});
+	const cleanupListeners: Array<() => void> = [];
+	let verificationPromise: Promise<void> | null = null;
+	let operationError: unknown;
+	const cleanupFailures: string[] = [];
+
+	cleanupListeners.push(
+		attachListener(client, 'connect', () => {
+			if (recoveryWindowOpen) {
+				appendEvent(report, 'socket.connect');
+			}
+		}),
+		attachListener(client, 'disconnect', () => {
+			if (recoveryWindowOpen && !report.recovery.disconnectObserved) {
+				report.recovery.disconnectObserved = true;
+				appendEvent(report, 'socket.disconnect');
+			}
+		}),
+		...['reconnect_attempt', 'reconnect_error', 'reconnecting'].map((event) =>
+			attachListener(client, event, () => {
+				if (recoveryWindowOpen && report.recovery.disconnectObserved) {
+					appendEvent(report, `socket.${event}`);
+				}
+			}),
+		),
+		attachListener(client, 'reconnect', () => {
+			if (!recoveryWindowOpen || !report.recovery.disconnectObserved || report.recovery.transportReconnected) {
+				return;
+			}
+
+			report.recovery.transportReconnected = true;
+			appendEvent(report, 'socket.reconnect');
+			verificationPromise = (async () => {
+				try {
+					await waitForManagerResubscription(client, config, wait);
+					report.recovery.managerResubscribed = true;
+					appendEvent(report, 'manager.resubscribe.observed');
+					await runOperation('post-reconnect inventory read', config.timeoutMs, () =>
+						client.devices.getDevices({ $timeout: config.timeoutMs }),
+					);
+					report.recovery.inventoryReadSucceeded = true;
+					appendEvent(report, 'inventory.read.resolved');
+					resolveRecovery?.();
+				} catch (error: unknown) {
+					rejectRecovery?.(error instanceof Error ? error : new Error('Homey recovery verification failed'));
+				}
+			})();
+		}),
+	);
+
+	try {
+		await runOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
+		report.session.managerSubscribed = true;
+		appendEvent(report, 'manager.subscribe.resolved');
+		recoveryWindowOpen = true;
+		appendEvent(report, 'recovery.window.open');
+		onWindowOpen();
+
+		await waitForRecoveryCompletion(recoveryCompletion, config.observeMs);
+	} catch (error: unknown) {
+		operationError = error;
+	} finally {
+		recoveryWindowOpen = false;
+
+		if (verificationPromise !== null) {
+			try {
+				await verificationPromise;
+			} catch {
+				// The fixed verification error is already captured through recoveryCompletion.
+			}
+		}
+
+		const cleanup = async (
+			label: string,
+			resolvedEvent: string,
+			failedEvent: string,
+			operation: () => Promise<unknown>,
+		): Promise<void> => {
+			try {
+				await runOperation(label, config.timeoutMs, operation);
+				appendEvent(report, resolvedEvent);
+			} catch {
+				cleanupFailures.push(label);
+				appendEvent(report, failedEvent);
+			}
+		};
+
+		await cleanup('manager unsubscribe', 'manager.unsubscribe.resolved', 'manager.unsubscribe.failed', () =>
+			client.devices.disconnect(),
+		);
+		await cleanup('socket disconnect', 'socket.disconnect.resolved', 'socket.disconnect.failed', () =>
+			client.disconnect(),
+		);
+		cleanupListeners.forEach((cleanupListener) => cleanupListener());
+
+		try {
+			client.destroy();
+			appendEvent(report, 'sdk.destroyed');
+		} catch {
+			cleanupFailures.push('client destroy');
+			appendEvent(report, 'sdk.destroy.failed');
+		}
+
+		report.session.cleanupCompleted = cleanupFailures.length === 0;
+	}
+
+	if (cleanupFailures.length > 0) {
+		throw new Error(`Homey recovery cleanup failed: ${cleanupFailures.join(', ')}`);
+	}
+
+	if (operationError !== undefined) {
+		throw operationError;
+	}
+
+	return report;
+};
+
+export function assertHomeyShsRecoveryReportSchema(value: unknown): asserts value is HomeyShsRecoveryReport {
+	const report = requireExactKeys(value, ['metadata', 'recovery', 'session'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const recovery = requireExactKeys(
+		report.recovery,
+		['disconnectObserved', 'inventoryReadSucceeded', 'managerResubscribed', 'transportReconnected'],
+		'recovery',
+	);
+	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
+
+	if (metadata.probe !== 'homey-shs-recovery' || metadata.schemaVersion !== 1 || metadata.sdkVersion !== SDK_VERSION) {
+		throw new Error('Homey recovery report metadata schema is invalid');
+	}
+
+	if (
+		Object.values(recovery).some((item) => typeof item !== 'boolean') ||
+		typeof session.cleanupCompleted !== 'boolean' ||
+		typeof session.managerSubscribed !== 'boolean' ||
+		!Array.isArray(session.events)
+	) {
+		throw new Error('Homey recovery report state schema is invalid');
+	}
+
+	for (const eventValue of session.events) {
+		const event = requireExactKeys(eventValue, ['event', 'order'], 'event');
+
+		if (
+			typeof event.event !== 'string' ||
+			!SAFE_EVENT_LABELS.has(event.event) ||
+			typeof event.order !== 'number' ||
+			!Number.isInteger(event.order) ||
+			event.order < 1
+		) {
+			throw new Error('Homey recovery report event schema is invalid');
+		}
+	}
+}
+
+export function assertHomeyShsRecoveryReportSafe(
+	value: unknown,
+	config: HomeyShsRecoveryProbeConfig,
+): asserts value is HomeyShsRecoveryReport {
+	assertHomeyShsRecoveryReportSchema(value);
+
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbiddenValues = [config.apiKey, config.expectedHost, ...config.privateTerms]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
+
+	if (forbiddenValues.some((item) => serialized.includes(item))) {
+		throw new Error('Sanitized Homey recovery report contains a configured secret or private value');
+	}
+
+	if (
+		!value.session.managerSubscribed ||
+		!value.session.cleanupCompleted ||
+		!value.recovery.disconnectObserved ||
+		!value.recovery.transportReconnected ||
+		!value.recovery.managerResubscribed ||
+		!value.recovery.inventoryReadSucceeded
+	) {
+		throw new Error('Homey recovery probe did not verify restart recovery and cleanup');
+	}
+
+	if (value.session.events.some(({ event, order }, index) => !SAFE_EVENT_LABELS.has(event) || order !== index + 1)) {
+		throw new Error('Homey recovery report contains an unsafe or unordered event label');
+	}
+
+	const eventNames = value.session.events.map(({ event }) => event);
+	const requiredOrder = [
+		'manager.subscribe.resolved',
+		'recovery.window.open',
+		'socket.disconnect',
+		'socket.reconnect',
+		'manager.resubscribe.observed',
+		'inventory.read.resolved',
+	];
+	let previousIndex = -1;
+
+	for (const event of requiredOrder) {
+		const index = eventNames.indexOf(event);
+
+		if (index <= previousIndex) {
+			throw new Error('Homey recovery report does not contain the required restart ordering');
+		}
+
+		previousIndex = index;
+	}
+}
+
+export const writeHomeyShsRecoveryReport = async (
+	report: HomeyShsRecoveryReport,
+	outputRoot: string,
+): Promise<string> => {
+	assertHomeyShsRecoveryReportSchema(report);
+
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `recovery-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsRecoveryProbeConfig(process.env);
+	const report = await probeHomeyShsRecovery(config, sdkFactory, sleep, () => {
+		process.stdout.write(
+			`Homey recovery observation window is open for ${config.observeMs} ms. Restart the test SHS now.\n`,
+		);
+	});
+
+	assertHomeyShsRecoveryReportSafe(report, config);
+
+	const outputDirectory = await writeHomeyShsRecoveryReport(report, config.outputRoot);
+
+	process.stdout.write(
+		`Sanitized Homey recovery report written to ${outputDirectory} ` +
+			`(${report.session.events.length} ordered events).\n`,
+	);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS recovery probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/apps/backend/test/support/homey-shs-recovery-probe.ts
+++ b/apps/backend/test/support/homey-shs-recovery-probe.ts
@@ -239,7 +239,7 @@ const waitForManagerResubscription = async (
 	}
 };
 
-const waitForRecoveryCompletion = async (completion: Promise<void>, observeMs: number): Promise<void> => {
+const waitForTransportRecovery = async (recoveryDetected: Promise<void>, observeMs: number): Promise<void> => {
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
 		timeout = setTimeout(
@@ -249,7 +249,7 @@ const waitForRecoveryCompletion = async (completion: Promise<void>, observeMs: n
 	});
 
 	try {
-		await Promise.race([completion, timeoutPromise]);
+		await Promise.race([recoveryDetected, timeoutPromise]);
 	} finally {
 		if (timeout !== undefined) {
 			clearTimeout(timeout);
@@ -276,22 +276,38 @@ export const probeHomeyShsRecovery = async (
 	const client = await createClient(config, factory);
 	appendEvent(report, 'sdk.create.resolved');
 	let recoveryWindowOpen = false;
-	let resolveRecovery: (() => void) | undefined;
-	let rejectRecovery: ((error: Error) => void) | undefined;
-	const recoveryCompletion = new Promise<void>((resolvePromise, rejectPromise) => {
-		resolveRecovery = resolvePromise;
-		rejectRecovery = rejectPromise;
+	let resolveTransportRecovery: (() => void) | undefined;
+	const transportRecoveryDetected = new Promise<void>((resolvePromise) => {
+		resolveTransportRecovery = resolvePromise;
 	});
 	const cleanupListeners: Array<() => void> = [];
 	let verificationPromise: Promise<void> | null = null;
 	let operationError: unknown;
 	const cleanupFailures: string[] = [];
+	const beginRecoveryVerification = (event: 'socket.connect' | 'socket.reconnect'): void => {
+		if (!recoveryWindowOpen || !report.recovery.disconnectObserved || report.recovery.transportReconnected) {
+			return;
+		}
+
+		report.recovery.transportReconnected = true;
+		appendEvent(report, event);
+		verificationPromise = (async () => {
+			await waitForManagerResubscription(client, config, wait);
+			report.recovery.managerResubscribed = true;
+			appendEvent(report, 'manager.resubscribe.observed');
+			await runOperation('post-reconnect inventory read', config.timeoutMs, () =>
+				client.devices.getDevices({ $timeout: config.timeoutMs }),
+			);
+			report.recovery.inventoryReadSucceeded = true;
+			appendEvent(report, 'inventory.read.resolved');
+		})();
+		void verificationPromise.catch(() => undefined);
+		resolveTransportRecovery?.();
+	};
 
 	cleanupListeners.push(
 		attachListener(client, 'connect', () => {
-			if (recoveryWindowOpen) {
-				appendEvent(report, 'socket.connect');
-			}
+			beginRecoveryVerification('socket.connect');
 		}),
 		attachListener(client, 'disconnect', () => {
 			if (recoveryWindowOpen && !report.recovery.disconnectObserved) {
@@ -307,27 +323,7 @@ export const probeHomeyShsRecovery = async (
 			}),
 		),
 		attachListener(client, 'reconnect', () => {
-			if (!recoveryWindowOpen || !report.recovery.disconnectObserved || report.recovery.transportReconnected) {
-				return;
-			}
-
-			report.recovery.transportReconnected = true;
-			appendEvent(report, 'socket.reconnect');
-			verificationPromise = (async () => {
-				try {
-					await waitForManagerResubscription(client, config, wait);
-					report.recovery.managerResubscribed = true;
-					appendEvent(report, 'manager.resubscribe.observed');
-					await runOperation('post-reconnect inventory read', config.timeoutMs, () =>
-						client.devices.getDevices({ $timeout: config.timeoutMs }),
-					);
-					report.recovery.inventoryReadSucceeded = true;
-					appendEvent(report, 'inventory.read.resolved');
-					resolveRecovery?.();
-				} catch (error: unknown) {
-					rejectRecovery?.(error instanceof Error ? error : new Error('Homey recovery verification failed'));
-				}
-			})();
+			beginRecoveryVerification('socket.reconnect');
 		}),
 	);
 
@@ -339,7 +335,13 @@ export const probeHomeyShsRecovery = async (
 		appendEvent(report, 'recovery.window.open');
 		onWindowOpen();
 
-		await waitForRecoveryCompletion(recoveryCompletion, config.observeMs);
+		await waitForTransportRecovery(transportRecoveryDetected, config.observeMs);
+
+		if (verificationPromise === null) {
+			throw new Error('Homey recovery verification did not start');
+		}
+
+		await verificationPromise;
 	} catch (error: unknown) {
 		operationError = error;
 	} finally {
@@ -349,7 +351,7 @@ export const probeHomeyShsRecovery = async (
 			try {
 				await verificationPromise;
 			} catch {
-				// The fixed verification error is already captured through recoveryCompletion.
+				// The fixed verification error is already captured as operationError.
 			}
 		}
 
@@ -467,17 +469,30 @@ export function assertHomeyShsRecoveryReportSafe(
 	}
 
 	const eventNames = value.session.events.map(({ event }) => event);
-	const requiredOrder = [
-		'manager.subscribe.resolved',
-		'recovery.window.open',
-		'socket.disconnect',
-		'socket.reconnect',
-		'manager.resubscribe.observed',
-		'inventory.read.resolved',
-	];
+	const requiredBeforeRecovery = ['manager.subscribe.resolved', 'recovery.window.open', 'socket.disconnect'];
 	let previousIndex = -1;
 
-	for (const event of requiredOrder) {
+	for (const event of requiredBeforeRecovery) {
+		const index = eventNames.indexOf(event);
+
+		if (index <= previousIndex) {
+			throw new Error('Homey recovery report does not contain the required restart ordering');
+		}
+
+		previousIndex = index;
+	}
+
+	const recoveryIndex = eventNames.findIndex(
+		(event, index) => index > previousIndex && (event === 'socket.connect' || event === 'socket.reconnect'),
+	);
+
+	if (recoveryIndex <= previousIndex) {
+		throw new Error('Homey recovery report does not contain the required restart ordering');
+	}
+
+	previousIndex = recoveryIndex;
+
+	for (const event of ['manager.resubscribe.observed', 'inventory.read.resolved']) {
 		const index = eventNames.indexOf(event);
 
 		if (index <= previousIndex) {

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -23,7 +23,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`        | Repeat over HTTPS `4860` if enabled                                     |
 | System, zone, device inventory, and individual device | Captured and sanitized                         | Add lifecycle delta evidence on the disposable test device              |
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read   | Add allowlisted write and read-back evidence                            |
-| Socket.IO events and reconnect                        | Connect/subscription/cleanup passed live       | Capture capability/availability events, restart, and reconnect ordering |
+| Socket.IO events and reconnect                        | Recovery probe ready; live restart pending     | Capture capability/availability events, restart, and reconnect ordering |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled         | Use only the designated harmless test capability                        |
 | Error classification                                  | SDK invalid key returned `401`; matrix pending | Verify missing-scope, bad-URL, unavailable, and timeout behavior        |
 | Disposable-device lifecycle                           | Contract defined, disabled                     | Use only the separately gated virtual/test device                       |
@@ -188,6 +188,42 @@ FB_HOMEY_SHS_LIFECYCLE_OPERATIONS=add,rename,zone-move,availability,remove
 The implementation must validate the exact operation list, require a synthetic test-device marker established during
 setup, and clean up only resources created by that run. It must never pair, rename, move, make unavailable, remove, or
 unpair ordinary household devices.
+
+## Operator-controlled restart recovery probe
+
+The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It
+first creates the local SDK client and subscribes to the devices manager. Only then does it print that the observation
+window is open. During that window, the operator restarts only the designated test SHS instance from a separate
+terminal or management interface. The probe requires this ordered evidence before writing a report:
+
+1. the subscribed socket disconnects;
+2. the SDK transport reconnects;
+3. the devices manager reports that its subscription is restored; and
+4. a bounded post-reconnect inventory read succeeds.
+
+Cleanup then unsubscribes the manager, disconnects the socket, and destroys the SDK client. The exact-schema report
+contains only fixed event labels, their order, and completion booleans. It contains no endpoint, API key, device data,
+inventory count, event payload, error detail, or identifier.
+
+Start from the same interactive shell as the read-only probe, ensure every `FB_HOMEY_SHS_WRITE_*` and
+`FB_HOMEY_SHS_LIFECYCLE_*` variable is unset, then enable only the operator-controlled recovery gate:
+
+```bash
+unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
+unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+export FB_HOMEY_SHS_RECOVERY_ENABLE=I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE
+pnpm run homey:probe-recovery
+```
+
+Wait for `Homey recovery observation window is open`, restart the test SHS, and do not alter networking, credentials,
+or ordinary household devices during the run. `FB_HOMEY_SHS_RECOVERY_OBSERVE_MS` optionally controls the operator
+window from `10000` through `300000` milliseconds and defaults to `90000`. SDK creation, manager operations,
+post-reconnect verification, and cleanup remain independently bounded by `FB_HOMEY_SHS_TIMEOUT_MS`. A timeout or
+cleanup failure writes no report and exposes only a fixed sanitized error.
+
+This runbook does not authorize Smart Panel tooling or an automated agent to restart SHS. Live evidence remains pending
+until an operator intentionally performs the restart while the gated probe is open.
 
 ## Privacy-safe mDNS observation probe
 


### PR DESCRIPTION
## Summary

- add an explicit, operator-gated SHS restart/reconnect compatibility probe
- verify ordered disconnect, transport reconnect, devices-manager resubscription, post-reconnect inventory read, and cleanup
- persist only fixed event labels, ordering, and completion booleans in an exact-schema report
- add offline coverage and an operator runbook with an exact observation-window notification

## Why

The Homey compatibility gate still needs evidence for SDK behavior across a real SHS restart. This probe creates a safe measurement path without allowing Smart Panel tooling or an automated agent to restart SHS, alter networking, revoke credentials, or mutate devices.

The CLI refuses to run unless the exact recovery acknowledgement is present, and it rejects any active write or lifecycle mutation gate.

## Impact

This is compatibility-test tooling only. It does not ship production reconnection behavior and contains no automatic restart mechanism. Live recovery evidence remains pending until an operator intentionally restarts the designated test SHS after the probe reports that its observation window is open.

Reports cannot contain endpoints, API keys, device data, inventory counts, event payloads, identifiers, or raw errors.

## Validation

- `pnpm --dir apps/backend run test:homey-spike` — 5 suites, 74 tests
- targeted ESLint for the recovery probe and suite
- `pnpm --dir apps/backend run type-check`
- Prettier and `git diff --check`
- default-deny CLI check confirmed the ungated probe exits before client creation or network access