### PR TITLE
feat(cross): add Homey lifecycle synchronization

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-connector.factory.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-connector.factory.ts
@@ -1,0 +1,16 @@
+import { HomeyConnector } from './homey-connector.interface';
+
+export interface HomeyConnectorFactoryConfig {
+	readonly url: string;
+	readonly apiKey: string;
+	readonly connectionTimeout: number;
+}
+
+/**
+ * Creates a fresh connector for one saved Homey configuration generation.
+ * The production transport remains behind this boundary until live SHS proof
+ * selects the SDK or direct protocol adapter.
+ */
+export interface HomeyConnectorFactory {
+	create(config: HomeyConnectorFactoryConfig): HomeyConnector;
+}

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -6,7 +6,7 @@ export const DEVICES_HOMEY_TYPE = 'devices-homey';
 
 export const DEVICES_HOMEY_CONNECTOR_SERVICE_ID = 'connector';
 
-export const HOMEY_CONNECTOR = Symbol('HOMEY_CONNECTOR');
+export const HOMEY_CONNECTOR_FACTORY = Symbol('HOMEY_CONNECTOR_FACTORY');
 
 export const DEVICES_HOMEY_PLUGIN_API_TAG_NAME = 'Devices Homey plugin';
 

--- a/apps/backend/src/plugins/devices-homey/index.ts
+++ b/apps/backend/src/plugins/devices-homey/index.ts
@@ -1,5 +1,6 @@
 export * from './devices-homey.constants';
 export * from './devices-homey.plugin';
+export * from './connectors/homey-connector.factory';
 export * from './connectors/homey-connector.interface';
 export * from './connectors/homey-connector.types';
 export * from './dto/update-config.dto';

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -1,4 +1,7 @@
 import { ConfigService } from '../../../modules/config/services/config.service';
+import { HomeyConnectorFactory } from '../connectors/homey-connector.factory';
+import { HomeyConnector } from '../connectors/homey-connector.interface';
+import { HomeyEventListener } from '../connectors/homey-connector.types';
 import {
 	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
 	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
@@ -6,16 +9,60 @@ import {
 	DEVICES_HOMEY_PLUGIN_NAME,
 	HomeyConnectionState,
 } from '../devices-homey.constants';
+import {
+	HomeyConnectorError,
+	HomeyConnectorErrorCategory,
+	HomeyConnectorOperation,
+} from '../errors/homey-connector.error';
 import { HomeyConfigModel } from '../models/config.model';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEventType } from '../models/homey-event.model';
+import { HomeySystemInfo } from '../models/homey-system-info.model';
+import { HomeyZone } from '../models/homey-zone.model';
 
 import { HomeyService } from './homey.service';
