### PR TITLE
feat(backend): scope Buddy action references

### DIFF
--- a/apps/backend/src/modules/buddy/buddy.module.spec.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.spec.ts
@@ -14,4 +14,30 @@ describe('BuddyModule home read tools', () => {
 		expect(imports.map((moduleType) => moduleType.name)).not.toContain('McpModule');
 		expect(providers).toContain(HomeContextToolProviderService);
 	});
+
+	it('registers the Buddy home read provider during module initialization', () => {
+		const registerToolProvider = jest.fn();
+		const homeContextTools = {} as HomeContextToolProviderService;
+		const module = new BuddyModule(
+			{ register: jest.fn() } as never,
+			{ registerMapping: jest.fn() } as never,
+			{ registerModuleMetadata: jest.fn() } as never,
+			{ reset: jest.fn() } as never,
+			{ resolvePersonalityPath: jest.fn() } as never,
+			{ register: jest.fn() } as never,
+			{ register: jest.fn() } as never,
+			{ registerEvaluator: jest.fn() } as never,
+			{} as never,
+			{} as never,
+			{} as never,
+			{} as never,
+			{} as never,
+			{ register: registerToolProvider } as never,
+			homeContextTools,
+		);
+
+		module.onModuleInit();
+
+		expect(registerToolProvider).toHaveBeenCalledWith(homeContextTools);
+	});
 });

--- a/apps/backend/src/modules/buddy/buddy.module.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.ts
@@ -14,6 +14,7 @@ import { SwaggerModelsRegistryService } from '../swagger/services/swagger-models
 import { SwaggerModule } from '../swagger/swagger.module';
 import { BackupContributionRegistry } from '../system/services/backup-contribution-registry.service';
 import { FactoryResetRegistryService } from '../system/services/factory-reset-registry.service';
+import { ToolProviderRegistryService } from '../tools/services/tool-provider-registry.service';
 import { ToolsModule } from '../tools/tools.module';
 import { WeatherModule } from '../weather/weather.module';
 
@@ -94,7 +95,6 @@ import { EvaluatorRulesLoaderService } from './spec/evaluator-rules-loader.servi
 		LlmProviderRegistryService,
 		LlmProviderService,
 		BuddyConversationService,
-		// Provider foundation only. Live registration waits for conversation-scoped action-resolution proof.
 		HomeContextToolProviderService,
 		PatternDetectorService,
 		SuggestionEngineService,
