### PR TITLE
feat(backend): add bounded current-state queries

### DIFF
--- a/apps/backend/src/modules/devices/services/channels.properties.service.integration.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.integration.spec.ts
@@ -1,0 +1,273 @@
+import { DataSource, EntitySchema, EntitySubscriberInterface, LoadEvent } from 'typeorm';
+
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../devices.constants';
+
+import { ChannelsPropertiesService } from './channels.properties.service';
+
+interface TestDeviceRow {
+	id: string;
+	name: string;
+	enabled: boolean;
+	hidden: boolean;
+	roomId: string | null;
+}
+
+interface TestChannelRow {
+	id: string;
+	name: string;
+	category: string;
+	device: TestDeviceRow;
+}
+
+interface TestPropertyRow {
+	id: string;
+	name: string | null;
+	identifier: string | null;
+	category: string;
+	dataType: string;
+	permissions: string[];
+	channel: TestChannelRow;
+}
+
+interface TestDeviceZoneRow {
+	deviceId: string;
+	zoneId: string;
+	device: TestDeviceRow;
+}
+
+interface TestSpaceRow {
+	id: string;
+	name: string;
+	parentId: string | null;
+}
+
+const deviceSchema = new EntitySchema<TestDeviceRow>({
+	name: 'CurrentStateTestDevice',
+	tableName: 'devices_module_devices',
+	columns: {
+		id: { type: String, primary: true },
+		name: { type: String },
+		enabled: { type: Boolean },
+		hidden: { type: Boolean },
+		roomId: { type: String, nullable: true },
+	},
+	relations: {
+		deviceZones: {
+			type: 'one-to-many',
+			target: 'CurrentStateTestDeviceZone',
+			inverseSide: 'device',
+		},
+	} as never,
+});
+
+const channelSchema = new EntitySchema<TestChannelRow>({
+	name: 'CurrentStateTestChannel',
+	tableName: 'devices_module_channels',
+	columns: {
+		id: { type: String, primary: true },
+		name: { type: String },
+		category: { type: String },
+	},
+	relations: {
+		device: {
+			type: 'many-to-one',
+			target: 'CurrentStateTestDevice',
+			joinColumn: { name: 'deviceId' },
+		},
+	},
+});
+
+const propertySchema = new EntitySchema<TestPropertyRow>({
+	name: 'CurrentStateTestProperty',
+	tableName: 'devices_module_channels_properties',
+	columns: {
+		id: { type: String, primary: true },
+		name: { type: String, nullable: true },
+		identifier: { type: String, nullable: true },
+		category: { type: String },
+		dataType: { type: String },
+		permissions: { type: 'simple-array' },
+	},
+	relations: {
+		channel: {
+			type: 'many-to-one',
+			target: 'CurrentStateTestChannel',
+			joinColumn: { name: 'channelId' },
+		},
+	},
+});
+
+const deviceZoneSchema = new EntitySchema<TestDeviceZoneRow>({
+	name: 'CurrentStateTestDeviceZone',
+	tableName: 'devices_module_devices_zones',
+	columns: {
+		deviceId: { type: String, primary: true },
+		zoneId: { type: String, primary: true },
+	},
+	relations: {
+		device: {
+			type: 'many-to-one',
+			target: 'CurrentStateTestDevice',
+			joinColumn: { name: 'deviceId' },
+		},
+	},
+});
+
+const spaceSchema = new EntitySchema<TestSpaceRow>({
+	name: 'CurrentStateTestSpace',
+	tableName: 'spaces_module_spaces',
+	columns: {
+		id: { type: String, primary: true },
+		name: { type: String },
+		parentId: { type: String, nullable: true },
+	},
+});
+
+const valueStorageReadProbe = jest.fn();
+
+class PropertyValueLoadProbeSubscriber implements EntitySubscriberInterface<Record<string, unknown>> {
+	afterLoad(_entity: Record<string, unknown>, event?: LoadEvent<Record<string, unknown>>): void {
+		if (event?.metadata.tableName === 'devices_module_channels_properties') {
+			valueStorageReadProbe();
+		}
+	}
+}
+
+describe('ChannelsPropertiesService.findVisibleReadableStateCandidates SQLite integration', () => {
+	let dataSource: DataSource;
+	let service: ChannelsPropertiesService;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [deviceSchema, channelSchema, propertySchema, deviceZoneSchema, spaceSchema],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+		dataSource.subscribers.push(new PropertyValueLoadProbeSubscriber());
+
+		service = Object.create(ChannelsPropertiesService.prototype) as ChannelsPropertiesService;
+		Object.defineProperty(service, 'repository', {
+			value: dataSource.getRepository<TestPropertyRow>('CurrentStateTestProperty'),
+		});
+
+		await seedCatalog();
+		valueStorageReadProbe.mockClear();
+	});
+
+	afterEach(async () => {
+		await dataSource.destroy();
+	});
+
+	async function seedCatalog(): Promise<void> {
+		await dataSource.query(
+			`INSERT INTO spaces_module_spaces (id, name, "parentId") VALUES
+			 ('floor-a', 'First floor', NULL),
+			 ('room-a', 'Living room', 'floor-a'),
+			 ('room-b', 'Kitchen', 'floor-a'),
+			 ('room-c', 'Garage', NULL)`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_devices (id, name, enabled, hidden, "roomId") VALUES
+			 ('device-disabled', 'Alpha disabled', 0, 0, 'room-a'),
+			 ('device-visible', 'Beta visible', 1, 0, 'room-b'),
+			 ('device-hidden', 'Gamma hidden', 1, 1, 'room-a'),
+			 ('device-garage', 'Delta garage', 1, 0, 'room-c')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_devices_zones ("deviceId", "zoneId") VALUES
+			 ('device-disabled', 'zone-a'),
+			 ('device-garage', 'zone-a')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels (id, name, category, "deviceId") VALUES
+			 ('channel-disabled-temp', 'Temperature', 'temperature', 'device-disabled'),
+			 ('channel-disabled-humidity', 'Humidity', 'humidity', 'device-disabled'),
+			 ('channel-visible-temp', 'Temperature', 'temperature', 'device-visible'),
+			 ('channel-hidden-temp', 'Temperature', 'temperature', 'device-hidden'),
+			 ('channel-garage-temp', 'Temperature', 'temperature', 'device-garage')`,
+		);
+		await dataSource.query(
+			`INSERT INTO devices_module_channels_properties
+			 (id, name, identifier, category, "dataType", permissions, "channelId") VALUES
+			 ('disabled-ro', 'Air temperature', 'disabled-ro', 'generic', 'float', 'ro', 'channel-disabled-temp'),
+			 ('disabled-rw', 'Target temperature', 'disabled-rw', 'target_temperature', 'float', 'rw',
+			  'channel-disabled-temp'),
+			 ('disabled-wo', 'Write only', 'disabled-wo', 'generic', 'float', 'wo', 'channel-disabled-temp'),
+			 ('disabled-ev', 'Event only', 'disabled-ev', 'generic', 'bool', 'ev', 'channel-disabled-temp'),
+			 ('disabled-humidity', 'Humidity', 'disabled-humidity', 'generic', 'float', 'ro',
+			  'channel-disabled-humidity'),
+			 ('visible-ro', 'Kitchen temperature', 'visible-ro', 'generic', 'float', 'ro', 'channel-visible-temp'),
+			 ('hidden-ro', 'Hidden temperature', 'hidden-ro', 'generic', 'float', 'ro', 'channel-hidden-temp'),
+			 ('garage-ro', 'Garage temperature', 'garage-ro', 'generic', 'int', 'ro', 'channel-garage-temp')`,
+		);
+	}
+
+	it('enforces readable visibility while retaining disabled owners and exact bounded ordering totals', async () => {
+		await dataSource.getRepository<TestPropertyRow>('CurrentStateTestProperty').findOneByOrFail({ id: 'disabled-ro' });
+		expect(valueStorageReadProbe).toHaveBeenCalledTimes(1);
+		valueStorageReadProbe.mockClear();
+
+		const full = await service.findVisibleReadableStateCandidates({ limit: 500 });
+
+		expect(full.properties.map((property) => property.id)).toEqual([
+			'disabled-humidity',
+			'disabled-ro',
+			'disabled-rw',
+			'visible-ro',
+			'garage-ro',
+		]);
+		expect(full.total).toBe(5);
+		expect(full.properties[0].channel).toMatchObject({
+			id: 'channel-disabled-humidity',
+			device: { id: 'device-disabled', enabled: false, hidden: false },
+		});
+		expect(full.properties.map((property) => property.id)).not.toEqual(
+			expect.arrayContaining(['disabled-wo', 'disabled-ev', 'hidden-ro']),
+		);
+
+		const bounded = await service.findVisibleReadableStateCandidates({ limit: 2 });
+
+		expect(bounded.properties.map((property) => property.id)).toEqual(['disabled-humidity', 'disabled-ro']);
+		expect(bounded.total).toBe(5);
+		expect(valueStorageReadProbe).not.toHaveBeenCalled();
+	});
+
+	it('applies room, zone, and floor-parent scopes in SQLite before returning candidates', async () => {
+		const room = await service.findVisibleReadableStateCandidates({ limit: 500, scope: { roomIds: ['room-b'] } });
+		const zone = await service.findVisibleReadableStateCandidates({ limit: 500, scope: { zoneId: 'zone-a' } });
+		const floor = await service.findVisibleReadableStateCandidates({ limit: 500, roomParentId: 'floor-a' });
+
+		expect(room.properties.map((property) => property.id)).toEqual(['visible-ro']);
+		expect(room.total).toBe(1);
+		expect(zone.properties.map((property) => property.id)).toEqual([
+			'disabled-humidity',
+			'disabled-ro',
+			'disabled-rw',
+			'garage-ro',
+		]);
+		expect(zone.total).toBe(4);
+		expect(floor.properties.map((property) => property.id)).toEqual([
+			'disabled-humidity',
+			'disabled-ro',
+			'disabled-rw',
+			'visible-ro',
+		]);
+		expect(floor.total).toBe(4);
+		expect(valueStorageReadProbe).not.toHaveBeenCalled();
+	});
+
+	it('combines channel, property, and data-type filters in the database', async () => {
+		const result = await service.findVisibleReadableStateCandidates({
+			limit: 500,
+			channelCategories: [ChannelCategory.TEMPERATURE],
+			propertyCategories: [PropertyCategory.GENERIC],
+			dataTypes: [DataTypeType.FLOAT],
+		});
+
+		expect(result.properties.map((property) => property.id)).toEqual(['disabled-ro', 'visible-ro']);
+		expect(result.total).toBe(2);
+		expect(valueStorageReadProbe).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -288,6 +288,134 @@ describe('ChannelsPropertiesService', () => {
 		});
 	});
 
+	describe('findVisibleReadableStateCandidates', () => {
+		const createCandidateQueryBuilder = (properties: ChannelPropertyEntity[] = [], total = 0) => ({
+			innerJoinAndSelect: jest.fn().mockReturnThis(),
+			innerJoin: jest.fn().mockReturnThis(),
+			addSelect: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			orderBy: jest.fn().mockReturnThis(),
+			addOrderBy: jest.fn().mockReturnThis(),
+			callListeners: jest.fn().mockReturnThis(),
+			take: jest.fn().mockReturnThis(),
+			skip: jest.fn().mockReturnThis(),
+			getManyAndCount: jest.fn().mockResolvedValue([properties, total]),
+		});
+
+		it('applies visibility, readability, resolved scope, metadata filters, and deterministic bounds in SQL', async () => {
+			const disabledVisibleProperty = {
+				...mockChannelProperty,
+				channel: {
+					...mockChannel,
+					device: {
+						id: 'disabled-device',
+						name: 'Disabled visible sensor',
+						hidden: false,
+						enabled: false,
+					},
+				},
+			} as unknown as ChannelPropertyEntity;
+			const queryBuilder = createCandidateQueryBuilder([disabledVisibleProperty], 42);
+			jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilder as never);
+
+			await expect(
+				channelsPropertiesService.findVisibleReadableStateCandidates({
+					limit: 100,
+					offset: 7,
+					scope: { roomIds: ['room-id'], zoneId: 'zone-id' },
+					roomParentId: 'floor-id',
+					channelCategories: [ChannelCategory.TEMPERATURE],
+					propertyCategories: [PropertyCategory.GENERIC],
+					dataTypes: [DataTypeType.FLOAT],
+				}),
+			).resolves.toEqual({ properties: [disabledVisibleProperty], total: 42 });
+
+			expect(queryBuilder.innerJoinAndSelect).toHaveBeenNthCalledWith(1, 'property.channel', 'channel');
+			expect(queryBuilder.innerJoinAndSelect).toHaveBeenNthCalledWith(2, 'channel.device', 'device');
+			expect(queryBuilder.where).toHaveBeenCalledWith('device.hidden = :hidden', { hidden: false });
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+				expect.stringContaining('property.permissions = :readOnly'),
+				expect.objectContaining({
+					readOnly: PermissionType.READ_ONLY,
+					readWrite: PermissionType.READ_WRITE,
+				}),
+			);
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('device.roomId IN (:...roomIds)', {
+				roomIds: ['room-id'],
+			});
+			expect(queryBuilder.innerJoin).toHaveBeenCalledWith('device.deviceZones', 'stateCandidateZone');
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('stateCandidateZone.zoneId = :zoneId', {
+				zoneId: 'zone-id',
+			});
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+				expect.stringContaining('state_candidate_room.parentId = :roomParentId'),
+				{ roomParentId: 'floor-id' },
+			);
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('channel.category IN (:...channelCategories)', {
+				channelCategories: [ChannelCategory.TEMPERATURE],
+			});
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('property.category IN (:...propertyCategories)', {
+				propertyCategories: [PropertyCategory.GENERIC],
+			});
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('property.dataType IN (:...dataTypes)', {
+				dataTypes: [DataTypeType.FLOAT],
+			});
+			const whereCalls = queryBuilder.where.mock.calls as Array<[string, ...unknown[]]>;
+			const andWhereCalls = queryBuilder.andWhere.mock.calls as Array<[string, ...unknown[]]>;
+			const predicates = [...whereCalls, ...andWhereCalls].map(([predicate]) => predicate);
+			expect(predicates.some((predicate) => predicate.includes('device.enabled'))).toBe(false);
+			expect(queryBuilder.orderBy).toHaveBeenCalledWith('device.name', 'ASC');
+			expect(queryBuilder.addSelect).toHaveBeenCalledWith(
+				'COALESCE(property.name, property.identifier, property.id)',
+				'stateCandidatePropertyOrder',
+			);
+			expect(queryBuilder.addOrderBy.mock.calls).toEqual([
+				['device.id', 'ASC'],
+				['channel.name', 'ASC'],
+				['channel.id', 'ASC'],
+				['stateCandidatePropertyOrder', 'ASC'],
+				['property.id', 'ASC'],
+			]);
+			expect(queryBuilder.callListeners).toHaveBeenCalledWith(false);
+			expect(queryBuilder.take).toHaveBeenCalledWith(100);
+			expect(queryBuilder.skip).toHaveBeenCalledWith(7);
+			expect(propertyValueService.readLatestStrict).not.toHaveBeenCalled();
+			expect(propertyValueService.readLatestManyStrict).not.toHaveBeenCalled();
+		});
+
+		it('accepts the exact hard cap and rejects a larger page before constructing a query', async () => {
+			const queryBuilder = createCandidateQueryBuilder([], 501);
+			jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilder as never);
+
+			await expect(channelsPropertiesService.findVisibleReadableStateCandidates({ limit: 500 })).resolves.toEqual({
+				properties: [],
+				total: 501,
+			});
+			expect(queryBuilder.take).toHaveBeenCalledWith(500);
+
+			jest.mocked(repository.createQueryBuilder).mockClear();
+			await expect(channelsPropertiesService.findVisibleReadableStateCandidates({ limit: 501 })).rejects.toThrow(
+				'At most 500 visible readable state candidates',
+			);
+			expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+		});
+
+		it.each([
+			{ limit: 0 },
+			{ limit: 10, scope: { roomIds: [] } },
+			{ limit: 10, channelCategories: [] },
+			{ limit: 10, propertyCategories: [] },
+			{ limit: 10, dataTypes: [] },
+		])('short-circuits an explicitly empty candidate set %#', async (input) => {
+			await expect(channelsPropertiesService.findVisibleReadableStateCandidates(input)).resolves.toEqual({
+				properties: [],
+				total: 0,
+			});
+			expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('searchVisibleSummaryPage', () => {
 		it('returns bounded joined metadata without reading values or excluding disabled owners', async () => {
 			const query = jest.spyOn(dataSource, 'query');

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -42,6 +42,26 @@ export interface WritablePropertyCandidates {
 	total: number;
 }
 
+export interface VisibleReadableStateCandidateScope {
+	roomIds?: string[];
+	zoneId?: string;
+}
+
+export interface VisibleReadableStateCandidatesInput {
+	limit: number;
+	offset?: number;
+	scope?: VisibleReadableStateCandidateScope;
+	roomParentId?: string;
+	channelCategories?: ChannelCategory[];
+	propertyCategories?: PropertyCategory[];
+	dataTypes?: DataTypeType[];
+}
+
+export interface VisibleReadableStateCandidates {
+	properties: ChannelPropertyEntity[];
+	total: number;
+}
+
 export interface VisiblePropertySearchSummary {
 	id: string;
 	name: string | null;
@@ -85,6 +105,7 @@ export interface VisiblePropertySearchSummaryPage {
 @Injectable()
 export class ChannelsPropertiesService {
 	private readonly logger = createExtensionLogger(DEVICES_MODULE_NAME, 'ChannelsPropertiesService');
+	private static readonly VISIBLE_READABLE_STATE_CANDIDATE_MAX_LIMIT = 500;
 
 	constructor(
 		@InjectRepository(ChannelPropertyEntity)
@@ -258,6 +279,99 @@ export class ChannelsPropertiesService {
 			.take(limit)
 			.skip(offset);
 		const [properties, total] = await query.getManyAndCount();
+
+		return { properties, total };
+	}
+
+	async findVisibleReadableStateCandidates(
+		input: VisibleReadableStateCandidatesInput,
+	): Promise<VisibleReadableStateCandidates> {
+		const offset = input.offset ?? 0;
+
+		if (!Number.isInteger(input.limit) || input.limit < 0) {
+			throw new RangeError('Visible readable state candidate limit must be a non-negative integer');
+		}
+		if (input.limit > ChannelsPropertiesService.VISIBLE_READABLE_STATE_CANDIDATE_MAX_LIMIT) {
+			throw new RangeError(
+				`At most ${ChannelsPropertiesService.VISIBLE_READABLE_STATE_CANDIDATE_MAX_LIMIT} visible readable state candidates may be selected at once`,
+			);
+		}
+		if (!Number.isInteger(offset) || offset < 0) {
+			throw new RangeError('Visible readable state candidate offset must be a non-negative integer');
+		}
+		if (
+			input.limit === 0 ||
+			input.scope?.roomIds?.length === 0 ||
+			input.channelCategories?.length === 0 ||
+			input.propertyCategories?.length === 0 ||
+			input.dataTypes?.length === 0
+		) {
+			return { properties: [], total: 0 };
+		}
+
+		const query = this.repository
+			.createQueryBuilder('property')
+			.innerJoinAndSelect('property.channel', 'channel')
+			.innerJoinAndSelect('channel.device', 'device')
+			.where('device.hidden = :hidden', { hidden: false })
+			.andWhere(
+				'(property.permissions = :readOnly OR property.permissions = :readWrite ' +
+					'OR property.permissions LIKE :readOnlyFirst OR property.permissions LIKE :readOnlyMiddle ' +
+					'OR property.permissions LIKE :readOnlyLast OR property.permissions LIKE :readWriteFirst ' +
+					'OR property.permissions LIKE :readWriteMiddle OR property.permissions LIKE :readWriteLast)',
+				{
+					readOnly: PermissionType.READ_ONLY,
+					readWrite: PermissionType.READ_WRITE,
+					readOnlyFirst: `${PermissionType.READ_ONLY},%`,
+					readOnlyMiddle: `%,${PermissionType.READ_ONLY},%`,
+					readOnlyLast: `%,${PermissionType.READ_ONLY}`,
+					readWriteFirst: `${PermissionType.READ_WRITE},%`,
+					readWriteMiddle: `%,${PermissionType.READ_WRITE},%`,
+					readWriteLast: `%,${PermissionType.READ_WRITE}`,
+				},
+			);
+
+		if (input.scope?.roomIds) {
+			query.andWhere('device.roomId IN (:...roomIds)', { roomIds: input.scope.roomIds });
+		}
+		if (input.scope?.zoneId) {
+			query
+				.innerJoin('device.deviceZones', 'stateCandidateZone')
+				.andWhere('stateCandidateZone.zoneId = :zoneId', { zoneId: input.scope.zoneId });
+		}
+		if (input.roomParentId) {
+			query.andWhere(
+				'device.roomId IN (SELECT state_candidate_room.id FROM spaces_module_spaces state_candidate_room ' +
+					'WHERE state_candidate_room.parentId = :roomParentId)',
+				{ roomParentId: input.roomParentId },
+			);
+		}
+		if (input.channelCategories) {
+			query.andWhere('channel.category IN (:...channelCategories)', {
+				channelCategories: input.channelCategories,
+			});
+		}
+		if (input.propertyCategories) {
+			query.andWhere('property.category IN (:...propertyCategories)', {
+				propertyCategories: input.propertyCategories,
+			});
+		}
+		if (input.dataTypes) {
+			query.andWhere('property.dataType IN (:...dataTypes)', { dataTypes: input.dataTypes });
+		}
+
+		const [properties, total] = await query
+			.addSelect('COALESCE(property.name, property.identifier, property.id)', 'stateCandidatePropertyOrder')
+			.orderBy('device.name', 'ASC')
+			.addOrderBy('device.id', 'ASC')
+			.addOrderBy('channel.name', 'ASC')
+			.addOrderBy('channel.id', 'ASC')
+			.addOrderBy('stateCandidatePropertyOrder', 'ASC')
+			.addOrderBy('property.id', 'ASC')
+			.callListeners(false)
+			.take(input.limit)
+			.skip(offset)
+			.getManyAndCount();
 
 		return { properties, total };
 	}

--- a/apps/backend/src/modules/home-context/home-context.constants.ts
+++ b/apps/backend/src/modules/home-context/home-context.constants.ts
@@ -99,3 +99,61 @@ export const HOME_SEARCH_MATCH_REASONS = [
 ] as const;
 
 export type HomeSearchMatchReason = (typeof HOME_SEARCH_MATCH_REASONS)[number];
+
+export const HOME_CURRENT_STATE_PROFILE_BUDDY_V1 = 'buddy-current-state-v1' as const;
+
+export type HomeCurrentStateProfile = typeof HOME_CURRENT_STATE_PROFILE_BUDDY_V1;
+
+export interface HomeCurrentStateLimitProfile {
+	defaultRows: number;
+	maxRows: number;
+	maxCandidates: number;
+	maxChannelCategories: number;
+	maxPropertyCategories: number;
+	maxDataTypes: number;
+	maxPredicateStringCharacters: number;
+}
+
+export const HOME_CURRENT_STATE_LIMIT_PROFILES: Readonly<
+	Record<HomeCurrentStateProfile, Readonly<HomeCurrentStateLimitProfile>>
+> = Object.freeze({
+	[HOME_CURRENT_STATE_PROFILE_BUDDY_V1]: Object.freeze({
+		defaultRows: 20,
+		maxRows: 50,
+		maxCandidates: 500,
+		maxChannelCategories: 16,
+		maxPropertyCategories: 16,
+		maxDataTypes: 16,
+		maxPredicateStringCharacters: 256,
+	}),
+});
+
+export const HOME_CURRENT_STATE_OPERATIONS = ['rows', 'any', 'all', 'count_matches'] as const;
+
+export type HomeCurrentStateOperation = (typeof HOME_CURRENT_STATE_OPERATIONS)[number];
+
+export const HOME_CURRENT_STATE_EQUALITY_OPERATORS = ['eq', 'ne'] as const;
+export const HOME_CURRENT_STATE_ORDERING_OPERATORS = ['gt', 'gte', 'lt', 'lte'] as const;
+
+export type HomeCurrentStateEqualityOperator = (typeof HOME_CURRENT_STATE_EQUALITY_OPERATORS)[number];
+export type HomeCurrentStateOrderingOperator = (typeof HOME_CURRENT_STATE_ORDERING_OPERATORS)[number];
+
+export const HOME_CURRENT_STATE_PARTIAL_REASONS = [
+	'scan_limit',
+	'missing_values',
+	'unprocessed_values',
+	'unknown_freshness',
+	'type_mismatch',
+	'unit_mismatch',
+] as const;
+
+export type HomeCurrentStatePartialReason = (typeof HOME_CURRENT_STATE_PARTIAL_REASONS)[number];
+
+export const HOME_CURRENT_STATE_AGGREGATE_STATUSES = [
+	'complete',
+	'conclusive_partial',
+	'indeterminate',
+	'no_eligible',
+] as const;
+
+export type HomeCurrentStateAggregateStatus = (typeof HOME_CURRENT_STATE_AGGREGATE_STATUSES)[number];

--- a/apps/backend/src/modules/home-context/home-context.module.ts
+++ b/apps/backend/src/modules/home-context/home-context.module.ts
@@ -8,13 +8,26 @@ import { SpacesModule } from '../spaces/spaces.module';
 import { WeatherModule } from '../weather/weather.module';
 
 import { HomeContextQueryService } from './services/home-context-query.service';
+import { HomeCurrentStateQueryService } from './services/home-current-state-query.service';
 import { HomeSearchQueryService } from './services/home-search-query.service';
 import { HomeStateQueryService } from './services/home-state-query.service';
 import { HomeTargetQueryService } from './services/home-target-query.service';
 
 @Module({
 	imports: [DevicesModule, EnergyModule, ScenesModule, SecurityModule, SpacesModule, WeatherModule],
-	providers: [HomeContextQueryService, HomeSearchQueryService, HomeStateQueryService, HomeTargetQueryService],
-	exports: [HomeContextQueryService, HomeSearchQueryService, HomeStateQueryService, HomeTargetQueryService],
+	providers: [
+		HomeContextQueryService,
+		HomeCurrentStateQueryService,
+		HomeSearchQueryService,
+		HomeStateQueryService,
+		HomeTargetQueryService,
+	],
+	exports: [
+		HomeContextQueryService,
+		HomeCurrentStateQueryService,
+		HomeSearchQueryService,
+		HomeStateQueryService,
+		HomeTargetQueryService,
+	],
 })
 export class HomeContextModule {}

--- a/apps/backend/src/modules/home-context/home-current-state.errors.ts
+++ b/apps/backend/src/modules/home-context/home-current-state.errors.ts
@@ -1,0 +1,8 @@
+export class HomeCurrentStateCandidateMetadataError extends Error {
+	readonly code = 'invalid_state_candidate_metadata';
+
+	constructor(readonly propertyId: string) {
+		super(`Home current-state candidate ${propertyId} is missing its channel or device metadata`);
+		this.name = HomeCurrentStateCandidateMetadataError.name;
+	}
+}

--- a/apps/backend/src/modules/home-context/models/home-current-state-query.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-current-state-query.model.ts
@@ -1,0 +1,46 @@
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HomeCurrentStateEqualityOperator,
+	HomeCurrentStateOperation,
+	HomeCurrentStateOrderingOperator,
+	HomeCurrentStateProfile,
+} from '../home-context.constants';
+
+export type HomeCurrentStateScalar = string | number | boolean;
+
+export type HomeCurrentStatePredicate =
+	| {
+			operator: HomeCurrentStateEqualityOperator;
+			value: string | boolean;
+	  }
+	| {
+			operator: HomeCurrentStateEqualityOperator;
+			value: number;
+			unit: string;
+	  }
+	| {
+			operator: HomeCurrentStateOrderingOperator;
+			value: number;
+			unit: string;
+	  };
+
+interface HomeCurrentStateQueryBase {
+	profile: HomeCurrentStateProfile;
+	spaceId?: string;
+	channelCategories?: ChannelCategory[];
+	propertyCategories?: PropertyCategory[];
+	dataTypes?: DataTypeType[];
+	limit?: number;
+}
+
+export interface HomeCurrentStateRowsQuery extends HomeCurrentStateQueryBase {
+	operation: 'rows';
+	predicate?: HomeCurrentStatePredicate;
+}
+
+export interface HomeCurrentStateAggregateQuery extends HomeCurrentStateQueryBase {
+	operation: Exclude<HomeCurrentStateOperation, 'rows'>;
+	predicate: HomeCurrentStatePredicate;
+}
+
+export type HomeCurrentStateQuery = HomeCurrentStateRowsQuery | HomeCurrentStateAggregateQuery;

--- a/apps/backend/src/modules/home-context/models/home-current-state-result.model.ts
+++ b/apps/backend/src/modules/home-context/models/home-current-state-result.model.ts
@@ -1,0 +1,86 @@
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HomeCurrentStateAggregateStatus,
+	HomeCurrentStateOperation,
+	HomeCurrentStatePartialReason,
+	HomeCurrentStateProfile,
+} from '../home-context.constants';
+
+import { HomeCurrentStatePredicate, HomeCurrentStateScalar } from './home-current-state-query.model';
+
+export type HomeCurrentStateValueSource = 'cache' | 'storage';
+export type HomeCurrentStateStorageStatus = 'not_needed' | 'available' | 'disconnected' | 'failed' | 'timed_out';
+
+export interface HomeCurrentStateRow {
+	property_id: string;
+	property_name: string | null;
+	property_category: PropertyCategory;
+	data_type: DataTypeType;
+	unit: string | null;
+	value: HomeCurrentStateScalar;
+	value_observed_at: string;
+	freshness: 'known_timestamp';
+	source: HomeCurrentStateValueSource;
+	device: {
+		id: string;
+		name: string;
+		enabled: boolean;
+		room_id: string | null;
+	};
+	channel: {
+		id: string;
+		name: string;
+		category: ChannelCategory;
+	};
+}
+
+export interface HomeCurrentStateResultBase {
+	profile: HomeCurrentStateProfile;
+	operation: HomeCurrentStateOperation;
+	predicate: HomeCurrentStatePredicate | null;
+	space_id: string | null;
+	rows: HomeCurrentStateRow[];
+	observed_at: string;
+	eligible: number;
+	scanned: number;
+	evaluated: number;
+	unknown: number;
+	matched: number;
+	returned: number;
+	complete: boolean;
+	partial: boolean;
+	partial_reasons: HomeCurrentStatePartialReason[];
+	truncated: boolean;
+	storage_status: HomeCurrentStateStorageStatus;
+	cache_count: number;
+	storage_count: number;
+	missing_count: number;
+	unprocessed_count: number;
+	oldest_last_updated: string | null;
+	newest_last_updated: string | null;
+	freshness_unknown_count: number;
+}
+
+export interface HomeCurrentStateRowsResult extends HomeCurrentStateResultBase {
+	operation: 'rows';
+	match_count: number | null;
+}
+
+export interface HomeCurrentStateBooleanResult extends HomeCurrentStateResultBase {
+	operation: 'any' | 'all';
+	value: boolean | null;
+	definitive: boolean;
+	status: HomeCurrentStateAggregateStatus;
+}
+
+export interface HomeCurrentStateCountResult extends HomeCurrentStateResultBase {
+	operation: 'count_matches';
+	value: number | null;
+	definitive: boolean;
+	status: HomeCurrentStateAggregateStatus;
+}
+
+export type HomeCurrentStateResult =
+	| HomeCurrentStateRowsResult
+	| HomeCurrentStateBooleanResult
+	| HomeCurrentStateCountResult;

--- a/apps/backend/src/modules/home-context/schemas/home-current-state-input.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-current-state-input.schemas.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HOME_CURRENT_STATE_EQUALITY_OPERATORS,
+	HOME_CURRENT_STATE_LIMIT_PROFILES,
+	HOME_CURRENT_STATE_ORDERING_OPERATORS,
+	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+} from '../home-context.constants';
+
+const limits = HOME_CURRENT_STATE_LIMIT_PROFILES[HOME_CURRENT_STATE_PROFILE_BUDDY_V1];
+
+const uniqueArray = <T extends z.ZodType>(schema: T, max: number, label: string) =>
+	z
+		.array(schema)
+		.min(1)
+		.max(max)
+		.refine((values) => new Set(values).size === values.length, `${label} must be unique`)
+		.optional();
+
+const unitSchema = z.string().trim().min(1).max(32);
+
+export const homeCurrentStatePredicateSchema = z.union([
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_EQUALITY_OPERATORS),
+			value: z.union([z.string().max(limits.maxPredicateStringCharacters), z.boolean()]),
+		})
+		.strict(),
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_EQUALITY_OPERATORS),
+			value: z.number().finite(),
+			unit: unitSchema,
+		})
+		.strict(),
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_ORDERING_OPERATORS),
+			value: z.number().finite(),
+			unit: unitSchema,
+		})
+		.strict(),
+]);
+
+const commonQueryShape = {
+	profile: z.literal(HOME_CURRENT_STATE_PROFILE_BUDDY_V1),
+	spaceId: z.string().trim().min(1).max(128).optional(),
+	channelCategories: uniqueArray(z.enum(ChannelCategory), limits.maxChannelCategories, 'Channel categories'),
+	propertyCategories: uniqueArray(z.enum(PropertyCategory), limits.maxPropertyCategories, 'Property categories'),
+	dataTypes: uniqueArray(z.enum(DataTypeType), limits.maxDataTypes, 'Data types'),
+	limit: z.number().int().min(1).max(limits.maxRows).optional(),
+};
+
+export const homeCurrentStateQuerySchema = z.discriminatedUnion('operation', [
+	z
+		.object({
+			...commonQueryShape,
+			operation: z.literal('rows'),
+			predicate: homeCurrentStatePredicateSchema.optional(),
+		})
+		.strict(),
+	z.object({ ...commonQueryShape, operation: z.literal('any'), predicate: homeCurrentStatePredicateSchema }).strict(),
+	z.object({ ...commonQueryShape, operation: z.literal('all'), predicate: homeCurrentStatePredicateSchema }).strict(),
+	z
+		.object({ ...commonQueryShape, operation: z.literal('count_matches'), predicate: homeCurrentStatePredicateSchema })
+		.strict(),
+]);

--- a/apps/backend/src/modules/home-context/schemas/home-current-state-output.schemas.ts
+++ b/apps/backend/src/modules/home-context/schemas/home-current-state-output.schemas.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HOME_CURRENT_STATE_AGGREGATE_STATUSES,
+	HOME_CURRENT_STATE_LIMIT_PROFILES,
+	HOME_CURRENT_STATE_PARTIAL_REASONS,
+	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+} from '../home-context.constants';
+
+import { homeCurrentStatePredicateSchema } from './home-current-state-input.schemas';
+
+const limits = HOME_CURRENT_STATE_LIMIT_PROFILES[HOME_CURRENT_STATE_PROFILE_BUDDY_V1];
+
+const rowSchema = z
+	.object({
+		property_id: z.string(),
+		property_name: z.string().nullable(),
+		property_category: z.enum(PropertyCategory),
+		data_type: z.enum(DataTypeType),
+		unit: z.string().nullable(),
+		value: z.union([z.string(), z.number(), z.boolean()]),
+		value_observed_at: z.string().datetime(),
+		freshness: z.literal('known_timestamp'),
+		source: z.enum(['cache', 'storage']),
+		device: z
+			.object({
+				id: z.string(),
+				name: z.string(),
+				enabled: z.boolean(),
+				room_id: z.string().nullable(),
+			})
+			.strict(),
+		channel: z
+			.object({
+				id: z.string(),
+				name: z.string(),
+				category: z.enum(ChannelCategory),
+			})
+			.strict(),
+	})
+	.strict();
+
+const commonResultShape = {
+	profile: z.literal(HOME_CURRENT_STATE_PROFILE_BUDDY_V1),
+	predicate: homeCurrentStatePredicateSchema.nullable(),
+	space_id: z.string().nullable(),
+	rows: z.array(rowSchema).max(limits.maxRows),
+	observed_at: z.string().datetime(),
+	eligible: z.number().int().nonnegative(),
+	scanned: z.number().int().nonnegative(),
+	evaluated: z.number().int().nonnegative(),
+	unknown: z.number().int().nonnegative(),
+	matched: z.number().int().nonnegative(),
+	returned: z.number().int().nonnegative().max(limits.maxRows),
+	complete: z.boolean(),
+	partial: z.boolean(),
+	partial_reasons: z.array(z.enum(HOME_CURRENT_STATE_PARTIAL_REASONS)),
+	truncated: z.boolean(),
+	storage_status: z.enum(['not_needed', 'available', 'disconnected', 'failed', 'timed_out']),
+	cache_count: z.number().int().nonnegative(),
+	storage_count: z.number().int().nonnegative(),
+	missing_count: z.number().int().nonnegative(),
+	unprocessed_count: z.number().int().nonnegative(),
+	oldest_last_updated: z.string().datetime().nullable(),
+	newest_last_updated: z.string().datetime().nullable(),
+	freshness_unknown_count: z.number().int().nonnegative(),
+};
+
+export const homeCurrentStateResultSchema = z
+	.discriminatedUnion('operation', [
+		z
+			.object({
+				...commonResultShape,
+				operation: z.literal('rows'),
+				match_count: z.number().int().nonnegative().nullable(),
+			})
+			.strict(),
+		z
+			.object({
+				...commonResultShape,
+				operation: z.enum(['any', 'all']),
+				value: z.boolean().nullable(),
+				definitive: z.boolean(),
+				status: z.enum(HOME_CURRENT_STATE_AGGREGATE_STATUSES),
+			})
+			.strict(),
+		z
+			.object({
+				...commonResultShape,
+				operation: z.literal('count_matches'),
+				value: z.number().int().nonnegative().nullable(),
+				definitive: z.boolean(),
+				status: z.enum(HOME_CURRENT_STATE_AGGREGATE_STATUSES),
+			})
+			.strict(),
+	])
+	.superRefine((result, context) => {
+		const invariant = (valid: boolean, message: string, path: PropertyKey[]) => {
+			if (!valid) {
+				context.addIssue({ code: 'custom', message, path });
+			}
+		};
+
+		invariant(result.returned === result.rows.length, 'Returned must equal the row count', ['returned']);
+		invariant(result.scanned <= result.eligible, 'Scanned may not exceed eligible', ['scanned']);
+		invariant(result.scanned <= limits.maxCandidates, 'Scanned exceeds the profile limit', ['scanned']);
+		invariant(result.evaluated <= result.scanned, 'Evaluated may not exceed scanned', ['evaluated']);
+		invariant(result.matched <= result.evaluated, 'Matched may not exceed evaluated', ['matched']);
+		invariant(result.unknown === result.eligible - result.evaluated, 'Unknown count is inconsistent', ['unknown']);
+		invariant(result.complete === (result.unknown === 0), 'Complete is inconsistent with unknown', ['complete']);
+		invariant(result.partial === !result.complete, 'Partial must be the inverse of complete', ['partial']);
+		invariant(
+			new Set(result.partial_reasons).size === result.partial_reasons.length,
+			'Partial reasons must be unique',
+			['partial_reasons'],
+		);
+		invariant(
+			result.partial ? result.partial_reasons.length > 0 : result.partial_reasons.length === 0,
+			'Partial reasons are inconsistent with partial',
+			['partial_reasons'],
+		);
+
+		if (result.operation === 'rows') {
+			invariant(result.match_count === (result.complete ? result.matched : null), 'Match count is inconsistent', [
+				'match_count',
+			]);
+		} else {
+			invariant(result.predicate !== null, 'Aggregate results require a predicate', ['predicate']);
+			invariant(
+				result.definitive === (result.status === 'complete' || result.status === 'conclusive_partial'),
+				'Definitive is inconsistent with status',
+				['definitive'],
+			);
+			invariant((result.status === 'no_eligible') === (result.eligible === 0), 'No-eligible status is inconsistent', [
+				'status',
+			]);
+			if (result.status === 'complete') {
+				invariant(result.complete && result.eligible > 0, 'Complete aggregate status is inconsistent', ['status']);
+			}
+			if (result.status === 'conclusive_partial' || result.status === 'indeterminate') {
+				invariant(result.partial, 'Partial aggregate status requires partial coverage', ['status']);
+			}
+			invariant(
+				result.status === 'indeterminate' || result.status === 'no_eligible'
+					? result.value === null
+					: result.value !== null,
+				'Aggregate value is inconsistent with status',
+				['value'],
+			);
+			if (result.operation === 'count_matches') {
+				invariant(result.status !== 'conclusive_partial', 'Counts cannot be conclusive with partial coverage', [
+					'status',
+				]);
+				if (result.status === 'complete') {
+					invariant(result.value === result.matched, 'Complete count must equal matched', ['value']);
+				}
+			} else if (result.value !== null) {
+				invariant(
+					result.value === (result.operation === 'any' ? result.matched > 0 : result.evaluated === result.matched),
+					'Boolean aggregate value is inconsistent',
+					['value'],
+				);
+			}
+		}
+	});

--- a/apps/backend/src/modules/home-context/services/home-current-state-query.service.spec.ts
+++ b/apps/backend/src/modules/home-context/services/home-current-state-query.service.spec.ts
@@ -1,0 +1,455 @@
+import { ZodError } from 'zod';
+
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import { ChannelPropertyEntity } from '../../devices/entities/devices.entity';
+import { PropertyValueState } from '../../devices/models/property-value-state.model';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
+import {
+	BoundedPropertyValueItem,
+	BoundedPropertyValueReadResult,
+	PropertyValueService,
+} from '../../devices/services/property-value.service';
+import { SpaceEntity } from '../../spaces/entities/space.entity';
+import { SpacesService } from '../../spaces/services/spaces.service';
+import { SpaceType, SpaceZoneCategory } from '../../spaces/spaces.constants';
+import { HOME_CURRENT_STATE_PROFILE_BUDDY_V1 } from '../home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../home-context.errors';
+import { homeCurrentStateQuerySchema } from '../schemas/home-current-state-input.schemas';
+import { homeCurrentStateResultSchema } from '../schemas/home-current-state-output.schemas';
+
+import { HomeCurrentStateQueryService } from './home-current-state-query.service';
+
+const profile = HOME_CURRENT_STATE_PROFILE_BUDDY_V1;
+const observedAt = '2026-08-15T12:00:00.000Z';
+
+describe('HomeCurrentStateQueryService', () => {
+	let spaces: jest.Mocked<Pick<SpacesService, 'findOne' | 'resolveSnapshotScope'>>;
+	let properties: jest.Mocked<Pick<ChannelsPropertiesService, 'findVisibleReadableStateCandidates'>>;
+	let values: jest.Mocked<Pick<PropertyValueService, 'readLatestManyBounded'>>;
+	let service: HomeCurrentStateQueryService;
+
+	beforeEach(() => {
+		spaces = {
+			findOne: jest.fn().mockResolvedValue(null),
+			resolveSnapshotScope: jest.fn(),
+		};
+		properties = {
+			findVisibleReadableStateCandidates: jest.fn().mockResolvedValue({ properties: [], total: 0 }),
+		};
+		values = {
+			readLatestManyBounded: jest.fn().mockResolvedValue(readResult([])),
+		};
+		service = new HomeCurrentStateQueryService(
+			spaces as unknown as SpacesService,
+			properties as unknown as ChannelsPropertiesService,
+			values as unknown as PropertyValueService,
+		);
+	});
+
+	it('returns bounded latest-observed rows without requiring a predicate and keeps row truncation complete', async () => {
+		const first = propertyFixture('property-a', 21, false);
+		const second = propertyFixture('property-b', 22, true);
+		const space = { id: 'room-id', type: SpaceType.ROOM } as SpaceEntity;
+		spaces.findOne.mockResolvedValue(space);
+		spaces.resolveSnapshotScope.mockResolvedValue({ deviceScope: { roomIds: ['room-id'] }, wholeHome: false });
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [first, second], total: 2 });
+		values.readLatestManyBounded.mockResolvedValue(
+			readResult([available(first.id, 21, 'cache'), available(second.id, 22, 'storage')]),
+		);
+
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'rows',
+			spaceId: 'room-id',
+			channelCategories: [ChannelCategory.TEMPERATURE],
+			propertyCategories: [PropertyCategory.TEMPERATURE],
+			dataTypes: [DataTypeType.FLOAT],
+			limit: 1,
+		});
+
+		expect(properties.findVisibleReadableStateCandidates).toHaveBeenCalledWith({
+			limit: 500,
+			offset: 0,
+			scope: { roomIds: ['room-id'] },
+			roomParentId: undefined,
+			channelCategories: [ChannelCategory.TEMPERATURE],
+			propertyCategories: [PropertyCategory.TEMPERATURE],
+			dataTypes: [DataTypeType.FLOAT],
+		});
+		expect(values.readLatestManyBounded).toHaveBeenCalledWith([first, second]);
+		expect(result).toEqual(
+			expect.objectContaining({
+				operation: 'rows',
+				predicate: null,
+				eligible: 2,
+				scanned: 2,
+				evaluated: 2,
+				unknown: 0,
+				matched: 2,
+				returned: 1,
+				complete: true,
+				partial: false,
+				partial_reasons: [],
+				truncated: true,
+				match_count: 2,
+			}),
+		);
+		expect(result.rows).toEqual([
+			{
+				property_id: 'property-a',
+				property_name: 'Temperature property-a',
+				property_category: PropertyCategory.TEMPERATURE,
+				data_type: DataTypeType.FLOAT,
+				unit: '°C',
+				value: 21,
+				value_observed_at: observedAt,
+				freshness: 'known_timestamp',
+				source: 'cache',
+				device: {
+					id: 'device-property-a',
+					name: 'Device property-a',
+					enabled: false,
+					room_id: 'room-id',
+				},
+				channel: {
+					id: 'channel-property-a',
+					name: 'Channel property-a',
+					category: ChannelCategory.TEMPERATURE,
+				},
+			},
+		]);
+		expect(homeCurrentStateResultSchema.parse(result)).toEqual(result);
+	});
+
+	it('uses a typed missing-space error before metadata or value reads', async () => {
+		await expect(service.queryCurrentState({ profile, operation: 'rows', spaceId: 'missing' })).rejects.toEqual(
+			expect.objectContaining({ constructor: HomeContextSpaceNotFoundError, spaceId: 'missing' }),
+		);
+		expect(properties.findVisibleReadableStateCandidates).not.toHaveBeenCalled();
+		expect(values.readLatestManyBounded).not.toHaveBeenCalled();
+	});
+
+	it('uses a database-bounded parent-room scope for floor zones', async () => {
+		spaces.findOne.mockResolvedValue({
+			id: 'floor-id',
+			type: SpaceType.ZONE,
+			category: SpaceZoneCategory.FLOOR_FIRST,
+		} as unknown as SpaceEntity);
+
+		await service.queryCurrentState({ profile, operation: 'rows', spaceId: 'floor-id' });
+
+		expect(spaces.resolveSnapshotScope).not.toHaveBeenCalled();
+		expect(properties.findVisibleReadableStateCandidates).toHaveBeenCalledWith(
+			expect.objectContaining({ scope: undefined, roomParentId: 'floor-id' }),
+		);
+	});
+
+	it('marks any=true as conclusive partial when the metadata scan limit leaves unknown candidates', async () => {
+		const property = propertyFixture('open-window', true);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [property], total: 501 });
+		values.readLatestManyBounded.mockResolvedValue(readResult([available(property.id, true, 'cache')]));
+
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'any',
+			predicate: { operator: 'eq', value: true },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				value: true,
+				definitive: true,
+				status: 'conclusive_partial',
+				eligible: 501,
+				scanned: 1,
+				evaluated: 1,
+				unknown: 500,
+				partial: true,
+				partial_reasons: ['scan_limit'],
+			}),
+		);
+		expect(result.rows.map((row) => row.property_id)).toEqual(['open-window']);
+	});
+
+	it('treats equality type and numeric unit mismatches as unknown rather than definitive negatives', async () => {
+		const booleanProperty = propertyFixture('boolean', true);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [booleanProperty], total: 1 });
+		values.readLatestManyBounded.mockResolvedValue(readResult([available(booleanProperty.id, true, 'cache')]));
+
+		await expect(
+			service.queryCurrentState({
+				profile,
+				operation: 'any',
+				predicate: { operator: 'eq', value: 'true' },
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({ value: null, status: 'indeterminate', partial_reasons: ['type_mismatch'] }),
+		);
+
+		const numericProperty = propertyFixture('numeric', 20);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [numericProperty], total: 1 });
+		values.readLatestManyBounded.mockResolvedValue(readResult([available(numericProperty.id, 20, 'cache')]));
+
+		await expect(
+			service.queryCurrentState({
+				profile,
+				operation: 'count_matches',
+				predicate: { operator: 'gte', value: 10, unit: '°F' },
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({ value: null, status: 'indeterminate', partial_reasons: ['unit_mismatch'] }),
+		);
+	});
+
+	it('keeps any=false indeterminate when a missing value prevents complete coverage', async () => {
+		const known = propertyFixture('closed-window', false);
+		const missingProperty = propertyFixture('unknown-window', true);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [known, missingProperty], total: 2 });
+		values.readLatestManyBounded.mockResolvedValue(
+			readResult([available(known.id, false, 'cache'), missing(missingProperty.id)]),
+		);
+
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'any',
+			predicate: { operator: 'eq', value: true },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				value: null,
+				definitive: false,
+				status: 'indeterminate',
+				evaluated: 1,
+				unknown: 1,
+				partial_reasons: ['missing_values'],
+			}),
+		);
+		expect(result.rows).toEqual([]);
+	});
+
+	it('marks all=false conclusive when another available value has an incompatible ordered type', async () => {
+		const counterexample = propertyFixture('cold', 5);
+		const incompatible = propertyFixture('label', 'warm');
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({
+			properties: [counterexample, incompatible],
+			total: 2,
+		});
+		values.readLatestManyBounded.mockResolvedValue(
+			readResult([available(counterexample.id, 5, 'storage'), available(incompatible.id, 'warm', 'storage')]),
+		);
+
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'all',
+			predicate: { operator: 'gt', value: 10, unit: '°C' },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				value: false,
+				definitive: true,
+				status: 'conclusive_partial',
+				evaluated: 1,
+				unknown: 1,
+				partial_reasons: ['type_mismatch'],
+			}),
+		);
+		expect(result.rows.map((row) => row.property_id)).toEqual(['cold']);
+	});
+
+	it('returns complete all=true and an exact complete count, but never an incomplete count', async () => {
+		const first = propertyFixture('first', 20);
+		const second = propertyFixture('second', 10);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [first, second], total: 2 });
+		values.readLatestManyBounded.mockResolvedValue(
+			readResult([available(first.id, 20, 'cache'), available(second.id, 10, 'cache')]),
+		);
+
+		await expect(
+			service.queryCurrentState({
+				profile,
+				operation: 'all',
+				predicate: { operator: 'gte', value: 10, unit: '°C' },
+			}),
+		).resolves.toEqual(expect.objectContaining({ value: true, definitive: true, status: 'complete', complete: true }));
+		await expect(
+			service.queryCurrentState({
+				profile,
+				operation: 'count_matches',
+				predicate: { operator: 'gte', value: 10, unit: '°C' },
+			}),
+		).resolves.toEqual(expect.objectContaining({ value: 2, definitive: true, status: 'complete' }));
+
+		const missingSecond = readResult([available(first.id, 20, 'cache'), unprocessed(second.id)], {
+			storageStatus: 'timed_out',
+		});
+		values.readLatestManyBounded.mockResolvedValueOnce(missingSecond);
+
+		await expect(
+			service.queryCurrentState({
+				profile,
+				operation: 'count_matches',
+				predicate: { operator: 'gte', value: 10, unit: '°C' },
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({
+				value: null,
+				definitive: false,
+				status: 'indeterminate',
+				partial_reasons: ['unprocessed_values'],
+			}),
+		);
+	});
+
+	it('reports no eligible values instead of using vacuous truth for all', async () => {
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'all',
+			predicate: { operator: 'eq', value: true },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				value: null,
+				definitive: false,
+				status: 'no_eligible',
+				eligible: 0,
+				complete: true,
+				partial: false,
+			}),
+		);
+	});
+
+	it('does not use a latest value with an unknown observation timestamp for a current claim', async () => {
+		const property = propertyFixture('timestamp-unknown', true);
+		properties.findVisibleReadableStateCandidates.mockResolvedValue({ properties: [property], total: 1 });
+		values.readLatestManyBounded.mockResolvedValue(
+			readResult([available(property.id, true, 'cache', null)], { freshnessUnknownCount: 1 }),
+		);
+
+		const result = await service.queryCurrentState({
+			profile,
+			operation: 'any',
+			predicate: { operator: 'eq', value: true },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				value: null,
+				status: 'indeterminate',
+				evaluated: 0,
+				unknown: 1,
+				partial_reasons: ['unknown_freshness'],
+				freshness_unknown_count: 1,
+			}),
+		);
+	});
+
+	it('strictly validates row and aggregate query variants', () => {
+		expect(homeCurrentStateQuerySchema.parse({ profile, operation: 'rows' })).toEqual({ profile, operation: 'rows' });
+		expect(() => homeCurrentStateQuerySchema.parse({ profile, operation: 'any' })).toThrow(ZodError);
+		expect(() =>
+			homeCurrentStateQuerySchema.parse({
+				profile,
+				operation: 'all',
+				predicate: { operator: 'gt', value: true, unit: '°C' },
+			}),
+		).toThrow(ZodError);
+		expect(() => homeCurrentStateQuerySchema.parse({ profile, operation: 'rows', arbitrary: true })).toThrow(ZodError);
+		expect(() =>
+			homeCurrentStateQuerySchema.parse({
+				profile,
+				operation: 'any',
+				predicate: { operator: 'eq', value: 'x'.repeat(257) },
+			}),
+		).toThrow(ZodError);
+	});
+
+	it('rejects cross-field inconsistent result metadata', async () => {
+		const result = await service.queryCurrentState({ profile, operation: 'rows' });
+
+		expect(() => homeCurrentStateResultSchema.parse({ ...result, returned: 1 })).toThrow(ZodError);
+		expect(() => homeCurrentStateResultSchema.parse({ ...result, unknown: 1, complete: true })).toThrow(ZodError);
+	});
+});
+
+function propertyFixture(id: string, _value: string | number | boolean, enabled = true): ChannelPropertyEntity {
+	return {
+		id,
+		name: `Temperature ${id}`,
+		identifier: id,
+		category: PropertyCategory.TEMPERATURE,
+		dataType: DataTypeType.FLOAT,
+		unit: null,
+		channel: {
+			id: `channel-${id}`,
+			name: `Channel ${id}`,
+			category: ChannelCategory.TEMPERATURE,
+			device: {
+				id: `device-${id}`,
+				name: `Device ${id}`,
+				enabled,
+				hidden: false,
+				roomId: 'room-id',
+			},
+		},
+	} as unknown as ChannelPropertyEntity;
+}
+
+function available(
+	propertyId: string,
+	value: string | number | boolean,
+	source: 'cache' | 'storage',
+	lastUpdated: string | null = observedAt,
+): BoundedPropertyValueItem {
+	return {
+		propertyId,
+		sourcePropertyId: propertyId,
+		status: 'available',
+		source,
+		state: new PropertyValueState(value, lastUpdated) as PropertyValueState & {
+			value: string | number | boolean;
+		},
+	};
+}
+
+function missing(propertyId: string): BoundedPropertyValueItem {
+	return { propertyId, sourcePropertyId: propertyId, status: 'missing', source: 'storage', state: null };
+}
+
+function unprocessed(propertyId: string): BoundedPropertyValueItem {
+	return { propertyId, sourcePropertyId: propertyId, status: 'unprocessed', source: null, state: null };
+}
+
+function readResult(
+	items: BoundedPropertyValueItem[],
+	overrides: Partial<BoundedPropertyValueReadResult> = {},
+): BoundedPropertyValueReadResult {
+	const availableItems = items.filter((item) => item.status === 'available');
+	const missingCount = items.filter((item) => item.status === 'missing').length;
+	const unprocessedCount = items.filter((item) => item.status === 'unprocessed').length;
+	const timestamps = availableItems
+		.map((item) => item.state.lastUpdated)
+		.filter((timestamp): timestamp is string => timestamp !== null && !Number.isNaN(Date.parse(timestamp)))
+		.sort();
+
+	return {
+		items,
+		requestedCount: items.length,
+		availableCount: availableItems.length,
+		unknownCount: missingCount + unprocessedCount,
+		complete: missingCount + unprocessedCount === 0,
+		storageStatus: 'not_needed',
+		cacheCount: items.filter((item) => item.source === 'cache').length,
+		storageCount: items.filter((item) => item.source === 'storage').length,
+		missingCount,
+		unprocessedCount,
+		oldestLastUpdated: timestamps[0] ?? null,
+		newestLastUpdated: timestamps[timestamps.length - 1] ?? null,
+		freshnessUnknownCount: availableItems.filter(
+			(item) => item.state.lastUpdated === null || Number.isNaN(Date.parse(item.state.lastUpdated)),
+		).length,
+		...overrides,
+	};
+}

--- a/apps/backend/src/modules/home-context/services/home-current-state-query.service.ts
+++ b/apps/backend/src/modules/home-context/services/home-current-state-query.service.ts
@@ -1,0 +1,303 @@
+import { Injectable } from '@nestjs/common';
+
+import { ChannelPropertyEntity, DeviceEntity } from '../../devices/entities/devices.entity';
+import { ChannelsPropertiesService } from '../../devices/services/channels.properties.service';
+import { BoundedPropertyValueItem, PropertyValueService } from '../../devices/services/property-value.service';
+import { resolvePropertyUnit } from '../../devices/utils/property-metadata.utils';
+import { SpacesService } from '../../spaces/services/spaces.service';
+import { SpaceType, isFloorZoneCategory } from '../../spaces/spaces.constants';
+import {
+	HOME_CURRENT_STATE_LIMIT_PROFILES,
+	HomeCurrentStateAggregateStatus,
+	HomeCurrentStatePartialReason,
+} from '../home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../home-context.errors';
+import { HomeCurrentStateCandidateMetadataError } from '../home-current-state.errors';
+import {
+	HomeCurrentStatePredicate,
+	HomeCurrentStateQuery,
+	HomeCurrentStateScalar,
+} from '../models/home-current-state-query.model';
+import {
+	HomeCurrentStateResult,
+	HomeCurrentStateResultBase,
+	HomeCurrentStateRow,
+} from '../models/home-current-state-result.model';
+import { homeCurrentStateQuerySchema } from '../schemas/home-current-state-input.schemas';
+import { homeCurrentStateResultSchema } from '../schemas/home-current-state-output.schemas';
+
+type PredicateEvaluation = boolean | 'type_mismatch' | 'unit_mismatch';
+
+@Injectable()
+export class HomeCurrentStateQueryService {
+	constructor(
+		private readonly spacesService: SpacesService,
+		private readonly propertiesService: ChannelsPropertiesService,
+		private readonly propertyValueService: PropertyValueService,
+	) {}
+
+	async queryCurrentState(query: HomeCurrentStateQuery): Promise<HomeCurrentStateResult> {
+		const input = homeCurrentStateQuerySchema.parse(query) as HomeCurrentStateQuery;
+		const limits = HOME_CURRENT_STATE_LIMIT_PROFILES[input.profile];
+		const selectedSpace = input.spaceId ? await this.spacesService.findOne(input.spaceId) : null;
+
+		if (input.spaceId && !selectedSpace) {
+			throw new HomeContextSpaceNotFoundError(input.spaceId);
+		}
+
+		const stateScope = selectedSpace ? this.resolveStateScope(selectedSpace) : {};
+		const candidates = await this.propertiesService.findVisibleReadableStateCandidates({
+			limit: limits.maxCandidates,
+			offset: 0,
+			scope: stateScope.scope,
+			roomParentId: stateScope.roomParentId,
+			channelCategories: input.channelCategories,
+			propertyCategories: input.propertyCategories,
+			dataTypes: input.dataTypes,
+		});
+		const read = await this.propertyValueService.readLatestManyBounded(candidates.properties);
+		const itemByPropertyId = new Map(read.items.map((item) => [item.propertyId, item]));
+		const partialReasons = new Set<HomeCurrentStatePartialReason>();
+
+		if (candidates.total > candidates.properties.length) {
+			partialReasons.add('scan_limit');
+		}
+		if (read.missingCount > 0) {
+			partialReasons.add('missing_values');
+		}
+		if (read.unprocessedCount > 0) {
+			partialReasons.add('unprocessed_values');
+		}
+
+		const matchedRows: HomeCurrentStateRow[] = [];
+		const counterexampleRows: HomeCurrentStateRow[] = [];
+		let evaluated = 0;
+		let matched = 0;
+		let freshnessUnknownCount = 0;
+
+		for (const property of candidates.properties) {
+			const item = itemByPropertyId.get(property.id);
+
+			if (!item || item.status !== 'available') {
+				continue;
+			}
+
+			const observedAt = item.state.lastUpdated;
+
+			const observedTime = observedAt === null ? Number.NaN : Date.parse(observedAt);
+
+			if (!Number.isFinite(observedTime)) {
+				partialReasons.add('unknown_freshness');
+				freshnessUnknownCount += 1;
+				continue;
+			}
+			const normalizedObservedAt = new Date(observedTime).toISOString();
+
+			const predicateResult = input.predicate
+				? this.evaluatePredicate(item.state.value, resolvePropertyUnit(property), input.predicate)
+				: true;
+
+			if (predicateResult === 'type_mismatch') {
+				partialReasons.add('type_mismatch');
+				continue;
+			}
+			if (predicateResult === 'unit_mismatch') {
+				partialReasons.add('unit_mismatch');
+				continue;
+			}
+
+			evaluated += 1;
+
+			if (!predicateResult) {
+				counterexampleRows.push(this.mapRow(property, item, normalizedObservedAt));
+				continue;
+			}
+
+			matched += 1;
+			matchedRows.push(this.mapRow(property, item, normalizedObservedAt));
+		}
+
+		const eligible = candidates.total;
+		const unknown = Math.max(eligible - evaluated, 0);
+		const complete = unknown === 0;
+
+		if (!complete && partialReasons.size === 0) {
+			partialReasons.add('unprocessed_values');
+		}
+
+		const rowLimit = input.limit ?? limits.defaultRows;
+		const evidenceRows = input.operation === 'all' ? counterexampleRows : matchedRows;
+		const rows = evidenceRows.slice(0, rowLimit);
+		const base: HomeCurrentStateResultBase = {
+			profile: input.profile,
+			operation: input.operation,
+			predicate: input.predicate ?? null,
+			space_id: selectedSpace?.id ?? null,
+			rows,
+			observed_at: new Date().toISOString(),
+			eligible,
+			scanned: candidates.properties.length,
+			evaluated,
+			unknown,
+			matched,
+			returned: rows.length,
+			complete,
+			partial: !complete,
+			partial_reasons: [...partialReasons],
+			truncated: evidenceRows.length > rows.length,
+			storage_status: read.storageStatus,
+			cache_count: read.cacheCount,
+			storage_count: read.storageCount,
+			missing_count: read.missingCount,
+			unprocessed_count: read.unprocessedCount,
+			oldest_last_updated: this.normalizeTimestamp(read.oldestLastUpdated),
+			newest_last_updated: this.normalizeTimestamp(read.newestLastUpdated),
+			freshness_unknown_count: freshnessUnknownCount,
+		};
+		const result = this.buildResult(base, evaluated, matched);
+
+		homeCurrentStateResultSchema.parse(result);
+
+		return result;
+	}
+
+	private evaluatePredicate(
+		value: HomeCurrentStateScalar,
+		unit: string | null,
+		predicate: HomeCurrentStatePredicate,
+	): PredicateEvaluation {
+		if (typeof value === 'number' && !Number.isFinite(value)) {
+			return 'type_mismatch';
+		}
+		if (typeof value !== typeof predicate.value) {
+			return 'type_mismatch';
+		}
+		if (typeof predicate.value === 'number' && 'unit' in predicate && unit !== predicate.unit) {
+			return 'unit_mismatch';
+		}
+
+		switch (predicate.operator) {
+			case 'eq':
+				return value === predicate.value;
+			case 'ne':
+				return value !== predicate.value;
+			case 'gt':
+			case 'gte':
+			case 'lt':
+			case 'lte':
+				if (typeof value !== 'number' || !Number.isFinite(value)) {
+					return 'type_mismatch';
+				}
+				return predicate.operator === 'gt'
+					? value > predicate.value
+					: predicate.operator === 'gte'
+						? value >= predicate.value
+						: predicate.operator === 'lt'
+							? value < predicate.value
+							: value <= predicate.value;
+		}
+	}
+
+	private resolveStateScope(space: { id: string; type: SpaceType; category?: string | null }): {
+		scope?: { roomIds?: string[]; zoneId?: string };
+		roomParentId?: string;
+	} {
+		if (space.type === SpaceType.MASTER) {
+			return {};
+		}
+		if (space.type === SpaceType.ROOM) {
+			return { scope: { roomIds: [space.id] } };
+		}
+		if (space.type === SpaceType.ENTRY || space.type !== SpaceType.ZONE) {
+			return { scope: { roomIds: [] } };
+		}
+		if (isFloorZoneCategory(space.category ?? null)) {
+			return { roomParentId: space.id };
+		}
+
+		return { scope: { zoneId: space.id } };
+	}
+
+	private normalizeTimestamp(value: string | null): string | null {
+		const timestamp = value === null ? Number.NaN : Date.parse(value);
+
+		return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+	}
+
+	private mapRow(
+		property: ChannelPropertyEntity,
+		item: Extract<BoundedPropertyValueItem, { status: 'available' }>,
+		observedAt: string,
+	): HomeCurrentStateRow {
+		const channel = typeof property.channel === 'string' ? null : property.channel;
+		const device = channel && typeof channel.device === 'string' ? null : channel?.device;
+
+		if (!channel || !device) {
+			throw new HomeCurrentStateCandidateMetadataError(property.id);
+		}
+
+		const typedDevice = device as DeviceEntity;
+
+		return {
+			property_id: property.id,
+			property_name: property.name,
+			property_category: property.category,
+			data_type: property.dataType,
+			unit: resolvePropertyUnit(property),
+			value: item.state.value,
+			value_observed_at: observedAt,
+			freshness: 'known_timestamp',
+			source: item.source,
+			device: {
+				id: typedDevice.id,
+				name: typedDevice.name,
+				enabled: typedDevice.enabled,
+				room_id: typedDevice.roomId,
+			},
+			channel: {
+				id: channel.id,
+				name: channel.name,
+				category: channel.category,
+			},
+		};
+	}
+
+	private buildResult(base: HomeCurrentStateResultBase, evaluated: number, matched: number): HomeCurrentStateResult {
+		if (base.operation === 'rows') {
+			return { ...base, operation: 'rows', match_count: base.complete ? matched : null };
+		}
+
+		if (base.eligible === 0) {
+			return {
+				...base,
+				operation: base.operation,
+				value: null,
+				definitive: false,
+				status: 'no_eligible',
+			};
+		}
+
+		if (base.operation === 'count_matches') {
+			return {
+				...base,
+				operation: 'count_matches',
+				value: base.complete ? matched : null,
+				definitive: base.complete,
+				status: base.complete ? 'complete' : 'indeterminate',
+			};
+		}
+
+		const counterexamples = evaluated - matched;
+		const conclusivePartial =
+			(base.operation === 'any' && matched > 0) || (base.operation === 'all' && counterexamples > 0);
+		const definitive = base.complete || conclusivePartial;
+		const status: HomeCurrentStateAggregateStatus = base.complete
+			? 'complete'
+			: conclusivePartial
+				? 'conclusive_partial'
+				: 'indeterminate';
+		const value = !definitive ? null : base.operation === 'any' ? matched > 0 : counterexamples === 0;
+
+		return { ...base, operation: base.operation, value, definitive, status };
+	}
+}

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1233,14 +1233,18 @@ captured as an opt-in/expected baseline measurement rather than a failing normal
       Expose candidate capabilities derived from persisted metadata and the static command-type allowlist without
       treating discovery as authorization, online availability, or proof that an action can execute.
 - [ ] Expose the bounded metadata search through a Buddy read tool after the structured tool-result loop is available.
-- [ ] Add safe filtered/aggregate current-state queries.
+- [x] Add database-bounded current-state rows plus `any`, `all`, and exact `count_matches` predicates over readable
+      properties. Require explicit units for numeric comparisons; report eligible/scanned/evaluated/unknown coverage,
+      bounded evidence rows, typed partial reasons, and only logically conclusive partial boolean outcomes.
+- [ ] Extend current-state queries with role/online filters and completeness-safe numeric minimum, maximum, sum, and
+      average operations after their unit/freshness contracts are defined.
 - [x] Add a Devices-owned bounded current-value reconciliation primitive: preserve cache hits when storage is
       unavailable, read at most 500 logical properties in sequential 50-source chunks, deduplicate projected source
       keys, enforce a 750 ms soft response deadline, and report available/missing/unprocessed coverage plus value-time
       bounds without changing strict MCP/device reads.
-- [ ] Add a bounded `PropertyValueService` batch/aggregate contract for current-value predicates and aggregates. Resolve
-      eligible metadata in the database, reconcile cache/storage values in chunks, short-circuit only sound outcomes,
-      and return eligible/evaluated/unknown/freshness/partial metadata when completeness cannot be established.
+- [x] Add a bounded HomeContext predicate/aggregate contract backed by the Devices-owned value reconciliation primitive.
+      Resolve eligible metadata in the database, reconcile cache/storage values in chunks, conclude only sound outcomes,
+      and return eligible/scanned/evaluated/unknown/freshness/partial metadata when completeness cannot be established.
 - [ ] Preserve `observed_at`, `total`, `returned`, `partial`, and `truncated` metadata.
 - [ ] Import `HomeContextModule` from MCP and prove the MCP endpoint can be disabled while shared queries still work.
 - [x] Avoid a Buddy-to-`McpModule` dependency and avoid a domain-to-`ToolsModule` cycle.


### PR DESCRIPTION
> 👍 Codex review passed on commit `a83f40df46` with no major issues.

## Summary

- add a SQL-bounded readable-property selector with hidden-owner exclusion, disabled-owner retention, deterministic ordering, exact totals, and room/zone/floor/category/type filters
- add a provider-neutral `HomeCurrentStateQueryService` for bounded latest-observed rows and safe `any`, `all`, and exact `count_matches` predicates
- reconcile values through the bounded `PropertyValueService` cache/storage primitive and expose eligible, scanned, evaluated, unknown, source, timestamp, and partial-coverage metadata
- require explicit matching units for numeric predicates and treat type, unit, missing, unprocessed, freshness, and scan-limit gaps as unknown rather than false or zero
- keep Buddy/MCP tool exposure, online/role filters, string serialization caps, and numeric min/max/sum/average operations deferred

## Safety semantics

- scans at most 500 eligible properties and returns 20 evidence rows by default, with a hard maximum of 50
- `any=true` and `all=false` may be conclusive with partial coverage; the inverse outcomes and exact counts require complete evaluation
- empty eligibility returns `no_eligible` rather than vacuous `all=true`
- `all` returns counterexample evidence; output truncation is distinct from aggregate coverage loss
- floor scopes use a bounded SQL parent-room subquery rather than materializing an unbounded child-room ID list
- current-state results are not action authorization and are not yet exposed as a Buddy tool

## Validation

- 70 HomeContext service tests
- 34 readable-candidate unit and real-SQLite integration tests
- backend TypeScript type-check
- focused ESLint and Prettier checks for changed TypeScript
- `git diff --check`

The real SQLite suite also caught and fixed a TypeORM pagination failure in the computed property ordering expression.