### PR TITLE
feat(cross): add Homey reconnect backoff

### DIFF
--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -25,6 +25,12 @@ export const MIN_HOMEY_RECONCILIATION_INTERVAL_MS = 30000;
 
 export const MAX_HOMEY_RECONCILIATION_INTERVAL_MS = 3600000;
 
+export const HOMEY_RECONNECT_INITIAL_DELAY_MS = 1000;
+
+export const HOMEY_RECONNECT_MAX_DELAY_MS = 30000;
+
+export const HOMEY_RECONNECT_JITTER_RATIO = 0.2;
+
 export enum HomeyConnectionState {
 	STOPPED = 'stopped',
 	CONNECTING = 'connecting',

--- a/apps/backend/src/plugins/devices-homey/services/homey-reconnect-backoff.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-reconnect-backoff.spec.ts
@@ -1,0 +1,25 @@
+import { HOMEY_RECONNECT_INITIAL_DELAY_MS, HOMEY_RECONNECT_MAX_DELAY_MS } from '../devices-homey.constants';
+
+import { calculateHomeyReconnectDelay } from './homey-reconnect-backoff';
+
+describe('calculateHomeyReconnectDelay', () => {
+	it('doubles the neutral-jitter delay for each attempt', () => {
+		expect(calculateHomeyReconnectDelay(0, 0.5)).toBe(HOMEY_RECONNECT_INITIAL_DELAY_MS);
+		expect(calculateHomeyReconnectDelay(1, 0.5)).toBe(HOMEY_RECONNECT_INITIAL_DELAY_MS * 2);
+		expect(calculateHomeyReconnectDelay(2, 0.5)).toBe(HOMEY_RECONNECT_INITIAL_DELAY_MS * 4);
+	});
+
+	it('applies bounded symmetric jitter', () => {
+		expect(calculateHomeyReconnectDelay(0, 0)).toBe(800);
+		expect(calculateHomeyReconnectDelay(0, 1)).toBe(1200);
+		expect(calculateHomeyReconnectDelay(0, -10)).toBe(800);
+		expect(calculateHomeyReconnectDelay(0, 10)).toBe(1200);
+	});
+
+	it('caps large and invalid attempts at the maximum delay', () => {
+		expect(calculateHomeyReconnectDelay(100, 1)).toBe(HOMEY_RECONNECT_MAX_DELAY_MS);
+		expect(calculateHomeyReconnectDelay(Number.POSITIVE_INFINITY, 0.5)).toBe(HOMEY_RECONNECT_MAX_DELAY_MS);
+		expect(calculateHomeyReconnectDelay(-1, 0.5)).toBe(HOMEY_RECONNECT_INITIAL_DELAY_MS);
+		expect(calculateHomeyReconnectDelay(Number.NaN, Number.NaN)).toBe(HOMEY_RECONNECT_INITIAL_DELAY_MS);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-reconnect-backoff.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-reconnect-backoff.ts
@@ -1,0 +1,22 @@
+import {
+	HOMEY_RECONNECT_INITIAL_DELAY_MS,
+	HOMEY_RECONNECT_JITTER_RATIO,
+	HOMEY_RECONNECT_MAX_DELAY_MS,
+} from '../devices-homey.constants';
+
+/** Calculate a bounded full-generation reconnect delay with symmetric jitter. */
+export function calculateHomeyReconnectDelay(attempt: number, randomValue: number = Math.random()): number {
+	const normalizedAttempt = Number.isFinite(attempt)
+		? Math.max(0, Math.floor(attempt))
+		: attempt > 0
+			? Number.MAX_SAFE_INTEGER
+			: 0;
+	const normalizedRandom = Number.isFinite(randomValue) ? Math.min(1, Math.max(0, randomValue)) : 0.5;
+	const exponentialDelay = Math.min(
+		HOMEY_RECONNECT_INITIAL_DELAY_MS * 2 ** normalizedAttempt,
+		HOMEY_RECONNECT_MAX_DELAY_MS,
+	);
+	const jitterFactor = 1 - HOMEY_RECONNECT_JITTER_RATIO + normalizedRandom * HOMEY_RECONNECT_JITTER_RATIO * 2;
+
+	return Math.min(HOMEY_RECONNECT_MAX_DELAY_MS, Math.max(1, Math.round(exponentialDelay * jitterFactor)));
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -153,6 +153,36 @@ describe('HomeyService', () => {
 		expect(await service.isHealthy()).toBe(false);
 	});
 
+	it('recovers from a retryable initial startup failure without a config change', async () => {
+		const replacementConnector = createConnectorMock(() => undefined, jest.fn());
+		connector.connect.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.CONNECT),
+		);
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(replacementConnector);
+
+		await service.start();
+
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'started',
+			connectionState: HomeyConnectionState.RECONNECTING,
+			healthy: false,
+			lastError: 'Homey connection is temporarily unavailable',
+		});
+		expect(jest.getTimerCount()).toBe(1);
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(replacementConnector.connect.mock.calls).toHaveLength(1);
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'started',
+			connectionState: HomeyConnectionState.CONNECTED,
+			healthy: true,
+			lastError: null,
+		});
+
+		await service.stop();
+	});
+
 	it('performs a targeted authoritative read for an event received during the startup snapshot', async () => {
 		const freshDevice = { ...staleDevice, available: false, availabilityMessage: 'Offline' };
 		connector.getDevice.mockResolvedValue(freshDevice);
@@ -396,6 +426,49 @@ describe('HomeyService', () => {
 
 		expect(connectorFactory.create.mock.calls).toHaveLength(1);
 		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.STOPPED);
+	});
+
+	it('drains an active reconciliation before disconnecting for reconnect', async () => {
+		const replacementConnector = createConnectorMock(() => undefined, jest.fn());
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(replacementConnector);
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+		const event = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		} as const;
+
+		await listener?.(event);
+
+		let rejectRead: (error: Error) => void = () => undefined;
+		connector.getDevice.mockImplementationOnce(
+			() =>
+				new Promise((_, reject) => {
+					rejectRead = reject;
+				}),
+		);
+		const activeReconciliation = listener?.(event);
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(connector.disconnect.mock.calls).toHaveLength(0);
+
+		rejectRead(new Error('in-flight read ended'));
+		await activeReconciliation;
+
+		for (let index = 0; index < 10; index += 1) {
+			await Promise.resolve();
+		}
+
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(replacementConnector.connect.mock.calls).toHaveLength(1);
+
+		await service.stop();
 	});
 
 	it('refreshes device zone paths after a live zone change', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -50,6 +50,23 @@ const staleDevice: HomeyDevice = {
 	capabilities: [],
 };
 
+function createConnectorMock(onSubscribe: (listener: HomeyEventListener) => void, unsubscribe: jest.Mock) {
+	return {
+		connect: jest.fn().mockResolvedValue(undefined),
+		disconnect: jest.fn().mockResolvedValue(undefined),
+		getSystemInfo: jest.fn().mockResolvedValue(systemInfo),
+		getZones: jest.fn().mockResolvedValue(zones),
+		getDevices: jest.fn().mockResolvedValue([staleDevice]),
+		getDevice: jest.fn().mockResolvedValue(staleDevice),
+		setCapabilityValue: jest.fn().mockResolvedValue(undefined),
+		subscribe: jest.fn().mockImplementation((nextListener: HomeyEventListener) => {
+			onSubscribe(nextListener);
+
+			return Promise.resolve(unsubscribe);
+		}),
+	} satisfies jest.Mocked<HomeyConnector>;
+}
+
 describe('HomeyService', () => {
 	let config: HomeyConfigModel;
 	let configService: jest.Mocked<Pick<ConfigService, 'getPluginConfig'>>;
@@ -61,6 +78,7 @@ describe('HomeyService', () => {
 
 	beforeEach(() => {
 		jest.useFakeTimers();
+		jest.spyOn(Math, 'random').mockReturnValue(0.5);
 		listener = null;
 		unsubscribe = jest.fn();
 		config = Object.assign(new HomeyConfigModel(), {
@@ -71,26 +89,16 @@ describe('HomeyService', () => {
 			reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
 		});
 		configService = { getPluginConfig: jest.fn().mockReturnValue(config) };
-		connector = {
-			connect: jest.fn().mockResolvedValue(undefined),
-			disconnect: jest.fn().mockResolvedValue(undefined),
-			getSystemInfo: jest.fn().mockResolvedValue(systemInfo),
-			getZones: jest.fn().mockResolvedValue(zones),
-			getDevices: jest.fn().mockResolvedValue([staleDevice]),
-			getDevice: jest.fn().mockResolvedValue(staleDevice),
-			setCapabilityValue: jest.fn().mockResolvedValue(undefined),
-			subscribe: jest.fn().mockImplementation((nextListener: HomeyEventListener) => {
-				listener = nextListener;
-
-				return Promise.resolve(unsubscribe);
-			}),
-		};
+		connector = createConnectorMock((nextListener) => {
+			listener = nextListener;
+		}, unsubscribe);
 		connectorFactory = { create: jest.fn().mockReturnValue(connector) };
 		service = new HomeyService(configService as unknown as ConfigService, connectorFactory);
 	});
 
 	afterEach(() => {
 		jest.useRealTimers();
+		jest.restoreAllMocks();
 	});
 
 	it('exposes the managed connector identity and starts stopped', () => {
@@ -205,7 +213,13 @@ describe('HomeyService', () => {
 		await service.stop();
 	});
 
-	it('degrades on a transient live synchronization failure and recovers on reconciliation', async () => {
+	it('replaces the connector after a transient live synchronization failure', async () => {
+		let replacementListener: HomeyEventListener | null = null;
+		const replacementUnsubscribe = jest.fn();
+		const replacementConnector = createConnectorMock((nextListener) => {
+			replacementListener = nextListener;
+		}, replacementUnsubscribe);
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(replacementConnector);
 		await service.start();
 		connector.getDevice.mockRejectedValueOnce(
 			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
@@ -219,13 +233,20 @@ describe('HomeyService', () => {
 		});
 
 		expect(service.getStatus()).toMatchObject({
-			connectionState: HomeyConnectionState.DEGRADED_POLLING,
+			connectionState: HomeyConnectionState.RECONNECTING,
 			healthy: false,
 			lastError: 'Homey connection is temporarily unavailable',
 		});
+		expect(jest.getTimerCount()).toBe(1);
 
-		await jest.advanceTimersByTimeAsync(config.reconciliationInterval);
+		await jest.advanceTimersByTimeAsync(999);
+		expect(connectorFactory.create.mock.calls).toHaveLength(1);
 
+		await jest.advanceTimersByTimeAsync(1);
+
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(replacementConnector.connect.mock.calls).toHaveLength(1);
+		expect(replacementListener).not.toBeNull();
 		expect(service.getStatus()).toMatchObject({
 			connectionState: HomeyConnectionState.CONNECTED,
 			healthy: true,
@@ -233,6 +254,148 @@ describe('HomeyService', () => {
 		});
 
 		await service.stop();
+		expect(replacementUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(replacementConnector.disconnect.mock.calls).toHaveLength(1);
+	});
+
+	it('backs off exponentially after consecutive transient reconnect failures', async () => {
+		const failingReplacement = createConnectorMock(() => undefined, jest.fn());
+		failingReplacement.connect.mockRejectedValue(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.TIMEOUT, HomeyConnectorOperation.CONNECT),
+		);
+		const recoveredConnector = createConnectorMock(() => undefined, jest.fn());
+		connectorFactory.create
+			.mockReset()
+			.mockReturnValueOnce(connector)
+			.mockReturnValueOnce(failingReplacement)
+			.mockReturnValueOnce(recoveredConnector);
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+
+		await listener?.({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		});
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(connectorFactory.create.mock.calls).toHaveLength(2);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
+
+		await jest.advanceTimersByTimeAsync(1999);
+		expect(connectorFactory.create.mock.calls).toHaveLength(2);
+
+		await jest.advanceTimersByTimeAsync(1);
+
+		expect(connectorFactory.create.mock.calls).toHaveLength(3);
+		expect(recoveredConnector.connect.mock.calls).toHaveLength(1);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+
+		await service.stop();
+	});
+
+	it('cancels a pending reconnect when authoritative traffic recovers', async () => {
+		await service.start();
+		connector.getDevice
+			.mockRejectedValueOnce(
+				new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+			)
+			.mockResolvedValue(staleDevice);
+		const event = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		} as const;
+
+		await listener?.(event);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
+
+		await listener?.(event);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+		expect(jest.getTimerCount()).toBe(1);
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(connectorFactory.create.mock.calls).toHaveLength(1);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+
+		await service.stop();
+	});
+
+	it('does not retry authentication failures encountered while reconnecting', async () => {
+		const rejectedConnector = createConnectorMock(() => undefined, jest.fn());
+		rejectedConnector.connect.mockRejectedValue(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHORIZATION, HomeyConnectorOperation.CONNECT),
+		);
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(rejectedConnector);
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+
+		await listener?.({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		});
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.AUTHENTICATION_FAILED,
+			healthy: false,
+			lastError: 'Homey authentication or authorization failed',
+		});
+		expect(jest.getTimerCount()).toBe(0);
+
+		await service.stop();
+	});
+
+	it('stops periodic work after a live authentication failure', async () => {
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHENTICATION, HomeyConnectorOperation.GET_DEVICE),
+		);
+
+		await listener?.({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		});
+
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.AUTHENTICATION_FAILED);
+		expect(jest.getTimerCount()).toBe(0);
+
+		await service.stop();
+	});
+
+	it('coalesces concurrent reconnect requests and cancels the pending attempt on stop', async () => {
+		await service.start();
+		connector.getDevice.mockRejectedValue(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+		const event = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		} as const;
+
+		await Promise.all([listener?.(event), listener?.(event)]);
+
+		expect(jest.getTimerCount()).toBe(1);
+		expect(connectorFactory.create.mock.calls).toHaveLength(1);
+
+		await service.stop();
+		await jest.advanceTimersByTimeAsync(30000);
+
+		expect(connectorFactory.create.mock.calls).toHaveLength(1);
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.STOPPED);
 	});
 
 	it('refreshes device zone paths after a live zone change', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -243,6 +243,55 @@ describe('HomeyService', () => {
 		await service.stop();
 	});
 
+	it('waits for every periodic inventory read to settle before reconnecting', async () => {
+		const replacementConnector = createConnectorMock(() => undefined, jest.fn());
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(replacementConnector);
+		await service.start();
+
+		let rejectZones: (error: Error) => void = () => undefined;
+		let resolveDevices: (devices: readonly HomeyDevice[]) => void = () => undefined;
+		connector.getZones.mockImplementationOnce(
+			() =>
+				new Promise<readonly HomeyZone[]>((_, reject) => {
+					rejectZones = reject;
+				}),
+		);
+		connector.getDevices.mockImplementationOnce(
+			() =>
+				new Promise<readonly HomeyDevice[]>((resolve) => {
+					resolveDevices = resolve;
+				}),
+		);
+
+		jest.advanceTimersByTime(config.reconciliationInterval);
+		await Promise.resolve();
+		await Promise.resolve();
+		rejectZones(new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_ZONES));
+
+		for (let index = 0; index < 10; index += 1) {
+			await Promise.resolve();
+		}
+
+		expect(jest.getTimerCount()).toBe(0);
+		expect(connector.disconnect.mock.calls).toHaveLength(0);
+
+		resolveDevices([staleDevice]);
+
+		for (let index = 0; index < 10; index += 1) {
+			await Promise.resolve();
+		}
+
+		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
+		expect(jest.getTimerCount()).toBe(1);
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(connector.disconnect.mock.calls).toHaveLength(1);
+		expect(replacementConnector.connect.mock.calls).toHaveLength(1);
+
+		await service.stop();
+	});
+
 	it('replaces the connector after a transient live synchronization failure', async () => {
 		let replacementListener: HomeyEventListener | null = null;
 		const replacementUnsubscribe = jest.fn();

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -86,7 +86,17 @@ export class HomeyService extends BaseManagedPluginService {
 				this.logger.log('Homey connector started and initial inventory synchronized');
 			} catch (error) {
 				this.applyFailureState(error, 'Homey service failed to start');
+				const retryable = this.isRetryableFailure(error);
+				const retryGeneration = ++this.generation;
 				await this.cleanupRuntime();
+
+				if (retryable) {
+					this.state = 'started';
+					this.scheduleReconnect(retryGeneration);
+					this.logger.warn('Homey service startup is unavailable; reconnect scheduled');
+					return;
+				}
+
 				this.state = 'error';
 				this.healthy = false;
 				this.logger.error(this.lastError ?? 'Homey service failed to start');
@@ -375,10 +385,11 @@ export class HomeyService extends BaseManagedPluginService {
 				this.logger.log('Homey connector reconnected and inventory synchronized');
 			} catch (error) {
 				this.applyFailureState(error, 'Homey service failed to reconnect', HomeyConnectionState.RECONNECTING);
+				const retryGeneration = ++this.generation;
 				await this.cleanupRuntime();
 
 				if (this.isRetryableFailure(error)) {
-					this.scheduleReconnect(generation);
+					this.scheduleReconnect(retryGeneration);
 				}
 
 				this.logger.error(this.lastError ?? 'Homey service failed to reconnect');
@@ -433,6 +444,8 @@ export class HomeyService extends BaseManagedPluginService {
 			}
 		}
 
+		await this.synchronizationTail;
+
 		if (connector) {
 			try {
 				await connector.disconnect();
@@ -441,8 +454,6 @@ export class HomeyService extends BaseManagedPluginService {
 				disconnectSucceeded = false;
 			}
 		}
-
-		await this.synchronizationTail;
 
 		if (disconnectSucceeded && (unsubscribeSucceeded || connector !== null)) {
 			this.unsubscribe = null;

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -322,14 +322,22 @@ export class HomeyService extends BaseManagedPluginService {
 
 		await this.enqueueSynchronization(async () => {
 			try {
-				const [zones, devices] = await Promise.all([connector.getZones(), connector.getDevices()]);
+				const [zonesResult, devicesResult] = await Promise.allSettled([connector.getZones(), connector.getDevices()]);
+
+				if (zonesResult.status === 'rejected') {
+					throw zonesResult.reason as unknown;
+				}
+
+				if (devicesResult.status === 'rejected') {
+					throw devicesResult.reason as unknown;
+				}
 
 				if (!this.isCurrentGeneration(connector, generation)) {
 					return;
 				}
 
-				this.zones = zones;
-				this.replaceDevices(devices);
+				this.zones = zonesResult.value;
+				this.replaceDevices(devicesResult.value);
 				this.markRuntimeHealthy(connector, generation);
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -21,6 +21,8 @@ import { HomeySystemInfo } from '../models/homey-system-info.model';
 import { HomeyZone } from '../models/homey-zone.model';
 import { HomeyStatusModel } from '../models/status.model';
 
+import { calculateHomeyReconnectDelay } from './homey-reconnect-backoff';
+
 @Injectable()
 export class HomeyService extends BaseManagedPluginService {
 	private readonly logger = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'HomeyService');
@@ -41,6 +43,8 @@ export class HomeyService extends BaseManagedPluginService {
 	private generation = 0;
 	private synchronizationTail: Promise<void> = Promise.resolve();
 	private reconciliationTimer: ReturnType<typeof setTimeout> | null = null;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private reconnectAttempt = 0;
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -61,6 +65,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 			this.state = 'starting';
 			this.pluginConfig = null;
+			this.resetReconnectState();
 			this.lastError = null;
 			this.healthy = false;
 			this.connectionState = HomeyConnectionState.CONNECTING;
@@ -107,6 +112,7 @@ export class HomeyService extends BaseManagedPluginService {
 			const cleaned = await this.cleanupRuntime();
 
 			this.pluginConfig = null;
+			this.resetReconnectState();
 
 			if (!cleaned) {
 				this.state = 'error';
@@ -227,9 +233,10 @@ export class HomeyService extends BaseManagedPluginService {
 		return this.enqueueSynchronization(async () => {
 			try {
 				await this.reconcileEvents(connector, generation, [event]);
+				this.markRuntimeHealthy(connector, generation);
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
-					this.applyFailureState(error, 'Homey event synchronization failed', HomeyConnectionState.DEGRADED_POLLING);
+					this.handleRuntimeFailure(error, 'Homey event synchronization failed', generation);
 					this.logger.error(this.lastError ?? 'Homey event synchronization failed');
 				}
 			}
@@ -286,7 +293,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 		const interval = this.pluginConfig?.reconciliationInterval;
 
-		if (!interval) {
+		if (!interval || this.reconnectTimer) {
 			return;
 		}
 
@@ -313,20 +320,70 @@ export class HomeyService extends BaseManagedPluginService {
 
 				this.zones = zones;
 				this.replaceDevices(devices);
-				this.connectionState = HomeyConnectionState.CONNECTED;
-				this.healthy = true;
-				this.lastError = null;
+				this.markRuntimeHealthy(connector, generation);
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
-					this.applyFailureState(error, 'Homey inventory reconciliation failed', HomeyConnectionState.DEGRADED_POLLING);
+					this.handleRuntimeFailure(error, 'Homey inventory reconciliation failed', generation);
 					this.logger.error(this.lastError ?? 'Homey inventory reconciliation failed');
 				}
 			}
 		});
 
-		if (this.isCurrentGeneration(connector, generation) && this.state === 'started') {
+		if (this.isCurrentGeneration(connector, generation) && this.state === 'started' && this.reconnectTimer === null) {
 			this.scheduleReconciliation(generation);
 		}
+	}
+
+	private scheduleReconnect(generation: number): void {
+		if (this.reconnectTimer || this.state !== 'started' || this.generation !== generation) {
+			return;
+		}
+
+		this.clearReconciliationTimer();
+		this.connectionState = HomeyConnectionState.RECONNECTING;
+		this.healthy = false;
+		const delay = calculateHomeyReconnectDelay(this.reconnectAttempt);
+		this.reconnectAttempt += 1;
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			void this.runReconnect(generation);
+		}, delay);
+	}
+
+	private async runReconnect(expectedGeneration: number): Promise<void> {
+		await this.withLock(async () => {
+			if (this.state !== 'started' || this.generation !== expectedGeneration) {
+				return;
+			}
+
+			this.connectionState = HomeyConnectionState.RECONNECTING;
+			this.healthy = false;
+			const generation = ++this.generation;
+
+			if (!(await this.cleanupRuntime())) {
+				this.lastError = 'Homey connector cleanup failed before reconnect';
+				this.scheduleReconnect(generation);
+				return;
+			}
+
+			try {
+				const connector = this.createConnector(this.getPluginConfig());
+				this.connector = connector;
+				await connector.connect();
+				await this.synchronizeStartup(connector, generation);
+				this.markRuntimeHealthy(connector, generation);
+				this.logger.log('Homey connector reconnected and inventory synchronized');
+			} catch (error) {
+				this.applyFailureState(error, 'Homey service failed to reconnect', HomeyConnectionState.RECONNECTING);
+				await this.cleanupRuntime();
+
+				if (this.isRetryableFailure(error)) {
+					this.scheduleReconnect(generation);
+				}
+
+				this.logger.error(this.lastError ?? 'Homey service failed to reconnect');
+			}
+		});
 	}
 
 	private enqueueSynchronization(operation: () => Promise<void>): Promise<void> {
@@ -360,6 +417,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 	private async cleanupRuntime(): Promise<boolean> {
 		this.clearReconciliationTimer();
+		this.clearReconnectTimer();
 		this.startupEvents = null;
 		const unsubscribe = this.unsubscribe;
 		const connector = this.connector;
@@ -404,8 +462,20 @@ export class HomeyService extends BaseManagedPluginService {
 		}
 	}
 
+	private clearReconnectTimer(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+	}
+
 	private hasRuntimeResources(): boolean {
-		return this.connector !== null || this.unsubscribe !== null || this.reconciliationTimer !== null;
+		return (
+			this.connector !== null ||
+			this.unsubscribe !== null ||
+			this.reconciliationTimer !== null ||
+			this.reconnectTimer !== null
+		);
 	}
 
 	private isCurrentGeneration(connector: HomeyConnector, generation: number): boolean {
@@ -440,6 +510,42 @@ export class HomeyService extends BaseManagedPluginService {
 
 		this.connectionState = HomeyConnectionState.ERROR;
 		this.lastError = fallback;
+	}
+
+	private markRuntimeHealthy(connector: HomeyConnector, generation: number): void {
+		if (!this.isCurrentGeneration(connector, generation)) {
+			return;
+		}
+
+		const recovered = this.connectionState !== HomeyConnectionState.CONNECTED;
+		this.clearReconnectTimer();
+		this.reconnectAttempt = 0;
+		this.connectionState = HomeyConnectionState.CONNECTED;
+		this.healthy = true;
+		this.lastError = null;
+
+		if (recovered && this.state === 'started') {
+			this.scheduleReconciliation(generation);
+		}
+	}
+
+	private isRetryableFailure(error: unknown): boolean {
+		return error instanceof HomeyConnectorError && error.retryable;
+	}
+
+	private handleRuntimeFailure(error: unknown, fallback: string, generation: number): void {
+		this.applyFailureState(error, fallback, HomeyConnectionState.RECONNECTING);
+
+		if (this.isRetryableFailure(error)) {
+			this.scheduleReconnect(generation);
+		} else {
+			this.clearReconciliationTimer();
+		}
+	}
+
+	private resetReconnectState(): void {
+		this.clearReconnectTimer();
+		this.reconnectAttempt = 0;
 	}
 
 	private getCurrentPluginConfigOrDefault(): HomeyConfigModel {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -238,9 +238,9 @@ index.ts
 - [x] Use Homey ordering metadata verified in Phase 0 to merge snapshot/events. If none is reliable, perform a final targeted reconciliation for capabilities touched while the startup snapshot was in flight before releasing the barrier.
 - [x] Stop subscriptions/timers/connector on disable, config change, module shutdown, or failed startup cleanup.
 - [x] Reconfigure safely when URL/key/timeouts change; never overlap old/new connectors.
-- [ ] Use exponential reconnect backoff with jitter and a maximum delay.
+- [x] Use exponential reconnect backoff with jitter and a maximum delay.
 - [x] Treat authentication/authorization failures differently from transient network failures.
-- [ ] Prevent concurrent reconnect and reconciliation loops.
+- [x] Prevent concurrent reconnect and reconciliation loops.
 - [ ] Track last successful connection, inventory sync, event, error category, reconnect count, and degraded state.
 - [ ] Unit-test all state transitions with fake timers.
 


### PR DESCRIPTION
## Summary

- add a bounded exponential reconnect policy with symmetric jitter and a 30-second maximum delay
- replace the failed connector generation before reconnecting, then rerun subscription-first inventory synchronization
- serialize reconnect work through the managed lifecycle lock and generation fence
- coalesce concurrent transient failures into one retry timer
- cancel pending retries when authoritative traffic recovers, configuration stops the service, or the connector is replaced
- treat authentication and authorization failures as terminal until configuration changes
- update the Homey implementation plan for the reconnect and loop-ownership acceptance items proven by this slice

## Why

The Homey lifecycle could detect degraded runtime reads, but it had no bounded recovery owner. A transient transport failure therefore remained unhealthy until the much slower periodic reconciliation and could not safely replace a failed connector generation.

This PR adds deterministic recovery while preserving the transport evidence gate: it operates entirely through `HomeyConnectorFactory` and does not select the production SHS SDK/direct-protocol adapter.

## Impact

Transient runtime failures now transition to `reconnecting`, retry with jittered 1s/2s/4s-style delays capped at 30 seconds, clean up the old connector, and perform a complete subscription-first resynchronization. Successful traffic cancels a pending retry. Authentication failures stop timers instead of creating an endless retry loop.

Status metrics and the secret-safe test-connection API remain follow-up work.

## Validation

- `pnpm exec jest --runInBand src/plugins/devices-homey` — 13 suites, 144 tests
- `pnpm exec eslint` on the changed Homey sources and tests
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `pnpm run build`
- `git diff --check`