### PR TITLE
test(backend): freeze MCP context contract

### DIFF
--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -306,6 +306,10 @@ describe('ChannelsPropertiesService', () => {
 				totals: { [mockChannel.id]: 45 },
 			});
 			expect(dataSource.query).toHaveBeenCalledWith(expect.stringContaining('ROW_NUMBER() OVER'), [mockChannel.id, 40]);
+			expect(dataSource.query).toHaveBeenCalledWith(
+				expect.stringContaining(`ORDER BY COALESCE(property."name", ''), property."id"`),
+				[mockChannel.id, 40],
+			);
 			expect(entityQuery.where).toHaveBeenCalledWith('property.id IN (:...propertyIds)', {
 				propertyIds: [mockChannelProperty.id],
 			});

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -276,6 +276,12 @@ describe('ChannelsPropertiesService', () => {
 				expect.stringContaining('property.permissions'),
 				expect.objectContaining({ readWrite: PermissionType.READ_WRITE, writeOnly: PermissionType.WRITE_ONLY }),
 			);
+			expect(queryBuilder.orderBy).toHaveBeenCalledTimes(1);
+			expect(queryBuilder.orderBy).toHaveBeenCalledWith('device.name', 'ASC');
+			expect(queryBuilder.addOrderBy).toHaveBeenCalledTimes(3);
+			expect(queryBuilder.addOrderBy).toHaveBeenNthCalledWith(1, 'channel.name', 'ASC');
+			expect(queryBuilder.addOrderBy).toHaveBeenNthCalledWith(2, 'property.name', 'ASC');
+			expect(queryBuilder.addOrderBy).toHaveBeenNthCalledWith(3, 'property.id', 'ASC');
 			expect(queryBuilder.callListeners).toHaveBeenCalledWith(false);
 			expect(queryBuilder.take).toHaveBeenCalledWith(100);
 			expect(queryBuilder.skip).toHaveBeenCalledWith(0);

--- a/apps/backend/src/modules/devices/services/channels.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.service.spec.ts
@@ -286,6 +286,11 @@ describe('ChannelsService', () => {
 				ChannelCategory.ALARM,
 				2,
 			]);
+			expect(dataSource.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY channel."name", channel."id"'), [
+				mockDevice.id,
+				ChannelCategory.ALARM,
+				2,
+			]);
 			expect(queryBuilderMock.where).toHaveBeenCalledWith('channel.id IN (:...channelIds)', {
 				channelIds: [mockChannel.id],
 			});

--- a/apps/backend/src/modules/devices/services/channels.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.service.spec.ts
@@ -259,6 +259,7 @@ describe('ChannelsService', () => {
 				total: 25,
 			});
 			expect(queryBuilderMock.innerJoin).toHaveBeenCalledWith('channel.device', 'device');
+			expect(queryBuilderMock.orderBy).toHaveBeenCalledWith('channel.name', 'ASC');
 			expect(queryBuilderMock.take).toHaveBeenCalledWith(20);
 		});
 	});

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -348,8 +348,8 @@ describe('DevicesService', () => {
 			expect(result.devices[0].zoneIds).toEqual(['selected-zone', 'other-zone']);
 		});
 
