### PR TITLE
test(cross): add guarded Homey credential rotation probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -72,6 +72,7 @@
     "test:homey-spike": "jest --config ./test/jest-homey-spike.json --runInBand",
     "test:oauth-spike": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest --config ./test/jest-oauth-spike.json --runInBand",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
+    "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",
     "homey:generate-normalized-fixtures": "ts-node --project tsconfig.json test/support/generate-homey-normalized-fixtures.ts",
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",

--- a/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
+++ b/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
@@ -38,6 +38,14 @@ const authorizationToken = (init: RequestInit): string | null => {
 	return authorization?.replace(/^Bearer /, '') ?? null;
 };
 
+const isPingRequest = (input: URL): boolean => input.pathname === '/api/manager/system/ping';
+
+const homeyPingResponse = (): Response =>
+	new Response(null, {
+		status: 200,
+		headers: { 'x-homey-id': 'synthetic-homey-id', 'x-homey-version': '13.4.0' },
+	});
+
 describe('Homey SHS credential rotation compatibility probe', () => {
 	it('requires the exact acknowledgement, distinct replacement key, and isolated gates', () => {
 		expect(() =>
@@ -95,7 +103,11 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 		let primaryRequests = 0;
 		let nowMs = 0;
 		let windowOpenCount = 0;
-		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((_input, init) => {
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((input, init) => {
+			if (isPingRequest(input)) {
+				return Promise.resolve(homeyPingResponse());
+			}
+
 			const token = authorizationToken(init);
 
 			if (token === config.apiKey) {
@@ -135,20 +147,25 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 			},
 			session: {
 				events: [
-					{ event: 'primary.validation.resolved', order: 1 },
-					{ event: 'replacement.preflight.resolved', order: 2 },
-					{ event: 'rotation.window.open', order: 3 },
-					{ event: 'primary.revocation.observed', order: 4 },
-					{ event: 'replacement.validation.resolved', order: 5 },
+					{ event: 'endpoint.identity.resolved', order: 1 },
+					{ event: 'primary.validation.resolved', order: 2 },
+					{ event: 'replacement.preflight.resolved', order: 3 },
+					{ event: 'rotation.window.open', order: 4 },
+					{ event: 'primary.revocation.observed', order: 5 },
+					{ event: 'replacement.validation.resolved', order: 6 },
 				],
 			},
 		});
-		expect(fetchImplementation).toHaveBeenCalledTimes(5);
+		expect(fetchImplementation).toHaveBeenCalledTimes(6);
+		expect(isPingRequest(fetchImplementation.mock.calls[0][0])).toBe(true);
+		expect(new Headers(fetchImplementation.mock.calls[0][1].headers).has('authorization')).toBe(false);
 		expect(
-			fetchImplementation.mock.calls.every(
-				([input, init]) =>
-					input.pathname === '/api/manager/devices/device' && init.method === 'GET' && init.redirect === 'error',
-			),
+			fetchImplementation.mock.calls
+				.slice(1)
+				.every(
+					([input, init]) =>
+						input.pathname === '/api/manager/devices/device' && init.method === 'GET' && init.redirect === 'error',
+				),
 		).toBe(true);
 		expect(windowOpenCount).toBe(1);
 		expect(() => assertHomeyShsCredentialRotationReportSafe(report, config)).not.toThrow();
@@ -159,8 +176,8 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 	it('times out safely when the primary key is not revoked', async () => {
 		const config = createConfig({ observeMs: 10 });
 		let nowMs = 0;
-		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
-			Promise.resolve(new Response(null, { status: 200 })),
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((input) =>
+			Promise.resolve(isPingRequest(input) ? homeyPingResponse() : new Response(null, { status: 200 })),
 		);
 
 		await expect(
@@ -181,7 +198,11 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 	it('requires both replacement-key validations to succeed', async () => {
 		const config = createConfig();
 		let replacementRequests = 0;
-		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((_input, init) => {
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((input, init) => {
+			if (isPingRequest(input)) {
+				return Promise.resolve(homeyPingResponse());
+			}
+
 			if (authorizationToken(init) === config.apiKey) {
 				return Promise.resolve(new Response(null, { status: 200 }));
 			}
@@ -197,7 +218,11 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 
 		let primaryRequests = 0;
 		replacementRequests = 0;
-		fetchImplementation.mockImplementation((_input, init) => {
+		fetchImplementation.mockImplementation((input, init) => {
+			if (isPingRequest(input)) {
+				return Promise.resolve(homeyPingResponse());
+			}
+
 			if (authorizationToken(init) === config.apiKey) {
 				primaryRequests += 1;
 
@@ -214,14 +239,28 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 		);
 	});
 
-	it('returns fixed request errors without exposing transport detail', async () => {
+	it('rejects a non-Homey endpoint before sending either credential', async () => {
+		const config = createConfig();
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
+			Promise.resolve(new Response(null, { status: 200 })),
+		);
+
+		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.toThrow(
+			'Homey credential rotation endpoint identity validation failed',
+		);
+		expect(fetchImplementation).toHaveBeenCalledTimes(1);
+		expect(isPingRequest(fetchImplementation.mock.calls[0][0])).toBe(true);
+		expect(new Headers(fetchImplementation.mock.calls[0][1].headers).has('authorization')).toBe(false);
+	});
+
+	it('returns fixed identity request errors without exposing transport detail', async () => {
 		const config = createConfig();
 		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
 			Promise.reject(new Error(`${config.origin.origin}?key=${config.apiKey}`)),
 		);
 
 		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.toThrow(
-			'Homey credential rotation inventory request failed',
+			'Homey credential rotation endpoint identity request failed',
 		);
 		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.not.toThrow(config.apiKey);
 	});
@@ -229,7 +268,11 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 	it('rejects unsafe or structurally changed reports', async () => {
 		const config = createConfig();
 		let primaryRequests = 0;
-		const fetchImplementation: HomeyCredentialRotationFetch = (_input, init) => {
+		const fetchImplementation: HomeyCredentialRotationFetch = (input, init) => {
+			if (isPingRequest(input)) {
+				return Promise.resolve(homeyPingResponse());
+			}
+
 			if (authorizationToken(init) === config.apiKey) {
 				primaryRequests += 1;
 
@@ -255,7 +298,11 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 	it('writes a new restrictive, schema-validated report directory', async () => {
 		const config = createConfig();
 		let primaryRequests = 0;
-		const report = await probeHomeyShsCredentialRotation(config, (_input, init) => {
+		const report = await probeHomeyShsCredentialRotation(config, (input, init) => {
+			if (isPingRequest(input)) {
+				return Promise.resolve(homeyPingResponse());
+			}
+
 			if (authorizationToken(init) === config.apiKey) {
 				primaryRequests += 1;
 

--- a/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
+++ b/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
@@ -1,0 +1,282 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	type HomeyCredentialRotationFetch,
+	type HomeyShsCredentialRotationProbeConfig,
+	assertHomeyShsCredentialRotationReportSafe,
+	assertHomeyShsCredentialRotationReportSchema,
+	loadHomeyShsCredentialRotationProbeConfig,
+	probeHomeyShsCredentialRotation,
+	writeHomeyShsCredentialRotationReport,
+} from './support/homey-shs-credential-rotation-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'primary-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE: 'I_WILL_REVOKE_THE_TEST_KEY_DURING_THIS_PROBE',
+	FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS: '10000',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_REPLACEMENT_API_KEY: 'replacement-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const createConfig = (
+	overrides: Partial<HomeyShsCredentialRotationProbeConfig> = {},
+): HomeyShsCredentialRotationProbeConfig => ({
+	...loadHomeyShsCredentialRotationProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-credential-rotation-spike'),
+	observeMs: 20,
+	timeoutMs: 10,
+	...overrides,
+});
+
+const authorizationToken = (init: RequestInit): string | null => {
+	const authorization = new Headers(init.headers).get('authorization');
+
+	return authorization?.replace(/^Bearer /, '') ?? null;
+};
+
+describe('Homey SHS credential rotation compatibility probe', () => {
+	it('requires the exact acknowledgement, distinct replacement key, and isolated gates', () => {
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE: undefined,
+			}),
+		).toThrow('required operator acknowledgement');
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_REPLACEMENT_API_KEY: undefined,
+			}),
+		).toThrow('FB_HOMEY_SHS_REPLACEMENT_API_KEY is required');
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_REPLACEMENT_API_KEY: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY,
+			}),
+		).toThrow('must differ from FB_HOMEY_SHS_API_KEY');
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_WRITE_ENABLE: '',
+			}),
+		).toThrow('mutation and recovery gates must be unset');
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_ENABLE: '',
+			}),
+		).toThrow('mutation and recovery gates must be unset');
+	});
+
+	it('loads a bounded operator window', () => {
+		const config = loadHomeyShsCredentialRotationProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-credential-rotation-spike');
+
+		expect(config.observeMs).toBe(10_000);
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS: '9999',
+			}),
+		).toThrow('between 10000 and 300000');
+		expect(() =>
+			loadHomeyShsCredentialRotationProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS: '300001',
+			}),
+		).toThrow('between 10000 and 300000');
+	});
+
+	it('proves primary revocation and replacement access without retaining credentials', async () => {
+		const config = createConfig({ observeMs: 2_000 });
+		let primaryRequests = 0;
+		let nowMs = 0;
+		let windowOpenCount = 0;
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((_input, init) => {
+			const token = authorizationToken(init);
+
+			if (token === config.apiKey) {
+				primaryRequests += 1;
+
+				return Promise.resolve(new Response(null, { status: primaryRequests < 3 ? 200 : 401 }));
+			}
+
+			if (token === config.replacementApiKey) {
+				return Promise.resolve(new Response(null, { status: 200 }));
+			}
+
+			return Promise.reject(new Error('unexpected credential'));
+		});
+		const report = await probeHomeyShsCredentialRotation(
+			config,
+			fetchImplementation,
+			(milliseconds) => {
+				nowMs += milliseconds;
+
+				return Promise.resolve();
+			},
+			() => {
+				windowOpenCount += 1;
+			},
+			() => nowMs,
+		);
+
+		expect(report).toStrictEqual({
+			metadata: { probe: 'homey-shs-credential-rotation', schemaVersion: 1 },
+			rotation: {
+				primaryKeyInitiallyValid: true,
+				replacementKeyInitiallyValid: true,
+				replacementKeyValidAfterRevocation: true,
+				revocationObserved: true,
+				revocationStatusCode: 401,
+			},
+			session: {
+				events: [
+					{ event: 'primary.validation.resolved', order: 1 },
+					{ event: 'replacement.preflight.resolved', order: 2 },
+					{ event: 'rotation.window.open', order: 3 },
+					{ event: 'primary.revocation.observed', order: 4 },
+					{ event: 'replacement.validation.resolved', order: 5 },
+				],
+			},
+		});
+		expect(fetchImplementation).toHaveBeenCalledTimes(5);
+		expect(
+			fetchImplementation.mock.calls.every(
+				([input, init]) =>
+					input.pathname === '/api/manager/devices/device' && init.method === 'GET' && init.redirect === 'error',
+			),
+		).toBe(true);
+		expect(windowOpenCount).toBe(1);
+		expect(() => assertHomeyShsCredentialRotationReportSafe(report, config)).not.toThrow();
+		expect(JSON.stringify(report)).not.toContain(config.apiKey);
+		expect(JSON.stringify(report)).not.toContain(config.replacementApiKey);
+	});
+
+	it('times out safely when the primary key is not revoked', async () => {
+		const config = createConfig({ observeMs: 10 });
+		let nowMs = 0;
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
+			Promise.resolve(new Response(null, { status: 200 })),
+		);
+
+		await expect(
+			probeHomeyShsCredentialRotation(
+				config,
+				fetchImplementation,
+				(milliseconds) => {
+					nowMs += milliseconds;
+
+					return Promise.resolve();
+				},
+				undefined,
+				() => nowMs,
+			),
+		).rejects.toThrow('revocation observation timed out after 10 ms');
+	});
+
+	it('requires both replacement-key validations to succeed', async () => {
+		const config = createConfig();
+		let replacementRequests = 0;
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>((_input, init) => {
+			if (authorizationToken(init) === config.apiKey) {
+				return Promise.resolve(new Response(null, { status: 200 }));
+			}
+
+			replacementRequests += 1;
+
+			return Promise.resolve(new Response(null, { status: replacementRequests === 1 ? 401 : 200 }));
+		});
+
+		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.toThrow(
+			'replacement key preflight did not authenticate',
+		);
+
+		let primaryRequests = 0;
+		replacementRequests = 0;
+		fetchImplementation.mockImplementation((_input, init) => {
+			if (authorizationToken(init) === config.apiKey) {
+				primaryRequests += 1;
+
+				return Promise.resolve(new Response(null, { status: primaryRequests === 1 ? 200 : 401 }));
+			}
+
+			replacementRequests += 1;
+
+			return Promise.resolve(new Response(null, { status: replacementRequests === 1 ? 200 : 401 }));
+		});
+
+		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.toThrow(
+			'replacement key after revocation did not authenticate',
+		);
+	});
+
+	it('returns fixed request errors without exposing transport detail', async () => {
+		const config = createConfig();
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
+			Promise.reject(new Error(`${config.origin.origin}?key=${config.apiKey}`)),
+		);
+
+		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.toThrow(
+			'Homey credential rotation inventory request failed',
+		);
+		await expect(probeHomeyShsCredentialRotation(config, fetchImplementation)).rejects.not.toThrow(config.apiKey);
+	});
+
+	it('rejects unsafe or structurally changed reports', async () => {
+		const config = createConfig();
+		let primaryRequests = 0;
+		const fetchImplementation: HomeyCredentialRotationFetch = (_input, init) => {
+			if (authorizationToken(init) === config.apiKey) {
+				primaryRequests += 1;
+
+				return Promise.resolve(new Response(null, { status: primaryRequests === 1 ? 200 : 401 }));
+			}
+
+			return Promise.resolve(new Response(null, { status: 200 }));
+		};
+		const report = await probeHomeyShsCredentialRotation(config, fetchImplementation);
+		const extra = structuredClone(report) as unknown as Record<string, unknown>;
+
+		extra.endpoint = 'private-endpoint';
+
+		expect(() => assertHomeyShsCredentialRotationReportSchema(extra)).toThrow('root schema is invalid');
+
+		const unsafeConfig = { ...config, replacementApiKey: report.metadata.probe };
+
+		expect(() => assertHomeyShsCredentialRotationReportSafe(report, unsafeConfig)).toThrow(
+			'configured secret or private value',
+		);
+	});
+
+	it('writes a new restrictive, schema-validated report directory', async () => {
+		const config = createConfig();
+		let primaryRequests = 0;
+		const report = await probeHomeyShsCredentialRotation(config, (_input, init) => {
+			if (authorizationToken(init) === config.apiKey) {
+				primaryRequests += 1;
+
+				return Promise.resolve(new Response(null, { status: primaryRequests === 1 ? 200 : 401 }));
+			}
+
+			return Promise.resolve(new Response(null, { status: 200 }));
+		});
+		const root = await mkdtemp(join(tmpdir(), 'homey-credential-rotation-spike-'));
+
+		try {
+			const outputDirectory = await writeHomeyShsCredentialRotationReport(report, root);
+			const outputStat = await stat(outputDirectory);
+			const reportStat = await stat(join(outputDirectory, 'report.json'));
+			const written = JSON.parse(await readFile(join(outputDirectory, 'report.json'), 'utf8')) as unknown;
+
+			expect(outputStat.mode & 0o777).toBe(0o700);
+			expect(reportStat.mode & 0o777).toBe(0o600);
+			expect(written).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/support/homey-shs-credential-rotation-probe.ts
+++ b/apps/backend/test/support/homey-shs-credential-rotation-probe.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
 
 const DEVICE_PATH = '/api/manager/devices/device';
+const PING_PATH = '/api/manager/system/ping';
 const CREDENTIAL_ROTATION_ACKNOWLEDGEMENT = 'I_WILL_REVOKE_THE_TEST_KEY_DURING_THIS_PROBE';
 const DEFAULT_OBSERVE_MS = 90_000;
 const MIN_OBSERVE_MS = 10_000;
@@ -13,6 +14,7 @@ const REVOCATION_POLL_MS = 1_000;
 const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
 const INCOMPATIBLE_GATE_PREFIXES = ['FB_HOMEY_SHS_LIFECYCLE_', 'FB_HOMEY_SHS_RECOVERY_', 'FB_HOMEY_SHS_WRITE_'];
 const EXPECTED_EVENTS = [
+	'endpoint.identity.resolved',
 	'primary.validation.resolved',
 	'replacement.preflight.resolved',
 	'rotation.window.open',
@@ -155,6 +157,42 @@ const requestInventory = async (
 	}
 };
 
+const verifyHomeyIdentity = async (
+	config: HomeyShsCredentialRotationProbeConfig,
+	fetchImplementation: HomeyCredentialRotationFetch,
+): Promise<void> => {
+	let response: Response;
+
+	try {
+		response = await fetchImplementation(new URL(PING_PATH, config.origin), {
+			headers: new Headers({ accept: 'application/json' }),
+			method: 'GET',
+			redirect: 'error',
+			signal: AbortSignal.timeout(config.timeoutMs),
+		});
+	} catch {
+		// Raw transport errors may contain the candidate endpoint or private network detail.
+		throw new Error('Homey credential rotation endpoint identity request failed');
+	}
+
+	try {
+		const homeyId = response.headers.get('x-homey-id');
+		const homeyVersion = response.headers.get('x-homey-version');
+
+		if (
+			!response.ok ||
+			homeyId?.trim() === '' ||
+			homeyId === null ||
+			homeyVersion?.trim() === '' ||
+			homeyVersion === null
+		) {
+			throw new Error('Homey credential rotation endpoint identity validation failed');
+		}
+	} finally {
+		await discardResponse(response);
+	}
+};
+
 const requireValidKey = async (
 	config: HomeyShsCredentialRotationProbeConfig,
 	token: string,
@@ -238,6 +276,8 @@ export const probeHomeyShsCredentialRotation = async (
 		session: { events: [] },
 	};
 
+	await verifyHomeyIdentity(config, fetchImplementation);
+	appendEvent(report, 'endpoint.identity.resolved');
 	await requireValidKey(config, config.apiKey, 'primary key', fetchImplementation);
 	appendEvent(report, 'primary.validation.resolved');
 	await requireValidKey(config, config.replacementApiKey, 'replacement key preflight', fetchImplementation);

--- a/apps/backend/test/support/homey-shs-credential-rotation-probe.ts
+++ b/apps/backend/test/support/homey-shs-credential-rotation-probe.ts
@@ -1,0 +1,361 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const DEVICE_PATH = '/api/manager/devices/device';
+const CREDENTIAL_ROTATION_ACKNOWLEDGEMENT = 'I_WILL_REVOKE_THE_TEST_KEY_DURING_THIS_PROBE';
+const DEFAULT_OBSERVE_MS = 90_000;
+const MIN_OBSERVE_MS = 10_000;
+const MAX_OBSERVE_MS = 300_000;
+const REVOCATION_POLL_MS = 1_000;
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
+const INCOMPATIBLE_GATE_PREFIXES = ['FB_HOMEY_SHS_LIFECYCLE_', 'FB_HOMEY_SHS_RECOVERY_', 'FB_HOMEY_SHS_WRITE_'];
+const EXPECTED_EVENTS = [
+	'primary.validation.resolved',
+	'replacement.preflight.resolved',
+	'rotation.window.open',
+	'primary.revocation.observed',
+	'replacement.validation.resolved',
+] as const;
+
+export type HomeyCredentialRotationFetch = (input: URL, init: RequestInit) => Promise<Response>;
+export type HomeyCredentialRotationWait = (milliseconds: number) => Promise<void>;
+
+export interface HomeyShsCredentialRotationProbeConfig extends HomeyShsProbeConfig {
+	observeMs: number;
+	replacementApiKey: string;
+}
+
+export interface HomeyShsCredentialRotationReport {
+	metadata: {
+		probe: 'homey-shs-credential-rotation';
+		schemaVersion: 1;
+	};
+	rotation: {
+		primaryKeyInitiallyValid: true;
+		replacementKeyInitiallyValid: true;
+		replacementKeyValidAfterRevocation: true;
+		revocationObserved: true;
+		revocationStatusCode: 401;
+	};
+	session: {
+		events: Array<{ event: (typeof EXPECTED_EVENTS)[number]; order: number }>;
+	};
+}
+
+class HomeyShsCredentialRotationTimeoutError extends Error {
+	constructor(timeoutMs: number) {
+		super(`Homey credential rotation revocation observation timed out after ${timeoutMs} ms`);
+		this.name = 'HomeyShsCredentialRotationTimeoutError';
+	}
+}
+
+const sleep: HomeyCredentialRotationWait = async (milliseconds) =>
+	new Promise((resolvePromise) => {
+		setTimeout(resolvePromise, milliseconds);
+	});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey credential rotation report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey credential rotation report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+const parseObserveMs = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_OBSERVE_MS;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(
+			`FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`,
+		);
+	}
+
+	return parsed;
+};
+
+export const loadHomeyShsCredentialRotationProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsCredentialRotationProbeConfig => {
+	if (environment.FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE !== CREDENTIAL_ROTATION_ACKNOWLEDGEMENT) {
+		throw new Error('FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE does not contain the required operator acknowledgement');
+	}
+
+	const incompatibleGate = Object.keys(environment).find((name) =>
+		INCOMPATIBLE_GATE_PREFIXES.some((prefix) => name.startsWith(prefix)),
+	);
+
+	if (incompatibleGate !== undefined) {
+		throw new Error('Homey mutation and recovery gates must be unset during the credential rotation probe');
+	}
+
+	const config = loadHomeyShsProbeConfig(environment, workingDirectory);
+	const replacementApiKey = environment.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
+
+	if (replacementApiKey === undefined || replacementApiKey.trim() === '') {
+		throw new Error('FB_HOMEY_SHS_REPLACEMENT_API_KEY is required');
+	}
+
+	if (replacementApiKey === config.apiKey) {
+		throw new Error('FB_HOMEY_SHS_REPLACEMENT_API_KEY must differ from FB_HOMEY_SHS_API_KEY');
+	}
+
+	return {
+		...config,
+		observeMs: parseObserveMs(environment.FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS),
+		replacementApiKey,
+	};
+};
+
+const discardResponse = async (response: Response): Promise<void> => {
+	try {
+		await response.body?.cancel();
+	} catch {
+		throw new Error('Homey credential rotation response cleanup failed');
+	}
+};
+
+const requestInventory = async (
+	config: HomeyShsCredentialRotationProbeConfig,
+	token: string,
+	timeoutMs: number,
+	fetchImplementation: HomeyCredentialRotationFetch,
+): Promise<Response> => {
+	try {
+		return await fetchImplementation(new URL(DEVICE_PATH, config.origin), {
+			headers: new Headers({ accept: 'application/json', authorization: `Bearer ${token}` }),
+			method: 'GET',
+			redirect: 'error',
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+	} catch {
+		// Raw transport errors may contain the pinned endpoint or other private network detail.
+		throw new Error('Homey credential rotation inventory request failed');
+	}
+};
+
+const requireValidKey = async (
+	config: HomeyShsCredentialRotationProbeConfig,
+	token: string,
+	label: 'primary key' | 'replacement key after revocation' | 'replacement key preflight',
+	fetchImplementation: HomeyCredentialRotationFetch,
+): Promise<void> => {
+	const response = await requestInventory(config, token, config.timeoutMs, fetchImplementation);
+
+	try {
+		if (!response.ok) {
+			throw new Error(`Homey credential rotation ${label} did not authenticate for device inventory`);
+		}
+	} finally {
+		await discardResponse(response);
+	}
+};
+
+const waitForRevocation = async (
+	config: HomeyShsCredentialRotationProbeConfig,
+	fetchImplementation: HomeyCredentialRotationFetch,
+	wait: HomeyCredentialRotationWait,
+	now: () => number,
+): Promise<void> => {
+	const deadline = now() + config.observeMs;
+
+	while (true) {
+		const remainingMs = deadline - now();
+
+		if (remainingMs <= 0) {
+			throw new HomeyShsCredentialRotationTimeoutError(config.observeMs);
+		}
+
+		const response = await requestInventory(
+			config,
+			config.apiKey,
+			Math.min(config.timeoutMs, remainingMs),
+			fetchImplementation,
+		);
+		const status = response.status;
+
+		await discardResponse(response);
+
+		if (status === 401) {
+			return;
+		}
+
+		if (status !== 200) {
+			throw new Error('Homey credential rotation primary key returned an unexpected status');
+		}
+
+		const waitMs = Math.min(REVOCATION_POLL_MS, Math.max(0, deadline - now()));
+
+		if (waitMs === 0) {
+			throw new HomeyShsCredentialRotationTimeoutError(config.observeMs);
+		}
+
+		await wait(waitMs);
+	}
+};
+
+const appendEvent = (report: HomeyShsCredentialRotationReport, event: (typeof EXPECTED_EVENTS)[number]): void => {
+	report.session.events.push({ event, order: report.session.events.length + 1 });
+};
+
+export const probeHomeyShsCredentialRotation = async (
+	config: HomeyShsCredentialRotationProbeConfig,
+	fetchImplementation: HomeyCredentialRotationFetch = fetch,
+	wait: HomeyCredentialRotationWait = sleep,
+	onWindowOpen: () => void = () => undefined,
+	now: () => number = Date.now,
+): Promise<HomeyShsCredentialRotationReport> => {
+	const report: HomeyShsCredentialRotationReport = {
+		metadata: { probe: 'homey-shs-credential-rotation', schemaVersion: 1 },
+		rotation: {
+			primaryKeyInitiallyValid: true,
+			replacementKeyInitiallyValid: true,
+			replacementKeyValidAfterRevocation: true,
+			revocationObserved: true,
+			revocationStatusCode: 401,
+		},
+		session: { events: [] },
+	};
+
+	await requireValidKey(config, config.apiKey, 'primary key', fetchImplementation);
+	appendEvent(report, 'primary.validation.resolved');
+	await requireValidKey(config, config.replacementApiKey, 'replacement key preflight', fetchImplementation);
+	appendEvent(report, 'replacement.preflight.resolved');
+	appendEvent(report, 'rotation.window.open');
+	onWindowOpen();
+	await waitForRevocation(config, fetchImplementation, wait, now);
+	appendEvent(report, 'primary.revocation.observed');
+	await requireValidKey(config, config.replacementApiKey, 'replacement key after revocation', fetchImplementation);
+	appendEvent(report, 'replacement.validation.resolved');
+
+	return report;
+};
+
+export function assertHomeyShsCredentialRotationReportSchema(
+	value: unknown,
+): asserts value is HomeyShsCredentialRotationReport {
+	const report = requireExactKeys(value, ['metadata', 'rotation', 'session'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion'], 'metadata');
+	const rotation = requireExactKeys(
+		report.rotation,
+		[
+			'primaryKeyInitiallyValid',
+			'replacementKeyInitiallyValid',
+			'replacementKeyValidAfterRevocation',
+			'revocationObserved',
+			'revocationStatusCode',
+		],
+		'rotation',
+	);
+	const session = requireExactKeys(report.session, ['events'], 'session');
+
+	if (
+		metadata.probe !== 'homey-shs-credential-rotation' ||
+		metadata.schemaVersion !== 1 ||
+		rotation.primaryKeyInitiallyValid !== true ||
+		rotation.replacementKeyInitiallyValid !== true ||
+		rotation.replacementKeyValidAfterRevocation !== true ||
+		rotation.revocationObserved !== true ||
+		rotation.revocationStatusCode !== 401 ||
+		!Array.isArray(session.events) ||
+		session.events.length !== EXPECTED_EVENTS.length
+	) {
+		throw new Error('Homey credential rotation report state schema is invalid');
+	}
+
+	for (const [index, eventValue] of session.events.entries()) {
+		const event = requireExactKeys(eventValue, ['event', 'order'], 'event');
+
+		if (event.event !== EXPECTED_EVENTS[index] || event.order !== index + 1) {
+			throw new Error('Homey credential rotation report event schema is invalid');
+		}
+	}
+}
+
+export function assertHomeyShsCredentialRotationReportSafe(
+	value: unknown,
+	config: HomeyShsCredentialRotationProbeConfig,
+): asserts value is HomeyShsCredentialRotationReport {
+	assertHomeyShsCredentialRotationReportSchema(value);
+
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbiddenValues = [config.apiKey, config.replacementApiKey, config.expectedHost, ...config.privateTerms]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
+
+	if (forbiddenValues.some((item) => serialized.includes(item))) {
+		throw new Error('Sanitized Homey credential rotation report contains a configured secret or private value');
+	}
+
+	if (
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized)
+	) {
+		throw new Error('Sanitized Homey credential rotation report contains an address, email, or URL');
+	}
+}
+
+export const writeHomeyShsCredentialRotationReport = async (
+	report: HomeyShsCredentialRotationReport,
+	outputRoot: string,
+): Promise<string> => {
+	assertHomeyShsCredentialRotationReportSchema(report);
+
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `credential-rotation-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsCredentialRotationProbeConfig(process.env);
+	const report = await probeHomeyShsCredentialRotation(config, fetch, sleep, () => {
+		process.stdout.write(
+			`Homey credential rotation observation window is open for ${config.observeMs} ms. Revoke only the dedicated primary test key now.\n`,
+		);
+	});
+
+	assertHomeyShsCredentialRotationReportSafe(report, config);
+
+	const outputDirectory = await writeHomeyShsCredentialRotationReport(report, config.outputRoot);
+
+	process.stdout.write(`Sanitized Homey credential rotation report written to ${outputDirectory}.\n`);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS credential rotation probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -229,10 +229,11 @@ until an operator intentionally performs the restart while the gated probe is op
 ## Operator-controlled API-key revocation and replacement probe
 
 The credential-rotation probe verifies the remaining revoked-key behavior without changing devices or revoking a key
-itself. Before opening its operator window, it proves that both the primary dedicated test key and a distinct
-replacement key can read device inventory. The operator then revokes only the primary test key through Homey. The
-probe polls the same pinned inventory endpoint until that key returns HTTP `401`, then proves the replacement key still
-works. It performs only GET requests, refuses redirects, and sends both keys only to the already validated SHS origin.
+itself. Before attaching either credential, it performs the unauthenticated system ping and requires the Homey identity
+and version headers. It then proves that both the primary dedicated test key and a distinct replacement key can read
+device inventory. The operator revokes only the primary test key through Homey. The probe polls the same pinned
+inventory endpoint until that key returns HTTP `401`, then proves the replacement key still works. It performs only GET
+requests, refuses redirects, and sends both keys only after the configured endpoint proves it is Homey.
 
 Do not use a key shared by Smart Panel, another application, or a person. Create two disposable test keys with
 `homey.device.readonly`, enter the replacement without adding it to shell history, and ensure every write, lifecycle,
@@ -254,7 +255,7 @@ Wait for `Homey credential rotation observation window is open`, then revoke onl
 `FB_HOMEY_SHS_TIMEOUT_MS`, while the whole polling loop cannot exceed the operator window. Any transport failure,
 unexpected status, replacement-key failure, timeout, or report-safety failure writes no evidence.
 
-The exact-schema report contains only five fixed ordered event labels, completion booleans, and the expected `401`
+The exact-schema report contains only six fixed ordered event labels, completion booleans, and the expected `401`
 status. It contains no endpoint, token, device data, inventory count, response body, raw error, or identifier. After a
 successful run, replace the exported primary value for any later probe and clear the rotation-only variables:
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,7 +1,7 @@
 # Homey SHS Compatibility Record
 
 **Status:** In progress; safe inventory, SDK session/cleanup, and pre-restart mDNS host-match evidence captured; live
-capability-event, write, error-matrix, reconnect, and recovery evidence pending
+capability-event, write, error-matrix, reconnect, recovery, and credential-rotation evidence pending
 
 **Started:** 2026-08-12
 
@@ -26,6 +26,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Socket.IO events and reconnect                        | Recovery probe ready; live restart pending     | Capture capability/availability events, restart, and reconnect ordering |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled         | Use only the designated harmless test capability                        |
 | Error classification                                  | SDK invalid key returned `401`; matrix pending | Verify missing-scope, bad-URL, unavailable, and timeout behavior        |
+| API-key revocation and replacement                    | Operator-controlled probe ready                | Revoke only a dedicated test key during the gated observation window    |
 | Disposable-device lifecycle                           | Contract defined, disabled                     | Use only the separately gated virtual/test device                       |
 | mDNS discovery                                        | Partial pre-restart observation                | Attribute the generic host record and repeat after SHS restart          |
 | SDK decision                                          | Live session/cleanup passed; provisional hold  | Complete event, timeout, cleanup-failure, and reconnect comparison      |
@@ -224,6 +225,47 @@ cleanup failure writes no report and exposes only a fixed sanitized error.
 
 This runbook does not authorize Smart Panel tooling or an automated agent to restart SHS. Live evidence remains pending
 until an operator intentionally performs the restart while the gated probe is open.
+
+## Operator-controlled API-key revocation and replacement probe
+
+The credential-rotation probe verifies the remaining revoked-key behavior without changing devices or revoking a key
+itself. Before opening its operator window, it proves that both the primary dedicated test key and a distinct
+replacement key can read device inventory. The operator then revokes only the primary test key through Homey. The
+probe polls the same pinned inventory endpoint until that key returns HTTP `401`, then proves the replacement key still
+works. It performs only GET requests, refuses redirects, and sends both keys only to the already validated SHS origin.
+
+Do not use a key shared by Smart Panel, another application, or a person. Create two disposable test keys with
+`homey.device.readonly`, enter the replacement without adding it to shell history, and ensure every write, lifecycle,
+and recovery gate is unset:
+
+```bash
+read -r -s FB_HOMEY_SHS_REPLACEMENT_API_KEY
+export FB_HOMEY_SHS_REPLACEMENT_API_KEY
+unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
+unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OPERATIONS FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_OBSERVE_MS
+export FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE=I_WILL_REVOKE_THE_TEST_KEY_DURING_THIS_PROBE
+pnpm run homey:probe-credential-rotation
+```
+
+Wait for `Homey credential rotation observation window is open`, then revoke only the key currently stored in
+`FB_HOMEY_SHS_API_KEY`. `FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS` controls the operator window from `10000` through
+`300000` milliseconds and defaults to `90000`. Each inventory request remains independently bounded by
+`FB_HOMEY_SHS_TIMEOUT_MS`, while the whole polling loop cannot exceed the operator window. Any transport failure,
+unexpected status, replacement-key failure, timeout, or report-safety failure writes no evidence.
+
+The exact-schema report contains only five fixed ordered event labels, completion booleans, and the expected `401`
+status. It contains no endpoint, token, device data, inventory count, response body, raw error, or identifier. After a
+successful run, replace the exported primary value for any later probe and clear the rotation-only variables:
+
+```bash
+export FB_HOMEY_SHS_API_KEY="$FB_HOMEY_SHS_REPLACEMENT_API_KEY"
+unset FB_HOMEY_SHS_REPLACEMENT_API_KEY FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE
+unset FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS
+```
+
+This runbook authorizes only the operator to revoke the dedicated primary test key. The probe and automated agents do
+not create, revoke, rotate, or otherwise administer Homey credentials.
 
 ## Privacy-safe mDNS observation probe
 


### PR DESCRIPTION
## Summary

- add an operator-controlled Homey SHS API-key revocation and replacement probe
- validate distinct primary and replacement device-read keys before opening the observation window
- detect primary-key revocation through bounded, pinned-origin GET requests and verify replacement access afterward
- write only a fixed-schema sanitized report with restrictive directory and file permissions
- document the exact gate, safe operator workflow, and post-run environment cleanup

## Why

The Homey compatibility matrix still needs live evidence for API-key revocation and replacement before the production connector can finalize authentication-failure behavior. This probe measures that behavior without administering credentials itself or mutating any Homey device.

## Safety

- requires the exact `FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE` acknowledgement
- requires two distinct disposable test keys
- refuses concurrent write, lifecycle, and recovery gates
- performs only GET requests against the validated SHS origin and blocks redirects
- never writes tokens, endpoint data, device payloads, response bodies, or raw errors
- leaves the actual key revocation exclusively to the operator

## Validation

- `pnpm run test:homey-spike` — 6 suites, 84 tests passed
- targeted ESLint passed
- backend `pnpm run type-check` passed
- targeted Prettier and `git diff --check` passed
- package JSON parse validation passed
- default-deny CLI check passed

## Live verification

Not run automatically. An operator must create two disposable `homey.device.readonly` test keys and intentionally revoke only the primary key after the probe announces that its observation window is open.