### PR TITLE
feat(backend): add Buddy home read tool provider

### DIFF
--- a/apps/backend/src/modules/buddy/buddy.module.spec.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.spec.ts
@@ -1,0 +1,17 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+
+import { HomeContextModule } from '../home-context/home-context.module';
+
+import { BuddyModule } from './buddy.module';
+import { HomeContextToolProviderService } from './services/home-context-tool-provider.service';
+
+describe('BuddyModule home read tools', () => {
+	it('imports the provider-neutral HomeContext module without an MCP module dependency', () => {
+		const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, BuddyModule) as Array<{ name?: string }>;
+		const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, BuddyModule) as unknown[];
+
+		expect(imports).toContain(HomeContextModule);
+		expect(imports.map((moduleType) => moduleType.name)).not.toContain('McpModule');
+		expect(providers).toContain(HomeContextToolProviderService);
+	});
+});

--- a/apps/backend/src/modules/buddy/buddy.module.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.ts
@@ -5,6 +5,7 @@ import { ModulesTypeMapperService } from '../config/services/modules-type-mapper
 import { DevicesModule } from '../devices/devices.module';
 import { EnergyModule } from '../energy/energy.module';
 import { ExtensionsService } from '../extensions/services/extensions.service';
+import { HomeContextModule } from '../home-context/home-context.module';
 import { IntentsModule } from '../intents/intents.module';
 import { ScenesModule } from '../scenes/scenes.module';
 import { SpacesModule } from '../spaces/spaces.module';
@@ -39,6 +40,7 @@ import { BuddyProviderStatusService } from './services/buddy-provider-status.ser
 import { ConflictDetectorEvaluator } from './services/conflict-detector-evaluator.service';
 import { EnergyEvaluator } from './services/energy-evaluator.service';
 import { HeartbeatService } from './services/heartbeat.service';
+import { HomeContextToolProviderService } from './services/home-context-tool-provider.service';
 import { LlmProviderRegistryService } from './services/llm-provider-registry.service';
 import { LlmProviderService } from './services/llm-provider.service';
 import { MessagingProviderStatusService } from './services/messaging-provider-status.service';
@@ -72,6 +74,7 @@ import { EvaluatorRulesLoaderService } from './spec/evaluator-rules-loader.servi
 		ToolsModule,
 		WeatherModule,
 		EnergyModule,
