### PR TITLE
feat(backend): adopt native Buddy tool results

### DIFF
--- a/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
@@ -1,0 +1,498 @@
+import {
+	LlmToolCall,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+} from '../../tools/platforms/tool-provider.platform';
+import { MessageRole } from '../buddy.constants';
+import { BuddyProviderErrorException } from '../buddy.exceptions';
+import type { LlmConversationItem, LlmOptions, LlmResponse, LlmResponseMeta } from '../platforms/llm-provider.platform';
+
+import { BuddyConversationService } from './buddy-conversation.service';
+
+interface NativeToolLoopHarness {
+	sendWithToolExecution(
+		systemPrompt: string,
+		messages: LlmConversationItem[],
+		tools?: ToolDefinition[],
+		maxIterations?: number,
+	): Promise<LlmResponse>;
+}
+
+type SendMessage = (
+	systemPrompt: string,
+	messages: LlmConversationItem[],
+	options?: LlmOptions,
+	expectedProviderType?: string,
+) => Promise<LlmResponse>;
+type SupportsNativeToolResults = (providerType?: string) => boolean;
+type ExecuteTool = (toolCall: LlmToolCall, context?: Partial<ToolExecutionContext>) => Promise<ToolExecutionResult>;
+
+const createMeta = (ordinal: number): LlmResponseMeta => ({
+	provider: 'native-provider',
+	model: 'native-model',
+	inputTokens: ordinal,
+	outputTokens: ordinal * 2,
+	finishReason: `finish-${ordinal}`,
+	durationMs: ordinal * 10,
+	cacheReadTokens: ordinal * 3,
+	cacheWriteTokens: ordinal * 4,
+});
+
+describe('BuddyConversationService native tool loop', () => {
+	let llmProvider: {
+		sendMessage: jest.MockedFunction<SendMessage>;
+		supportsNativeToolResults: jest.MockedFunction<SupportsNativeToolResults>;
+	};
+	let toolProviderRegistry: {
+		executeTool: jest.MockedFunction<ExecuteTool>;
+	};
+	let service: BuddyConversationService;
+
+	beforeEach(() => {
+		llmProvider = {
+			sendMessage: jest.fn<ReturnType<SendMessage>, Parameters<SendMessage>>(),
+			supportsNativeToolResults: jest
+				.fn<ReturnType<SupportsNativeToolResults>, Parameters<SupportsNativeToolResults>>()
+				.mockReturnValue(true),
+		};
+		toolProviderRegistry = {
+			executeTool: jest.fn<ReturnType<ExecuteTool>, Parameters<ExecuteTool>>(),
+		};
+		service = new BuddyConversationService(
+			{} as never,
+			{} as never,
+			{} as never,
+			llmProvider as never,
+			{} as never,
+			{} as never,
+			toolProviderRegistry as never,
+			{} as never,
+			{} as never,
+			{} as never,
+		);
+	});
+
+	it('carries ordered structured results and active provider state through dependent native iterations', async () => {
+		const providerItems = [
+			{
+				provider: 'native-provider',
+				outputIndex: 0,
+				item: {
+					type: 'reasoning' as const,
+					id: 'reasoning-1',
+					summary: [],
+					encrypted_content: 'encrypted-state',
+					status: 'completed' as const,
+				},
+			},
+		];
+
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: 'I am checking the first reading.',
+				toolCalls: [{ id: 'ollama-0', name: 'read_temperature', arguments: { room: 'kitchen' } }],
+				providerItems,
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [{ id: 'ollama-0', name: 'read_humidity', arguments: { room: 'kitchen' } }],
+				meta: createMeta(2),
+			})
+			.mockResolvedValueOnce({ content: 'The kitchen is comfortable.', meta: createMeta(3) });
+		toolProviderRegistry.executeTool
+			.mockResolvedValueOnce({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				message: 'Temperature read',
+				data: { value: 21.5, unit: 'C' },
+			})
+			.mockResolvedValueOnce({
+				success: false,
+				status: ToolExecutionStatus.TIMED_OUT,
+				message: 'Humidity read timed out',
+				data: { attempted: 2 },
+				errorCode: 'TOOL_TIMEOUT',
+			});
+
+		const response = await runToolLoop(service);
+
+		expect(response).toEqual({
+			content: 'The kitchen is comfortable.',
+			meta: {
+				...createMeta(1),
+				inputTokens: 6,
+				outputTokens: 12,
+				finishReason: 'finish-3',
+				durationMs: 60,
+				cacheReadTokens: 18,
+				cacheWriteTokens: 24,
+			},
+		});
+		expect(llmProvider.supportsNativeToolResults).toHaveBeenCalledWith('native-provider');
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(3);
+
+		const secondMessages = llmProvider.sendMessage.mock.calls[1][1];
+		const firstCallGroup = secondMessages[1];
+		const firstResultGroup = secondMessages[2];
+		const firstCallId = getOnlyCallId(firstCallGroup);
+
+		expect(firstCallGroup).toEqual({
+			type: 'assistant_tool_calls',
+			content: 'I am checking the first reading.',
+			calls: [
+				{
+					callId: firstCallId,
+					providerCallId: 'ollama-0',
+					name: 'read_temperature',
+					arguments: { room: 'kitchen' },
+				},
+			],
+			providerItems,
+		});
+		expect(firstResultGroup).toEqual({
+			type: 'tool_results',
+			results: [
+				{
+					callId: firstCallId,
+					providerCallId: 'ollama-0',
+					toolName: 'read_temperature',
+					status: 'completed',
+					message: 'Temperature read',
+					data: { value: 21.5, unit: 'C' },
+					truncated: false,
+				},
+			],
+		});
+
+		const thirdMessages = llmProvider.sendMessage.mock.calls[2][1];
+		const secondCallGroup = thirdMessages[3];
+		const secondResultGroup = thirdMessages[4];
+		const secondCallId = getOnlyCallId(secondCallGroup);
+
+		expect(secondCallId).not.toBe(firstCallId);
+		expect(secondCallGroup).toEqual({
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [
+				{
+					callId: secondCallId,
+					providerCallId: 'ollama-0',
+					name: 'read_humidity',
+					arguments: { room: 'kitchen' },
+				},
+			],
+		});
+		expect(secondResultGroup).toEqual({
+			type: 'tool_results',
+			results: [
+				{
+					callId: secondCallId,
+					providerCallId: 'ollama-0',
+					toolName: 'read_humidity',
+					status: 'timed_out',
+					message: 'Humidity read timed out',
+					data: { attempted: 2 },
+					errorCode: 'TOOL_TIMEOUT',
+					truncated: false,
+				},
+			],
+		});
+		expect(firstResultGroup).not.toHaveProperty('providerItems');
+		expect(secondCallGroup).not.toHaveProperty('providerItems');
+
+		expect(toolProviderRegistry.executeTool).toHaveBeenNthCalledWith(
+			1,
+			{ id: 'ollama-0', name: 'read_temperature', arguments: { room: 'kitchen' } },
+			expect.objectContaining({
+				audience: ToolAudience.BUDDY,
+				source: ToolAudience.BUDDY,
+				requestId: firstCallId,
+			}),
+		);
+		expect(toolProviderRegistry.executeTool).toHaveBeenNthCalledWith(
+			2,
+			{ id: 'ollama-0', name: 'read_humidity', arguments: { room: 'kitchen' } },
+			expect.objectContaining({
+				audience: ToolAudience.BUDDY,
+				source: ToolAudience.BUDDY,
+				requestId: secondCallId,
+			}),
+		);
+	});
+
+	it('preserves the legacy mixed-content success early return', async () => {
+		llmProvider.supportsNativeToolResults.mockReturnValue(false);
+		llmProvider.sendMessage.mockResolvedValue({
+			content: 'The light command was accepted.',
+			toolCalls: [{ id: 'provider-1', name: 'set_light', arguments: { on: true } }],
+			meta: createMeta(1),
+		});
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'Light switched on',
+		});
+
+		const response = await runToolLoop(service);
+
+		expect(response.content).toBe('The light command was accepted.');
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(1);
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(1);
+	});
+
+	it('stops safely when the provider cannot continue after a completed native tool step', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [{ id: 'provider-1', name: 'set_light', arguments: { on: true } }],
+				meta: createMeta(1),
+			})
+			.mockRejectedValueOnce(new BuddyProviderErrorException('The LLM provider changed during the active turn'));
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'Light switched on',
+		});
+		const tools = [{} as ToolDefinition];
+
+		const response = await runToolLoop(service, 5, tools);
+
+		expect(response.content).toContain('could not safely continue the assistant turn');
+		expect(response.content).toContain('check the current state before retrying');
+		expect(llmProvider.sendMessage).toHaveBeenNthCalledWith(
+			2,
+			'system',
+			expect.any(Array),
+			{ tools },
+			'native-provider',
+		);
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(1);
+	});
+
+	it('preserves the legacy prose fallback when execution fails', async () => {
+		llmProvider.supportsNativeToolResults.mockReturnValue(false);
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: 'I will switch the light.',
+				toolCalls: [{ id: 'provider-1', name: 'set_light', arguments: { on: true } }],
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({ content: 'I could not switch the light.', meta: createMeta(2) });
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: 'Device is offline',
+			errorCode: 'DEVICE_OFFLINE',
+		});
+
+		await runToolLoop(service);
+
+		expect(llmProvider.sendMessage.mock.calls[1][1]).toEqual([
+			{ role: MessageRole.USER, content: 'Control the kitchen.' },
+			{ role: MessageRole.ASSISTANT, content: 'I will switch the light.' },
+			{
+				role: MessageRole.USER,
+				content:
+					'[Tool execution results]\nTool "set_light" (id=provider-1): FAILED — Device is offline\n\n' +
+					'Please provide a natural language response based on these results.',
+			},
+		]);
+	});
+
+	it('uses the whole-iteration prose fallback for native provider parse errors', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolErrors: [{ toolCallId: 'bad-1', toolName: 'set_light', error: 'Invalid JSON arguments' }],
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({ content: 'Please specify the light state again.', meta: createMeta(2) });
+
+		await runToolLoop(service);
+
+		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
+		expect(llmProvider.sendMessage.mock.calls[1][1]).toEqual([
+			{ role: MessageRole.USER, content: 'Control the kitchen.' },
+			{ role: MessageRole.ASSISTANT, content: '[Executing tools: set_light (parse error)]' },
+			{
+				role: MessageRole.USER,
+				content:
+					'[Tool execution results]\nTool "set_light" (id=bad-1): FAILED — Invalid JSON arguments\n\n' +
+					'Please provide a natural language response based on these results.',
+			},
+		]);
+	});
+
+	it('aborts remaining calls and disables tools after an indeterminate registry execution', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [
+					{ id: 'provider-1', name: 'uncertain_action', arguments: {} },
+					{ id: 'provider-2', name: 'read_state', arguments: {} },
+				],
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({ content: 'I could only confirm the state read.', meta: createMeta(2) });
+		toolProviderRegistry.executeTool.mockRejectedValueOnce(new Error('private provider detail'));
+		const tools = [{} as ToolDefinition];
+
+		const response = await runToolLoop(service, 5, tools);
+
+		const resultGroup = llmProvider.sendMessage.mock.calls[1][1][2];
+
+		expect(resultGroup).toEqual({
+			type: 'tool_results',
+			results: [
+				expect.objectContaining({
+					providerCallId: 'provider-1',
+					toolName: 'uncertain_action',
+					status: 'indeterminate',
+					message: 'Tool "uncertain_action" execution outcome is uncertain',
+					errorCode: 'TOOL_EXECUTION_INDETERMINATE',
+				}),
+				expect.objectContaining({
+					providerCallId: 'provider-2',
+					toolName: 'read_state',
+					status: 'denied',
+					message: 'Tool "read_state" was not executed after an uncertain earlier outcome',
+					errorCode: 'TOOL_BATCH_ABORTED_AFTER_INDETERMINATE',
+				}),
+			],
+		});
+		expect(JSON.stringify(resultGroup)).not.toContain('private provider detail');
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(1);
+		expect(llmProvider.sendMessage).toHaveBeenNthCalledWith(
+			2,
+			'system',
+			expect.any(Array),
+			{ tools: undefined },
+			'native-provider',
+		);
+		expect(response.content).toBe(
+			'I could not confirm whether the requested operation completed, so I stopped further actions.',
+		);
+	});
+
+	it('returns deterministic uncertainty when the no-tools follow-up rejects', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [{ id: 'provider-1', name: 'uncertain_action', arguments: {} }],
+				meta: createMeta(1),
+			})
+			.mockRejectedValueOnce(new Error('follow-up provider unavailable'));
+		toolProviderRegistry.executeTool.mockRejectedValueOnce(new Error('private provider detail'));
+
+		const response = await runToolLoop(service, 5, [{} as ToolDefinition]);
+
+		expect(response.content).toBe(
+			'I could not confirm whether the requested operation completed, so I stopped further actions.',
+		);
+		expect(response.content).not.toContain('provider');
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(2);
+	});
+
+	it('rejects duplicate native provider IDs before executing any tool', async () => {
+		llmProvider.sendMessage.mockResolvedValue({
+			content: '',
+			toolCalls: [
+				{ id: 'duplicate', name: 'read_one', arguments: {} },
+				{ id: 'duplicate', name: 'read_two', arguments: {} },
+			],
+			meta: createMeta(1),
+		});
+
+		const error = await runToolLoop(service).catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(BuddyProviderErrorException);
+		expect(error).toHaveProperty('message', expect.stringContaining('empty or duplicate provider call ID'));
+		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
+	});
+
+	it('returns a bounded fallback after max iterations and strips active provider state', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [{ id: 'provider-1', name: 'read_state', arguments: {} }],
+				providerItems: [
+					{
+						provider: 'native-provider',
+						outputIndex: 0,
+						item: {
+							type: 'reasoning',
+							id: 'reasoning-1',
+							summary: [],
+							encrypted_content: 'encrypted-state',
+						},
+					},
+				],
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({
+				content: 'I will read the state again.',
+				toolCalls: [{ id: 'provider-2', name: 'read_state_again', arguments: {} }],
+				providerItems: [
+					{
+						provider: 'native-provider',
+						outputIndex: 0,
+						item: {
+							type: 'reasoning',
+							id: 'reasoning-2',
+							summary: [],
+							encrypted_content: 'encrypted-state-2',
+						},
+					},
+				],
+				meta: createMeta(2),
+			});
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'State read',
+		});
+
+		const response = await runToolLoop(service, 1);
+
+		expect(response.content).toContain('reached the maximum number of steps');
+		expect(response.meta).toEqual({
+			...createMeta(1),
+			inputTokens: 3,
+			outputTokens: 6,
+			finishReason: 'finish-2',
+			durationMs: 30,
+			cacheReadTokens: 9,
+			cacheWriteTokens: 12,
+		});
+		expect(response.toolCalls).toBeUndefined();
+		expect(response.toolErrors).toBeUndefined();
+		expect(response.providerItems).toBeUndefined();
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(2);
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(1);
+	});
+});
+
+async function runToolLoop(
+	service: BuddyConversationService,
+	maxIterations: number = 5,
+	tools?: ToolDefinition[],
+): Promise<LlmResponse> {
+	return (service as unknown as NativeToolLoopHarness).sendWithToolExecution(
+		'system',
+		[{ role: MessageRole.USER, content: 'Control the kitchen.' }],
+		tools,
+		maxIterations,
+	);
+}
+
+function getOnlyCallId(item: LlmConversationItem): string {
+	if (!('type' in item) || item.type !== 'assistant_tool_calls' || item.calls.length !== 1) {
+		throw new TypeError('Expected one assistant tool call');
+	}
+
+	return item.calls[0].callId;
+}

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -153,6 +153,7 @@ describe('BuddyConversationService', () => {
 				},
 			}),
 			supportsTools: jest.fn().mockReturnValue(false),