@@ -149,6 +149,8 @@ export class BuddyModule implements OnModuleInit {
 		private readonly energyEvaluator: EnergyEvaluator,
 		private readonly conflictDetector: ConflictDetectorEvaluator,
 		private readonly sceneSuggestion: SceneSuggestionEvaluator,
+		private readonly toolProviderRegistry: ToolProviderRegistryService,
+		private readonly homeContextTools: HomeContextToolProviderService,
 	) {}
 
 	onModuleInit() {
@@ -178,6 +180,7 @@ export class BuddyModule implements OnModuleInit {
 		this.heartbeatService.registerEvaluator(this.energyEvaluator);
 		this.heartbeatService.registerEvaluator(this.conflictDetector);
 		this.heartbeatService.registerEvaluator(this.sceneSuggestion);
+		this.toolProviderRegistry.register(this.homeContextTools);
 		this.modulesMapperService.registerMapping<BuddyConfigModel, UpdateBuddyConfigDto>({
 			type: BUDDY_MODULE_NAME,
 			class: BuddyConfigModel,

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
@@ -21,6 +21,7 @@ interface NativeToolLoopHarness {
 	sendWithToolExecution(
 		systemPrompt: string,
 		messages: LlmConversationItem[],
+		conversationId: string,
 		tools?: ToolDefinition[],
 		maxIterations?: number,
 	): Promise<LlmResponse>;
@@ -215,6 +216,7 @@ describe('BuddyConversationService native tool loop', () => {
 			expect.objectContaining({
 				audience: ToolAudience.BUDDY,
 				source: ToolAudience.BUDDY,
+				conversationId: 'conversation-native-loop',
 				requestId: firstCallId,
 			}),
 		);
@@ -224,6 +226,7 @@ describe('BuddyConversationService native tool loop', () => {
 			expect.objectContaining({
 				audience: ToolAudience.BUDDY,
 				source: ToolAudience.BUDDY,
+				conversationId: 'conversation-native-loop',
 				requestId: secondCallId,
 			}),
 		);
@@ -657,6 +660,7 @@ async function runToolLoop(
 	return (service as unknown as NativeToolLoopHarness).sendWithToolExecution(
 		'system',
 		[{ role: MessageRole.USER, content: 'Control the kitchen.' }],
+		'conversation-native-loop',
 		tools,
 		maxIterations,
 	);

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -5,8 +5,13 @@ import { z } from 'zod';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { ConfigService } from '../../config/services/config.service';
+import { PropertyCategory } from '../../devices/devices.constants';
 import { ToolAccessKind, ToolAudience, createToolDefinition } from '../../tools/platforms/tool-provider.platform';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import {
+	MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION,
+	ScopedShortIdTargetKind,
+	ShortIdMappingService,
+} from '../../tools/services/short-id-mapping.service';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import { EventType, MessageRole } from '../buddy.constants';
 import { BuddyConversationNotFoundException, BuddyProviderNotConfiguredException } from '../buddy.exceptions';
@@ -94,6 +99,7 @@ describe('BuddyConversationService', () => {
 	let personalityService: Record<string, jest.Mock>;
 	let toolProviderRegistry: Record<string, jest.Mock>;
 	let eventEmitter: jest.Mocked<EventEmitter2>;
+	let shortIdMapping: ShortIdMappingService;
 	let configService: Record<string, jest.Mock>;
 
 	const mockConversation: BuddyConversationEntity = {
@@ -189,6 +195,7 @@ describe('BuddyConversationService', () => {
 		configService = {
 			getModuleConfig: jest.fn().mockReturnValue({ name: 'Buddy', maxToolIterations: 5, contextWindowTokens: 8_000 }),
 		};
+		shortIdMapping = new ShortIdMappingService();
 
 		service = new BuddyConversationService(
 			conversationRepo as unknown as Repository<BuddyConversationEntity>,
@@ -199,7 +206,7 @@ describe('BuddyConversationService', () => {
 			personalityService as unknown as BuddyPersonalityService,
 			toolProviderRegistry as unknown as ToolProviderRegistryService,
 			eventEmitter,
-			new ShortIdMappingService(),
+			shortIdMapping,
 			configService as unknown as ConfigService,
 		);
 	});
@@ -554,6 +561,89 @@ describe('BuddyConversationService', () => {
 			);
 		});
 
+		it('exposes prompt action references only inside the active conversation scope', async () => {
+			const context = createBuddyContextFixture(1, { spaceId: 'space-1' });
+			const propertyId = context.devices[0].channels[0].properties[0].id;
+			context.scenes = [{ id: 'scene-1', name: 'Evening', enabled: true, space: 'space-1' }];
+			contextService.buildContext.mockResolvedValue(context);
+			llmProvider.supportsTools.mockReturnValue(true);
+
+			await service.sendMessage('conv-1', 'Set the evening mood.');
+
+			const systemPrompt = llmProvider.sendMessage.mock.calls[0][0] as string;
+			const spaceToken = systemPrompt.match(/\[id=(sp_[^\]]+)\]/)?.[1];
+			const sceneToken = systemPrompt.match(/\[id=(sc_[^\]]+)\]/)?.[1];
+			const propertyToken = systemPrompt.match(/\[p=(pr_[^\]]+)\]/)?.[1];
+
+			expect(spaceToken).toBeDefined();
+			expect(sceneToken).toBeDefined();
+			expect(propertyToken).toBeDefined();
+			expect(shortIdMapping.resolveScoped('conv-1', spaceToken ?? '', ScopedShortIdTargetKind.SPACE)).toBe('space-1');
+			expect(shortIdMapping.resolveScoped('conv-1', sceneToken ?? '', ScopedShortIdTargetKind.SCENE)).toBe('scene-1');
+			expect(shortIdMapping.resolveScoped('conv-1', propertyToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
+				propertyId,
+			);
+			expect(
+				shortIdMapping.resolveScoped('another-conversation', propertyToken ?? '', ScopedShortIdTargetKind.PROPERTY),
+			).toBeNull();
+		});
+
+		it('keeps read context visible without emitting invalid action references when the scope is full', async () => {
+			for (let index = 0; index < MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION; index += 1) {
+				shortIdMapping.exposeScoped('conv-1', `existing-property-${index}`, ScopedShortIdTargetKind.PROPERTY);
+			}
+			const context = createBuddyContextFixture(1, { spaceId: 'space-overflow' });
+			context.scenes = [{ id: 'scene-overflow', name: 'Overflow Scene', enabled: true, space: 'space-overflow' }];
+			contextService.buildContext.mockResolvedValue(context);
+			llmProvider.supportsTools.mockReturnValue(true);
+
+			await service.sendMessage('conv-1', 'Describe the visible home context.');
+
+			const systemPrompt = llmProvider.sendMessage.mock.calls[0][0] as string;
+			expect(systemPrompt).toContain('Evaluation space-overflow');
+			expect(systemPrompt).toContain('Overflow Scene');
+			expect(systemPrompt).toContain(PropertyCategory.ON);
+			expect(systemPrompt).not.toContain('id=null');
+			expect(systemPrompt).not.toContain('p=null');
+		});
+
+		it('allocates action references only for detail that is retained in the prompt', async () => {
+			for (let index = 0; index < MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION - 2; index += 1) {
+				shortIdMapping.exposeScoped('conv-1', `existing-property-${index}`, ScopedShortIdTargetKind.PROPERTY);
+			}
+
+			const context = createBuddyContextFixture(1, { spaceId: 'space-discarded' });
+			const baseProperty = context.devices[0].channels[0].properties[0];
+			context.devices[0].channels[0].properties = Array.from({ length: 500 }, (_, index) => ({
+				...baseProperty,
+				id: `discarded-property-${index}`,
+			}));
+			for (const channel of context.devices[0].channels.slice(1)) {
+				channel.properties = [];
+			}
+			context.scenes = [{ id: 'scene-retained', name: 'Retained Scene', enabled: true, space: 'space-discarded' }];
+			contextService.buildContext.mockResolvedValue(context);
+			llmProvider.supportsTools.mockReturnValue(true);
+			const exposeScoped = jest.spyOn(shortIdMapping, 'exposeScoped');
+
+			await service.sendMessage('conv-1', 'Summarize this home.');
+
+			const systemPrompt = llmProvider.sendMessage.mock.calls[0][0] as string;
+			const sceneToken = systemPrompt.match(/\[id=(sc_[^\]]+)\]/)?.[1];
+
+			expect(systemPrompt).toContain('[Evaluation space-discarded: 1 device(s) — ask for details]');
+			expect(systemPrompt).not.toContain('[p=');
+			expect(sceneToken).toBeDefined();
+			expect(shortIdMapping.resolveScoped('conv-1', sceneToken ?? '', ScopedShortIdTargetKind.SCENE)).toBe(
+				'scene-retained',
+			);
+			expect(exposeScoped.mock.calls.map(([, , kind]) => kind)).toEqual([
+				ScopedShortIdTargetKind.SPACE,
+				ScopedShortIdTargetKind.SCENE,
+			]);
+			expect(shortIdMapping.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION);
+		});
+
 		it('should use atomic title update with WHERE title IS NULL', async () => {
 			let capturedManager: Record<string, jest.Mock> | undefined;
 
@@ -666,8 +756,8 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 18,
 			      },
 			      "system": {
-			        "estimatedTokens": 1422,
-			        "jsonUtf8Bytes": 4265,
+			        "estimatedTokens": 1626,
+			        "jsonUtf8Bytes": 4878,
 			      },
 			      "toolResults": {
 			        "estimatedTokens": 0,
@@ -679,9 +769,9 @@ describe('BuddyConversationService', () => {
 			      },
 			    },
 			    "deviceCount": 10,
-			    "estimatedInputTokens": 2693,
+			    "estimatedInputTokens": 2898,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 8108,
+			    "jsonUtf8Bytes": 8721,
 			  },
 			  {
 			    "availableInputTokens": 126688,
@@ -699,8 +789,8 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 18,
 			      },
 			      "system": {
-			        "estimatedTokens": 6276,
-			        "jsonUtf8Bytes": 18826,
+			        "estimatedTokens": 3792,
+			        "jsonUtf8Bytes": 11374,
 			      },
 			      "toolResults": {
 			        "estimatedTokens": 0,
@@ -712,9 +802,9 @@ describe('BuddyConversationService', () => {
 			      },
 			    },
 			    "deviceCount": 100,
-			    "estimatedInputTokens": 7547,
+			    "estimatedInputTokens": 5063,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 22669,
+			    "jsonUtf8Bytes": 15217,
 			  },
 			  {
 			    "availableInputTokens": 126688,
@@ -732,8 +822,8 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 18,
 			      },
 			      "system": {
-			        "estimatedTokens": 337,
-			        "jsonUtf8Bytes": 1010,
+			        "estimatedTokens": 352,
+			        "jsonUtf8Bytes": 1054,
 			      },
 			      "toolResults": {
 			        "estimatedTokens": 0,
@@ -745,12 +835,12 @@ describe('BuddyConversationService', () => {
 			      },
 			    },
 			    "deviceCount": 1000,
-			    "estimatedInputTokens": 1608,
+			    "estimatedInputTokens": 1623,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 4853,
+			    "jsonUtf8Bytes": 4897,
 			  },
 			]
-			`);
+		`);
 		});
 
 		it('should record the current eager request as over budget for a 2k-token model', async () => {
@@ -807,8 +897,8 @@ describe('BuddyConversationService', () => {
 			      "jsonUtf8Bytes": 18,
 			    },
 			    "system": {
-			      "estimatedTokens": 1422,
-			      "jsonUtf8Bytes": 4265,
+			      "estimatedTokens": 1390,
+			      "jsonUtf8Bytes": 4170,
 			    },
 			    "toolResults": {
 			      "estimatedTokens": 0,
@@ -819,9 +909,9 @@ describe('BuddyConversationService', () => {
 			      "jsonUtf8Bytes": 1670,
 			    },
 			  },
-			  "estimatedInputTokens": 2693,
+			  "estimatedInputTokens": 2662,
 			  "fitsWindow": false,
-			  "jsonUtf8Bytes": 8108,
+			  "jsonUtf8Bytes": 8013,
 			}
 		`);
 		});
@@ -884,7 +974,7 @@ describe('BuddyConversationService', () => {
 			expect(systemPrompt).toContain('omitted for brevity');
 
 			// The prompt should be within a reasonable size
-			const estimatedTokens = Math.ceil(systemPrompt.length / 4);
+			const estimatedTokens = estimateConservativeTokens(systemPrompt);
 
 			expect(estimatedTokens).toBeLessThan(8_000);
 		});
@@ -983,16 +1073,28 @@ describe('BuddyConversationService', () => {
 
 	describe('remove', () => {
 		it('should delete conversation and its messages', async () => {
+			const exposed = shortIdMapping.exposeScoped('conv-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+
 			await service.remove('conv-1');
 
 			expect(messageRepo.delete).toHaveBeenCalledWith({ conversationId: 'conv-1' });
 			expect(conversationRepo.delete).toHaveBeenCalledWith('conv-1');
+			expect(shortIdMapping.resolveScoped('conv-1', exposed, ScopedShortIdTargetKind.PROPERTY)).toBeNull();
 		});
 
 		it('should throw BuddyConversationNotFoundException when not found', async () => {
 			conversationRepo.findOne.mockResolvedValue(null);
 
 			await expect(service.remove('nonexistent')).rejects.toThrow(BuddyConversationNotFoundException);
+		});
+
+		it('clears scoped action references before a persistent deletion can fail', async () => {
+			const exposed = shortIdMapping.exposeScoped('conv-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			messageRepo.delete.mockRejectedValue(new Error('database unavailable'));
+
+			await expect(service.remove('conv-1')).rejects.toThrow('database unavailable');
+			expect(shortIdMapping.resolveScoped('conv-1', exposed, ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(conversationRepo.delete).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -32,6 +32,7 @@ import {
 import { BuddyContextService } from './buddy-context.service';
 import { BuddyConversationService } from './buddy-conversation.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
+import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
 import { LlmProviderService } from './llm-provider.service';
 
 const BUDDY_EVALUATION_HISTORY: Partial<BuddyMessageEntity>[] = Array.from({ length: 19 }, (_, index) => ({
@@ -335,6 +336,36 @@ describe('BuddyConversationService', () => {
 				]),
 				expect.objectContaining({}),
 			);
+		});
+
+		it('does not advertise structured home read tools without native tool-result support', async () => {
+			const legacyCompatibleTool = createToolDefinition({
+				name: 'run_scene',
+				description: 'Run a scene.',
+				audiences: [ToolAudience.BUDDY],
+				access: ToolAccessKind.TRIGGER,
+				inputSchema: z.object({ scene_id: z.string() }),
+				outputSchema: toolOutputSchema,
+			});
+			const structuredReadTools = [SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME].map((name) =>
+				createToolDefinition({
+					name,
+					description: 'Return structured home data.',
+					audiences: [ToolAudience.BUDDY],
+					access: ToolAccessKind.READ,
+					inputSchema: z.object({}),
+					outputSchema: toolOutputSchema,
+				}),
+			);
+			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(false);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue([...structuredReadTools, legacyCompatibleTool]);
+
+			await service.sendMessage('conv-1', 'Run a scene.');
+
+			expect(llmProvider.sendMessage).toHaveBeenCalledWith(expect.any(String), expect.any(Array), {
+				tools: [legacyCompatibleTool],
+			});
 		});
 
 		it('should format energy values with kW units and omit battery when absent', async () => {

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -619,6 +619,23 @@ describe('BuddyConversationService', () => {
 			).toBeNull();
 		});
 
+		it('does not allocate action references for providers without tool support', async () => {
+			const context = createBuddyContextFixture(1, { spaceId: 'space-read-only' });
+			context.scenes = [{ id: 'scene-read-only', name: 'Read-only Scene', enabled: true, space: 'space-read-only' }];
+			contextService.buildContext.mockResolvedValue(context);
+			llmProvider.supportsTools.mockReturnValue(false);
+
+			await service.sendMessage('conv-1', 'Describe the home.');
+
+			const systemPrompt = llmProvider.sendMessage.mock.calls[0][0] as string;
+
+			expect(systemPrompt).toContain('Evaluation space-read-only');
+			expect(systemPrompt).toContain('Read-only Scene');
+			expect(systemPrompt).not.toContain('[id=');
+			expect(systemPrompt).not.toContain('[p=');
+			expect(shortIdMapping.scopedSize).toBe(0);
+		});
+
 		it('keeps read context visible without emitting invalid action references when the scope is full', async () => {
 			for (let index = 0; index < MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION; index += 1) {
 				shortIdMapping.exposeScoped('conv-1', `existing-property-${index}`, ScopedShortIdTargetKind.PROPERTY);

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -667,7 +667,9 @@ export class BuddyConversationService {
 			lines.push('', '## Spaces');
 
 			for (const space of context.spaces) {
-				const sid = this.shortIdMapping.exposeScoped(conversationId, space.id, ScopedShortIdTargetKind.SPACE);
+				const sid = hasTools
+					? this.shortIdMapping.exposeScoped(conversationId, space.id, ScopedShortIdTargetKind.SPACE)
+					: null;
 				const reference = sid === null ? '' : ` [id=${sid}]`;
 
 				lines.push(`- ${space.name}${reference} (${space.category ?? 'unknown'}): ${space.deviceCount} devices`);
@@ -701,7 +703,9 @@ export class BuddyConversationService {
 				lines.push('', '## Scenes');
 
 				for (const scene of context.scenes) {
-					const sid = this.shortIdMapping.exposeScoped(conversationId, scene.id, ScopedShortIdTargetKind.SCENE);
+					const sid = hasTools
+						? this.shortIdMapping.exposeScoped(conversationId, scene.id, ScopedShortIdTargetKind.SCENE)
+						: null;
 					const reference = sid === null ? '' : ` [id=${sid}]`;
 
 					lines.push(`- ${scene.name}${reference}: ${scene.enabled ? 'enabled' : 'disabled'}`);

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -42,6 +42,7 @@ import {
 
 import { BuddyContext, BuddyContextService } from './buddy-context.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
+import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
 import { ChatMessage, LlmProviderService } from './llm-provider.service';
 
 const MAX_HISTORY_MESSAGES = 20;
@@ -156,8 +157,16 @@ export class BuddyConversationService {
 		chatMessages.push({ role: MessageRole.USER, content });
 
 		// 3. Call LLM provider with tool support if available
-		const tools = this.llmProvider.supportsTools()
-			? this.toolProviderRegistry.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
+		const supportsTools = this.llmProvider.supportsTools();
+		const supportsNativeToolResults = supportsTools && this.llmProvider.supportsNativeToolResults();
+		const tools = supportsTools
+			? this.toolProviderRegistry
+					.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
+					.filter(
+						(definition) =>
+							supportsNativeToolResults ||
+							(definition.name !== SEARCH_HOME_TOOL_NAME && definition.name !== QUERY_HOME_STATE_TOOL_NAME),
+					)
 			: undefined;
 		const maxIterations = this.getMaxToolIterations();
 		const llmResponse = await this.sendWithToolExecution(

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { createExtensionLogger } from '../../../common/logger';
 import { ConfigService } from '../../config/services/config.service';
 import { ToolAudience, ToolExecutionResult, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import {
 	BUDDY_MODULE_NAME,
@@ -53,11 +53,11 @@ const MAX_HISTORY_MESSAGES = 20;
 const PROMPT_TOKEN_BUDGET_RATIO = 0.8;
 
 /**
- * Estimate the number of tokens in a text string.
- * Uses the ~4 characters per token heuristic for English text.
+ * Conservatively estimate the number of tokens in prompt text from its UTF-8 byte length.
+ * Opaque action references have high entropy and must not be budgeted like ordinary English prose.
  */
 function estimateTokens(text: string): number {
-	return Math.ceil(text.length / 4);
+	return Math.ceil(Buffer.byteLength(text, 'utf8') / 3);
 }
 
 @Injectable()
@@ -135,7 +135,7 @@ export class BuddyConversationService {
 		// to the same short ID, so concurrent requests from different bot adapters
 		// won't interfere with each other.
 		const context = await this.contextService.buildContext(conversation.spaceId ?? undefined);
-		const systemPrompt = await this.buildSystemPrompt(context, conversation.spaceId ?? undefined);
+		const systemPrompt = await this.buildSystemPrompt(context, conversation.id, conversation.spaceId ?? undefined);
 
 		// 2. Load most recent conversation history and append the new user message
 		const history = await this.messageRepository.find({
@@ -160,7 +160,13 @@ export class BuddyConversationService {
 			? this.toolProviderRegistry.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
 			: undefined;
 		const maxIterations = this.getMaxToolIterations();
-		const llmResponse = await this.sendWithToolExecution(systemPrompt, chatMessages, tools, maxIterations);
+		const llmResponse = await this.sendWithToolExecution(
+			systemPrompt,
+			chatMessages,
+			conversation.id,
+			tools,
+			maxIterations,
+		);
 
 		// 4. Persist both user message and assistant response in a single transaction
 		const { savedUser, savedAssistant } = await this.dataSource.transaction(async (manager) => {
@@ -225,6 +231,10 @@ export class BuddyConversationService {
 	async remove(id: string): Promise<void> {
 		const conversation = await this.findOneOrThrow(id);
 
+		// Fail closed at deletion admission: a partial database deletion must not
+		// leave action references for a conversation the user asked to remove.
+		this.shortIdMapping.clearScope(conversation.id);
+
 		// Delete messages first (cascade)
 		await this.messageRepository.delete({ conversationId: conversation.id });
 		await this.conversationRepository.delete(conversation.id);
@@ -240,6 +250,7 @@ export class BuddyConversationService {
 	private async sendWithToolExecution(
 		systemPrompt: string,
 		messages: LlmConversationItem[],
+		conversationId: string,
 		tools?: ToolDefinition[],
 		maxIterations: number = DEFAULT_MAX_TOOL_ITERATIONS,
 	): Promise<LlmResponse> {
@@ -325,6 +336,7 @@ export class BuddyConversationService {
 						result = await this.toolProviderRegistry.executeTool(toolCall, {
 							audience: ToolAudience.BUDDY,
 							source: ToolAudience.BUDDY,
+							conversationId,
 							requestId: canonicalCall.callId,
 						});
 					} catch {
@@ -434,6 +446,7 @@ export class BuddyConversationService {
 				const result = await this.toolProviderRegistry.executeTool(toolCall, {
 					audience: ToolAudience.BUDDY,
 					source: ToolAudience.BUDDY,
+					conversationId,
 					requestId: canonicalCallIds[callIndex],
 				});
 
@@ -611,7 +624,11 @@ export class BuddyConversationService {
 		return (a ?? 0) + (b ?? 0);
 	}
 
-	private async buildSystemPrompt(context: BuddyContext, conversationSpaceId?: string): Promise<string> {
+	private async buildSystemPrompt(
+		context: BuddyContext,
+		conversationId: string,
+		conversationSpaceId?: string,
+	): Promise<string> {
 		const hasTools = this.llmProvider.supportsTools();
 		const personality = await this.personalityService.getPersonality();
 		const buddyName = this.getBuddyName();
@@ -641,9 +658,10 @@ export class BuddyConversationService {
 			lines.push('', '## Spaces');
 
 			for (const space of context.spaces) {
-				const sid = this.shortIdMapping.shorten(space.id);
+				const sid = this.shortIdMapping.exposeScoped(conversationId, space.id, ScopedShortIdTargetKind.SPACE);
+				const reference = sid === null ? '' : ` [id=${sid}]`;
 
-				lines.push(`- ${space.name} [id=${sid}] (${space.category ?? 'unknown'}): ${space.deviceCount} devices`);
+				lines.push(`- ${space.name}${reference} (${space.category ?? 'unknown'}): ${space.deviceCount} devices`);
 			}
 		}
 
@@ -652,7 +670,15 @@ export class BuddyConversationService {
 			const currentTokens = estimateTokens(lines.join('\n'));
 
 			if (currentTokens < tokenBudget) {
-				this.appendDevices(lines, context.devices, hasTools, tokenBudget, context.spaces, conversationSpaceId);
+				this.appendDevices(
+					lines,
+					context.devices,
+					hasTools,
+					tokenBudget,
+					context.spaces,
+					conversationId,
+					conversationSpaceId,
+				);
 			}
 		}
 
@@ -666,9 +692,10 @@ export class BuddyConversationService {
 				lines.push('', '## Scenes');
 
 				for (const scene of context.scenes) {
-					const sid = this.shortIdMapping.shorten(scene.id);
+					const sid = this.shortIdMapping.exposeScoped(conversationId, scene.id, ScopedShortIdTargetKind.SCENE);
+					const reference = sid === null ? '' : ` [id=${sid}]`;
 
-					lines.push(`- ${scene.name} [id=${sid}]: ${scene.enabled ? 'enabled' : 'disabled'}`);
+					lines.push(`- ${scene.name}${reference}: ${scene.enabled ? 'enabled' : 'disabled'}`);
 				}
 			} else {
 				omittedSections.push('scenes');
@@ -746,6 +773,7 @@ export class BuddyConversationService {
 		hasTools: boolean,
 		tokenBudget: number,
 		spaces: BuddyContext['spaces'],
+		conversationId: string,
 		conversationSpaceId?: string,
 	): void {
 		// Quick estimate: can ALL devices fit with full detail?
@@ -756,7 +784,7 @@ export class BuddyConversationService {
 
 		if (baseTokens + fullDetailEstimate < tokenBudget) {
 			// Everything fits — build the actual formatted lines (registers short IDs)
-			const fullDeviceLines = this.buildDeviceLines(devices, hasTools);
+			const fullDeviceLines = this.buildDeviceLines(devices, hasTools, conversationId);
 
 			lines.push('', '## Devices', ...fullDeviceLines);
 
@@ -790,11 +818,11 @@ export class BuddyConversationService {
 
 		// Add current space devices with full detail (or summarize if still too large)
 		if (currentSpaceDevices.length > 0) {
-			const currentLines = this.buildDeviceLines(currentSpaceDevices, hasTools);
-			const withCurrentSpace = estimateTokens([...lines, ...currentLines].join('\n'));
+			const withCurrentSpace =
+				estimateTokens(lines.join('\n')) + this.estimateDeviceTokens(currentSpaceDevices, hasTools);
 
 			if (withCurrentSpace < tokenBudget) {
-				lines.push(...currentLines);
+				lines.push(...this.buildDeviceLines(currentSpaceDevices, hasTools, conversationId));
 			} else {
 				// Even current space exceeds budget — add without tool details
 				for (const device of currentSpaceDevices) {
@@ -830,12 +858,11 @@ export class BuddyConversationService {
 				break;
 			}
 
-			// Try full detail for this space's devices
-			const spaceDeviceLines = this.buildDeviceLines(spaceDevices, hasTools);
-			const withFullDetail = estimateTokens([...lines, ...spaceDeviceLines].join('\n'));
+			// Estimate without exposing action references; allocate them only after the detail block is accepted.
+			const withFullDetail = estimateTokens(lines.join('\n')) + this.estimateDeviceTokens(spaceDevices, hasTools);
 
 			if (withFullDetail < tokenBudget) {
-				lines.push(...spaceDeviceLines);
+				lines.push(...this.buildDeviceLines(spaceDevices, hasTools, conversationId));
 			} else {
 				// Summarize: just device count for this space
 				const spaceName = spaces.find((s) => s.id === spaceId)?.name ?? spaceId ?? 'unassigned';
@@ -853,7 +880,7 @@ export class BuddyConversationService {
 	/**
 	 * Build device detail lines (shared between full and truncated rendering).
 	 */
-	private buildDeviceLines(devices: BuddyContext['devices'], hasTools: boolean): string[] {
+	private buildDeviceLines(devices: BuddyContext['devices'], hasTools: boolean, conversationId: string): string[] {
 		const lines: string[] = [];
 
 		for (const device of devices) {
@@ -880,10 +907,11 @@ export class BuddyConversationService {
 					lines.push(`  - ${channel.name}:`);
 
 					for (const prop of channel.properties) {
-						const pid = this.shortIdMapping.shorten(prop.id);
+						const pid = this.shortIdMapping.exposeScoped(conversationId, prop.id, ScopedShortIdTargetKind.PROPERTY);
 						const val = prop.value != null ? JSON.stringify(prop.value) : 'null';
+						const reference = pid === null ? '' : ` [p=${pid}]`;
 
-						lines.push(`    - ${prop.category} [p=${pid}] value=${val}`);
+						lines.push(`    - ${prop.category}${reference} value=${val}`);
 					}
 				}
 			}
@@ -903,8 +931,8 @@ export class BuddyConversationService {
 		const STATE_ENTRY_CHARS = 20;
 		// "  - channelName:\n" ≈ 25 chars
 		const CHANNEL_CHARS = 25;
-		// "    - category [p=XXXX] value=...\n" ≈ 45 chars
-		const PROPERTY_CHARS = 45;
+		// "    - category [p=pr_<opaque-reference>] value=...\n" ≈ 60 chars
+		const PROPERTY_CHARS = 60;
 		// "## Devices\n\n"
 		const HEADER_CHARS = 15;
 
@@ -924,7 +952,7 @@ export class BuddyConversationService {
 			}
 		}
 
-		return Math.ceil(chars / 4);
+		return Math.ceil(chars / 3);
 	}
 
 	/**

--- a/apps/backend/src/modules/buddy/services/home-context-tool-action-containment.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-action-containment.spec.ts
@@ -1,0 +1,115 @@
+import { DeviceControlToolService } from '../../devices/services/device-control-tool.service';
+import { PropertyCommandService } from '../../devices/services/property-command.service';
+import { HomeCurrentStateQueryService } from '../../home-context/services/home-current-state-query.service';
+import { HomeSearchQueryService } from '../../home-context/services/home-search-query.service';
+import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
+
+import { HomeContextToolProviderService, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
+
+describe('Buddy home search action containment', () => {
+	it('does not let a canonical property ID returned by search authorize a Buddy write', async () => {
+		const canonicalPropertyId = 'property-canonical';
+		const searchEntities = jest.fn().mockResolvedValue({
+			query: 'kitchen light',
+			entities: [
+				{
+					kind: 'property',
+					id: canonicalPropertyId,
+					name: 'Kitchen light power',
+					score: 900,
+					reasons: ['exact_name'],
+					candidate_capabilities: ['read', 'write'],
+					property_name: 'Power',
+					identifier: 'power',
+					category: 'on',
+					data_type: 'bool',
+					permissions: ['read_write'],
+					device: { id: 'device-1', name: 'Kitchen light', enabled: true },
+					channel: { id: 'channel-1', name: 'Light', category: 'light' },
+				},
+			],
+			observed_at: '2026-08-15T12:00:00.000Z',
+			total: 1,
+			returned: 1,
+			totals_by_kind: { space: 0, device: 0, property: 1, scene: 0 },
+			partial: false,
+			truncated: false,
+			refine_required: false,
+		});
+		const executePropertyCommandById = jest.fn().mockResolvedValue({
+			device: 'device-1',
+			deviceName: 'Kitchen light',
+			channel: 'channel-1',
+			property: canonicalPropertyId,
+			value: true,
+			success: true,
+		});
+		const shortIdMapping = new ShortIdMappingService();
+		const registry = new ToolProviderRegistryService();
+		registry.register(
+			new HomeContextToolProviderService(
+				{ searchEntities } as unknown as HomeSearchQueryService,
+				{ queryCurrentState: jest.fn() } as unknown as HomeCurrentStateQueryService,
+				shortIdMapping,
+			),
+		);
+		registry.register(
+			new DeviceControlToolService({ executePropertyCommandById } as unknown as PropertyCommandService, shortIdMapping),
+		);
+
+		const search = await registry.executeTool(
+			{ id: 'search-call', name: SEARCH_HOME_TOOL_NAME, arguments: { query: 'kitchen light' } },
+			{
+				audience: ToolAudience.BUDDY,
+				source: ToolAudience.BUDDY,
+				conversationId: 'conversation-1',
+				allowedAccessKinds: [ToolAccessKind.READ],
+			},
+		);
+		expect(search.data).toMatchObject({ entities: [{ id: canonicalPropertyId }] });
+
+		const denied = await registry.executeTool(
+			{
+				id: 'write-canonical',
+				name: 'control_device',
+				arguments: { property_id: canonicalPropertyId, value: true },
+			},
+			{
+				audience: ToolAudience.BUDDY,
+				source: ToolAudience.BUDDY,
+				conversationId: 'conversation-1',
+				allowedAccessKinds: [ToolAccessKind.WRITE],
+			},
+		);
+		expect(denied).toEqual({
+			success: false,
+			status: ToolExecutionStatus.DENIED,
+			message: 'The requested target is not available in this Buddy conversation.',
+			errorCode: 'BUDDY_TARGET_NOT_EXPOSED',
+		});
+		expect(executePropertyCommandById).not.toHaveBeenCalled();
+
+		const exposedReference = shortIdMapping.exposeScoped(
+			'conversation-1',
+			canonicalPropertyId,
+			ScopedShortIdTargetKind.PROPERTY,
+		);
+		expect(exposedReference).not.toBeNull();
+		await registry.executeTool(
+			{
+				id: 'write-exposed',
+				name: 'control_device',
+				arguments: { property_id: exposedReference, value: true },
+			},
+			{
+				audience: ToolAudience.BUDDY,
+				source: ToolAudience.BUDDY,
+				conversationId: 'conversation-1',
+				allowedAccessKinds: [ToolAccessKind.WRITE],
+			},
+		);
+		expect(executePropertyCommandById).toHaveBeenCalledWith(canonicalPropertyId, true, expect.any(Object));
+	});
+});

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.spec.ts
@@ -10,6 +10,7 @@ import { HomeEntitySearchResponse } from '../../home-context/models/home-search-
 import { HomeCurrentStateQueryService } from '../../home-context/services/home-current-state-query.service';
 import { HomeSearchQueryService } from '../../home-context/services/home-search-query.service';
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { ToolProviderRegistryService } from '../../tools/services/tool-provider-registry.service';
 import { MessageRole } from '../buddy.constants';
 import { buildAnthropicRequestPayload } from '../platforms/anthropic-sdk.utils';
@@ -28,14 +29,17 @@ describe('HomeContextToolProviderService', () => {
 	const observedAt = '2026-08-15T12:00:00.000Z';
 	let searchEntities: jest.MockedFunction<HomeSearchQueryService['searchEntities']>;
 	let queryCurrentState: jest.MockedFunction<HomeCurrentStateQueryService['queryCurrentState']>;
+	let shortIdMapping: ShortIdMappingService;
 	let provider: HomeContextToolProviderService;
 
 	beforeEach(() => {
 		searchEntities = jest.fn();
 		queryCurrentState = jest.fn();
+		shortIdMapping = new ShortIdMappingService();
 		provider = new HomeContextToolProviderService(
 			{ searchEntities } as unknown as HomeSearchQueryService,
 			{ queryCurrentState } as unknown as HomeCurrentStateQueryService,
+			shortIdMapping,
 		);
 	});
 
@@ -110,6 +114,7 @@ describe('HomeContextToolProviderService', () => {
 	});
 
 	it('maps the complete search ABI to the fixed Buddy search profile and preserves bounded data', async () => {
+		const scopedSpaceId = shortIdMapping.exposeScoped('conversation-1', 'space-1', ScopedShortIdTargetKind.SPACE);
 		const result: HomeEntitySearchResponse = {
 			query: 'kitchen light',
 			entities: [],
@@ -131,14 +136,18 @@ describe('HomeContextToolProviderService', () => {
 				arguments: {
 					query: ' kitchen light ',
 					kinds: ['property'],
-					space_id: 'space-1',
+					space_id: scopedSpaceId,
 					categories: ['light'],
 					candidate_capability: 'read',
 					limit: 7,
 					cursor: 'cursor-1',
 				},
 			},
-			{ audience: ToolAudience.BUDDY, allowedAccessKinds: [ToolAccessKind.READ] },
+			{
+				audience: ToolAudience.BUDDY,
+				conversationId: 'conversation-1',
+				allowedAccessKinds: [ToolAccessKind.READ],
+			},
 		);
 
 		expect(searchEntities).toHaveBeenCalledWith({

--- a/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
+++ b/apps/backend/src/modules/buddy/services/home-context-tool-provider.service.ts
@@ -32,6 +32,7 @@ import {
 	createToolDefinition,
 } from '../../tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { BUDDY_MODULE_NAME } from '../buddy.constants';
 
 export const BUDDY_HOME_READ_TOOLS_PROVIDER = 'buddy-home-read-tools';
@@ -125,6 +126,7 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 	constructor(
 		private readonly homeSearch: HomeSearchQueryService,
 		private readonly currentState: HomeCurrentStateQueryService,
+		private readonly shortIdMapping: ShortIdMappingService,
 	) {
 		super();
 	}
@@ -163,20 +165,23 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 
 	protected async handleToolCall(
 		toolCall: LlmToolCall,
-		_context: ToolExecutionContext,
+		context: ToolExecutionContext,
 	): Promise<ToolExecutionResult | null> {
 		if (toolCall.name === SEARCH_HOME_TOOL_NAME) {
-			return this.searchHome(toolCall.arguments);
+			return this.searchHome(toolCall.arguments, context);
 		}
 
 		if (toolCall.name === QUERY_HOME_STATE_TOOL_NAME) {
-			return this.queryHomeState(toolCall.arguments);
+			return this.queryHomeState(toolCall.arguments, context);
 		}
 
 		return null;
 	}
 
-	private async searchHome(argumentsValue: Record<string, unknown>): Promise<ToolExecutionResult> {
+	private async searchHome(
+		argumentsValue: Record<string, unknown>,
+		context: ToolExecutionContext,
+	): Promise<ToolExecutionResult> {
 		const parsed = searchHomeToolInputSchema.safeParse(argumentsValue);
 
 		if (!parsed.success) {
@@ -188,7 +193,7 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 				profile: HOME_SEARCH_PROFILE_BUDDY_V1,
 				query: parsed.data.query,
 				kinds: parsed.data.kinds,
-				spaceId: parsed.data.space_id,
+				spaceId: this.resolveSpaceId(parsed.data.space_id, context),
 				categories: parsed.data.categories,
 				candidateCapability: parsed.data.candidate_capability,
 				limit: parsed.data.limit,
@@ -209,7 +214,10 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 		}
 	}
 
-	private async queryHomeState(argumentsValue: Record<string, unknown>): Promise<ToolExecutionResult> {
+	private async queryHomeState(
+		argumentsValue: Record<string, unknown>,
+		context: ToolExecutionContext,
+	): Promise<ToolExecutionResult> {
 		const parsed = queryHomeStateToolInputSchema.safeParse(argumentsValue);
 
 		if (!parsed.success) {
@@ -220,7 +228,7 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 			const query = {
 				profile: HOME_CURRENT_STATE_PROFILE_BUDDY_V1,
 				operation: parsed.data.operation,
-				spaceId: parsed.data.space_id,
+				spaceId: this.resolveSpaceId(parsed.data.space_id, context),
 				channelCategories: parsed.data.channel_categories,
 				propertyCategories: parsed.data.property_categories,
 				dataTypes: parsed.data.data_types,
@@ -252,6 +260,14 @@ export class HomeContextToolProviderService extends BaseToolProviderService {
 			message: `Invalid arguments for tool "${toolName}"`,
 			errorCode: 'INVALID_TOOL_ARGUMENTS',
 		};
+	}
+
+	private resolveSpaceId(spaceId: string | undefined, context: ToolExecutionContext): string | undefined {
+		if (spaceId === undefined || context.conversationId === undefined) {
+			return spaceId;
+		}
+
+		return this.shortIdMapping.resolveScoped(context.conversationId, spaceId, ScopedShortIdTargetKind.SPACE) ?? spaceId;
 	}
 
 	private mapExpectedError(error: unknown): ToolExecutionResult {

--- a/apps/backend/src/modules/buddy/services/module-reset.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/module-reset.service.spec.ts
@@ -1,0 +1,41 @@
+import { Repository } from 'typeorm';
+
+import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { BuddyConversationEntity } from '../entities/buddy-conversation.entity';
+import { BuddyMessageEntity } from '../entities/buddy-message.entity';
+import { BuddySuggestionEntity } from '../entities/buddy-suggestion.entity';
+
+import { BuddyModuleResetService } from './module-reset.service';
+
+describe('BuddyModuleResetService scoped references', () => {
+	it('clears scoped action references after persistent Buddy state is cleared', async () => {
+		const messages = { clear: jest.fn().mockResolvedValue(undefined) };
+		const conversations = { clear: jest.fn().mockResolvedValue(undefined) };
+		const suggestions = { clear: jest.fn().mockResolvedValue(undefined) };
+		const shortIdMapping = { clearAllScopes: jest.fn() };
+		const service = new BuddyModuleResetService(
+			messages as unknown as Repository<BuddyMessageEntity>,
+			conversations as unknown as Repository<BuddyConversationEntity>,
+			suggestions as unknown as Repository<BuddySuggestionEntity>,
+			shortIdMapping as unknown as ShortIdMappingService,
+		);
+
+		await expect(service.reset()).resolves.toEqual({ success: true });
+		expect(shortIdMapping.clearAllScopes).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears scoped references before a persistent reset can fail', async () => {
+		const resetFailure = new Error('database unavailable');
+		const messages = { clear: jest.fn().mockRejectedValue(resetFailure) };
+		const shortIdMapping = { clearAllScopes: jest.fn() };
+		const service = new BuddyModuleResetService(
+			messages as unknown as Repository<BuddyMessageEntity>,
+			{ clear: jest.fn() } as unknown as Repository<BuddyConversationEntity>,
+			{ clear: jest.fn() } as unknown as Repository<BuddySuggestionEntity>,
+			shortIdMapping as unknown as ShortIdMappingService,
+		);
+
+		await expect(service.reset()).resolves.toEqual({ success: false, reason: resetFailure.message });
+		expect(shortIdMapping.clearAllScopes).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/backend/src/modules/buddy/services/module-reset.service.ts
+++ b/apps/backend/src/modules/buddy/services/module-reset.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { BUDDY_MODULE_NAME } from '../buddy.constants';
 import { BuddyConversationEntity } from '../entities/buddy-conversation.entity';
 import { BuddyMessageEntity } from '../entities/buddy-message.entity';
@@ -20,17 +21,20 @@ export class BuddyModuleResetService {
 		private readonly conversationsRepository: Repository<BuddyConversationEntity>,
 		@InjectRepository(BuddySuggestionEntity)
 		private readonly suggestionsRepository: Repository<BuddySuggestionEntity>,
+		private readonly shortIdMapping: ShortIdMappingService,
 	) {}
 
 	async reset(): Promise<{ success: boolean; reason?: string }> {
 		this.logger.log('[RESET] Starting buddy module factory reset');
+		// Fail closed at reset admission: a partial persistent reset must not leave
+		// action references for conversations that may already have been deleted.
+		this.shortIdMapping.clearAllScopes();
 
 		try {
 			// Delete messages first (foreign key to conversations)
 			await this.messagesRepository.clear();
 			await this.conversationsRepository.clear();
 			await this.suggestionsRepository.clear();
-
 			this.logger.log('[RESET] Buddy module factory reset completed successfully');
 
 			return { success: true };

--- a/apps/backend/src/modules/devices/services/device-control-tool.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/device-control-tool.service.spec.ts
@@ -1,5 +1,5 @@
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 
 import { DeviceControlToolService } from './device-control-tool.service';
 import { PropertyCommandService } from './property-command.service';
@@ -80,7 +80,7 @@ describe('DeviceControlToolService', () => {
 		});
 	});
 
-	it('preserves Buddy as the default execution source', async () => {
+	it('preserves the MCP canonical-ID fallback', async () => {
 		propertyCommandService.executePropertyCommandById.mockResolvedValue({
 			device: 'device-1',
 			deviceName: 'Light',
@@ -90,11 +90,43 @@ describe('DeviceControlToolService', () => {
 			success: true,
 		});
 
-		await service.executeTool({
-			id: 'call-1',
-			name: 'control_device',
-			arguments: { property_id: 'property-1', value: 50 },
+		await service.executeTool(
+			{
+				id: 'call-1',
+				name: 'control_device',
+				arguments: { property_id: 'property-1', value: 50 },
+			},
+			{ audience: ToolAudience.MCP, source: 'mcp' },
+		);
+
+		expect(propertyCommandService.executePropertyCommandById).toHaveBeenCalledWith(
+			'property-1',
+			50,
+			expect.any(Object),
+		);
+	});
+
+	it('executes a Buddy property only through a same-conversation scoped property token', async () => {
+		const token = shortIdMapping.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+
+		expect(token).not.toBeNull();
+		propertyCommandService.executePropertyCommandById.mockResolvedValue({
+			device: 'device-1',
+			deviceName: 'Light',
+			channel: 'channel-1',
+			property: 'property-1',
+			value: 50,
+			success: true,
 		});
+
+		await service.executeTool(
+			{
+				id: 'call-1',
+				name: 'control_device',
+				arguments: { property_id: token, value: 50 },
+			},
+			{ audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-1' },
+		);
 
 		expect(propertyCommandService.executePropertyCommandById).toHaveBeenCalledWith(
 			'property-1',
@@ -112,18 +144,74 @@ describe('DeviceControlToolService', () => {
 		});
 	});
 
+	it('denies unscoped, foreign, wrong-kind, stale, and canonical Buddy property IDs without a domain call', async () => {
+		const valid = shortIdMapping.exposeScoped('conversation-a', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+		const wrongKind = shortIdMapping.exposeScoped('conversation-a', 'scene-1', ScopedShortIdTargetKind.SCENE);
+		const stale = shortIdMapping.exposeScoped('conversation-stale', 'property-2', ScopedShortIdTargetKind.PROPERTY);
+
+		expect(valid).not.toBeNull();
+		expect(wrongKind).not.toBeNull();
+		expect(stale).not.toBeNull();
+		shortIdMapping.clearScope('conversation-stale');
+
+		const attempts = [
+			{ propertyId: valid, context: { audience: ToolAudience.BUDDY, source: 'buddy' } },
+			{
+				propertyId: valid,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-b' },
+			},
+			{
+				propertyId: wrongKind,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+			},
+			{
+				propertyId: stale,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-stale' },
+			},
+			{
+				propertyId: 'property-1',
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+			},
+		];
+
+		for (const attempt of attempts) {
+			await expect(
+				service.executeTool(
+					{
+						id: 'call-denied',
+						name: 'control_device',
+						arguments: { property_id: attempt.propertyId, value: true },
+					},
+					attempt.context,
+				),
+			).resolves.toEqual({
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: 'The requested target is not available in this Buddy conversation.',
+				errorCode: 'BUDDY_TARGET_NOT_EXPOSED',
+			});
+		}
+
+		expect(propertyCommandService.executePropertyCommandById).not.toHaveBeenCalled();
+	});
+
 	it('returns a structured failure from the command service', async () => {
+		const token = shortIdMapping.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+
 		propertyCommandService.executePropertyCommandById.mockResolvedValue({
 			device: 'device-1',
 			success: false,
 			reason: 'Property is not writable',
 		});
 
-		const result = await service.executeTool({
-			id: 'call-1',
-			name: 'control_device',
-			arguments: { property_id: 'property-1', value: true },
-		});
+		const result = await service.executeTool(
+			{
+				id: 'call-1',
+				name: 'control_device',
+				arguments: { property_id: token, value: true },
+			},
+			{ audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-1' },
+		);
 
 		expect(result).toEqual(
 			expect.objectContaining({

--- a/apps/backend/src/modules/devices/services/device-control-tool.service.ts
+++ b/apps/backend/src/modules/devices/services/device-control-tool.service.ts
@@ -14,12 +14,14 @@ import {
 	createToolDefinition,
 } from '../../tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
 
 import { PropertyCommandService } from './property-command.service';
 
 const DEVICE_CONTROL_TOOLS_PROVIDER = 'device-control-tools';
+const BUDDY_TARGET_NOT_EXPOSED_MESSAGE = 'The requested target is not available in this Buddy conversation.';
+const BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE = 'BUDDY_TARGET_NOT_EXPOSED';
 
 const CONTROL_DEVICE_INPUT_SCHEMA = z.object({
 	property_id: z.string().min(1).describe('Short property ID from the home context (the p=... value)'),
@@ -81,7 +83,25 @@ export class DeviceControlToolService extends BaseToolProviderService {
 			};
 		}
 
-		const propertyId = this.shortIdMapping.resolve(parsed.data.property_id) ?? parsed.data.property_id;
+		const propertyId =
+			context.audience === ToolAudience.BUDDY
+				? context.conversationId
+					? this.shortIdMapping.resolveScoped(
+							context.conversationId,
+							parsed.data.property_id,
+							ScopedShortIdTargetKind.PROPERTY,
+						)
+					: null
+				: (this.shortIdMapping.resolve(parsed.data.property_id) ?? parsed.data.property_id);
+
+		if (propertyId === null) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: BUDDY_TARGET_NOT_EXPOSED_MESSAGE,
+				errorCode: BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE,
+			};
+		}
 		const result = await this.propertyCommandService.executePropertyCommandById(propertyId, parsed.data.value, {
 			requestId: context.requestId,
 			context: {

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.spec.ts
@@ -1,5 +1,5 @@
 import { ToolAccessKind, ToolAudience, ToolExecutionStatus } from '../../tools/platforms/tool-provider.platform';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 
 import { SceneExecutorService } from './scene-executor.service';
 import { SceneToolService } from './scene-tool.service';
@@ -9,6 +9,7 @@ describe('SceneToolService', () => {
 	let service: SceneToolService;
 	let scenesService: Record<string, jest.Mock>;
 	let sceneExecutor: Record<string, jest.Mock>;
+	let shortIdMapping: ShortIdMappingService;
 
 	beforeEach(() => {
 		scenesService = {
@@ -19,10 +20,11 @@ describe('SceneToolService', () => {
 			triggerScene: jest.fn(),
 		};
 
+		shortIdMapping = new ShortIdMappingService();
 		service = new SceneToolService(
 			scenesService as unknown as ScenesService,
 			sceneExecutor as unknown as SceneExecutorService,
-			new ShortIdMappingService(),
+			shortIdMapping,
 		);
 	});
 
@@ -60,11 +62,7 @@ describe('SceneToolService', () => {
 				totalActions: 3,
 			});
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'scene-1' },
-			});
+			const result = await executeBuddyScene('scene-1');
 
 			expect(result.success).toBe(true);
 			expect(result.status).toBe(ToolExecutionStatus.COMPLETED);
@@ -83,14 +81,80 @@ describe('SceneToolService', () => {
 			});
 		});
 
+		it('preserves MCP global short-ID and canonical-ID fallback', async () => {
+			const globalShortId = shortIdMapping.shorten('scene-1');
+
+			scenesService.findOne.mockResolvedValue({ id: 'scene-1', name: 'Movie Night', enabled: true });
+			sceneExecutor.triggerScene.mockResolvedValue({
+				status: 'completed',
+				successfulActions: 3,
+				totalActions: 3,
+			});
+
+			for (const sceneId of [globalShortId, 'scene-1']) {
+				await service.executeTool(
+					{ id: 'mcp-call', name: 'run_scene', arguments: { scene_id: sceneId } },
+					{ audience: ToolAudience.MCP, source: 'mcp' },
+				);
+			}
+
+			expect(scenesService.findOne).toHaveBeenNthCalledWith(1, 'scene-1');
+			expect(scenesService.findOne).toHaveBeenNthCalledWith(2, 'scene-1');
+			expect(sceneExecutor.triggerScene).toHaveBeenCalledTimes(2);
+		});
+
+		it('denies unscoped, foreign, wrong-kind, stale, and canonical Buddy scene IDs without a domain call', async () => {
+			const valid = shortIdMapping.exposeScoped('conversation-a', 'scene-1', ScopedShortIdTargetKind.SCENE);
+			const wrongKind = shortIdMapping.exposeScoped('conversation-a', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const stale = shortIdMapping.exposeScoped('conversation-stale', 'scene-2', ScopedShortIdTargetKind.SCENE);
+
+			expect(valid).not.toBeNull();
+			expect(wrongKind).not.toBeNull();
+			expect(stale).not.toBeNull();
+			shortIdMapping.clearScope('conversation-stale');
+
+			const attempts = [
+				{ sceneId: valid, context: { audience: ToolAudience.BUDDY, source: 'buddy' } },
+				{
+					sceneId: valid,
+					context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-b' },
+				},
+				{
+					sceneId: wrongKind,
+					context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+				},
+				{
+					sceneId: stale,
+					context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-stale' },
+				},
+				{
+					sceneId: 'scene-1',
+					context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+				},
+			];
+
+			for (const attempt of attempts) {
+				await expect(
+					service.executeTool(
+						{ id: 'call-denied', name: 'run_scene', arguments: { scene_id: attempt.sceneId } },
+						attempt.context,
+					),
+				).resolves.toEqual({
+					success: false,
+					status: ToolExecutionStatus.DENIED,
+					message: 'The requested target is not available in this Buddy conversation.',
+					errorCode: 'BUDDY_TARGET_NOT_EXPOSED',
+				});
+			}
+
+			expect(scenesService.findOne).not.toHaveBeenCalled();
+			expect(sceneExecutor.triggerScene).not.toHaveBeenCalled();
+		});
+
 		it('should return failure for non-existent scene', async () => {
 			scenesService.findOne.mockResolvedValue(null);
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'nonexistent' },
-			});
+			const result = await executeBuddyScene('nonexistent');
 
 			expect(result.success).toBe(false);
 			expect(result.message).toContain('not found');
@@ -115,11 +179,7 @@ describe('SceneToolService', () => {
 				totalActions: 3,
 			});
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'scene-1' },
-			});
+			const result = await executeBuddyScene('scene-1');
 
 			expect(result.success).toBe(true);
 			expect(result.status).toBe(ToolExecutionStatus.PARTIAL);
@@ -136,11 +196,7 @@ describe('SceneToolService', () => {
 				error: 'No platforms registered',
 			});
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'scene-1' },
-			});
+			const result = await executeBuddyScene('scene-1');
 
 			expect(result.success).toBe(false);
 			expect(result.status).toBe(ToolExecutionStatus.FAILED);
@@ -154,11 +210,7 @@ describe('SceneToolService', () => {
 		it('should return failure when scene is disabled', async () => {
 			scenesService.findOne.mockResolvedValue({ id: 'scene-1', name: 'Test', enabled: false });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'scene-1' },
-			});
+			const result = await executeBuddyScene('scene-1');
 
 			expect(result.success).toBe(false);
 			expect(result.status).toBe(ToolExecutionStatus.DENIED);
@@ -169,11 +221,7 @@ describe('SceneToolService', () => {
 			scenesService.findOne.mockResolvedValue({ id: 'scene-1', name: 'Test', enabled: true });
 			sceneExecutor.triggerScene.mockRejectedValue(new Error('Connection timeout'));
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'run_scene',
-				arguments: { scene_id: 'scene-1' },
-			});
+			const result = await executeBuddyScene('scene-1');
 
 			expect(result.success).toBe(false);
 			expect(result.status).toBe(ToolExecutionStatus.FAILED);
@@ -193,4 +241,15 @@ describe('SceneToolService', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	async function executeBuddyScene(canonicalId: string) {
+		const token = shortIdMapping.exposeScoped('conversation-1', canonicalId, ScopedShortIdTargetKind.SCENE);
+
+		expect(token).not.toBeNull();
+
+		return service.executeTool(
+			{ id: 'call-1', name: 'run_scene', arguments: { scene_id: token } },
+			{ audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-1' },
+		);
+	}
 });

--- a/apps/backend/src/modules/scenes/services/scene-tool.service.ts
+++ b/apps/backend/src/modules/scenes/services/scene-tool.service.ts
@@ -14,13 +14,15 @@ import {
 	createToolDefinition,
 } from '../../tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../tools/services/base-tool-provider.service';
-import { ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
+import { ScopedShortIdTargetKind, ShortIdMappingService } from '../../tools/services/short-id-mapping.service';
 import { SCENES_MODULE_NAME, SceneExecutionStatus } from '../scenes.constants';
 
 import { SceneExecutorService } from './scene-executor.service';
 import { ScenesService } from './scenes.service';
 
 const SCENE_TOOLS_PROVIDER = 'scene-tools';
+const BUDDY_TARGET_NOT_EXPOSED_MESSAGE = 'The requested target is not available in this Buddy conversation.';
+const BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE = 'BUDDY_TARGET_NOT_EXPOSED';
 
 const RUN_SCENE_INPUT_SCHEMA = z.object({
 	scene_id: z.string().min(1).describe('Short scene ID from the home context (the id=... value)'),
@@ -77,7 +79,25 @@ export class SceneToolService extends BaseToolProviderService {
 			};
 		}
 
-		const sceneId = this.shortIdMapping.resolve(parsed.data.scene_id) ?? parsed.data.scene_id;
+		const sceneId =
+			context.audience === ToolAudience.BUDDY
+				? context.conversationId
+					? this.shortIdMapping.resolveScoped(
+							context.conversationId,
+							parsed.data.scene_id,
+							ScopedShortIdTargetKind.SCENE,
+						)
+					: null
+				: (this.shortIdMapping.resolve(parsed.data.scene_id) ?? parsed.data.scene_id);
+
+		if (sceneId === null) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: BUDDY_TARGET_NOT_EXPOSED_MESSAGE,
+				errorCode: BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE,
+			};
+		}
 		const scene = await this.scenesService.findOne(sceneId);
 
 		if (!scene) {

--- a/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
+++ b/apps/backend/src/modules/tools/platforms/tool-provider.platform.ts
@@ -74,6 +74,7 @@ export interface ToolExecutionResult {
 export interface ToolExecutionContext {
 	audience: ToolAudience;
 	source: string;
+	conversationId?: string;
 	actorId?: string;
 	requestId?: string;
 	allowedAccessKinds?: ToolAccessKind[];
@@ -90,6 +91,7 @@ export const createToolExecutionContext = (
 ): ToolExecutionContext => ({
 	audience: context?.audience ?? ToolAudience.BUDDY,
 	source: context?.source ?? ToolAudience.BUDDY,
+	conversationId: context?.conversationId,
 	actorId: context?.actorId,
 	requestId: context?.requestId ?? toolCall.id,
 	allowedAccessKinds: context?.allowedAccessKinds,

--- a/apps/backend/src/modules/tools/services/short-id-mapping.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/short-id-mapping.service.spec.ts
@@ -195,13 +195,13 @@ describe('ShortIdMappingService', () => {
 			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.PROPERTY)).toBe('property-0');
 		});
 
-		it('evicts only another conversation under global pressure and never reassigns its stale token', () => {
+		it('rejects new global-cap exposures without invalidating any retained conversation', () => {
 			const activeToken = service.exposeScoped(
 				'active-conversation',
 				'property-kept',
 				ScopedShortIdTargetKind.PROPERTY,
 			);
-			let evictedToken: string | null = null;
+			let otherConversationToken: string | null = null;
 			let remaining = MAX_SCOPED_SHORT_ID_MAPPINGS - 1;
 
 			for (let conversationIndex = 1; remaining > 0; conversationIndex += 1) {
@@ -215,7 +215,7 @@ describe('ShortIdMappingService', () => {
 					);
 
 					if (conversationIndex === 1 && targetIndex === 0) {
-						evictedToken = token;
+						otherConversationToken = token;
 					}
 				}
 
@@ -225,20 +225,13 @@ describe('ShortIdMappingService', () => {
 			expect(service.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS);
 			const newest = service.exposeScoped('active-conversation', 'property-new', ScopedShortIdTargetKind.PROPERTY);
 
-			expect(newest).not.toBeNull();
-			expect(service.resolveScoped('conversation-1', evictedToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(newest).toBeNull();
+			expect(
+				service.resolveScoped('conversation-1', otherConversationToken ?? '', ScopedShortIdTargetKind.PROPERTY),
+			).toBe('property-0');
 			expect(service.resolveScoped('active-conversation', activeToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
 				'property-kept',
 			);
-			expect(service.resolveScoped('active-conversation', newest ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
-				'property-new',
-			);
-
-			const replacement = service.exposeScoped('conversation-1', 'property-0', ScopedShortIdTargetKind.PROPERTY);
-
-			expect(replacement).not.toBeNull();
-			expect(replacement).not.toBe(evictedToken);
-			expect(service.resolveScoped('conversation-1', evictedToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
 			expect(service.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS);
 		});
 	});

--- a/apps/backend/src/modules/tools/services/short-id-mapping.service.spec.ts
+++ b/apps/backend/src/modules/tools/services/short-id-mapping.service.spec.ts
@@ -1,4 +1,9 @@
-import { ShortIdMappingService } from './short-id-mapping.service';
+import {
+	MAX_SCOPED_SHORT_ID_MAPPINGS,
+	MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION,
+	ScopedShortIdTargetKind,
+	ShortIdMappingService,
+} from './short-id-mapping.service';
 
 describe('ShortIdMappingService', () => {
 	let service: ShortIdMappingService;
@@ -72,6 +77,169 @@ describe('ShortIdMappingService', () => {
 
 			expect(service.resolve(firstShortId)).toBeNull();
 			expect(service.size).toBe(10_000);
+		});
+	});
+
+	describe('conversation-scoped references', () => {
+		it('returns a stable opaque kind-prefixed token for a retained exposure', () => {
+			const first = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const second = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(first).toBe(second);
+			expect(first).toMatch(/^pr_[0-9a-z]+_[A-Za-z0-9_-]{10}$/);
+			expect(first).not.toContain('property-1');
+			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.PROPERTY)).toBe('property-1');
+		});
+
+		it('isolates identical targets between conversations', () => {
+			const first = service.exposeScoped('conversation-1', 'scene-1', ScopedShortIdTargetKind.SCENE);
+			const second = service.exposeScoped('conversation-2', 'scene-1', ScopedShortIdTargetKind.SCENE);
+
+			expect(first).not.toBe(second);
+			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.SCENE)).toBe('scene-1');
+			expect(service.resolveScoped('conversation-2', first, ScopedShortIdTargetKind.SCENE)).toBeNull();
+			expect(service.resolveScoped('conversation-2', second, ScopedShortIdTargetKind.SCENE)).toBe('scene-1');
+		});
+
+		it('isolates the same opaque token string when it collides across conversations', () => {
+			jest
+				.spyOn(
+					service as unknown as {
+						createScopedToken: (conversationId: string, canonicalId: string, kind: ScopedShortIdTargetKind) => string;
+					},
+					'createScopedToken',
+				)
+				.mockReturnValue('pr_shared-token');
+
+			const first = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const second = service.exposeScoped('conversation-2', 'property-2', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(first).toBe(second);
+			expect(service.resolveScoped('conversation-1', first ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe('property-1');
+			expect(service.resolveScoped('conversation-2', second ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
+				'property-2',
+			);
+		});
+
+		it('does not resolve a token under the wrong target kind', () => {
+			const token = service.exposeScoped('conversation-1', 'target-1', ScopedShortIdTargetKind.SPACE);
+
+			expect(service.resolveScoped('conversation-1', token, ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.resolveScoped('conversation-1', token, ScopedShortIdTargetKind.SCENE)).toBeNull();
+			expect(service.resolveScoped('conversation-1', token, ScopedShortIdTargetKind.SPACE)).toBe('target-1');
+		});
+
+		it('clears only the requested conversation and never falls back to the global mapping', () => {
+			const globalToken = service.shorten('property-1');
+			const first = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const second = service.exposeScoped('conversation-2', 'property-2', ScopedShortIdTargetKind.PROPERTY);
+
+			service.clearScope('conversation-1');
+
+			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.resolveScoped('conversation-1', globalToken, ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.resolveScoped('conversation-2', second, ScopedShortIdTargetKind.PROPERTY)).toBe('property-2');
+			expect(service.resolve(globalToken)).toBe('property-1');
+		});
+
+		it('clears all scoped references without changing the global mapping or reusing old tokens', () => {
+			const globalToken = service.shorten('property-global');
+			const first = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const second = service.exposeScoped('conversation-2', 'scene-1', ScopedShortIdTargetKind.SCENE);
+
+			service.clearAllScopes();
+
+			expect(service.scopedSize).toBe(0);
+			expect(service.resolveScoped('conversation-1', first ?? '', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.resolveScoped('conversation-2', second ?? '', ScopedShortIdTargetKind.SCENE)).toBeNull();
+			expect(service.resolve(globalToken)).toBe('property-global');
+
+			const replacement = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(replacement).not.toBe(first);
+		});
+
+		it('retries an active token collision without reassigning the original token', () => {
+			const createScopedToken = jest.spyOn(
+				service as unknown as {
+					createScopedToken: (conversationId: string, canonicalId: string, kind: ScopedShortIdTargetKind) => string;
+				},
+				'createScopedToken',
+			);
+
+			createScopedToken
+				.mockReturnValueOnce('pr_collision')
+				.mockReturnValueOnce('pr_collision')
+				.mockReturnValueOnce('pr_next');
+
+			const first = service.exposeScoped('conversation-1', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+			const second = service.exposeScoped('conversation-1', 'property-2', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(first).toBe('pr_collision');
+			expect(second).toBe('pr_next');
+			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.PROPERTY)).toBe('property-1');
+			expect(service.resolveScoped('conversation-1', second, ScopedShortIdTargetKind.PROPERTY)).toBe('property-2');
+		});
+
+		it('returns null at the conversation cap without invalidating a previously exposed token', () => {
+			const first = service.exposeScoped('conversation-1', 'property-0', ScopedShortIdTargetKind.PROPERTY);
+
+			for (let index = 1; index < MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION; index += 1) {
+				expect(
+					service.exposeScoped('conversation-1', `property-${index}`, ScopedShortIdTargetKind.PROPERTY),
+				).not.toBeNull();
+			}
+
+			expect(service.exposeScoped('conversation-1', 'property-overflow', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION);
+			expect(service.resolveScoped('conversation-1', first, ScopedShortIdTargetKind.PROPERTY)).toBe('property-0');
+		});
+
+		it('evicts only another conversation under global pressure and never reassigns its stale token', () => {
+			const activeToken = service.exposeScoped(
+				'active-conversation',
+				'property-kept',
+				ScopedShortIdTargetKind.PROPERTY,
+			);
+			let evictedToken: string | null = null;
+			let remaining = MAX_SCOPED_SHORT_ID_MAPPINGS - 1;
+
+			for (let conversationIndex = 1; remaining > 0; conversationIndex += 1) {
+				const conversationEntries = Math.min(MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION, remaining);
+
+				for (let targetIndex = 0; targetIndex < conversationEntries; targetIndex += 1) {
+					const token = service.exposeScoped(
+						`conversation-${conversationIndex}`,
+						`property-${targetIndex}`,
+						ScopedShortIdTargetKind.PROPERTY,
+					);
+
+					if (conversationIndex === 1 && targetIndex === 0) {
+						evictedToken = token;
+					}
+				}
+
+				remaining -= conversationEntries;
+			}
+
+			expect(service.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS);
+			const newest = service.exposeScoped('active-conversation', 'property-new', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(newest).not.toBeNull();
+			expect(service.resolveScoped('conversation-1', evictedToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.resolveScoped('active-conversation', activeToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
+				'property-kept',
+			);
+			expect(service.resolveScoped('active-conversation', newest ?? '', ScopedShortIdTargetKind.PROPERTY)).toBe(
+				'property-new',
+			);
+
+			const replacement = service.exposeScoped('conversation-1', 'property-0', ScopedShortIdTargetKind.PROPERTY);
+
+			expect(replacement).not.toBeNull();
+			expect(replacement).not.toBe(evictedToken);
+			expect(service.resolveScoped('conversation-1', evictedToken ?? '', ScopedShortIdTargetKind.PROPERTY)).toBeNull();
+			expect(service.scopedSize).toBe(MAX_SCOPED_SHORT_ID_MAPPINGS);
 		});
 	});
 });

--- a/apps/backend/src/modules/tools/services/short-id-mapping.service.ts
+++ b/apps/backend/src/modules/tools/services/short-id-mapping.service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, createHmac, randomBytes } from 'crypto';
 
 import { Injectable } from '@nestjs/common';
 
@@ -14,6 +14,22 @@ const SHORT_ID_LENGTH = 4;
  * 10 000 entries is generous for a home automation context and caps memory usage.
  */
 const MAX_MAPPINGS = 10_000;
+
+export enum ScopedShortIdTargetKind {
+	SPACE = 'space',
+	PROPERTY = 'property',
+	SCENE = 'scene',
+}
+
+export const MAX_SCOPED_SHORT_ID_MAPPINGS = 10_000;
+export const MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION = 1_000;
+
+interface ScopedShortIdMapping {
+	canonicalId: string;
+	conversationId: string;
+	kind: ScopedShortIdTargetKind;
+	token: string;
+}
 
 /**
  * Generates deterministic short IDs for UUIDs used in the LLM system prompt and
@@ -36,6 +52,19 @@ export class ShortIdMappingService {
 
 	/** Full UUID → short ID (reverse lookup to avoid generating duplicates for the same UUID) */
 	private readonly uuidToShort = new Map<string, string>();
+
+	/** Conversation + opaque token -> scoped target. Map insertion order is the global scoped LRU. */
+	private readonly scopedMappings = new Map<string, ScopedShortIdMapping>();
+
+	/** Conversation + kind + canonical ID -> opaque token. */
+	private readonly scopedTargets = new Map<string, string>();
+	private readonly scopedConversationSizes = new Map<string, number>();
+
+	/** Per-process secret keeps scoped references opaque and non-derivable from canonical IDs. */
+	private readonly scopedSecret = randomBytes(32);
+
+	/** Monotonic component guarantees that an evicted token is never reassigned during this service lifetime. */
+	private scopedTokenSequence = 0n;
 
 	/**
 	 * Get or create a short ID for the given UUID.
@@ -83,6 +112,101 @@ export class ShortIdMappingService {
 		return this.shortToUuid.size;
 	}
 
+	/**
+	 * Expose a target under a conversation-scoped opaque reference.
+	 * Repeated exposure of the same kind/target in one conversation returns the same token while retained.
+	 */
+	exposeScoped(conversationId: string, canonicalId: string, kind: ScopedShortIdTargetKind): string | null {
+		if (conversationId.length === 0 || canonicalId.length === 0) {
+			throw new TypeError('Scoped short IDs require non-empty conversation and canonical IDs');
+		}
+
+		const targetKey = this.scopedTargetKey(conversationId, kind, canonicalId);
+		const existing = this.scopedTargets.get(targetKey);
+
+		if (existing) {
+			const mappingKey = this.scopedMappingKey(conversationId, existing);
+			const mapping = this.scopedMappings.get(mappingKey);
+
+			if (mapping) {
+				this.scopedMappings.delete(mappingKey);
+				this.scopedMappings.set(mappingKey, mapping);
+
+				return existing;
+			}
+
+			this.scopedTargets.delete(targetKey);
+		}
+
+		if (this.getScopedConversationSize(conversationId) >= MAX_SCOPED_SHORT_ID_MAPPINGS_PER_CONVERSATION) {
+			return null;
+		}
+
+		let token: string;
+		let attempts = 0;
+
+		do {
+			token = this.createScopedToken(conversationId, canonicalId, kind);
+			attempts += 1;
+
+			if (attempts > 100) {
+				throw new Error('ShortIdMappingService: failed to generate a unique scoped short ID after 100 attempts');
+			}
+		} while (this.scopedMappings.has(this.scopedMappingKey(conversationId, token)));
+
+		if (!this.reserveScopedCapacity(conversationId)) {
+			return null;
+		}
+
+		const mapping: ScopedShortIdMapping = { canonicalId, conversationId, kind, token };
+
+		this.scopedMappings.set(this.scopedMappingKey(conversationId, token), mapping);
+		this.scopedTargets.set(targetKey, token);
+		this.scopedConversationSizes.set(conversationId, this.getScopedConversationSize(conversationId) + 1);
+
+		return token;
+	}
+
+	/** Resolve an opaque reference only inside the same conversation and target kind. */
+	resolveScoped(conversationId: string, token: string, kind: ScopedShortIdTargetKind): string | null {
+		const mappingKey = this.scopedMappingKey(conversationId, token);
+		const mapping = this.scopedMappings.get(mappingKey);
+
+		if (!mapping || mapping.kind !== kind) {
+			return null;
+		}
+
+		this.scopedMappings.delete(mappingKey);
+		this.scopedMappings.set(mappingKey, mapping);
+
+		return mapping.canonicalId;
+	}
+
+	/** Remove every scoped reference exposed in one conversation. */
+	clearScope(conversationId: string): void {
+		for (const [mappingKey, mapping] of this.scopedMappings) {
+			if (mapping.conversationId !== conversationId) {
+				continue;
+			}
+
+			this.scopedMappings.delete(mappingKey);
+			this.scopedTargets.delete(this.scopedTargetKey(mapping.conversationId, mapping.kind, mapping.canonicalId));
+		}
+
+		this.scopedConversationSizes.delete(conversationId);
+	}
+
+	/** Remove all scoped references without resetting token identity. */
+	clearAllScopes(): void {
+		this.scopedMappings.clear();
+		this.scopedTargets.clear();
+		this.scopedConversationSizes.clear();
+	}
+
+	get scopedSize(): number {
+		return this.scopedMappings.size;
+	}
+
 	private evictIfNeeded(): void {
 		while (this.shortToUuid.size >= MAX_MAPPINGS) {
 			// Map iteration order is insertion order — first entry is the oldest
@@ -100,6 +224,74 @@ export class ShortIdMappingService {
 				this.uuidToShort.delete(oldUuid);
 			}
 		}
+	}
+
+	private reserveScopedCapacity(activeConversationId: string): boolean {
+		while (this.scopedMappings.size >= MAX_SCOPED_SHORT_ID_MAPPINGS) {
+			const oldestKey = [...this.scopedMappings].find(
+				([, mapping]) => mapping.conversationId !== activeConversationId,
+			)?.[0];
+
+			if (!oldestKey) {
+				return false;
+			}
+
+			const oldest = this.scopedMappings.get(oldestKey);
+
+			this.scopedMappings.delete(oldestKey);
+
+			if (oldest) {
+				this.scopedTargets.delete(this.scopedTargetKey(oldest.conversationId, oldest.kind, oldest.canonicalId));
+				this.decrementScopedConversationSize(oldest.conversationId);
+			}
+		}
+
+		return true;
+	}
+
+	private getScopedConversationSize(conversationId: string): number {
+		return this.scopedConversationSizes.get(conversationId) ?? 0;
+	}
+
+	private decrementScopedConversationSize(conversationId: string): void {
+		const nextSize = this.getScopedConversationSize(conversationId) - 1;
+
+		if (nextSize <= 0) {
+			this.scopedConversationSizes.delete(conversationId);
+		} else {
+			this.scopedConversationSizes.set(conversationId, nextSize);
+		}
+	}
+
+	private createScopedToken(conversationId: string, canonicalId: string, kind: ScopedShortIdTargetKind): string {
+		this.scopedTokenSequence += 1n;
+
+		const sequence = this.scopedTokenSequence.toString(36);
+		const signature = createHmac('sha256', this.scopedSecret)
+			.update(`${conversationId}\u0000${kind}\u0000${canonicalId}\u0000${sequence}`)
+			.digest('base64url')
+			.slice(0, 10);
+
+		return `${this.scopedKindPrefix(kind)}_${sequence}_${signature}`;
+	}
+
+	private scopedKindPrefix(kind: ScopedShortIdTargetKind): string {
+		switch (kind) {
+			case ScopedShortIdTargetKind.SPACE:
+				return 'sp';
+			case ScopedShortIdTargetKind.PROPERTY:
+				return 'pr';
+			case ScopedShortIdTargetKind.SCENE:
+				return 'sc';
+		}
+	}
+
+	private scopedMappingKey(conversationId: string, token: string): string {
+		return `${conversationId}\u0000${token}`;
+	}
+
+	private scopedTargetKey(conversationId: string, kind: ScopedShortIdTargetKind, canonicalId: string): string {
+		return `${conversationId}\u0000${kind}\u0000${canonicalId}`;
 	}
 
 	/**

--- a/apps/backend/src/modules/tools/services/short-id-mapping.service.ts
+++ b/apps/backend/src/modules/tools/services/short-id-mapping.service.ts
@@ -154,7 +154,7 @@ export class ShortIdMappingService {
 			}
 		} while (this.scopedMappings.has(this.scopedMappingKey(conversationId, token)));
 
-		if (!this.reserveScopedCapacity(conversationId)) {
+		if (!this.reserveScopedCapacity()) {
 			return null;
 		}
 
@@ -226,27 +226,10 @@ export class ShortIdMappingService {
 		}
 	}
 
-	private reserveScopedCapacity(activeConversationId: string): boolean {
-		while (this.scopedMappings.size >= MAX_SCOPED_SHORT_ID_MAPPINGS) {
-			const oldestKey = [...this.scopedMappings].find(
-				([, mapping]) => mapping.conversationId !== activeConversationId,
-			)?.[0];
-
-			if (!oldestKey) {
-				return false;
-			}
-
-			const oldest = this.scopedMappings.get(oldestKey);
-
-			this.scopedMappings.delete(oldestKey);
-
-			if (oldest) {
-				this.scopedTargets.delete(this.scopedTargetKey(oldest.conversationId, oldest.kind, oldest.canonicalId));
-				this.decrementScopedConversationSize(oldest.conversationId);
-			}
-		}
-
-		return true;
+	private reserveScopedCapacity(): boolean {
+		// Never evict a reference that may still be present in an in-flight prompt.
+		// Conversation deletion and module reset provide explicit reclamation points.
+		return this.scopedMappings.size < MAX_SCOPED_SHORT_ID_MAPPINGS;
 	}
 
 	private getScopedConversationSize(conversationId: string): number {

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.spec.ts
@@ -7,7 +7,10 @@ import {
 	ToolAudience,
 	ToolExecutionStatus,
 } from '../../../modules/tools/platforms/tool-provider.platform';
-import { ShortIdMappingService } from '../../../modules/tools/services/short-id-mapping.service';
+import {
+	ScopedShortIdTargetKind,
+	ShortIdMappingService,
+} from '../../../modules/tools/services/short-id-mapping.service';
 
 import { SpaceLightingToolService } from './space-lighting-tool.service';
 
@@ -15,6 +18,7 @@ describe('SpaceLightingToolService', () => {
 	let service: SpaceLightingToolService;
 	let spacesService: Record<string, jest.Mock>;
 	let spaceIntentService: Record<string, jest.Mock>;
+	let shortIdMapping: ShortIdMappingService;
 
 	beforeEach(async () => {
 		spacesService = {
@@ -29,10 +33,11 @@ describe('SpaceLightingToolService', () => {
 			get: jest.fn().mockReturnValue(spaceIntentService),
 		};
 
+		shortIdMapping = new ShortIdMappingService();
 		service = new SpaceLightingToolService(
 			spacesService as unknown as SpacesService,
 			moduleRef as unknown as ModuleRef,
-			new ShortIdMappingService(),
+			shortIdMapping,
 		);
 
 		// Simulate onModuleInit which resolves SpaceIntentService lazily
@@ -77,11 +82,7 @@ describe('SpaceLightingToolService', () => {
 			});
 			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Living Room' });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'space-1', mode: 'off' },
-			});
+			const result = await executeBuddyLighting('space-1', 'off');
 
 			expect(result.success).toBe(true);
 			expect(result.status).toBe(ToolExecutionStatus.COMPLETED);
@@ -105,11 +106,7 @@ describe('SpaceLightingToolService', () => {
 			});
 			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Bedroom' });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'space-1', mode: 'relax' },
-			});
+			const result = await executeBuddyLighting('space-1', 'relax');
 
 			expect(result.success).toBe(true);
 			expect(spaceIntentService.executeLightingIntent).toHaveBeenCalledWith(
@@ -122,11 +119,7 @@ describe('SpaceLightingToolService', () => {
 		it('should return failure for non-existent space', async () => {
 			spaceIntentService.executeLightingIntent.mockResolvedValue(null);
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'nonexistent', mode: 'off' },
-			});
+			const result = await executeBuddyLighting('nonexistent', 'off');
 
 			expect(result.success).toBe(false);
 			expect(result.message).toContain('not found');
@@ -162,11 +155,7 @@ describe('SpaceLightingToolService', () => {
 			});
 			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'space-1', mode: 'work' },
-			});
+			const result = await executeBuddyLighting('space-1', 'work');
 
 			expect(result).toEqual(
 				expect.objectContaining({
@@ -186,11 +175,7 @@ describe('SpaceLightingToolService', () => {
 			});
 			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'space-1', mode: 'work' },
-			});
+			const result = await executeBuddyLighting('space-1', 'work');
 
 			expect(result).toEqual(
 				expect.objectContaining({
@@ -215,11 +200,7 @@ describe('SpaceLightingToolService', () => {
 			});
 			spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Office' });
 
-			const result = await service.executeTool({
-				id: 'call-1',
-				name: 'set_space_lighting',
-				arguments: { space_id: 'space-1', mode: 'work' },
-			});
+			const result = await executeBuddyLighting('space-1', 'work');
 
 			expect(result).toEqual(
 				expect.objectContaining({
@@ -233,19 +214,25 @@ describe('SpaceLightingToolService', () => {
 	});
 
 	it('returns a structured failure when the optional lighting service is unavailable', async () => {
+		const unavailableMapping = new ShortIdMappingService();
+		const token = unavailableMapping.exposeScoped('conversation-1', 'space-1', ScopedShortIdTargetKind.SPACE);
 		const unavailableService = new SpaceLightingToolService(
 			spacesService as unknown as SpacesService,
 			{ get: jest.fn().mockReturnValue(undefined) } as unknown as ModuleRef,
-			new ShortIdMappingService(),
+			unavailableMapping,
 		);
 
+		expect(token).not.toBeNull();
 		await unavailableService.onModuleInit();
 
-		const result = await unavailableService.executeTool({
-			id: 'call-1',
-			name: 'set_space_lighting',
-			arguments: { space_id: 'space-1', mode: 'off' },
-		});
+		const result = await unavailableService.executeTool(
+			{
+				id: 'call-1',
+				name: 'set_space_lighting',
+				arguments: { space_id: token, mode: 'off' },
+			},
+			{ audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-1' },
+		);
 
 		expect(result).toEqual(
 			expect.objectContaining({
@@ -254,6 +241,89 @@ describe('SpaceLightingToolService', () => {
 				errorCode: 'SPACE_LIGHTING_UNAVAILABLE',
 			}),
 		);
+	});
+
+	it('preserves MCP global short-ID and canonical-ID fallback', async () => {
+		const globalShortId = shortIdMapping.shorten('space-1');
+
+		spaceIntentService.executeLightingIntent.mockResolvedValue({
+			success: true,
+			affectedDevices: 1,
+			failedDevices: 0,
+		});
+		spacesService.findOne.mockResolvedValue({ id: 'space-1', name: 'Living Room' });
+
+		for (const spaceId of [globalShortId, 'space-1']) {
+			await service.executeTool(
+				{ id: 'mcp-call', name: 'set_space_lighting', arguments: { space_id: spaceId, mode: 'off' } },
+				{ audience: ToolAudience.MCP, source: 'mcp' },
+			);
+		}
+
+		expect(spaceIntentService.executeLightingIntent).toHaveBeenNthCalledWith(
+			1,
+			'space-1',
+			expect.any(Object),
+			expect.any(Object),
+		);
+		expect(spaceIntentService.executeLightingIntent).toHaveBeenNthCalledWith(
+			2,
+			'space-1',
+			expect.any(Object),
+			expect.any(Object),
+		);
+	});
+
+	it('denies unscoped, foreign, wrong-kind, stale, and canonical Buddy space IDs without a domain call', async () => {
+		const valid = shortIdMapping.exposeScoped('conversation-a', 'space-1', ScopedShortIdTargetKind.SPACE);
+		const wrongKind = shortIdMapping.exposeScoped('conversation-a', 'property-1', ScopedShortIdTargetKind.PROPERTY);
+		const stale = shortIdMapping.exposeScoped('conversation-stale', 'space-2', ScopedShortIdTargetKind.SPACE);
+
+		expect(valid).not.toBeNull();
+		expect(wrongKind).not.toBeNull();
+		expect(stale).not.toBeNull();
+		shortIdMapping.clearScope('conversation-stale');
+
+		const attempts = [
+			{ spaceId: valid, context: { audience: ToolAudience.BUDDY, source: 'buddy' } },
+			{
+				spaceId: valid,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-b' },
+			},
+			{
+				spaceId: wrongKind,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+			},
+			{
+				spaceId: stale,
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-stale' },
+			},
+			{
+				spaceId: 'space-1',
+				context: { audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-a' },
+			},
+		];
+
+		for (const attempt of attempts) {
+			await expect(
+				service.executeTool(
+					{
+						id: 'call-denied',
+						name: 'set_space_lighting',
+						arguments: { space_id: attempt.spaceId, mode: 'off' },
+					},
+					attempt.context,
+				),
+			).resolves.toEqual({
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: 'The requested target is not available in this Buddy conversation.',
+				errorCode: 'BUDDY_TARGET_NOT_EXPOSED',
+			});
+		}
+
+		expect(spaceIntentService.executeLightingIntent).not.toHaveBeenCalled();
+		expect(spacesService.findOne).not.toHaveBeenCalled();
 	});
 
 	describe('executeTool - unknown tool', () => {
@@ -267,4 +337,19 @@ describe('SpaceLightingToolService', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	async function executeBuddyLighting(canonicalId: string, mode: 'off' | 'on' | 'work' | 'relax' | 'night') {
+		const token = shortIdMapping.exposeScoped('conversation-1', canonicalId, ScopedShortIdTargetKind.SPACE);
+
+		expect(token).not.toBeNull();
+
+		return service.executeTool(
+			{
+				id: 'call-1',
+				name: 'set_space_lighting',
+				arguments: { space_id: token, mode },
+			},
+			{ audience: ToolAudience.BUDDY, source: 'buddy', conversationId: 'conversation-1' },
+		);
+	}
 });

--- a/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
+++ b/apps/backend/src/plugins/spaces-home-control/services/space-lighting-tool.service.ts
@@ -17,11 +17,16 @@ import {
 	createToolDefinition,
 } from '../../../modules/tools/platforms/tool-provider.platform';
 import { BaseToolProviderService } from '../../../modules/tools/services/base-tool-provider.service';
-import { ShortIdMappingService } from '../../../modules/tools/services/short-id-mapping.service';
+import {
+	ScopedShortIdTargetKind,
+	ShortIdMappingService,
+} from '../../../modules/tools/services/short-id-mapping.service';
 import { LightingIntentDto } from '../dto/lighting-intent.dto';
 import { LightingIntentType, LightingMode } from '../spaces-home-control.constants';
 
 const SPACE_LIGHTING_TOOLS_PROVIDER = 'space-lighting-tools';
+const BUDDY_TARGET_NOT_EXPOSED_MESSAGE = 'The requested target is not available in this Buddy conversation.';
+const BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE = 'BUDDY_TARGET_NOT_EXPOSED';
 const LIGHTING_MODES = ['off', 'on', 'work', 'relax', 'night'] as const;
 
 const SET_SPACE_LIGHTING_INPUT_SCHEMA = z.object({
@@ -92,7 +97,25 @@ export class SpaceLightingToolService extends BaseToolProviderService implements
 			};
 		}
 
-		const spaceId = this.shortIdMapping.resolve(parsed.data.space_id) ?? parsed.data.space_id;
+		const spaceId =
+			context.audience === ToolAudience.BUDDY
+				? context.conversationId
+					? this.shortIdMapping.resolveScoped(
+							context.conversationId,
+							parsed.data.space_id,
+							ScopedShortIdTargetKind.SPACE,
+						)
+					: null
+				: (this.shortIdMapping.resolve(parsed.data.space_id) ?? parsed.data.space_id);
+
+		if (spaceId === null) {
+			return {
+				success: false,
+				status: ToolExecutionStatus.DENIED,
+				message: BUDDY_TARGET_NOT_EXPOSED_MESSAGE,
+				errorCode: BUDDY_TARGET_NOT_EXPOSED_ERROR_CODE,
+			};
+		}
 
 		if (!this.spaceIntentService) {
 			return {

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1563,9 +1563,9 @@ busy response leaves an ownerless nonterminal sequence capable of blocking later
 - [x] Return concise messages plus bounded structured data and freshness/truncation/coverage metadata.
 - [x] Add bounded, opaque, kind-bound conversation-scoped Buddy mappings to `ShortIdMappingService`; register only
       references rendered in that conversation and require the same scope in every Buddy action lookup, with no
-      unscoped/global or canonical fallback. Capacity exhaustion omits further action references instead of invalidating
-      references already rendered in the active conversation. Preserve existing non-Buddy mapping behavior and canonical
-      UUID fallback.
+      unscoped/global or canonical fallback. Per-conversation or global capacity exhaustion omits further action references
+      instead of invalidating any reference that may be present in an in-flight prompt. Preserve existing non-Buddy mapping
+      behavior and canonical UUID fallback.
 - [ ] Add tool selection support so unrelated schemas are not advertised on every turn.
 - [x] Register the initial read tools behind conversation-scoped action-reference containment: discovered canonical IDs
       remain valid for dependent reads but cannot authorize Buddy writes/triggers. This containment is not the complete

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -364,8 +364,10 @@ unless tests prove the platform implementation insufficient.
 
 For reads, several close matches may be returned with scores/reasons. For writes/triggers, the resolver must mark the
 result ambiguous if more than one compatible candidate is plausible. Never use a tiny score difference to authorize an
-action. Canonical UUIDs remain valid tool inputs, but for a Buddy-origin action the UUID/short ID supplied by the model is
-not resolution proof. Search/read exposure never grants action authority. `BuddyActionResolutionService` must bind a
+action. Canonical UUIDs remain valid read and non-Buddy tool inputs, but for a Buddy-origin action an ID supplied by the
+model is not resolution proof. Until the complete proof service lands, live Buddy actions accept only an opaque target
+reference actually rendered in that same conversation; canonical IDs returned by search/read tools fail closed.
+Search/read exposure never grants action authority. `BuddyActionResolutionService` must bind a
 server-generated `BuddyActionResolutionProof` to the request claim, original-user-intent digest, deterministically
 extracted canonical action semantics/arguments, canonical target, candidate-set digest, conversation/safety epoch,
 resolution method, and expiry. Valid target methods are an identifier explicitly supplied by the user, a deterministic
@@ -1236,7 +1238,7 @@ captured as an opt-in/expected baseline measurement rather than a failing normal
 - [x] Add SQL-applied static metadata candidate filters for readable/writable properties and enabled triggerable scenes.
       Expose candidate capabilities derived from persisted metadata and the static command-type allowlist without
       treating discovery as authorization, online availability, or proof that an action can execute.
-- [ ] Expose the bounded metadata search through a Buddy read tool after the structured tool-result loop is available.
+- [x] Expose the bounded metadata search through a Buddy read tool after the structured tool-result loop is available.
 - [x] Add database-bounded current-state rows plus `any`, `all`, and exact `count_matches` predicates over readable
       properties. Require explicit units for numeric comparisons; report eligible/scanned/evaluated/unknown coverage,
       bounded evidence rows, typed partial reasons, and only logically conclusive partial boolean outcomes.
@@ -1555,23 +1557,26 @@ busy response leaves an ownerless nonterminal sequence capable of blocking later
 
 - [ ] Implement the bounded Buddy read tool catalog from Section 6.
 - [x] Add the provider foundation for `search_home` and completeness-safe `query_home_state` with server-selected Buddy
-      profiles; keep the remaining catalog entries and live registration open.
+      profiles; keep the remaining catalog entries open.
 - [x] Mark the initial tools `ToolAudience.BUDDY` and `ToolAccessKind.READ`.
 - [x] Validate their strict adapter inputs and structured outputs using the shared schemas.
 - [x] Return concise messages plus bounded structured data and freshness/truncation/coverage metadata.
-- [ ] Add conversation-scoped Buddy mappings to `ShortIdMappingService`; register only results exposed in that
-      conversation and require the same scope in every Buddy short-ID action lookup, with no unscoped/global fallback.
-      Preserve existing non-Buddy mapping behavior and canonical UUID fallback.
+- [x] Add bounded, opaque, kind-bound conversation-scoped Buddy mappings to `ShortIdMappingService`; register only
+      references rendered in that conversation and require the same scope in every Buddy action lookup, with no
+      unscoped/global or canonical fallback. Capacity exhaustion omits further action references instead of invalidating
+      references already rendered in the active conversation. Preserve existing non-Buddy mapping behavior and canonical
+      UUID fallback.
 - [ ] Add tool selection support so unrelated schemas are not advertised on every turn.
-- [ ] Register the initial read tools after conversation-scoped target exposure and action-resolution proof prevent a
-      discovered canonical ID from authorizing an action by itself.
+- [x] Register the initial read tools behind conversation-scoped action-reference containment: discovered canonical IDs
+      remain valid for dependent reads but cannot authorize Buddy writes/triggers. This containment is not the complete
+      server-held action-resolution proof from Section 5.4, which remains open.
 - [x] Verify no MCP configuration, token, policy, or server service is injected into the Buddy read provider.
 
 **Tests:** Every schema boundary and hard cap; missing optional modules; stale/missing entities; hidden/disabled entities;
 long labels/values; multi-language/diacritic search; same-token collisions across conversations; two colliding UUIDs in
 one conversation; and proof that a short ID exposed only in conversation A is denied in conversation B and after
-scope eviction instead of resolving through the global mapping; multiple plausible search results followed by a model
-choosing one exposed UUID/short ID still yielding ambiguity and zero execution.
+scope eviction instead of resolving through the global mapping. Multiple plausible search results and ambiguity-safe
+action resolution remain acceptance tests for the open `BuddyActionResolutionService` work in Phase 2.
 
 **Gate:** An isolated Buddy tool-loop integration harness can answer every read-only home-state row in the message matrix
 through the new provider without that provider calling the eager snapshot. A model can call `search_home`, receive


### PR DESCRIPTION
## Summary

- add bounded opaque, kind-bound action references scoped to one Buddy conversation
- require scoped references for Buddy device, scene, and space-lighting actions while preserving MCP canonical/global resolution
- register `search_home` and `query_home_state` after proving discovered canonical IDs cannot authorize Buddy actions
- clear references on conversation deletion and factory-reset admission, and budget opaque references conservatively

## Safety boundary

This is action-reference containment, not the complete `BuddyActionResolutionProof`. Search and state results retain canonical IDs for dependent reads, but Buddy writes/triggers fail closed unless the target reference was rendered in the same conversation. Full intent binding, ambiguity handling, expiry, claim/safety-epoch binding, and final action revalidation remain open in the plan.

## Validation

- Buddy Jest: 32 suites, 474 tests, 2 snapshots
- focused action/reference Jest: 10 suites, 129 tests
- backend type-check
- focused ESLint and Prettier
- `git diff --check`

> 👍 Codex review passed on `a3c938540a`.