### PR TITLE
feat(backend): add indexed home entity search

### DIFF
--- a/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
@@ -11,9 +11,9 @@ describe('buildSqliteFtsNameRankExpression', () => {
 		});
 
 		expect(result.sql).toContain('WHEN entity.id = ? COLLATE NOCASE THEN 0');
-		expect(result.sql).toContain("exact_term.col = 'name'");
-		expect(result.sql).toContain('exact_term.offset = 1 AND exact_term.term = ?');
-		expect(result.sql).toContain('prefix_term.offset = 1 AND prefix_term.term LIKE ?');
+		expect(result.sql).toContain("exact_term_name.col = 'name'");
+		expect(result.sql).toContain('exact_term_name.offset = 1 AND exact_term_name.term = ?');
+		expect(result.sql).toContain('prefix_term_name.offset = 1 AND prefix_term_name.term LIKE ?');
 		expect(result.parameters).toEqual(['Kitchen Light', 2, 'kitchen', 'light', 2, 'kitchen', 'light%']);
 	});
 
@@ -26,5 +26,35 @@ describe('buildSqliteFtsNameRankExpression', () => {
 		});
 
 		expect(result.parameters).toEqual([null, 1, 'light_%', 1, 'light\\_\\%%']);
+	});
+
+	it('ranks a fallback column as the display name only when the primary name is missing', () => {
+		const result = buildSqliteFtsNameRankExpression({
+			ftsTable: 'search_fts',
+			vocabularyTable: 'search_vocab',
+			entityIdExpression: 'property.id',
+			fallbackVocabularyColumn: 'identifier',
+			rawQuery: 'target-identifier',
+			normalizedTokens: ['target', 'identifier'],
+		});
+
+		expect(result.sql).toContain("primary_name_term.col = 'name'");
+		expect(result.sql).toContain("exact_term_fallback.col = 'identifier'");
+		expect(result.sql).toContain("prefix_term_fallback.col = 'identifier'");
+		expect(result.parameters).toEqual([
+			'target-identifier',
+			2,
+			'target',
+			'identifier',
+			2,
+			'target',
+			'identifier',
+			2,
+			'target',
+			'identifier%',
+			2,
+			'target',
+			'identifier%',
+		]);
 	});
 });

--- a/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
@@ -1,0 +1,30 @@
+import { buildSqliteFtsNameRankExpression } from './sqlite-fts.utils';
+
+describe('buildSqliteFtsNameRankExpression', () => {
+	it('builds bound exact-token and prefix-token rank predicates', () => {
+		const result = buildSqliteFtsNameRankExpression({
+			ftsTable: 'search_fts',
+			vocabularyTable: 'search_vocab',
+			entityIdExpression: 'entity.id',
+			rawQuery: ' Kitchen Light ',
+			normalizedTokens: ['kitchen', 'light'],
+		});
+
+		expect(result.sql).toContain('WHEN entity.id = ? COLLATE NOCASE THEN 0');
+		expect(result.sql).toContain("exact_term.col = 'name'");
+		expect(result.sql).toContain('exact_term.offset = 1 AND exact_term.term = ?');
+		expect(result.sql).toContain('prefix_term.offset = 1 AND prefix_term.term LIKE ?');
+		expect(result.parameters).toEqual(['Kitchen Light', 2, 'kitchen', 'light', 2, 'kitchen', 'light%']);
+	});
+
+	it('escapes LIKE metacharacters in a defensive direct-domain prefix', () => {
+		const result = buildSqliteFtsNameRankExpression({
+			ftsTable: 'search_fts',
+			vocabularyTable: 'search_vocab',
+			entityIdExpression: 'entity.id',
+			normalizedQuery: 'light_%',
+		});
+
+		expect(result.parameters).toEqual([null, 1, 'light_%', 1, 'light\\_\\%%']);
+	});
+});

--- a/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.spec.ts
@@ -33,12 +33,15 @@ describe('buildSqliteFtsNameRankExpression', () => {
 			ftsTable: 'search_fts',
 			vocabularyTable: 'search_vocab',
 			entityIdExpression: 'property.id',
-			fallbackVocabularyColumn: 'identifier',
+			fallbackName: {
+				vocabularyColumn: 'identifier',
+				whenPrimaryNameExpression: 'property.name',
+			},
 			rawQuery: 'target-identifier',
 			normalizedTokens: ['target', 'identifier'],
 		});
 
