### PR TITLE
feat(backend): expose Homey runtime health

### DIFF
--- a/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
@@ -1,3 +1,5 @@
+import { instanceToPlain } from 'class-transformer';
+
 import { HomeyConnectionState } from '../devices-homey.constants';
 import { HomeyStatusModel } from '../models/status.model';
 import { HomeyService } from '../services/homey.service';
@@ -12,6 +14,15 @@ describe('HomeyStatusController', () => {
 			enabled: true,
 			configured: true,
 			healthy: false,
+			degraded: false,
+			homeyId: 'homey-system',
+			homeyName: 'Homey Pro',
+			homeyVersion: '12.4.1',
+			lastConnectedAt: '2026-08-15T10:00:00.000Z',
+			lastInventorySyncAt: '2026-08-15T10:00:01.000Z',
+			lastEventAt: '2026-08-15T10:00:02.000Z',
+			reconnectCount: 1,
+			lastErrorCategory: null,
 			lastError: null,
 		});
 		const service = { getStatus: jest.fn().mockReturnValue(status) };
@@ -21,7 +32,19 @@ describe('HomeyStatusController', () => {
 
 		expect(response.data).toBe(status);
 		expect(service.getStatus).toHaveBeenCalledTimes(1);
-		expect(JSON.stringify(response)).not.toContain('api_key');
-		expect(JSON.stringify(response)).not.toContain('configured-secret');
+		const serialized = instanceToPlain(response);
+
+		expect(serialized.data).toMatchObject({
+			homey_id: 'homey-system',
+			homey_name: 'Homey Pro',
+			homey_version: '12.4.1',
+			last_connected_at: '2026-08-15T10:00:00.000Z',
+			last_inventory_sync_at: '2026-08-15T10:00:01.000Z',
+			last_event_at: '2026-08-15T10:00:02.000Z',
+			reconnect_count: 1,
+			last_error_category: null,
+		});
+		expect(JSON.stringify(serialized)).not.toContain('api_key');
+		expect(JSON.stringify(serialized)).not.toContain('configured-secret');
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/models/status.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/status.model.ts
@@ -1,11 +1,12 @@
 import { Expose } from 'class-transformer';
-import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDateString, IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 import { ServiceState } from '../../../modules/extensions/services/managed-plugin-service.interface';
 import { HomeyConnectionState } from '../devices-homey.constants';
+import { HomeyConnectorErrorCategory } from '../errors/homey-connector.error';
 
 @ApiSchema({ name: 'DevicesHomeyPluginDataStatus' })
 export class HomeyStatusModel {
@@ -41,6 +42,76 @@ export class HomeyStatusModel {
 	@Expose()
 	@IsBoolean()
 	healthy: boolean;
+
+	@ApiProperty({ description: 'Whether event delivery is unavailable while polling remains operational' })
+	@Expose()
+	@IsBoolean()
+	degraded: boolean;
+
+	@ApiPropertyOptional({ description: 'Connected Homey identifier', nullable: true, name: 'homey_id' })
+	@Expose({ name: 'homey_id' })
+	@IsOptional()
+	@IsString()
+	homeyId: string | null;
+
+	@ApiPropertyOptional({ description: 'Connected Homey display name', nullable: true, name: 'homey_name' })
+	@Expose({ name: 'homey_name' })
+	@IsOptional()
+	@IsString()
+	homeyName: string | null;
+
+	@ApiPropertyOptional({ description: 'Connected Homey software version', nullable: true, name: 'homey_version' })
+	@Expose({ name: 'homey_version' })
+	@IsOptional()
+	@IsString()
+	homeyVersion: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Timestamp of the last successful transport connection',
+		nullable: true,
+		name: 'last_connected_at',
+	})
+	@Expose({ name: 'last_connected_at' })
+	@IsOptional()
+	@IsDateString()
+	lastConnectedAt: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Timestamp of the last successful authoritative inventory synchronization',
+		nullable: true,
+		name: 'last_inventory_sync_at',
+	})
+	@Expose({ name: 'last_inventory_sync_at' })
+	@IsOptional()
+	@IsDateString()
+	lastInventorySyncAt: string | null;
+
+	@ApiPropertyOptional({
+		description: 'Timestamp of the last successfully processed Homey event',
+		nullable: true,
+		name: 'last_event_at',
+	})
+	@Expose({ name: 'last_event_at' })
+	@IsOptional()
+	@IsDateString()
+	lastEventAt: string | null;
+
+	@ApiProperty({ description: 'Reconnect attempts executed since the last explicit start', name: 'reconnect_count' })
+	@Expose({ name: 'reconnect_count' })
+	@IsInt()
+	@Min(0)
+	reconnectCount: number;
+
+	@ApiPropertyOptional({
+		description: 'Normalized category for the current sanitized connector error',
+		enum: HomeyConnectorErrorCategory,
+		nullable: true,
+		name: 'last_error_category',
+	})
+	@Expose({ name: 'last_error_category' })
+	@IsOptional()
+	@IsEnum(HomeyConnectorErrorCategory)
+	lastErrorCategory: HomeyConnectorErrorCategory | null;
 
 	@ApiPropertyOptional({
 		description: 'Sanitized service error summary',

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -22,6 +22,8 @@ import { HomeyZone } from '../models/homey-zone.model';
 
 import { HomeyService } from './homey.service';
 
+const INITIAL_TIME = new Date('2026-08-15T10:00:00.000Z');
+
 const systemInfo: HomeySystemInfo = {
 	id: 'homey-system',
 	name: 'Homey Pro',
@@ -67,6 +69,21 @@ function createConnectorMock(onSubscribe: (listener: HomeyEventListener) => void
 	} satisfies jest.Mocked<HomeyConnector>;
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = (): void => undefined;
+	const promise = new Promise<void>((nextResolve) => {
+		resolve = nextResolve;
+	});
+
+	return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+	for (let index = 0; index < 10; index += 1) {
+		await Promise.resolve();
+	}
+}
+
 describe('HomeyService', () => {
 	let config: HomeyConfigModel;
 	let configService: jest.Mocked<Pick<ConfigService, 'getPluginConfig'>>;
@@ -78,6 +95,7 @@ describe('HomeyService', () => {
 
 	beforeEach(() => {
 		jest.useFakeTimers();
+		jest.setSystemTime(INITIAL_TIME);
 		jest.spyOn(Math, 'random').mockReturnValue(0.5);
 		listener = null;
 		unsubscribe = jest.fn();
@@ -142,7 +160,18 @@ describe('HomeyService', () => {
 		});
 		expect(service.getState()).toBe('started');
 		expect(await service.isHealthy()).toBe(true);
-		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.CONNECTED,
+			degraded: false,
+			homeyId: systemInfo.id,
+			homeyName: systemInfo.name,
+			homeyVersion: systemInfo.version,
+			lastConnectedAt: INITIAL_TIME.toISOString(),
+			lastInventorySyncAt: INITIAL_TIME.toISOString(),
+			lastEventAt: null,
+			reconnectCount: 0,
+			lastErrorCategory: null,
+		});
 
 		await service.stop();
 		await service.stop();
@@ -151,6 +180,121 @@ describe('HomeyService', () => {
 		expect(connector.disconnect.mock.calls).toHaveLength(1);
 		expect(service.getState()).toBe('stopped');
 		expect(await service.isHealthy()).toBe(false);
+	});
+
+	it('tracks successful events and exposes every lifecycle transition', async () => {
+		const connect = deferred();
+		connector.connect.mockReturnValueOnce(connect.promise);
+		const start = service.start();
+
+		await flushMicrotasks();
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'starting',
+			connectionState: HomeyConnectionState.CONNECTING,
+		});
+
+		connect.resolve();
+		await start;
+		jest.setSystemTime(new Date('2026-08-15T10:01:00.000Z'));
+		await listener?.({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: null,
+		});
+
+		expect(service.getStatus().lastEventAt).toBe('2026-08-15T10:01:00.000Z');
+
+		const disconnect = deferred();
+		connector.disconnect.mockReturnValueOnce(disconnect.promise);
+		const stop = service.stop();
+		await flushMicrotasks();
+
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'stopping',
+			connectionState: HomeyConnectionState.STOPPED,
+		});
+
+		disconnect.resolve();
+		await stop;
+		expect(service.getStatus().serviceState).toBe('stopped');
+	});
+
+	it('keeps authoritative inventory available in degraded polling mode', async () => {
+		connector.subscribe.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNSUPPORTED, HomeyConnectorOperation.SUBSCRIBE),
+		);
+
+		await service.start();
+
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'started',
+			connectionState: HomeyConnectionState.DEGRADED_POLLING,
+			healthy: false,
+			degraded: true,
+			lastInventorySyncAt: INITIAL_TIME.toISOString(),
+			lastErrorCategory: HomeyConnectorErrorCategory.UNSUPPORTED,
+			lastError: 'Homey event subscription is unavailable; polling is active',
+		});
+		expect(jest.getTimerCount()).toBe(1);
+
+		jest.setSystemTime(new Date('2026-08-15T10:05:00.000Z'));
+		await jest.advanceTimersByTimeAsync(config.reconciliationInterval);
+
+		expect(connector.getDevices.mock.calls).toHaveLength(2);
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.DEGRADED_POLLING,
+			degraded: true,
+			lastInventorySyncAt: '2026-08-15T10:10:00.000Z',
+			reconnectCount: 0,
+		});
+
+		await service.stop();
+	});
+
+	it('reconnects from transient degraded polling and counts the executed attempt', async () => {
+		const replacementConnector = createConnectorMock(() => undefined, jest.fn());
+		connector.subscribe.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.SUBSCRIBE),
+		);
+		connectorFactory.create.mockReset().mockReturnValueOnce(connector).mockReturnValueOnce(replacementConnector);
+
+		await service.start();
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.DEGRADED_POLLING,
+			degraded: true,
+			reconnectCount: 0,
+			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
+		});
+		expect(jest.getTimerCount()).toBe(2);
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.CONNECTED,
+			healthy: true,
+			degraded: false,
+			lastConnectedAt: '2026-08-15T10:00:01.000Z',
+			reconnectCount: 1,
+			lastErrorCategory: null,
+		});
+
+		await service.stop();
+	});
+
+	it('fails closed when event subscription lacks authorization', async () => {
+		connector.subscribe.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHORIZATION, HomeyConnectorOperation.SUBSCRIBE),
+		);
+
+		await expect(service.start()).rejects.toThrow('Homey authentication or authorization failed');
+		expect(service.getStatus()).toMatchObject({
+			serviceState: 'error',
+			connectionState: HomeyConnectionState.AUTHENTICATION_FAILED,
+			degraded: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.AUTHORIZATION,
+		});
 	});
 
 	it('recovers from a retryable initial startup failure without a config change', async () => {
@@ -166,6 +310,8 @@ describe('HomeyService', () => {
 			serviceState: 'started',
 			connectionState: HomeyConnectionState.RECONNECTING,
 			healthy: false,
+			reconnectCount: 0,
+			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
 			lastError: 'Homey connection is temporarily unavailable',
 		});
 		expect(jest.getTimerCount()).toBe(1);
@@ -177,6 +323,8 @@ describe('HomeyService', () => {
 			serviceState: 'started',
 			connectionState: HomeyConnectionState.CONNECTED,
 			healthy: true,
+			reconnectCount: 1,
+			lastErrorCategory: null,
 			lastError: null,
 		});
 
@@ -282,6 +430,10 @@ describe('HomeyService', () => {
 		}
 
 		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
+		expect(service.getStatus()).toMatchObject({
+			lastInventorySyncAt: INITIAL_TIME.toISOString(),
+			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
+		});
 		expect(jest.getTimerCount()).toBe(1);
 
 		await jest.advanceTimersByTimeAsync(1000);
@@ -314,6 +466,8 @@ describe('HomeyService', () => {
 		expect(service.getStatus()).toMatchObject({
 			connectionState: HomeyConnectionState.RECONNECTING,
 			healthy: false,
+			lastEventAt: null,
+			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
 			lastError: 'Homey connection is temporarily unavailable',
 		});
 		expect(jest.getTimerCount()).toBe(1);
@@ -371,7 +525,10 @@ describe('HomeyService', () => {
 
 		expect(connectorFactory.create.mock.calls).toHaveLength(3);
 		expect(recoveredConnector.connect.mock.calls).toHaveLength(1);
-		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.CONNECTED,
+			reconnectCount: 2,
+		});
 
 		await service.stop();
 	});
@@ -427,6 +584,7 @@ describe('HomeyService', () => {
 		expect(service.getStatus()).toMatchObject({
 			connectionState: HomeyConnectionState.AUTHENTICATION_FAILED,
 			healthy: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.AUTHORIZATION,
 			lastError: 'Homey authentication or authorization failed',
 		});
 		expect(jest.getTimerCount()).toBe(0);
@@ -549,6 +707,7 @@ describe('HomeyService', () => {
 			serviceState: 'error',
 			connectionState: HomeyConnectionState.AUTHENTICATION_FAILED,
 			healthy: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.AUTHENTICATION,
 			lastError: 'Homey authentication or authorization failed',
 		});
 	});
@@ -584,6 +743,7 @@ describe('HomeyService', () => {
 		expect(service.getStatus()).toMatchObject({
 			connectionState: HomeyConnectionState.ERROR,
 			healthy: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.UNSUPPORTED,
 			lastError: 'Homey service failed to start',
 		});
 	});
@@ -593,7 +753,11 @@ describe('HomeyService', () => {
 
 		await expect(service.start()).rejects.toThrow('Homey service failed to start');
 		expect(connectorFactory.create.mock.calls).toHaveLength(0);
-		expect(service.getStatus()).toMatchObject({ configured: false, healthy: false });
+		expect(service.getStatus()).toMatchObject({
+			configured: false,
+			healthy: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.VALIDATION,
+		});
 	});
 
 	it('reports configuration without exposing its URL or API key', () => {
@@ -605,6 +769,15 @@ describe('HomeyService', () => {
 			enabled: true,
 			configured: true,
 			healthy: false,
+			degraded: false,
+			homeyId: null,
+			homeyName: null,
+			homeyVersion: null,
+			lastConnectedAt: null,
+			lastInventorySyncAt: null,
+			lastEventAt: null,
+			reconnectCount: 0,
+			lastErrorCategory: null,
 			lastError: null,
 		});
 		expect(status).not.toHaveProperty('apiKey');

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -13,7 +13,11 @@ import {
 	HOMEY_CONNECTOR_FACTORY,
 	HomeyConnectionState,
 } from '../devices-homey.constants';
-import { HomeyConnectorError, HomeyConnectorErrorCategory } from '../errors/homey-connector.error';
+import {
+	HomeyConnectorError,
+	HomeyConnectorErrorCategory,
+	HomeyConnectorOperation,
+} from '../errors/homey-connector.error';
 import { HomeyConfigModel } from '../models/config.model';
 import { HomeyDevice } from '../models/homey-device.model';
 import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
@@ -37,6 +41,7 @@ export class HomeyService extends BaseManagedPluginService {
 	private connector: HomeyConnector | null = null;
 	private unsubscribe: HomeyUnsubscribe | null = null;
 	private systemInfo: HomeySystemInfo | null = null;
+	private lastSystemInfo: HomeySystemInfo | null = null;
 	private zones: readonly HomeyZone[] = [];
 	private devices = new Map<string, HomeyDevice>();
 	private startupEvents: HomeyEvent[] | null = null;
@@ -45,6 +50,11 @@ export class HomeyService extends BaseManagedPluginService {
 	private reconciliationTimer: ReturnType<typeof setTimeout> | null = null;
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private reconnectAttempt = 0;
+	private reconnectCount = 0;
+	private lastConnectedAt: string | null = null;
+	private lastInventorySyncAt: string | null = null;
+	private lastEventAt: string | null = null;
+	private lastErrorCategory: HomeyConnectorErrorCategory | null = null;
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -66,6 +76,7 @@ export class HomeyService extends BaseManagedPluginService {
 			this.state = 'starting';
 			this.pluginConfig = null;
 			this.resetReconnectState();
+			this.resetRuntimeHealth();
 			this.lastError = null;
 			this.healthy = false;
 			this.connectionState = HomeyConnectionState.CONNECTING;
@@ -77,13 +88,18 @@ export class HomeyService extends BaseManagedPluginService {
 				this.connector = connector;
 
 				await connector.connect();
-				await this.synchronizeStartup(connector, generation);
+				this.recordSuccessfulConnection();
+				const subscriptionFailure = await this.synchronizeStartup(connector, generation);
 
 				this.state = 'started';
-				this.connectionState = HomeyConnectionState.CONNECTED;
-				this.healthy = true;
-				this.scheduleReconciliation(generation);
-				this.logger.log('Homey connector started and initial inventory synchronized');
+
+				if (subscriptionFailure) {
+					this.markRuntimeDegraded(subscriptionFailure, generation);
+					this.logger.warn('Homey inventory synchronized with event delivery unavailable');
+				} else {
+					this.markRuntimeHealthy(connector, generation);
+					this.logger.log('Homey connector started and initial inventory synchronized');
+				}
 			} catch (error) {
 				this.applyFailureState(error, 'Homey service failed to start');
 				const retryable = this.isRetryableFailure(error);
@@ -127,6 +143,7 @@ export class HomeyService extends BaseManagedPluginService {
 			if (!cleaned) {
 				this.state = 'error';
 				this.lastError = 'Homey service failed to stop';
+				this.lastErrorCategory = null;
 				this.logger.error(this.lastError);
 
 				throw new Error(this.lastError);
@@ -134,6 +151,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 			this.state = 'stopped';
 			this.lastError = null;
+			this.lastErrorCategory = null;
 			this.logger.log('Homey connector stopped');
 		});
 	}
@@ -169,6 +187,15 @@ export class HomeyService extends BaseManagedPluginService {
 		status.enabled = config.enabled;
 		status.configured = this.isConfigured(config);
 		status.healthy = this.healthy;
+		status.degraded = this.connectionState === HomeyConnectionState.DEGRADED_POLLING;
+		status.homeyId = this.lastSystemInfo?.id ?? null;
+		status.homeyName = this.lastSystemInfo?.name ?? null;
+		status.homeyVersion = this.lastSystemInfo?.version ?? null;
+		status.lastConnectedAt = this.lastConnectedAt;
+		status.lastInventorySyncAt = this.lastInventorySyncAt;
+		status.lastEventAt = this.lastEventAt;
+		status.reconnectCount = this.reconnectCount;
+		status.lastErrorCategory = this.lastErrorCategory;
 		status.lastError = this.lastError;
 
 		return status;
@@ -184,11 +211,11 @@ export class HomeyService extends BaseManagedPluginService {
 
 	private createConnector(config: HomeyConfigModel): HomeyConnector {
 		if (!this.isConfigured(config)) {
-			throw new Error('Homey connector configuration is incomplete');
+			throw new HomeyConnectorError(HomeyConnectorErrorCategory.VALIDATION, HomeyConnectorOperation.CONNECT);
 		}
 
 		if (!this.connectorFactory) {
-			throw new Error('Homey connector transport is not available');
+			throw new HomeyConnectorError(HomeyConnectorErrorCategory.UNSUPPORTED, HomeyConnectorOperation.CONNECT);
 		}
 
 		return this.connectorFactory.create({
@@ -198,16 +225,36 @@ export class HomeyService extends BaseManagedPluginService {
 		});
 	}
 
-	private async synchronizeStartup(connector: HomeyConnector, generation: number): Promise<void> {
+	private async synchronizeStartup(connector: HomeyConnector, generation: number): Promise<HomeyConnectorError | null> {
 		this.systemInfo = await connector.getSystemInfo();
+		this.lastSystemInfo = this.systemInfo;
 		this.zones = await connector.getZones();
 		this.startupEvents = [];
-		this.unsubscribe = await connector.subscribe((event) => this.onConnectorEvent(connector, generation, event));
+		let subscriptionFailure: HomeyConnectorError | null = null;
+
+		try {
+			this.unsubscribe = await connector.subscribe((event) => this.onConnectorEvent(connector, generation, event));
+		} catch (error) {
+			this.startupEvents = null;
+
+			if (!this.isDegradableSubscriptionFailure(error)) {
+				throw error;
+			}
+
+			subscriptionFailure = error;
+		}
 
 		await this.enqueueSynchronization(async () => {
 			this.replaceDevices(await connector.getDevices());
-			await this.reconcileStartupEvents(connector, generation);
+
+			if (this.startupEvents) {
+				await this.reconcileStartupEvents(connector, generation);
+			}
+
+			this.recordSuccessfulInventorySync(connector, generation);
 		});
+
+		return subscriptionFailure;
 	}
 
 	private async reconcileStartupEvents(connector: HomeyConnector, generation: number): Promise<void> {
@@ -284,6 +331,10 @@ export class HomeyService extends BaseManagedPluginService {
 				this.devices.delete(deviceId);
 			}
 		}
+
+		if (events.length > 0 && this.isCurrentGeneration(connector, generation)) {
+			this.lastEventAt = this.now();
+		}
 	}
 
 	private isZoneEvent(event: HomeyEvent): boolean {
@@ -303,7 +354,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 		const interval = this.pluginConfig?.reconciliationInterval;
 
-		if (!interval || this.reconnectTimer) {
+		if (!interval || (this.reconnectTimer !== null && this.connectionState !== HomeyConnectionState.DEGRADED_POLLING)) {
 			return;
 		}
 
@@ -338,7 +389,14 @@ export class HomeyService extends BaseManagedPluginService {
 
 				this.zones = zonesResult.value;
 				this.replaceDevices(devicesResult.value);
-				this.markRuntimeHealthy(connector, generation);
+				this.recordSuccessfulInventorySync(connector, generation);
+
+				if (this.unsubscribe) {
+					this.markRuntimeHealthy(connector, generation);
+				} else {
+					this.connectionState = HomeyConnectionState.DEGRADED_POLLING;
+					this.healthy = false;
+				}
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
 					this.handleRuntimeFailure(error, 'Homey inventory reconciliation failed', generation);
@@ -347,18 +405,24 @@ export class HomeyService extends BaseManagedPluginService {
 			}
 		});
 
-		if (this.isCurrentGeneration(connector, generation) && this.state === 'started' && this.reconnectTimer === null) {
+		if (
+			this.isCurrentGeneration(connector, generation) &&
+			this.state === 'started' &&
+			(this.reconnectTimer === null || this.connectionState === HomeyConnectionState.DEGRADED_POLLING)
+		) {
 			this.scheduleReconciliation(generation);
 		}
 	}
 
-	private scheduleReconnect(generation: number): void {
+	private scheduleReconnect(generation: number, preserveDegradedPolling = false): void {
 		if (this.reconnectTimer || this.state !== 'started' || this.generation !== generation) {
 			return;
 		}
 
-		this.clearReconciliationTimer();
-		this.connectionState = HomeyConnectionState.RECONNECTING;
+		if (!preserveDegradedPolling) {
+			this.clearReconciliationTimer();
+			this.connectionState = HomeyConnectionState.RECONNECTING;
+		}
 		this.healthy = false;
 		const delay = calculateHomeyReconnectDelay(this.reconnectAttempt);
 		this.reconnectAttempt += 1;
@@ -376,10 +440,12 @@ export class HomeyService extends BaseManagedPluginService {
 
 			this.connectionState = HomeyConnectionState.RECONNECTING;
 			this.healthy = false;
+			this.reconnectCount += 1;
 			const generation = ++this.generation;
 
 			if (!(await this.cleanupRuntime())) {
 				this.lastError = 'Homey connector cleanup failed before reconnect';
+				this.lastErrorCategory = null;
 				this.scheduleReconnect(generation);
 				return;
 			}
@@ -388,9 +454,16 @@ export class HomeyService extends BaseManagedPluginService {
 				const connector = this.createConnector(this.getPluginConfig());
 				this.connector = connector;
 				await connector.connect();
-				await this.synchronizeStartup(connector, generation);
-				this.markRuntimeHealthy(connector, generation);
-				this.logger.log('Homey connector reconnected and inventory synchronized');
+				this.recordSuccessfulConnection();
+				const subscriptionFailure = await this.synchronizeStartup(connector, generation);
+
+				if (subscriptionFailure) {
+					this.markRuntimeDegraded(subscriptionFailure, generation);
+					this.logger.warn('Homey reconnected in degraded polling mode');
+				} else {
+					this.markRuntimeHealthy(connector, generation);
+					this.logger.log('Homey connector reconnected and inventory synchronized');
+				}
 			} catch (error) {
 				this.applyFailureState(error, 'Homey service failed to reconnect', HomeyConnectionState.RECONNECTING);
 				const retryGeneration = ++this.generation;
@@ -507,6 +580,7 @@ export class HomeyService extends BaseManagedPluginService {
 		transientState: HomeyConnectionState = HomeyConnectionState.ERROR,
 	): void {
 		this.healthy = false;
+		this.lastErrorCategory = error instanceof HomeyConnectorError ? error.category : null;
 
 		if (error instanceof HomeyConnectorError) {
 			switch (error.category) {
@@ -542,6 +616,7 @@ export class HomeyService extends BaseManagedPluginService {
 		this.connectionState = HomeyConnectionState.CONNECTED;
 		this.healthy = true;
 		this.lastError = null;
+		this.lastErrorCategory = null;
 
 		if (recovered && this.state === 'started') {
 			this.scheduleReconciliation(generation);
@@ -550,6 +625,29 @@ export class HomeyService extends BaseManagedPluginService {
 
 	private isRetryableFailure(error: unknown): boolean {
 		return error instanceof HomeyConnectorError && error.retryable;
+	}
+
+	private isDegradableSubscriptionFailure(error: unknown): error is HomeyConnectorError {
+		return (
+			error instanceof HomeyConnectorError &&
+			error.category !== HomeyConnectorErrorCategory.AUTHENTICATION &&
+			error.category !== HomeyConnectorErrorCategory.AUTHORIZATION &&
+			error.category !== HomeyConnectorErrorCategory.VALIDATION
+		);
+	}
+
+	private markRuntimeDegraded(error: HomeyConnectorError, generation: number): void {
+		this.connectionState = HomeyConnectionState.DEGRADED_POLLING;
+		this.healthy = false;
+		this.lastErrorCategory = error.category;
+		this.lastError = error.retryable
+			? 'Homey event subscription is temporarily unavailable; polling is active'
+			: 'Homey event subscription is unavailable; polling is active';
+		this.scheduleReconciliation(generation);
+
+		if (error.retryable) {
+			this.scheduleReconnect(generation, true);
+		}
 	}
 
 	private handleRuntimeFailure(error: unknown, fallback: string, generation: number): void {
@@ -565,6 +663,29 @@ export class HomeyService extends BaseManagedPluginService {
 	private resetReconnectState(): void {
 		this.clearReconnectTimer();
 		this.reconnectAttempt = 0;
+	}
+
+	private resetRuntimeHealth(): void {
+		this.lastSystemInfo = null;
+		this.lastConnectedAt = null;
+		this.lastInventorySyncAt = null;
+		this.lastEventAt = null;
+		this.lastErrorCategory = null;
+		this.reconnectCount = 0;
+	}
+
+	private recordSuccessfulConnection(): void {
+		this.lastConnectedAt = this.now();
+	}
+
+	private recordSuccessfulInventorySync(connector: HomeyConnector, generation: number): void {
+		if (this.isCurrentGeneration(connector, generation)) {
+			this.lastInventorySyncAt = this.now();
+		}
+	}
+
+	private now(): string {
+		return new Date().toISOString();
 	}
 
 	private getCurrentPluginConfigOrDefault(): HomeyConfigModel {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -241,12 +241,12 @@ index.ts
 - [x] Use exponential reconnect backoff with jitter and a maximum delay.
 - [x] Treat authentication/authorization failures differently from transient network failures.
 - [x] Prevent concurrent reconnect and reconciliation loops.
-- [ ] Track last successful connection, inventory sync, event, error category, reconnect count, and degraded state.
-- [ ] Unit-test all state transitions with fake timers.
+- [x] Track last successful connection, inventory sync, event, error category, reconnect count, and degraded state.
+- [x] Unit-test all state transitions with fake timers.
 
 ### Task 2.3: Implement status and connection test APIs
 
-- [ ] Expand the status model with state, Homey identity/version, last sync/event timestamps, reconnect count, and sanitized error.
+- [x] Expand the status model with state, Homey identity/version, last sync/event timestamps, reconnect count, and sanitized error.
 - [ ] Add `POST test-connection` with a discriminated request: `saved` accepts no endpoint/mode override and may resolve the persisted key; `candidate` requires a complete unsaved URL plus a newly entered key and must never resolve the persisted key.
 - [ ] Reject mixed requests, including an overridden URL with an omitted key, even when the candidate URL canonicalizes to the saved URL. Stored-secret reuse is authorized only by explicit `saved` mode.
 - [ ] Use a temporary connector for connection tests and always disconnect it.


### PR DESCRIPTION
## Summary

- track the last successful Homey connection, inventory synchronization, and processed event
- expose Homey identity/version, reconnect count, degraded polling state, and normalized error category through the status API
- retain authoritative inventory polling when event subscription is unavailable and reconnect transient subscription failures
- keep authentication and authorization failures fail-closed
- cover lifecycle transitions and telemetry semantics with deterministic fake-timer tests
- update the verified Homey implementation-plan checkpoints

## Why

The Homey lifecycle already supported reconnect backoff and reconciliation, but its public status only exposed a coarse healthy flag. Operators could not distinguish a healthy event connection from polling-only degraded operation or see when the last successful transport, inventory, or event activity occurred.

## Impact

Administrators receive secret-free runtime diagnostics for connected, degraded polling, reconnecting, authentication-failed, error, and stopped states. No Homey endpoint or API key is exposed by the status model.

## Validation

- `pnpm --dir apps/backend exec jest --runInBand src/plugins/devices-homey` — 13 suites, 151 tests passed
- targeted ESLint and Prettier checks for changed backend files
- `pnpm --dir apps/backend run type-check`
- `pnpm --dir apps/backend run build`
- `pnpm --dir apps/backend run lint:api`
- `pnpm run generate:openapi`
- `pnpm --dir apps/backend run lint:openapi:spec`
- `git diff --check`