### PR TITLE
feat(backend): bound Buddy tool transcripts

### DIFF
--- a/apps/backend/src/modules/buddy/buddy.constants.ts
+++ b/apps/backend/src/modules/buddy/buddy.constants.ts
@@ -111,6 +111,23 @@ export const CONFLICT_LIGHTS_UNOCCUPIED_MINUTES = 15; // minutes of no occupancy
 
 export const DEFAULT_MAX_TOOL_ITERATIONS = 5;
 
+/** Hard canonical-JSON bounds for one active Buddy tool turn. */
+export const BUDDY_MAX_TOOL_ITEMS_PER_ITERATION = 8;
+
+export const BUDDY_MAX_TOOL_ITEMS_PER_TURN = 32;
+
+export const BUDDY_MAX_TOOL_ITEM_JSON_BYTES = 16 * 1024;
+
+export const BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION = 16;
+
+export const BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES = 48 * 1024;
+
+export const BUDDY_MAX_TOOL_BATCH_JSON_BYTES = 64 * 1024;
+
+export const BUDDY_MAX_TOOL_RESULT_GROUP_JSON_BYTES = 64 * 1024;
+
+export const BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES = 128 * 1024;
+
 export const BUDDY_CORE_TOOLS_PROVIDER = 'buddy-core-tools';
 
 export const CONTEXT_CACHE_GLOBAL_KEY = '__global__';

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation-bounds.utils.spec.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation-bounds.utils.spec.ts
@@ -1,0 +1,315 @@
+import {
+	BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES,
+	BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES,
+	BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_BATCH_JSON_BYTES,
+	BUDDY_MAX_TOOL_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_ITEMS_PER_TURN,
+	BUDDY_MAX_TOOL_ITEM_JSON_BYTES,
+} from '../buddy.constants';
+
+import {
+	admitBuddyToolResponse,
+	canReserveBuddyToolResultGroup,
+	fitBuddyToolResultGroup,
+	measureJsonUtf8Bytes,
+} from './llm-conversation-bounds.utils';
+import type {
+	LlmAssistantToolCallsItem,
+	LlmConversationProviderItem,
+	LlmConversationToolResult,
+	LlmResponse,
+	LlmResponseMeta,
+} from './llm-provider.platform';
+
+const meta: LlmResponseMeta = {
+	provider: 'provider',
+	model: 'model',
+	inputTokens: null,
+	outputTokens: null,
+	finishReason: null,
+	durationMs: null,
+	cacheReadTokens: null,
+	cacheWriteTokens: null,
+};
+
+const responseWithCalls = (count: number): LlmResponse => ({
+	content: '',
+	toolCalls: Array.from({ length: count }, (_, index) => ({ id: `p-${index}`, name: 'read', arguments: {} })),
+	meta,
+});
+
+describe('LLM conversation bounds', () => {
+	it('accepts the literal iteration and turn item boundaries and rejects the next item', () => {
+		expect(admitBuddyToolResponse(responseWithCalls(BUDDY_MAX_TOOL_ITEMS_PER_ITERATION), 0)).toEqual({
+			accepted: true,
+			itemCount: BUDDY_MAX_TOOL_ITEMS_PER_ITERATION,
+		});
+		expect(admitBuddyToolResponse(responseWithCalls(BUDDY_MAX_TOOL_ITEMS_PER_ITERATION + 1), 0)).toEqual({
+			accepted: false,
+			reason: 'iteration_items',
+		});
+		expect(
+			admitBuddyToolResponse(responseWithCalls(BUDDY_MAX_TOOL_ITEMS_PER_ITERATION), BUDDY_MAX_TOOL_ITEMS_PER_TURN - 8),
+		).toEqual({ accepted: true, itemCount: BUDDY_MAX_TOOL_ITEMS_PER_ITERATION });
+		expect(
+			admitBuddyToolResponse(responseWithCalls(BUDDY_MAX_TOOL_ITEMS_PER_ITERATION), BUDDY_MAX_TOOL_ITEMS_PER_TURN - 7),
+		).toEqual({ accepted: false, reason: 'turn_items' });
+	});
+
+	it('rejects a non-serializable or oversized call before execution', () => {
+		const cyclic: Record<string, unknown> = {};
+
+		cyclic.self = cyclic;
+
+		expect(
+			admitBuddyToolResponse({ content: '', toolCalls: [{ id: 'p-1', name: 'read', arguments: cyclic }], meta }, 0),
+		).toEqual({ accepted: false, reason: 'non_serializable' });
+		expect(
+			admitBuddyToolResponse(
+				{
+					content: '',
+					toolCalls: [{ id: 'p-1', name: 'read', arguments: { value: 'x'.repeat(BUDDY_MAX_TOOL_ITEM_JSON_BYTES) } }],
+					meta,
+				},
+				0,
+			),
+		).toEqual({ accepted: false, reason: 'tool_item_bytes' });
+	});
+
+	it('accepts an exact-size call and rejects one additional UTF-8 byte', () => {
+		const baseCall = { id: 'p-1', name: 'read', arguments: { value: '' } };
+		const baseBytes = measureJsonUtf8Bytes(baseCall) ?? 0;
+		const exactCall = {
+			...baseCall,
+			arguments: { value: 'x'.repeat(BUDDY_MAX_TOOL_ITEM_JSON_BYTES - baseBytes) },
+		};
+
+		expect(measureJsonUtf8Bytes(exactCall)).toBe(BUDDY_MAX_TOOL_ITEM_JSON_BYTES);
+		expect(admitBuddyToolResponse({ content: '', toolCalls: [exactCall], meta }, 0)).toEqual({
+			accepted: true,
+			itemCount: 1,
+		});
+		expect(
+			admitBuddyToolResponse(
+				{ content: '', toolCalls: [{ ...exactCall, arguments: { value: `${exactCall.arguments.value}x` } }], meta },
+				0,
+			),
+		).toEqual({ accepted: false, reason: 'tool_item_bytes' });
+	});
+
+	it('treats provider continuation as atomic and bounded', () => {
+		const providerItems: LlmConversationProviderItem[] = Array.from(
+			{ length: BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION + 1 },
+			(_, outputIndex) => ({
+				provider: 'provider',
+				outputIndex,
+				item: {
+					type: 'reasoning',
+					id: `reasoning-${outputIndex}`,
+					summary: [],
+					encrypted_content: 'state',
+				},
+			}),
+		);
+
+		expect(admitBuddyToolResponse({ ...responseWithCalls(1), providerItems }, 0)).toEqual({
+			accepted: false,
+			reason: 'provider_item_count',
+		});
+		expect(
+			admitBuddyToolResponse(
+				{
+					...responseWithCalls(1),
+					providerItems: [
+						{
+							provider: 'provider',
+							outputIndex: 0,
+							item: {
+								type: 'reasoning',
+								id: 'reasoning',
+								summary: [],
+								encrypted_content: 'x'.repeat(BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES),
+							},
+						},
+					],
+				},
+				0,
+			),
+		).toEqual({ accepted: false, reason: 'provider_item_bytes' });
+
+		const baseProviderItem: LlmConversationProviderItem = {
+			provider: 'provider',
+			outputIndex: 0,
+			item: { type: 'reasoning', id: 'reasoning', summary: [], encrypted_content: '' },
+		};
+		const baseProviderBytes = measureJsonUtf8Bytes([baseProviderItem]) ?? 0;
+		const exactProviderItem: LlmConversationProviderItem = {
+			provider: 'provider',
+			outputIndex: 0,
+			item: {
+				type: 'reasoning',
+				id: 'reasoning',
+				summary: [],
+				encrypted_content: 'x'.repeat(BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES - baseProviderBytes),
+			},
+		};
+
+		expect(measureJsonUtf8Bytes([exactProviderItem])).toBe(BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES);
+		expect(admitBuddyToolResponse({ ...responseWithCalls(1), providerItems: [exactProviderItem] }, 0)).toEqual({
+			accepted: true,
+			itemCount: 1,
+		});
+		expect(
+			admitBuddyToolResponse(
+				{
+					...responseWithCalls(1),
+					providerItems: [
+						{
+							provider: 'provider',
+							outputIndex: 0,
+							item: {
+								type: 'reasoning',
+								id: 'reasoning',
+								summary: [],
+								encrypted_content: `${'x'.repeat(BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES - baseProviderBytes)}x`,
+							},
+						},
+					],
+				},
+				0,
+			),
+		).toEqual({ accepted: false, reason: 'provider_item_bytes' });
+	});
+
+	it('reserves the complete canonical batch before dispatch', () => {
+		const callItem: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: Array.from({ length: 5 }, (_, index) => ({
+				callId: `c-${index}`,
+				providerCallId: `${'p'.repeat(12_000)}${index}`,
+				name: 'read',
+				arguments: {},
+			})),
+		};
+
+		expect(measureJsonUtf8Bytes(callItem)).toBeLessThan(64 * 1024);
+		expect(canReserveBuddyToolResultGroup(callItem, 0)).toBe(false);
+	});
+
+	it('accepts the exact canonical batch and cumulative boundaries and rejects one more byte', () => {
+		const baseCallItem: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [canonicalCall('c-1')],
+		};
+		const reservedResult = {
+			type: 'tool_results' as const,
+			results: [
+				{
+					...canonicalResult('c-1'),
+					status: 'indeterminate' as const,
+					message: 'Tool result detail omitted to fit the active-turn limit',
+					truncated: true,
+				},
+			],
+		};
+		const baseGroupBytes = measureJsonUtf8Bytes([baseCallItem, reservedResult]) ?? 0;
+		const exactCallItem = {
+			...baseCallItem,
+			content: 'x'.repeat(BUDDY_MAX_TOOL_BATCH_JSON_BYTES - baseGroupBytes),
+		};
+		const exactGroupBytes = measureJsonUtf8Bytes([exactCallItem, reservedResult]) ?? 0;
+		const exactCumulativeStart = BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES - exactGroupBytes + 1;
+
+		expect(exactGroupBytes).toBe(BUDDY_MAX_TOOL_BATCH_JSON_BYTES);
+		expect(canReserveBuddyToolResultGroup(exactCallItem, 0)).toBe(true);
+		expect(canReserveBuddyToolResultGroup({ ...exactCallItem, content: `${exactCallItem.content}x` }, 0)).toBe(false);
+		expect(canReserveBuddyToolResultGroup(exactCallItem, exactCumulativeStart)).toBe(true);
+		expect(canReserveBuddyToolResultGroup(exactCallItem, exactCumulativeStart + 1)).toBe(false);
+	});
+
+	it('drops structured data from the end while preserving every correlated result', () => {
+		const callItem: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [canonicalCall('c-1'), canonicalCall('c-2')],
+		};
+		const results: LlmConversationToolResult[] = [
+			canonicalResult('c-1', { value: 'a'.repeat(32 * 1024) }),
+			{
+				...canonicalResult('c-2', { value: 'b'.repeat(32 * 1024) }),
+				status: 'timed_out',
+				errorCode: 'TIMEOUT',
+			},
+		];
+		const bounded = fitBuddyToolResultGroup(callItem, results, 0);
+
+		expect(bounded).not.toBeNull();
+		expect(bounded?.item.results).toHaveLength(2);
+		expect(bounded?.item.results[0]).toHaveProperty('data');
+		expect(bounded?.item.results[1]).toEqual(
+			expect.objectContaining({
+				callId: 'c-2',
+				providerCallId: 'c-2',
+				toolName: 'read',
+				status: 'timed_out',
+				errorCode: 'TIMEOUT',
+				truncated: true,
+			}),
+		);
+		expect(bounded?.item.results[1]).not.toHaveProperty('data');
+		expect(results[1]).toHaveProperty('data');
+	});
+
+	it('refuses execution when even the minimum correlated result group cannot fit the turn', () => {
+		const callItem: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [canonicalCall('c-1')],
+		};
+
+		expect(canReserveBuddyToolResultGroup(callItem, BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES)).toBe(false);
+		expect(
+			fitBuddyToolResultGroup(callItem, [canonicalResult('c-1')], BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES),
+		).toBe(null);
+		expect(measureJsonUtf8Bytes({ text: 'Ž' })).toBe(Buffer.byteLength(JSON.stringify({ text: 'Ž' }), 'utf8'));
+	});
+
+	it('accounts multiple canonical groups as one flattened JSON array', () => {
+		const firstCall: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [canonicalCall('c-1')],
+		};
+		const secondCall: LlmAssistantToolCallsItem = {
+			type: 'assistant_tool_calls',
+			content: '',
+			calls: [canonicalCall('c-2')],
+		};
+		const first = fitBuddyToolResultGroup(firstCall, [canonicalResult('c-1')], 0);
+		const second = fitBuddyToolResultGroup(secondCall, [canonicalResult('c-2')], first?.nextActiveTranscriptBytes ?? 0);
+		const flattenedBytes = measureJsonUtf8Bytes([firstCall, first?.item, secondCall, second?.item]);
+
+		expect(first).not.toBeNull();
+		expect(second).not.toBeNull();
+		expect(second?.nextActiveTranscriptBytes).toBe(flattenedBytes);
+	});
+});
+
+function canonicalCall(callId: string) {
+	return { callId, providerCallId: callId, name: 'read', arguments: {} };
+}
+
+function canonicalResult(callId: string, data?: Record<string, unknown>): LlmConversationToolResult {
+	return {
+		callId,
+		providerCallId: callId,
+		toolName: 'read',
+		status: 'completed',
+		message: 'done',
+		...(data === undefined ? {} : { data }),
+		truncated: false,
+	};
+}