-		expect(result.sql).toContain("primary_name_term.col = 'name'");
+		expect(result.sql).toContain('property.name IS NULL');
 		expect(result.sql).toContain("exact_term_fallback.col = 'identifier'");
 		expect(result.sql).toContain("prefix_term_fallback.col = 'identifier'");
 		expect(result.parameters).toEqual([

--- a/apps/backend/src/common/utils/sqlite-fts.utils.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.ts
@@ -1,0 +1,65 @@
+export interface SqliteFtsNameRankOptions {
+	ftsTable: string;
+	vocabularyTable: string;
+	entityIdExpression: string;
+	rawQuery?: string;
+	normalizedQuery?: string;
+	normalizedTokens?: string[];
+}
+
+export interface SqliteFtsNameRankExpression {
+	sql: string;
+	parameters: Array<string | number | null>;
+}
+
+export function buildSqliteFtsNameRankExpression(options: SqliteFtsNameRankOptions): SqliteFtsNameRankExpression {
+	const tokens = options.normalizedTokens ?? options.normalizedQuery?.split(' ').filter(Boolean) ?? [];
+	const exactTerms = tokens
+		.map(
+			(_token, offset) =>
+				`EXISTS (SELECT 1 FROM ${options.vocabularyTable} exact_term ` +
+				`WHERE exact_term.doc = ${options.ftsTable}.rowid AND exact_term.col = 'name' ` +
+				`AND exact_term.offset = ${offset} AND exact_term.term = ?)`,
+		)
+		.join(' AND ');
+	const prefixTerms = tokens
+		.map((_token, offset) => {
+			const comparison = offset === tokens.length - 1 ? `prefix_term.term LIKE ? ESCAPE '\\'` : 'prefix_term.term = ?';
+
+			return (
+				`EXISTS (SELECT 1 FROM ${options.vocabularyTable} prefix_term ` +
+				`WHERE prefix_term.doc = ${options.ftsTable}.rowid AND prefix_term.col = 'name' ` +
+				`AND prefix_term.offset = ${offset} AND ${comparison})`
+			);
+		})
+		.join(' AND ');
+	const exactNamePredicate =
+		tokens.length === 0
+			? '0'
+			: `(SELECT COUNT(*) FROM ${options.vocabularyTable} exact_count ` +
+				`WHERE exact_count.doc = ${options.ftsTable}.rowid AND exact_count.col = 'name') = ? AND ${exactTerms}`;
+	const prefixNamePredicate =
+		tokens.length === 0
+			? '0'
+			: `(SELECT COUNT(*) FROM ${options.vocabularyTable} prefix_count ` +
+				`WHERE prefix_count.doc = ${options.ftsTable}.rowid AND prefix_count.col = 'name') >= ? AND ${prefixTerms}`;
+	const escapedPrefix = tokens.length === 0 ? null : `${escapeSqlLike(tokens[tokens.length - 1])}%`;
+
+	return {
+		sql: `CASE
+		WHEN ${options.entityIdExpression} = ? COLLATE NOCASE THEN 0
+		WHEN ${exactNamePredicate} THEN 1
+		WHEN ${prefixNamePredicate} THEN 2
+		ELSE 3
+	END`,
+		parameters: [
+			options.rawQuery?.trim() ?? null,
+			...(tokens.length > 0 ? [tokens.length, ...tokens] : []),
+			...(tokens.length > 0 ? [tokens.length, ...tokens.slice(0, -1), escapedPrefix] : []),
+		],
+	};
+}
+
+function escapeSqlLike(value: string): string {
+	return value.replace(/[\\%_]/g, '\\$&');
+}

--- a/apps/backend/src/common/utils/sqlite-fts.utils.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.ts
@@ -2,7 +2,10 @@ export interface SqliteFtsNameRankOptions {
 	ftsTable: string;
 	vocabularyTable: string;
 	entityIdExpression: string;
-	fallbackVocabularyColumn?: 'identifier';
+	fallbackName?: {
+		vocabularyColumn: 'identifier';
+		whenPrimaryNameExpression: string;
+	};
 	rawQuery?: string;
 	normalizedQuery?: string;
 	normalizedTokens?: string[];
@@ -43,24 +46,22 @@ export function buildSqliteFtsNameRankExpression(options: SqliteFtsNameRankOptio
 	const primaryExact = tokens.length > 0 ? buildColumnPredicate('name', false, 'name') : null;
 	const primaryPrefix = tokens.length > 0 ? buildColumnPredicate('name', true, 'name') : null;
 	const fallbackExact =
-		tokens.length > 0 && options.fallbackVocabularyColumn
-			? buildColumnPredicate(options.fallbackVocabularyColumn, false, 'fallback')
+		tokens.length > 0 && options.fallbackName
+			? buildColumnPredicate(options.fallbackName.vocabularyColumn, false, 'fallback')
 			: null;
 	const fallbackPrefix =
-		tokens.length > 0 && options.fallbackVocabularyColumn
-			? buildColumnPredicate(options.fallbackVocabularyColumn, true, 'fallback')
+		tokens.length > 0 && options.fallbackName
+			? buildColumnPredicate(options.fallbackName.vocabularyColumn, true, 'fallback')
 			: null;
-	const primaryNameMissing =
-		`NOT EXISTS (SELECT 1 FROM ${options.vocabularyTable} primary_name_term ` +
-		`WHERE primary_name_term.doc = ${options.ftsTable}.rowid AND primary_name_term.col = 'name')`;
+	const fallbackNameAllowed = options.fallbackName ? `${options.fallbackName.whenPrimaryNameExpression} IS NULL` : '0';
 	const exactNamePredicate = primaryExact
 		? fallbackExact
-			? `(${primaryExact.sql} OR (${primaryNameMissing} AND ${fallbackExact.sql}))`
+			? `(${primaryExact.sql} OR (${fallbackNameAllowed} AND ${fallbackExact.sql}))`
 			: primaryExact.sql
 		: '0';
 	const prefixNamePredicate = primaryPrefix
 		? fallbackPrefix
-			? `(${primaryPrefix.sql} OR (${primaryNameMissing} AND ${fallbackPrefix.sql}))`
+			? `(${primaryPrefix.sql} OR (${fallbackNameAllowed} AND ${fallbackPrefix.sql}))`
 			: primaryPrefix.sql
 		: '0';
 

--- a/apps/backend/src/common/utils/sqlite-fts.utils.ts
+++ b/apps/backend/src/common/utils/sqlite-fts.utils.ts
@@ -2,6 +2,7 @@ export interface SqliteFtsNameRankOptions {
 	ftsTable: string;
 	vocabularyTable: string;
 	entityIdExpression: string;
+	fallbackVocabularyColumn?: 'identifier';
 	rawQuery?: string;
 	normalizedQuery?: string;
 	normalizedTokens?: string[];
@@ -14,36 +15,54 @@ export interface SqliteFtsNameRankExpression {
 
 export function buildSqliteFtsNameRankExpression(options: SqliteFtsNameRankOptions): SqliteFtsNameRankExpression {
 	const tokens = options.normalizedTokens ?? options.normalizedQuery?.split(' ').filter(Boolean) ?? [];
-	const exactTerms = tokens
-		.map(
-			(_token, offset) =>
-				`EXISTS (SELECT 1 FROM ${options.vocabularyTable} exact_term ` +
-				`WHERE exact_term.doc = ${options.ftsTable}.rowid AND exact_term.col = 'name' ` +
-				`AND exact_term.offset = ${offset} AND exact_term.term = ?)`,
-		)
-		.join(' AND ');
-	const prefixTerms = tokens
-		.map((_token, offset) => {
-			const comparison = offset === tokens.length - 1 ? `prefix_term.term LIKE ? ESCAPE '\\'` : 'prefix_term.term = ?';
-
-			return (
-				`EXISTS (SELECT 1 FROM ${options.vocabularyTable} prefix_term ` +
-				`WHERE prefix_term.doc = ${options.ftsTable}.rowid AND prefix_term.col = 'name' ` +
-				`AND prefix_term.offset = ${offset} AND ${comparison})`
-			);
-		})
-		.join(' AND ');
-	const exactNamePredicate =
-		tokens.length === 0
-			? '0'
-			: `(SELECT COUNT(*) FROM ${options.vocabularyTable} exact_count ` +
-				`WHERE exact_count.doc = ${options.ftsTable}.rowid AND exact_count.col = 'name') = ? AND ${exactTerms}`;
-	const prefixNamePredicate =
-		tokens.length === 0
-			? '0'
-			: `(SELECT COUNT(*) FROM ${options.vocabularyTable} prefix_count ` +
-				`WHERE prefix_count.doc = ${options.ftsTable}.rowid AND prefix_count.col = 'name') >= ? AND ${prefixTerms}`;
 	const escapedPrefix = tokens.length === 0 ? null : `${escapeSqlLike(tokens[tokens.length - 1])}%`;
+	const buildColumnPredicate = (column: string, prefix: boolean, aliasSuffix: string) => {
+		const countAlias = `${prefix ? 'prefix' : 'exact'}_count_${aliasSuffix}`;
+		const termAlias = `${prefix ? 'prefix' : 'exact'}_term_${aliasSuffix}`;
+		const terms = tokens
+			.map((_token, offset) => {
+				const comparison =
+					prefix && offset === tokens.length - 1 ? `${termAlias}.term LIKE ? ESCAPE '\\'` : `${termAlias}.term = ?`;
+
+				return (
+					`EXISTS (SELECT 1 FROM ${options.vocabularyTable} ${termAlias} ` +
+					`WHERE ${termAlias}.doc = ${options.ftsTable}.rowid AND ${termAlias}.col = '${column}' ` +
+					`AND ${termAlias}.offset = ${offset} AND ${comparison})`
+				);
+			})
+			.join(' AND ');
+
+		return {
+			sql:
+				`(SELECT COUNT(*) FROM ${options.vocabularyTable} ${countAlias} ` +
+				`WHERE ${countAlias}.doc = ${options.ftsTable}.rowid AND ${countAlias}.col = '${column}') ` +
+				`${prefix ? '>=' : '='} ? AND ${terms}`,
+			parameters: [tokens.length, ...tokens.slice(0, -1), prefix ? escapedPrefix : tokens[tokens.length - 1]],
+		};
+	};
+	const primaryExact = tokens.length > 0 ? buildColumnPredicate('name', false, 'name') : null;
+	const primaryPrefix = tokens.length > 0 ? buildColumnPredicate('name', true, 'name') : null;
+	const fallbackExact =
+		tokens.length > 0 && options.fallbackVocabularyColumn
+			? buildColumnPredicate(options.fallbackVocabularyColumn, false, 'fallback')
+			: null;
+	const fallbackPrefix =
+		tokens.length > 0 && options.fallbackVocabularyColumn
+			? buildColumnPredicate(options.fallbackVocabularyColumn, true, 'fallback')
+			: null;
+	const primaryNameMissing =
+		`NOT EXISTS (SELECT 1 FROM ${options.vocabularyTable} primary_name_term ` +
+		`WHERE primary_name_term.doc = ${options.ftsTable}.rowid AND primary_name_term.col = 'name')`;
+	const exactNamePredicate = primaryExact
+		? fallbackExact
+			? `(${primaryExact.sql} OR (${primaryNameMissing} AND ${fallbackExact.sql}))`
+			: primaryExact.sql
+		: '0';
+	const prefixNamePredicate = primaryPrefix
+		? fallbackPrefix
+			? `(${primaryPrefix.sql} OR (${primaryNameMissing} AND ${fallbackPrefix.sql}))`
+			: primaryPrefix.sql
+		: '0';
 
 	return {
 		sql: `CASE
@@ -54,8 +73,10 @@ export function buildSqliteFtsNameRankExpression(options: SqliteFtsNameRankOptio
 	END`,
 		parameters: [
 			options.rawQuery?.trim() ?? null,
-			...(tokens.length > 0 ? [tokens.length, ...tokens] : []),
-			...(tokens.length > 0 ? [tokens.length, ...tokens.slice(0, -1), escapedPrefix] : []),
+			...(primaryExact?.parameters ?? []),
+			...(fallbackExact?.parameters ?? []),
+			...(primaryPrefix?.parameters ?? []),
+			...(fallbackPrefix?.parameters ?? []),
 		],
 	};
 }

--- a/apps/backend/src/migrations/1000000000020-AddHomeEntitySearchIndex.ts
+++ b/apps/backend/src/migrations/1000000000020-AddHomeEntitySearchIndex.ts
@@ -1,0 +1,140 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const SEARCH_TABLE = 'home_context_entity_search_fts';
+const SEARCH_VOCABULARY_TABLE = 'home_context_entity_search_vocab';
+
+interface SearchSource {
+	name: string;
+	table: string;
+	kind: string;
+	identifier: (prefix: 'NEW' | 'OLD') => string;
+	context: (prefix: 'NEW' | 'OLD') => string;
+	updatedColumns: string[];
+}
+
+const quoteColumns = (columns: string[]): string => columns.map((column) => `"${column}"`).join(', ');
+
+const sources: SearchSource[] = [
+	{
+		name: 'spaces',
+		table: 'spaces_module_spaces',
+		kind: 'space',
+		identifier: () => `''`,
+		context: (prefix) =>
+			`COALESCE(${prefix}."type", '') || ' ' || COALESCE(${prefix}."category", '') || ' ' || COALESCE(${prefix}."parentId", '')`,
+		updatedColumns: ['id', 'name', 'type', 'category', 'parentId'],
+	},
+	{
+		name: 'devices',
+		table: 'devices_module_devices',
+		kind: 'device',
+		identifier: (prefix) => `COALESCE(${prefix}."identifier", '')`,
+		context: (prefix) =>
+			`COALESCE(${prefix}."type", '') || ' ' || COALESCE(${prefix}."category", '') || ' ' || COALESCE(${prefix}."roomId", '')`,
+		updatedColumns: ['id', 'name', 'identifier', 'type', 'category', 'roomId'],
+	},
+	{
+		name: 'properties',
+		table: 'devices_module_channels_properties',
+		kind: 'property',
+		identifier: (prefix) => `COALESCE(${prefix}."identifier", '')`,
+		context: (prefix) =>
+			`COALESCE(${prefix}."type", '') || ' ' || COALESCE(${prefix}."category", '') || ' ' || COALESCE(${prefix}."dataType", '') || ' ' || COALESCE(${prefix}."permissions", '') || ' ' || COALESCE(${prefix}."channelId", '')`,
+		updatedColumns: ['id', 'name', 'identifier', 'type', 'category', 'dataType', 'permissions', 'channelId'],
+	},
+	{
+		name: 'scenes',
+		table: 'scenes_module_scenes',
+		kind: 'scene',
+		identifier: () => `''`,
+		context: (prefix) => `COALESCE(${prefix}."category", '') || ' ' || COALESCE(${prefix}."primarySpaceId", '')`,
+		updatedColumns: ['id', 'name', 'category', 'primarySpaceId'],
+	},
+];
+
+export class AddHomeEntitySearchIndex1000000000020 implements MigrationInterface {
+	name = 'AddHomeEntitySearchIndex1000000000020';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE VIRTUAL TABLE "${SEARCH_TABLE}" USING fts5(
+				"entity_kind" UNINDEXED,
+				"entity_id",
+				"name",
+				"identifier",
+				"context",
+				tokenize = 'unicode61 remove_diacritics 2'
+			)`,
+		);
+		await queryRunner.query(
+			`CREATE VIRTUAL TABLE "${SEARCH_VOCABULARY_TABLE}" USING fts5vocab('${SEARCH_TABLE}', 'instance')`,
+		);
+
+		await queryRunner.query(
+			`INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+			 SELECT 'space', "id", COALESCE("name", ''), '',
+			        COALESCE("type", '') || ' ' || COALESCE("category", '') || ' ' || COALESCE("parentId", '')
+			 FROM "spaces_module_spaces"`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+			 SELECT 'device', "id", COALESCE("name", ''), COALESCE("identifier", ''),
+			        COALESCE("type", '') || ' ' || COALESCE("category", '') || ' ' || COALESCE("roomId", '')
+			 FROM "devices_module_devices"`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+			 SELECT 'property', "id", COALESCE("name", ''), COALESCE("identifier", ''),
+			        COALESCE("type", '') || ' ' || COALESCE("category", '') || ' ' || COALESCE("dataType", '') || ' ' || COALESCE("permissions", '') || ' ' || COALESCE("channelId", '')
+			 FROM "devices_module_channels_properties"`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+			 SELECT 'scene', "id", COALESCE("name", ''), '',
+			        COALESCE("category", '') || ' ' || COALESCE("primarySpaceId", '')
+			 FROM "scenes_module_scenes"`,
+		);
+
+		for (const source of sources) {
+			await this.createTriggers(queryRunner, source);
+		}
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		for (const source of [...sources].reverse()) {
+			await queryRunner.query(`DROP TRIGGER IF EXISTS "TRG_home_search_${source.name}_delete"`);
+			await queryRunner.query(`DROP TRIGGER IF EXISTS "TRG_home_search_${source.name}_update"`);
+			await queryRunner.query(`DROP TRIGGER IF EXISTS "TRG_home_search_${source.name}_insert"`);
+		}
+
+		await queryRunner.query(`DROP TABLE IF EXISTS "${SEARCH_VOCABULARY_TABLE}"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "${SEARCH_TABLE}"`);
+	}
+
+	private async createTriggers(queryRunner: QueryRunner, source: SearchSource): Promise<void> {
+		await queryRunner.query(
+			`CREATE TRIGGER "TRG_home_search_${source.name}_insert"
+			 AFTER INSERT ON "${source.table}"
+			 BEGIN
+				INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+				VALUES ('${source.kind}', NEW."id", COALESCE(NEW."name", ''), ${source.identifier('NEW')}, ${source.context('NEW')});
+			 END`,
+		);
+		await queryRunner.query(
+			`CREATE TRIGGER "TRG_home_search_${source.name}_update"
+			 AFTER UPDATE OF ${quoteColumns(source.updatedColumns)} ON "${source.table}"
+			 BEGIN
+				DELETE FROM "${SEARCH_TABLE}" WHERE "entity_kind" = '${source.kind}' AND "entity_id" = OLD."id";
+				INSERT INTO "${SEARCH_TABLE}" ("entity_kind", "entity_id", "name", "identifier", "context")
+				VALUES ('${source.kind}', NEW."id", COALESCE(NEW."name", ''), ${source.identifier('NEW')}, ${source.context('NEW')});
+			 END`,
+		);
+		await queryRunner.query(
+			`CREATE TRIGGER "TRG_home_search_${source.name}_delete"
+			 AFTER DELETE ON "${source.table}"
+			 BEGIN
+				DELETE FROM "${SEARCH_TABLE}" WHERE "entity_kind" = '${source.kind}' AND "entity_id" = OLD."id";
+			 END`,
+		);
+	}
+}

--- a/apps/backend/src/migrations/__tests__/1000000000020-AddHomeEntitySearchIndex.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000020-AddHomeEntitySearchIndex.spec.ts
@@ -1,0 +1,243 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddHomeEntitySearchIndex1000000000020 } from '../1000000000020-AddHomeEntitySearchIndex';
+
+interface SearchRow {
+	entity_kind: string;
+	entity_id: string;
+	name: string;
+	identifier: string;
+	context: string;
+}
+
+describe('AddHomeEntitySearchIndex1000000000020', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+
+	const migration = new AddHomeEntitySearchIndex1000000000020();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+		await createSourceTables(queryRunner);
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('uses the bundled FTS5 implementation with unicode diacritic removal', async () => {
+		const [support] = (await queryRunner.query(
+			`SELECT sqlite_compileoption_used('ENABLE_FTS5') AS "enabled"`,
+		)) as Array<{ enabled: number }>;
+
+		expect(support?.enabled).toBe(1);
+
+		await queryRunner.query(
+			`INSERT INTO "spaces_module_spaces" ("id", "name", "type", "category")
+			 VALUES ('space-kitchen', 'Küche', 'room', 'living')`,
+		);
+		await migration.up(queryRunner);
+
+		await expect(search(queryRunner, 'Kuche')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: 'space', entity_id: 'space-kitchen', name: 'Küche' }),
+		]);
+		await expect(
+			queryRunner.query(
+				`SELECT "term", "col", "offset" FROM "home_context_entity_search_vocab"
+				 WHERE "doc" = (SELECT rowid FROM "home_context_entity_search_fts" WHERE "entity_id" = 'space-kitchen')
+				   AND "col" = 'name'`,
+			),
+		).resolves.toEqual([{ term: 'kuche', col: 'name', offset: 0 }]);
+	});
+
+	it('backfills searchable IDs, names, identifiers, and context for every owning table', async () => {
+		await queryRunner.query(
+			`INSERT INTO "spaces_module_spaces" ("id", "name", "type", "category", "parentId")
+			 VALUES ('space-1', 'Living Room', 'room', 'living', 'floor-1')`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "devices_module_devices" ("id", "name", "identifier", "type", "category", "roomId")
+			 VALUES ('device-1', 'Ceiling Lamp', 'living-lamp', 'devices-test', 'lighting', 'space-1')`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "devices_module_channels_properties"
+			 ("id", "name", "identifier", "type", "category", "dataType", "permissions", "channelId")
+			 VALUES ('property-1', 'Brightness', 'brightness-level', 'property-test', 'brightness', 'uchar', 'rw', 'channel-1')`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "scenes_module_scenes" ("id", "name", "category", "primarySpaceId")
+			 VALUES ('scene-1', 'Movie Night', 'movie', 'space-1')`,
+		);
+
+		await migration.up(queryRunner);
+
+		const rows = (await queryRunner.query(
+			`SELECT "entity_kind", "entity_id", "name", "identifier", "context"
+			 FROM "home_context_entity_search_fts"
+			 ORDER BY "entity_kind"`,
+		)) as SearchRow[];
+		expect(rows).toEqual([
+			{
+				entity_kind: 'device',
+				entity_id: 'device-1',
+				name: 'Ceiling Lamp',
+				identifier: 'living-lamp',
+				context: 'devices-test lighting space-1',
+			},
+			{
+				entity_kind: 'property',
+				entity_id: 'property-1',
+				name: 'Brightness',
+				identifier: 'brightness-level',
+				context: 'property-test brightness uchar rw channel-1',
+			},
+			{
+				entity_kind: 'scene',
+				entity_id: 'scene-1',
+				name: 'Movie Night',
+				identifier: '',
+				context: 'movie space-1',
+			},
+			{
+				entity_kind: 'space',
+				entity_id: 'space-1',
+				name: 'Living Room',
+				identifier: '',
+				context: 'room living floor-1',
+			},
+		]);
+		await expect(search(queryRunner, '"device-1"')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: 'device', entity_id: 'device-1' }),
+		]);
+		await expect(search(queryRunner, '"living-lamp"')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: 'device', identifier: 'living-lamp' }),
+		]);
+		await expect(search(queryRunner, 'brightness')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: 'property', entity_id: 'property-1' }),
+		]);
+	});
+
+	it.each([
+		{
+			kind: 'space',
+			table: 'spaces_module_spaces',
+			insert: `INSERT INTO "spaces_module_spaces" ("id", "name", "type", "category") VALUES ('probe-id', 'InsertedProbe', 'room', 'living')`,
+		},
+		{
+			kind: 'device',
+			table: 'devices_module_devices',
+			insert: `INSERT INTO "devices_module_devices" ("id", "name", "identifier", "type", "category") VALUES ('probe-id', 'InsertedProbe', 'probe-device', 'devices-test', 'lighting')`,
+		},
+		{
+			kind: 'property',
+			table: 'devices_module_channels_properties',
+			insert: `INSERT INTO "devices_module_channels_properties" ("id", "name", "identifier", "type", "category", "dataType", "permissions") VALUES ('probe-id', 'InsertedProbe', 'probe-property', 'property-test', 'on', 'bool', 'rw')`,
+		},
+		{
+			kind: 'scene',
+			table: 'scenes_module_scenes',
+			insert: `INSERT INTO "scenes_module_scenes" ("id", "name", "category") VALUES ('probe-id', 'InsertedProbe', 'generic')`,
+		},
+	])('keeps $kind entries synchronized after insert, rename, and delete', async ({ kind, table, insert }) => {
+		await migration.up(queryRunner);
+
+		await queryRunner.query(insert);
+		await expect(search(queryRunner, 'InsertedProbe')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: kind, entity_id: 'probe-id' }),
+		]);
+
+		await queryRunner.query(`UPDATE "${table}" SET "name" = 'RenamedProbe' WHERE "id" = 'probe-id'`);
+		await expect(search(queryRunner, 'InsertedProbe')).resolves.toEqual([]);
+		await expect(search(queryRunner, 'RenamedProbe')).resolves.toEqual([
+			expect.objectContaining({ entity_kind: kind, entity_id: 'probe-id' }),
+		]);
+
+		await queryRunner.query(`DELETE FROM "${table}" WHERE "id" = 'probe-id'`);
+		await expect(search(queryRunner, 'RenamedProbe')).resolves.toEqual([]);
+	});
+
+	it('participates in source transactions and rolls back index mutations', async () => {
+		await migration.up(queryRunner);
+		await queryRunner.startTransaction();
+		await queryRunner.query(
+			`INSERT INTO "scenes_module_scenes" ("id", "name", "category")
+			 VALUES ('transaction-scene', 'TransientProbe', 'generic')`,
+		);
+		await expect(search(queryRunner, 'TransientProbe')).resolves.toHaveLength(1);
+		await queryRunner.rollbackTransaction();
+
+		await expect(search(queryRunner, 'TransientProbe')).resolves.toEqual([]);
+	});
+
+	it('drops every trigger and the virtual table on rollback', async () => {
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		const objects = (await queryRunner.query(
+			`SELECT "name" FROM sqlite_master
+			 WHERE "name" LIKE 'home_context_entity_search_%' OR "name" LIKE 'TRG_home_search_%'`,
+		)) as Array<{ name: string }>;
+		expect(objects).toEqual([]);
+		await expect(
+			queryRunner.query(
+				`INSERT INTO "devices_module_devices" ("id", "name", "type", "category")
+				 VALUES ('after-down', 'Still Writable', 'devices-test', 'generic')`,
+			),
+		).resolves.toBeDefined();
+	});
+});
+
+async function createSourceTables(queryRunner: QueryRunner): Promise<void> {
+	await queryRunner.query(
+		`CREATE TABLE "spaces_module_spaces" (
+		 "id" varchar PRIMARY KEY NOT NULL,
+		 "name" varchar NOT NULL,
+		 "type" varchar,
+		 "category" varchar,
+		 "parentId" varchar
+		)`,
+	);
+	await queryRunner.query(
+		`CREATE TABLE "devices_module_devices" (
+		 "id" varchar PRIMARY KEY NOT NULL,
+		 "name" varchar NOT NULL,
+		 "identifier" varchar,
+		 "type" varchar,
+		 "category" varchar,
+		 "roomId" varchar
+		)`,
+	);
+	await queryRunner.query(
+		`CREATE TABLE "devices_module_channels_properties" (
+		 "id" varchar PRIMARY KEY NOT NULL,
+		 "name" varchar,
+		 "identifier" varchar,
+		 "type" varchar,
+		 "category" varchar,
+		 "dataType" varchar,
+		 "permissions" text,
+		 "channelId" varchar
+		)`,
+	);
+	await queryRunner.query(
+		`CREATE TABLE "scenes_module_scenes" (
+		 "id" varchar PRIMARY KEY NOT NULL,
+		 "name" varchar NOT NULL,
+		 "category" varchar,
+		 "primarySpaceId" varchar
+		)`,
+	);
+}
+
+async function search(queryRunner: QueryRunner, query: string): Promise<SearchRow[]> {
+	return queryRunner.query(
+		`SELECT "entity_kind", "entity_id", "name", "identifier", "context"
+		 FROM "home_context_entity_search_fts"
+		 WHERE "home_context_entity_search_fts" MATCH ?
+		 ORDER BY "entity_kind", "entity_id"`,
+		[query],
+	) as Promise<SearchRow[]>;
+}

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -349,11 +349,16 @@ describe('ChannelsPropertiesService', () => {
 			expect(selectSql).toContain('WHEN property.id = ? COLLATE NOCASE THEN 0');
 			expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
 			expect(selectSql).toContain('FROM home_context_entity_search_vocab prefix_term');
+			expect(selectSql).toContain("exact_term_fallback.col = 'identifier'");
 			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC');
 			expect(selectParameters).toEqual([
 				'temperature',
 				1,
 				'temperature',
+				1,
+				'temperature',
+				1,
+				'temperature%',
 				1,
 				'temperature%',
 				'property',

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -288,6 +288,98 @@ describe('ChannelsPropertiesService', () => {
 		});
 	});
 
+	describe('searchVisibleSummaryPage', () => {
+		it('returns bounded joined metadata without reading values or excluding disabled owners', async () => {
+			const query = jest.spyOn(dataSource, 'query');
+			query
+				.mockResolvedValueOnce([
+					{
+						id: mockChannelProperty.id,
+						name: mockChannelProperty.name,
+						identifier: null,
+						category: PropertyCategory.GENERIC,
+						dataType: DataTypeType.STRING,
+						permissions: `${PermissionType.READ_ONLY},${PermissionType.READ_WRITE}`,
+						channelId: mockChannel.id,
+						channelName: mockChannel.name,
+						channelCategory: ChannelCategory.GENERIC,
+						deviceId: 'device-id',
+						deviceName: 'Disabled sensor',
+						deviceCategory: 'generic',
+						deviceEnabled: 0,
+						roomId: null,
+						rankTier: '3',
+						lexicalScore: '-5',
+					},
+				])
+				.mockResolvedValueOnce([{ total: '4' }]);
+
+			await expect(
+				channelsPropertiesService.searchVisibleSummaryPage({
+					match: '"temperature"*',
+					rawQuery: 'temperature',
+					normalizedQuery: 'temperature',
+					offset: 3,
+					limit: 20,
+					roomParentId: 'floor-id',
+					categories: [PropertyCategory.GENERIC],
+				}),
+			).resolves.toEqual({
+				properties: [
+					expect.objectContaining({
+						id: mockChannelProperty.id,
+						deviceEnabled: false,
+						rankTier: 3,
+						lexicalScore: -5,
+						permissions: [PermissionType.READ_ONLY, PermissionType.READ_WRITE],
+					}),
+				],
+				total: 4,
+			});
+			const [selectSql, selectParameters] = query.mock.calls[0] as [string, unknown[]];
+			const [countSql, countParameters] = query.mock.calls[1] as [string, unknown[]];
+			expect(selectSql).toContain('home_context_entity_search_fts MATCH ?');
+			expect(selectSql.match(/INNER JOIN devices_module_channels channel/g)).toHaveLength(1);
+			expect(selectSql.match(/INNER JOIN devices_module_devices device/g)).toHaveLength(1);
+			expect(selectSql).toContain('device.hidden = 0');
+			expect(selectSql).not.toContain('device.enabled = 1');
+			expect(selectSql).toContain('device."roomId" IN (SELECT scoped_room.id FROM spaces_module_spaces scoped_room');
+			expect(selectSql).toContain('scoped_room."parentId" = ?');
+			expect(selectSql).toContain('property.category IN (?)');
+			expect(selectSql).toContain('WHEN property.id = ? COLLATE NOCASE THEN 0');
+			expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
+			expect(selectSql).toContain('FROM home_context_entity_search_vocab prefix_term');
+			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC');
+			expect(selectParameters).toEqual([
+				'temperature',
+				1,
+				'temperature',
+				1,
+				'temperature%',
+				'property',
+				'"temperature"*',
+				'floor-id',
+				PropertyCategory.GENERIC,
+				20,
+				3,
+			]);
+			expect(countSql).toContain('SELECT COUNT(*) AS total');
+			expect(countParameters).toEqual(['property', '"temperature"*', 'floor-id', PropertyCategory.GENERIC]);
+			expect(propertyValueService.readLatestManyStrict).not.toHaveBeenCalled();
+		});
+
+		it('does not query an explicitly empty scope', async () => {
+			await expect(
+				channelsPropertiesService.searchVisibleSummaryPage({
+					match: 'temperature',
+					limit: 20,
+					scope: { roomIds: [] },
+				}),
+			).resolves.toEqual({ properties: [], total: 0 });
+			expect(dataSource.query).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('findBoundedForChannels', () => {
 		it('selects capped property IDs before hydrating values', async () => {
 			const countQuery: any = {

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -350,6 +350,7 @@ describe('ChannelsPropertiesService', () => {
 			expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
 			expect(selectSql).toContain('FROM home_context_entity_search_vocab prefix_term');
 			expect(selectSql).toContain("exact_term_fallback.col = 'identifier'");
+			expect(selectSql).toContain('property.name IS NULL');
 			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC');
 			expect(selectParameters).toEqual([
 				'temperature',

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -8,8 +8,17 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { buildSqliteFtsNameRankExpression } from '../../../common/utils/sqlite-fts.utils';
 import { toInstance } from '../../../common/utils/transform.utils';
-import { DEVICES_MODULE_NAME, EventType, PermissionType } from '../devices.constants';
+import {
+	ChannelCategory,
+	DEVICES_MODULE_NAME,
+	DataTypeType,
+	DeviceCategory,
+	EventType,
+	PermissionType,
+	PropertyCategory,
+} from '../devices.constants';
 import { DevicesException, DevicesNotFoundException, DevicesValidationException } from '../devices.exceptions';
 import { CreateChannelPropertyDto } from '../dto/create-channel-property.dto';
 import { UpdateChannelPropertyDto } from '../dto/update-channel-property.dto';
@@ -30,6 +39,45 @@ export interface BoundedChannelProperties {
 
 export interface WritablePropertyCandidates {
 	properties: ChannelPropertyEntity[];
+	total: number;
+}
+
+export interface VisiblePropertySearchSummary {
+	id: string;
+	name: string | null;
+	identifier: string | null;
+	category: PropertyCategory;
+	dataType: DataTypeType;
+	permissions: PermissionType[];
+	channelId: string;
+	channelName: string;
+	channelCategory: ChannelCategory;
+	deviceId: string;
+	deviceName: string;
+	deviceCategory: DeviceCategory;
+	deviceEnabled: boolean;
+	roomId: string | null;
+	rankTier: number;
+	lexicalScore: number;
+}
+
+export interface VisiblePropertySearchSummaryInput {
+	match: string;
+	offset?: number;
+	limit: number;
+	rawQuery?: string;
+	normalizedQuery?: string;
+	normalizedTokens?: string[];
+	scope?: {
+		roomIds?: string[];
+		zoneId?: string;
+	};
+	roomParentId?: string;
+	categories?: PropertyCategory[];
+}
+
+export interface VisiblePropertySearchSummaryPage {
+	properties: VisiblePropertySearchSummary[];
 	total: number;
 }
 
@@ -211,6 +259,117 @@ export class ChannelsPropertiesService {
 		const [properties, total] = await query.getManyAndCount();
 
 		return { properties, total };
+	}
+
+	async searchVisibleSummaryPage(input: VisiblePropertySearchSummaryInput): Promise<VisiblePropertySearchSummaryPage> {
+		if (input.limit <= 0 || input.scope?.roomIds?.length === 0 || input.categories?.length === 0) {
+			return { properties: [], total: 0 };
+		}
+
+		const predicates = [
+			'home_context_entity_search_fts.entity_kind = ?',
+			'home_context_entity_search_fts MATCH ?',
+			'device.hidden = 0',
+		];
+		const parameters: Array<string | number> = ['property', input.match];
+
+		if (input.scope?.roomIds) {
+			predicates.push(`device."roomId" IN (${input.scope.roomIds.map(() => '?').join(', ')})`);
+			parameters.push(...input.scope.roomIds);
+		}
+
+		if (input.scope?.zoneId) {
+			predicates.push(
+				'EXISTS (SELECT 1 FROM devices_module_devices_zones scoped_zone ' +
+					'WHERE scoped_zone."deviceId" = device.id AND scoped_zone."zoneId" = ?)',
+			);
+			parameters.push(input.scope.zoneId);
+		}
+
+		if (input.roomParentId) {
+			predicates.push(
+				'device."roomId" IN (SELECT scoped_room.id FROM spaces_module_spaces scoped_room ' +
+					'WHERE scoped_room."parentId" = ?)',
+			);
+			parameters.push(input.roomParentId);
+		}
+
+		if (input.categories) {
+			predicates.push(`property.category IN (${input.categories.map(() => '?').join(', ')})`);
+			parameters.push(...input.categories);
+		}
+
+		interface PropertySearchRow extends Omit<
+			VisiblePropertySearchSummary,
+			'deviceEnabled' | 'rankTier' | 'lexicalScore' | 'permissions'
+		> {
+			deviceEnabled: boolean | number;
+			rankTier: string | number;
+			lexicalScore: string | number;
+			permissions: string;
+		}
+
+		interface CountRow {
+			total: string | number;
+		}
+
+		const joins = `FROM home_context_entity_search_fts
+			 INNER JOIN devices_module_channels_properties property
+			   ON property.id = home_context_entity_search_fts.entity_id
+			 INNER JOIN devices_module_channels channel ON channel.id = property."channelId"
+			 INNER JOIN devices_module_devices device ON device.id = channel."deviceId"`;
+		const where = predicates.join('\n AND ');
+		const rank = buildSqliteFtsNameRankExpression({
+			ftsTable: 'home_context_entity_search_fts',
+			vocabularyTable: 'home_context_entity_search_vocab',
+			entityIdExpression: 'property.id',
+			rawQuery: input.rawQuery,
+			normalizedQuery: input.normalizedQuery,
+			normalizedTokens: input.normalizedTokens,
+		});
+		const [rows, countRows] = await Promise.all([
+			this.dataSource.query<PropertySearchRow[]>(
+				`SELECT property.id AS id,
+				        property.name AS name,
+				        property.identifier AS identifier,
+				        property.category AS category,
+				        property."dataType" AS "dataType",
+				        property.permissions AS permissions,
+				        channel.id AS "channelId",
+				        channel.name AS "channelName",
+				        channel.category AS "channelCategory",
+				        device.id AS "deviceId",
+				        device.name AS "deviceName",
+				        device.category AS "deviceCategory",
+				        device.enabled AS "deviceEnabled",
+				        device."roomId" AS "roomId",
+				        ${rank.sql} AS "rankTier",
+				        bm25(home_context_entity_search_fts) AS "lexicalScore"
+				 ${joins}
+				 WHERE ${where}
+				 ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(device.name) ASC, LOWER(channel.name) ASC,
+				          LOWER(COALESCE(property.name, '')) ASC, property.id ASC
+				 LIMIT ? OFFSET ?`,
+				[...rank.parameters, ...parameters, input.limit, input.offset ?? 0],
+			),
+			this.dataSource.query<CountRow[]>(
+				`SELECT COUNT(*) AS total
+				 ${joins}
+				 WHERE ${where}`,
+				parameters,
+			),
+		]);
+
+		return {
+			properties: rows.map((row) => ({
+				...row,
+				deviceEnabled: Boolean(row.deviceEnabled),
+				rankTier: Number(row.rankTier),
+				lexicalScore: Number(row.lexicalScore),
+				permissions: row.permissions.split(',') as PermissionType[],
+			})),
+			total: Number(countRows[0]?.total ?? 0),
+		};
 	}
 
 	async findOne<TProperty extends ChannelPropertyEntity>(

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -323,7 +323,10 @@ export class ChannelsPropertiesService {
 			ftsTable: 'home_context_entity_search_fts',
 			vocabularyTable: 'home_context_entity_search_vocab',
 			entityIdExpression: 'property.id',
-			fallbackVocabularyColumn: 'identifier',
+			fallbackName: {
+				vocabularyColumn: 'identifier',
+				whenPrimaryNameExpression: 'property.name',
+			},
 			rawQuery: input.rawQuery,
 			normalizedQuery: input.normalizedQuery,
 			normalizedTokens: input.normalizedTokens,

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -323,6 +323,7 @@ export class ChannelsPropertiesService {
 			ftsTable: 'home_context_entity_search_fts',
 			vocabularyTable: 'home_context_entity_search_vocab',
 			entityIdExpression: 'property.id',
+			fallbackVocabularyColumn: 'identifier',
 			rawQuery: input.rawQuery,
 			normalizedQuery: input.normalizedQuery,
 			normalizedTokens: input.normalizedTokens,

--- a/apps/backend/src/modules/devices/services/devices.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.spec.ts
@@ -472,6 +472,74 @@ describe('DevicesService', () => {
 		});
 	});
 
+	describe('searchVisibleSummaryPage', () => {
+		it('keeps disabled devices while applying hidden, parent-room, category, and FTS bounds in SQL', async () => {
+			const query = jest.spyOn(dataSource, 'query');
+			query
+				.mockResolvedValueOnce([
+					{
+						id: mockDevice.id,
+						name: mockDevice.name,
+						identifier: mockDevice.identifier,
+						category: DeviceCategory.GENERIC,
+						enabled: 0,
+						roomId: null,
+						rankTier: '2',
+						lexicalScore: -4,
+					},
+				])
+				.mockResolvedValueOnce([{ total: 1 }]);
+
+			await expect(
+				service.searchVisibleSummaryPage({
+					match: '"sensor"*',
+					rawQuery: 'Sensor',
+					normalizedQuery: 'sensor',
+					offset: 5,
+					limit: 20,
+					roomParentId: 'floor-id',
+					categories: [DeviceCategory.GENERIC],
+				}),
+			).resolves.toEqual({
+				devices: [expect.objectContaining({ id: mockDevice.id, enabled: false, rankTier: 2, lexicalScore: -4 })],
+				total: 1,
+			});
+			const [selectSql, selectParameters] = query.mock.calls[0] as [string, unknown[]];
+			const [countSql, countParameters] = query.mock.calls[1] as [string, unknown[]];
+			expect(selectSql).toContain('home_context_entity_search_fts MATCH ?');
+			expect(selectSql).toContain('device.hidden = 0');
+			expect(selectSql).not.toContain('device.enabled = 1');
+			expect(selectSql).toContain('device."roomId" IN (SELECT scoped_room.id FROM spaces_module_spaces scoped_room');
+			expect(selectSql).toContain('scoped_room."parentId" = ?');
+			expect(selectSql).toContain('device.category IN (?)');
+			expect(selectSql).toContain('WHEN device.id = ? COLLATE NOCASE THEN 0');
+			expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
+			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(device.name) ASC, device.id ASC');
+			expect(selectParameters).toEqual([
+				'Sensor',
+				1,
+				'sensor',
+				1,
+				'sensor%',
+				'device',
+				'"sensor"*',
+				'floor-id',
+				DeviceCategory.GENERIC,
+				20,
+				5,
+			]);
+			expect(countSql).toContain('SELECT COUNT(*) AS total');
+			expect(countParameters).toEqual(['device', '"sensor"*', 'floor-id', DeviceCategory.GENERIC]);
+		});
+
+		it('does not query an explicitly empty room scope', async () => {
+			await expect(
+				service.searchVisibleSummaryPage({ match: 'sensor', limit: 20, scope: { roomIds: [] } }),
+			).resolves.toEqual({ devices: [], total: 0 });
+			expect(dataSource.query).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('findOne', () => {
 		it('should return a device if found', async () => {
 			const queryBuilderMock: any = {

--- a/apps/backend/src/modules/devices/services/devices.service.ts
+++ b/apps/backend/src/modules/devices/services/devices.service.ts
@@ -9,12 +9,14 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { buildSqliteFtsNameRankExpression } from '../../../common/utils/sqlite-fts.utils';
 import { toInstance, toSnakeCase, toSnakeCaseKeys } from '../../../common/utils/transform.utils';
 import { SpaceEntity } from '../../spaces/entities/space.entity';
 import { SpaceType } from '../../spaces/spaces.constants';
 import {
 	DEVICES_MODULE_NAME,
 	DEVICE_PLACEMENT_LOCKED_MESSAGE,
+	DeviceCategory,
 	DeviceHiddenBy,
 	DeviceHiddenFilter,
 	EventType,
@@ -44,6 +46,34 @@ export interface VisibleDeviceSummaryScope {
 
 export interface VisibleDeviceSummaryPage {
 	devices: DeviceEntity[];
+	total: number;
+}
+
+export interface VisibleDeviceSearchSummary {
+	id: string;
+	name: string;
+	identifier: string | null;
+	category: DeviceCategory;
+	enabled: boolean;
+	roomId: string | null;
+	rankTier: number;
+	lexicalScore: number;
+}
+
+export interface VisibleDeviceSearchSummaryInput {
+	match: string;
+	offset?: number;
+	limit: number;
+	rawQuery?: string;
+	normalizedQuery?: string;
+	normalizedTokens?: string[];
+	scope?: VisibleDeviceSummaryScope;
+	roomParentId?: string;
+	categories?: string[];
+}
+
+export interface VisibleDeviceSearchSummaryPage {
+	devices: VisibleDeviceSearchSummary[];
 	total: number;
 }
 
@@ -169,6 +199,102 @@ export class DevicesService {
 		const [devices, total] = await query.getManyAndCount();
 
 		return { devices, total };
+	}
+
+	async searchVisibleSummaryPage(input: VisibleDeviceSearchSummaryInput): Promise<VisibleDeviceSearchSummaryPage> {
+		if (input.limit <= 0 || input.scope?.roomIds?.length === 0 || input.categories?.length === 0) {
+			return { devices: [], total: 0 };
+		}
+
+		const predicates = [
+			'home_context_entity_search_fts.entity_kind = ?',
+			'home_context_entity_search_fts MATCH ?',
+			'device.hidden = 0',
+		];
+		const parameters: Array<string | number> = ['device', input.match];
+
+		if (input.scope?.roomIds) {
+			predicates.push(`device."roomId" IN (${input.scope.roomIds.map(() => '?').join(', ')})`);
+			parameters.push(...input.scope.roomIds);
+		}
+
+		if (input.scope?.zoneId) {
+			predicates.push(
+				'EXISTS (SELECT 1 FROM devices_module_devices_zones scoped_zone ' +
+					'WHERE scoped_zone."deviceId" = device.id AND scoped_zone."zoneId" = ?)',
+			);
+			parameters.push(input.scope.zoneId);
+		}
+
+		if (input.roomParentId) {
+			predicates.push(
+				'device."roomId" IN (SELECT scoped_room.id FROM spaces_module_spaces scoped_room ' +
+					'WHERE scoped_room."parentId" = ?)',
+			);
+			parameters.push(input.roomParentId);
+		}
+
+		if (input.categories) {
+			predicates.push(`device.category IN (${input.categories.map(() => '?').join(', ')})`);
+			parameters.push(...input.categories);
+		}
+
+		interface DeviceSearchRow extends Omit<VisibleDeviceSearchSummary, 'enabled' | 'rankTier' | 'lexicalScore'> {
+			enabled: boolean | number;
+			rankTier: string | number;
+			lexicalScore: string | number;
+		}
+
+		interface CountRow {
+			total: string | number;
+		}
+
+		const where = predicates.join('\n AND ');
+		const rank = buildSqliteFtsNameRankExpression({
+			ftsTable: 'home_context_entity_search_fts',
+			vocabularyTable: 'home_context_entity_search_vocab',
+			entityIdExpression: 'device.id',
+			rawQuery: input.rawQuery,
+			normalizedQuery: input.normalizedQuery,
+			normalizedTokens: input.normalizedTokens,
+		});
+		const [rows, countRows] = await Promise.all([
+			this.dataSource.query<DeviceSearchRow[]>(
+				`SELECT device.id AS id,
+				        device.name AS name,
+				        device.identifier AS identifier,
+				        device.category AS category,
+				        device.enabled AS enabled,
+				        device."roomId" AS "roomId",
+				        ${rank.sql} AS "rankTier",
+				        bm25(home_context_entity_search_fts) AS "lexicalScore"
+				 FROM home_context_entity_search_fts
+				 INNER JOIN devices_module_devices device
+				   ON device.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}
+				 ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(device.name) ASC, device.id ASC
+				 LIMIT ? OFFSET ?`,
+				[...rank.parameters, ...parameters, input.limit, input.offset ?? 0],
+			),
+			this.dataSource.query<CountRow[]>(
+				`SELECT COUNT(*) AS total
+				 FROM home_context_entity_search_fts
+				 INNER JOIN devices_module_devices device
+				   ON device.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}`,
+				parameters,
+			),
+		]);
+
+		return {
+			devices: rows.map((row) => ({
+				...row,
+				enabled: Boolean(row.enabled),
+				rankTier: Number(row.rankTier),
+				lexicalScore: Number(row.lexicalScore),
+			})),
+			total: Number(countRows[0]?.total ?? 0),
+		};
 	}
 
 	async findVisibleSummaryById(id: string): Promise<DeviceEntity | null> {

--- a/apps/backend/src/modules/home-context/home-context.constants.ts
+++ b/apps/backend/src/modules/home-context/home-context.constants.ts
@@ -48,3 +48,45 @@ export const HOME_CONTEXT_LIMIT_PROFILES: Readonly<Record<HomeContextProfile, Re
 export const HOME_TARGET_LIGHTING_MODES = ['off', 'on', 'work', 'relax', 'night'] as const;
 
 export type HomeTargetLightingMode = (typeof HOME_TARGET_LIGHTING_MODES)[number];
+
+export const HOME_SEARCH_PROFILE_BUDDY_V1 = 'buddy-search-v1' as const;
+
+export type HomeSearchProfile = typeof HOME_SEARCH_PROFILE_BUDDY_V1;
+
+export interface HomeSearchLimitProfile {
+	defaultResults: number;
+	maxResults: number;
+	maxCandidatesPerKind: number;
+	maxQueryCharacters: number;
+	maxQueryTokens: number;
+	maxKinds: number;
+	maxCategories: number;
+}
+
+export const HOME_SEARCH_LIMIT_PROFILES: Readonly<Record<HomeSearchProfile, Readonly<HomeSearchLimitProfile>>> =
+	Object.freeze({
+		[HOME_SEARCH_PROFILE_BUDDY_V1]: Object.freeze({
+			defaultResults: 10,
+			maxResults: 20,
+			maxCandidatesPerKind: 21,
+			maxQueryCharacters: 128,
+			maxQueryTokens: 8,
+			maxKinds: 4,
+			maxCategories: 16,
+		}),
+	});
+
+export const HOME_SEARCH_ENTITY_KINDS = ['space', 'device', 'property', 'scene'] as const;
+
+export type HomeSearchEntityKind = (typeof HOME_SEARCH_ENTITY_KINDS)[number];
+
+export const HOME_SEARCH_MATCH_REASONS = [
+	'exact_id',
+	'exact_name',
+	'name_prefix',
+	'lexical_match',
+	'space_filter',
+	'category_filter',
+] as const;
+
+export type HomeSearchMatchReason = (typeof HOME_SEARCH_MATCH_REASONS)[number];

--- a/apps/backend/src/modules/home-context/home-context.module.ts
+++ b/apps/backend/src/modules/home-context/home-context.module.ts
@@ -8,12 +8,13 @@ import { SpacesModule } from '../spaces/spaces.module';
 import { WeatherModule } from '../weather/weather.module';
 
 import { HomeContextQueryService } from './services/home-context-query.service';
+import { HomeSearchQueryService } from './services/home-search-query.service';
 import { HomeStateQueryService } from './services/home-state-query.service';
 import { HomeTargetQueryService } from './services/home-target-query.service';
 
 @Module({
 	imports: [DevicesModule, EnergyModule, ScenesModule, SecurityModule, SpacesModule, WeatherModule],
-	providers: [HomeContextQueryService, HomeStateQueryService, HomeTargetQueryService],
-	exports: [HomeContextQueryService, HomeStateQueryService, HomeTargetQueryService],
+	providers: [HomeContextQueryService, HomeSearchQueryService, HomeStateQueryService, HomeTargetQueryService],
+	exports: [HomeContextQueryService, HomeSearchQueryService, HomeStateQueryService, HomeTargetQueryService],
 })
 export class HomeContextModule {}

--- a/apps/backend/src/modules/home-context/home-search.errors.ts
+++ b/apps/backend/src/modules/home-context/home-search.errors.ts
@@ -1,0 +1,15 @@
+export class HomeSearchInvalidQueryError extends Error {
+	readonly code = 'invalid_query';
+
+	constructor(
+		readonly reason: 'no_search_tokens' | 'too_many_tokens',
+		readonly maxTokens?: number,
+	) {
+		super(
+			reason === 'too_many_tokens' && maxTokens !== undefined
+				? `Home search query may contain at most ${maxTokens} tokens`
+				: 'Home search query must contain at least one searchable token',
+		);
+		this.name = 'HomeSearchInvalidQueryError';
+	}
+}

--- a/apps/backend/src/modules/home-context/models/home-search-query.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-search-query.model.ts
@@ -1,0 +1,10 @@
+import { HomeSearchEntityKind, HomeSearchProfile } from '../home-context.constants';
+
+export interface HomeEntitySearchQuery {
+	profile: HomeSearchProfile;
+	query: string;
+	kinds?: HomeSearchEntityKind[];
+	spaceId?: string;
+	categories?: string[];
+	limit?: number;
+}

--- a/apps/backend/src/modules/home-context/models/home-search-result.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-search-result.model.ts
@@ -1,0 +1,76 @@
+import { HomeSearchEntityKind, HomeSearchMatchReason } from '../home-context.constants';
+
+export interface HomeEntitySearchResultBase {
+	kind: HomeSearchEntityKind;
+	id: string;
+	name: string;
+	score: number;
+	reasons: HomeSearchMatchReason[];
+}
+
+export interface HomeSpaceSearchResult extends HomeEntitySearchResultBase {
+	kind: 'space';
+	type: string;
+	category: string | null;
+	parent_id: string | null;
+}
+
+export interface HomeDeviceSearchResult extends HomeEntitySearchResultBase {
+	kind: 'device';
+	identifier: string | null;
+	category: string;
+	enabled: boolean;
+	room_id: string | null;
+}
+
+export interface HomePropertySearchResult extends HomeEntitySearchResultBase {
+	kind: 'property';
+	property_name: string | null;
+	identifier: string | null;
+	category: string;
+	data_type: string;
+	permissions: string[];
+	device: {
+		id: string;
+		name: string;
+		enabled: boolean;
+	};
+	channel: {
+		id: string;
+		name: string;
+		category: string;
+	};
+}
+
+export interface HomeSceneSearchResult extends HomeEntitySearchResultBase {
+	kind: 'scene';
+	category: string;
+	enabled: boolean;
+	triggerable: boolean;
+	primary_space_id: string | null;
+}
+
+export type HomeEntitySearchResult =
+	| HomeSpaceSearchResult
+	| HomeDeviceSearchResult
+	| HomePropertySearchResult
+	| HomeSceneSearchResult;
+
+export interface HomeEntitySearchTotalsByKind {
+	space: number;
+	device: number;
+	property: number;
+	scene: number;
+}
+
+export interface HomeEntitySearchResponse {
+	query: string;
+	entities: HomeEntitySearchResult[];
+	observed_at: string;
+	total: number;
+	returned: number;
+	totals_by_kind: HomeEntitySearchTotalsByKind;
+	partial: false;
+	truncated: boolean;
+	refine_required: boolean;
+}

--- a/apps/backend/src/modules/home-context/schemas/home-search-input.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-search-input.schemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+import {
+	HOME_SEARCH_ENTITY_KINDS,
+	HOME_SEARCH_LIMIT_PROFILES,
+	HOME_SEARCH_PROFILE_BUDDY_V1,
+} from '../home-context.constants';
+
+const limits = HOME_SEARCH_LIMIT_PROFILES[HOME_SEARCH_PROFILE_BUDDY_V1];
+
+export const homeEntitySearchQuerySchema = z
+	.object({
+		profile: z.literal(HOME_SEARCH_PROFILE_BUDDY_V1),
+		query: z.string().trim().min(1).max(limits.maxQueryCharacters),
+		kinds: z
+			.array(z.enum(HOME_SEARCH_ENTITY_KINDS))
+			.min(1)
+			.max(limits.maxKinds)
+			.refine((kinds) => new Set(kinds).size === kinds.length, 'Search kinds must be unique')
+			.optional(),
+		spaceId: z.string().trim().min(1).max(128).optional(),
+		categories: z
+			.array(z.string().trim().min(1).max(64))
+			.min(1)
+			.max(limits.maxCategories)
+			.refine((categories) => new Set(categories).size === categories.length, 'Search categories must be unique')
+			.optional(),
+		limit: z.number().int().min(1).max(limits.maxResults).optional(),
+	})
+	.strict();

--- a/apps/backend/src/modules/home-context/schemas/home-search-output.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-search-output.schemas.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import {
+	HOME_SEARCH_ENTITY_KINDS,
+	HOME_SEARCH_LIMIT_PROFILES,
+	HOME_SEARCH_MATCH_REASONS,
+	HOME_SEARCH_PROFILE_BUDDY_V1,
+} from '../home-context.constants';
+
+const limits = HOME_SEARCH_LIMIT_PROFILES[HOME_SEARCH_PROFILE_BUDDY_V1];
+const reasonSchema = z.enum(HOME_SEARCH_MATCH_REASONS);
+const baseFields = {
+	id: z.string(),
+	name: z.string(),
+	score: z.number().int().nonnegative(),
+	reasons: z.array(reasonSchema).min(1),
+};
+
+const entitySchema = z.discriminatedUnion('kind', [
+	z
+		.object({
+			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[0]),
+			...baseFields,
+			type: z.string(),
+			category: z.string().nullable(),
+			parent_id: z.string().nullable(),
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[1]),
+			...baseFields,
+			identifier: z.string().nullable(),
+			category: z.string(),
+			enabled: z.boolean(),
+			room_id: z.string().nullable(),
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[2]),
+			...baseFields,
+			property_name: z.string().nullable(),
+			identifier: z.string().nullable(),
+			category: z.string(),
+			data_type: z.string(),
+			permissions: z.array(z.string()),
+			device: z.object({ id: z.string(), name: z.string(), enabled: z.boolean() }).strict(),
+			channel: z.object({ id: z.string(), name: z.string(), category: z.string() }).strict(),
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[3]),
+			...baseFields,
+			category: z.string(),
+			enabled: z.boolean(),
+			triggerable: z.boolean(),
+			primary_space_id: z.string().nullable(),
+		})
+		.strict(),
+]);
+
+export const homeEntitySearchResponseSchema = z
+	.object({
+		query: z.string(),
+		entities: z.array(entitySchema).max(limits.maxResults),
+		observed_at: z.string().datetime(),
+		total: z.number().int().nonnegative(),
+		returned: z.number().int().nonnegative().max(limits.maxResults),
+		totals_by_kind: z
+			.object({
+				space: z.number().int().nonnegative(),
+				device: z.number().int().nonnegative(),
+				property: z.number().int().nonnegative(),
+				scene: z.number().int().nonnegative(),
+			})
+			.strict(),
+		partial: z.literal(false),
+		truncated: z.boolean(),
+		refine_required: z.boolean(),
+	})
+	.strict();

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -144,6 +144,63 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		expect(result.truncated).toBe(true);
 	});
 
+	it('keeps an unnamed property with an exact identifier ahead of the per-kind candidate cap', async () => {
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('property-owner', 'Target owner', 'property-owner', 'test', 'sensor', 1, 0, NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId")
+			 VALUES ('property-channel', 'Target channel', 'generic', 'property-owner')`,
+		);
+		for (let index = 0; index < 30; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_channels_properties
+				 (id, name, identifier, type, category, "dataType", permissions, "channelId")
+				 VALUES (?, ?, ?, 'test', 'generic', 'string', 'ro', 'property-channel')`,
+				[
+					`property-competitor-${index}`,
+					`Target identifier competitor ${index} target identifier`,
+					`competitor-${index}`,
+				],
+			);
+		}
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId")
+			 VALUES ('property-exact', NULL, 'target-identifier', 'test', 'generic', 'string', 'ro',
+			         'property-channel')`,
+		);
+
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as DevicesService,
+			propertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'target-identifier',
+			kinds: ['property'],
+			limit: 20,
+		});
+
+		expect(result.entities).toHaveLength(20);
+		expect(result.entities[0]).toMatchObject({
+			kind: 'property',
+			id: 'property-exact',
+			name: 'target-identifier',
+			score: 900,
+			reasons: ['exact_name'],
+		});
+		expect(result.total).toBe(31);
+		expect(result.truncated).toBe(true);
+	});
+
 	it('executes all four owning-domain queries against the real FTS index and joined metadata', async () => {
 		await dataSource.query(
 			`INSERT INTO spaces_module_spaces (id, name, type, category, "parentId")

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -176,6 +176,47 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		]);
 	});
 
+	it('folds Greek final sigma like unicode61 before applying the candidate cap', async () => {
+		for (let index = 0; index < 30; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_devices
+				 (id, name, identifier, type, category, enabled, hidden, "roomId")
+				 VALUES (?, ?, ?, 'test', 'sensor', 1, 0, NULL)`,
+				[`greek-competitor-${index}`, `ΟΣ competitor ${index} ΟΣ ΟΣ`, `greek-competitor-${index}`],
+			);
+		}
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('greek-exact', 'ΟΣ', 'greek-exact', 'test', 'sensor', 1, 0, NULL)`,
+		);
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			devicesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as ChannelsPropertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'ΟΣ',
+			kinds: ['device'],
+			limit: 20,
+		});
+
+		expect(result.entities[0]).toMatchObject({
+			id: 'greek-exact',
+			name: 'ΟΣ',
+			score: 900,
+			reasons: ['exact_name'],
+		});
+		expect(result.total).toBe(31);
+		expect(result.truncated).toBe(true);
+	});
+
 	it('keeps an unnamed property with an exact identifier ahead of the per-kind candidate cap', async () => {
 		await dataSource.query(
 			`INSERT INTO devices_module_devices

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -144,6 +144,38 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		expect(result.truncated).toBe(true);
 	});
 
