### PR TITLE
feat(backend): add paged capability-aware home search

### DIFF
--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -384,6 +384,89 @@ describe('ChannelsPropertiesService', () => {
 			).resolves.toEqual({ properties: [], total: 0 });
 			expect(dataSource.query).not.toHaveBeenCalled();
 		});
+
+		it('filters readable candidates by exact permission boundaries while retaining disabled owners', async () => {
+			const query = jest.spyOn(dataSource, 'query');
+			query.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+
+			await channelsPropertiesService.searchVisibleSummaryPage({
+				match: '"sensor"*',
+				offset: 7,
+				limit: 10,
+				scope: { zoneId: 'zone-id' },
+				categories: [PropertyCategory.GENERIC],
+				candidateCapability: 'read',
+			});
+
+			const [selectSql, selectParameters] = query.mock.calls[0] as [string, unknown[]];
+			const [countSql, countParameters] = query.mock.calls[1] as [string, unknown[]];
+			for (const sql of [selectSql, countSql]) {
+				expect(sql).toContain('device.hidden = 0');
+				expect(sql).toContain('devices_module_devices_zones scoped_zone');
+				expect(sql).toContain('property.category IN (?)');
+				expect(sql).toContain('property.permissions = ?');
+				expect(sql).toContain('property.permissions LIKE ?');
+				expect(sql).not.toContain('device.enabled = 1');
+				expect(sql).not.toContain('property."dataType" IN');
+			}
+			const filterParameters = [
+				'property',
+				'"sensor"*',
+				'zone-id',
+				PropertyCategory.GENERIC,
+				PermissionType.READ_ONLY,
+				`${PermissionType.READ_ONLY},%`,
+				`%,${PermissionType.READ_ONLY},%`,
+				`%,${PermissionType.READ_ONLY}`,
+				PermissionType.READ_WRITE,
+				`${PermissionType.READ_WRITE},%`,
+				`%,${PermissionType.READ_WRITE},%`,
+				`%,${PermissionType.READ_WRITE}`,
+			];
+			expect(selectParameters).toEqual([null, ...filterParameters, 10, 7]);
+			expect(countParameters).toEqual(filterParameters);
+		});
+
+		it('filters writable candidates by permissions, command data type, and enabled owner before paging', async () => {
+			const query = jest.spyOn(dataSource, 'query');
+			query.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+
+			await channelsPropertiesService.searchVisibleSummaryPage({
+				match: '"switch"*',
+				offset: 5,
+				limit: 20,
+				roomParentId: 'floor-id',
+				candidateCapability: 'write',
+			});
+
+			const [selectSql, selectParameters] = query.mock.calls[0] as [string, unknown[]];
+			const [countSql, countParameters] = query.mock.calls[1] as [string, unknown[]];
+			for (const sql of [selectSql, countSql]) {
+				expect(sql).toContain('device.hidden = 0');
+				expect(sql).toContain('scoped_room."parentId" = ?');
+				expect(sql).toContain('property.permissions = ?');
+				expect(sql).toContain('device.enabled = 1');
+				expect(sql).toContain(
+					`property."dataType" IN (${SUPPORTED_PROPERTY_COMMAND_DATA_TYPES.map(() => '?').join(', ')})`,
+				);
+			}
+			const filterParameters = [
+				'property',
+				'"switch"*',
+				'floor-id',
+				PermissionType.READ_WRITE,
+				`${PermissionType.READ_WRITE},%`,
+				`%,${PermissionType.READ_WRITE},%`,
+				`%,${PermissionType.READ_WRITE}`,
+				PermissionType.WRITE_ONLY,
+				`${PermissionType.WRITE_ONLY},%`,
+				`%,${PermissionType.WRITE_ONLY},%`,
+				`%,${PermissionType.WRITE_ONLY}`,
+				...SUPPORTED_PROPERTY_COMMAND_DATA_TYPES,
+			];
+			expect(selectParameters).toEqual([null, ...filterParameters, 20, 5]);
+			expect(countParameters).toEqual(filterParameters);
+		});
 	});
 
 	describe('findBoundedForChannels', () => {

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -352,6 +352,9 @@ describe('ChannelsPropertiesService', () => {
 			expect(selectSql).toContain("exact_term_fallback.col = 'identifier'");
 			expect(selectSql).toContain('property.name IS NULL');
 			expect(selectSql).toContain('ORDER BY "rankTier" ASC, "lexicalScore" ASC');
+			expect(selectSql).toContain('LOWER(COALESCE(property.name, property.identifier, property.id)) ASC');
+			expect(selectSql).not.toContain('LOWER(device.name) ASC');
+			expect(selectSql).not.toContain('LOWER(channel.name) ASC');
 			expect(selectParameters).toEqual([
 				'temperature',
 				1,

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -74,6 +74,7 @@ export interface VisiblePropertySearchSummaryInput {
 	};
 	roomParentId?: string;
 	categories?: PropertyCategory[];
+	candidateCapability?: 'read' | 'write';
 }
 
 export interface VisiblePropertySearchSummaryPage {
@@ -299,6 +300,23 @@ export class ChannelsPropertiesService {
 			parameters.push(...input.categories);
 		}
 
+		if (input.candidateCapability) {
+			const permissionFilter = this.buildSearchPermissionFilter(
+				input.candidateCapability === 'read'
+					? [PermissionType.READ_ONLY, PermissionType.READ_WRITE]
+					: [PermissionType.READ_WRITE, PermissionType.WRITE_ONLY],
+			);
+
+			predicates.push(permissionFilter.sql);
+			parameters.push(...permissionFilter.parameters);
+
+			if (input.candidateCapability === 'write') {
+				predicates.push('device.enabled = 1');
+				predicates.push(`property."dataType" IN (${SUPPORTED_PROPERTY_COMMAND_DATA_TYPES.map(() => '?').join(', ')})`);
+				parameters.push(...SUPPORTED_PROPERTY_COMMAND_DATA_TYPES);
+			}
+		}
+
 		interface PropertySearchRow extends Omit<
 			VisiblePropertySearchSummary,
 			'deviceEnabled' | 'rankTier' | 'lexicalScore' | 'permissions'
@@ -373,6 +391,29 @@ export class ChannelsPropertiesService {
 				permissions: row.permissions.split(',') as PermissionType[],
 			})),
 			total: Number(countRows[0]?.total ?? 0),
+		};
+	}
+
+	private buildSearchPermissionFilter(permissions: PermissionType[]): {
+		sql: string;
+		parameters: string[];
+	} {
+		const predicate = permissions
+			.map(
+				() =>
+					'(property.permissions = ? OR property.permissions LIKE ? OR property.permissions LIKE ? ' +
+					'OR property.permissions LIKE ?)',
+			)
+			.join(' OR ');
+
+		return {
+			sql: `(${predicate})`,
+			parameters: permissions.flatMap((permission) => [
+				permission,
+				`${permission},%`,
+				`%,${permission},%`,
+				`%,${permission}`,
+			]),
 		};
 	}
 

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -369,8 +369,8 @@ export class ChannelsPropertiesService {
 				        bm25(home_context_entity_search_fts) AS "lexicalScore"
 				 ${joins}
 				 WHERE ${where}
-				 ORDER BY "rankTier" ASC, "lexicalScore" ASC, LOWER(device.name) ASC, LOWER(channel.name) ASC,
-				          LOWER(COALESCE(property.name, '')) ASC, property.id ASC
+				 ORDER BY "rankTier" ASC, "lexicalScore" ASC,
+				          LOWER(COALESCE(property.name, property.identifier, property.id)) ASC, property.id ASC
 				 LIMIT ? OFFSET ?`,
 				[...rank.parameters, ...parameters, input.limit, input.offset ?? 0],
 			),

--- a/apps/backend/src/modules/home-context/home-context.constants.ts
+++ b/apps/backend/src/modules/home-context/home-context.constants.ts
@@ -57,10 +57,12 @@ export interface HomeSearchLimitProfile {
 	defaultResults: number;
 	maxResults: number;
 	maxCandidatesPerKind: number;
+	maxPageableResults: number;
 	maxQueryCharacters: number;
 	maxQueryTokens: number;
 	maxKinds: number;
 	maxCategories: number;
+	maxCursorCharacters: number;
 }
 
 export const HOME_SEARCH_LIMIT_PROFILES: Readonly<Record<HomeSearchProfile, Readonly<HomeSearchLimitProfile>>> =
@@ -68,17 +70,23 @@ export const HOME_SEARCH_LIMIT_PROFILES: Readonly<Record<HomeSearchProfile, Read
 		[HOME_SEARCH_PROFILE_BUDDY_V1]: Object.freeze({
 			defaultResults: 10,
 			maxResults: 20,
-			maxCandidatesPerKind: 21,
+			maxCandidatesPerKind: 100,
+			maxPageableResults: 100,
 			maxQueryCharacters: 128,
 			maxQueryTokens: 8,
 			maxKinds: 4,
 			maxCategories: 16,
+			maxCursorCharacters: 512,
 		}),
 	});
 
 export const HOME_SEARCH_ENTITY_KINDS = ['space', 'device', 'property', 'scene'] as const;
 
 export type HomeSearchEntityKind = (typeof HOME_SEARCH_ENTITY_KINDS)[number];
+
+export const HOME_SEARCH_CANDIDATE_CAPABILITIES = ['read', 'write', 'trigger'] as const;
+
+export type HomeSearchCandidateCapability = (typeof HOME_SEARCH_CANDIDATE_CAPABILITIES)[number];
 
 export const HOME_SEARCH_MATCH_REASONS = [
 	'exact_id',
@@ -87,6 +95,7 @@ export const HOME_SEARCH_MATCH_REASONS = [
 	'lexical_match',
 	'space_filter',
 	'category_filter',
+	'candidate_capability_filter',
 ] as const;
 
 export type HomeSearchMatchReason = (typeof HOME_SEARCH_MATCH_REASONS)[number];

--- a/apps/backend/src/modules/home-context/home-search.errors.ts
+++ b/apps/backend/src/modules/home-context/home-search.errors.ts
@@ -13,3 +13,12 @@ export class HomeSearchInvalidQueryError extends Error {
 		this.name = 'HomeSearchInvalidQueryError';
 	}
 }
+
+export class HomeSearchInvalidCursorError extends Error {
+	readonly code = 'invalid_cursor';
+
+	constructor(readonly reason: 'malformed' | 'query_mismatch' | 'offset_out_of_range') {
+		super('Home search cursor is invalid for this query');
+		this.name = 'HomeSearchInvalidCursorError';
+	}
+}

--- a/apps/backend/src/modules/home-context/models/home-search-query.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-search-query.model.ts
@@ -1,4 +1,4 @@
-import { HomeSearchEntityKind, HomeSearchProfile } from '../home-context.constants';
+import { HomeSearchCandidateCapability, HomeSearchEntityKind, HomeSearchProfile } from '../home-context.constants';
 
 export interface HomeEntitySearchQuery {
 	profile: HomeSearchProfile;
@@ -6,5 +6,8 @@ export interface HomeEntitySearchQuery {
 	kinds?: HomeSearchEntityKind[];
 	spaceId?: string;
 	categories?: string[];
+	candidateCapability?: HomeSearchCandidateCapability;
 	limit?: number;
+	/** Opaque by contract but untrusted; filters and visibility are always reapplied. */
+	cursor?: string;
 }

--- a/apps/backend/src/modules/home-context/models/home-search-result.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-search-result.model.ts
@@ -1,4 +1,4 @@
-import { HomeSearchEntityKind, HomeSearchMatchReason } from '../home-context.constants';
+import { HomeSearchCandidateCapability, HomeSearchEntityKind, HomeSearchMatchReason } from '../home-context.constants';
 
 export interface HomeEntitySearchResultBase {
 	kind: HomeSearchEntityKind;
@@ -6,10 +6,12 @@ export interface HomeEntitySearchResultBase {
 	name: string;
 	score: number;
 	reasons: HomeSearchMatchReason[];
+	candidate_capabilities: HomeSearchCandidateCapability[];
 }
 
 export interface HomeSpaceSearchResult extends HomeEntitySearchResultBase {
 	kind: 'space';
+	candidate_capabilities: [];
 	type: string;
 	category: string | null;
 	parent_id: string | null;
@@ -17,6 +19,7 @@ export interface HomeSpaceSearchResult extends HomeEntitySearchResultBase {
 
 export interface HomeDeviceSearchResult extends HomeEntitySearchResultBase {
 	kind: 'device';
+	candidate_capabilities: [];
 	identifier: string | null;
 	category: string;
 	enabled: boolean;
@@ -25,6 +28,7 @@ export interface HomeDeviceSearchResult extends HomeEntitySearchResultBase {
 
 export interface HomePropertySearchResult extends HomeEntitySearchResultBase {
 	kind: 'property';
+	candidate_capabilities: Array<'read' | 'write'>;
 	property_name: string | null;
 	identifier: string | null;
 	category: string;
@@ -44,6 +48,7 @@ export interface HomePropertySearchResult extends HomeEntitySearchResultBase {
 
 export interface HomeSceneSearchResult extends HomeEntitySearchResultBase {
 	kind: 'scene';
+	candidate_capabilities: Array<'trigger'>;
 	category: string;
 	enabled: boolean;
 	triggerable: boolean;
@@ -73,4 +78,7 @@ export interface HomeEntitySearchResponse {
 	partial: false;
 	truncated: boolean;
 	refine_required: boolean;
+	candidate_capability_filter?: HomeSearchCandidateCapability;
+	/** Best-effort continuation for the current bounded candidate window, not an authorization artifact. */
+	next_cursor?: string;
 }

--- a/apps/backend/src/modules/home-context/schemas/home-search-input.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-search-input.schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+	HOME_SEARCH_CANDIDATE_CAPABILITIES,
 	HOME_SEARCH_ENTITY_KINDS,
 	HOME_SEARCH_LIMIT_PROFILES,
 	HOME_SEARCH_PROFILE_BUDDY_V1,
@@ -25,6 +26,8 @@ export const homeEntitySearchQuerySchema = z
 			.max(limits.maxCategories)
 			.refine((categories) => new Set(categories).size === categories.length, 'Search categories must be unique')
 			.optional(),
+		candidateCapability: z.enum(HOME_SEARCH_CANDIDATE_CAPABILITIES).optional(),
 		limit: z.number().int().min(1).max(limits.maxResults).optional(),
+		cursor: z.string().min(1).max(limits.maxCursorCharacters).optional(),
 	})
 	.strict();

--- a/apps/backend/src/modules/home-context/schemas/home-search-output.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-search-output.schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+	HOME_SEARCH_CANDIDATE_CAPABILITIES,
 	HOME_SEARCH_ENTITY_KINDS,
 	HOME_SEARCH_LIMIT_PROFILES,
 	HOME_SEARCH_MATCH_REASONS,
@@ -21,6 +22,7 @@ const entitySchema = z.discriminatedUnion('kind', [
 		.object({
 			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[0]),
 			...baseFields,
+			candidate_capabilities: z.array(z.never()).max(0),
 			type: z.string(),
 			category: z.string().nullable(),
 			parent_id: z.string().nullable(),
@@ -30,6 +32,7 @@ const entitySchema = z.discriminatedUnion('kind', [
 		.object({
 			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[1]),
 			...baseFields,
+			candidate_capabilities: z.array(z.never()).max(0),
 			identifier: z.string().nullable(),
 			category: z.string(),
 			enabled: z.boolean(),
@@ -40,6 +43,7 @@ const entitySchema = z.discriminatedUnion('kind', [
 		.object({
 			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[2]),
 			...baseFields,
+			candidate_capabilities: z.array(z.enum(['read', 'write'])).max(2),
 			property_name: z.string().nullable(),
 			identifier: z.string().nullable(),
 			category: z.string(),
@@ -53,6 +57,7 @@ const entitySchema = z.discriminatedUnion('kind', [
 		.object({
 			kind: z.literal(HOME_SEARCH_ENTITY_KINDS[3]),
 			...baseFields,
+			candidate_capabilities: z.array(z.literal('trigger')).max(1),
 			category: z.string(),
 			enabled: z.boolean(),
 			triggerable: z.boolean(),
@@ -79,5 +84,7 @@ export const homeEntitySearchResponseSchema = z
 		partial: z.literal(false),
 		truncated: z.boolean(),
 		refine_required: z.boolean(),
+		candidate_capability_filter: z.enum(HOME_SEARCH_CANDIDATE_CAPABILITIES).optional(),
+		next_cursor: z.string().min(1).max(limits.maxCursorCharacters).optional(),
 	})
 	.strict();

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -312,6 +312,58 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		]);
 	});
 
+	it('uses the global property display-name tie-break before the 100-candidate SQL cap', async () => {
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId") VALUES
+			 ('alpha-owner', 'Alpha owner', 'alpha-owner', 'test', 'sensor', 1, 0, NULL),
+			 ('zulu-owner', 'Zulu owner', 'zulu-owner', 'test', 'sensor', 1, 0, NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId") VALUES
+			 ('alpha-channel', 'Alpha channel', 'generic', 'alpha-owner'),
+			 ('zulu-channel', 'Zulu channel', 'generic', 'zulu-owner')`,
+		);
+		for (let index = 0; index < 100; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_channels_properties
+				 (id, name, identifier, type, category, "dataType", permissions, "channelId")
+				 VALUES (?, ?, ?, 'test', 'generic', 'string', 'ro', 'alpha-channel')`,
+				[
+					`tie-competitor-${String(index).padStart(3, '0')}`,
+					`Target competitor ${String(index).padStart(3, '0')}`,
+					`tie-competitor-${index}`,
+				],
+			);
+		}
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId")
+			 VALUES ('tie-aardvark', 'Target aardvark', 'tie-aardvark', 'test', 'generic', 'string', 'ro',
+			         'zulu-channel')`,
+		);
+
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as DevicesService,
+			propertiesService,
+			{ searchSummaryPage: jest.fn() } as unknown as ScenesService,
+		);
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'target',
+			kinds: ['property'],
+			limit: 20,
+		});
+
+		expect(result.entities[0]).toMatchObject({ kind: 'property', id: 'tie-aardvark', name: 'Target aardvark' });
+		expect(result.total).toBe(101);
+		expect(result.refine_required).toBe(false);
+	});
+
 	it('executes all four owning-domain queries against the real FTS index and joined metadata', async () => {
 		await dataSource.query(
 			`INSERT INTO spaces_module_spaces (id, name, type, category, "parentId")

--- a/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.integration.spec.ts
@@ -101,8 +101,8 @@ describe('HomeSearchQueryService SQLite integration', () => {
 		expect(result.truncated).toBe(false);
 	});
 
-	it('keeps a diacritic-normalized exact name ahead of more than 21 competing matches before the hard cap', async () => {
-		for (let index = 0; index < 30; index += 1) {
+	it('keeps a diacritic-normalized exact name ahead of more than 100 competing matches before the hard cap', async () => {
+		for (let index = 0; index < 110; index += 1) {
 			await dataSource.query(
 				`INSERT INTO devices_module_devices
 				 (id, name, identifier, type, category, enabled, hidden, "roomId")
@@ -140,7 +140,7 @@ describe('HomeSearchQueryService SQLite integration', () => {
 			reasons: ['exact_name'],
 			enabled: false,
 		});
-		expect(result.total).toBe(31);
+		expect(result.total).toBe(111);
 		expect(result.truncated).toBe(true);
 	});
 
@@ -177,7 +177,7 @@ describe('HomeSearchQueryService SQLite integration', () => {
 	});
 
 	it('folds Greek final sigma like unicode61 before applying the candidate cap', async () => {
-		for (let index = 0; index < 30; index += 1) {
+		for (let index = 0; index < 110; index += 1) {
 			await dataSource.query(
 				`INSERT INTO devices_module_devices
 				 (id, name, identifier, type, category, enabled, hidden, "roomId")
@@ -213,7 +213,7 @@ describe('HomeSearchQueryService SQLite integration', () => {
 			score: 900,
 			reasons: ['exact_name'],
 		});
-		expect(result.total).toBe(31);
+		expect(result.total).toBe(111);
 		expect(result.truncated).toBe(true);
 	});
 
@@ -227,7 +227,7 @@ describe('HomeSearchQueryService SQLite integration', () => {
 			`INSERT INTO devices_module_channels (id, name, category, "deviceId")
 			 VALUES ('property-channel', 'Target channel', 'generic', 'property-owner')`,
 		);
-		for (let index = 0; index < 30; index += 1) {
+		for (let index = 0; index < 110; index += 1) {
 			await dataSource.query(
 				`INSERT INTO devices_module_channels_properties
 				 (id, name, identifier, type, category, "dataType", permissions, "channelId")
@@ -270,7 +270,7 @@ describe('HomeSearchQueryService SQLite integration', () => {
 			score: 900,
 			reasons: ['exact_name'],
 		});
-		expect(result.total).toBe(31);
+		expect(result.total).toBe(111);
 		expect(result.truncated).toBe(true);
 	});
 
@@ -372,6 +372,134 @@ describe('HomeSearchQueryService SQLite integration', () => {
 			enabled: false,
 			triggerable: false,
 		});
+	});
+
+	it('walks a stable mixed-kind candidate window through opaque cursors without duplicates', async () => {
+		for (let index = 0; index < 25; index += 1) {
+			await dataSource.query(
+				`INSERT INTO devices_module_devices
+				 (id, name, identifier, type, category, enabled, hidden, "roomId")
+				 VALUES (?, ?, ?, 'test', 'sensor', 1, 0, NULL)`,
+				[`page-device-${index}`, `Pageable ${String(index).padStart(2, '0')}`, `page-device-${index}`],
+			);
+		}
+		for (let index = 0; index < 5; index += 1) {
+			await dataSource.query(
+				`INSERT INTO scenes_module_scenes (id, name, category, enabled, triggerable, "primarySpaceId")
+				 VALUES (?, ?, 'generic', 1, 1, NULL)`,
+				[`page-scene-${index}`, `Pageable ${String(index).padStart(2, '0')}`],
+			);
+		}
+
+		const devicesService = Object.create(DevicesService.prototype) as DevicesService;
+		Object.defineProperty(devicesService, 'dataSource', { value: dataSource });
+		const scenesService = Object.create(ScenesService.prototype) as ScenesService;
+		Object.defineProperty(scenesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			devicesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as ChannelsPropertiesService,
+			scenesService,
+		);
+		const ids: string[] = [];
+		let cursor: string | undefined;
+		let pages = 0;
+
+		do {
+			const result = await service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'pageable',
+				kinds: ['device', 'scene'],
+				limit: 7,
+				cursor,
+			});
+
+			expect(result.total).toBe(30);
+			expect(result.refine_required).toBe(false);
+			ids.push(...result.entities.map(({ id }) => id));
+			cursor = result.next_cursor;
+			pages += 1;
+		} while (cursor);
+
+		expect(pages).toBe(5);
+		expect(ids).toHaveLength(30);
+		expect(new Set(ids).size).toBe(30);
+	});
+
+	it('applies static property and scene candidate capabilities in real SQL before limits', async () => {
+		await dataSource.query(
+			`INSERT INTO devices_module_devices
+			 (id, name, identifier, type, category, enabled, hidden, "roomId") VALUES
+			 ('enabled-owner', 'Capability enabled', 'enabled-owner', 'test', 'lighting', 1, 0, NULL),
+			 ('disabled-owner', 'Capability disabled', 'disabled-owner', 'test', 'lighting', 0, 0, NULL),
+			 ('hidden-owner', 'Capability hidden', 'hidden-owner', 'test', 'lighting', 1, 1, NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId") VALUES
+			 ('enabled-channel', 'Capability enabled', 'light', 'enabled-owner'),
+			 ('disabled-channel', 'Capability disabled', 'light', 'disabled-owner'),
+			 ('hidden-channel', 'Capability hidden', 'light', 'hidden-owner')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, type, category, "dataType", permissions, "channelId") VALUES
+			 ('read-only', 'Capability read only', 'read-only', 'test', 'generic', 'bool', 'ro', 'enabled-channel'),
+			 ('read-write', 'Capability read write', 'read-write', 'test', 'generic', 'bool', 'rw', 'enabled-channel'),
+			 ('write-only', 'Capability write only', 'write-only', 'test', 'generic', 'bool', 'wo', 'enabled-channel'),
+			 ('event-only', 'Capability event only', 'event-only', 'test', 'generic', 'bool', 'ev', 'enabled-channel'),
+			 ('unsupported-write', 'Capability unsupported', 'unsupported-write', 'test', 'generic', 'unknown', 'rw',
+			  'enabled-channel'),
+			 ('disabled-write', 'Capability disabled write', 'disabled-write', 'test', 'generic', 'bool', 'wo',
+			  'disabled-channel'),
+			 ('hidden-write', 'Capability hidden write', 'hidden-write', 'test', 'generic', 'bool', 'rw',
+			  'hidden-channel')`,
+		);
+		await dataSource.query(
+			`INSERT INTO scenes_module_scenes (id, name, category, enabled, triggerable, "primarySpaceId") VALUES
+			 ('trigger-ready', 'Capability trigger ready', 'generic', 1, 1, NULL),
+			 ('trigger-disabled', 'Capability trigger disabled', 'generic', 0, 1, NULL),
+			 ('trigger-blocked', 'Capability trigger blocked', 'generic', 1, 0, NULL)`,
+		);
+
+		const propertiesService = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(propertiesService, 'dataSource', { value: dataSource });
+		const scenesService = Object.create(ScenesService.prototype) as ScenesService;
+		Object.defineProperty(scenesService, 'dataSource', { value: dataSource });
+		const service = new HomeSearchQueryService(
+			{ findOne: jest.fn(), searchSummaryPage: jest.fn() } as unknown as SpacesService,
+			{ searchVisibleSummaryPage: jest.fn() } as unknown as DevicesService,
+			propertiesService,
+			scenesService,
+		);
+
+		const readable = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'capability',
+			candidateCapability: 'read',
+		});
+		const writable = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'capability',
+			candidateCapability: 'write',
+		});
+		const triggerable = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'capability',
+			candidateCapability: 'trigger',
+		});
+
+		expect(readable.entities.map(({ id }) => id).sort()).toEqual(['read-only', 'read-write', 'unsupported-write']);
+		expect(readable.total).toBe(3);
+		expect(writable.entities.map(({ id }) => id).sort()).toEqual(['read-write', 'write-only']);
+		expect(writable.total).toBe(2);
+		expect(triggerable.entities.map(({ id }) => id)).toEqual(['trigger-ready']);
+		expect(triggerable.total).toBe(1);
+		expect(
+			writable.entities.every(
+				(entity) => entity.kind === 'property' && entity.candidate_capabilities.includes('write'),
+			),
+		).toBe(true);
+		expect(triggerable.entities[0]).toMatchObject({ candidate_capabilities: ['trigger'] });
 	});
 
 	it('applies floor scope, category filters, and hidden-owner visibility in real SQL', async () => {

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.spec.ts
@@ -14,6 +14,8 @@ import { SpacesService } from '../../spaces/services/spaces.service';
 import { SpaceType, SpaceZoneCategory } from '../../spaces/spaces.constants';
 import { HOME_SEARCH_PROFILE_BUDDY_V1 } from '../home-context.constants';
 import { HomeContextSpaceNotFoundError } from '../home-context.errors';
+import { HomeSearchInvalidCursorError } from '../home-search.errors';
+import { HomeEntitySearchQuery } from '../models/home-search-query.model';
 import { homeEntitySearchQuerySchema } from '../schemas/home-search-input.schemas';
 import { homeEntitySearchResponseSchema } from '../schemas/home-search-output.schemas';
 
@@ -128,7 +130,7 @@ describe('HomeSearchQueryService', () => {
 			normalizedQuery: 'kuche',
 			normalizedTokens: ['kuche'],
 			offset: 0,
-			limit: 21,
+			limit: 100,
 			spaceIds: undefined,
 			parentSpaceId: undefined,
 			categories: undefined,
@@ -139,7 +141,7 @@ describe('HomeSearchQueryService', () => {
 			normalizedQuery: 'kuche',
 			normalizedTokens: ['kuche'],
 			offset: 0,
-			limit: 21,
+			limit: 100,
 			scope: undefined,
 			roomParentId: undefined,
 			categories: undefined,
@@ -156,6 +158,7 @@ describe('HomeSearchQueryService', () => {
 					type: SpaceType.ROOM,
 					category: null,
 					parent_id: null,
+					candidate_capabilities: [],
 				},
 				{
 					kind: 'device',
@@ -167,6 +170,7 @@ describe('HomeSearchQueryService', () => {
 					category: DeviceCategory.LIGHTING,
 					enabled: false,
 					room_id: 'space-1',
+					candidate_capabilities: [],
 				},
 				{
 					kind: 'property',
@@ -181,6 +185,7 @@ describe('HomeSearchQueryService', () => {
 					permissions: [PermissionType.READ_WRITE],
 					device: { id: 'device-1', name: 'Küche ceiling', enabled: false },
 					channel: { id: 'channel-1', name: 'Main light', category: ChannelCategory.LIGHT },
+					candidate_capabilities: ['read'],
 				},
 				{
 					kind: 'scene',
@@ -192,6 +197,7 @@ describe('HomeSearchQueryService', () => {
 					enabled: false,
 					triggerable: false,
 					primary_space_id: 'space-1',
+					candidate_capabilities: [],
 				},
 			],
 			observed_at: '2026-08-15T10:00:00.000Z',
@@ -280,11 +286,326 @@ describe('HomeSearchQueryService', () => {
 		expect(result.total).toBe(1_001);
 		expect(result.returned).toBe(20);
 		expect(result.truncated).toBe(true);
-		expect(result.refine_required).toBe(true);
-		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledWith(expect.objectContaining({ limit: 21 }));
+		expect(result.refine_required).toBe(false);
+		expect(result.next_cursor).toBeDefined();
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
 		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
 		expect(channelsPropertiesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
 		expect(scenesService.searchSummaryPage).not.toHaveBeenCalled();
+	});
+
+	it('paginates the fixed cross-kind candidate window without changing domain offsets', async () => {
+		spacesService.searchSummaryPage.mockResolvedValue({
+			spaces: Array.from({ length: 3 }, (_, index) => ({
+				id: `space-${index}`,
+				name: `Light ${index}`,
+				type: SpaceType.ROOM,
+				category: null,
+				parentId: null,
+				rankTier: 2,
+				lexicalScore: index,
+			})),
+			total: 3,
+		});
+		devicesService.searchVisibleSummaryPage.mockResolvedValue({
+			devices: Array.from({ length: 3 }, (_, index) => ({
+				id: `device-${index}`,
+				name: `Light ${index}`,
+				identifier: null,
+				category: DeviceCategory.LIGHTING,
+				enabled: true,
+				roomId: null,
+				rankTier: 2,
+				lexicalScore: index + 0.5,
+			})),
+			total: 3,
+		});
+
+		const firstPage = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['space', 'device'],
+			categories: ['lighting', 'sensor'],
+			limit: 2,
+		});
+		const secondPage = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['device', 'space'],
+			categories: ['sensor', 'lighting'],
+			limit: 3,
+			cursor: firstPage.next_cursor,
+		});
+		const thirdPage = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['space', 'device'],
+			categories: ['lighting', 'sensor'],
+			limit: 3,
+			cursor: secondPage.next_cursor,
+		});
+
+		expect([
+			...firstPage.entities.map(({ id }) => id),
+			...secondPage.entities.map(({ id }) => id),
+			...thirdPage.entities.map(({ id }) => id),
+		]).toEqual(['space-0', 'device-0', 'space-1', 'device-1', 'space-2', 'device-2']);
+		expect(
+			new Set([...firstPage.entities, ...secondPage.entities, ...thirdPage.entities].map(({ id }) => id)).size,
+		).toBe(6);
+		expect(firstPage).toMatchObject({ returned: 2, truncated: true, refine_required: false });
+		expect(secondPage).toMatchObject({ returned: 3, truncated: true, refine_required: false });
+		expect(thirdPage).toMatchObject({ returned: 1, truncated: false, refine_required: false });
+		expect(thirdPage.next_cursor).toBeUndefined();
+		expect(spacesService.searchSummaryPage).toHaveBeenCalledTimes(3);
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledTimes(3);
+		for (const [searchInput] of spacesService.searchSummaryPage.mock.calls) {
+			expect(searchInput).toEqual(expect.objectContaining({ offset: 0, limit: 100 }));
+		}
+		for (const [searchInput] of devicesService.searchVisibleSummaryPage.mock.calls) {
+			expect(searchInput).toEqual(expect.objectContaining({ offset: 0, limit: 100 }));
+		}
+	});
+
+	it('stops at the fixed 100-result paging ceiling and requires query refinement', async () => {
+		devicesService.searchVisibleSummaryPage.mockResolvedValue({
+			devices: Array.from({ length: 100 }, (_, index) => ({
+				id: `device-${String(index).padStart(3, '0')}`,
+				name: `Sensor ${String(index).padStart(3, '0')}`,
+				identifier: null,
+				category: DeviceCategory.SENSOR,
+				enabled: true,
+				roomId: null,
+				rankTier: 2,
+				lexicalScore: index,
+			})),
+			total: 1_001,
+		});
+		let cursor: string | undefined;
+		let lastPage: Awaited<ReturnType<HomeSearchQueryService['searchEntities']>> | undefined;
+
+		for (let page = 0; page < 5; page += 1) {
+			lastPage = await service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'sensor',
+				kinds: ['device'],
+				limit: 20,
+				cursor,
+			});
+			cursor = lastPage.next_cursor;
+		}
+
+		expect(lastPage).toMatchObject({
+			total: 1_001,
+			returned: 20,
+			truncated: true,
+			refine_required: true,
+		});
+		expect(lastPage?.next_cursor).toBeUndefined();
+		expect(devicesService.searchVisibleSummaryPage).toHaveBeenCalledTimes(5);
+	});
+
+	it.each([
+		['read', 'property'],
+		['write', 'property'],
+		['trigger', 'scene'],
+	] as const)('routes the %s candidate filter only to compatible %s metadata', async (candidateCapability, kind) => {
+		channelsPropertiesService.searchVisibleSummaryPage.mockResolvedValue({
+			properties: [
+				{
+					id: 'property-1',
+					name: 'Switch',
+					identifier: null,
+					category: PropertyCategory.ON,
+					dataType: DataTypeType.BOOL,
+					permissions: [PermissionType.READ_WRITE],
+					channelId: 'channel-1',
+					channelName: 'Light',
+					channelCategory: ChannelCategory.LIGHT,
+					deviceId: 'device-1',
+					deviceName: 'Lamp',
+					deviceCategory: DeviceCategory.LIGHTING,
+					deviceEnabled: true,
+					roomId: null,
+					rankTier: 1,
+					lexicalScore: -1,
+				},
+			],
+			total: 1,
+		});
+		scenesService.searchSummaryPage.mockResolvedValue({
+			scenes: [
+				{
+					id: 'scene-1',
+					name: 'Evening',
+					category: SceneCategory.LIGHTING,
+					enabled: true,
+					triggerable: true,
+					primarySpaceId: null,
+					rankTier: 1,
+					lexicalScore: -1,
+				},
+			],
+			total: 1,
+		});
+
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			candidateCapability,
+		});
+
+		expect(result.entities).toHaveLength(1);
+		expect(result.entities[0]).toMatchObject({
+			kind,
+			candidate_capabilities: candidateCapability === 'trigger' ? ['trigger'] : ['read', 'write'],
+		});
+		expect(result.entities[0]?.reasons).toContain('candidate_capability_filter');
+		expect(result.candidate_capability_filter).toBe(candidateCapability);
+		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
+		expect(devicesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		if (kind === 'property') {
+			expect(channelsPropertiesService.searchVisibleSummaryPage).toHaveBeenCalledWith(
+				expect.objectContaining({ candidateCapability }),
+			);
+			expect(scenesService.searchSummaryPage).not.toHaveBeenCalled();
+		} else {
+			expect(scenesService.searchSummaryPage).toHaveBeenCalledWith(expect.objectContaining({ candidateTrigger: true }));
+			expect(channelsPropertiesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		}
+	});
+
+	it('returns an exact empty result when requested kinds cannot satisfy the candidate capability', async () => {
+		const result = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['device'],
+			candidateCapability: 'write',
+		});
+
+		expect(result).toMatchObject({
+			entities: [],
+			total: 0,
+			returned: 0,
+			truncated: false,
+			refine_required: false,
+			candidate_capability_filter: 'write',
+		});
+		expect(spacesService.searchSummaryPage).not.toHaveBeenCalled();
+		expect(devicesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(channelsPropertiesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(scenesService.searchSummaryPage).not.toHaveBeenCalled();
+	});
+
+	it('treats cursor offsets as untrusted bounded state and rejects malformed or mismatched cursors', async () => {
+		devicesService.searchVisibleSummaryPage.mockResolvedValue({
+			devices: Array.from({ length: 3 }, (_, index) => ({
+				id: `device-${index}`,
+				name: `Light ${index}`,
+				identifier: null,
+				category: DeviceCategory.LIGHTING,
+				enabled: true,
+				roomId: null,
+				rankTier: 2,
+				lexicalScore: index,
+			})),
+			total: 3,
+		});
+		const firstPage = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['device'],
+			limit: 1,
+		});
+		const decoded: unknown = JSON.parse(Buffer.from(firstPage.next_cursor, 'base64url').toString('utf8'));
+
+		if (
+			typeof decoded !== 'object' ||
+			decoded === null ||
+			!('fingerprint' in decoded) ||
+			typeof decoded.fingerprint !== 'string'
+		) {
+			throw new Error('Expected an encoded search cursor');
+		}
+
+		const randomAccessCursor = Buffer.from(
+			JSON.stringify({ v: 1, fingerprint: decoded.fingerprint, offset: 2 }),
+			'utf8',
+		).toString('base64url');
+		const randomAccessPage = await service.searchEntities({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'light',
+			kinds: ['device'],
+			cursor: randomAccessCursor,
+		});
+
+		expect(randomAccessPage.entities.map(({ id }) => id)).toEqual(['device-2']);
+		jest.clearAllMocks();
+
+		await expect(
+			service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'different',
+				kinds: ['device'],
+				cursor: firstPage.next_cursor,
+			}),
+		).rejects.toMatchObject({ reason: 'query_mismatch' });
+		const changedFilterCases: Array<Partial<HomeEntitySearchQuery>> = [
+			{ kinds: ['scene'] },
+			{ kinds: ['device'], categories: ['lighting'] },
+			{ kinds: ['device'], spaceId: 'space-1' },
+			{ kinds: ['device'], candidateCapability: 'read' },
+		];
+
+		for (const changedFilters of changedFilterCases) {
+			await expect(
+				service.searchEntities({
+					profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+					query: 'light',
+					...changedFilters,
+					cursor: firstPage.next_cursor,
+				}),
+			).rejects.toMatchObject({ reason: 'query_mismatch' });
+		}
+		await expect(
+			service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				kinds: ['device'],
+				cursor: 'not+a+cursor',
+			}),
+		).rejects.toBeInstanceOf(HomeSearchInvalidCursorError);
+		const outOfRangeCursor = Buffer.from(
+			JSON.stringify({ v: 1, fingerprint: decoded.fingerprint, offset: 100 }),
+			'utf8',
+		).toString('base64url');
+		await expect(
+			service.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				kinds: ['device'],
+				cursor: outOfRangeCursor,
+			}),
+		).rejects.toMatchObject({ reason: 'offset_out_of_range' });
+		for (const malformedPayload of [
+			{ v: 2, fingerprint: decoded.fingerprint, offset: 1 },
+			{ v: 1, fingerprint: decoded.fingerprint, offset: -1 },
+			{ v: 1, fingerprint: decoded.fingerprint, offset: 1.5 },
+			{ v: 1, fingerprint: decoded.fingerprint, offset: 1, extra: true },
+		]) {
+			const malformedCursor = Buffer.from(JSON.stringify(malformedPayload), 'utf8').toString('base64url');
+
+			await expect(
+				service.searchEntities({
+					profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+					query: 'light',
+					kinds: ['device'],
+					cursor: malformedCursor,
+				}),
+			).rejects.toMatchObject({ reason: 'malformed' });
+		}
+		expect(devicesService.searchVisibleSummaryPage).not.toHaveBeenCalled();
+		expect(spacesService.findOne).not.toHaveBeenCalled();
 	});
 
 	it('rejects a missing explicit space before searching any catalog', async () => {
@@ -326,6 +647,20 @@ describe('HomeSearchQueryService', () => {
 				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
 				query: 'light',
 				limit: 21,
+			}).success,
+		).toBe(false);
+		expect(
+			homeEntitySearchQuerySchema.safeParse({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				candidateCapability: 'execute',
+			}).success,
+		).toBe(false);
+		expect(
+			homeEntitySearchQuerySchema.safeParse({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: 'light',
+				cursor: '',
 			}).success,
 		).toBe(false);
 	});