+		HomeContextModule,
 	],
 	controllers: [
 		BuddyConversationsController,
@@ -91,6 +94,8 @@ import { EvaluatorRulesLoaderService } from './spec/evaluator-rules-loader.servi
 		LlmProviderRegistryService,
 		LlmProviderService,
 		BuddyConversationService,
+		// Provider foundation only. Live registration waits for conversation-scoped action-resolution proof.
+		HomeContextToolProviderService,
 		PatternDetectorService,
 		SuggestionEngineService,
 		HeartbeatService,

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
@@ -52,14 +52,13 @@ describe('HomeContextToolProviderService', () => {
 		}
 		expect(stateDefinition.parameters).toMatchObject({
 			type: 'object',
-			properties: {
-				operation: {
-					type: 'string',
-					enum: ['rows', 'any', 'all', 'count_matches'],
-				},
-			},
 		});
-		expect(stateDefinition.parameters).not.toHaveProperty('oneOf');
+		const stateBranches = stateDefinition.parameters.oneOf as Array<{ required: string[] }>;
+		expect(stateBranches).toHaveLength(4);
+		expect(stateBranches[0].required).toEqual(['operation']);
+		for (const branch of stateBranches.slice(1)) {
+			expect(branch.required).toEqual(['operation', 'predicate']);
+		}
 
 		const anthropicPayload = buildAnthropicRequestPayload(
 			'claude-test',
@@ -72,13 +71,19 @@ describe('HomeContextToolProviderService', () => {
 			tools: [
 				{
 					name: QUERY_HOME_STATE_TOOL_NAME,
-					input_schema: { type: 'object' },
+					input_schema: stateDefinition.parameters,
 				},
 			],
 		});
 
 		expect(searchHomeToolInputSchema.safeParse({ query: 'kitchen', profile: 'mcp-compatibility' }).success).toBe(false);
-		expect(queryHomeStateToolInputSchema.safeParse({ operation: 'any' }).success).toBe(false);
+		expect(queryHomeStateToolInputSchema.safeParse({ operation: 'rows' }).success).toBe(true);
+		for (const operation of ['any', 'all', 'count_matches'] as const) {
+			expect(queryHomeStateToolInputSchema.safeParse({ operation }).success).toBe(false);
+			expect(
+				queryHomeStateToolInputSchema.safeParse({ operation, predicate: { operator: 'eq', value: true } }).success,
+			).toBe(true);
+		}
 		expect(
 			queryHomeStateToolInputSchema.safeParse({
 				operation: 'rows',

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
@@ -41,6 +41,7 @@ describe('HomeContextToolProviderService', () => {
 
 	it('publishes exactly two Buddy-only READ tools with server-owned profiles', () => {
 		const definitions = provider.getToolDefinitions();
+		const searchDefinition = definitions[0];
 		const stateDefinition = definitions[1];
 
 		expect(provider.getType()).toBe(BUDDY_HOME_READ_TOOLS_PROVIDER);
@@ -50,14 +51,30 @@ describe('HomeContextToolProviderService', () => {
 			expect(definition.access).toBe(ToolAccessKind.READ);
 			expect(definition.parameters).not.toHaveProperty('properties.profile');
 		}
+		expect(searchDefinition.parameters).toMatchObject({
+			properties: {
+				kinds: { uniqueItems: true },
+				categories: { uniqueItems: true },
+			},
+		});
 		expect(stateDefinition.parameters).toMatchObject({
 			type: 'object',
 		});
-		const stateBranches = stateDefinition.parameters.oneOf as Array<{ required: string[] }>;
+		const stateBranches = stateDefinition.parameters.oneOf as Array<{
+			required: string[];
+			properties: Record<string, Record<string, unknown>>;
+		}>;
 		expect(stateBranches).toHaveLength(4);
 		expect(stateBranches[0].required).toEqual(['operation']);
-		for (const branch of stateBranches.slice(1)) {
-			expect(branch.required).toEqual(['operation', 'predicate']);
+		for (const [index, branch] of stateBranches.entries()) {
+			expect(branch.properties).toMatchObject({
+				channel_categories: { uniqueItems: true },
+				property_categories: { uniqueItems: true },
+				data_types: { uniqueItems: true },
+			});
+			if (index > 0) {
+				expect(branch.required).toEqual(['operation', 'predicate']);
+			}
 		}
 
 		const anthropicPayload = buildAnthropicRequestPayload(

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
@@ -1,0 +1,344 @@
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+	HOME_SEARCH_PROFILE_BUDDY_V1,
+} from '../../home-context/home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../../home-context/home-context.errors';
+import { HomeSearchInvalidCursorError } from '../../home-context/home-search.errors';
+import { HomeCurrentStateResult } from '../../home-context/models/home-current-state-result.model';
+import { HomeEntitySearchResponse } from '../../home-context/models/home-search-result.model';
+import { HomeCurrentStateQueryService } from '../../home-context/services/home-current-state-query.service';
+import { HomeSearchQueryService } from '../../home-context/services/home-search-query.service';
+import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
+import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
+
+import {
+	BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS,
+	BUDDY_HOME_READ_TOOLS_PROVIDER,
+	HomeContextToolProviderService,
+	QUERY_HOME_STATE_TOOL_NAME,
+	SEARCH_HOME_TOOL_NAME,
+	queryHomeStateToolInputSchema,
+	searchHomeToolInputSchema,
+} from './home-context-tool-provider.service';
+
+describe('HomeContextToolProviderService', () => {
+	const observedAt = '2026-08-15T12:00:00.000Z';
+	let searchEntities: jest.MockedFunction<HomeSearchQueryService['searchEntities']>;
+	let queryCurrentState: jest.MockedFunction<HomeCurrentStateQueryService['queryCurrentState']>;
+	let provider: HomeContextToolProviderService;
+
+	beforeEach(() => {
+		searchEntities = jest.fn();
+		queryCurrentState = jest.fn();
+		provider = new HomeContextToolProviderService(
+			{ searchEntities } as unknown as HomeSearchQueryService,
+			{ queryCurrentState } as unknown as HomeCurrentStateQueryService,
+		);
+	});
+
+	it('publishes exactly two Buddy-only READ tools with server-owned profiles', () => {
+		const definitions = provider.getToolDefinitions();
+
+		expect(provider.getType()).toBe(BUDDY_HOME_READ_TOOLS_PROVIDER);
+		expect(definitions.map(({ name }) => name)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		for (const definition of definitions) {
+			expect(definition.audiences).toEqual([ToolAudience.BUDDY]);
+			expect(definition.access).toBe(ToolAccessKind.READ);
+			expect(definition.parameters).not.toHaveProperty('properties.profile');
+		}
+
+		expect(searchHomeToolInputSchema.safeParse({ query: 'kitchen', profile: 'mcp-compatibility' }).success).toBe(false);
+		expect(queryHomeStateToolInputSchema.safeParse({ operation: 'any' }).success).toBe(false);
+		expect(
+			queryHomeStateToolInputSchema.safeParse({
+				operation: 'rows',
+				limit: BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS + 1,
+			}).success,
+		).toBe(false);
+	});
+
+	it('maps the complete search ABI to the fixed Buddy search profile and preserves bounded data', async () => {
+		const result: HomeEntitySearchResponse = {
+			query: 'kitchen light',
+			entities: [],
+			observed_at: observedAt,
+			total: 42,
+			returned: 0,
+			totals_by_kind: { space: 1, device: 2, property: 39, scene: 0 },
+			partial: false,
+			truncated: true,
+			refine_required: true,
+			next_cursor: 'cursor-2',
+		};
+		searchEntities.mockResolvedValue(result);
+
+		const execution = await provider.executeTool(
+			{
+				id: 'call-search',
+				name: SEARCH_HOME_TOOL_NAME,
+				arguments: {
+					query: ' kitchen light ',
+					kinds: ['property'],
+					space_id: 'space-1',
+					categories: ['light'],
+					candidate_capability: 'read',
+					limit: 7,
+					cursor: 'cursor-1',
+				},
+			},
+			{ audience: ToolAudience.BUDDY, allowedAccessKinds: [ToolAccessKind.READ] },
+		);
+
+		expect(searchEntities).toHaveBeenCalledWith({
+			profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+			query: 'kitchen light',
+			kinds: ['property'],
+			spaceId: 'space-1',
+			categories: ['light'],
+			candidateCapability: 'read',
+			limit: 7,
+			cursor: 'cursor-1',
+		});
+		expect(execution).toEqual({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message:
+				'Returned 0 of 42 matching home entities. Refine the query to search beyond the bounded candidate window.',
+			data: result,
+		});
+	});
+
+	it('maps current-state filters to the fixed profile and reports partial aggregates without inventing a value', async () => {
+		const result = partialAnyResult();
+		queryCurrentState.mockResolvedValue(result);
+
+		const execution = await provider.executeTool({
+			id: 'call-state',
+			name: QUERY_HOME_STATE_TOOL_NAME,
+			arguments: {
+				operation: 'any',
+				space_id: 'space-1',
+				channel_categories: [ChannelCategory.CONTACT],
+				property_categories: [PropertyCategory.DETECTED],
+				data_types: [DataTypeType.BOOL],
+				predicate: { operator: 'eq', value: true },
+				limit: 5,
+			},
+		});
+
+		expect(queryCurrentState).toHaveBeenCalledWith({
+			profile: HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+			operation: 'any',
+			spaceId: 'space-1',
+			channelCategories: [ChannelCategory.CONTACT],
+			propertyCategories: [PropertyCategory.DETECTED],
+			dataTypes: [DataTypeType.BOOL],
+			predicate: { operator: 'eq', value: true },
+			limit: 5,
+		});
+		expect(execution).toEqual({
+			success: true,
+			status: ToolExecutionStatus.PARTIAL,
+			message: 'Current-state any result is indeterminate; evaluated 1/2 eligible values.',
+			data: result,
+		});
+	});
+
+	it('returns a successful completed no-eligible aggregate without turning it into false', async () => {
+		const result: HomeCurrentStateResult = {
+			...emptyStateBase(),
+			operation: 'count_matches',
+			predicate: { operator: 'eq', value: true },
+			value: null,
+			definitive: false,
+			status: 'no_eligible',
+		};
+		queryCurrentState.mockResolvedValue(result);
+
+		const execution = await provider.executeTool({
+			id: 'call-empty',
+			name: QUERY_HOME_STATE_TOOL_NAME,
+			arguments: { operation: 'count_matches', predicate: { operator: 'eq', value: true } },
+		});
+
+		expect(execution).toMatchObject({
+			success: true,
+			status: ToolExecutionStatus.COMPLETED,
+			message: 'Current-state count_matches result is no_eligible; evaluated 0/0 eligible values.',
+			data: result,
+		});
+	});
+
+	it('sanitizes adapter arguments and expected shared errors', async () => {
+		const invalid = await provider.executeTool({
+			id: 'call-invalid',
+			name: SEARCH_HOME_TOOL_NAME,
+			arguments: { query: 'light', profile: HOME_SEARCH_PROFILE_BUDDY_V1 },
+		});
+
+		expect(searchEntities).not.toHaveBeenCalled();
+		expect(invalid).toMatchObject({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			errorCode: 'INVALID_TOOL_ARGUMENTS',
+		});
+
+		searchEntities.mockRejectedValueOnce(new HomeSearchInvalidCursorError('query_mismatch'));
+		const cursor = await provider.executeTool({
+			id: 'call-cursor',
+			name: SEARCH_HOME_TOOL_NAME,
+			arguments: { query: 'light', cursor: 'stale' },
+		});
+		expect(cursor).toEqual({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: 'The search cursor is invalid for these filters.',
+			errorCode: 'HOME_SEARCH_INVALID_CURSOR',
+		});
+
+		queryCurrentState.mockRejectedValueOnce(new HomeContextSpaceNotFoundError('private-space-id'));
+		const missing = await provider.executeTool({
+			id: 'call-space',
+			name: QUERY_HOME_STATE_TOOL_NAME,
+			arguments: { operation: 'rows', space_id: 'private-space-id' },
+		});
+		expect(missing).toEqual({
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: 'The requested space was not found.',
+			errorCode: 'HOME_SPACE_NOT_FOUND',
+		});
+	});
+
+	it('is excluded from MCP listing and execution by the real registry', async () => {
+		const registry = new ToolProviderRegistryService();
+		registry.register(provider);
+		searchEntities.mockResolvedValue({
+			query: 'light',
+			entities: [],
+			observed_at: observedAt,
+			total: 0,
+			returned: 0,
+			totals_by_kind: { space: 0, device: 0, property: 0, scene: 0 },
+			partial: false,
+			truncated: false,
+			refine_required: false,
+		});
+
+		expect(registry.getAllToolDefinitions({ audience: ToolAudience.MCP })).toEqual([]);
+		const denied = await registry.executeTool(
+			{ id: 'mcp-call', name: SEARCH_HOME_TOOL_NAME, arguments: { query: 'light' } },
+			{ audience: ToolAudience.MCP, source: ToolAudience.MCP },
+		);
+
+		expect(denied).toEqual({
+			success: false,
+			status: ToolExecutionStatus.DENIED,
+			message: `Tool "${SEARCH_HOME_TOOL_NAME}" is not available to mcp`,
+			errorCode: 'TOOL_AUDIENCE_DENIED',
+		});
+		expect(searchEntities).not.toHaveBeenCalled();
+	});
+
+	it('uses the registry transport bound without echoing pathological home labels in the message', async () => {
+		const registry = new ToolProviderRegistryService();
+		const pathologicalName = 'x'.repeat(33 * 1024);
+		registry.register(provider);
+		searchEntities.mockResolvedValue({
+			query: 'room',
+			entities: [
+				{
+					kind: 'space',
+					id: 'space-1',
+					name: pathologicalName,
+					score: 900,
+					reasons: ['exact_name'],
+					candidate_capabilities: [],
+					type: 'room',
+					category: null,
+					parent_id: null,
+				},
+			],
+			observed_at: observedAt,
+			total: 1,
+			returned: 1,
+			totals_by_kind: { space: 1, device: 0, property: 0, scene: 0 },
+			partial: false,
+			truncated: false,
+			refine_required: false,
+		});
+
+		const execution = await registry.executeTool({
+			id: 'bounded-call',
+			name: SEARCH_HOME_TOOL_NAME,
+			arguments: { query: 'room' },
+		});
+
+		expect(execution.success).toBe(true);
+		expect(execution.message).toBe('Returned 1 of 1 matching home entities.');
+		expect(execution.message).not.toContain(pathologicalName);
+		expect(execution.data).toBeUndefined();
+		expect(execution.truncated).toBe(true);
+	});
+
+	function emptyStateBase(): Omit<HomeCurrentStateResult, 'operation'> {
+		return {
+			profile: HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+			predicate: null,
+			space_id: null,
+			rows: [],
+			observed_at: observedAt,
+			eligible: 0,
+			scanned: 0,
+			evaluated: 0,
+			unknown: 0,
+			matched: 0,
+			returned: 0,
+			complete: true,
+			partial: false,
+			partial_reasons: [],
+			truncated: false,
+			storage_status: 'not_needed',
+			cache_count: 0,
+			storage_count: 0,
+			missing_count: 0,
+			unprocessed_count: 0,
+			oldest_last_updated: null,
+			newest_last_updated: null,
+			freshness_unknown_count: 0,
+		};
+	}
+
+	function partialAnyResult(): HomeCurrentStateResult {
+		return {
+			profile: HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+			operation: 'any',
+			predicate: { operator: 'eq', value: true },
+			space_id: 'space-1',
+			rows: [],
+			observed_at: observedAt,
+			eligible: 2,
+			scanned: 2,
+			evaluated: 1,
+			unknown: 1,
+			matched: 0,
+			returned: 0,
+			complete: false,
+			partial: true,
+			partial_reasons: ['missing_values'],
+			truncated: false,
+			storage_status: 'disconnected',
+			cache_count: 1,
+			storage_count: 0,
+			missing_count: 1,
+			unprocessed_count: 0,
+			oldest_last_updated: observedAt,
+			newest_last_updated: observedAt,
+			freshness_unknown_count: 0,
+			value: null,
+			definitive: false,
+			status: 'indeterminate',
+		};
+	}
+});

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
@@ -11,6 +11,8 @@ import { HomeCurrentStateQueryService } from '../../home-context/services/home-c
 import { HomeSearchQueryService } from '../../home-context/services/home-search-query.service';
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
+import { MessageRole } from '../buddy.constants';
+import { buildAnthropicRequestPayload } from '../platforms/anthropic-sdk.utils';
 
 import {
 	BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS,
@@ -39,6 +41,7 @@ describe('HomeContextToolProviderService', () => {
 
 	it('publishes exactly two Buddy-only READ tools with server-owned profiles', () => {
 		const definitions = provider.getToolDefinitions();
+		const stateDefinition = definitions[1];
 
 		expect(provider.getType()).toBe(BUDDY_HOME_READ_TOOLS_PROVIDER);
 		expect(definitions.map(({ name }) => name)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
@@ -47,6 +50,32 @@ describe('HomeContextToolProviderService', () => {
 			expect(definition.access).toBe(ToolAccessKind.READ);
 			expect(definition.parameters).not.toHaveProperty('properties.profile');
 		}
+		expect(stateDefinition.parameters).toMatchObject({
+			type: 'object',
+			properties: {
+				operation: {
+					type: 'string',
+					enum: ['rows', 'any', 'all', 'count_matches'],
+				},
+			},
+		});
+		expect(stateDefinition.parameters).not.toHaveProperty('oneOf');
+
+		const anthropicPayload = buildAnthropicRequestPayload(
+			'claude-test',
+			'system',
+			[{ role: MessageRole.USER, content: 'Are any windows open?' }],
+			1024,
+			[stateDefinition],
+		);
+		expect(anthropicPayload).toMatchObject({
+			tools: [
+				{
+					name: QUERY_HOME_STATE_TOOL_NAME,
+					input_schema: { type: 'object' },
+				},
+			],
+		});
 
 		expect(searchHomeToolInputSchema.safeParse({ query: 'kitchen', profile: 'mcp-compatibility' }).success).toBe(false);
 		expect(queryHomeStateToolInputSchema.safeParse({ operation: 'any' }).success).toBe(false);

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
@@ -1,0 +1,277 @@
+import { z } from 'zod';
+
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/devices.constants';
+import {
+	HOME_CURRENT_STATE_EQUALITY_OPERATORS,
+	HOME_CURRENT_STATE_LIMIT_PROFILES,
+	HOME_CURRENT_STATE_ORDERING_OPERATORS,
+	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+	HOME_SEARCH_CANDIDATE_CAPABILITIES,
+	HOME_SEARCH_ENTITY_KINDS,
+	HOME_SEARCH_LIMIT_PROFILES,
+	HOME_SEARCH_PROFILE_BUDDY_V1,
+} from '../../home-context/home-context.constants';
+import { HomeContextSpaceNotFoundError } from '../../home-context/home-context.errors';
+import { HomeSearchInvalidCursorError, HomeSearchInvalidQueryError } from '../../home-context/home-search.errors';
+import { HomeCurrentStateQuery } from '../../home-context/models/home-current-state-query.model';
+import { homeCurrentStateResultSchema } from '../../home-context/schemas/home-current-state-output.schemas';
+import { homeEntitySearchResponseSchema } from '../../home-context/schemas/home-search-output.schemas';
+import { HomeCurrentStateQueryService } from '../../home-context/services/home-current-state-query.service';
+import { HomeSearchQueryService } from '../../home-context/services/home-search-query.service';
+import {
+	LlmToolCall,
+	ToolAccessKind,
+	ToolAudience,
+	ToolDefinition,
+	ToolExecutionContext,
+	ToolExecutionResult,
+	ToolExecutionStatus,
+	createToolDefinition,
+} from '../../tools/platforms/tool-provider.platform';
+import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
+import { BUDDY_MODULE_NAME } from '../buddy.constants';
+
+export const BUDDY_HOME_READ_TOOLS_PROVIDER = 'buddy-home-read-tools';
+export const SEARCH_HOME_TOOL_NAME = 'search_home';
+export const QUERY_HOME_STATE_TOOL_NAME = 'query_home_state';
+export const BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS = 20;
+
+const searchLimits = HOME_SEARCH_LIMIT_PROFILES[HOME_SEARCH_PROFILE_BUDDY_V1];
+const stateLimits = HOME_CURRENT_STATE_LIMIT_PROFILES[HOME_CURRENT_STATE_PROFILE_BUDDY_V1];
+
+export const searchHomeToolInputSchema = z
+	.object({
+		query: z.string().trim().min(1).max(searchLimits.maxQueryCharacters),
+		kinds: z
+			.array(z.enum(HOME_SEARCH_ENTITY_KINDS))
+			.min(1)
+			.max(searchLimits.maxKinds)
+			.refine((kinds) => new Set(kinds).size === kinds.length, 'Search kinds must be unique')
+			.optional(),
+		space_id: z.string().trim().min(1).max(128).optional(),
+		categories: z
+			.array(z.string().trim().min(1).max(64))
+			.min(1)
+			.max(searchLimits.maxCategories)
+			.refine((categories) => new Set(categories).size === categories.length, 'Search categories must be unique')
+			.optional(),
+		candidate_capability: z.enum(HOME_SEARCH_CANDIDATE_CAPABILITIES).optional(),
+		limit: z.number().int().min(1).max(searchLimits.maxResults).optional(),
+		cursor: z.string().min(1).max(searchLimits.maxCursorCharacters).optional(),
+	})
+	.strict();
+
+const uniqueArray = <T extends z.ZodType>(schema: T, max: number, label: string) =>
+	z
+		.array(schema)
+		.min(1)
+		.max(max)
+		.refine((values) => new Set(values).size === values.length, `${label} must be unique`)
+		.optional();
+
+const statePredicateSchema = z.union([
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_EQUALITY_OPERATORS),
+			value: z.union([z.string().max(stateLimits.maxPredicateStringCharacters), z.boolean()]),
+		})
+		.strict(),
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_EQUALITY_OPERATORS),
+			value: z.number().finite(),
+			unit: z.string().trim().min(1).max(32),
+		})
+		.strict(),
+	z
+		.object({
+			operator: z.enum(HOME_CURRENT_STATE_ORDERING_OPERATORS),
+			value: z.number().finite(),
+			unit: z.string().trim().min(1).max(32),
+		})
+		.strict(),
+]);
+
+const stateInputShape = {
+	space_id: z.string().trim().min(1).max(128).optional(),
+	channel_categories: uniqueArray(z.enum(ChannelCategory), stateLimits.maxChannelCategories, 'Channel categories'),
+	property_categories: uniqueArray(z.enum(PropertyCategory), stateLimits.maxPropertyCategories, 'Property categories'),
+	data_types: uniqueArray(z.enum(DataTypeType), stateLimits.maxDataTypes, 'Data types'),
+	limit: z.number().int().min(1).max(BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS).optional(),
+};
+
+export const queryHomeStateToolInputSchema = z.discriminatedUnion('operation', [
+	z.object({ ...stateInputShape, operation: z.literal('rows'), predicate: statePredicateSchema.optional() }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('any'), predicate: statePredicateSchema }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('all'), predicate: statePredicateSchema }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('count_matches'), predicate: statePredicateSchema }).strict(),
+]);
+
+@Injectable()
+export class HomeContextToolProviderService extends BaseToolProviderService {
+	protected readonly logger = createExtensionLogger(BUDDY_MODULE_NAME, 'HomeContextToolProviderService');
+
+	constructor(
+		private readonly homeSearch: HomeSearchQueryService,
+		private readonly currentState: HomeCurrentStateQueryService,
+	) {
+		super();
+	}
+
+	getType(): string {
+		return BUDDY_HOME_READ_TOOLS_PROVIDER;
+	}
+
+	getToolDefinitions(): ToolDefinition[] {
+		return [
+			createToolDefinition({
+				name: SEARCH_HOME_TOOL_NAME,
+				description:
+					'Search bounded home catalog metadata for spaces, devices, properties, and scenes. ' +
+					'Use this to discover canonical IDs for focused reads. IDs and candidate capabilities are metadata hints only, ' +
+					'not action authorization or proof that an action can execute. Refine the query when refine_required is true.',
+				audiences: [ToolAudience.BUDDY],
+				access: ToolAccessKind.READ,
+				inputSchema: searchHomeToolInputSchema,
+				outputSchema: homeEntitySearchResponseSchema,
+			}),
+			createToolDefinition({
+				name: QUERY_HOME_STATE_TOOL_NAME,
+				description:
+					'Read a bounded set of current property values or evaluate completeness-safe any, all, and count_matches predicates. ' +
+					'Never treat an indeterminate or partial result as a complete negative or exact count. Numeric predicates require an explicit unit.',
+				audiences: [ToolAudience.BUDDY],
+				access: ToolAccessKind.READ,
+				inputSchema: queryHomeStateToolInputSchema,
+				outputSchema: homeCurrentStateResultSchema,
+			}),
+		];
+	}
+
+	protected async handleToolCall(
+		toolCall: LlmToolCall,
+		_context: ToolExecutionContext,
+	): Promise<ToolExecutionResult | null> {
+		if (toolCall.name === SEARCH_HOME_TOOL_NAME) {
+			return this.searchHome(toolCall.arguments);
+		}
+
+		if (toolCall.name === QUERY_HOME_STATE_TOOL_NAME) {
+			return this.queryHomeState(toolCall.arguments);
+		}
+
+		return null;
+	}
+
+	private async searchHome(argumentsValue: Record<string, unknown>): Promise<ToolExecutionResult> {
+		const parsed = searchHomeToolInputSchema.safeParse(argumentsValue);
+
+		if (!parsed.success) {
+			return this.invalidArguments(SEARCH_HOME_TOOL_NAME);
+		}
+
+		try {
+			const result = await this.homeSearch.searchEntities({
+				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
+				query: parsed.data.query,
+				kinds: parsed.data.kinds,
+				spaceId: parsed.data.space_id,
+				categories: parsed.data.categories,
+				candidateCapability: parsed.data.candidate_capability,
+				limit: parsed.data.limit,
+				cursor: parsed.data.cursor,
+			});
+			const refinement = result.refine_required
+				? ' Refine the query to search beyond the bounded candidate window.'
+				: '';
+
+			return {
+				success: true,
+				status: ToolExecutionStatus.COMPLETED,
+				message: `Returned ${result.returned} of ${result.total} matching home entities.${refinement}`,
+				data: result as unknown as Record<string, unknown>,
+			};
+		} catch (error) {
+			return this.mapExpectedError(error);
+		}
+	}
+
+	private async queryHomeState(argumentsValue: Record<string, unknown>): Promise<ToolExecutionResult> {
+		const parsed = queryHomeStateToolInputSchema.safeParse(argumentsValue);
+
+		if (!parsed.success) {
+			return this.invalidArguments(QUERY_HOME_STATE_TOOL_NAME);
+		}
+
+		try {
+			const query = {
+				profile: HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
+				operation: parsed.data.operation,
+				spaceId: parsed.data.space_id,
+				channelCategories: parsed.data.channel_categories,
+				propertyCategories: parsed.data.property_categories,
+				dataTypes: parsed.data.data_types,
+				limit: parsed.data.limit,
+				...(parsed.data.predicate === undefined ? {} : { predicate: parsed.data.predicate }),
+			} as HomeCurrentStateQuery;
+			const result = await this.currentState.queryCurrentState(query);
+			const coverage = `${result.evaluated}/${result.eligible} eligible values`;
+			const message =
+				result.operation === 'rows'
+					? `Evaluated ${coverage} and returned ${result.returned} bounded evidence rows${result.partial ? ' with partial coverage' : ''}.`
+					: `Current-state ${result.operation} result is ${result.status}; evaluated ${coverage}.`;
+
+			return {
+				success: true,
+				status: result.partial ? ToolExecutionStatus.PARTIAL : ToolExecutionStatus.COMPLETED,
+				message,
+				data: result as unknown as Record<string, unknown>,
+			};
+		} catch (error) {
+			return this.mapExpectedError(error);
+		}
+	}
+
+	private invalidArguments(toolName: string): ToolExecutionResult {
+		return {
+			success: false,
+			status: ToolExecutionStatus.FAILED,
+			message: `Invalid arguments for tool "${toolName}"`,
+			errorCode: 'INVALID_TOOL_ARGUMENTS',
+		};
+	}
+
+	private mapExpectedError(error: unknown): ToolExecutionResult {
+		if (error instanceof HomeContextSpaceNotFoundError) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'The requested space was not found.',
+				errorCode: 'HOME_SPACE_NOT_FOUND',
+			};
+		}
+
+		if (error instanceof HomeSearchInvalidCursorError) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'The search cursor is invalid for these filters.',
+				errorCode: 'HOME_SEARCH_INVALID_CURSOR',
+			};
+		}
+
+		if (error instanceof HomeSearchInvalidQueryError) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.FAILED,
+				message: 'The home search query is invalid.',
+				errorCode: 'HOME_SEARCH_INVALID_QUERY',
+			};
+		}
+
+		throw error;
+	}
+}

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
@@ -7,6 +7,7 @@ import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/d
 import {
 	HOME_CURRENT_STATE_EQUALITY_OPERATORS,
 	HOME_CURRENT_STATE_LIMIT_PROFILES,
+	HOME_CURRENT_STATE_OPERATIONS,
 	HOME_CURRENT_STATE_ORDERING_OPERATORS,
 	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
 	HOME_SEARCH_CANDIDATE_CAPABILITIES,
@@ -103,12 +104,22 @@ const stateInputShape = {
 	limit: z.number().int().min(1).max(BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS).optional(),
 };
 
-export const queryHomeStateToolInputSchema = z.discriminatedUnion('operation', [
-	z.object({ ...stateInputShape, operation: z.literal('rows'), predicate: statePredicateSchema.optional() }).strict(),
-	z.object({ ...stateInputShape, operation: z.literal('any'), predicate: statePredicateSchema }).strict(),
-	z.object({ ...stateInputShape, operation: z.literal('all'), predicate: statePredicateSchema }).strict(),
-	z.object({ ...stateInputShape, operation: z.literal('count_matches'), predicate: statePredicateSchema }).strict(),
-]);
+export const queryHomeStateToolInputSchema = z
+	.object({
+		...stateInputShape,
+		operation: z.enum(HOME_CURRENT_STATE_OPERATIONS),
+		predicate: statePredicateSchema.optional(),
+	})
+	.strict()
+	.superRefine((input, context) => {
+		if (input.operation !== 'rows' && input.predicate === undefined) {
+			context.addIssue({
+				code: 'custom',
+				path: ['predicate'],
+				message: `A predicate is required for the ${input.operation} operation`,
+			});
+		}
+	});
 
 @Injectable()
 export class HomeContextToolProviderService extends BaseToolProviderService {

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
@@ -7,7 +7,6 @@ import { ChannelCategory, DataTypeType, PropertyCategory } from '../../devices/d
 import {
 	HOME_CURRENT_STATE_EQUALITY_OPERATORS,
 	HOME_CURRENT_STATE_LIMIT_PROFILES,
-	HOME_CURRENT_STATE_OPERATIONS,
 	HOME_CURRENT_STATE_ORDERING_OPERATORS,
 	HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
 	HOME_SEARCH_CANDIDATE_CAPABILITIES,
@@ -104,22 +103,17 @@ const stateInputShape = {
 	limit: z.number().int().min(1).max(BUDDY_CURRENT_STATE_MAX_EVIDENCE_ROWS).optional(),
 };
 
-export const queryHomeStateToolInputSchema = z
-	.object({
-		...stateInputShape,
-		operation: z.enum(HOME_CURRENT_STATE_OPERATIONS),
-		predicate: statePredicateSchema.optional(),
-	})
-	.strict()
-	.superRefine((input, context) => {
-		if (input.operation !== 'rows' && input.predicate === undefined) {
-			context.addIssue({
-				code: 'custom',
-				path: ['predicate'],
-				message: `A predicate is required for the ${input.operation} operation`,
-			});
-		}
-	});
+export const queryHomeStateToolInputSchema = z.discriminatedUnion('operation', [
+	z.object({ ...stateInputShape, operation: z.literal('rows'), predicate: statePredicateSchema.optional() }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('any'), predicate: statePredicateSchema }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('all'), predicate: statePredicateSchema }).strict(),
+	z.object({ ...stateInputShape, operation: z.literal('count_matches'), predicate: statePredicateSchema }).strict(),
+]);
+
+const withObjectRootParameters = (definition: ToolDefinition): ToolDefinition => ({
+	...definition,
+	parameters: { ...definition.parameters, type: 'object' },
+});
 
 @Injectable()
 export class HomeContextToolProviderService extends BaseToolProviderService {
@@ -149,16 +143,18 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 				inputSchema: searchHomeToolInputSchema,
 				outputSchema: homeEntitySearchResponseSchema,
 			}),
-			createToolDefinition({
-				name: QUERY_HOME_STATE_TOOL_NAME,
-				description:
-					'Read a bounded set of current property values or evaluate completeness-safe any, all, and count_matches predicates. ' +
-					'Never treat an indeterminate or partial result as a complete negative or exact count. Numeric predicates require an explicit unit.',
-				audiences: [ToolAudience.BUDDY],
-				access: ToolAccessKind.READ,
-				inputSchema: queryHomeStateToolInputSchema,
-				outputSchema: homeCurrentStateResultSchema,
-			}),
+			withObjectRootParameters(
+				createToolDefinition({
+					name: QUERY_HOME_STATE_TOOL_NAME,
+					description:
+						'Read a bounded set of current property values or evaluate completeness-safe any, all, and count_matches predicates. ' +
+						'Never treat an indeterminate or partial result as a complete negative or exact count. Numeric predicates require an explicit unit.',
+					audiences: [ToolAudience.BUDDY],
+					access: ToolAccessKind.READ,
+					inputSchema: queryHomeStateToolInputSchema,
+					outputSchema: homeCurrentStateResultSchema,
+				}),
+			),
 		];
 	}
 

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
@@ -50,6 +50,7 @@ export const searchHomeToolInputSchema = z
 			.min(1)
 			.max(searchLimits.maxKinds)
 			.refine((kinds) => new Set(kinds).size === kinds.length, 'Search kinds must be unique')
+			.meta({ uniqueItems: true })
 			.optional(),
 		space_id: z.string().trim().min(1).max(128).optional(),
 		categories: z
@@ -57,6 +58,7 @@ export const searchHomeToolInputSchema = z
 			.min(1)
 			.max(searchLimits.maxCategories)
 			.refine((categories) => new Set(categories).size === categories.length, 'Search categories must be unique')
+			.meta({ uniqueItems: true })
 			.optional(),
 		candidate_capability: z.enum(HOME_SEARCH_CANDIDATE_CAPABILITIES).optional(),
 		limit: z.number().int().min(1).max(searchLimits.maxResults).optional(),
@@ -70,6 +72,7 @@ const uniqueArray = <T extends z.ZodType>(schema: T, max: number, label: string)
 		.min(1)
 		.max(max)
 		.refine((values) => new Set(values).size === values.length, `${label} must be unique`)
+		.meta({ uniqueItems: true })
 		.optional();
 
 const statePredicateSchema = z.union([

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1554,14 +1554,18 @@ busy response leaves an ownerless nonterminal sequence capable of blocking later
 **Tasks:**
 
 - [ ] Implement the bounded Buddy read tool catalog from Section 6.
-- [ ] Mark tools `ToolAudience.BUDDY` and `ToolAccessKind.READ`.
-- [ ] Validate inputs and outputs using the shared schemas.
-- [ ] Return concise messages plus bounded structured data and freshness/truncation metadata.
+- [x] Add the provider foundation for `search_home` and completeness-safe `query_home_state` with server-selected Buddy
+      profiles; keep the remaining catalog entries and live registration open.
+- [x] Mark the initial tools `ToolAudience.BUDDY` and `ToolAccessKind.READ`.
+- [x] Validate their strict adapter inputs and structured outputs using the shared schemas.
+- [x] Return concise messages plus bounded structured data and freshness/truncation/coverage metadata.
 - [ ] Add conversation-scoped Buddy mappings to `ShortIdMappingService`; register only results exposed in that
       conversation and require the same scope in every Buddy short-ID action lookup, with no unscoped/global fallback.
       Preserve existing non-Buddy mapping behavior and canonical UUID fallback.
 - [ ] Add tool selection support so unrelated schemas are not advertised on every turn.
-- [ ] Verify no MCP configuration, token, policy, or server service is injected.
+- [ ] Register the initial read tools after conversation-scoped target exposure and action-resolution proof prevent a
+      discovered canonical ID from authorizing an action by itself.
+- [x] Verify no MCP configuration, token, policy, or server service is injected into the Buddy read provider.
 
 **Tests:** Every schema boundary and hard cap; missing optional modules; stale/missing entities; hidden/disabled entities;
 long labels/values; multi-language/diacritic search; same-token collisions across conversations; two colliding UUIDs in


### PR DESCRIPTION
## Summary

- add a Buddy-owned provider foundation for bounded `search_home` metadata discovery and completeness-safe `query_home_state` reads
- inject fixed server-side Buddy profiles, strict snake_case adapter schemas, shared output validation, and concise count/coverage messages
- wire the provider through `HomeContextModule` without importing MCP configuration, policy, tokens, or server services
- document the intentional rollout boundary in the adaptive-context plan

## Safety boundary

The provider is intentionally **not registered** in the live tool registry yet. Search and current-state results contain canonical IDs, while the existing Buddy action tools do not yet require conversation-scoped exposure/action-resolution proof. Keeping registration deferred prevents a discovered ID from becoming action authority by itself and leaves existing runtime behavior unchanged.

## Validation

- `pnpm --dir apps/backend exec jest src/modules/buddy src/modules/home-context src/modules/tools/services/tool-provider-registry.service.spec.ts --runInBand` — 37 suites / 549 tests passed before rebase
- `pnpm --dir apps/backend exec jest src/modules/buddy/buddy.module.spec.ts src/modules/buddy/services/home-context-tool-provider.service.spec.ts src/modules/home-context --runInBand` — 8 suites / 78 tests passed after rebase
- `pnpm --dir apps/backend run type-check`
- focused ESLint and Prettier checks for changed TypeScript files
- `git diff --check`

The repository-wide Jest aggregate was also attempted; it was interrupted by the existing Home Assistant websocket mock's late `this.ws?.terminate()` call. That Home Assistant suite passes when run in isolation.

## Follow-up

Live registration remains open until conversation-scoped target exposure and action-resolution proof are enforced. The remaining Buddy read catalog and per-turn tool selection also remain unchecked in the plan.

> 👍 Codex review passed on `9deb358040`.