### PR TITLE
feat(cross): add Homey local connector core

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -137,6 +137,7 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 	private transportConnectCount = 0;
 	private transportDisconnectCount = 0;
 	private connectGate: Promise<void> | null = null;
+	private unsubscribeFailure: Error | null = null;
 
 	get writes(): readonly CapabilityWrite[] {
 		return this.capabilityWrites;
@@ -156,6 +157,10 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 
 	failNext(operation: HomeyConnectorOperation, category: HomeyConnectorErrorCategory): void {
 		this.failures.set(operation, category);
+	}
+
+	failNextUnsubscribe(): void {
+		this.unsubscribeFailure = Object.assign(new Error('sentinel-secret'), { code: 'ECONNRESET' });
 	}
 
 	deferNextConnect(): () => void {
@@ -242,14 +247,22 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 			this.listeners.add(listener);
 			let active = true;
 
-			return () => {
-				if (!active) {
-					return;
-				}
+			return () =>
+				this.execute(() => {
+					if (!active) {
+						return;
+					}
 
-				active = false;
-				this.listeners.delete(listener);
-			};
+					const failure = this.unsubscribeFailure;
+					this.unsubscribeFailure = null;
+
+					if (failure !== null) {
+						throw failure;
+					}
+
+					active = false;
+					this.listeners.delete(listener);
+				});
 		});
 	}
 
@@ -318,6 +331,28 @@ describeHomeyConnectorContract('Local', (): HomeyConnectorContractHarness => {
 });
 
 describe('Homey local connector lifecycle serialization', () => {
+	it('keeps failed subscription cleanup retryable while suppressing further delivery', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+		const listener = jest.fn();
+
+		await connector.connect();
+		const unsubscribe = await connector.subscribe(listener);
+		transport.failNextUnsubscribe();
+
+		await expect(unsubscribe()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+			operation: HomeyConnectorOperation.SUBSCRIBE,
+		});
+		expect(transport.subscriberCount).toBe(1);
+		await transport.emit(contractFixtures.events[0]);
+		expect(listener).not.toHaveBeenCalled();
+
+		await expect(unsubscribe()).resolves.toBeUndefined();
+		expect(transport.subscriberCount).toBe(0);
+		await connector.disconnect();
+	});
+
 	it('honors connect, disconnect, connect call order while the first connection is pending', async () => {
 		const transport = new FakeHomeyLocalTransport();
 		const connector = new HomeyLocalConnector(transport);

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -348,6 +348,22 @@ describe('Homey local connector lifecycle serialization', () => {
 		});
 		await expect(connector.connect()).resolves.toBeUndefined();
 		expect(transport.connectCount).toBe(2);
+		expect(transport.disconnectCount).toBe(2);
 		await connector.disconnect();
+	});
+
+	it('retries a failed transport teardown on a later disconnect', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+
+		await connector.connect();
+		transport.failNext(HomeyConnectorOperation.DISCONNECT, HomeyConnectorErrorCategory.UNAVAILABLE);
+
+		await expect(connector.disconnect()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+		});
+		await expect(connector.disconnect()).resolves.toBeUndefined();
+		await expect(connector.disconnect()).resolves.toBeUndefined();
+		expect(transport.disconnectCount).toBe(2);
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -137,7 +137,8 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 	private transportConnectCount = 0;
 	private transportDisconnectCount = 0;
 	private connectGate: Promise<void> | null = null;
-	private unsubscribeFailure: Error | null = null;
+	private unsubscribeFailuresRemaining = 0;
+	private transportUnsubscribeCount = 0;
 
 	get writes(): readonly CapabilityWrite[] {
 		return this.capabilityWrites;
@@ -155,12 +156,16 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 		return this.transportDisconnectCount;
 	}
 
+	get unsubscribeCount(): number {
+		return this.transportUnsubscribeCount;
+	}
+
 	failNext(operation: HomeyConnectorOperation, category: HomeyConnectorErrorCategory): void {
 		this.failures.set(operation, category);
 	}
 
-	failNextUnsubscribe(): void {
-		this.unsubscribeFailure = Object.assign(new Error('sentinel-secret'), { code: 'ECONNRESET' });
+	failNextUnsubscribe(times = 1): void {
+		this.unsubscribeFailuresRemaining = times;
 	}
 
 	deferNextConnect(): () => void {
@@ -253,11 +258,11 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 						return;
 					}
 
-					const failure = this.unsubscribeFailure;
-					this.unsubscribeFailure = null;
+					this.transportUnsubscribeCount += 1;
 
-					if (failure !== null) {
-						throw failure;
+					if (this.unsubscribeFailuresRemaining > 0) {
+						this.unsubscribeFailuresRemaining -= 1;
+						throw Object.assign(new Error('sentinel-secret'), { code: 'ECONNRESET' });
 					}
 
 					active = false;
@@ -351,6 +356,27 @@ describe('Homey local connector lifecycle serialization', () => {
 		await expect(unsubscribe()).resolves.toBeUndefined();
 		expect(transport.subscriberCount).toBe(0);
 		await connector.disconnect();
+	});
+
+	it('retires stale subscriptions after a transport cleanup retry succeeds before reconnect', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+
+		await connector.connect();
+		const unsubscribe = await connector.subscribe(() => undefined);
+		transport.failNextUnsubscribe(2);
+		transport.failNext(HomeyConnectorOperation.DISCONNECT, HomeyConnectorErrorCategory.UNAVAILABLE);
+
+		await expect(unsubscribe()).rejects.toMatchObject({ category: HomeyConnectorErrorCategory.UNAVAILABLE });
+		await expect(connector.disconnect()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+		});
+		await expect(connector.connect()).resolves.toBeUndefined();
+		await expect(unsubscribe()).resolves.toBeUndefined();
+		expect(transport.unsubscribeCount).toBe(2);
+
+		await connector.disconnect();
+		expect(transport.unsubscribeCount).toBe(2);
 	});
 
 	it('honors connect, disconnect, connect call order while the first connection is pending', async () => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -137,6 +137,7 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 	private transportConnectCount = 0;
 	private transportDisconnectCount = 0;
 	private connectGate: Promise<void> | null = null;
+	private subscribeGate: Promise<void> | null = null;
 	private unsubscribeFailuresRemaining = 0;
 	private transportUnsubscribeCount = 0;
 
@@ -171,6 +172,15 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 	deferNextConnect(): () => void {
 		let release = (): void => undefined;
 		this.connectGate = new Promise((resolve) => {
+			release = resolve;
+		});
+
+		return release;
+	}
+
+	deferNextSubscribe(): () => void {
+		let release = (): void => undefined;
+		this.subscribeGate = new Promise((resolve) => {
 			release = resolve;
 		});
 
@@ -246,7 +256,14 @@ class FakeHomeyLocalTransport implements HomeyLocalTransport {
 		});
 	}
 
