### PR TITLE
feat(backend): add native LLM tool transcripts

### DIFF
--- a/apps/backend/src/modules/buddy/platforms/anthropic-sdk.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/anthropic-sdk.utils.ts
@@ -1,7 +1,15 @@
 import type { LlmToolCall, ToolDefinition } from '../../tools/platforms/tool-provider.platform';
 import { MessageRole } from '../buddy.constants';
 
-import type { ChatMessage } from './llm-provider.platform';
+import {
+	isChatMessage,
+	isLlmAssistantToolCallsItem,
+	isLlmToolResultError,
+	requireProviderCallId,
+	serializeLlmConversationToolResult,
+	validateLlmConversationItems,
+} from './llm-conversation.utils';
+import type { LlmConversationItem } from './llm-provider.platform';
 
 // Module path as variable to prevent TypeScript from statically resolving optional peer dependency
 const ANTHROPIC_SDK_MODULE = '@anthropic-ai/sdk';
@@ -34,7 +42,7 @@ export interface AnthropicSdkResult {
 export function buildAnthropicRequestPayload(
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	maxTokens: number = 1024,
 	tools?: ToolDefinition[],
 ): Record<string, unknown> {
@@ -42,10 +50,7 @@ export function buildAnthropicRequestPayload(
 		model,
 		max_tokens: maxTokens,
 		system: systemPrompt,
-		messages: messages.map((message) => ({
-			role: message.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
-			content: message.content,
-		})),
+		messages: buildAnthropicConversationMessages(messages),
 	};
 
 	if (tools && tools.length > 0) {
@@ -67,7 +72,7 @@ export async function sendAnthropicMessage(
 	credentials: AnthropicCredentials,
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	timeout: number,
 	maxTokens: number = 1024,
 	tools?: ToolDefinition[],
@@ -133,4 +138,48 @@ export async function sendAnthropicMessage(
 		cacheReadTokens: usage?.cache_read_input_tokens ?? null,
 		cacheWriteTokens: usage?.cache_creation_input_tokens ?? null,
 	};
+}
+
+function buildAnthropicConversationMessages(messages: LlmConversationItem[]): Array<Record<string, unknown>> {
+	validateLlmConversationItems(messages);
+
+	return messages.flatMap((item): Array<Record<string, unknown>> => {
+		if (isChatMessage(item)) {
+			return [
+				{
+					role: item.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
+					content: item.content,
+				},
+			];
+		}
+
+		if (isLlmAssistantToolCallsItem(item)) {
+			return [
+				{
+					role: 'assistant',
+					content: [
+						...(item.content.length > 0 ? [{ type: 'text', text: item.content }] : []),
+						...item.calls.map((call) => ({
+							type: 'tool_use',
+							id: requireProviderCallId('Anthropic', call.providerCallId),
+							name: call.name,
+							input: call.arguments,
+						})),
+					],
+				},
+			];
+		}
+
+		return [
+			{
+				role: 'user',
+				content: item.results.map((result) => ({
+					type: 'tool_result',
+					tool_use_id: requireProviderCallId('Anthropic', result.providerCallId),
+					content: serializeLlmConversationToolResult(result),
+					...(isLlmToolResultError(result) ? { is_error: true } : {}),
+				})),
+			},
+		];
+	});
 }

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
@@ -40,6 +40,7 @@ export function requireProviderCallId(provider: string, providerCallId: string |
  */
 export function validateLlmConversationItems(items: LlmConversationItem[]): void {
 	const seenCallIds = new Set<string>();
+	const seenProviderCallIds = new Set<string>();
 
 	for (let index = 0; index < items.length; index += 1) {
 		const item = items[index];
@@ -71,6 +72,13 @@ export function validateLlmConversationItems(items: LlmConversationItem[]): void
 			}
 			seenCallIds.add(call.callId);
 
+			if (call.providerCallId !== null) {
+				if (call.providerCallId.length === 0 || seenProviderCallIds.has(call.providerCallId)) {
+					throw new TypeError(`Tool call at index ${index}:${callIndex} has an empty or duplicate provider ID`);
+				}
+				seenProviderCallIds.add(call.providerCallId);
+			}
+
 			const result = resultItem.results[callIndex];
 
 			if (
@@ -79,6 +87,21 @@ export function validateLlmConversationItems(items: LlmConversationItem[]): void
 				result.toolName !== call.name
 			) {
 				throw new TypeError(`Tool result at index ${index + 1}:${callIndex} does not match its ordered call`);
+			}
+		}
+
+		for (const [providerItemIndex, providerItem] of (item.providerItems ?? []).entries()) {
+			if (providerItem.provider.length === 0) {
+				throw new TypeError(`Provider item at index ${index}:${providerItemIndex} has an empty provider`);
+			}
+
+			if (
+				providerItem.beforeProviderCallId !== null &&
+				!item.calls.some((call) => call.providerCallId === providerItem.beforeProviderCallId)
+			) {
+				throw new TypeError(
+					`Provider item at index ${index}:${providerItemIndex} references an unknown provider call ID`,
+				);
 			}
 		}
 

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
@@ -40,7 +40,6 @@ export function requireProviderCallId(provider: string, providerCallId: string |
  */
 export function validateLlmConversationItems(items: LlmConversationItem[]): void {
 	const seenCallIds = new Set<string>();
-	const seenProviderCallIds = new Set<string>();
 
 	for (let index = 0; index < items.length; index += 1) {
 		const item = items[index];
@@ -65,6 +64,8 @@ export function validateLlmConversationItems(items: LlmConversationItem[]): void
 		if (resultItem.results.length !== item.calls.length) {
 			throw new TypeError(`Assistant tool call group at index ${index} must have exactly one result per call`);
 		}
+
+		const seenProviderCallIds = new Set<string>();
 
 		for (const [callIndex, call] of item.calls.entries()) {
 			if (call.callId.length === 0 || seenCallIds.has(call.callId)) {

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
@@ -1,0 +1,94 @@
+import type {
+	ChatMessage,
+	LlmAssistantToolCallsItem,
+	LlmConversationItem,
+	LlmConversationToolResult,
+	LlmToolResultsItem,
+} from './llm-provider.platform';
+
+export const isLlmAssistantToolCallsItem = (item: LlmConversationItem): item is LlmAssistantToolCallsItem =>
+	'type' in item && item.type === 'assistant_tool_calls';
+
+export const isLlmToolResultsItem = (item: LlmConversationItem): item is LlmToolResultsItem =>
+	'type' in item && item.type === 'tool_results';
+
+export const isChatMessage = (item: LlmConversationItem): item is ChatMessage => !('type' in item);
+
+export function serializeLlmConversationToolResult(result: LlmConversationToolResult): string {
+	return JSON.stringify({
+		call_id: result.callId,
+		tool_name: result.toolName,
+		status: result.status,
+		message: result.message,
+		...(result.data === undefined ? {} : { data: result.data }),
+		...(result.errorCode === undefined ? {} : { error_code: result.errorCode }),
+		truncated: result.truncated,
+	});
+}
+
+export function requireProviderCallId(provider: string, providerCallId: string | null): string {
+	if (providerCallId === null || providerCallId.length === 0) {
+		throw new TypeError(`${provider} tool transcript requires a provider call ID`);
+	}
+
+	return providerCallId;
+}
+
+/**
+ * Validate complete, adjacent call/result groups before any provider request is built.
+ * This prevents orphaned or reordered results from reaching strict native protocols.
+ */
+export function validateLlmConversationItems(items: LlmConversationItem[]): void {
+	const seenCallIds = new Set<string>();
+
+	for (let index = 0; index < items.length; index += 1) {
+		const item = items[index];
+
+		if (isChatMessage(item)) {
+			continue;
+		}
+
+		if (isLlmToolResultsItem(item)) {
+			throw new TypeError(`Tool result group at index ${index} has no immediately preceding assistant call group`);
+		}
+
+		if (item.calls.length === 0) {
+			throw new TypeError(`Assistant tool call group at index ${index} must contain at least one call`);
+		}
+
+		const resultItem = items[index + 1];
+
+		if (resultItem === undefined || !isLlmToolResultsItem(resultItem)) {
+			throw new TypeError(`Assistant tool call group at index ${index} must be immediately followed by its results`);
+		}
+		if (resultItem.results.length !== item.calls.length) {
+			throw new TypeError(`Assistant tool call group at index ${index} must have exactly one result per call`);
+		}
+
+		for (const [callIndex, call] of item.calls.entries()) {
+			if (call.callId.length === 0 || seenCallIds.has(call.callId)) {
+				throw new TypeError(`Tool call at index ${index}:${callIndex} has an empty or duplicate canonical ID`);
+			}
+			seenCallIds.add(call.callId);
+
+			const result = resultItem.results[callIndex];
+
+			if (
+				result.callId !== call.callId ||
+				result.providerCallId !== call.providerCallId ||
+				result.toolName !== call.name
+			) {
+				throw new TypeError(`Tool result at index ${index + 1}:${callIndex} does not match its ordered call`);
+			}
+		}
+
+		index += 1;
+	}
+}
+
+export const isLlmToolResultError = (result: LlmConversationToolResult): boolean =>
+	result.status === 'failed' ||
+	result.status === 'timed_out' ||
+	result.status === 'denied' ||
+	result.status === 'indeterminate' ||
+	result.status === 'malformed';

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation.utils.ts
@@ -90,19 +90,23 @@ export function validateLlmConversationItems(items: LlmConversationItem[]): void
 			}
 		}
 
+		const seenProviderOutputIndexes = new Set<number>();
+
 		for (const [providerItemIndex, providerItem] of (item.providerItems ?? []).entries()) {
 			if (providerItem.provider.length === 0) {
 				throw new TypeError(`Provider item at index ${index}:${providerItemIndex} has an empty provider`);
 			}
 
 			if (
-				providerItem.beforeProviderCallId !== null &&
-				!item.calls.some((call) => call.providerCallId === providerItem.beforeProviderCallId)
+				!Number.isInteger(providerItem.outputIndex) ||
+				providerItem.outputIndex < 0 ||
+				seenProviderOutputIndexes.has(providerItem.outputIndex)
 			) {
 				throw new TypeError(
-					`Provider item at index ${index}:${providerItemIndex} references an unknown provider call ID`,
+					`Provider item at index ${index}:${providerItemIndex} has an invalid or duplicate output index`,
 				);
 			}
+			seenProviderOutputIndexes.add(providerItem.outputIndex);
 		}
 
 		index += 1;

--- a/apps/backend/src/modules/buddy/platforms/llm-native-transcript-serialization.spec.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-native-transcript-serialization.spec.ts
@@ -1,0 +1,218 @@
+import { MessageRole } from '../buddy.constants';
+
+import { buildAnthropicRequestPayload } from './anthropic-sdk.utils';
+import { serializeLlmConversationToolResult } from './llm-conversation.utils';
+import type { LlmConversationItem, LlmConversationToolResult } from './llm-provider.platform';
+import { buildOpenAiRequestPayload } from './openai-sdk.utils';
+
+describe('native tool transcript serialization', () => {
+	const firstResult: LlmConversationToolResult = {
+		callId: 'call-1',
+		providerCallId: 'provider-call-1',
+		toolName: 'read_device',
+		status: 'completed',
+		message: 'Device read',
+		data: { value: 21.5, unit: 'celsius' },
+		truncated: false,
+	};
+	const secondResult: LlmConversationToolResult = {
+		callId: 'call-2',
+		providerCallId: 'provider-call-2',
+		toolName: 'read_history',
+		status: 'timed_out',
+		message: 'Storage deadline exceeded',
+		errorCode: 'storage_timeout',
+		truncated: true,
+	};
+	const nativeTranscript: LlmConversationItem[] = [
+		{ role: MessageRole.USER, content: 'Read the room' },
+		{
+			type: 'assistant_tool_calls',
+			content: 'I will check both readings.',
+			calls: [
+				{
+					callId: 'call-1',
+					providerCallId: 'provider-call-1',
+					name: 'read_device',
+					arguments: { device_id: 'device-1' },
+					rawArguments: '{ "device_id": "device-1" }',
+				},
+				{
+					callId: 'call-2',
+					providerCallId: 'provider-call-2',
+					name: 'read_history',
+					arguments: { property_id: 'property-1' },
+				},
+			],
+		},
+		{ type: 'tool_results', results: [firstResult, secondResult] },
+	];
+
+	it('preserves the exact OpenAI text-only payload shape', () => {
+		expect(
+			buildOpenAiRequestPayload('gpt-test', 'System prompt', [
+				{ role: MessageRole.USER, content: 'Hello' },
+				{ role: MessageRole.ASSISTANT, content: 'Hi' },
+			]),
+		).toEqual({
+			model: 'gpt-test',
+			max_completion_tokens: 1024,
+			messages: [
+				{ role: 'system', content: 'System prompt' },
+				{ role: 'user', content: 'Hello' },
+				{ role: 'assistant', content: 'Hi' },
+			],
+		});
+	});
+
+	it('serializes ordered native OpenAI calls and individual correlated results', () => {
+		expect(buildOpenAiRequestPayload('gpt-test', 'System prompt', nativeTranscript)).toEqual({
+			model: 'gpt-test',
+			max_completion_tokens: 1024,
+			messages: [
+				{ role: 'system', content: 'System prompt' },
+				{ role: 'user', content: 'Read the room' },
+				{
+					role: 'assistant',
+					content: 'I will check both readings.',
+					tool_calls: [
+						{
+							id: 'provider-call-1',
+							type: 'function',
+							function: { name: 'read_device', arguments: '{ "device_id": "device-1" }' },
+						},
+						{
+							id: 'provider-call-2',
+							type: 'function',
+							function: { name: 'read_history', arguments: '{"property_id":"property-1"}' },
+						},
+					],
+				},
+				{
+					role: 'tool',
+					tool_call_id: 'provider-call-1',
+					content: serializeLlmConversationToolResult(firstResult),
+				},
+				{
+					role: 'tool',
+					tool_call_id: 'provider-call-2',
+					content: serializeLlmConversationToolResult(secondResult),
+				},
+			],
+		});
+	});
+
+	it('preserves the exact Anthropic text-only payload shape', () => {
+		expect(
+			buildAnthropicRequestPayload('claude-test', 'System prompt', [
+				{ role: MessageRole.USER, content: 'Hello' },
+				{ role: MessageRole.ASSISTANT, content: 'Hi' },
+			]),
+		).toEqual({
+			model: 'claude-test',
+			max_tokens: 1024,
+			system: 'System prompt',
+			messages: [
+				{ role: 'user', content: 'Hello' },
+				{ role: 'assistant', content: 'Hi' },
+			],
+		});
+	});
+
+	it('serializes Anthropic calls and one ordered grouped result message', () => {
+		expect(buildAnthropicRequestPayload('claude-test', 'System prompt', nativeTranscript)).toEqual({
+			model: 'claude-test',
+			max_tokens: 1024,
+			system: 'System prompt',
+			messages: [
+				{ role: 'user', content: 'Read the room' },
+				{
+					role: 'assistant',
+					content: [
+						{ type: 'text', text: 'I will check both readings.' },
+						{
+							type: 'tool_use',
+							id: 'provider-call-1',
+							name: 'read_device',
+							input: { device_id: 'device-1' },
+						},
+						{
+							type: 'tool_use',
+							id: 'provider-call-2',
+							name: 'read_history',
+							input: { property_id: 'property-1' },
+						},
+					],
+				},
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'provider-call-1',
+							content: serializeLlmConversationToolResult(firstResult),
+						},
+						{
+							type: 'tool_result',
+							tool_use_id: 'provider-call-2',
+							content: serializeLlmConversationToolResult(secondResult),
+							is_error: true,
+						},
+					],
+				},
+			],
+		});
+	});
+
+	const invalidTranscripts: Array<[string, LlmConversationItem[], string]> = [
+		[
+			'orphan results',
+			[{ type: 'tool_results', results: [firstResult] }] satisfies LlmConversationItem[],
+			'no immediately preceding assistant call group',
+		],
+		['missing results', nativeTranscript.slice(0, 2), 'must be immediately followed by its results'],
+		[
+			'reordered results',
+			[nativeTranscript[0], nativeTranscript[1], { type: 'tool_results', results: [secondResult, firstResult] }],
+			'does not match its ordered call',
+		],
+	];
+
+	it.each(invalidTranscripts)(
+		'rejects %s before building a provider request',
+		(_description, transcript, expectedMessage) => {
+			expect(() => buildOpenAiRequestPayload('gpt-test', 'System prompt', transcript)).toThrow(expectedMessage);
+			expect(() => buildAnthropicRequestPayload('claude-test', 'System prompt', transcript)).toThrow(expectedMessage);
+		},
+	);
+
+	it('rejects native provider protocols when a provider call ID is unavailable', () => {
+		const transcript: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [{ callId: 'canonical-only', providerCallId: null, name: 'read', arguments: {} }],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'canonical-only',
+						providerCallId: null,
+						toolName: 'read',
+						status: 'completed',
+						message: 'Done',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(() => buildOpenAiRequestPayload('gpt-test', 'System prompt', transcript)).toThrow(
+			'OpenAI Chat tool transcript requires a provider call ID',
+		);
+		expect(() => buildAnthropicRequestPayload('claude-test', 'System prompt', transcript)).toThrow(
+			'Anthropic tool transcript requires a provider call ID',
+		);
+	});
+});

--- a/apps/backend/src/modules/buddy/platforms/llm-native-transcript-serialization.spec.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-native-transcript-serialization.spec.ts
@@ -1,7 +1,7 @@
 import { MessageRole } from '../buddy.constants';
 
 import { buildAnthropicRequestPayload } from './anthropic-sdk.utils';
-import { serializeLlmConversationToolResult } from './llm-conversation.utils';
+import { serializeLlmConversationToolResult, validateLlmConversationItems } from './llm-conversation.utils';
 import type { LlmConversationItem, LlmConversationToolResult } from './llm-provider.platform';
 import { buildOpenAiRequestPayload } from './openai-sdk.utils';
 
@@ -214,5 +214,70 @@ describe('native tool transcript serialization', () => {
 		expect(() => buildAnthropicRequestPayload('claude-test', 'System prompt', transcript)).toThrow(
 			'Anthropic tool transcript requires a provider call ID',
 		);
+	});
+
+	it('allows a provider call ID to repeat across dependent groups while canonical IDs remain unique', () => {
+		const dependentTranscript: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [{ callId: 'turn-1-call-1', providerCallId: 'ollama-0', name: 'read', arguments: {} }],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'turn-1-call-1',
+						providerCallId: 'ollama-0',
+						toolName: 'read',
+						status: 'completed',
+						message: 'First result',
+						truncated: false,
+					},
+				],
+			},
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [{ callId: 'turn-1-call-2', providerCallId: 'ollama-0', name: 'read', arguments: {} }],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'turn-1-call-2',
+						providerCallId: 'ollama-0',
+						toolName: 'read',
+						status: 'completed',
+						message: 'Second result',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(() => validateLlmConversationItems(dependentTranscript)).not.toThrow();
+	});
+
+	it('rejects duplicate provider call IDs within one parallel group', () => {
+		const duplicateProviderIds: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [
+					{ callId: 'call-1', providerCallId: 'provider-1', name: 'read', arguments: {} },
+					{ callId: 'call-2', providerCallId: 'provider-1', name: 'read', arguments: {} },
+				],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{ ...firstResult, callId: 'call-1', providerCallId: 'provider-1', toolName: 'read' },
+					{ ...firstResult, callId: 'call-2', providerCallId: 'provider-1', toolName: 'read' },
+				],
+			},
+		];
+
+		expect(() => validateLlmConversationItems(duplicateProviderIds)).toThrow('duplicate provider ID');
 	});
 });

