### PR TITLE
test(cross): add guarded Homey network recovery probe

### DIFF
--- a/apps/backend/test/homey-shs-recovery.homey-spike.ts
+++ b/apps/backend/test/homey-shs-recovery.homey-spike.ts
@@ -24,6 +24,12 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
 };
 
+const NETWORK_ENVIRONMENT: NodeJS.ProcessEnv = {
+	...BASE_ENVIRONMENT,
+	FB_HOMEY_SHS_RECOVERY_ENABLE: 'I_WILL_INTERRUPT_AND_RESTORE_THE_TEST_SHS_NETWORK_DURING_THIS_PROBE',
+	FB_HOMEY_SHS_RECOVERY_SCENARIO: 'network-interruption',
+};
+
 type RecoveryScenario =
 	| 'connect-recovery'
 	| 'inventory-failure'
@@ -159,6 +165,24 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(() =>
 			loadHomeyShsRecoveryProbeConfig({
 				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_SCENARIO: 'network-interruption',
+			}),
+		).toThrow('required operator acknowledgement');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...NETWORK_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_ENABLE: BASE_ENVIRONMENT.FB_HOMEY_SHS_RECOVERY_ENABLE,
+			}),
+		).toThrow('required operator acknowledgement');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RECOVERY_SCENARIO: 'unsupported',
+			}),
+		).toThrow('must be network-interruption or restart');
+		expect(() =>
+			loadHomeyShsRecoveryProbeConfig({
+				...BASE_ENVIRONMENT,
 				FB_HOMEY_SHS_RECOVERY_ENABLE: undefined,
 			}),
 		).toThrow('required operator acknowledgement');
@@ -190,6 +214,7 @@ describe('Homey SHS recovery compatibility probe', () => {
 			expectedHost: '127.0.0.1',
 			observeMs: 10_000,
 			outputRoot: '/tmp/homey-recovery-spike/test/.homey-shs-captures',
+			scenario: 'restart',
 			timeoutMs: 1000,
 		});
 		expect(config.origin.origin).toBe('http://127.0.0.1:4859');