--- a/apps/backend/src/modules/buddy/platforms/llm-conversation-bounds.utils.ts
+++ b/apps/backend/src/modules/buddy/platforms/llm-conversation-bounds.utils.ts
@@ -1,0 +1,227 @@
+import {
+	BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES,
+	BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES,
+	BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_BATCH_JSON_BYTES,
+	BUDDY_MAX_TOOL_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_ITEMS_PER_TURN,
+	BUDDY_MAX_TOOL_ITEM_JSON_BYTES,
+	BUDDY_MAX_TOOL_RESULT_GROUP_JSON_BYTES,
+	MessageRole,
+} from '../buddy.constants';
+
+import type {
+	LlmAssistantToolCallsItem,
+	LlmConversationToolResult,
+	LlmResponse,
+	LlmToolResultsItem,
+} from './llm-provider.platform';
+
+export type BuddyToolResponseLimitReason =
+	| 'iteration_items'
+	| 'turn_items'
+	| 'tool_item_bytes'
+	| 'tool_batch_bytes'
+	| 'provider_item_count'
+	| 'provider_item_bytes'
+	| 'non_serializable';
+
+export type BuddyToolResponseAdmission =
+	| { accepted: true; itemCount: number }
+	| { accepted: false; reason: BuddyToolResponseLimitReason };
+
+export interface BoundedToolResultGroup {
+	item: LlmToolResultsItem;
+	nextActiveTranscriptBytes: number;
+}
+
+export const BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE = 'Tool result detail omitted to fit the active-turn limit';
+
+export function measureJsonUtf8Bytes(value: unknown): number | null {
+	try {
+		const serialized = JSON.stringify(value);
+
+		return serialized === undefined ? null : Buffer.byteLength(serialized, 'utf8');
+	} catch {
+		return null;
+	}
+}
+
+export function admitBuddyToolResponse(response: LlmResponse, currentTurnItems: number): BuddyToolResponseAdmission {
+	const toolCalls = response.toolCalls ?? [];
+	const toolErrors = response.toolErrors ?? [];
+	const providerItems = response.providerItems ?? [];
+	const itemCount = toolCalls.length + toolErrors.length;
+
+	if (itemCount > BUDDY_MAX_TOOL_ITEMS_PER_ITERATION) {
+		return { accepted: false, reason: 'iteration_items' };
+	}
+	if (currentTurnItems + itemCount > BUDDY_MAX_TOOL_ITEMS_PER_TURN) {
+		return { accepted: false, reason: 'turn_items' };
+	}
+	if (providerItems.length > BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION) {
+		return { accepted: false, reason: 'provider_item_count' };
+	}
+
+	for (const item of [...toolCalls, ...toolErrors]) {
+		const bytes = measureJsonUtf8Bytes(item);
+
+		if (bytes === null) {
+			return { accepted: false, reason: 'non_serializable' };
+		}
+		if (bytes > BUDDY_MAX_TOOL_ITEM_JSON_BYTES) {
+			return { accepted: false, reason: 'tool_item_bytes' };
+		}
+	}
+
+	const batchBytes = measureJsonUtf8Bytes({ content: response.content, toolCalls, toolErrors });
+
+	if (batchBytes === null) {
+		return { accepted: false, reason: 'non_serializable' };
+	}
+	if (batchBytes > BUDDY_MAX_TOOL_BATCH_JSON_BYTES) {
+		return { accepted: false, reason: 'tool_batch_bytes' };
+	}
+
+	const providerBytes = measureJsonUtf8Bytes(providerItems);
+
+	if (providerBytes === null) {
+		return { accepted: false, reason: 'non_serializable' };
+	}
+	if (providerBytes > BUDDY_MAX_PROVIDER_ITEMS_JSON_BYTES) {
+		return { accepted: false, reason: 'provider_item_bytes' };
+	}
+
+	return { accepted: true, itemCount };
+}
+
+export function canReserveBuddyToolResultGroup(
+	callItem: LlmAssistantToolCallsItem,
+	activeTranscriptBytes: number,
+): boolean {
+	const minimalResults: LlmConversationToolResult[] = callItem.calls.map((call) => ({
+		callId: call.callId,
+		providerCallId: call.providerCallId,
+		toolName: call.name,
+		status: 'indeterminate',
+		message: BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE,
+		truncated: true,
+	}));
+	const resultItem: LlmToolResultsItem = { type: 'tool_results', results: minimalResults };
+	const resultBytes = measureJsonUtf8Bytes(resultItem);
+	const groupBytes = measureJsonUtf8Bytes([callItem, resultItem]);
+
+	return (
+		resultBytes !== null &&
+		groupBytes !== null &&
+		resultBytes <= BUDDY_MAX_TOOL_RESULT_GROUP_JSON_BYTES &&
+		groupBytes <= BUDDY_MAX_TOOL_BATCH_JSON_BYTES &&
+		nextActiveTranscriptBytes(activeTranscriptBytes, groupBytes) <= BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES
+	);
+}
+
+export function fitBuddyToolResultGroup(
+	callItem: LlmAssistantToolCallsItem,
+	results: LlmConversationToolResult[],
+	activeTranscriptBytes: number,
+): BoundedToolResultGroup | null {
+	const boundedResults = results.map((result) => ({ ...result }));
+	const fit = (): BoundedToolResultGroup | null => {
+		const item: LlmToolResultsItem = { type: 'tool_results', results: boundedResults };
+		const resultBytes = measureJsonUtf8Bytes(item);
+		const groupBytes = measureJsonUtf8Bytes([callItem, item]);
+
+		if (resultBytes === null || groupBytes === null) {
+			return null;
+		}
+
+		const nextBytes = nextActiveTranscriptBytes(activeTranscriptBytes, groupBytes);
+
+		return resultBytes <= BUDDY_MAX_TOOL_RESULT_GROUP_JSON_BYTES &&
+			groupBytes <= BUDDY_MAX_TOOL_BATCH_JSON_BYTES &&
+			nextBytes <= BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES
+			? { item, nextActiveTranscriptBytes: nextBytes }
+			: null;
+	};
+
+	let fitted = fit();
+
+	if (fitted !== null) {
+		return fitted;
+	}
+
+	for (let resultIndex = boundedResults.length - 1; resultIndex >= 0; resultIndex -= 1) {
+		const result = boundedResults[resultIndex];
+
+		if (result.data !== undefined) {
+			delete result.data;
+			result.truncated = true;
+			fitted = fit();
+
+			if (fitted !== null) {
+				return fitted;
+			}
+		}
+	}
+
+	for (let resultIndex = boundedResults.length - 1; resultIndex >= 0; resultIndex -= 1) {
+		const result = boundedResults[resultIndex];
+
+		result.message = BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE;
+		delete result.errorCode;
+		result.truncated = true;
+		fitted = fit();
+
+		if (fitted !== null) {
+			return fitted;
+		}
+	}
+
+	return null;
+}
+
+export function fitsBuddyLegacyToolTranscript(value: unknown, activeTranscriptBytes: number): number | null {
+	const bytes = measureJsonUtf8Bytes(value);
+	const nextBytes = bytes === null ? null : nextActiveTranscriptBytes(activeTranscriptBytes, bytes);
+
+	if (
+		bytes === null ||
+		bytes > BUDDY_MAX_TOOL_RESULT_GROUP_JSON_BYTES ||
+		nextBytes === null ||
+		nextBytes > BUDDY_MAX_ACTIVE_TOOL_TRANSCRIPT_JSON_BYTES
+	) {
+		return null;
+	}
+
+	return nextBytes;
+}
+
+export function canReserveBuddyLegacyToolTranscript(response: LlmResponse, activeTranscriptBytes: number): boolean {
+	const summaries = [
+		...(response.toolErrors ?? []).map(
+			(error) => `Tool "${error.toolName}" (id=${error.toolCallId}): FAILED — ${BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE}`,
+		),
+		...(response.toolCalls ?? []).map(
+			(call) => `Tool "${call.name}" (id=${call.id}): SUCCESS — ${BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE}`,
+		),
+	];
+	const assistantContent = response.content
+		? response.content
+		: `[Executing tools: ${[
+				...(response.toolCalls ?? []).map((call) => call.name),
+				...(response.toolErrors ?? []).map((error) => `${error.toolName} (parse error)`),
+			].join(', ')}]`;
+	const messages = [
+		{ role: MessageRole.ASSISTANT, content: assistantContent },
+		{
+			role: MessageRole.USER,
+			content: `[Tool execution results]\n${summaries.join('\n')}\n\nPlease provide a natural language response based on these results.`,
+		},
+	];
+
+	return fitsBuddyLegacyToolTranscript(messages, activeTranscriptBytes) !== null;
+}
+
+function nextActiveTranscriptBytes(currentBytes: number, groupBytes: number): number {
+	return currentBytes === 0 ? groupBytes : currentBytes + groupBytes - 1;
+}

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
@@ -6,7 +6,12 @@ import {
 	ToolExecutionResult,
 	ToolExecutionStatus,
 } from '../../tools/platforms/tool-provider.platform';
