### PR TITLE
feat(backend): add bounded property value reads

### DIFF
--- a/apps/backend/src/modules/devices/services/property-value.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.spec.ts
@@ -196,6 +196,301 @@ describe('PropertyValueService', () => {
 		});
 	});
 
+	describe('readLatestManyBounded', () => {
+		const makeProperties = (count: number): ChannelPropertyEntity[] =>
+			Array.from(
+				{ length: count },
+				(_, index) =>
+					({
+						id: `property-${index}`,
+						dataType: DataTypeType.INT,
+					}) as ChannelPropertyEntity,
+			);
+
+		it('returns an empty complete result without consulting storage', async () => {
+			await expect(service.readLatestManyBounded([])).resolves.toEqual({
+				items: [],
+				requestedCount: 0,
+				availableCount: 0,
+				unknownCount: 0,
+				complete: true,
+				storageStatus: 'not_needed',
+				cacheCount: 0,
+				storageCount: 0,
+				missingCount: 0,
+				unprocessedCount: 0,
+				oldestLastUpdated: null,
+				newestLastUpdated: null,
+				freshnessUnknownCount: 0,
+			});
+			expect(storageService.isConnected).not.toHaveBeenCalled();
+		});
+
+		it('preserves complete cache-only values while storage is disconnected', async () => {
+			const properties = makeProperties(2);
+			service['valuesMap'].set(properties[0].id, new PropertyValueState(10, '2026-08-15T10:00:00.000Z'));
+			service['valuesMap'].set(properties[1].id, new PropertyValueState(20, null));
+			storageService.isConnected.mockReturnValue(false);
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(result).toMatchObject({
+				requestedCount: 2,
+				availableCount: 2,
+				unknownCount: 0,
+				complete: true,
+				storageStatus: 'not_needed',
+				cacheCount: 2,
+				storageCount: 0,
+				freshnessUnknownCount: 1,
+			});
+			expect(result.items.map((item) => [item.propertyId, item.status, item.source])).toEqual([
+				['property-0', 'available', 'cache'],
+				['property-1', 'available', 'cache'],
+			]);
+			expect(storageService.isConnected).not.toHaveBeenCalled();
+		});
+
+		it('keeps cached coverage and marks only unresolved values when storage is disconnected', async () => {
+			const properties = makeProperties(2);
+			service['valuesMap'].set(properties[0].id, new PropertyValueState(10, '2026-08-15T10:00:00.000Z'));
+			storageService.isConnected.mockReturnValue(false);
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(result).toMatchObject({
+				availableCount: 1,
+				unknownCount: 1,
+				complete: false,
+				storageStatus: 'disconnected',
+				cacheCount: 1,
+				unprocessedCount: 1,
+			});
+			expect(result.items[1]).toEqual({
+				propertyId: 'property-1',
+				sourcePropertyId: 'property-1',
+				status: 'unprocessed',
+				source: null,
+				state: null,
+			});
+			expect(storageService.queryStrict).not.toHaveBeenCalled();
+		});
+
+		it('treats a cached null value as missing rather than a false scalar', async () => {
+			const [property] = makeProperties(1);
+			service['valuesMap'].set(property.id, new PropertyValueState(null, '2026-08-15T10:00:00.000Z'));
+
+			const result = await service.readLatestManyBounded([property]);
+
+			expect(result).toMatchObject({
+				availableCount: 0,
+				unknownCount: 1,
+				complete: false,
+				storageStatus: 'not_needed',
+				cacheCount: 1,
+				missingCount: 1,
+			});
+			expect(result.items[0]).toMatchObject({ status: 'missing', source: 'cache', state: { value: null } });
+		});
+
+		it('rechecks the cache before reporting an unresolved disconnected value', async () => {
+			const [property] = makeProperties(1);
+			storageService.isConnected.mockImplementation(() => {
+				service['valuesMap'].set(property.id, new PropertyValueState(9, '2026-08-15T10:00:00.000Z'));
+
+				return false;
+			});
+
+			const result = await service.readLatestManyBounded([property]);
+
+			expect(result.items[0]).toMatchObject({ status: 'available', source: 'cache', state: { value: 9 } });
+			expect(result).toMatchObject({
+				availableCount: 1,
+				unknownCount: 0,
+				storageStatus: 'disconnected',
+				complete: true,
+			});
+		});
+
+		it('distinguishes a completed storage miss from an unprocessed value', async () => {
+			const [property] = makeProperties(1);
+			storageService.queryStrict.mockResolvedValue([]);
+
+			const result = await service.readLatestManyBounded([property]);
+
+			expect(result).toMatchObject({
+				availableCount: 0,
+				unknownCount: 1,
+				complete: false,
+				storageStatus: 'available',
+				storageCount: 1,
+				missingCount: 1,
+				unprocessedCount: 0,
+			});
+			expect(result.items[0]).toEqual({
+				propertyId: property.id,
+				sourcePropertyId: property.id,
+				status: 'missing',
+				source: 'storage',
+				state: null,
+			});
+		});
+
+		it('keeps a newer concurrent cache value instead of an older storage row', async () => {
+			const [property] = makeProperties(1);
+			storageService.queryStrict.mockImplementation(() => {
+				service['valuesMap'].set(property.id, new PropertyValueState(42, '2026-08-15T12:00:00.000Z'));
+
+				return Promise.resolve([{ propertyId: property.id, numberValue: 10, time: '2026-08-15T11:00:00.000Z' }]);
+			});
+
+			const result = await service.readLatestManyBounded([property]);
+
+			expect(result.items[0]).toMatchObject({ status: 'available', source: 'cache', state: { value: 42 } });
+			expect(service['valuesMap'].get(property.id)?.value).toBe(42);
+		});
+
+		it('uses a newer storage row and computes its numeric trend before caching', async () => {
+			const [property] = makeProperties(1);
+			storageService.queryStrict.mockImplementation(() => {
+				service['valuesMap'].set(property.id, new PropertyValueState(5, '2026-08-15T10:00:00.000Z'));
+
+				return Promise.resolve([
+					{ propertyId: property.id, numberValue: 12, time: '2026-08-15T12:00:00.000Z' },
+					{ propertyId: property.id, numberValue: 10, time: '2026-08-15T11:00:00.000Z' },
+				]);
+			});
+
+			const result = await service.readLatestManyBounded([property]);
+
+			expect(result.items[0]).toMatchObject({
+				status: 'available',
+				source: 'storage',
+				state: { value: 12, trend: 'rising' },
+			});
+			expect(service['valuesMap'].get(property.id)).toMatchObject({ value: 12, trend: 'rising' });
+		});
+
+		it('deduplicates projected source keys and preserves logical property order', async () => {
+			const registry = module.get<PropertyValueSourceRegistryService>(PropertyValueSourceRegistryService);
+			registry.register({
+				getType: () => 'virtual',
+				resolve: (property) => (property.type === 'virtual' ? 'source-property' : null),
+			});
+			const properties = [
+				{ id: 'projection-a', type: 'virtual', dataType: DataTypeType.INT },
+				{ id: 'projection-b', type: 'virtual', dataType: DataTypeType.INT },
+			] as ChannelPropertyEntity[];
+			storageService.queryStrict.mockResolvedValue([
+				{ propertyId: 'source-property', numberValue: 7, time: '2026-08-15T12:00:00.000Z' },
+			]);
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(storageService.queryStrict).toHaveBeenCalledTimes(1);
+			expect(storageService.queryStrict).toHaveBeenCalledWith(
+				expect.stringContaining("propertyId = 'source-property'"),
+			);
+			expect((storageService.queryStrict.mock.calls[0][0].match(/propertyId =/g) ?? []).length).toBe(1);
+			expect(result.items.map((item) => [item.propertyId, item.sourcePropertyId, item.state?.value])).toEqual([
+				['projection-a', 'source-property', 7],
+				['projection-b', 'source-property', 7],
+			]);
+		});
+
+		it('accepts exactly 500 properties and reads distinct sources in sequential chunks of at most 50', async () => {
+			const properties = makeProperties(500);
+			storageService.queryStrict.mockResolvedValue([]);
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(result.requestedCount).toBe(500);
+			expect(storageService.queryStrict).toHaveBeenCalledTimes(10);
+			for (const [query] of storageService.queryStrict.mock.calls) {
+				expect((query.match(/propertyId =/g) ?? []).length).toBe(50);
+			}
+		});
+
+		it('rejects 501 properties before consulting storage', async () => {
+			await expect(service.readLatestManyBounded(makeProperties(501))).rejects.toThrow(
+				'At most 500 property values may be read at once',
+			);
+			expect(storageService.isConnected).not.toHaveBeenCalled();
+			expect(storageService.queryStrict).not.toHaveBeenCalled();
+		});
+
+		it('retains completed chunks and marks the remainder when a later storage chunk fails', async () => {
+			const properties = makeProperties(51);
+			storageService.queryStrict
+				.mockResolvedValueOnce(properties.slice(0, 50).map((property) => ({ propertyId: property.id, numberValue: 1 })))
+				.mockRejectedValueOnce(new Error('storage failed'));
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(result).toMatchObject({
+				availableCount: 50,
+				unknownCount: 1,
+				storageStatus: 'failed',
+				storageCount: 50,
+				unprocessedCount: 1,
+				complete: false,
+			});
+			expect(result.items[50].status).toBe('unprocessed');
+		});
+
+		it('retains completed chunks and stops scheduling after a later chunk times out', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(new Date('2026-08-15T12:00:00.000Z'));
+			try {
+				const properties = makeProperties(101);
+				storageService.queryStrict
+					.mockResolvedValueOnce(
+						properties.slice(0, 50).map((property) => ({ propertyId: property.id, numberValue: 1 })),
+					)
+					.mockReturnValueOnce(new Promise(() => undefined));
+				const read = service.readLatestManyBounded(properties);
+
+				await jest.advanceTimersByTimeAsync(750);
+
+				await expect(read).resolves.toMatchObject({
+					availableCount: 50,
+					unknownCount: 51,
+					storageStatus: 'timed_out',
+					storageCount: 50,
+					unprocessedCount: 51,
+					complete: false,
+				});
+				expect(storageService.queryStrict).toHaveBeenCalledTimes(2);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+
+		it('enforces the hard 750 ms ceiling even when a caller supplies a later deadline', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(new Date('2026-08-15T12:00:00.000Z'));
+			try {
+				const [property] = makeProperties(1);
+				storageService.queryStrict.mockReturnValue(new Promise(() => undefined));
+				const read = service.readLatestManyBounded([property], {
+					deadlineAt: new Date('2026-08-15T13:00:00.000Z'),
+				});
+
+				await jest.advanceTimersByTimeAsync(750);
+
+				await expect(read).resolves.toMatchObject({
+					storageStatus: 'timed_out',
+					availableCount: 0,
+					unprocessedCount: 1,
+					complete: false,
+				});
+				expect(storageService.queryStrict).toHaveBeenCalledTimes(1);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+	});
+
 	describe('delete', () => {
 		it('should delete property data from storage and cache', async () => {
 			const property: ChannelPropertyEntity = {

--- a/apps/backend/src/modules/devices/services/property-value.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.spec.ts
@@ -10,6 +10,7 @@ import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { StorageService } from '../../storage/services/storage.service';
+import { StorageQueryOptions } from '../../storage/storage.types';
 import { DataTypeType } from '../devices.constants';
 import { ChannelPropertyEntity } from '../entities/devices.entity';
 import { PropertyValueState } from '../models/property-value-state.model';
@@ -206,6 +207,25 @@ describe('PropertyValueService', () => {
 						dataType: DataTypeType.INT,
 					}) as ChannelPropertyEntity,
 			);
+		const waitForAbort = (_query: string, options?: StorageQueryOptions): Promise<never> =>
+			new Promise((_, reject) => {
+				const signal = options?.signal;
+
+				if (!signal) {
+					reject(new Error('Expected a storage abort signal'));
+					return;
+				}
+				if (signal.aborted) {
+					reject(signal.reason instanceof Error ? signal.reason : new Error('Storage query aborted'));
+					return;
+				}
+
+				signal.addEventListener(
+					'abort',
+					() => reject(signal.reason instanceof Error ? signal.reason : new Error('Storage query aborted')),
+					{ once: true },
+				);
+			});
 
 		it('returns an empty complete result without consulting storage', async () => {
 			await expect(service.readLatestManyBounded([])).resolves.toEqual({
@@ -410,6 +430,7 @@ describe('PropertyValueService', () => {
 			expect(storageService.queryStrict).toHaveBeenCalledTimes(1);
 			expect(storageService.queryStrict).toHaveBeenCalledWith(
 				expect.stringContaining("propertyId = 'source-property'"),
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
 			);
 			expect((storageService.queryStrict.mock.calls[0][0].match(/propertyId =/g) ?? []).length).toBe(1);
 			expect(result.items.map((item) => [item.propertyId, item.sourcePropertyId, item.state?.value])).toEqual([
@@ -467,7 +488,7 @@ describe('PropertyValueService', () => {
 					.mockResolvedValueOnce(
 						properties.slice(0, 50).map((property) => ({ propertyId: property.id, numberValue: 1 })),
 					)
-					.mockReturnValueOnce(new Promise(() => undefined));
+					.mockImplementationOnce(waitForAbort);
 				const read = service.readLatestManyBounded(properties);
 
 				await jest.advanceTimersByTimeAsync(750);
@@ -491,7 +512,12 @@ describe('PropertyValueService', () => {
 			jest.setSystemTime(new Date('2026-08-15T12:00:00.000Z'));
 			try {
 				const [property] = makeProperties(1);
-				storageService.queryStrict.mockReturnValue(new Promise(() => undefined));
+				let receivedSignal: AbortSignal | undefined;
+				storageService.queryStrict.mockImplementation((query, options) => {
+					receivedSignal = options?.signal;
+
+					return waitForAbort(query, options);
+				});
 				const read = service.readLatestManyBounded([property], {
 					deadlineAt: new Date('2026-08-15T13:00:00.000Z'),
 				});
@@ -505,6 +531,7 @@ describe('PropertyValueService', () => {
 					complete: false,
 				});
 				expect(storageService.queryStrict).toHaveBeenCalledTimes(1);
+				expect(receivedSignal?.aborted).toBe(true);
 			} finally {
 				jest.useRealTimers();
 			}

--- a/apps/backend/src/modules/devices/services/property-value.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.spec.ts
@@ -371,6 +371,26 @@ describe('PropertyValueService', () => {
 			expect(service['valuesMap'].get(property.id)).toMatchObject({ value: 12, trend: 'rising' });
 		});
 
+		it('refreshes a completed chunk when a later chunk observes a newer cache write', async () => {
+			const properties = makeProperties(51);
+			storageService.queryStrict.mockResolvedValueOnce([]).mockImplementationOnce(() => {
+				service['valuesMap'].set(properties[0].id, new PropertyValueState(99, '2026-08-15T12:00:00.000Z'));
+
+				return Promise.resolve([]);
+			});
+
+			const result = await service.readLatestManyBounded(properties);
+
+			expect(storageService.queryStrict).toHaveBeenCalledTimes(2);
+			expect(result.items[0]).toMatchObject({ status: 'available', source: 'cache', state: { value: 99 } });
+			expect(result).toMatchObject({
+				availableCount: 1,
+				missingCount: 50,
+				cacheCount: 1,
+				storageCount: 50,
+			});
+		});
+
 		it('deduplicates projected source keys and preserves logical property order', async () => {
 			const registry = module.get<PropertyValueSourceRegistryService>(PropertyValueSourceRegistryService);
 			registry.register({

--- a/apps/backend/src/modules/devices/services/property-value.service.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.ts
@@ -12,12 +12,65 @@ import { PropertyValueSourceRegistryService } from './property-value-source.regi
  * Number of recent data points used for trend computation.
  */
 const TREND_POINTS_COUNT = 5;
+const BOUNDED_READ_MAX_PROPERTIES = 500;
+const BOUNDED_READ_SOURCE_CHUNK_SIZE = 50;
+const BOUNDED_READ_DEFAULT_DEADLINE_MS = 750;
 
 interface PropertyValueRow {
 	time?: Date | string;
 	stringValue?: string;
 	numberValue?: number;
 	propertyId: ChannelPropertyEntity['id'];
+}
+
+export type BoundedPropertyValueSource = 'cache' | 'storage';
+export type BoundedPropertyValueStorageStatus = 'not_needed' | 'available' | 'disconnected' | 'failed' | 'timed_out';
+
+interface BoundedPropertyValueItemBase {
+	propertyId: ChannelPropertyEntity['id'];
+	sourcePropertyId: ChannelPropertyEntity['id'];
+}
+
+export type BoundedPropertyValueItem =
+	| (BoundedPropertyValueItemBase & {
+			status: 'available';
+			source: BoundedPropertyValueSource;
+			state: PropertyValueState & { value: string | number | boolean };
+	  })
+	| (BoundedPropertyValueItemBase & {
+			status: 'missing';
+			source: BoundedPropertyValueSource;
+			state: PropertyValueState | null;
+	  })
+	| (BoundedPropertyValueItemBase & {
+			status: 'unprocessed';
+			source: null;
+			state: null;
+	  });
+
+export interface BoundedPropertyValueReadOptions {
+	deadlineAt?: Date;
+}
+
+export interface BoundedPropertyValueReadResult {
+	items: BoundedPropertyValueItem[];
+	requestedCount: number;
+	availableCount: number;
+	unknownCount: number;
+	complete: boolean;
+	storageStatus: BoundedPropertyValueStorageStatus;
+	cacheCount: number;
+	storageCount: number;
+	missingCount: number;
+	unprocessedCount: number;
+	oldestLastUpdated: string | null;
+	newestLastUpdated: string | null;
+	freshnessUnknownCount: number;
+}
+
+interface BoundedPropertyValueSourceGroup {
+	property: ChannelPropertyEntity;
+	indexes: number[];
 }
 
 @Injectable()
@@ -264,6 +317,320 @@ export class PropertyValueService {
 
 			throw error;
 		}
+	}
+
+	/**
+	 * Reconciles a bounded property set against the live cache and cold storage without discarding cache hits when
+	 * storage is unavailable. Counts are per logical property; projected properties share one source lookup but retain
+	 * separate ordered result items. The optional deadline may tighten, but never extend, the 750 ms response ceiling.
+	 */
+	async readLatestManyBounded(
+		properties: ChannelPropertyEntity[],
+		options: BoundedPropertyValueReadOptions = {},
+	): Promise<BoundedPropertyValueReadResult> {
+		if (properties.length > BOUNDED_READ_MAX_PROPERTIES) {
+			throw new RangeError(`At most ${BOUNDED_READ_MAX_PROPERTIES} property values may be read at once`);
+		}
+
+		const startedAt = Date.now();
+		const requestedDeadlineAt = options.deadlineAt?.getTime() ?? startedAt + BOUNDED_READ_DEFAULT_DEADLINE_MS;
+
+		if (!Number.isFinite(requestedDeadlineAt)) {
+			throw new RangeError('Property value read deadline must be a valid date');
+		}
+
+		const deadlineAt = Math.min(requestedDeadlineAt, startedAt + BOUNDED_READ_DEFAULT_DEADLINE_MS);
+
+		const items = new Array<BoundedPropertyValueItem | undefined>(properties.length);
+		const unresolvedBySource = new Map<ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup>();
+
+		for (const [index, property] of properties.entries()) {
+			const sourcePropertyId = this.valueSourceRegistry.resolve(property);
+			const cached = this.valuesMap.get(sourcePropertyId);
+
+			if (cached) {
+				items[index] = this.toBoundedItem(property.id, sourcePropertyId, cached, 'cache');
+				continue;
+			}
+
+			const group = unresolvedBySource.get(sourcePropertyId);
+
+			if (group) {
+				group.indexes.push(index);
+			} else {
+				unresolvedBySource.set(sourcePropertyId, { property, indexes: [index] });
+			}
+		}
+
+		if (unresolvedBySource.size === 0) {
+			return this.buildBoundedResult(items, 'not_needed');
+		}
+
+		if (Date.now() >= deadlineAt) {
+			this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+			this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
+
+			return this.buildBoundedResult(items, 'timed_out');
+		}
+
+		if (!this.storageService.isConnected()) {
+			this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+			this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
+
+			return this.buildBoundedResult(items, 'disconnected');
+		}
+
+		const sourceEntries = [...unresolvedBySource.entries()];
+		let storageStatus: BoundedPropertyValueStorageStatus = 'available';
+
+		for (let offset = 0; offset < sourceEntries.length; offset += BOUNDED_READ_SOURCE_CHUNK_SIZE) {
+			if (Date.now() >= deadlineAt) {
+				storageStatus = 'timed_out';
+				break;
+			}
+
+			const chunk = sourceEntries.slice(offset, offset + BOUNDED_READ_SOURCE_CHUNK_SIZE);
+			const query = this.buildBoundedPropertyValueQuery(chunk.map(([sourcePropertyId]) => sourcePropertyId));
+
+			try {
+				const queryResult = await this.queryPropertyValuesBeforeDeadline(query, deadlineAt);
+
+				if (queryResult === null) {
+					storageStatus = 'timed_out';
+					break;
+				}
+
+				this.applyBoundedStorageRows(items, properties, chunk, queryResult);
+
+				for (const [sourcePropertyId] of chunk) {
+					unresolvedBySource.delete(sourcePropertyId);
+				}
+			} catch (error) {
+				const err = error as Error;
+				this.logger.error(`Failed to bounded-batch read latest property values error=${err.message}`, err.stack);
+				storageStatus = 'failed';
+				break;
+			}
+		}
+
+		this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+		this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
+
+		return this.buildBoundedResult(items, storageStatus);
+	}
+
+	private buildBoundedPropertyValueQuery(sourcePropertyIds: ChannelPropertyEntity['id'][]): string {
+		const predicate = sourcePropertyIds
+			.map((sourcePropertyId) => `propertyId = '${this.escapeTagValue(sourcePropertyId)}'`)
+			.join(' OR ');
+
+		return `
+	        SELECT *
+	        FROM property_value
+	        WHERE (${predicate})
+			GROUP BY "propertyId"
+			ORDER BY time DESC
+			LIMIT ${TREND_POINTS_COUNT}
+	      `;
+	}
+
+	private async queryPropertyValuesBeforeDeadline(
+		query: string,
+		deadlineAt: number,
+	): Promise<PropertyValueRow[] | null> {
+		const remainingMs = deadlineAt - Date.now();
+
+		if (remainingMs <= 0) {
+			return null;
+		}
+
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+
+		try {
+			return await Promise.race([
+				this.storageService.queryStrict<PropertyValueRow>(query),
+				new Promise<null>((resolve) => {
+					timeout = setTimeout(() => resolve(null), remainingMs);
+				}),
+			]);
+		} finally {
+			if (timeout !== undefined) {
+				clearTimeout(timeout);
+			}
+		}
+	}
+
+	private applyBoundedStorageRows(
+		items: Array<BoundedPropertyValueItem | undefined>,
+		properties: ChannelPropertyEntity[],
+		chunk: Array<[ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup]>,
+		rows: PropertyValueRow[],
+	): void {
+		const rowsBySource = new Map<ChannelPropertyEntity['id'], PropertyValueRow[]>();
+
+		for (const row of rows) {
+			rowsBySource.set(row.propertyId, [...(rowsBySource.get(row.propertyId) ?? []), row]);
+		}
+
+		for (const [sourcePropertyId, group] of chunk) {
+			const sourceRows = rowsBySource.get(sourcePropertyId) ?? [];
+			const firstRow = sourceRows[0];
+			let storedState = firstRow ? this.toState(group.property, sourcePropertyId, firstRow) : null;
+			const concurrentCache = this.valuesMap.get(sourcePropertyId);
+			const useCache = concurrentCache !== undefined && this.isStateNewerOrEqual(concurrentCache, storedState);
+
+			if (!useCache && firstRow) {
+				this.updateRecentValuesFromRows(group.property, sourcePropertyId, sourceRows);
+				storedState = this.toState(group.property, sourcePropertyId, firstRow);
+			}
+
+			const state = useCache ? concurrentCache : storedState;
+			const source: BoundedPropertyValueSource = useCache ? 'cache' : 'storage';
+
+			if (!useCache && storedState) {
+				this.valuesMap.set(sourcePropertyId, storedState);
+			}
+
+			for (const index of group.indexes) {
+				items[index] = this.toBoundedItem(properties[index].id, sourcePropertyId, state, source);
+			}
+		}
+	}
+
+	private isStateNewerOrEqual(cached: PropertyValueState, stored: PropertyValueState | null): boolean {
+		if (!stored) {
+			return true;
+		}
+
+		const cachedTime = cached.lastUpdated === null ? null : Date.parse(cached.lastUpdated);
+		const storedTime = stored.lastUpdated === null ? null : Date.parse(stored.lastUpdated);
+
+		if (cachedTime === null || Number.isNaN(cachedTime)) {
+			return storedTime === null || Number.isNaN(storedTime);
+		}
+		if (storedTime === null || Number.isNaN(storedTime)) {
+			return true;
+		}
+
+		return cachedTime >= storedTime;
+	}
+
+	private updateRecentValuesFromRows(
+		property: ChannelPropertyEntity,
+		sourcePropertyId: ChannelPropertyEntity['id'],
+		rows: PropertyValueRow[],
+	): void {
+		if (!this.isNumericDataType(property.dataType)) {
+			return;
+		}
+
+		this.recentValuesMap.set(
+			sourcePropertyId,
+			rows
+				.map((row) => row.numberValue)
+				.filter((value): value is number => value !== undefined)
+				.reverse(),
+		);
+	}
+
+	private toBoundedItem(
+		propertyId: ChannelPropertyEntity['id'],
+		sourcePropertyId: ChannelPropertyEntity['id'],
+		state: PropertyValueState | null,
+		source: BoundedPropertyValueSource,
+	): BoundedPropertyValueItem {
+		if (state === null || state.value === null) {
+			return { propertyId, sourcePropertyId, status: 'missing', source, state };
+		}
+
+		return {
+			propertyId,
+			sourcePropertyId,
+			status: 'available',
+			source,
+			state: state as PropertyValueState & { value: string | number | boolean },
+		};
+	}
+
+	private fillConcurrentCachedBoundedItems(
+		items: Array<BoundedPropertyValueItem | undefined>,
+		properties: ChannelPropertyEntity[],
+		groups: Map<ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup>,
+	): void {
+		for (const [sourcePropertyId, group] of groups) {
+			const cached = this.valuesMap.get(sourcePropertyId);
+
+			if (!cached) {
+				continue;
+			}
+
+			for (const index of group.indexes) {
+				items[index] = this.toBoundedItem(properties[index].id, sourcePropertyId, cached, 'cache');
+			}
+
+			groups.delete(sourcePropertyId);
+		}
+	}
+
+	private fillUnprocessedBoundedItems(
+		items: Array<BoundedPropertyValueItem | undefined>,
+		properties: ChannelPropertyEntity[],
+		groups: Map<ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup>,
+	): void {
+		for (const [sourcePropertyId, group] of groups) {
+			for (const index of group.indexes) {
+				if (items[index] !== undefined) {
+					continue;
+				}
+
+				items[index] = {
+					propertyId: properties[index].id,
+					sourcePropertyId,
+					status: 'unprocessed',
+					source: null,
+					state: null,
+				};
+			}
+		}
+	}
+
+	private buildBoundedResult(
+		items: Array<BoundedPropertyValueItem | undefined>,
+		storageStatus: BoundedPropertyValueStorageStatus,
+	): BoundedPropertyValueReadResult {
+		const resolvedItems = items.filter((item): item is BoundedPropertyValueItem => item !== undefined);
+		const cacheCount = resolvedItems.filter((item) => item.source === 'cache').length;
+		const storageCount = resolvedItems.filter((item) => item.source === 'storage').length;
+		const missingCount = resolvedItems.filter((item) => item.status === 'missing').length;
+		const unprocessedCount = resolvedItems.filter((item) => item.status === 'unprocessed').length;
+		const availableCount = resolvedItems.filter((item) => item.status === 'available').length;
+		const unknownCount = missingCount + unprocessedCount;
+		const freshnessUnknownCount = resolvedItems.filter(
+			(item) =>
+				item.status === 'available' &&
+				(item.state.lastUpdated === null || Number.isNaN(Date.parse(item.state.lastUpdated))),
+		).length;
+		const timestamps = resolvedItems
+			.filter((item) => item.status === 'available' && item.state?.lastUpdated !== null)
+			.map((item) => item.state?.lastUpdated)
+			.filter((timestamp): timestamp is string => timestamp !== undefined && !Number.isNaN(Date.parse(timestamp)))
+			.sort((left, right) => Date.parse(left) - Date.parse(right));
+
+		return {
+			items: resolvedItems,
+			requestedCount: items.length,
+			availableCount,
+			unknownCount,
+			complete: unknownCount === 0,
+			storageStatus,
+			cacheCount,
+			storageCount,
+			missingCount,
+			unprocessedCount,
+			oldestLastUpdated: timestamps[0] ?? null,
+			newestLastUpdated: timestamps[timestamps.length - 1] ?? null,
+			freshnessUnknownCount,
+		};
 	}
 
 	private async readLatestInternal(

--- a/apps/backend/src/modules/devices/services/property-value.service.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.ts
@@ -342,10 +342,12 @@ export class PropertyValueService {
 		const deadlineAt = Math.min(requestedDeadlineAt, startedAt + BOUNDED_READ_DEFAULT_DEADLINE_MS);
 
 		const items = new Array<BoundedPropertyValueItem | undefined>(properties.length);
+		const sourcePropertyIds = new Array<ChannelPropertyEntity['id']>(properties.length);
 		const unresolvedBySource = new Map<ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup>();
 
 		for (const [index, property] of properties.entries()) {
 			const sourcePropertyId = this.valueSourceRegistry.resolve(property);
+			sourcePropertyIds[index] = sourcePropertyId;
 			const cached = this.valuesMap.get(sourcePropertyId);
 
 			if (cached) {
@@ -367,14 +369,14 @@ export class PropertyValueService {
 		}
 
 		if (Date.now() >= deadlineAt) {
-			this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+			this.refreshBoundedItemsFromCache(items, properties, sourcePropertyIds);
 			this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
 
 			return this.buildBoundedResult(items, 'timed_out');
 		}
 
 		if (!this.storageService.isConnected()) {
-			this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+			this.refreshBoundedItemsFromCache(items, properties, sourcePropertyIds);
 			this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
 
 			return this.buildBoundedResult(items, 'disconnected');
@@ -413,7 +415,7 @@ export class PropertyValueService {
 			}
 		}
 
-		this.fillConcurrentCachedBoundedItems(items, properties, unresolvedBySource);
+		this.refreshBoundedItemsFromCache(items, properties, sourcePropertyIds);
 		this.fillUnprocessedBoundedItems(items, properties, unresolvedBySource);
 
 		return this.buildBoundedResult(items, storageStatus);
@@ -552,23 +554,28 @@ export class PropertyValueService {
 		};
 	}
 
-	private fillConcurrentCachedBoundedItems(
+	private refreshBoundedItemsFromCache(
 		items: Array<BoundedPropertyValueItem | undefined>,
 		properties: ChannelPropertyEntity[],
-		groups: Map<ChannelPropertyEntity['id'], BoundedPropertyValueSourceGroup>,
+		sourcePropertyIds: ChannelPropertyEntity['id'][],
 	): void {
-		for (const [sourcePropertyId, group] of groups) {
+		for (const [index, property] of properties.entries()) {
+			const sourcePropertyId = sourcePropertyIds[index];
 			const cached = this.valuesMap.get(sourcePropertyId);
 
 			if (!cached) {
 				continue;
 			}
+			const current = items[index];
 
-			for (const index of group.indexes) {
-				items[index] = this.toBoundedItem(properties[index].id, sourcePropertyId, cached, 'cache');
+			if (current?.state === cached) {
+				continue;
+			}
+			if (current?.state && !this.isStateNewerOrEqual(cached, current.state)) {
+				continue;
 			}
 
-			groups.delete(sourcePropertyId);
+			items[index] = this.toBoundedItem(property.id, sourcePropertyId, cached, 'cache');
 		}
 	}
 

--- a/apps/backend/src/modules/devices/services/property-value.service.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.ts
@@ -446,19 +446,22 @@ export class PropertyValueService {
 			return null;
 		}
 
-		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(new Error('Property value storage query timed out')),
+			remainingMs,
+		);
 
 		try {
-			return await Promise.race([
-				this.storageService.queryStrict<PropertyValueRow>(query),
-				new Promise<null>((resolve) => {
-					timeout = setTimeout(() => resolve(null), remainingMs);
-				}),
-			]);
-		} finally {
-			if (timeout !== undefined) {
-				clearTimeout(timeout);
+			return await this.storageService.queryStrict<PropertyValueRow>(query, { signal: controller.signal });
+		} catch (error) {
+			if (controller.signal.aborted) {
+				return null;
 			}
+
+			throw error;
+		} finally {
+			clearTimeout(timeout);
 		}
 	}
 

--- a/apps/backend/src/modules/storage/services/storage.service.spec.ts
+++ b/apps/backend/src/modules/storage/services/storage.service.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ConfigService } from '../../config/services/config.service';
 import { StoragePlugin } from '../interfaces/storage-plugin.interface';
+import { StorageQueryOptions } from '../storage.types';
 
 import { StorageService } from './storage.service';
 
@@ -54,6 +55,37 @@ describe('StorageService', () => {
 		await expect(service.queryStrict<{ value: number }>('SELECT * FROM test')).resolves.toEqual([{ value: 42 }]);
 		expect(primary.queryStrict).toHaveBeenCalledTimes(1);
 		expect(primary.query).not.toHaveBeenCalled();
+	});
+
+	it('does not start a fallback query after the primary request is aborted', async () => {
+		const service = new StorageService({
+			getModuleConfig: jest.fn().mockReturnValue({ primaryStorage: 'primary', fallbackStorage: 'fallback' }),
+		} as unknown as ConfigService);
+		const primary = createPlugin('primary');
+		const fallback = createPlugin('fallback');
+		const controller = new AbortController();
+		const abortError = new Error('query deadline exceeded');
+		primary.queryStrict = jest.fn().mockImplementation(
+			(_query: string, options?: StorageQueryOptions) =>
+				new Promise((_, reject) => {
+					const signal = options?.signal;
+
+					signal?.addEventListener(
+						'abort',
+						() => reject(signal.reason instanceof Error ? signal.reason : new Error('Storage query aborted')),
+						{ once: true },
+					);
+				}),
+		);
+		fallback.query.mockResolvedValue([{ value: 42 }]);
+		service.registerPlugin(primary.name, primary);
+		service.registerPlugin(fallback.name, fallback);
+		const query = service.queryStrict('SELECT * FROM test', { signal: controller.signal });
+
+		controller.abort(abortError);
+
+		await expect(query).rejects.toBe(abortError);
+		expect(fallback.query).not.toHaveBeenCalled();
 	});
 
 	it('rejects a strict query when no backend is available', async () => {

--- a/apps/backend/src/modules/storage/services/storage.service.ts
+++ b/apps/backend/src/modules/storage/services/storage.service.ts
@@ -143,11 +143,14 @@ export class StorageService {
 	}
 
 	async query<T>(query: string, options?: StorageQueryOptions): Promise<T[]> {
+		this.throwIfQueryAborted(options?.signal);
+
 		// Try primary first, fall back on transient failure
 		if (this.primary?.isAvailable()) {
 			try {
 				return await this.primary.query<T>(query, options);
 			} catch (error) {
+				this.throwIfQueryAborted(options?.signal);
 				const err = error as Error;
 
 				this.logger.error(`Primary query failed, trying fallback: ${err.message}`);
@@ -155,6 +158,7 @@ export class StorageService {
 		}
 
 		if (this.fallback?.isAvailable()) {
+			this.throwIfQueryAborted(options?.signal);
 			return this.fallback.query<T>(query, options);
 		}
 
@@ -166,12 +170,14 @@ export class StorageService {
 	 * but propagate the final failure instead of returning an empty result.
 	 */
 	async queryStrict<T>(query: string, options?: StorageQueryOptions): Promise<T[]> {
+		this.throwIfQueryAborted(options?.signal);
 		let primaryError: unknown;
 
 		if (this.primary?.isAvailable()) {
 			try {
 				return await (this.primary.queryStrict?.<T>(query, options) ?? this.primary.query<T>(query, options));
 			} catch (error) {
+				this.throwIfQueryAborted(options?.signal);
 				primaryError = error;
 				const err = error as Error;
 
@@ -180,6 +186,7 @@ export class StorageService {
 		}
 
 		if (this.fallback?.isAvailable()) {
+			this.throwIfQueryAborted(options?.signal);
 			return this.fallback.queryStrict?.<T>(query, options) ?? this.fallback.query<T>(query, options);
 		}
 
@@ -191,10 +198,13 @@ export class StorageService {
 	}
 
 	async queryRaw<T>(query: string, options?: StorageQueryOptions): Promise<T> {
+		this.throwIfQueryAborted(options?.signal);
+
 		if (this.primary?.isAvailable()) {
 			try {
 				return await this.primary.queryRaw<T>(query, options);
 			} catch (error) {
+				this.throwIfQueryAborted(options?.signal);
 				const err = error as Error;
 
 				this.logger.error(`Primary raw query failed, trying fallback: ${err.message}`);
@@ -202,10 +212,19 @@ export class StorageService {
 		}
 
 		if (this.fallback?.isAvailable()) {
+			this.throwIfQueryAborted(options?.signal);
 			return this.fallback.queryRaw<T>(query, options);
 		}
 
 		return { results: [] } as T;
+	}
+
+	private throwIfQueryAborted(signal?: AbortSignal): void {
+		if (!signal?.aborted) {
+			return;
+		}
+
+		throw signal.reason instanceof Error ? signal.reason : new Error('Storage query aborted');
 	}
 
 	// ─── Measurement Management ───────────────────────────────────────

--- a/apps/backend/src/modules/storage/storage.types.ts
+++ b/apps/backend/src/modules/storage/storage.types.ts
@@ -61,4 +61,6 @@ export interface StorageQueryOptions {
 	retentionPolicy?: string;
 	/** Request-level precision (nanoseconds, milliseconds, etc.). */
 	precision?: 'n' | 'u' | 'ms' | 's' | 'm' | 'h';
+	/** Cancels an in-flight row query and suppresses primary-to-fallback work after cancellation. */
+	signal?: AbortSignal;
 }

--- a/apps/backend/src/plugins/influx-v1/services/influx-v1.storage.spec.ts
+++ b/apps/backend/src/plugins/influx-v1/services/influx-v1.storage.spec.ts
@@ -13,4 +13,18 @@ describe('InfluxV1Storage', () => {
 		await expect(storage.queryStrict('SELECT * FROM property_value')).rejects.toBe(storageError);
 		expect(setupDatabase).toHaveBeenCalledTimes(1);
 	});
+
+	it('forwards the storage abort signal to the Influx v1 request', async () => {
+		const storage = new InfluxV1Storage({ database: 'test' });
+		const query = jest.fn().mockResolvedValue([]);
+		(storage as any).connection = { query };
+		const controller = new AbortController();
+
+		await storage.queryStrict('SELECT * FROM property_value', { signal: controller.signal });
+
+		expect(query).toHaveBeenCalledWith(
+			'SELECT * FROM property_value',
+			expect.objectContaining({ signal: controller.signal }),
+		);
+	});
 });

--- a/apps/backend/src/plugins/influx-v1/services/influx-v1.storage.ts
+++ b/apps/backend/src/plugins/influx-v1/services/influx-v1.storage.ts
@@ -110,6 +110,7 @@ function toInfluxQueryOptions(options?: StorageQueryOptions): IQueryOptions | un
 		database: options.database,
 		retentionPolicy: options.retentionPolicy,
 		precision: options.precision,
+		signal: options.signal,
 	};
 }
 

--- a/apps/backend/src/plugins/influx-v2/services/influx-v2.storage.spec.ts
+++ b/apps/backend/src/plugins/influx-v2/services/influx-v2.storage.spec.ts
@@ -5,7 +5,7 @@ eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-un
 Reason: The mocking and test setup requires dynamic assignment and
 handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
-import { HttpError, InfluxDB, Point } from '@influxdata/influxdb-client';
+import { FluxResultObserver, HttpError, InfluxDB, Point } from '@influxdata/influxdb-client';
 
 import { StorageFieldType, StorageMeasurementSchema, StoragePoint } from '../../../modules/storage/storage.types';
 
@@ -14,6 +14,7 @@ import { InfluxV2Storage } from './influx-v2.storage';
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 const mockCollectRows = jest.fn();
+const mockQueryRows = jest.fn();
 const mockWritePoint = jest.fn();
 const mockFlush = jest.fn();
 const mockClose = jest.fn();
@@ -31,6 +32,7 @@ jest.mock('@influxdata/influxdb-client', () => {
 			}),
 			getQueryApi: jest.fn().mockReturnValue({
 				collectRows: mockCollectRows,
+				queryRows: mockQueryRows,
 			}),
 		})),
 	};
@@ -168,6 +170,28 @@ describe('InfluxV2Storage', () => {
 			mockCollectRows.mockRejectedValue(error);
 
 			await expect(storage.queryStrict('from(bucket: "missing")')).rejects.toBe(error);
+		});
+
+		it('should cancel a strict query when its storage signal is aborted', async () => {
+			const cancel = jest.fn();
+			const controller = new AbortController();
+			const abortError = new Error('query deadline exceeded');
+			mockQueryRows.mockImplementation((_query: string, observer: FluxResultObserver<string[]>) => {
+				observer.useCancellable?.({ cancel, isCancelled: () => false });
+			});
+			const query = storage.queryStrict(
+				`SELECT * FROM property_value
+				 WHERE (propertyId = 'property-a')
+				 GROUP BY "propertyId"
+				 ORDER BY time DESC
+				 LIMIT 5`,
+				{ signal: controller.signal },
+			);
+
+			controller.abort(abortError);
+
+			await expect(query).rejects.toBe(abortError);
+			expect(cancel).toHaveBeenCalledTimes(1);
 		});
 
 		it('should translate grouped latest-value InfluxQL and normalize timestamps', async () => {

--- a/apps/backend/src/plugins/influx-v2/services/influx-v2.storage.ts
+++ b/apps/backend/src/plugins/influx-v2/services/influx-v2.storage.ts
@@ -324,9 +324,9 @@ export class InfluxV2Storage implements StoragePlugin {
 		}
 	}
 
-	async query<T>(query: string, _options?: StorageQueryOptions): Promise<T[]> {
+	async query<T>(query: string, options?: StorageQueryOptions): Promise<T[]> {
 		try {
-			const rows = await this.getQueryApi().collectRows<T>(query);
+			const rows = await this.collectRows<T>(query, options?.signal);
 
 			return rows;
 		} catch (error) {
@@ -340,9 +340,9 @@ export class InfluxV2Storage implements StoragePlugin {
 		}
 	}
 
-	async queryStrict<T>(query: string, _options?: StorageQueryOptions): Promise<T[]> {
+	async queryStrict<T>(query: string, options?: StorageQueryOptions): Promise<T[]> {
 		const fluxQuery = translateStrictInfluxQl(query, this.config.bucket);
-		const rows = await this.getQueryApi().collectRows<Record<string, unknown>>(fluxQuery);
+		const rows = await this.collectRows<Record<string, unknown>>(fluxQuery, options?.signal);
 
 		return normalizeFluxRows<T>(rows);
 	}
@@ -445,5 +445,59 @@ schema.measurements(bucket: ${bucket})`;
 		}
 
 		return this.queryApi;
+	}
+
+	private collectRows<T>(query: string, signal?: AbortSignal): Promise<T[]> {
+		if (!signal) {
+			return this.getQueryApi().collectRows<T>(query);
+		}
+		if (signal.aborted) {
+			return Promise.reject(this.getAbortReason(signal));
+		}
+
+		return new Promise<T[]>((resolve, reject) => {
+			const rows: T[] = [];
+			let settled = false;
+			let cancellable: { cancel(): void } | undefined;
+			const cleanup = (): void => signal.removeEventListener('abort', onAbort);
+			const finish = (callback: () => void): void => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				cleanup();
+				callback();
+			};
+			const onAbort = (): void => {
+				finish(() => reject(this.getAbortReason(signal)));
+				cancellable?.cancel();
+			};
+
+			signal.addEventListener('abort', onAbort, { once: true });
+
+			try {
+				this.getQueryApi().queryRows(query, {
+					next: (values, tableMeta) => {
+						if (!settled) {
+							rows.push(tableMeta.toObject(values) as T);
+						}
+					},
+					error: (error) => finish(() => reject(error)),
+					complete: () => finish(() => resolve(rows)),
+					useCancellable: (nextCancellable) => {
+						cancellable = nextCancellable;
+						if (signal.aborted) {
+							onAbort();
+						}
+					},
+				});
+			} catch (error) {
+				finish(() => reject(error as Error));
+			}
+		});
+	}
+
+	private getAbortReason(signal: AbortSignal): Error {
+		return signal.reason instanceof Error ? signal.reason : new Error('Storage query aborted');
 	}
 }

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1234,6 +1234,10 @@ captured as an opt-in/expected baseline measurement rather than a failing normal
       treating discovery as authorization, online availability, or proof that an action can execute.
 - [ ] Expose the bounded metadata search through a Buddy read tool after the structured tool-result loop is available.
 - [ ] Add safe filtered/aggregate current-state queries.
+- [x] Add a Devices-owned bounded current-value reconciliation primitive: preserve cache hits when storage is
+      unavailable, read at most 500 logical properties in sequential 50-source chunks, deduplicate projected source
+      keys, enforce a 750 ms soft response deadline, and report available/missing/unprocessed coverage plus value-time
+      bounds without changing strict MCP/device reads.
 - [ ] Add a bounded `PropertyValueService` batch/aggregate contract for current-value predicates and aggregates. Resolve
       eligible metadata in the database, reconcile cache/storage values in chunks, short-circuit only sound outcomes,
       and return eligible/evaluated/unknown/freshness/partial metadata when completeness cannot be established.


### PR DESCRIPTION
> 👍 Codex review passed on commit `bf6eb69deb` with no major issues.

## Summary

- add a Devices-owned bounded current-value reconciliation API alongside the existing strict reads
- preserve cache hits when storage is disconnected, fails, or exceeds the response deadline
- deduplicate projected source keys while returning one ordered result per logical property
- report available, missing, unprocessed, storage-source, and timestamp coverage for safe downstream aggregates
- propagate cancellation through StorageService and both Influx adapters so timed-out reads cannot accumulate in flight or start fallback work after abort
- document the completed primitive in the Buddy adaptive-context plan without marking aggregate queries complete

## Bounds and semantics

- accepts at most 500 logical properties
- queries at most 50 distinct source keys per sequential storage chunk
- clamps the caller response deadline to 750 ms and cancels the active storage request on expiry
- treats null values and completed no-row lookups as missing rather than false or zero
- keeps completed chunks and performs a final timestamp-aware cache refresh so later device writes supersede stale earlier results
- leaves existing strict MCP/device read behavior unchanged

## Validation

- 75 focused tests across bounded property reads, StorageService fallback cancellation, and Influx v1/v2 cancellation
- backend TypeScript type-check
- focused ESLint and Prettier checks for all changed backend files
- `git diff --check`