--- a/apps/backend/src/modules/home-context/services/home-search-query.service.ts
+++ b/apps/backend/src/modules/home-context/services/home-search-query.service.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
+
 import { Injectable } from '@nestjs/common';
 
-import { PropertyCategory } from '../../devices/devices.constants';
+import { PermissionType, PropertyCategory } from '../../devices/devices.constants';
 import {
 	ChannelsPropertiesService,
 	VisiblePropertySearchSummary,
@@ -12,6 +14,7 @@ import {
 	VisibleDeviceSearchSummaryPage,
 	VisibleDeviceSummaryScope,
 } from '../../devices/services/devices.service';
+import { isSupportedPropertyCommandDataType } from '../../devices/utils/property-command-value.utils';
 import { SceneCategory } from '../../scenes/scenes.constants';
 import { SceneSearchSummary, SceneSearchSummaryPage, ScenesService } from '../../scenes/services/scenes.service';
 import { SpaceEntity } from '../../spaces/entities/space.entity';
@@ -20,11 +23,12 @@ import { SpaceType, isFloorZoneCategory } from '../../spaces/spaces.constants';
 import {
 	HOME_SEARCH_ENTITY_KINDS,
 	HOME_SEARCH_LIMIT_PROFILES,
+	HomeSearchCandidateCapability,
 	HomeSearchEntityKind,
 	HomeSearchMatchReason,
 } from '../home-context.constants';
 import { HomeContextSpaceNotFoundError } from '../home-context.errors';
-import { HomeSearchInvalidQueryError } from '../home-search.errors';
+import { HomeSearchInvalidCursorError, HomeSearchInvalidQueryError } from '../home-search.errors';
 import { HomeEntitySearchQuery } from '../models/home-search-query.model';
 import {
 	HomeDeviceSearchResult,
@@ -71,6 +75,12 @@ interface RankedHomeEntity {
 	id: string;
 }
 
+interface HomeSearchCursorPayload {
+	v: 1;
+	fingerprint: string;
+	offset: number;
+}
+
 @Injectable()
 export class HomeSearchQueryService {
 	constructor(
@@ -93,9 +103,12 @@ export class HomeSearchQueryService {
 			throw new HomeSearchInvalidQueryError('too_many_tokens', profile.maxQueryTokens);
 		}
 
-		const selectedKinds = input.kinds ?? [...HOME_SEARCH_ENTITY_KINDS];
+		const requestedKinds = input.kinds ?? [...HOME_SEARCH_ENTITY_KINDS];
+		const selectedKinds = this.getEffectiveKinds(requestedKinds, input.candidateCapability);
 		const selectedKindSet = new Set(selectedKinds);
 		const match = tokens.map((token) => `"${token}"*`).join(' AND ');
+		const fingerprint = this.createCursorFingerprint(input, normalizedQuery, requestedKinds);
+		const cursorOffset = this.decodeCursor(input.cursor, fingerprint, profile.maxPageableResults);
 		const selectedSpace = input.spaceId ? await this.spacesService.findOne(input.spaceId) : null;
 
 		if (input.spaceId && !selectedSpace) {
@@ -149,6 +162,10 @@ export class HomeSearchQueryService {
 						scope: scope.deviceScope,
 						roomParentId: scope.roomParentId,
 						categories: propertyCategories,
+						candidateCapability:
+							input.candidateCapability === 'read' || input.candidateCapability === 'write'
+								? input.candidateCapability
+								: undefined,
 					})
 				: Promise.resolve(emptyPropertyPage),
 			selectedKindSet.has('scene')
@@ -163,6 +180,7 @@ export class HomeSearchQueryService {
 						primarySpaceId: scope.primarySpaceId,
 						primarySpaceParentId: scope.primarySpaceParentId,
 						categories: sceneCategories,
+						candidateTrigger: input.candidateCapability === 'trigger' ? true : undefined,
 					})
 				: Promise.resolve(emptyScenePage),
 		]);
@@ -197,9 +215,9 @@ export class HomeSearchQueryService {
 				id: scene.id,
 			})),
 		].sort((left, right) => this.compareRankedEntities(left, right));
