### PR TITLE
test(cross): add guarded Homey lifecycle probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -79,6 +79,7 @@
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",
     "homey:probe-mdns": "ts-node --project tsconfig.json test/support/homey-shs-mdns-probe.ts",
     "homey:probe-recovery": "ts-node --project tsconfig.json test/support/homey-shs-recovery-probe.ts",
+    "homey:probe-lifecycle": "ts-node --project tsconfig.json test/support/homey-shs-lifecycle-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",
     "typeorm:migration:generate": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:generate -d ./src/dataSource.ts",

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -60,14 +60,6 @@ const COMPLETE_EVENTS = [
 	'sdk.destroyed',
 ] as const;
 
-const REQUIRED_SCOPES = [
-	'homey.device',
-	'homey.device.readonly',
-	'homey.flow.readonly',
-	'homey.system.readonly',
-	'homey.zone.readonly',
-] as const;
-
 const completeReport = (): HomeyShsLifecycleReport => ({
 	lifecycle: {
 		addVerified: true,
@@ -101,17 +93,17 @@ type FakeDevice = EventEmitter &
 class FakeLifecycleFlowManager {
 	advancedFlows: Record<string, unknown> = {};
 	readonly advancedFlowReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
-	failFlowRead = false;
+	failFlowReadAt?: number;
 	flows: Record<string, unknown> = {};
 	readonly flowReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
-	hangAdvancedFlowRead = false;
+	hangAdvancedFlowReadAt?: number;
 
 	getAdvancedFlows(
 		options: { $cache?: boolean; $timeout?: number; $updateCache?: boolean } = {},
 	): Promise<Record<string, unknown>> {
 		this.advancedFlowReadOptions.push(options);
 
-		if (this.hangAdvancedFlowRead) {
+		if (this.advancedFlowReadOptions.length === this.hangAdvancedFlowReadAt) {
 			return new Promise((_resolvePromise) => undefined);
 		}
 
@@ -123,9 +115,23 @@ class FakeLifecycleFlowManager {
 	): Promise<Record<string, unknown>> {
 		this.flowReadOptions.push(options);
 
-		return this.failFlowRead
+		return this.flowReadOptions.length === this.failFlowReadAt
 			? Promise.reject(new Error('raw private flow failure'))
 			: Promise.resolve({ ...this.flows });
+	}
+}
+
+const fakeApiError = (statusCode: number): Error & { statusCode: number } =>
+	Object.assign(new Error('raw private API failure'), { statusCode });
+
+class FakeLifecycleDriversManager {
+	failStatusCode = 404;
+	readonly pairSessionRequests: Array<{ $timeout?: number; id: string }> = [];
+
+	getPairSession(options: { $timeout?: number; id: string }): Promise<unknown> {
+		this.pairSessionRequests.push(options);
+
+		return Promise.reject(fakeApiError(this.failStatusCode));
 	}
 }
 
@@ -134,6 +140,7 @@ class FakeLifecycleDevicesManager extends EventEmitter {
 	deleteRequests: Array<{ $timeout?: number; id: string }> = [];
 	disconnectCount = 0;
 	failDisconnect = false;
+	failInventoryReadAt?: number;
 	inventory: Record<string, FakeDevice> = {};
 	inventoryReadHook?: (readCount: number) => void;
 	readonly inventoryReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
@@ -156,6 +163,10 @@ class FakeLifecycleDevicesManager extends EventEmitter {
 	): Promise<Record<string, FakeDevice>> {
 		this.inventoryReadOptions.push(options);
 		this.inventoryReadHook?.(this.inventoryReadOptions.length);
+
+		if (this.inventoryReadOptions.length === this.failInventoryReadAt) {
+			return Promise.reject(new Error('raw private inventory failure'));
+		}
 
 		return Promise.resolve({ ...this.inventory });
 	}
@@ -195,9 +206,14 @@ class FakeLifecycleClient {
 	disconnectCount = 0;
 	failDestroy = false;
 	failDisconnect = false;
+	failSystemRead = false;
+	failZoneRead = false;
 	readonly devices = new FakeLifecycleDevicesManager();
+	readonly drivers = new FakeLifecycleDriversManager();
 	readonly flow = new FakeLifecycleFlowManager();
-	readonly scopes = new Set<string>(REQUIRED_SCOPES);
+	readonly system: {
+		getInfo(options?: { $timeout?: number }): Promise<unknown>;
+	};
 	readonly zones: {
 		getZones(options?: {
 			$cache?: boolean;
@@ -207,12 +223,18 @@ class FakeLifecycleClient {
 	};
 
 	constructor(config: HomeyShsLifecycleProbeConfig) {
+		this.system = {
+			getInfo: () =>
+				this.failSystemRead ? Promise.reject(new Error('raw private system failure')) : Promise.resolve({ ok: true }),
+		};
 		this.zones = {
 			getZones: () =>
-				Promise.resolve({
-					[config.destinationZoneId]: {},
-					[config.sourceZoneId]: {},
-				}),
+				this.failZoneRead
+					? Promise.reject(new Error('raw private zone failure'))
+					: Promise.resolve({
+							[config.destinationZoneId]: {},
+							[config.sourceZoneId]: {},
+						}),
 		};
 	}
 
@@ -229,10 +251,6 @@ class FakeLifecycleClient {
 		this.disconnectCount += 1;
 
 		return this.failDisconnect ? Promise.reject(new Error('raw private socket cleanup detail')) : Promise.resolve();
-	}
-
-	hasScope(scope: string): boolean {
-		return this.scopes.has(scope);
 	}
 }
 
@@ -389,12 +407,49 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		).toThrow('between 10000 and 300000');
 	});
 
-	it.each(REQUIRED_SCOPES)('refuses a key missing %s before opening the add window', async (scope) => {
+	it.each([
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.drivers.failStatusCode = 403;
+			},
+			permission: 'device write',
+		},
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.devices.failInventoryReadAt = 1;
+			},
+			permission: 'device read',
+		},
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.flow.failFlowReadAt = 1;
+			},
+			permission: 'standard-flow read',
+		},
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.flow.hangAdvancedFlowReadAt = 1;
+			},
+			permission: 'advanced-flow read',
+		},
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.failSystemRead = true;
+			},
+			permission: 'system read',
+		},
+		{
+			deny: (client: FakeLifecycleClient): void => {
+				client.failZoneRead = true;
+			},
+			permission: 'zone read',
+		},
+	])('refuses a key without $permission permission before opening the add window', async ({ deny }) => {
 		const config = fastConfig();
 		const harness = createHarness(config);
 		let addWindowCount = 0;
 
-		harness.client.scopes.delete(scope);
+		deny(harness.client);
 
 		await expect(
 			probeHomeyShsLifecycle(config, harness.factory, {
@@ -402,23 +457,21 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 					addWindowCount += 1;
 				},
 			}),
-		).rejects.toThrow('dedicated Homey lifecycle key is missing a required scope');
+		).rejects.toThrow('dedicated Homey lifecycle key failed the required permission preflight');
 		expect(addWindowCount).toBe(0);
 		expect(harness.client.devices.connectCount).toBe(0);
 		expect(harness.client.devices.updateRequests).toStrictEqual([]);
 		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
 	});
 
