### PR TITLE
feat(backend): add Homey mapping loader

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -38,6 +38,14 @@
         "outDir": "dist"
       },
       {
+        "include": "plugins/devices-homey/mappings/schema/**/*.json",
+        "outDir": "dist"
+      },
+      {
+        "include": "plugins/devices-homey/mappings/definitions/**/*.yaml",
+        "outDir": "dist"
+      },
+      {
         "include": "plugins/simulator/scenarios/schema/**/*.json",
         "outDir": "dist"
       },

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -14,6 +14,8 @@ import { DEVICES_HOMEY_PLUGIN_NAME, DEVICES_HOMEY_TYPE, HOMEY_CONNECTOR_FACTORY 
 import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.openapi';
 import { DevicesHomeyPlugin } from './devices-homey.plugin';
 import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
+import { HomeyMappingLoaderService } from './mappings/mapping-loader.service';
+import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-storage.service';
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
 import { HomeyService } from './services/homey.service';
@@ -77,7 +79,13 @@ describe('DevicesHomeyPlugin', () => {
 		const controllers = Reflect.getMetadata('controllers', DevicesHomeyPlugin) as unknown[];
 
 		expect(providers).toEqual(
-			expect.arrayContaining([HomeySdkClientFactoryService, HomeyLocalConnectorFactory, HomeyConnectionTestService]),
+			expect.arrayContaining([
+				HomeySdkClientFactoryService,
+				HomeyLocalConnectorFactory,
+				HomeyConnectionTestService,
+				HomeyMappingLoaderService,
+				HomeyPropertyMappingStorageService,
+			]),
 		);
 		expect(providers).toContainEqual({
 			provide: HOMEY_CONNECTOR_FACTORY,

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -42,6 +42,8 @@ import { UpdateHomeyChannelDto } from './dto/update-channel.dto';
 import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateHomeyDeviceDto } from './dto/update-device.dto';
 import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './entities/devices-homey.entity';
+import { HomeyMappingLoaderService } from './mappings/mapping-loader.service';
+import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-storage.service';
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
@@ -69,10 +71,12 @@ import { HomeyService } from './services/homey.service';
 			useExisting: HomeyLocalConnectorFactory,
 		},
 		HomeyConnectionTestService,
+		HomeyMappingLoaderService,
+		HomeyPropertyMappingStorageService,
 		HomeyService,
 	],
 	controllers: [HomeyStatusController, HomeyTestConnectionController],
-	exports: [HomeyService],
+	exports: [HomeyMappingLoaderService, HomeyPropertyMappingStorageService, HomeyService],
 })
 export class DevicesHomeyPlugin implements OnModuleInit {
 	constructor(

--- a/apps/backend/src/plugins/devices-homey/index.ts
+++ b/apps/backend/src/plugins/devices-homey/index.ts
@@ -8,6 +8,7 @@ export * from './dto/test-connection.dto';
 export * from './dto/update-config.dto';
 export * from './entities/devices-homey.entity';
 export * from './errors/homey-connector.error';
+export * from './mappings';
 export * from './models/config.model';
 export * from './models/homey-capability.model';
 export * from './models/homey-device.model';

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -1,0 +1,33 @@
+# Homey mapping definitions
+
+Homey mappings are split into three strict YAML documents:
+
+- `devices.yaml` selects a Smart Panel device category.
+- `channels.yaml` creates stable channel descriptors.
+- `properties.yaml` maps full Homey capabilities to Smart Panel properties.
+
+Built-in files live in `mappings/definitions`. Upgrade-safe user overrides use these exact repository data paths:
+
+- `var/data/plugin.devices-homey.devices.yaml`
+- `var/data/plugin.devices-homey.channels.yaml`
+- `var/data/plugin.devices-homey.properties.yaml`
+
+Each user file must have the same `kind` as its filename. A user descriptor replaces a built-in descriptor only when
+both have the same `name`; otherwise it is added. Resolution is deterministic: priority descending, user source before
+built-in source, then mapping name. Invalid user files are isolated and ignored as a whole, while an invalid built-in
+file prevents the plugin from starting.
+
+Matches use exact Homey `class` values and capability base IDs. Optional `driver_ids`, `manufacturers`, and `models`
+may narrow a descriptor but should not be used for generic mappings. Property matching derives the base ID from the
+first dot only, while every resolved property binding retains the original full capability ID for reads and writes.
+
+Every descriptor supports:
+
+- `priority`: integer ordering, higher first;
+- `exclusive`: the highest-priority exclusive match suppresses other matches of that kind;
+- `conflict`: `first`, `warn`, or `error` for equal-priority mappings targeting the same output;
+- property `direction`: `read_only`, `write_only`, or `bidirectional`;
+- property unit/range expectations and inline `scale`, `map`, `boolean`, `clamp`, or `round` transforms.
+
+The JSON schema rejects unknown keys and malformed structures. Semantic validation additionally rejects unknown Smart
+Panel enum values, inverted ranges, and degenerate transformations.

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -29,5 +29,9 @@ Every descriptor supports:
 - property `direction`: `read_only`, `write_only`, or `bidirectional`;
 - property unit/range expectations and inline `scale`, `map`, `boolean`, `clamp`, or `round` transforms.
 
+Map transforms must declare a `read` table for read-capable directions and an explicit `write` table for writable
+directions. Bidirectional maps require both tables; the loader never guesses an inverse from potentially non-injective
+read values.
+
 The JSON schema rejects unknown keys and malformed structures. Semantic validation additionally rejects unknown Smart
 Panel enum values, inverted ranges, and degenerate transformations.

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -1,0 +1,3 @@
+version: 1
+kind: channels
+mappings: []

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
@@ -1,0 +1,3 @@
+version: 1
+kind: devices
+mappings: []

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -1,0 +1,3 @@
+version: 1
+kind: properties
+mappings: []

--- a/apps/backend/src/plugins/devices-homey/mappings/homey-mapping.error.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/homey-mapping.error.ts
@@ -1,0 +1,9 @@
+export class HomeyMappingConfigurationError extends Error {
+	constructor(
+		readonly source: string,
+		readonly issues: readonly string[],
+	) {
+		super(`Homey built-in mapping configuration is invalid: ${source}`);
+		this.name = 'HomeyMappingConfigurationError';
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/index.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/index.ts
@@ -1,0 +1,5 @@
+export * from './homey-mapping.error';
+export * from './mapping-loader.service';
+export * from './mapping.constants';
+export * from './mapping.types';
+export * from './property-mapping-storage.service';

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
@@ -1,0 +1,355 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { stringify as stringifyYaml } from 'yaml';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { HomeyCapabilityType, createHomeyCapability } from '../models/homey-capability.model';
+import { HomeyDevice } from '../models/homey-device.model';
+
+import { HomeyMappingConfigurationError } from './homey-mapping.error';
+import { HomeyMappingLoaderService } from './mapping-loader.service';
+import { HOMEY_MAPPING_FILE_NAMES, HOMEY_USER_MAPPING_FILE_NAMES } from './mapping.constants';
+import { HomeyMappingKind } from './mapping.types';
+
+const emptyConfig = (kind: HomeyMappingKind) => ({ version: 1, kind, mappings: [] });
+
+const deviceDefinition = (overrides: Record<string, unknown> = {}) => ({
+	name: 'sensor-device',
+	priority: 100,
+	match: {
+		classes: ['sensor'],
+		all_capabilities: ['measure_temperature'],
+	},
+	device: { category: 'sensor' },
+	...overrides,
+});
+
+const channelDefinition = (overrides: Record<string, unknown> = {}) => ({
+	name: 'temperature-channel',
+	priority: 100,
+	match: {
+		classes: ['sensor'],
+		all_capabilities: ['measure_temperature'],
+	},
+	channel: { identifier: 'temperature', category: 'temperature' },
+	...overrides,
+});
+
+const propertyDefinition = (overrides: Record<string, unknown> = {}) => ({
+	name: 'measured-temperature',
+	priority: 100,
+	match: {
+		classes: ['sensor'],
+		capability_base_ids: ['measure_temperature'],
+	},
+	property: {
+		channel: 'temperature',
+		category: 'temperature',
+		data_type: 'float',
+		direction: 'read_only',
+		unit: '°C',
+		range: { minimum: -50, maximum: 100, step: 0.1 },
+		transform: {
+			type: 'round',
+			precision: 1,
+		},
+	},
+	...overrides,
+});
+
+const createCapability = (id: string, value: number) =>
+	createHomeyCapability({
+		id,
+		title: id,
+		value,
+		type: HomeyCapabilityType.NUMBER,
+		unit: '°C',
+		minimum: -50,
+		maximum: 100,
+		step: 0.1,
+		enumValues: [],
+		readable: true,
+		writable: false,
+		available: true,
+		lastUpdatedAt: null,
+	});
+
+const createDevice = (overrides: Partial<HomeyDevice> = {}): HomeyDevice => ({
+	id: 'homey-device-1',
+	name: 'Synthetic sensor',
+	class: 'sensor',
+	zoneId: null,
+	zoneName: null,
+	zonePath: [],
+	available: true,
+	availabilityMessage: null,
+	driverId: 'homey:app:test:driver:synthetic',
+	manufacturer: 'Synthetic vendor',
+	model: 'Synthetic model',
+	energy: null,
+	capabilities: [
+		createCapability('measure_temperature.inside', 21.5),
+		createCapability('measure_temperature.outside', 12.25),
+	],
+	...overrides,
+});
+
+describe('HomeyMappingLoaderService', () => {
+	let rootPath: string;
+	let builtinMappingsPath: string;
+	let userDataPath: string;
+	let service: HomeyMappingLoaderService;
+
+	const writeConfig = (path: string, config: unknown): void => {
+		writeFileSync(path, stringifyYaml(config));
+	};
+
+	const writeBuiltin = (kind: HomeyMappingKind, mappings: unknown[]): void => {
+		writeConfig(join(builtinMappingsPath, HOMEY_MAPPING_FILE_NAMES[kind]), { version: 1, kind, mappings });
+	};
+
+	const writeUser = (kind: HomeyMappingKind, mappings: unknown[]): void => {
+		writeConfig(join(userDataPath, HOMEY_USER_MAPPING_FILE_NAMES[kind]), { version: 1, kind, mappings });
+	};
+
+	const createService = (): HomeyMappingLoaderService =>
+		new HomeyMappingLoaderService({
+			builtinMappingsPath,
+			userDataPath,
+			schemaPath: join(__dirname, 'schema', 'mapping-schema.json'),
+		});
+
+	beforeEach(() => {
+		rootPath = mkdtempSync(join(tmpdir(), 'homey-mappings-'));
+		builtinMappingsPath = join(rootPath, 'builtin');
+		userDataPath = join(rootPath, 'user');
+		mkdirSync(builtinMappingsPath);
+		mkdirSync(userDataPath);
+
+		for (const kind of ['devices', 'channels', 'properties'] as const) {
+			writeConfig(join(builtinMappingsPath, HOMEY_MAPPING_FILE_NAMES[kind]), emptyConfig(kind));
+		}
+
+		service = createService();
+	});
+
+	afterEach(() => {
+		rmSync(rootPath, { recursive: true, force: true });
+	});
+
+	it('loads strict device, channel, and property descriptors', () => {
+		writeBuiltin('devices', [deviceDefinition()]);
+		writeBuiltin('channels', [channelDefinition()]);
+		writeBuiltin('properties', [propertyDefinition()]);
+
+		service.loadAllMappings();
+
+		expect(service.getDeviceMappings()).toHaveLength(1);
+		expect(service.getChannelMappings()).toHaveLength(1);
+		expect(service.getPropertyMappings()).toHaveLength(1);
+		expect(service.getDeviceMappings()[0]).toMatchObject({
+			name: 'sensor-device',
+			deviceCategory: DeviceCategory.SENSOR,
+			priority: 100,
+			exclusive: false,
+			conflict: 'error',
+		});
+	});
+
+	it('matches suffixed capabilities by base ID while preserving both full IDs', () => {
+		writeBuiltin('properties', [propertyDefinition()]);
+		service.loadAllMappings();
+
+		const resolution = service.resolvePropertyMappings(createDevice());
+
+		expect(resolution.conflicts).toEqual([]);
+		expect(resolution.mappings.map((binding) => binding.capabilityBaseId)).toEqual([
+			'measure_temperature',
+			'measure_temperature',
+		]);
+		expect(resolution.mappings.map((binding) => binding.capabilityId)).toEqual([
+			'measure_temperature.inside',
+			'measure_temperature.outside',
+		]);
+	});
+
+	it('replaces a built-in descriptor with a same-name user override', () => {
+		writeBuiltin('devices', [deviceDefinition({ priority: 500 })]);
+		writeUser('devices', [
+			deviceDefinition({
+				priority: 5,
+				device: { category: 'thermostat' },
+			}),
+		]);
+
+		service.loadAllMappings();
+
+		expect(service.getDeviceMappings()).toHaveLength(1);
+		expect(service.getDeviceMappings()[0]).toMatchObject({
+			name: 'sensor-device',
+			source: 'user',
+			priority: 5,
+			deviceCategory: DeviceCategory.THERMOSTAT,
+		});
+	});
+
+	it('orders added user mappings deterministically by priority, source, and name', () => {
+		writeBuiltin('devices', [deviceDefinition({ name: 'zeta', priority: 10 })]);
+		writeUser('devices', [
+			deviceDefinition({ name: 'beta', priority: 10 }),
+			deviceDefinition({ name: 'alpha', priority: 10 }),
+			deviceDefinition({ name: 'highest', priority: 20 }),
+		]);
+
+		service.loadAllMappings();
+
+		expect(service.getDeviceMappings().map((mapping) => mapping.name)).toEqual(['highest', 'alpha', 'beta', 'zeta']);
+	});
+
+	it('isolates an invalid user file and retains valid built-ins', () => {
+		writeBuiltin('devices', [deviceDefinition()]);
+		writeConfig(join(userDataPath, HOMEY_USER_MAPPING_FILE_NAMES.devices), {
+			version: 1,
+			kind: 'devices',
+			mappings: [{ ...deviceDefinition(), unexpected: true }],
+		});
+
+		service.loadAllMappings();
+
+		expect(service.getDeviceMappings()).toHaveLength(1);
+		expect(service.getDeviceMappings()[0]?.source).toBe('builtin');
+		expect(service.getLoadResults()).toEqual(
+			expect.arrayContaining([expect.objectContaining({ source: 'user', kind: 'devices', success: false })]),
+		);
+	});
+
+	it('fails plugin initialization for an invalid built-in file', () => {
+		writeBuiltin('devices', [{ ...deviceDefinition(), unexpected: true }]);
+
+		expect(() => service.onModuleInit()).toThrow(HomeyMappingConfigurationError);
+	});
+
+	it('fails plugin initialization when a required built-in file is missing', () => {
+		unlinkSync(join(builtinMappingsPath, HOMEY_MAPPING_FILE_NAMES.channels));
+
+		try {
+			service.onModuleInit();
+			throw new Error('Expected the missing built-in file to fail');
+		} catch (error) {
+			expect(error).toBeInstanceOf(HomeyMappingConfigurationError);
+			expect((error as HomeyMappingConfigurationError).issues).toEqual(['Mapping file does not exist']);
+		}
+	});
+
+	it('rejects a mapping symlink that escapes the allowed directory', () => {
+		const externalPath = join(rootPath, 'external.yaml');
+		const linkPath = join(userDataPath, HOMEY_USER_MAPPING_FILE_NAMES.devices);
+		writeConfig(externalPath, { version: 1, kind: 'devices', mappings: [deviceDefinition()] });
+		symlinkSync(externalPath, linkPath);
+
+		const result = service.loadMappingFile(linkPath, 'user', 'devices', userDataPath);
+
+		expect(result).toMatchObject({ success: false, errors: ['Mapping path is outside its allowed directory'] });
+	});
+
+	it('rejects duplicate names within one file', () => {
+		writeBuiltin('devices', [deviceDefinition(), deviceDefinition()]);
+
+		try {
+			service.loadAllMappings();
+			throw new Error('Expected duplicate mapping names to fail');
+		} catch (error) {
+			expect(error).toBeInstanceOf(HomeyMappingConfigurationError);
+			expect((error as HomeyMappingConfigurationError).issues).toContain("Duplicate mapping name 'sensor-device'");
+		}
+	});
+
+	it('reports an error conflict instead of choosing an ambiguous mapping', () => {
+		writeBuiltin('channels', [
+			channelDefinition({ name: 'beta', conflict: 'error' }),
+			channelDefinition({ name: 'alpha', conflict: 'warn' }),
+		]);
+		service.loadAllMappings();
+
+		const resolution = service.resolveChannelMappings(createDevice());
+
+		expect(resolution.mappings).toEqual([]);
+		expect(resolution.conflicts).toEqual([
+			{
+				kind: 'channels',
+				key: 'temperature',
+				policy: 'error',
+				mappings: ['alpha', 'beta'],
+			},
+		]);
+	});
+
+	it('selects a deterministic winner while retaining a warning conflict', () => {
+		writeBuiltin('channels', [
+			channelDefinition({ name: 'beta', conflict: 'warn' }),
+			channelDefinition({ name: 'alpha', conflict: 'warn' }),
+		]);
+		service.loadAllMappings();
+
+		const resolution = service.resolveChannelMappings(createDevice());
+
+		expect(resolution.mappings.map((mapping) => mapping.name)).toEqual(['alpha']);
+		expect(resolution.conflicts[0]).toMatchObject({ policy: 'warn', mappings: ['alpha', 'beta'] });
+	});
+
+	it('lets the highest-priority exclusive mapping suppress other channel targets', () => {
+		writeBuiltin('channels', [
+			channelDefinition({ name: 'exclusive', exclusive: true, priority: 200 }),
+			channelDefinition({
+				name: 'secondary',
+				priority: 100,
+				channel: { identifier: 'secondary', category: 'generic' },
+			}),
+		]);
+		service.loadAllMappings();
+
+		const resolution = service.resolveChannelMappings(createDevice());
+
+		expect(resolution.mappings.map((mapping) => mapping.name)).toEqual(['exclusive']);
+	});
+
+	it('applies optional driver and manufacturer narrowing only when declared', () => {
+		writeBuiltin('devices', [
+			deviceDefinition({
+				match: {
+					classes: ['sensor'],
+					all_capabilities: ['measure_temperature'],
+					driver_ids: ['homey:app:test:driver:synthetic'],
+					manufacturers: ['Synthetic vendor'],
+				},
+			}),
+		]);
+		service.loadAllMappings();
+
+		expect(service.resolveDeviceMappings(createDevice()).mappings).toHaveLength(1);
+		expect(service.resolveDeviceMappings(createDevice({ manufacturer: 'Different vendor' })).mappings).toHaveLength(0);
+	});
+
+	it('isolates semantically invalid ranges and transforms in user overrides', () => {
+		writeBuiltin('properties', [propertyDefinition()]);
+		writeUser('properties', [
+			propertyDefinition({
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'float',
+					direction: 'read_only',
+					range: { minimum: 100, maximum: -50 },
+					transform: { type: 'scale', input_range: [1, 1], output_range: [0, 100] },
+				},
+			}),
+		]);
+
+		service.loadAllMappings();
+
+		expect(service.getPropertyMappings()).toHaveLength(1);
+		expect(service.getPropertyMappings()[0]?.source).toBe('builtin');
+		expect(service.getLoadResults().at(-1)).toMatchObject({ source: 'user', success: false });
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
@@ -352,4 +352,78 @@ describe('HomeyMappingLoaderService', () => {
 		expect(service.getPropertyMappings()[0]?.source).toBe('builtin');
 		expect(service.getLoadResults().at(-1)).toMatchObject({ source: 'user', success: false });
 	});
+
+	it.each(['bidirectional', 'write_only'] as const)(
+		'rejects a %s map transform without an explicit write table',
+		(direction) => {
+			writeBuiltin('properties', [
+				propertyDefinition({
+					property: {
+						channel: 'temperature',
+						category: 'temperature',
+						data_type: 'float',
+						direction,
+						transform: { type: 'map', read: { cold: 0, warm: 1 } },
+					},
+				}),
+			]);
+
+			try {
+				service.loadAllMappings();
+				throw new Error('Expected writable map validation to fail');
+			} catch (error) {
+				expect(error).toBeInstanceOf(HomeyMappingConfigurationError);
+				expect((error as HomeyMappingConfigurationError).issues).toContain(
+					`Mapping 'measured-temperature' is invalid: map transform requires a write table for ${direction} direction`,
+				);
+			}
+		},
+	);
+
+	it('accepts direction-complete map transforms', () => {
+		writeBuiltin('properties', [
+			propertyDefinition({
+				name: 'read-map',
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'enum',
+					direction: 'read_only',
+					transform: { type: 'map', read: { cold: 0, warm: 1 } },
+				},
+			}),
+			propertyDefinition({
+				name: 'write-map',
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'enum',
+					direction: 'write_only',
+					transform: { type: 'map', write: { '0': 'cold', '1': 'warm' } },
+				},
+			}),
+			propertyDefinition({
+				name: 'bidirectional-map',
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'enum',
+					direction: 'bidirectional',
+					transform: {
+						type: 'map',
+						read: { cold: 0, warm: 1 },
+						write: { '0': 'cold', '1': 'warm' },
+					},
+				},
+			}),
+		]);
+
+		service.loadAllMappings();
+
+		expect(service.getPropertyMappings().map((mapping) => mapping.name)).toEqual([
+			'bidirectional-map',
+			'read-map',
+			'write-map',
+		]);
+	});
 });

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
@@ -1,0 +1,545 @@
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
+import { isAbsolute, join, relative, resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+import { Inject, Injectable, OnModuleInit, Optional } from '@nestjs/common';
+
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+import {
+	ChannelCategory,
+	DataTypeType,
+	DeviceCategory,
+	PropertyCategory,
+} from '../../../modules/devices/devices.constants';
+import { DEVICES_HOMEY_PLUGIN_NAME } from '../devices-homey.constants';
+import { HomeyCapability } from '../models/homey-capability.model';
+import { HomeyDevice } from '../models/homey-device.model';
+
+import { HomeyMappingConfigurationError } from './homey-mapping.error';
+import {
+	HOMEY_MAPPING_FILE_NAMES,
+	HOMEY_MAPPING_LOADER_OPTIONS,
+	HOMEY_USER_MAPPING_FILE_NAMES,
+} from './mapping.constants';
+import {
+	HomeyChannelMappingDefinition,
+	HomeyDeviceMappingDefinition,
+	HomeyMappingConfig,
+	HomeyMappingConflict,
+	HomeyMappingConflictPolicy,
+	HomeyMappingDefinition,
+	HomeyMappingKind,
+	HomeyMappingLoadResult,
+	HomeyMappingLoaderOptions,
+	HomeyMappingResolution,
+	HomeyMappingSource,
+	HomeyPropertyMappingDefinition,
+	ResolvedHomeyChannelMapping,
+	ResolvedHomeyDeviceMapping,
+	ResolvedHomeyMapping,
+	ResolvedHomeyMappingBase,
+	ResolvedHomeyPropertyBinding,
+	ResolvedHomeyPropertyMapping,
+} from './mapping.types';
+
+const MAX_MAPPING_FILE_BYTES = 1024 * 1024;
+
+const KIND_ORDER: readonly HomeyMappingKind[] = ['devices', 'channels', 'properties'];
+
+const CONFLICT_SEVERITY: Record<HomeyMappingConflictPolicy, number> = {
+	first: 0,
+	warn: 1,
+	error: 2,
+};
+
+@Injectable()
+export class HomeyMappingLoaderService implements OnModuleInit {
+	private readonly logger: ExtensionLoggerService = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'MappingLoader');
+
+	private readonly builtinMappingsPath: string;
+	private readonly userDataPath: string;
+	private readonly validateSchema: ValidateFunction;
+
+	private deviceMappings: ResolvedHomeyDeviceMapping[] = [];
+	private channelMappings: ResolvedHomeyChannelMapping[] = [];
+	private propertyMappings: ResolvedHomeyPropertyMapping[] = [];
+	private loadResults: HomeyMappingLoadResult[] = [];
+
+	constructor(
+		@Optional()
+		@Inject(HOMEY_MAPPING_LOADER_OPTIONS)
+		options: HomeyMappingLoaderOptions = {},
+	) {
+		this.builtinMappingsPath = options.builtinMappingsPath ?? join(__dirname, 'definitions');
+		this.userDataPath = options.userDataPath ?? join(__dirname, '../../../../../../var/data');
+
+		const schemaPath = options.schemaPath ?? join(__dirname, 'schema', 'mapping-schema.json');
+		const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as Record<string, unknown>;
+		this.validateSchema = new Ajv({ allErrors: true, strict: false }).compile(schema);
+	}
+
+	onModuleInit(): void {
+		this.loadAllMappings();
+	}
+
+	loadAllMappings(): void {
+		const nextMappings = new Map<HomeyMappingKind, ResolvedHomeyMapping[]>();
+		const nextResults: HomeyMappingLoadResult[] = [];
+
+		for (const kind of KIND_ORDER) {
+			const builtinPath = join(this.builtinMappingsPath, HOMEY_MAPPING_FILE_NAMES[kind]);
+			const builtinResult = this.loadMappingFile(builtinPath, 'builtin', kind, this.builtinMappingsPath);
+			nextResults.push(builtinResult);
+
+			if (!builtinResult.success) {
+				throw new HomeyMappingConfigurationError(builtinPath, builtinResult.errors ?? ['Unknown mapping error']);
+			}
+
+			let mappings = [...(builtinResult.mappings ?? [])];
+			const userPath = join(this.userDataPath, HOMEY_USER_MAPPING_FILE_NAMES[kind]);
+
+			if (existsSync(userPath)) {
+				const userResult = this.loadMappingFile(userPath, 'user', kind, this.userDataPath);
+				nextResults.push(userResult);
+
+				if (userResult.success) {
+					mappings = this.applyUserOverrides(mappings, userResult.mappings ?? []);
+				} else {
+					this.logger.error('Ignored invalid Homey user mapping file', {
+						source: userPath,
+						errors: userResult.errors,
+					});
+				}
+			}
+
+			nextMappings.set(
+				kind,
+				mappings.sort((left, right) => this.compareMappings(left, right)),
+			);
+		}
+
+		this.deviceMappings = nextMappings.get('devices') as ResolvedHomeyDeviceMapping[];
+		this.channelMappings = nextMappings.get('channels') as ResolvedHomeyChannelMapping[];
+		this.propertyMappings = nextMappings.get('properties') as ResolvedHomeyPropertyMapping[];
+		this.loadResults = nextResults;
+
+		this.logger.log(
+			`Loaded ${this.deviceMappings.length} device, ${this.channelMappings.length} channel, and ` +
+				`${this.propertyMappings.length} property Homey mappings`,
+		);
+	}
+
+	loadMappingFile(
+		filePath: string,
+		source: HomeyMappingSource,
+		expectedKind: HomeyMappingKind,
+		allowedBasePath: string,
+	): HomeyMappingLoadResult {
+		if (!existsSync(filePath)) {
+			return this.failedResult(source, expectedKind, filePath, ['Mapping file does not exist']);
+		}
+
+		if (!this.isPathInside(allowedBasePath, filePath)) {
+			return this.failedResult(source, expectedKind, filePath, ['Mapping path is outside its allowed directory']);
+		}
+
+		try {
+			if (statSync(filePath).size > MAX_MAPPING_FILE_BYTES) {
+				return this.failedResult(source, expectedKind, filePath, ['Mapping file exceeds the 1 MiB limit']);
+			}
+
+			const parsed = parseYaml(readFileSync(filePath, 'utf8'), { maxAliasCount: 0 }) as unknown;
+
+			if (!this.validateSchema(parsed)) {
+				return this.failedResult(source, expectedKind, filePath, this.formatSchemaErrors(this.validateSchema.errors));
+			}
+
+			const config = parsed as HomeyMappingConfig;
+
+			if (config.kind !== expectedKind) {
+				return this.failedResult(source, expectedKind, filePath, [
+					`Expected mapping kind '${expectedKind}' but received '${config.kind}'`,
+				]);
+			}
+
+			const duplicateNames = this.findDuplicateNames(config.mappings);
+			if (duplicateNames.length > 0) {
+				return this.failedResult(
+					source,
+					expectedKind,
+					filePath,
+					duplicateNames.map((name) => `Duplicate mapping name '${name}'`),
+				);
+			}
+
+			const mappings: ResolvedHomeyMapping[] = [];
+			const errors: string[] = [];
+
+			for (const definition of config.mappings) {
+				try {
+					mappings.push(this.resolveMapping(expectedKind, source, definition));
+				} catch (error) {
+					errors.push(
+						`Mapping '${definition.name}' is invalid: ${error instanceof Error ? error.message : 'Unknown error'}`,
+					);
+				}
+			}
+
+			if (errors.length > 0) {
+				return this.failedResult(source, expectedKind, filePath, errors);
+			}
+
+			return {
+				source,
+				kind: expectedKind,
+				path: filePath,
+				success: true,
+				mappings,
+			};
+		} catch {
+			return this.failedResult(source, expectedKind, filePath, ['Unable to read or parse mapping YAML']);
+		}
+	}
+
+	getDeviceMappings(): readonly ResolvedHomeyDeviceMapping[] {
+		return [...this.deviceMappings];
+	}
+
+	getChannelMappings(): readonly ResolvedHomeyChannelMapping[] {
+		return [...this.channelMappings];
+	}
+
+	getPropertyMappings(): readonly ResolvedHomeyPropertyMapping[] {
+		return [...this.propertyMappings];
+	}
+
+	getLoadResults(): readonly HomeyMappingLoadResult[] {
+		return [...this.loadResults];
+	}
+
+	resolveDeviceMappings(device: HomeyDevice): HomeyMappingResolution<ResolvedHomeyDeviceMapping> {
+		return this.resolveCandidateGroups(
+			'devices',
+			this.deviceMappings.filter((mapping) => this.matchesDevice(mapping.match, device)),
+			() => 'device',
+		);
+	}
+
+	resolveChannelMappings(device: HomeyDevice): HomeyMappingResolution<ResolvedHomeyChannelMapping> {
+		return this.resolveCandidateGroups(
+			'channels',
+			this.channelMappings.filter((mapping) => this.matchesDevice(mapping.match, device)),
+			(mapping) => mapping.channel.identifier,
+		);
+	}
+
+	resolvePropertyMappings(device: HomeyDevice): HomeyMappingResolution<ResolvedHomeyPropertyBinding> {
+		const bindings: ResolvedHomeyPropertyBinding[] = [];
+		const conflicts: HomeyMappingConflict[] = [];
+
+		for (const capability of device.capabilities) {
+			const candidates = this.propertyMappings.filter(
+				(mapping) =>
+					this.matchesPropertyDevice(mapping, device) && mapping.match.capabilityBaseIds.includes(capability.baseId),
+			);
+			const resolution = this.resolveCandidateGroups(
+				'properties',
+				candidates,
+				(mapping) => `${capability.id}:${mapping.property.channel}:${mapping.property.category}`,
+			);
+
+			bindings.push(...resolution.mappings.map((mapping) => this.bindPropertyMapping(capability, mapping)));
+			conflicts.push(...resolution.conflicts);
+		}
+
+		return { mappings: bindings, conflicts };
+	}
+
+	private applyUserOverrides(
+		builtins: readonly ResolvedHomeyMapping[],
+		users: readonly ResolvedHomeyMapping[],
+	): ResolvedHomeyMapping[] {
+		const merged = new Map(builtins.map((mapping) => [mapping.name, mapping]));
+
+		for (const mapping of users) {
+			merged.set(mapping.name, mapping);
+		}
+
+		return [...merged.values()];
+	}
+
+	private resolveMapping(
+		kind: HomeyMappingKind,
+		source: HomeyMappingSource,
+		definition: HomeyMappingDefinition,
+	): ResolvedHomeyMapping {
+		const base: ResolvedHomeyMappingBase = {
+			kind,
+			source,
+			name: definition.name,
+			description: definition.description,
+			priority: definition.priority ?? 0,
+			exclusive: definition.exclusive ?? false,
+			conflict: definition.conflict ?? 'error',
+		};
+
+		if (kind === 'devices') {
+			const deviceDefinition = definition as HomeyDeviceMappingDefinition;
+			return {
+				...base,
+				kind,
+				match: this.resolveDeviceMatch(deviceDefinition.match),
+				deviceCategory: this.resolveEnum(DeviceCategory, deviceDefinition.device.category, 'device category'),
+			};
+		}
+
+		if (kind === 'channels') {
+			const channelDefinition = definition as HomeyChannelMappingDefinition;
+			return {
+				...base,
+				kind,
+				match: this.resolveDeviceMatch(channelDefinition.match),
+				channel: {
+					identifier: channelDefinition.channel.identifier,
+					category: this.resolveEnum(ChannelCategory, channelDefinition.channel.category, 'channel category'),
+					name: channelDefinition.channel.name,
+				},
+			};
+		}
+
+		const propertyDefinition = definition as HomeyPropertyMappingDefinition;
+		this.validatePropertyDefinition(propertyDefinition);
+
+		return {
+			...base,
+			kind,
+			match: {
+				classes: [...propertyDefinition.match.classes],
+				capabilityBaseIds: [...propertyDefinition.match.capability_base_ids],
+				driverIds: [...(propertyDefinition.match.driver_ids ?? [])],
+				manufacturers: [...(propertyDefinition.match.manufacturers ?? [])],
+				models: [...(propertyDefinition.match.models ?? [])],
+			},
+			property: {
+				channel: propertyDefinition.property.channel,
+				category: this.resolveEnum(PropertyCategory, propertyDefinition.property.category, 'property category'),
+				dataType: this.resolveEnum(DataTypeType, propertyDefinition.property.data_type, 'data type'),
+				direction: propertyDefinition.property.direction,
+				unit: propertyDefinition.property.unit,
+				range: propertyDefinition.property.range ? { ...propertyDefinition.property.range } : undefined,
+				transform: propertyDefinition.property.transform
+					? structuredClone(propertyDefinition.property.transform)
+					: undefined,
+			},
+		};
+	}
+
+	private resolveDeviceMatch(match: HomeyDeviceMappingDefinition['match']) {
+		return {
+			classes: [...match.classes],
+			allCapabilities: [...(match.all_capabilities ?? [])],
+			anyCapabilities: [...(match.any_capabilities ?? [])],
+			driverIds: [...(match.driver_ids ?? [])],
+			manufacturers: [...(match.manufacturers ?? [])],
+			models: [...(match.models ?? [])],
+		};
+	}
+
+	private validatePropertyDefinition(definition: HomeyPropertyMappingDefinition): void {
+		const { range, transform } = definition.property;
+
+		if (range?.minimum !== undefined && range.maximum !== undefined && range.minimum > range.maximum) {
+			throw new Error('range minimum must not exceed maximum');
+		}
+
+		if (transform?.type === 'scale') {
+			if (transform.input_range[0] === transform.input_range[1]) {
+				throw new Error('scale input range must have distinct endpoints');
+			}
+			if (transform.output_range[0] === transform.output_range[1]) {
+				throw new Error('scale output range must have distinct endpoints');
+			}
+		}
+
+		if (transform?.type === 'clamp' && transform.minimum > transform.maximum) {
+			throw new Error('clamp minimum must not exceed maximum');
+		}
+	}
+
+	private resolveEnum<TEnum extends Record<string, string>>(
+		enumType: TEnum,
+		value: string,
+		label: string,
+	): TEnum[keyof TEnum] {
+		const values = Object.values(enumType);
+		if (!values.includes(value)) {
+			throw new Error(`Unknown ${label} '${value}'`);
+		}
+		return value as TEnum[keyof TEnum];
+	}
+
+	private matchesDevice(match: ResolvedHomeyDeviceMapping['match'], device: HomeyDevice): boolean {
+		if (!match.classes.includes(device.class) || !this.matchesNarrowingFilters(match, device)) {
+			return false;
+		}
+
+		const capabilityBaseIds = new Set(device.capabilities.map((capability) => capability.baseId));
+		if (!match.allCapabilities.every((baseId) => capabilityBaseIds.has(baseId))) {
+			return false;
+		}
+
+		return match.anyCapabilities.length === 0 || match.anyCapabilities.some((baseId) => capabilityBaseIds.has(baseId));
+	}
+
+	private matchesPropertyDevice(mapping: ResolvedHomeyPropertyMapping, device: HomeyDevice): boolean {
+		return mapping.match.classes.includes(device.class) && this.matchesNarrowingFilters(mapping.match, device);
+	}
+
+	private matchesNarrowingFilters(
+		match: {
+			readonly driverIds: readonly string[];
+			readonly manufacturers: readonly string[];
+			readonly models: readonly string[];
+		},
+		device: HomeyDevice,
+	): boolean {
+		return (
+			this.matchesOptionalValue(match.driverIds, device.driverId) &&
+			this.matchesOptionalValue(match.manufacturers, device.manufacturer) &&
+			this.matchesOptionalValue(match.models, device.model)
+		);
+	}
+
+	private matchesOptionalValue(allowed: readonly string[], actual: string | null): boolean {
+		return allowed.length === 0 || (actual !== null && allowed.includes(actual));
+	}
+
+	private resolveCandidateGroups<TMapping extends ResolvedHomeyMapping>(
+		kind: HomeyMappingKind,
+		candidates: readonly TMapping[],
+		groupKey: (mapping: TMapping) => string,
+	): HomeyMappingResolution<TMapping> {
+		const sorted = [...candidates].sort((left, right) => this.compareMappings(left, right));
+		if (sorted.length === 0) {
+			return { mappings: [], conflicts: [] };
+		}
+
+		const highestPriority = sorted[0].priority;
+		const exclusive = sorted.filter((mapping) => mapping.priority === highestPriority && mapping.exclusive);
+		if (exclusive.length > 0) {
+			return this.resolveGroup(kind, 'exclusive', exclusive);
+		}
+
+		const groups = new Map<string, TMapping[]>();
+		for (const mapping of sorted) {
+			const key = groupKey(mapping);
+			const group = groups.get(key) ?? [];
+			group.push(mapping);
+			groups.set(key, group);
+		}
+
+		const mappings: TMapping[] = [];
+		const conflicts: HomeyMappingConflict[] = [];
+		for (const key of [...groups.keys()].sort()) {
+			const resolution = this.resolveGroup(kind, key, groups.get(key) ?? []);
+			mappings.push(...resolution.mappings);
+			conflicts.push(...resolution.conflicts);
+		}
+
+		return { mappings, conflicts };
+	}
+
+	private resolveGroup<TMapping extends ResolvedHomeyMapping>(
+		kind: HomeyMappingKind,
+		key: string,
+		candidates: readonly TMapping[],
+	): HomeyMappingResolution<TMapping> {
+		const sorted = [...candidates].sort((left, right) => this.compareMappings(left, right));
+		const topPriority = sorted[0]?.priority;
+		const top = sorted.filter((mapping) => mapping.priority === topPriority);
+
+		if (top.length <= 1) {
+			return { mappings: top, conflicts: [] };
+		}
+
+		const policy = top.reduce<HomeyMappingConflictPolicy>(
+			(current, mapping) =>
+				CONFLICT_SEVERITY[mapping.conflict] > CONFLICT_SEVERITY[current] ? mapping.conflict : current,
+			'first',
+		);
+		const conflict: HomeyMappingConflict = {
+			kind,
+			key,
+			policy,
+			mappings: top.map((mapping) => mapping.name),
+		};
+
+		return {
+			mappings: policy === 'error' ? [] : [top[0]],
+			conflicts: [conflict],
+		};
+	}
+
+	private bindPropertyMapping(
+		capability: HomeyCapability,
+		mapping: ResolvedHomeyPropertyMapping,
+	): ResolvedHomeyPropertyBinding {
+		return {
+			capabilityId: capability.id,
+			capabilityBaseId: capability.baseId,
+			mapping,
+		};
+	}
+
+	private compareMappings(left: ResolvedHomeyMapping, right: ResolvedHomeyMapping): number {
+		if (left.priority !== right.priority) {
+			return right.priority - left.priority;
+		}
+		if (left.source !== right.source) {
+			return left.source === 'user' ? -1 : 1;
+		}
+		return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+	}
+
+	private findDuplicateNames(definitions: readonly HomeyMappingDefinition[]): string[] {
+		const seen = new Set<string>();
+		const duplicates = new Set<string>();
+
+		for (const definition of definitions) {
+			if (seen.has(definition.name)) {
+				duplicates.add(definition.name);
+			}
+			seen.add(definition.name);
+		}
+
+		return [...duplicates].sort();
+	}
+
+	private formatSchemaErrors(errors: ErrorObject[] | null | undefined): string[] {
+		const formatted = new Set(
+			(errors ?? []).map((error) => `${error.instancePath || '/'} ${error.message ?? 'is invalid'}`),
+		);
+		return formatted.size > 0 ? [...formatted] : ['Mapping schema validation failed'];
+	}
+
+	private failedResult(
+		source: HomeyMappingSource,
+		kind: HomeyMappingKind,
+		path: string,
+		errors: readonly string[],
+	): HomeyMappingLoadResult {
+		return { source, kind, path, success: false, errors };
+	}
+
+	private isPathInside(basePath: string, filePath: string): boolean {
+		try {
+			const base = realpathSync(resolve(basePath));
+			const file = realpathSync(resolve(filePath));
+			const pathFromBase = relative(base, file);
+			return pathFromBase !== '' && !pathFromBase.startsWith('..') && !isAbsolute(pathFromBase);
+		} catch {
+			return false;
+		}
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
@@ -347,7 +347,7 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 	}
 
 	private validatePropertyDefinition(definition: HomeyPropertyMappingDefinition): void {
-		const { range, transform } = definition.property;
+		const { direction, range, transform } = definition.property;
 
 		if (range?.minimum !== undefined && range.maximum !== undefined && range.minimum > range.maximum) {
 			throw new Error('range minimum must not exceed maximum');
@@ -364,6 +364,16 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 
 		if (transform?.type === 'clamp' && transform.minimum > transform.maximum) {
 			throw new Error('clamp minimum must not exceed maximum');
+		}
+
+		if (transform?.type === 'map') {
+			if (direction !== 'write_only' && transform.read === undefined) {
+				throw new Error(`map transform requires a read table for ${direction} direction`);
+			}
+
+			if (direction !== 'read_only' && transform.write === undefined) {
+				throw new Error(`map transform requires a write table for ${direction} direction`);
+			}
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping.constants.ts
@@ -1,0 +1,15 @@
+export const HOMEY_MAPPING_SCHEMA_VERSION = 1;
+
+export const HOMEY_MAPPING_LOADER_OPTIONS = Symbol('HOMEY_MAPPING_LOADER_OPTIONS');
+
+export const HOMEY_MAPPING_FILE_NAMES = {
+	devices: 'devices.yaml',
+	channels: 'channels.yaml',
+	properties: 'properties.yaml',
+} as const;
+
+export const HOMEY_USER_MAPPING_FILE_NAMES = {
+	devices: 'plugin.devices-homey.devices.yaml',
+	channels: 'plugin.devices-homey.channels.yaml',
+	properties: 'plugin.devices-homey.properties.yaml',
+} as const;

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
@@ -1,0 +1,226 @@
+import {
+	ChannelCategory,
+	DataTypeType,
+	DeviceCategory,
+	PropertyCategory,
+} from '../../../modules/devices/devices.constants';
+
+export type HomeyMappingKind = 'devices' | 'channels' | 'properties';
+
+export type HomeyMappingSource = 'builtin' | 'user';
+
+export type HomeyMappingDirection = 'read_only' | 'write_only' | 'bidirectional';
+
+export type HomeyMappingConflictPolicy = 'first' | 'warn' | 'error';
+
+export type HomeyMappingScalar = boolean | number | string | null;
+
+export interface HomeyMappingLoaderOptions {
+	readonly builtinMappingsPath?: string;
+	readonly userDataPath?: string;
+	readonly schemaPath?: string;
+}
+
+export interface HomeyDeviceMatchDefinition {
+	classes: string[];
+	all_capabilities?: string[];
+	any_capabilities?: string[];
+	driver_ids?: string[];
+	manufacturers?: string[];
+	models?: string[];
+}
+
+export interface HomeyPropertyMatchDefinition {
+	classes: string[];
+	capability_base_ids: string[];
+	driver_ids?: string[];
+	manufacturers?: string[];
+	models?: string[];
+}
+
+export interface HomeyMappingDefinitionBase {
+	name: string;
+	description?: string;
+	priority?: number;
+	exclusive?: boolean;
+	conflict?: HomeyMappingConflictPolicy;
+}
+
+export interface HomeyDeviceMappingDefinition extends HomeyMappingDefinitionBase {
+	match: HomeyDeviceMatchDefinition;
+	device: {
+		category: string;
+	};
+}
+
+export interface HomeyChannelMappingDefinition extends HomeyMappingDefinitionBase {
+	match: HomeyDeviceMatchDefinition;
+	channel: {
+		identifier: string;
+		category: string;
+		name?: string;
+	};
+}
+
+export interface HomeyValueRangeDefinition {
+	minimum?: number;
+	maximum?: number;
+	step?: number;
+}
+
+export interface HomeyScaleTransformDefinition {
+	type: 'scale';
+	input_range: [number, number];
+	output_range: [number, number];
+	clamp?: boolean;
+}
+
+export interface HomeyMapTransformDefinition {
+	type: 'map';
+	read: Record<string, HomeyMappingScalar>;
+	write?: Record<string, HomeyMappingScalar>;
+}
+
+export interface HomeyBooleanTransformDefinition {
+	type: 'boolean';
+	true_value: HomeyMappingScalar;
+	false_value: HomeyMappingScalar;
+	invert?: boolean;
+}
+
+export interface HomeyClampTransformDefinition {
+	type: 'clamp';
+	minimum: number;
+	maximum: number;
+}
+
+export interface HomeyRoundTransformDefinition {
+	type: 'round';
+	precision?: number;
+}
+
+export type HomeyTransformDefinition =
+	| HomeyScaleTransformDefinition
+	| HomeyMapTransformDefinition
+	| HomeyBooleanTransformDefinition
+	| HomeyClampTransformDefinition
+	| HomeyRoundTransformDefinition;
+
+export interface HomeyPropertyMappingDefinition extends HomeyMappingDefinitionBase {
+	match: HomeyPropertyMatchDefinition;
+	property: {
+		channel: string;
+		category: string;
+		data_type: string;
+		direction: HomeyMappingDirection;
+		unit?: string;
+		range?: HomeyValueRangeDefinition;
+		transform?: HomeyTransformDefinition;
+	};
+}
+
+export type HomeyMappingDefinition =
+	| HomeyDeviceMappingDefinition
+	| HomeyChannelMappingDefinition
+	| HomeyPropertyMappingDefinition;
+
+export interface HomeyMappingConfig<TDefinition extends HomeyMappingDefinition = HomeyMappingDefinition> {
+	version: number;
+	kind: HomeyMappingKind;
+	mappings: TDefinition[];
+}
+
+export interface ResolvedHomeyDeviceMatch {
+	classes: readonly string[];
+	allCapabilities: readonly string[];
+	anyCapabilities: readonly string[];
+	driverIds: readonly string[];
+	manufacturers: readonly string[];
+	models: readonly string[];
+}
+
+export interface ResolvedHomeyPropertyMatch {
+	classes: readonly string[];
+	capabilityBaseIds: readonly string[];
+	driverIds: readonly string[];
+	manufacturers: readonly string[];
+	models: readonly string[];
+}
+
+export interface ResolvedHomeyMappingBase {
+	readonly kind: HomeyMappingKind;
+	readonly source: HomeyMappingSource;
+	readonly name: string;
+	readonly description?: string;
+	readonly priority: number;
+	readonly exclusive: boolean;
+	readonly conflict: HomeyMappingConflictPolicy;
+}
+
+export interface ResolvedHomeyDeviceMapping extends ResolvedHomeyMappingBase {
+	readonly kind: 'devices';
+	readonly match: ResolvedHomeyDeviceMatch;
+	readonly deviceCategory: DeviceCategory;
+}
+
+export interface ResolvedHomeyChannelMapping extends ResolvedHomeyMappingBase {
+	readonly kind: 'channels';
+	readonly match: ResolvedHomeyDeviceMatch;
+	readonly channel: {
+		readonly identifier: string;
+		readonly category: ChannelCategory;
+		readonly name?: string;
+	};
+}
+
+export interface ResolvedHomeyPropertyMapping extends ResolvedHomeyMappingBase {
+	readonly kind: 'properties';
+	readonly match: ResolvedHomeyPropertyMatch;
+	readonly property: {
+		readonly channel: string;
+		readonly category: PropertyCategory;
+		readonly dataType: DataTypeType;
+		readonly direction: HomeyMappingDirection;
+		readonly unit?: string;
+		readonly range?: HomeyValueRangeDefinition;
+		readonly transform?: HomeyTransformDefinition;
+	};
+}
+
+export type ResolvedHomeyMapping =
+	| ResolvedHomeyDeviceMapping
+	| ResolvedHomeyChannelMapping
+	| ResolvedHomeyPropertyMapping;
+
+export interface ResolvedHomeyPropertyBinding {
+	readonly capabilityId: string;
+	readonly capabilityBaseId: string;
+	readonly mapping: ResolvedHomeyPropertyMapping;
+}
+
+export interface HomeyMappingLoadResult {
+	readonly source: HomeyMappingSource;
+	readonly kind: HomeyMappingKind;
+	readonly path: string;
+	readonly success: boolean;
+	readonly errors?: readonly string[];
+	readonly mappings?: readonly ResolvedHomeyMapping[];
+}
+
+export interface HomeyMappingConflict {
+	readonly kind: HomeyMappingKind;
+	readonly key: string;
+	readonly policy: HomeyMappingConflictPolicy;
+	readonly mappings: readonly string[];
+}
+
+export interface HomeyMappingResolution<TMapping> {
+	readonly mappings: readonly TMapping[];
+	readonly conflicts: readonly HomeyMappingConflict[];
+}
+
+export interface HomeyPropertyMappingBinding {
+	readonly homeyDeviceId: string;
+	readonly capabilityId: string;
+	readonly mapping: ResolvedHomeyPropertyMapping;
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
@@ -77,7 +77,7 @@ export interface HomeyScaleTransformDefinition {
 
 export interface HomeyMapTransformDefinition {
 	type: 'map';
-	read: Record<string, HomeyMappingScalar>;
+	read?: Record<string, HomeyMappingScalar>;
 	write?: Record<string, HomeyMappingScalar>;
 }
 

--- a/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.spec.ts
@@ -1,0 +1,62 @@
+import { DataTypeType, PropertyCategory } from '../../../modules/devices/devices.constants';
+
+import { HomeyPropertyMappingBinding, ResolvedHomeyPropertyMapping } from './mapping.types';
+import { HomeyPropertyMappingStorageService } from './property-mapping-storage.service';
+
+const mapping: ResolvedHomeyPropertyMapping = {
+	kind: 'properties',
+	source: 'builtin',
+	name: 'measured-temperature',
+	priority: 100,
+	exclusive: false,
+	conflict: 'error',
+	match: {
+		classes: ['sensor'],
+		capabilityBaseIds: ['measure_temperature'],
+		driverIds: [],
+		manufacturers: [],
+		models: [],
+	},
+	property: {
+		channel: 'temperature',
+		category: PropertyCategory.TEMPERATURE,
+		dataType: DataTypeType.FLOAT,
+		direction: 'read_only',
+	},
+};
+
+const binding = (capabilityId: string): HomeyPropertyMappingBinding => ({
+	homeyDeviceId: 'device-1',
+	capabilityId,
+	mapping,
+});
+
+describe('HomeyPropertyMappingStorageService', () => {
+	it('stores, replaces, removes, and clears property bindings', () => {
+		const service = new HomeyPropertyMappingStorageService();
+		service.store('property-1', binding('measure_temperature.inside'));
+		service.store('property-1', binding('measure_temperature.outside'));
+
+		expect(service.size).toBe(1);
+		expect(service.get('property-1')?.capabilityId).toBe('measure_temperature.outside');
+
+		service.remove('property-1');
+		expect(service.get('property-1')).toBeUndefined();
+
+		service.store('property-2', binding('measure_temperature.inside'));
+		service.clear();
+		expect(service.size).toBe(0);
+	});
+
+	it('finds bindings only by exact device and full capability ID', () => {
+		const service = new HomeyPropertyMappingStorageService();
+		service.store('inside', binding('measure_temperature.inside'));
+		service.store('outside', binding('measure_temperature.outside'));
+
+		expect(service.findByCapability('device-1', 'measure_temperature.inside')).toEqual([
+			binding('measure_temperature.inside'),
+		]);
+		expect(service.findByCapability('device-1', 'measure_temperature')).toEqual([]);
+		expect(service.findByCapability('device-2', 'measure_temperature.inside')).toEqual([]);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+import { HomeyPropertyMappingBinding } from './mapping.types';
+
+@Injectable()
+export class HomeyPropertyMappingStorageService {
+	private readonly bindings = new Map<string, HomeyPropertyMappingBinding>();
+
+	store(propertyId: string, binding: HomeyPropertyMappingBinding): void {
+		this.bindings.set(propertyId, binding);
+	}
+
+	get(propertyId: string): HomeyPropertyMappingBinding | undefined {
+		return this.bindings.get(propertyId);
+	}
+
+	remove(propertyId: string): void {
+		this.bindings.delete(propertyId);
+	}
+
+	findByCapability(homeyDeviceId: string, capabilityId: string): readonly HomeyPropertyMappingBinding[] {
+		return [...this.bindings.values()].filter(
+			(binding) => binding.homeyDeviceId === homeyDeviceId && binding.capabilityId === capabilityId,
+		);
+	}
+
+	clear(): void {
+		this.bindings.clear();
+	}
+
+	get size(): number {
+		return this.bindings.size;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
+++ b/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "oneOf": [
+    { "$ref": "#/definitions/deviceFile" },
+    { "$ref": "#/definitions/channelFile" },
+    { "$ref": "#/definitions/propertyFile" }
+  ],
+  "definitions": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "uniqueStrings": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/nonEmptyString" },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/definitions/nonEmptyString" },
+        "description": { "$ref": "#/definitions/nonEmptyString" },
+        "priority": { "type": "integer", "minimum": -100000, "maximum": 100000 },
+        "exclusive": { "type": "boolean" },
+        "conflict": { "enum": ["first", "warn", "error"] }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "deviceMatch": {
+      "type": "object",
+      "properties": {
+        "classes": { "$ref": "#/definitions/uniqueStrings" },
+        "all_capabilities": { "$ref": "#/definitions/uniqueStrings" },
+        "any_capabilities": { "$ref": "#/definitions/uniqueStrings" },
+        "driver_ids": { "$ref": "#/definitions/uniqueStrings" },
+        "manufacturers": { "$ref": "#/definitions/uniqueStrings" },
+        "models": { "$ref": "#/definitions/uniqueStrings" }
+      },
+      "required": ["classes"],
+      "anyOf": [{ "required": ["all_capabilities"] }, { "required": ["any_capabilities"] }],
+      "additionalProperties": false
+    },
+    "propertyMatch": {
+      "type": "object",
+      "properties": {
+        "classes": { "$ref": "#/definitions/uniqueStrings" },
+        "capability_base_ids": { "$ref": "#/definitions/uniqueStrings" },
+        "driver_ids": { "$ref": "#/definitions/uniqueStrings" },
+        "manufacturers": { "$ref": "#/definitions/uniqueStrings" },
+        "models": { "$ref": "#/definitions/uniqueStrings" }
+      },
+      "required": ["classes", "capability_base_ids"],
+      "additionalProperties": false
+    },
+    "deviceMapping": {
+      "allOf": [
+        { "$ref": "#/definitions/metadata" },
+        {
+          "type": "object",
+          "properties": {
+            "name": true,
+            "description": true,
+            "priority": true,
+            "exclusive": true,
+            "conflict": true,
+            "match": { "$ref": "#/definitions/deviceMatch" },
+            "device": {
+              "type": "object",
+              "properties": { "category": { "$ref": "#/definitions/nonEmptyString" } },
+              "required": ["category"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["name", "match", "device"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "channelMapping": {
+      "allOf": [
+        { "$ref": "#/definitions/metadata" },
+        {
+          "type": "object",
+          "properties": {
+            "name": true,
+            "description": true,
+            "priority": true,
+            "exclusive": true,
+            "conflict": true,
+            "match": { "$ref": "#/definitions/deviceMatch" },
+            "channel": {
+              "type": "object",
+              "properties": {
+                "identifier": { "$ref": "#/definitions/nonEmptyString" },
+                "category": { "$ref": "#/definitions/nonEmptyString" },
+                "name": { "$ref": "#/definitions/nonEmptyString" }
+              },
+              "required": ["identifier", "category"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["name", "match", "channel"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "range": {
+      "type": "object",
+      "properties": {
+        "minimum": { "type": "number" },
+        "maximum": { "type": "number" },
+        "step": { "type": "number", "exclusiveMinimum": 0 }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "scalar": {
+      "type": ["boolean", "number", "string", "null"]
+    },
+    "numberPair": {
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "transform": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "scale" },
+            "input_range": { "$ref": "#/definitions/numberPair" },
+            "output_range": { "$ref": "#/definitions/numberPair" },
+            "clamp": { "type": "boolean" }
+          },
+          "required": ["type", "input_range", "output_range"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "map" },
+            "read": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/definitions/scalar" },
+              "minProperties": 1
+            },
+            "write": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/definitions/scalar" },
+              "minProperties": 1
+            }
+          },
+          "required": ["type", "read"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "boolean" },
+            "true_value": { "$ref": "#/definitions/scalar" },
+            "false_value": { "$ref": "#/definitions/scalar" },
+            "invert": { "type": "boolean" }
+          },
+          "required": ["type", "true_value", "false_value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "clamp" },
+            "minimum": { "type": "number" },
+            "maximum": { "type": "number" }
+          },
+          "required": ["type", "minimum", "maximum"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "round" },
+            "precision": { "type": "integer", "minimum": 0, "maximum": 12 }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "propertyMapping": {
+      "allOf": [
+        { "$ref": "#/definitions/metadata" },
+        {
+          "type": "object",
+          "properties": {
+            "name": true,
+            "description": true,
+            "priority": true,
+            "exclusive": true,
+            "conflict": true,
+            "match": { "$ref": "#/definitions/propertyMatch" },
+            "property": {
+              "type": "object",
+              "properties": {
+                "channel": { "$ref": "#/definitions/nonEmptyString" },
+                "category": { "$ref": "#/definitions/nonEmptyString" },
+                "data_type": {
+                  "enum": ["char", "uchar", "short", "ushort", "int", "uint", "float", "bool", "string", "enum", "unknown"]
+                },
+                "direction": { "enum": ["read_only", "write_only", "bidirectional"] },
+                "unit": { "$ref": "#/definitions/nonEmptyString" },
+                "range": { "$ref": "#/definitions/range" },
+                "transform": { "$ref": "#/definitions/transform" }
+              },
+              "required": ["channel", "category", "data_type", "direction"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["name", "match", "property"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "deviceFile": {
+      "type": "object",
+      "properties": {
+        "version": { "const": 1 },
+        "kind": { "const": "devices" },
+        "mappings": { "type": "array", "items": { "$ref": "#/definitions/deviceMapping" } }
+      },
+      "required": ["version", "kind", "mappings"],
+      "additionalProperties": false
+    },
+    "channelFile": {
+      "type": "object",
+      "properties": {
+        "version": { "const": 1 },
+        "kind": { "const": "channels" },
+        "mappings": { "type": "array", "items": { "$ref": "#/definitions/channelMapping" } }
+      },
+      "required": ["version", "kind", "mappings"],
+      "additionalProperties": false
+    },
+    "propertyFile": {
+      "type": "object",
+      "properties": {
+        "version": { "const": 1 },
+        "kind": { "const": "properties" },
+        "mappings": { "type": "array", "items": { "$ref": "#/definitions/propertyMapping" } }
+      },
+      "required": ["version", "kind", "mappings"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
+++ b/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
@@ -153,7 +153,8 @@
               "minProperties": 1
             }
           },
-          "required": ["type", "read"],
+          "required": ["type"],
+          "anyOf": [{ "required": ["read"] }, { "required": ["write"] }],
           "additionalProperties": false
         },
         {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -282,12 +282,12 @@ remain supported. Revisit only after a Homey-specific identity and restart-stabl
 - `mappings/property-mapping-storage.service.ts`
 - Mapping schemas/types/specs
 
-- [ ] Define strict schemas for device, channel, and property descriptors.
-- [ ] Match on Homey class plus capability base ID; permit driver/vendor restrictions only where necessary.
-- [ ] Define priority, exclusivity/conflict, read/write direction, unit/range, and transformations.
-- [ ] Load built-ins and deterministic user overrides from `var/data/plugin.devices-homey.*.yaml` or the closest established naming scheme.
-- [ ] Validate mappings at startup and fail the plugin clearly on invalid built-ins while isolating invalid user overrides with actionable errors.
-- [ ] Add tests for precedence, duplicates, invalid schemas, ambiguous matches, and suffix/base-ID handling.
+- [x] Define strict schemas for device, channel, and property descriptors.
+- [x] Match on Homey class plus capability base ID; permit driver/vendor restrictions only where necessary.
+- [x] Define priority, exclusivity/conflict, read/write direction, unit/range, and transformations.
+- [x] Load built-ins and deterministic user overrides from `var/data/plugin.devices-homey.*.yaml` or the closest established naming scheme.
+- [x] Validate mappings at startup and fail the plugin clearly on invalid built-ins while isolating invalid user overrides with actionable errors.
+- [x] Add tests for precedence, duplicates, invalid schemas, ambiguous matches, and suffix/base-ID handling.
 
 ### Task 3.2: Add MVP mapping definitions
 


### PR DESCRIPTION
## Summary

- add strict JSON-schema validation for Homey device, channel, and property YAML mapping documents
- add deterministic built-in and upgrade-safe user override loading from `var/data/plugin.devices-homey.*.yaml`
- fail plugin initialization for missing or invalid built-ins while isolating invalid user files with actionable errors
- define priority, exclusivity, conflict, read/write direction, unit/range, and inline transformation contracts
- resolve Homey class/capability-base matches while retaining full suffixed capability IDs for downstream reads and writes
- add property mapping binding storage and register/export both mapping services from the Homey plugin
- package the Homey mapping schema and definitions in production builds
- complete Task 3.1 in the Homey implementation plan

## Why

Mapping, preview, adoption, synchronization, and control need a single transport-independent mapping foundation before the MVP capability catalog is added. The loader follows existing provider patterns while making override precedence and ambiguous-match behavior explicit and deterministic.

## Validation

- Homey unit suite: 20 suites / 222 tests passed
- targeted ESLint passed
- backend TypeScript type-check passed
- backend production build passed
- packaged schema/definition runtime smoke test passed
- `git diff --check origin/main...HEAD` passed