+			supportsNativeToolResults: jest.fn().mockReturnValue(false),
 		};
 
 		contextService = {

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -7,6 +7,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { ConfigService } from '../../config/services/config.service';
+import { ToolAudience, ToolExecutionResult, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import {
@@ -16,11 +17,20 @@ import {
 	EventType,
 	MessageRole,
 } from '../buddy.constants';
-import { BuddyConversationNotFoundException } from '../buddy.exceptions';
+import { BuddyConversationNotFoundException, BuddyProviderErrorException } from '../buddy.exceptions';
 import { BuddyConversationEntity } from '../entities/buddy-conversation.entity';
 import { BuddyMessageEntity } from '../entities/buddy-message.entity';
 import { BuddyConfigModel } from '../models/config.model';
-import { LlmResponse, LlmResponseMeta, ToolDefinition } from '../platforms/llm-provider.platform';
+import {
+	LlmConversationItem,
+	LlmConversationToolCall,
+	LlmConversationToolResult,
+	LlmResponse,
+	LlmResponseMeta,
+	LlmToolCall,
+	LlmToolResultStatus,
+	ToolDefinition,
+} from '../platforms/llm-provider.platform';
 
 import { BuddyContext, BuddyContextService } from './buddy-context.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
@@ -138,7 +148,9 @@ export class BuddyConversationService {
 		chatMessages.push({ role: MessageRole.USER, content });
 
 		// 3. Call LLM provider with tool support if available
-		const tools = this.llmProvider.supportsTools() ? this.toolProviderRegistry.getAllToolDefinitions() : undefined;
+		const tools = this.llmProvider.supportsTools()
+			? this.toolProviderRegistry.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
+			: undefined;
 		const maxIterations = this.getMaxToolIterations();
 		const llmResponse = await this.sendWithToolExecution(systemPrompt, chatMessages, tools, maxIterations);
 
@@ -219,21 +231,24 @@ export class BuddyConversationService {
 	 */
 	private async sendWithToolExecution(
 		systemPrompt: string,
-		messages: ChatMessage[],
+		messages: LlmConversationItem[],
 		tools?: ToolDefinition[],
 		maxIterations: number = DEFAULT_MAX_TOOL_ITERATIONS,
 	): Promise<LlmResponse> {
 		// Work on a shallow copy so we never mutate the caller's array
-		const workingMessages = [...messages];
+		const workingMessages: LlmConversationItem[] = [...messages];
+		const activeTurnId = uuid();
 
 		let response = await this.llmProvider.sendMessage(systemPrompt, workingMessages, { tools });
+		const activeProviderType = response.meta.provider;
+		const useNativeToolResults = this.llmProvider.supportsNativeToolResults(activeProviderType);
 
 		const hasToolWork = (r: typeof response): boolean =>
 			(r.toolCalls !== undefined && r.toolCalls.length > 0) || (r.toolErrors !== undefined && r.toolErrors.length > 0);
 
 		// If no tool calls or errors, return directly
 		if (!hasToolWork(response)) {
-			return response;
+			return this.clearActiveToolState(response);
 		}
 
 		// Accumulate token usage and duration across all LLM calls
@@ -245,14 +260,124 @@ export class BuddyConversationService {
 				break;
 			}
 
-			// If the LLM returned both content and tool calls, the content is its final answer.
-			// Execute the tools for their side effects but return the response as-is afterwards.
 			const hasContentWithTools = !!response.content;
 
 			const callCount = response.toolCalls?.length ?? 0;
 			const errorCount = response.toolErrors?.length ?? 0;
 
 			this.logger.debug(`Tool iteration ${iteration + 1}: ${callCount} tool call(s), ${errorCount} parse error(s)`);
+
+			const toolCalls = response.toolCalls ?? [];
+			const canonicalCallIds = toolCalls.map(
+				(_toolCall, callIndex) => `buddy:${activeTurnId}:${iteration + 1}:${callIndex + 1}`,
+			);
+
+			if (useNativeToolResults && errorCount === 0) {
+				this.assertNativeProviderCallIds(toolCalls);
+
+				const canonicalCalls: LlmConversationToolCall[] = toolCalls.map((toolCall, callIndex) => ({
+					callId: canonicalCallIds[callIndex],
+					providerCallId: toolCall.id,
+					name: toolCall.name,
+					arguments: toolCall.arguments,
+				}));
+				const canonicalResults: LlmConversationToolResult[] = [];
+				let hasIndeterminateExecution = false;
+
+				for (const [callIndex, toolCall] of toolCalls.entries()) {
+					const canonicalCall = canonicalCalls[callIndex];
+					let result: ToolExecutionResult;
+
+					try {
+						result = await this.toolProviderRegistry.executeTool(toolCall, {
+							audience: ToolAudience.BUDDY,
+							source: ToolAudience.BUDDY,
+							requestId: canonicalCall.callId,
+						});
+					} catch {
+						hasIndeterminateExecution = true;
+						canonicalResults.push({
+							callId: canonicalCall.callId,
+							providerCallId: canonicalCall.providerCallId,
+							toolName: canonicalCall.name,
+							status: 'indeterminate',
+							message: `Tool "${canonicalCall.name}" execution outcome is uncertain`,
+							errorCode: 'TOOL_EXECUTION_INDETERMINATE',
+							truncated: false,
+						});
+
+						for (const skippedCall of canonicalCalls.slice(callIndex + 1)) {
+							canonicalResults.push({
+								callId: skippedCall.callId,
+								providerCallId: skippedCall.providerCallId,
+								toolName: skippedCall.name,
+								status: 'denied',
+								message: `Tool "${skippedCall.name}" was not executed after an uncertain earlier outcome`,
+								errorCode: 'TOOL_BATCH_ABORTED_AFTER_INDETERMINATE',
+								truncated: false,
+							});
+						}
+
+						break;
+					}
+
+					canonicalResults.push({
+						callId: canonicalCall.callId,
+						providerCallId: canonicalCall.providerCallId,
+						toolName: canonicalCall.name,
+						status: this.toLlmToolResultStatus(result.status),
+						message: result.message,
+						...(result.data === undefined ? {} : { data: result.data }),
+						...(result.errorCode === undefined ? {} : { errorCode: result.errorCode }),
+						truncated: result.truncated ?? false,
+					});
+				}
+
+				workingMessages.push(
+					{
+						type: 'assistant_tool_calls',
+						content: response.content,
+						calls: canonicalCalls,
+						...(response.providerItems === undefined ? {} : { providerItems: response.providerItems }),
+					},
+					{ type: 'tool_results', results: canonicalResults },
+				);
+
+				if (hasIndeterminateExecution) {
+					const uncertaintyMessage =
+						'I could not confirm whether the requested operation completed, so I stopped further actions.';
+
+					try {
+						response = await this.llmProvider.sendMessage(
+							systemPrompt,
+							workingMessages,
+							{ tools: undefined },
+							activeProviderType,
+						);
+						this.accumulateMeta(accumulatedMeta, response.meta);
+					} catch {
+						// The deterministic uncertainty response must survive provider failure
+						// because retrying an action with an unknown outcome may duplicate it.
+					}
+
+					return this.clearActiveToolState({ ...response, meta: accumulatedMeta, content: uncertaintyMessage });
+				}
+
+				try {
+					response = await this.llmProvider.sendMessage(systemPrompt, workingMessages, { tools }, activeProviderType);
+					this.accumulateMeta(accumulatedMeta, response.meta);
+				} catch {
+					return this.clearActiveToolState({
+						...response,
+						meta: accumulatedMeta,
+						content:
+							'I processed the requested tool step but could not safely continue the assistant turn. ' +
+							'Please check the current state before retrying.',
+					});
+				}
+
+				continue;
+			}
 
 			// Execute all tool calls and include parse errors for malformed arguments
 			const toolResults: { success: boolean; summary: string }[] = [];
@@ -267,8 +392,12 @@ export class BuddyConversationService {
 				}
 			}
 
-			for (const toolCall of response.toolCalls ?? []) {
-				const result = await this.toolProviderRegistry.executeTool(toolCall);
+			for (const [callIndex, toolCall] of toolCalls.entries()) {
+				const result = await this.toolProviderRegistry.executeTool(toolCall, {
+					audience: ToolAudience.BUDDY,
+					source: ToolAudience.BUDDY,
+					requestId: canonicalCallIds[callIndex],
+				});
 
 				toolResults.push({
 					success: result.success,
@@ -278,12 +407,14 @@ export class BuddyConversationService {
 
 			const allSucceeded = toolResults.every((r) => r.success);
 
+			// Legacy/custom providers may emit a final answer with successful tool calls.
+			// Preserve that historical shortcut only for the prose fallback path.
 			// If the LLM already provided a final answer alongside the tool calls
 			// and all tools succeeded, return the LLM's content as-is.
 			// If any tool failed, fall through to re-query the LLM so it can
 			// provide an accurate response reflecting the failures.
 			if (hasContentWithTools && allSucceeded) {
-				return { ...response, meta: accumulatedMeta, toolCalls: undefined, toolErrors: undefined };
+				return this.clearActiveToolState({ ...response, meta: accumulatedMeta });
 			}
 
 			// Append the assistant's tool call response and tool results as a follow-up user message
@@ -311,24 +442,80 @@ export class BuddyConversationService {
 			});
 
 			// Call LLM again with tools so multi-step tool use works
-			response = await this.llmProvider.sendMessage(systemPrompt, workingMessages, { tools });
-			this.accumulateMeta(accumulatedMeta, response.meta);
+			try {
+				response = await this.llmProvider.sendMessage(
+					systemPrompt,
+					workingMessages,
+					{ tools },
+					useNativeToolResults ? activeProviderType : undefined,
+				);
+				this.accumulateMeta(accumulatedMeta, response.meta);
+			} catch (error) {
+				if (!useNativeToolResults || callCount === 0) {
+					throw error;
+				}
+
+				return this.clearActiveToolState({
+					...response,
+					meta: accumulatedMeta,
+					content:
+						'I processed the requested tool step but could not safely continue the assistant turn. ' +
+						'Please check the current state before retrying.',
+				});
+			}
 		}
 
-		// If loop exhausted and final response has no text content, provide a fallback
-		if (!response.content && hasToolWork(response)) {
-			return {
+		// Never present pre-execution assistant text as final when the loop stops with
+		// outstanding tool work. Those final calls have not been executed.
+		if (hasToolWork(response)) {
+			return this.clearActiveToolState({
 				...response,
 				meta: accumulatedMeta,
 				content:
 					'I attempted to perform the requested actions but reached the maximum number of steps. ' +
 					'Please try again or simplify your request.',
-				toolCalls: undefined,
-				toolErrors: undefined,
-			};
+			});
 		}
 
-		return { ...response, meta: accumulatedMeta, toolCalls: undefined, toolErrors: undefined };
+		return this.clearActiveToolState({ ...response, meta: accumulatedMeta });
+	}
+
+	private assertNativeProviderCallIds(toolCalls: LlmToolCall[]): void {
+		const providerCallIds = new Set<string>();
+
+		for (const [callIndex, toolCall] of toolCalls.entries()) {
+			if (toolCall.id.length === 0 || providerCallIds.has(toolCall.id)) {
+				throw new BuddyProviderErrorException(
+					`Native tool response has an empty or duplicate provider call ID at index ${callIndex}`,
+				);
+			}
+
+			providerCallIds.add(toolCall.id);
+		}
+	}
+
+	private toLlmToolResultStatus(status: ToolExecutionStatus): LlmToolResultStatus {
+		switch (status) {
+			case ToolExecutionStatus.COMPLETED:
+				return 'completed';
+			case ToolExecutionStatus.PARTIAL:
+				return 'partial';
+			case ToolExecutionStatus.FAILED:
+				return 'failed';
+			case ToolExecutionStatus.TIMED_OUT:
+				return 'timed_out';
+			case ToolExecutionStatus.DENIED:
+				return 'denied';
+		}
+	}
+
+	private clearActiveToolState(response: LlmResponse): LlmResponse {
+		return {
+			...response,
+			toolCalls: undefined,
+			toolErrors: undefined,
+			providerItems: undefined,
+		};
 	}
 
 	/**

--- a/apps/backend/src/modules/buddy/services/llm-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/llm-provider.service.spec.ts
@@ -175,6 +175,15 @@ describe('LlmProviderService', () => {
 				expect.objectContaining({ timeout: 60_000 }),
 			);
 		});
+
+		it('should reject an active-turn continuation after the configured provider changes', async () => {
+			configService.getModuleConfig.mockReturnValue(makeConfig({ provider: 'buddy-openai-plugin' }));
+
+			await expect(service.sendMessage(systemPrompt, messages, undefined, 'buddy-claude-plugin')).rejects.toThrow(
+				'provider changed during the active turn',
+			);
+			expect(openaiSendMessage).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('native tool-result capability', () => {
@@ -187,6 +196,13 @@ describe('LlmProviderService', () => {
 			configService.getModuleConfig.mockReturnValue(makeConfig({ provider: 'buddy-native-plugin' }));
 
 			expect(service.supportsNativeToolResults()).toBe(true);
+		});
+
+		it('resolves capability for the provider that produced the active response', () => {
+			registry.register(makeMockProvider('buddy-native-plugin', jest.fn(), true));
+
+			expect(service.supportsNativeToolResults('buddy-native-plugin')).toBe(true);
+			expect(service.supportsNativeToolResults('buddy-claude-plugin')).toBe(false);
 		});
 
 		it('returns false when there is no configured provider', () => {

--- a/apps/backend/src/modules/buddy/services/llm-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/llm-provider.service.ts
@@ -25,7 +25,12 @@ export class LlmProviderService {
 		private readonly providerRegistry: LlmProviderRegistryService,
 	) {}
 
-	async sendMessage(systemPrompt: string, messages: LlmConversationItem[], options?: LlmOptions): Promise<LlmResponse> {
+	async sendMessage(
+		systemPrompt: string,
+		messages: LlmConversationItem[],
+		options?: LlmOptions,
+		expectedProviderType?: string,
+	): Promise<LlmResponse> {
 		const config = this.getConfig();
 		const providerName = config.provider;
 
@@ -41,6 +46,10 @@ export class LlmProviderService {
 			);
 
 			throw new BuddyProviderNotConfiguredException();
+		}
+
+		if (expectedProviderType !== undefined && provider.getType() !== expectedProviderType) {
+			throw new BuddyProviderErrorException('The LLM provider changed during the active turn');
 		}
 
 		const timeoutMs = config.llmTimeoutMs;
@@ -87,8 +96,12 @@ export class LlmProviderService {
 		}
 	}
 
-	supportsNativeToolResults(): boolean {
+	supportsNativeToolResults(providerType?: string): boolean {
 		try {
+			if (providerType !== undefined) {
+				return this.providerRegistry.get(providerType)?.supportsNativeToolResults?.() ?? false;
+			}
+
 			const config = this.getConfig();
 			const providerName = config.provider;
 

--- a/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
+++ b/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
@@ -67,6 +67,8 @@ export interface ToolExecutionResult {
 	message: string;
 	data?: Record<string, unknown>;
 	errorCode?: string;
+	/** True when structured data was omitted because it was invalid or exceeded the transport bound. */
+	truncated?: boolean;
 }
 
 export interface ToolExecutionContext {

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '../platforms/tool-provider.platform';
 
 import { BaseToolProviderService } from './base-tool-provider.service';
-import { ToolProviderRegistryService } from './tool-provider-registry.service';
+import { TOOL_RESULT_MAX_JSON_BYTES, ToolProviderRegistryService } from './tool-provider-registry.service';
 
 const inputSchema = z.object({ value: z.string() });
 const outputSchema = z.object({ value: z.string() });
@@ -158,6 +158,66 @@ describe('ToolProviderRegistryService', () => {
 				source: 'mcp',
 				actorId: 'client-1',
 				requestId: 'request-1',
+			}),
+		]);
+	});
+
+	it('returns the original validated structured data object', async () => {
+		const result = completed('validated');
+
+		registry.register(
+			new TestToolProvider('provider-a', [definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)], () =>
+				Promise.resolve(result),
+			),
+		);
+
+		await expect(registry.executeTool({ id: 'request-1', name: 'read-tool', arguments: { value: 'x' } })).resolves.toBe(
+			result,
+		);
+	});
+
+	it('omits invalid, oversized, and non-serializable structured data without changing execution status', async () => {
+		const cyclicData: Record<string, unknown> = { value: 'cyclic' };
+
+		cyclicData.self = cyclicData;
+
+		const results: ToolExecutionResult[] = [
+			{ ...completed('invalid'), data: { unexpected: true } },
+			{ ...completed('oversized'), data: { value: 'x'.repeat(TOOL_RESULT_MAX_JSON_BYTES) } },
+			{ ...completed('cyclic'), data: cyclicData },
+		];
+		const provider = new TestToolProvider(
+			'provider-a',
+			[definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			() => Promise.resolve(results.shift() ?? null),
+		);
+
+		registry.register(provider);
+
+		const bounded = await Promise.all(
+			[1, 2, 3].map((id) => registry.executeTool({ id: String(id), name: 'read-tool', arguments: { value: 'x' } })),
+		);
+
+		expect(bounded).toEqual([
+			expect.objectContaining({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				data: undefined,
+				errorCode: 'INVALID_TOOL_RESULT_DATA',
+				truncated: true,
+			}),
+			expect.objectContaining({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				data: undefined,
+				truncated: true,
+			}),
+			expect.objectContaining({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				data: undefined,
+				errorCode: 'INVALID_TOOL_RESULT_DATA',
+				truncated: true,
 			}),
 		]);
 	});

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
@@ -162,18 +162,25 @@ describe('ToolProviderRegistryService', () => {
 		]);
 	});
 
-	it('returns the original validated structured data object', async () => {
-		const result = completed('validated');
+	it('returns only schema-parsed structured data', async () => {
+		const result = {
+			...completed('validated'),
+			data: { value: ' validated ', secret: 'must not reach the model' },
+		};
+		const parsedDefinition = createToolDefinition({
+			name: 'read-tool',
+			description: 'read-tool description',
+			audiences: [ToolAudience.BUDDY],
+			access: ToolAccessKind.READ,
+			inputSchema,
+			outputSchema: z.object({ value: z.string().transform((value) => value.trim()) }),
+		});
 
-		registry.register(
-			new TestToolProvider('provider-a', [definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)], () =>
-				Promise.resolve(result),
-			),
-		);
+		registry.register(new TestToolProvider('provider-a', [parsedDefinition], () => Promise.resolve(result)));
 
-		await expect(registry.executeTool({ id: 'request-1', name: 'read-tool', arguments: { value: 'x' } })).resolves.toBe(
-			result,
-		);
+		await expect(
+			registry.executeTool({ id: 'request-1', name: 'read-tool', arguments: { value: 'x' } }),
+		).resolves.toEqual({ ...result, data: { value: 'validated' } });
 	});
 
 	it('omits invalid, oversized, and non-serializable structured data without changing execution status', async () => {
@@ -188,14 +195,26 @@ describe('ToolProviderRegistryService', () => {
 		];
 		const provider = new TestToolProvider(
 			'provider-a',
-			[definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			[
+				definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ),
+				createToolDefinition({
+					name: 'passthrough-tool',
+					description: 'passthrough-tool description',
+					audiences: [ToolAudience.BUDDY],
+					access: ToolAccessKind.READ,
+					inputSchema,
+					outputSchema: outputSchema.passthrough(),
+				}),
+			],
 			() => Promise.resolve(results.shift() ?? null),
 		);
 
 		registry.register(provider);
 
 		const bounded = await Promise.all(
-			[1, 2, 3].map((id) => registry.executeTool({ id: String(id), name: 'read-tool', arguments: { value: 'x' } })),
+			['read-tool', 'read-tool', 'passthrough-tool'].map((name, index) =>
+				registry.executeTool({ id: String(index + 1), name, arguments: { value: 'x' } }),
+			),
 		);
 
 		expect(bounded).toEqual([

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
@@ -143,15 +143,26 @@ export class ToolProviderRegistryService {
 		}
 
 		const parsed = definition.outputSchema.safeParse(result.data);
+
+		if (!parsed.success || typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) {
+			return {
+				...result,
+				data: undefined,
+				errorCode: result.errorCode ?? 'INVALID_TOOL_RESULT_DATA',
+				truncated: true,
+			};
+		}
+
+		const parsedData = parsed.data as Record<string, unknown>;
 		let serialized: string | undefined;
 
 		try {
-			serialized = JSON.stringify(result.data);
+			serialized = JSON.stringify(parsedData);
 		} catch {
 			serialized = undefined;
 		}
 
-		if (!parsed.success || serialized === undefined) {
+		if (serialized === undefined) {
 			return {
 				...result,
 				data: undefined,
@@ -164,7 +175,7 @@ export class ToolProviderRegistryService {
 			return { ...result, data: undefined, truncated: true };
 		}
 
-		return result;
+		return { ...result, data: parsedData };
 	}
 
 	/**

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
@@ -14,6 +14,8 @@ import {
 } from '../platforms/tool-provider.platform';
 import { TOOLS_MODULE_NAME } from '../tools.constants';
 
+export const TOOL_RESULT_MAX_JSON_BYTES = 32 * 1024;
+
 @Injectable()
 export class ToolProviderRegistryService {
 	private readonly logger = createExtensionLogger(TOOLS_MODULE_NAME, 'ToolProviderRegistryService');
@@ -124,7 +126,7 @@ export class ToolProviderRegistryService {
 		const result = await registered.provider.executeTool(toolCall, context);
 
 		if (result !== null) {
-			return result;
+			return this.boundToolResultData(registered.definition, result);
 		}
 
 		return {
@@ -133,6 +135,36 @@ export class ToolProviderRegistryService {
 			message: `Provider failed to handle registered tool: ${toolCall.name}`,
 			errorCode: 'TOOL_PROVIDER_MISMATCH',
 		};
+	}
+
+	private boundToolResultData(definition: ToolDefinition, result: ToolExecutionResult): ToolExecutionResult {
+		if (result.data === undefined) {
+			return result;
+		}
+
+		const parsed = definition.outputSchema.safeParse(result.data);
+		let serialized: string | undefined;
+
+		try {
+			serialized = JSON.stringify(result.data);
+		} catch {
+			serialized = undefined;
+		}
+
+		if (!parsed.success || serialized === undefined) {
+			return {
+				...result,
+				data: undefined,
+				errorCode: result.errorCode ?? 'INVALID_TOOL_RESULT_DATA',
+				truncated: true,
+			};
+		}
+
+		if (Buffer.byteLength(serialized, 'utf8') > TOOL_RESULT_MAX_JSON_BYTES) {
+			return { ...result, data: undefined, truncated: true };
+		}
+
+		return result;
 	}
 
 	/**

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.spec.ts
@@ -303,6 +303,182 @@ describe('OpenAiCodexProvider native transcript', () => {
 		}
 	});
 
+	it('returns bounded tool errors for malformed JSON while retaining valid calls and provider items', async () => {
+		const malformedFunctionCallItem = {
+			...firstFunctionCallItem,
+			arguments: '{"room":',
+		};
+		const events = [
+			{
+				type: 'response.completed',
+				response: { output: [malformedFunctionCallItem, secondFunctionCallItem] },
+			},
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			const response = await provider.sendMessage(
+				'system',
+				[{ role: MessageRole.USER, content: 'Read the kitchen.' }],
+				'codex-test',
+			);
+
+			expect(response.toolCalls).toEqual([
+				{ id: 'provider-call-2', name: 'get_humidity', arguments: { room: 'kitchen' } },
+			]);
+			expect(response.toolErrors).toEqual([
+				{
+					toolCallId: 'provider-call-1',
+					toolName: 'get_temperature',
+					error: 'Invalid JSON arguments',
+				},
+			]);
+			expect(response.providerItems).toEqual(
+				[malformedFunctionCallItem, secondFunctionCallItem].map((item, outputIndex) => ({
+					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
+					outputIndex,
+					item,
+				})),
+			);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('rejects duplicate provider call IDs from different output items before returning tool calls', async () => {
+		const duplicateFunctionCallItem = {
+			...secondFunctionCallItem,
+			call_id: firstFunctionCallItem.call_id,
+		};
+		const events = [
+			{
+				type: 'response.completed',
+				response: { output: [firstFunctionCallItem, duplicateFunctionCallItem] },
+			},
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			await expect(
+				provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+			).rejects.toThrow('OpenAI Codex response contains duplicate call ID at output index 1');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('rejects distinct provider call IDs assigned to the same output index', async () => {
+		const events = [
+			{ type: 'response.output_item.done', output_index: 0, item: firstFunctionCallItem },
+			{ type: 'response.output_item.done', output_index: 0, item: secondFunctionCallItem },
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			await expect(
+				provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+			).rejects.toThrow('OpenAI Codex response contains duplicate output index 0');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('rejects a function call and non-function item assigned to the same output index', async () => {
+		for (const items of [
+			[firstFunctionCallItem, assistantMessageItem],
+			[assistantMessageItem, firstFunctionCallItem],
+		]) {
+			const events = items.map((item) => ({ type: 'response.output_item.done', output_index: 0, item }));
+			const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+			const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+			const configService = {
+				getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+			};
+			const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+			try {
+				await expect(
+					provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+				).rejects.toThrow('OpenAI Codex response contains duplicate output index 0');
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		}
+	});
+
+	it('rejects an added function call that never receives a completion event', async () => {
+		const events = [
+			{ type: 'response.output_item.added', output_index: 0, item: { ...firstFunctionCallItem, arguments: '' } },
+			{
+				type: 'response.function_call_arguments.delta',
+				output_index: 0,
+				call_id: firstFunctionCallItem.call_id,
+				delta: firstFunctionCallItem.arguments,
+			},
+		];
+		const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+		};
+		const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+		try {
+			await expect(
+				provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+			).rejects.toThrow(`OpenAI Codex function call "${firstFunctionCallItem.call_id}" did not complete`);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('rejects function call argument deltas after completion or for a different output index', async () => {
+		for (const deltaOutputIndex of [0, 1]) {
+			const events = [
+				{ type: 'response.output_item.done', output_index: 0, item: firstFunctionCallItem },
+				{
+					type: 'response.function_call_arguments.delta',
+					output_index: deltaOutputIndex,
+					call_id: firstFunctionCallItem.call_id,
+					delta: ' ',
+				},
+			];
+			const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n')}\ndata: [DONE]\n`;
+			const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+			const configService = {
+				getPluginConfig: jest.fn().mockReturnValue({ accessToken: 'test-token', model: null }),
+			};
+			const provider = new OpenAiCodexProvider(configService as unknown as ConfigService);
+
+			try {
+				await expect(
+					provider.sendMessage('system', [{ role: MessageRole.USER, content: 'Read the kitchen.' }], 'codex-test'),
+				).rejects.toThrow(
+					deltaOutputIndex === 0
+						? 'OpenAI Codex function call arguments changed after completion'
+						: 'OpenAI Codex function call argument delta has a mismatched output index',
+				);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		}
+	});
+
 	it('rejects partial text when the response exhausts max output tokens', async () => {
 		const events = [
 			{ type: 'response.output_text.delta', output_index: 0, delta: 'This answer is partial' },

--- a/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/platforms/openai-codex.provider.ts
@@ -22,6 +22,7 @@ import {
 	LlmConversationReasoningItem,
 	LlmOptions,
 	LlmResponse,
+	LlmToolError,
 } from '../../../modules/buddy/platforms/llm-provider.platform';
 import { OAuthTokenManager } from '../../../modules/buddy/platforms/oauth-token-manager';
 import { ConfigService } from '../../../modules/config/services/config.service';
@@ -544,12 +545,13 @@ export class OpenAiCodexProvider implements ILlmProvider {
 				throw new Error(`${response.status} ${errorBody || response.statusText}`);
 			}
 
-			const { content, toolCalls, providerItems } = await this.collectStreamResponse(response);
+			const { content, toolCalls, toolErrors, providerItems } = await this.collectStreamResponse(response);
 			const durationMs = Date.now() - start;
 
 			return {
 				content,
 				toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+				toolErrors: toolErrors.length > 0 ? toolErrors : undefined,
 				providerItems: providerItems.length > 0 ? providerItems : undefined,
 				meta: {
 					provider: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
@@ -567,13 +569,16 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		}
 	}
 
-	private async collectStreamResponse(
-		response: Response,
-	): Promise<{ content: string; toolCalls: LlmToolCall[]; providerItems: LlmConversationProviderItem[] }> {
+	private async collectStreamResponse(response: Response): Promise<{
+		content: string;
+		toolCalls: LlmToolCall[];
+		toolErrors: LlmToolError[];
+		providerItems: LlmConversationProviderItem[];
+	}> {
 		const body = response.body;
 
 		if (!body) {
-			return { content: '', toolCalls: [], providerItems: [] };
+			return { content: '', toolCalls: [], toolErrors: [], providerItems: [] };
 		}
 
 		const reader = body.getReader();
@@ -583,19 +588,60 @@ export class OpenAiCodexProvider implements ILlmProvider {
 
 		// Track tool calls: Responses API emits function_call_arguments.delta events
 		// with a call_id, and we accumulate the JSON argument strings per call
-		const toolCallMap = new Map<string, { id: string; name: string; args: string; outputIndex: number }>();
+		const toolCallMap = new Map<
+			string,
+			{ id: string; name: string; args: string; outputIndex: number; complete: boolean }
+		>();
+		const outputItemIdentityByIndex = new Map<number, string>();
 		const providerItemMap = new Map<number, LlmConversationProviderOutputItem>();
 
 		const captureOutputItem = (item: OpenAiCodexOutputItem, outputIndex: number, complete: boolean): void => {
-			if (complete) {
-				providerItemMap.set(outputIndex, parseOpenAiCodexProviderOutputItem(item));
+			const outputItemIdentity =
+				item.type === 'function_call' && typeof item.call_id === 'string' && item.call_id.length > 0
+					? `function_call:${item.call_id}`
+					: typeof item.type === 'string' && typeof item.id === 'string' && item.id.length > 0
+						? `${item.type}:${item.id}`
+						: undefined;
+			const existingOutputItemIdentity = outputItemIdentityByIndex.get(outputIndex);
+
+			if (
+				existingOutputItemIdentity !== undefined &&
+				outputItemIdentity !== undefined &&
+				existingOutputItemIdentity !== outputItemIdentity
+			) {
+				throw new Error(`OpenAI Codex response contains duplicate output index ${outputIndex}`);
 			}
 
 			if (item.type !== 'function_call' || typeof item.call_id !== 'string' || item.call_id.length === 0) {
+				if (complete) {
+					const providerItem = parseOpenAiCodexProviderOutputItem(item);
+
+					if (outputItemIdentity !== undefined) {
+						outputItemIdentityByIndex.set(outputIndex, outputItemIdentity);
+					}
+
+					providerItemMap.set(outputIndex, providerItem);
+				} else if (outputItemIdentity !== undefined) {
+					outputItemIdentityByIndex.set(outputIndex, outputItemIdentity);
+				}
+
 				return;
 			}
 
 			const existing = toolCallMap.get(item.call_id);
+
+			if (existing !== undefined && existing.outputIndex !== outputIndex) {
+				throw new Error(`OpenAI Codex response contains duplicate call ID at output index ${outputIndex}`);
+			}
+
+			if (complete) {
+				const providerItem = parseOpenAiCodexProviderOutputItem(item);
+
+				providerItemMap.set(outputIndex, providerItem);
+			}
+
+			outputItemIdentityByIndex.set(outputIndex, `function_call:${item.call_id}`);
+
 			const itemArguments = typeof item.arguments === 'string' ? item.arguments : undefined;
 
 			toolCallMap.set(item.call_id, {
@@ -603,6 +649,7 @@ export class OpenAiCodexProvider implements ILlmProvider {
 				name: typeof item.name === 'string' ? item.name : (existing?.name ?? ''),
 				args: itemArguments ?? existing?.args ?? '',
 				outputIndex,
+				complete: complete || existing?.complete === true,
 			});
 		};
 
@@ -646,6 +693,14 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					const existing = toolCallMap.get(event.call_id);
 
 					if (existing) {
+						if (!isValidOutputIndex(event.output_index) || event.output_index !== existing.outputIndex) {
+							throw new Error('OpenAI Codex function call argument delta has a mismatched output index');
+						}
+
+						if (existing.complete) {
+							throw new Error('OpenAI Codex function call arguments changed after completion');
+						}
+
 						existing.args += event.delta;
 					}
 				} else if (
@@ -665,6 +720,12 @@ export class OpenAiCodexProvider implements ILlmProvider {
 		}
 
 		const toolCalls: LlmToolCall[] = [];
+		const toolErrors: LlmToolError[] = [];
+		const incompleteToolCall = [...toolCallMap.values()].find((toolCall) => !toolCall.complete);
+
+		if (incompleteToolCall !== undefined) {
+			throw new Error(`OpenAI Codex function call "${incompleteToolCall.id}" did not complete`);
+		}
 
 		const orderedToolCalls = [...toolCallMap.values()].sort((left, right) => left.outputIndex - right.outputIndex);
 
@@ -676,7 +737,11 @@ export class OpenAiCodexProvider implements ILlmProvider {
 					arguments: JSON.parse(tc.args || '{}') as Record<string, unknown>,
 				});
 			} catch {
-				// Skip tool calls with malformed arguments
+				toolErrors.push({
+					toolCallId: tc.id,
+					toolName: tc.name,
+					error: 'Invalid JSON arguments',
+				});
 			}
 		}
 
@@ -701,7 +766,7 @@ export class OpenAiCodexProvider implements ILlmProvider {
 			content = providerContent;
 		}
 
-		return { content, toolCalls, providerItems };
+		return { content, toolCalls, toolErrors, providerItems };
 	}
 
 	private getPluginConfig(): BuddyOpenaiCodexConfigModel | null {

--- a/apps/backend/test/buddy.e2e-spec.ts
+++ b/apps/backend/test/buddy.e2e-spec.ts
@@ -39,6 +39,7 @@ describe('Buddy module (e2e)', () => {
 					},
 				}),
 				supportsTools: jest.fn().mockReturnValue(false),
+				supportsNativeToolResults: jest.fn().mockReturnValue(false),
 			})
 			.compile();
 

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1314,8 +1314,10 @@ snapshots are produced through the shared query layer without making that eager 
 - [x] Define additive provider-neutral assistant tool-call/result conversation items, including canonical and native call
       IDs, structured data/status/error fields, and validation of complete adjacent correlation groups. Existing text-only
       callers remain compatible.
-- [ ] Generate request/iteration/ordinal-qualified canonical call IDs and adopt the conversation items in live Buddy turns.
-- [ ] Carry validated `ToolExecutionResult.data` to the next model iteration.
+- [x] Generate turn/iteration/ordinal-qualified canonical call IDs and adopt the conversation items in live Buddy
+      turns for native-capable providers, while retaining the legacy prose path for other providers.
+- [x] Carry schema-validated, individually 32 KiB-bounded `ToolExecutionResult.data` to the next model iteration; keep
+      aggregate call/result byte limits as an open task.
 - [x] Map canonical items to native OpenAI Chat, Anthropic, Ollama, and OpenAI Codex Responses formats. For Codex, emit
       correlated `function_call`/`function_call_output` input items rather than ordinary messages.
 - [ ] Preserve ordering and one result/error per call, including malformed provider responses.


### PR DESCRIPTION
> 👍 Codex review passed on `04230bcecc`.

## Summary

- adopt provider-native assistant tool-call/result transcripts in live Buddy turns with turn/iteration/ordinal canonical IDs
- preserve structured, schema-validated tool result data with a 32 KiB per-result data bound
- retain the existing prose fallback for providers without native result support and malformed mixed provider responses
- pin the active provider across a turn and return deterministic uncertainty when an execution outcome cannot be confirmed
- reject malformed Codex stream correlations and incomplete calls before any tool can be executed

## Safety behavior

- native mixed-content responses are never treated as final before correlated results are returned to the model
- indeterminate execution stops the remaining batch, disables further tools, and returns a deterministic uncertainty message
- invalid, cyclic, or oversized structured result data is omitted without slicing JSON
- active provider continuation items remain in-memory and are cleared before persistence

## Validation

- focused Jest: 5 suites, 92 tests, 2 snapshots
- OpenAI Codex provider: 17 tests
- backend TypeScript type-check
- ESLint and Prettier on every touched Backend file
- `git diff --check`
- Buddy E2E: 18 tests

## Deferred

- aggregate per-turn call/result/message/provider-item byte limits
- exact native malformed-call interleaving (malformed iterations currently use the bounded prose fallback)
- durable action idempotency and full verified Buddy actor/access context