### PR TITLE
docs(cross): defer Homey server discovery

### DIFF
--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,7 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory, SDK session/cleanup, and pre-restart mDNS host-match evidence captured; live
-capability-event, write, error-matrix, reconnect, recovery, and credential-rotation evidence pending
+**Status:** In progress; safe inventory and SDK session/cleanup evidence captured, automatic mDNS discovery explicitly
+deferred for the local MVP, and live capability-event, write, error-matrix, reconnect, recovery, and
+credential-rotation evidence pending
 
 **Started:** 2026-08-12
 
@@ -28,7 +29,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Error classification                                  | SDK invalid key returned `401`; matrix pending  | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
 | API-key revocation and replacement                    | Operator-controlled probe ready                 | Revoke only a dedicated test key during the gated observation window |
 | Disposable-device lifecycle                           | Guarded operator probe ready                    | Use only the separately gated virtual/test device                    |
-| mDNS discovery                                        | Partial pre-restart observation                 | Attribute the generic host record and repeat after SHS restart       |
+| mDNS discovery                                        | Deferred; manual URL only for local MVP         | Revisit only after an attributable stable service is verified        |
 | SDK decision                                          | Live session/cleanup passed; provisional hold   | Complete event, timeout, cleanup-failure, and reconnect comparison   |
 | Sanitized fixture corpus                              | Nine representative live fixtures promoted      | Add event/reconnect fixtures and missing capability families/classes |
 
@@ -387,7 +388,35 @@ Two consecutive five-second observations on 2026-08-14 produced the same sanitiz
 `80` with no TXT keys. The reviewed report is committed as
 `__fixtures__/evidence/2026-08-14-shs-13.4.0-mdns-host-match.json`. Because the record is generic and the observed port
 is not either documented SHS API port, this does not establish that SHS owns the advertisement or provide a safe
-discovery discriminator. The discovery gate remains open pending attribution and an observation after SHS restart.
+discovery discriminator.
+
+### Server-discovery decision
+
+Automatic Homey server discovery is explicitly deferred for the local MVP. Smart Panel does not register a Homey
+mDNS discoverer and does not expose Homey server-discovery or rescan endpoints. Shipping `_http._tcp` port `80` as a
+Homey discriminator could present unrelated LAN services as Homey instances, so the observed record is insufficient
+even if a later observation finds it again after an SHS restart.
+
+Administrators configure the local Homey URL manually through the plugin configuration and can verify either the
+fully saved configuration or a complete candidate URL/new-key pair through the connection-test endpoint. Manual setup
+does not depend on the mDNS module and remains the supported fallback if automatic discovery is reconsidered later.
+
+For manual setup:
+
+1. Enter the complete `http` or `https` SHS/Homey local API URL, including its configured port. The URL must not contain
+   embedded credentials.
+2. Enter a newly created scoped API key in the write-only `api_key` field and save the plugin configuration. A later
+   update may omit the field to preserve the stored key; config responses return only `api_key_configured`.
+3. Test the persisted URL/key with `saved` connection-test mode, or test an unsaved URL only by supplying both the
+   candidate URL and a new key in `candidate` mode.
+4. Enable the plugin after the saved configuration passes validation. No discovery scan or discovery result is needed
+   before the connector starts.
+
+The ignored live-capture probe and sanitized evidence fixture remain available for future compatibility work. Automatic
+discovery may be reconsidered only when an advertisement can be attributed specifically to SHS/Homey, is stable before
+and after restart, exposes enough non-secret metadata to deduplicate by Homey identity, and can be validated without
+sending credentials to an unverified endpoint. Until all of those conditions are met, no guessed service type, port,
+TXT field, or discovery route is shipped.
 
 ## Non-mutating error-classification probe
 
@@ -474,7 +503,7 @@ Fill this matrix using synthetic aliases only.
 | SHS restart and reconnect                 | Pending                             |                                                                                                                                                      |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
-| Stable mDNS service before/after restart  | Partial pre-restart evidence        | Two identical windows matched generic `_http._tcp` port `80` with no TXT keys; SHS attribution and post-restart stability remain unproven            |
+| Stable mDNS service before/after restart  | Deferred for local MVP              | Two identical windows matched only generic `_http._tcp` port `80` with no TXT keys; the record cannot be safely attributed to SHS                    |
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -255,11 +255,15 @@ index.ts
 
 ### Task 2.4: Implement server discovery only from evidence
 