-		it('loads one visible device without channel relations', async () => {
-			const visibleDevice = toInstance(MockDevice, { ...mockDevice, hidden: false });
+		it('loads one disabled-but-visible device without channel relations', async () => {
+			const visibleDevice = toInstance(MockDevice, { ...mockDevice, enabled: false, hidden: false });
 			const queryBuilderMock: any = {
 				leftJoinAndSelect: jest.fn().mockReturnThis(),
 				where: jest.fn().mockReturnThis(),
@@ -359,9 +359,13 @@ describe('DevicesService', () => {
 			};
 			jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilderMock);
 
-			await expect(service.findVisibleSummaryById(mockDevice.id)).resolves.toEqual(visibleDevice);
+			await expect(service.findVisibleSummaryById(mockDevice.id)).resolves.toEqual(
+				expect.objectContaining({ id: visibleDevice.id, enabled: false, hidden: false }),
+			);
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledTimes(1);
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith('device.deviceZones', 'deviceZones');
+			expect(queryBuilderMock.andWhere).toHaveBeenCalledWith('device.hidden = :hidden', { hidden: false });
+			expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(expect.stringContaining('enabled'), expect.anything());
 			expect(queryBuilderMock.callListeners).toHaveBeenCalledWith(false);
 		});
 	});

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -272,6 +272,26 @@ describe('DevicesService', () => {
 	});
 
 	describe('findVisibleSummaryPage', () => {
+		it('includes disabled devices while excluding hidden devices at the query boundary', async () => {
+			const disabledVisibleDevice = toInstance(MockDevice, { ...mockDevice, enabled: false, hidden: false });
+			const queryBuilderMock: any = {
+				leftJoinAndSelect: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				orderBy: jest.fn().mockReturnThis(),
+				callListeners: jest.fn().mockReturnThis(),
+				take: jest.fn().mockReturnThis(),
+				getManyAndCount: jest.fn().mockResolvedValue([[disabledVisibleDevice], 1]),
+			};
+			jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilderMock);
+
+			await expect(service.findVisibleSummaryPage(100)).resolves.toEqual({
+				devices: [expect.objectContaining({ id: disabledVisibleDevice.id, enabled: false, hidden: false })],
+				total: 1,
+			});
+			expect(queryBuilderMock.where).toHaveBeenCalledWith('device.hidden = :hidden', { hidden: false });
+			expect(queryBuilderMock.where).not.toHaveBeenCalledWith(expect.stringContaining('enabled'), expect.anything());
+		});
+
 		it('bounds the query before loading device summaries', async () => {
 			const visibleDevice = toInstance(MockDevice, { ...mockDevice, hidden: false });
 			const queryBuilderMock: any = {

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -316,6 +316,7 @@ describe('DevicesService', () => {
 			});
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledTimes(1);
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith('device.deviceZones', 'deviceZones');
+			expect(queryBuilderMock.orderBy).toHaveBeenCalledWith('device.name', 'ASC');
 			expect(queryBuilderMock.take).toHaveBeenCalledWith(10);
 			expect(queryBuilderMock.callListeners).toHaveBeenCalledWith(false);
 			expect(queryBuilderMock.andWhere).toHaveBeenCalledWith('device.roomId IN (:...roomIds)', {

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -417,6 +417,11 @@ describe('DevicesService', () => {
 				'room-1',
 				2,
 			]);
+			expect(dataSource.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY device."name", device."id"'), [
+				ChannelCategory.ALARM,
+				'room-1',
+				2,
+			]);
 			expect(channelsService.findBoundedForDevices).toHaveBeenCalledWith(['device-1'], [ChannelCategory.ALARM], 10);
 			expect(propertiesService.findBoundedForChannels).toHaveBeenCalledWith(['channel-1'], 20, true, undefined);
 		});

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -277,6 +277,7 @@ describe('DevicesService', () => {
 			const queryBuilderMock: any = {
 				leftJoinAndSelect: jest.fn().mockReturnThis(),
 				where: jest.fn().mockReturnThis(),
+				andWhere: jest.fn().mockReturnThis(),
 				orderBy: jest.fn().mockReturnThis(),
 				callListeners: jest.fn().mockReturnThis(),
 				take: jest.fn().mockReturnThis(),
@@ -289,7 +290,10 @@ describe('DevicesService', () => {
 				total: 1,
 			});
 			expect(queryBuilderMock.where).toHaveBeenCalledWith('device.hidden = :hidden', { hidden: false });
-			expect(queryBuilderMock.where).not.toHaveBeenCalledWith(expect.stringContaining('enabled'), expect.anything());
+			const predicates = [...queryBuilderMock.where.mock.calls, ...queryBuilderMock.andWhere.mock.calls].map(
+				([predicate]: [unknown]) => predicate,
+			);
+			expect(predicates).not.toEqual(expect.arrayContaining([expect.stringContaining('enabled')]));
 		});
 
 		it('bounds the query before loading device summaries', async () => {
@@ -365,7 +369,10 @@ describe('DevicesService', () => {
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledTimes(1);
 			expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith('device.deviceZones', 'deviceZones');
 			expect(queryBuilderMock.andWhere).toHaveBeenCalledWith('device.hidden = :hidden', { hidden: false });
-			expect(queryBuilderMock.andWhere).not.toHaveBeenCalledWith(expect.stringContaining('enabled'), expect.anything());
+			const predicates = [...queryBuilderMock.where.mock.calls, ...queryBuilderMock.andWhere.mock.calls].map(
+				([predicate]: [unknown]) => predicate,
+			);
+			expect(predicates).not.toEqual(expect.arrayContaining([expect.stringContaining('enabled')]));
 			expect(queryBuilderMock.callListeners).toHaveBeenCalledWith(false);
 		});
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -17,10 +17,14 @@ import {
 	MCP_MAX_CONTEXT_DEVICES,
 	MCP_MAX_CONTEXT_SCENES,
 	MCP_MAX_CONTEXT_SPACES,
+	MCP_MAX_ENERGY_RANGE_DAYS,
+	MCP_MAX_FORECAST_DAYS,
 	MCP_MAX_PROPERTIES_PER_CHANNEL,
+	MCP_MAX_SECURITY_ALERTS,
 	MCP_MAX_SECURITY_CHANNELS_PER_DEVICE,
 	MCP_MAX_SECURITY_DEVICES,
 	MCP_MAX_SECURITY_PROPERTIES_PER_CHANNEL,
+	MCP_MAX_TIMESERIES_POINTS,
 	McpCapability,
 } from '../mcp.constants';
 
@@ -384,6 +388,41 @@ describe('McpContextService', () => {
 		expect(result.limits).toEqual(expect.objectContaining({ scenes_truncated: true }));
 	});
 
+	it('preserves disabled visible devices and scenes in the MCP snapshot', async () => {
+		devices.findVisibleSummaryPage.mockResolvedValue({
+			devices: [
+				{
+					id: 'disabled-device',
+					name: 'Disabled lamp',
+					category: 'lighting',
+					enabled: false,
+					hidden: false,
+					roomId: null,
+					zoneIds: [],
+				} as unknown as DeviceEntity,
+			],
+			total: 1,
+		});
+		scenes.findSummaryPage.mockResolvedValue({
+			scenes: [
+				{
+					id: 'disabled-scene',
+					name: 'Disabled scene',
+					category: 'generic',
+					enabled: false,
+					triggerable: false,
+					primarySpaceId: null,
+				},
+			],
+			total: 1,
+		});
+
+		const result = await service.getHomeContext();
+
+		expect(result.devices).toEqual([expect.objectContaining({ id: 'disabled-device', enabled: false })]);
+		expect(result.scenes).toEqual([expect.objectContaining({ id: 'disabled-scene', enabled: false })]);
+	});
+
 	it('marks bounded security output as incomplete when device selection is truncated', async () => {
 		security.getBoundedStatus.mockResolvedValue({
 			status: {
@@ -409,6 +448,32 @@ describe('McpContextService', () => {
 				state_truncated: true,
 			}),
 		);
+	});
+
+	it('caps security alerts and preserves alert truncation metadata', async () => {
+		security.getBoundedStatus.mockResolvedValue({
+			status: {
+				armedState: 'armed',
+				alarmState: null,
+				highestSeverity: 'warning',
+				activeAlertsCount: MCP_MAX_SECURITY_ALERTS + 3,
+				hasCriticalAlert: false,
+				activeAlerts: Array.from({ length: MCP_MAX_SECURITY_ALERTS + 3 }, (_, index) => ({
+					id: `alert-${index}`,
+					severity: 'warning',
+					message: `Alert ${index}`,
+				})),
+			},
+			devicesTruncated: false,
+			channelsTruncated: false,
+			propertiesTruncated: false,
+		});
+
+		const result = await service.getSecurityStatus();
+
+		expect(result.active_alerts).toHaveLength(MCP_MAX_SECURITY_ALERTS);
+		expect(result).toEqual(expect.objectContaining({ active_alerts_count: MCP_MAX_SECURITY_ALERTS + 3 }));
+		expect(result.alerts_truncated).toBe(true);
 	});
 
 	it('maps current values only for a requested visible device', async () => {
@@ -530,6 +595,39 @@ describe('McpContextService', () => {
 		expect(energy.getSpaceSummary).not.toHaveBeenCalled();
 	});
 
+	it('rejects energy ranges beyond the MCP compatibility limit before querying', async () => {
+		const from = '2026-01-01T00:00:00.000Z';
+		const to = new Date(Date.parse(from) + (MCP_MAX_ENERGY_RANGE_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+
+		await expect(service.getEnergySummary(from, to)).rejects.toThrow(
+			`may not exceed ${MCP_MAX_ENERGY_RANGE_DAYS} days`,
+		);
+		expect(energy.getSummary).not.toHaveBeenCalled();
+	});
+
+	it('uses primary or explicit weather selection and caps the forecast', async () => {
+		const forecast = Array.from({ length: MCP_MAX_FORECAST_DAYS + 2 }, (_, index) => ({
+			date: `2026-08-${String(index + 15).padStart(2, '0')}`,
+		}));
+		const weatherResult = {
+			locationId: 'location-id',
+			location: 'Prague',
+			current: { temperature: 21 },
+			forecast,
+		};
+		weather.getPrimaryWeather.mockResolvedValue(weatherResult);
+		weather.getWeather.mockResolvedValue(weatherResult);
+
+		const primary = await service.getWeather();
+		const explicit = await service.getWeather('location-id');
+
+		expect(weather.getPrimaryWeather).toHaveBeenCalledTimes(1);
+		expect(weather.getWeather).toHaveBeenCalledWith('location-id');
+		expect(primary.forecast).toHaveLength(MCP_MAX_FORECAST_DAYS);
+		expect(explicit).toEqual(primary);
+		expect(explicit).toEqual(expect.objectContaining({ location_id: 'location-id', location: 'Prague' }));
+	});
+
 	it('rejects a timeseries bucket that could exceed the result cap before querying storage', async () => {
 		await expect(
 			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', '1m'),
@@ -551,6 +649,27 @@ describe('McpContextService', () => {
 		await expect(
 			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-01T01:00:00.000Z', '5m'),
 		).resolves.toEqual(expect.objectContaining({ property_id: 'property-id', bucket: '5m', truncated: false }));
+	});
+
+	it('caps returned timeseries points and reports truncation', async () => {
+		properties.findOne.mockResolvedValue({
+			id: 'property-id',
+			channel: { device: { hidden: false } },
+		} as unknown as ChannelPropertyEntity);
+		timeseries.queryTimeseriesStrict.mockResolvedValue({
+			bucket: '1h',
+			points: Array.from({ length: MCP_MAX_TIMESERIES_POINTS + 1 }, (_, index) => ({ time: index, value: index })),
+		});
+
+		const result = await service.getPropertyTimeseries(
+			'property-id',
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-14T00:00:00.000Z',
+			'1h',
+		);
+
+		expect(result.points).toHaveLength(MCP_MAX_TIMESERIES_POINTS);
+		expect(result.truncated).toBe(true);
 	});
 
 	it('propagates storage failures from strict property history reads', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -781,6 +781,23 @@ describe('McpContextService', () => {
 		expect(timeseries.queryTimeseriesStrict).not.toHaveBeenCalled();
 	});
 
+	it('accepts a 14-day timeseries range and rejects a longer range before querying storage', async () => {
+		properties.findOne.mockResolvedValue({
+			id: 'property-id',
+			channel: { device: { hidden: false } },
+		} as unknown as ChannelPropertyEntity);
+		timeseries.queryTimeseriesStrict.mockResolvedValue({ bucket: '1h', points: [] });
+
+		await expect(
+			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-15T00:00:00.000Z', '1h'),
+		).resolves.toEqual(expect.objectContaining({ property_id: 'property-id', bucket: '1h' }));
+		await expect(
+			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-15T00:00:01.000Z', '1h'),
+		).rejects.toThrow('may not exceed 14 days');
+		expect(properties.findOne).toHaveBeenCalledTimes(1);
+		expect(timeseries.queryTimeseriesStrict).toHaveBeenCalledTimes(1);
+	});
+
 	it('returns bounded property history for a visible device', async () => {
 		properties.findOne.mockResolvedValue({
 			id: 'property-id',

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -769,7 +769,7 @@ describe('McpContextService', () => {
 		expect(result.alerts_truncated).toBe(true);
 	});
 
-	it('maps current values for a requested disabled-but-visible device', async () => {
+	it('maps the complete direct device-state contract for a requested disabled-but-visible device', async () => {
 		devices.findVisibleSummaryById.mockResolvedValue({
 			id: 'device-id',
 			name: 'Lamp',
@@ -777,7 +777,7 @@ describe('McpContextService', () => {
 			enabled: false,
 			hidden: false,
 			roomId: 'room-id',
-			zoneIds: [],
+			zoneIds: ['zone-id'],
 			status: { online: true, status: 'connected', lastChanged: new Date('2026-08-06T12:00:00Z') },
 		} as unknown as DeviceEntity);
 		channels.findSummaryPage.mockResolvedValue({
@@ -807,19 +807,40 @@ describe('McpContextService', () => {
 
 		const result = await service.getDeviceState('device-id');
 
-		expect(result).toEqual(
-			expect.objectContaining({
-				id: 'device-id',
-				enabled: false,
-				channels_truncated: true,
-				channels: [
-					expect.objectContaining({
-						properties_truncated: true,
-						properties: [expect.objectContaining({ id: 'property-id', value: 50, trend: 'stable' })],
-					}),
-				],
-			}),
-		);
+		expect(result).toEqual({
+			id: 'device-id',
+			name: 'Lamp',
+			category: 'lighting',
+			enabled: false,
+			room_id: 'room-id',
+			zone_ids: ['zone-id'],
+			status: {
+				online: true,
+				state: 'connected',
+				last_changed: '2026-08-06T12:00:00.000Z',
+			},
+			channels: [
+				{
+					id: 'channel-id',
+					name: 'Light',
+					category: 'light',
+					properties: [
+						{
+							id: 'property-id',
+							name: 'Brightness',
+							category: 'brightness',
+							data_type: 'uchar',
+							unit: '%',
+							value: 50,
+							last_updated: '2026-08-06T12:00:00Z',
+							trend: 'stable',
+						},
+					],
+					properties_truncated: true,
+				},
+			],
+			channels_truncated: true,
+		});
 		expect(channels.findSummaryPage).toHaveBeenCalledWith('device-id', MCP_MAX_CHANNELS_PER_DEVICE);
 		expect(connectionStates.readLatestManyStrict).toHaveBeenCalledWith([expect.objectContaining({ id: 'device-id' })]);
 		expect(properties.findBoundedForChannels).toHaveBeenCalledWith(
@@ -950,19 +971,43 @@ describe('McpContextService', () => {
 		expect(timeseries.queryTimeseriesStrict).toHaveBeenCalledTimes(1);
 	});
 
-	it('returns bounded property history for a visible device', async () => {
+	it('maps the complete direct property-timeseries contract for a visible device', async () => {
 		properties.findOne.mockResolvedValue({
 			id: 'property-id',
 			channel: { device: { hidden: false } },
 		} as unknown as ChannelPropertyEntity);
 		timeseries.queryTimeseriesStrict.mockResolvedValue({
 			bucket: '5m',
-			points: [{ time: '2026-08-01T00:00:00.000Z', value: 1 }],
+			points: [
+				{ time: '2026-08-01T00:00:00.000Z', value: 1 },
+				{ time: '2026-08-01T00:05:00.000Z', value: 2 },
+			],
 		});
 
-		await expect(
-			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-01T01:00:00.000Z', '5m'),
-		).resolves.toEqual(expect.objectContaining({ property_id: 'property-id', bucket: '5m', truncated: false }));
+		const result = await service.getPropertyTimeseries(
+			'property-id',
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-01T01:00:00.000Z',
+			'5m',
+		);
+
+		expect(result).toEqual({
+			property_id: 'property-id',
+			from: '2026-08-01T00:00:00.000Z',
+			to: '2026-08-01T01:00:00.000Z',
+			bucket: '5m',
+			points: [
+				{ time: '2026-08-01T00:00:00.000Z', value: 1 },
+				{ time: '2026-08-01T00:05:00.000Z', value: 2 },
+			],
+			truncated: false,
+		});
+		expect(timeseries.queryTimeseriesStrict).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'property-id' }),
+			new Date('2026-08-01T00:00:00.000Z'),
+			new Date('2026-08-01T01:00:00.000Z'),
+			'5m',
+		);
 	});
 
 	it('caps returned timeseries points and reports truncation', async () => {

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -124,6 +124,10 @@ describe('McpContextService', () => {
 		);
 	});
 
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	it('returns stable installation metadata with effective capabilities', async () => {
 		await expect(
 			service.getInstallation([McpCapability.READ], 'https://panel.test/api/v1/modules/mcp'),
@@ -222,6 +226,8 @@ describe('McpContextService', () => {
 	});
 
 	it('returns the exact whole-home composite contract with stable collection ordering', async () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
 		spaces.findSummaryPage.mockResolvedValue({
 			spaces: [
 				{ id: 'room-1', name: 'Kitchen', type: SpaceType.ROOM, parentId: null } as unknown as SpaceEntity,
@@ -262,6 +268,48 @@ describe('McpContextService', () => {
 			],
 			total: 1,
 		});
+		weather.getPrimaryWeather.mockResolvedValue({
+			locationId: 'location-1',
+			location: 'Prague',
+			current: { temperature: 21, condition: 'clear' },
+			forecast: [{ date: '2026-08-15', temperature: 23 }],
+		});
+		energy.getSummary.mockResolvedValue({
+			totalConsumptionKwh: 12.5,
+			totalProductionKwh: 3.25,
+			totalGridImportKwh: 10,
+			totalGridExportKwh: 0.75,
+			hasGridMetrics: true,
+			lastUpdatedAt: '2026-08-14T11:55:00.000Z',
+		});
+		security.getBoundedStatus.mockResolvedValue({
+			status: {
+				armedState: 'armed_away',
+				alarmState: 'idle',
+				highestSeverity: 'warning',
+				activeAlertsCount: 1,
+				hasCriticalAlert: false,
+				activeAlerts: [
+					{
+						id: 'alert-1',
+						type: 'intrusion',
+						severity: 'warning',
+						timestamp: '2026-08-14T11:58:00.000Z',
+						acknowledged: false,
+						sourceDeviceId: 'device-1',
+						message: 'Motion detected',
+					},
+				],
+				lastEvent: {
+					type: 'intrusion',
+					timestamp: '2026-08-14T11:58:00.000Z',
+					sourceDeviceId: 'device-1',
+				},
+			},
+			devicesTruncated: false,
+			channelsTruncated: false,
+			propertiesTruncated: false,
+		});
 
 		await expect(service.getHomeContext()).resolves.toEqual({
 			scope: { type: 'home' },
@@ -290,30 +338,133 @@ describe('McpContextService', () => {
 					primary_space_id: 'room-1',
 				},
 			],
-			weather: null,
-			energy: null,
-			security: null,
+			weather: {
+				location_id: 'location-1',
+				location: 'Prague',
+				current: { temperature: 21, condition: 'clear' },
+				forecast: [{ date: '2026-08-15', temperature: 23 }],
+			},
+			energy: {
+				scope: { type: 'home' },
+				from: '2026-08-13T12:00:00.000Z',
+				to: '2026-08-14T12:00:00.000Z',
+				totalConsumptionKwh: 12.5,
+				totalProductionKwh: 3.25,
+				totalGridImportKwh: 10,
+				totalGridExportKwh: 0.75,
+				hasGridMetrics: true,
+				lastUpdatedAt: '2026-08-14T11:55:00.000Z',
+			},
+			security: {
+				armed_state: 'armed_away',
+				alarm_state: 'idle',
+				highest_severity: 'warning',
+				active_alerts_count: 1,
+				has_critical_alert: false,
+				active_alerts: [
+					{
+						id: 'alert-1',
+						type: 'intrusion',
+						severity: 'warning',
+						timestamp: '2026-08-14T11:58:00.000Z',
+						acknowledged: false,
+						source_device_id: 'device-1',
+						message: 'Motion detected',
+					},
+				],
+				alerts_truncated: false,
+				devices_truncated: false,
+				channels_truncated: false,
+				properties_truncated: false,
+				state_truncated: false,
+				last_event: {
+					type: 'intrusion',
+					timestamp: '2026-08-14T11:58:00.000Z',
+					sourceDeviceId: 'device-1',
+				},
+			},
 			limits: { spaces_truncated: false, devices_truncated: false, scenes_truncated: false },
 		});
 	});
 
 	it('returns the exact scoped composite contract', async () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
 		spaces.findOne.mockResolvedValue({
 			id: 'room-1',
 			name: 'Kitchen',
 			type: SpaceType.ROOM,
 			parentId: null,
 		} as unknown as SpaceEntity);
-		energy.getSpaceSummary.mockRejectedValue(new Error('energy unavailable'));
+		weather.getPrimaryWeather.mockResolvedValue({
+			locationId: 'location-1',
+			location: 'Prague',
+			current: { temperature: 21, condition: 'clear' },
+			forecast: [{ date: '2026-08-15', temperature: 23 }],
+		});
+		energy.getSpaceSummary.mockResolvedValue({
+			totalConsumptionKwh: 4,
+			totalProductionKwh: 1,
+			totalGridImportKwh: 3.5,
+			totalGridExportKwh: 0.5,
+			netKwh: 3,
+			netGridKwh: 3,
+			hasGridMetrics: true,
+			lastUpdatedAt: '2026-08-14T11:55:00.000Z',
+		});
+		security.getBoundedStatus.mockResolvedValue({
+			status: {
+				armedState: 'disarmed',
+				alarmState: null,
+				highestSeverity: 'info',
+				activeAlertsCount: 0,
+				hasCriticalAlert: false,
+				activeAlerts: [],
+				lastEvent: undefined,
+			},
+			devicesTruncated: false,
+			channelsTruncated: false,
+			propertiesTruncated: false,
+		});
 
 		await expect(service.getHomeContext('room-1')).resolves.toEqual({
 			scope: { type: 'space', id: 'room-1', name: 'Kitchen' },
 			spaces: [{ id: 'room-1', name: 'Kitchen', type: SpaceType.ROOM, parent_id: null, device_count: 0 }],
 			devices: [],
 			scenes: [],
-			weather: null,
-			energy: null,
-			security: null,
+			weather: {
+				location_id: 'location-1',
+				location: 'Prague',
+				current: { temperature: 21, condition: 'clear' },
+				forecast: [{ date: '2026-08-15', temperature: 23 }],
+			},
+			energy: {
+				scope: { type: 'space', id: 'room-1' },
+				from: '2026-08-13T12:00:00.000Z',
+				to: '2026-08-14T12:00:00.000Z',
+				totalConsumptionKwh: 4,
+				totalProductionKwh: 1,
+				totalGridImportKwh: 3.5,
+				totalGridExportKwh: 0.5,
+				netKwh: 3,
+				netGridKwh: 3,
+				hasGridMetrics: true,
+				lastUpdatedAt: '2026-08-14T11:55:00.000Z',
+			},
+			security: {
+				armed_state: 'disarmed',
+				alarm_state: null,
+				highest_severity: 'info',
+				active_alerts_count: 0,
+				has_critical_alert: false,
+				active_alerts: [],
+				alerts_truncated: false,
+				devices_truncated: false,
+				channels_truncated: false,
+				properties_truncated: false,
+				state_truncated: false,
+				last_event: null,
+			},
 			limits: { spaces_truncated: false, devices_truncated: false, scenes_truncated: false },
 		});
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -618,12 +618,12 @@ describe('McpContextService', () => {
 		expect(result.alerts_truncated).toBe(true);
 	});
 
-	it('maps current values only for a requested visible device', async () => {
+	it('maps current values for a requested disabled-but-visible device', async () => {
 		devices.findVisibleSummaryById.mockResolvedValue({
 			id: 'device-id',
 			name: 'Lamp',
 			category: 'lighting',
-			enabled: true,
+			enabled: false,
 			hidden: false,
 			roomId: 'room-id',
 			zoneIds: [],
@@ -659,6 +659,7 @@ describe('McpContextService', () => {
 		expect(result).toEqual(
 			expect.objectContaining({
 				id: 'device-id',
+				enabled: false,
 				channels_truncated: true,
 				channels: [
 					expect.objectContaining({

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -976,15 +976,31 @@ describe('McpContextService', () => {
 		expect(energy.getSpaceSummary).not.toHaveBeenCalled();
 	});
 
-	it('rejects energy ranges beyond the MCP compatibility limit before querying', async () => {
+	it('maps an explicit 31-day home energy range and rejects a longer range before querying', async () => {
 		const from = '2026-01-01T00:00:00.000Z';
 		const atLimit = '2026-02-01T00:00:00.000Z';
 		const beyondLimit = '2026-02-02T00:00:00.000Z';
-		energy.getSummary.mockResolvedValue({ totalConsumptionKwh: 1 });
+		energy.getSummary.mockResolvedValue({
+			totalConsumptionKwh: 12.5,
+			totalProductionKwh: 3.25,
+			totalGridImportKwh: 10,
+			totalGridExportKwh: 0.75,
+			hasGridMetrics: true,
+			lastUpdatedAt: '2026-01-31T23:55:00.000Z',
+		});
 
-		await expect(service.getEnergySummary(from, atLimit)).resolves.toEqual(
-			expect.objectContaining({ totalConsumptionKwh: 1 }),
-		);
+		await expect(service.getEnergySummary(from, atLimit)).resolves.toEqual({
+			scope: { type: 'home' },
+			from,
+			to: atLimit,
+			totalConsumptionKwh: 12.5,
+			totalProductionKwh: 3.25,
+			totalGridImportKwh: 10,
+			totalGridExportKwh: 0.75,
+			hasGridMetrics: true,
+			lastUpdatedAt: '2026-01-31T23:55:00.000Z',
+		});
+		expect(energy.getSummary).toHaveBeenCalledWith(new Date(from), new Date(atLimit));
 		await expect(service.getEnergySummary(from, beyondLimit)).rejects.toThrow('may not exceed 31 days');
 		expect(energy.getSummary).toHaveBeenCalledTimes(1);
 	});

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -25,6 +25,11 @@ import {
 	MCP_MAX_SECURITY_DEVICES,
 	MCP_MAX_SECURITY_PROPERTIES_PER_CHANNEL,
 	MCP_MAX_TIMESERIES_POINTS,
+	MCP_MAX_TIMESERIES_RANGE_DAYS,
+	MCP_MAX_TRIGGER_SCENES,
+	MCP_MAX_TRIGGER_SPACES,
+	MCP_MAX_WRITABLE_PROPERTIES,
+	MCP_MAX_WRITABLE_PROPERTY_CANDIDATES,
 	McpCapability,
 } from '../mcp.constants';
 
@@ -131,6 +136,46 @@ describe('McpContextService', () => {
 				effective_capabilities: [McpCapability.READ],
 			}),
 		);
+	});
+
+	it('freezes the numeric MCP context and discovery compatibility limits', () => {
+		expect({
+			spaces: MCP_MAX_CONTEXT_SPACES,
+			devices: MCP_MAX_CONTEXT_DEVICES,
+			channelsPerDevice: MCP_MAX_CHANNELS_PER_DEVICE,
+			propertiesPerChannel: MCP_MAX_PROPERTIES_PER_CHANNEL,
+			scenes: MCP_MAX_CONTEXT_SCENES,
+			writableProperties: MCP_MAX_WRITABLE_PROPERTIES,
+			writableCandidates: MCP_MAX_WRITABLE_PROPERTY_CANDIDATES,
+			triggerScenes: MCP_MAX_TRIGGER_SCENES,
+			triggerSpaces: MCP_MAX_TRIGGER_SPACES,
+			securityAlerts: MCP_MAX_SECURITY_ALERTS,
+			securityDevices: MCP_MAX_SECURITY_DEVICES,
+			securityChannelsPerDevice: MCP_MAX_SECURITY_CHANNELS_PER_DEVICE,
+			securityPropertiesPerChannel: MCP_MAX_SECURITY_PROPERTIES_PER_CHANNEL,
+			forecastDays: MCP_MAX_FORECAST_DAYS,
+			timeseriesRangeDays: MCP_MAX_TIMESERIES_RANGE_DAYS,
+			timeseriesPoints: MCP_MAX_TIMESERIES_POINTS,
+			energyRangeDays: MCP_MAX_ENERGY_RANGE_DAYS,
+		}).toEqual({
+			spaces: 50,
+			devices: 100,
+			channelsPerDevice: 20,
+			propertiesPerChannel: 40,
+			scenes: 50,
+			writableProperties: 100,
+			writableCandidates: 500,
+			triggerScenes: 50,
+			triggerSpaces: 50,
+			securityAlerts: 20,
+			securityDevices: 100,
+			securityChannelsPerDevice: 10,
+			securityPropertiesPerChannel: 20,
+			forecastDays: 5,
+			timeseriesRangeDays: 14,
+			timeseriesPoints: 500,
+			energyRangeDays: 31,
+		});
 	});
 
 	it('bounds compact home context and normalizes unavailable optional domains', async () => {
@@ -553,9 +598,9 @@ describe('McpContextService', () => {
 				armedState: 'armed',
 				alarmState: null,
 				highestSeverity: 'warning',
-				activeAlertsCount: MCP_MAX_SECURITY_ALERTS + 3,
+				activeAlertsCount: 23,
 				hasCriticalAlert: false,
-				activeAlerts: Array.from({ length: MCP_MAX_SECURITY_ALERTS + 3 }, (_, index) => ({
+				activeAlerts: Array.from({ length: 23 }, (_, index) => ({
 					id: `alert-${index}`,
 					severity: 'warning',
 					message: `Alert ${index}`,
@@ -568,8 +613,8 @@ describe('McpContextService', () => {
 
 		const result = await service.getSecurityStatus();
 
-		expect(result.active_alerts).toHaveLength(MCP_MAX_SECURITY_ALERTS);
-		expect(result).toEqual(expect.objectContaining({ active_alerts_count: MCP_MAX_SECURITY_ALERTS + 3 }));
+		expect(result.active_alerts).toHaveLength(20);
+		expect(result).toEqual(expect.objectContaining({ active_alerts_count: 23 }));
 		expect(result.alerts_truncated).toBe(true);
 	});
 
@@ -694,16 +739,19 @@ describe('McpContextService', () => {
 
 	it('rejects energy ranges beyond the MCP compatibility limit before querying', async () => {
 		const from = '2026-01-01T00:00:00.000Z';
-		const to = new Date(Date.parse(from) + (MCP_MAX_ENERGY_RANGE_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+		const atLimit = '2026-02-01T00:00:00.000Z';
+		const beyondLimit = '2026-02-02T00:00:00.000Z';
+		energy.getSummary.mockResolvedValue({ totalConsumptionKwh: 1 });
 
-		await expect(service.getEnergySummary(from, to)).rejects.toThrow(
-			`may not exceed ${MCP_MAX_ENERGY_RANGE_DAYS} days`,
+		await expect(service.getEnergySummary(from, atLimit)).resolves.toEqual(
+			expect.objectContaining({ totalConsumptionKwh: 1 }),
 		);
-		expect(energy.getSummary).not.toHaveBeenCalled();
+		await expect(service.getEnergySummary(from, beyondLimit)).rejects.toThrow('may not exceed 31 days');
+		expect(energy.getSummary).toHaveBeenCalledTimes(1);
 	});
 
 	it('uses primary or explicit weather selection and caps the forecast', async () => {
-		const forecast = Array.from({ length: MCP_MAX_FORECAST_DAYS + 2 }, (_, index) => ({
+		const forecast = Array.from({ length: 7 }, (_, index) => ({
 			date: `2026-08-${String(index + 15).padStart(2, '0')}`,
 		}));
 		const weatherResult = {
@@ -720,7 +768,7 @@ describe('McpContextService', () => {
 
 		expect(weather.getPrimaryWeather).toHaveBeenCalledTimes(1);
 		expect(weather.getWeather).toHaveBeenCalledWith('location-id');
-		expect(primary.forecast).toHaveLength(MCP_MAX_FORECAST_DAYS);
+		expect(primary.forecast).toHaveLength(5);
 		expect(explicit).toEqual(primary);
 		expect(explicit).toEqual(expect.objectContaining({ location_id: 'location-id', location: 'Prague' }));
 	});
@@ -755,7 +803,7 @@ describe('McpContextService', () => {
 		} as unknown as ChannelPropertyEntity);
 		timeseries.queryTimeseriesStrict.mockResolvedValue({
 			bucket: '1h',
-			points: Array.from({ length: MCP_MAX_TIMESERIES_POINTS + 1 }, (_, index) => ({ time: index, value: index })),
+			points: Array.from({ length: 501 }, (_, index) => ({ time: index, value: index })),
 		});
 
 		const result = await service.getPropertyTimeseries(
@@ -765,7 +813,7 @@ describe('McpContextService', () => {
 			'1h',
 		);
 
-		expect(result.points).toHaveLength(MCP_MAX_TIMESERIES_POINTS);
+		expect(result.points).toHaveLength(500);
 		expect(result.truncated).toBe(true);
 	});
 

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -225,6 +225,28 @@ describe('McpContextService', () => {
 		);
 	});
 
+	it('caps a whole-home snapshot at 100 devices and reports the omitted device', async () => {
+		devices.findVisibleSummaryPage.mockResolvedValue({
+			devices: Array.from({ length: 100 }, (_, index) => ({
+				id: `device-${index}`,
+				name: `Device ${index}`,
+				category: 'generic',
+				enabled: true,
+				hidden: false,
+				roomId: null,
+				zoneIds: [],
+				status: { online: true, status: 'connected', lastChanged: null },
+			})) as DeviceEntity[],
+			total: 101,
+		});
+
+		const result = await service.getHomeContext();
+
+		expect(devices.findVisibleSummaryPage).toHaveBeenCalledWith(100);
+		expect(result.devices).toHaveLength(100);
+		expect(result.limits).toEqual(expect.objectContaining({ devices_truncated: true }));
+	});
+
 	it('returns the exact whole-home composite contract with stable collection ordering', async () => {
 		jest.useFakeTimers();
 		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
@@ -761,6 +783,7 @@ describe('McpContextService', () => {
 
 		const result = await service.getSecurityStatus();
 
+		expect(security.getBoundedStatus).toHaveBeenCalledWith(100, 10, 20);
 		expect(result).toEqual(
 			expect.objectContaining({
 				devices_truncated: false,

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -795,6 +795,15 @@ describe('McpContextService', () => {
 	});
 
 	it('caps security alerts and preserves alert truncation metadata', async () => {
+		const activeAlerts = Array.from({ length: 23 }, (_, index) => ({
+			id: `alert-${index}`,
+			type: 'intrusion',
+			severity: 'warning',
+			timestamp: `2026-08-14T12:${String(index).padStart(2, '0')}:00.000Z`,
+			acknowledged: index % 2 === 0,
+			sourceDeviceId: `device-${index}`,
+			message: `Alert ${index}`,
+		}));
 		security.getBoundedStatus.mockResolvedValue({
 			status: {
 				armedState: 'armed',
@@ -802,11 +811,7 @@ describe('McpContextService', () => {
 				highestSeverity: 'warning',
 				activeAlertsCount: 23,
 				hasCriticalAlert: false,
-				activeAlerts: Array.from({ length: 23 }, (_, index) => ({
-					id: `alert-${index}`,
-					severity: 'warning',
-					message: `Alert ${index}`,
-				})),
+				activeAlerts,
 			},
 			devicesTruncated: false,
 			channelsTruncated: false,
@@ -815,7 +820,17 @@ describe('McpContextService', () => {
 
 		const result = await service.getSecurityStatus();
 
-		expect(result.active_alerts).toHaveLength(20);
+		expect(result.active_alerts).toEqual(
+			Array.from({ length: 20 }, (_, index) => ({
+				id: `alert-${index}`,
+				type: 'intrusion',
+				severity: 'warning',
+				timestamp: `2026-08-14T12:${String(index).padStart(2, '0')}:00.000Z`,
+				acknowledged: index % 2 === 0,
+				source_device_id: `device-${index}`,
+				message: `Alert ${index}`,
+			})),
+		);
 		expect(result).toEqual(expect.objectContaining({ active_alerts_count: 23 }));
 		expect(result.alerts_truncated).toBe(true);
 	});
@@ -992,7 +1007,13 @@ describe('McpContextService', () => {
 
 		expect(weather.getPrimaryWeather).toHaveBeenCalledTimes(1);
 		expect(weather.getWeather).toHaveBeenCalledWith('location-id');
-		expect(primary.forecast).toHaveLength(5);
+		expect(primary.forecast).toEqual([
+			{ date: '2026-08-15' },
+			{ date: '2026-08-16' },
+			{ date: '2026-08-17' },
+			{ date: '2026-08-18' },
+			{ date: '2026-08-19' },
+		]);
 		expect(explicit).toEqual(primary);
 		expect(explicit).toEqual(expect.objectContaining({ location_id: 'location-id', location: 'Prague' }));
 	});
@@ -1078,7 +1099,7 @@ describe('McpContextService', () => {
 			'1h',
 		);
 
-		expect(result.points).toHaveLength(500);
+		expect(result.points).toEqual(Array.from({ length: 500 }, (_, index) => ({ time: index, value: index })));
 		expect(result.truncated).toBe(true);
 	});
 

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -469,6 +469,34 @@ describe('McpContextService', () => {
 		});
 	});
 
+	it('caps a scoped space snapshot at 100 devices and reports the omitted device', async () => {
+		spaces.findOne.mockResolvedValue({
+			id: 'room-1',
+			name: 'Kitchen',
+			type: SpaceType.ROOM,
+			parentId: null,
+		} as unknown as SpaceEntity);
+		spaces.findVisibleDeviceSummariesBySpace.mockResolvedValue({
+			devices: Array.from({ length: 100 }, (_, index) => ({
+				id: `device-${index}`,
+				name: `Device ${index}`,
+				category: 'generic',
+				enabled: true,
+				hidden: false,
+				roomId: 'room-1',
+				zoneIds: [],
+				status: { online: true, status: 'connected', lastChanged: null },
+			})) as DeviceEntity[],
+			total: 101,
+		});
+
+		const result = await service.getHomeContext('room-1');
+
+		expect(spaces.findVisibleDeviceSummariesBySpace).toHaveBeenCalledWith('room-1', 100);
+		expect(result.devices).toHaveLength(100);
+		expect(result.limits).toEqual(expect.objectContaining({ devices_truncated: true }));
+	});
+
 	it('propagates strict connection status failures from home context', async () => {
 		devices.findVisibleSummaryPage.mockResolvedValue({
 			devices: [{ id: 'device-id', hidden: false } as DeviceEntity],

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -176,6 +176,103 @@ describe('McpContextService', () => {
 		);
 	});
 
+	it('returns the exact whole-home composite contract with stable collection ordering', async () => {
+		spaces.findSummaryPage.mockResolvedValue({
+			spaces: [
+				{ id: 'room-1', name: 'Kitchen', type: SpaceType.ROOM, parentId: null } as unknown as SpaceEntity,
+				{ id: 'room-2', name: 'Office', type: SpaceType.ROOM, parentId: null } as unknown as SpaceEntity,
+			],
+			total: 2,
+		});
+		devices.findVisibleSummaryPage.mockResolvedValue({
+			devices: [
+				{
+					id: 'device-1',
+					name: 'Kitchen light',
+					category: 'lighting',
+					enabled: true,
+					hidden: false,
+					roomId: 'room-1',
+					zoneIds: ['zone-1'],
+					status: { online: true, status: 'connected', lastChanged: new Date('2026-08-14T12:00:00.000Z') },
+				} as unknown as DeviceEntity,
+			],
+			total: 1,
+		});
+		devices.getVisibleSpaceCounts.mockResolvedValue({
+			rooms: { 'room-1': 1, 'room-2': 0 },
+			zones: {},
+			floors: {},
+		});
+		scenes.findSummaryPage.mockResolvedValue({
+			scenes: [
+				{
+					id: 'scene-1',
+					name: 'Morning',
+					category: 'generic',
+					enabled: true,
+					triggerable: true,
+					primarySpaceId: 'room-1',
+				},
+			],
+			total: 1,
+		});
+
+		await expect(service.getHomeContext()).resolves.toEqual({
+			scope: { type: 'home' },
+			spaces: [
+				{ id: 'room-1', name: 'Kitchen', type: SpaceType.ROOM, parent_id: null, device_count: 1 },
+				{ id: 'room-2', name: 'Office', type: SpaceType.ROOM, parent_id: null, device_count: 0 },
+			],
+			devices: [
+				{
+					id: 'device-1',
+					name: 'Kitchen light',
+					category: 'lighting',
+					enabled: true,
+					room_id: 'room-1',
+					zone_ids: ['zone-1'],
+					status: { online: true, state: 'connected', last_changed: '2026-08-14T12:00:00.000Z' },
+				},
+			],
+			scenes: [
+				{
+					id: 'scene-1',
+					name: 'Morning',
+					category: 'generic',
+					enabled: true,
+					triggerable: true,
+					primary_space_id: 'room-1',
+				},
+			],
+			weather: null,
+			energy: null,
+			security: null,
+			limits: { spaces_truncated: false, devices_truncated: false, scenes_truncated: false },
+		});
+	});
+
+	it('returns the exact scoped composite contract', async () => {
+		spaces.findOne.mockResolvedValue({
+			id: 'room-1',
+			name: 'Kitchen',
+			type: SpaceType.ROOM,
+			parentId: null,
+		} as unknown as SpaceEntity);
+		energy.getSpaceSummary.mockRejectedValue(new Error('energy unavailable'));
+
+		await expect(service.getHomeContext('room-1')).resolves.toEqual({
+			scope: { type: 'space', id: 'room-1', name: 'Kitchen' },
+			spaces: [{ id: 'room-1', name: 'Kitchen', type: SpaceType.ROOM, parent_id: null, device_count: 0 }],
+			devices: [],
+			scenes: [],
+			weather: null,
+			energy: null,
+			security: null,
+			limits: { spaces_truncated: false, devices_truncated: false, scenes_truncated: false },
+		});
+	});
+
 	it('propagates strict connection status failures from home context', async () => {
 		devices.findVisibleSummaryPage.mockResolvedValue({
 			devices: [{ id: 'device-id', hidden: false } as DeviceEntity],

--- a/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
+++ b/apps/backend/src/modules/mcp/services/mcp-context.service.spec.ts
@@ -1059,6 +1059,18 @@ describe('McpContextService', () => {
 		expect(timeseries.queryTimeseriesStrict).toHaveBeenCalledTimes(1);
 	});
 
+	it('rejects property history when the owning device is hidden before querying storage', async () => {
+		properties.findOne.mockResolvedValue({
+			id: 'property-id',
+			channel: { device: { hidden: true } },
+		} as unknown as ChannelPropertyEntity);
+
+		await expect(
+			service.getPropertyTimeseries('property-id', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', '1h'),
+		).rejects.toThrow('Requested property does not exist');
+		expect(timeseries.queryTimeseriesStrict).not.toHaveBeenCalled();
+	});
+
 	it('maps the complete direct property-timeseries contract for a visible device', async () => {
 		properties.findOne.mockResolvedValue({
 			id: 'property-id',

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -250,6 +250,35 @@ describe('McpReadToolService', () => {
 	});
 
 	it('reauthorizes a tool call and returns structured installation metadata', async () => {
+		const securityStatus = {
+			armed_state: 'armed_away',
+			alarm_state: 'triggered',
+			highest_severity: 'critical',
+			active_alerts_count: 2,
+			has_critical_alert: true,
+			active_alerts: [
+				{
+					id: 'alert-id',
+					type: 'intrusion',
+					severity: 'critical',
+					timestamp: '2026-08-15T08:00:00.000Z',
+					acknowledged: false,
+					source_device_id: '10000000-0000-4000-8000-000000000001',
+					message: 'Entry sensor opened while armed',
+				},
+			],
+			alerts_truncated: true,
+			devices_truncated: true,
+			channels_truncated: true,
+			properties_truncated: true,
+			state_truncated: true,
+			last_event: {
+				id: 'event-id',
+				type: 'alarm_triggered',
+				timestamp: '2026-08-15T08:00:00.000Z',
+			},
+		};
+		contextService.getSecurityStatus.mockResolvedValue(securityStatus);
 		service.register(server(), authInfo([McpCapability.READ]));
 		const callback = callbacks.get('get_security_status');
 
@@ -265,7 +294,8 @@ describe('McpReadToolService', () => {
 		expect(result?.structuredContent.installation).toEqual(expect.objectContaining({ id: 'installation-id' }));
 		expect(result?.structuredContent.tool).toBe('get_security_status');
 		expect(result?.structuredContent.request_id).toBe('17');
-		expect(result?.structuredContent.data).toEqual({ active_alerts_count: 0 });
+		expect(result?.structuredContent.data).toBe(securityStatus);
+		expect(result?.structuredContent.data).toEqual(securityStatus);
 		expect(auditService.recordToolResult).toHaveBeenCalledWith(
 			expect.objectContaining({
 				requestId: '17',

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -14,7 +14,13 @@ type ToolCallback = (
 	args: Record<string, unknown>,
 	ctx: ServerContext,
 ) => Promise<{ isError?: boolean; structuredContent: Record<string, unknown> }>;
-type ResourceCallback = (uri: URL, ctx: ServerContext) => Promise<unknown>;
+type ResourceReadResult = { contents: Array<{ uri: string; mimeType: string; text: string }> };
+type ResourceCallback = (uri: URL, ctx: ServerContext) => Promise<ResourceReadResult>;
+type ResourceTemplateCallback = (
+	uri: URL,
+	variables: Record<string, string>,
+	ctx: ServerContext,
+) => Promise<ResourceReadResult>;
 type ResourceListCallback = (
 	request: { params?: { cursor?: string } },
 	ctx: ServerContext,
@@ -38,6 +44,7 @@ describe('McpReadToolService', () => {
 	let registerResource: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
 	let resourceCallbacks: Map<string, ResourceCallback>;
+	let resourceTemplateCallbacks: Map<string, ResourceTemplateCallback>;
 	let resourceListCallback: ResourceListCallback | undefined;
 
 	beforeEach(() => {
@@ -81,13 +88,20 @@ describe('McpReadToolService', () => {
 		};
 		callbacks = new Map();
 		resourceCallbacks = new Map();
+		resourceTemplateCallbacks = new Map();
 		resourceListCallback = undefined;
 		registerTool = jest.fn((name: string, _config: unknown, callback: ToolCallback) => {
 			callbacks.set(name, callback);
 		});
-		registerResource = jest.fn((name: string, _uri: unknown, _config: unknown, callback: ResourceCallback) => {
-			resourceCallbacks.set(name, callback);
-		});
+		registerResource = jest.fn(
+			(name: string, _uri: unknown, _config: unknown, callback: ResourceCallback | ResourceTemplateCallback) => {
+				if (name === 'space-snapshot') {
+					resourceTemplateCallbacks.set(name, callback as ResourceTemplateCallback);
+				} else {
+					resourceCallbacks.set(name, callback as ResourceCallback);
+				}
+			},
+		);
 		service = new McpReadToolService(
 			contextService as unknown as McpContextService,
 			policyService as unknown as McpPolicyService,
@@ -471,6 +485,109 @@ describe('McpReadToolService', () => {
 					outcome: 'timed_out',
 				}),
 			);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('reads the home-context resource with whole-home forwarding and the exact compatible JSON wrapper', async () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		try {
+			const result = await resourceCallbacks.get('home-context')?.(
+				new URL('smart-panel://home/context'),
+				requestContext(),
+			);
+
+			expect(contextService.getHomeContext).toHaveBeenCalledTimes(1);
+			expect(contextService.getHomeContext).toHaveBeenCalledWith();
+			expect(result).toEqual({
+				contents: [
+					{
+						uri: 'smart-panel://home/context',
+						mimeType: 'application/json',
+						text: JSON.stringify({
+							installation: {
+								id: 'installation-id',
+								name: 'FastyBird Smart Panel',
+								version: '1.0.0',
+								timezone: 'UTC',
+								endpoint: 'https://panel.test/api/v1/modules/mcp',
+								effective_capabilities: [McpCapability.READ],
+							},
+							observed_at: '2026-08-14T12:00:00.000Z',
+							data: {
+								scope: { type: 'home' },
+								spaces: [],
+								devices: [],
+								scenes: [],
+								weather: null,
+								energy: null,
+								security: null,
+								limits: {
+									spaces_truncated: false,
+									devices_truncated: false,
+									scenes_truncated: false,
+								},
+							},
+						}),
+					},
+				],
+			});
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('reads a space snapshot resource with scoped forwarding and the exact compatible JSON wrapper', async () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+		const spaceId = '20000000-0000-4000-8000-000000000001';
+		const scopedContext = {
+			scope: { type: 'space', id: spaceId, name: 'Living room' },
+			spaces: [{ id: spaceId, name: 'Living room', type: 'room', device_count: 1 }],
+			devices: [{ id: 'device-id', name: 'Lamp' }],
+			scenes: [],
+			weather: null,
+			energy: null,
+			security: null,
+			limits: {
+				spaces_truncated: false,
+				devices_truncated: false,
+				scenes_truncated: false,
+			},
+		};
+		contextService.getHomeContext.mockResolvedValue(scopedContext);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		try {
+			const uri = new URL(`smart-panel://spaces/${spaceId}/snapshot`);
+			const result = await resourceTemplateCallbacks.get('space-snapshot')?.(uri, { spaceId }, requestContext());
+
+			expect(contextService.getHomeContext).toHaveBeenCalledTimes(1);
+			expect(contextService.getHomeContext).toHaveBeenCalledWith(spaceId);
+			expect(result).toEqual({
+				contents: [
+					{
+						uri: `smart-panel://spaces/${spaceId}/snapshot`,
+						mimeType: 'application/json',
+						text: JSON.stringify({
+							installation: {
+								id: 'installation-id',
+								name: 'FastyBird Smart Panel',
+								version: '1.0.0',
+								timezone: 'UTC',
+								endpoint: 'https://panel.test/api/v1/modules/mcp',
+								effective_capabilities: [McpCapability.READ],
+							},
+							observed_at: '2026-08-14T12:00:00.000Z',
+							data: scopedContext,
+						}),
+					},
+				],
+			});
 		} finally {
 			jest.useRealTimers();
 		}

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -132,6 +132,7 @@ describe('McpReadToolService', () => {
 			'get_security_status',
 		]);
 		expect(registerResource).toHaveBeenCalledTimes(3);
+		expect(registeredResourceUris.get('installation')).toBe('smart-panel://installation');
 		expect(registeredResourceUris.get('home-context')).toBe('smart-panel://home/context');
 
 		const spaceSnapshotTemplate = registeredResourceUris.get('space-snapshot');

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -1,4 +1,4 @@
-import { AuthInfo, McpServer, ServerContext } from '@modelcontextprotocol/server';
+import { AuthInfo, McpServer, ResourceTemplate, ServerContext } from '@modelcontextprotocol/server';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 
 import { WeatherNotFoundException } from '../../weather/weather.exceptions';
@@ -44,6 +44,7 @@ describe('McpReadToolService', () => {
 	let registerResource: jest.Mock;
 	let callbacks: Map<string, ToolCallback>;
 	let resourceCallbacks: Map<string, ResourceCallback>;
+	let registeredResourceUris: Map<string, unknown>;
 	let resourceTemplateCallbacks: Map<string, ResourceTemplateCallback>;
 	let resourceListCallback: ResourceListCallback | undefined;
 
@@ -88,13 +89,16 @@ describe('McpReadToolService', () => {
 		};
 		callbacks = new Map();
 		resourceCallbacks = new Map();
+		registeredResourceUris = new Map();
 		resourceTemplateCallbacks = new Map();
 		resourceListCallback = undefined;
 		registerTool = jest.fn((name: string, _config: unknown, callback: ToolCallback) => {
 			callbacks.set(name, callback);
 		});
 		registerResource = jest.fn(
-			(name: string, _uri: unknown, _config: unknown, callback: ResourceCallback | ResourceTemplateCallback) => {
+			(name: string, uri: unknown, _config: unknown, callback: ResourceCallback | ResourceTemplateCallback) => {
+				registeredResourceUris.set(name, uri);
+
 				if (name === 'space-snapshot') {
 					resourceTemplateCallbacks.set(name, callback as ResourceTemplateCallback);
 				} else {
@@ -128,6 +132,15 @@ describe('McpReadToolService', () => {
 			'get_security_status',
 		]);
 		expect(registerResource).toHaveBeenCalledTimes(3);
+		expect(registeredResourceUris.get('home-context')).toBe('smart-panel://home/context');
+
+		const spaceSnapshotTemplate = registeredResourceUris.get('space-snapshot');
+
+		expect(spaceSnapshotTemplate).toBeInstanceOf(ResourceTemplate);
+		if (!(spaceSnapshotTemplate instanceof ResourceTemplate)) {
+			throw new Error('Space snapshot did not register an MCP ResourceTemplate');
+		}
+		expect(spaceSnapshotTemplate.uriTemplate.toString()).toBe('smart-panel://spaces/{spaceId}/snapshot');
 	});
 
 	it('forwards get_device_state arguments and envelopes the exact direct-read data unchanged', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -504,6 +504,37 @@ describe('McpReadToolService', () => {
 		}
 	});
 
+	it('reads the installation resource with live capabilities and the exact bare JSON wrapper', async () => {
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await resourceCallbacks.get('installation')?.(
+			new URL('smart-panel://installation'),
+			requestContext(),
+		);
+
+		expect(contextService.getInstallation).toHaveBeenCalledTimes(1);
+		expect(contextService.getInstallation).toHaveBeenCalledWith(
+			[McpCapability.READ],
+			'https://panel.test/api/v1/modules/mcp',
+		);
+		expect(result).toEqual({
+			contents: [
+				{
+					uri: 'smart-panel://installation',
+					mimeType: 'application/json',
+					text: JSON.stringify({
+						id: 'installation-id',
+						name: 'FastyBird Smart Panel',
+						version: '1.0.0',
+						timezone: 'UTC',
+						endpoint: 'https://panel.test/api/v1/modules/mcp',
+						effective_capabilities: [McpCapability.READ],
+					}),
+				},
+			],
+		});
+	});
+
 	it('reads the home-context resource with whole-home forwarding and the exact compatible JSON wrapper', async () => {
 		jest.useFakeTimers();
 		jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -41,7 +41,12 @@ describe('McpReadToolService', () => {
 		contextService = {
 			getHomeContext: jest.fn().mockResolvedValue({
 				scope: { type: 'home' },
+				spaces: [],
 				devices: [],
+				scenes: [],
+				weather: null,
+				energy: null,
+				security: null,
 				limits: {
 					spaces_truncated: false,
 					devices_truncated: false,
@@ -143,7 +148,12 @@ describe('McpReadToolService', () => {
 		expect(result?.structuredContent.tool).toBe('get_home_context');
 		expect(result?.structuredContent.data).toEqual({
 			scope: { type: 'home' },
+			spaces: [],
 			devices: [],
+			scenes: [],
+			weather: null,
+			energy: null,
+			security: null,
 			limits: {
 				spaces_truncated: false,
 				devices_truncated: false,

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -23,8 +23,10 @@ type ResourceListCallback = (
 describe('McpReadToolService', () => {
 	let service: McpReadToolService;
 	let contextService: {
+		getDeviceState: jest.Mock;
 		getHomeContext: jest.Mock;
 		getInstallation: jest.Mock;
+		getPropertyTimeseries: jest.Mock;
 		getSecurityStatus: jest.Mock;
 		getWeather: jest.Mock;
 		listSpaces: jest.Mock;
@@ -39,6 +41,7 @@ describe('McpReadToolService', () => {
 
 	beforeEach(() => {
 		contextService = {
+			getDeviceState: jest.fn(),
 			getHomeContext: jest.fn().mockResolvedValue({
 				scope: { type: 'home' },
 				spaces: [],
@@ -61,6 +64,7 @@ describe('McpReadToolService', () => {
 				endpoint: 'https://panel.test/api/v1/modules/mcp',
 				effective_capabilities: [McpCapability.READ],
 			}),
+			getPropertyTimeseries: jest.fn(),
 			getSecurityStatus: jest.fn().mockResolvedValue({ active_alerts_count: 0 }),
 			getWeather: jest.fn().mockResolvedValue({ location: 'Prague' }),
 			listSpaces: jest.fn().mockResolvedValue({ spaces: [], nextCursor: undefined }),
@@ -108,6 +112,86 @@ describe('McpReadToolService', () => {
 			'get_security_status',
 		]);
 		expect(registerResource).toHaveBeenCalledTimes(3);
+	});
+
+	it('forwards get_device_state arguments and envelopes the exact direct-read data unchanged', async () => {
+		const deviceId = '10000000-0000-4000-8000-000000000001';
+		const deviceState = {
+			id: deviceId,
+			name: 'Lamp',
+			category: 'lighting',
+			enabled: true,
+			room_id: '20000000-0000-4000-8000-000000000001',
+			zone_ids: ['30000000-0000-4000-8000-000000000001'],
+			status: {
+				online: true,
+				state: 'connected',
+				last_changed: '2026-08-06T12:00:00.000Z',
+			},
+			channels: [
+				{
+					id: '40000000-0000-4000-8000-000000000001',
+					name: 'Light',
+					category: 'light',
+					properties: [
+						{
+							id: '50000000-0000-4000-8000-000000000001',
+							name: 'Brightness',
+							category: 'brightness',
+							data_type: 'uchar',
+							unit: '%',
+							value: 50,
+							last_updated: '2026-08-06T12:00:00.000Z',
+							trend: 'stable',
+						},
+					],
+					properties_truncated: false,
+				},
+			],
+			channels_truncated: false,
+		};
+		contextService.getDeviceState.mockResolvedValue(deviceState);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_device_state')?.({ device_id: deviceId }, requestContext());
+
+		expect(contextService.getDeviceState).toHaveBeenCalledTimes(1);
+		expect(contextService.getDeviceState).toHaveBeenCalledWith(deviceId);
+		expect(result?.isError).toBeUndefined();
+		expect(result?.structuredContent.tool).toBe('get_device_state');
+		expect(result?.structuredContent.data).toBe(deviceState);
+		expect(result?.structuredContent.data).toEqual(deviceState);
+	});
+
+	it('forwards get_property_timeseries arguments and envelopes the exact direct-read data unchanged', async () => {
+		const propertyId = '50000000-0000-4000-8000-000000000001';
+		const from = '2026-08-01T00:00:00.000Z';
+		const to = '2026-08-01T01:00:00.000Z';
+		const propertyTimeseries = {
+			property_id: propertyId,
+			from,
+			to,
+			bucket: '5m',
+			points: [
+				{ time: '2026-08-01T00:00:00.000Z', value: 1 },
+				{ time: '2026-08-01T00:05:00.000Z', value: 2 },
+			],
+			truncated: false,
+		};
+		contextService.getPropertyTimeseries.mockResolvedValue(propertyTimeseries);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_property_timeseries')?.(
+			{ property_id: propertyId, from, to, bucket: '5m' },
+			requestContext(),
+		);
+
+		expect(contextService.getPropertyTimeseries).toHaveBeenCalledTimes(1);
+		expect(contextService.getPropertyTimeseries).toHaveBeenCalledWith(propertyId, from, to, '5m');
+		expect(result?.isError).toBeUndefined();
+		expect(result?.structuredContent.tool).toBe('get_property_timeseries');
+		expect(result?.structuredContent.data).toBe(propertyTimeseries);
+		expect(result?.structuredContent.data).toEqual(propertyTimeseries);
 	});
 
 	it('reauthorizes a tool call and returns structured installation metadata', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -24,6 +24,7 @@ describe('McpReadToolService', () => {
 	let service: McpReadToolService;
 	let contextService: {
 		getDeviceState: jest.Mock;
+		getEnergySummary: jest.Mock;
 		getHomeContext: jest.Mock;
 		getInstallation: jest.Mock;
 		getPropertyTimeseries: jest.Mock;
@@ -42,6 +43,7 @@ describe('McpReadToolService', () => {
 	beforeEach(() => {
 		contextService = {
 			getDeviceState: jest.fn(),
+			getEnergySummary: jest.fn(),
 			getHomeContext: jest.fn().mockResolvedValue({
 				scope: { type: 'home' },
 				spaces: [],
@@ -192,6 +194,31 @@ describe('McpReadToolService', () => {
 		expect(result?.structuredContent.tool).toBe('get_property_timeseries');
 		expect(result?.structuredContent.data).toBe(propertyTimeseries);
 		expect(result?.structuredContent.data).toEqual(propertyTimeseries);
+	});
+
+	it('forwards get_energy_summary arguments in service order and envelopes the exact data unchanged', async () => {
+		const from = '2026-08-01T00:00:00.000Z';
+		const to = '2026-08-02T00:00:00.000Z';
+		const spaceId = '20000000-0000-4000-8000-000000000001';
+		const energySummary = {
+			scope: { type: 'space', id: spaceId },
+			from,
+			to,
+			totalConsumptionKwh: 12.5,
+			totalCost: 4.25,
+			currency: 'EUR',
+		};
+		contextService.getEnergySummary.mockResolvedValue(energySummary);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_energy_summary')?.({ from, to, space_id: spaceId }, requestContext());
+
+		expect(contextService.getEnergySummary).toHaveBeenCalledTimes(1);
+		expect(contextService.getEnergySummary).toHaveBeenCalledWith(from, to, spaceId);
+		expect(result?.isError).toBeUndefined();
+		expect(result?.structuredContent.tool).toBe('get_energy_summary');
+		expect(result?.structuredContent.data).toBe(energySummary);
+		expect(result?.structuredContent.data).toEqual(energySummary);
 	});
 
 	it('reauthorizes a tool call and returns structured installation metadata', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-read-tool.service.spec.ts
@@ -23,6 +23,7 @@ type ResourceListCallback = (
 describe('McpReadToolService', () => {
 	let service: McpReadToolService;
 	let contextService: {
+		getHomeContext: jest.Mock;
 		getInstallation: jest.Mock;
 		getSecurityStatus: jest.Mock;
 		getWeather: jest.Mock;
@@ -38,6 +39,15 @@ describe('McpReadToolService', () => {
 
 	beforeEach(() => {
 		contextService = {
+			getHomeContext: jest.fn().mockResolvedValue({
+				scope: { type: 'home' },
+				devices: [],
+				limits: {
+					spaces_truncated: false,
+					devices_truncated: false,
+					scenes_truncated: false,
+				},
+			}),
 			getInstallation: jest.fn().mockResolvedValue({
 				id: 'installation-id',
 				name: 'FastyBird Smart Panel',
@@ -121,6 +131,101 @@ describe('McpReadToolService', () => {
 				outcome: 'completed',
 			}),
 		);
+	});
+
+	it('requests whole-home context when get_home_context omits a space', async () => {
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_home_context')?.({}, requestContext());
+
+		expect(contextService.getHomeContext).toHaveBeenCalledTimes(1);
+		expect(contextService.getHomeContext).toHaveBeenCalledWith(undefined);
+		expect(result?.structuredContent.tool).toBe('get_home_context');
+		expect(result?.structuredContent.data).toEqual({
+			scope: { type: 'home' },
+			devices: [],
+			limits: {
+				spaces_truncated: false,
+				devices_truncated: false,
+				scenes_truncated: false,
+			},
+		});
+	});
+
+	it('passes the requested space to get_home_context and preserves bounded-output metadata in the envelope', async () => {
+		const spaceId = '550e8400-e29b-41d4-a716-446655440000';
+		const scopedContext = {
+			scope: { type: 'space', id: spaceId, name: 'Living room' },
+			spaces: [{ id: spaceId, name: 'Living room', type: 'room', device_count: 101 }],
+			devices: [{ id: 'device-id', name: 'Ceiling light' }],
+			scenes: [],
+			weather: null,
+			energy: null,
+			security: {
+				devices_truncated: true,
+				channels_truncated: true,
+				properties_truncated: true,
+				state_truncated: true,
+			},
+			limits: {
+				spaces_truncated: false,
+				devices_truncated: true,
+				scenes_truncated: true,
+			},
+		};
+		contextService.getHomeContext.mockResolvedValue(scopedContext);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_home_context')?.({ space_id: spaceId }, requestContext());
+		const installation = result?.structuredContent.installation as { id: string } | undefined;
+
+		expect(contextService.getHomeContext).toHaveBeenCalledTimes(1);
+		expect(contextService.getHomeContext).toHaveBeenCalledWith(spaceId);
+		expect(result?.isError).toBeUndefined();
+		expect(installation?.id).toBe('installation-id');
+		expect(result?.structuredContent.tool).toBe('get_home_context');
+		expect(result?.structuredContent.request_id).toBe('17');
+		expect(typeof result?.structuredContent.observed_at).toBe('string');
+		expect(result?.structuredContent.data).toBe(scopedContext);
+	});
+
+	it('requests primary weather when get_weather omits a location', async () => {
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_weather')?.({}, requestContext());
+
+		expect(contextService.getWeather).toHaveBeenCalledTimes(1);
+		expect(contextService.getWeather).toHaveBeenCalledWith(undefined);
+		expect(result?.structuredContent).toEqual(
+			expect.objectContaining({
+				tool: 'get_weather',
+				data: { location: 'Prague' },
+			}),
+		);
+	});
+
+	it('passes an explicit location to get_weather and preserves its output in the envelope', async () => {
+		const locationId = '550e8400-e29b-41d4-a716-446655440000';
+		const weatherContext = {
+			location_id: locationId,
+			location: 'Prague',
+			current: { temperature: 21 },
+			forecast: [{ date: '2026-08-15', temperature_max: 25 }],
+		};
+		contextService.getWeather.mockResolvedValue(weatherContext);
+		service.register(server(), authInfo([McpCapability.READ]));
+
+		const result = await callbacks.get('get_weather')?.({ location_id: locationId }, requestContext());
+
+		expect(contextService.getWeather).toHaveBeenCalledTimes(1);
+		expect(contextService.getWeather).toHaveBeenCalledWith(locationId);
+		expect(result?.structuredContent).toEqual(
+			expect.objectContaining({
+				tool: 'get_weather',
+				data: weatherContext,
+			}),
+		);
+		expect(result?.structuredContent.data).toBe(weatherContext);
 	});
 
 	it('returns a sanitized denial when live policy no longer grants read', async () => {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -121,18 +121,23 @@ describe('McpTargetDiscoveryToolService', () => {
 		const connected = property('10000000-0000-4000-8000-000000000001', PermissionType.READ_WRITE);
 		connected.category = PropertyCategory.TEMPERATURE;
 		connected.dataType = DataTypeType.FLOAT;
+		connected.format = [-40, 125];
+		connected.step = 0.1;
+		connected.invalid = -999;
 		(connected.channel as { category: ChannelCategory }).category = ChannelCategory.TEMPERATURE;
 		const disconnected = property('10000000-0000-4000-8000-000000000002', PermissionType.WRITE_ONLY);
 		const readOnly = property('10000000-0000-4000-8000-000000000003', PermissionType.READ_ONLY);
+		const connectedSecond = property('10000000-0000-4000-8000-000000000004', PermissionType.WRITE_ONLY);
 		channelsPropertiesService.findWritableCandidates.mockResolvedValue({
-			properties: [connected, disconnected, readOnly],
-			total: 3,
+			properties: [connected, disconnected, readOnly, connectedSecond],
+			total: 4,
 		});
 		deviceConnectionStateService.readLatestMany.mockResolvedValue(
 			new Map([
 				[deviceId(connected), { online: true, status: ConnectionState.CONNECTED, lastChanged: new Date() }],
 				[deviceId(disconnected), { online: false, status: ConnectionState.DISCONNECTED, lastChanged: new Date() }],
 				[deviceId(readOnly), { online: true, status: ConnectionState.CONNECTED, lastChanged: new Date() }],
+				[deviceId(connectedSecond), { online: true, status: ConnectionState.CONNECTED, lastChanged: new Date() }],
 			]),
 		);
 		service.register(server(), authInfo([McpCapability.WRITE]));
@@ -146,29 +151,52 @@ describe('McpTargetDiscoveryToolService', () => {
 			McpCapability.WRITE,
 		);
 		expect(data.properties).toEqual([
-			expect.objectContaining({
+			{
 				property_id: connected.id,
+				property_name: 'Power 1',
+				property_category: PropertyCategory.TEMPERATURE,
 				device_id: deviceId(connected),
+				device_name: 'Device 1',
+				channel_id: '20000000-0000-4000-8000-000000000001',
+				channel_name: 'Switch 1',
+				channel_category: ChannelCategory.TEMPERATURE,
 				data_type: DataTypeType.FLOAT,
 				unit: '°C',
-			}),
+				format: [-40, 125],
+				step: 0.1,
+				invalid: -999,
+			},
+			{
+				property_id: connectedSecond.id,
+				property_name: 'Power 4',
+				property_category: PropertyCategory.ON,
+				device_id: deviceId(connectedSecond),
+				device_name: 'Device 4',
+				channel_id: '20000000-0000-4000-8000-000000000004',
+				channel_name: 'Switch 4',
+				channel_category: ChannelCategory.SWITCHER,
+				data_type: DataTypeType.BOOL,
+				unit: null,
+				format: null,
+				step: null,
+				invalid: null,
+			},
 		]);
-		expect(data.properties[0]).not.toHaveProperty('value');
 		expect(scenesService.findTriggerableSummaryPage).not.toHaveBeenCalled();
 	});
 
-	it('lets a trigger-only client discover enabled scenes and lighting-capable spaces', async () => {
+	it('maps exact mixed trigger targets with independent scene and space truncation', async () => {
 		providerTools = [
 			providerTool('run_scene', ToolAccessKind.TRIGGER),
 			providerTool('set_space_lighting', ToolAccessKind.TRIGGER),
 		];
 		scenesService.findTriggerableSummaryPage.mockResolvedValue({
 			scenes: [scene(true), scene(false)],
-			total: 2,
+			total: 51,
 		});
 		spacesService.findLightingTriggerSummaryPage.mockResolvedValue({
 			spaces: [space()],
-			total: 1,
+			total: 50,
 		});
 		service.register(server(), authInfo([McpCapability.TRIGGER]));
 
@@ -177,10 +205,30 @@ describe('McpTargetDiscoveryToolService', () => {
 		const data = result?.structuredContent.data as {
 			scenes: Array<Record<string, unknown>>;
 			spaces: Array<Record<string, unknown>>;
+			truncated: { scenes: boolean; spaces: boolean };
 		};
 
-		expect(data.scenes).toHaveLength(1);
-		expect(data.spaces).toEqual([expect.objectContaining({ modes: ['off', 'on', 'work', 'relax', 'night'] })]);
+		expect(scenesService.findTriggerableSummaryPage).toHaveBeenCalledWith(50);
+		expect(spacesService.findLightingTriggerSummaryPage).toHaveBeenCalledWith(50);
+		expect(data).toEqual({
+			scenes: [
+				{
+					scene_id: '40000000-0000-4000-8000-000000000001',
+					name: 'Movie night',
+					category: SceneCategory.GENERIC,
+					primary_space_id: null,
+				},
+			],
+			spaces: [
+				{
+					space_id: '50000000-0000-4000-8000-000000000001',
+					name: 'Living room',
+					type: SpaceType.ROOM,
+					modes: ['off', 'on', 'work', 'relax', 'night'],
+				},
+			],
+			truncated: { scenes: true, spaces: false },
+		});
 		expect(channelsPropertiesService.findWritableCandidates).not.toHaveBeenCalled();
 	});
 

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -256,6 +256,41 @@ describe('McpTargetDiscoveryToolService', () => {
 		expect(data.truncated).toBe(false);
 	});
 
+	it('returns all 100 actionable writable properties without marking the discovery result as truncated', async () => {
+		const targets = writableProperties(100);
+		channelsPropertiesService.findWritableCandidates.mockResolvedValue({
+			properties: targets,
+			total: 100,
+		});
+		service.register(server(), authInfo([McpCapability.WRITE]));
+
+		const result = await callbacks.get('list_writable_properties')?.({}, requestContext([McpCapability.WRITE]));
+		const data = result?.structuredContent.data as { properties: Array<{ property_id: string }>; truncated: boolean };
+
+		expect(data.properties).toHaveLength(100);
+		expect(data.properties[0]?.property_id).toBe(targets[0]?.id);
+		expect(data.properties[99]?.property_id).toBe(targets[99]?.id);
+		expect(data.truncated).toBe(false);
+	});
+
+	it('returns only 100 of 101 actionable writable properties and marks the discovery result as truncated', async () => {
+		const targets = writableProperties(101);
+		channelsPropertiesService.findWritableCandidates.mockResolvedValue({
+			properties: targets,
+			total: 101,
+		});
+		service.register(server(), authInfo([McpCapability.WRITE]));
+
+		const result = await callbacks.get('list_writable_properties')?.({}, requestContext([McpCapability.WRITE]));
+		const data = result?.structuredContent.data as { properties: Array<{ property_id: string }>; truncated: boolean };
+
+		expect(data.properties).toHaveLength(100);
+		expect(data.properties[0]?.property_id).toBe(targets[0]?.id);
+		expect(data.properties[99]?.property_id).toBe(targets[99]?.id);
+		expect(data.properties).not.toContainEqual(expect.objectContaining({ property_id: targets[100]?.id }));
+		expect(data.truncated).toBe(true);
+	});
+
 	it('omits space targets and the lighting tool when the optional provider is absent', async () => {
 		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
 		service.register(server(), authInfo([McpCapability.TRIGGER]));
@@ -540,6 +575,12 @@ describe('McpTargetDiscoveryToolService', () => {
 				},
 			},
 		} as unknown as ChannelPropertyEntity;
+	}
+
+	function writableProperties(count: number): ChannelPropertyEntity[] {
+		return Array.from({ length: count }, (_, index) =>
+			property(`10000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`, PermissionType.READ_WRITE),
+		);
 	}
 
 	function deviceId(target: ChannelPropertyEntity): string {

--- a/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
+++ b/apps/backend/src/modules/mcp/tools/mcp-target-discovery-tool.service.spec.ts
@@ -184,6 +184,80 @@ describe('McpTargetDiscoveryToolService', () => {
 		expect(channelsPropertiesService.findWritableCandidates).not.toHaveBeenCalled();
 	});
 
+	it('queries and returns 50 triggerable scenes without marking the scene collection as truncated', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		const targets = triggerableScenes(50);
+		scenesService.findTriggerableSummaryPage.mockResolvedValue({ scenes: targets, total: 50 });
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('list_trigger_targets')?.({}, requestContext([McpCapability.TRIGGER]));
+		const data = result?.structuredContent.data as {
+			scenes: Array<{ scene_id: string }>;
+			truncated: { scenes: boolean; spaces: boolean };
+		};
+
+		expect(scenesService.findTriggerableSummaryPage).toHaveBeenCalledWith(50);
+		expect(data.scenes).toHaveLength(50);
+		expect(data.scenes[0]?.scene_id).toBe(targets[0]?.id);
+		expect(data.scenes[49]?.scene_id).toBe(targets[49]?.id);
+		expect(data.truncated.scenes).toBe(false);
+	});
+
+	it('returns 50 of 51 triggerable scenes and marks the scene collection as truncated', async () => {
+		providerTools = [providerTool('run_scene', ToolAccessKind.TRIGGER)];
+		const targets = triggerableScenes(50);
+		scenesService.findTriggerableSummaryPage.mockResolvedValue({ scenes: targets, total: 51 });
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('list_trigger_targets')?.({}, requestContext([McpCapability.TRIGGER]));
+		const data = result?.structuredContent.data as {
+			scenes: Array<{ scene_id: string }>;
+			truncated: { scenes: boolean; spaces: boolean };
+		};
+
+		expect(scenesService.findTriggerableSummaryPage).toHaveBeenCalledWith(50);
+		expect(data.scenes).toHaveLength(50);
+		expect(data.scenes[49]?.scene_id).toBe(targets[49]?.id);
+		expect(data.truncated.scenes).toBe(true);
+	});
+
+	it('queries and returns 50 lighting spaces without marking the space collection as truncated', async () => {
+		providerTools = [providerTool('set_space_lighting', ToolAccessKind.TRIGGER)];
+		const targets = lightingSpaces(50);
+		spacesService.findLightingTriggerSummaryPage.mockResolvedValue({ spaces: targets, total: 50 });
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('list_trigger_targets')?.({}, requestContext([McpCapability.TRIGGER]));
+		const data = result?.structuredContent.data as {
+			spaces: Array<{ space_id: string }>;
+			truncated: { scenes: boolean; spaces: boolean };
+		};
+
+		expect(spacesService.findLightingTriggerSummaryPage).toHaveBeenCalledWith(50);
+		expect(data.spaces).toHaveLength(50);
+		expect(data.spaces[0]?.space_id).toBe(targets[0]?.id);
+		expect(data.spaces[49]?.space_id).toBe(targets[49]?.id);
+		expect(data.truncated.spaces).toBe(false);
+	});
+
+	it('returns 50 of 51 lighting spaces and marks the space collection as truncated', async () => {
+		providerTools = [providerTool('set_space_lighting', ToolAccessKind.TRIGGER)];
+		const targets = lightingSpaces(50);
+		spacesService.findLightingTriggerSummaryPage.mockResolvedValue({ spaces: targets, total: 51 });
+		service.register(server(), authInfo([McpCapability.TRIGGER]));
+
+		const result = await callbacks.get('list_trigger_targets')?.({}, requestContext([McpCapability.TRIGGER]));
+		const data = result?.structuredContent.data as {
+			spaces: Array<{ space_id: string }>;
+			truncated: { scenes: boolean; spaces: boolean };
+		};
+
+		expect(spacesService.findLightingTriggerSummaryPage).toHaveBeenCalledWith(50);
+		expect(data.spaces).toHaveLength(50);
+		expect(data.spaces[49]?.space_id).toBe(targets[49]?.id);
+		expect(data.truncated.spaces).toBe(true);
+	});
+
 	it('does not advertise or control writable properties without a registered device platform', async () => {
 		providerTools = [providerTool('control_device', ToolAccessKind.WRITE)];
 		const target = property('10000000-0000-4000-8000-000000000001', PermissionType.READ_WRITE);
@@ -598,11 +672,30 @@ describe('McpTargetDiscoveryToolService', () => {
 		} as SceneEntity;
 	}
 
+	function triggerableScenes(count: number): SceneEntity[] {
+		return Array.from({ length: count }, (_, index) => ({
+			id: `40000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+			name: `Scene ${index + 1}`,
+			category: SceneCategory.GENERIC,
+			enabled: true,
+			triggerable: true,
+			primarySpaceId: null,
+		})) as SceneEntity[];
+	}
+
 	function space(): SpaceEntity {
 		return {
 			id: '50000000-0000-4000-8000-000000000001',
 			name: 'Living room',
 			type: SpaceType.ROOM,
 		} as SpaceEntity;
+	}
+
+	function lightingSpaces(count: number): SpaceEntity[] {
+		return Array.from({ length: count }, (_, index) => ({
+			id: `50000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+			name: `Room ${index + 1}`,
+			type: SpaceType.ROOM,
+		})) as SpaceEntity[];
 	}
 });

--- a/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
@@ -9,6 +9,31 @@ import { SceneActionsService } from './scene-actions.service';
 import { ScenesService } from './scenes.service';
 
 describe('ScenesService', () => {
+	it('includes disabled scenes in summary queries', async () => {
+		const disabledScene = { id: 'disabled-scene', name: 'Disabled scene', enabled: false } as SceneEntity;
+		const query = {
+			select: jest.fn().mockReturnThis(),
+			orderBy: jest.fn().mockReturnThis(),
+			take: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			getManyAndCount: jest.fn().mockResolvedValue([[disabledScene], 1]),
+		};
+		const repository = {
+			createQueryBuilder: jest.fn().mockReturnValue(query),
+		} as unknown as Repository<SceneEntity>;
+		const service = new ScenesService(
+			repository,
+			{} as SceneActionsService,
+			{} as SpacesService,
+			{} as DataSource,
+			{} as EventEmitter2,
+		);
+
+		await expect(service.findSummaryPage(50)).resolves.toEqual({ scenes: [disabledScene], total: 1 });
+		expect(query.where).not.toHaveBeenCalled();
+		expect(query.select).toHaveBeenCalledWith(expect.arrayContaining(['scene.enabled']));
+	});
+
 	it('applies the summary cap without loading scene actions', async () => {
 		const scene = { id: 'scene-id', name: 'Movie night' } as SceneEntity;
 		const query = {

--- a/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
@@ -56,6 +56,7 @@ describe('ScenesService', () => {
 
 		await expect(service.findSummaryPage(50, 'space-id')).resolves.toEqual({ scenes: [scene], total: 60 });
 		expect(query.select).toHaveBeenCalledWith(expect.not.arrayContaining(['scene.actions']));
+		expect(query.orderBy).toHaveBeenCalledWith('scene.name', 'ASC');
 		expect(query.where).toHaveBeenCalledWith('scene.primarySpaceId = :primarySpaceId', {
 			primarySpaceId: 'space-id',
 		});

--- a/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
@@ -115,6 +115,8 @@ describe('ScenesService', () => {
 		await expect(service.findTriggerableSummaryPage(50)).resolves.toEqual({ scenes: [scene], total: 1 });
 		expect(query.where).toHaveBeenCalledWith('scene.enabled = :enabled', { enabled: true });
 		expect(query.andWhere).toHaveBeenCalledWith('scene.triggerable = :triggerable', { triggerable: true });
+		expect(query.orderBy).toHaveBeenCalledWith('scene.name', 'ASC');
+		expect(query.addOrderBy).toHaveBeenCalledWith('scene.id', 'ASC');
 		expect(query.take).toHaveBeenCalledWith(50);
 	});
 });

--- a/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
@@ -635,6 +635,9 @@ describe('SpacesService', () => {
 				expect.stringContaining('spaces_module_space_roles'),
 				expect.any(Object),
 			);
+			expect(queryBuilder.orderBy).toHaveBeenCalledWith('space.displayOrder', 'ASC');
+			expect(queryBuilder.addOrderBy).toHaveBeenNthCalledWith(1, 'space.name', 'ASC');
+			expect(queryBuilder.addOrderBy).toHaveBeenNthCalledWith(2, 'space.id', 'ASC');
 			expect(queryBuilder.take).toHaveBeenCalledWith(50);
 			expect(deviceQueryBuilder.take).toHaveBeenCalledWith(100);
 			expect(deviceConnectionStateService.readLatestMany).toHaveBeenCalledWith([onlineDevice]);

--- a/tasks/plans/buddy-adaptive-context-mcp-baseline.md
+++ b/tasks/plans/buddy-adaptive-context-mcp-baseline.md
@@ -1,0 +1,82 @@
+# Buddy Adaptive Context — MCP Pre-extraction Contract
+
+Date: 2026-08-14
+Plan: [plan-buddy-adaptive-context.md](./plan-buddy-adaptive-context.md)
+
+## Purpose
+
+This baseline freezes the MCP read behavior that Phase 1 must preserve while moving provider-neutral home queries out of
+the MCP transport module. It is a compatibility contract, not a recommendation that Buddy should inject the composite
+MCP home snapshot into its prompt. Buddy will use narrower query profiles and stricter result budgets.
+
+The regression coverage is split between `McpContextService`, which owns the current domain mapping and bounds, and
+`McpReadToolService`, which owns MCP authorization, deadlines, envelopes, and tool/resource registration.
+
+## Current Bounds
+
+| Domain                               |   Bound |
+| ------------------------------------ | ------: |
+| Home spaces                          |      50 |
+| Home devices                         |     100 |
+| Channels per device                  |      20 |
+| Properties per channel               |      40 |
+| Home scenes                          |      50 |
+| Writable properties returned         |     100 |
+| Writable candidates scanned per page |     500 |
+| Triggerable scenes                   |      50 |
+| Triggerable spaces                   |      50 |
+| Security alerts                      |      20 |
+| Security devices                     |     100 |
+| Security channels per device         |      10 |
+| Security properties per channel      |      20 |
+| Weather forecast                     |  5 days |
+| Timeseries range                     | 14 days |
+| Timeseries points                    |     500 |
+| Energy range                         | 31 days |
+
+These values remain MCP compatibility constants during extraction. Buddy-facing adapters may impose smaller limits after
+the shared query layer returns typed domain results.
+
+## Home Snapshot Contract
+
+- A whole-home snapshot reads a limit-plus-one space page, visible device summaries, bounded scene summaries, primary
+  weather, whole-home energy, and bounded security state.
+- A scoped snapshot returns the selected space as its only space summary and applies the resolved room/zone/master scope
+  to devices, scenes, energy, and security. A master space retains whole-home domain behavior.
+- Hidden devices remain excluded by the visible-domain queries. Disabled visible devices and disabled scenes remain in
+  MCP snapshots with their `enabled` state.
+- Device connection state is a strict read. Optional weather, energy, and security failures become `null` sections in the
+  composite snapshot; strict device state failures still propagate.
+- The composite result keeps `scope`, `spaces`, `devices`, `scenes`, `weather`, `energy`, `security`, and `limits`.
+  `limits` independently reports `spaces_truncated`, `devices_truncated`, and `scenes_truncated`.
+- Device state keeps nested channel/property values and independently reports `channels_truncated` and
+  `properties_truncated` at the affected levels.
+- Security output keeps device/channel/property truncation flags plus the derived `state_truncated` flag. Alert selection
+  has its own `alerts_truncated` flag.
+
+## Domain Read Contract
+
+- `get_weather` with `location_id` calls the exact configured location; omitting the ID calls the primary location.
+- Timeseries validates the date range and projected bucket count before storage access, returns no more than 500 points,
+  and preserves its `truncated` marker.
+- Energy validates its range and retains room, explicit zone-membership, and master/whole-home selection semantics.
+- Space resources use a stable offset cursor and do not repeat static installation/home resources after the first page.
+
+## MCP Adapter Contract
+
+Successful tools retain the established envelope fields:
+
+```text
+installation, request_id, tool, observed_at, data
+```
+
+Tool arguments are passed through without silently changing whole-home versus scoped behavior. Policy, installation
+identity, client credentials, audit records, MCP deadlines, sanitized errors, and protocol registration remain in the MCP
+adapter. Phase 1 may replace the mapper behind `McpContextService`, but must not move these transport concerns into the
+shared query module.
+
+## Phase 1 Regression Rule
+
+Run the focused MCP service/tool specs before and after each extraction slice. Existing external output, ordering, totals,
+truncation flags, explicit/primary weather selection, and scoped/whole-home routing must remain unchanged. Any intentional
+MCP protocol change requires a separate compatibility decision and is outside the Buddy context optimization.

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1184,7 +1184,8 @@ regenerate checked-in artifacts from backend Swagger sources; never edit generat
 - [x] Record the eager small-window budget violation as a measured baseline fixture or opt-in expected-failure evaluation
       excluded from normal CI. Keep the Phase 0 verification suite green; promote the fixture to a required passing
       bounded-request assertion when Phase 7 switches the production conversation path.
-- [ ] Confirm existing MCP context outputs/limits in tests before extracting them.
+- [x] Confirm existing MCP context outputs/limits in tests before extracting them; the frozen compatibility contract is
+      recorded in [buddy-adaptive-context-mcp-baseline.md](./buddy-adaptive-context-mcp-baseline.md).
 
 **Gate:** Baseline numbers and green characterization tests exist, and the eager full-home small-window failure is
 captured as an opt-in/expected baseline measurement rather than a failing normal-CI test.


### PR DESCRIPTION
> 👍 Codex review passed on commit `75669a0a2` with no major issues.

## Summary

- lock whole-home and scoped `get_home_context` routing and MCP envelope preservation
- freeze exact MCP payloads, numeric caps, truncation behavior, and deterministic source ordering
- characterize disabled-but-visible compatibility and reject hidden-device property history
- assert security, weather, energy, timeseries, discovery, resource, and installation contracts
- document the provider-neutral extraction contract and complete the final Phase 0 checklist item

## Why

Phase 1 will move domain queries behind a provider-neutral home-context module. These tests freeze the current MCP protocol behavior first, so Buddy can reuse domain services without silently changing MCP output, limits, scope, policy, visibility, or transport semantics.

## Validation

- final MCP/domain regression slice: 51 suites, 628 tests, 2 snapshots passed
- focused review-fix suites, ESLint, and Prettier checks passed
- backend type-check passed
- `git diff --check` passed
- all review threads resolved; Codex review found no major issues