+	it('preserves compatibility characters so query tokens match the SQLite tokenizer', async () => {
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('ligature-floor', 'ﬂoor', 'ligature-floor', 'test', 'sensor', 1, 0, NULL)`,
+		);
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			devicesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as ChannelsPropertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'ﬂoor',
+			kinds: ['device'],
+		});
+
+		expect(result.entities).toEqual([
+			expect.objectContaining({
+				id: 'ligature-floor',
+				name: 'ﬂoor',
+				score: 900,
+				reasons: ['exact_name'],
+			}),
+		]);
+	});
+
 	it('keeps an unnamed property with an exact identifier ahead of the per-kind candidate cap', async () => {
 		await dataSource.query(
 			`INSERT INTO devices_module_devices

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -1,0 +1,320 @@
+import { DataSource } from 'typeorm';
+
+import { AddHomeEntitySearchIndex1000000000020 } from '../../../migrations/1000000000020-AddHomeEntitySearchIndex';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
+import { DevicesService } from '../../devices/services/devices.service';
+import { ScenesService } from '../../scenes/services/scenes.service';
+import { SpaceSearchSummaryInput, SpacesService } from '../../spaces/services/spaces.service';
+import { SpaceType, SpaceZoneCategory } from '../../spaces/spaces.constants';
+import { HOME_SEARCH_PROFILE_BUDDY_V1 } from '../home-context.constants';
+
+import { HomeSearchQueryService } from './home-search-query.service';
+
+describe('HomeSearchQueryService SQLite integration', () => {
+	let dataSource: DataSource;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+		await dataSource.initialize();
+		await dataSource.query(
+			`CREATE TABLE spaces_module_spaces (
+				id varchar PRIMARY KEY, name varchar NOT NULL, type varchar, category varchar, "parentId" varchar
+			)`,
+		);
+		await dataSource.query(
+			`CREATE TABLE devices_module_devices (
+				id varchar PRIMARY KEY, name varchar NOT NULL, identifier varchar, type varchar, category varchar,
+				enabled boolean NOT NULL, hidden boolean NOT NULL, "roomId" varchar
+			)`,
+		);
+		await dataSource.query(
+			`CREATE TABLE devices_module_channels_properties (
+				id varchar PRIMARY KEY, name varchar, identifier varchar, type varchar, category varchar,
+				"dataType" varchar, permissions text, "channelId" varchar
+			)`,
+		);
+		await dataSource.query(
+			`CREATE TABLE devices_module_channels (
+				id varchar PRIMARY KEY, name varchar NOT NULL, category varchar, "deviceId" varchar
+			)`,
+		);
+		await dataSource.query(
+			`CREATE TABLE devices_module_devices_zones ("deviceId" varchar NOT NULL, "zoneId" varchar NOT NULL)`,
+		);
+		await dataSource.query(
+			`CREATE TABLE scenes_module_scenes (
+				id varchar PRIMARY KEY, name varchar NOT NULL, category varchar, enabled boolean NOT NULL,
+				triggerable boolean NOT NULL, "primarySpaceId" varchar
+			)`,
+		);
+		await new AddHomeEntitySearchIndex1000000000020().up(dataSource.createQueryRunner());
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	it('finds a disabled visible target beyond the first 100 alphabetical devices without leaking its hidden twin', async () => {
+		for (let index = 0; index < 101; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_devices
+				 (id, name, identifier, type, category, enabled, hidden, "roomId")
+				 VALUES (?, ?, ?, 'test', 'sensor', 1, 0, NULL)`,
+				[`device-${index}`, `Alpha device ${String(index).padStart(3, '0')}`, `alpha-${index}`],
+			);
+		}
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES
+			 ('target-visible', 'Zeta Target Sensor', 'zeta-target', 'test', 'sensor', 0, 0, NULL),
+			 ('target-hidden', 'Zeta Target Sensor Hidden', 'zeta-target-hidden', 'test', 'sensor', 1, 1, NULL)`,
+		);
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const spacesService = {
+			findOne: jest.fn(),
+			resolveSnapshotScope: jest.fn(),
+			searchSummaryPage: jest.fn(),
+		} as unknown as SpacesService;
+		const propertiesService = { searchVisibleSummaryPage: jest.fn() } as unknown as ChannelsPropertiesService;
+		const scenesService = { searchSummaryPage: jest.fn() } as unknown as ScenesService;
+		const service = new HomeSearchQueryService(spacesService, devicesService, propertiesService, scenesService);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'target',
+			kinds: ['device'],
+		});
+
+		expect(result.entities).toEqual([
+			expect.objectContaining({
+				kind: 'device',
+				id: 'target-visible',
+				name: 'Zeta Target Sensor',
+				enabled: false,
+			}),
+		]);
+		expect(result.total).toBe(1);
+		expect(result.returned).toBe(1);
+		expect(result.truncated).toBe(false);
+	});
+
+	it('keeps a diacritic-normalized exact name ahead of more than 21 competing matches before the hard cap', async () => {
+		for (let index = 0; index < 30; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_devices
+				 (id, name, identifier, type, category, enabled, hidden, "roomId")
+				 VALUES (?, ?, ?, 'test', 'sensor', 1, 0, NULL)`,
+				[`competitor-${index}`, `Kuche competitor ${index} kuche kuche`, `kuche-competitor-${index}`],
+			);
+		}
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('exact-kitchen', 'Küche', 'exact-kitchen', 'test', 'sensor', 0, 0, NULL)`,
+		);
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			devicesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as ChannelsPropertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'Kuche',
+			kinds: ['device'],
+			limit: 20,
+		});
+
+		expect(result.entities).toHaveLength(20);
+		expect(result.entities[0]).toMatchObject({
+			id: 'exact-kitchen',
+			name: 'Küche',
+			score: 900,
+			reasons: ['exact_name'],
+			enabled: false,
+		});
+		expect(result.total).toBe(31);
+		expect(result.truncated).toBe(true);
+	});
+
+	it('executes all four owning-domain queries against the real FTS index and joined metadata', async () => {
+		await dataSource.query(
+			`INSERT INTO spaces_module_spaces (id, name, type, category, "parentId")
+			 VALUES ('space-kitchen', 'Kitchen', 'room', NULL, NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('device-light', 'Kitchen light', 'kitchen-light', 'test', 'lighting', 1, 0, 'space-kitchen')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId")
+			 VALUES ('channel-light', 'Kitchen light', 'light', 'device-light')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId")
+			 VALUES ('property-brightness', 'Kitchen brightness', 'brightness', 'test', 'brightness', 'uchar',
+			         'ro,rw', 'channel-light')`,
+		);
+		await dataSource.query(
+			`INSERT INTO scenes_module_scenes (id, name, category, enabled, triggerable, "primarySpaceId")
+			 VALUES ('scene-evening', 'Kitchen evening', 'lighting', 0, 0, 'space-kitchen')`,
+		);
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const spacesService = Object.create(SpacesService.prototype) as SpacesService;
+		Object.defineProperty(spacesService, 'dataSource', { value: dataSource });
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const scenesService = Object.create(ScenesService.prototype) as ScenesService;
+		Object.defineProperty(scenesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(spacesService, devicesService, propertiesService, scenesService);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'kitchen',
+		});
+
+		expect(result.entities[0]).toMatchObject({ kind: 'space', id: 'space-kitchen' });
+		expect(result.entities.map(({ kind, id }) => ({ kind, id }))).toEqual(
+			expect.arrayContaining([
+				{ kind: 'space', id: 'space-kitchen' },
+				{ kind: 'device', id: 'device-light' },
+				{ kind: 'property', id: 'property-brightness' },
+				{ kind: 'scene', id: 'scene-evening' },
+			]),
+		);
+		expect(result.totals_by_kind).toEqual({ space: 1, device: 1, property: 1, scene: 1 });
+		expect(result.entities.find((entity) => entity.kind === 'device')).toMatchObject({ enabled: true });
+		expect(result.entities.find((entity) => entity.kind === 'property')).toMatchObject({
+			permissions: [expect.stringMatching(/^r/), expect.stringMatching(/^r/)],
+			device: { id: 'device-light', name: 'Kitchen light', enabled: true },
+			channel: { id: 'channel-light', name: 'Kitchen light', category: 'light' },
+		});
+		expect(result.entities.find((entity) => entity.kind === 'scene')).toMatchObject({
+			enabled: false,
+			triggerable: false,
+		});
+	});
+
+	it('applies floor scope, category filters, and hidden-owner visibility in real SQL', async () => {
+		await dataSource.query(
+			`INSERT INTO spaces_module_spaces (id, name, type, category, "parentId") VALUES
+			 ('floor-id', 'Probe floor', 'zone', 'generic', NULL),
+			 ('child-room', 'Probe child room', 'room', 'generic', 'floor-id'),
+			 ('other-room', 'Probe other room', 'room', 'generic', NULL),
+			 ('zone-id', 'Probe zone', 'zone', 'generic', NULL),
+			 ('entry-id', 'Probe entry', 'entry', 'generic', NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId") VALUES
+			 ('visible-child', 'Probe visible child', 'visible-child', 'test', 'generic', 1, 0, 'child-room'),
+			 ('hidden-child', 'Probe hidden child', 'hidden-child', 'test', 'generic', 1, 1, 'child-room'),
+			 ('other-device', 'Probe other device', 'other-device', 'test', 'generic', 1, 0, 'other-room'),
+			 ('zone-device', 'Probe zone device', 'zone-device', 'test', 'generic', 1, 0, 'other-room')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_devices_zones ("deviceId", "zoneId") VALUES ('zone-device', 'zone-id')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId") VALUES
+			 ('visible-channel', 'Probe visible channel', 'generic', 'visible-child'),
+			 ('hidden-channel', 'Probe hidden channel', 'generic', 'hidden-child'),
+			 ('other-channel', 'Probe other channel', 'generic', 'other-device')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId") VALUES
+			 ('visible-property', 'Probe visible property', 'visible-property', 'test', 'generic', 'bool', 'ro',
+			  'visible-channel'),
+			 ('hidden-property', 'Probe hidden property', 'hidden-property', 'test', 'generic', 'bool', 'ro',
+			  'hidden-channel'),
+			 ('other-property', 'Probe other property', 'other-property', 'test', 'generic', 'bool', 'ro',
+			  'other-channel')`,
+		);
+		await dataSource.query(
+			`INSERT INTO scenes_module_scenes (id, name, category, enabled, triggerable, "primarySpaceId") VALUES
+			 ('floor-scene', 'Probe floor scene', 'generic', 1, 1, 'floor-id'),
+			 ('child-scene', 'Probe child scene', 'generic', 1, 1, 'child-room'),
+			 ('other-scene', 'Probe other scene', 'generic', 1, 1, 'other-room')`,
+		);
+
+		const rawSpacesService = Object.create(SpacesService.prototype) as SpacesService;
+		Object.defineProperty(rawSpacesService, 'dataSource', { value: dataSource });
+		const findOne = jest.fn().mockResolvedValue({
+			id: 'floor-id',
+			name: 'Probe floor',
+			type: SpaceType.ZONE,
+			category: SpaceZoneCategory.FLOOR_FIRST,
+		});
+		const spacesService = {
+			findOne,
+			searchSummaryPage: (input: SpaceSearchSummaryInput) => rawSpacesService.searchSummaryPage(input),
+		} as unknown as SpacesService;
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const scenesService = Object.create(ScenesService.prototype) as ScenesService;
+		Object.defineProperty(scenesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(spacesService, devicesService, propertiesService, scenesService);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'probe',
+			spaceId: 'floor-id',
+			categories: ['generic'],
+		});
+
+		expect(result.totals_by_kind).toEqual({ space: 2, device: 1, property: 1, scene: 2 });
+		expect(result.entities.map((entity) => entity.id).sort()).toEqual([
+			'child-room',
+			'child-scene',
+			'floor-id',
+			'floor-scene',
+			'visible-child',
+			'visible-property',
+		]);
+		expect(result.entities.every((entity) => entity.reasons.includes('space_filter'))).toBe(true);
+		expect(result.entities.every((entity) => entity.reasons.includes('category_filter'))).toBe(true);
+
+		findOne.mockResolvedValue({ id: 'child-room', name: 'Probe child room', type: SpaceType.ROOM });
+		const roomResult = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'probe',
+			spaceId: 'child-room',
+			categories: ['generic'],
+			kinds: ['device'],
+		});
+		expect(roomResult.entities.map((entity) => entity.id)).toEqual(['visible-child']);
+
+		findOne.mockResolvedValue({ id: 'zone-id', name: 'Probe zone', type: SpaceType.ZONE, category: 'custom' });
+		const zoneResult = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'probe',
+			spaceId: 'zone-id',
+			categories: ['generic'],
+			kinds: ['device'],
+		});
+		expect(zoneResult.entities.map((entity) => entity.id)).toEqual(['zone-device']);
+
+		findOne.mockResolvedValue({ id: 'entry-id', name: 'Probe entry', type: SpaceType.ENTRY });
+		const entryResult = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'probe',
+			spaceId: 'entry-id',
+			kinds: ['device'],
+		});
+		expect(entryResult).toMatchObject({ total: 0, returned: 0, entities: [] });
+	});
+});

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -201,6 +201,44 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		expect(result.truncated).toBe(true);
 	});
 