+
+const systemInfo: HomeySystemInfo = {
+	id: 'homey-system',
+	name: 'Homey Pro',
+	version: '13.4.0',
+	tier: 'pro',
+	model: 'Homey Pro',
+};
+
+const zones: readonly HomeyZone[] = [
+	{ id: 'zone-living', name: 'Living room', parentId: null, active: true, path: ['Living room'] },
+];
+
+const staleDevice: HomeyDevice = {
+	id: 'device-light',
+	name: 'Light',
+	class: 'light',
+	zoneId: 'zone-living',
+	zoneName: 'Living room',
+	zonePath: ['Living room'],
+	available: true,
+	availabilityMessage: null,
+	driverId: 'homey:app:driver:light',
+	manufacturer: 'Example',
+	model: 'Light',
+	energy: null,
+	capabilities: [],
+};
 
 describe('HomeyService', () => {
 	let config: HomeyConfigModel;
 	let configService: jest.Mocked<Pick<ConfigService, 'getPluginConfig'>>;
+	let connector: jest.Mocked<HomeyConnector>;
+	let connectorFactory: jest.Mocked<HomeyConnectorFactory>;
+	let listener: HomeyEventListener | null;
+	let unsubscribe: jest.Mock;
 	let service: HomeyService;
 
 	beforeEach(() => {
+		jest.useFakeTimers();
+		listener = null;
+		unsubscribe = jest.fn();
 		config = Object.assign(new HomeyConfigModel(), {
 			enabled: true,
 			url: 'http://homey.local:4859',
@@ -24,7 +71,26 @@ describe('HomeyService', () => {
 			reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
 		});
 		configService = { getPluginConfig: jest.fn().mockReturnValue(config) };
-		service = new HomeyService(configService as unknown as ConfigService);
+		connector = {
+			connect: jest.fn().mockResolvedValue(undefined),
+			disconnect: jest.fn().mockResolvedValue(undefined),
+			getSystemInfo: jest.fn().mockResolvedValue(systemInfo),
+			getZones: jest.fn().mockResolvedValue(zones),
+			getDevices: jest.fn().mockResolvedValue([staleDevice]),
+			getDevice: jest.fn().mockResolvedValue(staleDevice),
+			setCapabilityValue: jest.fn().mockResolvedValue(undefined),
+			subscribe: jest.fn().mockImplementation((nextListener: HomeyEventListener) => {
+				listener = nextListener;
+
+				return Promise.resolve(unsubscribe);
+			}),
+		};
+		connectorFactory = { create: jest.fn().mockReturnValue(connector) };
+		service = new HomeyService(configService as unknown as ConfigService, connectorFactory);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
 	});
 
 	it('exposes the managed connector identity and starts stopped', () => {
@@ -33,28 +99,216 @@ describe('HomeyService', () => {
 		expect(service.getState()).toBe('stopped');
 	});
 
-	it('starts and stops idempotently without opening a transport', async () => {
+	it('connects, subscribes before inventory, and stops idempotently', async () => {
+		const order: string[] = [];
+		connector.connect.mockImplementation(() => {
+			order.push('connect');
+			return Promise.resolve();
+		});
+		connector.getSystemInfo.mockImplementation(() => {
+			order.push('system');
+			return Promise.resolve(systemInfo);
+		});
+		connector.getZones.mockImplementation(() => {
+			order.push('zones');
+			return Promise.resolve(zones);
+		});
+		connector.subscribe.mockImplementation((nextListener: HomeyEventListener) => {
+			order.push('subscribe');
+			listener = nextListener;
+			return Promise.resolve(unsubscribe);
+		});
+		connector.getDevices.mockImplementation(() => {
+			order.push('devices');
+			return Promise.resolve([staleDevice]);
+		});
+
 		await service.start();
 		await service.start();
 
+		expect(order).toEqual(['connect', 'system', 'zones', 'subscribe', 'devices']);
+		expect(connectorFactory.create.mock.calls[0]?.[0]).toEqual({
+			url: config.url,
+			apiKey: config.apiKey,
+			connectionTimeout: config.connectionTimeout,
+		});
 		expect(service.getState()).toBe('started');
-		expect(configService.getPluginConfig).toHaveBeenCalledTimes(1);
+		expect(await service.isHealthy()).toBe(true);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+
+		await service.stop();
+		await service.stop();
+
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(service.getState()).toBe('stopped');
 		expect(await service.isHealthy()).toBe(false);
+	});
+
+	it('performs a targeted authoritative read for an event received during the startup snapshot', async () => {
+		const freshDevice = { ...staleDevice, available: false, availabilityMessage: 'Offline' };
+		connector.getDevice.mockResolvedValue(freshDevice);
+		connector.getDevices.mockImplementation(async () => {
+			await listener?.({
+				type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+				deviceId: staleDevice.id,
+				available: false,
+				availabilityMessage: 'Offline',
+				occurredAt: null,
+				sequence: null,
+			});
+
+			return [staleDevice];
+		});
+
+		await service.start();
+
+		expect(connector.subscribe.mock.invocationCallOrder[0]).toBeLessThan(
+			connector.getDevices.mock.invocationCallOrder[0],
+		);
+		expect(connector.getDevice.mock.calls).toContainEqual([staleDevice.id]);
+		expect(await service.isHealthy()).toBe(true);
 
 		await service.stop();
+	});
+
+	it('serializes periodic reconciliation and does not schedule an overlapping run', async () => {
+		let resolveInventory: ((devices: readonly HomeyDevice[]) => void) | null = null;
+
+		await service.start();
+		connector.getDevices.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveInventory = resolve;
+				}),
+		);
+
+		jest.advanceTimersByTime(config.reconciliationInterval);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(connector.getDevices.mock.calls).toHaveLength(2);
+
+		jest.advanceTimersByTime(config.reconciliationInterval * 2);
+		await Promise.resolve();
+
+		expect(connector.getDevices.mock.calls).toHaveLength(2);
+
+		resolveInventory?.([staleDevice]);
+
+		for (let index = 0; index < 10; index += 1) {
+			await Promise.resolve();
+		}
+
+		expect(jest.getTimerCount()).toBe(1);
+
+		await service.stop();
+	});
+
+	it('degrades on a transient live synchronization failure and recovers on reconciliation', async () => {
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+
+		await listener?.({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		});
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.DEGRADED_POLLING,
+			healthy: false,
+			lastError: 'Homey connection is temporarily unavailable',
+		});
+
+		await jest.advanceTimersByTimeAsync(config.reconciliationInterval);
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.CONNECTED,
+			healthy: true,
+			lastError: null,
+		});
+
+		await service.stop();
+	});
+
+	it('refreshes device zone paths after a live zone change', async () => {
+		await service.start();
+		connector.getZones.mockClear();
+		connector.getDevices.mockClear();
+
+		await listener?.({
+			type: HomeyEventType.ZONE_UPDATED,
+			zoneId: zones[0].id,
+			occurredAt: null,
+			sequence: null,
+		});
+
+		expect(connector.getZones.mock.calls).toHaveLength(1);
+		expect(connector.getDevices.mock.calls).toHaveLength(1);
+
+		await service.stop();
+	});
+
+	it('categorizes authentication failures and cleans up partial startup', async () => {
+		connector.connect.mockRejectedValue(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHENTICATION, HomeyConnectorOperation.CONNECT),
+		);
+
+		await expect(service.start()).rejects.toThrow('Homey authentication or authorization failed');
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'error',
+			connectionState: HomeyConnectionState.AUTHENTICATION_FAILED,
+			healthy: false,
+			lastError: 'Homey authentication or authorization failed',
+		});
+	});
+
+	it('cleans up a subscription after a failed inventory snapshot without exposing raw details', async () => {
+		connector.getDevices.mockRejectedValue(new Error('configured-secret at http://homey.local:4859'));
+
+		await expect(service.start()).rejects.toThrow('Homey service failed to start');
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(JSON.stringify(service.getStatus())).not.toContain('configured-secret');
+		expect(JSON.stringify(service.getStatus())).not.toContain('homey.local');
+	});
+
+	it('retries connector cleanup after a sanitized stop failure', async () => {
+		await service.start();
+		connector.disconnect.mockRejectedValueOnce(new Error('configured-secret cleanup detail'));
+
+		await expect(service.stop()).rejects.toThrow('Homey service failed to stop');
+		expect(service.getState()).toBe('error');
+		expect(service.getStatus().lastError).toBe('Homey service failed to stop');
+
 		await service.stop();
 
+		expect(connector.disconnect.mock.calls).toHaveLength(2);
 		expect(service.getState()).toBe('stopped');
 	});
 