-		const entities = rankedEntities.map(({ entity }) => entity);
+		const entities = rankedEntities.map(({ entity }) => entity).slice(0, profile.maxPageableResults);
 		const limit = input.limit ?? profile.defaultResults;
-		const returnedEntities = entities.slice(0, limit);
+		const returnedEntities = entities.slice(cursorOffset, cursorOffset + limit);
 		const totalsByKind = {
 			space: spacePage.total,
 			device: devicePage.total,
@@ -207,7 +225,10 @@ export class HomeSearchQueryService {
 			scene: scenePage.total,
 		};
 		const total = Object.values(totalsByKind).reduce((sum, count) => sum + count, 0);
-		const truncated = total > returnedEntities.length;
+		const nextOffset = cursorOffset + returnedEntities.length;
+		const hasMoreCandidates = nextOffset < entities.length;
+		const truncated = nextOffset < total;
+		const refineRequired = truncated && !hasMoreCandidates;
 		const result: HomeEntitySearchResponse = {
 			query: input.query,
 			entities: returnedEntities,
@@ -217,7 +238,9 @@ export class HomeSearchQueryService {
 			totals_by_kind: totalsByKind,
 			partial: false,
 			truncated,
-			refine_required: truncated,
+			refine_required: refineRequired,
+			...(input.candidateCapability ? { candidate_capability_filter: input.candidateCapability } : {}),
+			...(hasMoreCandidates ? { next_cursor: this.encodeCursor(fingerprint, nextOffset) } : {}),
 		};
 
 		homeEntitySearchResponseSchema.parse(result);
@@ -235,6 +258,7 @@ export class HomeSearchQueryService {
 			type: space.type,
 			category: space.category,
 			parent_id: space.parentId,
+			candidate_capabilities: [],
 		};
 	}
 
@@ -249,6 +273,7 @@ export class HomeSearchQueryService {
 			category: device.category,
 			enabled: device.enabled,
 			room_id: device.roomId,
+			candidate_capabilities: [],
 		};
 	}
 