+	it('does not rank an identifier as the display name when a symbol-only property name is non-null', async () => {
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId")
+			 VALUES ('symbol-owner', 'Symbol owner', 'symbol-owner', 'test', 'sensor', 1, 0, NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId")
+			 VALUES ('symbol-channel', 'Symbol channel', 'generic', 'symbol-owner')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId") VALUES
+			 ('genuine-display-name', 'Symbol fallback', 'genuine', 'test', 'generic', 'string', 'ro', 'symbol-channel'),
+			 ('symbol-only-name', '---', 'symbol-fallback', 'test', 'generic', 'string', 'ro', 'symbol-channel')`,
+		);
+
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as DevicesService,
+			propertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'symbol-fallback',
+			kinds: ['property'],
+		});
+
+		expect(result.entities.map((entity) => ({ id: entity.id, name: entity.name, score: entity.score }))).toEqual([
+			{ id: 'genuine-display-name', name: 'Symbol fallback', score: 900 },
+			{ id: 'symbol-only-name', name: '---', score: 600 },
+		]);
+	});
+
 	it('executes all four owning-domain queries against the real FTS index and joined metadata', async () => {
 		await dataSource.query(
 			`INSERT INTO spaces_module_spaces (id, name, type, category, "parentId")

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.spec.ts
@@ -1,0 +1,332 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import {
+	ChannelCategory,
+	DataTypeType,
+	DeviceCategory,
+	PermissionType,
+	PropertyCategory,
+} from '../../devices/devices.constants';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
+import { DevicesService } from '../../devices/services/devices.service';
+import { SceneCategory } from '../../scenes/scenes.constants';
+import { ScenesService } from '../../scenes/services/scenes.service';
+import { SpacesService } from '../../spaces/services/spaces.service';
+import { SpaceType, SpaceZoneCategory } from '../../spaces/spaces.constants';
+import { HOME_SEARCH_PROFILE_BUDDY_V1 } from '../home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../home-context.errors';
+import { homeEntitySearchQuerySchema } from '../schemas/home-search-input.schemas';
+import { homeEntitySearchResponseSchema } from '../schemas/home-search-output.schemas';
+
+import { HomeSearchQueryService } from './home-search-query.service';
+
+describe('HomeSearchQueryService', () => {
+	let spacesService: jest.Mocked<SpacesService>;
+	let devicesService: jest.Mocked<DevicesService>;
+	let channelsPropertiesService: jest.Mocked<ChannelsPropertiesService>;
+	let scenesService: jest.Mocked<ScenesService>;
+	let service: HomeSearchQueryService;
+
+	beforeEach(() => {
+		spacesService = {
+			findOne: jest.fn().mockResolvedValue(null),
+			searchSummaryPage: jest.fn().mockResolvedValue({ spaces: [], total: 0 }),
+		} as unknown as jest.Mocked<SpacesService>;
+		devicesService = {
+			searchVisibleSummaryPage: jest.fn().mockResolvedValue({ devices: [], total: 0 }),
+		} as unknown as jest.Mocked<DevicesService>;
+		channelsPropertiesService = {
+			searchVisibleSummaryPage: jest.fn().mockResolvedValue({ properties: [], total: 0 }),
+		} as unknown as jest.Mocked<ChannelsPropertiesService>;
+		scenesService = {
+			searchSummaryPage: jest.fn().mockResolvedValue({ scenes: [], total: 0 }),
+		} as unknown as jest.Mocked<ScenesService>;
+		service = new HomeSearchQueryService(spacesService, devicesService, channelsPropertiesService, scenesService);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('searches selected metadata domains in parallel and returns stable cross-kind ranking', async () => {
+		jest.useFakeTimers().setSystemTime(new Date('2026-08-15T10:00:00.000Z'));
+		spacesService.searchSummaryPage.mockResolvedValue({
+			spaces: [
+				{
+					id: 'space-1',
+					name: 'Küche',
+					type: SpaceType.ROOM,
+					category: null,
+					parentId: null,
+					rankTier: 1,
+					lexicalScore: -4,
+				},
+			],
+			total: 1,
+		});
+		devicesService.searchVisibleSummaryPage.mockResolvedValue({
+			devices: [
+				{
+					id: 'device-1',
+					name: 'Küche ceiling',
+					identifier: 'kitchen-ceiling',
+					category: DeviceCategory.LIGHTING,
+					enabled: false,
+					roomId: 'space-1',
+					rankTier: 2,
+					lexicalScore: -8,
+				},
+			],
+			total: 2,
+		});
+		channelsPropertiesService.searchVisibleSummaryPage.mockResolvedValue({
+			properties: [
+				{
+					id: 'property-1',
+					name: null,
+					identifier: 'kuche-switch',
+					category: PropertyCategory.ON,
+					dataType: DataTypeType.BOOL,
+					permissions: [PermissionType.READ_WRITE],
+					channelId: 'channel-1',
+					channelName: 'Main light',
+					channelCategory: ChannelCategory.LIGHT,
+					deviceId: 'device-1',
+					deviceName: 'Küche ceiling',
+					deviceCategory: DeviceCategory.LIGHTING,
+					deviceEnabled: false,
+					roomId: 'space-1',
+					rankTier: 2,
+					lexicalScore: -2,
+				},
+			],
+			total: 1,
+		});
+		scenesService.searchSummaryPage.mockResolvedValue({
+			scenes: [
+				{
+					id: 'scene-1',
+					name: 'Evening Küche',
+					category: SceneCategory.LIGHTING,
+					enabled: false,
+					triggerable: false,
+					primarySpaceId: 'space-1',
+					rankTier: 3,
+					lexicalScore: -3,
+				},
+			],
+			total: 1,
+		});
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: '  Kuche  ',
+		});
+
+		expect(spacesService.searchSummaryPage).toHaveBeenCalledWith({
+			match: '"kuche"*',
+			rawQuery: 'Kuche',
+			normalizedQuery: 'kuche',
+			normalizedTokens: ['kuche'],
+			offset: 0,
+			limit: 21,
+			spaceIds: undefined,
+			parentSpaceId: undefined,
+			categories: undefined,
+		});
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledWith({
+			match: '"kuche"*',
+			rawQuery: 'Kuche',
+			normalizedQuery: 'kuche',
+			normalizedTokens: ['kuche'],
+			offset: 0,
+			limit: 21,
+			scope: undefined,
+			roomParentId: undefined,
+			categories: undefined,
+		});
+		expect(result).toEqual({
+			query: 'Kuche',
+			entities: [
+				{
+					kind: 'space',
+					id: 'space-1',
+					name: 'Küche',
+					score: 900,
+					reasons: ['exact_name'],
+					type: SpaceType.ROOM,
+					category: null,
+					parent_id: null,
+				},
+				{
+					kind: 'device',
+					id: 'device-1',
+					name: 'Küche ceiling',
+					score: 800,
+					reasons: ['name_prefix'],
+					identifier: 'kitchen-ceiling',
+					category: DeviceCategory.LIGHTING,
+					enabled: false,
+					room_id: 'space-1',
+				},
+				{
+					kind: 'property',
+					id: 'property-1',
+					name: 'kuche-switch',
+					score: 800,
+					reasons: ['name_prefix'],
+					property_name: null,
+					identifier: 'kuche-switch',
+					category: PropertyCategory.ON,
+					data_type: DataTypeType.BOOL,
+					permissions: [PermissionType.READ_WRITE],
+					device: { id: 'device-1', name: 'Küche ceiling', enabled: false },
+					channel: { id: 'channel-1', name: 'Main light', category: ChannelCategory.LIGHT },
+				},
+				{
+					kind: 'scene',
+					id: 'scene-1',
+					name: 'Evening Küche',
+					score: 600,
+					reasons: ['lexical_match'],
+					category: SceneCategory.LIGHTING,
+					enabled: false,
+					triggerable: false,
+					primary_space_id: 'space-1',
+				},
+			],
+			observed_at: '2026-08-15T10:00:00.000Z',
+			total: 5,
+			returned: 4,
+			totals_by_kind: { space: 1, device: 2, property: 1, scene: 1 },
+			partial: false,
+			truncated: true,
+			refine_required: true,
+		});
+		expect(homeEntitySearchResponseSchema.safeParse(result).success).toBe(true);
+	});
+
+	it('resolves an explicit space once and applies scope and category filters before limits', async () => {
+		const selectedSpace = {
+			id: 'zone-1',
+			name: 'Floor',
+			type: SpaceType.ZONE,
+			category: SpaceZoneCategory.FLOOR_FIRST,
+		};
+		spacesService.findOne.mockResolvedValue(selectedSpace as never);
+
+		await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['space', 'device', 'property', 'scene'],
+			spaceId: ' zone-1 ',
+			categories: [' lighting ', 'on', 'not-a-domain-category'],
+			limit: 5,
+		});
+
+		expect(spacesService.findOne).toHaveBeenCalledWith('zone-1');
+		expect(spacesService.searchSummaryPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				spaceIds: ['zone-1'],
+				parentSpaceId: 'zone-1',
+				categories: ['lighting', 'on', 'not-a-domain-category'],
+			}),
+		);
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: undefined,
+				roomParentId: 'zone-1',
+				categories: ['lighting', 'on', 'not-a-domain-category'],
+			}),
+		);
+		expect(channelsPropertiesService.searchVisibleSummaryPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: undefined,
+				roomParentId: 'zone-1',
+				categories: [PropertyCategory.ON],
+			}),
+		);
+		expect(scenesService.searchSummaryPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				primarySpaceId: 'zone-1',
+				primarySpaceParentId: 'zone-1',
+				categories: [SceneCategory.LIGHTING],
+			}),
+		);
+	});
+
+	it('returns at most the requested hard-bounded number and reports exact totals', async () => {
+		devicesService.searchVisibleSummaryPage.mockResolvedValue({
+			devices: Array.from({ length: 21 }, (_, index) => ({
+				id: `device-${String(index).padStart(2, '0')}`,
+				name: `Sensor ${String(index).padStart(2, '0')}`,
+				identifier: null,
+				category: DeviceCategory.SENSOR,
+				enabled: true,
+				roomId: null,
+				rankTier: 2,
+				lexicalScore: index,
+			})),
+			total: 1_001,
+		});
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'sensor',
+			kinds: ['device'],
+			limit: 20,
+		});
+
+		expect(result.entities).toHaveLength(20);
+		expect(result.total).toBe(1_001);
+		expect(result.returned).toBe(20);
+		expect(result.truncated).toBe(true);
+		expect(result.refine_required).toBe(true);
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledWith(expect.objectContaining({ limit: 21 }));
+		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
+		expect(channelsPropertiesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(scenesService.searchSummaryPage).not.toHaveBeenCalled();
+	});
+
+	it('rejects a missing explicit space before searching any catalog', async () => {
+		await expect(
+			service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				spaceId: 'missing-space',
+			}),
+		).rejects.toBeInstanceOf(HomeContextSpaceNotFoundError);
+		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
+		expect(devicesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(channelsPropertiesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(scenesService.searchSummaryPage).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['punctuation-only text', '---', 'no_search_tokens'],
+		['more than eight tokens', 'one two three four five six seven eight nine', 'too_many_tokens'],
+	] as const)('rejects %s without querying domains', async (_label, query, reason) => {
+		await expect(service.searchEntities({ profile: HOME_SEARCH_PROFILE_BUDDY_V1, query })).rejects.toMatchObject({
+			reason,
+		});
+		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
+		expect(devicesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+	});
+
+	it('enforces closed profiles, unique filters, and hard input limits', () => {
+		expect(homeEntitySearchQuerySchema.safeParse({ profile: 'mcp-compatibility', query: 'light' }).success).toBe(false);
+		expect(
+			homeEntitySearchQuerySchema.safeParse({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				kinds: ['device', 'device'],
+			}).success,
+		).toBe(false);
+		expect(
+			homeEntitySearchQuerySchema.safeParse({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				limit: 21,
+			}).success,
+		).toBe(false);
+	});
+});

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.ts
@@ -362,7 +362,7 @@ export class HomeSearchQueryService {
 
 	private normalize(value: string): string {
 		return value
-			.normalize('NFKD')
+			.normalize('NFD')
 			.replace(/\p{M}/gu, '')
 			.toLocaleLowerCase('en-US')
 			.replace(/[^\p{L}\p{N}]+/gu, ' ')

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.ts
@@ -1,0 +1,372 @@
+import { Injectable } from '@nestjs/common';
+
+import { PropertyCategory } from '../../devices/devices.constants';
+import {
+	ChannelsPropertiesService,
+	VisiblePropertySearchSummary,
+	VisiblePropertySearchSummaryPage,
+} from '../../devices/services/channels.properties.service';
+import {
+	DevicesService,
+	VisibleDeviceSearchSummary,
+	VisibleDeviceSearchSummaryPage,
+	VisibleDeviceSummaryScope,
+} from '../../devices/services/devices.service';
+import { SceneCategory } from '../../scenes/scenes.constants';
+import { SceneSearchSummary, SceneSearchSummaryPage, ScenesService } from '../../scenes/services/scenes.service';
+import { SpaceEntity } from '../../spaces/entities/space.entity';
+import { SpaceSearchSummary, SpaceSearchSummaryPage, SpacesService } from '../../spaces/services/spaces.service';
+import { SpaceType, isFloorZoneCategory } from '../../spaces/spaces.constants';
+import {
+	HOME_SEARCH_ENTITY_KINDS,
+	HOME_SEARCH_LIMIT_PROFILES,
+	HomeSearchEntityKind,
+	HomeSearchMatchReason,
+} from '../home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../home-context.errors';
+import { HomeSearchInvalidQueryError } from '../home-search.errors';
+import { HomeEntitySearchQuery } from '../models/home-search-query.model';
+import {
+	HomeDeviceSearchResult,
+	HomeEntitySearchResponse,
+	HomeEntitySearchResult,
+	HomePropertySearchResult,
+	HomeSceneSearchResult,
+	HomeSpaceSearchResult,
+} from '../models/home-search-result.model';
+import { homeEntitySearchQuerySchema } from '../schemas/home-search-input.schemas';
+import { homeEntitySearchResponseSchema } from '../schemas/home-search-output.schemas';
+
+const KIND_ORDER = new Map<HomeSearchEntityKind, number>(HOME_SEARCH_ENTITY_KINDS.map((kind, index) => [kind, index]));
+
+interface HomeEntitySearchScope {
+	spaceIds?: string[];
+	parentSpaceId?: string;
+	deviceScope?: VisibleDeviceSummaryScope;
+	roomParentId?: string;
+	primarySpaceIds?: string[];
+	primarySpaceId?: string;
+	primarySpaceParentId?: string;
+}
+
+interface RankedHomeEntity {
+	entity: HomeEntitySearchResult;
+	rankTier: number;
+	lexicalScore: number;
+	normalizedName: string;
+	id: string;
+}
+
+@Injectable()
+export class HomeSearchQueryService {
+	constructor(
+		private readonly spacesService: SpacesService,
+		private readonly devicesService: DevicesService,
+		private readonly channelsPropertiesService: ChannelsPropertiesService,
+		private readonly scenesService: ScenesService,
+	) {}
+
+	async searchEntities(query: HomeEntitySearchQuery): Promise<HomeEntitySearchResponse> {
+		const input = homeEntitySearchQuerySchema.parse(query);
+		const profile = HOME_SEARCH_LIMIT_PROFILES[input.profile];
+		const normalizedQuery = this.normalize(input.query);
+		const tokens = normalizedQuery.split(' ').filter(Boolean);
+
+		if (tokens.length === 0) {
+			throw new HomeSearchInvalidQueryError('no_search_tokens');
+		}
+		if (tokens.length > profile.maxQueryTokens) {
+			throw new HomeSearchInvalidQueryError('too_many_tokens', profile.maxQueryTokens);
+		}
+
+		const selectedKinds = input.kinds ?? [...HOME_SEARCH_ENTITY_KINDS];
+		const selectedKindSet = new Set(selectedKinds);
+		const match = tokens.map((token) => `"${token}"*`).join(' AND ');
+		const selectedSpace = input.spaceId ? await this.spacesService.findOne(input.spaceId) : null;
+
+		if (input.spaceId && !selectedSpace) {
+			throw new HomeContextSpaceNotFoundError(input.spaceId);
+		}
+
+		const scope = selectedSpace ? this.resolveSearchScope(selectedSpace) : {};
+		const propertyCategories = this.filterEnumValues(input.categories, Object.values(PropertyCategory));
+		const sceneCategories = this.filterEnumValues(input.categories, Object.values(SceneCategory));
+		const candidateLimit = profile.maxCandidatesPerKind;
+		const emptySpacePage: SpaceSearchSummaryPage = { spaces: [], total: 0 };
+		const emptyDevicePage: VisibleDeviceSearchSummaryPage = { devices: [], total: 0 };
+		const emptyPropertyPage: VisiblePropertySearchSummaryPage = { properties: [], total: 0 };
+		const emptyScenePage: SceneSearchSummaryPage = { scenes: [], total: 0 };
+		const resultQuery = selectedSpace?.type === SpaceType.MASTER ? { ...input, spaceId: undefined } : input;
+		const [spacePage, devicePage, propertyPage, scenePage] = await Promise.all([
+			selectedKindSet.has('space')
+				? this.spacesService.searchSummaryPage({
+						match,
+						rawQuery: input.query,
+						normalizedQuery,
+						normalizedTokens: tokens,
+						offset: 0,
+						limit: candidateLimit,
+						spaceIds: scope.spaceIds,
+						parentSpaceId: scope.parentSpaceId,
+						categories: input.categories,
+					})
+				: Promise.resolve(emptySpacePage),
+			selectedKindSet.has('device')
+				? this.devicesService.searchVisibleSummaryPage({
+						match,
+						rawQuery: input.query,
+						normalizedQuery,
+						normalizedTokens: tokens,
+						offset: 0,
+						limit: candidateLimit,
+						scope: scope.deviceScope,
+						roomParentId: scope.roomParentId,
+						categories: input.categories,
+					})
+				: Promise.resolve(emptyDevicePage),
+			selectedKindSet.has('property')
+				? this.channelsPropertiesService.searchVisibleSummaryPage({
+						match,
+						rawQuery: input.query,
+						normalizedQuery,
+						normalizedTokens: tokens,
+						offset: 0,
+						limit: candidateLimit,
+						scope: scope.deviceScope,
+						roomParentId: scope.roomParentId,
+						categories: propertyCategories,
+					})
+				: Promise.resolve(emptyPropertyPage),
+			selectedKindSet.has('scene')
+				? this.scenesService.searchSummaryPage({
+						match,
+						rawQuery: input.query,
+						normalizedQuery,
+						normalizedTokens: tokens,
+						offset: 0,
+						limit: candidateLimit,
+						primarySpaceIds: scope.primarySpaceIds,
+						primarySpaceId: scope.primarySpaceId,
+						primarySpaceParentId: scope.primarySpaceParentId,
+						categories: sceneCategories,
+					})
+				: Promise.resolve(emptyScenePage),
+		]);
+
+		const rankedEntities: RankedHomeEntity[] = [
+			...spacePage.spaces.map((space) => ({
+				entity: this.mapSpace(space, resultQuery),
+				rankTier: space.rankTier,
+				lexicalScore: space.lexicalScore,
+				normalizedName: this.normalize(space.name),
+				id: space.id,
+			})),
+			...devicePage.devices.map((device) => ({
+				entity: this.mapDevice(device, resultQuery),
+				rankTier: device.rankTier,
+				lexicalScore: device.lexicalScore,
+				normalizedName: this.normalize(device.name),
+				id: device.id,
+			})),
+			...propertyPage.properties.map((property) => ({
+				entity: this.mapProperty(property, resultQuery),
+				rankTier: property.rankTier,
+				lexicalScore: property.lexicalScore,
+				normalizedName: this.normalize(property.name ?? property.identifier ?? property.id),
+				id: property.id,
+			})),
+			...scenePage.scenes.map((scene) => ({
+				entity: this.mapScene(scene, resultQuery),
+				rankTier: scene.rankTier,
+				lexicalScore: scene.lexicalScore,
+				normalizedName: this.normalize(scene.name),
+				id: scene.id,
+			})),
+		].sort((left, right) => this.compareRankedEntities(left, right));
+		const entities = rankedEntities.map(({ entity }) => entity);
+		const limit = input.limit ?? profile.defaultResults;
+		const returnedEntities = entities.slice(0, limit);
+		const totalsByKind = {
+			space: spacePage.total,
+			device: devicePage.total,
+			property: propertyPage.total,
+			scene: scenePage.total,
+		};
+		const total = Object.values(totalsByKind).reduce((sum, count) => sum + count, 0);
+		const truncated = total > returnedEntities.length;
+		const result: HomeEntitySearchResponse = {
+			query: input.query,
+			entities: returnedEntities,
+			observed_at: new Date().toISOString(),
+			total,
+			returned: returnedEntities.length,
+			totals_by_kind: totalsByKind,
+			partial: false,
+			truncated,
+			refine_required: truncated,
+		};
+
+		homeEntitySearchResponseSchema.parse(result);
+
+		return result;
+	}
+
+	private mapSpace(space: SpaceSearchSummary, query: HomeEntitySearchQuery): HomeSpaceSearchResult {
+		return {
+			kind: 'space',
+			id: space.id,
+			name: space.name,
+			score: this.getScore(space.rankTier),
+			reasons: this.withFilterReasons(this.getMatchReason(space.rankTier), query),
+			type: space.type,
+			category: space.category,
+			parent_id: space.parentId,
+		};
+	}
+
+	private mapDevice(device: VisibleDeviceSearchSummary, query: HomeEntitySearchQuery): HomeDeviceSearchResult {
+		return {
+			kind: 'device',
+			id: device.id,
+			name: device.name,
+			score: this.getScore(device.rankTier),
+			reasons: this.withFilterReasons(this.getMatchReason(device.rankTier), query),
+			identifier: device.identifier,
+			category: device.category,
+			enabled: device.enabled,
+			room_id: device.roomId,
+		};
+	}
+
+	private mapProperty(property: VisiblePropertySearchSummary, query: HomeEntitySearchQuery): HomePropertySearchResult {
+		const displayName = property.name ?? property.identifier ?? property.id;
+
+		return {
+			kind: 'property',
+			id: property.id,
+			name: displayName,
+			score: this.getScore(property.rankTier),
+			reasons: this.withFilterReasons(this.getMatchReason(property.rankTier), query),
+			property_name: property.name,
+			identifier: property.identifier,
+			category: property.category,
+			data_type: property.dataType,
+			permissions: property.permissions,
+			device: {
+				id: property.deviceId,
+				name: property.deviceName,
+				enabled: property.deviceEnabled,
+			},
+			channel: {
+				id: property.channelId,
+				name: property.channelName,
+				category: property.channelCategory,
+			},
+		};
+	}
+
+	private mapScene(scene: SceneSearchSummary, query: HomeEntitySearchQuery): HomeSceneSearchResult {
+		return {
+			kind: 'scene',
+			id: scene.id,
+			name: scene.name,
+			score: this.getScore(scene.rankTier),
+			reasons: this.withFilterReasons(this.getMatchReason(scene.rankTier), query),
+			category: scene.category,
+			enabled: scene.enabled,
+			triggerable: scene.triggerable,
+			primary_space_id: scene.primarySpaceId,
+		};
+	}
+
+	private getScore(rankTier: number): number {
+		return [1000, 900, 800, 600][rankTier] ?? 500;
+	}
+
+	private getMatchReason(rankTier: number): HomeSearchMatchReason {
+		return (['exact_id', 'exact_name', 'name_prefix', 'lexical_match'] as const)[rankTier] ?? 'lexical_match';
+	}
+
+	private withFilterReasons(matchReason: HomeSearchMatchReason, query: HomeEntitySearchQuery): HomeSearchMatchReason[] {
+		return [
+			matchReason,
+			...(query.spaceId ? (['space_filter'] as const) : []),
+			...(query.categories ? (['category_filter'] as const) : []),
+		];
+	}
+
+	private compareRankedEntities(left: RankedHomeEntity, right: RankedHomeEntity): number {
+		return (
+			left.rankTier - right.rankTier ||
+			left.lexicalScore - right.lexicalScore ||
+			left.normalizedName.localeCompare(right.normalizedName) ||
+			left.id.localeCompare(right.id) ||
+			(KIND_ORDER.get(left.entity.kind) ?? 0) - (KIND_ORDER.get(right.entity.kind) ?? 0)
+		);
+	}
+
+	private filterEnumValues<T extends string>(values: string[] | undefined, allowed: T[]): T[] | undefined {
+		if (values === undefined) {
+			return undefined;
+		}
+
+		const allowedValues = new Set<string>(allowed);
+
+		return values.filter((value): value is T => allowedValues.has(value));
+	}
+
+	private resolveSearchScope(space: SpaceEntity): HomeEntitySearchScope {
+		if (space.type === SpaceType.MASTER) {
+			return {};
+		}
+		if (space.type === SpaceType.ROOM) {
+			return {
+				spaceIds: [space.id],
+				deviceScope: { roomIds: [space.id] },
+				primarySpaceId: space.id,
+			};
+		}
+		if (space.type === SpaceType.ENTRY) {
+			return {
+				spaceIds: [space.id],
+				deviceScope: { roomIds: [] },
+				primarySpaceIds: [],
+			};
+		}
+		if (space.type !== SpaceType.ZONE) {
+			return {
+				spaceIds: [space.id],
+				deviceScope: { roomIds: [] },
+				primarySpaceIds: [],
+			};
+		}
+
+		const category = (space as { category?: string | null }).category ?? null;
+
+		if (!isFloorZoneCategory(category)) {
+			return {
+				spaceIds: [space.id],
+				deviceScope: { zoneId: space.id },
+				primarySpaceId: space.id,
+			};
+		}
+
+		return {
+			spaceIds: [space.id],
+			parentSpaceId: space.id,
+			roomParentId: space.id,
+			primarySpaceId: space.id,
+			primarySpaceParentId: space.id,
+		};
+	}
+
+	private normalize(value: string): string {
+		return value
+			.normalize('NFKD')
+			.replace(/\p{M}/gu, '')
+			.toLocaleLowerCase('en-US')
+			.replace(/[^\p{L}\p{N}]+/gu, ' ')
+			.trim()
+			.replace(/\s+/g, ' ');
+	}
+}

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.ts
@@ -37,6 +37,20 @@ import {
 import { homeEntitySearchQuerySchema } from '../schemas/home-search-input.schemas';
 import { homeEntitySearchResponseSchema } from '../schemas/home-search-output.schemas';
 
+const SQLITE_UNICODE61_FOLD_OVERRIDES: Readonly<Record<string, string>> = {
+	µ: 'μ',
+	ſ: 's',
+	ς: 'σ',
+	ϐ: 'β',
+	ϑ: 'θ',
+	ϕ: 'φ',
+	ϖ: 'π',
+	ϰ: 'κ',
+	ϱ: 'ρ',
+	ϵ: 'ε',
+	ẛ: 's',
+};
+
 const KIND_ORDER = new Map<HomeSearchEntityKind, number>(HOME_SEARCH_ENTITY_KINDS.map((kind, index) => [kind, index]));
 
 interface HomeEntitySearchScope {
@@ -361,10 +375,22 @@ export class HomeSearchQueryService {
 	}
 
 	private normalize(value: string): string {
-		return value
+		const canonicalValue = value
 			.normalize('NFD')
 			.replace(/\p{M}/gu, '')
-			.toLocaleLowerCase('en-US')
+			.split('')
+			.map((character) => {
+				const codePoint = character.codePointAt(0) ?? 0;
+
+				if (codePoint >= 0x13a0 && codePoint <= 0x13f5) {
+					return character;
+				}
+
+				return SQLITE_UNICODE61_FOLD_OVERRIDES[character] ?? character.toLocaleLowerCase('en-US');
+			})
+			.join('');
+
+		return canonicalValue
 			.replace(/[^\p{L}\p{N}]+/gu, ' ')
 			.trim()
 			.replace(/\s+/g, ' ');

--- a/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
@@ -4,11 +4,90 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { SpacesService } from '../../spaces/services/spaces.service';
 import { SceneEntity } from '../entities/scenes.entity';
+import { SceneCategory } from '../scenes.constants';
 
 import { SceneActionsService } from './scene-actions.service';
 import { ScenesService } from './scenes.service';
 
 describe('ScenesService', () => {
+	it('returns bounded FTS-ranked scene metadata without excluding disabled or non-triggerable scenes', async () => {
+		const dataSource = {
+			query: jest
+				.fn()
+				.mockResolvedValueOnce([
+					{
+						id: 'scene-id',
+						name: 'Quiet evening',
+						category: 'generic',
+						enabled: 0,
+						triggerable: 0,
+						primarySpaceId: 'space-id',
+						rankTier: '0',
+						lexicalScore: '-3.25',
+					},
+				])
+				.mockResolvedValueOnce([{ total: '2' }]),
+		};
+		const service = new ScenesService(
+			{} as Repository<SceneEntity>,
+			{} as SceneActionsService,
+			{} as SpacesService,
+			dataSource as unknown as DataSource,
+			{} as EventEmitter2,
+		);
+
+		await expect(
+			service.searchSummaryPage({
+				match: '"quiet"*',
+				rawQuery: 'scene-id',
+				normalizedQuery: 'quiet',
+				offset: 1,
+				limit: 20,
+				primarySpaceId: 'floor-id',
+				primarySpaceParentId: 'floor-id',
+				categories: [SceneCategory.GENERIC],
+			}),
+		).resolves.toEqual({
+			scenes: [
+				expect.objectContaining({
+					id: 'scene-id',
+					enabled: false,
+					triggerable: false,
+					rankTier: 0,
+					lexicalScore: -3.25,
+				}),
+			],
+			total: 2,
+		});
+		const [selectSql, selectParameters] = dataSource.query.mock.calls[0] as [string, unknown[]];
+		const [countSql, countParameters] = dataSource.query.mock.calls[1] as [string, unknown[]];
+		expect(selectSql).toContain('home_context_entity_search_fts MATCH ?');
+		expect(selectSql).toContain('(scene."primarySpaceId" = ? OR scene."primarySpaceId" IN (SELECT scoped_space.id');
+		expect(selectSql).toContain('scoped_space."parentId" = ?)');
+		expect(selectSql).toContain('scene.category IN (?)');
+		expect(selectSql).not.toContain('scene.enabled = 1');
+		expect(selectSql).not.toContain('scene.triggerable = 1');
+		expect(selectSql).toContain('WHEN scene.id = ? COLLATE NOCASE THEN 0');
+		expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
+		expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(scene.name) ASC, scene.id ASC');
+		expect(selectParameters).toEqual([
+			'scene-id',
+			1,
+			'quiet',
+			1,
+			'quiet%',
+			'scene',
+			'"quiet"*',
+			'floor-id',
+			'floor-id',
+			'generic',
+			20,
+			1,
+		]);
+		expect(countSql).toContain('SELECT COUNT(*) AS total');
+		expect(countParameters).toEqual(['scene', '"quiet"*', 'floor-id', 'floor-id', 'generic']);
+	});
+
 	it('includes disabled scenes in summary queries', async () => {
 		const disabledScene = { id: 'disabled-scene', name: 'Disabled scene', enabled: false } as SceneEntity;
 		const query = {

--- a/apps/backend/src/modules/scenes/services/scenes.service.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.ts
@@ -9,13 +9,14 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger';
+import { buildSqliteFtsNameRankExpression } from '../../../common/utils/sqlite-fts.utils';
 import { toInstance } from '../../../common/utils/transform.utils';
 import { SpacesService } from '../../spaces/services/spaces.service';
 import { CreateSceneActionDto } from '../dto/create-scene-action.dto';
 import { CreateSceneDto } from '../dto/create-scene.dto';
 import { UpdateSceneDto } from '../dto/update-scene.dto';
 import { SceneEntity } from '../entities/scenes.entity';
-import { EventType, SCENES_MODULE_NAME } from '../scenes.constants';
+import { EventType, SCENES_MODULE_NAME, SceneCategory } from '../scenes.constants';
 import {
 	ScenesNotEditableException,
 	ScenesNotFoundException,
@@ -27,6 +28,35 @@ import { SceneActionsService } from './scene-actions.service';
 
 export interface SceneSummaryPage {
 	scenes: SceneEntity[];
+	total: number;
+}
+
+export interface SceneSearchSummary {
+	id: string;
+	name: string;
+	category: SceneCategory;
+	enabled: boolean;
+	triggerable: boolean;
+	primarySpaceId: string | null;
+	rankTier: number;
+	lexicalScore: number;
+}
+
+export interface SceneSearchSummaryInput {
+	match: string;
+	offset?: number;
+	limit: number;
+	rawQuery?: string;
+	normalizedQuery?: string;
+	normalizedTokens?: string[];
+	primarySpaceIds?: string[];
+	primarySpaceId?: string;
+	primarySpaceParentId?: string;
+	categories?: SceneCategory[];
+}
+
+export interface SceneSearchSummaryPage {
+	scenes: SceneSearchSummary[];
 	total: number;
 }
 
@@ -126,6 +156,103 @@ export class ScenesService {
 		const [scenes, total] = await query.getManyAndCount();
 
 		return { scenes, total };
+	}
+
+	async searchSummaryPage(input: SceneSearchSummaryInput): Promise<SceneSearchSummaryPage> {
+		if (input.limit <= 0 || input.primarySpaceIds?.length === 0 || input.categories?.length === 0) {
+			return { scenes: [], total: 0 };
+		}
+
+		const predicates = ['home_context_entity_search_fts.entity_kind = ?', 'home_context_entity_search_fts MATCH ?'];
+		const parameters: Array<string | number> = ['scene', input.match];
+
+		const spacePredicates: string[] = [];
+
+		if (input.primarySpaceIds) {
+			spacePredicates.push(`scene."primarySpaceId" IN (${input.primarySpaceIds.map(() => '?').join(', ')})`);
+			parameters.push(...input.primarySpaceIds);
+		}
+
+		if (input.primarySpaceId) {
+			spacePredicates.push('scene."primarySpaceId" = ?');
+			parameters.push(input.primarySpaceId);
+		}
+
+		if (input.primarySpaceParentId) {
+			spacePredicates.push(
+				'scene."primarySpaceId" IN (SELECT scoped_space.id FROM spaces_module_spaces scoped_space ' +
+					'WHERE scoped_space."parentId" = ?)',
+			);
+			parameters.push(input.primarySpaceParentId);
+		}
+
+		if (spacePredicates.length > 0) {
+			predicates.push(`(${spacePredicates.join(' OR ')})`);
+		}
+
+		if (input.categories) {
+			predicates.push(`scene.category IN (${input.categories.map(() => '?').join(', ')})`);
+			parameters.push(...input.categories);
+		}
+
+		interface SceneSearchRow extends Omit<SceneSearchSummary, 'enabled' | 'triggerable' | 'rankTier' | 'lexicalScore'> {
+			enabled: boolean | number;
+			triggerable: boolean | number;
+			rankTier: string | number;
+			lexicalScore: string | number;
+		}
+
+		interface CountRow {
+			total: string | number;
+		}
+
+		const where = predicates.join('\n AND ');
+		const rank = buildSqliteFtsNameRankExpression({
+			ftsTable: 'home_context_entity_search_fts',
+			vocabularyTable: 'home_context_entity_search_vocab',
+			entityIdExpression: 'scene.id',
+			rawQuery: input.rawQuery,
+			normalizedQuery: input.normalizedQuery,
+			normalizedTokens: input.normalizedTokens,
+		});
+		const [rows, countRows] = await Promise.all([
+			this.dataSource.query<SceneSearchRow[]>(
+				`SELECT scene.id AS id,
+				        scene.name AS name,
+				        scene.category AS category,
+				        scene.enabled AS enabled,
+				        scene.triggerable AS triggerable,
+				        scene."primarySpaceId" AS "primarySpaceId",
+				        ${rank.sql} AS "rankTier",
+				        bm25(home_context_entity_search_fts) AS "lexicalScore"
+				 FROM home_context_entity_search_fts
+				 INNER JOIN scenes_module_scenes scene
+				   ON scene.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}
+				 ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(scene.name) ASC, scene.id ASC
+				 LIMIT ? OFFSET ?`,
+				[...rank.parameters, ...parameters, input.limit, input.offset ?? 0],
+			),
+			this.dataSource.query<CountRow[]>(
+				`SELECT COUNT(*) AS total
+				 FROM home_context_entity_search_fts
+				 INNER JOIN scenes_module_scenes scene
+				   ON scene.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}`,
+				parameters,
+			),
+		]);
+
+		return {
+			scenes: rows.map((row) => ({
+				...row,
+				enabled: Boolean(row.enabled),
+				triggerable: Boolean(row.triggerable),
+				rankTier: Number(row.rankTier),
+				lexicalScore: Number(row.lexicalScore),
+			})),
+			total: Number(countRows[0]?.total ?? 0),
+		};
 	}
 
 	async findTriggerableSummaryPage(limit: number): Promise<SceneSummaryPage> {

--- a/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.spec.ts
@@ -583,6 +583,91 @@ describe('SpacesService', () => {
 		});
 	});
 
+	describe('searchSummaryPage', () => {
+		it('returns bounded FTS-ranked metadata with type, category, and scope filters', async () => {
+			dataSourceQueryMock
+				.mockResolvedValueOnce([
+					{
+						id: mockSpace.id,
+						name: mockSpace.name,
+						type: SpaceType.ROOM,
+						category: SpaceRoomCategory.LIVING_ROOM,
+						parentId: 'floor-id',
+						rankTier: '1',
+						lexicalScore: '-2.5',
+					},
+				])
+				.mockResolvedValueOnce([{ total: '3' }]);
+
+			await expect(
+				service.searchSummaryPage({
+					match: '"living"*',
+					rawQuery: ' Living%Room_ ',
+					normalizedQuery: 'living%room_',
+					offset: 2,
+					limit: 20,
+					spaceIds: [mockSpace.id],
+					parentSpaceId: 'floor-id',
+					types: [SpaceType.ROOM],
+					categories: [SpaceRoomCategory.LIVING_ROOM],
+				}),
+			).resolves.toEqual({
+				spaces: [
+					expect.objectContaining({
+						id: mockSpace.id,
+						category: SpaceRoomCategory.LIVING_ROOM,
+						rankTier: 1,
+						lexicalScore: -2.5,
+					}),
+				],
+				total: 3,
+			});
+			const [selectSql, selectParameters] = dataSourceQueryMock.mock.calls[0] as [string, unknown[]];
+			const [countSql, countParameters] = dataSourceQueryMock.mock.calls[1] as [string, unknown[]];
+			expect(selectSql).toContain('home_context_entity_search_fts MATCH ?');
+			expect(selectSql).toContain('(space.id IN (?) OR space."parentId" = ?)');
+			expect(selectSql).toContain('space.type IN (?)');
+			expect(selectSql).toContain('space.category IN (?)');
+			expect(selectSql).toContain('WHEN space.id = ? COLLATE NOCASE THEN 0');
+			expect(selectSql).toContain('FROM home_context_entity_search_vocab exact_count');
+			expect(selectSql).toContain('FROM home_context_entity_search_vocab prefix_term');
+			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(space.name) ASC, space.id ASC');
+			expect(selectSql).toContain('LIMIT ? OFFSET ?');
+			expect(selectParameters).toEqual([
+				'Living%Room_',
+				1,
+				'living%room_',
+				1,
+				'living\\%room\\_%',
+				'space',
+				'"living"*',
+				mockSpace.id,
+				'floor-id',
+				SpaceType.ROOM,
+				SpaceRoomCategory.LIVING_ROOM,
+				20,
+				2,
+			]);
+			expect(countSql).toContain('SELECT COUNT(*) AS total');
+			expect(countParameters).toEqual([
+				'space',
+				'"living"*',
+				mockSpace.id,
+				'floor-id',
+				SpaceType.ROOM,
+				SpaceRoomCategory.LIVING_ROOM,
+			]);
+		});
+
+		it('does not query an explicitly empty scope', async () => {
+			await expect(service.searchSummaryPage({ match: 'living', limit: 20, spaceIds: [] })).resolves.toEqual({
+				spaces: [],
+				total: 0,
+			});
+			expect(dataSourceQueryMock).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('findLightingTriggerSummaryPage', () => {
 		it('returns only bounded spaces with enabled visible writable lighting targets', async () => {
 			const onlineDevice = { id: 'device-1' } as DeviceEntity;

--- a/apps/backend/src/modules/spaces/services/spaces.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces.service.ts
@@ -8,6 +8,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger';
+import { buildSqliteFtsNameRankExpression } from '../../../common/utils/sqlite-fts.utils';
 import { toInstance } from '../../../common/utils/transform.utils';
 import {
 	ChannelCategory,
@@ -54,6 +55,34 @@ export interface SpaceSnapshotScope {
 
 export interface SpaceSummaryPage {
 	spaces: SpaceEntity[];
+	total: number;
+}
+
+export interface SpaceSearchSummary {
+	id: string;
+	name: string;
+	type: SpaceType;
+	category: string | null;
+	parentId: string | null;
+	rankTier: number;
+	lexicalScore: number;
+}
+
+export interface SpaceSearchSummaryInput {
+	match: string;
+	offset?: number;
+	limit: number;
+	rawQuery?: string;
+	normalizedQuery?: string;
+	normalizedTokens?: string[];
+	spaceIds?: string[];
+	parentSpaceId?: string;
+	types?: SpaceType[];
+	categories?: string[];
+}
+
+export interface SpaceSearchSummaryPage {
+	spaces: SpaceSearchSummary[];
 	total: number;
 }
 
@@ -132,6 +161,100 @@ export class SpacesService {
 			.getManyAndCount();
 
 		return { spaces, total };
+	}
+
+	async searchSummaryPage(input: SpaceSearchSummaryInput): Promise<SpaceSearchSummaryPage> {
+		if (
+			input.limit <= 0 ||
+			input.spaceIds?.length === 0 ||
+			input.types?.length === 0 ||
+			input.categories?.length === 0
+		) {
+			return { spaces: [], total: 0 };
+		}
+
+		const predicates = ['home_context_entity_search_fts.entity_kind = ?', 'home_context_entity_search_fts MATCH ?'];
+		const parameters: Array<string | number> = ['space', input.match];
+
+		const scopePredicates: string[] = [];
+
+		if (input.spaceIds) {
+			scopePredicates.push(`space.id IN (${input.spaceIds.map(() => '?').join(', ')})`);
+			parameters.push(...input.spaceIds);
+		}
+
+		if (input.parentSpaceId) {
+			scopePredicates.push('space."parentId" = ?');
+			parameters.push(input.parentSpaceId);
+		}
+
+		if (scopePredicates.length > 0) {
+			predicates.push(`(${scopePredicates.join(' OR ')})`);
+		}
+
+		if (input.types) {
+			predicates.push(`space.type IN (${input.types.map(() => '?').join(', ')})`);
+			parameters.push(...input.types);
+		}
+
+		if (input.categories) {
+			predicates.push(`space.category IN (${input.categories.map(() => '?').join(', ')})`);
+			parameters.push(...input.categories);
+		}
+
+		interface SpaceSearchRow extends Omit<SpaceSearchSummary, 'rankTier' | 'lexicalScore'> {
+			rankTier: string | number;
+			lexicalScore: string | number;
+		}
+
+		interface CountRow {
+			total: string | number;
+		}
+
+		const where = predicates.join('\n AND ');
+		const rank = buildSqliteFtsNameRankExpression({
+			ftsTable: 'home_context_entity_search_fts',
+			vocabularyTable: 'home_context_entity_search_vocab',
+			entityIdExpression: 'space.id',
+			rawQuery: input.rawQuery,
+			normalizedQuery: input.normalizedQuery,
+			normalizedTokens: input.normalizedTokens,
+		});
+		const [rows, countRows] = await Promise.all([
+			this.dataSource.query<SpaceSearchRow[]>(
+				`SELECT space.id AS id,
+				        space.name AS name,
+				        space.type AS type,
+				        space.category AS category,
+				        space."parentId" AS "parentId",
+				        ${rank.sql} AS "rankTier",
+				        bm25(home_context_entity_search_fts) AS "lexicalScore"
+				 FROM home_context_entity_search_fts
+				 INNER JOIN spaces_module_spaces space
+				   ON space.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}
+				 ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(space.name) ASC, space.id ASC
+				 LIMIT ? OFFSET ?`,
+				[...rank.parameters, ...parameters, input.limit, input.offset ?? 0],
+			),
+			this.dataSource.query<CountRow[]>(
+				`SELECT COUNT(*) AS total
+				 FROM home_context_entity_search_fts
+				 INNER JOIN spaces_module_spaces space
+				   ON space.id = home_context_entity_search_fts.entity_id
+				 WHERE ${where}`,
+				parameters,
+			),
+		]);
+
+		return {
+			spaces: rows.map((row) => ({
+				...row,
+				rankTier: Number(row.rankTier),
+				lexicalScore: Number(row.lexicalScore),
+			})),
+			total: Number(countRows[0]?.total ?? 0),
+		};
 	}
 
 	async findLightingTriggerSummaryPage(limit: number): Promise<SpaceSummaryPage> {

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1221,7 +1221,11 @@ captured as an opt-in/expected baseline measurement rather than a failing normal
 - [x] Keep MCP installation identity, auth, policy, auditing, request envelope, and transport deadlines in MCP.
 - [x] Extract the existing MCP-compatible writable/trigger discovery logic from the MCP tool adapter; query, space,
       category, and capability filters remain part of the bounded search task below.
-- [ ] Add database-bounded lexical/entity search and safe filtered/aggregate state queries.
+- [x] Add database-bounded metadata-only lexical/entity search with fixed query count, bounded candidates/results,
+      SQL-applied visibility, space and category filters, deterministic ranking, exact totals, and explicit
+      truncation/refinement metadata. Search results do not include live values or authorize actions.
+- [ ] Add cursor pagination and static candidate-capability filters to metadata search before exposing it as a Buddy tool.
+- [ ] Add safe filtered/aggregate current-state queries.
 - [ ] Add a bounded `PropertyValueService` batch/aggregate contract for current-value predicates and aggregates. Resolve
       eligible metadata in the database, reconcile cache/storage values in chunks, short-circuit only sound outcomes,
       and return eligible/evaluated/unknown/freshness/partial metadata when completeness cannot be established.


### PR DESCRIPTION
> 👍 Codex review passed on commit `59932863e6` with no major issues.

## Summary
- add a transactional SQLite FTS5 catalog index for spaces, devices, properties, and scenes, including backfill and synchronization triggers
- add bounded provider-neutral metadata search with strict profiles and schemas, exact totals, deterministic rank tiers, and truncation/refinement metadata
- apply visibility, category, and room/zone/floor/entry scope filtering in SQL without loading the full catalog or property values

## Safety and compatibility
- hidden devices and property owners are excluded; disabled devices and scenes remain readable metadata
- search results contain no live values or status and do not authorize actions
- no Buddy or MCP transport is exposed in this slice; cursor/capability filters and live aggregates remain follow-up work
- Unicode ranking follows the configured SQLite `unicode61` tokenizer, including diacritics, compatibility characters, and special case folds

## Validation
- `pnpm --filter ./apps/backend run type-check`
- focused Jest: 8 suites / 157 tests
- focused ESLint and Prettier
- real SQLite: FTS5/diacritics/triggers/rollback, >100-device discovery, >21 exact-name ranking, nullable-name fallback, Unicode tokenizer alignment, and scoped/category/visibility cases
- dependency audit remains at the existing 12-cycle baseline