--- a/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
@@ -8,6 +8,54 @@ export interface ChatMessage {
 	content: string;
 }
 
+export type LlmToolResultStatus =
+	| 'completed'
+	| 'partial'
+	| 'failed'
+	| 'timed_out'
+	| 'denied'
+	| 'indeterminate'
+	| 'malformed';
+
+export interface LlmConversationToolCall {
+	/** Stable provider-neutral ID for this active transcript. */
+	callId: string;
+	/** Provider-issued correlation ID, or null when the native protocol has none. */
+	providerCallId: string | null;
+	name: string;
+	arguments: Record<string, unknown>;
+	/** Exact provider argument text when the native protocol uses encoded JSON. */
+	rawArguments?: string;
+}
+
+export interface LlmConversationToolResult {
+	callId: string;
+	providerCallId: string | null;
+	toolName: string;
+	status: LlmToolResultStatus;
+	message: string;
+	data?: Record<string, unknown>;
+	errorCode?: string;
+	truncated: boolean;
+}
+
+export interface LlmAssistantToolCallsItem {
+	type: 'assistant_tool_calls';
+	content: string;
+	calls: LlmConversationToolCall[];
+}
+
+export interface LlmToolResultsItem {
+	type: 'tool_results';
+	results: LlmConversationToolResult[];
+}
+
+/**
+ * Additive provider-neutral active-turn transcript. Existing text-only callers can
+ * keep passing ChatMessage objects unchanged.
+ */
+export type LlmConversationItem = ChatMessage | LlmAssistantToolCallsItem | LlmToolResultsItem;
+
 export interface LlmOptions {
 	timeout?: number;
 	model?: string;
@@ -89,11 +137,19 @@ export interface ILlmProvider {
 	 * @param options Additional options (timeout, tools, etc.)
 	 * @returns The assistant's response content and metadata
 	 */
-	sendMessage(systemPrompt: string, messages: ChatMessage[], model: string, options?: LlmOptions): Promise<LlmResponse>;
+	sendMessage(
+		systemPrompt: string,
+		messages: LlmConversationItem[],
+		model: string,
+		options?: LlmOptions,
+	): Promise<LlmResponse>;
 
 	/**
 	 * Whether this provider supports tool use (function calling).
 	 * Providers that don't support tools will gracefully degrade to text-only responses.
 	 */
 	supportsTools?(): boolean;
+
+	/** Whether this provider can receive native correlated tool-result transcript items. */
+	supportsNativeToolResults?(): boolean;
 }

--- a/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
@@ -58,16 +58,44 @@ export interface LlmConversationReasoningItem {
 	status?: 'in_progress' | 'completed' | 'incomplete';
 }
 
+export interface LlmConversationAssistantTextPart {
+	type: 'output_text';
+	text: string;
+	annotations: [];
+}
+
+export interface LlmConversationAssistantMessageItem {
+	type: 'message';
+	id: string;
+	role: 'assistant';
+	content: LlmConversationAssistantTextPart[];
+	status?: 'in_progress' | 'completed' | 'incomplete';
+}
+
+export interface LlmConversationFunctionCallItem {
+	type: 'function_call';
+	id?: string;
+	call_id: string;
+	name: string;
+	arguments: string;
+	status?: 'in_progress' | 'completed' | 'incomplete';
+}
+
+export type LlmConversationProviderOutputItem =
+	| LlmConversationReasoningItem
+	| LlmConversationAssistantMessageItem
+	| LlmConversationFunctionCallItem;
+
 /**
  * Provider-owned active-turn state that must be replayed to continue a native
  * tool exchange. It is never persisted as ordinary conversation history.
  */
 export interface LlmConversationProviderItem {
 	provider: string;
-	/** Native call before which this output item appeared, or null when it followed all calls. */
-	beforeProviderCallId: string | null;
-	/** Validated active-turn reasoning output returned by the provider. */
-	item: LlmConversationReasoningItem;
+	/** Exact position in the provider's response output array. */
+	outputIndex: number;
+	/** Validated active-turn output returned by the provider. */
+	item: LlmConversationProviderOutputItem;
 }
 
 export interface LlmAssistantToolCallsItem {

--- a/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
@@ -69,6 +69,7 @@ export interface LlmConversationAssistantMessageItem {
 	id: string;
 	role: 'assistant';
 	content: LlmConversationAssistantTextPart[];
+	phase?: 'commentary' | 'final_answer';
 	status?: 'in_progress' | 'completed' | 'incomplete';
 }
 

--- a/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
@@ -58,17 +58,69 @@ export interface LlmConversationReasoningItem {
 	status?: 'in_progress' | 'completed' | 'incomplete';
 }
 
+export interface LlmConversationFileCitationAnnotation {
+	type: 'file_citation';
+	file_id: string;
+	filename: string;
+	index: number;
+}
+
+export interface LlmConversationUrlCitationAnnotation {
+	type: 'url_citation';
+	end_index: number;
+	start_index: number;
+	title: string;
+	url: string;
+}
+
+export interface LlmConversationContainerFileCitationAnnotation {
+	type: 'container_file_citation';
+	container_id: string;
+	end_index: number;
+	file_id: string;
+	filename: string;
+	start_index: number;
+}
+
+export interface LlmConversationFilePathAnnotation {
+	type: 'file_path';
+	file_id: string;
+	index: number;
+}
+
+export type LlmConversationAssistantTextAnnotation =
+	| LlmConversationFileCitationAnnotation
+	| LlmConversationUrlCitationAnnotation
+	| LlmConversationContainerFileCitationAnnotation
+	| LlmConversationFilePathAnnotation;
+
+export interface LlmConversationAssistantTopLogprob {
+	token: string;
+	bytes: number[];
+	logprob: number;
+}
+
+export interface LlmConversationAssistantLogprob extends LlmConversationAssistantTopLogprob {
+	top_logprobs: LlmConversationAssistantTopLogprob[];
+}
+
 export interface LlmConversationAssistantTextPart {
 	type: 'output_text';
 	text: string;
-	annotations: [];
+	annotations: LlmConversationAssistantTextAnnotation[];
+	logprobs?: LlmConversationAssistantLogprob[];
+}
+
+export interface LlmConversationAssistantRefusalPart {
+	type: 'refusal';
+	refusal: string;
 }
 
 export interface LlmConversationAssistantMessageItem {
 	type: 'message';
 	id: string;
 	role: 'assistant';
-	content: LlmConversationAssistantTextPart[];
+	content: Array<LlmConversationAssistantTextPart | LlmConversationAssistantRefusalPart>;
 	phase?: 'commentary' | 'final_answer';
 	status?: 'in_progress' | 'completed' | 'incomplete';
 }

--- a/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-provider.platform.ts
@@ -39,10 +39,42 @@ export interface LlmConversationToolResult {
 	truncated: boolean;
 }
 
+export interface LlmConversationReasoningSummaryPart {
+	type: 'summary_text';
+	text: string;
+}
+
+export interface LlmConversationReasoningContentPart {
+	type: 'reasoning_text';
+	text: string;
+}
+
+export interface LlmConversationReasoningItem {
+	type: 'reasoning';
+	id: string;
+	summary: LlmConversationReasoningSummaryPart[];
+	content?: LlmConversationReasoningContentPart[];
+	encrypted_content: string;
+	status?: 'in_progress' | 'completed' | 'incomplete';
+}
+
+/**
+ * Provider-owned active-turn state that must be replayed to continue a native
+ * tool exchange. It is never persisted as ordinary conversation history.
+ */
+export interface LlmConversationProviderItem {
+	provider: string;
+	/** Native call before which this output item appeared, or null when it followed all calls. */
+	beforeProviderCallId: string | null;
+	/** Validated active-turn reasoning output returned by the provider. */
+	item: LlmConversationReasoningItem;
+}
+
 export interface LlmAssistantToolCallsItem {
 	type: 'assistant_tool_calls';
 	content: string;
 	calls: LlmConversationToolCall[];
+	providerItems?: LlmConversationProviderItem[];
 }
 
 export interface LlmToolResultsItem {
@@ -93,6 +125,8 @@ export interface LlmResponse {
 	content: string;
 	toolCalls?: LlmToolCall[];
 	toolErrors?: LlmToolError[];
+	/** Provider-owned continuation state for the active tool turn only. */
+	providerItems?: LlmConversationProviderItem[];
 	meta: LlmResponseMeta;
 }
 

--- a/apps/backend/src/modules/buddy/platforms/openai-sdk.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/openai-sdk.utils.ts
@@ -1,7 +1,14 @@
 import type { LlmToolCall, ToolDefinition } from '../../tools/platforms/tool-provider.platform';
 import { MessageRole } from '../buddy.constants';
 
-import type { ChatMessage, LlmToolError } from './llm-provider.platform';
+import {
+	isChatMessage,
+	isLlmAssistantToolCallsItem,
+	requireProviderCallId,
+	serializeLlmConversationToolResult,
+	validateLlmConversationItems,
+} from './llm-conversation.utils';
+import type { LlmConversationItem, LlmToolError } from './llm-provider.platform';
 
 // Module path as variable to prevent TypeScript from statically resolving optional peer dependency
 const OPENAI_SDK_MODULE = 'openai';
@@ -23,20 +30,14 @@ export interface OpenAiSdkResult {
 export function buildOpenAiRequestPayload(
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	maxTokens: number = 1024,
 	tools?: ToolDefinition[],
 ): Record<string, unknown> {
 	const requestPayload: Record<string, unknown> = {
 		model,
 		max_completion_tokens: maxTokens,
-		messages: [
-			{ role: 'system' as const, content: systemPrompt },
-			...messages.map((message) => ({
-				role: message.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
-				content: message.content,
-			})),
-		],
+		messages: [{ role: 'system' as const, content: systemPrompt }, ...buildOpenAiConversationMessages(messages)],
 	};
 
 	if (tools && tools.length > 0) {
@@ -61,7 +62,7 @@ export async function sendOpenAiMessage(
 	apiKey: string,
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	timeout: number,
 	maxTokens: number = 1024,
 	tools?: ToolDefinition[],
@@ -137,4 +138,42 @@ export async function sendOpenAiMessage(
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		finishReason: (response.choices[0]?.finish_reason as string) ?? null,
 	};
+}
+
+function buildOpenAiConversationMessages(messages: LlmConversationItem[]): Array<Record<string, unknown>> {
+	validateLlmConversationItems(messages);
+
+	return messages.flatMap((item): Array<Record<string, unknown>> => {
+		if (isChatMessage(item)) {
+			return [
+				{
+					role: item.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
+					content: item.content,
+				},
+			];
+		}
+
+		if (isLlmAssistantToolCallsItem(item)) {
+			return [
+				{
+					role: 'assistant',
+					content: item.content.length > 0 ? item.content : null,
+					tool_calls: item.calls.map((call) => ({
+						id: requireProviderCallId('OpenAI Chat', call.providerCallId),
+						type: 'function',
+						function: {
+							name: call.name,
+							arguments: call.rawArguments ?? JSON.stringify(call.arguments),
+						},
+					})),
+				},
+			];
+		}
+
+		return item.results.map((result) => ({
+			role: 'tool',
+			tool_call_id: requireProviderCallId('OpenAI Chat', result.providerCallId),
+			content: serializeLlmConversationToolResult(result),
+		}));
+	});
 }

--- a/apps/backend/src/modules/buddy/services/llm-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/llm-provider.service.spec.ts
@@ -46,7 +46,7 @@ describe('LlmProviderService', () => {
 		};
 	}
 
-	function makeMockProvider(type: string, sendMessageMock: jest.Mock): ILlmProvider {
+	function makeMockProvider(type: string, sendMessageMock: jest.Mock, nativeToolResults?: boolean): ILlmProvider {
 		return {
 			getType: () => type,
 			getName: () => type,
@@ -54,6 +54,7 @@ describe('LlmProviderService', () => {
 			getDefaultModel: () => 'mock-model',
 			isConfigured: () => true,
 			sendMessage: sendMessageMock,
+			...(nativeToolResults === undefined ? {} : { supportsNativeToolResults: (): boolean => nativeToolResults }),
 		};
 	}
 
@@ -173,6 +174,25 @@ describe('LlmProviderService', () => {
 				'mock-model',
 				expect.objectContaining({ timeout: 60_000 }),
 			);
+		});
+	});
+
+	describe('native tool-result capability', () => {
+		it('defaults to false when the configured provider does not declare support', () => {
+			expect(service.supportsNativeToolResults()).toBe(false);
+		});
+
+		it('returns the configured provider capability', () => {
+			registry.register(makeMockProvider('buddy-native-plugin', jest.fn(), true));
+			configService.getModuleConfig.mockReturnValue(makeConfig({ provider: 'buddy-native-plugin' }));
+
+			expect(service.supportsNativeToolResults()).toBe(true);
+		});
+
+		it('returns false when there is no configured provider', () => {
+			configService.getModuleConfig.mockReturnValue(makeConfig({ provider: LLM_PROVIDER_NONE }));
+
+			expect(service.supportsNativeToolResults()).toBe(false);
 		});
 	});
 });

--- a/apps/backend/src/modules/buddy/services/llm-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/llm-provider.service.ts
@@ -10,11 +10,11 @@ import {
 } from '../buddy.exceptions';
 import { isTimeoutError, withServiceTimeout } from '../buddy.utils';
 import { BuddyConfigModel } from '../models/config.model';
-import { ChatMessage, LlmOptions, LlmResponse } from '../platforms/llm-provider.platform';
+import { LlmConversationItem, LlmOptions, LlmResponse } from '../platforms/llm-provider.platform';
 
 import { LlmProviderRegistryService } from './llm-provider-registry.service';
 
-export { ChatMessage, LlmOptions, LlmResponse } from '../platforms/llm-provider.platform';
+export { ChatMessage, LlmConversationItem, LlmOptions, LlmResponse } from '../platforms/llm-provider.platform';
 
 @Injectable()
 export class LlmProviderService {
@@ -25,7 +25,7 @@ export class LlmProviderService {
 		private readonly providerRegistry: LlmProviderRegistryService,
 	) {}
 
-	async sendMessage(systemPrompt: string, messages: ChatMessage[], options?: LlmOptions): Promise<LlmResponse> {
+	async sendMessage(systemPrompt: string, messages: LlmConversationItem[], options?: LlmOptions): Promise<LlmResponse> {
 		const config = this.getConfig();
 		const providerName = config.provider;
 
@@ -82,6 +82,21 @@ export class LlmProviderService {
 			const provider = this.providerRegistry.get(providerName);
 
 			return provider?.supportsTools?.() ?? false;
+		} catch {
+			return false;
+		}
+	}
+
+	supportsNativeToolResults(): boolean {
+		try {
+			const config = this.getConfig();
+			const providerName = config.provider;
+
+			if (!providerName || providerName === 'none') {
+				return false;
+			}
+
+			return this.providerRegistry.get(providerName)?.supportsNativeToolResults?.() ?? false;
 		} catch {
 			return false;
 		}

--- a/apps/backend/src/modules/buddy/testing/llm-native-tool-transcript.serialization.spec.ts
+++ b/apps/backend/src/modules/buddy/testing/llm-native-tool-transcript.serialization.spec.ts
@@ -1,0 +1,133 @@
+import { buildOllamaRequestPayload } from '../../../plugins/buddy-ollama/platforms/ollama.provider';
+import { buildOpenAiCodexRequestPayload } from '../../../plugins/buddy-openai-codex/platforms/openai-codex.provider';
+import { MessageRole } from '../buddy.constants';
+import { buildAnthropicRequestPayload } from '../platforms/anthropic-sdk.utils';
+import { LlmConversationItem } from '../platforms/llm-provider.platform';
+import { buildOpenAiRequestPayload } from '../platforms/openai-sdk.utils';
+
+const transcript: LlmConversationItem[] = [
+	{ role: MessageRole.USER, content: 'Check both areas' },
+	{
+		type: 'assistant_tool_calls',
+		content: '',
+		calls: [
+			{
+				callId: 'canonical-1',
+				providerCallId: 'provider-1',
+				name: 'query_home_state',
+				arguments: { space_id: 'kitchen' },
+			},
+			{
+				callId: 'canonical-2',
+				providerCallId: 'provider-2',
+				name: 'get_device_state',
+				arguments: { device_ids: ['garage'] },
+			},
+		],
+	},
+	{
+		type: 'tool_results',
+		results: [
+			{
+				callId: 'canonical-1',
+				providerCallId: 'provider-1',
+				toolName: 'query_home_state',
+				status: 'completed',
+				message: 'Kitchen checked',
+				data: { matched: 1 },
+				truncated: false,
+			},
+			{
+				callId: 'canonical-2',
+				providerCallId: 'provider-2',
+				toolName: 'get_device_state',
+				status: 'failed',
+				message: 'Garage unavailable',
+				errorCode: 'device_unavailable',
+				truncated: false,
+			},
+		],
+	},
+];
+
+describe('cross-provider native tool transcript contract', () => {
+	it('maps explicit output caps for the same text-only input', () => {
+		const text: LlmConversationItem[] = [{ role: MessageRole.USER, content: 'Hello' }];
+
+		expect(buildOpenAiRequestPayload('openai', 'system', text, 321)).toHaveProperty('max_completion_tokens', 321);
+		expect(buildAnthropicRequestPayload('anthropic', 'system', text, 322)).toHaveProperty('max_tokens', 322);
+		expect(buildOllamaRequestPayload('ollama', 'system', text, undefined, 323)).toHaveProperty(
+			'options.num_predict',
+			323,
+		);
+		expect(buildOpenAiCodexRequestPayload('codex', 'system', text, undefined, 324)).toHaveProperty(
+			'max_output_tokens',
+			324,
+		);
+	});
+
+	it('preserves ordered native and canonical correlation for completed and error results', () => {
+		const openAiMessages = records(buildOpenAiRequestPayload('openai', 'system', transcript).messages);
+		const anthropicMessages = records(buildAnthropicRequestPayload('anthropic', 'system', transcript).messages);
+		const ollamaMessages = records(buildOllamaRequestPayload('ollama', 'system', transcript).messages);
+		const codexInput = records(buildOpenAiCodexRequestPayload('codex', 'system', transcript).input);
+
+		const openAiCallMessage = record(openAiMessages[2]);
+		const openAiCalls = records(openAiCallMessage.tool_calls);
+		const openAiResults = openAiMessages.slice(3);
+		expect(openAiCalls.map((call) => call.id)).toEqual(['provider-1', 'provider-2']);
+		expect(openAiResults.map((result) => result.tool_call_id)).toEqual(['provider-1', 'provider-2']);
+		expectSerializedResults(openAiResults.map((result) => result.content));
+
+		const anthropicCallBlocks = records(anthropicMessages[1].content).filter((block) => block.type === 'tool_use');
+		const anthropicResultBlocks = records(anthropicMessages[2].content);
+		expect(anthropicCallBlocks.map((block) => block.id)).toEqual(['provider-1', 'provider-2']);
+		expect(anthropicResultBlocks.map((block) => block.tool_use_id)).toEqual(['provider-1', 'provider-2']);
+		expect(anthropicResultBlocks.map((block) => block.is_error ?? false)).toEqual([false, true]);
+		expectSerializedResults(anthropicResultBlocks.map((block) => block.content));
+
+		const ollamaCallMessage = record(ollamaMessages[2]);
+		const ollamaCalls = records(ollamaCallMessage.tool_calls).map((call) => record(call.function));
+		const ollamaResults = ollamaMessages.slice(3);
+		expect(ollamaCalls.map((call) => call.name)).toEqual(['query_home_state', 'get_device_state']);
+		expect(ollamaResults.map((result) => result.tool_name)).toEqual(['query_home_state', 'get_device_state']);
+		expectSerializedResults(ollamaResults.map((result) => result.content));
+
+		const codexCalls = codexInput.filter((item) => item.type === 'function_call');
+		const codexResults = codexInput.filter((item) => item.type === 'function_call_output');
+		expect(codexCalls.map((call) => call.call_id)).toEqual(['provider-1', 'provider-2']);
+		expect(codexResults.map((result) => result.call_id)).toEqual(['provider-1', 'provider-2']);
+		expectSerializedResults(codexResults.map((result) => result.output));
+	});
+});
+
+function expectSerializedResults(values: unknown[]): void {
+	expect(values.map(parseSerializedResult)).toEqual([
+		expect.objectContaining({ call_id: 'canonical-1', status: 'completed', data: { matched: 1 } }),
+		expect.objectContaining({ call_id: 'canonical-2', status: 'failed', error_code: 'device_unavailable' }),
+	]);
+}
+
+function parseSerializedResult(value: unknown): Record<string, unknown> {
+	if (typeof value !== 'string') {
+		throw new TypeError('Expected a serialized tool result');
+	}
+
+	return record(JSON.parse(value) as unknown);
+}
+
+function records(value: unknown): Array<Record<string, unknown>> {
+	if (!Array.isArray(value)) {
+		throw new TypeError('Expected a native item array');
+	}
+
+	return value.map(record);
+}
+
+function record(value: unknown): Record<string, unknown> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		throw new TypeError('Expected a native item object');
+	}
+
+	return value as Record<string, unknown>;
+}

--- a/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.spec.ts
+++ b/apps/backend/src/modules/buddy/testing/llm-request-measurement.helper.spec.ts
@@ -60,12 +60,12 @@ describe('native LLM request payload builders', () => {
 		]);
 	});
 
-	it('characterizes Ollama and Codex as currently omitting maxTokens', () => {
-		const ollama = buildOllamaRequestPayload('llama-test', 'system', messages, [nestedTool]);
-		const codex = buildOpenAiCodexRequestPayload('codex-test', 'system', messages, [nestedTool]);
+	it('builds Ollama and Codex payloads with their native output caps', () => {
+		const ollama = buildOllamaRequestPayload('llama-test', 'system', messages, [nestedTool], 321);
+		const codex = buildOpenAiCodexRequestPayload('codex-test', 'system', messages, [nestedTool], 321);
 
-		expect(ollama).not.toHaveProperty('options.num_predict');
-		expect(codex).not.toHaveProperty('max_output_tokens');
+		expect(ollama).toMatchObject({ options: { num_predict: 321 } });
+		expect(codex).toMatchObject({ max_output_tokens: 321 });
 		expect(ollama.tools).toEqual([
 			{
 				type: 'function',
@@ -148,17 +148,20 @@ describe('LLM request measurement', () => {
 		expect(measurement.fitsWindow).toBe(measurement.estimatedInputTokens <= 156);
 	});
 
-	it('reports missing and mismatched native output caps', () => {
-		const ollama = measureLlmRequestPayload(buildOllamaRequestPayload('llama-test', 'system', messages), {
-			contextWindowTokens: 8_192,
-			requestedOutputTokens: 512,
-		});
+	it('reports enforced and mismatched native output caps', () => {
+		const ollama = measureLlmRequestPayload(
+			buildOllamaRequestPayload('llama-test', 'system', messages, undefined, 512),
+			{
+				contextWindowTokens: 8_192,
+				requestedOutputTokens: 512,
+			},
+		);
 		const anthropic = measureLlmRequestPayload(buildAnthropicRequestPayload('claude-test', 'system', messages, 256), {
 			contextWindowTokens: 8_192,
 			requestedOutputTokens: 512,
 		});
 
-		expect(ollama.output).toEqual({ requestedTokens: 512, nativeCapTokens: null, status: 'missing' });
+		expect(ollama.output).toEqual({ requestedTokens: 512, nativeCapTokens: 512, status: 'enforced' });
 		expect(anthropic.output).toEqual({ requestedTokens: 512, nativeCapTokens: 256, status: 'mismatched' });
 	});
 });

--- a/apps/backend/src/plugins/buddy-claude-setup-token/platforms/claude-setup-token.provider.ts
+++ b/apps/backend/src/plugins/buddy-claude-setup-token/platforms/claude-setup-token.provider.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 
 import { sendAnthropicMessage } from '../../../modules/buddy/platforms/anthropic-sdk.utils';
 import {
-	ChatMessage,
 	ILlmProvider,
+	LlmConversationItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -45,9 +45,13 @@ export class ClaudeSetupTokenProvider implements ILlmProvider {
 		return true;
 	}
 
+	supportsNativeToolResults(): boolean {
+		return true;
+	}
+
 	async sendMessage(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		model: string,
 		options?: LlmOptions,
 	): Promise<LlmResponse> {

--- a/apps/backend/src/plugins/buddy-claude/platforms/claude.provider.ts
+++ b/apps/backend/src/plugins/buddy-claude/platforms/claude.provider.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 
 import { sendAnthropicMessage } from '../../../modules/buddy/platforms/anthropic-sdk.utils';
 import {
-	ChatMessage,
 	ILlmProvider,
+	LlmConversationItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -45,9 +45,13 @@ export class ClaudeProvider implements ILlmProvider {
 		return true;
 	}
 
+	supportsNativeToolResults(): boolean {
+		return true;
+	}
+
 	async sendMessage(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		model: string,
 		options?: LlmOptions,
 	): Promise<LlmResponse> {

--- a/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.spec.ts
@@ -1,0 +1,103 @@
+import { MessageRole } from '../../../modules/buddy/buddy.constants';
+import { LlmConversationItem } from '../../../modules/buddy/platforms/llm-provider.platform';
+import { ConfigService } from '../../../modules/config/services/config.service';
+
+import { OllamaProvider, buildOllamaRequestPayload } from './ollama.provider';
+
+const transcript: LlmConversationItem[] = [
+	{ role: MessageRole.USER, content: 'Read the kitchen.' },
+	{
+		type: 'assistant_tool_calls',
+		content: '',
+		calls: [
+			{
+				callId: 'call-1',
+				providerCallId: null,
+				name: 'get_temperature',
+				arguments: { room: 'kitchen' },
+			},
+			{
+				callId: 'call-2',
+				providerCallId: null,
+				name: 'get_humidity',
+				arguments: { room: 'kitchen' },
+			},
+		],
+	},
+	{
+		type: 'tool_results',
+		results: [
+			{
+				callId: 'call-1',
+				providerCallId: null,
+				toolName: 'get_temperature',
+				status: 'completed',
+				message: 'Temperature read',
+				data: { value: 21.5, unit: 'C' },
+				truncated: false,
+			},
+			{
+				callId: 'call-2',
+				providerCallId: null,
+				toolName: 'get_humidity',
+				status: 'partial',
+				message: 'Humidity read from one sensor',
+				data: { value: 48 },
+				errorCode: 'PARTIAL_COVERAGE',
+				truncated: true,
+			},
+		],
+	},
+	{ role: MessageRole.ASSISTANT, content: 'The kitchen is comfortable.' },
+];
+
+describe('OllamaProvider native transcript', () => {
+	it('maps ordered tool calls and correlated structured results and enforces the output cap', () => {
+		expect(buildOllamaRequestPayload('llama-test', 'system', transcript, undefined, 321)).toEqual({
+			model: 'llama-test',
+			stream: false,
+			messages: [
+				{ role: 'system', content: 'system' },
+				{ role: 'user', content: 'Read the kitchen.' },
+				{
+					role: 'assistant',
+					content: '',
+					tool_calls: [
+						{ function: { name: 'get_temperature', arguments: { room: 'kitchen' } } },
+						{ function: { name: 'get_humidity', arguments: { room: 'kitchen' } } },
+					],
+				},
+				{
+					role: 'tool',
+					content:
+						'{"call_id":"call-1","tool_name":"get_temperature","status":"completed","message":"Temperature read","data":{"value":21.5,"unit":"C"},"truncated":false}',
+					tool_name: 'get_temperature',
+				},
+				{
+					role: 'tool',
+					content:
+						'{"call_id":"call-2","tool_name":"get_humidity","status":"partial","message":"Humidity read from one sensor","data":{"value":48},"error_code":"PARTIAL_COVERAGE","truncated":true}',
+					tool_name: 'get_humidity',
+				},
+				{ role: 'assistant', content: 'The kitchen is comfortable.' },
+			],
+			options: { num_predict: 321 },
+		});
+	});
+
+	it('preserves the text-only payload and advertises native tool-result support', () => {
+		const messages: LlmConversationItem[] = [{ role: MessageRole.USER, content: 'Hello' }];
+		const provider = new OllamaProvider({} as ConfigService);
+
+		expect(buildOllamaRequestPayload('llama-test', 'system', messages)).toEqual({
+			model: 'llama-test',
+			stream: false,
+			messages: [
+				{ role: 'system', content: 'system' },
+				{ role: 'user', content: 'Hello' },
+			],
+			options: { num_predict: 1024 },
+		});
+		expect(provider.supportsNativeToolResults()).toBe(true);
+	});
+});

--- a/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.ts
+++ b/apps/backend/src/plugins/buddy-ollama/platforms/ollama.provider.ts
@@ -2,8 +2,14 @@ import { Injectable } from '@nestjs/common';
 
 import { MessageRole } from '../../../modules/buddy/buddy.constants';
 import {
-	ChatMessage,
+	isChatMessage,
+	isLlmAssistantToolCallsItem,
+	serializeLlmConversationToolResult,
+	validateLlmConversationItems,
+} from '../../../modules/buddy/platforms/llm-conversation.utils';
+import {
 	ILlmProvider,
+	LlmConversationItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -33,19 +39,49 @@ interface OllamaResponse {
 export function buildOllamaRequestPayload(
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	tools?: ToolDefinition[],
+	maxTokens: number = 1024,
 ): Record<string, unknown> {
+	validateLlmConversationItems(messages);
+
+	const nativeMessages = messages.flatMap((message) => {
+		if (isChatMessage(message)) {
+			return [
+				{
+					role: message.role === MessageRole.USER ? 'user' : 'assistant',
+					content: message.content,
+				},
+			];
+		}
+
+		if (isLlmAssistantToolCallsItem(message)) {
+			return [
+				{
+					role: 'assistant',
+					content: message.content,
+					tool_calls: message.calls.map((call) => ({
+						function: {
+							name: call.name,
+							arguments: call.arguments,
+						},
+					})),
+				},
+			];
+		}
+
+		return message.results.map((result) => ({
+			role: 'tool',
+			content: serializeLlmConversationToolResult(result),
+			tool_name: result.toolName,
+		}));
+	});
+
 	const requestPayload: Record<string, unknown> = {
 		model,
 		stream: false,
-		messages: [
-			{ role: 'system', content: systemPrompt },
-			...messages.map((message) => ({
-				role: message.role === MessageRole.USER ? 'user' : 'assistant',
-				content: message.content,
-			})),
-		],
+		messages: [{ role: 'system', content: systemPrompt }, ...nativeMessages],
+		options: { num_predict: maxTokens },
 	};
 
 	if (tools && tools.length > 0) {
@@ -92,9 +128,13 @@ export class OllamaProvider implements ILlmProvider {
 		return true;
 	}
 
+	supportsNativeToolResults(): boolean {
+		return true;
+	}
+
 	async sendMessage(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		model: string,
 		options?: LlmOptions,
 	): Promise<LlmResponse> {
@@ -109,7 +149,13 @@ export class OllamaProvider implements ILlmProvider {
 		const start = Date.now();
 
 		try {
-			const requestPayload = buildOllamaRequestPayload(resolvedModel, systemPrompt, messages, options?.tools);
+			const requestPayload = buildOllamaRequestPayload(
+				resolvedModel,
+				systemPrompt,
+				messages,
+				options?.tools,
+				options?.maxTokens ?? 1024,
+			);
 
 			const response = await fetch(`${baseUrl}/api/chat`, {
 				method: 'POST',

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -36,6 +36,14 @@ const assistantMessageItem = {
 	status: 'completed',
 } satisfies LlmConversationAssistantMessageItem;
 
+const assistantMessageWithoutPhase = {
+	id: 'message-1',
+	type: 'message',
+	role: 'assistant',
+	content: [{ type: 'output_text', text: 'I will check both sensors.', annotations: [] }],
+	status: 'completed',
+} satisfies LlmConversationAssistantMessageItem;
+
 const firstFunctionCallItem = {
 	id: 'function-item-1',
 	type: 'function_call',
@@ -181,7 +189,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 		expect(provider.supportsNativeToolResults()).toBe(true);
 	});
 
-	it('captures and replays completed message, reasoning, and calls in exact response output order', async () => {
+	it('captures exact output order and normalizes a null completed-message phase before replay', async () => {
 		const events = [
 			{
 				type: 'response.output_item.done',
@@ -208,7 +216,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 				type: 'response.completed',
 				response: {
 					output: [
-						assistantMessageItem,
+						{ ...assistantMessageItem, phase: null },
 						reasoningItem,
 						firstFunctionCallItem,
 						secondReasoningItem,
@@ -238,9 +246,13 @@ describe('OpenAiCodexProvider native transcript', () => {
 				{ id: 'provider-call-2', name: 'get_humidity', arguments: { room: 'kitchen' } },
 			]);
 			expect(response.providerItems).toEqual(
-				[assistantMessageItem, reasoningItem, firstFunctionCallItem, secondReasoningItem, secondFunctionCallItem].map(
-					(item, outputIndex) => ({ provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME, outputIndex, item }),
-				),
+				[
+					assistantMessageWithoutPhase,
+					reasoningItem,
+					firstFunctionCallItem,
+					secondReasoningItem,
+					secondFunctionCallItem,
+				].map((item, outputIndex) => ({ provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME, outputIndex, item })),
 			);
 
 			const requestBody = fetchSpy.mock.calls[0][1]?.body;
@@ -287,7 +299,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 
 			expect(continuationPayload.input).toEqual([
 				{ role: 'user', content: 'Read the kitchen.', type: 'message' },
-				assistantMessageItem,
+				assistantMessageWithoutPhase,
 				reasoningItem,
 				firstFunctionCallItem,
 				secondReasoningItem,

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -1,14 +1,47 @@
 import { MessageRole } from '../../../modules/buddy/buddy.constants';
-import { LlmConversationItem } from '../../../modules/buddy/platforms/llm-provider.platform';
+import {
+	LlmConversationItem,
+	LlmConversationReasoningItem,
+} from '../../../modules/buddy/platforms/llm-provider.platform';
 import { ConfigService } from '../../../modules/config/services/config.service';
+import { BUDDY_OPENAI_CODEX_PLUGIN_NAME } from '../buddy-openai-codex.constants';
 
 import { OpenAiCodexProvider, buildOpenAiCodexRequestPayload } from './openai-codex.provider';
+
+const reasoningItem = {
+	id: 'reasoning-1',
+	type: 'reasoning',
+	encrypted_content: 'encrypted-reasoning-state',
+	summary: [{ type: 'summary_text', text: 'Checking the requested sensors.' }],
+	content: [],
+	status: 'completed',
+} satisfies LlmConversationReasoningItem;
+
+const secondReasoningItem = {
+	id: 'reasoning-2',
+	type: 'reasoning',
+	encrypted_content: 'second-encrypted-reasoning-state',
+	summary: [{ type: 'summary_text', text: 'Checking the second sensor.' }],
+	status: 'completed',
+} satisfies LlmConversationReasoningItem;
 
 const transcript: LlmConversationItem[] = [
 	{ role: MessageRole.USER, content: 'Read the kitchen.' },
 	{
 		type: 'assistant_tool_calls',
 		content: 'I will check both sensors.',
+		providerItems: [
+			{
+				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+				beforeProviderCallId: 'provider-call-1',
+				item: reasoningItem,
+			},
+			{
+				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+				beforeProviderCallId: 'provider-call-2',
+				item: secondReasoningItem,
+			},
+		],
 		calls: [
 			{
 				callId: 'call-1',
@@ -59,12 +92,14 @@ describe('OpenAiCodexProvider native transcript', () => {
 			input: [
 				{ role: 'user', content: 'Read the kitchen.', type: 'message' },
 				{ role: 'assistant', content: 'I will check both sensors.', type: 'message' },
+				reasoningItem,
 				{
 					type: 'function_call',
 					call_id: 'provider-call-1',
 					name: 'get_temperature',
 					arguments: '{"room":"kitchen"}',
 				},
+				secondReasoningItem,
 				{
 					type: 'function_call',
 					call_id: 'provider-call-2',
@@ -87,6 +122,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 			],
 			stream: true,
 			store: false,
+			include: ['reasoning.encrypted_content'],
 			max_output_tokens: 321,
 			tools: [],
 			tool_choice: 'auto',
@@ -103,11 +139,89 @@ describe('OpenAiCodexProvider native transcript', () => {
 			input: [{ role: 'user', content: 'Hello', type: 'message' }],
 			stream: true,
 			store: false,
+			include: ['reasoning.encrypted_content'],
 			max_output_tokens: 1024,
 			tools: [],
 			tool_choice: 'auto',
 		});
 		expect(provider.supportsNativeToolResults()).toBe(true);
+	});
+
+	it('captures complete encrypted reasoning output and associates it with the following native function call', async () => {
+		const functionCallItem = {
+			id: 'function-item-1',
+			type: 'function_call',
+			call_id: 'provider-call-1',
+			name: 'get_temperature',
+			arguments: '{"room":"kitchen"}',
+			status: 'completed',
+		};
+		const events = [
+			{
+				type: 'response.output_item.done',
+				item: { ...reasoningItem, encrypted_content: 'must-not-use-without-an-output-index' },
+			},
+			{
+				type: 'response.output_item.added',
+				output_index: -1,
+				item: { ...reasoningItem, encrypted_content: 'must-not-use-with-a-negative-output-index' },
+			},
+			{ type: 'response.output_item.added', output_index: 0, item: { ...reasoningItem, encrypted_content: null } },
+			{ type: 'response.output_item.done', output_index: 0, item: reasoningItem },
+			{ type: 'response.output_item.added', output_index: 1, item: { ...functionCallItem, arguments: '' } },
+			{
+				type: 'response.function_call_arguments.delta',
+				output_index: 1,
+				call_id: 'provider-call-1',
+				delta: '{"room":"kitchen"}',
+			},
+			{ type: 'response.output_item.done', output_index: 1, item: functionCallItem },
+			{ type: 'response.completed', response: { output: [reasoningItem, functionCallItem] } },
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			const response = await provider.sendMessage(
+				'system',
+				[{ role: MessageRole.USER, content: 'Read the kitchen.' }],
+				'codex-test',
+				{ maxTokens: 321 },
+			);
+
+			expect(response.toolCalls).toEqual([
+				{ id: 'provider-call-1', name: 'get_temperature', arguments: { room: 'kitchen' } },
+			]);
+			expect(response.providerItems).toEqual([
+				{
+					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+					beforeProviderCallId: 'provider-call-1',
+					item: reasoningItem,
+				},
+			]);
+
+			const requestBody = fetchSpy.mock.calls[0][1]?.body;
+
+			if (typeof requestBody !== 'string') {
+				throw new TypeError('Expected a serialized Codex request body');
+			}
+
+			const request = JSON.parse(requestBody) as Record<string, unknown>;
+
+			expect(request).toEqual(
+				expect.objectContaining({
+					store: false,
+					include: ['reasoning.encrypted_content'],
+					max_output_tokens: 321,
+				}),
+			);
+		} finally {
+			fetchSpy.mockRestore();
+		}
 	});
 
 	it('rejects a Codex transcript without native provider call IDs', () => {
@@ -134,6 +248,78 @@ describe('OpenAiCodexProvider native transcript', () => {
 
 		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', missingProviderCallId)).toThrow(
 			'OpenAI Codex tool transcript requires a provider call ID',
+		);
+	});
+
+	it('rejects incomplete provider continuation items before replay', () => {
+		const invalidProviderItems: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [{ callId: 'call-1', providerCallId: 'provider-call-1', name: 'read', arguments: {} }],
+				providerItems: [
+					{
+						provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+						beforeProviderCallId: 'provider-call-1',
+						item: { type: 'reasoning', id: 'reasoning-1' } as unknown as LlmConversationReasoningItem,
+					},
+				],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'call-1',
+						providerCallId: 'provider-call-1',
+						toolName: 'read',
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', invalidProviderItems)).toThrow(
+			'OpenAI Codex reasoning continuation requires complete encrypted content',
+		);
+	});
+
+	it('rejects duplicate native provider call IDs before serialization', () => {
+		const duplicateProviderCallIds: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [
+					{ callId: 'call-1', providerCallId: 'provider-call-1', name: 'read_one', arguments: {} },
+					{ callId: 'call-2', providerCallId: 'provider-call-1', name: 'read_two', arguments: {} },
+				],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'call-1',
+						providerCallId: 'provider-call-1',
+						toolName: 'read_one',
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					},
+					{
+						callId: 'call-2',
+						providerCallId: 'provider-call-1',
+						toolName: 'read_two',
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', duplicateProviderCallIds)).toThrow(
+			'empty or duplicate provider ID',
 		);
 	});
 });

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -1,5 +1,7 @@
 import { MessageRole } from '../../../modules/buddy/buddy.constants';
 import {
+	LlmConversationAssistantMessageItem,
+	LlmConversationFunctionCallItem,
 	LlmConversationItem,
 	LlmConversationReasoningItem,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -25,6 +27,32 @@ const secondReasoningItem = {
 	status: 'completed',
 } satisfies LlmConversationReasoningItem;
 
+const assistantMessageItem = {
+	id: 'message-1',
+	type: 'message',
+	role: 'assistant',
+	content: [{ type: 'output_text', text: 'I will check both sensors.', annotations: [] }],
+	status: 'completed',
+} satisfies LlmConversationAssistantMessageItem;
+
+const firstFunctionCallItem = {
+	id: 'function-item-1',
+	type: 'function_call',
+	call_id: 'provider-call-1',
+	name: 'get_temperature',
+	arguments: '{"room":"kitchen"}',
+	status: 'completed',
+} satisfies LlmConversationFunctionCallItem;
+
+const secondFunctionCallItem = {
+	id: 'function-item-2',
+	type: 'function_call',
+	call_id: 'provider-call-2',
+	name: 'get_humidity',
+	arguments: '{"room":"kitchen"}',
+	status: 'completed',
+} satisfies LlmConversationFunctionCallItem;
+
 const transcript: LlmConversationItem[] = [
 	{ role: MessageRole.USER, content: 'Read the kitchen.' },
 	{
@@ -33,13 +61,28 @@ const transcript: LlmConversationItem[] = [
 		providerItems: [
 			{
 				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
-				beforeProviderCallId: 'provider-call-1',
+				outputIndex: 0,
+				item: assistantMessageItem,
+			},
+			{
+				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+				outputIndex: 1,
 				item: reasoningItem,
 			},
 			{
 				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
-				beforeProviderCallId: 'provider-call-2',
+				outputIndex: 2,
+				item: firstFunctionCallItem,
+			},
+			{
+				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+				outputIndex: 3,
 				item: secondReasoningItem,
+			},
+			{
+				provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+				outputIndex: 4,
+				item: secondFunctionCallItem,
 			},
 		],
 		calls: [
@@ -91,21 +134,11 @@ describe('OpenAiCodexProvider native transcript', () => {
 			instructions: 'system',
 			input: [
 				{ role: 'user', content: 'Read the kitchen.', type: 'message' },
-				{ role: 'assistant', content: 'I will check both sensors.', type: 'message' },
+				assistantMessageItem,
 				reasoningItem,
-				{
-					type: 'function_call',
-					call_id: 'provider-call-1',
-					name: 'get_temperature',
-					arguments: '{"room":"kitchen"}',
-				},
+				firstFunctionCallItem,
 				secondReasoningItem,
-				{
-					type: 'function_call',
-					call_id: 'provider-call-2',
-					name: 'get_humidity',
-					arguments: '{"room":"kitchen"}',
-				},
+				secondFunctionCallItem,
 				{
 					type: 'function_call_output',
 					call_id: 'provider-call-1',
@@ -147,15 +180,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 		expect(provider.supportsNativeToolResults()).toBe(true);
 	});
 
-	it('captures complete encrypted reasoning output and associates it with the following native function call', async () => {
-		const functionCallItem = {
-			id: 'function-item-1',
-			type: 'function_call',
-			call_id: 'provider-call-1',
-			name: 'get_temperature',
-			arguments: '{"room":"kitchen"}',
-			status: 'completed',
-		};
+	it('captures and replays completed message, reasoning, and calls in exact response output order', async () => {
 		const events = [
 			{
 				type: 'response.output_item.done',
@@ -166,17 +191,30 @@ describe('OpenAiCodexProvider native transcript', () => {
 				output_index: -1,
 				item: { ...reasoningItem, encrypted_content: 'must-not-use-with-a-negative-output-index' },
 			},
-			{ type: 'response.output_item.added', output_index: 0, item: { ...reasoningItem, encrypted_content: null } },
-			{ type: 'response.output_item.done', output_index: 0, item: reasoningItem },
-			{ type: 'response.output_item.added', output_index: 1, item: { ...functionCallItem, arguments: '' } },
+			{ type: 'response.output_item.added', output_index: 0, item: { ...assistantMessageItem, content: [] } },
+			{ type: 'response.output_text.delta', output_index: 0, delta: 'I will check both sensors.' },
+			{ type: 'response.output_item.added', output_index: 1, item: { ...reasoningItem, encrypted_content: null } },
+			{ type: 'response.output_item.done', output_index: 1, item: reasoningItem },
+			{ type: 'response.output_item.added', output_index: 2, item: { ...firstFunctionCallItem, arguments: '' } },
 			{
 				type: 'response.function_call_arguments.delta',
-				output_index: 1,
+				output_index: 2,
 				call_id: 'provider-call-1',
 				delta: '{"room":"kitchen"}',
 			},
-			{ type: 'response.output_item.done', output_index: 1, item: functionCallItem },
-			{ type: 'response.completed', response: { output: [reasoningItem, functionCallItem] } },
+			{ type: 'response.output_item.done', output_index: 2, item: firstFunctionCallItem },
+			{
+				type: 'response.completed',
+				response: {
+					output: [
+						assistantMessageItem,
+						reasoningItem,
+						firstFunctionCallItem,
+						secondReasoningItem,
+						secondFunctionCallItem,
+					],
+				},
+			},
 		];
 		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
 		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
@@ -193,16 +231,16 @@ describe('OpenAiCodexProvider native transcript', () => {
 				{ maxTokens: 321 },
 			);
 
+			expect(response.content).toBe('I will check both sensors.');
 			expect(response.toolCalls).toEqual([
 				{ id: 'provider-call-1', name: 'get_temperature', arguments: { room: 'kitchen' } },
+				{ id: 'provider-call-2', name: 'get_humidity', arguments: { room: 'kitchen' } },
 			]);
-			expect(response.providerItems).toEqual([
-				{
-					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
-					beforeProviderCallId: 'provider-call-1',
-					item: reasoningItem,
-				},
-			]);
+			expect(response.providerItems).toEqual(
+				[assistantMessageItem, reasoningItem, firstFunctionCallItem, secondReasoningItem, secondFunctionCallItem].map(
+					(item, outputIndex) => ({ provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME, outputIndex, item }),
+				),
+			);
 
 			const requestBody = fetchSpy.mock.calls[0][1]?.body;
 
@@ -219,6 +257,43 @@ describe('OpenAiCodexProvider native transcript', () => {
 					max_output_tokens: 321,
 				}),
 			);
+
+			const continuationPayload = buildOpenAiCodexRequestPayload('codex-test', 'system', [
+				{ role: MessageRole.USER, content: 'Read the kitchen.' },
+				{
+					type: 'assistant_tool_calls',
+					content: response.content,
+					calls: response.toolCalls.map((call, index) => ({
+						callId: `call-${index + 1}`,
+						providerCallId: call.id,
+						name: call.name,
+						arguments: call.arguments,
+					})),
+					providerItems: response.providerItems,
+				},
+				{
+					type: 'tool_results',
+					results: response.toolCalls.map((call, index) => ({
+						callId: `call-${index + 1}`,
+						providerCallId: call.id,
+						toolName: call.name,
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					})),
+				},
+			]);
+
+			expect(continuationPayload.input).toEqual([
+				{ role: 'user', content: 'Read the kitchen.', type: 'message' },
+				assistantMessageItem,
+				reasoningItem,
+				firstFunctionCallItem,
+				secondReasoningItem,
+				secondFunctionCallItem,
+				expect.objectContaining({ type: 'function_call_output', call_id: 'provider-call-1' }),
+				expect.objectContaining({ type: 'function_call_output', call_id: 'provider-call-2' }),
+			]);
 		} finally {
 			fetchSpy.mockRestore();
 		}
@@ -260,7 +335,7 @@ describe('OpenAiCodexProvider native transcript', () => {
 				providerItems: [
 					{
 						provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
-						beforeProviderCallId: 'provider-call-1',
+						outputIndex: 0,
 						item: { type: 'reasoning', id: 'reasoning-1' } as unknown as LlmConversationReasoningItem,
 					},
 				],
@@ -282,6 +357,21 @@ describe('OpenAiCodexProvider native transcript', () => {
 
 		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', invalidProviderItems)).toThrow(
 			'OpenAI Codex reasoning continuation requires complete encrypted content',
+		);
+	});
+
+	it('rejects native message state that does not exactly match canonical assistant content', () => {
+		const ambiguousProviderState = structuredClone(transcript);
+		const assistantTurn = ambiguousProviderState[1];
+
+		if (!('type' in assistantTurn) || assistantTurn.type !== 'assistant_tool_calls') {
+			throw new TypeError('Expected an assistant tool call fixture');
+		}
+
+		assistantTurn.content = 'Different canonical content.';
+
+		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', ambiguousProviderState)).toThrow(
+			'OpenAI Codex provider message state does not match canonical assistant content',
 		);
 	});
 

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -32,6 +32,7 @@ const assistantMessageItem = {
 	type: 'message',
 	role: 'assistant',
 	content: [{ type: 'output_text', text: 'I will check both sensors.', annotations: [] }],
+	phase: 'commentary',
 	status: 'completed',
 } satisfies LlmConversationAssistantMessageItem;
 

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -303,6 +303,60 @@ describe('OpenAiCodexProvider native transcript', () => {
 		}
 	});
 
+	it('rejects partial text when the response exhausts max output tokens', async () => {
+		const events = [
+			{ type: 'response.output_text.delta', output_index: 0, delta: 'This answer is partial' },
+			{
+				type: 'response.incomplete',
+				response: { incomplete_details: { reason: 'max_output_tokens' } },
+			},
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			await expect(
+				provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Write a long answer.' }], 'codex-test'),
+			).rejects.toEqual(new Error('OpenAI Codex response incomplete: max_output_tokens'));
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('rejects truncated tool JSON and sanitizes malformed incomplete details', async () => {
+		const events = [
+			{ type: 'response.output_item.added', output_index: 0, item: { ...firstFunctionCallItem, arguments: '' } },
+			{
+				type: 'response.function_call_arguments.delta',
+				output_index: 0,
+				call_id: 'provider-call-1',
+				delta: '{"room":',
+			},
+			{
+				type: 'response.incomplete',
+				response: { incomplete_details: { reason: 'private-unbounded-provider-detail' } },
+			},
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			await expect(
+				provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+			).rejects.toEqual(new Error('OpenAI Codex response incomplete: unknown'));
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	it('captures exact output order and normalizes a null completed-message phase before replay', async () => {
 		const events = [
 			{

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -1,0 +1,139 @@
+import { MessageRole } from '../../../modules/buddy/buddy.constants';
+import { LlmConversationItem } from '../../../modules/buddy/platforms/llm-provider.platform';
+import { ConfigService } from '../../../modules/config/services/config.service';
+
+import { OpenAiCodexProvider, buildOpenAiCodexRequestPayload } from './openai-codex.provider';
+
+const transcript: LlmConversationItem[] = [
+	{ role: MessageRole.USER, content: 'Read the kitchen.' },
+	{
+		type: 'assistant_tool_calls',
+		content: 'I will check both sensors.',
+		calls: [
+			{
+				callId: 'call-1',
+				providerCallId: 'provider-call-1',
+				name: 'get_temperature',
+				arguments: { room: 'kitchen' },
+				rawArguments: '{"room":"kitchen"}',
+			},
+			{
+				callId: 'call-2',
+				providerCallId: 'provider-call-2',
+				name: 'get_humidity',
+				arguments: { room: 'kitchen' },
+			},
+		],
+	},
+	{
+		type: 'tool_results',
+		results: [
+			{
+				callId: 'call-1',
+				providerCallId: 'provider-call-1',
+				toolName: 'get_temperature',
+				status: 'completed',
+				message: 'Temperature read',
+				data: { value: 21.5, unit: 'C' },
+				truncated: false,
+			},
+			{
+				callId: 'call-2',
+				providerCallId: 'provider-call-2',
+				toolName: 'get_humidity',
+				status: 'timed_out',
+				message: 'Humidity read timed out',
+				errorCode: 'TOOL_EXECUTION_TIMEOUT',
+				truncated: false,
+			},
+		],
+	},
+	{ role: MessageRole.ASSISTANT, content: 'The temperature is 21.5 C.' },
+];
+
+describe('OpenAiCodexProvider native transcript', () => {
+	it('maps ordered function calls and outputs with exact provider call IDs and enforces the output cap', () => {
+		expect(buildOpenAiCodexRequestPayload('codex-test', 'system', transcript, undefined, 321)).toEqual({
+			model: 'codex-test',
+			instructions: 'system',
+			input: [
+				{ role: 'user', content: 'Read the kitchen.', type: 'message' },
+				{ role: 'assistant', content: 'I will check both sensors.', type: 'message' },
+				{
+					type: 'function_call',
+					call_id: 'provider-call-1',
+					name: 'get_temperature',
+					arguments: '{"room":"kitchen"}',
+				},
+				{
+					type: 'function_call',
+					call_id: 'provider-call-2',
+					name: 'get_humidity',
+					arguments: '{"room":"kitchen"}',
+				},
+				{
+					type: 'function_call_output',
+					call_id: 'provider-call-1',
+					output:
+						'{"call_id":"call-1","tool_name":"get_temperature","status":"completed","message":"Temperature read","data":{"value":21.5,"unit":"C"},"truncated":false}',
+				},
+				{
+					type: 'function_call_output',
+					call_id: 'provider-call-2',
+					output:
+						'{"call_id":"call-2","tool_name":"get_humidity","status":"timed_out","message":"Humidity read timed out","error_code":"TOOL_EXECUTION_TIMEOUT","truncated":false}',
+				},
+				{ role: 'assistant', content: 'The temperature is 21.5 C.', type: 'message' },
+			],
+			stream: true,
+			store: false,
+			max_output_tokens: 321,
+			tools: [],
+			tool_choice: 'auto',
+		});
+	});
+
+	it('preserves the text-only payload and advertises native tool-result support', () => {
+		const messages: LlmConversationItem[] = [{ role: MessageRole.USER, content: 'Hello' }];
+		const provider = new OpenAiCodexProvider({} as ConfigService);
+
+		expect(buildOpenAiCodexRequestPayload('codex-test', 'system', messages)).toEqual({
+			model: 'codex-test',
+			instructions: 'system',
+			input: [{ role: 'user', content: 'Hello', type: 'message' }],
+			stream: true,
+			store: false,
+			max_output_tokens: 1024,
+			tools: [],
+			tool_choice: 'auto',
+		});
+		expect(provider.supportsNativeToolResults()).toBe(true);
+	});
+
+	it('rejects a Codex transcript without native provider call IDs', () => {
+		const missingProviderCallId: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: '',
+				calls: [{ callId: 'call-1', providerCallId: null, name: 'get_temperature', arguments: {} }],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'call-1',
+						providerCallId: null,
+						toolName: 'get_temperature',
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(() => buildOpenAiCodexRequestPayload('codex-test', 'system', missingProviderCallId)).toThrow(
+			'OpenAI Codex tool transcript requires a provider call ID',
+		);
+	});
+});

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -44,6 +44,47 @@ const assistantMessageWithoutPhase = {
 	status: 'completed',
 } satisfies LlmConversationAssistantMessageItem;
 
+const annotatedRefusalMessageItem = {
+	id: 'message-annotated',
+	type: 'message',
+	role: 'assistant',
+	content: [
+		{
+			type: 'output_text',
+			text: 'See source.',
+			annotations: [
+				{ type: 'file_citation', file_id: 'file-1', filename: 'guide.pdf', index: 0 },
+				{
+					type: 'url_citation',
+					start_index: 0,
+					end_index: 10,
+					title: 'Guide',
+					url: 'https://example.com/guide',
+				},
+				{
+					type: 'container_file_citation',
+					container_id: 'container-1',
+					start_index: 0,
+					end_index: 10,
+					file_id: 'container-file-1',
+					filename: 'result.txt',
+				},
+				{ type: 'file_path', file_id: 'file-2', index: 1 },
+			],
+			logprobs: [
+				{
+					token: 'See',
+					bytes: [83, 101, 101],
+					logprob: -0.1,
+					top_logprobs: [{ token: 'Read', bytes: [82, 101, 97, 100], logprob: -1.2 }],
+				},
+			],
+		},
+		{ type: 'refusal', refusal: 'I cannot share more.' },
+	],
+	status: 'completed',
+} satisfies LlmConversationAssistantMessageItem;
+
 const firstFunctionCallItem = {
 	id: 'function-item-1',
 	type: 'function_call',
@@ -187,6 +228,79 @@ describe('OpenAiCodexProvider native transcript', () => {
 			tool_choice: 'auto',
 		});
 		expect(provider.supportsNativeToolResults()).toBe(true);
+	});
+
+	it('replays every supported output message content and annotation variant exactly', () => {
+		const annotatedContinuation: LlmConversationItem[] = [
+			{
+				type: 'assistant_tool_calls',
+				content: 'See source.I cannot share more.',
+				calls: [
+					{
+						callId: 'call-1',
+						providerCallId: 'provider-call-1',
+						name: 'get_temperature',
+						arguments: { room: 'kitchen' },
+					},
+				],
+				providerItems: [
+					{ provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME, outputIndex: 0, item: annotatedRefusalMessageItem },
+					{ provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME, outputIndex: 1, item: firstFunctionCallItem },
+				],
+			},
+			{
+				type: 'tool_results',
+				results: [
+					{
+						callId: 'call-1',
+						providerCallId: 'provider-call-1',
+						toolName: 'get_temperature',
+						status: 'completed',
+						message: 'ok',
+						truncated: false,
+					},
+				],
+			},
+		];
+
+		expect(buildOpenAiCodexRequestPayload('codex-test', 'system', annotatedContinuation).input).toEqual([
+			annotatedRefusalMessageItem,
+			firstFunctionCallItem,
+			expect.objectContaining({ type: 'function_call_output', call_id: 'provider-call-1' }),
+		]);
+	});
+
+	it('returns completed annotated text and refusal content to text-only callers', async () => {
+		const events = [
+			{ type: 'response.output_text.delta', output_index: 0, delta: 'See source.' },
+			{ type: 'response.refusal.delta', output_index: 0, delta: 'I cannot share more.' },
+			{ type: 'response.completed', response: { output: [annotatedRefusalMessageItem] } },
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			const response = await provider.sendMessage(
+				'system',
+				[{ role: MessageRole.USER, content: 'Show the source.' }],
+				'codex-test',
+			);
+
+			expect(response.content).toBe('See source.I cannot share more.');
+			expect(response.providerItems).toEqual([
+				{
+					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+					outputIndex: 0,
+					item: annotatedRefusalMessageItem,
+				},
+			]);
+		} finally {
+			fetchSpy.mockRestore();
+		}
 	});
 
 	it('captures exact output order and normalizes a null completed-message phase before replay', async () => {

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -273,7 +273,7 @@ function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmC
 	const allowedPhases = ['commentary', 'final_answer'] as const;
 	const phase = allowedPhases.find((candidate) => candidate === item.phase);
 
-	if (item.phase !== undefined && phase === undefined) {
+	if (item.phase !== undefined && item.phase !== null && phase === undefined) {
 		throw new TypeError('OpenAI Codex assistant message continuation has an invalid phase');
 	}
 	const status = parseOpenAiCodexOutputStatus(item.status, 'assistant message');

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -55,7 +55,7 @@ interface OpenAiCodexStreamEvent {
 	call_id?: string;
 	output_index?: number;
 	item?: OpenAiCodexOutputItem;
-	response?: { output?: OpenAiCodexOutputItem[] };
+	response?: { output?: OpenAiCodexOutputItem[]; incomplete_details?: unknown };
 }
 
 /** Build the exact JSON payload sent to the OpenAI Codex Responses endpoint. */
@@ -634,6 +634,12 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					continue;
 				}
 
+				if (event.type === 'response.incomplete') {
+					throw new Error(
+						`OpenAI Codex response incomplete: ${parseOpenAiCodexIncompleteReason(event.response?.incomplete_details)}`,
+					);
+				}
+
 				if ((event.type === 'response.output_text.delta' || event.type === 'response.refusal.delta') && event.delta) {
 					content += event.delta;
 				} else if (event.type === 'response.function_call_arguments.delta' && event.call_id && event.delta) {
@@ -709,6 +715,14 @@ export class OpenAiCodexProvider implements ILlmProvider {
 
 function isValidOutputIndex(value: unknown): value is number {
 	return isNonnegativeInteger(value);
+}
+
+function parseOpenAiCodexIncompleteReason(details: unknown): 'max_output_tokens' | 'content_filter' | 'unknown' {
+	if (!isRecord(details)) {
+		return 'unknown';
+	}
+
+	return details.reason === 'max_output_tokens' || details.reason === 'content_filter' ? details.reason : 'unknown';
 }
 
 function isNonnegativeInteger(value: unknown): value is number {

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -11,6 +11,8 @@ import {
 import {
 	ILlmProvider,
 	LlmConversationItem,
+	LlmConversationProviderItem,
+	LlmConversationReasoningItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -25,6 +27,27 @@ import {
 	BUDDY_OPENAI_CODEX_TOKEN_URL,
 } from '../buddy-openai-codex.constants';
 import { BuddyOpenaiCodexConfigModel } from '../models/config.model';
+
+interface OpenAiCodexOutputItem {
+	type?: string;
+	id?: string;
+	call_id?: string;
+	name?: string;
+	arguments?: string;
+	encrypted_content?: unknown;
+	summary?: unknown;
+	content?: unknown;
+	status?: unknown;
+}
+
+interface OpenAiCodexStreamEvent {
+	type?: string;
+	delta?: string;
+	call_id?: string;
+	output_index?: number;
+	item?: OpenAiCodexOutputItem;
+	response?: { output?: OpenAiCodexOutputItem[] };
+}
 
 /** Build the exact JSON payload sent to the OpenAI Codex Responses endpoint. */
 export function buildOpenAiCodexRequestPayload(
@@ -48,14 +71,25 @@ export function buildOpenAiCodexRequestPayload(
 		}
 
 		if (isLlmAssistantToolCallsItem(message)) {
-			return [
-				...(message.content.length === 0 ? [] : [{ role: 'assistant', content: message.content, type: 'message' }]),
-				...message.calls.map((call) => ({
+			const providerItems = message.providerItems ?? [];
+			const nativeCalls = message.calls.flatMap<Record<string, unknown>>((call) => [
+				...providerItems
+					.filter((providerItem) => providerItem.beforeProviderCallId === call.providerCallId)
+					.map(toOpenAiCodexProviderItem),
+				{
 					type: 'function_call',
 					call_id: requireProviderCallId('OpenAI Codex', call.providerCallId),
 					name: call.name,
 					arguments: call.rawArguments ?? JSON.stringify(call.arguments),
-				})),
+				},
+			]);
+
+			return [
+				...(message.content.length === 0 ? [] : [{ role: 'assistant', content: message.content, type: 'message' }]),
+				...nativeCalls,
+				...providerItems
+					.filter((providerItem) => providerItem.beforeProviderCallId === null)
+					.map(toOpenAiCodexProviderItem),
 			];
 		}
 
@@ -72,6 +106,7 @@ export function buildOpenAiCodexRequestPayload(
 		input,
 		stream: true,
 		store: false,
+		include: ['reasoning.encrypted_content'],
 		max_output_tokens: maxTokens,
 		tools:
 			tools?.map((tool) => ({
@@ -82,6 +117,71 @@ export function buildOpenAiCodexRequestPayload(
 			})) ?? [],
 		tool_choice: 'auto',
 	};
+}
+
+function toOpenAiCodexProviderItem(providerItem: LlmConversationProviderItem): Record<string, unknown> {
+	if (providerItem.provider !== BUDDY_OPENAI_CODEX_PLUGIN_NAME) {
+		throw new TypeError(`OpenAI Codex cannot replay provider item for "${providerItem.provider}"`);
+	}
+
+	return { ...parseOpenAiCodexReasoningItem(providerItem.item) };
+}
+
+function parseOpenAiCodexReasoningItem(item: OpenAiCodexOutputItem): LlmConversationReasoningItem {
+	if (
+		item.type !== 'reasoning' ||
+		typeof item.id !== 'string' ||
+		item.id.length === 0 ||
+		typeof item.encrypted_content !== 'string' ||
+		item.encrypted_content.length === 0 ||
+		!Array.isArray(item.summary)
+	) {
+		throw new TypeError('OpenAI Codex reasoning continuation requires complete encrypted content');
+	}
+
+	const summary = item.summary.map((part) => {
+		if (!isRecord(part) || part.type !== 'summary_text' || typeof part.text !== 'string') {
+			throw new TypeError('OpenAI Codex reasoning continuation has an invalid summary');
+		}
+
+		return { type: 'summary_text' as const, text: part.text };
+	});
+
+	let content: LlmConversationReasoningItem['content'];
+
+	if (item.content !== undefined) {
+		if (!Array.isArray(item.content)) {
+			throw new TypeError('OpenAI Codex reasoning continuation has invalid content');
+		}
+
+		content = item.content.map((part) => {
+			if (!isRecord(part) || part.type !== 'reasoning_text' || typeof part.text !== 'string') {
+				throw new TypeError('OpenAI Codex reasoning continuation has invalid content');
+			}
+
+			return { type: 'reasoning_text' as const, text: part.text };
+		});
+	}
+
+	const allowedStatuses = ['in_progress', 'completed', 'incomplete'] as const;
+	const status = allowedStatuses.find((candidate) => candidate === item.status);
+
+	if (item.status !== undefined && status === undefined) {
+		throw new TypeError('OpenAI Codex reasoning continuation has an invalid status');
+	}
+
+	return {
+		type: 'reasoning',
+		id: item.id,
+		summary,
+		...(content === undefined ? {} : { content }),
+		encrypted_content: item.encrypted_content,
+		...(status === undefined ? {} : { status }),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 @Injectable()
@@ -174,12 +274,13 @@ export class OpenAiCodexProvider implements ILlmProvider {
 				throw new Error(`${response.status} ${errorBody || response.statusText}`);
 			}
 
-			const { content, toolCalls } = await this.collectStreamResponse(response);
+			const { content, toolCalls, providerItems } = await this.collectStreamResponse(response);
 			const durationMs = Date.now() - start;
 
 			return {
 				content,
 				toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+				providerItems: providerItems.length > 0 ? providerItems : undefined,
 				meta: {
 					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
 					model: resolvedModel,
@@ -196,11 +297,13 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		}
 	}
 
-	private async collectStreamResponse(response: Response): Promise<{ content: string; toolCalls: LlmToolCall[] }> {
+	private async collectStreamResponse(
+		response: Response,
+	): Promise<{ content: string; toolCalls: LlmToolCall[]; providerItems: LlmConversationProviderItem[] }> {
 		const body = response.body;
 
 		if (!body) {
-			return { content: '', toolCalls: [] };
+			return { content: '', toolCalls: [], providerItems: [] };
 		}
 
 		const reader = body.getReader();
@@ -210,7 +313,29 @@ export class OpenAiCodexProvider implements ILlmProvider {
 
 		// Track tool calls: Responses API emits function_call_arguments.delta events
 		// with a call_id, and we accumulate the JSON argument strings per call
-		const toolCallMap = new Map<string, { id: string; name: string; args: string }>();
+		const toolCallMap = new Map<string, { id: string; name: string; args: string; outputIndex: number }>();
+		const reasoningItemMap = new Map<number, LlmConversationReasoningItem>();
+
+		const captureOutputItem = (item: OpenAiCodexOutputItem, outputIndex: number, complete: boolean): void => {
+			if (item.type === 'reasoning' && complete) {
+				reasoningItemMap.set(outputIndex, parseOpenAiCodexReasoningItem(item));
+				return;
+			}
+
+			if (item.type !== 'function_call' || typeof item.call_id !== 'string' || item.call_id.length === 0) {
+				return;
+			}
+
+			const existing = toolCallMap.get(item.call_id);
+			const itemArguments = typeof item.arguments === 'string' ? item.arguments : undefined;
+
+			toolCallMap.set(item.call_id, {
+				id: item.call_id,
+				name: typeof item.name === 'string' ? item.name : (existing?.name ?? ''),
+				args: itemArguments ?? existing?.args ?? '',
+				outputIndex,
+			});
+		};
 
 		while (true) {
 			const { done, value } = await reader.read();
@@ -231,43 +356,44 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					continue;
 				}
 
+				let event: OpenAiCodexStreamEvent;
+
 				try {
-					const event = JSON.parse(line.slice(6)) as {
-						type?: string;
-						delta?: string;
-						call_id?: string;
-						name?: string;
-						item?: { type?: string; call_id?: string; name?: string };
-					};
-
-					if (event.type === 'response.output_text.delta' && event.delta) {
-						content += event.delta;
-					} else if (event.type === 'response.function_call_arguments.delta' && event.call_id && event.delta) {
-						const existing = toolCallMap.get(event.call_id);
-
-						if (existing) {
-							existing.args += event.delta;
-						}
-					} else if (
-						event.type === 'response.output_item.added' &&
-						event.item?.type === 'function_call' &&
-						event.item.call_id
-					) {
-						toolCallMap.set(event.item.call_id, {
-							id: event.item.call_id,
-							name: event.item.name ?? '',
-							args: '',
-						});
-					}
+					event = JSON.parse(line.slice(6)) as OpenAiCodexStreamEvent;
 				} catch {
 					// Skip malformed JSON lines
+					continue;
+				}
+
+				if (event.type === 'response.output_text.delta' && event.delta) {
+					content += event.delta;
+				} else if (event.type === 'response.function_call_arguments.delta' && event.call_id && event.delta) {
+					const existing = toolCallMap.get(event.call_id);
+
+					if (existing) {
+						existing.args += event.delta;
+					}
+				} else if (
+					event.type === 'response.output_item.added' &&
+					event.item &&
+					isValidOutputIndex(event.output_index)
+				) {
+					captureOutputItem(event.item, event.output_index, false);
+				} else if (event.type === 'response.output_item.done' && event.item && isValidOutputIndex(event.output_index)) {
+					captureOutputItem(event.item, event.output_index, true);
+				} else if (event.type === 'response.completed' && event.response?.output) {
+					for (const [outputIndex, item] of event.response.output.entries()) {
+						captureOutputItem(item, outputIndex, true);
+					}
 				}
 			}
 		}
 
 		const toolCalls: LlmToolCall[] = [];
 
-		for (const tc of toolCallMap.values()) {
+		const orderedToolCalls = [...toolCallMap.values()].sort((left, right) => left.outputIndex - right.outputIndex);
+
+		for (const tc of orderedToolCalls) {
 			try {
 				toolCalls.push({
 					id: tc.id,
@@ -279,7 +405,17 @@ export class OpenAiCodexProvider implements ILlmProvider {
 			}
 		}
 
-		return { content, toolCalls };
+		const providerItems = [...reasoningItemMap.entries()]
+			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+			.map(
+				([reasoningIndex, item]): LlmConversationProviderItem => ({
+					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+					beforeProviderCallId: orderedToolCalls.find((toolCall) => toolCall.outputIndex > reasoningIndex)?.id ?? null,
+					item,
+				}),
+			);
+
+		return { content, toolCalls, providerItems };
 	}
 
 	private getPluginConfig(): BuddyOpenaiCodexConfigModel | null {
@@ -289,4 +425,8 @@ export class OpenAiCodexProvider implements ILlmProvider {
 			return null;
 		}
 	}
+}
+
+function isValidOutputIndex(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -10,8 +10,12 @@ import {
 } from '../../../modules/buddy/platforms/llm-conversation.utils';
 import {
 	ILlmProvider,
+	LlmAssistantToolCallsItem,
+	LlmConversationAssistantMessageItem,
+	LlmConversationFunctionCallItem,
 	LlmConversationItem,
 	LlmConversationProviderItem,
+	LlmConversationProviderOutputItem,
 	LlmConversationReasoningItem,
 	LlmOptions,
 	LlmResponse,
@@ -38,6 +42,7 @@ interface OpenAiCodexOutputItem {
 	summary?: unknown;
 	content?: unknown;
 	status?: unknown;
+	role?: unknown;
 }
 
 interface OpenAiCodexStreamEvent {
@@ -72,24 +77,19 @@ export function buildOpenAiCodexRequestPayload(
 
 		if (isLlmAssistantToolCallsItem(message)) {
 			const providerItems = message.providerItems ?? [];
-			const nativeCalls = message.calls.flatMap<Record<string, unknown>>((call) => [
-				...providerItems
-					.filter((providerItem) => providerItem.beforeProviderCallId === call.providerCallId)
-					.map(toOpenAiCodexProviderItem),
-				{
+
+			if (providerItems.length > 0) {
+				return serializeOpenAiCodexProviderItems(message.content, message.calls, providerItems);
+			}
+
+			return [
+				...(message.content.length === 0 ? [] : [{ role: 'assistant', content: message.content, type: 'message' }]),
+				...message.calls.map((call) => ({
 					type: 'function_call',
 					call_id: requireProviderCallId('OpenAI Codex', call.providerCallId),
 					name: call.name,
 					arguments: call.rawArguments ?? JSON.stringify(call.arguments),
-				},
-			]);
-
-			return [
-				...(message.content.length === 0 ? [] : [{ role: 'assistant', content: message.content, type: 'message' }]),
-				...nativeCalls,
-				...providerItems
-					.filter((providerItem) => providerItem.beforeProviderCallId === null)
-					.map(toOpenAiCodexProviderItem),
+				})),
 			];
 		}
 
@@ -119,12 +119,77 @@ export function buildOpenAiCodexRequestPayload(
 	};
 }
 
-function toOpenAiCodexProviderItem(providerItem: LlmConversationProviderItem): Record<string, unknown> {
+function serializeOpenAiCodexProviderItems(
+	content: string,
+	calls: LlmAssistantToolCallsItem['calls'],
+	providerItems: LlmConversationProviderItem[],
+): Record<string, unknown>[] {
+	const orderedProviderItems = [...providerItems].sort((left, right) => left.outputIndex - right.outputIndex);
+	const nativeItems = orderedProviderItems.map(toOpenAiCodexProviderItem);
+	const providerMessages = nativeItems.filter(
+		(item): item is LlmConversationAssistantMessageItem => item.type === 'message',
+	);
+	const providerCalls = nativeItems.filter(
+		(item): item is LlmConversationFunctionCallItem => item.type === 'function_call',
+	);
+	const providerContent = providerMessages
+		.flatMap((message) => message.content)
+		.map((part) => part.text)
+		.join('');
+
+	if (providerContent !== content) {
+		throw new TypeError('OpenAI Codex provider message state does not match canonical assistant content');
+	}
+
+	if (providerCalls.length !== calls.length) {
+		throw new TypeError('OpenAI Codex provider state must contain exactly one native item per function call');
+	}
+
+	for (const [callIndex, call] of calls.entries()) {
+		const providerCall = providerCalls[callIndex];
+		const providerCallId = requireProviderCallId('OpenAI Codex', call.providerCallId);
+		let providerArguments: unknown;
+
+		try {
+			providerArguments = JSON.parse(providerCall.arguments);
+		} catch {
+			throw new TypeError('OpenAI Codex provider function call contains invalid arguments');
+		}
+
+		if (
+			providerCall.call_id !== providerCallId ||
+			providerCall.name !== call.name ||
+			JSON.stringify(providerArguments) !== JSON.stringify(call.arguments)
+		) {
+			throw new TypeError(`OpenAI Codex provider function call at index ${callIndex} is ambiguous`);
+		}
+	}
+
+	return nativeItems.map((item) => ({ ...item }));
+}
+
+function toOpenAiCodexProviderItem(providerItem: LlmConversationProviderItem): LlmConversationProviderOutputItem {
 	if (providerItem.provider !== BUDDY_OPENAI_CODEX_PLUGIN_NAME) {
 		throw new TypeError(`OpenAI Codex cannot replay provider item for "${providerItem.provider}"`);
 	}
 
-	return { ...parseOpenAiCodexReasoningItem(providerItem.item) };
+	return parseOpenAiCodexProviderOutputItem(providerItem.item);
+}
+
+function parseOpenAiCodexProviderOutputItem(item: OpenAiCodexOutputItem): LlmConversationProviderOutputItem {
+	if (item.type === 'reasoning') {
+		return parseOpenAiCodexReasoningItem(item);
+	}
+
+	if (item.type === 'message') {
+		return parseOpenAiCodexAssistantMessageItem(item);
+	}
+
+	if (item.type === 'function_call') {
+		return parseOpenAiCodexFunctionCallItem(item);
+	}
+
+	throw new TypeError('OpenAI Codex provider continuation contains an unsupported output item');
 }
 
 function parseOpenAiCodexReasoningItem(item: OpenAiCodexOutputItem): LlmConversationReasoningItem {
@@ -178,6 +243,84 @@ function parseOpenAiCodexReasoningItem(item: OpenAiCodexOutputItem): LlmConversa
 		encrypted_content: item.encrypted_content,
 		...(status === undefined ? {} : { status }),
 	};
+}
+
+function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmConversationAssistantMessageItem {
+	if (
+		item.type !== 'message' ||
+		typeof item.id !== 'string' ||
+		item.id.length === 0 ||
+		item.role !== 'assistant' ||
+		!Array.isArray(item.content)
+	) {
+		throw new TypeError('OpenAI Codex assistant message continuation is incomplete');
+	}
+
+	const content = item.content.map((part) => {
+		if (
+			!isRecord(part) ||
+			part.type !== 'output_text' ||
+			typeof part.text !== 'string' ||
+			!Array.isArray(part.annotations) ||
+			part.annotations.length !== 0
+		) {
+			throw new TypeError('OpenAI Codex assistant message continuation has invalid content');
+		}
+
+		return { type: 'output_text' as const, text: part.text, annotations: [] as [] };
+	});
+	const status = parseOpenAiCodexOutputStatus(item.status, 'assistant message');
+
+	return {
+		type: 'message',
+		id: item.id,
+		role: 'assistant',
+		content,
+		...(status === undefined ? {} : { status }),
+	};
+}
+
+function parseOpenAiCodexFunctionCallItem(item: OpenAiCodexOutputItem): LlmConversationFunctionCallItem {
+	if (
+		item.type !== 'function_call' ||
+		typeof item.call_id !== 'string' ||
+		item.call_id.length === 0 ||
+		typeof item.name !== 'string' ||
+		item.name.length === 0 ||
+		typeof item.arguments !== 'string'
+	) {
+		throw new TypeError('OpenAI Codex function call continuation is incomplete');
+	}
+
+	if (item.id !== undefined && (typeof item.id !== 'string' || item.id.length === 0)) {
+		throw new TypeError('OpenAI Codex function call continuation has an invalid ID');
+	}
+
+	const status = parseOpenAiCodexOutputStatus(item.status, 'function call');
+
+	return {
+		type: 'function_call',
+		...(item.id === undefined ? {} : { id: item.id }),
+		call_id: item.call_id,
+		name: item.name,
+		arguments: item.arguments,
+		...(status === undefined ? {} : { status }),
+	};
+}
+
+function parseOpenAiCodexOutputStatus(
+	value: unknown,
+	label: string,
+): 'in_progress' | 'completed' | 'incomplete' | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (value === 'in_progress' || value === 'completed' || value === 'incomplete') {
+		return value;
+	}
+
+	throw new TypeError(`OpenAI Codex ${label} continuation has an invalid status`);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -314,12 +457,11 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		// Track tool calls: Responses API emits function_call_arguments.delta events
 		// with a call_id, and we accumulate the JSON argument strings per call
 		const toolCallMap = new Map<string, { id: string; name: string; args: string; outputIndex: number }>();
-		const reasoningItemMap = new Map<number, LlmConversationReasoningItem>();
+		const providerItemMap = new Map<number, LlmConversationProviderOutputItem>();
 
 		const captureOutputItem = (item: OpenAiCodexOutputItem, outputIndex: number, complete: boolean): void => {
-			if (item.type === 'reasoning' && complete) {
-				reasoningItemMap.set(outputIndex, parseOpenAiCodexReasoningItem(item));
-				return;
+			if (complete) {
+				providerItemMap.set(outputIndex, parseOpenAiCodexProviderOutputItem(item));
 			}
 
 			if (item.type !== 'function_call' || typeof item.call_id !== 'string' || item.call_id.length === 0) {
@@ -405,15 +547,27 @@ export class OpenAiCodexProvider implements ILlmProvider {
 			}
 		}
 
-		const providerItems = [...reasoningItemMap.entries()]
+		const providerItems = [...providerItemMap.entries()]
 			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
 			.map(
-				([reasoningIndex, item]): LlmConversationProviderItem => ({
+				([outputIndex, item]): LlmConversationProviderItem => ({
 					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
-					beforeProviderCallId: orderedToolCalls.find((toolCall) => toolCall.outputIndex > reasoningIndex)?.id ?? null,
+					outputIndex,
 					item,
 				}),
 			);
+		const providerContent = [...providerItemMap.entries()]
+			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+			.flatMap(([, item]) => (item.type === 'message' ? item.content : []))
+			.map((part) => part.text)
+			.join('');
+
+		if (providerContent.length > 0) {
+			if (content.length > 0 && content !== providerContent) {
+				throw new TypeError('OpenAI Codex streamed text does not match its completed message output');
+			}
+			content = providerContent;
+		}
 
 		return { content, toolCalls, providerItems };
 	}

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -42,6 +42,7 @@ interface OpenAiCodexOutputItem {
 	summary?: unknown;
 	content?: unknown;
 	status?: unknown;
+	phase?: unknown;
 	role?: unknown;
 }
 
@@ -269,6 +270,12 @@ function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmC
 
 		return { type: 'output_text' as const, text: part.text, annotations: [] as [] };
 	});
+	const allowedPhases = ['commentary', 'final_answer'] as const;
+	const phase = allowedPhases.find((candidate) => candidate === item.phase);
+
+	if (item.phase !== undefined && phase === undefined) {
+		throw new TypeError('OpenAI Codex assistant message continuation has an invalid phase');
+	}
 	const status = parseOpenAiCodexOutputStatus(item.status, 'assistant message');
 
 	return {
@@ -276,6 +283,7 @@ function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmC
 		id: item.id,
 		role: 'assistant',
 		content,
+		...(phase === undefined ? {} : { phase }),
 		...(status === undefined ? {} : { status }),
 	};
 }

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -2,8 +2,15 @@ import { Injectable } from '@nestjs/common';
 
 import { MessageRole } from '../../../modules/buddy/buddy.constants';
 import {
-	ChatMessage,
+	isChatMessage,
+	isLlmAssistantToolCallsItem,
+	requireProviderCallId,
+	serializeLlmConversationToolResult,
+	validateLlmConversationItems,
+} from '../../../modules/buddy/platforms/llm-conversation.utils';
+import {
 	ILlmProvider,
+	LlmConversationItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -23,19 +30,49 @@ import { BuddyOpenaiCodexConfigModel } from '../models/config.model';
 export function buildOpenAiCodexRequestPayload(
 	model: string,
 	systemPrompt: string,
-	messages: ChatMessage[],
+	messages: LlmConversationItem[],
 	tools?: ToolDefinition[],
+	maxTokens: number = 1024,
 ): Record<string, unknown> {
+	validateLlmConversationItems(messages);
+
+	const input = messages.flatMap<Record<string, unknown>>((message) => {
+		if (isChatMessage(message)) {
+			return [
+				{
+					role: message.role === MessageRole.USER ? 'user' : 'assistant',
+					content: message.content,
+					type: 'message',
+				},
+			];
+		}
+
+		if (isLlmAssistantToolCallsItem(message)) {
+			return [
+				...(message.content.length === 0 ? [] : [{ role: 'assistant', content: message.content, type: 'message' }]),
+				...message.calls.map((call) => ({
+					type: 'function_call',
+					call_id: requireProviderCallId('OpenAI Codex', call.providerCallId),
+					name: call.name,
+					arguments: call.rawArguments ?? JSON.stringify(call.arguments),
+				})),
+			];
+		}
+
+		return message.results.map((result) => ({
+			type: 'function_call_output',
+			call_id: requireProviderCallId('OpenAI Codex', result.providerCallId),
+			output: serializeLlmConversationToolResult(result),
+		}));
+	});
+
 	return {
 		model,
 		instructions: systemPrompt,
-		input: messages.map((message) => ({
-			role: message.role === MessageRole.USER ? 'user' : 'assistant',
-			content: message.content,
-			type: 'message',
-		})),
+		input,
 		stream: true,
 		store: false,
+		max_output_tokens: maxTokens,
 		tools:
 			tools?.map((tool) => ({
 				type: 'function',
@@ -91,9 +128,13 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		return true;
 	}
 
+	supportsNativeToolResults(): boolean {
+		return true;
+	}
+
 	async sendMessage(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		model: string,
 		options?: LlmOptions,
 	): Promise<LlmResponse> {
@@ -102,7 +143,13 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		const resolvedModel = config?.model ?? model;
 		const timeout = options?.timeout ?? 30_000;
 
-		const requestPayload = buildOpenAiCodexRequestPayload(resolvedModel, systemPrompt, messages, options?.tools);
+		const requestPayload = buildOpenAiCodexRequestPayload(
+			resolvedModel,
+			systemPrompt,
+			messages,
+			options?.tools,
+			options?.maxTokens ?? 1024,
+		);
 
 		// ChatGPT backend requires streaming. We collect SSE chunks and assemble the response.
 		const controller = new AbortController();

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -11,7 +11,10 @@ import {
 import {
 	ILlmProvider,
 	LlmAssistantToolCallsItem,
+	LlmConversationAssistantLogprob,
 	LlmConversationAssistantMessageItem,
+	LlmConversationAssistantTextAnnotation,
+	LlmConversationAssistantTopLogprob,
 	LlmConversationFunctionCallItem,
 	LlmConversationItem,
 	LlmConversationProviderItem,
@@ -133,10 +136,7 @@ function serializeOpenAiCodexProviderItems(
 	const providerCalls = nativeItems.filter(
 		(item): item is LlmConversationFunctionCallItem => item.type === 'function_call',
 	);
-	const providerContent = providerMessages
-		.flatMap((message) => message.content)
-		.map((part) => part.text)
-		.join('');
+	const providerContent = providerMessages.map(getOpenAiCodexAssistantMessageText).join('');
 
 	if (providerContent !== content) {
 		throw new TypeError('OpenAI Codex provider message state does not match canonical assistant content');
@@ -257,19 +257,7 @@ function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmC
 		throw new TypeError('OpenAI Codex assistant message continuation is incomplete');
 	}
 
-	const content = item.content.map((part) => {
-		if (
-			!isRecord(part) ||
-			part.type !== 'output_text' ||
-			typeof part.text !== 'string' ||
-			!Array.isArray(part.annotations) ||
-			part.annotations.length !== 0
-		) {
-			throw new TypeError('OpenAI Codex assistant message continuation has invalid content');
-		}
-
-		return { type: 'output_text' as const, text: part.text, annotations: [] as [] };
-	});
+	const content = item.content.map(parseOpenAiCodexAssistantContentPart);
 	const allowedPhases = ['commentary', 'final_answer'] as const;
 	const phase = allowedPhases.find((candidate) => candidate === item.phase);
 
@@ -286,6 +274,137 @@ function parseOpenAiCodexAssistantMessageItem(item: OpenAiCodexOutputItem): LlmC
 		...(phase === undefined ? {} : { phase }),
 		...(status === undefined ? {} : { status }),
 	};
+}
+
+function parseOpenAiCodexAssistantContentPart(part: unknown): LlmConversationAssistantMessageItem['content'][number] {
+	if (!isRecord(part)) {
+		throw new TypeError('OpenAI Codex assistant message continuation has invalid content');
+	}
+
+	if (part.type === 'refusal' && typeof part.refusal === 'string') {
+		return { type: 'refusal', refusal: part.refusal };
+	}
+
+	if (part.type !== 'output_text' || typeof part.text !== 'string' || !Array.isArray(part.annotations)) {
+		throw new TypeError('OpenAI Codex assistant message continuation has invalid content');
+	}
+
+	const annotations = part.annotations.map(parseOpenAiCodexAssistantTextAnnotation);
+	let logprobs: LlmConversationAssistantLogprob[] | undefined;
+
+	if (part.logprobs !== undefined) {
+		if (!Array.isArray(part.logprobs)) {
+			throw new TypeError('OpenAI Codex assistant message continuation has invalid log probabilities');
+		}
+		logprobs = part.logprobs.map(parseOpenAiCodexAssistantLogprob);
+	}
+
+	return {
+		type: 'output_text',
+		text: part.text,
+		annotations,
+		...(logprobs === undefined ? {} : { logprobs }),
+	};
+}
+
+function parseOpenAiCodexAssistantTextAnnotation(annotation: unknown): LlmConversationAssistantTextAnnotation {
+	if (!isRecord(annotation)) {
+		throw new TypeError('OpenAI Codex assistant message continuation has an invalid annotation');
+	}
+
+	if (
+		annotation.type === 'file_citation' &&
+		typeof annotation.file_id === 'string' &&
+		typeof annotation.filename === 'string' &&
+		isNonnegativeInteger(annotation.index)
+	) {
+		return {
+			type: 'file_citation',
+			file_id: annotation.file_id,
+			filename: annotation.filename,
+			index: annotation.index,
+		};
+	}
+
+	if (
+		annotation.type === 'url_citation' &&
+		isNonnegativeInteger(annotation.end_index) &&
+		isNonnegativeInteger(annotation.start_index) &&
+		typeof annotation.title === 'string' &&
+		typeof annotation.url === 'string'
+	) {
+		return {
+			type: 'url_citation',
+			end_index: annotation.end_index,
+			start_index: annotation.start_index,
+			title: annotation.title,
+			url: annotation.url,
+		};
+	}
+
+	if (
+		annotation.type === 'container_file_citation' &&
+		typeof annotation.container_id === 'string' &&
+		isNonnegativeInteger(annotation.end_index) &&
+		typeof annotation.file_id === 'string' &&
+		typeof annotation.filename === 'string' &&
+		isNonnegativeInteger(annotation.start_index)
+	) {
+		return {
+			type: 'container_file_citation',
+			container_id: annotation.container_id,
+			end_index: annotation.end_index,
+			file_id: annotation.file_id,
+			filename: annotation.filename,
+			start_index: annotation.start_index,
+		};
+	}
+
+	if (
+		annotation.type === 'file_path' &&
+		typeof annotation.file_id === 'string' &&
+		isNonnegativeInteger(annotation.index)
+	) {
+		return { type: 'file_path', file_id: annotation.file_id, index: annotation.index };
+	}
+
+	throw new TypeError('OpenAI Codex assistant message continuation has an invalid annotation');
+}
+
+function parseOpenAiCodexAssistantLogprob(logprob: unknown): LlmConversationAssistantLogprob {
+	if (!isRecord(logprob) || !Array.isArray(logprob.top_logprobs)) {
+		throw new TypeError('OpenAI Codex assistant message continuation has invalid log probabilities');
+	}
+
+	return {
+		...parseOpenAiCodexAssistantTopLogprob(logprob),
+		top_logprobs: logprob.top_logprobs.map(parseOpenAiCodexAssistantTopLogprob),
+	};
+}
+
+function parseOpenAiCodexAssistantTopLogprob(logprob: unknown): LlmConversationAssistantTopLogprob {
+	if (
+		!isRecord(logprob) ||
+		typeof logprob.token !== 'string' ||
+		!isByteArray(logprob.bytes) ||
+		typeof logprob.logprob !== 'number' ||
+		!Number.isFinite(logprob.logprob)
+	) {
+		throw new TypeError('OpenAI Codex assistant message continuation has invalid log probabilities');
+	}
+
+	return { token: logprob.token, bytes: [...logprob.bytes], logprob: logprob.logprob };
+}
+
+function getOpenAiCodexAssistantMessageText(message: LlmConversationAssistantMessageItem): string {
+	return message.content.map((part) => (part.type === 'output_text' ? part.text : part.refusal)).join('');
+}
+
+function isByteArray(value: unknown): value is number[] {
+	return (
+		Array.isArray(value) &&
+		value.every((byte: unknown) => typeof byte === 'number' && Number.isInteger(byte) && byte >= 0 && byte <= 255)
+	);
 }
 
 function parseOpenAiCodexFunctionCallItem(item: OpenAiCodexOutputItem): LlmConversationFunctionCallItem {
@@ -515,7 +634,7 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					continue;
 				}
 
-				if (event.type === 'response.output_text.delta' && event.delta) {
+				if ((event.type === 'response.output_text.delta' || event.type === 'response.refusal.delta') && event.delta) {
 					content += event.delta;
 				} else if (event.type === 'response.function_call_arguments.delta' && event.call_id && event.delta) {
 					const existing = toolCallMap.get(event.call_id);
@@ -564,13 +683,12 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					item,
 				}),
 			);
-		const providerContent = [...providerItemMap.entries()]
+		const providerMessages = [...providerItemMap.entries()]
 			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
-			.flatMap(([, item]) => (item.type === 'message' ? item.content : []))
-			.map((part) => part.text)
-			.join('');
+			.flatMap(([, item]) => (item.type === 'message' ? [item] : []));
+		const providerContent = providerMessages.map(getOpenAiCodexAssistantMessageText).join('');
 
-		if (providerContent.length > 0) {
+		if (providerMessages.length > 0) {
 			if (content.length > 0 && content !== providerContent) {
 				throw new TypeError('OpenAI Codex streamed text does not match its completed message output');
 			}
@@ -590,5 +708,9 @@ export class OpenAiCodexProvider implements ILlmProvider {
 }
 
 function isValidOutputIndex(value: unknown): value is number {
+	return isNonnegativeInteger(value);
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
 	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }

--- a/apps/backend/src/plugins/buddy-openai/platforms/openai.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai/platforms/openai.provider.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 
 import {
-	ChatMessage,
 	ILlmProvider,
+	LlmConversationItem,
 	LlmOptions,
 	LlmResponse,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
@@ -45,9 +45,13 @@ export class OpenAiProvider implements ILlmProvider {
 		return true;
 	}
 
+	supportsNativeToolResults(): boolean {
+		return true;
+	}
+
 	async sendMessage(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		model: string,
 		options?: LlmOptions,
 	): Promise<LlmResponse> {

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1307,9 +1307,12 @@ snapshots are produced through the shared query layer without making that eager 
 
 **Tasks:**
 
-- [ ] Represent assistant tool calls and tool results as canonical conversation items with stable call IDs.
+- [x] Define additive provider-neutral assistant tool-call/result conversation items, including canonical and native call
+      IDs, structured data/status/error fields, and validation of complete adjacent correlation groups. Existing text-only
+      callers remain compatible.
+- [ ] Generate request/iteration/ordinal-qualified canonical call IDs and adopt the conversation items in live Buddy turns.
 - [ ] Carry validated `ToolExecutionResult.data` to the next model iteration.
-- [ ] Map canonical items to native OpenAI Chat, Anthropic, Ollama, and OpenAI Codex Responses formats. For Codex, emit
+- [x] Map canonical items to native OpenAI Chat, Anthropic, Ollama, and OpenAI Codex Responses formats. For Codex, emit
       correlated `function_call`/`function_call_output` input items rather than ordinary messages.
 - [ ] Preserve ordering and one result/error per call, including malformed provider responses.
 - [ ] Pass explicit Buddy audience/source/access context to the registry.
@@ -1635,9 +1638,10 @@ No deterministic action path can execute without a successful claim-bound capaci
       orphan assistant message or make Phase 5 depend on Phase 6 persistence.
 - [ ] Recompute the budget before every tool-loop provider call.
 - [ ] Add token-aware compaction in the required order and preserve complete tool groups.
-- [ ] Pass the reserved output limit as `LlmOptions.maxTokens` on every provider iteration and require every registered
-      adapter to map it to its native generation cap. In particular, add Ollama's `options.num_predict` and the OpenAI
-      Codex Responses API `max_output_tokens`; do not treat a budget subtraction as enforcement when the payload omits it.
+- [x] Map `LlmOptions.maxTokens` to every built-in adapter's native generation cap, including Ollama's
+      `options.num_predict` and the OpenAI Codex Responses API `max_output_tokens`.
+- [ ] Pass the budgeted reserved output limit on every provider iteration and reject adapters that do not enforce it;
+      do not treat a budget subtraction as enforcement when the payload omits its native cap.
 - [ ] Add provider-adapter final serialized-payload checks that verify both the input bound and native output cap.
 - [ ] Add irreducible-input preflight and `BuddyMessageCapacityExceededException`; document the REST/voice 422 response
       and provider-free messaging fallback without changing the successful response contract.

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -475,6 +475,9 @@ to their native assistant-tool-call and tool-result formats. The Codex adapter e
 `function_call_output` input items correlated by the native `call_id`; it must not serialize a dependent tool result as
 an ordinary user/assistant `message`. Do not emulate tool results as ordinary user prose in any adapter.
 
+Because the Codex Responses adapter uses `store: false`, retain validated encrypted reasoning output items in active-turn
+provider state and replay them in native output order. Never persist or log encrypted reasoning as ordinary history.
+
 Canonical tool transcripts may remain in memory for the active turn. Existing persistence can continue to store the
 original user message and final assistant response; the rolling summary, entity references, and action-result metadata
 carry only the bounded information required by later turns. Persisting full tool transcripts is not required by this

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -475,8 +475,9 @@ to their native assistant-tool-call and tool-result formats. The Codex adapter e
 `function_call_output` input items correlated by the native `call_id`; it must not serialize a dependent tool result as
 an ordinary user/assistant `message`. Do not emulate tool results as ordinary user prose in any adapter.
 
-Because the Codex Responses adapter uses `store: false`, retain validated encrypted reasoning output items in active-turn
-provider state and replay them in native output order. Never persist or log encrypted reasoning as ordinary history.
+Because the Codex Responses adapter uses `store: false`, retain validated completed assistant-message, function-call, and
+encrypted-reasoning output items in active-turn provider state and replay them in native output order. Never persist or
+log encrypted reasoning as ordinary history.
 
 Canonical tool transcripts may remain in memory for the active turn. Existing persistence can continue to store the
 original user message and final assistant response; the rolling summary, entity references, and action-result metadata


### PR DESCRIPTION
> 👍 Codex review passed on `2b03b7ff4`.

## Summary

- define additive provider-neutral assistant tool-call and structured result conversation items
- validate complete adjacent call/result groups before provider dispatch
- serialize native correlated transcripts for OpenAI Chat, Anthropic, Ollama, and OpenAI Codex Responses
- preserve and replay validated completed Codex message, reasoning, and function-call output items in native order for `store:false` continuations
- expose native-result capability while preserving text-only and third-party provider compatibility
- enforce `maxTokens` through Ollama `num_predict` and Codex `max_output_tokens`
- update the adaptive-context plan without claiming the Buddy loop migration is complete

## Validation

- `pnpm run type-check`
- `pnpm run lint:js`
- focused native transcript/provider Jest suites
- changed TypeScript Prettier check
- `git diff --check`

## Scope

This is the provider/serialization foundation only. Buddy still uses its existing prose tool-result loop; canonical ID generation, structured result adoption, result bounds, and persistence remain follow-up work. Codex provider output is retained only as typed active-turn state; encrypted reasoning is not persisted as conversation history.