@@ -205,12 +230,21 @@ describe('Homey SHS recovery compatibility probe', () => {
 		const config = fastConfig();
 		const harness = createFactory('success');
 		let windowOpenCount = 0;
-		const report = await probeHomeyShsRecovery(config, harness.factory, undefined, () => {
-			windowOpenCount += 1;
-		});
+		let disconnectObservedCount = 0;
+		const report = await probeHomeyShsRecovery(
+			config,
+			harness.factory,
+			undefined,
+			() => {
+				windowOpenCount += 1;
+			},
+			() => {
+				disconnectObservedCount += 1;
+			},
+		);
 
 		expect(report).toStrictEqual({
-			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			metadata: { probe: 'homey-shs-recovery', scenario: 'restart', schemaVersion: 2, sdkVersion: '3.19.2' },
 			recovery: {
 				disconnectObserved: true,
 				inventoryReadSucceeded: true,
@@ -244,9 +278,28 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(harness.clients[0].disconnectCount).toBe(1);
 		expect(harness.clients[0].destroyCount).toBe(1);
 		expect(windowOpenCount).toBe(1);
+		expect(disconnectObservedCount).toBe(1);
 		expect(() => assertHomeyShsRecoveryReportSafe(report, config)).not.toThrow();
 		expect(JSON.stringify(report)).not.toContain('test-api-key-that-must-not-leak');
 		expect(JSON.stringify(report)).not.toContain('Private Device');
+	});
+
+	it('records operator-controlled network interruption as distinct recovery evidence', async () => {
+		const config = {
+			...loadHomeyShsRecoveryProbeConfig(NETWORK_ENVIRONMENT, '/tmp/homey-recovery-spike'),
+			observeMs: 100,
+			timeoutMs: 50,
+		};
+		const report = await probeHomeyShsRecovery(config, createFactory('success').factory);
+
+		expect(report.metadata.scenario).toBe('network-interruption');
+		expect(report.recovery).toStrictEqual({
+			disconnectObserved: true,
+			inventoryReadSucceeded: true,
+			managerResubscribed: true,
+			transportReconnected: true,
+		});
+		expect(() => assertHomeyShsRecoveryReportSafe(report, config)).not.toThrow();
 	});
 
 	it('accepts a post-disconnect connect event as transport recovery', async () => {
@@ -298,6 +351,20 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(harness.clients[0].destroyCount).toBe(1);
 	});
 
+	it('uses a network-specific timeout when restoration is not observed', async () => {
+		const config = {
+			...loadHomeyShsRecoveryProbeConfig(NETWORK_ENVIRONMENT, '/tmp/homey-recovery-spike'),
+			observeMs: 10,
+			timeoutMs: 50,
+		};
+		const harness = createFactory('no-recovery');
+
+		await expect(probeHomeyShsRecovery(config, harness.factory)).rejects.toThrow(
+			'Homey recovery operator network restoration timed out after 10 ms',
+		);
+		expect(harness.clients[0].destroyCount).toBe(1);
+	});
+
 	it('requires manager restoration after transport reconnect and sanitizes failures', async () => {
 		const offlineConfig = fastConfig({ timeoutMs: 10 });
 		const offlineHarness = createFactory('manager-offline');
@@ -332,7 +399,7 @@ describe('Homey SHS recovery compatibility probe', () => {
 
 	it('rejects extra fields, invalid state, unsafe values, and unordered evidence', () => {
 		const report: HomeyShsRecoveryReport = {
-			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			metadata: { probe: 'homey-shs-recovery', scenario: 'restart', schemaVersion: 2, sdkVersion: '3.19.2' },
 			recovery: {
 				disconnectObserved: true,
 				inventoryReadSucceeded: true,
@@ -368,6 +435,9 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(() => assertHomeyShsRecoveryReportSafe(incomplete, fastConfig())).toThrow(
 			'did not verify restart recovery and cleanup',
 		);
+		expect(() =>
+			assertHomeyShsRecoveryReportSafe(report, { ...fastConfig(), scenario: 'network-interruption' }),
+		).toThrow('scenario does not match the requested scenario');
 
 		const unordered = structuredClone(report);
 		unordered.session.events = [
@@ -380,14 +450,14 @@ describe('Homey SHS recovery compatibility probe', () => {
 		];
 
 		expect(() => assertHomeyShsRecoveryReportSafe(unordered, fastConfig())).toThrow(
-			'does not contain the required restart ordering',
+			'does not contain the required recovery ordering',
 		);
 	});
 
 	it('writes a new restrictive, schema-validated report directory', async () => {
 		const root = await mkdtemp(join(tmpdir(), 'homey-recovery-spike-'));
 		const report: HomeyShsRecoveryReport = {
-			metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: '3.19.2' },
+			metadata: { probe: 'homey-shs-recovery', scenario: 'restart', schemaVersion: 2, sdkVersion: '3.19.2' },
 			recovery: {
 				disconnectObserved: true,
 				inventoryReadSucceeded: true,

--- a/apps/backend/test/support/homey-shs-recovery-probe.ts
+++ b/apps/backend/test/support/homey-shs-recovery-probe.ts
@@ -6,7 +6,10 @@ import { resolve } from 'node:path';
 import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
 
 const SDK_VERSION = '3.19.2';
-const RECOVERY_ACKNOWLEDGEMENT = 'I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE';
+const RECOVERY_ACKNOWLEDGEMENTS = {
+	'network-interruption': 'I_WILL_INTERRUPT_AND_RESTORE_THE_TEST_SHS_NETWORK_DURING_THIS_PROBE',
+	restart: 'I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE',
+} as const;
 const DEFAULT_OBSERVE_MS = 90_000;
 const MIN_OBSERVE_MS = 10_000;
 const MAX_OBSERVE_MS = 300_000;
@@ -34,6 +37,8 @@ const SAFE_EVENT_LABELS = new Set([
 ]);
 
 type EventListener = (...arguments_: unknown[]) => void;
+
+export type HomeyShsRecoveryScenario = keyof typeof RECOVERY_ACKNOWLEDGEMENTS;
 
 class HomeyShsRecoveryTimeoutError extends Error {
 	constructor(label: string, timeoutMs: number) {
@@ -66,12 +71,14 @@ export interface HomeyRecoverySdkFactory {
 
 export interface HomeyShsRecoveryProbeConfig extends HomeyShsProbeConfig {
 	observeMs: number;
+	scenario: HomeyShsRecoveryScenario;
 }
 
 export interface HomeyShsRecoveryReport {
 	metadata: {
 		probe: 'homey-shs-recovery';
-		schemaVersion: 1;
+		scenario: HomeyShsRecoveryScenario;
+		schemaVersion: 2;
 		sdkVersion: string;
 	};
 	recovery: {
@@ -136,11 +143,23 @@ const parseObserveMs = (value: string | undefined): number => {
 	return parsed;
 };
 
+const parseScenario = (value: string | undefined): HomeyShsRecoveryScenario => {
+	const scenario = value ?? 'restart';
+
+	if (scenario !== 'network-interruption' && scenario !== 'restart') {
+		throw new Error('FB_HOMEY_SHS_RECOVERY_SCENARIO must be network-interruption or restart');
+	}
+
+	return scenario;
+};
+
 export const loadHomeyShsRecoveryProbeConfig = (
 	environment: NodeJS.ProcessEnv,
 	workingDirectory = process.cwd(),
 ): HomeyShsRecoveryProbeConfig => {
-	if (environment.FB_HOMEY_SHS_RECOVERY_ENABLE !== RECOVERY_ACKNOWLEDGEMENT) {
+	const scenario = parseScenario(environment.FB_HOMEY_SHS_RECOVERY_SCENARIO);
+
+	if (environment.FB_HOMEY_SHS_RECOVERY_ENABLE !== RECOVERY_ACKNOWLEDGEMENTS[scenario]) {
 		throw new Error('FB_HOMEY_SHS_RECOVERY_ENABLE does not contain the required operator acknowledgement');
 	}
 
@@ -155,6 +174,7 @@ export const loadHomeyShsRecoveryProbeConfig = (
 	return {
 		...loadHomeyShsProbeConfig(environment, workingDirectory),
 		observeMs: parseObserveMs(environment.FB_HOMEY_SHS_RECOVERY_OBSERVE_MS),
+		scenario,
 	};
 };
 
@@ -239,12 +259,16 @@ const waitForManagerResubscription = async (
 	}
 };
 
-const waitForTransportRecovery = async (recoveryDetected: Promise<void>, observeMs: number): Promise<void> => {
+const waitForTransportRecovery = async (
+	recoveryDetected: Promise<void>,
+	config: HomeyShsRecoveryProbeConfig,
+): Promise<void> => {
 	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const label = config.scenario === 'restart' ? 'operator restart observation' : 'operator network restoration';
 	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
 		timeout = setTimeout(
-			() => rejectPromise(new HomeyShsRecoveryTimeoutError('operator restart observation', observeMs)),
-			observeMs,
+			() => rejectPromise(new HomeyShsRecoveryTimeoutError(label, config.observeMs)),
+			config.observeMs,
 		);
 	});
 
@@ -262,9 +286,15 @@ export const probeHomeyShsRecovery = async (
 	factory: HomeyRecoverySdkFactory = sdkFactory,
 	wait: HomeyRecoveryWait = sleep,
 	onWindowOpen: () => void = () => undefined,
+	onDisconnectObserved: () => void = () => undefined,
 ): Promise<HomeyShsRecoveryReport> => {
 	const report: HomeyShsRecoveryReport = {
-		metadata: { probe: 'homey-shs-recovery', schemaVersion: 1, sdkVersion: SDK_VERSION },
+		metadata: {
+			probe: 'homey-shs-recovery',
+			scenario: config.scenario,
+			schemaVersion: 2,
+			sdkVersion: SDK_VERSION,
+		},
 		recovery: {
 			disconnectObserved: false,
 			inventoryReadSucceeded: false,
@@ -313,6 +343,7 @@ export const probeHomeyShsRecovery = async (
 			if (recoveryWindowOpen && !report.recovery.disconnectObserved) {
 				report.recovery.disconnectObserved = true;
 				appendEvent(report, 'socket.disconnect');
+				onDisconnectObserved();
 			}
 		}),
 		...['reconnect_attempt', 'reconnect_error', 'reconnecting'].map((event) =>
@@ -335,7 +366,7 @@ export const probeHomeyShsRecovery = async (
 		appendEvent(report, 'recovery.window.open');
 		onWindowOpen();
 
-		await waitForTransportRecovery(transportRecoveryDetected, config.observeMs);
+		await waitForTransportRecovery(transportRecoveryDetected, config);
 
 		if (verificationPromise === null) {
 			throw new Error('Homey recovery verification did not start');
@@ -402,7 +433,7 @@ export const probeHomeyShsRecovery = async (
 
 export function assertHomeyShsRecoveryReportSchema(value: unknown): asserts value is HomeyShsRecoveryReport {
 	const report = requireExactKeys(value, ['metadata', 'recovery', 'session'], 'root');
-	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'scenario', 'schemaVersion', 'sdkVersion'], 'metadata');
 	const recovery = requireExactKeys(
 		report.recovery,
 		['disconnectObserved', 'inventoryReadSucceeded', 'managerResubscribed', 'transportReconnected'],
@@ -410,7 +441,12 @@ export function assertHomeyShsRecoveryReportSchema(value: unknown): asserts valu
 	);
 	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
 
-	if (metadata.probe !== 'homey-shs-recovery' || metadata.schemaVersion !== 1 || metadata.sdkVersion !== SDK_VERSION) {
+	if (
+		metadata.probe !== 'homey-shs-recovery' ||
+		(metadata.scenario !== 'network-interruption' && metadata.scenario !== 'restart') ||
+		metadata.schemaVersion !== 2 ||
+		metadata.sdkVersion !== SDK_VERSION
+	) {
 		throw new Error('Homey recovery report metadata schema is invalid');
 	}
 
@@ -453,6 +489,10 @@ export function assertHomeyShsRecoveryReportSafe(
 		throw new Error('Sanitized Homey recovery report contains a configured secret or private value');
 	}
 
+	if (value.metadata.scenario !== config.scenario) {
+		throw new Error('Homey recovery report scenario does not match the requested scenario');
+	}
+
 	if (
 		!value.session.managerSubscribed ||
 		!value.session.cleanupCompleted ||
@@ -461,7 +501,7 @@ export function assertHomeyShsRecoveryReportSafe(
 		!value.recovery.managerResubscribed ||
 		!value.recovery.inventoryReadSucceeded
 	) {
-		throw new Error('Homey recovery probe did not verify restart recovery and cleanup');
+		throw new Error(`Homey recovery probe did not verify ${config.scenario} recovery and cleanup`);
 	}
 
 	if (value.session.events.some(({ event, order }, index) => !SAFE_EVENT_LABELS.has(event) || order !== index + 1)) {
@@ -476,7 +516,7 @@ export function assertHomeyShsRecoveryReportSafe(
 		const index = eventNames.indexOf(event);
 
 		if (index <= previousIndex) {
-			throw new Error('Homey recovery report does not contain the required restart ordering');
+			throw new Error('Homey recovery report does not contain the required recovery ordering');
 		}
 
 		previousIndex = index;
@@ -487,7 +527,7 @@ export function assertHomeyShsRecoveryReportSafe(
 	);
 
 	if (recoveryIndex <= previousIndex) {
-		throw new Error('Homey recovery report does not contain the required restart ordering');
+		throw new Error('Homey recovery report does not contain the required recovery ordering');
 	}
 
 	previousIndex = recoveryIndex;
@@ -496,7 +536,7 @@ export function assertHomeyShsRecoveryReportSafe(
 		const index = eventNames.indexOf(event);
 
 		if (index <= previousIndex) {
-			throw new Error('Homey recovery report does not contain the required restart ordering');
+			throw new Error('Homey recovery report does not contain the required recovery ordering');
 		}
 
 		previousIndex = index;
@@ -524,11 +564,26 @@ export const writeHomeyShsRecoveryReport = async (
 
 const run = async (): Promise<void> => {
 	const config = loadHomeyShsRecoveryProbeConfig(process.env);
-	const report = await probeHomeyShsRecovery(config, sdkFactory, sleep, () => {
-		process.stdout.write(
-			`Homey recovery observation window is open for ${config.observeMs} ms. Restart the test SHS now.\n`,
-		);
-	});
+	const report = await probeHomeyShsRecovery(
+		config,
+		sdkFactory,
+		sleep,
+		() => {
+			const instruction =
+				config.scenario === 'restart'
+					? 'Restart the test SHS now.'
+					: 'Interrupt only the test SHS network now; wait for disconnect confirmation before restoring it.';
+
+			process.stdout.write(
+				`Homey ${config.scenario} recovery observation window is open for ${config.observeMs} ms. ${instruction}\n`,
+			);
+		},
+		() => {
+			if (config.scenario === 'network-interruption') {
+				process.stdout.write('Homey network disconnect observed. Restore the test SHS network now.\n');
+			}
+		},
+	);
 
 	assertHomeyShsRecoveryReportSafe(report, config);
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -18,19 +18,19 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                         | Evidence still required                                                 |
-| ----------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`        | Repeat over HTTPS `4860` if enabled                                     |
-| System, zone, device inventory, and individual device | Captured and sanitized                         | Add lifecycle delta evidence on the disposable test device              |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read   | Add allowlisted write and read-back evidence                            |
-| Socket.IO events and reconnect                        | Recovery probe ready; live restart pending     | Capture capability/availability events, restart, and reconnect ordering |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled         | Use only the designated harmless test capability                        |
-| Error classification                                  | SDK invalid key returned `401`; matrix pending | Verify missing-scope, bad-URL, unavailable, and timeout behavior        |
-| API-key revocation and replacement                    | Operator-controlled probe ready                | Revoke only a dedicated test key during the gated observation window    |
-| Disposable-device lifecycle                           | Contract defined, disabled                     | Use only the separately gated virtual/test device                       |
-| mDNS discovery                                        | Partial pre-restart observation                | Attribute the generic host record and repeat after SHS restart          |
-| SDK decision                                          | Live session/cleanup passed; provisional hold  | Complete event, timeout, cleanup-failure, and reconnect comparison      |
-| Sanitized fixture corpus                              | Nine representative live fixtures promoted     | Add event/reconnect fixtures and missing capability families/classes    |
+| Area                                                  | Status                                          | Evidence still required                                              |
+| ----------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`         | Repeat over HTTPS `4860` if enabled                                  |
+| System, zone, device inventory, and individual device | Captured and sanitized                          | Add lifecycle delta evidence on the disposable test device           |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read    | Add allowlisted write and read-back evidence                         |
+| Socket.IO events and reconnect                        | Restart/network probes ready; live runs pending | Capture capability/availability events and both recovery orderings   |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled          | Use only the designated harmless test capability                     |
+| Error classification                                  | SDK invalid key returned `401`; matrix pending  | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
+| API-key revocation and replacement                    | Operator-controlled probe ready                 | Revoke only a dedicated test key during the gated observation window |
+| Disposable-device lifecycle                           | Contract defined, disabled                      | Use only the separately gated virtual/test device                    |
+| mDNS discovery                                        | Partial pre-restart observation                 | Attribute the generic host record and repeat after SHS restart       |
+| SDK decision                                          | Live session/cleanup passed; provisional hold   | Complete event, timeout, cleanup-failure, and reconnect comparison   |
+| Sanitized fixture corpus                              | Nine representative live fixtures promoted      | Add event/reconnect fixtures and missing capability families/classes |
 
 ## Installation evidence
 
@@ -213,18 +213,53 @@ Start from the same interactive shell as the read-only probe, ensure every `FB_H
 unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
 unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID
 unset FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+export FB_HOMEY_SHS_RECOVERY_SCENARIO=restart
 export FB_HOMEY_SHS_RECOVERY_ENABLE=I_WILL_RESTART_THE_TEST_SHS_DURING_THIS_PROBE
 pnpm run homey:probe-recovery
 ```
 
-Wait for `Homey recovery observation window is open`, restart the test SHS, and do not alter networking, credentials,
-or ordinary household devices during the run. `FB_HOMEY_SHS_RECOVERY_OBSERVE_MS` optionally controls the operator
-window from `10000` through `300000` milliseconds and defaults to `90000`. SDK creation, manager operations,
-post-reconnect verification, and cleanup remain independently bounded by `FB_HOMEY_SHS_TIMEOUT_MS`. A timeout or
-cleanup failure writes no report and exposes only a fixed sanitized error.
+Wait for `Homey restart recovery observation window is open`, restart the test SHS, and do not alter networking,
+credentials, or ordinary household devices during the run. `FB_HOMEY_SHS_RECOVERY_OBSERVE_MS` optionally controls the
+operator window from `10000` through `300000` milliseconds and defaults to `90000`. SDK creation, manager operations,
+post-reconnect verification, and cleanup remain independently bounded by `FB_HOMEY_SHS_TIMEOUT_MS`. A timeout or cleanup
+failure writes no report and exposes only a fixed sanitized error.
 
 This runbook does not authorize Smart Panel tooling or an automated agent to restart SHS. Live evidence remains pending
 until an operator intentionally performs the restart while the gated probe is open.
+
+### Operator-controlled network interruption and restoration
+
+The same recovery harness can record a network interruption as a separate exact-schema scenario. It does not change
+interfaces, routes, firewall rules, containers, or network state. After the manager subscription is active, the
+operator temporarily interrupts only the designated test SHS network path. The probe prints a second message after it
+observes the socket disconnect; only then does the operator restore the test path. The probe requires transport
+reconnection, manager resubscription, a fresh inventory read, and complete cleanup exactly as it does for restart.
+
+Start from the base read-only environment, ensure every write and lifecycle variable is unset, then select the network
+scenario and its distinct acknowledgement:
+
+```bash
+unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
+unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+export FB_HOMEY_SHS_RECOVERY_SCENARIO=network-interruption
+export FB_HOMEY_SHS_RECOVERY_ENABLE=I_WILL_INTERRUPT_AND_RESTORE_THE_TEST_SHS_NETWORK_DURING_THIS_PROBE
+pnpm run homey:probe-recovery
+```
+
+Wait for the network-scenario observation window, interrupt only the test SHS path, then wait for `Homey network
+disconnect observed` before restoring it. Do not interrupt the broader household LAN, the Smart Panel agent host, or an
+ordinary Homey installation. The restart acknowledgement is rejected in network mode and the network acknowledgement
+is rejected in restart mode, preventing one operator authorization from being reused for a different action.
+
+After the run, restore the default restart mode explicitly or clear the scenario and acknowledgement:
+
+```bash
+unset FB_HOMEY_SHS_RECOVERY_SCENARIO FB_HOMEY_SHS_RECOVERY_ENABLE
+```
+
+This runbook authorizes only the operator to interrupt and restore the dedicated test SHS path. The probe and automated
+agents do not change networking.
 
 ## Operator-controlled API-key revocation and replacement probe
 
@@ -245,6 +280,7 @@ export FB_HOMEY_SHS_REPLACEMENT_API_KEY
 unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
 unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID
 unset FB_HOMEY_SHS_LIFECYCLE_OPERATIONS FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_OBSERVE_MS
+unset FB_HOMEY_SHS_RECOVERY_SCENARIO
 export FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE=I_WILL_REVOKE_THE_TEST_KEY_DURING_THIS_PROBE
 pnpm run homey:probe-credential-rotation
 ```


### PR DESCRIPTION
## Summary

- extend the guarded Homey recovery harness with distinct restart and network-interruption scenarios
- require scenario-specific operator acknowledgements
- record the scenario in a versioned exact-schema report
- notify the operator after disconnect so network restoration happens only after evidence is observed
- document the operator-only network interruption workflow

## Why

The Phase 0 Homey compatibility matrix still needs network interruption/restoration evidence. The existing restart harness already verifies disconnect, transport recovery, manager resubscription, post-recovery inventory, and cleanup, so this change reuses that reviewed path while keeping restart and network evidence distinct.

## Safety

- the harness never changes interfaces, routes, firewall rules, containers, or network state
- network interruption/restoration remains exclusively an operator action
- restart and network modes require different exact acknowledgements
- write and lifecycle gates must be unset
- reports contain only fixed event labels, completion state, scenario metadata, and SDK version
- no endpoint, credential, identifiers, payloads, or raw errors are persisted

## Validation

- `pnpm run test:homey-spike` — 6 suites, 87 tests passed
- targeted ESLint passed
- backend `pnpm run type-check` passed
- targeted Prettier and `git diff --check` passed
- default-deny CLI check passed

## Live verification

Not run automatically. An operator must interrupt and restore only the dedicated test SHS network path after the probe announces the appropriate observation prompts.