-	subscribe(listener: HomeyLocalTransportEventListener): Promise<HomeyLocalTransportUnsubscribe> {
+	async subscribe(listener: HomeyLocalTransportEventListener): Promise<HomeyLocalTransportUnsubscribe> {
+		const gate = this.subscribeGate;
+		this.subscribeGate = null;
+
+		if (gate !== null) {
+			await gate;
+		}
+
 		return this.execute(() => {
 			this.throwNextFailure(HomeyConnectorOperation.SUBSCRIBE);
 			this.listeners.add(listener);
@@ -336,6 +353,30 @@ describeHomeyConnectorContract('Local', (): HomeyConnectorContractHarness => {
 });
 
 describe('Homey local connector lifecycle serialization', () => {
+	it('retires a stale subscription that resolves and fails cleanup after transport teardown', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+
+		await connector.connect();
+		const releaseSubscribe = transport.deferNextSubscribe();
+		const subscribe = connector.subscribe(() => undefined);
+
+		await connector.disconnect();
+		transport.failNextUnsubscribe();
+		releaseSubscribe();
+
+		await expect(subscribe).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+			operation: HomeyConnectorOperation.SUBSCRIBE,
+		});
+		expect(transport.subscriberCount).toBe(1);
+
+		await expect(connector.connect()).resolves.toBeUndefined();
+		expect(transport.disconnectCount).toBe(2);
+		expect(transport.subscriberCount).toBe(0);
+		await connector.disconnect();
+	});
+
 	it('keeps failed subscription cleanup retryable while suppressing further delivery', async () => {
 		const transport = new FakeHomeyLocalTransport();
 		const connector = new HomeyLocalConnector(transport);

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -353,6 +353,44 @@ describeHomeyConnectorContract('Local', (): HomeyConnectorContractHarness => {
 });
 
 describe('Homey local connector lifecycle serialization', () => {
+	it('serializes asynchronous event delivery independently for each subscriber', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+		let releaseFirst = (): void => undefined;
+		let markFirstStarted = (): void => undefined;
+		const firstBlocked = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const firstStarted = new Promise<void>((resolve) => {
+			markFirstStarted = resolve;
+		});
+		const started: HomeyEventType[] = [];
+
+		await connector.connect();
+		await connector.subscribe(async (event) => {
+			started.push(event.type);
+
+			if (started.length === 1) {
+				markFirstStarted();
+				await firstBlocked;
+			}
+		});
+
+		const firstDelivery = transport.emit(contractFixtures.events[0]);
+		await firstStarted;
+		const secondDelivery = transport.emit(contractFixtures.events[1]);
+		await Promise.resolve();
+		expect(started).toStrictEqual([HomeyEventType.CAPABILITY_VALUE_CHANGED]);
+
+		releaseFirst();
+		await Promise.all([firstDelivery, secondDelivery]);
+		expect(started).toStrictEqual([
+			HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+		]);
+		await connector.disconnect();
+	});
+
 	it('retires a stale subscription that resolves and fails cleanup after transport teardown', async () => {
 		const transport = new FakeHomeyLocalTransport();
 		const connector = new HomeyLocalConnector(transport);
@@ -372,6 +410,29 @@ describe('Homey local connector lifecycle serialization', () => {
 		expect(transport.subscriberCount).toBe(1);
 
 		await expect(connector.connect()).resolves.toBeUndefined();
+		expect(transport.disconnectCount).toBe(2);
+		expect(transport.subscriberCount).toBe(0);
+		await connector.disconnect();
+	});
+
+	it('waits for an old pending subscription before reconnecting', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+
+		await connector.connect();
+		const releaseSubscribe = transport.deferNextSubscribe();
+		const subscribe = connector.subscribe(() => undefined);
+		await connector.disconnect();
+		const reconnect = connector.connect();
+
+		await Promise.resolve();
+		expect(transport.connectCount).toBe(1);
+		transport.failNextUnsubscribe();
+		releaseSubscribe();
+
+		await expect(subscribe).rejects.toMatchObject({ category: HomeyConnectorErrorCategory.UNAVAILABLE });
+		await expect(reconnect).resolves.toBeUndefined();
+		expect(transport.connectCount).toBe(2);
 		expect(transport.disconnectCount).toBe(2);
 		expect(transport.subscriberCount).toBe(0);
 		await connector.disconnect();

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.spec.ts
@@ -1,0 +1,353 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+	HomeyConnectorContractFixtures,
+	HomeyConnectorContractHarness,
+	describeHomeyConnectorContract,
+} from '../../../../test/support/homey-connector.contract';
+import { HomeyConnectorErrorCategory, HomeyConnectorOperation } from '../errors/homey-connector.error';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+import { HomeyZone } from '../models/homey-zone.model';
+
+import { HomeyLocalConnector } from './homey-local.connector';
+import {
+	HomeyLocalTransport,
+	HomeyLocalTransportEvent,
+	HomeyLocalTransportEventListener,
+	HomeyLocalTransportUnsubscribe,
+} from './homey-local.transport';
+
+interface CapabilityWrite {
+	deviceId: string;
+	capabilityId: string;
+	value: unknown;
+}
+
+const fixtureRoot = resolve(__dirname, '../__fixtures__');
+const expectedRoot = resolve(fixtureRoot, 'expected/v1');
+const sourceRoot = resolve(fixtureRoot, 'versions/2026-08-13-shs-13.4.0');
+const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
+
+const rawZones = readJson(resolve(sourceRoot, 'zones.json'));
+const rawDevice = readJson(resolve(sourceRoot, 'devices/repeated-capabilities.json'));
+const expectedZones = readJson(resolve(expectedRoot, 'zones.json')) as HomeyZone[];
+const expectedDevice = readJson(resolve(expectedRoot, 'devices/repeated-capabilities.json')) as HomeyDevice;
+
+const contractFixtures: HomeyConnectorContractFixtures = {
+	systemInfo: {
+		id: 'homey-1',
+		name: 'Homey Pro',
+		version: '12.4.0',
+		tier: 'pro',
+		model: 'Homey Pro',
+	},
+	zones: expectedZones,
+	devices: [expectedDevice],
+	events: [
+		{
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: expectedDevice.id,
+			capabilityId: 'measure_temperature.capability-suffix-000001',
+			value: 22,
+			lastUpdatedAt: '2026-08-13T10:01:00.000Z',
+			occurredAt: '2026-08-13T10:01:00.000Z',
+			sequence: 1,
+		},
+		{
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: expectedDevice.id,
+			available: false,
+			availabilityMessage: 'Device unavailable',
+			occurredAt: '2026-08-13T10:02:00.000Z',
+			sequence: 2,
+		},
+	],
+	writeTarget: {
+		deviceId: expectedDevice.id,
+		capabilityId: 'measure_temperature.capability-suffix-000001',
+	},
+};
+
+const rawFailure = (category: HomeyConnectorErrorCategory): Error => {
+	switch (category) {
+		case HomeyConnectorErrorCategory.AUTHENTICATION:
+			return Object.assign(new Error('sentinel-secret'), { statusCode: 401 });
+		case HomeyConnectorErrorCategory.AUTHORIZATION:
+			return Object.assign(new Error('sentinel-secret'), { statusCode: 403 });
+		case HomeyConnectorErrorCategory.TIMEOUT:
+			return Object.assign(new Error('sentinel-secret'), { name: 'TimeoutError' });
+		case HomeyConnectorErrorCategory.UNAVAILABLE:
+			return Object.assign(new Error('sentinel-secret'), { code: 'ECONNREFUSED' });
+		case HomeyConnectorErrorCategory.VALIDATION:
+			return Object.assign(new Error('sentinel-secret'), { statusCode: 422 });
+		case HomeyConnectorErrorCategory.UNSUPPORTED:
+			return Object.assign(new Error('sentinel-secret'), { code: 'HOMEY_UNSUPPORTED' });
+		case HomeyConnectorErrorCategory.PROTOCOL:
+			return new Error('sentinel-secret');
+	}
+};
+
+const toRawEvent = (event: HomeyEvent): HomeyLocalTransportEvent => {
+	switch (event.type) {
+		case HomeyEventType.CAPABILITY_VALUE_CHANGED:
+			return {
+				type: 'capability',
+				deviceId: event.deviceId,
+				payload: {
+					capabilityId: event.capabilityId,
+					lastUpdatedAt: event.lastUpdatedAt,
+					occurredAt: event.occurredAt,
+					sequence: event.sequence,
+					value: event.value,
+				},
+			};
+		case HomeyEventType.DEVICE_AVAILABILITY_CHANGED:
+			return {
+				type: 'device.availability',
+				payload: {
+					available: event.available,
+					availabilityMessage: event.availabilityMessage,
+					id: event.deviceId,
+					occurredAt: event.occurredAt,
+					sequence: event.sequence,
+				},
+			};
+		case HomeyEventType.DEVICE_ADDED:
+			return { type: 'device.create', payload: { id: event.deviceId } };
+		case HomeyEventType.DEVICE_UPDATED:
+			return { type: 'device.update', payload: { id: event.deviceId } };
+		case HomeyEventType.DEVICE_REMOVED:
+			return { type: 'device.delete', payload: { id: event.deviceId } };
+		case HomeyEventType.ZONE_ADDED:
+			return { type: 'zone.create', payload: { id: event.zoneId } };
+		case HomeyEventType.ZONE_UPDATED:
+			return { type: 'zone.update', payload: { id: event.zoneId } };
+		case HomeyEventType.ZONE_REMOVED:
+			return { type: 'zone.delete', payload: { id: event.zoneId } };
+	}
+};
+
+class FakeHomeyLocalTransport implements HomeyLocalTransport {
+	private connected = false;
+	private readonly listeners = new Set<HomeyLocalTransportEventListener>();
+	private readonly failures = new Map<HomeyConnectorOperation, HomeyConnectorErrorCategory>();
+	private readonly capabilityWrites: CapabilityWrite[] = [];
+	private transportConnectCount = 0;
+	private transportDisconnectCount = 0;
+	private connectGate: Promise<void> | null = null;
+
+	get writes(): readonly CapabilityWrite[] {
+		return this.capabilityWrites;
+	}
+
+	get subscriberCount(): number {
+		return this.listeners.size;
+	}
+
+	get connectCount(): number {
+		return this.transportConnectCount;
+	}
+
+	get disconnectCount(): number {
+		return this.transportDisconnectCount;
+	}
+
+	failNext(operation: HomeyConnectorOperation, category: HomeyConnectorErrorCategory): void {
+		this.failures.set(operation, category);
+	}
+
+	deferNextConnect(): () => void {
+		let release = (): void => undefined;
+		this.connectGate = new Promise((resolve) => {
+			release = resolve;
+		});
+
+		return release;
+	}
+
+	async connect(): Promise<void> {
+		const gate = this.connectGate;
+		this.connectGate = null;
+
+		if (gate !== null) {
+			await gate;
+		}
+
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.CONNECT);
+			this.transportConnectCount += 1;
+			this.connected = true;
+		});
+	}
+
+	disconnect(): Promise<void> {
+		return this.execute(() => {
+			const failure = this.takeNextFailure(HomeyConnectorOperation.DISCONNECT);
+			this.transportDisconnectCount += 1;
+			this.connected = false;
+			this.listeners.clear();
+
+			if (failure !== undefined) {
+				throw failure;
+			}
+		});
+	}
+
+	getSystemInfo(): Promise<unknown> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.GET_SYSTEM_INFO);
+			return {
+				homeyId: contractFixtures.systemInfo.id,
+				homeyModelName: contractFixtures.systemInfo.model,
+				homeyName: contractFixtures.systemInfo.name,
+				homeyTier: contractFixtures.systemInfo.tier,
+				homeyVersion: contractFixtures.systemInfo.version,
+			};
+		});
+	}
+
+	getZones(): Promise<unknown> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.GET_ZONES);
+			return structuredClone(rawZones);
+		});
+	}
+
+	getDevices(): Promise<unknown> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.GET_DEVICES);
+			return { [expectedDevice.id]: structuredClone(rawDevice) };
+		});
+	}
+
+	getDevice(deviceId: string): Promise<unknown> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.GET_DEVICE);
+			return deviceId === expectedDevice.id ? structuredClone(rawDevice) : null;
+		});
+	}
+
+	setCapabilityValue(deviceId: string, capabilityId: string, value: unknown): Promise<void> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.SET_CAPABILITY_VALUE);
+			this.capabilityWrites.push({ deviceId, capabilityId, value });
+		});
+	}
+
+	subscribe(listener: HomeyLocalTransportEventListener): Promise<HomeyLocalTransportUnsubscribe> {
+		return this.execute(() => {
+			this.throwNextFailure(HomeyConnectorOperation.SUBSCRIBE);
+			this.listeners.add(listener);
+			let active = true;
+
+			return () => {
+				if (!active) {
+					return;
+				}
+
+				active = false;
+				this.listeners.delete(listener);
+			};
+		});
+	}
+
+	async emit(event: HomeyEvent): Promise<void> {
+		if (!this.connected) {
+			return;
+		}
+
+		await Promise.all(
+			[...this.listeners].map((listener) => Promise.resolve(listener(structuredClone(toRawEvent(event))))),
+		);
+	}
+
+	private throwNextFailure(operation: HomeyConnectorOperation): void {
+		const failure = this.takeNextFailure(operation);
+
+		if (failure !== undefined) {
+			throw failure;
+		}
+	}
+
+	private takeNextFailure(operation: HomeyConnectorOperation): Error | undefined {
+		const category = this.failures.get(operation);
+
+		if (category === undefined) {
+			return undefined;
+		}
+
+		this.failures.delete(operation);
+
+		return rawFailure(category);
+	}
+
+	private execute<T>(operation: () => T): Promise<T> {
+		try {
+			return Promise.resolve(operation());
+		} catch (error) {
+			return Promise.reject(error instanceof Error ? error : new Error('Fake Homey local transport failed'));
+		}
+	}
+}
+
+describeHomeyConnectorContract('Local', (): HomeyConnectorContractHarness => {
+	const transport = new FakeHomeyLocalTransport();
+	const connector = new HomeyLocalConnector(transport);
+
+	return {
+		connector,
+		fixtures: contractFixtures,
+		emit: (event) => transport.emit(event),
+		failNext: (operation, category) => transport.failNext(operation, category),
+		get writes() {
+			return transport.writes;
+		},
+		get subscriberCount() {
+			return transport.subscriberCount;
+		},
+		get connectCount() {
+			return transport.connectCount;
+		},
+		get disconnectCount() {
+			return transport.disconnectCount;
+		},
+		dispose: () => connector.disconnect(),
+	};
+});
+
+describe('Homey local connector lifecycle serialization', () => {
+	it('honors connect, disconnect, connect call order while the first connection is pending', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+		const releaseConnect = transport.deferNextConnect();
+
+		const firstConnect = connector.connect();
+		const disconnect = connector.disconnect();
+		const finalConnect = connector.connect();
+
+		releaseConnect();
+		await expect(Promise.all([firstConnect, disconnect, finalConnect])).resolves.toBeDefined();
+		expect(transport.connectCount).toBe(2);
+		expect(transport.disconnectCount).toBe(1);
+		await expect(connector.getSystemInfo()).resolves.toStrictEqual(contractFixtures.systemInfo);
+		await connector.disconnect();
+	});
+
+	it('allows a fresh connection after transport disconnect fails', async () => {
+		const transport = new FakeHomeyLocalTransport();
+		const connector = new HomeyLocalConnector(transport);
+
+		await connector.connect();
+		transport.failNext(HomeyConnectorOperation.DISCONNECT, HomeyConnectorErrorCategory.UNAVAILABLE);
+
+		await expect(connector.disconnect()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+			operation: HomeyConnectorOperation.DISCONNECT,
+		});
+		await expect(connector.connect()).resolves.toBeUndefined();
+		expect(transport.connectCount).toBe(2);
+		await connector.disconnect();
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -24,6 +24,12 @@ interface HomeyLocalSubscription {
 	cleanup: HomeyLocalTransportUnsubscribe;
 	cleanupNeeded: boolean;
 	cleanupPromise: Promise<void> | null;
+	deliveryTail: Promise<void>;
+}
+
+interface HomeyPendingSubscription {
+	settled: Promise<void>;
+	settle: () => void;
 }
 
 /**
@@ -36,6 +42,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 	private connectionGeneration = 0;
 	private lifecycleTail: Promise<void> = Promise.resolve();
 	private readonly subscriptions = new Set<HomeyLocalSubscription>();
+	private readonly pendingSubscriptions = new Set<HomeyPendingSubscription>();
 
 	constructor(private readonly transport: HomeyLocalTransport) {}
 
@@ -106,6 +113,17 @@ export class HomeyLocalConnector implements HomeyConnector {
 
 	async subscribe(listener: HomeyEventListener): Promise<HomeyUnsubscribe> {
 		this.assertConnected(HomeyConnectorOperation.SUBSCRIBE);
+		const pending = this.createPendingSubscription();
+
+		try {
+			return await this.subscribeTransport(listener);
+		} finally {
+			this.pendingSubscriptions.delete(pending);
+			pending.settle();
+		}
+	}
+
+	private async subscribeTransport(listener: HomeyEventListener): Promise<HomeyUnsubscribe> {
 		const connectionGeneration = this.connectionGeneration;
 
 		const subscription: HomeyLocalSubscription = {
@@ -113,19 +131,24 @@ export class HomeyLocalConnector implements HomeyConnector {
 			cleanup: () => undefined,
 			cleanupNeeded: false,
 			cleanupPromise: null,
+			deliveryTail: Promise.resolve(),
 		};
 
 		try {
-			subscription.cleanup = await this.transport.subscribe(async (rawEvent) => {
-				if (!subscription.active || !this.connected || connectionGeneration !== this.connectionGeneration) {
-					return;
-				}
+			subscription.cleanup = await this.transport.subscribe((rawEvent) => {
+				subscription.deliveryTail = subscription.deliveryTail.then(async () => {
+					if (!subscription.active || !this.connected || connectionGeneration !== this.connectionGeneration) {
+						return;
+					}
 
-				try {
-					await listener(transformHomeyLocalEvent(rawEvent));
-				} catch {
-					// Malformed upstream events and consumer failures cannot stop sibling subscribers.
-				}
+					try {
+						await listener(transformHomeyLocalEvent(rawEvent));
+					} catch {
+						// Malformed upstream events and consumer failures cannot stop sibling subscribers.
+					}
+				});
+
+				return subscription.deliveryTail;
 			});
 			subscription.cleanupNeeded = true;
 			this.subscriptions.add(subscription);
@@ -163,6 +186,8 @@ export class HomeyLocalConnector implements HomeyConnector {
 	}
 
 	private async connectTransport(): Promise<void> {
+		await Promise.all([...this.pendingSubscriptions].map((pending) => pending.settled));
+
 		if (this.transportCleanupNeeded) {
 			try {
 				await this.transport.disconnect();
@@ -286,6 +311,19 @@ export class HomeyLocalConnector implements HomeyConnector {
 		}
 
 		this.subscriptions.clear();
+	}
+
+	private createPendingSubscription(): HomeyPendingSubscription {
+		let settle = (): void => undefined;
+		const pending: HomeyPendingSubscription = {
+			settled: new Promise((resolve) => {
+				settle = resolve;
+			}),
+			settle: () => settle(),
+		};
+		this.pendingSubscriptions.add(pending);
+
+		return pending;
 	}
 
 	private assertConnected(operation: HomeyConnectorOperation): void {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -1,0 +1,246 @@
+import {
+	HomeyConnectorError,
+	HomeyConnectorErrorCategory,
+	HomeyConnectorOperation,
+} from '../errors/homey-connector.error';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeySystemInfo } from '../models/homey-system-info.model';
+import { HomeyZone } from '../models/homey-zone.model';
+
+import { HomeyConnector } from './homey-connector.interface';
+import { HomeyEventListener, HomeyUnsubscribe } from './homey-connector.types';
+import { mapHomeyLocalTransportError } from './homey-local.error-mapper';
+import {
+	transformHomeyLocalDevice,
+	transformHomeyLocalDevices,
+	transformHomeyLocalEvent,
+	transformHomeyLocalSystemInfo,
+	transformHomeyLocalZones,
+} from './homey-local.transformer';
+import { HomeyLocalTransport, HomeyLocalTransportUnsubscribe } from './homey-local.transport';
+
+interface HomeyLocalSubscription {
+	active: boolean;
+	cleanup: HomeyLocalTransportUnsubscribe;
+}
+
+/**
+ * Transport-neutral local connector orchestration. A separate adapter owns the
+ * eventual SDK or direct HTTP/realtime implementation selected by live proof.
+ */
+export class HomeyLocalConnector implements HomeyConnector {
+	private connected = false;
+	private connectionGeneration = 0;
+	private lifecycleTail: Promise<void> = Promise.resolve();
+	private readonly subscriptions = new Set<HomeyLocalSubscription>();
+
+	constructor(private readonly transport: HomeyLocalTransport) {}
+
+	connect(): Promise<void> {
+		return this.enqueueLifecycle(async () => {
+			if (!this.connected) {
+				await this.connectTransport();
+			}
+		});
+	}
+
+	disconnect(): Promise<void> {
+		return this.enqueueLifecycle(() => this.disconnectTransport());
+	}
+
+	async getSystemInfo(): Promise<HomeySystemInfo> {
+		this.assertConnected(HomeyConnectorOperation.GET_SYSTEM_INFO);
+
+		try {
+			return transformHomeyLocalSystemInfo(await this.transport.getSystemInfo());
+		} catch (error) {
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.GET_SYSTEM_INFO);
+		}
+	}
+
+	async getZones(): Promise<readonly HomeyZone[]> {
+		this.assertConnected(HomeyConnectorOperation.GET_ZONES);
+
+		try {
+			return transformHomeyLocalZones(await this.transport.getZones());
+		} catch (error) {
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.GET_ZONES);
+		}
+	}
+
+	async getDevices(): Promise<readonly HomeyDevice[]> {
+		this.assertConnected(HomeyConnectorOperation.GET_DEVICES);
+
+		try {
+			const [rawZones, rawDevices] = await Promise.all([this.transport.getZones(), this.transport.getDevices()]);
+			return transformHomeyLocalDevices(rawDevices, transformHomeyLocalZones(rawZones));
+		} catch (error) {
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.GET_DEVICES);
+		}
+	}
+
+	async getDevice(deviceId: string): Promise<HomeyDevice | null> {
+		this.assertConnected(HomeyConnectorOperation.GET_DEVICE);
+
+		try {
+			const [rawZones, rawDevice] = await Promise.all([this.transport.getZones(), this.transport.getDevice(deviceId)]);
+
+			return rawDevice === null ? null : transformHomeyLocalDevice(rawDevice, transformHomeyLocalZones(rawZones));
+		} catch (error) {
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.GET_DEVICE);
+		}
+	}
+
+	async setCapabilityValue(deviceId: string, capabilityId: string, value: unknown): Promise<void> {
+		this.assertConnected(HomeyConnectorOperation.SET_CAPABILITY_VALUE);
+
+		try {
+			await this.transport.setCapabilityValue(deviceId, capabilityId, value);
+		} catch (error) {
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SET_CAPABILITY_VALUE);
+		}
+	}
+
+	async subscribe(listener: HomeyEventListener): Promise<HomeyUnsubscribe> {
+		this.assertConnected(HomeyConnectorOperation.SUBSCRIBE);
+		const connectionGeneration = this.connectionGeneration;
+
+		const subscription: HomeyLocalSubscription = {
+			active: true,
+			cleanup: () => undefined,
+		};
+
+		try {
+			subscription.cleanup = await this.transport.subscribe(async (rawEvent) => {
+				if (!subscription.active || !this.connected || connectionGeneration !== this.connectionGeneration) {
+					return;
+				}
+
+				try {
+					await listener(transformHomeyLocalEvent(rawEvent));
+				} catch {
+					// Malformed upstream events and consumer failures cannot stop sibling subscribers.
+				}
+			});
+		} catch (error) {
+			subscription.active = false;
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SUBSCRIBE);
+		}
+
+		if (!this.connected || connectionGeneration !== this.connectionGeneration) {
+			subscription.active = false;
+
+			try {
+				await this.cleanupSubscription(subscription);
+			} catch (error) {
+				throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SUBSCRIBE);
+			}
+
+			throw new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.SUBSCRIBE);
+		}
+
+		this.subscriptions.add(subscription);
+
+		return async () => {
+			if (!subscription.active) {
+				return;
+			}
+
+			subscription.active = false;
+			this.subscriptions.delete(subscription);
+
+			try {
+				await this.cleanupSubscription(subscription);
+			} catch (error) {
+				throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SUBSCRIBE);
+			}
+		};
+	}
+
+	private async connectTransport(): Promise<void> {
+		try {
+			await this.transport.connect();
+			this.connected = true;
+			this.connectionGeneration += 1;
+		} catch (error) {
+			this.connected = false;
+
+			try {
+				await this.transport.disconnect();
+			} catch {
+				// Preserve the categorized connect failure after best-effort partial cleanup.
+			}
+
+			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.CONNECT);
+		}
+	}
+
+	private async disconnectTransport(): Promise<void> {
+		if (!this.connected && this.subscriptions.size === 0) {
+			return;
+		}
+
+		const wasConnected = this.connected;
+		const subscriptions = [...this.subscriptions];
+		this.connected = false;
+		this.connectionGeneration += 1;
+		this.subscriptions.clear();
+		for (const subscription of subscriptions) {
+			subscription.active = false;
+		}
+
+		const cleanupResults = await Promise.allSettled(
+			subscriptions.map((subscription) => this.cleanupSubscription(subscription)),
+		);
+		let failed = false;
+		let failureReason: unknown;
+
+		for (const result of cleanupResults) {
+			if (result.status === 'rejected') {
+				failed = true;
+				failureReason = result.reason as unknown;
+				break;
+			}
+		}
+
+		if (wasConnected) {
+			try {
+				await this.transport.disconnect();
+			} catch (error) {
+				if (!failed) {
+					failed = true;
+					failureReason = error;
+				}
+			}
+		}
+
+		if (failed) {
+			throw mapHomeyLocalTransportError(failureReason, HomeyConnectorOperation.DISCONNECT);
+		}
+	}
+
+	private enqueueLifecycle(operation: () => Promise<void>): Promise<void> {
+		const result: Promise<void> = this.lifecycleTail.then(() => operation());
+		this.lifecycleTail = this.settleLifecycle(result);
+
+		return result;
+	}
+
+	private async settleLifecycle(operation: Promise<void>): Promise<void> {
+		try {
+			await operation;
+		} catch {
+			// Keep the serialization queue usable after a caller observes an operation failure.
+		}
+	}
+
+	private async cleanupSubscription(subscription: HomeyLocalSubscription): Promise<void> {
+		await subscription.cleanup();
+	}
+
+	private assertConnected(operation: HomeyConnectorOperation): void {
+		if (!this.connected) {
+			throw new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, operation);
+		}
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -30,6 +30,7 @@ interface HomeyLocalSubscription {
  */
 export class HomeyLocalConnector implements HomeyConnector {
 	private connected = false;
+	private transportCleanupNeeded = false;
 	private connectionGeneration = 0;
 	private lifecycleTail: Promise<void> = Promise.resolve();
 	private readonly subscriptions = new Set<HomeyLocalSubscription>();
@@ -158,6 +159,17 @@ export class HomeyLocalConnector implements HomeyConnector {
 	}
 
 	private async connectTransport(): Promise<void> {
+		if (this.transportCleanupNeeded) {
+			try {
+				await this.transport.disconnect();
+				this.transportCleanupNeeded = false;
+			} catch (error) {
+				throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.CONNECT);
+			}
+		}
+
+		this.transportCleanupNeeded = true;
+
 		try {
 			await this.transport.connect();
 			this.connected = true;
@@ -167,6 +179,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 
 			try {
 				await this.transport.disconnect();
+				this.transportCleanupNeeded = false;
 			} catch {
 				// Preserve the categorized connect failure after best-effort partial cleanup.
 			}
@@ -176,11 +189,11 @@ export class HomeyLocalConnector implements HomeyConnector {
 	}
 
 	private async disconnectTransport(): Promise<void> {
-		if (!this.connected && this.subscriptions.size === 0) {
+		if (!this.connected && !this.transportCleanupNeeded && this.subscriptions.size === 0) {
 			return;
 		}
 
-		const wasConnected = this.connected;
+		const shouldDisconnectTransport = this.connected || this.transportCleanupNeeded;
 		const subscriptions = [...this.subscriptions];
 		this.connected = false;
 		this.connectionGeneration += 1;
@@ -203,10 +216,13 @@ export class HomeyLocalConnector implements HomeyConnector {
 			}
 		}
 
-		if (wasConnected) {
+		if (shouldDisconnectTransport) {
 			try {
 				await this.transport.disconnect();
+				this.transportCleanupNeeded = false;
 			} catch (error) {
+				this.transportCleanupNeeded = true;
+
 				if (!failed) {
 					failed = true;
 					failureReason = error;

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -22,6 +22,8 @@ import { HomeyLocalTransport, HomeyLocalTransportUnsubscribe } from './homey-loc
 interface HomeyLocalSubscription {
 	active: boolean;
 	cleanup: HomeyLocalTransportUnsubscribe;
+	cleanupNeeded: boolean;
+	cleanupPromise: Promise<void> | null;
 }
 
 /**
@@ -109,6 +111,8 @@ export class HomeyLocalConnector implements HomeyConnector {
 		const subscription: HomeyLocalSubscription = {
 			active: true,
 			cleanup: () => undefined,
+			cleanupNeeded: false,
+			cleanupPromise: null,
 		};
 
 		try {
@@ -123,6 +127,8 @@ export class HomeyLocalConnector implements HomeyConnector {
 					// Malformed upstream events and consumer failures cannot stop sibling subscribers.
 				}
 			});
+			subscription.cleanupNeeded = true;
+			this.subscriptions.add(subscription);
 		} catch (error) {
 			subscription.active = false;
 			throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SUBSCRIBE);
@@ -140,15 +146,12 @@ export class HomeyLocalConnector implements HomeyConnector {
 			throw new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.SUBSCRIBE);
 		}
 
-		this.subscriptions.add(subscription);
-
 		return async () => {
-			if (!subscription.active) {
+			if (!subscription.cleanupNeeded) {
 				return;
 			}
 
 			subscription.active = false;
-			this.subscriptions.delete(subscription);
 
 			try {
 				await this.cleanupSubscription(subscription);
@@ -197,7 +200,6 @@ export class HomeyLocalConnector implements HomeyConnector {
 		const subscriptions = [...this.subscriptions];
 		this.connected = false;
 		this.connectionGeneration += 1;
-		this.subscriptions.clear();
 		for (const subscription of subscriptions) {
 			subscription.active = false;
 		}
@@ -220,6 +222,12 @@ export class HomeyLocalConnector implements HomeyConnector {
 			try {
 				await this.transport.disconnect();
 				this.transportCleanupNeeded = false;
+
+				for (const subscription of this.subscriptions) {
+					subscription.cleanupNeeded = false;
+				}
+
+				this.subscriptions.clear();
 			} catch (error) {
 				this.transportCleanupNeeded = true;
 
@@ -251,7 +259,27 @@ export class HomeyLocalConnector implements HomeyConnector {
 	}
 
 	private async cleanupSubscription(subscription: HomeyLocalSubscription): Promise<void> {
+		if (!subscription.cleanupNeeded) {
+			return;
+		}
+
+		if (subscription.cleanupPromise !== null) {
+			return subscription.cleanupPromise;
+		}
+
+		subscription.cleanupPromise = this.performSubscriptionCleanup(subscription);
+
+		try {
+			await subscription.cleanupPromise;
+		} finally {
+			subscription.cleanupPromise = null;
+		}
+	}
+
+	private async performSubscriptionCleanup(subscription: HomeyLocalSubscription): Promise<void> {
 		await subscription.cleanup();
+		subscription.cleanupNeeded = false;
+		this.subscriptions.delete(subscription);
 	}
 
 	private assertConnected(operation: HomeyConnectorOperation): void {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -165,7 +165,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 		if (this.transportCleanupNeeded) {
 			try {
 				await this.transport.disconnect();
-				this.transportCleanupNeeded = false;
+				this.markTransportCleaned();
 			} catch (error) {
 				throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.CONNECT);
 			}
@@ -182,7 +182,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 
 			try {
 				await this.transport.disconnect();
-				this.transportCleanupNeeded = false;
+				this.markTransportCleaned();
 			} catch {
 				// Preserve the categorized connect failure after best-effort partial cleanup.
 			}
@@ -221,13 +221,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 		if (shouldDisconnectTransport) {
 			try {
 				await this.transport.disconnect();
-				this.transportCleanupNeeded = false;
-
-				for (const subscription of this.subscriptions) {
-					subscription.cleanupNeeded = false;
-				}
-
-				this.subscriptions.clear();
+				this.markTransportCleaned();
 			} catch (error) {
 				this.transportCleanupNeeded = true;
 
@@ -280,6 +274,17 @@ export class HomeyLocalConnector implements HomeyConnector {
 		await subscription.cleanup();
 		subscription.cleanupNeeded = false;
 		this.subscriptions.delete(subscription);
+	}
+
+	private markTransportCleaned(): void {
+		this.transportCleanupNeeded = false;
+
+		for (const subscription of this.subscriptions) {
+			subscription.active = false;
+			subscription.cleanupNeeded = false;
+		}
+
+		this.subscriptions.clear();
 	}
 
 	private assertConnected(operation: HomeyConnectorOperation): void {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.connector.ts
@@ -140,6 +140,7 @@ export class HomeyLocalConnector implements HomeyConnector {
 			try {
 				await this.cleanupSubscription(subscription);
 			} catch (error) {
+				this.transportCleanupNeeded = true;
 				throw mapHomeyLocalTransportError(error, HomeyConnectorOperation.SUBSCRIBE);
 			}
 

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.spec.ts
@@ -17,6 +17,7 @@ describe('Homey local transport error mapper', () => {
 		[{ statusCode: 422 }, HomeyConnectorErrorCategory.VALIDATION],
 		[{ statusCode: 500 }, HomeyConnectorErrorCategory.UNAVAILABLE],
 		[{ name: 'AbortError' }, HomeyConnectorErrorCategory.TIMEOUT],
+		[{ code: 'ECONNABORTED' }, HomeyConnectorErrorCategory.TIMEOUT],
 		[{ code: 'ETIMEDOUT' }, HomeyConnectorErrorCategory.TIMEOUT],
 		[{ code: 'ECONNREFUSED' }, HomeyConnectorErrorCategory.UNAVAILABLE],
 		[{ code: 'HOMEY_UNSUPPORTED' }, HomeyConnectorErrorCategory.UNSUPPORTED],

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.spec.ts
@@ -1,0 +1,52 @@
+import {
+	HomeyConnectorError,
+	HomeyConnectorErrorCategory,
+	HomeyConnectorOperation,
+} from '../errors/homey-connector.error';
+
+import { classifyHomeyLocalTransportError, mapHomeyLocalTransportError } from './homey-local.error-mapper';
+
+describe('Homey local transport error mapper', () => {
+	it.each<[unknown, HomeyConnectorErrorCategory]>([
+		[{ statusCode: 401 }, HomeyConnectorErrorCategory.AUTHENTICATION],
+		[{ status: 403 }, HomeyConnectorErrorCategory.AUTHORIZATION],
+		[{ statusCode: 408 }, HomeyConnectorErrorCategory.TIMEOUT],
+		[{ statusCode: 504 }, HomeyConnectorErrorCategory.TIMEOUT],
+		[{ statusCode: 400 }, HomeyConnectorErrorCategory.VALIDATION],
+		[{ statusCode: 409 }, HomeyConnectorErrorCategory.VALIDATION],
+		[{ statusCode: 422 }, HomeyConnectorErrorCategory.VALIDATION],
+		[{ statusCode: 500 }, HomeyConnectorErrorCategory.UNAVAILABLE],
+		[{ name: 'AbortError' }, HomeyConnectorErrorCategory.TIMEOUT],
+		[{ code: 'ETIMEDOUT' }, HomeyConnectorErrorCategory.TIMEOUT],
+		[{ code: 'ECONNREFUSED' }, HomeyConnectorErrorCategory.UNAVAILABLE],
+		[{ code: 'HOMEY_UNSUPPORTED' }, HomeyConnectorErrorCategory.UNSUPPORTED],
+		[new Error('unexpected protocol failure'), HomeyConnectorErrorCategory.PROTOCOL],
+	])('classifies %# without inspecting message text', (error, category) => {
+		expect(classifyHomeyLocalTransportError(error)).toBe(category);
+	});
+
+	it('rebuilds normalized failures for the public operation and discards sensitive raw details', () => {
+		const rawSecret = 'sentinel-api-key@private-address';
+		const mapped = mapHomeyLocalTransportError(
+			{ body: rawSecret, message: rawSecret, statusCode: 401, url: `http://${rawSecret}` },
+			HomeyConnectorOperation.CONNECT,
+		);
+
+		expect(mapped).toStrictEqual(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHENTICATION, HomeyConnectorOperation.CONNECT),
+		);
+		expect(JSON.stringify(mapped)).not.toContain(rawSecret);
+		expect(mapped.stack).not.toContain(rawSecret);
+	});
+
+	it('preserves only the category when remapping an existing connector error', () => {
+		const mapped = mapHomeyLocalTransportError(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.TIMEOUT, HomeyConnectorOperation.GET_ZONES),
+			HomeyConnectorOperation.GET_DEVICES,
+		);
+
+		expect(mapped).toStrictEqual(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.TIMEOUT, HomeyConnectorOperation.GET_DEVICES),
+		);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.ts
@@ -1,0 +1,83 @@
+import {
+	HomeyConnectorError,
+	HomeyConnectorErrorCategory,
+	HomeyConnectorOperation,
+} from '../errors/homey-connector.error';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const valueOf = (error: unknown, key: string): unknown => (isRecord(error) ? error[key] : undefined);
+
+const numericCode = (error: unknown): number | null => {
+	for (const value of [valueOf(error, 'statusCode'), valueOf(error, 'status'), valueOf(error, 'code')]) {
+		if (typeof value === 'number' && Number.isInteger(value)) {
+			return value;
+		}
+	}
+
+	return null;
+};
+
+const stringCode = (error: unknown): string | null => {
+	for (const value of [valueOf(error, 'code'), valueOf(error, 'name')]) {
+		if (typeof value === 'string') {
+			return value.toUpperCase();
+		}
+	}
+
+	return null;
+};
+
+export const classifyHomeyLocalTransportError = (error: unknown): HomeyConnectorErrorCategory => {
+	if (error instanceof HomeyConnectorError) {
+		return error.category;
+	}
+
+	const statusCode = numericCode(error);
+
+	if (statusCode === 401) {
+		return HomeyConnectorErrorCategory.AUTHENTICATION;
+	}
+
+	if (statusCode === 403) {
+		return HomeyConnectorErrorCategory.AUTHORIZATION;
+	}
+
+	if (statusCode === 408 || statusCode === 504) {
+		return HomeyConnectorErrorCategory.TIMEOUT;
+	}
+
+	if (statusCode === 400 || statusCode === 409 || statusCode === 422) {
+		return HomeyConnectorErrorCategory.VALIDATION;
+	}
+
+	if (statusCode !== null && statusCode >= 500) {
+		return HomeyConnectorErrorCategory.UNAVAILABLE;
+	}
+
+	const code = stringCode(error);
+
+	if (code !== null && ['ABORTERROR', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code)) {
+		return HomeyConnectorErrorCategory.TIMEOUT;
+	}
+
+	if (
+		code !== null &&
+		['ECONNABORTED', 'ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code)
+	) {
+		return HomeyConnectorErrorCategory.UNAVAILABLE;
+	}
+
+	if (code === 'HOMEY_UNSUPPORTED' || code === 'UNSUPPORTED') {
+		return HomeyConnectorErrorCategory.UNSUPPORTED;
+	}
+
+	return HomeyConnectorErrorCategory.PROTOCOL;
+};
+
+/** Discards raw messages, response bodies, endpoints, and causes. */
+export const mapHomeyLocalTransportError = (error: unknown, operation: HomeyConnectorOperation): HomeyConnectorError =>
+	error instanceof HomeyConnectorError
+		? new HomeyConnectorError(error.category, operation)
+		: new HomeyConnectorError(classifyHomeyLocalTransportError(error), operation);

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.error-mapper.ts
@@ -58,14 +58,11 @@ export const classifyHomeyLocalTransportError = (error: unknown): HomeyConnector
 
 	const code = stringCode(error);
 
-	if (code !== null && ['ABORTERROR', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code)) {
+	if (code !== null && ['ABORTERROR', 'ECONNABORTED', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code)) {
 		return HomeyConnectorErrorCategory.TIMEOUT;
 	}
 
-	if (
-		code !== null &&
-		['ECONNABORTED', 'ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code)
-	) {
+	if (code !== null && ['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code)) {
 		return HomeyConnectorErrorCategory.UNAVAILABLE;
 	}
 

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.spec.ts
@@ -2,10 +2,13 @@ import { readFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
 import { HomeyCapabilityType } from '../models/homey-capability.model';
+import { HomeyEventType } from '../models/homey-event.model';
 
 import {
 	transformHomeyLocalDevice,
 	transformHomeyLocalDevices,
+	transformHomeyLocalEvent,
+	transformHomeyLocalSystemInfo,
 	transformHomeyLocalZones,
 } from './homey-local.transformer';
 
@@ -24,6 +27,25 @@ const rawZones = readJson(resolve(sourceRoot, 'zones.json'));
 const expectedZones = readJson(resolve(EXPECTED_ROOT, 'zones.json'));
 
 describe('Homey local protocol transformer', () => {
+	it('normalizes local system aliases without retaining the source object', () => {
+		const raw = {
+			homeyId: 'homey-1',
+			homeyModelName: 'Homey Pro',
+			homeyName: 'House',
+			homeyTier: 'pro',
+			homeyVersion: '12.4.0',
+			privateField: 'must-not-leak',
+		};
+
+		expect(transformHomeyLocalSystemInfo(raw)).toStrictEqual({
+			id: 'homey-1',
+			model: 'Homey Pro',
+			name: 'House',
+			tier: 'pro',
+			version: '12.4.0',
+		});
+	});
+
 	it('normalizes the captured zone hierarchy in source order', () => {
 		expect(transformHomeyLocalZones(rawZones)).toStrictEqual(expectedZones);
 	});
@@ -143,5 +165,63 @@ describe('Homey local protocol transformer', () => {
 		expect(() => transformHomeyLocalDevice({ class: 'other', id: 'private-source-value' }, [])).toThrow(
 			'Homey protocol device name is missing',
 		);
+	});
+
+	it('normalizes capability and availability events with full IDs and metadata', () => {
+		expect(
+			transformHomeyLocalEvent({
+				type: 'capability',
+				deviceId: 'device-1',
+				payload: {
+					capabilityId: 'measure_temperature.inside',
+					lastUpdated: '2026-08-13T10:01:00.000Z',
+					sequence: 1,
+					value: 0,
+				},
+			}),
+		).toStrictEqual({
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: 'device-1',
+			capabilityId: 'measure_temperature.inside',
+			value: 0,
+			lastUpdatedAt: '2026-08-13T10:01:00.000Z',
+			occurredAt: '2026-08-13T10:01:00.000Z',
+			sequence: 1,
+		});
+
+		expect(
+			transformHomeyLocalEvent({
+				type: 'device.availability',
+				payload: {
+					available: false,
+					id: 'device-1',
+					sequence: 'event-2',
+					unavailableMessage: 'Device unavailable',
+				},
+			}),
+		).toStrictEqual({
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'device-1',
+			available: false,
+			availabilityMessage: 'Device unavailable',
+			occurredAt: null,
+			sequence: 'event-2',
+		});
+	});
+
+	it.each([
+		['device.create', HomeyEventType.DEVICE_ADDED, 'deviceId'],
+		['device.update', HomeyEventType.DEVICE_UPDATED, 'deviceId'],
+		['device.delete', HomeyEventType.DEVICE_REMOVED, 'deviceId'],
+		['zone.create', HomeyEventType.ZONE_ADDED, 'zoneId'],
+		['zone.update', HomeyEventType.ZONE_UPDATED, 'zoneId'],
+		['zone.delete', HomeyEventType.ZONE_REMOVED, 'zoneId'],
+	] as const)('normalizes %s lifecycle events', (type, normalizedType, idKey) => {
+		expect(transformHomeyLocalEvent({ type, payload: { id: 'entity-1' } })).toStrictEqual({
+			type: normalizedType,
+			[idKey]: 'entity-1',
+			occurredAt: null,
+			sequence: null,
+		});
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.spec.ts
@@ -209,6 +209,31 @@ describe('Homey local protocol transformer', () => {
 		});
 	});
 
+	it('preserves explicit null capability events and rejects missing or malformed values', () => {
+		const event = {
+			type: 'capability' as const,
+			deviceId: 'device-1',
+			payload: { capabilityId: 'meter_power.instance', value: null },
+		};
+
+		expect(transformHomeyLocalEvent(event)).toMatchObject({ value: null });
+		expect(() => transformHomeyLocalEvent({ ...event, payload: { capabilityId: 'meter_power.instance' } })).toThrow(
+			'Homey protocol event capability value is missing',
+		);
+		expect(() =>
+			transformHomeyLocalEvent({
+				...event,
+				payload: { capabilityId: 'meter_power.instance', value: { leaked: 'invalid' } },
+			}),
+		).toThrow('Homey protocol event capability value is malformed');
+		expect(() =>
+			transformHomeyLocalEvent({
+				...event,
+				payload: { capabilityId: 'meter_power.instance', value: Number.NaN },
+			}),
+		).toThrow('Homey protocol event capability value is malformed');
+	});
+
 	it.each([
 		['device.create', HomeyEventType.DEVICE_ADDED, 'deviceId'],
 		['device.update', HomeyEventType.DEVICE_UPDATED, 'deviceId'],

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.ts
@@ -88,6 +88,28 @@ const capabilityValue = (value: unknown): HomeyCapabilityValue => {
 	return asNumber(value);
 };
 
+const requireCapabilityValue = (value: HomeyProtocolRecord, key: string, label: string): HomeyCapabilityValue => {
+	if (!Object.hasOwn(value, key)) {
+		throw new Error(`Homey protocol ${label} is missing`);
+	}
+
+	const candidate = value[key];
+
+	if (candidate === null) {
+		return null;
+	}
+
+	if (typeof candidate === 'boolean' || typeof candidate === 'string') {
+		return candidate;
+	}
+
+	if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+		return candidate;
+	}
+
+	throw new Error(`Homey protocol ${label} is malformed`);
+};
+
 const enumValues = (value: unknown): readonly HomeyCapabilityEnumValue[] => {
 	if (!Array.isArray(value)) {
 		return [];
@@ -257,7 +279,7 @@ export const transformHomeyLocalEvent = (event: HomeyLocalTransportEvent): Homey
 				type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
 				deviceId: requireString(event.deviceId ?? payload.deviceId, 'event device id'),
 				capabilityId: requireString(firstString(payload.capabilityId, payload.capability), 'event capability id'),
-				value: capabilityValue(payload.value),
+				value: requireCapabilityValue(payload, 'value', 'event capability value'),
 				lastUpdatedAt: firstString(payload.lastUpdatedAt, payload.lastUpdated),
 				...metadata,
 			};

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.transformer.ts
@@ -6,7 +6,11 @@ import {
 	createHomeyCapability,
 } from '../models/homey-capability.model';
 import { HomeyDevice, HomeyDeviceEnergy } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+import { HomeySystemInfo } from '../models/homey-system-info.model';
 import { HomeyZone } from '../models/homey-zone.model';
+
+import { HomeyLocalTransportEvent } from './homey-local.transport';
 
 type HomeyProtocolRecord = Record<string, unknown>;
 
@@ -29,6 +33,36 @@ const requireString = (value: unknown, label: string): string => {
 
 	return parsed;
 };
+
+const requireBoolean = (value: unknown, label: string): boolean => {
+	const parsed = asBoolean(value);
+
+	if (parsed === null) {
+		throw new Error(`Homey protocol ${label} is missing`);
+	}
+
+	return parsed;
+};
+
+const firstString = (...values: unknown[]): string | null => {
+	for (const value of values) {
+		const parsed = asString(value);
+
+		if (parsed !== null && parsed.length > 0) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+const eventMetadata = (value: HomeyProtocolRecord): Pick<HomeyEvent, 'occurredAt' | 'sequence'> => ({
+	occurredAt: firstString(value.occurredAt, value.timestamp, value.lastUpdated),
+	sequence:
+		typeof value.sequence === 'string' || (typeof value.sequence === 'number' && Number.isFinite(value.sequence))
+			? value.sequence
+			: null,
+});
 
 const capabilityType = (value: unknown): HomeyCapabilityType => {
 	switch (value) {
@@ -117,6 +151,21 @@ const capabilityIds = (device: HomeyProtocolRecord, capabilities: HomeyProtocolR
 	return Object.keys(capabilities);
 };
 
+/** Converts the local system manager response into a transport-neutral snapshot. */
+export const transformHomeyLocalSystemInfo = (value: unknown): HomeySystemInfo => {
+	if (!isRecord(value)) {
+		throw new Error('Homey protocol system response is malformed');
+	}
+
+	return {
+		id: requireString(firstString(value.id, value.homeyId, value.cloudId, value._id), 'system id'),
+		name: firstString(value.name, value.homeyName),
+		version: requireString(firstString(value.homeyVersion, value.version), 'system version'),
+		tier: firstString(value.tier, value.homeyTier),
+		model: firstString(value.homeyModelName, value.model),
+	};
+};
+
 /** Converts the Homey zone map into source-ordered normalized zones with root-to-leaf paths. */
 export const transformHomeyLocalZones = (value: unknown): readonly HomeyZone[] => {
 	if (!isRecord(value)) {
@@ -191,4 +240,70 @@ export const transformHomeyLocalDevices = (value: unknown, zones: readonly Homey
 	}
 
 	return Object.values(value).map((device) => transformHomeyLocalDevice(device, zones));
+};
+
+/** Converts one local manager/item event while preserving full capability IDs. */
+export const transformHomeyLocalEvent = (event: HomeyLocalTransportEvent): HomeyEvent => {
+	if (!isRecord(event.payload)) {
+		throw new Error('Homey protocol event payload is malformed');
+	}
+
+	const payload = event.payload;
+	const metadata = eventMetadata(payload);
+
+	switch (event.type) {
+		case 'capability':
+			return {
+				type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+				deviceId: requireString(event.deviceId ?? payload.deviceId, 'event device id'),
+				capabilityId: requireString(firstString(payload.capabilityId, payload.capability), 'event capability id'),
+				value: capabilityValue(payload.value),
+				lastUpdatedAt: firstString(payload.lastUpdatedAt, payload.lastUpdated),
+				...metadata,
+			};
+		case 'device.create':
+			return {
+				type: HomeyEventType.DEVICE_ADDED,
+				deviceId: requireString(firstString(payload.id, payload.deviceId), 'event device id'),
+				...metadata,
+			};
+		case 'device.delete':
+			return {
+				type: HomeyEventType.DEVICE_REMOVED,
+				deviceId: requireString(firstString(payload.id, payload.deviceId), 'event device id'),
+				...metadata,
+			};
+		case 'device.availability':
+			return {
+				type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+				deviceId: requireString(firstString(payload.id, payload.deviceId), 'event device id'),
+				available: requireBoolean(payload.available, 'event availability'),
+				availabilityMessage: firstString(payload.unavailableMessage, payload.availabilityMessage),
+				...metadata,
+			};
+		case 'device.update':
+			return {
+				type: HomeyEventType.DEVICE_UPDATED,
+				deviceId: requireString(firstString(payload.id, payload.deviceId), 'event device id'),
+				...metadata,
+			};
+		case 'zone.create':
+			return {
+				type: HomeyEventType.ZONE_ADDED,
+				zoneId: requireString(firstString(payload.id, payload.zoneId), 'event zone id'),
+				...metadata,
+			};
+		case 'zone.delete':
+			return {
+				type: HomeyEventType.ZONE_REMOVED,
+				zoneId: requireString(firstString(payload.id, payload.zoneId), 'event zone id'),
+				...metadata,
+			};
+		case 'zone.update':
+			return {
+				type: HomeyEventType.ZONE_UPDATED,
+				zoneId: requireString(firstString(payload.id, payload.zoneId), 'event zone id'),
+				...metadata,
+			};
+	}
 };

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local.transport.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local.transport.ts
@@ -1,0 +1,37 @@
+export type HomeyLocalTransportEventType =
+	| 'capability'
+	| 'device.availability'
+	| 'device.create'
+	| 'device.delete'
+	| 'device.update'
+	| 'zone.create'
+	| 'zone.delete'
+	| 'zone.update';
+
+export interface HomeyLocalTransportEvent {
+	readonly type: HomeyLocalTransportEventType;
+	readonly payload: unknown;
+	/** Required for item-level capability events whose payload does not contain the device ID. */
+	readonly deviceId?: string;
+}
+
+export type HomeyLocalTransportEventListener = (event: HomeyLocalTransportEvent) => Promise<void> | void;
+
+export type HomeyLocalTransportUnsubscribe = () => Promise<void> | void;
+
+/**
+ * Local transport boundary. The eventual SDK or direct-protocol adapter owns
+ * wire-specific event attribution and is the only layer allowed to expose raw
+ * Homey values to this interface.
+ */
+export interface HomeyLocalTransport {
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+	getSystemInfo(): Promise<unknown>;
+	getZones(): Promise<unknown>;
+	getDevices(): Promise<unknown>;
+	/** Resolves to null only when the device is authoritatively absent. */
+	getDevice(deviceId: string): Promise<unknown>;
+	setCapabilityValue(deviceId: string, capabilityId: string, value: unknown): Promise<void>;
+	subscribe(listener: HomeyLocalTransportEventListener): Promise<HomeyLocalTransportUnsubscribe>;
+}

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -213,17 +213,20 @@ index.ts
 **Proposed files:**
 
 - `connectors/homey-local.connector.ts`
+- `connectors/homey-local.transport.ts`
+- `connectors/homey-local.error-mapper.ts`
 - `connectors/homey-local.transformer.ts`
 - Corresponding specs using captured fixtures/fakes
 
 - [ ] Add the reviewed dependency only if Milestone 0 selected the SDK.
 - [ ] Construct a local API client from validated address/token without logging either.
 - [ ] Apply explicit connect/read/write/subscription timeouts.
-- [ ] Transform SDK/protocol objects into normalized models.
-- [ ] Convert raw errors into normalized categories.
-- [ ] Implement inventory, zones, system info, device lookup, capability writes, subscriptions, and cleanup.
-- [ ] Ensure one connector instance owns one transport connection.
-- [ ] Add fixture-backed tests for every operation and error category.
+- [x] Transform SDK/protocol objects into normalized models.
+- [x] Convert raw errors into normalized categories.
+- [x] Implement transport-neutral connector orchestration and cleanup behind an injectable local transport.
+- [x] Ensure one connector core owns one transport and passes the reusable fake-transport contract suite.
+- [ ] Implement the production adapter for inventory, zones, system info, device lookup, capability writes, and subscriptions.
+- [ ] Add adapter-specific fixture-backed tests for every operation and error category.
 - [ ] Add environment-gated contract tests against live SHS.
 
 ### Task 2.2: Implement plugin lifecycle and connection state machine


### PR DESCRIPTION
## Summary

- add a transport-neutral Homey local connector with serialized lifecycle and idempotent cleanup
- normalize local system, inventory, lifecycle, availability, and capability events
- map raw transport failures to secret-safe connector error categories
- run the reusable connector contract against captured SHS fixtures and a fake local transport
- record the completed connector-core slice while leaving the production adapter and live SHS validation open

## Why

This establishes a stable connector boundary before selecting and wiring the production Homey SDK or direct-protocol transport. The separation keeps transport details out of plugin-domain logic and lets local and cloud implementations share the same behavior contract.

## Validation

- `pnpm exec eslint src/plugins/devices-homey/connectors/homey-local*.ts --max-warnings 0`
- `pnpm exec tsc --noEmit --incremental false --pretty false`
- `pnpm exec jest --runInBand src/plugins/devices-homey` — 12 suites, 120 tests
- `pnpm run test:homey-spike` — 7 suites, 122 tests
- `git diff --check`