-	it('enters error state with a sanitized status if configuration loading fails', async () => {
-		configService.getPluginConfig.mockImplementation(() => {
-			throw new Error('raw configuration detail');
-		});
+	it('fails safely when the production connector factory is not registered', async () => {
+		service = new HomeyService(configService as unknown as ConfigService);
 
 		await expect(service.start()).rejects.toThrow('Homey service failed to start');
-		expect(service.getState()).toBe('error');
-		expect(service.getStatus().lastError).toBe('Homey service failed to start');
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.ERROR,
+			healthy: false,
+			lastError: 'Homey service failed to start',
+		});
+	});
+
+	it('does not create a connector from incomplete saved configuration', async () => {
+		config.apiKey = null;
+
+		await expect(service.start()).rejects.toThrow('Homey service failed to start');
+		expect(connectorFactory.create.mock.calls).toHaveLength(0);
+		expect(service.getStatus()).toMatchObject({ configured: false, healthy: false });
 	});
 
 	it('reports configuration without exposing its URL or API key', () => {
@@ -97,5 +351,7 @@ describe('HomeyService', () => {
 		);
 
 		expect(await service.onConfigChanged()).toEqual({ restartRequired: true });
+
+		await service.stop();
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -1,15 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { ConfigService } from '../../../modules/config/services/config.service';
 import { BaseManagedPluginService } from '../../../modules/extensions/services/base-managed-plugin.service';
 import { ConfigChangeResult } from '../../../modules/extensions/services/managed-plugin-service.interface';
+import { HomeyConnectorFactory } from '../connectors/homey-connector.factory';
+import { HomeyConnector } from '../connectors/homey-connector.interface';
+import { HomeyUnsubscribe } from '../connectors/homey-connector.types';
 import {
 	DEVICES_HOMEY_CONNECTOR_SERVICE_ID,
 	DEVICES_HOMEY_PLUGIN_NAME,
+	HOMEY_CONNECTOR_FACTORY,
 	HomeyConnectionState,
 } from '../devices-homey.constants';
+import { HomeyConnectorError, HomeyConnectorErrorCategory } from '../errors/homey-connector.error';
 import { HomeyConfigModel } from '../models/config.model';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+import { HomeySystemInfo } from '../models/homey-system-info.model';
+import { HomeyZone } from '../models/homey-zone.model';
 import { HomeyStatusModel } from '../models/status.model';
 
 @Injectable()
@@ -21,52 +30,95 @@ export class HomeyService extends BaseManagedPluginService {
 
 	private pluginConfig: HomeyConfigModel | null = null;
 	private lastError: string | null = null;
+	private connectionState = HomeyConnectionState.STOPPED;
+	private healthy = false;
+	private connector: HomeyConnector | null = null;
+	private unsubscribe: HomeyUnsubscribe | null = null;
+	private systemInfo: HomeySystemInfo | null = null;
+	private zones: readonly HomeyZone[] = [];
+	private devices = new Map<string, HomeyDevice>();
+	private startupEvents: HomeyEvent[] | null = null;
+	private generation = 0;
+	private synchronizationTail: Promise<void> = Promise.resolve();
+	private reconciliationTimer: ReturnType<typeof setTimeout> | null = null;
 
-	constructor(private readonly configService: ConfigService) {
+	constructor(
+		private readonly configService: ConfigService,
+		@Optional()
+		@Inject(HOMEY_CONNECTOR_FACTORY)
+		private readonly connectorFactory: HomeyConnectorFactory | null = null,
+	) {
 		super();
 	}
 
 	async start(): Promise<void> {
-		await this.withLock(() => {
+		await this.withLock(async () => {
 			if (this.state === 'started') {
-				return Promise.resolve();
+				return;
 			}
+
+			await this.cleanupPreviousGeneration();
 
 			this.state = 'starting';
 			this.pluginConfig = null;
 			this.lastError = null;
+			this.healthy = false;
+			this.connectionState = HomeyConnectionState.CONNECTING;
+			const generation = ++this.generation;
 
 			try {
-				this.getPluginConfig();
+				const config = this.getPluginConfig();
+				const connector = this.createConnector(config);
+				this.connector = connector;
 
-				// The live connector is introduced by Task 2.1. Until then the
-				// managed shell deliberately performs no network activity.
+				await connector.connect();
+				await this.synchronizeStartup(connector, generation);
+
 				this.state = 'started';
-				this.logger.log('Homey plugin shell started; connector is not initialized yet');
-			} catch {
+				this.connectionState = HomeyConnectionState.CONNECTED;
+				this.healthy = true;
+				this.scheduleReconciliation(generation);
+				this.logger.log('Homey connector started and initial inventory synchronized');
+			} catch (error) {
+				this.applyFailureState(error, 'Homey service failed to start');
+				await this.cleanupRuntime();
 				this.state = 'error';
-				this.lastError = 'Homey service failed to start';
+				this.healthy = false;
+				this.logger.error(this.lastError ?? 'Homey service failed to start');
+
+				// Raw connector/config errors can contain the write-only key or endpoint.
+				// eslint-disable-next-line preserve-caught-error
+				throw new Error(this.lastError ?? 'Homey service failed to start');
+			}
+		});
+	}
+
+	async stop(): Promise<void> {
+		await this.withLock(async () => {
+			if (this.state === 'stopped' && !this.hasRuntimeResources()) {
+				return;
+			}
+
+			this.state = 'stopping';
+			this.generation += 1;
+			this.healthy = false;
+			this.connectionState = HomeyConnectionState.STOPPED;
+
+			const cleaned = await this.cleanupRuntime();
+
+			this.pluginConfig = null;
+
+			if (!cleaned) {
+				this.state = 'error';
+				this.lastError = 'Homey service failed to stop';
 				this.logger.error(this.lastError);
 
 				throw new Error(this.lastError);
 			}
 
-			return Promise.resolve();
-		});
-	}
-
-	async stop(): Promise<void> {
-		await this.withLock(() => {
-			if (this.state === 'stopped') {
-				return Promise.resolve();
-			}
-
-			this.state = 'stopping';
-			this.pluginConfig = null;
 			this.state = 'stopped';
-			this.logger.log('Homey plugin shell stopped');
-
-			return Promise.resolve();
+			this.lastError = null;
+			this.logger.log('Homey connector stopped');
 		});
 	}
 
@@ -89,7 +141,7 @@ export class HomeyService extends BaseManagedPluginService {
 	}
 
 	isHealthy(): Promise<boolean> {
-		return Promise.resolve(false);
+		return Promise.resolve(this.healthy && this.state === 'started');
 	}
 
 	getStatus(): HomeyStatusModel {
@@ -97,10 +149,10 @@ export class HomeyService extends BaseManagedPluginService {
 		const status = new HomeyStatusModel();
 
 		status.serviceState = this.getState();
-		status.connectionState = HomeyConnectionState.STOPPED;
+		status.connectionState = this.connectionState;
 		status.enabled = config.enabled;
 		status.configured = this.isConfigured(config);
-		status.healthy = false;
+		status.healthy = this.healthy;
 		status.lastError = this.lastError;
 
 		return status;
@@ -112,6 +164,282 @@ export class HomeyService extends BaseManagedPluginService {
 		}
 
 		return this.pluginConfig;
+	}
+
+	private createConnector(config: HomeyConfigModel): HomeyConnector {
+		if (!this.isConfigured(config)) {
+			throw new Error('Homey connector configuration is incomplete');
+		}
+
+		if (!this.connectorFactory) {
+			throw new Error('Homey connector transport is not available');
+		}
+
+		return this.connectorFactory.create({
+			url: config.url,
+			apiKey: config.apiKey,
+			connectionTimeout: config.connectionTimeout,
+		});
+	}
+
+	private async synchronizeStartup(connector: HomeyConnector, generation: number): Promise<void> {
+		this.systemInfo = await connector.getSystemInfo();
+		this.zones = await connector.getZones();
+		this.startupEvents = [];
+		this.unsubscribe = await connector.subscribe((event) => this.onConnectorEvent(connector, generation, event));
+
+		await this.enqueueSynchronization(async () => {
+			this.replaceDevices(await connector.getDevices());
+			await this.reconcileStartupEvents(connector, generation);
+		});
+	}
+
+	private async reconcileStartupEvents(connector: HomeyConnector, generation: number): Promise<void> {
+		let cursor = 0;
+		let pass = 0;
+
+		while (this.startupEvents && cursor < this.startupEvents.length && pass < 10) {
+			const events = this.startupEvents.slice(cursor);
+			cursor += events.length;
+			pass += 1;
+			await this.reconcileEvents(connector, generation, events);
+		}
+
+		const remainingEvents = this.startupEvents?.slice(cursor) ?? [];
+		this.startupEvents = null;
+
+		if (remainingEvents.length > 0) {
+			await this.reconcileEvents(connector, generation, remainingEvents);
+		}
+	}
+
+	private onConnectorEvent(connector: HomeyConnector, generation: number, event: HomeyEvent): Promise<void> | void {
+		if (!this.isCurrentGeneration(connector, generation)) {
+			return;
+		}
+
+		if (this.startupEvents) {
+			this.startupEvents.push(event);
+
+			return;
+		}
+
+		return this.enqueueSynchronization(async () => {
+			try {
+				await this.reconcileEvents(connector, generation, [event]);
+			} catch (error) {
+				if (this.isCurrentGeneration(connector, generation)) {
+					this.applyFailureState(error, 'Homey event synchronization failed', HomeyConnectionState.DEGRADED_POLLING);
+					this.logger.error(this.lastError ?? 'Homey event synchronization failed');
+				}
+			}
+		});
+	}
+
+	private async reconcileEvents(
+		connector: HomeyConnector,
+		generation: number,
+		events: readonly HomeyEvent[],
+	): Promise<void> {
+		if (!this.isCurrentGeneration(connector, generation)) {
+			return;
+		}
+
+		const containsZoneEvent = events.some((event) => this.isZoneEvent(event));
+
+		if (containsZoneEvent) {
+			this.zones = await connector.getZones();
+			this.replaceDevices(await connector.getDevices());
+		}
+
+		const deviceIds = [...new Set(events.flatMap((event) => ('deviceId' in event ? [event.deviceId] : [])))];
+
+		for (const deviceId of deviceIds) {
+			const device = await connector.getDevice(deviceId);
+
+			if (!this.isCurrentGeneration(connector, generation)) {
+				return;
+			}
+
+			if (device) {
+				this.devices.set(device.id, device);
+			} else {
+				this.devices.delete(deviceId);
+			}
+		}
+	}
+
+	private isZoneEvent(event: HomeyEvent): boolean {
+		return (
+			event.type === HomeyEventType.ZONE_ADDED ||
+			event.type === HomeyEventType.ZONE_UPDATED ||
+			event.type === HomeyEventType.ZONE_REMOVED
+		);
+	}
+
+	private replaceDevices(devices: readonly HomeyDevice[]): void {
+		this.devices = new Map(devices.map((device) => [device.id, device]));
+	}
+
+	private scheduleReconciliation(generation: number): void {
+		this.clearReconciliationTimer();
+
+		const interval = this.pluginConfig?.reconciliationInterval;
+
+		if (!interval) {
+			return;
+		}
+
+		this.reconciliationTimer = setTimeout(() => {
+			this.reconciliationTimer = null;
+			void this.runPeriodicReconciliation(generation);
+		}, interval);
+	}
+
+	private async runPeriodicReconciliation(generation: number): Promise<void> {
+		const connector = this.connector;
+
+		if (!connector || !this.isCurrentGeneration(connector, generation) || this.state !== 'started') {
+			return;
+		}
+
+		await this.enqueueSynchronization(async () => {
+			try {
+				const [zones, devices] = await Promise.all([connector.getZones(), connector.getDevices()]);
+
+				if (!this.isCurrentGeneration(connector, generation)) {
+					return;
+				}
+
+				this.zones = zones;
+				this.replaceDevices(devices);
+				this.connectionState = HomeyConnectionState.CONNECTED;
+				this.healthy = true;
+				this.lastError = null;
+			} catch (error) {
+				if (this.isCurrentGeneration(connector, generation)) {
+					this.applyFailureState(error, 'Homey inventory reconciliation failed', HomeyConnectionState.DEGRADED_POLLING);
+					this.logger.error(this.lastError ?? 'Homey inventory reconciliation failed');
+				}
+			}
+		});
+
+		if (this.isCurrentGeneration(connector, generation) && this.state === 'started') {
+			this.scheduleReconciliation(generation);
+		}
+	}
+
+	private enqueueSynchronization(operation: () => Promise<void>): Promise<void> {
+		const result = this.synchronizationTail.then(async () => {
+			await operation();
+		});
+		this.synchronizationTail = this.settleSynchronization(result);
+
+		return result;
+	}
+
+	private async settleSynchronization(operation: Promise<void>): Promise<void> {
+		try {
+			await operation;
+		} catch {
+			// Callers observe the failure while the serialization queue stays usable.
+		}
+	}
+
+	private async cleanupPreviousGeneration(): Promise<void> {
+		if (!this.hasRuntimeResources()) {
+			return;
+		}
+
+		this.generation += 1;
+
+		if (!(await this.cleanupRuntime())) {
+			throw new Error('Homey service could not clean up its previous connector');
+		}
+	}
+
+	private async cleanupRuntime(): Promise<boolean> {
+		this.clearReconciliationTimer();
+		this.startupEvents = null;
+		const unsubscribe = this.unsubscribe;
+		const connector = this.connector;
+		let unsubscribeSucceeded = true;
+		let disconnectSucceeded = connector === null;
+
+		if (unsubscribe) {
+			try {
+				await unsubscribe();
+				this.unsubscribe = null;
+			} catch {
+				unsubscribeSucceeded = false;
+			}
+		}
+
+		if (connector) {
+			try {
+				await connector.disconnect();
+				disconnectSucceeded = true;
+			} catch {
+				disconnectSucceeded = false;
+			}
+		}
+
+		await this.synchronizationTail;
+
+		if (disconnectSucceeded && (unsubscribeSucceeded || connector !== null)) {
+			this.unsubscribe = null;
+			this.connector = null;
+			this.systemInfo = null;
+			this.zones = [];
+			this.devices.clear();
+		}
+
+		return disconnectSucceeded && (unsubscribeSucceeded || connector !== null);
+	}
+
+	private clearReconciliationTimer(): void {
+		if (this.reconciliationTimer) {
+			clearTimeout(this.reconciliationTimer);
+			this.reconciliationTimer = null;
+		}
+	}
+
+	private hasRuntimeResources(): boolean {
+		return this.connector !== null || this.unsubscribe !== null || this.reconciliationTimer !== null;
+	}
+
+	private isCurrentGeneration(connector: HomeyConnector, generation: number): boolean {
+		return this.connector === connector && this.generation === generation;
+	}
+
+	private applyFailureState(
+		error: unknown,
+		fallback: string,
+		transientState: HomeyConnectionState = HomeyConnectionState.ERROR,
+	): void {
+		this.healthy = false;
+
+		if (error instanceof HomeyConnectorError) {
+			switch (error.category) {
+				case HomeyConnectorErrorCategory.AUTHENTICATION:
+				case HomeyConnectorErrorCategory.AUTHORIZATION:
+					this.connectionState = HomeyConnectionState.AUTHENTICATION_FAILED;
+					this.lastError = 'Homey authentication or authorization failed';
+					return;
+				case HomeyConnectorErrorCategory.TIMEOUT:
+				case HomeyConnectorErrorCategory.UNAVAILABLE:
+					this.connectionState = transientState;
+					this.lastError = 'Homey connection is temporarily unavailable';
+					return;
+				default:
+					this.connectionState = HomeyConnectionState.ERROR;
+					this.lastError = fallback;
+					return;
+			}
+		}
+
+		this.connectionState = HomeyConnectionState.ERROR;
+		this.lastError = fallback;
 	}
 
 	private getCurrentPluginConfigOrDefault(): HomeyConfigModel {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -233,13 +233,13 @@ index.ts
 
 **Proposed service:** `services/homey.service.ts`
 
-- [ ] Start only when enabled and minimally configured.
-- [ ] Connect, load system/zone metadata, establish event subscriptions, perform the authoritative inventory reconciliation behind a startup event barrier, merge buffered events, then publish healthy state.
-- [ ] Use Homey ordering metadata verified in Phase 0 to merge snapshot/events. If none is reliable, perform a final targeted reconciliation for capabilities touched while the startup snapshot was in flight before releasing the barrier.
-- [ ] Stop subscriptions/timers/connector on disable, config change, module shutdown, or failed startup cleanup.
-- [ ] Reconfigure safely when URL/key/timeouts change; never overlap old/new connectors.
+- [x] Start only when enabled and minimally configured.
+- [x] Connect, load system/zone metadata, establish event subscriptions, perform the authoritative inventory reconciliation behind a startup event barrier, merge buffered events, then publish healthy state.
+- [x] Use Homey ordering metadata verified in Phase 0 to merge snapshot/events. If none is reliable, perform a final targeted reconciliation for capabilities touched while the startup snapshot was in flight before releasing the barrier.
+- [x] Stop subscriptions/timers/connector on disable, config change, module shutdown, or failed startup cleanup.
+- [x] Reconfigure safely when URL/key/timeouts change; never overlap old/new connectors.
 - [ ] Use exponential reconnect backoff with jitter and a maximum delay.
-- [ ] Treat authentication/authorization failures differently from transient network failures.
+- [x] Treat authentication/authorization failures differently from transient network failures.
 - [ ] Prevent concurrent reconnect and reconciliation loops.
 - [ ] Track last successful connection, inventory sync, event, error category, reconnect count, and degraded state.
 - [ ] Unit-test all state transitions with fake timers.


### PR DESCRIPTION
## Summary

- add a configuration-aware `HomeyConnectorFactory` boundary so each saved configuration generation owns a fresh connector
- replace the managed plugin shell with real lifecycle orchestration and accurate connected, degraded, authentication-failed, error, and stopped health states
- subscribe before the authoritative inventory snapshot, buffer startup events, and perform targeted authoritative reads before publishing healthy state
- serialize live and periodic reconciliation so inventory repair cannot overlap
- clean up subscriptions, timers, and connectors on stop, restart, and partial startup failure without exposing endpoint or API-key details
- update the Homey implementation plan for the lifecycle acceptance items proven by this slice

## Why

The previous service could enter `started` without opening a connector and always reported unhealthy. Homey needs a transport-independent lifecycle before the production SHS adapter can be selected safely. This PR establishes that lifecycle while keeping the concrete SDK/direct-protocol choice gated on the remaining live SHS evidence.

## Impact

Enabled Homey configurations now fail honestly when no production connector factory is registered instead of reporting a false start. Once an adapter is registered, the same service provides subscription-first synchronization, race repair, periodic reconciliation, safe reconfiguration, and sanitized status handling.

The production SHS adapter, exponential reconnect backoff, expanded status metrics, discovery/adoption, and control remain follow-up work.

## Validation

- `pnpm exec jest --runInBand src/plugins/devices-homey`
- `pnpm exec jest --runInBand src/plugins/devices-homey/services/homey.service.spec.ts`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `pnpm run build`
- `pnpm run generate:openapi`
- `pnpm run lint:js` (0 errors; two unrelated existing warnings in Buddy Discord/Telegram providers)
- `git diff --check`