### PR TITLE
feat(backend): add Homey local SDK adapter

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.spec.ts
@@ -1,0 +1,23 @@
+import { HomeyLocalConnectorFactory } from './homey-local-connector.factory';
+import { HomeyLocalConnector } from './homey-local.connector';
+import { HomeySdkClientFactoryService } from './homey-sdk.client';
+
+describe('HomeyLocalConnectorFactory', () => {
+	it('creates a distinct connector core for each saved configuration generation', () => {
+		const sdkFactory = { createLocalApi: jest.fn() };
+		const factory = new HomeyLocalConnectorFactory(sdkFactory as unknown as HomeySdkClientFactoryService);
+		const config = {
+			url: 'http://homey.invalid:4859',
+			apiKey: 'sentinel-api-key',
+			connectionTimeout: 1000,
+		};
+
+		const first = factory.create(config);
+		const second = factory.create(config);
+
+		expect(first).toBeInstanceOf(HomeyLocalConnector);
+		expect(second).toBeInstanceOf(HomeyLocalConnector);
+		expect(second).not.toBe(first);
+		expect(sdkFactory.createLocalApi).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+import { HomeyConnectorFactory, HomeyConnectorFactoryConfig } from './homey-connector.factory';
+import { HomeyConnector } from './homey-connector.interface';
+import { HomeyLocalConnector } from './homey-local.connector';
+import { HomeySdkClientFactoryService } from './homey-sdk.client';
+import { HomeySdkTransport } from './homey-sdk.transport';
+
+@Injectable()
+export class HomeyLocalConnectorFactory implements HomeyConnectorFactory {
+	constructor(private readonly sdkFactory: HomeySdkClientFactoryService) {}
+
+	create(config: HomeyConnectorFactoryConfig): HomeyConnector {
+		return new HomeyLocalConnector(new HomeySdkTransport(config, this.sdkFactory));
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -1,0 +1,73 @@
+import { HomeyAPI } from 'homey-api';
+
+import { Injectable } from '@nestjs/common';
+
+export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
+
+export interface HomeySdkEventSource {
+	on(event: string, listener: HomeySdkEventListener): unknown;
+	off?(event: string, listener: HomeySdkEventListener): unknown;
+}
+
+export interface HomeySdkOperationOptions {
+	readonly $cache?: boolean;
+	readonly $timeout?: number;
+	readonly $updateCache?: boolean;
+}
+
+export interface HomeySdkDevice extends HomeySdkEventSource {
+	readonly id: string;
+	readonly available?: unknown;
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+}
+
+export interface HomeySdkDevicesManager extends HomeySdkEventSource {
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+	getDevices(options?: HomeySdkOperationOptions): Promise<Record<string, HomeySdkDevice>>;
+	getDevice(options: HomeySdkOperationOptions & { id: string }): Promise<HomeySdkDevice>;
+	setCapabilityValue(
+		options: HomeySdkOperationOptions & {
+			capabilityId: string;
+			deviceId: string;
+			value: unknown;
+		},
+	): Promise<unknown>;
+}
+
+export interface HomeySdkZonesManager extends HomeySdkEventSource {
+	connect(): Promise<void>;
+	disconnect(): Promise<void>;
+	getZones(options?: HomeySdkOperationOptions): Promise<Record<string, unknown>>;
+}
+
+export interface HomeySdkSystemManager {
+	getInfo(options?: HomeySdkOperationOptions): Promise<unknown>;
+}
+
+export interface HomeySdkClient {
+	readonly id: string | null;
+	readonly name: string | null;
+	readonly version: string | null;
+	readonly devices: HomeySdkDevicesManager;
+	readonly system: HomeySdkSystemManager;
+	readonly zones: HomeySdkZonesManager;
+	disconnect(): Promise<void>;
+	destroy(): void;
+}
+
+export interface HomeySdkClientFactory {
+	createLocalApi(options: { address: string; token: string }): Promise<HomeySdkClient>;
+}
+
+@Injectable()
+export class HomeySdkClientFactoryService implements HomeySdkClientFactory {
+	async createLocalApi(options: { address: string; token: string }): Promise<HomeySdkClient> {
+		return (await HomeyAPI.createLocalAPI({
+			address: options.address,
+			token: options.token,
+			debug: null,
+		})) as HomeySdkClient;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.spec.ts
@@ -76,6 +76,12 @@ class FakeEventSource implements HomeySdkEventSource {
 		await Promise.all([...(this.listeners.get(event) ?? [])].map(async (listener) => await listener(payload)));
 	}
 
+	emitSynchronously(event: string, payload: unknown): void {
+		for (const listener of this.listeners.get(event) ?? []) {
+			void listener(payload);
+		}
+	}
+
 	listenerCount(event: string): number {
 		return this.listeners.get(event)?.size ?? 0;
 	}
@@ -178,6 +184,32 @@ const createConnector = (client = new FakeSdkClient()) => {
 	const connector = new HomeyLocalConnector(transport);
 
 	return { client, connector, factory, transport };
+};
+
+const createDeviceEventRecorder = () => {
+	const events: HomeyEvent[] = [];
+	let expectedEvent: { deviceId: string; resolve: () => void; type: HomeyEventType } | null = null;
+
+	return {
+		events,
+		listener: (event: HomeyEvent): void => {
+			events.push(event);
+
+			if (
+				expectedEvent !== null &&
+				event.type === expectedEvent.type &&
+				'deviceId' in event &&
+				event.deviceId === expectedEvent.deviceId
+			) {
+				expectedEvent.resolve();
+				expectedEvent = null;
+			}
+		},
+		waitFor: (type: HomeyEventType, deviceId: string): Promise<void> =>
+			new Promise((resolvePromise) => {
+				expectedEvent = { deviceId, resolve: resolvePromise, type };
+			}),
+	};
 };
 
 describe('HomeySdkTransport', () => {
@@ -375,22 +407,58 @@ describe('HomeySdkTransport', () => {
 
 	it('attaches and detaches devices announced after subscription without leaking item listeners', async () => {
 		const { client, connector } = createConnector();
-		const events: HomeyEvent[] = [];
+		const recorder = createDeviceEventRecorder();
 		const addedDevice = new FakeSdkDevice({ ...rawDevice, id: 'added-device' });
 		await connector.connect();
-		await connector.subscribe((event) => {
-			events.push(event);
-		});
+		await connector.subscribe(recorder.listener);
 
+		const createdEvent = recorder.waitFor(HomeyEventType.DEVICE_ADDED, addedDevice.id);
 		await client.devices.emit('device.create', addedDevice);
+		await createdEvent;
 		expect(addedDevice.connect).toHaveBeenCalledTimes(1);
 		expect(addedDevice.listenerCount('capability')).toBe(1);
-		expect(events.at(-1)).toMatchObject({ type: HomeyEventType.DEVICE_ADDED, deviceId: addedDevice.id });
+		expect(recorder.events.at(-1)).toMatchObject({
+			type: HomeyEventType.DEVICE_ADDED,
+			deviceId: addedDevice.id,
+		});
 
+		const deletedEvent = recorder.waitFor(HomeyEventType.DEVICE_REMOVED, addedDevice.id);
 		await client.devices.emit('device.delete', { id: addedDevice.id });
+		await deletedEvent;
 		expect(addedDevice.disconnect).toHaveBeenCalledTimes(1);
 		expect(addedDevice.listenerCount('capability')).toBe(0);
-		expect(events.at(-1)).toMatchObject({ type: HomeyEventType.DEVICE_REMOVED, deviceId: addedDevice.id });
+		expect(recorder.events.at(-1)).toMatchObject({
+			type: HomeyEventType.DEVICE_REMOVED,
+			deviceId: addedDevice.id,
+		});
+
+		await connector.disconnect();
+	});
+
+	it('settles runtime attach and detach failures from synchronous SDK emitters while routing lifecycle events', async () => {
+		const { client, connector } = createConnector();
+		const recorder = createDeviceEventRecorder();
+		const failingAttachDevice = new FakeSdkDevice({ ...rawDevice, id: 'failing-attach-device' });
+		const failingDetachDevice = new FakeSdkDevice({ ...rawDevice, id: 'failing-detach-device' });
+		failingAttachDevice.connect.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.TIMEOUT));
+		await connector.connect();
+		await connector.subscribe(recorder.listener);
+
+		const attachEvent = recorder.waitFor(HomeyEventType.DEVICE_ADDED, failingAttachDevice.id);
+		client.devices.emitSynchronously('device.create', failingAttachDevice);
+		await attachEvent;
+		expect(failingAttachDevice.listenerCount('capability')).toBe(0);
+
+		const createdEvent = recorder.waitFor(HomeyEventType.DEVICE_ADDED, failingDetachDevice.id);
+		client.devices.emitSynchronously('device.create', failingDetachDevice);
+		await createdEvent;
+		expect(failingDetachDevice.listenerCount('capability')).toBe(1);
+		failingDetachDevice.disconnect.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.UNAVAILABLE));
+
+		const detachEvent = recorder.waitFor(HomeyEventType.DEVICE_REMOVED, failingDetachDevice.id);
+		client.devices.emitSynchronously('device.delete', { id: failingDetachDevice.id });
+		await detachEvent;
+		expect(failingDetachDevice.listenerCount('capability')).toBe(0);
 
 		await connector.disconnect();
 	});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.spec.ts
@@ -1,0 +1,449 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { HomeyConnectorErrorCategory, HomeyConnectorOperation } from '../errors/homey-connector.error';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+import { HomeyZone } from '../models/homey-zone.model';
+
+import { HomeyLocalConnector } from './homey-local.connector';
+import {
+	HomeySdkClient,
+	HomeySdkClientFactory,
+	HomeySdkDevice,
+	HomeySdkDevicesManager,
+	HomeySdkEventListener,
+	HomeySdkEventSource,
+	HomeySdkOperationOptions,
+	HomeySdkSystemManager,
+	HomeySdkZonesManager,
+} from './homey-sdk.client';
+import { HomeySdkTransport } from './homey-sdk.transport';
+
+const fixtureRoot = resolve(__dirname, '../__fixtures__');
+const sourceRoot = resolve(fixtureRoot, 'versions/2026-08-13-shs-13.4.0');
+const expectedRoot = resolve(fixtureRoot, 'expected/v1');
+const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
+const rawSystemInfo = {
+	homeyModelName: 'Homey Pro',
+	homeyTier: 'pro',
+	homeyVersion: '13.4.0',
+};
+const rawZones = readJson(resolve(sourceRoot, 'zones.json')) as Record<string, unknown>;
+const rawDevice = readJson(resolve(sourceRoot, 'devices/repeated-capabilities.json')) as Record<string, unknown>;
+const expectedZones = readJson(resolve(expectedRoot, 'zones.json')) as HomeyZone[];
+const expectedDevice = readJson(resolve(expectedRoot, 'devices/repeated-capabilities.json')) as HomeyDevice;
+
+const config = {
+	url: 'http://homey.invalid:4859',
+	apiKey: 'sentinel-api-key',
+	connectionTimeout: 1000,
+} as const;
+
+const rawFailure = (category: HomeyConnectorErrorCategory): Error => {
+	switch (category) {
+		case HomeyConnectorErrorCategory.AUTHENTICATION:
+			return Object.assign(new Error('private authentication response'), { statusCode: 401 });
+		case HomeyConnectorErrorCategory.AUTHORIZATION:
+			return Object.assign(new Error('private authorization response'), { statusCode: 403 });
+		case HomeyConnectorErrorCategory.TIMEOUT:
+			return Object.assign(new Error('private timeout response'), { name: 'TimeoutError' });
+		case HomeyConnectorErrorCategory.UNAVAILABLE:
+			return Object.assign(new Error('private unavailable response'), { code: 'ECONNREFUSED' });
+		case HomeyConnectorErrorCategory.VALIDATION:
+			return Object.assign(new Error('private validation response'), { statusCode: 422 });
+		case HomeyConnectorErrorCategory.UNSUPPORTED:
+			return Object.assign(new Error('private unsupported response'), { code: 'HOMEY_UNSUPPORTED' });
+		case HomeyConnectorErrorCategory.PROTOCOL:
+			return new Error('private protocol response');
+	}
+};
+
+class FakeEventSource implements HomeySdkEventSource {
+	private readonly listeners = new Map<string, Set<HomeySdkEventListener>>();
+
+	on(event: string, listener: HomeySdkEventListener): void {
+		const listeners = this.listeners.get(event) ?? new Set<HomeySdkEventListener>();
+		listeners.add(listener);
+		this.listeners.set(event, listeners);
+	}
+
+	off(event: string, listener: HomeySdkEventListener): void {
+		this.listeners.get(event)?.delete(listener);
+	}
+
+	async emit(event: string, payload: unknown): Promise<void> {
+		await Promise.all([...(this.listeners.get(event) ?? [])].map(async (listener) => await listener(payload)));
+	}
+
+	listenerCount(event: string): number {
+		return this.listeners.get(event)?.size ?? 0;
+	}
+}
+
+class FakeSdkDevice extends FakeEventSource implements HomeySdkDevice {
+	readonly id: string;
+	readonly available?: unknown;
+	readonly connect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly disconnect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+	constructor(raw: Record<string, unknown>) {
+		super();
+
+		if (typeof raw.id !== 'string') {
+			throw new Error('Fake Homey SDK device requires an ID');
+		}
+
+		Object.assign(this, structuredClone(raw));
+		this.id = raw.id;
+		this.available = raw.available;
+	}
+}
+
+class FakeDevicesManager extends FakeEventSource implements HomeySdkDevicesManager {
+	readonly connect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly disconnect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly getDevices = jest
+		.fn<Promise<Record<string, HomeySdkDevice>>, [HomeySdkOperationOptions?]>()
+		.mockImplementation(() => Promise.resolve(this.devices));
+	readonly getDevice = jest
+		.fn<Promise<HomeySdkDevice>, [HomeySdkOperationOptions & { id: string }]>()
+		.mockImplementation(({ id }) => {
+			const device = this.devices[id];
+
+			if (device === undefined) {
+				throw Object.assign(new Error('private missing-device response'), { statusCode: 404 });
+			}
+
+			return Promise.resolve(device);
+		});
+	readonly setCapabilityValue = jest
+		.fn<
+			Promise<unknown>,
+			[
+				HomeySdkOperationOptions & {
+					capabilityId: string;
+					deviceId: string;
+					value: unknown;
+				},
+			]
+		>()
+		.mockResolvedValue(undefined);
+
+	constructor(readonly devices: Record<string, FakeSdkDevice>) {
+		super();
+	}
+}
+
+class FakeZonesManager extends FakeEventSource implements HomeySdkZonesManager {
+	readonly connect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly disconnect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly getZones = jest
+		.fn<Promise<Record<string, unknown>>, [HomeySdkOperationOptions?]>()
+		.mockResolvedValue(structuredClone(rawZones));
+}
+
+class FakeSystemManager implements HomeySdkSystemManager {
+	readonly getInfo = jest
+		.fn<Promise<unknown>, [HomeySdkOperationOptions?]>()
+		.mockResolvedValue(structuredClone(rawSystemInfo));
+}
+
+class FakeSdkClient implements HomeySdkClient {
+	readonly id = 'homey-system';
+	readonly name = 'Homey';
+	readonly version = '13.4.0';
+	readonly devices: FakeDevicesManager;
+	readonly zones = new FakeZonesManager();
+	readonly system = new FakeSystemManager();
+	readonly disconnect = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+	readonly destroy = jest.fn<void, []>();
+
+	constructor(device = new FakeSdkDevice(rawDevice)) {
+		this.devices = new FakeDevicesManager({ [device.id]: device });
+	}
+}
+
+class FakeSdkFactory implements HomeySdkClientFactory {
+	readonly createLocalApi = jest.fn<Promise<HomeySdkClient>, [{ address: string; token: string }]>();
+
+	constructor(client: HomeySdkClient) {
+		this.createLocalApi.mockResolvedValue(client);
+	}
+}
+
+const createConnector = (client = new FakeSdkClient()) => {
+	const factory = new FakeSdkFactory(client);
+	const transport = new HomeySdkTransport(config, factory);
+	const connector = new HomeyLocalConnector(transport);
+
+	return { client, connector, factory, transport };
+};
+
+describe('HomeySdkTransport', () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('authenticates during connect and forwards every authoritative operation with explicit timeouts', async () => {
+		const { client, connector, factory } = createConnector();
+
+		await connector.connect();
+
+		expect(factory.createLocalApi).toHaveBeenCalledWith({ address: config.url, token: config.apiKey });
+		expect(client.system.getInfo).toHaveBeenCalledWith({ $timeout: config.connectionTimeout });
+		await expect(connector.getSystemInfo()).resolves.toStrictEqual({
+			id: client.id,
+			model: rawSystemInfo.homeyModelName,
+			name: client.name,
+			tier: rawSystemInfo.homeyTier,
+			version: client.version,
+		});
+		await expect(connector.getZones()).resolves.toStrictEqual(expectedZones);
+		await expect(connector.getDevices()).resolves.toStrictEqual([expectedDevice]);
+		await expect(connector.getDevice(expectedDevice.id)).resolves.toStrictEqual(expectedDevice);
+		await expect(connector.getDevice('missing-device')).resolves.toBeNull();
+		await connector.setCapabilityValue(expectedDevice.id, 'measure_temperature.inside', null);
+
+		expect(client.zones.getZones).toHaveBeenLastCalledWith({
+			$cache: false,
+			$timeout: config.connectionTimeout,
+			$updateCache: true,
+		});
+		expect(client.devices.getDevices).toHaveBeenLastCalledWith({
+			$cache: false,
+			$timeout: config.connectionTimeout,
+			$updateCache: true,
+		});
+		expect(client.devices.getDevice).toHaveBeenCalledWith({
+			$cache: false,
+			$timeout: config.connectionTimeout,
+			$updateCache: true,
+			id: expectedDevice.id,
+		});
+		expect(client.devices.setCapabilityValue).toHaveBeenCalledWith({
+			$timeout: config.connectionTimeout,
+			capabilityId: 'measure_temperature.inside',
+			deviceId: expectedDevice.id,
+			value: null,
+		});
+
+		await connector.disconnect();
+		expect(client.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(Object.values(HomeyConnectorErrorCategory))(
+		'normalizes the SDK error category %s without retaining raw detail',
+		async (category) => {
+			const { client, connector } = createConnector();
+			await connector.connect();
+			client.system.getInfo.mockRejectedValueOnce(rawFailure(category));
+			let observedError: unknown;
+
+			try {
+				await connector.getSystemInfo();
+			} catch (error) {
+				observedError = error;
+			}
+
+			expect(observedError).toMatchObject({
+				category,
+				operation: HomeyConnectorOperation.GET_SYSTEM_INFO,
+			});
+			expect(JSON.stringify(observedError)).not.toContain('private');
+
+			await connector.disconnect();
+		},
+	);
+
+	it.each([
+		HomeyConnectorOperation.GET_ZONES,
+		HomeyConnectorOperation.GET_DEVICES,
+		HomeyConnectorOperation.GET_DEVICE,
+		HomeyConnectorOperation.SET_CAPABILITY_VALUE,
+		HomeyConnectorOperation.SUBSCRIBE,
+		HomeyConnectorOperation.DISCONNECT,
+	])('maps an SDK failure to the public %s operation', async (operation) => {
+		const { client, connector } = createConnector();
+		await connector.connect();
+		const failure = rawFailure(HomeyConnectorErrorCategory.PROTOCOL);
+		let invocation: Promise<unknown>;
+
+		switch (operation) {
+			case HomeyConnectorOperation.GET_ZONES:
+				client.zones.getZones.mockRejectedValueOnce(failure);
+				invocation = connector.getZones();
+				break;
+			case HomeyConnectorOperation.GET_DEVICES:
+				client.devices.getDevices.mockRejectedValueOnce(failure);
+				invocation = connector.getDevices();
+				break;
+			case HomeyConnectorOperation.GET_DEVICE:
+				client.devices.getDevice.mockRejectedValueOnce(failure);
+				invocation = connector.getDevice(expectedDevice.id);
+				break;
+			case HomeyConnectorOperation.SET_CAPABILITY_VALUE:
+				client.devices.setCapabilityValue.mockRejectedValueOnce(failure);
+				invocation = connector.setCapabilityValue(expectedDevice.id, 'onoff', true);
+				break;
+			case HomeyConnectorOperation.SUBSCRIBE:
+				client.devices.connect.mockRejectedValueOnce(failure);
+				invocation = connector.subscribe(() => undefined);
+				break;
+			case HomeyConnectorOperation.DISCONNECT:
+				client.disconnect.mockRejectedValueOnce(failure);
+				invocation = connector.disconnect();
+				break;
+			default:
+				throw new Error(`Unexpected test operation: ${operation}`);
+		}
+
+		await expect(invocation).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.PROTOCOL,
+			operation,
+		});
+
+		if (operation !== HomeyConnectorOperation.DISCONNECT) {
+			await connector.disconnect();
+		}
+	});
+
+	it('maps an authenticated SDK bootstrap failure to connect and destroys the partial client', async () => {
+		const { client, connector } = createConnector();
+		client.system.getInfo.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.AUTHENTICATION));
+
+		await expect(connector.connect()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.AUTHENTICATION,
+			operation: HomeyConnectorOperation.CONNECT,
+		});
+		expect(client.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('subscribes managers and devices once, then emits normalized device, capability, availability, and zone events', async () => {
+		const { client, connector } = createConnector();
+		const device = Object.values(client.devices.devices)[0];
+		const events: HomeyEvent[] = [];
+		const secondEvents: HomeyEvent[] = [];
+		await connector.connect();
+		const unsubscribe = await connector.subscribe((event) => {
+			events.push(event);
+		});
+		const unsubscribeSecond = await connector.subscribe((event) => {
+			secondEvents.push(event);
+		});
+
+		expect(client.devices.connect).toHaveBeenCalledTimes(1);
+		expect(client.zones.connect).toHaveBeenCalledTimes(1);
+		expect(device.connect).toHaveBeenCalledTimes(1);
+
+		await device.emit('capability', {
+			capabilityId: 'measure_temperature.inside',
+			lastUpdated: '2026-08-15T10:00:00.000Z',
+			value: 0,
+		});
+		await device.emit('update', { available: false, unavailableMessage: 'Unavailable' });
+		await client.devices.emit('device.update', device);
+		await client.zones.emit('zone.update', { id: expectedZones[0].id });
+
+		expect(events).toStrictEqual([
+			expect.objectContaining({
+				type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+				deviceId: expectedDevice.id,
+				capabilityId: 'measure_temperature.inside',
+				value: 0,
+			}),
+			expect.objectContaining({
+				type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+				deviceId: expectedDevice.id,
+				available: false,
+			}),
+			expect.objectContaining({ type: HomeyEventType.DEVICE_UPDATED, deviceId: expectedDevice.id }),
+			expect.objectContaining({ type: HomeyEventType.ZONE_UPDATED, zoneId: expectedZones[0].id }),
+		]);
+		expect(secondEvents).toStrictEqual(events);
+
+		await unsubscribe();
+		expect(client.devices.disconnect).not.toHaveBeenCalled();
+		await unsubscribeSecond();
+		expect(device.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.devices.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.zones.disconnect).toHaveBeenCalledTimes(1);
+		await connector.disconnect();
+	});
+
+	it('attaches and detaches devices announced after subscription without leaking item listeners', async () => {
+		const { client, connector } = createConnector();
+		const events: HomeyEvent[] = [];
+		const addedDevice = new FakeSdkDevice({ ...rawDevice, id: 'added-device' });
+		await connector.connect();
+		await connector.subscribe((event) => {
+			events.push(event);
+		});
+
+		await client.devices.emit('device.create', addedDevice);
+		expect(addedDevice.connect).toHaveBeenCalledTimes(1);
+		expect(addedDevice.listenerCount('capability')).toBe(1);
+		expect(events.at(-1)).toMatchObject({ type: HomeyEventType.DEVICE_ADDED, deviceId: addedDevice.id });
+
+		await client.devices.emit('device.delete', { id: addedDevice.id });
+		expect(addedDevice.disconnect).toHaveBeenCalledTimes(1);
+		expect(addedDevice.listenerCount('capability')).toBe(0);
+		expect(events.at(-1)).toMatchObject({ type: HomeyEventType.DEVICE_REMOVED, deviceId: addedDevice.id });
+
+		await connector.disconnect();
+	});
+
+	it('cleans partial realtime setup while preserving the original subscription category', async () => {
+		const { client, connector } = createConnector();
+		await connector.connect();
+		client.zones.connect.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.UNAVAILABLE));
+
+		await expect(connector.subscribe(() => undefined)).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+			operation: HomeyConnectorOperation.SUBSCRIBE,
+		});
+		expect(client.devices.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.zones.disconnect).toHaveBeenCalledTimes(1);
+
+		await connector.disconnect();
+	});
+
+	it('bounds SDK client creation and destroys a client that resolves after the timeout', async () => {
+		jest.useFakeTimers();
+		const client = new FakeSdkClient();
+		let resolveCreation = (_client: HomeySdkClient): void => undefined;
+		const creation = new Promise<HomeySdkClient>((resolvePromise) => {
+			resolveCreation = resolvePromise;
+		});
+		const factory: HomeySdkClientFactory = { createLocalApi: jest.fn().mockReturnValue(creation) };
+		const connector = new HomeyLocalConnector(new HomeySdkTransport(config, factory));
+		const connecting = connector.connect();
+
+		await jest.advanceTimersByTimeAsync(config.connectionTimeout);
+		await expect(connecting).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.TIMEOUT,
+			operation: HomeyConnectorOperation.CONNECT,
+		});
+
+		resolveCreation(client);
+		await Promise.resolve();
+		expect(client.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('destroys the SDK client even when realtime and socket cleanup fail', async () => {
+		const { client, connector } = createConnector();
+		await connector.connect();
+		await connector.subscribe(() => undefined);
+		client.devices.disconnect.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.UNAVAILABLE));
+		client.disconnect.mockRejectedValueOnce(rawFailure(HomeyConnectorErrorCategory.UNAVAILABLE));
+
+		await expect(connector.disconnect()).rejects.toMatchObject({
+			category: HomeyConnectorErrorCategory.UNAVAILABLE,
+			operation: HomeyConnectorOperation.DISCONNECT,
+		});
+		expect(client.zones.disconnect).toHaveBeenCalledTimes(1);
+		expect(client.destroy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.ts
@@ -1,0 +1,506 @@
+import { HomeyConnectorFactoryConfig } from './homey-connector.factory';
+import {
+	HomeyLocalTransport,
+	HomeyLocalTransportEvent,
+	HomeyLocalTransportEventListener,
+	HomeyLocalTransportUnsubscribe,
+} from './homey-local.transport';
+import {
+	HomeySdkClient,
+	HomeySdkClientFactory,
+	HomeySdkDevice,
+	HomeySdkEventListener,
+	HomeySdkEventSource,
+} from './homey-sdk.client';
+
+interface HomeySdkEventBinding {
+	source: HomeySdkEventSource;
+	event: string;
+	listener: HomeySdkEventListener;
+}
+
+interface HomeySdkDeviceBinding {
+	device: HomeySdkDevice;
+	bindings: HomeySdkEventBinding[];
+}
+
+class HomeySdkTimeoutError extends Error {
+	constructor() {
+		super('Homey SDK operation timed out');
+		this.name = 'TimeoutError';
+	}
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const identifierOf = (value: unknown): string | null => {
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	return typeof value.id === 'string' && value.id.length > 0 ? value.id : null;
+};
+
+const statusCodeOf = (error: unknown): number | null => {
+	if (!isRecord(error)) {
+		return null;
+	}
+
+	for (const value of [error.statusCode, error.status, error.code]) {
+		if (typeof value === 'number' && Number.isInteger(value)) {
+			return value;
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Production adapter for the Homey local SDK. Raw SDK values and failures stay
+ * behind HomeyLocalTransport and are normalized by HomeyLocalConnector.
+ */
+export class HomeySdkTransport implements HomeyLocalTransport {
+	private client: HomeySdkClient | null = null;
+	private readonly subscribers = new Set<HomeyLocalTransportEventListener>();
+	private readonly managerBindings: HomeySdkEventBinding[] = [];
+	private readonly deviceBindings = new Map<string, HomeySdkDeviceBinding>();
+	private realtimeActive = false;
+	private lifecycleTail: Promise<void> = Promise.resolve();
+	private deliveryTail: Promise<void> = Promise.resolve();
+
+	constructor(
+		private readonly config: HomeyConnectorFactoryConfig,
+		private readonly sdkFactory: HomeySdkClientFactory,
+	) {}
+
+	connect(): Promise<void> {
+		return this.enqueueLifecycle(async () => {
+			if (this.client !== null) {
+				return;
+			}
+
+			const client = await this.createClient();
+
+			try {
+				// createLocalAPI proves only that a Homey answered the unauthenticated ping.
+				// An authenticated system read makes connect() honor the connector contract.
+				await this.runSdkOperation(() => client.system.getInfo({ $timeout: this.config.connectionTimeout }));
+				this.client = client;
+			} catch (error) {
+				await this.disposeClient(client);
+				throw error;
+			}
+		});
+	}
+
+	disconnect(): Promise<void> {
+		return this.enqueueLifecycle(async () => {
+			const client = this.client;
+			this.client = null;
+			this.subscribers.clear();
+			let failure: unknown;
+
+			try {
+				await this.stopRealtime(client);
+			} catch (error) {
+				failure = error;
+			}
+
+			if (client !== null) {
+				try {
+					await this.runSdkOperation(() => client.disconnect());
+				} catch (error) {
+					failure ??= error;
+				}
+
+				try {
+					client.destroy();
+				} catch (error) {
+					failure ??= error;
+				}
+			}
+
+			if (failure !== undefined) {
+				throw failure;
+			}
+		});
+	}
+
+	async getSystemInfo(): Promise<unknown> {
+		const client = this.requireClient();
+		const systemInfo = await this.runSdkOperation(() =>
+			client.system.getInfo({ $timeout: this.config.connectionTimeout }),
+		);
+
+		if (!isRecord(systemInfo)) {
+			return systemInfo;
+		}
+
+		return {
+			...systemInfo,
+			...(client.id === null ? {} : { id: client.id }),
+			...(client.name === null ? {} : { name: client.name }),
+			...(client.version === null ? {} : { version: client.version }),
+		};
+	}
+
+	getZones(): Promise<unknown> {
+		const client = this.requireClient();
+
+		return this.runSdkOperation(() =>
+			client.zones.getZones({
+				$cache: false,
+				$timeout: this.config.connectionTimeout,
+				$updateCache: true,
+			}),
+		);
+	}
+
+	getDevices(): Promise<unknown> {
+		const client = this.requireClient();
+
+		return this.runSdkOperation(() =>
+			client.devices.getDevices({
+				$cache: false,
+				$timeout: this.config.connectionTimeout,
+				$updateCache: true,
+			}),
+		);
+	}
+
+	async getDevice(deviceId: string): Promise<unknown> {
+		const client = this.requireClient();
+
+		try {
+			return await this.runSdkOperation(() =>
+				client.devices.getDevice({
+					$cache: false,
+					$timeout: this.config.connectionTimeout,
+					$updateCache: true,
+					id: deviceId,
+				}),
+			);
+		} catch (error) {
+			if (statusCodeOf(error) === 404) {
+				return null;
+			}
+
+			throw error;
+		}
+	}
+
+	setCapabilityValue(deviceId: string, capabilityId: string, value: unknown): Promise<void> {
+		const client = this.requireClient();
+
+		return this.runSdkOperation(async () => {
+			await client.devices.setCapabilityValue({
+				$timeout: this.config.connectionTimeout,
+				capabilityId,
+				deviceId,
+				value,
+			});
+		});
+	}
+
+	async subscribe(listener: HomeyLocalTransportEventListener): Promise<HomeyLocalTransportUnsubscribe> {
+		let active = true;
+
+		await this.enqueueLifecycle(async () => {
+			this.requireClient();
+			this.subscribers.add(listener);
+
+			if (this.realtimeActive) {
+				return;
+			}
+
+			try {
+				await this.startRealtime();
+			} catch (error) {
+				this.subscribers.delete(listener);
+				throw error;
+			}
+		});
+
+		return async () => {
+			if (!active) {
+				return;
+			}
+
+			active = false;
+
+			await this.enqueueLifecycle(async () => {
+				this.subscribers.delete(listener);
+
+				if (this.subscribers.size === 0) {
+					await this.stopRealtime(this.client);
+				}
+			});
+		};
+	}
+
+	private async createClient(): Promise<HomeySdkClient> {
+		const creation = this.sdkFactory.createLocalApi({
+			address: this.config.url,
+			token: this.config.apiKey,
+		});
+
+		try {
+			return await this.runSdkOperation(() => creation);
+		} catch (error) {
+			if (error instanceof HomeySdkTimeoutError) {
+				void creation.then(
+					(lateClient) => {
+						try {
+							lateClient.destroy();
+						} catch {
+							// The sanitized timeout has already been returned to the connector.
+						}
+					},
+					() => undefined,
+				);
+			}
+
+			throw error;
+		}
+	}
+
+	private async startRealtime(): Promise<void> {
+		const client = this.requireClient();
+		this.bindManagerEvents(client);
+
+		try {
+			await this.runSdkOperation(() => client.devices.connect());
+			await this.runSdkOperation(() => client.zones.connect());
+			const devices = await this.runSdkOperation(() =>
+				client.devices.getDevices({
+					$cache: false,
+					$timeout: this.config.connectionTimeout,
+					$updateCache: true,
+				}),
+			);
+
+			for (const device of Object.values(devices)) {
+				await this.attachDevice(device);
+			}
+
+			this.realtimeActive = true;
+		} catch (error) {
+			try {
+				await this.stopRealtime(client);
+			} catch {
+				// Preserve the original categorized subscription failure.
+			}
+
+			throw error;
+		}
+	}
+
+	private bindManagerEvents(client: HomeySdkClient): void {
+		this.bind(client.devices, 'device.create', async (payload) => {
+			if (isRecord(payload) && typeof payload.id === 'string') {
+				await this.attachDevice(payload as unknown as HomeySdkDevice);
+			}
+
+			await this.queueEvent({ type: 'device.create', payload });
+		});
+		this.bind(client.devices, 'device.update', async (payload) => {
+			if (isRecord(payload) && typeof payload.id === 'string' && !this.deviceBindings.has(payload.id)) {
+				await this.attachDevice(payload as unknown as HomeySdkDevice);
+			}
+
+			await this.queueEvent({ type: 'device.update', payload });
+		});
+		this.bind(client.devices, 'device.delete', async (payload) => {
+			const deviceId = identifierOf(payload);
+
+			if (deviceId !== null) {
+				await this.detachDevice(deviceId);
+			}
+
+			await this.queueEvent({ type: 'device.delete', payload });
+		});
+		this.bind(client.zones, 'zone.create', (payload) => this.queueEvent({ type: 'zone.create', payload }));
+		this.bind(client.zones, 'zone.update', (payload) => this.queueEvent({ type: 'zone.update', payload }));
+		this.bind(client.zones, 'zone.delete', (payload) => this.queueEvent({ type: 'zone.delete', payload }));
+	}
+
+	private async attachDevice(device: HomeySdkDevice): Promise<void> {
+		const deviceId = identifierOf(device);
+
+		if (deviceId === null || this.deviceBindings.has(deviceId)) {
+			return;
+		}
+
+		const bindings: HomeySdkEventBinding[] = [];
+		const capabilityListener: HomeySdkEventListener = (payload) =>
+			this.queueEvent({ type: 'capability', deviceId, payload });
+		const updateListener: HomeySdkEventListener = (payload) => {
+			if (
+				!isRecord(payload) ||
+				(!Object.hasOwn(payload, 'available') && !Object.hasOwn(payload, 'unavailableMessage'))
+			) {
+				return;
+			}
+
+			const available = typeof payload.available === 'boolean' ? payload.available : device.available;
+
+			if (typeof available !== 'boolean') {
+				return;
+			}
+
+			return this.queueEvent({
+				type: 'device.availability',
+				payload: { ...payload, available, id: deviceId },
+			});
+		};
+
+		bindings.push(this.bind(device, 'capability', capabilityListener, false));
+		bindings.push(this.bind(device, 'update', updateListener, false));
+		this.deviceBindings.set(deviceId, { device, bindings });
+
+		try {
+			await this.runSdkOperation(() => device.connect());
+		} catch (error) {
+			this.unbindAll(bindings);
+			this.deviceBindings.delete(deviceId);
+			throw error;
+		}
+	}
+
+	private async detachDevice(deviceId: string): Promise<void> {
+		const binding = this.deviceBindings.get(deviceId);
+
+		if (binding === undefined) {
+			return;
+		}
+
+		this.deviceBindings.delete(deviceId);
+		this.unbindAll(binding.bindings);
+		await this.runSdkOperation(() => binding.device.disconnect());
+	}
+
+	private async stopRealtime(client: HomeySdkClient | null): Promise<void> {
+		const hadResources = this.realtimeActive || this.managerBindings.length > 0 || this.deviceBindings.size > 0;
+		this.realtimeActive = false;
+		this.unbindAll(this.managerBindings);
+		this.managerBindings.length = 0;
+
+		const deviceBindings = [...this.deviceBindings.values()];
+		this.deviceBindings.clear();
+		deviceBindings.forEach((binding) => this.unbindAll(binding.bindings));
+
+		if (client === null || !hadResources) {
+			await this.deliveryTail;
+			return;
+		}
+
+		const results = await Promise.allSettled([
+			...deviceBindings.map((binding) => this.runSdkOperation(() => binding.device.disconnect())),
+			this.runSdkOperation(() => client.devices.disconnect()),
+			this.runSdkOperation(() => client.zones.disconnect()),
+		]);
+		await this.deliveryTail;
+		const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+		if (failure !== undefined) {
+			throw failure.reason as unknown;
+		}
+	}
+
+	private bind(
+		source: HomeySdkEventSource,
+		event: string,
+		listener: HomeySdkEventListener,
+		manager = true,
+	): HomeySdkEventBinding {
+		const binding = { source, event, listener };
+		source.on(event, listener);
+
+		if (manager) {
+			this.managerBindings.push(binding);
+		}
+
+		return binding;
+	}
+
+	private unbindAll(bindings: readonly HomeySdkEventBinding[]): void {
+		for (const binding of bindings) {
+			binding.source.off?.(binding.event, binding.listener);
+		}
+	}
+
+	private queueEvent(event: HomeyLocalTransportEvent): Promise<void> {
+		const delivery = this.deliveryTail.then(async () => {
+			await Promise.allSettled(
+				[...this.subscribers].map(async (listener) => {
+					await listener(event);
+				}),
+			);
+		});
+		this.deliveryTail = this.settleDelivery(delivery);
+
+		return delivery;
+	}
+
+	private requireClient(): HomeySdkClient {
+		if (this.client === null) {
+			throw Object.assign(new Error('Homey SDK client is disconnected'), { code: 'ECONNRESET' });
+		}
+
+		return this.client;
+	}
+
+	private async runSdkOperation<T>(operation: () => Promise<T>): Promise<T> {
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const operationPromise = operation();
+		const timeoutPromise = new Promise<never>((_resolve, reject) => {
+			timeout = setTimeout(() => reject(new HomeySdkTimeoutError()), this.config.connectionTimeout);
+		});
+
+		try {
+			return await Promise.race([operationPromise, timeoutPromise]);
+		} finally {
+			if (timeout !== undefined) {
+				clearTimeout(timeout);
+			}
+		}
+	}
+
+	private async disposeClient(client: HomeySdkClient): Promise<void> {
+		try {
+			await this.runSdkOperation(() => client.disconnect());
+		} catch {
+			// Authentication/connect failure remains the primary categorized error.
+		}
+
+		try {
+			client.destroy();
+		} catch {
+			// Authentication/connect failure remains the primary categorized error.
+		}
+	}
+
+	private enqueueLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+		const result: Promise<T> = this.lifecycleTail.then(async () => await operation());
+		this.lifecycleTail = this.settleLifecycle(result);
+
+		return result;
+	}
+
+	private async settleLifecycle(operation: Promise<unknown>): Promise<void> {
+		try {
+			await operation;
+		} catch {
+			// Keep SDK lifecycle serialization usable after a caller observes a failure.
+		}
+	}
+
+	private async settleDelivery(operation: Promise<void>): Promise<void> {
+		try {
+			await operation;
+		} catch {
+			// A consumer failure cannot break ordering for later Homey events.
+		}
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.transport.ts
@@ -297,32 +297,44 @@ export class HomeySdkTransport implements HomeyLocalTransport {
 	}
 
 	private bindManagerEvents(client: HomeySdkClient): void {
-		this.bind(client.devices, 'device.create', async (payload) => {
-			if (isRecord(payload) && typeof payload.id === 'string') {
-				await this.attachDevice(payload as unknown as HomeySdkDevice);
-			}
-
-			await this.queueEvent({ type: 'device.create', payload });
+		this.bind(client.devices, 'device.create', (payload) => {
+			this.routeRuntimeDeviceEvent('device.create', payload);
 		});
-		this.bind(client.devices, 'device.update', async (payload) => {
-			if (isRecord(payload) && typeof payload.id === 'string' && !this.deviceBindings.has(payload.id)) {
-				await this.attachDevice(payload as unknown as HomeySdkDevice);
-			}
-
-			await this.queueEvent({ type: 'device.update', payload });
+		this.bind(client.devices, 'device.update', (payload) => {
+			this.routeRuntimeDeviceEvent('device.update', payload);
 		});
-		this.bind(client.devices, 'device.delete', async (payload) => {
-			const deviceId = identifierOf(payload);
-
-			if (deviceId !== null) {
-				await this.detachDevice(deviceId);
-			}
-
-			await this.queueEvent({ type: 'device.delete', payload });
+		this.bind(client.devices, 'device.delete', (payload) => {
+			this.routeRuntimeDeviceEvent('device.delete', payload);
 		});
 		this.bind(client.zones, 'zone.create', (payload) => this.queueEvent({ type: 'zone.create', payload }));
 		this.bind(client.zones, 'zone.update', (payload) => this.queueEvent({ type: 'zone.update', payload }));
 		this.bind(client.zones, 'zone.delete', (payload) => this.queueEvent({ type: 'zone.delete', payload }));
+	}
+
+	private routeRuntimeDeviceEvent(type: 'device.create' | 'device.update' | 'device.delete', payload: unknown): void {
+		void this.handleRuntimeDeviceEvent(type, payload).catch(() => undefined);
+	}
+
+	private async handleRuntimeDeviceEvent(
+		type: 'device.create' | 'device.update' | 'device.delete',
+		payload: unknown,
+	): Promise<void> {
+		try {
+			const deviceId = identifierOf(payload);
+
+			if (type === 'device.delete') {
+				if (deviceId !== null) {
+					await this.detachDevice(deviceId);
+				}
+			} else if (deviceId !== null && !this.deviceBindings.has(deviceId)) {
+				await this.attachDevice(payload as HomeySdkDevice);
+			}
+		} catch {
+			// The SDK emitter does not observe returned promises. Keep failures settled;
+			// a later update can retry attachment, while the lifecycle event still routes.
+		}
+
+		await this.queueEvent({ type, payload });
 	}
 
 	private async attachDevice(device: HomeySdkDevice): Promise<void> {

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -7,7 +7,9 @@ import { PluginServiceManagerService } from '../../modules/extensions/services/p
 import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
 
-import { DEVICES_HOMEY_PLUGIN_NAME, DEVICES_HOMEY_TYPE } from './devices-homey.constants';
+import { HomeyLocalConnectorFactory } from './connectors/homey-local-connector.factory';
+import { HomeySdkClientFactoryService } from './connectors/homey-sdk.client';
+import { DEVICES_HOMEY_PLUGIN_NAME, DEVICES_HOMEY_TYPE, HOMEY_CONNECTOR_FACTORY } from './devices-homey.constants';
 import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.openapi';
 import { DevicesHomeyPlugin } from './devices-homey.plugin';
 import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
@@ -66,5 +68,15 @@ describe('DevicesHomeyPlugin', () => {
 			expect.objectContaining({ type: DEVICES_HOMEY_PLUGIN_NAME, name: 'Homey', defaultEnabled: false }),
 		);
 		expect(pluginServiceManager.register).toHaveBeenCalledWith(homeyService);
+	});
+
+	it('provides a production SDK-backed connector factory through the transport-neutral token', () => {
+		const providers = Reflect.getMetadata('providers', DevicesHomeyPlugin) as unknown[];
+
+		expect(providers).toEqual(expect.arrayContaining([HomeySdkClientFactoryService, HomeyLocalConnectorFactory]));
+		expect(providers).toContainEqual({
+			provide: HOMEY_CONNECTOR_FACTORY,
+			useExisting: HomeyLocalConnectorFactory,
+		});
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -22,12 +22,15 @@ import { ExtendedDiscriminatorService } from '../../modules/swagger/services/ext
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
 import { SwaggerModule } from '../../modules/swagger/swagger.module';
 
+import { HomeyLocalConnectorFactory } from './connectors/homey-local-connector.factory';
+import { HomeySdkClientFactoryService } from './connectors/homey-sdk.client';
 import { HomeyStatusController } from './controllers/homey-status.controller';
 import {
 	DEVICES_HOMEY_PLUGIN_API_TAG_DESCRIPTION,
 	DEVICES_HOMEY_PLUGIN_API_TAG_NAME,
 	DEVICES_HOMEY_PLUGIN_NAME,
 	DEVICES_HOMEY_TYPE,
+	HOMEY_CONNECTOR_FACTORY,
 } from './devices-homey.constants';
 import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.openapi';
 import { CreateHomeyChannelPropertyDto } from './dto/create-channel-property.dto';
@@ -55,7 +58,16 @@ import { HomeyService } from './services/homey.service';
 		ExtensionsModule,
 		SwaggerModule,
 	],
-	providers: [HomeyConfigValidatorService, HomeyService],
+	providers: [
+		HomeyConfigValidatorService,
+		HomeySdkClientFactoryService,
+		HomeyLocalConnectorFactory,
+		{
+			provide: HOMEY_CONNECTOR_FACTORY,
+			useExisting: HomeyLocalConnectorFactory,
+		},
+		HomeyService,
+	],
 	controllers: [HomeyStatusController],
 	exports: [HomeyService],
 })

--- a/apps/backend/src/plugins/devices-homey/index.ts
+++ b/apps/backend/src/plugins/devices-homey/index.ts
@@ -3,6 +3,7 @@ export * from './devices-homey.plugin';
 export * from './connectors/homey-connector.factory';
 export * from './connectors/homey-connector.interface';
 export * from './connectors/homey-connector.types';
+export * from './connectors/homey-local-connector.factory';
 export * from './dto/update-config.dto';
 export * from './entities/devices-homey.entity';
 export * from './errors/homey-connector.error';

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -218,15 +218,15 @@ index.ts
 - `connectors/homey-local.transformer.ts`
 - Corresponding specs using captured fixtures/fakes
 
-- [ ] Add the reviewed dependency only if Milestone 0 selected the SDK.
-- [ ] Construct a local API client from validated address/token without logging either.
-- [ ] Apply explicit connect/read/write/subscription timeouts.
+- [x] Add the reviewed dependency only if Milestone 0 selected the SDK.
+- [x] Construct a local API client from validated address/token without logging either.
+- [x] Apply explicit connect/read/write/subscription timeouts.
 - [x] Transform SDK/protocol objects into normalized models.
 - [x] Convert raw errors into normalized categories.
 - [x] Implement transport-neutral connector orchestration and cleanup behind an injectable local transport.
 - [x] Ensure one connector core owns one transport and passes the reusable fake-transport contract suite.
-- [ ] Implement the production adapter for inventory, zones, system info, device lookup, capability writes, and subscriptions.
-- [ ] Add adapter-specific fixture-backed tests for every operation and error category.
+- [x] Implement the production adapter for inventory, zones, system info, device lookup, capability writes, and subscriptions.
+- [x] Add adapter-specific fixture-backed tests for every operation and error category.
 - [ ] Add environment-gated contract tests against live SHS.
 
 ### Task 2.2: Implement plugin lifecycle and connection state machine


### PR DESCRIPTION
## Summary

- add a production Homey SDK client factory and local transport adapter
- register the local connector factory through the Homey connector factory token
- authenticate connections with Homey system information and retain stable client identity
- use explicit watchdog and SDK timeouts for uncached inventory reads, device reads, and capability writes
- translate Homey manager and device events into the transport-neutral connector contract
- clean up subscriptions, managers, sockets, and late SDK clients across partial failures
- cover every connector operation and normalized error category with fixture-backed tests
- mark the completed Task 2.1 implementation items in the Homey integration plan

## Why

The Homey lifecycle had an optional connector factory but no production provider. That left saved local Homey configurations unable to construct a real connector and blocked the upcoming test-connection endpoint.

## Security and reliability

- no API keys or raw SDK errors are exposed
- reads bypass stale SDK caches
- capability writes preserve full capability IDs and falsey values
- timeout and cleanup behavior is deterministic, including late client creation and partial subscription failures

## Validation

- `pnpm --dir apps/backend exec jest --runInBand src/plugins/devices-homey` — 15 suites, 173 tests
- `pnpm --dir apps/backend run type-check`
- targeted ESLint
- Prettier on changed files
- backend build
- `pnpm run generate:openapi` — 263 endpoints, no generated diff
- API conventions validation
- Spectral validation
- `git diff --check`