-import { MessageRole } from '../buddy.constants';
+import {
+	BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_ITEMS_PER_ITERATION,
+	BUDDY_MAX_TOOL_ITEM_JSON_BYTES,
+	MessageRole,
+} from '../buddy.constants';
 import { BuddyProviderErrorException } from '../buddy.exceptions';
 import type { LlmConversationItem, LlmOptions, LlmResponse, LlmResponseMeta } from '../platforms/llm-provider.platform';
 
@@ -327,6 +332,37 @@ describe('BuddyConversationService native tool loop', () => {
 		]);
 	});
 
+	it('preserves the whole-iteration prose fallback for a mixed valid and malformed native batch', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: [{ id: 'provider-1', name: 'set_light', arguments: { on: true } }],
+				toolErrors: [{ toolCallId: 'bad-1', toolName: 'set_light', error: 'Invalid JSON arguments' }],
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({ content: 'I could not apply the malformed request.', meta: createMeta(2) });
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'Light switched on',
+		});
+
+		await runToolLoop(service);
+
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(1);
+		expect(llmProvider.sendMessage.mock.calls[1][1]).toEqual([
+			{ role: MessageRole.USER, content: 'Control the kitchen.' },
+			{ role: MessageRole.ASSISTANT, content: '[Executing tools: set_light, set_light (parse error)]' },
+			{
+				role: MessageRole.USER,
+				content:
+					'[Tool execution results]\nTool "set_light" (id=bad-1): FAILED — Invalid JSON arguments\n' +
+					'Tool "set_light" (id=provider-1): SUCCESS — Light switched on\n\n' +
+					'Please provide a natural language response based on these results.',
+			},
+		]);
+	});
+
 	it('aborts remaining calls and disables tools after an indeterminate registry execution', async () => {
 		llmProvider.sendMessage
 			.mockResolvedValueOnce({
@@ -414,6 +450,143 @@ describe('BuddyConversationService native tool loop', () => {
 		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
 	});
 
+	it('rejects an oversized tool batch before executing any call', async () => {
+		llmProvider.sendMessage.mockResolvedValue({
+			content: '',
+			toolCalls: createToolCalls('provider', BUDDY_MAX_TOOL_ITEMS_PER_ITERATION + 1),
+			meta: createMeta(1),
+		});
+
+		const response = await runToolLoop(service);
+
+		expect(response.content).toBe(
+			'I could not safely process that many tool operations in one turn. Please simplify the request.',
+		);
+		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it('preflights every call before dispatch when the final call is oversized', async () => {
+		llmProvider.sendMessage.mockResolvedValue({
+			content: '',
+			toolCalls: [
+				{ id: 'provider-1', name: 'set_light', arguments: { on: true } },
+				{
+					id: 'provider-2',
+					name: 'set_light',
+					arguments: { value: 'x'.repeat(BUDDY_MAX_TOOL_ITEM_JSON_BYTES) },
+				},
+			],
+			meta: createMeta(1),
+		});
+
+		const response = await runToolLoop(service);
+
+		expect(response.content).toContain('Please simplify the request');
+		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
+	});
+
+	it('rejects oversized provider continuation atomically before executing any call', async () => {
+		llmProvider.sendMessage.mockResolvedValue({
+			content: '',
+			toolCalls: createToolCalls('provider', 1),
+			providerItems: Array.from({ length: BUDDY_MAX_PROVIDER_ITEMS_PER_ITERATION + 1 }, (_, outputIndex) => ({
+				provider: 'native-provider',
+				outputIndex,
+				item: {
+					type: 'reasoning' as const,
+					id: `reasoning-${outputIndex}`,
+					summary: [],
+					encrypted_content: 'state',
+				},
+			})),
+			meta: createMeta(1),
+		});
+
+		const response = await runToolLoop(service);
+
+		expect(response.content).toContain('Please simplify the request');
+		expect(toolProviderRegistry.executeTool).not.toHaveBeenCalled();
+		expect(response.providerItems).toBeUndefined();
+	});
+
+	it('stops before a later batch exceeds the cumulative turn item cap', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('first', BUDDY_MAX_TOOL_ITEMS_PER_ITERATION),
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('second', BUDDY_MAX_TOOL_ITEMS_PER_ITERATION),
+				meta: createMeta(2),
+			})
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('third', BUDDY_MAX_TOOL_ITEMS_PER_ITERATION),
+				meta: createMeta(3),
+			})
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('fourth', BUDDY_MAX_TOOL_ITEMS_PER_ITERATION),
+				meta: createMeta(4),
+			})
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('fifth', 1),
+				meta: createMeta(5),
+			});
+		toolProviderRegistry.executeTool.mockResolvedValue({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'done',
+		});
+
+		const response = await runToolLoop(service);
+
+		expect(toolProviderRegistry.executeTool).toHaveBeenCalledTimes(BUDDY_MAX_TOOL_ITEMS_PER_ITERATION * 4);
+		expect(llmProvider.sendMessage).toHaveBeenCalledTimes(5);
+		expect(response.content).toContain('Earlier steps may have completed');
+	});
+
+	it('drops later structured data to keep one truthful correlated result per call', async () => {
+		llmProvider.sendMessage
+			.mockResolvedValueOnce({
+				content: '',
+				toolCalls: createToolCalls('provider', 2),
+				meta: createMeta(1),
+			})
+			.mockResolvedValueOnce({ content: 'done', meta: createMeta(2) });
+		toolProviderRegistry.executeTool
+			.mockResolvedValueOnce({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				message: 'first',
+				data: { value: 'a'.repeat(32 * 1024) },
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				message: 'second',
+				data: { value: 'b'.repeat(32 * 1024) },
+			});
+
+		await runToolLoop(service);
+
+		const resultItem = llmProvider.sendMessage.mock.calls[1][1][2];
+
+		if ('type' in resultItem && resultItem.type === 'tool_results') {
+			expect(resultItem.results).toHaveLength(2);
+			expect(resultItem.results[0].providerCallId).toBe('provider-0');
+			expect(resultItem.results[0].data).toEqual({ value: 'a'.repeat(32 * 1024) });
+			expect(resultItem.results[1]).toEqual(expect.objectContaining({ providerCallId: 'provider-1', truncated: true }));
+			expect(resultItem.results[1]).not.toHaveProperty('data');
+		} else {
+			throw new TypeError('Expected tool result group');
+		}
+	});
+
 	it('returns a bounded fallback after max iterations and strips active provider state', async () => {
 		llmProvider.sendMessage
 			.mockResolvedValueOnce({
@@ -495,4 +668,12 @@ function getOnlyCallId(item: LlmConversationItem): string {
 	}
 
 	return item.calls[0].callId;
+}
+
+function createToolCalls(prefix: string, count: number): LlmToolCall[] {
+	return Array.from({ length: count }, (_, index) => ({
+		id: `${prefix}-${index}`,
+		name: `read_${index}`,
+		arguments: { index },
+	}));
 }

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -22,6 +22,14 @@ import { BuddyConversationEntity } from '../entities/buddy-conversation.entity';
 import { BuddyMessageEntity } from '../entities/buddy-message.entity';
 import { BuddyConfigModel } from '../models/config.model';
 import {
+	BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE,
+	admitBuddyToolResponse,
+	canReserveBuddyLegacyToolTranscript,
+	canReserveBuddyToolResultGroup,
+	fitBuddyToolResultGroup,
+	fitsBuddyLegacyToolTranscript,
+} from '../platforms/llm-conversation-bounds.utils';
+import {
 	LlmConversationItem,
 	LlmConversationToolCall,
 	LlmConversationToolResult,
@@ -238,6 +246,9 @@ export class BuddyConversationService {
 		// Work on a shallow copy so we never mutate the caller's array
 		const workingMessages: LlmConversationItem[] = [...messages];
 		const activeTurnId = uuid();
+		let activeToolItems = 0;
+		let activeToolTranscriptBytes = 0;
+		let hasAttemptedToolExecution = false;
 
 		let response = await this.llmProvider.sendMessage(systemPrompt, workingMessages, { tools });
 		const activeProviderType = response.meta.provider;
@@ -264,6 +275,13 @@ export class BuddyConversationService {
 
 			const callCount = response.toolCalls?.length ?? 0;
 			const errorCount = response.toolErrors?.length ?? 0;
+			const admission = admitBuddyToolResponse(response, activeToolItems);
+
+			if (!admission.accepted) {
+				return this.toolLimitResponse(response, accumulatedMeta, hasAttemptedToolExecution);
+			}
+
+			activeToolItems += admission.itemCount;
 
 			this.logger.debug(`Tool iteration ${iteration + 1}: ${callCount} tool call(s), ${errorCount} parse error(s)`);
 
@@ -272,21 +290,36 @@ export class BuddyConversationService {
 				(_toolCall, callIndex) => `buddy:${activeTurnId}:${iteration + 1}:${callIndex + 1}`,
 			);
 
-			if (useNativeToolResults && errorCount === 0) {
+			if (useNativeToolResults && callCount > 0) {
 				this.assertNativeProviderCallIds(toolCalls);
+			}
 
+			if (useNativeToolResults && errorCount === 0) {
 				const canonicalCalls: LlmConversationToolCall[] = toolCalls.map((toolCall, callIndex) => ({
 					callId: canonicalCallIds[callIndex],
 					providerCallId: toolCall.id,
 					name: toolCall.name,
 					arguments: toolCall.arguments,
 				}));
+				const callItem = {
+					type: 'assistant_tool_calls' as const,
+					content: response.content,
+					calls: canonicalCalls,
+					...(response.providerItems === undefined ? {} : { providerItems: response.providerItems }),
+				};
+
+				if (!canReserveBuddyToolResultGroup(callItem, activeToolTranscriptBytes)) {
+					return this.toolLimitResponse(response, accumulatedMeta, hasAttemptedToolExecution);
+				}
+
 				const canonicalResults: LlmConversationToolResult[] = [];
 				let hasIndeterminateExecution = false;
 
 				for (const [callIndex, toolCall] of toolCalls.entries()) {
 					const canonicalCall = canonicalCalls[callIndex];
 					let result: ToolExecutionResult;
+
+					hasAttemptedToolExecution = true;
 
 					try {
 						result = await this.toolProviderRegistry.executeTool(toolCall, {
@@ -333,15 +366,14 @@ export class BuddyConversationService {
 					});
 				}
 
-				workingMessages.push(
-					{
-						type: 'assistant_tool_calls',
-						content: response.content,
-						calls: canonicalCalls,
-						...(response.providerItems === undefined ? {} : { providerItems: response.providerItems }),
-					},
-					{ type: 'tool_results', results: canonicalResults },
-				);
+				const boundedResultGroup = fitBuddyToolResultGroup(callItem, canonicalResults, activeToolTranscriptBytes);
+
+				if (boundedResultGroup === null) {
+					return this.toolLimitResponse(response, accumulatedMeta, true);
+				}
+
+				activeToolTranscriptBytes = boundedResultGroup.nextActiveTranscriptBytes;
+				workingMessages.push(callItem, boundedResultGroup.item);
 
 				if (hasIndeterminateExecution) {
 					const uncertaintyMessage =
@@ -380,7 +412,11 @@ export class BuddyConversationService {
 			}
 
 			// Execute all tool calls and include parse errors for malformed arguments
-			const toolResults: { success: boolean; summary: string }[] = [];
+			if (!canReserveBuddyLegacyToolTranscript(response, activeToolTranscriptBytes)) {
+				return this.toolLimitResponse(response, accumulatedMeta, hasAttemptedToolExecution);
+			}
+
+			const toolResults: { success: boolean; summary: string; compactSummary: string }[] = [];
 
 			// Report malformed tool call arguments back to the LLM as failed results
 			if (response.toolErrors && response.toolErrors.length > 0) {
@@ -388,11 +424,13 @@ export class BuddyConversationService {
 					toolResults.push({
 						success: false,
 						summary: `Tool "${toolError.toolName}" (id=${toolError.toolCallId}): FAILED — ${toolError.error}`,
+						compactSummary: `Tool "${toolError.toolName}" (id=${toolError.toolCallId}): FAILED — ${BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE}`,
 					});
 				}
 			}
 
 			for (const [callIndex, toolCall] of toolCalls.entries()) {
+				hasAttemptedToolExecution = true;
 				const result = await this.toolProviderRegistry.executeTool(toolCall, {
 					audience: ToolAudience.BUDDY,
 					source: ToolAudience.BUDDY,
@@ -402,6 +440,7 @@ export class BuddyConversationService {
 				toolResults.push({
 					success: result.success,
 					summary: `Tool "${toolCall.name}" (id=${toolCall.id}): ${result.success ? 'SUCCESS' : 'FAILED'} — ${result.message}`,
+					compactSummary: `Tool "${toolCall.name}" (id=${toolCall.id}): ${result.success ? 'SUCCESS' : 'FAILED'} — ${BUDDY_TRUNCATED_TOOL_RESULT_MESSAGE}`,
 				});
 			}
 
@@ -422,24 +461,45 @@ export class BuddyConversationService {
 			// provider-specific tool result message formats
 			const toolResultsSummary = toolResults.map((r) => r.summary).join('\n');
 
+			const legacyMessages: LlmConversationItem[] = [];
+
 			if (response.content) {
-				workingMessages.push({ role: MessageRole.ASSISTANT, content: response.content });
+				legacyMessages.push({ role: MessageRole.ASSISTANT, content: response.content });
 			} else {
 				const toolNames = [
 					...(response.toolCalls ?? []).map((tc) => tc.name),
 					...(response.toolErrors ?? []).map((te) => `${te.toolName} (parse error)`),
 				].join(', ');
 
-				workingMessages.push({
+				legacyMessages.push({
 					role: MessageRole.ASSISTANT,
 					content: `[Executing tools: ${toolNames}]`,
 				});
 			}
 
-			workingMessages.push({
+			legacyMessages.push({
 				role: MessageRole.USER,
 				content: `[Tool execution results]\n${toolResultsSummary}\n\nPlease provide a natural language response based on these results.`,
 			});
+
+			let legacyTranscriptBytes = fitsBuddyLegacyToolTranscript(legacyMessages, activeToolTranscriptBytes);
+
+			if (legacyTranscriptBytes === null) {
+				legacyMessages[legacyMessages.length - 1] = {
+					role: MessageRole.USER,
+					content:
+						`[Tool execution results]\n${toolResults.map((result) => result.compactSummary).join('\n')}\n\n` +
+						'Please provide a natural language response based on these results.',
+				};
+				legacyTranscriptBytes = fitsBuddyLegacyToolTranscript(legacyMessages, activeToolTranscriptBytes);
+			}
+
+			if (legacyTranscriptBytes === null) {
+				return this.toolLimitResponse(response, accumulatedMeta, hasAttemptedToolExecution);
+			}
+
+			activeToolTranscriptBytes = legacyTranscriptBytes;
+			workingMessages.push(...legacyMessages);
 
 			// Call LLM again with tools so multi-step tool use works
 			try {
@@ -478,6 +538,21 @@ export class BuddyConversationService {
 		}
 
 		return this.clearActiveToolState({ ...response, meta: accumulatedMeta });
+	}
+
+	private toolLimitResponse(
+		response: LlmResponse,
+		meta: LlmResponseMeta,
+		hasAttemptedToolExecution: boolean,
+	): LlmResponse {
+		return this.clearActiveToolState({
+			...response,
+			meta,
+			content: hasAttemptedToolExecution
+				? 'I stopped the tool sequence because it exceeded the safe active-turn limits. ' +
+					'Earlier steps may have completed; please check the current state before retrying.'
+				: 'I could not safely process that many tool operations in one turn. Please simplify the request.',
+		});
 	}
 
 	private assertNativeProviderCallIds(toolCalls: LlmToolCall[]): void {

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.spec.ts
@@ -13,7 +13,12 @@ import {
 } from '../platforms/tool-provider.platform';
 
 import { BaseToolProviderService } from './base-tool-provider.service';
-import { TOOL_RESULT_MAX_JSON_BYTES, ToolProviderRegistryService } from './tool-provider-registry.service';
+import {
+	TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES,
+	TOOL_RESULT_MAX_JSON_BYTES,
+	TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES,
+	ToolProviderRegistryService,
+} from './tool-provider-registry.service';
 
 const inputSchema = z.object({ value: z.string() });
 const outputSchema = z.object({ value: z.string() });
@@ -137,6 +142,20 @@ describe('ToolProviderRegistryService', () => {
 		expect(handler).not.toHaveBeenCalled();
 	});
 
+	it('bounds registry-generated messages for Buddy while preserving the MCP text', async () => {
+		const toolName = 'missing-'.padEnd(TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES + 200, 'x');
+		const buddy = await registry.executeTool({ id: 'buddy', name: toolName, arguments: {} });
+		const mcp = await registry.executeTool(
+			{ id: 'mcp', name: toolName, arguments: {} },
+			{ audience: ToolAudience.MCP, source: ToolAudience.MCP },
+		);
+
+		expect(Buffer.byteLength(buddy.message, 'utf8')).toBe(TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES);
+		expect(buddy.truncated).toBe(true);
+		expect(mcp.message).toBe(`Unknown tool: ${toolName}`);
+		expect(mcp.truncated).toBeUndefined();
+	});
+
 	it('propagates execution context to the indexed provider', async () => {
 		const provider = new TestToolProvider(
 			'provider-a',
@@ -162,7 +181,7 @@ describe('ToolProviderRegistryService', () => {
 		]);
 	});
 
-	it('returns only schema-parsed structured data', async () => {
+	it('strips and transforms Buddy structured data through the output schema', async () => {
 		const result = {
 			...completed('validated'),
 			data: { value: ' validated ', secret: 'must not reach the model' },
@@ -181,6 +200,127 @@ describe('ToolProviderRegistryService', () => {
 		await expect(
 			registry.executeTool({ id: 'request-1', name: 'read-tool', arguments: { value: 'x' } }),
 		).resolves.toEqual({ ...result, data: { value: 'validated' } });
+	});
+
+	it('accepts exactly 32 KiB of Buddy structured JSON and omits one byte over', async () => {
+		const envelopeBytes = Buffer.byteLength(JSON.stringify({ value: '' }), 'utf8');
+		const exactValue = 'x'.repeat(TOOL_RESULT_MAX_JSON_BYTES - envelopeBytes);
+		const results = [completed(exactValue), completed(`${exactValue}x`)];
+		const provider = new TestToolProvider(
+			'provider-a',
+			[definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			() => Promise.resolve(results.shift() ?? null),
+		);
+
+		registry.register(provider);
+
+		const accepted = await registry.executeTool({ id: '1', name: 'read-tool', arguments: {} });
+		const omitted = await registry.executeTool({ id: '2', name: 'read-tool', arguments: {} });
+
+		expect(Buffer.byteLength(JSON.stringify(accepted.data), 'utf8')).toBe(TOOL_RESULT_MAX_JSON_BYTES);
+		expect(accepted.data).toEqual({ value: exactValue });
+		expect(omitted).toEqual(expect.objectContaining({ data: undefined, truncated: true }));
+	});
+
+	it('bounds no-data Buddy messages and error codes at exact UTF-8 boundaries', async () => {
+		const exactMessage = `${'m'.repeat(TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES - 4)}😀`;
+		const exactErrorCode = 'E'.repeat(TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES);
+		const results: ToolExecutionResult[] = [
+			{
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: exactMessage,
+				errorCode: exactErrorCode,
+			},
+			{
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: `${exactMessage}x`,
+				errorCode: `${exactErrorCode}X`,
+			},
+		];
+		const provider = new TestToolProvider(
+			'provider-a',
+			[definition('read-tool', [ToolAudience.BUDDY], ToolAccessKind.READ)],
+			() => Promise.resolve(results.shift() ?? null),
+		);
+
+		registry.register(provider);
+
+		await expect(registry.executeTool({ id: '1', name: 'read-tool', arguments: {} })).resolves.toEqual({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: exactMessage,
+			errorCode: exactErrorCode,
+		});
+		await expect(registry.executeTool({ id: '2', name: 'read-tool', arguments: {} })).resolves.toEqual({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: exactMessage,
+			errorCode: exactErrorCode,
+			truncated: true,
+		});
+	});
+
+	it('omits Buddy data when an output-schema transform throws while preserving execution status', async () => {
+		const throwingDefinition = createToolDefinition({
+			name: 'read-tool',
+			description: 'read-tool description',
+			audiences: [ToolAudience.BUDDY],
+			access: ToolAccessKind.READ,
+			inputSchema,
+			outputSchema: z.object({
+				value: z.string().transform(() => {
+					throw new Error('private transform detail');
+				}),
+			}),
+		});
+		const result: ToolExecutionResult = {
+			success: true,
+			status: ToolExecutionStatus.PARTIAL,
+			message: 'Partial read',
+			data: { value: 'unsafe' },
+		};
+
+		registry.register(new TestToolProvider('provider-a', [throwingDefinition], () => Promise.resolve(result)));
+
+		await expect(registry.executeTool({ id: '1', name: 'read-tool', arguments: {} })).resolves.toEqual({
+			success: true,
+			status: ToolExecutionStatus.PARTIAL,
+			message: 'Partial read',
+			errorCode: 'INVALID_TOOL_RESULT_DATA',
+			truncated: true,
+		});
+	});
+
+	it('preserves MCP string fields while retaining the shared schema and data bound', async () => {
+		const rawResult: ToolExecutionResult = {
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'm'.repeat(TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES + 1),
+			data: { value: ' raw ', secret: 'strip me' },
+			errorCode: 'E'.repeat(TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES + 1),
+		};
+		const mcpDefinition = createToolDefinition({
+			name: 'read-tool',
+			description: 'read-tool description',
+			audiences: [ToolAudience.BUDDY, ToolAudience.MCP],
+			access: ToolAccessKind.READ,
+			inputSchema,
+			outputSchema: z.object({ value: z.string().transform((value) => value.trim()) }),
+		});
+
+		registry.register(new TestToolProvider('provider-a', [mcpDefinition], () => Promise.resolve(rawResult)));
+
+		const result = await registry.executeTool(
+			{ id: '1', name: 'read-tool', arguments: {} },
+			{ audience: ToolAudience.MCP, source: ToolAudience.MCP },
+		);
+
+		expect(result).toEqual({ ...rawResult, data: { value: 'raw' } });
+		expect(result.message).toBe(rawResult.message);
+		expect(result.errorCode).toBe(rawResult.errorCode);
+		expect(result.truncated).toBeUndefined();
 	});
 
 	it('omits invalid, oversized, and non-serializable structured data without changing execution status', async () => {

--- a/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
+++ b/apps/backend/src/modules/tools/services/tool-provider-registry.service.ts
@@ -12,9 +12,18 @@ import {
 	ToolListingOptions,
 	createToolExecutionContext,
 } from '../platforms/tool-provider.platform';
-import { TOOLS_MODULE_NAME } from '../tools.constants';
+import {
+	TOOLS_MODULE_NAME,
+	TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES,
+	TOOL_RESULT_MAX_JSON_BYTES,
+	TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES,
+} from '../tools.constants';
 
-export const TOOL_RESULT_MAX_JSON_BYTES = 32 * 1024;
+export {
+	TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES,
+	TOOL_RESULT_MAX_JSON_BYTES,
+	TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES,
+} from '../tools.constants';
 
 @Injectable()
 export class ToolProviderRegistryService {
@@ -90,92 +99,114 @@ export class ToolProviderRegistryService {
 		toolCall: LlmToolCall,
 		providedContext?: Partial<ToolExecutionContext>,
 	): Promise<ToolExecutionResult> {
+		const context = createToolExecutionContext(toolCall, providedContext);
 		const registered = this.tools.get(toolCall.name);
 
 		if (!registered) {
 			this.logger.warn(`No provider found for tool: ${toolCall.name}`);
 
-			return {
+			return this.finishToolResult(context, {
 				success: false,
 				status: ToolExecutionStatus.FAILED,
 				message: `Unknown tool: ${toolCall.name}`,
 				errorCode: 'UNKNOWN_TOOL',
-			};
+			});
 		}
 
-		const context = createToolExecutionContext(toolCall, providedContext);
-
 		if (!registered.definition.audiences.includes(context.audience)) {
-			return {
+			return this.finishToolResult(context, {
 				success: false,
 				status: ToolExecutionStatus.DENIED,
 				message: `Tool "${toolCall.name}" is not available to ${context.audience}`,
 				errorCode: 'TOOL_AUDIENCE_DENIED',
-			};
+			});
 		}
 
 		if (context.allowedAccessKinds && !context.allowedAccessKinds.includes(registered.definition.access)) {
-			return {
+			return this.finishToolResult(context, {
 				success: false,
 				status: ToolExecutionStatus.DENIED,
 				message: `Tool "${toolCall.name}" requires ${registered.definition.access} access`,
 				errorCode: 'TOOL_ACCESS_DENIED',
-			};
+			});
 		}
 
 		const result = await registered.provider.executeTool(toolCall, context);
 
 		if (result !== null) {
-			return this.boundToolResultData(registered.definition, result);
+			return this.finishToolResult(context, result, registered.definition);
 		}
 
-		return {
+		return this.finishToolResult(context, {
 			success: false,
 			status: ToolExecutionStatus.FAILED,
 			message: `Provider failed to handle registered tool: ${toolCall.name}`,
 			errorCode: 'TOOL_PROVIDER_MISMATCH',
-		};
+		});
 	}
 
-	private boundToolResultData(definition: ToolDefinition, result: ToolExecutionResult): ToolExecutionResult {
-		if (result.data === undefined) {
-			return result;
+	private finishToolResult(
+		context: ToolExecutionContext,
+		result: ToolExecutionResult,
+		definition?: ToolDefinition,
+	): ToolExecutionResult {
+		return this.boundToolResult(definition, result, context.audience === ToolAudience.BUDDY);
+	}
+
+	private boundToolResult(
+		definition: ToolDefinition | undefined,
+		result: ToolExecutionResult,
+		boundBuddyStrings: boolean,
+	): ToolExecutionResult {
+		const hadData = result.data !== undefined;
+		const message = boundBuddyStrings
+			? boundUtf8String(result.message, TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES)
+			: { value: result.message, truncated: false };
+		const boundedErrorCode =
+			result.errorCode === undefined
+				? undefined
+				: boundBuddyStrings
+					? boundUtf8String(result.errorCode, TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES)
+					: { value: result.errorCode, truncated: false };
+		let data = result.data;
+		let errorCode = boundedErrorCode?.value;
+		let truncated = result.truncated === true || message.truncated || boundedErrorCode?.truncated === true;
+
+		if (data !== undefined && definition !== undefined) {
+			try {
+				const parsed = definition.outputSchema.safeParse(data);
+
+				if (!parsed.success || typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) {
+					throw new TypeError('Invalid tool result data');
+				}
+
+				data = parsed.data as Record<string, unknown>;
+				const serialized = JSON.stringify(data);
+
+				if (serialized === undefined || Buffer.byteLength(serialized, 'utf8') > TOOL_RESULT_MAX_JSON_BYTES) {
+					data = undefined;
+					truncated = true;
+				}
+			} catch {
+				data = undefined;
+				errorCode ??= 'INVALID_TOOL_RESULT_DATA';
+				truncated = true;
+			}
 		}
 
-		const parsed = definition.outputSchema.safeParse(result.data);
+		const bounded: ToolExecutionResult = {
+			...result,
+			message: message.value,
+			...(hadData ? { data } : {}),
+			...(errorCode === undefined ? {} : { errorCode }),
+			...(truncated || result.truncated !== undefined ? { truncated } : {}),
+		};
 
-		if (!parsed.success || typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) {
-			return {
-				...result,
-				data: undefined,
-				errorCode: result.errorCode ?? 'INVALID_TOOL_RESULT_DATA',
-				truncated: true,
-			};
+		if (errorCode === undefined) {
+			delete bounded.errorCode;
 		}
 
-		const parsedData = parsed.data as Record<string, unknown>;
-		let serialized: string | undefined;
-
-		try {
-			serialized = JSON.stringify(parsedData);
-		} catch {
-			serialized = undefined;
-		}
-
-		if (serialized === undefined) {
-			return {
-				...result,
-				data: undefined,
-				errorCode: result.errorCode ?? 'INVALID_TOOL_RESULT_DATA',
-				truncated: true,
-			};
-		}
-
-		if (Buffer.byteLength(serialized, 'utf8') > TOOL_RESULT_MAX_JSON_BYTES) {
-			return { ...result, data: undefined, truncated: true };
-		}
-
-		return { ...result, data: parsedData };
+		return bounded;
 	}
 
 	/**
@@ -184,4 +215,26 @@ export class ToolProviderRegistryService {
 	list(): string[] {
 		return [...this.providers.keys()];
 	}
+}
+
+function boundUtf8String(value: string, maxBytes: number): { value: string; truncated: boolean } {
+	if (Buffer.byteLength(value, 'utf8') <= maxBytes) {
+		return { value, truncated: false };
+	}
+
+	let bounded = '';
+	let bytes = 0;
+
+	for (const character of value) {
+		const characterBytes = Buffer.byteLength(character, 'utf8');
+
+		if (bytes + characterBytes > maxBytes) {
+			break;
+		}
+
+		bounded += character;
+		bytes += characterBytes;
+	}
+
+	return { value: bounded, truncated: true };
 }

--- a/apps/backend/src/modules/tools/tools.constants.ts
+++ b/apps/backend/src/modules/tools/tools.constants.ts
@@ -1,1 +1,7 @@
 export const TOOLS_MODULE_NAME = 'tools-module';
+
+export const TOOL_RESULT_MAX_JSON_BYTES = 32 * 1024;
+
+export const TOOL_RESULT_MAX_MESSAGE_UTF8_BYTES = 2 * 1024;
+
+export const TOOL_RESULT_MAX_ERROR_CODE_UTF8_BYTES = 256;

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1316,8 +1316,13 @@ snapshots are produced through the shared query layer without making that eager 
       callers remain compatible.
 - [x] Generate turn/iteration/ordinal-qualified canonical call IDs and adopt the conversation items in live Buddy
       turns for native-capable providers, while retaining the legacy prose path for other providers.
-- [x] Carry schema-validated, individually 32 KiB-bounded `ToolExecutionResult.data` to the next model iteration; keep
-      aggregate call/result byte limits as an open task.
+- [x] Carry schema-validated, individually 32 KiB-bounded `ToolExecutionResult.data` to the next model iteration. Apply
+      Buddy-only message/error bounds while preserving existing MCP schema/data mapping behavior.
+- [x] Enforce Buddy active-turn abuse bounds before dispatch: at most 8 calls/errors per iteration and 32 per
+      turn, 16 KiB per call/error, 16 provider items/48 KiB of atomic continuation state, 64 KiB result groups, and a
+      128 KiB cumulative canonical tool transcript. Reject an over-limit batch before executing any prefix; if a known
+      result group is too large, omit structured data from later results without changing status or correlation. These
+      are exact canonical compact-JSON/UTF-8 bounds, not provider-wire, token, or full-request context-window admission.
 - [x] Map canonical items to native OpenAI Chat, Anthropic, Ollama, and OpenAI Codex Responses formats. For Codex, emit
       correlated `function_call`/`function_call_output` input items rather than ordinary messages.
 - [ ] Preserve ordering and one result/error per call, including malformed provider responses.


### PR DESCRIPTION
## Summary

- reject oversized Buddy tool batches and provider continuation state before dispatch
- bound canonical call/result groups and the cumulative active-turn transcript
- preserve one correlated result per call while dropping oversized structured data safely
- keep shared MCP schema/data validation and isolate new message/error truncation to Buddy
- document the completed adaptive-context safety slice

## Validation

- Backend type-check
- touched Backend ESLint
- 92 focused Buddy/Tools tests
- full Backend unit suite: 4,635 passed; one unrelated migration test failed in the aggregate run and passed on immediate isolated rerun

## Safety semantics

- no prefix of an over-limit batch is executed
- provider continuation state is atomic and never truncated
- post-execution compaction preserves status and correlation
- limits are canonical compact-JSON/UTF-8 bounds, not full provider-wire or token-window admission

> 👍 Codex review passed on `70d4ee9d4f`.