-- [ ] If Milestone 0 found a stable mDNS service, implement a Homey discoverer using the existing mDNS module.
-- [ ] Deduplicate by stable server identity and retain manual URL as fallback.
-- [ ] Expose start/restart/results endpoints following existing discovery patterns.
-- [ ] Test expiry, duplicate records, restart, and malformed TXT records.
-- [ ] If no stable record exists, document manual-only setup and mark automatic discovery deferred; do not ship guessed records.
+**Decision (2026-08-15):** The live probe found only an unattributable generic `_http._tcp` record on port `80` with
+no TXT keys. Automatic server discovery is deferred for the local MVP; manual URL configuration and connection testing
+remain supported. Revisit only after a Homey-specific identity and restart-stable advertisement are verified.
+
+- [x] Evaluate the Milestone 0 evidence and do not register a discoverer without a stable Homey-specific service.
+- [x] Defer stable-identity deduplication and retain manual URL configuration as the supported setup path.
+- [x] Do not expose start/restart/results endpoints while automatic server discovery is deferred.
+- [x] Defer expiry, duplicate-record, restart, and malformed-TXT tests until an evidence-backed service contract exists.
+- [x] Document manual-only setup and the evidence required to reconsider automatic discovery; do not ship guessed records.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-12-homey-integration-design.md
+++ b/docs/superpowers/specs/2026-08-12-homey-integration-design.md
@@ -295,6 +295,11 @@ There are two distinct meanings of discovery:
 
 Manual server URL entry is always supported. mDNS discovery is implemented only after the one-month compatibility spike identifies a stable service type and verifies behavior across SHS restarts. No guessed service record is shipped.
 
+The 2026-08-15 compatibility decision deferred automatic server discovery for the local MVP: the only matched record
+was generic `_http._tcp` on port `80`, without TXT keys or evidence that it belonged to SHS. Consequently, the local
+MVP accepts a manual URL and intentionally omits the optional server-discovery/rescan routes. The compatibility record
+defines the evidence required to revisit this decision.
+
 Device discovery is an authenticated inventory request through the active connector. It does not start radio pairing mode and must remain read-only.
 
 ## Adoption
@@ -387,6 +392,8 @@ The backend remains the OpenAPI source of truth. Proposed plugin routes, under t
 | `POST` | `/plugins/devices-homey/adopt/batch` | Adopt selected devices with per-device results |
 
 Exact path naming should follow the closest current controller convention at implementation time. All actions require the standard tags, operations, response envelopes, validation, and authorization decorators.
+
+The two conditional server-discovery routes are omitted from the local MVP under the recorded manual-only decision.
 
 ## Security
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -83,7 +83,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] A designated harmless writable capability can be controlled and its resulting event observed.
 - [ ] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
 - [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
-- [ ] mDNS behavior is verified; discovery is either specified from evidence or explicitly deferred.
+- [x] mDNS behavior is verified; automatic discovery is explicitly deferred because no attributable stable Homey service was observed.
 - [ ] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
 - [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.
 - [ ] Fixture-backed tests can run without live SHS access.
@@ -104,7 +104,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] A `HomeyConnector` abstraction prevents SDK/transport objects from leaking into domain services.
 - [ ] The local connector supports connection testing, inventory, zones, device reads, events, and capability writes.
 - [ ] Health exposes connected, degraded polling, reconnecting, authentication failed, and stopped states.
-- [ ] Manual URL setup works without mDNS.
+- [x] Manual URL setup works without mDNS.
 - [ ] Authenticated device discovery lists all logical Homey devices with adoption/support status.
 - [ ] Normalization preserves full device and capability IDs, including capability suffixes.
 - [ ] Mapping definitions cover the agreed MVP light, switch, sensor, climate, cover, lock, battery, and energy capabilities.

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -122,7 +122,8 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 ### Backend API and OpenAPI
 
-- [ ] Status, test-connection, discovery, device inventory, mapping-preview, and adoption endpoints follow repository controller conventions.
+- [ ] Status, test-connection, device inventory, mapping-preview, and adoption endpoints follow repository controller conventions.
+- [x] Server-discovery endpoints are required only when compatibility evidence establishes a stable Homey-specific advertisement; they are intentionally omitted from the manual-only local MVP.
 - [ ] Every controller action has the required Swagger tags, operation metadata, response envelope, validation, authorization, and error responses.
 - [ ] `pnpm run generate:openapi` succeeds after backend Swagger changes.
 - [ ] No generated OpenAPI, admin API type, panel API client, or generated spec file is edited manually.


### PR DESCRIPTION
## Summary

- explicitly defer automatic Homey/SHS mDNS server discovery for the local MVP
- document manual URL configuration and saved/candidate connection testing as the supported setup path
- record why the observed generic `_http._tcp` port `80` advertisement is not a safe Homey discriminator
- define the evidence required before automatic discovery and its optional routes can be reconsidered
- complete Task 2.4 and the corresponding feature acceptance criteria without shipping guessed discovery behavior

## Why

The privacy-safe live probe found only an unattributable generic HTTP advertisement with no TXT keys and no documented SHS API port. Treating that record as Homey could present unrelated LAN services as Homey instances and risk sending credentials to an unverified endpoint. The approved design already requires an evidence-backed, restart-stable Homey service before mDNS discovery is implemented.

## Validation

- `pnpm run test:unit -- src/plugins/devices-homey/dto/test-connection.dto.spec.ts src/plugins/devices-homey/services/homey-connection-test.service.spec.ts src/plugins/devices-homey/controllers/homey-test-connection.controller.spec.ts --runInBand` — 32 tests passed
- `pnpm run test:homey-spike -- homey-shs-mdns.homey-spike.ts` — 12 tests passed
- `git diff --check origin/main...HEAD`