@@ -276,6 +301,7 @@ export class HomeSearchQueryService {
 				name: property.channelName,
 				category: property.channelCategory,
 			},
+			candidate_capabilities: this.getPropertyCandidateCapabilities(property),
 		};
 	}
 
@@ -290,6 +316,7 @@ export class HomeSearchQueryService {
 			enabled: scene.enabled,
 			triggerable: scene.triggerable,
 			primary_space_id: scene.primarySpaceId,
+			candidate_capabilities: scene.enabled && scene.triggerable ? ['trigger'] : [],
 		};
 	}
 
@@ -306,7 +333,117 @@ export class HomeSearchQueryService {
 			matchReason,
 			...(query.spaceId ? (['space_filter'] as const) : []),
 			...(query.categories ? (['category_filter'] as const) : []),
+			...(query.candidateCapability ? (['candidate_capability_filter'] as const) : []),
 		];
+	}
+
+	private getEffectiveKinds(
+		requestedKinds: HomeSearchEntityKind[],
+		candidateCapability?: HomeSearchCandidateCapability,
+	): HomeSearchEntityKind[] {
+		if (candidateCapability === 'read' || candidateCapability === 'write') {
+			return requestedKinds.includes('property') ? ['property'] : [];
+		}
+		if (candidateCapability === 'trigger') {
+			return requestedKinds.includes('scene') ? ['scene'] : [];
+		}
+
+		return requestedKinds;
+	}
+
+	private getPropertyCandidateCapabilities(property: VisiblePropertySearchSummary): Array<'read' | 'write'> {
+		const capabilities: Array<'read' | 'write'> = [];
+		const permissions = new Set(property.permissions);
+
+		if (permissions.has(PermissionType.READ_ONLY) || permissions.has(PermissionType.READ_WRITE)) {
+			capabilities.push('read');
+		}
+		if (
+			property.deviceEnabled &&
+			isSupportedPropertyCommandDataType(property.dataType) &&
+			(permissions.has(PermissionType.READ_WRITE) || permissions.has(PermissionType.WRITE_ONLY))
+		) {
+			capabilities.push('write');
+		}
+
+		return capabilities;
+	}
+
+	private createCursorFingerprint(
+		query: HomeEntitySearchQuery,
+		normalizedQuery: string,
+		requestedKinds: HomeSearchEntityKind[],
+	): string {
+		const requestedKindSet = new Set(requestedKinds);
+		const canonicalKinds = HOME_SEARCH_ENTITY_KINDS.filter((kind) => requestedKindSet.has(kind));
+		const canonicalCategories = query.categories ? [...query.categories].sort() : [];
+		const serializedFilters = JSON.stringify({
+			cursorVersion: 1,
+			rankingVersion: 1,
+			profile: query.profile,
+			rawQuery: query.query,
+			query: normalizedQuery,
+			kinds: canonicalKinds,
+			spaceId: query.spaceId ?? null,
+			categories: canonicalCategories,
+			candidateCapability: query.candidateCapability ?? null,
+			maxCandidatesPerKind: HOME_SEARCH_LIMIT_PROFILES[query.profile].maxCandidatesPerKind,
+			maxPageableResults: HOME_SEARCH_LIMIT_PROFILES[query.profile].maxPageableResults,
+		});
+
+		return createHash('sha256').update(serializedFilters).digest('base64url');
+	}
+
+	private decodeCursor(cursor: string | undefined, fingerprint: string, maxOffset: number): number {
+		if (cursor === undefined) {
+			return 0;
+		}
+
+		try {
+			if (!/^[A-Za-z0-9_-]+$/.test(cursor)) {
+				throw new HomeSearchInvalidCursorError('malformed');
+			}
+
+			const cursorBuffer = Buffer.from(cursor, 'base64url');
+
+			if (cursorBuffer.toString('base64url') !== cursor) {
+				throw new HomeSearchInvalidCursorError('malformed');
+			}
+
+			const decoded = cursorBuffer.toString('utf8');
+			const parsed = JSON.parse(decoded) as Partial<HomeSearchCursorPayload>;
+
+			if (
+				Object.keys(parsed).length !== 3 ||
+				parsed.v !== 1 ||
+				typeof parsed.fingerprint !== 'string' ||
+				typeof parsed.offset !== 'number' ||
+				!Number.isSafeInteger(parsed.offset) ||
+				parsed.offset < 0
+			) {
+				throw new HomeSearchInvalidCursorError('malformed');
+			}
+			if (parsed.fingerprint !== fingerprint) {
+				throw new HomeSearchInvalidCursorError('query_mismatch');
+			}
+			if (parsed.offset >= maxOffset) {
+				throw new HomeSearchInvalidCursorError('offset_out_of_range');
+			}
+
+			return parsed.offset;
+		} catch (error) {
+			if (error instanceof HomeSearchInvalidCursorError) {
+				throw error;
+			}
+
+			throw new HomeSearchInvalidCursorError('malformed');
+		}
+	}
+
+	private encodeCursor(fingerprint: string, offset: number): string {
+		const payload: HomeSearchCursorPayload = { v: 1, fingerprint, offset };
+
+		return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
 	}
 
 	private compareRankedEntities(left: RankedHomeEntity, right: RankedHomeEntity): number {

--- a/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.spec.ts
@@ -88,6 +88,42 @@ describe('ScenesService', () => {
 		expect(countParameters).toEqual(['scene', '"quiet"*', 'floor-id', 'floor-id', 'generic']);
 	});
 
+	it('filters trigger candidates by enabled and triggerable state before paging and counting', async () => {
+		const dataSource = {
+			query: jest
+				.fn()
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([{ total: 0 }]),
+		};
+		const service = new ScenesService(
+			{} as Repository<SceneEntity>,
+			{} as SceneActionsService,
+			{} as SpacesService,
+			dataSource as unknown as DataSource,
+			{} as EventEmitter2,
+		);
+
+		await service.searchSummaryPage({
+			match: '"movie"*',
+			offset: 4,
+			limit: 10,
+			primarySpaceId: 'space-id',
+			categories: [SceneCategory.GENERIC],
+			candidateTrigger: true,
+		});
+
+		const [selectSql, selectParameters] = dataSource.query.mock.calls[0] as [string, unknown[]];
+		const [countSql, countParameters] = dataSource.query.mock.calls[1] as [string, unknown[]];
+		for (const sql of [selectSql, countSql]) {
+			expect(sql).toContain('scene."primarySpaceId" = ?');
+			expect(sql).toContain('scene.category IN (?)');
+			expect(sql).toContain('scene.enabled = 1');
+			expect(sql).toContain('scene.triggerable = 1');
+		}
+		expect(selectParameters).toEqual([null, 'scene', '"movie"*', 'space-id', 'generic', 10, 4]);
+		expect(countParameters).toEqual(['scene', '"movie"*', 'space-id', 'generic']);
+	});
+
 	it('includes disabled scenes in summary queries', async () => {
 		const disabledScene = { id: 'disabled-scene', name: 'Disabled scene', enabled: false } as SceneEntity;
 		const query = {

--- a/apps/backend/src/modules/scenes/services/scenes.service.ts
+++ b/apps/backend/src/modules/scenes/services/scenes.service.ts
@@ -53,6 +53,7 @@ export interface SceneSearchSummaryInput {
 	primarySpaceId?: string;
 	primarySpaceParentId?: string;
 	categories?: SceneCategory[];
+	candidateTrigger?: boolean;
 }
 
 export interface SceneSearchSummaryPage {
@@ -193,6 +194,11 @@ export class ScenesService {
 		if (input.categories) {
 			predicates.push(`scene.category IN (${input.categories.map(() => '?').join(', ')})`);
 			parameters.push(...input.categories);
+		}
+
+		if (input.candidateTrigger === true) {
+			predicates.push('scene.enabled = 1');
+			predicates.push('scene.triggerable = 1');
 		}
 
 		interface SceneSearchRow extends Omit<SceneSearchSummary, 'enabled' | 'triggerable' | 'rankTier' | 'lexicalScore'> {

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1224,7 +1224,15 @@ captured as an opt-in/expected baseline measurement rather than a failing normal
 - [x] Add database-bounded metadata-only lexical/entity search with fixed query count, bounded candidates/results,
       SQL-applied visibility, space and category filters, deterministic ranking, exact totals, and explicit
       truncation/refinement metadata. Search results do not include live values or authorize actions.
-- [ ] Add cursor pagination and static candidate-capability filters to metadata search before exposing it as a Buddy tool.
+- [x] Add bounded opaque best-effort cursor pagination to metadata search. Bind cursors to the query, profile, filters,
+      and ranking contract; fetch at most 100 candidates per selected kind, expose a fixed 100-result global paging
+      window through `next_cursor`, and stop at its ceiling with `refine_required`. Treat the cursor offset as untrusted
+      bounded random-access continuation state, reapply every visibility/filter predicate, and do not claim snapshot
+      consistency across catalog mutations or use the cursor as authorization.
+- [x] Add SQL-applied static metadata candidate filters for readable/writable properties and enabled triggerable scenes.
+      Expose candidate capabilities derived from persisted metadata and the static command-type allowlist without
+      treating discovery as authorization, online availability, or proof that an action can execute.
+- [ ] Expose the bounded metadata search through a Buddy read tool after the structured tool-result loop is available.
 - [ ] Add safe filtered/aggregate current-state queries.
 - [ ] Add a bounded `PropertyValueService` batch/aggregate contract for current-value predicates and aggregates. Resolve
       eligible metadata in the database, reconcile cache/storage values in chunks, short-circuit only sound outcomes,


### PR DESCRIPTION
> 👍 Codex review passed on commit `f2f009f545` with no major issues.

## Summary

- add opaque, query-bound pagination over a fixed 100-result global HomeSearch window while keeping domain fetches bounded to 100 candidates per selected kind
- add SQL-applied static candidate filters for readable/writable properties and enabled triggerable scenes
- expose candidate capability metadata without treating it as authorization, online availability, or proof of execution
- align property SQL candidate ordering with the global paging comparator
- update the Buddy adaptive-context plan with the completed bounded-search contracts

## Cursor contract

- cursors bind the normalized and raw query, profile, kinds, space, categories, capability filter, ranking version, and paging limits
- every continuation re-runs visibility and filter predicates; cursor offsets are untrusted bounded random-access state, not authorization
- pagination is best-effort across catalog mutations and stops at the 100-result global window with `refine_required`

## Validation

- 162 focused backend regression tests across HomeSearch, FTS migration/helper, Spaces, Devices, Properties, and Scenes
- backend TypeScript type-check
- ESLint and Prettier on all touched TypeScript
- `git diff --check`

## Plan

Updates `tasks/plans/plan-buddy-adaptive-context.md`. Buddy tool exposure remains intentionally unchecked until the structured tool-result loop is available.