-	it('sanitizes scope-preflight failures before any lifecycle action', async () => {
+	it('sanitizes unexpected permission-preflight failures before any lifecycle action', async () => {
 		const config = fastConfig();
 		const harness = createHarness(config);
 
-		jest.spyOn(harness.client, 'hasScope').mockImplementation(() => {
-			throw new Error('raw private scope detail');
-		});
+		harness.client.drivers.failStatusCode = 500;
 
 		await expect(probeHomeyShsLifecycle(config, harness.factory)).rejects.toThrow(
-			'dedicated Homey lifecycle key is missing a required scope',
+			'dedicated Homey lifecycle key failed the required permission preflight',
 		);
 		expect(harness.client.devices.connectCount).toBe(0);
 		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
@@ -478,11 +531,16 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(harness.client.flow.flowReadOptions).toStrictEqual([
 			{ $cache: false, $timeout: 25, $updateCache: false },
 			{ $cache: false, $timeout: 25, $updateCache: false },
+			{ $cache: false, $timeout: 25, $updateCache: false },
 		]);
 		expect(harness.client.flow.advancedFlowReadOptions).toStrictEqual([
 			{ $cache: false, $timeout: 25, $updateCache: false },
 			{ $cache: false, $timeout: 25, $updateCache: false },
+			{ $cache: false, $timeout: 25, $updateCache: false },
 		]);
+		expect(harness.client.drivers.pairSessionRequests).toHaveLength(1);
+		expect(harness.client.drivers.pairSessionRequests[0]).toMatchObject({ $timeout: 25 });
+		expect(harness.client.drivers.pairSessionRequests[0]?.id).toMatch(/^fbsp-lifecycle-scope-preflight-[a-f0-9]{32}$/);
 		expect(harness.client.devices.disconnectCount).toBe(1);
 		expect(harness.client.disconnectCount).toBe(1);
 		expect(harness.client.destroyCount).toBe(1);
@@ -739,8 +797,8 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		});
 
 		harness.client.devices.inventory[unrelatedId] = unrelated;
-		harness.client.flow.failFlowRead = true;
-		harness.client.flow.hangAdvancedFlowRead = true;
+		harness.client.flow.failFlowReadAt = 2;
+		harness.client.flow.hangAdvancedFlowReadAt = 2;
 
 		await expect(
 			probeHomeyShsLifecycle(config, harness.factory, {
@@ -750,8 +808,12 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 				},
 			}),
 		).rejects.toThrow('manual disposable-device cleanup required');
-		expect(harness.client.flow.flowReadOptions).toStrictEqual([{ $cache: false, $timeout: 5, $updateCache: false }]);
+		expect(harness.client.flow.flowReadOptions).toStrictEqual([
+			{ $cache: false, $timeout: 5, $updateCache: false },
+			{ $cache: false, $timeout: 5, $updateCache: false },
+		]);
 		expect(harness.client.flow.advancedFlowReadOptions).toStrictEqual([
+			{ $cache: false, $timeout: 5, $updateCache: false },
 			{ $cache: false, $timeout: 5, $updateCache: false },
 		]);
 		expect(harness.client.devices.deleteRequests).toStrictEqual([]);

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -1,0 +1,1015 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	type HomeyLifecycleSdkFactory,
+	type HomeyShsLifecycleProbeConfig,
+	type HomeyShsLifecycleReport,
+	assertHomeyShsLifecycleReportSafe,
+	assertHomeyShsLifecycleReportSchema,
+	loadHomeyShsLifecycleProbeConfig,
+	probeHomeyShsLifecycle,
+	writeHomeyShsLifecycleReport,
+} from './support/homey-shs-lifecycle-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'test-api-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID: 'destination-zone-that-must-not-leak',
+	FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER: 'fbsp-lifecycle-test-marker-that-must-not-leak',
+	FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:test-owner-that-must-not-leak:driver:test-driver-that-must-not-leak',
+	FB_HOMEY_SHS_LIFECYCLE_ENABLE: 'I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE',
+	FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME: 'FBSP Lifecycle Initial Private Name',
+	FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS: '10000',
+	FB_HOMEY_SHS_LIFECYCLE_OPERATIONS: 'add,rename,zone-move,availability,remove',
+	FB_HOMEY_SHS_LIFECYCLE_OWNER_URI: 'homey:app:test-owner-that-must-not-leak',
+	FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME: 'FBSP Lifecycle Renamed Private Name',
+	FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID: 'source-zone-that-must-not-leak',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const COMPLETE_EVENTS = [
+	'sdk.create.resolved',
+	'manager.subscribe.resolved',
+	'baseline.absence.verified',
+	'add.window.open',
+	'device.create.observed',
+	'add.readback.resolved',
+	'flows.absence.verified',
+	'device.rename.requested',
+	'device.update.rename.observed',
+	'rename.readback.resolved',
+	'device.zone-move.requested',
+	'device.update.zone-move.observed',
+	'zone-move.readback.resolved',
+	'availability.unavailable.requested',
+	'device.update.unavailable.observed',
+	'unavailable.readback.resolved',
+	'availability.restore.requested',
+	'device.update.available.observed',
+	'availability.readback.resolved',
+	'device.remove.requested',
+	'device.delete.observed',
+	'final.absence.verified',
+	'manager.unsubscribe.resolved',
+	'socket.disconnect.resolved',
+	'sdk.destroyed',
+] as const;
+
+const REQUIRED_SCOPES = [
+	'homey.device',
+	'homey.device.readonly',
+	'homey.flow.readonly',
+	'homey.system.readonly',
+	'homey.zone.readonly',
+] as const;
+
+const completeReport = (): HomeyShsLifecycleReport => ({
+	lifecycle: {
+		addVerified: true,
+		availabilityRestored: true,
+		finalAbsenceVerified: true,
+		flowAbsenceVerified: true,
+		removeVerified: true,
+		renameVerified: true,
+		unavailableVerified: true,
+		zoneMoveVerified: true,
+	},
+	metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 1, sdkVersion: '3.19.2' },
+	session: {
+		cleanupCompleted: true,
+		events: COMPLETE_EVENTS.map((event, index) => ({ event, order: index + 1 })),
+		managerSubscribed: true,
+	},
+});
+
+type FakeDevice = EventEmitter &
+	Record<string, unknown> & {
+		available: boolean;
+		data: { id: string };
+		driverId: string;
+		id: string;
+		name: string;
+		ownerUri: string;
+		zone: string;
+	};
+
+class FakeLifecycleFlowManager {
+	advancedFlows: Record<string, unknown> = {};
+	readonly advancedFlowReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
+	failFlowRead = false;
+	flows: Record<string, unknown> = {};
+	readonly flowReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
+	hangAdvancedFlowRead = false;
+
+	getAdvancedFlows(
+		options: { $cache?: boolean; $timeout?: number; $updateCache?: boolean } = {},
+	): Promise<Record<string, unknown>> {
+		this.advancedFlowReadOptions.push(options);
+
+		if (this.hangAdvancedFlowRead) {
+			return new Promise((_resolvePromise) => undefined);
+		}
+
+		return Promise.resolve({ ...this.advancedFlows });
+	}
+
+	getFlows(
+		options: { $cache?: boolean; $timeout?: number; $updateCache?: boolean } = {},
+	): Promise<Record<string, unknown>> {
+		this.flowReadOptions.push(options);
+
+		return this.failFlowRead
+			? Promise.reject(new Error('raw private flow failure'))
+			: Promise.resolve({ ...this.flows });
+	}
+}
+
+class FakeLifecycleDevicesManager extends EventEmitter {
+	connectCount = 0;
+	deleteRequests: Array<{ $timeout?: number; id: string }> = [];
+	disconnectCount = 0;
+	failDisconnect = false;
+	inventory: Record<string, FakeDevice> = {};
+	inventoryReadHook?: (readCount: number) => void;
+	readonly inventoryReadOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
+	updateRequests: Array<{ $timeout?: number; device: { name?: string; zone?: string }; id: string }> = [];
+
+	connect(): Promise<void> {
+		this.connectCount += 1;
+
+		return Promise.resolve();
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+
+		return this.failDisconnect ? Promise.reject(new Error('raw private manager cleanup detail')) : Promise.resolve();
+	}
+
+	getDevices(
+		options: { $cache?: boolean; $timeout?: number; $updateCache?: boolean } = {},
+	): Promise<Record<string, FakeDevice>> {
+		this.inventoryReadOptions.push(options);
+		this.inventoryReadHook?.(this.inventoryReadOptions.length);
+
+		return Promise.resolve({ ...this.inventory });
+	}
+
+	updateDevice(options: { $timeout?: number; device: { name?: string; zone?: string }; id: string }): Promise<unknown> {
+		this.updateRequests.push(options);
+		const device = this.inventory[options.id];
+
+		if (device === undefined) {
+			return Promise.reject(new Error('raw missing-device detail'));
+		}
+
+		Object.assign(device, options.device);
+		device.emit('update', { ...options.device });
+		this.emit('device.update', { ...device, id: 'wrong-device-id' });
+		this.emit('device.update', { ...device });
+
+		return Promise.resolve(device);
+	}
+
+	deleteDevice(options: { $timeout?: number; id: string }): Promise<unknown> {
+		this.deleteRequests.push(options);
+		const existing = this.inventory[options.id];
+
+		if (existing !== undefined) {
+			delete this.inventory[options.id];
+			this.emit('device.delete', { id: 'wrong-device-id' });
+			this.emit('device.delete', { id: options.id });
+		}
+
+		return Promise.resolve();
+	}
+}
+
+class FakeLifecycleClient {
+	destroyCount = 0;
+	disconnectCount = 0;
+	failDestroy = false;
+	failDisconnect = false;
+	readonly devices = new FakeLifecycleDevicesManager();
+	readonly flow = new FakeLifecycleFlowManager();
+	readonly scopes = new Set<string>(REQUIRED_SCOPES);
+	readonly zones: {
+		getZones(options?: {
+			$cache?: boolean;
+			$timeout?: number;
+			$updateCache?: boolean;
+		}): Promise<Record<string, unknown>>;
+	};
+
+	constructor(config: HomeyShsLifecycleProbeConfig) {
+		this.zones = {
+			getZones: () =>
+				Promise.resolve({
+					[config.destinationZoneId]: {},
+					[config.sourceZoneId]: {},
+				}),
+		};
+	}
+
+	destroy(): void {
+		this.destroyCount += 1;
+		this.devices.removeAllListeners();
+
+		if (this.failDestroy) {
+			throw new Error('raw private destroy detail');
+		}
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+
+		return this.failDisconnect ? Promise.reject(new Error('raw private socket cleanup detail')) : Promise.resolve();
+	}
+
+	hasScope(scope: string): boolean {
+		return this.scopes.has(scope);
+	}
+}
+
+const fastConfig = (overrides: Partial<HomeyShsLifecycleProbeConfig> = {}): HomeyShsLifecycleProbeConfig => ({
+	...loadHomeyShsLifecycleProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-lifecycle-spike'),
+	observeMs: 25,
+	timeoutMs: 25,
+	...overrides,
+});
+
+const makeOwnedDevice = (
+	config: HomeyShsLifecycleProbeConfig,
+	id: string,
+	overrides: Partial<FakeDevice> = {},
+): FakeDevice =>
+	Object.assign(new EventEmitter(), {
+		available: true,
+		data: { id: config.deviceMarker },
+		driverId: config.expectedDriverId,
+		id,
+		name: config.initialName,
+		ownerUri: config.expectedOwnerUri,
+		zone: config.sourceZoneId,
+		...overrides,
+	}) as FakeDevice;
+
+const createHarness = (
+	config: HomeyShsLifecycleProbeConfig,
+): {
+	client: FakeLifecycleClient;
+	factory: HomeyLifecycleSdkFactory;
+	requests: Array<{ address: string; token: string }>;
+} => {
+	const client = new FakeLifecycleClient(config);
+	const requests: Array<{ address: string; token: string }> = [];
+	const factory: HomeyLifecycleSdkFactory = {
+		createLocalApi: ({ address, token }) => {
+			requests.push({ address, token });
+
+			return Promise.resolve(client);
+		},
+	};
+
+	return { client, factory, requests };
+};
+
+describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
+	it('requires the exact lifecycle acknowledgement and canonical operation list', () => {
+		for (const enable of [undefined, '', 'yes', 'I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE ']) {
+			expect(() =>
+				loadHomeyShsLifecycleProbeConfig({
+					...BASE_ENVIRONMENT,
+					FB_HOMEY_SHS_LIFECYCLE_ENABLE: enable,
+				}),
+			).toThrow('required acknowledgement');
+		}
+
+		for (const operations of [
+			undefined,
+			'',
+			'add,rename,zone-move,availability',
+			'rename,add,zone-move,availability,remove',
+			'add,rename,zone-move,availability,remove,remove',
+			'add, rename,zone-move,availability,remove',
+		]) {
+			expect(() =>
+				loadHomeyShsLifecycleProbeConfig({
+					...BASE_ENVIRONMENT,
+					FB_HOMEY_SHS_LIFECYCLE_OPERATIONS: operations,
+				}),
+			).toThrow('must exactly list add,rename,zone-move,availability,remove');
+		}
+	});
+
+	it('refuses conflicting mutation, recovery, and credential-rotation gates even when empty', () => {
+		for (const name of [
+			'FB_HOMEY_SHS_WRITE_ENABLE',
+			'FB_HOMEY_SHS_RECOVERY_ENABLE',
+			'FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE',
+		]) {
+			expect(() => loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, [name]: '' })).toThrow(
+				'gates must be unset during the lifecycle probe',
+			);
+		}
+	});
+
+	it('rejects incomplete or unsafe allowlist values', () => {
+		for (const name of [
+			'FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER',
+			'FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID',
+			'FB_HOMEY_SHS_LIFECYCLE_OWNER_URI',
+			'FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME',
+			'FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME',
+			'FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID',
+			'FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID',
+		]) {
+			expect(() => loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, [name]: '' })).toThrow();
+		}
+
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER: 'ordinary-device',
+			}),
+		).toThrow('specific synthetic fbsp-lifecycle-* marker');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME: 'Ordinary Device',
+			}),
+		).toThrow('synthetic FBSP Lifecycle prefix');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:another-owner:driver:test-driver',
+			}),
+		).toThrow('must belong to the dedicated Homey test app');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_OWNER_URI: 'homey:app:x',
+			}),
+		).toThrow('must identify the dedicated Homey test app');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: `${BASE_ENVIRONMENT.FB_HOMEY_SHS_LIFECYCLE_OWNER_URI}:driver:`,
+			}),
+		).toThrow('must belong to the dedicated Homey test app');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID: BASE_ENVIRONMENT.FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID,
+			}),
+		).toThrow('must differ');
+	});
+
+	it('loads the bounded lifecycle configuration through the shared endpoint contract', () => {
+		const config = loadHomeyShsLifecycleProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-lifecycle-spike');
+
+		expect(config).toMatchObject({
+			apiKey: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY,
+			expectedHost: '127.0.0.1',
+			observeMs: 10_000,
+			outputRoot: '/tmp/homey-lifecycle-spike/test/.homey-shs-captures',
+			timeoutMs: 1000,
+		});
+		expect(config.origin.origin).toBe('http://127.0.0.1:4859');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS: '9999' }),
+		).toThrow('between 10000 and 300000');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS: '300001' }),
+		).toThrow('between 10000 and 300000');
+	});
+
+	it.each(REQUIRED_SCOPES)('refuses a key missing %s before opening the add window', async (scope) => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		let addWindowCount = 0;
+
+		harness.client.scopes.delete(scope);
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					addWindowCount += 1;
+				},
+			}),
+		).rejects.toThrow('dedicated Homey lifecycle key is missing a required scope');
+		expect(addWindowCount).toBe(0);
+		expect(harness.client.devices.connectCount).toBe(0);
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+	});
+
+	it('sanitizes scope-preflight failures before any lifecycle action', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+
+		jest.spyOn(harness.client, 'hasScope').mockImplementation(() => {
+			throw new Error('raw private scope detail');
+		});
+
+		await expect(probeHomeyShsLifecycle(config, harness.factory)).rejects.toThrow(
+			'dedicated Homey lifecycle key is missing a required scope',
+		);
+		expect(harness.client.devices.connectCount).toBe(0);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+	});
+
+	it('verifies the full lifecycle in exact order while ignoring wrong and early events', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-disposable-id';
+		const device = makeOwnedDevice(config, deviceId);
+		const hooksCalled: string[] = [];
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				hooksCalled.push('add');
+				harness.client.devices.emit('device.create', {
+					...device,
+					data: { id: 'fbsp-lifecycle-wrong-marker' },
+				});
+				// This matching availability event is deliberately too early to satisfy the later stage.
+				device.emit('update', { available: false });
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				hooksCalled.push('available');
+				device.emit('update', { available: false });
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				hooksCalled.push('unavailable');
+				device.emit('update', { available: true });
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+		expect(hooksCalled).toStrictEqual(['add', 'unavailable', 'available']);
+		expect(harness.requests).toStrictEqual([
+			{ address: 'http://127.0.0.1:4859', token: 'test-api-key-that-must-not-leak' },
+		]);
+		expect(harness.client.devices.updateRequests).toStrictEqual([
+			{ $timeout: 25, device: { name: config.renamedName }, id: deviceId },
+			{ $timeout: 25, device: { zone: config.destinationZoneId }, id: deviceId },
+		]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: deviceId }]);
+		expect(harness.client.devices.inventory).toStrictEqual({});
+		expect(harness.client.devices.inventoryReadOptions).not.toHaveLength(0);
+		expect(harness.client.devices.inventoryReadOptions).toEqual(
+			harness.client.devices.inventoryReadOptions.map(() => ({
+				$cache: false,
+				$timeout: 25,
+				$updateCache: false,
+			})),
+		);
+		expect(harness.client.flow.flowReadOptions).toStrictEqual([
+			{ $cache: false, $timeout: 25, $updateCache: false },
+			{ $cache: false, $timeout: 25, $updateCache: false },
+		]);
+		expect(harness.client.flow.advancedFlowReadOptions).toStrictEqual([
+			{ $cache: false, $timeout: 25, $updateCache: false },
+			{ $cache: false, $timeout: 25, $updateCache: false },
+		]);
+		expect(harness.client.devices.disconnectCount).toBe(1);
+		expect(harness.client.disconnectCount).toBe(1);
+		expect(harness.client.destroyCount).toBe(1);
+		expect(() => assertHomeyShsLifecycleReportSafe(report, config)).not.toThrow();
+		expect(JSON.stringify(report)).not.toContain(deviceId);
+	});
+
+	it('requires a newly bound device to start available and leaves it for manual cleanup otherwise', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId, { available: false });
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+	});
+
+	it('freshly rechecks availability before asking the operator to make the device unavailable', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+		let unavailableRequestCount = 0;
+
+		harness.client.devices.inventoryReadHook = (readCount) => {
+			if (readCount === 5) {
+				owned.available = false;
+			}
+		};
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+				onUnavailableRequested: () => {
+					unavailableRequestCount += 1;
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(unavailableRequestCount).toBe(0);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+	});
+
+	it('does not mistake an aggregate manager update for the rename delta', async () => {
+		const config = fastConfig({ observeMs: 5 });
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+
+		jest.spyOn(harness.client.devices, 'updateDevice').mockImplementation((options) => {
+			harness.client.devices.updateRequests.push(options);
+			Object.assign(owned, options.device);
+			harness.client.devices.emit('device.update', { ...owned });
+
+			return Promise.resolve(owned);
+		});
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('rename event observation timed out after 5 ms');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: ownedId }]);
+	});
+
+	it('refuses a marker that exists at baseline and never opens the add window or deletes it', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const baselineId = 'preexisting-device-id';
+		let addWindowCount = 0;
+
+		harness.client.devices.inventory[baselineId] = makeOwnedDevice(config, baselineId);
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					addWindowCount += 1;
+				},
+			}),
+		).rejects.toThrow('marker already exists at baseline');
+		expect(addWindowCount).toBe(0);
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[baselineId]).toBeDefined();
+		expect(harness.client.devices.disconnectCount).toBe(1);
+		expect(harness.client.disconnectCount).toBe(1);
+		expect(harness.client.destroyCount).toBe(1);
+	});
+
+	it('refuses a lifecycle app that already owns another device', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const siblingId = 'preexisting-sibling-device-id';
+
+		harness.client.devices.inventory[siblingId] = makeOwnedDevice(config, siblingId, {
+			data: { id: 'fbsp-lifecycle-different-marker' },
+			name: 'FBSP Lifecycle Existing Sibling',
+		});
+
+		await expect(probeHomeyShsLifecycle(config, harness.factory)).rejects.toThrow(
+			'dedicated Homey lifecycle app is not isolated',
+		);
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[siblingId]).toBeDefined();
+	});
+
+	it('requires both allowlisted zones to be own inventory entries', async () => {
+		const config = fastConfig({ sourceZoneId: 'toString' });
+		const harness = createHarness(config);
+		jest.spyOn(harness.client.zones, 'getZones').mockResolvedValue({});
+
+		await expect(probeHomeyShsLifecycle(config, harness.factory)).rejects.toThrow(
+			'allowlisted Homey lifecycle zones were not found exactly',
+		);
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+	});
+
+	it('does not let wrong create events satisfy the add stage and never deletes an unbound device', async () => {
+		const config = fastConfig({ observeMs: 5 });
+		const harness = createHarness(config);
+		const unrelatedId = 'ordinary-device-id';
+		const unrelated = makeOwnedDevice(config, unrelatedId, {
+			data: { id: 'fbsp-lifecycle-unrelated-marker' },
+			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			name: 'Ordinary Device',
+			ownerUri: 'homey:app:ordinary-owner',
+		});
+
+		harness.client.devices.inventory[unrelatedId] = unrelated;
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.emit('device.create', unrelated);
+				},
+			}),
+		).rejects.toThrow('operator add observation timed out after 5 ms');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[unrelatedId]).toBe(unrelated);
+	});
+
+	it('attempts every transport cleanup step and returns only a fixed cleanup error', async () => {
+		const config = fastConfig({ observeMs: 5 });
+		const harness = createHarness(config);
+
+		harness.client.devices.failDisconnect = true;
+		harness.client.failDisconnect = true;
+		harness.client.failDestroy = true;
+
+		await expect(probeHomeyShsLifecycle(config, harness.factory)).rejects.toThrow(
+			'Homey lifecycle transport cleanup failed',
+		);
+		expect(harness.client.devices.disconnectCount).toBe(1);
+		expect(harness.client.disconnectCount).toBe(1);
+		expect(harness.client.destroyCount).toBe(1);
+	});
+
+	it('destroys a client that resolves after the bounded creation timeout', async () => {
+		jest.useFakeTimers();
+
+		try {
+			const config = fastConfig({ timeoutMs: 5 });
+			const lateClient = new FakeLifecycleClient(config);
+			const factory: HomeyLifecycleSdkFactory = {
+				createLocalApi: () =>
+					new Promise((resolvePromise) => {
+						setTimeout(() => resolvePromise(lateClient), 10);
+					}),
+			};
+			const probePromise = probeHomeyShsLifecycle(config, factory);
+			const rejection = expect(probePromise).rejects.toThrow('Homey lifecycle client creation timed out after 5 ms');
+
+			await jest.advanceTimersByTimeAsync(5);
+			await rejection;
+			await jest.advanceTimersByTimeAsync(5);
+			expect(lateClient.destroyCount).toBe(1);
+			expect(lateClient.devices.connectCount).toBe(0);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('sanitizes listener registration and operator hook failures', async () => {
+		const config = fastConfig();
+		const registrationHarness = createHarness(config);
+		jest.spyOn(registrationHarness.client.devices, 'on').mockImplementation(() => {
+			throw new Error('raw private listener registration detail');
+		});
+
+		await expect(probeHomeyShsLifecycle(config, registrationHarness.factory)).rejects.toThrow(
+			'Homey lifecycle operator add observation listener registration failed',
+		);
+
+		const hookHarness = createHarness(config);
+
+		await expect(
+			probeHomeyShsLifecycle(config, hookHarness.factory, {
+				onAddWindowOpen: () => {
+					throw new Error('raw private operator hook detail');
+				},
+			}),
+		).rejects.toThrow('Homey lifecycle operator add observation trigger failed');
+	});
+
+	it('turns listener removal failure after create into a manual-cleanup warning', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+		jest.spyOn(harness.client.devices, 'off').mockImplementation(() => {
+			throw new Error('raw private listener removal detail');
+		});
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+	});
+
+	it('settles both flow checks and never auto-deletes when flow permission cannot be verified', async () => {
+		const config = fastConfig({ timeoutMs: 5 });
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const unrelatedId = 'unrelated-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+		const unrelated = makeOwnedDevice(config, unrelatedId, {
+			data: { id: 'fbsp-lifecycle-unrelated-marker' },
+			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			name: 'Ordinary Device',
+			ownerUri: 'homey:app:ordinary-owner',
+		});
+
+		harness.client.devices.inventory[unrelatedId] = unrelated;
+		harness.client.flow.failFlowRead = true;
+		harness.client.flow.hangAdvancedFlowRead = true;
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.flow.flowReadOptions).toStrictEqual([{ $cache: false, $timeout: 5, $updateCache: false }]);
+		expect(harness.client.flow.advancedFlowReadOptions).toStrictEqual([
+			{ $cache: false, $timeout: 5, $updateCache: false },
+		]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+		expect(harness.client.devices.inventory[unrelatedId]).toBe(unrelated);
+	});
+
+	it.each([
+		{
+			attach: (client: FakeLifecycleClient, deviceId: string): void => {
+				client.flow.flows['attached-standard-flow'] = {
+					actions: [{ id: `homey:device:${deviceId}:action` }],
+				};
+			},
+			label: 'standard flow',
+		},
+		{
+			attach: (client: FakeLifecycleClient, deviceId: string): void => {
+				client.flow.advancedFlows['attached-advanced-flow'] = {
+					cards: {
+						'action-card': { id: `homey:device:${deviceId}:action`, type: 'action' },
+					},
+				};
+			},
+			label: 'advanced flow',
+		},
+	])('refuses to mutate or auto-delete a device referenced by a $label', async ({ attach }) => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+
+		attach(harness.client, ownedId);
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+	});
+
+	it('ignores unrelated standard and advanced flows', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+
+		harness.client.flow.flows['unrelated-standard-flow'] = {
+			actions: [{ id: 'homey:device:unrelated-device-id:action' }],
+		};
+		harness.client.flow.advancedFlows['unrelated-advanced-flow'] = {
+			cards: {
+				'action-card': { id: 'homey:device:unrelated-device-id:action', type: 'action' },
+			},
+		};
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[ownedId] = owned;
+				harness.client.devices.emit('device.create', owned);
+			},
+			onAvailabilityRestoreRequested: () => {
+				owned.available = true;
+				owned.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				owned.available = false;
+				owned.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: ownedId }]);
+	});
+
+	it('failure cleanup deletes only the exact run-owned device after flow safety is verified', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const unrelatedId = 'unrelated-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+		const unrelated = makeOwnedDevice(config, unrelatedId, {
+			data: { id: 'fbsp-lifecycle-unrelated-marker' },
+			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			name: 'Ordinary Device',
+			ownerUri: 'homey:app:ordinary-owner',
+		});
+
+		harness.client.devices.inventory[unrelatedId] = unrelated;
+		jest.spyOn(harness.client.devices, 'updateDevice').mockRejectedValue(new Error('raw private update failure'));
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+			}),
+		).rejects.toThrow('Homey lifecycle device rename failed');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: ownedId }]);
+		expect(harness.client.devices.inventory[ownedId]).toBeUndefined();
+		expect(harness.client.devices.inventory[unrelatedId]).toBe(unrelated);
+	});
+
+	it.each([
+		{
+			label: 'a newly attached flow',
+			mutate: (device: FakeDevice, client: FakeLifecycleClient): void => {
+				client.flow.flows['late-flow'] = {
+					actions: [{ id: `homey:device:${device.id}:action` }],
+				};
+			},
+		},
+		{
+			label: 'ownership drift',
+			mutate: (device: FakeDevice, _client: FakeLifecycleClient): void => {
+				device.driverId = 'homey:app:unexpected-owner:driver:unexpected-driver';
+			},
+		},
+	])('does not use stale cleanup authorization after $label', async ({ mutate }) => {
+		const config = fastConfig({ observeMs: 5 });
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+				onUnavailableRequested: () => {
+					mutate(owned, harness.client);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
+	});
+
+	it('does not report final absence when the lifecycle identity reappears under another id', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const ownedId = 'freshly-owned-device-id';
+		const recreatedId = 'recreated-owned-device-id';
+		const owned = makeOwnedDevice(config, ownedId);
+
+		jest.spyOn(harness.client.devices, 'deleteDevice').mockImplementation((options) => {
+			harness.client.devices.deleteRequests.push(options);
+			delete harness.client.devices.inventory[options.id];
+			harness.client.devices.emit('device.delete', { id: options.id });
+			harness.client.devices.inventory[recreatedId] = makeOwnedDevice(config, recreatedId);
+
+			return Promise.resolve();
+		});
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					harness.client.devices.inventory[ownedId] = owned;
+					harness.client.devices.emit('device.create', owned);
+				},
+				onAvailabilityRestoreRequested: () => {
+					owned.available = true;
+					owned.emit('update', { available: true });
+				},
+				onUnavailableRequested: () => {
+					owned.available = false;
+					owned.emit('update', { available: false });
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: ownedId }]);
+		expect(harness.client.devices.inventory[recreatedId]).toBeDefined();
+	});
+
+	it.each([
+		{
+			label: 'ambiguous',
+			populate: (manager: FakeLifecycleDevicesManager, config: HomeyShsLifecycleProbeConfig, device: FakeDevice) => {
+				manager.inventory[device.id] = device;
+				manager.inventory['second-owned-device-id'] = makeOwnedDevice(config, 'second-owned-device-id');
+			},
+		},
+		{
+			label: 'unverified',
+			populate: (manager: FakeLifecycleDevicesManager, config: HomeyShsLifecycleProbeConfig, device: FakeDevice) => {
+				manager.inventory[device.id] = makeOwnedDevice(config, device.id, { driverId: 'unexpected-driver' });
+			},
+		},
+	])('never auto-deletes after $label ownership read-back', async ({ populate }) => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const device = makeOwnedDevice(config, 'candidate-device-id');
+
+		await expect(
+			probeHomeyShsLifecycle(config, harness.factory, {
+				onAddWindowOpen: () => {
+					populate(harness.client.devices, config, device);
+					harness.client.devices.emit('device.create', device);
+				},
+			}),
+		).rejects.toThrow('manual disposable-device cleanup required');
+		expect(harness.client.devices.deleteRequests).toStrictEqual([]);
+		expect(harness.client.devices.updateRequests).toStrictEqual([]);
+	});
+
+	it('rejects extra fields, invalid state, unsafe values, and unordered evidence', () => {
+		const config = loadHomeyShsLifecycleProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-lifecycle-spike');
+		const extra = completeReport() as unknown as Record<string, unknown>;
+		extra.rawPayload = 'private-payload';
+
+		expect(() => assertHomeyShsLifecycleReportSchema(extra)).toThrow('root schema is invalid');
+
+		const invalidState = completeReport();
+		(invalidState.lifecycle as unknown as Record<string, unknown>).renameVerified = 'true';
+
+		expect(() => assertHomeyShsLifecycleReportSchema(invalidState)).toThrow('result schema is invalid');
+
+		const incomplete = completeReport();
+		(incomplete.lifecycle as unknown as Record<string, unknown>).finalAbsenceVerified = false;
+
+		expect(() => assertHomeyShsLifecycleReportSafe(incomplete, config)).toThrow('result schema is invalid');
+
+		const unordered = completeReport();
+		[unordered.session.events[3], unordered.session.events[4]] = [
+			unordered.session.events[4],
+			unordered.session.events[3],
+		];
+
+		expect(() => assertHomeyShsLifecycleReportSafe(unordered, config)).toThrow();
+
+		expect(() => assertHomeyShsLifecycleReportSafe(completeReport(), { ...config, privateTerms: ['rename'] })).toThrow(
+			'configured secret or private value',
+		);
+	});
+
+	it('writes a new restrictive, schema-validated report directory', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'homey-lifecycle-spike-'));
+		const report = completeReport();
+
+		try {
+			const outputDirectory = await writeHomeyShsLifecycleReport(report, root);
+			const outputStat = await stat(outputDirectory);
+			const reportStat = await stat(join(outputDirectory, 'report.json'));
+			const written = JSON.parse(await readFile(join(outputDirectory, 'report.json'), 'utf8')) as unknown;
+
+			expect(outputStat.mode & 0o777).toBe(0o700);
+			expect(reportStat.mode & 0o777).toBe(0o600);
+			expect(written).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -1,0 +1,983 @@
+import { HomeyAPI } from 'homey-api';
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const SDK_VERSION = '3.19.2';
+const LIFECYCLE_ACKNOWLEDGEMENT = 'I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE';
+const LIFECYCLE_OPERATIONS = 'add,rename,zone-move,availability,remove';
+const DEFAULT_OBSERVE_MS = 90_000;
+const MIN_OBSERVE_MS = 10_000;
+const MAX_OBSERVE_MS = 300_000;
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
+const CONFLICTING_GATE_PREFIXES = [
+	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
+	'FB_HOMEY_SHS_RECOVERY_',
+	'FB_HOMEY_SHS_WRITE_',
+];
+const REQUIRED_SCOPES = [
+	'homey.device',
+	'homey.device.readonly',
+	'homey.flow.readonly',
+	'homey.system.readonly',
+	'homey.zone.readonly',
+] as const;
+const EXPECTED_EVENTS = [
+	'sdk.create.resolved',
+	'manager.subscribe.resolved',
+	'baseline.absence.verified',
+	'add.window.open',
+	'device.create.observed',
+	'add.readback.resolved',
+	'flows.absence.verified',
+	'device.rename.requested',
+	'device.update.rename.observed',
+	'rename.readback.resolved',
+	'device.zone-move.requested',
+	'device.update.zone-move.observed',
+	'zone-move.readback.resolved',
+	'availability.unavailable.requested',
+	'device.update.unavailable.observed',
+	'unavailable.readback.resolved',
+	'availability.restore.requested',
+	'device.update.available.observed',
+	'availability.readback.resolved',
+	'device.remove.requested',
+	'device.delete.observed',
+	'final.absence.verified',
+	'manager.unsubscribe.resolved',
+	'socket.disconnect.resolved',
+	'sdk.destroyed',
+] as const;
+
+type EventListener = (...arguments_: unknown[]) => void;
+type LifecycleEvent = (typeof EXPECTED_EVENTS)[number];
+
+class HomeyShsLifecycleTimeoutError extends Error {
+	constructor(label: string, timeoutMs: number) {
+		super(`Homey lifecycle ${label} timed out after ${timeoutMs} ms`);
+		this.name = 'HomeyShsLifecycleTimeoutError';
+	}
+}
+
+interface EventSource {
+	off?(event: string, listener: EventListener): unknown;
+	on(event: string, listener: EventListener): unknown;
+}
+
+interface HomeyLifecycleDevice extends EventSource, Record<string, unknown> {
+	available?: unknown;
+	data?: unknown;
+	driverId?: unknown;
+	id: string;
+	name?: unknown;
+	ownerUri?: unknown;
+	zone?: unknown;
+}
+
+interface HomeyLifecycleFlowManager {
+	getAdvancedFlows(options?: {
+		$cache?: boolean;
+		$timeout?: number;
+		$updateCache?: boolean;
+	}): Promise<Record<string, unknown>>;
+	getFlows(options?: { $cache?: boolean; $timeout?: number; $updateCache?: boolean }): Promise<Record<string, unknown>>;
+}
+
+interface HomeyLifecycleDevicesManager extends EventSource {
+	connect(): Promise<void>;
+	deleteDevice(options: { $timeout?: number; id: string }): Promise<unknown>;
+	disconnect(): Promise<void>;
+	getDevices(options?: {
+		$cache?: boolean;
+		$timeout?: number;
+		$updateCache?: boolean;
+	}): Promise<Record<string, HomeyLifecycleDevice>>;
+	updateDevice(options: { $timeout?: number; device: { name?: string; zone?: string }; id: string }): Promise<unknown>;
+}
+
+interface HomeyLifecycleZonesManager {
+	getZones(options?: { $cache?: boolean; $timeout?: number; $updateCache?: boolean }): Promise<Record<string, unknown>>;
+}
+
+interface HomeyLifecycleClient {
+	destroy(): void;
+	disconnect(): Promise<void>;
+	devices: HomeyLifecycleDevicesManager;
+	flow: HomeyLifecycleFlowManager;
+	hasScope(scope: string): boolean;
+	zones: HomeyLifecycleZonesManager;
+}
+
+export interface HomeyLifecycleSdkFactory {
+	createLocalApi(options: { address: string; token: string }): Promise<HomeyLifecycleClient>;
+}
+
+export interface HomeyShsLifecycleProbeConfig extends HomeyShsProbeConfig {
+	destinationZoneId: string;
+	deviceMarker: string;
+	expectedDriverId: string;
+	expectedOwnerUri: string;
+	initialName: string;
+	observeMs: number;
+	renamedName: string;
+	sourceZoneId: string;
+}
+
+export interface HomeyShsLifecycleReport {
+	lifecycle: {
+		addVerified: boolean;
+		availabilityRestored: boolean;
+		finalAbsenceVerified: boolean;
+		flowAbsenceVerified: boolean;
+		removeVerified: boolean;
+		renameVerified: boolean;
+		unavailableVerified: boolean;
+		zoneMoveVerified: boolean;
+	};
+	metadata: {
+		probe: 'homey-shs-lifecycle';
+		schemaVersion: 1;
+		sdkVersion: string;
+	};
+	session: {
+		cleanupCompleted: boolean;
+		events: Array<{ event: LifecycleEvent; order: number }>;
+		managerSubscribed: boolean;
+	};
+}
+
+export interface HomeyLifecycleOperatorHooks {
+	onAddWindowOpen?(): void;
+	onAvailabilityRestoreRequested?(): void;
+	onUnavailableRequested?(): void;
+}
+
+const sdkFactory: HomeyLifecycleSdkFactory = {
+	createLocalApi: async ({ address, token }) =>
+		(await HomeyAPI.createLocalAPI({ address, token, debug: null })) as HomeyLifecycleClient,
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey lifecycle report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey lifecycle report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+const parseObserveMs = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_OBSERVE_MS;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(
+			`FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`,
+		);
+	}
+
+	return parsed;
+};
+
+const requireEnvironmentValue = (environment: NodeJS.ProcessEnv, name: string): string => {
+	const value = environment[name]?.trim();
+
+	if (!value) {
+		throw new Error(`${name} is required and must not be empty`);
+	}
+
+	return value;
+};
+
+export const loadHomeyShsLifecycleProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsLifecycleProbeConfig => {
+	if (environment.FB_HOMEY_SHS_LIFECYCLE_ENABLE !== LIFECYCLE_ACKNOWLEDGEMENT) {
+		throw new Error('FB_HOMEY_SHS_LIFECYCLE_ENABLE does not contain the required acknowledgement');
+	}
+
+	if (environment.FB_HOMEY_SHS_LIFECYCLE_OPERATIONS !== LIFECYCLE_OPERATIONS) {
+		throw new Error('FB_HOMEY_SHS_LIFECYCLE_OPERATIONS must exactly list add,rename,zone-move,availability,remove');
+	}
+
+	const conflictingGate = Object.keys(environment).find((name) =>
+		CONFLICTING_GATE_PREFIXES.some((prefix) => name.startsWith(prefix)),
+	);
+
+	if (conflictingGate !== undefined) {
+		throw new Error('Homey write, recovery, and credential-rotation gates must be unset during the lifecycle probe');
+	}
+
+	const deviceMarker = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER');
+	const expectedDriverId = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID');
+	const expectedOwnerUri = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_OWNER_URI');
+	const initialName = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME');
+	const renamedName = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME');
+	const sourceZoneId = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID');
+	const destinationZoneId = requireEnvironmentValue(environment, 'FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID');
+
+	if (!/^fbsp-lifecycle-[a-z0-9][a-z0-9-]{7,63}$/.test(deviceMarker)) {
+		throw new Error('FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER must be a specific synthetic fbsp-lifecycle-* marker');
+	}
+
+	if (!initialName.startsWith('FBSP Lifecycle ') || !renamedName.startsWith('FBSP Lifecycle ')) {
+		throw new Error('Homey lifecycle names must use the synthetic FBSP Lifecycle prefix');
+	}
+
+	if (initialName === renamedName) {
+		throw new Error('Homey lifecycle initial and renamed names must differ');
+	}
+
+	const ownerId = expectedOwnerUri.slice('homey:app:'.length);
+
+	if (!expectedOwnerUri.startsWith('homey:app:') || !/^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/.test(ownerId)) {
+		throw new Error('FB_HOMEY_SHS_LIFECYCLE_OWNER_URI must identify the dedicated Homey test app');
+	}
+
+	const driverPrefix = `${expectedOwnerUri}:driver:`;
+	const driverId = expectedDriverId.slice(driverPrefix.length);
+
+	if (!expectedDriverId.startsWith(driverPrefix) || !/^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/.test(driverId)) {
+		throw new Error('FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID must belong to the dedicated Homey test app');
+	}
+
+	if (sourceZoneId === destinationZoneId) {
+		throw new Error('Homey lifecycle source and destination zones must differ');
+	}
+
+	return {
+		...loadHomeyShsProbeConfig(environment, workingDirectory),
+		destinationZoneId,
+		deviceMarker,
+		expectedDriverId,
+		expectedOwnerUri,
+		initialName,
+		observeMs: parseObserveMs(environment.FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS),
+		renamedName,
+		sourceZoneId,
+	};
+};
+
+const settleOperation = async <T>(label: string, timeoutMs: number, operation: () => Promise<T>): Promise<T> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const operationPromise = operation();
+	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
+		timeout = setTimeout(() => rejectPromise(new HomeyShsLifecycleTimeoutError(label, timeoutMs)), timeoutMs);
+	});
+
+	try {
+		return await Promise.race([operationPromise, timeoutPromise]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
+};
+
+const runOperation = async <T>(label: string, timeoutMs: number, operation: () => Promise<T>): Promise<T> => {
+	try {
+		return await settleOperation(label, timeoutMs, operation);
+	} catch (error: unknown) {
+		if (error instanceof HomeyShsLifecycleTimeoutError) {
+			throw error;
+		}
+
+		// eslint-disable-next-line preserve-caught-error -- SDK errors may contain private endpoint or device detail.
+		throw new Error(`Homey lifecycle ${label} failed`);
+	}
+};
+
+const createClient = async (
+	config: HomeyShsLifecycleProbeConfig,
+	factory: HomeyLifecycleSdkFactory,
+): Promise<HomeyLifecycleClient> => {
+	const creationPromise = factory.createLocalApi({ address: config.origin.origin, token: config.apiKey });
+
+	try {
+		return await runOperation('client creation', config.timeoutMs, () => creationPromise);
+	} catch (error: unknown) {
+		if (error instanceof HomeyShsLifecycleTimeoutError) {
+			void creationPromise.then(
+				(lateClient) => {
+					try {
+						lateClient.destroy();
+					} catch {
+						// The caller already receives the fixed, sanitized creation timeout.
+					}
+				},
+				() => undefined,
+			);
+		}
+
+		throw error;
+	}
+};
+
+const appendEvent = (report: HomeyShsLifecycleReport, event: LifecycleEvent): void => {
+	report.session.events.push({ event, order: report.session.events.length + 1 });
+};
+
+const deviceMarkerOf = (device: HomeyLifecycleDevice): unknown => (isRecord(device.data) ? device.data.id : undefined);
+
+const hasImmutableOwnership = (device: HomeyLifecycleDevice, config: HomeyShsLifecycleProbeConfig): boolean =>
+	deviceMarkerOf(device) === config.deviceMarker &&
+	device.driverId === config.expectedDriverId &&
+	device.ownerUri === config.expectedOwnerUri;
+
+const isInitialDevice = (device: HomeyLifecycleDevice, config: HomeyShsLifecycleProbeConfig): boolean =>
+	hasImmutableOwnership(device, config) && device.name === config.initialName && device.zone === config.sourceZoneId;
+
+const freshDevices = async (
+	client: HomeyLifecycleClient,
+	config: HomeyShsLifecycleProbeConfig,
+): Promise<Record<string, HomeyLifecycleDevice>> =>
+	runOperation('fresh inventory read', config.timeoutMs, () =>
+		client.devices.getDevices({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+	);
+
+const requireSingleOwnedDevice = (
+	devices: Record<string, HomeyLifecycleDevice>,
+	config: HomeyShsLifecycleProbeConfig,
+	expectedId?: string,
+): HomeyLifecycleDevice => {
+	const matches = Object.values(devices).filter((device) => hasImmutableOwnership(device, config));
+
+	if (matches.length !== 1 || (expectedId !== undefined && matches[0].id !== expectedId)) {
+		throw new Error('Homey lifecycle ownership verification failed');
+	}
+
+	return matches[0];
+};
+
+const assertDedicatedOwnerIsolation = (
+	devices: Record<string, HomeyLifecycleDevice>,
+	config: HomeyShsLifecycleProbeConfig,
+	expectedId?: string,
+): void => {
+	const ownerMatches = Object.values(devices).filter((device) => device.ownerUri === config.expectedOwnerUri);
+
+	if (
+		(expectedId === undefined && ownerMatches.length !== 0) ||
+		(expectedId !== undefined && (ownerMatches.length !== 1 || ownerMatches[0].id !== expectedId))
+	) {
+		throw new Error('The dedicated Homey lifecycle app is not isolated to the run-owned device');
+	}
+};
+
+const hasLifecycleResidue = (
+	devices: Record<string, HomeyLifecycleDevice>,
+	config: HomeyShsLifecycleProbeConfig,
+	boundDeviceId: string,
+): boolean =>
+	Object.hasOwn(devices, boundDeviceId) ||
+	Object.values(devices).some(
+		(device) => deviceMarkerOf(device) === config.deviceMarker || device.ownerUri === config.expectedOwnerUri,
+	);
+
+const observeManagerEvent = async (
+	source: EventSource,
+	event: string,
+	label: string,
+	timeoutMs: number,
+	predicate: (payload: unknown) => boolean,
+	trigger: () => Promise<void> | void,
+): Promise<unknown> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	let resolveEvent: (payload: unknown) => void = () => undefined;
+	const eventPromise = new Promise<unknown>((resolvePromise) => {
+		resolveEvent = resolvePromise;
+	});
+	const listener: EventListener = (payload: unknown): void => {
+		if (predicate(payload)) {
+			resolveEvent(payload);
+		}
+	};
+
+	try {
+		source.on(event, listener);
+	} catch {
+		throw new Error(`Homey lifecycle ${label} listener registration failed`);
+	}
+
+	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
+		timeout = setTimeout(() => rejectPromise(new HomeyShsLifecycleTimeoutError(label, timeoutMs)), timeoutMs);
+	});
+
+	const triggerPromise = Promise.resolve().then(async () => {
+		try {
+			await trigger();
+		} catch (error: unknown) {
+			if (
+				error instanceof HomeyShsLifecycleTimeoutError ||
+				(error instanceof Error && error.message.startsWith('Homey lifecycle '))
+			) {
+				throw error;
+			}
+
+			// eslint-disable-next-line preserve-caught-error -- Operator/SDK hook errors may contain private detail.
+			throw new Error(`Homey lifecycle ${label} trigger failed`);
+		}
+	});
+	let observationError: unknown;
+	let observationFailed = false;
+	let listenerRemovalFailed = false;
+	let result: unknown;
+
+	try {
+		await Promise.race([triggerPromise, timeoutPromise]);
+		result = await Promise.race([eventPromise, timeoutPromise]);
+	} catch (error: unknown) {
+		observationError = error;
+		observationFailed = true;
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+		try {
+			source.off?.(event, listener);
+		} catch {
+			listenerRemovalFailed = true;
+		}
+	}
+
+	if (listenerRemovalFailed) {
+		throw new Error(`Homey lifecycle ${label} listener removal failed`);
+	}
+
+	if (observationFailed) {
+		throw observationError;
+	}
+
+	return result;
+};
+
+const flowCardReferencesDevice = (card: unknown, deviceUri: string): boolean => {
+	if (!isRecord(card) || typeof card.id !== 'string') {
+		return false;
+	}
+
+	return card.id === deviceUri || card.id.startsWith(`${deviceUri}:`);
+};
+
+const standardFlowReferencesDevice = (flow: unknown, deviceUri: string): boolean => {
+	if (!isRecord(flow)) {
+		return false;
+	}
+
+	return (
+		flowCardReferencesDevice(flow.trigger, deviceUri) ||
+		(Array.isArray(flow.conditions) && flow.conditions.some((card) => flowCardReferencesDevice(card, deviceUri))) ||
+		(Array.isArray(flow.actions) && flow.actions.some((card) => flowCardReferencesDevice(card, deviceUri)))
+	);
+};
+
+const advancedFlowReferencesDevice = (flow: unknown, deviceUri: string): boolean => {
+	if (!isRecord(flow) || !isRecord(flow.cards)) {
+		return false;
+	}
+
+	return Object.values(flow.cards).some(
+		(card) =>
+			isRecord(card) &&
+			typeof card.type === 'string' &&
+			['action', 'condition', 'trigger'].includes(card.type) &&
+			flowCardReferencesDevice(card, deviceUri),
+	);
+};
+
+const assertNoAttachedFlows = async (
+	client: HomeyLifecycleClient,
+	deviceId: string,
+	config: HomeyShsLifecycleProbeConfig,
+): Promise<void> => {
+	const flowResults = await Promise.allSettled([
+		runOperation('flow safety read', config.timeoutMs, () =>
+			client.flow.getFlows({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+		runOperation('advanced-flow safety read', config.timeoutMs, () =>
+			client.flow.getAdvancedFlows({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+	]);
+
+	if (flowResults.some((result) => result.status === 'rejected')) {
+		throw new Error('Homey lifecycle flow safety verification failed');
+	}
+
+	const [flows, advancedFlows] = flowResults.map((result) => (result.status === 'fulfilled' ? result.value : {}));
+
+	const deviceUri = `homey:device:${deviceId}`;
+
+	if (
+		Object.values(flows).some((flow) => standardFlowReferencesDevice(flow, deviceUri)) ||
+		Object.values(advancedFlows).some((flow) => advancedFlowReferencesDevice(flow, deviceUri))
+	) {
+		throw new Error('The disposable Homey lifecycle device is referenced by a flow');
+	}
+};
+
+const assertRequiredScopes = (client: HomeyLifecycleClient): void => {
+	let hasAllRequiredScopes = false;
+
+	try {
+		hasAllRequiredScopes =
+			typeof client.hasScope === 'function' && REQUIRED_SCOPES.every((scope) => client.hasScope(scope));
+	} catch {
+		// The caller receives only the fixed scope-preflight error below.
+	}
+
+	if (!hasAllRequiredScopes) {
+		throw new Error('The dedicated Homey lifecycle key is missing a required scope');
+	}
+};
+
+const deviceIdOf = (payload: unknown): string | null =>
+	isRecord(payload) && typeof payload.id === 'string' ? payload.id : null;
+
+const assertZonePreflight = async (
+	client: HomeyLifecycleClient,
+	config: HomeyShsLifecycleProbeConfig,
+): Promise<void> => {
+	const zones = await runOperation('zone preflight read', config.timeoutMs, () =>
+		client.zones.getZones({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+	);
+
+	if (!Object.hasOwn(zones, config.sourceZoneId) || !Object.hasOwn(zones, config.destinationZoneId)) {
+		throw new Error('The allowlisted Homey lifecycle zones were not found exactly');
+	}
+};
+
+export const probeHomeyShsLifecycle = async (
+	config: HomeyShsLifecycleProbeConfig,
+	factory: HomeyLifecycleSdkFactory = sdkFactory,
+	hooks: HomeyLifecycleOperatorHooks = {},
+): Promise<HomeyShsLifecycleReport> => {
+	const report = {
+		lifecycle: {
+			addVerified: true,
+			availabilityRestored: true,
+			finalAbsenceVerified: true,
+			flowAbsenceVerified: true,
+			removeVerified: true,
+			renameVerified: true,
+			unavailableVerified: true,
+			zoneMoveVerified: true,
+		},
+		metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 1, sdkVersion: SDK_VERSION },
+		session: { cleanupCompleted: true, events: [], managerSubscribed: true },
+	} as HomeyShsLifecycleReport;
+	const client = await createClient(config, factory);
+	appendEvent(report, 'sdk.create.resolved');
+	let boundDeviceId: string | undefined;
+	let createdDuringRun = false;
+	let deletionAuthorized = false;
+	let deleteAttempted = false;
+	let finalAbsenceVerified = false;
+	let operationError: unknown;
+	let manualCleanupRequired = false;
+	const transportCleanupFailures: string[] = [];
+
+	try {
+		assertRequiredScopes(client);
+		await runOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
+		appendEvent(report, 'manager.subscribe.resolved');
+		await assertZonePreflight(client, config);
+		const baseline = await freshDevices(client, config);
+
+		if (Object.values(baseline).some((device) => deviceMarkerOf(device) === config.deviceMarker)) {
+			throw new Error('The disposable Homey lifecycle marker already exists at baseline');
+		}
+
+		assertDedicatedOwnerIsolation(baseline, config);
+
+		appendEvent(report, 'baseline.absence.verified');
+		appendEvent(report, 'add.window.open');
+		const createdPayload = await observeManagerEvent(
+			client.devices,
+			'device.create',
+			'operator add observation',
+			config.observeMs,
+			(payload) => {
+				const matches = isRecord(payload) && isInitialDevice(payload as HomeyLifecycleDevice, config);
+
+				if (matches) {
+					boundDeviceId = deviceIdOf(payload) ?? undefined;
+					manualCleanupRequired = boundDeviceId !== undefined;
+				}
+
+				return matches;
+			},
+			() => hooks.onAddWindowOpen?.(),
+		);
+		boundDeviceId = deviceIdOf(createdPayload) ?? undefined;
+		manualCleanupRequired = boundDeviceId !== undefined;
+
+		if (boundDeviceId === undefined) {
+			throw new Error('Homey lifecycle create event did not contain a device identifier');
+		}
+
+		appendEvent(report, 'device.create.observed');
+		const createdInventory = await freshDevices(client, config);
+		const createdDevice = requireSingleOwnedDevice(createdInventory, config, boundDeviceId);
+		const boundEventDevice = createdPayload as HomeyLifecycleDevice;
+
+		if (!isInitialDevice(createdDevice, config)) {
+			throw new Error('The created Homey lifecycle device failed its fresh identity read-back');
+		}
+
+		if (createdDevice.available !== true) {
+			throw new Error('The created Homey lifecycle device must initially be available');
+		}
+
+		if (typeof boundEventDevice.on !== 'function' || typeof boundEventDevice.off !== 'function') {
+			throw new Error('The created Homey lifecycle device does not expose safe update events');
+		}
+
+		createdDuringRun = true;
+		manualCleanupRequired = false;
+		assertDedicatedOwnerIsolation(createdInventory, config, boundDeviceId);
+		appendEvent(report, 'add.readback.resolved');
+		await assertNoAttachedFlows(client, boundDeviceId, config);
+		deletionAuthorized = true;
+		appendEvent(report, 'flows.absence.verified');
+
+		await observeManagerEvent(
+			boundEventDevice,
+			'update',
+			'rename event observation',
+			config.observeMs,
+			(payload) => isRecord(payload) && payload.name === config.renamedName,
+			async () => {
+				appendEvent(report, 'device.rename.requested');
+				await runOperation('device rename', config.timeoutMs, () =>
+					client.devices.updateDevice({
+						$timeout: config.timeoutMs,
+						device: { name: config.renamedName },
+						id: boundDeviceId,
+					}),
+				);
+			},
+		);
+		appendEvent(report, 'device.update.rename.observed');
+		const renamedDevice = requireSingleOwnedDevice(await freshDevices(client, config), config, boundDeviceId);
+
+		if (renamedDevice.name !== config.renamedName) {
+			throw new Error('Homey lifecycle rename read-back did not match');
+		}
+
+		appendEvent(report, 'rename.readback.resolved');
+
+		await observeManagerEvent(
+			boundEventDevice,
+			'update',
+			'zone-move event observation',
+			config.observeMs,
+			(payload) => isRecord(payload) && payload.zone === config.destinationZoneId,
+			async () => {
+				appendEvent(report, 'device.zone-move.requested');
+				await runOperation('device zone move', config.timeoutMs, () =>
+					client.devices.updateDevice({
+						$timeout: config.timeoutMs,
+						device: { zone: config.destinationZoneId },
+						id: boundDeviceId,
+					}),
+				);
+			},
+		);
+		appendEvent(report, 'device.update.zone-move.observed');
+		const movedDevice = requireSingleOwnedDevice(await freshDevices(client, config), config, boundDeviceId);
+
+		if (movedDevice.zone !== config.destinationZoneId) {
+			throw new Error('Homey lifecycle zone-move read-back did not match');
+		}
+
+		appendEvent(report, 'zone-move.readback.resolved');
+		const preUnavailableInventory = await freshDevices(client, config);
+		const preUnavailableDevice = requireSingleOwnedDevice(preUnavailableInventory, config, boundDeviceId);
+		assertDedicatedOwnerIsolation(preUnavailableInventory, config, boundDeviceId);
+
+		if (preUnavailableDevice.available !== true) {
+			throw new Error('The Homey lifecycle device must be available before unavailable observation');
+		}
+
+		appendEvent(report, 'availability.unavailable.requested');
+		await observeManagerEvent(
+			boundEventDevice,
+			'update',
+			'unavailable event observation',
+			config.observeMs,
+			(payload) => isRecord(payload) && payload.available === false,
+			() => hooks.onUnavailableRequested?.(),
+		);
+		appendEvent(report, 'device.update.unavailable.observed');
+		const unavailableInventory = await freshDevices(client, config);
+		const unavailableDevice = requireSingleOwnedDevice(unavailableInventory, config, boundDeviceId);
+		assertDedicatedOwnerIsolation(unavailableInventory, config, boundDeviceId);
+
+		if (unavailableDevice.available !== false) {
+			throw new Error('Homey lifecycle unavailable read-back did not match');
+		}
+
+		appendEvent(report, 'unavailable.readback.resolved');
+		appendEvent(report, 'availability.restore.requested');
+		await observeManagerEvent(
+			boundEventDevice,
+			'update',
+			'availability restoration event observation',
+			config.observeMs,
+			(payload) => isRecord(payload) && payload.available === true,
+			() => hooks.onAvailabilityRestoreRequested?.(),
+		);
+		appendEvent(report, 'device.update.available.observed');
+		const availableInventory = await freshDevices(client, config);
+		const availableDevice = requireSingleOwnedDevice(availableInventory, config, boundDeviceId);
+		assertDedicatedOwnerIsolation(availableInventory, config, boundDeviceId);
+
+		if (availableDevice.available !== true) {
+			throw new Error('Homey lifecycle availability restoration read-back did not match');
+		}
+
+		appendEvent(report, 'availability.readback.resolved');
+		deletionAuthorized = false;
+		await assertNoAttachedFlows(client, boundDeviceId, config);
+		deletionAuthorized = true;
+		appendEvent(report, 'device.remove.requested');
+		deleteAttempted = true;
+		await observeManagerEvent(
+			client.devices,
+			'device.delete',
+			'delete event observation',
+			config.observeMs,
+			(payload) => deviceIdOf(payload) === boundDeviceId,
+			async () => {
+				await runOperation('device removal', config.timeoutMs, () =>
+					client.devices.deleteDevice({ $timeout: config.timeoutMs, id: boundDeviceId }),
+				);
+			},
+		);
+		appendEvent(report, 'device.delete.observed');
+
+		if (hasLifecycleResidue(await freshDevices(client, config), config, boundDeviceId)) {
+			throw new Error('The disposable Homey lifecycle device still exists after removal');
+		}
+
+		finalAbsenceVerified = true;
+		appendEvent(report, 'final.absence.verified');
+	} catch (error: unknown) {
+		operationError = error;
+	} finally {
+		if (createdDuringRun && !finalAbsenceVerified && boundDeviceId !== undefined) {
+			try {
+				const currentDevices = await freshDevices(client, config);
+
+				if (!hasLifecycleResidue(currentDevices, config, boundDeviceId)) {
+					finalAbsenceVerified = true;
+				} else if (deletionAuthorized && !deleteAttempted) {
+					const cleanupDevice = requireSingleOwnedDevice(currentDevices, config, boundDeviceId);
+					assertDedicatedOwnerIsolation(currentDevices, config, boundDeviceId);
+
+					if (cleanupDevice.available === true) {
+						await assertNoAttachedFlows(client, boundDeviceId, config);
+						deleteAttempted = true;
+						await runOperation('failure cleanup removal', config.timeoutMs, () =>
+							client.devices.deleteDevice({ $timeout: config.timeoutMs, id: boundDeviceId }),
+						);
+						finalAbsenceVerified = !hasLifecycleResidue(await freshDevices(client, config), config, boundDeviceId);
+					}
+				}
+			} catch {
+				finalAbsenceVerified = false;
+			}
+
+			manualCleanupRequired ||= !finalAbsenceVerified;
+		}
+
+		try {
+			await runOperation('manager unsubscribe', config.timeoutMs, () => client.devices.disconnect());
+			if (operationError === undefined) appendEvent(report, 'manager.unsubscribe.resolved');
+		} catch {
+			transportCleanupFailures.push('manager unsubscribe');
+		}
+
+		try {
+			await runOperation('socket disconnect', config.timeoutMs, () => client.disconnect());
+			if (operationError === undefined) appendEvent(report, 'socket.disconnect.resolved');
+		} catch {
+			transportCleanupFailures.push('socket disconnect');
+		}
+
+		try {
+			client.destroy();
+			if (operationError === undefined) appendEvent(report, 'sdk.destroyed');
+		} catch {
+			transportCleanupFailures.push('client destroy');
+		}
+	}
+
+	if (manualCleanupRequired) {
+		throw new Error('Homey lifecycle failed; manual disposable-device cleanup required');
+	}
+
+	if (transportCleanupFailures.length > 0) {
+		throw new Error('Homey lifecycle transport cleanup failed');
+	}
+
+	if (operationError !== undefined) {
+		throw operationError;
+	}
+
+	return report;
+};
+
+/** Validates every persisted key, scalar, and event before lifecycle evidence is accepted. */
+export function assertHomeyShsLifecycleReportSchema(value: unknown): asserts value is HomeyShsLifecycleReport {
+	const report = requireExactKeys(value, ['lifecycle', 'metadata', 'session'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const lifecycle = requireExactKeys(
+		report.lifecycle,
+		[
+			'addVerified',
+			'availabilityRestored',
+			'finalAbsenceVerified',
+			'flowAbsenceVerified',
+			'removeVerified',
+			'renameVerified',
+			'unavailableVerified',
+			'zoneMoveVerified',
+		],
+		'lifecycle',
+	);
+	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
+
+	if (metadata.probe !== 'homey-shs-lifecycle' || metadata.schemaVersion !== 1 || metadata.sdkVersion !== SDK_VERSION) {
+		throw new Error('Homey lifecycle report metadata schema is invalid');
+	}
+
+	if (Object.values(lifecycle).some((result) => result !== true)) {
+		throw new Error('Homey lifecycle report result schema is invalid');
+	}
+
+	if (session.cleanupCompleted !== true || session.managerSubscribed !== true || !Array.isArray(session.events)) {
+		throw new Error('Homey lifecycle report session schema is invalid');
+	}
+
+	if (session.events.length !== EXPECTED_EVENTS.length) {
+		throw new Error('Homey lifecycle report event schema is invalid');
+	}
+
+	for (const [index, eventValue] of session.events.entries()) {
+		const event = requireExactKeys(eventValue, ['event', 'order'], 'event');
+
+		if (event.event !== EXPECTED_EVENTS[index] || event.order !== index + 1) {
+			throw new Error('Homey lifecycle report event schema is invalid');
+		}
+	}
+}
+
+export function assertHomeyShsLifecycleReportSafe(
+	value: unknown,
+	config: HomeyShsLifecycleProbeConfig,
+): asserts value is HomeyShsLifecycleReport {
+	assertHomeyShsLifecycleReportSchema(value);
+
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbiddenValues = [
+		config.apiKey,
+		config.expectedHost,
+		config.deviceMarker,
+		config.expectedDriverId,
+		config.expectedOwnerUri,
+		config.initialName,
+		config.renamedName,
+		config.sourceZoneId,
+		config.destinationZoneId,
+		...config.privateTerms,
+	]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
+
+	if (forbiddenValues.some((item) => serialized.includes(item))) {
+		throw new Error('Sanitized Homey lifecycle report contains a configured secret or private value');
+	}
+
+	if (
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized) ||
+		/(?:[0-9a-f]{2}(?:[:-][0-9a-f]{2}){5}|[0-9a-f]{4}(?:\.[0-9a-f]{4}){2})/i.test(serialized)
+	) {
+		throw new Error('Sanitized Homey lifecycle report contains an address, email, or URL');
+	}
+}
+
+export const writeHomeyShsLifecycleReport = async (
+	report: HomeyShsLifecycleReport,
+	outputRoot: string,
+): Promise<string> => {
+	assertHomeyShsLifecycleReportSchema(report);
+
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `lifecycle-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsLifecycleProbeConfig(process.env);
+	const report = await probeHomeyShsLifecycle(config, sdkFactory, {
+		onAddWindowOpen: () => {
+			process.stdout.write(
+				'Homey lifecycle add window is open. Add only the allowlisted disposable test device now.\n',
+			);
+		},
+		onAvailabilityRestoreRequested: () => {
+			process.stdout.write(
+				'Homey lifecycle availability restoration window is open. Restore only the bound test device now.\n',
+			);
+		},
+		onUnavailableRequested: () => {
+			process.stdout.write(
+				'Homey lifecycle unavailable window is open. Make only the bound disposable test device unavailable now.\n',
+			);
+		},
+	});
+
+	assertHomeyShsLifecycleReportSafe(report, config);
+	const outputDirectory = await writeHomeyShsLifecycleReport(report, config.outputRoot);
+
+	process.stdout.write(`Sanitized Homey lifecycle report written to ${outputDirectory}.\n`);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS lifecycle probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -17,13 +17,6 @@ const CONFLICTING_GATE_PREFIXES = [
 	'FB_HOMEY_SHS_RECOVERY_',
 	'FB_HOMEY_SHS_WRITE_',
 ];
-const REQUIRED_SCOPES = [
-	'homey.device',
-	'homey.device.readonly',
-	'homey.flow.readonly',
-	'homey.system.readonly',
-	'homey.zone.readonly',
-] as const;
 const EXPECTED_EVENTS = [
 	'sdk.create.resolved',
 	'manager.subscribe.resolved',
@@ -86,6 +79,10 @@ interface HomeyLifecycleFlowManager {
 	getFlows(options?: { $cache?: boolean; $timeout?: number; $updateCache?: boolean }): Promise<Record<string, unknown>>;
 }
 
+interface HomeyLifecycleDriversManager {
+	getPairSession(options: { $timeout?: number; id: string }): Promise<unknown>;
+}
+
 interface HomeyLifecycleDevicesManager extends EventSource {
 	connect(): Promise<void>;
 	deleteDevice(options: { $timeout?: number; id: string }): Promise<unknown>;
@@ -102,12 +99,17 @@ interface HomeyLifecycleZonesManager {
 	getZones(options?: { $cache?: boolean; $timeout?: number; $updateCache?: boolean }): Promise<Record<string, unknown>>;
 }
 
+interface HomeyLifecycleSystemManager {
+	getInfo(options?: { $timeout?: number }): Promise<unknown>;
+}
+
 interface HomeyLifecycleClient {
 	destroy(): void;
 	disconnect(): Promise<void>;
 	devices: HomeyLifecycleDevicesManager;
+	drivers: HomeyLifecycleDriversManager;
 	flow: HomeyLifecycleFlowManager;
-	hasScope(scope: string): boolean;
+	system: HomeyLifecycleSystemManager;
 	zones: HomeyLifecycleZonesManager;
 }
 
@@ -534,18 +536,60 @@ const assertNoAttachedFlows = async (
 	}
 };
 
-const assertRequiredScopes = (client: HomeyLifecycleClient): void => {
-	let hasAllRequiredScopes = false;
+const statusCodeOf = (error: unknown): number | null =>
+	isRecord(error) && typeof error.statusCode === 'number' ? error.statusCode : null;
+
+const proveDeviceWriteScope = async (
+	client: HomeyLifecycleClient,
+	config: HomeyShsLifecycleProbeConfig,
+): Promise<void> => {
+	const missingPairSessionId = `fbsp-lifecycle-scope-preflight-${randomBytes(16).toString('hex')}`;
 
 	try {
-		hasAllRequiredScopes =
-			typeof client.hasScope === 'function' && REQUIRED_SCOPES.every((scope) => client.hasScope(scope));
-	} catch {
-		// The caller receives only the fixed scope-preflight error below.
+		await settleOperation('device write-scope preflight', config.timeoutMs, () =>
+			client.drivers.getPairSession({ $timeout: config.timeoutMs, id: missingPairSessionId }),
+		);
+	} catch (error: unknown) {
+		if (statusCodeOf(error) === 404) {
+			return;
+		}
+
+		if (error instanceof HomeyShsLifecycleTimeoutError) {
+			throw error;
+		}
+
+		// eslint-disable-next-line preserve-caught-error -- API errors can contain endpoint and authorization detail.
+		throw new Error('Homey lifecycle device write-scope preflight failed');
 	}
 
-	if (!hasAllRequiredScopes) {
-		throw new Error('The dedicated Homey lifecycle key is missing a required scope');
+	throw new Error('Homey lifecycle device write-scope preflight returned an unexpected pair session');
+};
+
+const assertPermissionPreflight = async (
+	client: HomeyLifecycleClient,
+	config: HomeyShsLifecycleProbeConfig,
+): Promise<void> => {
+	const results = await Promise.allSettled([
+		runOperation('system permission preflight', config.timeoutMs, () =>
+			client.system.getInfo({ $timeout: config.timeoutMs }),
+		),
+		runOperation('device-read permission preflight', config.timeoutMs, () =>
+			client.devices.getDevices({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+		runOperation('zone permission preflight', config.timeoutMs, () =>
+			client.zones.getZones({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+		runOperation('flow permission preflight', config.timeoutMs, () =>
+			client.flow.getFlows({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+		runOperation('advanced-flow permission preflight', config.timeoutMs, () =>
+			client.flow.getAdvancedFlows({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+		),
+		proveDeviceWriteScope(client, config),
+	]);
+
+	if (results.some((result) => result.status === 'rejected')) {
+		throw new Error('The dedicated Homey lifecycle key failed the required permission preflight');
 	}
 };
 
@@ -596,7 +640,7 @@ export const probeHomeyShsLifecycle = async (
 	const transportCleanupFailures: string[] = [];
 
 	try {
-		assertRequiredScopes(client);
+		await assertPermissionPreflight(client, config);
 		await runOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
 		appendEvent(report, 'manager.subscribe.resolved');
 		await assertZonePreflight(client, config);

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -184,8 +184,10 @@ Lifecycle evidence uses a separate management-scoped, disposable API key and may
 created for this run. Do not reuse the regular read-only or capability-control key. The lifecycle key needs
 `homey.device` for metadata updates and removal, plus `homey.device.readonly`, `homey.zone.readonly`,
 `homey.system.readonly`, and `homey.flow.readonly` for fail-closed preflight, ownership, zone, instance, and flow
-validation. The probe verifies all five scopes before it opens the operator add window. Revoke the key when the run is
-complete.
+validation. Before it opens the operator add window, the probe exercises each read permission with bounded,
+cache-bypassing requests and proves `homey.device` through a non-mutating lookup of a fresh cryptographically random
+pair-session ID: only `404` proves authorization, while a collision, permission error, timeout, or transport failure
+fails closed. Revoke the key when the run is complete.
 
 The local Web API cannot generically create a virtual device or set device availability. The probe therefore
 subscribes first and then opens a bounded observation window. During that window, the operator or a dedicated test

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -27,7 +27,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled          | Use only the designated harmless test capability                     |
 | Error classification                                  | SDK invalid key returned `401`; matrix pending  | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
 | API-key revocation and replacement                    | Operator-controlled probe ready                 | Revoke only a dedicated test key during the gated observation window |
-| Disposable-device lifecycle                           | Contract defined, disabled                      | Use only the separately gated virtual/test device                    |
+| Disposable-device lifecycle                           | Guarded operator probe ready                    | Use only the separately gated virtual/test device                    |
 | mDNS discovery                                        | Partial pre-restart observation                 | Attribute the generic host record and repeat after SHS restart       |
 | SDK decision                                          | Live session/cleanup passed; provisional hold   | Complete event, timeout, cleanup-failure, and reconnect comparison   |
 | Sanitized fixture corpus                              | Nine representative live fixtures promoted      | Add event/reconnect fixtures and missing capability families/classes |
@@ -178,17 +178,73 @@ original value. The requested value must differ from that original. It then requ
 read-back, restores the original value in `finally`, and requires a second read-back confirming restoration before the
 sanitized report can be written.
 
-Lifecycle mutations have a separate gate and may target only the designated disposable virtual/test device:
+## Operator-controlled disposable-device lifecycle probe
 
-```text
-FB_HOMEY_SHS_LIFECYCLE_ENABLE=I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE
-FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID=<disposable virtual/test device ID>
-FB_HOMEY_SHS_LIFECYCLE_OPERATIONS=add,rename,zone-move,availability,remove
+Lifecycle evidence uses a separate management-scoped, disposable API key and may target only a virtual/test device
+created for this run. Do not reuse the regular read-only or capability-control key. The lifecycle key needs
+`homey.device` for metadata updates and removal, plus `homey.device.readonly`, `homey.zone.readonly`,
+`homey.system.readonly`, and `homey.flow.readonly` for fail-closed preflight, ownership, zone, instance, and flow
+validation. The probe verifies all five scopes before it opens the operator add window. Revoke the key when the run is
+complete.
+
+The local Web API cannot generically create a virtual device or set device availability. The probe therefore
+subscribes first and then opens a bounded observation window. During that window, the operator or a dedicated test
+driver adds exactly one disposable device carrying the configured synthetic marker. Later, when prompted, the
+operator or that same test driver makes only that device unavailable and available again. Do not disable a shared app:
+that could change every device owned by the app. The probe rejects a lifecycle owner that has any device at baseline
+and requires the run-bound device to remain its only device during availability checks.
+
+After the `device.create` event exactly matches the marker, driver, owner, initial name, and source zone allowlist, the
+probe binds the new runtime device ID in memory. Only after that binding may it use the bounded local API operations
+to rename the device, move it to the destination zone, and remove it. The probe observes `device.update` for rename,
+zone, and availability changes and `device.delete` for removal, with fresh reads after mutations. It never accepts the
+first unrelated lifecycle event and never writes an identifier, name, event payload, or raw error to the report.
+
+Start from the base URL, expected-host, and private-term environment used by the safe read probe, but replace
+`FB_HOMEY_SHS_API_KEY` with the dedicated lifecycle key. Enter all private values interactively:
+
+```bash
+read -r -s FB_HOMEY_SHS_API_KEY
+read -r FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER
+read -r FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID
+read -r FB_HOMEY_SHS_LIFECYCLE_OWNER_URI
+read -r FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME
+read -r FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME
+read -r FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID
+read -r FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID
+export FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER
+export FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID FB_HOMEY_SHS_LIFECYCLE_OWNER_URI
+export FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME
+export FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID
+export FB_HOMEY_SHS_LIFECYCLE_ENABLE=I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE
+export FB_HOMEY_SHS_LIFECYCLE_OPERATIONS=add,rename,zone-move,availability,remove
+pnpm run homey:probe-lifecycle
 ```
 
-The implementation must validate the exact operation list, require a synthetic test-device marker established during
-setup, and clean up only resources created by that run. It must never pair, rename, move, make unavailable, remove, or
-unpair ordinary household devices.
+The probe fails closed unless the acknowledgement and ordered operation list match those exact values. The device
+marker must start with `fbsp-lifecycle-`, and both names must start with `FBSP Lifecycle`. The driver ID must belong to
+the exact owner URI using Homey's `<owner-uri>:driver:<driver>` form. Driver ID, owner URI, initial and renamed names,
+and both distinct zone IDs are exact allowlist values. `FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS` optionally sets the bounded
+time available for each requested operator action from `10000` through `300000` milliseconds and defaults to `90000`.
+
+Never add, rename, move, make unavailable, or remove an ordinary household device. Use a dedicated test driver where
+possible, and do not pair or discover physical equipment as part of this run. Successful completion requires the
+device to be available again before removal, cleanup to complete, and a fresh final inventory read to prove the
+runtime-bound ID, marker, and dedicated-app ownership are all absent. Automatic failure cleanup revalidates ownership,
+app isolation, and the absence of standard or advanced flows immediately before its single permitted delete attempt.
+If the probe stops after creation, follow its cleanup warning and remove only the marker-matching disposable device;
+do not guess an ID or broaden the allowlist.
+
+Clear the lifecycle variables and the disposable management key immediately after the final absence check:
+
+```bash
+unset FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+unset FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OWNER_URI FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME
+unset FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
+unset FB_HOMEY_SHS_API_KEY
+```
 
 ## Operator-controlled restart recovery probe
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -52,7 +52,10 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Designate one disposable virtual/test device for lifecycle mutations. It must not represent household equipment, and repository documents record only its synthetic alias.
 - [x] Define environment variables for live tests. Do not store secret values in shell history, fixtures, `.env` files, or repository config.
 - [x] Add an explicit live-write allowlist contract requiring both device ID and capability ID.
-- [x] Add a separately enabled lifecycle-mutation allowlist containing the disposable device ID and the exact permitted operations: add, rename, zone move, availability change, and remove.
+- [x] Add a separately enabled lifecycle-mutation allowlist with an immutable synthetic marker, exact test
+      driver/owner/names/zones, and the canonical operations: add, rename, zone move, availability change, and remove.
+      Bind the runtime device ID only after a matching create event and fresh ownership read-back because Homey assigns
+      the top-level ID during creation.
 
 **Verification:** Review the compatibility document for secret/private data before committing it.
 


### PR DESCRIPTION
## Summary

- add a separately gated Homey SHS lifecycle probe for disposable test devices
- bind the runtime device only after an exact create-event and fresh ownership read-back
- verify rename, zone move, unavailable/available transitions, removal, and final absence
- add fail-closed scope, owner isolation, availability, flow-reference, timeout, and cleanup safeguards
- document the operator workflow, required scopes, environment gates, and secret-safe cleanup

## Safety

The probe never targets a pre-existing or ordinary household device. It requires an exact synthetic marker, dedicated app/driver, names, zones, operation acknowledgement, and all required API scopes before opening the operator add window. Failure cleanup deletes only a freshly revalidated, available, unreferenced device created during the run.

Reports contain only fixed evidence labels and booleans, are schema-checked for private values, and are written with 0700/0600 permissions.

## Validation

- `pnpm run type-check`
- `pnpm run test:homey-spike` — 7 suites, 122 tests
- targeted ESLint for the lifecycle probe and spike
- default-deny CLI smoke check

The live operator mutation run was not performed; it remains pending until a dedicated test app/device and scoped disposable API key are available.