### PR TITLE
test(backend): establish Buddy adaptive-context baseline

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -71,6 +71,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:homey-spike": "jest --config ./test/jest-homey-spike.json --runInBand",
     "test:oauth-spike": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest --config ./test/jest-oauth-spike.json --runInBand",
+    "test:buddy-context-soak": "jest --config ./test/jest-buddy-context-soak.json --runInBand",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",

--- a/apps/backend/src/modules/buddy/platforms/anthropic-sdk.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/anthropic-sdk.utils.ts
@@ -30,6 +30,35 @@ export interface AnthropicSdkResult {
 	cacheWriteTokens: number | null;
 }
 
+/** Build the exact JSON payload passed to the Anthropic Messages SDK. */
+export function buildAnthropicRequestPayload(
+	model: string,
+	systemPrompt: string,
+	messages: ChatMessage[],
+	maxTokens: number = 1024,
+	tools?: ToolDefinition[],
+): Record<string, unknown> {
+	const requestPayload: Record<string, unknown> = {
+		model,
+		max_tokens: maxTokens,
+		system: systemPrompt,
+		messages: messages.map((message) => ({
+			role: message.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
+			content: message.content,
+		})),
+	};
+
+	if (tools && tools.length > 0) {
+		requestPayload.tools = tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			input_schema: tool.parameters,
+		}));
+	}
+
+	return requestPayload;
+}
+
 /**
  * Shared Anthropic SDK interaction logic used by all Claude-based providers.
  * Handles SDK import, client creation, API call, and response parsing.
@@ -52,24 +81,7 @@ export async function sendAnthropicMessage(
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 	const client = new Anthropic({ ...credentials, timeout, defaultHeaders });
 
-	// Build the request payload
-	const requestPayload: Record<string, unknown> = {
-		model,
-		max_tokens: maxTokens,
-		system: systemPrompt,
-		messages: messages.map((m) => ({
-			role: m.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
-			content: m.content,
-		})),
-	};
-
-	if (tools && tools.length > 0) {
-		requestPayload.tools = tools.map((t) => ({
-			name: t.name,
-			description: t.description,
-			input_schema: t.parameters,
-		}));
-	}
+	const requestPayload = buildAnthropicRequestPayload(model, systemPrompt, messages, maxTokens, tools);
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 	const response = await client.messages.create(requestPayload);

--- a/apps/backend/src/modules/buddy/platforms/openai-sdk.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/openai-sdk.utils.ts
@@ -19,6 +19,40 @@ export interface OpenAiSdkResult {
 	finishReason: string | null;
 }
 
+/** Build the exact JSON payload passed to the OpenAI Chat Completions SDK. */
+export function buildOpenAiRequestPayload(
+	model: string,
+	systemPrompt: string,
+	messages: ChatMessage[],
+	maxTokens: number = 1024,
+	tools?: ToolDefinition[],
+): Record<string, unknown> {
+	const requestPayload: Record<string, unknown> = {
+		model,
+		max_completion_tokens: maxTokens,
+		messages: [
+			{ role: 'system' as const, content: systemPrompt },
+			...messages.map((message) => ({
+				role: message.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
+				content: message.content,
+			})),
+		],
+	};
+
+	if (tools && tools.length > 0) {
+		requestPayload.tools = tools.map((tool) => ({
+			type: 'function',
+			function: {
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.parameters,
+			},
+		}));
+	}
+
+	return requestPayload;
+}
+
 /**
  * Shared OpenAI SDK interaction logic used by all OpenAI-based providers.
  * Handles SDK import, client creation, API call, and response parsing.
@@ -37,29 +71,7 @@ export async function sendOpenAiMessage(
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 	const client = new OpenAI({ apiKey, timeout });
 
-	// Build the request payload
-	const requestPayload: Record<string, unknown> = {
-		model,
-		max_completion_tokens: maxTokens,
-		messages: [
-			{ role: 'system' as const, content: systemPrompt },
-			...messages.map((m) => ({
-				role: m.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
-				content: m.content,
-			})),
-		],
-	};
-
-	if (tools && tools.length > 0) {
-		requestPayload.tools = tools.map((t) => ({
-			type: 'function',
-			function: {
-				name: t.name,
-				description: t.description,
-				parameters: t.parameters,
-			},
-		}));
-	}
+	const requestPayload = buildOpenAiRequestPayload(model, systemPrompt, messages, maxTokens, tools);
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 	const response = await client.chat.completions.create(requestPayload);

--- a/apps/backend/src/modules/buddy/services/buddy-context.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-context.service.spec.ts
@@ -5,6 +5,11 @@ import { IntentType } from '../../intents/intents.constants';
 import { ScenesService } from '../../scenes/services/scenes.service';
 import { SpacesService } from '../../spaces/services/spaces.service';
 import { WeatherService } from '../../weather/services/weather.service';
+import {
+	BUDDY_CONTEXT_SCALE_DEVICE_COUNTS,
+	createBuddyContextFixture,
+	createBuddyDeviceEntityFixtures,
+} from '../testing/buddy-context-evaluation.fixtures';
 
 import { ActionObserverService } from './action-observer.service';
 import { BuddyContextService } from './buddy-context.service';
@@ -435,6 +440,66 @@ describe('BuddyContextService', () => {
 			const ctx = await service.buildContext('nonexistent');
 
 			expect(ctx.spaces).toHaveLength(0);
+		});
+	});
+
+	describe('eager snapshot characterization', () => {
+		it('should retain the current global domain query footprint', async () => {
+			await service.buildContext();
+
+			expect(spacesService.findAll).toHaveBeenCalledTimes(1);
+			expect(spacesService.findDevicesBySpace).toHaveBeenCalledTimes(2);
+			expect(spacesService.findDevicesBySpace).toHaveBeenNthCalledWith(1, 'space-1');
+			expect(spacesService.findDevicesBySpace).toHaveBeenNthCalledWith(2, 'space-2');
+			expect(devicesService.findAll).toHaveBeenCalledTimes(1);
+			expect(scenesService.findAll).toHaveBeenCalledTimes(1);
+			expect(scenesService.findBySpace).not.toHaveBeenCalled();
+			expect(weatherService.getPrimaryWeather).toHaveBeenCalledTimes(1);
+			expect(energyDataService.getDeltas).toHaveBeenCalledTimes(1);
+		});
+
+		it('should retain the current space-scoped domain query footprint', async () => {
+			spacesService.findDevicesBySpace.mockResolvedValue([]);
+
+			await service.buildContext('space-1');
+
+			expect(spacesService.findAll).not.toHaveBeenCalled();
+			expect(spacesService.findOne).toHaveBeenCalledTimes(1);
+			expect(spacesService.findOne).toHaveBeenCalledWith('space-1');
+			// The eager implementation separately queries the space count and device details.
+			expect(spacesService.findDevicesBySpace).toHaveBeenCalledTimes(2);
+			expect(spacesService.findDevicesBySpace).toHaveBeenNthCalledWith(1, 'space-1');
+			expect(spacesService.findDevicesBySpace).toHaveBeenNthCalledWith(2, 'space-1');
+			expect(devicesService.findAll).not.toHaveBeenCalled();
+			expect(scenesService.findAll).not.toHaveBeenCalled();
+			expect(scenesService.findBySpace).toHaveBeenCalledTimes(1);
+			expect(scenesService.findBySpace).toHaveBeenCalledWith('space-1');
+			expect(weatherService.getPrimaryWeather).toHaveBeenCalledTimes(1);
+			expect(energyDataService.getDeltas).toHaveBeenCalledTimes(1);
+		});
+
+		it('should preserve the last device, channel, and property in a full large space snapshot', async () => {
+			const deviceCount = BUDDY_CONTEXT_SCALE_DEVICE_COUNTS[BUDDY_CONTEXT_SCALE_DEVICE_COUNTS.length - 1];
+			const options = { spaceId: 'space-1' };
+			const rawDevices = createBuddyDeviceEntityFixtures(deviceCount, options);
+			const expected = createBuddyContextFixture(deviceCount, options);
+
+			spacesService.findDevicesBySpace.mockResolvedValue(rawDevices);
+
+			const context = await service.buildContext('space-1');
+			const lastDevice = context.devices[deviceCount - 1];
+			const expectedLastDevice = expected.devices[deviceCount - 1];
+			const lastChannel = lastDevice.channels[lastDevice.channels.length - 1];
+			const expectedLastChannel = expectedLastDevice.channels[expectedLastDevice.channels.length - 1];
+
+			expect(context.spaces[0].deviceCount).toBe(deviceCount);
+			expect(context.devices).toHaveLength(deviceCount);
+			expect(lastDevice).toEqual(expectedLastDevice);
+			expect(lastDevice.channels).toHaveLength(3);
+			expect(lastChannel).toEqual(expectedLastChannel);
+			expect(lastChannel.properties).toHaveLength(1);
+			expect(lastChannel.properties[0]).toEqual(expectedLastChannel.properties[0]);
+			expect(lastDevice.state['energy.power']).toBe(expectedLastDevice.state['energy.power']);
 		});
 	});
 

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -293,11 +293,14 @@ describe('BuddyConversationService', () => {
 
 		it.each(BUDDY_CONTEXT_EVALUATION_MATRIX)(
 			'should eagerly build one full context snapshot for $id',
-			async ({ conversationSpaceId, message }) => {
+			async ({ conversationSpaceId, message, priorTurns = [] }) => {
 				conversationRepo.findOne.mockResolvedValue({
 					...mockConversation,
 					spaceId: conversationSpaceId,
 				});
+				messageRepo.find.mockResolvedValue(
+					priorTurns.map(({ role, content }) => ({ role: role as MessageRole, content })),
+				);
 
 				await service.sendMessage('conv-1', message);
 

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -299,13 +299,21 @@ describe('BuddyConversationService', () => {
 					spaceId: conversationSpaceId,
 				});
 				messageRepo.find.mockResolvedValue(
-					priorTurns.map(({ role, content }) => ({ role: role as MessageRole, content })),
+					[...priorTurns].reverse().map(({ role, content }) => ({ role: role as MessageRole, content })),
 				);
 
 				await service.sendMessage('conv-1', message);
 
 				expect(contextService.buildContext).toHaveBeenCalledTimes(1);
 				expect(contextService.buildContext).toHaveBeenCalledWith(conversationSpaceId ?? undefined);
+				const providerMessages = llmProvider.sendMessage.mock.calls[0][1] as Array<{
+					role: MessageRole;
+					content: string;
+				}>;
+
+				expect(providerMessages.slice(0, priorTurns.length)).toEqual(
+					priorTurns.map(({ role, content }) => ({ role, content })),
+				);
 			},
 		);
 

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -1,65 +1,88 @@
 /* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { DataSource as OrmDataSource, Repository } from 'typeorm';
+import { z } from 'zod';
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { ConfigService } from '../../config/services/config.service';
+import { ToolAccessKind, ToolAudience, createToolDefinition } from '../../tools/platforms/tool-provider.platform';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import { EventType, MessageRole } from '../buddy.constants';
 import { BuddyConversationNotFoundException, BuddyProviderNotConfiguredException } from '../buddy.exceptions';
 import { BuddyConversationEntity } from '../entities/buddy-conversation.entity';
 import { BuddyMessageEntity } from '../entities/buddy-message.entity';
+import { buildOpenAiRequestPayload } from '../platforms/openai-sdk.utils';
+import {
+	BUDDY_CONTEXT_SCALE_DEVICE_COUNTS,
+	createBuddyContextFixture,
+} from '../testing/buddy-context-evaluation.fixtures';
+import { BUDDY_CONTEXT_EVALUATION_MATRIX } from '../testing/buddy-context-evaluation.matrix';
+import {
+	estimateConservativeTokens,
+	measureJsonUtf8Bytes,
+	measureLlmRequestPayload,
+} from '../testing/llm-request-measurement.helper';
 
 import { BuddyContextService } from './buddy-context.service';
 import { BuddyConversationService } from './buddy-conversation.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
 import { LlmProviderService } from './llm-provider.service';
 
-/**
- * Helper to generate N fake devices with channels and properties.
- * Each device gets 3 channels with 5 properties each to simulate a realistic home.
- */
-function generateDevices(
-	count: number,
-	spaceId: string | null = null,
-): {
-	id: string;
-	name: string;
-	space: string | null;
-	category: string;
-	state: Record<string, unknown>;
-	channels: { id: string; name: string; properties: { id: string; category: string; value: unknown }[] }[];
-}[] {
-	return Array.from({ length: count }, (_, i) => {
-		const channels = Array.from({ length: 3 }, (_, ch) => ({
-			id: `ch-${i}-${ch}`,
-			name: `channel_${ch}`,
-			properties: Array.from({ length: 5 }, (_, p) => ({
-				id: `prop-${i}-${ch}-${p}`,
-				category: `sensor_${p}`,
-				value: Math.round(Math.random() * 100) / 10,
-			})),
-		}));
+const BUDDY_EVALUATION_HISTORY: Partial<BuddyMessageEntity>[] = Array.from({ length: 19 }, (_, index) => ({
+	role: index % 2 === 0 ? MessageRole.USER : MessageRole.ASSISTANT,
+	content:
+		index % 2 === 0
+			? `Earlier request ${index + 1}: report the living-room temperature and lighting state.`
+			: `Earlier response ${index + 1}: the room is comfortable and its main light is available.`,
+}));
 
-		const state: Record<string, unknown> = {};
-
-		for (const ch of channels) {
-			for (const prop of ch.properties) {
-				state[`${ch.name}.${prop.category}`] = prop.value;
-			}
-		}
-
-		return {
-			id: `device-${i}`,
-			name: `Device ${i}`,
-			space: spaceId,
-			category: 'sensor',
-			state,
-			channels,
-		};
-	});
-}
+const toolOutputSchema = z.object({ success: z.boolean(), message: z.string() });
+const BUDDY_EVALUATION_TOOLS = [
+	createToolDefinition({
+		name: 'search_home_entities',
+		description: 'Find devices, spaces, properties, and scenes matching a user-provided name or capability.',
+		audiences: [ToolAudience.BUDDY],
+		access: ToolAccessKind.READ,
+		inputSchema: z.object({
+			query: z.string().min(1).describe('Name or capability to find'),
+			space_id: z.string().optional().describe('Optional space identifier used to narrow the search'),
+			limit: z.number().int().min(1).max(25).default(10),
+		}),
+		outputSchema: toolOutputSchema,
+	}),
+	createToolDefinition({
+		name: 'get_device_state',
+		description: 'Read the current state and selected properties of an exact smart-home device.',
+		audiences: [ToolAudience.BUDDY],
+		access: ToolAccessKind.READ,
+		inputSchema: z.object({
+			device_id: z.string().min(1).describe('Exact device identifier returned by entity search'),
+			property_categories: z.array(z.string()).max(20).optional(),
+		}),
+		outputSchema: toolOutputSchema,
+	}),
+	createToolDefinition({
+		name: 'set_device_property',
+		description: 'Set one writable property on an exact device after resolving an unambiguous target.',
+		audiences: [ToolAudience.BUDDY],
+		access: ToolAccessKind.WRITE,
+		inputSchema: z.object({
+			device_id: z.string().min(1),
+			property_id: z.string().min(1),
+			value: z.union([z.boolean(), z.number(), z.string()]),
+		}),
+		outputSchema: toolOutputSchema,
+	}),
+	createToolDefinition({
+		name: 'run_scene',
+		description: 'Trigger an enabled scene by its exact identifier.',
+		audiences: [ToolAudience.BUDDY],
+		access: ToolAccessKind.TRIGGER,
+		inputSchema: z.object({ scene_id: z.string().min(1) }),
+		outputSchema: toolOutputSchema,
+	}),
+];
 
 describe('BuddyConversationService', () => {
 	let service: BuddyConversationService;
@@ -71,6 +94,7 @@ describe('BuddyConversationService', () => {
 	let personalityService: Record<string, jest.Mock>;
 	let toolProviderRegistry: Record<string, jest.Mock>;
 	let eventEmitter: jest.Mocked<EventEmitter2>;
+	let configService: Record<string, jest.Mock>;
 
 	const mockConversation: BuddyConversationEntity = {
 		id: 'conv-1',
@@ -161,7 +185,7 @@ describe('BuddyConversationService', () => {
 			emit: jest.fn(),
 		} as any;
 
-		const configService = {
+		configService = {
 			getModuleConfig: jest.fn().mockReturnValue({ name: 'Buddy', maxToolIterations: 5, contextWindowTokens: 8_000 }),
 		};
 
@@ -266,6 +290,21 @@ describe('BuddyConversationService', () => {
 
 			expect(contextService.buildContext).toHaveBeenCalled();
 		});
+
+		it.each(BUDDY_CONTEXT_EVALUATION_MATRIX)(
+			'should eagerly build one full context snapshot for $id',
+			async ({ conversationSpaceId, message }) => {
+				conversationRepo.findOne.mockResolvedValue({
+					...mockConversation,
+					spaceId: conversationSpaceId,
+				});
+
+				await service.sendMessage('conv-1', message);
+
+				expect(contextService.buildContext).toHaveBeenCalledTimes(1);
+				expect(contextService.buildContext).toHaveBeenCalledWith(conversationSpaceId ?? undefined);
+			},
+		);
 
 		it('should call LLM provider with system prompt and messages', async () => {
 			await service.sendMessage('conv-1', 'What is the temperature?');
@@ -540,19 +579,250 @@ describe('BuddyConversationService', () => {
 		});
 	});
 
+	describe('sendMessage - Phase 0 complete request measurements', () => {
+		it('should snapshot the native provider request for 10, 100, and 1,000 devices', async () => {
+			const measurements: Array<Record<string, unknown>> = [];
+
+			llmProvider.supportsTools.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_EVALUATION_TOOLS);
+			messageRepo.find.mockResolvedValue(BUDDY_EVALUATION_HISTORY);
+
+			for (const deviceCount of BUDDY_CONTEXT_SCALE_DEVICE_COUNTS) {
+				contextService.buildContext.mockResolvedValue(createBuddyContextFixture(deviceCount));
+
+				await service.sendMessage('conv-1', 'Give me a complete status overview for the current home.');
+
+				const [systemPrompt, messages, options] = llmProvider.sendMessage.mock.calls.at(-1) as [
+					string,
+					Array<{ role: MessageRole.USER | MessageRole.ASSISTANT; content: string }>,
+					{ tools: typeof BUDDY_EVALUATION_TOOLS },
+				];
+				const payload = buildOpenAiRequestPayload('gpt-4o', systemPrompt, messages, 1_024, options.tools);
+				const measurement = measureLlmRequestPayload(payload, {
+					contextWindowTokens: 128_000,
+					requestedOutputTokens: 1_024,
+					providerFramingTokens: 32,
+					safetyMarginTokens: 256,
+				});
+				const nativeMessages = payload.messages as Array<{ role: string; content: string }>;
+
+				expect(nativeMessages).toHaveLength(21);
+				expect(nativeMessages[0]).toEqual({ role: 'system', content: systemPrompt });
+				expect(nativeMessages.slice(1, -1)).toHaveLength(19);
+				expect(nativeMessages.at(-1)).toEqual({
+					role: 'user',
+					content: 'Give me a complete status overview for the current home.',
+				});
+				expect(payload.tools).toHaveLength(BUDDY_EVALUATION_TOOLS.length);
+				expect(measurement.components.history.estimatedTokens).toBeGreaterThan(0);
+				expect(measurement.components.current.estimatedTokens).toBeGreaterThan(0);
+				expect(measurement.components.tools.estimatedTokens).toBeGreaterThan(0);
+				expect(measurement.components.toolResults.estimatedTokens).toBe(0);
+				expect(measurement.jsonUtf8Bytes).toBeGreaterThan(measureJsonUtf8Bytes(systemPrompt));
+				expect(measurement.estimatedInputTokens).toBeGreaterThan(estimateConservativeTokens(systemPrompt));
+				expect(measurement.output).toEqual({
+					requestedTokens: 1_024,
+					nativeCapTokens: 1_024,
+					status: 'enforced',
+				});
+
+				measurements.push({
+					deviceCount,
+					jsonUtf8Bytes: measurement.jsonUtf8Bytes,
+					estimatedInputTokens: measurement.estimatedInputTokens,
+					availableInputTokens: measurement.availableInputTokens,
+					fitsWindow: measurement.fitsWindow,
+					components: measurement.components,
+				});
+			}
+
+			expect(measurements).toMatchInlineSnapshot(`
+			[
+			  {
+			    "availableInputTokens": 126688,
+			    "components": {
+			      "current": {
+			        "estimatedTokens": 29,
+			        "jsonUtf8Bytes": 86,
+			      },
+			      "history": {
+			        "estimatedTokens": 674,
+			        "jsonUtf8Bytes": 2021,
+			      },
+			      "other": {
+			        "estimatedTokens": 6,
+			        "jsonUtf8Bytes": 18,
+			      },
+			      "system": {
+			        "estimatedTokens": 1422,
+			        "jsonUtf8Bytes": 4265,
+			      },
+			      "toolResults": {
+			        "estimatedTokens": 0,
+			        "jsonUtf8Bytes": 0,
+			      },
+			      "tools": {
+			        "estimatedTokens": 557,
+			        "jsonUtf8Bytes": 1670,
+			      },
+			    },
+			    "deviceCount": 10,
+			    "estimatedInputTokens": 2693,
+			    "fitsWindow": true,
+			    "jsonUtf8Bytes": 8108,
+			  },
+			  {
+			    "availableInputTokens": 126688,
+			    "components": {
+			      "current": {
+			        "estimatedTokens": 29,
+			        "jsonUtf8Bytes": 86,
+			      },
+			      "history": {
+			        "estimatedTokens": 674,
+			        "jsonUtf8Bytes": 2021,
+			      },
+			      "other": {
+			        "estimatedTokens": 6,
+			        "jsonUtf8Bytes": 18,
+			      },
+			      "system": {
+			        "estimatedTokens": 6276,
+			        "jsonUtf8Bytes": 18826,
+			      },
+			      "toolResults": {
+			        "estimatedTokens": 0,
+			        "jsonUtf8Bytes": 0,
+			      },
+			      "tools": {
+			        "estimatedTokens": 557,
+			        "jsonUtf8Bytes": 1670,
+			      },
+			    },
+			    "deviceCount": 100,
+			    "estimatedInputTokens": 7547,
+			    "fitsWindow": true,
+			    "jsonUtf8Bytes": 22669,
+			  },
+			  {
+			    "availableInputTokens": 126688,
+			    "components": {
+			      "current": {
+			        "estimatedTokens": 29,
+			        "jsonUtf8Bytes": 86,
+			      },
+			      "history": {
+			        "estimatedTokens": 674,
+			        "jsonUtf8Bytes": 2021,
+			      },
+			      "other": {
+			        "estimatedTokens": 6,
+			        "jsonUtf8Bytes": 18,
+			      },
+			      "system": {
+			        "estimatedTokens": 337,
+			        "jsonUtf8Bytes": 1010,
+			      },
+			      "toolResults": {
+			        "estimatedTokens": 0,
+			        "jsonUtf8Bytes": 0,
+			      },
+			      "tools": {
+			        "estimatedTokens": 557,
+			        "jsonUtf8Bytes": 1670,
+			      },
+			    },
+			    "deviceCount": 1000,
+			    "estimatedInputTokens": 1608,
+			    "fitsWindow": true,
+			    "jsonUtf8Bytes": 4853,
+			  },
+			]
+			`);
+		});
+
+		it('should record the current eager request as over budget for a 2k-token model', async () => {
+			configService.getModuleConfig.mockReturnValue({
+				name: 'Buddy',
+				maxToolIterations: 5,
+				contextWindowTokens: 2_000,
+			});
+			llmProvider.supportsTools.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_EVALUATION_TOOLS);
+			messageRepo.find.mockResolvedValue(BUDDY_EVALUATION_HISTORY);
+			contextService.buildContext.mockResolvedValue(createBuddyContextFixture(10));
+
+			await service.sendMessage('conv-1', 'Give me a complete status overview for the current home.');
+
+			const [systemPrompt, messages, options] = llmProvider.sendMessage.mock.calls[0] as [
+				string,
+				Array<{ role: MessageRole.USER | MessageRole.ASSISTANT; content: string }>,
+				{ tools: typeof BUDDY_EVALUATION_TOOLS },
+			];
+			const payload = buildOpenAiRequestPayload('gpt-4o', systemPrompt, messages, 1_024, options.tools);
+			const measurement = measureLlmRequestPayload(payload, {
+				contextWindowTokens: 2_000,
+				requestedOutputTokens: 1_024,
+				providerFramingTokens: 32,
+				safetyMarginTokens: 128,
+			});
+
+			expect(estimateConservativeTokens(systemPrompt)).toBeLessThanOrEqual(1_600);
+			expect(measurement.availableInputTokens).toBe(816);
+			expect(measurement.estimatedInputTokens).toBeGreaterThan(measurement.availableInputTokens);
+			expect(measurement.fitsWindow).toBe(false);
+			expect(measurement.output.status).toBe('enforced');
+			expect({
+				jsonUtf8Bytes: measurement.jsonUtf8Bytes,
+				estimatedInputTokens: measurement.estimatedInputTokens,
+				availableInputTokens: measurement.availableInputTokens,
+				fitsWindow: measurement.fitsWindow,
+				components: measurement.components,
+			}).toMatchInlineSnapshot(`
+			{
+			  "availableInputTokens": 816,
+			  "components": {
+			    "current": {
+			      "estimatedTokens": 29,
+			      "jsonUtf8Bytes": 86,
+			    },
+			    "history": {
+			      "estimatedTokens": 674,
+			      "jsonUtf8Bytes": 2021,
+			    },
+			    "other": {
+			      "estimatedTokens": 6,
+			      "jsonUtf8Bytes": 18,
+			    },
+			    "system": {
+			      "estimatedTokens": 1422,
+			      "jsonUtf8Bytes": 4265,
+			    },
+			    "toolResults": {
+			      "estimatedTokens": 0,
+			      "jsonUtf8Bytes": 0,
+			    },
+			    "tools": {
+			      "estimatedTokens": 557,
+			      "jsonUtf8Bytes": 1670,
+			    },
+			  },
+			  "estimatedInputTokens": 2693,
+			  "fitsWindow": false,
+			  "jsonUtf8Bytes": 8108,
+			}
+		`);
+		});
+	});
+
 	describe('sendMessage - prompt truncation', () => {
 		it('should include all devices for a small home (no truncation)', async () => {
-			const devices = generateDevices(5);
+			const fixture = createBuddyContextFixture(5);
+			const devices = fixture.devices;
 
 			contextService.buildContext.mockResolvedValue({
-				timestamp: new Date().toISOString(),
-				timezone: 'Europe/Prague',
+				...fixture,
 				spaces: [{ id: 'space-1', name: 'Living Room', category: 'room', deviceCount: 5 }],
-				devices,
-				scenes: [],
-				weather: null,
-				energy: null,
-				recentIntents: [],
 			});
 
 			await service.sendMessage('conv-1', 'Status?');
@@ -571,8 +841,11 @@ describe('BuddyConversationService', () => {
 		it('should truncate devices for a large global conversation', async () => {
 			// Global conversation (spaceId=null) with 100 devices across two spaces
 			// exceeds the 8k * 0.8 = 6.4k token budget
-			const space1Devices = generateDevices(10, 'space-1');
-			const space2Devices = generateDevices(90, 'space-2');
+			const space1Devices = createBuddyContextFixture(10, { spaceId: 'space-1' }).devices;
+			const space2Devices = createBuddyContextFixture(90, {
+				spaceId: 'space-2',
+				deviceIndexOffset: 10,
+			}).devices;
 			const allDevices = [...space1Devices, ...space2Devices];
 
 			contextService.buildContext.mockResolvedValue({
@@ -617,8 +890,11 @@ describe('BuddyConversationService', () => {
 
 			conversationRepo.findOne.mockResolvedValue(scopedConversation);
 
-			const currentDevices = generateDevices(5, 'space-1');
-			const otherDevices = generateDevices(80, 'space-2');
+			const currentDevices = createBuddyContextFixture(5, { spaceId: 'space-1' }).devices;
+			const otherDevices = createBuddyContextFixture(80, {
+				spaceId: 'space-2',
+				deviceIndexOffset: 5,
+			}).devices;
 			const allDevices = [...currentDevices, ...otherDevices];
 
 			contextService.buildContext.mockResolvedValue({
@@ -659,7 +935,7 @@ describe('BuddyConversationService', () => {
 
 		it('should aggressively truncate for a very large home', async () => {
 			// Generate 200 devices — far beyond budget, global conversation
-			const allDevices = generateDevices(200, 'space-other');
+			const allDevices = createBuddyContextFixture(200, { spaceId: 'space-other' }).devices;
 			const spaces = [
 				{ id: 'space-1', name: 'Master Bedroom', category: 'room', deviceCount: 5 },
 				{ id: 'space-other', name: 'Whole House', category: 'zone', deviceCount: 200 },

--- a/apps/backend/src/modules/buddy/services/heartbeat.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/heartbeat.service.spec.ts
@@ -4,6 +4,10 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { ConfigService } from '../../config/services/config.service';
 import { SpacesService } from '../../spaces/services/spaces.service';
 import { HEARTBEAT_DEFAULT_INTERVAL_MS, SuggestionType } from '../buddy.constants';
+import {
+	BUDDY_CONTEXT_SCALE_DEVICE_COUNTS,
+	createBuddyContextFixture,
+} from '../testing/buddy-context-evaluation.fixtures';
 
 import { BuddyContext, BuddyContextService } from './buddy-context.service';
 import { HeartbeatService } from './heartbeat.service';
@@ -297,6 +301,35 @@ describe('HeartbeatService', () => {
 			await service.runCycle();
 
 			expect(callOrder).toEqual(['eval1', 'eval2']);
+		});
+
+		it('should forward the exact complete context object unchanged to every evaluator', async () => {
+			const context = createBuddyContextFixture(BUDDY_CONTEXT_SCALE_DEVICE_COUNTS[0], { spaceId: 'space-1' });
+			const evaluator1Evaluate = jest.fn((receivedContext: BuddyContext) => {
+				expect(receivedContext).toBe(context);
+
+				return Promise.resolve([]);
+			});
+			const evaluator2Evaluate = jest.fn((receivedContext: BuddyContext) => {
+				expect(receivedContext).toBe(context);
+
+				return Promise.resolve([]);
+			});
+
+			spacesService.findAll.mockResolvedValue([{ id: 'space-1', suggestionsEnabled: true }]);
+			contextService.buildContext.mockResolvedValue(context);
+			service.registerEvaluator({ name: 'Evaluator1', evaluate: evaluator1Evaluate });
+			service.registerEvaluator({ name: 'Evaluator2', evaluate: evaluator2Evaluate });
+
+			await service.runCycle();
+
+			expect(contextService.buildContext).toHaveBeenCalledWith('space-1');
+			expect(evaluator1Evaluate).toHaveBeenCalledTimes(1);
+			expect(evaluator2Evaluate).toHaveBeenCalledTimes(1);
+			expect(evaluator1Evaluate).toHaveBeenCalledWith(context);
+			expect(evaluator2Evaluate).toHaveBeenCalledWith(context);
+			expect(context.devices).toHaveLength(BUDDY_CONTEXT_SCALE_DEVICE_COUNTS[0]);
+			expect(context.devices[context.devices.length - 1].channels).toHaveLength(3);
 		});
 	});
 

--- a/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.fixtures.ts
+++ b/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.fixtures.ts
@@ -1,0 +1,165 @@
+import { DeviceCategory, PropertyCategory } from '../../devices/devices.constants';
+import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
+import { PropertyValueState } from '../../devices/models/property-value-state.model';
+import { BuddyContext } from '../services/buddy-context.service';
+
+export const BUDDY_CONTEXT_SCALE_DEVICE_COUNTS = [10, 100, 1_000] as const;
+export const BUDDY_CONTEXT_SOAK_DEVICE_COUNT = 5_000;
+
+export interface BuddyContextFixtureOptions {
+	spaceId?: string;
+	spaceCount?: number;
+	deviceIndexOffset?: number;
+	timestamp?: string;
+	timezone?: string;
+}
+
+const DEFAULT_SPACE_COUNT = 4;
+const DEFAULT_TIMESTAMP = '2026-01-15T12:00:00.000Z';
+
+interface FixtureChannelDefinition {
+	identifier: string;
+	properties: ReadonlyArray<readonly [PropertyCategory, boolean | number]>;
+}
+
+const pad = (value: number): string => value.toString().padStart(6, '0');
+
+const getSpaceId = (index: number, options: BuddyContextFixtureOptions): string => {
+	if (options.spaceId) {
+		return options.spaceId;
+	}
+
+	const spaceCount = Math.max(1, options.spaceCount ?? DEFAULT_SPACE_COUNT);
+
+	return `space-${(index % spaceCount) + 1}`;
+};
+
+const createProperty = (
+	deviceNumber: string,
+	channelNumber: number,
+	propertyNumber: number,
+	category: PropertyCategory,
+	value: boolean | number,
+): ChannelPropertyEntity =>
+	Object.assign(new ChannelPropertyEntity(), {
+		id: `property-${deviceNumber}-${channelNumber}-${propertyNumber}`,
+		identifier: category,
+		name: category,
+		category,
+		value: new PropertyValueState(value, DEFAULT_TIMESTAMP, 'stable'),
+	});
+
+/**
+ * Produce the raw entity graph returned by DevicesService/SpacesService. Every
+ * device has three channels and five total properties so scale evaluations
+ * exercise both nested and flattened Buddy context representations.
+ */
+export function createBuddyDeviceEntityFixtures(
+	deviceCount: number,
+	options: BuddyContextFixtureOptions = {},
+): DeviceEntity[] {
+	const offset = options.deviceIndexOffset ?? 0;
+
+	return Array.from({ length: deviceCount }, (_, fixtureIndex) => {
+		const index = offset + fixtureIndex;
+		const deviceNumber = pad(index + 1);
+		const deviceId = `device-${deviceNumber}`;
+		const spaceId = getSpaceId(index, options);
+		const channelDefinitions: FixtureChannelDefinition[] = [
+			{
+				identifier: 'light',
+				properties: [
+					[PropertyCategory.ON, index % 2 === 0],
+					[PropertyCategory.BRIGHTNESS, (index * 7) % 101],
+				],
+			},
+			{
+				identifier: 'environment',
+				properties: [
+					[PropertyCategory.TEMPERATURE, 18 + (index % 12) * 0.5],
+					[PropertyCategory.HUMIDITY, 35 + (index % 45)],
+				],
+			},
+			{
+				identifier: 'energy',
+				properties: [[PropertyCategory.POWER, 5 + (index % 250)]],
+			},
+		];
+
+		const channels = channelDefinitions.map((definition, channelIndex) => {
+			const channelNumber = channelIndex + 1;
+			const channel = Object.assign(new ChannelEntity(), {
+				id: `channel-${deviceNumber}-${channelNumber}`,
+				identifier: definition.identifier,
+				name: definition.identifier,
+				properties: definition.properties.map(([category, value], propertyIndex) =>
+					createProperty(deviceNumber, channelNumber, propertyIndex + 1, category, value),
+				),
+			});
+
+			return channel;
+		});
+
+		const device = Object.assign(new DeviceEntity(), {
+			id: deviceId,
+			identifier: deviceId,
+			name: `Evaluation device ${deviceNumber}`,
+			category: DeviceCategory.LIGHTING,
+			roomId: spaceId,
+			channels,
+		});
+
+		return device;
+	});
+}
+
+/** Produce the flattened snapshot consumed by Buddy prompts and evaluators. */
+export function createBuddyContextFixture(deviceCount: number, options: BuddyContextFixtureOptions = {}): BuddyContext {
+	const devices = createBuddyDeviceEntityFixtures(deviceCount, options).map((device) => {
+		const state: Record<string, unknown> = {};
+		const channels = device.channels.map((channel) => ({
+			id: channel.id,
+			name: channel.identifier ?? channel.name ?? channel.id,
+			properties: channel.properties.map((property) => {
+				const value = property.value?.value ?? null;
+
+				state[`${channel.identifier ?? channel.name ?? channel.id}.${property.category}`] = value;
+
+				return { id: property.id, category: property.category, value };
+			}),
+		}));
+
+		return {
+			id: device.id,
+			name: device.name,
+			space: device.roomId,
+			category: device.category,
+			state,
+			channels,
+		};
+	});
+
+	const deviceCountsBySpace = new Map<string, number>();
+
+	for (const device of devices) {
+		if (device.space) {
+			deviceCountsBySpace.set(device.space, (deviceCountsBySpace.get(device.space) ?? 0) + 1);
+		}
+	}
+
+	return {
+		timestamp: options.timestamp ?? DEFAULT_TIMESTAMP,
+		timezone: options.timezone ?? 'UTC',
+		spaces: [...deviceCountsBySpace].map(([id, count]) => ({
+			id,
+			name: `Evaluation ${id}`,
+			category: 'living_room',
+			deviceCount: count,
+		})),
+		devices,
+		scenes: [],
+		weather: null,
+		energy: null,
+		recentIntents: [],
+	};
+}

--- a/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts
+++ b/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts
@@ -1,0 +1,180 @@
+export type BuddyContextEvaluationStrategy =
+	| 'no-home-context'
+	| 'model-tools'
+	| 'prefetch'
+	| 'deterministic-action'
+	| 'clarify';
+
+export type BuddyContextEvaluationDomain = 'general' | 'home' | 'weather' | 'energy' | 'security' | 'history';
+
+export interface BuddyContextEvaluationCase {
+	id: string;
+	message: string;
+	conversationSpaceId: string | null;
+	expectedDomains: BuddyContextEvaluationDomain[];
+	expectedStrategy: BuddyContextEvaluationStrategy;
+	expectsAction: boolean;
+	currentEagerSnapshot: true;
+}
+
+/**
+ * Stable message corpus used from Phase 0 through the production-path switch.
+ *
+ * Phase 0 characterizes today's eager behavior. Later phases keep the same rows
+ * and change assertions to the expected bounded strategy and domains.
+ */
+export const BUDDY_CONTEXT_EVALUATION_MATRIX: readonly BuddyContextEvaluationCase[] = [
+	{
+		id: 'casual-greeting',
+		message: 'Hi',
+		conversationSpaceId: null,
+		expectedDomains: ['general'],
+		expectedStrategy: 'no-home-context',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'general-explanation',
+		message: 'How does a thermostat work?',
+		conversationSpaceId: null,
+		expectedDomains: ['general'],
+		expectedStrategy: 'no-home-context',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'scoped-current-state',
+		message: 'What is the bedroom temperature?',
+		conversationSpaceId: null,
+		expectedDomains: ['home'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'contextual-current-state',
+		message: 'Is it too warm in here?',
+		conversationSpaceId: 'space-000',
+		expectedDomains: ['home'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'global-aggregate',
+		message: 'Are any windows open?',
+		conversationSpaceId: null,
+		expectedDomains: ['home'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'target-discovery',
+		message: 'Which lights can I dim?',
+		conversationSpaceId: null,
+		expectedDomains: ['home'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'exact-device-control',
+		message: 'Set kitchen light to 40%',
+		conversationSpaceId: 'space-000',
+		expectedDomains: ['home'],
+		expectedStrategy: 'deterministic-action',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'ambiguous-control',
+		message: 'Turn on the lamp',
+		conversationSpaceId: null,
+		expectedDomains: ['home'],
+		expectedStrategy: 'clarify',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'scene-trigger',
+		message: 'Start movie night',
+		conversationSpaceId: null,
+		expectedDomains: ['home'],
+		expectedStrategy: 'deterministic-action',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'weather',
+		message: 'Will it rain tomorrow?',
+		conversationSpaceId: null,
+		expectedDomains: ['weather'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'energy',
+		message: 'How much power did we use today?',
+		conversationSpaceId: null,
+		expectedDomains: ['energy'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'security',
+		message: 'Is the house secure?',
+		conversationSpaceId: null,
+		expectedDomains: ['security'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'historical',
+		message: 'Graph the living-room temperature for 24 hours',
+		conversationSpaceId: null,
+		expectedDomains: ['home', 'history'],
+		expectedStrategy: 'model-tools',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'recent-reference-follow-up',
+		message: 'Turn it off',
+		conversationSpaceId: 'space-000',
+		expectedDomains: ['home'],
+		expectedStrategy: 'clarify',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'compound-multi-domain',
+		message: 'If it is colder outside, lower the office thermostat',
+		conversationSpaceId: null,
+		expectedDomains: ['home', 'weather'],
+		expectedStrategy: 'model-tools',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'unsupported-domain',
+		message: 'Book a flight',
+		conversationSpaceId: null,
+		expectedDomains: ['general'],
+		expectedStrategy: 'no-home-context',
+		expectsAction: false,
+		currentEagerSnapshot: true,
+	},
+];
+
+export const BUDDY_CONTEXT_CURRENT_BASELINE = {
+	maxStoredHistoryRows: 19,
+	promptBudgetRatio: 0.8,
+	eagerDomains: ['spaces', 'devices', 'scenes', 'weather', 'energy'] as const,
+	optionalDomainFailure: 'omit-domain-and-continue',
+	providerFailure: 'abort-before-message-persistence',
+	toolResultTransport: 'status-and-message-only',
+} as const;

--- a/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts
+++ b/apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts
@@ -7,10 +7,23 @@ export type BuddyContextEvaluationStrategy =
 
 export type BuddyContextEvaluationDomain = 'general' | 'home' | 'weather' | 'energy' | 'security' | 'history';
 
+export interface BuddyContextEvaluationEntityReference {
+	kind: 'device' | 'space' | 'scene' | 'property';
+	id: string;
+	name: string;
+}
+
+export interface BuddyContextEvaluationPriorTurn {
+	role: 'user' | 'assistant';
+	content: string;
+	entityReferences?: readonly BuddyContextEvaluationEntityReference[];
+}
+
 export interface BuddyContextEvaluationCase {
 	id: string;
 	message: string;
 	conversationSpaceId: string | null;
+	priorTurns?: readonly BuddyContextEvaluationPriorTurn[];
 	expectedDomains: BuddyContextEvaluationDomain[];
 	expectedStrategy: BuddyContextEvaluationStrategy;
 	expectsAction: boolean;
@@ -142,9 +155,46 @@ export const BUDDY_CONTEXT_EVALUATION_MATRIX: readonly BuddyContextEvaluationCas
 		currentEagerSnapshot: true,
 	},
 	{
-		id: 'recent-reference-follow-up',
+		id: 'recent-reference-follow-up-resolvable',
 		message: 'Turn it off',
 		conversationSpaceId: 'space-000',
+		priorTurns: [
+			{ role: 'user', content: 'Turn on the reading lamp.' },
+			{
+				role: 'assistant',
+				content: 'The reading lamp is now on.',
+				entityReferences: [{ kind: 'device', id: 'device-reading-lamp', name: 'Reading lamp' }],
+			},
+		],
+		expectedDomains: ['home'],
+		expectedStrategy: 'deterministic-action',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'recent-reference-follow-up-missing',
+		message: 'Turn it off',
+		conversationSpaceId: 'space-000',
+		expectedDomains: ['home'],
+		expectedStrategy: 'clarify',
+		expectsAction: true,
+		currentEagerSnapshot: true,
+	},
+	{
+		id: 'recent-reference-follow-up-ambiguous',
+		message: 'Turn it off',
+		conversationSpaceId: 'space-000',
+		priorTurns: [
+			{ role: 'user', content: 'Turn on both bedside lamps.' },
+			{
+				role: 'assistant',
+				content: 'Both bedside lamps are now on.',
+				entityReferences: [
+					{ kind: 'device', id: 'device-left-bedside-lamp', name: 'Left bedside lamp' },
+					{ kind: 'device', id: 'device-right-bedside-lamp', name: 'Right bedside lamp' },
+				],
+			},
+		],
 		expectedDomains: ['home'],
 		expectedStrategy: 'clarify',
 		expectsAction: true,

--- a/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.spec.ts
+++ b/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.spec.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod';
+
+import { buildOllamaRequestPayload } from '../../../plugins/buddy-ollama/platforms/ollama.provider';
+import { buildOpenAiCodexRequestPayload } from '../../../plugins/buddy-openai-codex/platforms/openai-codex.provider';
+import { ToolAccessKind, ToolAudience, createToolDefinition } from '../../tools/platforms/tool-provider.platform';
+import { MessageRole } from '../buddy.constants';
+import { buildAnthropicRequestPayload } from '../platforms/anthropic-sdk.utils';
+import { ChatMessage } from '../platforms/llm-provider.platform';
+import { buildOpenAiRequestPayload } from '../platforms/openai-sdk.utils';
+
+import {
+	estimateConservativeTokens,
+	measureJsonUtf8Bytes,
+	measureLlmRequestPayload,
+} from './llm-request-measurement.helper';
+
+const messages: ChatMessage[] = [
+	{ role: MessageRole.USER, content: 'Turn on the kitchen light' },
+	{ role: MessageRole.ASSISTANT, content: 'Which kitchen light?' },
+	{ role: MessageRole.USER, content: 'The ceiling light' },
+];
+
+const nestedTool = createToolDefinition({
+	name: 'set_device_property',
+	description: 'Set a writable property',
+	audiences: [ToolAudience.BUDDY],
+	access: ToolAccessKind.WRITE,
+	inputSchema: z.object({
+		target: z.object({
+			deviceId: z.string().uuid(),
+			property: z.object({ category: z.string(), value: z.union([z.string(), z.number(), z.boolean()]) }),
+		}),
+	}),
+	outputSchema: z.object({ success: z.boolean() }),
+});
+
+describe('native LLM request payload builders', () => {
+	it('builds OpenAI and Anthropic payloads with their native output caps', () => {
+		const openAi = buildOpenAiRequestPayload('gpt-test', 'system', messages, 321, [nestedTool]);
+		const anthropic = buildAnthropicRequestPayload('claude-test', 'system', messages, 321, [nestedTool]);
+
+		expect(openAi).toMatchObject({ model: 'gpt-test', max_completion_tokens: 321 });
+		expect(anthropic).toMatchObject({ model: 'claude-test', max_tokens: 321, system: 'system' });
+		expect(openAi.tools).toEqual([
+			{
+				type: 'function',
+				function: {
+					name: nestedTool.name,
+					description: nestedTool.description,
+					parameters: nestedTool.parameters,
+				},
+			},
+		]);
+		expect(anthropic.tools).toEqual([
+			{
+				name: nestedTool.name,
+				description: nestedTool.description,
+				input_schema: nestedTool.parameters,
+			},
+		]);
+	});
+
+	it('characterizes Ollama and Codex as currently omitting maxTokens', () => {
+		const ollama = buildOllamaRequestPayload('llama-test', 'system', messages, [nestedTool]);
+		const codex = buildOpenAiCodexRequestPayload('codex-test', 'system', messages, [nestedTool]);
+
+		expect(ollama).not.toHaveProperty('options.num_predict');
+		expect(codex).not.toHaveProperty('max_output_tokens');
+		expect(ollama.tools).toEqual([
+			{
+				type: 'function',
+				function: {
+					name: nestedTool.name,
+					description: nestedTool.description,
+					parameters: nestedTool.parameters,
+				},
+			},
+		]);
+		expect(codex.tools).toEqual([
+			{
+				type: 'function',
+				name: nestedTool.name,
+				description: nestedTool.description,
+				parameters: nestedTool.parameters,
+			},
+		]);
+	});
+
+	it('serializes only native tool fields and excludes runtime Zod metadata', () => {
+		const payloads = [
+			buildOpenAiRequestPayload('gpt-test', 'system', messages, 321, [nestedTool]),
+			buildAnthropicRequestPayload('claude-test', 'system', messages, 321, [nestedTool]),
+			buildOllamaRequestPayload('llama-test', 'system', messages, [nestedTool]),
+			buildOpenAiCodexRequestPayload('codex-test', 'system', messages, [nestedTool]),
+		];
+
+		for (const payload of payloads) {
+			const serialized = JSON.stringify(payload);
+
+			expect(serialized).toContain('deviceId');
+			expect(serialized).toContain('property');
+			expect(serialized).not.toContain('inputSchema');
+			expect(serialized).not.toContain('outputSchema');
+			expect(serialized).not.toContain('audiences');
+			expect(serialized).not.toContain('Zod');
+		}
+	});
+});
+
+describe('LLM request measurement', () => {
+	it('measures exact compact JSON UTF-8 bytes conservatively', () => {
+		const value = { message: 'Žárovka 💡' };
+
+		expect(measureJsonUtf8Bytes(value)).toBe(Buffer.byteLength(JSON.stringify(value), 'utf8'));
+		expect(estimateConservativeTokens(value)).toBe(Math.ceil(Buffer.byteLength(JSON.stringify(value), 'utf8') / 3));
+	});
+
+	it('accounts for native components, reserve, framing, and the window', () => {
+		const payload = buildOpenAiRequestPayload(
+			'gpt-test',
+			'stable system prompt',
+			[
+				...messages,
+				{ role: MessageRole.ASSISTANT, content: '[Executing tools: get_device]' },
+				{
+					role: MessageRole.USER,
+					content: '[Tool execution results]\nDevice is on\n\nPlease provide a natural language response.',
+				},
+			],
+			321,
+			[nestedTool],
+		);
+		const measurement = measureLlmRequestPayload(payload, {
+			contextWindowTokens: 512,
+			requestedOutputTokens: 321,
+			providerFramingTokens: 25,
+			safetyMarginTokens: 10,
+		});
+
+		expect(measurement.jsonUtf8Bytes).toBe(Buffer.byteLength(JSON.stringify(payload), 'utf8'));
+		expect(measurement.components.system.jsonUtf8Bytes).toBeGreaterThan(0);
+		expect(measurement.components.history.jsonUtf8Bytes).toBeGreaterThan(0);
+		expect(measurement.components.current.jsonUtf8Bytes).toBeGreaterThan(0);
+		expect(measurement.components.tools.jsonUtf8Bytes).toBeGreaterThan(0);
+		expect(measurement.components.toolResults.jsonUtf8Bytes).toBeGreaterThan(0);
+		expect(measurement.output).toEqual({ requestedTokens: 321, nativeCapTokens: 321, status: 'enforced' });
+		expect(measurement.availableInputTokens).toBe(156);
+		expect(measurement.fitsWindow).toBe(measurement.estimatedInputTokens <= 156);
+	});
+
+	it('reports missing and mismatched native output caps', () => {
+		const ollama = measureLlmRequestPayload(buildOllamaRequestPayload('llama-test', 'system', messages), {
+			contextWindowTokens: 8_192,
+			requestedOutputTokens: 512,
+		});
+		const anthropic = measureLlmRequestPayload(buildAnthropicRequestPayload('claude-test', 'system', messages, 256), {
+			contextWindowTokens: 8_192,
+			requestedOutputTokens: 512,
+		});
+
+		expect(ollama.output).toEqual({ requestedTokens: 512, nativeCapTokens: null, status: 'missing' });
+		expect(anthropic.output).toEqual({ requestedTokens: 512, nativeCapTokens: 256, status: 'mismatched' });
+	});
+});

--- a/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.ts
+++ b/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.ts
@@ -1,0 +1,227 @@
+export interface LlmRequestMeasurementOptions {
+	contextWindowTokens: number;
+	requestedOutputTokens: number;
+	providerFramingTokens?: number;
+	safetyMarginTokens?: number;
+}
+
+export interface LlmRequestComponentMeasurement {
+	jsonUtf8Bytes: number;
+	estimatedTokens: number;
+}
+
+export type LlmOutputCapStatus = 'enforced' | 'missing' | 'mismatched';
+
+export interface LlmRequestMeasurement {
+	jsonUtf8Bytes: number;
+	estimatedInputTokens: number;
+	components: {
+		system: LlmRequestComponentMeasurement;
+		history: LlmRequestComponentMeasurement;
+		current: LlmRequestComponentMeasurement;
+		tools: LlmRequestComponentMeasurement;
+		toolResults: LlmRequestComponentMeasurement;
+		other: LlmRequestComponentMeasurement;
+	};
+	output: {
+		requestedTokens: number;
+		nativeCapTokens: number | null;
+		status: LlmOutputCapStatus;
+	};
+	availableInputTokens: number;
+	fitsWindow: boolean;
+}
+
+interface NativeMessage {
+	role?: unknown;
+	type?: unknown;
+	content?: unknown;
+	[key: string]: unknown;
+}
+
+const TOOL_RESULT_PREFIX = '[Tool execution results]';
+const TOOL_EXECUTION_PREFIX = '[Executing tools:';
+
+/** Return the byte size of the exact compact JSON representation used on the wire. */
+export function measureJsonUtf8Bytes(value: unknown): number {
+	if (value === undefined) {
+		return 0;
+	}
+
+	const serialized = JSON.stringify(value);
+
+	return serialized === undefined ? 0 : Buffer.byteLength(serialized, 'utf8');
+}
+
+/**
+ * Common Phase 0 estimate for providers without an exact tokenizer.
+ * Three UTF-8 bytes per token deliberately errs above the usual four-character heuristic.
+ */
+export function estimateConservativeTokens(value: unknown): number {
+	return Math.ceil(measureJsonUtf8Bytes(value) / 3);
+}
+
+/** Measure the complete native provider request without retaining runtime-only tool schema objects. */
+export function measureLlmRequestPayload(
+	payload: Record<string, unknown>,
+	options: LlmRequestMeasurementOptions,
+): LlmRequestMeasurement {
+	const nativeCapTokens = readNativeOutputCap(payload);
+	const messages = readMessages(payload);
+	const systemMessages = messages.filter((message) => message.role === 'system');
+	const conversationalMessages = messages.filter((message) => message.role !== 'system');
+	const toolResults = conversationalMessages.filter(isToolResultMessage);
+	const ordinaryMessages = conversationalMessages.filter((message) => !isToolResultMessage(message));
+	const currentIndex = findCurrentMessageIndex(ordinaryMessages);
+	const current = currentIndex === -1 ? [] : [ordinaryMessages[currentIndex]];
+	const history = ordinaryMessages.filter((_, index) => index !== currentIndex);
+	const system = [payload.system, payload.instructions, ...systemMessages].filter((value) => value !== undefined);
+	const tools = Array.isArray(payload.tools) ? payload.tools : [];
+	const other = omitMeasuredFields(payload);
+	const inputPayload = omitNativeOutputCap(payload);
+	const providerFramingTokens = options.providerFramingTokens ?? 0;
+	const safetyMarginTokens = options.safetyMarginTokens ?? 0;
+	const availableInputTokens = Math.max(
+		0,
+		options.contextWindowTokens - options.requestedOutputTokens - providerFramingTokens - safetyMarginTokens,
+	);
+	const estimatedInputTokens = estimateConservativeTokens(inputPayload);
+
+	return {
+		jsonUtf8Bytes: measureJsonUtf8Bytes(payload),
+		estimatedInputTokens,
+		components: {
+			system: measureComponent(system),
+			history: measureComponent(history),
+			current: measureComponent(current),
+			tools: measureComponent(tools),
+			toolResults: measureComponent(toolResults),
+			other: measureComponent(other),
+		},
+		output: {
+			requestedTokens: options.requestedOutputTokens,
+			nativeCapTokens,
+			status:
+				nativeCapTokens === null
+					? 'missing'
+					: nativeCapTokens === options.requestedOutputTokens
+						? 'enforced'
+						: 'mismatched',
+		},
+		availableInputTokens,
+		fitsWindow: estimatedInputTokens <= availableInputTokens,
+	};
+}
+
+function measureComponent(value: unknown[] | Record<string, unknown>): LlmRequestComponentMeasurement {
+	if (Array.isArray(value) && value.length === 0) {
+		return { jsonUtf8Bytes: 0, estimatedTokens: 0 };
+	}
+
+	if (!Array.isArray(value) && Object.keys(value).length === 0) {
+		return { jsonUtf8Bytes: 0, estimatedTokens: 0 };
+	}
+
+	return {
+		jsonUtf8Bytes: measureJsonUtf8Bytes(value),
+		estimatedTokens: estimateConservativeTokens(value),
+	};
+}
+
+function readMessages(payload: Record<string, unknown>): NativeMessage[] {
+	const candidate = Array.isArray(payload.messages)
+		? payload.messages
+		: Array.isArray(payload.input)
+			? payload.input
+			: [];
+
+	return candidate.filter(isRecord);
+}
+
+function isToolResultMessage(message: NativeMessage): boolean {
+	if (message.role === 'tool' || message.type === 'function_call_output' || message.type === 'tool_result') {
+		return true;
+	}
+
+	if (typeof message.content === 'string') {
+		return message.content.startsWith(TOOL_RESULT_PREFIX) || message.content.startsWith(TOOL_EXECUTION_PREFIX);
+	}
+
+	return (
+		Array.isArray(message.content) &&
+		message.content.some(
+			(block) => isRecord(block) && (block.type === 'tool_result' || block.type === 'function_call_output'),
+		)
+	);
+}
+
+function findCurrentMessageIndex(messages: NativeMessage[]): number {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		if (messages[index].role === 'user') {
+			return index;
+		}
+	}
+
+	return messages.length - 1;
+}
+
+function omitMeasuredFields(payload: Record<string, unknown>): Record<string, unknown> {
+	const result = { ...payload };
+
+	delete result.system;
+	delete result.instructions;
+	delete result.messages;
+	delete result.input;
+	delete result.tools;
+	delete result.max_tokens;
+	delete result.max_completion_tokens;
+	delete result.max_output_tokens;
+
+	if (isRecord(result.options)) {
+		const nativeOptions = { ...result.options };
+
+		delete nativeOptions.num_predict;
+		result.options = nativeOptions;
+	}
+
+	return result;
+}
+
+function omitNativeOutputCap(payload: Record<string, unknown>): Record<string, unknown> {
+	const result = { ...payload };
+
+	delete result.max_tokens;
+	delete result.max_completion_tokens;
+	delete result.max_output_tokens;
+
+	if (isRecord(result.options)) {
+		const nativeOptions = { ...result.options };
+
+		delete nativeOptions.num_predict;
+		result.options = nativeOptions;
+	}
+
+	return result;
+}
+
+function readNativeOutputCap(payload: Record<string, unknown>): number | null {
+	for (const value of [payload.max_completion_tokens, payload.max_tokens, payload.max_output_tokens]) {
+		if (typeof value === 'number' && Number.isFinite(value)) {
+			return value;
+		}
+	}
+
+	if (isRecord(payload.options)) {
+		const value = payload.options.num_predict;
+
+		if (typeof value === 'number' && Number.isFinite(value)) {
+			return value;
+		}
+	}
+
+	return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.ts
+++ b/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.ts
@@ -29,6 +29,39 @@ interface OllamaResponse {
 	done_reason?: string;
 }
 
+/** Build the exact JSON payload sent to Ollama's chat endpoint. */
+export function buildOllamaRequestPayload(
+	model: string,
+	systemPrompt: string,
+	messages: ChatMessage[],
+	tools?: ToolDefinition[],
+): Record<string, unknown> {
+	const requestPayload: Record<string, unknown> = {
+		model,
+		stream: false,
+		messages: [
+			{ role: 'system', content: systemPrompt },
+			...messages.map((message) => ({
+				role: message.role === MessageRole.USER ? 'user' : 'assistant',
+				content: message.content,
+			})),
+		],
+	};
+
+	if (tools && tools.length > 0) {
+		requestPayload.tools = tools.map((tool) => ({
+			type: 'function',
+			function: {
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.parameters,
+			},
+		}));
+	}
+
+	return requestPayload;
+}
+
 @Injectable()
 export class OllamaProvider implements ILlmProvider {
 	constructor(private readonly configService: ConfigService) {}
@@ -76,21 +109,7 @@ export class OllamaProvider implements ILlmProvider {
 		const start = Date.now();
 
 		try {
-			const requestPayload: Record<string, unknown> = {
-				model: resolvedModel,
-				stream: false,
-				messages: [
-					{ role: 'system', content: systemPrompt },
-					...messages.map((m) => ({
-						role: m.role === MessageRole.USER ? 'user' : 'assistant',
-						content: m.content,
-					})),
-				],
-			};
-
-			if (options?.tools && options.tools.length > 0) {
-				requestPayload.tools = this.formatTools(options.tools);
-			}
+			const requestPayload = buildOllamaRequestPayload(resolvedModel, systemPrompt, messages, options?.tools);
 
 			const response = await fetch(`${baseUrl}/api/chat`, {
 				method: 'POST',
@@ -136,17 +155,6 @@ export class OllamaProvider implements ILlmProvider {
 		} finally {
 			clearTimeout(timeoutId);
 		}
-	}
-
-	private formatTools(tools: ToolDefinition[]): unknown[] {
-		return tools.map((t) => ({
-			type: 'function',
-			function: {
-				name: t.name,
-				description: t.description,
-				parameters: t.parameters,
-			},
-		}));
 	}
 
 	private getPluginConfig(): BuddyOllamaConfigModel | null {

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -19,6 +19,34 @@ import {
 } from '../buddy-openai-codex.constants';
 import { BuddyOpenaiCodexConfigModel } from '../models/config.model';
 
+/** Build the exact JSON payload sent to the OpenAI Codex Responses endpoint. */
+export function buildOpenAiCodexRequestPayload(
+	model: string,
+	systemPrompt: string,
+	messages: ChatMessage[],
+	tools?: ToolDefinition[],
+): Record<string, unknown> {
+	return {
+		model,
+		instructions: systemPrompt,
+		input: messages.map((message) => ({
+			role: message.role === MessageRole.USER ? 'user' : 'assistant',
+			content: message.content,
+			type: 'message',
+		})),
+		stream: true,
+		store: false,
+		tools:
+			tools?.map((tool) => ({
+				type: 'function',
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.parameters,
+			})) ?? [],
+		tool_choice: 'auto',
+	};
+}
+
 @Injectable()
 export class OpenAiCodexProvider implements ILlmProvider {
 	private readonly tokenManager = new OAuthTokenManager({
@@ -74,15 +102,7 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		const resolvedModel = config?.model ?? model;
 		const timeout = options?.timeout ?? 30_000;
 
-		// Build input array matching the Codex Responses API format
-		const input = messages.map((m) => ({
-			role: m.role === MessageRole.USER ? 'user' : 'assistant',
-			content: m.content,
-			type: 'message',
-		}));
-
-		// Build tools in Responses API format
-		const tools = this.formatTools(options?.tools);
+		const requestPayload = buildOpenAiCodexRequestPayload(resolvedModel, systemPrompt, messages, options?.tools);
 
 		// ChatGPT backend requires streaming. We collect SSE chunks and assemble the response.
 		const controller = new AbortController();
@@ -97,15 +117,7 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					Authorization: `Bearer ${accessToken}`,
 					'Content-Type': 'application/json',
 				},
-				body: JSON.stringify({
-					model: resolvedModel,
-					instructions: systemPrompt,
-					input,
-					stream: true,
-					store: false,
-					tools,
-					tool_choice: 'auto',
-				}),
+				body: JSON.stringify(requestPayload),
 				signal: controller.signal,
 			});
 
@@ -135,19 +147,6 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		} finally {
 			clearTimeout(timeoutId);
 		}
-	}
-
-	private formatTools(tools?: ToolDefinition[]): unknown[] {
-		if (!tools || tools.length === 0) {
-			return [];
-		}
-
-		return tools.map((t) => ({
-			type: 'function',
-			name: t.name,
-			description: t.description,
-			parameters: t.parameters,
-		}));
 	}
 
 	private async collectStreamResponse(response: Response): Promise<{ content: string; toolCalls: LlmToolCall[] }> {

--- a/apps/backend/test/buddy-context.buddy-context-soak.ts
+++ b/apps/backend/test/buddy-context.buddy-context-soak.ts
@@ -1,0 +1,90 @@
+import { ActionObserverService } from '../src/modules/buddy/services/action-observer.service';
+import { BuddyContextService } from '../src/modules/buddy/services/buddy-context.service';
+import {
+	BUDDY_CONTEXT_SCALE_DEVICE_COUNTS,
+	BUDDY_CONTEXT_SOAK_DEVICE_COUNT,
+	createBuddyContextFixture,
+	createBuddyDeviceEntityFixtures,
+} from '../src/modules/buddy/testing/buddy-context-evaluation.fixtures';
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { DevicesService } from '../src/modules/devices/services/devices.service';
+import { EnergyDataService } from '../src/modules/energy/services/energy-data.service';
+import { ScenesService } from '../src/modules/scenes/services/scenes.service';
+import { SpacesService } from '../src/modules/spaces/services/spaces.service';
+import { WeatherService } from '../src/modules/weather/services/weather.service';
+
+const BUDDY_CONTEXT_SOAK_COUNTS = [...BUDDY_CONTEXT_SCALE_DEVICE_COUNTS, BUDDY_CONTEXT_SOAK_DEVICE_COUNT] as const;
+
+describe('Buddy context scale soak', () => {
+	it.each(BUDDY_CONTEXT_SOAK_COUNTS)(
+		'records the eager $deviceCount-device snapshot query, result, latency, and heap footprint',
+		async (deviceCount) => {
+			const rawDevices = createBuddyDeviceEntityFixtures(deviceCount, { spaceCount: 20 });
+			const expectedContext = createBuddyContextFixture(deviceCount, { spaceCount: 20 });
+			const spaces = expectedContext.spaces.map((space) => ({
+				id: space.id,
+				name: space.name,
+				category: space.category,
+			}));
+			const spacesService = {
+				findAll: jest.fn().mockResolvedValue(spaces),
+				findOne: jest.fn(),
+				findDevicesBySpace: jest
+					.fn()
+					.mockImplementation((spaceId: string) =>
+						Promise.resolve(rawDevices.filter((device) => device.roomId === spaceId)),
+					),
+			};
+			const devicesService = { findAll: jest.fn().mockResolvedValue(rawDevices) };
+			const scenesService = { findAll: jest.fn().mockResolvedValue([]), findBySpace: jest.fn().mockResolvedValue([]) };
+			const weatherService = { getPrimaryWeather: jest.fn().mockResolvedValue(null) };
+			const energyDataService = { getDeltas: jest.fn().mockResolvedValue([]) };
+			const configService = { getModuleConfig: jest.fn().mockReturnValue({ timezone: 'UTC' }) };
+			const service = new BuddyContextService(
+				configService as unknown as ConfigService,
+				spacesService as unknown as SpacesService,
+				devicesService as unknown as DevicesService,
+				scenesService as unknown as ScenesService,
+				weatherService as unknown as WeatherService,
+				energyDataService as unknown as EnergyDataService,
+				new ActionObserverService(),
+			);
+			const heapBefore = process.memoryUsage().heapUsed;
+			const startedAt = performance.now();
+			const context = await service.buildContext();
+			const durationMs = performance.now() - startedAt;
+			const heapDeltaBytes = Math.max(0, process.memoryUsage().heapUsed - heapBefore);
+			const serializedBytes = Buffer.byteLength(JSON.stringify(context), 'utf8');
+			const propertyCount = context.devices.reduce(
+				(total, device) =>
+					total + device.channels.reduce((channelTotal, channel) => channelTotal + channel.properties.length, 0),
+				0,
+			);
+
+			expect(context.devices).toHaveLength(deviceCount);
+			expect(propertyCount).toBe(deviceCount * 5);
+			expect(context.devices.at(-1)?.id).toBe(expectedContext.devices.at(-1)?.id);
+			expect(spacesService.findAll).toHaveBeenCalledTimes(1);
+			expect(spacesService.findDevicesBySpace).toHaveBeenCalledTimes(spaces.length);
+			expect(devicesService.findAll).toHaveBeenCalledTimes(1);
+			expect(scenesService.findAll).toHaveBeenCalledTimes(1);
+			expect(weatherService.getPrimaryWeather).toHaveBeenCalledTimes(1);
+			expect(energyDataService.getDeltas).toHaveBeenCalledTimes(1);
+			expect(durationMs).toBeLessThan(30_000);
+			expect(heapDeltaBytes).toBeLessThan(512 * 1024 * 1024);
+
+			process.stdout.write(
+				`${JSON.stringify({
+					deviceCount: context.devices.length,
+					propertyCount,
+					spaceCount: context.spaces.length,
+					serializedBytes,
+					durationMs: Math.round(durationMs * 100) / 100,
+					heapDeltaBytes,
+					spaceCountQueries: spacesService.findDevicesBySpace.mock.calls.length,
+				})}\n`,
+			);
+		},
+		60_000,
+	);
+});

--- a/apps/backend/test/jest-buddy-context-soak.json
+++ b/apps/backend/test/jest-buddy-context-soak.json
@@ -1,0 +1,17 @@
+{
+	"moduleFileExtensions": ["js", "json", "ts"],
+	"rootDir": ".",
+	"testEnvironment": "node",
+	"testEnvironmentOptions": {
+		"globalsCleanup": "off"
+	},
+	"testRegex": "\\.buddy-context-soak\\.ts$",
+	"transform": {
+		"^.+\\.(t|j)s$": ["ts-jest", { "tsconfig": { "allowJs": true } }]
+	},
+	"transformIgnorePatterns": ["node_modules/(?!(.pnpm|uuid)/)"],
+	"moduleNameMapper": {
+		"^inquirer$": "<rootDir>/__mocks__/inquirer.ts"
+	},
+	"setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"]
+}

--- a/tasks/plans/buddy-adaptive-context-phase-0-baseline.md
+++ b/tasks/plans/buddy-adaptive-context-phase-0-baseline.md
@@ -9,7 +9,8 @@ This baseline characterizes the current eager Buddy conversation path before the
 It is deliberately a green test suite: known budget failures are asserted as measured current behavior, not left as
 failing CI tests.
 
-The deterministic corpus covers all 16 message classes from the plan. Today every row— including greetings, general
+The deterministic corpus covers 18 cases across all message classes from the plan, including resolvable, missing, and
+ambiguous recent-reference follow-ups. Today every row—including greetings, general
 questions, unsupported requests, and single-domain queries—calls `BuddyContextService.buildContext(...)` exactly once
 before provider dispatch. The future strategy/domain expectations are checked in at
 `apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts` and remain stable through the later phases.

--- a/tasks/plans/buddy-adaptive-context-phase-0-baseline.md
+++ b/tasks/plans/buddy-adaptive-context-phase-0-baseline.md
@@ -1,0 +1,113 @@
+# Buddy Adaptive Context — Phase 0 Baseline
+
+Date: 2026-08-14
+Plan: [plan-buddy-adaptive-context.md](./plan-buddy-adaptive-context.md)
+
+## Purpose
+
+This baseline characterizes the current eager Buddy conversation path before the provider-neutral retrieval work begins.
+It is deliberately a green test suite: known budget failures are asserted as measured current behavior, not left as
+failing CI tests.
+
+The deterministic corpus covers all 16 message classes from the plan. Today every row— including greetings, general
+questions, unsupported requests, and single-domain queries—calls `BuddyContextService.buildContext(...)` exactly once
+before provider dispatch. The future strategy/domain expectations are checked in at
+`apps/backend/src/modules/buddy/testing/buddy-context-evaluation.matrix.ts` and remain stable through the later phases.
+
+## Measurement Method
+
+- Scale fixtures contain 10, 100, and 1,000 devices; each device has three channels and five realistic boolean/numeric
+  properties in both raw entity and flattened `BuddyContext` forms.
+- Native request measurements use the same pure payload builders used by the production OpenAI Chat, Anthropic, Ollama,
+  and OpenAI Codex adapters.
+- Request byte counts use compact JSON and UTF-8 `Buffer.byteLength`.
+- The Phase 0 conservative estimate is `ceil(JSON UTF-8 bytes / 3)`. It is intentionally stricter than the legacy
+  four-characters-per-token prompt estimate and is not presented as an exact provider tokenizer.
+- The measured OpenAI request contains the system prompt, 19 stored history rows, the current user message, four nested
+  read/write/trigger tool schemas, provider framing, and a 1,024-token output cap.
+- Component byte/token measurements are diagnostic partitions. JSON framing overlaps, so component totals are not
+  expected to add exactly to the whole request.
+
+## Complete Native Request Baseline
+
+The table below uses a 128,000-token model window so it records size without rejecting the request.
+
+| Devices | Native JSON bytes | Conservative input tokens | System tokens | History tokens | Current tokens | Tool-schema tokens | Fits 128k |
+| ------: | ----------------: | ------------------------: | ------------: | -------------: | -------------: | -----------------: | :-------: |
+|      10 |             8,108 |                     2,693 |         1,422 |            674 |             29 |                557 |    yes    |
+|     100 |            22,669 |                     7,547 |         6,276 |            674 |             29 |                557 |    yes    |
+|   1,000 |             4,853 |                     1,608 |           337 |            674 |             29 |                557 |    yes    |
+
+The 1,000-device request is smaller than the 100-device request because the current renderer drops into coarse space
+summaries. That keeps bytes down but loses target/state coverage; it is not evidence that the eager snapshot scales.
+The full 1,000-device snapshot is still loaded before this truncation occurs.
+
+### Measured small-window violation
+
+For a 2,000-token window with a 1,024-token output reserve, 32 framing tokens, and a 128-token safety margin:
+
+| Available input | Measured input | Native JSON bytes | Result                      |
+| --------------: | -------------: | ----------------: | --------------------------- |
+|      816 tokens |   2,693 tokens |       8,108 bytes | over budget by 1,877 tokens |
+
+The legacy system-prompt-only check still reports the prompt at or below its 1,600-token allocation. The complete native
+request proves that history, the current message, schemas, framing, and output reserve make the provider call invalid for
+the configured window.
+
+## Current Query Footprint
+
+The characterization tests pin service-level calls without pretending that mocks are SQL-query measurements.
+
+| Scope        | Current calls                                                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Global       | `spaces.findAll` ×1, `spaces.findDevicesBySpace` × number of spaces, `devices.findAll` ×1, `scenes.findAll` ×1, weather ×1, energy ×1 |
+| Space-scoped | `spaces.findOne` ×1, `spaces.findDevicesBySpace` ×2 (count plus detail), `scenes.findBySpace` ×1, weather ×1, energy ×1               |
+
+The 1,000-device scoped characterization also proves that the last device, channel, property, and flattened state value
+reach the broad snapshot unchanged. Heartbeat forwards that exact `BuddyContext` object to every registered evaluator;
+individual evaluators continue to consume only the fields relevant to their rules.
+
+## Opt-in Scale/Latency Soak
+
+Run with `pnpm --filter @fastybird/smart-panel-backend run test:buddy-context-soak`. It is isolated from the normal Jest
+test regex and uses in-memory domain mocks, so its latency is a mapping/serialization baseline rather than a database or
+production SLA.
+
+| Devices | Properties | Spaces | Serialized snapshot bytes | Build duration | Additional heap | Space-count calls |
+| ------: | ---------: | -----: | ------------------------: | -------------: | --------------: | ----------------: |
+|      10 |         50 |     10 |                     8,161 |        0.89 ms |    0 B measured |                10 |
+|     100 |        500 |     20 |                    73,621 |        0.40 ms |       298,392 B |                20 |
+|   1,000 |      5,000 |     20 |                   720,474 |        1.56 ms |     2,451,856 B |                20 |
+|   5,000 |     25,000 |     20 |                 3,594,780 |        4.33 ms |    11,703,528 B |                20 |
+
+The opt-in guardrails are 30 seconds and 512 MiB additional heap per row. They are intentionally generous and detect
+runaway fixture/query behavior without turning machine-dependent microbenchmarks into normal CI failures.
+
+## Failure and Provider-Cap Characterization
+
+- Optional home-domain failures are omitted by `BuddyContextService` and the provider request continues with partial
+  context.
+- Provider failure aborts before user/assistant message persistence.
+- Current tool feedback carries status and message text only; structured `ToolExecutionResult.data` remains a later-phase
+  gap.
+- OpenAI Chat and Anthropic payloads enforce the requested native output cap.
+- Ollama and OpenAI Codex currently omit a native output cap. Phase 5 must close that gap; Phase 0 records it without
+  changing provider behavior.
+
+## Verification Commands
+
+```bash
+cd apps/backend
+pnpm exec jest --runInBand \
+  src/modules/buddy/testing/llm-request-measurement.helper.spec.ts \
+  src/modules/buddy/services/buddy-context.service.spec.ts \
+  src/modules/buddy/services/heartbeat.service.spec.ts \
+  src/modules/buddy/services/buddy-conversation.service.spec.ts
+pnpm run test:buddy-context-soak
+pnpm run type-check
+pnpm run lint:js
+```
+
+Phase 7 promotes the measured over-budget fixture into a required passing bounded-request assertion. The production
+conversation switch must keep the same message corpus while replacing `currentEagerSnapshot: true` with the expected
+strategy/domain assertions.

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1174,13 +1174,14 @@ regenerate checked-in artifacts from backend Swagger sources; never edit generat
 
 **Tasks:**
 
-- [ ] Add fixtures for 10, 100, and 1,000-device installations with realistic channels/properties.
-- [ ] Add an opt-in 5,000-device soak fixture outside normal unit CI for query/result/memory bounds.
-- [ ] Record current prompt/request size, domain-query counts, latency, and failure behavior for the message matrix.
-- [ ] Add a serialization-level test helper that measures the complete provider input, not only the system prompt.
-- [ ] Add characterization tests proving heartbeat/evaluators consume the broad `BuddyContextService` snapshot.
-- [ ] Define test thresholds and a checked-in evaluation matrix; do not rely on anecdotal manual prompts.
-- [ ] Record the eager small-window budget violation as a measured baseline fixture or opt-in expected-failure evaluation
+- [x] Add fixtures for 10, 100, and 1,000-device installations with realistic channels/properties.
+- [x] Add an opt-in 5,000-device soak fixture outside normal unit CI for query/result/memory bounds.
+- [x] Record current prompt/request size, domain-query counts, latency, and failure behavior for the message matrix in
+      [buddy-adaptive-context-phase-0-baseline.md](./buddy-adaptive-context-phase-0-baseline.md).
+- [x] Add a serialization-level test helper that measures the complete provider input, not only the system prompt.
+- [x] Add characterization tests proving heartbeat/evaluators consume the broad `BuddyContextService` snapshot.
+- [x] Define test thresholds and a checked-in evaluation matrix; do not rely on anecdotal manual prompts.
+- [x] Record the eager small-window budget violation as a measured baseline fixture or opt-in expected-failure evaluation
       excluded from normal CI. Keep the Phase 0 verification suite green; promote the fixture to a required passing
       bounded-request assertion when Phase 7 switches the production conversation path.
 - [ ] Confirm existing MCP context outputs/limits in tests before extracting them.


### PR DESCRIPTION
> 👍 Codex review passed on commit `bdec06a05` with no major issues.

## Summary

- add deterministic 10, 100, and 1,000-device Buddy fixtures plus an isolated 5,000-device soak suite
- measure exact native OpenAI, Anthropic, Ollama, and Codex request payloads, including history, tool schemas, output reserve, and UTF-8 framing
- characterize the current eager-context behavior across an 18-case message matrix and record the measured 2k-window overflow
- distinguish resolvable, missing, and ambiguous follow-up references with chronological history fixtures
- lock in the broad heartbeat/evaluator snapshot contract before conversational retrieval is split from evaluation context
- check off and document Phase 0 in the adaptive-context implementation plan

## Why

Buddy currently assembles the complete device/property snapshot before every conversation request. This PR creates a stable, provider-level baseline so later retrieval, budgeting, and MCP service reuse can be implemented without silently breaking evaluator behavior or moving the overflow elsewhere.

## Validation

- focused Buddy Jest suite: 4 suites, 104 tests, 2 snapshots passed
- opt-in Buddy context soak: 10/100/1,000/5,000-device rows passed
- backend type-check passed
- JavaScript lint and formatting checks passed
- `git diff --check` passed
- Codex review passed with 👍

A local repository-wide Jest run reaches a pre-existing Home Assistant websocket mock issue under Node 24; the changed Buddy suites pass independently, and the GitHub Actions backend unit/E2E job is the authoritative full-suite check.