### PR TITLE
feat(backend): select Buddy tools by message

### DIFF
--- a/apps/backend/src/modules/buddy/buddy.module.ts
+++ b/apps/backend/src/modules/buddy/buddy.module.ts
@@ -38,6 +38,7 @@ import { BuddyContextService } from './services/buddy-context.service';
 import { BuddyConversationService } from './services/buddy-conversation.service';
 import { BuddyPersonalityService } from './services/buddy-personality.service';
 import { BuddyProviderStatusService } from './services/buddy-provider-status.service';
+import { BuddyToolSelectionService } from './services/buddy-tool-selection.service';
 import { ConflictDetectorEvaluator } from './services/conflict-detector-evaluator.service';
 import { EnergyEvaluator } from './services/energy-evaluator.service';
 import { HeartbeatService } from './services/heartbeat.service';
@@ -95,6 +96,7 @@ import { EvaluatorRulesLoaderService } from './spec/evaluator-rules-loader.servi
 		LlmProviderRegistryService,
 		LlmProviderService,
 		BuddyConversationService,
+		BuddyToolSelectionService,
 		HomeContextToolProviderService,
 		PatternDetectorService,
 		SuggestionEngineService,

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.native-tool-loop.spec.ts
@@ -16,6 +16,7 @@ import { BuddyProviderErrorException } from '../buddy.exceptions';
 import type { LlmConversationItem, LlmOptions, LlmResponse, LlmResponseMeta } from '../platforms/llm-provider.platform';
 
 import { BuddyConversationService } from './buddy-conversation.service';
+import { BuddyToolSelectionService } from './buddy-tool-selection.service';
 
 interface NativeToolLoopHarness {
 	sendWithToolExecution(
@@ -78,6 +79,7 @@ describe('BuddyConversationService native tool loop', () => {
 			{} as never,
 			{} as never,
 			{} as never,
+			new BuddyToolSelectionService(),
 		);
 	});
 

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.spec.ts
@@ -32,6 +32,7 @@ import {
 import { BuddyContextService } from './buddy-context.service';
 import { BuddyConversationService } from './buddy-conversation.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
+import { BuddyToolSelectionService } from './buddy-tool-selection.service';
 import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
 import { LlmProviderService } from './llm-provider.service';
 
@@ -89,6 +90,27 @@ const BUDDY_EVALUATION_TOOLS = [
 		outputSchema: toolOutputSchema,
 	}),
 ];
+const BUDDY_SELECTION_TOOLS = [
+	SEARCH_HOME_TOOL_NAME,
+	QUERY_HOME_STATE_TOOL_NAME,
+	'control_device',
+	'run_scene',
+	'set_space_lighting',
+].map((name) =>
+	createToolDefinition({
+		name,
+		description: `${name} test tool`,
+		audiences: [ToolAudience.BUDDY],
+		access:
+			name === 'control_device'
+				? ToolAccessKind.WRITE
+				: name === SEARCH_HOME_TOOL_NAME || name === QUERY_HOME_STATE_TOOL_NAME
+					? ToolAccessKind.READ
+					: ToolAccessKind.TRIGGER,
+		inputSchema: z.object({}),
+		outputSchema: toolOutputSchema,
+	}),
+);
 
 describe('BuddyConversationService', () => {
 	let service: BuddyConversationService;
@@ -102,6 +124,7 @@ describe('BuddyConversationService', () => {
 	let eventEmitter: jest.Mocked<EventEmitter2>;
 	let shortIdMapping: ShortIdMappingService;
 	let configService: Record<string, jest.Mock>;
+	let toolSelection: BuddyToolSelectionService;
 
 	const mockConversation: BuddyConversationEntity = {
 		id: 'conv-1',
@@ -197,6 +220,7 @@ describe('BuddyConversationService', () => {
 			getModuleConfig: jest.fn().mockReturnValue({ name: 'Buddy', maxToolIterations: 5, contextWindowTokens: 8_000 }),
 		};
 		shortIdMapping = new ShortIdMappingService();
+		toolSelection = new BuddyToolSelectionService();
 
 		service = new BuddyConversationService(
 			conversationRepo as unknown as Repository<BuddyConversationEntity>,
@@ -209,6 +233,7 @@ describe('BuddyConversationService', () => {
 			eventEmitter,
 			shortIdMapping,
 			configService as unknown as ConfigService,
+			toolSelection,
 		);
 	});
 
@@ -366,6 +391,40 @@ describe('BuddyConversationService', () => {
 			expect(llmProvider.sendMessage).toHaveBeenCalledWith(expect.any(String), expect.any(Array), {
 				tools: [legacyCompatibleTool],
 			});
+		});
+
+		it('omits built-in schemas and action references for general conversation', async () => {
+			contextService.buildContext.mockResolvedValue(createBuddyContextFixture(1));
+			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
+
+			await service.sendMessage('conv-1', 'Hello! Tell me a joke.');
+
+			const [systemPrompt, , options] = llmProvider.sendMessage.mock.calls[0] as [
+				string,
+				unknown[],
+				{ tools?: unknown[] },
+			];
+			expect(options.tools).toBeUndefined();
+			expect(systemPrompt).not.toContain('You can control the home');
+			expect(systemPrompt).not.toContain('[id=');
+			expect(systemPrompt).not.toContain('[p=');
+			expect(shortIdMapping.scopedSize).toBe(0);
+		});
+
+		it('advertises only the dependent read schemas for a focused state request', async () => {
+			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
+
+			await service.sendMessage('conv-1', 'What is the bedroom temperature?');
+
+			const options = llmProvider.sendMessage.mock.calls[0][2] as { tools?: Array<{ name: string }> };
+			expect(options.tools?.map((definition) => definition.name)).toEqual([
+				SEARCH_HOME_TOOL_NAME,
+				QUERY_HOME_STATE_TOOL_NAME,
+			]);
 		});
 
 		it('should format energy values with kW units and omit battery when absent', async () => {
@@ -598,6 +657,7 @@ describe('BuddyConversationService', () => {
 			context.scenes = [{ id: 'scene-1', name: 'Evening', enabled: true, space: 'space-1' }];
 			contextService.buildContext.mockResolvedValue(context);
 			llmProvider.supportsTools.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 
 			await service.sendMessage('conv-1', 'Set the evening mood.');
 
@@ -644,6 +704,7 @@ describe('BuddyConversationService', () => {
 			context.scenes = [{ id: 'scene-overflow', name: 'Overflow Scene', enabled: true, space: 'space-overflow' }];
 			contextService.buildContext.mockResolvedValue(context);
 			llmProvider.supportsTools.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 
 			await service.sendMessage('conv-1', 'Describe the visible home context.');
 
@@ -672,6 +733,7 @@ describe('BuddyConversationService', () => {
 			context.scenes = [{ id: 'scene-retained', name: 'Retained Scene', enabled: true, space: 'space-discarded' }];
 			contextService.buildContext.mockResolvedValue(context);
 			llmProvider.supportsTools.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 			const exposeScoped = jest.spyOn(shortIdMapping, 'exposeScoped');
 
 			await service.sendMessage('conv-1', 'Summarize this home.');
@@ -755,6 +817,7 @@ describe('BuddyConversationService', () => {
 					safetyMarginTokens: 256,
 				});
 				const nativeMessages = payload.messages as Array<{ role: string; content: string }>;
+				const payloadTools = payload.tools as Array<{ function: { name: string } }> | undefined;
 
 				expect(nativeMessages).toHaveLength(21);
 				expect(nativeMessages[0]).toEqual({ role: 'system', content: systemPrompt });
@@ -763,7 +826,11 @@ describe('BuddyConversationService', () => {
 					role: 'user',
 					content: 'Give me a complete status overview for the current home.',
 				});
-				expect(payload.tools).toHaveLength(BUDDY_EVALUATION_TOOLS.length);
+				expect(payloadTools?.map((item) => item.function.name)).toEqual([
+					'search_home_entities',
+					'get_device_state',
+					'set_device_property',
+				]);
 				expect(measurement.components.history.estimatedTokens).toBeGreaterThan(0);
 				expect(measurement.components.current.estimatedTokens).toBeGreaterThan(0);
 				expect(measurement.components.tools.estimatedTokens).toBeGreaterThan(0);
@@ -812,14 +879,14 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 0,
 			      },
 			      "tools": {
-			        "estimatedTokens": 557,
-			        "jsonUtf8Bytes": 1670,
+			        "estimatedTokens": 470,
+			        "jsonUtf8Bytes": 1410,
 			      },
 			    },
 			    "deviceCount": 10,
-			    "estimatedInputTokens": 2898,
+			    "estimatedInputTokens": 2811,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 8721,
+			    "jsonUtf8Bytes": 8461,
 			  },
 			  {
 			    "availableInputTokens": 126688,
@@ -845,14 +912,14 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 0,
 			      },
 			      "tools": {
-			        "estimatedTokens": 557,
-			        "jsonUtf8Bytes": 1670,
+			        "estimatedTokens": 470,
+			        "jsonUtf8Bytes": 1410,
 			      },
 			    },
 			    "deviceCount": 100,
-			    "estimatedInputTokens": 5063,
+			    "estimatedInputTokens": 4976,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 15217,
+			    "jsonUtf8Bytes": 14957,
 			  },
 			  {
 			    "availableInputTokens": 126688,
@@ -878,14 +945,14 @@ describe('BuddyConversationService', () => {
 			        "jsonUtf8Bytes": 0,
 			      },
 			      "tools": {
-			        "estimatedTokens": 557,
-			        "jsonUtf8Bytes": 1670,
+			        "estimatedTokens": 470,
+			        "jsonUtf8Bytes": 1410,
 			      },
 			    },
 			    "deviceCount": 1000,
-			    "estimatedInputTokens": 1623,
+			    "estimatedInputTokens": 1536,
 			    "fitsWindow": true,
-			    "jsonUtf8Bytes": 4897,
+			    "jsonUtf8Bytes": 4637,
 			  },
 			]
 		`);
@@ -953,13 +1020,13 @@ describe('BuddyConversationService', () => {
 			      "jsonUtf8Bytes": 0,
 			    },
 			    "tools": {
-			      "estimatedTokens": 557,
-			      "jsonUtf8Bytes": 1670,
+			      "estimatedTokens": 470,
+			      "jsonUtf8Bytes": 1410,
 			    },
 			  },
-			  "estimatedInputTokens": 2662,
+			  "estimatedInputTokens": 2575,
 			  "fitsWindow": false,
-			  "jsonUtf8Bytes": 8013,
+			  "jsonUtf8Bytes": 7753,
 			}
 		`);
 		});
@@ -1013,6 +1080,8 @@ describe('BuddyConversationService', () => {
 			});
 
 			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 
 			await service.sendMessage('conv-1', 'What is the temperature?');
 
@@ -1062,6 +1131,8 @@ describe('BuddyConversationService', () => {
 			});
 
 			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 
 			await service.sendMessage('conv-scoped', 'What is the temperature?');
 
@@ -1103,6 +1174,8 @@ describe('BuddyConversationService', () => {
 			});
 
 			llmProvider.supportsTools.mockReturnValue(true);
+			llmProvider.supportsNativeToolResults.mockReturnValue(true);
+			toolProviderRegistry.getAllToolDefinitions.mockReturnValue(BUDDY_SELECTION_TOOLS);
 
 			await service.sendMessage('conv-1', 'Overview');
 

--- a/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-conversation.service.ts
@@ -42,6 +42,7 @@ import {
 
 import { BuddyContext, BuddyContextService } from './buddy-context.service';
 import { BuddyPersonalityService } from './buddy-personality.service';
+import { BuddyToolSelectionService } from './buddy-tool-selection.service';
 import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
 import { ChatMessage, LlmProviderService } from './llm-provider.service';
 
@@ -78,6 +79,7 @@ export class BuddyConversationService {
 		private readonly eventEmitter: EventEmitter2,
 		private readonly shortIdMapping: ShortIdMappingService,
 		private readonly configService: ConfigService,
+		private readonly toolSelection: BuddyToolSelectionService,
 	) {}
 
 	async findAll(spaceId?: string): Promise<BuddyConversationEntity[]> {
@@ -130,13 +132,31 @@ export class BuddyConversationService {
 
 	async sendMessage(conversationId: string, content: string): Promise<BuddyMessageEntity> {
 		const conversation = await this.findOneOrThrow(conversationId);
+		const supportsTools = this.llmProvider.supportsTools();
+		const supportsNativeToolResults = supportsTools && this.llmProvider.supportsNativeToolResults();
+		const availableTools = supportsTools
+			? this.toolProviderRegistry
+					.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
+					.filter(
+						(definition) =>
+							supportsNativeToolResults ||
+							(definition.name !== SEARCH_HOME_TOOL_NAME && definition.name !== QUERY_HOME_STATE_TOOL_NAME),
+					)
+			: undefined;
+		const selectedTools = availableTools === undefined ? undefined : this.toolSelection.select(content, availableTools);
+		const tools = selectedTools && selectedTools.length > 0 ? selectedTools : undefined;
 
 		// 1. Build system prompt with context and personality
 		// Short ID mappings accumulate across requests — the same UUID always maps
 		// to the same short ID, so concurrent requests from different bot adapters
 		// won't interfere with each other.
 		const context = await this.contextService.buildContext(conversation.spaceId ?? undefined);
-		const systemPrompt = await this.buildSystemPrompt(context, conversation.id, conversation.spaceId ?? undefined);
+		const systemPrompt = await this.buildSystemPrompt(
+			context,
+			conversation.id,
+			conversation.spaceId ?? undefined,
+			tools !== undefined,
+		);
 
 		// 2. Load most recent conversation history and append the new user message
 		const history = await this.messageRepository.find({
@@ -157,17 +177,6 @@ export class BuddyConversationService {
 		chatMessages.push({ role: MessageRole.USER, content });
 
 		// 3. Call LLM provider with tool support if available
-		const supportsTools = this.llmProvider.supportsTools();
-		const supportsNativeToolResults = supportsTools && this.llmProvider.supportsNativeToolResults();
-		const tools = supportsTools
-			? this.toolProviderRegistry
-					.getAllToolDefinitions({ audience: ToolAudience.BUDDY })
-					.filter(
-						(definition) =>
-							supportsNativeToolResults ||
-							(definition.name !== SEARCH_HOME_TOOL_NAME && definition.name !== QUERY_HOME_STATE_TOOL_NAME),
-					)
-			: undefined;
 		const maxIterations = this.getMaxToolIterations();
 		const llmResponse = await this.sendWithToolExecution(
 			systemPrompt,
@@ -637,8 +646,8 @@ export class BuddyConversationService {
 		context: BuddyContext,
 		conversationId: string,
 		conversationSpaceId?: string,
+		hasTools = false,
 	): Promise<string> {
-		const hasTools = this.llmProvider.supportsTools();
 		const personality = await this.personalityService.getPersonality();
 		const buddyName = this.getBuddyName();
 		let contextWindowTokens = DEFAULT_CONTEXT_WINDOW_TOKENS;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -49,6 +49,7 @@ describe('BuddyToolSelectionService', () => {
 		'What is the bedroom temperature?',
 		'Are any windows open?',
 		'Find Aurora and show its current status.',
+		'Which lights can I dim?',
 		'Jaká je teplota a vlhkost v ložnici?',
 	])('selects only the dependent read pair for a state or search request: %s', (message) => {
 		expect(selectNames(message)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
@@ -249,6 +250,9 @@ describe('BuddyToolSelectionService', () => {
 		);
 		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Run Bedtime so long as Aurora is on.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Close the blinds while you run Evening.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime assuming the hallway sensor is triggered.')).toEqual(

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -181,6 +181,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Please check whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+import {
+	ToolAccessKind,
+	ToolAudience,
+	ToolDefinition,
+	createToolDefinition,
+} from '../../tools/platforms/tool-provider.platform';
+
+import { BuddyToolSelectionService } from './buddy-tool-selection.service';
+import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
+
+const names = {
+	control: 'control_device',
+	scene: 'run_scene',
+	spaceLighting: 'set_space_lighting',
+};
+
+function tool(name: string, access: ToolAccessKind): ToolDefinition {
+	return createToolDefinition({
+		name,
+		description: `${name} test tool`,
+		audiences: [ToolAudience.BUDDY],
+		access,
+		inputSchema: z.object({}),
+		outputSchema: z.object({ ok: z.boolean() }),
+	});
+}
+
+describe('BuddyToolSelectionService', () => {
+	const service = new BuddyToolSelectionService();
+	const definitions = [
+		tool(SEARCH_HOME_TOOL_NAME, ToolAccessKind.READ),
+		tool(QUERY_HOME_STATE_TOOL_NAME, ToolAccessKind.READ),
+		tool(names.control, ToolAccessKind.WRITE),
+		tool(names.scene, ToolAccessKind.TRIGGER),
+		tool(names.spaceLighting, ToolAccessKind.TRIGGER),
+	];
+	const selectNames = (message: string, available = definitions): string[] =>
+		service.select(message, available).map((definition) => definition.name);
+
+	it('omits all built-in schemas for general conversation', () => {
+		expect(selectNames('Hello! Tell me a joke.')).toEqual([]);
+	});
+
+	it.each([
+		'What is the bedroom temperature?',
+		'Are any windows open?',
+		'Find Aurora and show its current status.',
+		'Jaká je teplota a vlhkost v ložnici?',
+	])('selects only the dependent read pair for a state or search request: %s', (message) => {
+		expect(selectNames(message)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+	});
+
+	it('selects scene execution without unrelated device or lighting actions', () => {
+		expect(selectNames('Run the evening scene.')).toEqual([names.scene]);
+	});
+
+	it('selects individual device control for a specific lamp', () => {
+		expect(selectNames('Dim the desk lamp.')).toEqual([names.control]);
+	});
+
+	it('keeps both lighting action shapes when the request names a room', () => {
+		expect(selectNames('Turn off the kitchen lights.')).toEqual([names.control, names.spaceLighting]);
+	});
+
+	it('keeps all action shapes for an ambiguous follow-up reference', () => {
+		expect(selectNames('Turn it off.')).toEqual([names.control, names.scene, names.spaceLighting]);
+	});
+
+	it('combines read and relevant action tools for a compound request', () => {
+		expect(selectNames('Turn off the kitchen lights and tell me whether any window is open.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
+	});
+
+	it('falls back to every built-in tool for ambiguous home-related wording', () => {
+		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));
+	});
+
+	it('preserves unknown extension tools and original registry order', () => {
+		const extension = tool('extension_specific_tool', ToolAccessKind.READ);
+		const interleaved = [definitions[2], extension, definitions[0], definitions[4], definitions[1], definitions[3]];
+
+		expect(selectNames('What is the temperature?', interleaved)).toEqual([
+			'extension_specific_tool',
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+	});
+});

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -140,6 +140,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and tell me whether the window is open.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and read the hallway sensor.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 		expect(selectNames('Read the hallway sensor, then close the blinds')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
@@ -321,6 +324,10 @@ describe('BuddyToolSelectionService', () => {
 		]);
 		expect(selectNames('Could the window be open?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('What has the thermostat been set to?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('What did I set the thermostat to?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -126,6 +126,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and verify that the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime, check whether the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 		expect(selectNames('Run Bedtime and confirm that the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
@@ -194,6 +197,9 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Když je okno otevřené, spusť Večer.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Execute Evening if the window is open.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 	});
@@ -265,6 +271,10 @@ describe('BuddyToolSelectionService', () => {
 
 	it('treats tell-whether wording as a read-only state question', () => {
 		expect(selectNames('Tell me whether the window is open.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Can you tell me whether the window is open?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -77,6 +77,7 @@ describe('BuddyToolSelectionService', () => {
 
 	it('retains live reads for relative adjustments', () => {
 		expect(selectNames('Make the bedroom warmer')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Make the bedroom twice as bright')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Make the bedroom two degrees colder')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
@@ -162,6 +163,9 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime and make sure the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime, report whether the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 	});
@@ -397,6 +401,7 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Morning')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Good Morning')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Thank You')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Joke')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('falls back when an unrecognized action follows a read clause', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -278,6 +278,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Can you check whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 	});
 
 	it('treats an action verb used in an interrogative predicate as a state read', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -95,6 +95,12 @@ describe('BuddyToolSelectionService', () => {
 			names.scene,
 			names.spaceLighting,
 		]);
+		expect(selectNames('Zavři žaluzie a spusť Večer.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
 	});
 
 	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
@@ -109,17 +115,23 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('If the window is open run Bedtime')).toEqual(definitions.map((definition) => definition.name));
 	});
 
-	it.each(['How does a thermostat work?', 'Explain how smart-home lighting works.'])(
-		'keeps generic smart-home explanations tool-free: %s',
-		(message) => {
-			expect(selectNames(message)).toEqual([]);
-		},
-	);
+	it.each([
+		'How does a thermostat work?',
+		'How does a temperature sensor work?',
+		'Explain how smart-home lighting works.',
+	])('keeps generic smart-home explanations tool-free: %s', (message) => {
+		expect(selectNames(message)).toEqual([]);
+	});
 
 	it('retains live reads for explain-whether state questions', () => {
 		expect(selectNames('Explain whether the kitchen light is on.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Explain why the kitchen light is off.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -88,6 +88,15 @@ describe('BuddyToolSelectionService', () => {
 		]);
 	});
 
+	it('retains every action schema for multiple commands with an arbitrary target name', () => {
+		expect(selectNames('Close the blinds and run Bedtime.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
+	});
+
 	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
 		'preserves a command that follows a state-first clause: %s',
 		(message) => {
@@ -100,6 +109,13 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 	});
+
+	it.each(['How does a thermostat work?', 'Explain how smart-home lighting works.'])(
+		'keeps generic smart-home explanations tool-free: %s',
+		(message) => {
+			expect(selectNames(message)).toEqual([]);
+		},
+	);
 
 	it('falls back to every built-in tool for ambiguous home-related wording', () => {
 		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -114,6 +114,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Are any windows open, close them if so.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Jaká je teplota a nastav termostat na 20.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('does not use condition targets to narrow an ambiguous command target', () => {
@@ -132,6 +135,9 @@ describe('BuddyToolSelectionService', () => {
 
 	it('retains live reads needed to evaluate conditional actions', () => {
 		expect(selectNames('If Aurora is on, run Bedtime.')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('If the hallway sensor is triggered, run Bedtime.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it.each([

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -91,9 +91,15 @@ describe('BuddyToolSelectionService', () => {
 	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
 		'preserves a command that follows a state-first clause: %s',
 		(message) => {
-			expect(selectNames(message)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME, names.control]);
+			expect(selectNames(message)).toEqual(definitions.map((definition) => definition.name));
 		},
 	);
+
+	it('does not use condition targets to narrow an ambiguous command target', () => {
+		expect(selectNames('If the window is open, run Bedtime.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+	});
 
 	it('falls back to every built-in tool for ambiguous home-related wording', () => {
 		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -168,6 +168,12 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime, report whether the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and determine whether the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime and see whether the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -238,6 +238,7 @@ describe('BuddyToolSelectionService', () => {
 
 	it('treats an action verb used in an interrogative predicate as a state read', () => {
 		expect(selectNames('Is the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		expect(selectNames('Is the thermostat set to 20')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 	});
 
 	it('does not classify an explicit current-status question as a generic explanation', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -236,6 +236,10 @@ describe('BuddyToolSelectionService', () => {
 		]);
 	});
 
+	it('treats an action verb used in an interrogative predicate as a state read', () => {
+		expect(selectNames('Is the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+	});
+
 	it('does not classify an explicit current-status question as a generic explanation', () => {
 		expect(selectNames("What is a thermostat's current status?")).toEqual([
 			SEARCH_HOME_TOOL_NAME,
@@ -266,6 +270,15 @@ describe('BuddyToolSelectionService', () => {
 
 	it('falls back when an unrecognized action follows a read clause', () => {
 		expect(selectNames('Find Evening and launch it.')).toEqual(definitions.map((definition) => definition.name));
+	});
+
+	it('falls back when an unrecognized action follows a recognized command', () => {
+		expect(selectNames('Close the blinds and launch Evening.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
 	});
 
 	it('preserves unknown extension tools and original registry order', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -241,6 +241,19 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Is the thermostat set to 20')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 	});
 
+	it('preserves actions in polite interrogative commands', () => {
+		expect(selectNames('Are you able to turn off the kitchen light?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
+		expect(selectNames('Is it possible to turn off the kitchen light?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
+	});
+
 	it('does not classify an explicit current-status question as a generic explanation', () => {
 		expect(selectNames("What is a thermostat's current status?")).toEqual([
 			SEARCH_HOME_TOOL_NAME,
@@ -267,6 +280,7 @@ describe('BuddyToolSelectionService', () => {
 	it('preserves tools for an ambiguous bare clarification reply', () => {
 		expect(selectNames('Morning')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Good Morning')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Thank You')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('falls back when an unrecognized action follows a read clause', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -302,6 +302,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Can you check whether the window is open and close it if it is?')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Can you check whether the window is open before you close it?')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('treats an action verb used in an interrogative predicate as a state read', () => {
@@ -310,6 +313,10 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('What is the thermostat set to?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Was the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Did I turn off the kitchen light?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('What has the thermostat been set to?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -116,6 +116,12 @@ describe('BuddyToolSelectionService', () => {
 		);
 		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('If the window is open run Bedtime')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Spusť Večer pokud je okno otevřené.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Když je okno otevřené, spusť Večer.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it.each([

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -348,6 +348,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Can you report whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 		expect(selectNames('Can you check whether the window is open?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -92,6 +92,10 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Boost the bedroom temperature.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
+	it('falls back conservatively for a question-form command with an unknown verb', () => {
+		expect(selectNames('Would you execute Evening scene?')).toEqual(definitions.map((definition) => definition.name));
+	});
+
 	it('keeps both lighting action shapes when the request names a room', () => {
 		expect(selectNames('Turn off the kitchen lights.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -53,6 +53,8 @@ describe('BuddyToolSelectionService', () => {
 		'Report the hallway sensor reading.',
 		'Find Aurora and show its current status.',
 		'Which lights can I dim?',
+		'What lights am I able to dim?',
+		'Can you show which windows I can open?',
 		'Jaká je teplota a vlhkost v ložnici?',
 	])('selects only the dependent read pair for a state or search request: %s', (message) => {
 		expect(selectNames(message)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
@@ -130,6 +132,15 @@ describe('BuddyToolSelectionService', () => {
 	it('keeps both lighting action shapes when the request names a room', () => {
 		expect(selectNames('Turn off the kitchen lights.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
+	});
+
+	it('retains reads for grounded-state filters attached to actions', () => {
+		expect(selectNames('Turn off the kitchen lights that are on.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
 			names.control,
 			names.spaceLighting,
 		]);
@@ -316,6 +327,7 @@ describe('BuddyToolSelectionService', () => {
 		'How do I turn off the kitchen light?',
 		'How can I adjust a thermostat?',
 		'Tell me how to turn off the kitchen light.',
+		'Show me how to turn off the kitchen light.',
 	])('keeps generic smart-home explanations tool-free: %s', (message) => {
 		expect(selectNames(message)).toEqual([]);
 	});

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -201,6 +201,9 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 			names.control,
 		]);
+		expect(selectNames('Once Aurora is triggered, run Bedtime.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it.each([
@@ -258,6 +261,7 @@ describe('BuddyToolSelectionService', () => {
 
 	it('preserves tools for an ambiguous bare clarification reply', () => {
 		expect(selectNames('Morning')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Good Morning')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('falls back when an unrecognized action follows a read clause', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -176,6 +176,13 @@ describe('BuddyToolSelectionService', () => {
 		);
 	});
 
+	it('recognizes wh-complement state requests', () => {
+		expect(selectNames('Could you tell me what the thermostat is set to?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+	});
+
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {
 		expect(selectNames('Close the blinds and run Bedtime.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
@@ -232,6 +239,9 @@ describe('BuddyToolSelectionService', () => {
 		);
 		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Run Bedtime so long as Aurora is on.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime assuming the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('If the window is open run Bedtime')).toEqual(definitions.map((definition) => definition.name));
@@ -425,6 +435,12 @@ describe('BuddyToolSelectionService', () => {
 			names.spaceLighting,
 		]);
 		expect(selectNames('Close the blinds. Launch Evening.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
+		expect(selectNames('Close the blinds plus launch Evening.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			names.control,
 			names.scene,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -48,6 +48,9 @@ describe('BuddyToolSelectionService', () => {
 	it.each([
 		'What is the bedroom temperature?',
 		'Are any windows open?',
+		'Fetch the hallway sensor reading.',
+		'Get the hallway sensor reading.',
+		'Report the hallway sensor reading.',
 		'Find Aurora and show its current status.',
 		'Which lights can I dim?',
 		'Jaká je teplota a vlhkost v ložnici?',
@@ -248,6 +251,9 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Close the blinds while you run Evening.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Close the blinds before you launch Evening.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime assuming the hallway sensor is triggered.')).toEqual(

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -175,6 +175,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Jaká je teplota a nastav termostat na 20.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Is the thermostat set to 20, turn it down.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('retains reads for a grounded state-first clause without a question mark', () => {
@@ -254,6 +257,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Explain how warm the bedroom is.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 	});
 
 	it('treats tell-whether wording as a read-only state question', () => {
@@ -325,6 +332,9 @@ describe('BuddyToolSelectionService', () => {
 
 	it('falls back when an unrecognized action follows a read clause', () => {
 		expect(selectNames('Find Evening and launch it.')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Execute Evening scene and show the kitchen temperature.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('falls back when an unrecognized action follows a recognized command', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -104,6 +104,12 @@ describe('BuddyToolSelectionService', () => {
 			names.scene,
 			names.spaceLighting,
 		]);
+		expect(selectNames('Run Bedtime and also close the blinds.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
 	});
 
 	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
@@ -157,6 +163,17 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Explain why the kitchen light is off.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Explain why the hallway sensor is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+	});
+
+	it('treats tell-whether wording as a read-only state question', () => {
+		expect(selectNames('Tell me whether the window is open.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -110,6 +110,12 @@ describe('BuddyToolSelectionService', () => {
 		},
 	);
 
+	it('recognizes a punctuation-delimited command after a state-first clause', () => {
+		expect(selectNames('Are any windows open, close them if so.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+	});
+
 	it('does not use condition targets to narrow an ambiguous command target', () => {
 		expect(selectNames('If the window is open, run Bedtime.')).toEqual(
 			definitions.map((definition) => definition.name),
@@ -122,6 +128,10 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Když je okno otevřené, spusť Večer.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+	});
+
+	it('retains live reads needed to evaluate conditional actions', () => {
+		expect(selectNames('If Aurora is on, run Bedtime.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it.each([
@@ -138,6 +148,13 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Explain why the kitchen light is off.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+	});
+
+	it('does not classify an explicit current-status question as a generic explanation', () => {
+		expect(selectNames("What is a thermostat's current status?")).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -86,6 +86,9 @@ describe('BuddyToolSelectionService', () => {
 			names.control,
 			names.spaceLighting,
 		]);
+		expect(selectNames('Run Bedtime and tell me whether the window is open.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {
@@ -176,6 +179,10 @@ describe('BuddyToolSelectionService', () => {
 			expect(selectNames(message)).toEqual(definitions.map((definition) => definition.name));
 		},
 	);
+
+	it('does not treat an entity-like question as confidently tool-free', () => {
+		expect(selectNames('How is Morning?')).toEqual(definitions.map((definition) => definition.name));
+	});
 
 	it('preserves unknown extension tools and original registry order', () => {
 		const extension = tool('extension_specific_tool', ToolAccessKind.READ);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -352,6 +352,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Can you check whether a window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 		expect(selectNames('Can you check whether the window is open and close it if it is?')).toEqual(
 			definitions.map((definition) => definition.name),
 		);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -123,6 +123,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and tell me whether the window is open.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and verify that the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {
@@ -209,6 +212,11 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 			names.control,
 		]);
+		expect(selectNames('Close the blinds while the hallway sensor is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+		]);
 	});
 
 	it.each([
@@ -233,6 +241,10 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Explain what the kitchen temperature is?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Explain how the kitchen thermostat is doing right now.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -302,6 +302,8 @@ describe('BuddyToolSelectionService', () => {
 		'Explain how smart-home lighting works.',
 		'Explain how to adjust a thermostat.',
 		'Explain how to turn off the kitchen light.',
+		'How do I turn off the kitchen light?',
+		'How can I adjust a thermostat?',
 	])('keeps generic smart-home explanations tool-free: %s', (message) => {
 		expect(selectNames(message)).toEqual([]);
 	});
@@ -362,6 +364,7 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Is the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Is the thermostat set to 20')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('What is the thermostat set to?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		expect(selectNames("What's the thermostat set to?")).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Was the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Did I turn off the kitchen light?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -77,6 +77,9 @@ describe('BuddyToolSelectionService', () => {
 
 	it('retains live reads for relative adjustments', () => {
 		expect(selectNames('Make the bedroom warmer')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Make the bedroom two degrees colder')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 		expect(selectNames('Turn the bedroom light up a bit')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
@@ -316,6 +319,7 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Could the window be open?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('What has the thermostat been set to?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
@@ -384,6 +388,12 @@ describe('BuddyToolSelectionService', () => {
 
 	it('falls back when an unrecognized action follows a recognized command', () => {
 		expect(selectNames('Close the blinds and launch Evening.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
+		expect(selectNames('Close the blinds. Launch Evening.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			names.control,
 			names.scene,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -149,6 +149,12 @@ describe('BuddyToolSelectionService', () => {
 		},
 	);
 
+	it('falls back conservatively for an unrecognized adjustment after a state question', () => {
+		expect(selectNames('What is the bedroom temperature? Make it warmer.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+	});
+
 	it('recognizes a punctuation-delimited command after a state-first clause', () => {
 		expect(selectNames('Are any windows open, close them if so.')).toEqual(
 			definitions.map((definition) => definition.name),
@@ -181,6 +187,11 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('If the hallway sensor is triggered, run Bedtime.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Close the blinds unless Aurora is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+		]);
 	});
 
 	it.each([
@@ -233,6 +244,7 @@ describe('BuddyToolSelectionService', () => {
 
 	it('does not treat an entity-like question as confidently tool-free', () => {
 		expect(selectNames('How is Morning?')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Tell me about Morning.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('preserves unknown extension tools and original registry order', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -181,6 +181,9 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and fetch the hallway sensor reading.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and give me the hallway sensor reading.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('recognizes wh-complement state requests', () => {
@@ -195,24 +198,16 @@ describe('BuddyToolSelectionService', () => {
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {
-		expect(selectNames('Close the blinds and run Bedtime.')).toEqual([
-			SEARCH_HOME_TOOL_NAME,
-			names.control,
-			names.scene,
-			names.spaceLighting,
-		]);
+		expect(selectNames('Close the blinds and run Bedtime.')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Zavři žaluzie a spusť Večer.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			names.control,
 			names.scene,
 			names.spaceLighting,
 		]);
-		expect(selectNames('Run Bedtime and also close the blinds.')).toEqual([
-			SEARCH_HOME_TOOL_NAME,
-			names.control,
-			names.scene,
-			names.spaceLighting,
-		]);
+		expect(selectNames('Run Bedtime and also close the blinds.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
@@ -308,6 +303,7 @@ describe('BuddyToolSelectionService', () => {
 		'Explain how to turn off the kitchen light.',
 		'How do I turn off the kitchen light?',
 		'How can I adjust a thermostat?',
+		'Tell me how to turn off the kitchen light.',
 	])('keeps generic smart-home explanations tool-free: %s', (message) => {
 		expect(selectNames(message)).toEqual([]);
 	});
@@ -353,6 +349,18 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Can you report whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Could you read whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Could you get whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Could you fetch whether the window is open?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
@@ -459,24 +467,13 @@ describe('BuddyToolSelectionService', () => {
 	});
 
 	it('falls back when an unrecognized action follows a recognized command', () => {
-		expect(selectNames('Close the blinds and launch Evening.')).toEqual([
-			SEARCH_HOME_TOOL_NAME,
-			names.control,
-			names.scene,
-			names.spaceLighting,
-		]);
-		expect(selectNames('Close the blinds. Launch Evening.')).toEqual([
-			SEARCH_HOME_TOOL_NAME,
-			names.control,
-			names.scene,
-			names.spaceLighting,
-		]);
-		expect(selectNames('Close the blinds plus launch Evening.')).toEqual([
-			SEARCH_HOME_TOOL_NAME,
-			names.control,
-			names.scene,
-			names.spaceLighting,
-		]);
+		expect(selectNames('Close the blinds and launch Evening.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Close the blinds. Launch Evening.')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Close the blinds plus launch Evening.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('preserves unknown extension tools and original registry order', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -204,6 +204,11 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Once Aurora is triggered, run Bedtime.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Close the blinds until Aurora is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+		]);
 	});
 
 	it.each([
@@ -224,6 +229,10 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Explain why the hallway sensor is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Explain what the kitchen temperature is?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -126,6 +126,12 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and verify that the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and confirm that the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime and make sure the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('retains every action schema for multiple commands with an arbitrary target name', () => {
@@ -260,6 +266,8 @@ describe('BuddyToolSelectionService', () => {
 	it('treats an action verb used in an interrogative predicate as a state read', () => {
 		expect(selectNames('Is the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Is the thermostat set to 20')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		expect(selectNames('What is the thermostat set to?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		expect(selectNames('Was the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 	});
 
 	it('preserves actions in polite interrogative commands', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -340,6 +340,10 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Why is the thermostat set to 20?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 	});
 
 	it('preserves actions in polite interrogative commands', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -71,6 +71,27 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Dim the desk lamp.')).toEqual([SEARCH_HOME_TOOL_NAME, names.control]);
 	});
 
+	it('uses action verbs without allowing unrestricted target names to exclude schemas', () => {
+		expect(selectNames('Activate Window Watch.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
+		expect(selectNames('Turn off Bedtime Scene.')).toEqual([SEARCH_HOME_TOOL_NAME, names.control, names.scene]);
+	});
+
+	it.each(['Increase the bedroom temperature.', 'Sniž teplotu.'])(
+		'preserves device actions for adjustment wording: %s',
+		(message) => {
+			expect(selectNames(message)).toContain(names.control);
+		},
+	);
+
+	it('falls back conservatively for unrecognized imperative-looking state wording', () => {
+		expect(selectNames('Boost the bedroom temperature.')).toEqual(definitions.map((definition) => definition.name));
+	});
+
 	it('keeps both lighting action shapes when the request names a room', () => {
 		expect(selectNames('Turn off the kitchen lights.')).toEqual([
 			SEARCH_HOME_TOOL_NAME,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -301,6 +301,7 @@ describe('BuddyToolSelectionService', () => {
 		'How does a temperature sensor work?',
 		'Explain how smart-home lighting works.',
 		'Explain how to adjust a thermostat.',
+		'Explain how to turn off the kitchen light.',
 	])('keeps generic smart-home explanations tool-free: %s', (message) => {
 		expect(selectNames(message)).toEqual([]);
 	});
@@ -338,6 +339,10 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
 		expect(selectNames('Can you tell me whether the window is open?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+		expect(selectNames('Can you let me know whether the window is open?')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -55,19 +55,28 @@ describe('BuddyToolSelectionService', () => {
 	});
 
 	it('selects scene execution without unrelated device or lighting actions', () => {
-		expect(selectNames('Run the evening scene.')).toEqual([names.scene]);
+		expect(selectNames('Run the evening scene.')).toEqual([SEARCH_HOME_TOOL_NAME, names.scene]);
 	});
 
 	it('selects individual device control for a specific lamp', () => {
-		expect(selectNames('Dim the desk lamp.')).toEqual([names.control]);
+		expect(selectNames('Dim the desk lamp.')).toEqual([SEARCH_HOME_TOOL_NAME, names.control]);
 	});
 
 	it('keeps both lighting action shapes when the request names a room', () => {
-		expect(selectNames('Turn off the kitchen lights.')).toEqual([names.control, names.spaceLighting]);
+		expect(selectNames('Turn off the kitchen lights.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
 	});
 
 	it('keeps all action shapes for an ambiguous follow-up reference', () => {
-		expect(selectNames('Turn it off.')).toEqual([names.control, names.scene, names.spaceLighting]);
+		expect(selectNames('Turn it off.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
 	});
 
 	it('combines read and relevant action tools for a compound request', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -252,6 +252,17 @@ describe('BuddyToolSelectionService', () => {
 			names.control,
 			names.spaceLighting,
 		]);
+		expect(selectNames('Is there any way you can turn off the kitchen light?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
+	});
+
+	it('falls back conservatively for unknown verbs in polite adjustments', () => {
+		expect(selectNames('Could you reduce the bedroom temperature?')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('does not classify an explicit current-status question as a generic explanation', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -174,6 +174,12 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run Bedtime and see whether the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime and get the hallway sensor reading.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime and fetch the hallway sensor reading.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('recognizes wh-complement state requests', () => {
@@ -294,6 +300,7 @@ describe('BuddyToolSelectionService', () => {
 		'How does a thermostat work?',
 		'How does a temperature sensor work?',
 		'Explain how smart-home lighting works.',
+		'Explain how to adjust a thermostat.',
 	])('keeps generic smart-home explanations tool-free: %s', (message) => {
 		expect(selectNames(message)).toEqual([]);
 	});

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -52,6 +52,8 @@ describe('BuddyToolSelectionService', () => {
 		'Get the hallway sensor reading.',
 		'Report the hallway sensor reading.',
 		'Find Aurora and show its current status.',
+		'Find the open windows.',
+		'Show me open windows.',
 		'Which lights can I dim?',
 		'What lights am I able to dim?',
 		'Can you show which windows I can open?',

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -80,6 +80,12 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Make the bedroom two degrees colder')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Make the kitchen light 10% higher')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
 		expect(selectNames('Turn the bedroom light up a bit')).toEqual([
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
@@ -215,6 +221,9 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Run Bedtime so long as Aurora is on.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 		expect(selectNames('If the window is open run Bedtime')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Spusť Večer pokud je okno otevřené.')).toEqual(
 			definitions.map((definition) => definition.name),

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -41,6 +41,8 @@ describe('BuddyToolSelectionService', () => {
 
 	it('omits all built-in schemas for general conversation', () => {
 		expect(selectNames('Hello! Tell me a joke.')).toEqual([]);
+		expect(selectNames('How are you?')).toEqual([]);
+		expect(selectNames('Write me a poem.')).toEqual([]);
 	});
 
 	it.each([
@@ -80,6 +82,13 @@ describe('BuddyToolSelectionService', () => {
 	it('falls back to every built-in tool for ambiguous home-related wording', () => {
 		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));
 	});
+
+	it.each(['Is Aurora on?', '¿Está encendida Aurora?', 'Tell me about Aurora.'])(
+		'falls back to every built-in tool for unknown or low-confidence wording: %s',
+		(message) => {
+			expect(selectNames(message)).toEqual(definitions.map((definition) => definition.name));
+		},
+	);
 
 	it('preserves unknown extension tools and original registry order', () => {
 		const extension = tool('extension_specific_tool', ToolAccessKind.READ);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -82,6 +82,9 @@ describe('BuddyToolSelectionService', () => {
 	it('retains live reads for relative adjustments', () => {
 		expect(selectNames('Make the bedroom warmer')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Make the bedroom twice as bright')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Make the bedroom three times as bright')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 		expect(selectNames('Make the bedroom two degrees colder')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
@@ -257,6 +260,9 @@ describe('BuddyToolSelectionService', () => {
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime assuming the hallway sensor is triggered.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Run Bedtime given that the hallway sensor is triggered.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('If the window is open run Bedtime')).toEqual(definitions.map((definition) => definition.name));
@@ -478,6 +484,9 @@ describe('BuddyToolSelectionService', () => {
 		);
 		expect(selectNames('Close the blinds. Launch Evening.')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Close the blinds plus launch Evening.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Close the blinds as well as launch Evening.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 	});

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -108,6 +108,7 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('If the window is open, run Bedtime.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+		expect(selectNames('Run Bedtime if the window is open.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it.each(['How does a thermostat work?', 'Explain how smart-home lighting works.'])(
@@ -116,6 +117,13 @@ describe('BuddyToolSelectionService', () => {
 			expect(selectNames(message)).toEqual([]);
 		},
 	);
+
+	it('retains live reads for explain-whether state questions', () => {
+		expect(selectNames('Explain whether the kitchen light is on.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
+	});
 
 	it('falls back to every built-in tool for ambiguous home-related wording', () => {
 		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -68,7 +68,21 @@ describe('BuddyToolSelectionService', () => {
 	});
 
 	it('selects individual device control for a specific lamp', () => {
-		expect(selectNames('Dim the desk lamp.')).toEqual([SEARCH_HOME_TOOL_NAME, names.control]);
+		expect(selectNames('Dim the desk lamp.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+		]);
+	});
+
+	it('retains live reads for relative adjustments', () => {
+		expect(selectNames('Make the bedroom warmer')).toEqual(definitions.map((definition) => definition.name));
+		expect(selectNames('Turn the bedroom light up a bit')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+			names.spaceLighting,
+		]);
 	});
 
 	it('uses action verbs without allowing unrestricted target names to exclude schemas', () => {
@@ -121,6 +135,9 @@ describe('BuddyToolSelectionService', () => {
 			names.spaceLighting,
 		]);
 		expect(selectNames('Run Bedtime and tell me whether the window is open.')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
+		expect(selectNames('Read the hallway sensor, then close the blinds')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
 		expect(selectNames('Run Bedtime and verify that the hallway sensor is triggered.')).toEqual(

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -196,6 +196,11 @@ describe('BuddyToolSelectionService', () => {
 			QUERY_HOME_STATE_TOOL_NAME,
 			names.control,
 		]);
+		expect(selectNames('Close the blinds provided that Aurora is triggered.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+			names.control,
+		]);
 	});
 
 	it.each([
@@ -249,6 +254,14 @@ describe('BuddyToolSelectionService', () => {
 	it('does not treat an entity-like question as confidently tool-free', () => {
 		expect(selectNames('How is Morning?')).toEqual(definitions.map((definition) => definition.name));
 		expect(selectNames('Tell me about Morning.')).toEqual(definitions.map((definition) => definition.name));
+	});
+
+	it('preserves tools for an ambiguous bare clarification reply', () => {
+		expect(selectNames('Morning')).toEqual(definitions.map((definition) => definition.name));
+	});
+
+	it('falls back when an unrecognized action follows a read clause', () => {
+		expect(selectNames('Find Evening and launch it.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('preserves unknown extension tools and original registry order', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -58,6 +58,15 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Run the evening scene.')).toEqual([SEARCH_HOME_TOOL_NAME, names.scene]);
 	});
 
+	it('retains scene execution when an unrestricted scene name resembles a device', () => {
+		expect(selectNames('Run Window Watch.')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			names.control,
+			names.scene,
+			names.spaceLighting,
+		]);
+	});
+
 	it('selects individual device control for a specific lamp', () => {
 		expect(selectNames('Dim the desk lamp.')).toEqual([SEARCH_HOME_TOOL_NAME, names.control]);
 	});
@@ -126,6 +135,10 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Jaká je teplota a nastav termostat na 20.')).toEqual(
 			definitions.map((definition) => definition.name),
 		);
+	});
+
+	it('retains reads for a grounded state-first clause without a question mark', () => {
+		expect(selectNames('Is Aurora locked, unlock it.')).toEqual(definitions.map((definition) => definition.name));
 	});
 
 	it('does not use condition targets to narrow an ambiguous command target', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -88,6 +88,13 @@ describe('BuddyToolSelectionService', () => {
 		]);
 	});
 
+	it.each(['Are any windows open? If so, close them.', 'Are all doors closed, and open them if not.'])(
+		'preserves a command that follows a state-first clause: %s',
+		(message) => {
+			expect(selectNames(message)).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME, names.control]);
+		},
+	);
+
 	it('falls back to every built-in tool for ambiguous home-related wording', () => {
 		expect(selectNames('Help me with my smart home.')).toEqual(definitions.map((definition) => definition.name));
 	});

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.spec.ts
@@ -282,6 +282,9 @@ describe('BuddyToolSelectionService', () => {
 			SEARCH_HOME_TOOL_NAME,
 			QUERY_HOME_STATE_TOOL_NAME,
 		]);
+		expect(selectNames('Can you check whether the window is open and close it if it is?')).toEqual(
+			definitions.map((definition) => definition.name),
+		);
 	});
 
 	it('treats an action verb used in an interrogative predicate as a state read', () => {
@@ -289,6 +292,10 @@ describe('BuddyToolSelectionService', () => {
 		expect(selectNames('Is the thermostat set to 20')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('What is the thermostat set to?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
 		expect(selectNames('Was the thermostat set to 20?')).toEqual([SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME]);
+		expect(selectNames('Did I turn off the kitchen light?')).toEqual([
+			SEARCH_HOME_TOOL_NAME,
+			QUERY_HOME_STATE_TOOL_NAME,
+		]);
 	});
 
 	it('preserves actions in polite interrogative commands', () => {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -87,11 +87,11 @@ const ACTION_SIGNALS = new Set([
 	'zvys',
 ]);
 const ACTION_CLAUSE_PATTERN = new RegExp(
-	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	String.raw`(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|find|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|find|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
@@ -100,9 +100,9 @@ const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);
 const CONDITION_PATTERN =
-	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
+	/\b(?:after|as long as|as soon as|assuming(?: that)?|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const LEADING_CONDITION_PATTERN =
-	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
+	/^(?:after|as long as|as soon as|assuming(?: that)?|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -545,7 +545,7 @@ function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<str
 }
 
 function hasUnknownTrailingClause(normalizedMessage: string): boolean {
-	const trailingClause = sliceAfterFirst(normalizedMessage, /[.!?,;]|\b(?:and|potom|then)\b/u);
+	const trailingClause = sliceAfterFirst(normalizedMessage, /[.!?,;]|\b(?:and|plus|potom|then)\b/u);
 
 	if (trailingClause.length === 0) return false;
 
@@ -615,7 +615,7 @@ function getActionIntentTokens(
 		const trailingClause = [
 			sliceAfterFirst(
 				questionBody,
-				/[,;]|\b(?:a|after|and|before|if not|if so|once|please|potom|then|until|when|while)\b/u,
+				/[,;]|\b(?:a|after|and|assuming(?: that)?|before|if not|if so|once|please|plus|potom|then|until|when|while)\b/u,
 			),
 			questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1) : '',
 		].join(' ');
@@ -654,7 +654,13 @@ function getActionIntentTokens(
 }
 
 function isExplicitStateQuestion(normalizedMessage: string): boolean {
-	return /^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:show|tell) me|check|confirm|determine|ensure|find out|see|verify)\b.*\b(?:if|whether)\b/u.test(
+	const requestPattern =
+		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:show|tell) me|check|confirm|determine|ensure|find out|see|verify)\b/u;
+
+	if (!requestPattern.test(normalizedMessage)) return false;
+	if (/\b(?:if|whether)\b/u.test(normalizedMessage)) return true;
+
+	return /\b(?:how|what|when|where|which|why)\b.*\b(?:are|did|do|does|had|has|have|is|was|were)\b/u.test(
 		normalizedMessage,
 	);
 }

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -373,7 +373,7 @@ function getActionIntentTokens(
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;
 	}
 
-	const trailingCondition = normalizedMessage.search(/\b(?:if|when)\b/u);
+	const trailingCondition = normalizedMessage.search(/\b(?:if|kdyz|pokud|when)\b/u);
 
 	if (trailingCondition > 0) {
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
@@ -381,8 +381,8 @@ function getActionIntentTokens(
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 	}
 
-	if (/^(?:if|when)\b/u.test(normalizedMessage)) {
-		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\bthen\b/u));
+	if (/^(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage)) {
+		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\b(?:pak|potom|then)\b/u));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -582,6 +582,7 @@ function hasUnknownLeadingIntentBeforeRead(normalizedMessage: string): boolean {
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
+	if (/^explain how to\b/u.test(normalizedMessage)) return true;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
 	if (/\b(?:currently|right now)\b/u.test(normalizedMessage)) return false;
@@ -655,7 +656,7 @@ function getActionIntentTokens(
 
 function isExplicitStateQuestion(normalizedMessage: string): boolean {
 	const requestPattern =
-		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:show|tell) me|check|confirm|determine|ensure|find out|see|verify)\b/u;
+		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:let|show|tell) me(?: know)?|check|confirm|determine|ensure|find out|see|verify)\b/u;
 
 	if (!requestPattern.test(normalizedMessage)) return false;
 	if (/\b(?:if|whether)\b/u.test(normalizedMessage)) return true;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -95,7 +95,7 @@ const READ_CLAUSE_PATTERN =
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
-	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|(?:what|why) (?:are|did|had|has|have|is|was|were))\b/u;
+	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|(?:how|what|when|where|which|who|why)['’]s|(?:what|why) (?:are|did|had|has|have|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);
@@ -582,7 +582,7 @@ function hasUnknownLeadingIntentBeforeRead(normalizedMessage: string): boolean {
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
-	if (/^explain how to\b/u.test(normalizedMessage)) return true;
+	if (/^(?:explain how to|how (?:can|could|do|would) i)\b/u.test(normalizedMessage)) return true;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
 	if (/\b(?:currently|right now)\b/u.test(normalizedMessage)) return false;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -100,9 +100,9 @@ const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);
 const CONDITION_PATTERN =
-	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever|while)\b/u;
+	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const LEADING_CONDITION_PATTERN =
-	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever|while)\b/u;
+	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -127,6 +127,7 @@ const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
 	'dimmer',
 	'down',
 	'hotter',
+	'higher',
 	'increase',
 	'less',
 	'lower',

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -239,8 +239,14 @@ export class BuddyToolSelectionService {
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
+		const isStateExplanation = hasHomeSignal && /^explain (?:if|whether)\b/u.test(normalizedMessage);
 
-		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal && !isGenericExplanation)) {
+		if (
+			hasSearchSignal ||
+			hasStateSignal ||
+			isStateExplanation ||
+			(message.includes('?') && hasHomeSignal && !isGenericExplanation)
+		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
 
@@ -327,7 +333,7 @@ function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>
 		/^how (?:do|does) .+ work(?:s|ing)?\b/u.test(normalizedMessage) ||
 		/^what (?:do|does) .+ mean\b/u.test(normalizedMessage) ||
 		/^what (?:is|are) (?:a|an)\b/u.test(normalizedMessage) ||
-		/^explain\b/u.test(normalizedMessage)
+		/^explain (?:how|what|why)\b/u.test(normalizedMessage)
 	);
 }
 
@@ -351,6 +357,14 @@ function getActionIntentTokens(
 		const trailingTokens = tokenize(trailingClause);
 
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;
+	}
+
+	const trailingCondition = normalizedMessage.search(/\b(?:if|when)\b/u);
+
+	if (trailingCondition > 0) {
+		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
+
+		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 	}
 
 	if (/^(?:if|when)\b/u.test(normalizedMessage)) {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -93,20 +93,12 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
-	/^(?:are|did|do|does|had|has|have|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
-const PREDICATE_QUESTION_PATTERN = /^(?:are|did|had|has|have|is|was|were|what (?:are|had|has|have|is|was|were))\b/u;
+	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
+const PREDICATE_QUESTION_PATTERN =
+	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|what (?:are|had|has|have|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
-const ACTION_REQUEST_AUXILIARIES = new Set([
-	'able',
-	'can',
-	'could',
-	'may',
-	'might',
-	'possible',
-	'way',
-	'will',
-	'would',
-]);
+const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
+const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);
 const CONDITION_PATTERN =
 	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever|while)\b/u;
 const LEADING_CONDITION_PATTERN =
@@ -127,12 +119,14 @@ const EXPLICIT_STATE_REQUEST_SIGNALS = new Set(['all', 'any', 'count', 'current'
 const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
 	'brighten',
 	'brighter',
+	'colder',
 	'cooler',
 	'darker',
 	'decrease',
 	'dim',
 	'dimmer',
 	'down',
+	'hotter',
 	'increase',
 	'less',
 	'lower',
@@ -375,6 +369,11 @@ export class BuddyToolSelectionService {
 			!hasSearchSignal &&
 			(!message.includes('?') || UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage)) &&
 			!/^(?:explain|tell)\b/u.test(normalizedMessage);
+		const hasUnknownModalRequest =
+			actionTokens === null &&
+			hasHomeSignal &&
+			UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage) &&
+			!hasExplicitStateQuestion;
 		const hasUnrecognizedReadCompound =
 			actionTokens === null &&
 			(hasSearchSignal || hasStateReadSignal) &&
@@ -418,6 +417,10 @@ export class BuddyToolSelectionService {
 		}
 
 		if (hasUnrecognizedStateIntent) {
+			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
+		}
+
+		if (hasUnknownModalRequest) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -531,7 +534,7 @@ function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<str
 }
 
 function hasUnknownTrailingClause(normalizedMessage: string): boolean {
-	const trailingClause = sliceAfterFirst(normalizedMessage, /[,;]|\b(?:and|potom|then)\b/u);
+	const trailingClause = sliceAfterFirst(normalizedMessage, /[.!?,;]|\b(?:and|potom|then)\b/u);
 
 	if (trailingClause.length === 0) return false;
 
@@ -655,10 +658,14 @@ function hasActionRequestAuxiliary(normalizedMessage: string, tokens: Set<string
 	if (!intersects(tokens, ACTION_SIGNALS)) return false;
 
 	const actionMatch = new RegExp(String.raw`\b(?:${[...ACTION_SIGNALS].join('|')})\b`, 'u').exec(normalizedMessage);
+	const prefix = actionMatch === null ? '' : normalizedMessage.slice(0, actionMatch.index);
+	const prefixTokens = tokenize(prefix);
+	const [firstPrefixToken] = prefixTokens;
 
 	return (
 		actionMatch !== null &&
-		intersects(tokenize(normalizedMessage.slice(0, actionMatch.index)), ACTION_REQUEST_AUXILIARIES)
+		(intersects(prefixTokens, ACTION_REQUEST_AUXILIARIES) ||
+			(firstPrefixToken !== undefined && ACTION_REQUEST_MODALS.has(firstPrefixToken) && /^\w+\s+you\b/u.test(prefix)))
 	);
 }
 

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -93,6 +93,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN = /^(?:are|is)\b/u;
+const AUXILIARY_ACTION_REQUEST_PATTERN = /^(?:are you\b|is it possible\b)/u;
 const CONDITION_PATTERN =
 	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
 const LEADING_CONDITION_PATTERN =
@@ -322,6 +323,7 @@ export class BuddyToolSelectionService {
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const hasInterrogativeHomeQuestion =
 			hasHomeSignal &&
+			actionTokens === null &&
 			STATE_QUESTION_PATTERN.test(normalizedMessage) &&
 			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
@@ -348,7 +350,10 @@ export class BuddyToolSelectionService {
 					hasStateFirstAction ||
 					hasGroundedStateFirstAction ||
 					hasInterrogativeHomeQuestion ||
-					(message.includes('?') && hasHomeSignal && intersects(tokens, GROUNDED_STATE_SIGNALS))))
+					(actionTokens === null &&
+						message.includes('?') &&
+						hasHomeSignal &&
+						intersects(tokens, GROUNDED_STATE_SIGNALS))))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
@@ -465,7 +470,7 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 
 function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
-	if (tokens.size <= 2 && tokens.has('morning')) return false;
+	if (tokens.size <= 2 && (tokens.has('morning') || normalizedMessage === 'thank you')) return false;
 	if (/^(?:(?:how|who) is|tell me about)\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {
@@ -519,8 +524,7 @@ function getActionIntentTokens(
 		(hasStateSignal &&
 			(STATE_QUESTION_PATTERN.test(normalizedMessage) ||
 				/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage))) ||
-		(STATE_QUESTION_PATTERN.test(normalizedMessage) &&
-			(normalizedMessage.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens)));
+		isSyntacticPredicateQuestion(normalizedMessage, tokens);
 
 	if (isStateQuestion) {
 		const questionEnd = normalizedMessage.indexOf('?');
@@ -561,7 +565,11 @@ function getActionIntentTokens(
 }
 
 function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {
-	return PREDICATE_QUESTION_PATTERN.test(normalizedMessage) && intersects(tokens, ACTION_SIGNALS);
+	return (
+		PREDICATE_QUESTION_PATTERN.test(normalizedMessage) &&
+		!AUXILIARY_ACTION_REQUEST_PATTERN.test(normalizedMessage) &&
+		intersects(tokens, ACTION_SIGNALS)
+	);
 }
 
 function sliceAfterFirst(value: string, delimiter: RegExp): string {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -657,7 +657,7 @@ function getActionIntentTokens(
 
 function isExplicitStateQuestion(normalizedMessage: string): boolean {
 	const requestPattern =
-		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:let|show|tell) me(?: know)?|check|confirm|determine|ensure|find out|see|verify)\b/u;
+		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:let|show|tell) me(?: know)?|check|confirm|determine|ensure|find out|report|see|verify)\b/u;
 
 	if (!requestPattern.test(normalizedMessage)) return false;
 	if (/\b(?:if|whether)\b/u.test(normalizedMessage)) return true;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -94,6 +94,10 @@ const STATE_QUESTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`[,;]|\ba\b(?=\s+(?:${[...ACTION_SIGNALS].join('|')})\b)|\b(?:after|and|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b`,
 	'u',
 );
+const CAPABILITY_DISCOVERY_PATTERN = new RegExp(
+	String.raw`^(?:what|which)\b.*\bcan i\b.*\b(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	'u',
+);
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|fetch|find|get|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
@@ -337,8 +341,16 @@ export class BuddyToolSelectionService {
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
 		const hasAuxiliaryActionRequest = hasActionRequestAuxiliary(normalizedMessage, tokens);
 		const hasStateReadSignal = hasStateSignal && !hasAuxiliaryActionRequest;
-		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateReadSignal);
+		const isCapabilityDiscovery = isCapabilityDiscoveryRequest(normalizedMessage);
+		const actionTokens = isCapabilityDiscovery
+			? null
+			: getActionIntentTokens(normalizedMessage, tokens, hasStateReadSignal);
 		const hasConditionalAction = actionTokens !== null && CONDITION_PATTERN.test(normalizedMessage);
+		const trailingConditionIndex = normalizedMessage.search(CONDITION_PATTERN);
+		const hasActionInTrailingCondition =
+			actionTokens !== null &&
+			trailingConditionIndex > 0 &&
+			intersects(tokenize(normalizedMessage.slice(trailingConditionIndex)), ACTION_SIGNALS);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
 		const trailingQuestionClause = questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1).trim() : '';
@@ -423,7 +435,9 @@ export class BuddyToolSelectionService {
 			this.selectActionTools(
 				actionTokens,
 				selected,
-				ACTION_CLAUSE_PATTERN.test(normalizedMessage) || hasUnknownTrailingClause(normalizedMessage),
+				ACTION_CLAUSE_PATTERN.test(normalizedMessage) ||
+					hasActionInTrailingCondition ||
+					hasUnknownTrailingClause(normalizedMessage),
 			);
 		}
 
@@ -629,6 +643,10 @@ function getActionIntentTokens(
 	const trailingCondition = normalizedMessage.search(CONDITION_PATTERN);
 
 	if (trailingCondition > 0) {
+		const conditionTokens = tokenize(normalizedMessage.slice(trailingCondition));
+
+		if (intersects(conditionTokens, ACTION_SIGNALS)) return tokens;
+
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
@@ -665,6 +683,10 @@ function isExplicitStateQuestion(normalizedMessage: string): boolean {
 	return /\b(?:how|what|when|where|which|why)\b.*\b(?:are|did|do|does|had|has|have|is|was|were)\b/u.test(
 		normalizedMessage,
 	);
+}
+
+function isCapabilityDiscoveryRequest(normalizedMessage: string): boolean {
+	return CAPABILITY_DISCOVERY_PATTERN.test(normalizedMessage);
 }
 
 function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -95,7 +95,7 @@ const STATE_QUESTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const CAPABILITY_DISCOVERY_PATTERN = new RegExp(
-	String.raw`^(?:what|which)\b.*\bcan i\b.*\b(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	String.raw`^(?:(?:what|which)\b|(?:can|could|would) you (?:show|tell)(?: me)?\b).*\b(?:am i able to|can i|i can)\b.*\b(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
 const READ_CLAUSE_PATTERN =
@@ -123,6 +123,10 @@ const GROUNDED_STATE_SIGNALS = new Set([
 	'open',
 	'unlocked',
 ]);
+const GROUNDED_ACTION_FILTER_PATTERN = new RegExp(
+	String.raw`\b(?:that|which)\s+(?:are|is|was|were)\s+(?:${[...GROUNDED_STATE_SIGNALS].join('|')})\b`,
+	'u',
+);
 const EXPLICIT_STATE_REQUEST_SIGNALS = new Set(['all', 'any', 'count', 'current', 'state', 'status', 'value']);
 const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
 	'brighten',
@@ -389,6 +393,7 @@ export class BuddyToolSelectionService {
 			actionTokens !== null &&
 			(intersects(tokens, RELATIVE_ADJUSTMENT_SIGNALS) ||
 				/\b(?:\d+|eight|five|four|nine|one|seven|six|ten|three|two) times as\b/u.test(normalizedMessage));
+		const hasGroundedActionFilter = actionTokens !== null && GROUNDED_ACTION_FILTER_PATTERN.test(normalizedMessage);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -400,6 +405,7 @@ export class BuddyToolSelectionService {
 		const hasUnknownModalRequest =
 			actionTokens === null &&
 			hasHomeSignal &&
+			!isCapabilityDiscovery &&
 			UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage) &&
 			!hasExplicitStateQuestion;
 		const hasUnrecognizedReadCompound =
@@ -427,6 +433,7 @@ export class BuddyToolSelectionService {
 					hasExplicitStateQuestion ||
 					hasLeadingReadRequest ||
 					hasRelativeAdjustment ||
+					hasGroundedActionFilter ||
 					hasUnknownActionTrailingClause ||
 					(actionTokens === null &&
 						message.includes('?') &&
@@ -604,7 +611,9 @@ function hasUnknownLeadingIntentBeforeRead(normalizedMessage: string): boolean {
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
-	if (/^(?:explain how to|how (?:can|could|do|would) i|tell me how to)\b/u.test(normalizedMessage)) return true;
+	if (/^(?:explain how to|how (?:can|could|do|would) i|(?:show|tell) me how to)\b/u.test(normalizedMessage)) {
+		return true;
+	}
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
 	if (/\b(?:currently|right now)\b/u.test(normalizedMessage)) return false;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -177,6 +177,42 @@ const DEVICE_SIGNALS = new Set([
 	'zaluzie',
 	'zarizeni',
 ]);
+const GENERAL_CONVERSATION_SIGNALS = new Set([
+	'hello',
+	'hey',
+	'hi',
+	'how',
+	'joke',
+	'morning',
+	'poem',
+	'thank',
+	'thanks',
+	'who',
+	'ahoj',
+	'dekuji',
+	'diky',
+]);
+const GENERAL_CONVERSATION_FILLERS = new Set([
+	'a',
+	'am',
+	'are',
+	'about',
+	'good',
+	'i',
+	'is',
+	'me',
+	'morning',
+	'tell',
+	'the',
+	'write',
+	'you',
+	'your',
+	'jaky',
+	'jak',
+	'jsi',
+	'mi',
+	'rekni',
+]);
 
 /**
  * Selects built-in Buddy schemas for the current message.
@@ -206,7 +242,7 @@ export class BuddyToolSelectionService {
 			this.selectActionTools(tokens, selected);
 		}
 
-		if (hasHomeSignal && selected.size === 0) {
+		if (selected.size === 0 && (hasHomeSignal || !isClearlyGeneralConversation(tokens))) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -259,4 +295,14 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 	}
 
 	return false;
+}
+
+function isClearlyGeneralConversation(tokens: Set<string>): boolean {
+	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
+
+	for (const token of tokens) {
+		if (!GENERAL_CONVERSATION_SIGNALS.has(token) && !GENERAL_CONVERSATION_FILLERS.has(token)) return false;
+	}
+
+	return true;
 }

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -249,9 +249,8 @@ export class BuddyToolSelectionService {
 		const selected = new Set<string>();
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
-		const hasConditionalStateSignal =
-			/\b(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage) && intersects(tokens, GROUNDED_STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
+		const hasConditionalAction = actionTokens !== null && /\b(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const isStateExplanation =
@@ -262,7 +261,7 @@ export class BuddyToolSelectionService {
 		if (
 			isStateExplanation ||
 			(!isGenericExplanation &&
-				(hasSearchSignal || hasStateSignal || hasConditionalStateSignal || (message.includes('?') && hasHomeSignal)))
+				(hasSearchSignal || hasStateSignal || hasConditionalAction || (message.includes('?') && hasHomeSignal)))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
@@ -372,7 +371,7 @@ function getActionIntentTokens(
 		const trailingClause =
 			questionEnd >= 0
 				? normalizedMessage.slice(questionEnd + 1)
-				: sliceAfterFirst(normalizedMessage, /[,;]|\b(?:and|if not|if so|please|then)\b/u);
+				: sliceAfterFirst(normalizedMessage, /[,;]|\b(?:a|and|if not|if so|please|potom|then)\b/u);
 		const trailingTokens = tokenize(trailingClause);
 
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -93,9 +93,9 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|read|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
-	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
+	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
-	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|what (?:are|did|had|has|have|is|was|were))\b/u;
+	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|(?:what|why) (?:are|did|had|has|have|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -92,6 +92,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 );
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
+const PREDICATE_QUESTION_PATTERN = /^(?:are|is)\b/u;
 const CONDITION_PATTERN =
 	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
 const LEADING_CONDITION_PATTERN =
@@ -320,7 +321,9 @@ export class BuddyToolSelectionService {
 			/[,;]/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const hasInterrogativeHomeQuestion =
-			hasHomeSignal && message.includes('?') && STATE_QUESTION_PATTERN.test(normalizedMessage);
+			hasHomeSignal &&
+			STATE_QUESTION_PATTERN.test(normalizedMessage) &&
+			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateSignal &&
@@ -516,7 +519,8 @@ function getActionIntentTokens(
 		(hasStateSignal &&
 			(STATE_QUESTION_PATTERN.test(normalizedMessage) ||
 				/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage))) ||
-		(STATE_QUESTION_PATTERN.test(normalizedMessage) && normalizedMessage.includes('?'));
+		(STATE_QUESTION_PATTERN.test(normalizedMessage) &&
+			(normalizedMessage.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens)));
 
 	if (isStateQuestion) {
 		const questionEnd = normalizedMessage.indexOf('?');
@@ -554,6 +558,10 @@ function getActionIntentTokens(
 	}
 
 	return tokens;
+}
+
+function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {
+	return PREDICATE_QUESTION_PATTERN.test(normalizedMessage) && intersects(tokens, ACTION_SIGNALS);
 }
 
 function sliceAfterFirst(value: string, delimiter: RegExp): string {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -80,7 +80,7 @@ const ACTION_SIGNALS = new Set([
 	'zavri',
 ]);
 const ACTION_CLAUSE_PATTERN = new RegExp(
-	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:please\s+)?(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
@@ -252,17 +252,28 @@ export class BuddyToolSelectionService {
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasConditionalAction = actionTokens !== null && /\b(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage);
+		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
+		const questionEnd = normalizedMessage.indexOf('?');
+		const hasStateFirstAction =
+			actionTokens !== null &&
+			questionEnd >= 0 &&
+			intersects(tokenize(normalizedMessage.slice(questionEnd + 1)), ACTION_SIGNALS);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const isStateExplanation =
 			hasHomeSignal &&
 			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
-				(/^explain why\b/u.test(normalizedMessage) && intersects(tokens, GROUNDED_STATE_SIGNALS)));
+				(/^explain why\b/u.test(normalizedMessage) && !/\bwork(?:s|ing)?\b/u.test(normalizedMessage)));
 
 		if (
 			isStateExplanation ||
 			(!isGenericExplanation &&
-				(hasSearchSignal || hasStateSignal || hasConditionalAction || (message.includes('?') && hasHomeSignal)))
+				(hasSearchSignal ||
+					hasStateSignal ||
+					hasConditionalAction ||
+					hasTrailingReadClause ||
+					hasStateFirstAction ||
+					(message.includes('?') && hasHomeSignal)))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
@@ -370,7 +381,8 @@ function getActionIntentTokens(
 
 	const isStateQuestion =
 		hasStateSignal &&
-		/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage);
+		(/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage) ||
+			/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage));
 
 	if (isStateQuestion) {
 		const questionEnd = normalizedMessage.indexOf('?');

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -346,9 +346,11 @@ export class BuddyToolSelectionService {
 		const hasAuxiliaryActionRequest = hasActionRequestAuxiliary(normalizedMessage, tokens);
 		const hasStateReadSignal = hasStateSignal && !hasAuxiliaryActionRequest;
 		const isCapabilityDiscovery = isCapabilityDiscoveryRequest(normalizedMessage);
-		const actionTokens = isCapabilityDiscovery
-			? null
-			: getActionIntentTokens(normalizedMessage, tokens, hasStateReadSignal);
+		const isFilteredSearch = isGroundedFilteredSearchRequest(normalizedMessage, tokens);
+		const actionTokens =
+			isCapabilityDiscovery || isFilteredSearch
+				? null
+				: getActionIntentTokens(normalizedMessage, tokens, hasStateReadSignal);
 		const hasConditionalAction = actionTokens !== null && CONDITION_PATTERN.test(normalizedMessage);
 		const trailingConditionIndex = normalizedMessage.search(CONDITION_PATTERN);
 		const hasActionInTrailingCondition =
@@ -700,6 +702,17 @@ function isExplicitStateQuestion(normalizedMessage: string): boolean {
 
 function isCapabilityDiscoveryRequest(normalizedMessage: string): boolean {
 	return CAPABILITY_DISCOVERY_PATTERN.test(normalizedMessage);
+}
+
+function isGroundedFilteredSearchRequest(normalizedMessage: string, tokens: Set<string>): boolean {
+	if (!/^(?:find|list|locate|search|show(?: me)?)\b/u.test(normalizedMessage)) return false;
+	if (!intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
+
+	for (const token of tokens) {
+		if (ACTION_SIGNALS.has(token) && !GROUNDED_STATE_SIGNALS.has(token)) return false;
+	}
+
+	return true;
 }
 
 function hasPotentialActionIntent(clause: string): boolean {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,7 +91,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|read|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|read|report|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
@@ -125,7 +125,10 @@ const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
 	'decrease',
 	'dim',
 	'dimmer',
+	'double',
 	'down',
+	'half',
+	'halve',
 	'hotter',
 	'higher',
 	'increase',
@@ -133,6 +136,8 @@ const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
 	'lower',
 	'more',
 	'raise',
+	'triple',
+	'twice',
 	'up',
 	'warmer',
 ]);
@@ -524,7 +529,12 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 
 function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
-	if (tokens.size <= 2 && (tokens.has('morning') || normalizedMessage === 'thank you')) return false;
+	if (
+		(tokens.size === 1 && !tokens.has('hello') && !tokens.has('hey') && !tokens.has('hi') && !tokens.has('thanks')) ||
+		(tokens.size <= 2 && (tokens.has('morning') || normalizedMessage === 'thank you'))
+	) {
+		return false;
+	}
 	if (/^(?:(?:how|who) is|tell me about)\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -92,8 +92,8 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 );
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
-const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
-const PREDICATE_QUESTION_PATTERN = /^(?:are|is|was|were|what (?:are|is|was|were))\b/u;
+const STATE_QUESTION_PATTERN = /^(?:are|did|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
+const PREDICATE_QUESTION_PATTERN = /^(?:are|did|is|was|were|what (?:are|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set([
 	'able',
@@ -574,10 +574,11 @@ function getActionIntentTokens(
 
 	if (isStateQuestion) {
 		const questionEnd = normalizedMessage.indexOf('?');
-		const trailingClause =
-			questionEnd >= 0
-				? normalizedMessage.slice(questionEnd + 1)
-				: sliceAfterFirst(normalizedMessage, /[,;]|\b(?:a|and|if not|if so|please|potom|then)\b/u);
+		const questionBody = questionEnd >= 0 ? normalizedMessage.slice(0, questionEnd) : normalizedMessage;
+		const trailingClause = [
+			sliceAfterFirst(questionBody, /[,;]|\b(?:a|and|if not|if so|please|potom|then)\b/u),
+			questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1) : '',
+		].join(' ');
 		const trailingTokens = tokenize(trailingClause);
 
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -88,6 +88,7 @@ const HOME_SIGNALS = new Set([
 	'cooling',
 	'device',
 	'door',
+	'doors',
 	'energy',
 	'garage',
 	'heating',
@@ -107,6 +108,7 @@ const HOME_SIGNALS = new Set([
 	'temperature',
 	'thermostat',
 	'window',
+	'windows',
 	'dvere',
 	'dum',
 	'energie',
@@ -156,6 +158,7 @@ const DEVICE_SIGNALS = new Set([
 	'cooling',
 	'device',
 	'door',
+	'doors',
 	'heating',
 	'humidity',
 	'lamp',
@@ -165,6 +168,7 @@ const DEVICE_SIGNALS = new Set([
 	'temperature',
 	'thermostat',
 	'window',
+	'windows',
 	'dvere',
 	'lampa',
 	'okno',
@@ -228,10 +232,7 @@ export class BuddyToolSelectionService {
 		const selected = new Set<string>();
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
-		const isStateQuestion =
-			hasStateSignal &&
-			/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage);
-		const hasActionSignal = intersects(tokens, ACTION_SIGNALS) && !isStateQuestion;
+		const hasActionSignal = hasActionIntent(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 
 		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)) {
@@ -306,4 +307,22 @@ function isClearlyGeneralConversation(tokens: Set<string>): boolean {
 	}
 
 	return true;
+}
+
+function hasActionIntent(normalizedMessage: string, tokens: Set<string>, hasStateSignal: boolean): boolean {
+	if (!intersects(tokens, ACTION_SIGNALS)) return false;
+
+	const isStateQuestion =
+		hasStateSignal &&
+		/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage);
+
+	if (!isStateQuestion) return true;
+
+	const questionEnd = normalizedMessage.indexOf('?');
+
+	if (questionEnd >= 0 && intersects(tokenize(normalizedMessage.slice(questionEnd + 1)), ACTION_SIGNALS)) return true;
+
+	const conditionalClause = normalizedMessage.search(/\b(?:and|if not|if so|please|then)\b/u);
+
+	return conditionalClause >= 0 && intersects(tokenize(normalizedMessage.slice(conditionalClause + 1)), ACTION_SIGNALS);
 }

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -346,7 +346,7 @@ export class BuddyToolSelectionService {
 			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
 		const hasLiveStatusRequest =
 			hasHomeSignal && actionTokens === null && /\b(?:currently|right now)\b/u.test(normalizedMessage);
-		const hasTellWhetherStateQuestion = isTellWhetherStateQuestion(normalizedMessage);
+		const hasExplicitStateQuestion = isExplicitStateQuestion(normalizedMessage);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -376,7 +376,7 @@ export class BuddyToolSelectionService {
 					hasPredicateStateFirstAction ||
 					hasInterrogativeHomeQuestion ||
 					hasLiveStatusRequest ||
-					hasTellWhetherStateQuestion ||
+					hasExplicitStateQuestion ||
 					(actionTokens === null &&
 						message.includes('?') &&
 						hasHomeSignal &&
@@ -566,7 +566,7 @@ function getActionIntentTokens(
 	if (!intersects(tokens, ACTION_SIGNALS)) return null;
 
 	const isStateQuestion =
-		isTellWhetherStateQuestion(normalizedMessage) ||
+		isExplicitStateQuestion(normalizedMessage) ||
 		(hasStateSignal &&
 			!hasActionRequestAuxiliary(normalizedMessage, tokens) &&
 			STATE_QUESTION_PATTERN.test(normalizedMessage)) ||
@@ -612,8 +612,8 @@ function getActionIntentTokens(
 	return tokens;
 }
 
-function isTellWhetherStateQuestion(normalizedMessage: string): boolean {
-	return /^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(
+function isExplicitStateQuestion(normalizedMessage: string): boolean {
+	return /^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:show|tell) me|check|confirm|determine|ensure|find out|see|verify)\b.*\b(?:if|whether)\b/u.test(
 		normalizedMessage,
 	);
 }

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -79,6 +79,10 @@ const ACTION_SIGNALS = new Set([
 	'zapni',
 	'zavri',
 ]);
+const ACTION_CLAUSE_PATTERN = new RegExp(
+	String.raw`(?:\band\b|\bthen\b|[,;])\s*(?:please\s+)?(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	'u',
+);
 const HOME_SIGNALS = new Set([
 	'air',
 	'bathroom',
@@ -234,17 +238,18 @@ export class BuddyToolSelectionService {
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
+		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 
-		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)) {
+		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal && !isGenericExplanation)) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
 
 		if (actionTokens) {
 			selected.add(SEARCH_HOME_TOOL_NAME);
-			this.selectActionTools(actionTokens, selected);
+			this.selectActionTools(actionTokens, selected, ACTION_CLAUSE_PATTERN.test(normalizedMessage));
 		}
 
-		if (selected.size === 0 && (hasHomeSignal || !isClearlyGeneralConversation(tokens))) {
+		if (selected.size === 0 && !isGenericExplanation && (hasHomeSignal || !isClearlyGeneralConversation(tokens))) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -253,7 +258,13 @@ export class BuddyToolSelectionService {
 		);
 	}
 
-	private selectActionTools(tokens: Set<string>, selected: Set<string>): void {
+	private selectActionTools(tokens: Set<string>, selected: Set<string>, hasAdditionalActionClause: boolean): void {
+		if (hasAdditionalActionClause) {
+			for (const name of ACTION_TOOL_NAMES) selected.add(name);
+
+			return;
+		}
+
 		const hasSceneSignal = intersects(tokens, SCENE_SIGNALS);
 		const hasLightingSignal = intersects(tokens, LIGHTING_SIGNALS);
 		const hasDeviceSignal = intersects(tokens, DEVICE_SIGNALS);
@@ -307,6 +318,17 @@ function isClearlyGeneralConversation(tokens: Set<string>): boolean {
 	}
 
 	return true;
+}
+
+function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
+	if (!intersects(tokens, HOME_SIGNALS)) return false;
+
+	return (
+		/^how (?:do|does) .+ work(?:s|ing)?\b/u.test(normalizedMessage) ||
+		/^what (?:do|does) .+ mean\b/u.test(normalizedMessage) ||
+		/^what (?:is|are) (?:a|an)\b/u.test(normalizedMessage) ||
+		/^explain\b/u.test(normalizedMessage)
+	);
 }
 
 function getActionIntentTokens(

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -93,7 +93,18 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN = /^(?:are|is)\b/u;
-const AUXILIARY_ACTION_REQUEST_PATTERN = /^(?:are you\b|is it possible\b)/u;
+const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
+const ACTION_REQUEST_AUXILIARIES = new Set([
+	'able',
+	'can',
+	'could',
+	'may',
+	'might',
+	'possible',
+	'way',
+	'will',
+	'would',
+]);
 const CONDITION_PATTERN =
 	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
 const LEADING_CONDITION_PATTERN =
@@ -301,7 +312,9 @@ export class BuddyToolSelectionService {
 		const selected = new Set<string>();
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
-		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
+		const hasAuxiliaryActionRequest = hasActionRequestAuxiliary(normalizedMessage, tokens);
+		const hasStateReadSignal = hasStateSignal && !hasAuxiliaryActionRequest;
+		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateReadSignal);
 		const hasConditionalAction = actionTokens !== null && CONDITION_PATTERN.test(normalizedMessage);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
@@ -328,13 +341,13 @@ export class BuddyToolSelectionService {
 			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
-			hasStateSignal &&
+			hasStateReadSignal &&
 			actionTokens === null &&
 			!hasSearchSignal &&
-			!message.includes('?') &&
+			(!message.includes('?') || UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage)) &&
 			!/^(?:explain|tell)\b/u.test(normalizedMessage);
 		const hasUnrecognizedReadCompound =
-			actionTokens === null && (hasSearchSignal || hasStateSignal) && hasUnknownTrailingClause(normalizedMessage);
+			actionTokens === null && (hasSearchSignal || hasStateReadSignal) && hasUnknownTrailingClause(normalizedMessage);
 		const isStateExplanation =
 			hasHomeSignal &&
 			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
@@ -344,7 +357,7 @@ export class BuddyToolSelectionService {
 			isStateExplanation ||
 			(!isGenericExplanation &&
 				(hasSearchSignal ||
-					hasStateSignal ||
+					hasStateReadSignal ||
 					hasConditionalAction ||
 					hasTrailingReadClause ||
 					hasStateFirstAction ||
@@ -522,6 +535,7 @@ function getActionIntentTokens(
 
 	const isStateQuestion =
 		(hasStateSignal &&
+			!hasActionRequestAuxiliary(normalizedMessage, tokens) &&
 			(STATE_QUESTION_PATTERN.test(normalizedMessage) ||
 				/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage))) ||
 		isSyntacticPredicateQuestion(normalizedMessage, tokens);
@@ -565,10 +579,19 @@ function getActionIntentTokens(
 }
 
 function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {
+	if (!PREDICATE_QUESTION_PATTERN.test(normalizedMessage) || !intersects(tokens, ACTION_SIGNALS)) return false;
+
+	return !hasActionRequestAuxiliary(normalizedMessage, tokens);
+}
+
+function hasActionRequestAuxiliary(normalizedMessage: string, tokens: Set<string>): boolean {
+	if (!intersects(tokens, ACTION_SIGNALS)) return false;
+
+	const actionMatch = new RegExp(String.raw`\b(?:${[...ACTION_SIGNALS].join('|')})\b`, 'u').exec(normalizedMessage);
+
 	return (
-		PREDICATE_QUESTION_PATTERN.test(normalizedMessage) &&
-		!AUXILIARY_ACTION_REQUEST_PATTERN.test(normalizedMessage) &&
-		intersects(tokens, ACTION_SIGNALS)
+		actionMatch !== null &&
+		intersects(tokenize(normalizedMessage.slice(0, actionMatch.index)), ACTION_REQUEST_AUXILIARIES)
 	);
 }
 

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -106,9 +106,9 @@ const ACTION_REQUEST_AUXILIARIES = new Set([
 	'would',
 ]);
 const CONDITION_PATTERN =
-	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
+	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever)\b/u;
 const LEADING_CONDITION_PATTERN =
-	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
+	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -517,6 +517,7 @@ function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
+	if (intersects(tokens, STATE_SIGNALS) && /^explain what\b.*\b(?:are|is)\??$/u.test(normalizedMessage)) return false;
 
 	return (
 		/^how (?:do|does) .+ work(?:s|ing)?\b/u.test(normalizedMessage) ||

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -90,7 +90,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
-const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
+const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN = /^(?:are|is)\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
@@ -106,9 +106,9 @@ const ACTION_REQUEST_AUXILIARIES = new Set([
 	'would',
 ]);
 const CONDITION_PATTERN =
-	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever)\b/u;
+	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever|while)\b/u;
 const LEADING_CONDITION_PATTERN =
-	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever)\b/u;
+	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|until|when|whenever|while)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -339,6 +339,8 @@ export class BuddyToolSelectionService {
 			actionTokens === null &&
 			STATE_QUESTION_PATTERN.test(normalizedMessage) &&
 			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
+		const hasLiveStatusRequest =
+			hasHomeSignal && actionTokens === null && /\b(?:currently|right now)\b/u.test(normalizedMessage);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -363,6 +365,7 @@ export class BuddyToolSelectionService {
 					hasStateFirstAction ||
 					hasGroundedStateFirstAction ||
 					hasInterrogativeHomeQuestion ||
+					hasLiveStatusRequest ||
 					(actionTokens === null &&
 						message.includes('?') &&
 						hasHomeSignal &&
@@ -517,6 +520,7 @@ function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
+	if (/\b(?:currently|right now)\b/u.test(normalizedMessage)) return false;
 	if (intersects(tokens, STATE_SIGNALS) && /^explain what\b.*\b(?:are|is)\??$/u.test(normalizedMessage)) return false;
 
 	return (

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,7 +91,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/\b(?:a|and|potom|then)\s+(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN = /^(?:are|is|was|were|what (?:are|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
@@ -346,6 +346,7 @@ export class BuddyToolSelectionService {
 			(message.includes('?') || isSyntacticPredicateQuestion(normalizedMessage, tokens));
 		const hasLiveStatusRequest =
 			hasHomeSignal && actionTokens === null && /\b(?:currently|right now)\b/u.test(normalizedMessage);
+		const hasTellWhetherStateQuestion = isTellWhetherStateQuestion(normalizedMessage);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -375,6 +376,7 @@ export class BuddyToolSelectionService {
 					hasPredicateStateFirstAction ||
 					hasInterrogativeHomeQuestion ||
 					hasLiveStatusRequest ||
+					hasTellWhetherStateQuestion ||
 					(actionTokens === null &&
 						message.includes('?') &&
 						hasHomeSignal &&
@@ -564,10 +566,10 @@ function getActionIntentTokens(
 	if (!intersects(tokens, ACTION_SIGNALS)) return null;
 
 	const isStateQuestion =
+		isTellWhetherStateQuestion(normalizedMessage) ||
 		(hasStateSignal &&
 			!hasActionRequestAuxiliary(normalizedMessage, tokens) &&
-			(STATE_QUESTION_PATTERN.test(normalizedMessage) ||
-				/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage))) ||
+			STATE_QUESTION_PATTERN.test(normalizedMessage)) ||
 		isSyntacticPredicateQuestion(normalizedMessage, tokens);
 
 	if (isStateQuestion) {
@@ -587,6 +589,8 @@ function getActionIntentTokens(
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
+
+		return new Set();
 	}
 
 	if (LEADING_CONDITION_PATTERN.test(normalizedMessage)) {
@@ -606,6 +610,12 @@ function getActionIntentTokens(
 	}
 
 	return tokens;
+}
+
+function isTellWhetherStateQuestion(normalizedMessage: string): boolean {
+	return /^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(
+		normalizedMessage,
+	);
 }
 
 function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -350,7 +350,7 @@ export class BuddyToolSelectionService {
 		const hasActionInTrailingCondition =
 			actionTokens !== null &&
 			trailingConditionIndex > 0 &&
-			intersects(tokenize(normalizedMessage.slice(trailingConditionIndex)), ACTION_SIGNALS);
+			hasPotentialActionIntent(normalizedMessage.slice(trailingConditionIndex));
 		const hasUnknownActionTrailingClause = actionTokens !== null && hasUnknownTrailingClause(normalizedMessage);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
@@ -383,7 +383,8 @@ export class BuddyToolSelectionService {
 			hasHomeSignal && actionTokens === null && /\b(?:currently|right now)\b/u.test(normalizedMessage);
 		const hasExplicitStateQuestion = isExplicitStateQuestion(normalizedMessage);
 		const hasLeadingReadRequest =
-			hasHomeSignal && /^(?:check|confirm|determine|ensure|find out|read|see|show|verify)\b/u.test(normalizedMessage);
+			hasHomeSignal &&
+			/^(?:check|confirm|determine|ensure|fetch|find out|get|read|report|see|show|verify)\b/u.test(normalizedMessage);
 		const hasRelativeAdjustment = actionTokens !== null && intersects(tokens, RELATIVE_ADJUSTMENT_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
@@ -643,9 +644,9 @@ function getActionIntentTokens(
 	const trailingCondition = normalizedMessage.search(CONDITION_PATTERN);
 
 	if (trailingCondition > 0) {
-		const conditionTokens = tokenize(normalizedMessage.slice(trailingCondition));
+		const conditionClause = normalizedMessage.slice(trailingCondition);
 
-		if (intersects(conditionTokens, ACTION_SIGNALS)) return tokens;
+		if (hasPotentialActionIntent(conditionClause)) return tokens;
 
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
 
@@ -687,6 +688,10 @@ function isExplicitStateQuestion(normalizedMessage: string): boolean {
 
 function isCapabilityDiscoveryRequest(normalizedMessage: string): boolean {
 	return CAPABILITY_DISCOVERY_PATTERN.test(normalizedMessage);
+}
+
+function hasPotentialActionIntent(clause: string): boolean {
+	return intersects(tokenize(clause), ACTION_SIGNALS) || /\byou\b/u.test(clause);
 }
 
 function isSyntacticPredicateQuestion(normalizedMessage: string, tokens: Set<string>): boolean {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,7 +91,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|find|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|fetch|find|get|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
@@ -414,7 +414,7 @@ export class BuddyToolSelectionService {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
 
-		if (actionTokens) {
+		if (actionTokens && !isGenericExplanation) {
 			selected.add(SEARCH_HOME_TOOL_NAME);
 			this.selectActionTools(
 				actionTokens,

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -334,6 +334,10 @@ export class BuddyToolSelectionService {
 			/^(?:are|is|je|jsou)\b/u.test(normalizedMessage) &&
 			intersects(tokens, GROUNDED_STATE_SIGNALS) &&
 			/[,;]/u.test(normalizedMessage);
+		const hasPredicateStateFirstAction =
+			actionTokens !== null &&
+			isSyntacticPredicateQuestion(normalizedMessage, tokens) &&
+			/[,;]/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const hasInterrogativeHomeQuestion =
 			hasHomeSignal &&
@@ -350,11 +354,14 @@ export class BuddyToolSelectionService {
 			(!message.includes('?') || UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage)) &&
 			!/^(?:explain|tell)\b/u.test(normalizedMessage);
 		const hasUnrecognizedReadCompound =
-			actionTokens === null && (hasSearchSignal || hasStateReadSignal) && hasUnknownTrailingClause(normalizedMessage);
+			actionTokens === null &&
+			(hasSearchSignal || hasStateReadSignal) &&
+			(hasUnknownTrailingClause(normalizedMessage) || hasUnknownLeadingIntentBeforeRead(normalizedMessage));
 		const isStateExplanation =
 			hasHomeSignal &&
 			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
-				(/^explain why\b/u.test(normalizedMessage) && !/\bwork(?:s|ing)?\b/u.test(normalizedMessage)));
+				(/^explain why\b/u.test(normalizedMessage) && !/\bwork(?:s|ing)?\b/u.test(normalizedMessage)) ||
+				/^explain how\b.*\b(?:are|is)\.?$/u.test(normalizedMessage));
 
 		if (
 			isStateExplanation ||
@@ -365,6 +372,7 @@ export class BuddyToolSelectionService {
 					hasTrailingReadClause ||
 					hasStateFirstAction ||
 					hasGroundedStateFirstAction ||
+					hasPredicateStateFirstAction ||
 					hasInterrogativeHomeQuestion ||
 					hasLiveStatusRequest ||
 					(actionTokens === null &&
@@ -515,6 +523,22 @@ function hasUnknownTrailingClause(normalizedMessage: string): boolean {
 	}
 
 	return false;
+}
+
+function hasUnknownLeadingIntentBeforeRead(normalizedMessage: string): boolean {
+	const readClauseIndex = normalizedMessage.search(READ_CLAUSE_PATTERN);
+
+	if (readClauseIndex <= 0) return false;
+
+	const [firstToken] = tokenize(normalizedMessage.slice(0, readClauseIndex));
+
+	return (
+		firstToken !== undefined &&
+		!SEARCH_SIGNALS.has(firstToken) &&
+		!STATE_SIGNALS.has(firstToken) &&
+		!ACTION_SIGNALS.has(firstToken) &&
+		!GENERAL_CONVERSATION_FILLERS.has(firstToken)
+	);
 }
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -123,6 +123,23 @@ const GROUNDED_STATE_SIGNALS = new Set([
 	'unlocked',
 ]);
 const EXPLICIT_STATE_REQUEST_SIGNALS = new Set(['all', 'any', 'count', 'current', 'state', 'status', 'value']);
+const RELATIVE_ADJUSTMENT_SIGNALS = new Set([
+	'brighten',
+	'brighter',
+	'cooler',
+	'darker',
+	'decrease',
+	'dim',
+	'dimmer',
+	'down',
+	'increase',
+	'less',
+	'lower',
+	'more',
+	'raise',
+	'up',
+	'warmer',
+]);
 const HOME_SIGNALS = new Set([
 	'air',
 	'bathroom',
@@ -347,6 +364,9 @@ export class BuddyToolSelectionService {
 		const hasLiveStatusRequest =
 			hasHomeSignal && actionTokens === null && /\b(?:currently|right now)\b/u.test(normalizedMessage);
 		const hasExplicitStateQuestion = isExplicitStateQuestion(normalizedMessage);
+		const hasLeadingReadRequest =
+			hasHomeSignal && /^(?:check|confirm|determine|ensure|find out|read|see|show|verify)\b/u.test(normalizedMessage);
+		const hasRelativeAdjustment = actionTokens !== null && intersects(tokens, RELATIVE_ADJUSTMENT_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -377,6 +397,8 @@ export class BuddyToolSelectionService {
 					hasInterrogativeHomeQuestion ||
 					hasLiveStatusRequest ||
 					hasExplicitStateQuestion ||
+					hasLeadingReadRequest ||
+					hasRelativeAdjustment ||
 					(actionTokens === null &&
 						message.includes('?') &&
 						hasHomeSignal &&

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -150,6 +150,7 @@ const HOME_SIGNALS = new Set([
 	'zarizeni',
 ]);
 const SCENE_SIGNALS = new Set(['automation', 'preset', 'routine', 'scene', 'scena']);
+const SCENE_ACTION_SIGNALS = new Set(['run', 'spust']);
 const LIGHTING_SIGNALS = new Set(['lamp', 'lampa', 'light', 'lighting', 'lights', 'svetla', 'svetlo']);
 const SPACE_SIGNALS = new Set([
 	'all',
@@ -258,6 +259,11 @@ export class BuddyToolSelectionService {
 			actionTokens !== null &&
 			questionEnd >= 0 &&
 			intersects(tokenize(normalizedMessage.slice(questionEnd + 1)), ACTION_SIGNALS);
+		const hasGroundedStateFirstAction =
+			actionTokens !== null &&
+			/^(?:are|is|je|jsou)\b/u.test(normalizedMessage) &&
+			intersects(tokens, GROUNDED_STATE_SIGNALS) &&
+			/[,;]/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const isStateExplanation =
@@ -273,6 +279,7 @@ export class BuddyToolSelectionService {
 					hasConditionalAction ||
 					hasTrailingReadClause ||
 					hasStateFirstAction ||
+					hasGroundedStateFirstAction ||
 					(message.includes('?') && hasHomeSignal)))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
@@ -303,7 +310,16 @@ export class BuddyToolSelectionService {
 			return;
 		}
 
-		const hasSceneSignal = intersects(tokens, SCENE_SIGNALS);
+		const hasExplicitSceneSignal = intersects(tokens, SCENE_SIGNALS);
+		const hasSceneActionSignal = intersects(tokens, SCENE_ACTION_SIGNALS);
+
+		if (hasSceneActionSignal && !hasExplicitSceneSignal) {
+			for (const name of ACTION_TOOL_NAMES) selected.add(name);
+
+			return;
+		}
+
+		const hasSceneSignal = hasExplicitSceneSignal || hasSceneActionSignal;
 		const hasLightingSignal = intersects(tokens, LIGHTING_SIGNALS);
 		const hasDeviceSignal = intersects(tokens, DEVICE_SIGNALS);
 		let selectedSpecificAction = false;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -90,9 +90,10 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
-const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|verify|what|whether|which)\b/u;
+const READ_CLAUSE_PATTERN =
+	/\b(?:a|and|potom|then)\s+(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
-const PREDICATE_QUESTION_PATTERN = /^(?:are|is)\b/u;
+const PREDICATE_QUESTION_PATTERN = /^(?:are|is|was|were|what (?:are|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set([
 	'able',

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -92,8 +92,9 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 );
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
-const STATE_QUESTION_PATTERN = /^(?:are|did|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
-const PREDICATE_QUESTION_PATTERN = /^(?:are|did|is|was|were|what (?:are|is|was|were))\b/u;
+const STATE_QUESTION_PATTERN =
+	/^(?:are|did|do|does|had|has|have|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
+const PREDICATE_QUESTION_PATTERN = /^(?:are|did|had|has|have|is|was|were|what (?:are|had|has|have|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set([
 	'able',
@@ -598,7 +599,10 @@ function getActionIntentTokens(
 		const questionEnd = normalizedMessage.indexOf('?');
 		const questionBody = questionEnd >= 0 ? normalizedMessage.slice(0, questionEnd) : normalizedMessage;
 		const trailingClause = [
-			sliceAfterFirst(questionBody, /[,;]|\b(?:a|and|if not|if so|please|potom|then)\b/u),
+			sliceAfterFirst(
+				questionBody,
+				/[,;]|\b(?:a|after|and|before|if not|if so|once|please|potom|then|until|when|while)\b/u,
+			),
 			questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1) : '',
 		].join(' ');
 		const trailingTokens = tokenize(trailingClause);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,11 +91,11 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|read|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
-	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|what (?:are|had|has|have|is|was|were))\b/u;
+	/^(?:are|can|could|did|had|has|have|is|may|might|will|would|was|were|what (?:are|did|had|has|have|is|was|were))\b/u;
 const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s+you\b|please\b)/u;
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -90,6 +90,10 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
+const STATE_QUESTION_CLAUSE_PATTERN = new RegExp(
+	String.raw`[,;]|\ba\b(?=\s+(?:${[...ACTION_SIGNALS].join('|')})\b)|\b(?:after|and|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b`,
+	'u',
+);
 const READ_CLAUSE_PATTERN =
 	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|fetch|find|get|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
@@ -614,10 +618,7 @@ function getActionIntentTokens(
 		const questionEnd = normalizedMessage.indexOf('?');
 		const questionBody = questionEnd >= 0 ? normalizedMessage.slice(0, questionEnd) : normalizedMessage;
 		const trailingClause = [
-			sliceAfterFirst(
-				questionBody,
-				/[,;]|\b(?:a|after|and|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b/u,
-			),
+			sliceAfterFirst(questionBody, STATE_QUESTION_CLAUSE_PATTERN),
 			questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1) : '',
 		].join(' ');
 		const trailingTokens = tokenize(trailingClause);

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -83,6 +83,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:please\s+)?(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
+const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -271,7 +272,11 @@ export class BuddyToolSelectionService {
 			this.selectActionTools(actionTokens, selected, ACTION_CLAUSE_PATTERN.test(normalizedMessage));
 		}
 
-		if (selected.size === 0 && !isGenericExplanation && (hasHomeSignal || !isClearlyGeneralConversation(tokens))) {
+		if (
+			selected.size === 0 &&
+			!isGenericExplanation &&
+			(hasHomeSignal || !isClearlyGeneralConversation(normalizedMessage, tokens))
+		) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -332,8 +337,9 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 	return false;
 }
 
-function isClearlyGeneralConversation(tokens: Set<string>): boolean {
+function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
+	if (/^how is\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {
 		if (!GENERAL_CONVERSATION_SIGNALS.has(token) && !GENERAL_CONVERSATION_FILLERS.has(token)) return false;
@@ -391,6 +397,14 @@ function getActionIntentTokens(
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 
 		return new Set();
+	}
+
+	const trailingReadClause = normalizedMessage.search(READ_CLAUSE_PATTERN);
+
+	if (trailingReadClause > 0) {
+		const commandTokens = tokenize(normalizedMessage.slice(0, trailingReadClause));
+
+		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 	}
 
 	return tokens;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -87,11 +87,11 @@ const ACTION_SIGNALS = new Set([
 	'zvys',
 ]);
 const ACTION_CLAUSE_PATTERN = new RegExp(
-	String.raw`(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	String.raw`(?:\ba\b|\band\b|\bas well as\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
 const STATE_QUESTION_CLAUSE_PATTERN = new RegExp(
-	String.raw`[,;]|\ba\b(?=\s+(?:${[...ACTION_SIGNALS].join('|')})\b)|\b(?:after|and|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b`,
+	String.raw`[,;]|\ba\b(?=\s+(?:${[...ACTION_SIGNALS].join('|')})\b)|\b(?:after|and|as well as|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b`,
 	'u',
 );
 const CAPABILITY_DISCOVERY_PATTERN = new RegExp(
@@ -99,7 +99,7 @@ const CAPABILITY_DISCOVERY_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|fetch|find|get|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bas well as\b|\bplus\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|fetch|find|get|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =
@@ -108,9 +108,9 @@ const UNKNOWN_ACTION_REQUEST_PATTERN = /^(?:(?:can|could|may|might|will|would)\s
 const ACTION_REQUEST_AUXILIARIES = new Set(['able', 'possible', 'way']);
 const ACTION_REQUEST_MODALS = new Set(['can', 'could', 'may', 'might', 'will', 'would']);
 const CONDITION_PATTERN =
-	/\b(?:after|as long as|as soon as|assuming(?: that)?|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
+	/\b(?:after|as long as|as soon as|assuming(?: that)?|before|given that|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const LEADING_CONDITION_PATTERN =
-	/^(?:after|as long as|as soon as|assuming(?: that)?|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
+	/^(?:after|as long as|as soon as|assuming(?: that)?|before|given that|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|so long as|unless|until|when|whenever|while)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -385,7 +385,10 @@ export class BuddyToolSelectionService {
 		const hasLeadingReadRequest =
 			hasHomeSignal &&
 			/^(?:check|confirm|determine|ensure|fetch|find out|get|read|report|see|show|verify)\b/u.test(normalizedMessage);
-		const hasRelativeAdjustment = actionTokens !== null && intersects(tokens, RELATIVE_ADJUSTMENT_SIGNALS);
+		const hasRelativeAdjustment =
+			actionTokens !== null &&
+			(intersects(tokens, RELATIVE_ADJUSTMENT_SIGNALS) ||
+				/\b(?:\d+|eight|five|four|nine|one|seven|six|ten|three|two) times as\b/u.test(normalizedMessage));
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateReadSignal &&
@@ -564,7 +567,7 @@ function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<str
 }
 
 function hasUnknownTrailingClause(normalizedMessage: string): boolean {
-	const trailingClause = sliceAfterFirst(normalizedMessage, /[.!?,;]|\b(?:and|plus|potom|then)\b/u);
+	const trailingClause = sliceAfterFirst(normalizedMessage, /[.!?,;]|\b(?:and|as well as|plus|potom|then)\b/u);
 
 	if (trailingClause.length === 0) return false;
 

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -58,10 +58,14 @@ const ACTION_SIGNALS = new Set([
 	'brighten',
 	'change',
 	'close',
+	'decrease',
 	'deactivate',
 	'dim',
+	'increase',
 	'lock',
+	'lower',
 	'open',
+	'raise',
 	'run',
 	'set',
 	'start',
@@ -74,10 +78,12 @@ const ACTION_SIGNALS = new Set([
 	'otevri',
 	'spust',
 	'nastav',
+	'sniz',
 	'vypni',
 	'zamkni',
 	'zapni',
 	'zavri',
+	'zvys',
 ]);
 const ACTION_CLAUSE_PATTERN = new RegExp(
 	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:(?:also|please|take)\s+)*(?:${[...ACTION_SIGNALS].join('|')})\b`,
@@ -151,6 +157,33 @@ const HOME_SIGNALS = new Set([
 ]);
 const SCENE_SIGNALS = new Set(['automation', 'preset', 'routine', 'scene', 'scena']);
 const SCENE_ACTION_SIGNALS = new Set(['run', 'spust']);
+const AMBIGUOUS_ACTION_SIGNALS = new Set(['activate', 'deactivate', 'start', 'stop']);
+const DEVICE_ACTION_SIGNALS = new Set([
+	'adjust',
+	'brighten',
+	'change',
+	'close',
+	'decrease',
+	'dim',
+	'increase',
+	'lock',
+	'lower',
+	'nastav',
+	'odemkni',
+	'open',
+	'otevri',
+	'raise',
+	'set',
+	'sniz',
+	'switch',
+	'turn',
+	'unlock',
+	'vypni',
+	'zamkni',
+	'zapni',
+	'zavri',
+	'zvys',
+]);
 const LIGHTING_SIGNALS = new Set(['lamp', 'lampa', 'light', 'lighting', 'lights', 'svetla', 'svetlo']);
 const SPACE_SIGNALS = new Set([
 	'all',
@@ -266,6 +299,12 @@ export class BuddyToolSelectionService {
 			/[,;]/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
+		const hasUnrecognizedStateIntent =
+			hasStateSignal &&
+			actionTokens === null &&
+			!hasSearchSignal &&
+			!message.includes('?') &&
+			!/^(?:explain|tell)\b/u.test(normalizedMessage);
 		const isStateExplanation =
 			hasHomeSignal &&
 			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
@@ -290,6 +329,10 @@ export class BuddyToolSelectionService {
 			this.selectActionTools(actionTokens, selected, ACTION_CLAUSE_PATTERN.test(normalizedMessage));
 		}
 
+		if (hasUnrecognizedStateIntent) {
+			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
+		}
+
 		if (
 			selected.size === 0 &&
 			!isGenericExplanation &&
@@ -310,6 +353,12 @@ export class BuddyToolSelectionService {
 			return;
 		}
 
+		if (intersects(tokens, AMBIGUOUS_ACTION_SIGNALS)) {
+			for (const name of ACTION_TOOL_NAMES) selected.add(name);
+
+			return;
+		}
+
 		const hasExplicitSceneSignal = intersects(tokens, SCENE_SIGNALS);
 		const hasSceneActionSignal = intersects(tokens, SCENE_ACTION_SIGNALS);
 
@@ -321,7 +370,16 @@ export class BuddyToolSelectionService {
 
 		const hasSceneSignal = hasExplicitSceneSignal || hasSceneActionSignal;
 		const hasLightingSignal = intersects(tokens, LIGHTING_SIGNALS);
-		const hasDeviceSignal = intersects(tokens, DEVICE_SIGNALS);
+		const hasDeviceTargetSignal = intersects(tokens, DEVICE_SIGNALS);
+		const hasDeviceActionSignal = intersects(tokens, DEVICE_ACTION_SIGNALS);
+
+		if (hasDeviceActionSignal && !hasDeviceTargetSignal && !hasExplicitSceneSignal && !hasLightingSignal) {
+			for (const name of ACTION_TOOL_NAMES) selected.add(name);
+
+			return;
+		}
+
+		const hasDeviceSignal = hasDeviceTargetSignal || hasDeviceActionSignal;
 		let selectedSpecificAction = false;
 
 		if (hasSceneSignal) {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -351,6 +351,7 @@ export class BuddyToolSelectionService {
 			actionTokens !== null &&
 			trailingConditionIndex > 0 &&
 			intersects(tokenize(normalizedMessage.slice(trailingConditionIndex)), ACTION_SIGNALS);
+		const hasUnknownActionTrailingClause = actionTokens !== null && hasUnknownTrailingClause(normalizedMessage);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
 		const trailingQuestionClause = questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1).trim() : '';
@@ -422,6 +423,7 @@ export class BuddyToolSelectionService {
 					hasExplicitStateQuestion ||
 					hasLeadingReadRequest ||
 					hasRelativeAdjustment ||
+					hasUnknownActionTrailingClause ||
 					(actionTokens === null &&
 						message.includes('?') &&
 						hasHomeSignal &&
@@ -435,9 +437,7 @@ export class BuddyToolSelectionService {
 			this.selectActionTools(
 				actionTokens,
 				selected,
-				ACTION_CLAUSE_PATTERN.test(normalizedMessage) ||
-					hasActionInTrailingCondition ||
-					hasUnknownTrailingClause(normalizedMessage),
+				ACTION_CLAUSE_PATTERN.test(normalizedMessage) || hasActionInTrailingCondition || hasUnknownActionTrailingClause,
 			);
 		}
 
@@ -600,7 +600,7 @@ function hasUnknownLeadingIntentBeforeRead(normalizedMessage: string): boolean {
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
-	if (/^(?:explain how to|how (?:can|could|do|would) i)\b/u.test(normalizedMessage)) return true;
+	if (/^(?:explain how to|how (?:can|could|do|would) i|tell me how to)\b/u.test(normalizedMessage)) return true;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
 	if (/\b(?:currently|right now)\b/u.test(normalizedMessage)) return false;
@@ -675,7 +675,7 @@ function getActionIntentTokens(
 
 function isExplicitStateQuestion(normalizedMessage: string): boolean {
 	const requestPattern =
-		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:let|show|tell) me(?: know)?|check|confirm|determine|ensure|find out|report|see|verify)\b/u;
+		/^(?:(?:can|could|may|might|will|would)\s+you\s+)?(?:please\s+)?(?:(?:let|show|tell) me(?: know)?|check|confirm|determine|ensure|fetch|find out|get|read|report|see|verify)\b/u;
 
 	if (!requestPattern.test(normalizedMessage)) return false;
 	if (/\b(?:if|whether)\b/u.test(normalizedMessage)) return true;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -95,6 +95,7 @@ const GROUNDED_STATE_SIGNALS = new Set([
 	'open',
 	'unlocked',
 ]);
+const EXPLICIT_STATE_REQUEST_SIGNALS = new Set(['all', 'any', 'count', 'current', 'state', 'status', 'value']);
 const HOME_SIGNALS = new Set([
 	'air',
 	'bathroom',
@@ -248,6 +249,8 @@ export class BuddyToolSelectionService {
 		const selected = new Set<string>();
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
+		const hasConditionalStateSignal =
+			/\b(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage) && intersects(tokens, GROUNDED_STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
@@ -258,7 +261,8 @@ export class BuddyToolSelectionService {
 
 		if (
 			isStateExplanation ||
-			(!isGenericExplanation && (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)))
+			(!isGenericExplanation &&
+				(hasSearchSignal || hasStateSignal || hasConditionalStateSignal || (message.includes('?') && hasHomeSignal)))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
@@ -342,6 +346,7 @@ function isClearlyGeneralConversation(tokens: Set<string>): boolean {
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
 	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
+	if (intersects(tokens, EXPLICIT_STATE_REQUEST_SIGNALS)) return false;
 
 	return (
 		/^how (?:do|does) .+ work(?:s|ing)?\b/u.test(normalizedMessage) ||
@@ -367,7 +372,7 @@ function getActionIntentTokens(
 		const trailingClause =
 			questionEnd >= 0
 				? normalizedMessage.slice(questionEnd + 1)
-				: sliceAfterFirst(normalizedMessage, /\b(?:and|if not|if so|please|then)\b/u);
+				: sliceAfterFirst(normalizedMessage, /[,;]|\b(?:and|if not|if so|please|then)\b/u);
 		const trailingTokens = tokenize(trailingClause);
 
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -1,0 +1,262 @@
+import { Injectable } from '@nestjs/common';
+
+import { ToolDefinition } from '../platforms/llm-provider.platform';
+
+import { QUERY_HOME_STATE_TOOL_NAME, SEARCH_HOME_TOOL_NAME } from './home-context-tool-provider.service';
+
+const CONTROL_DEVICE_TOOL_NAME = 'control_device';
+const RUN_SCENE_TOOL_NAME = 'run_scene';
+const SET_SPACE_LIGHTING_TOOL_NAME = 'set_space_lighting';
+
+const BUILT_IN_TOOL_NAMES = new Set([
+	SEARCH_HOME_TOOL_NAME,
+	QUERY_HOME_STATE_TOOL_NAME,
+	CONTROL_DEVICE_TOOL_NAME,
+	RUN_SCENE_TOOL_NAME,
+	SET_SPACE_LIGHTING_TOOL_NAME,
+]);
+
+const READ_TOOL_NAMES = [SEARCH_HOME_TOOL_NAME, QUERY_HOME_STATE_TOOL_NAME] as const;
+const ACTION_TOOL_NAMES = [CONTROL_DEVICE_TOOL_NAME, RUN_SCENE_TOOL_NAME, SET_SPACE_LIGHTING_TOOL_NAME] as const;
+
+const SEARCH_SIGNALS = new Set([
+	'find',
+	'list',
+	'locate',
+	'overview',
+	'search',
+	'show',
+	'which',
+	'najdi',
+	'prehled',
+	'ukaž',
+	'ukaz',
+]);
+const STATE_SIGNALS = new Set([
+	'all',
+	'any',
+	'closed',
+	'count',
+	'current',
+	'humidity',
+	'open',
+	'state',
+	'status',
+	'temperature',
+	'value',
+	'vlhkost',
+	'otevrene',
+	'otevreny',
+	'stav',
+	'teplota',
+	'zavrene',
+	'zavreny',
+]);
+const ACTION_SIGNALS = new Set([
+	'activate',
+	'adjust',
+	'brighten',
+	'change',
+	'close',
+	'deactivate',
+	'dim',
+	'lock',
+	'open',
+	'run',
+	'set',
+	'start',
+	'stop',
+	'switch',
+	'turn',
+	'unlock',
+	'aktivuj',
+	'odemkni',
+	'otevri',
+	'spust',
+	'nastav',
+	'vypni',
+	'zamkni',
+	'zapni',
+	'zavri',
+]);
+const HOME_SIGNALS = new Set([
+	'air',
+	'bathroom',
+	'bedroom',
+	'blind',
+	'blinds',
+	'cooling',
+	'device',
+	'door',
+	'energy',
+	'garage',
+	'heating',
+	'home',
+	'house',
+	'humidity',
+	'kitchen',
+	'lamp',
+	'light',
+	'lighting',
+	'lights',
+	'room',
+	'scene',
+	'security',
+	'sensor',
+	'switch',
+	'temperature',
+	'thermostat',
+	'window',
+	'dvere',
+	'dum',
+	'energie',
+	'garaz',
+	'koupelna',
+	'kuchyn',
+	'lampa',
+	'loznice',
+	'okno',
+	'pokoj',
+	'scena',
+	'senzor',
+	'svetlo',
+	'teplota',
+	'termostat',
+	'topeni',
+	'vlhkost',
+	'vypinac',
+	'zabezpeceni',
+	'zaluzie',
+	'zarizeni',
+]);
+const SCENE_SIGNALS = new Set(['automation', 'preset', 'routine', 'scene', 'scena']);
+const LIGHTING_SIGNALS = new Set(['lamp', 'lampa', 'light', 'lighting', 'lights', 'svetla', 'svetlo']);
+const SPACE_SIGNALS = new Set([
+	'all',
+	'bathroom',
+	'bedroom',
+	'downstairs',
+	'garage',
+	'kitchen',
+	'lighting',
+	'lights',
+	'room',
+	'upstairs',
+	'garaz',
+	'koupelna',
+	'kuchyn',
+	'loznice',
+	'pokoj',
+	'svetla',
+]);
+const DEVICE_SIGNALS = new Set([
+	'air',
+	'blind',
+	'blinds',
+	'cooling',
+	'device',
+	'door',
+	'heating',
+	'humidity',
+	'lamp',
+	'lock',
+	'sensor',
+	'switch',
+	'temperature',
+	'thermostat',
+	'window',
+	'dvere',
+	'lampa',
+	'okno',
+	'senzor',
+	'teplota',
+	'termostat',
+	'topeni',
+	'vlhkost',
+	'vypinac',
+	'zaluzie',
+	'zarizeni',
+]);
+
+/**
+ * Selects built-in Buddy schemas for the current message.
+ *
+ * This is a conservative prompt-size optimization, not an authorization boundary. Unknown extension tools remain
+ * advertised, and every model-emitted call still goes through the registry and provider safety checks.
+ */
+@Injectable()
+export class BuddyToolSelectionService {
+	select(message: string, definitions: ToolDefinition[]): ToolDefinition[] {
+		const normalizedMessage = normalize(message);
+		const tokens = tokenize(normalizedMessage);
+		const selected = new Set<string>();
+		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
+		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
+		const isStateQuestion =
+			hasStateSignal &&
+			/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage);
+		const hasActionSignal = intersects(tokens, ACTION_SIGNALS) && !isStateQuestion;
+		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
+
+		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)) {
+			for (const name of READ_TOOL_NAMES) selected.add(name);
+		}
+
+		if (hasActionSignal) {
+			this.selectActionTools(tokens, selected);
+		}
+
+		if (hasHomeSignal && selected.size === 0) {
+			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
+		}
+
+		return definitions.filter(
+			(definition) => !BUILT_IN_TOOL_NAMES.has(definition.name) || selected.has(definition.name),
+		);
+	}
+
+	private selectActionTools(tokens: Set<string>, selected: Set<string>): void {
+		const hasSceneSignal = intersects(tokens, SCENE_SIGNALS);
+		const hasLightingSignal = intersects(tokens, LIGHTING_SIGNALS);
+		const hasDeviceSignal = intersects(tokens, DEVICE_SIGNALS);
+		let selectedSpecificAction = false;
+
+		if (hasSceneSignal) {
+			selected.add(RUN_SCENE_TOOL_NAME);
+			selectedSpecificAction = true;
+		}
+
+		if (hasLightingSignal) {
+			selected.add(CONTROL_DEVICE_TOOL_NAME);
+			if (intersects(tokens, SPACE_SIGNALS)) selected.add(SET_SPACE_LIGHTING_TOOL_NAME);
+			selectedSpecificAction = true;
+		} else if (hasDeviceSignal) {
+			selected.add(CONTROL_DEVICE_TOOL_NAME);
+			selectedSpecificAction = true;
+		}
+
+		if (!selectedSpecificAction) {
+			for (const name of ACTION_TOOL_NAMES) selected.add(name);
+		}
+	}
+}
+
+function tokenize(value: string): Set<string> {
+	return new Set(value.split(/[^\p{Letter}\p{Number}]+/u).filter((token) => token.length > 0));
+}
+
+function normalize(value: string): string {
+	return value
+		.normalize('NFKD')
+		.replace(/\p{Mark}/gu, '')
+		.toLocaleLowerCase('en-US')
+		.trim();
+}
+
+function intersects(tokens: Set<string>, signals: Set<string>): boolean {
+	for (const token of tokens) {
+		if (signals.has(token)) return true;
+	}
+
+	return false;
+}

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,7 +91,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN =
-	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|ensure|find|make sure|read|report|show|tell|verify|what|whether|which)\b/u;
+	/(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:check|confirm|determine|ensure|find|make sure|read|report|see|show|tell|verify|what|whether|which)\b/u;
 const STATE_QUESTION_PATTERN =
 	/^(?:are|can|could|did|do|does|had|has|have|how|is|may|might|what|which|where|why|will|would|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const PREDICATE_QUESTION_PATTERN =

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,6 +91,8 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
+const CONDITION_PATTERN = /\b(?:as long as|if|kdyz|only if|pokud|provided(?: that)?|unless|when)\b/u;
+const LEADING_CONDITION_PATTERN = /^(?:as long as|if|kdyz|only if|pokud|provided(?: that)?|unless|when)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -258,6 +260,8 @@ const GENERAL_CONVERSATION_FILLERS = new Set([
 	'good',
 	'i',
 	'is',
+	'it',
+	'its',
 	'me',
 	'morning',
 	'tell',
@@ -265,6 +269,12 @@ const GENERAL_CONVERSATION_FILLERS = new Set([
 	'write',
 	'you',
 	'your',
+	'if',
+	'not',
+	'please',
+	'so',
+	'v',
+	'whether',
 	'jaky',
 	'jak',
 	'jsi',
@@ -287,7 +297,7 @@ export class BuddyToolSelectionService {
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
-		const hasConditionalAction = actionTokens !== null && /\b(?:if|kdyz|pokud|unless|when)\b/u.test(normalizedMessage);
+		const hasConditionalAction = actionTokens !== null && CONDITION_PATTERN.test(normalizedMessage);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
 		const trailingQuestionClause = questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1).trim() : '';
@@ -313,6 +323,8 @@ export class BuddyToolSelectionService {
 			!hasSearchSignal &&
 			!message.includes('?') &&
 			!/^(?:explain|tell)\b/u.test(normalizedMessage);
+		const hasUnrecognizedReadCompound =
+			actionTokens === null && (hasSearchSignal || hasStateSignal) && hasUnknownTrailingClause(normalizedMessage);
 		const isStateExplanation =
 			hasHomeSignal &&
 			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
@@ -342,6 +354,10 @@ export class BuddyToolSelectionService {
 		}
 
 		if (hasUnrecognizedTrailingIntent) {
+			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
+		}
+
+		if (hasUnrecognizedReadCompound) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -436,6 +452,7 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 
 function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
+	if (tokens.size === 1 && tokens.has('morning')) return false;
 	if (/^(?:(?:how|who) is|tell me about)\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {
@@ -443,6 +460,26 @@ function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<str
 	}
 
 	return true;
+}
+
+function hasUnknownTrailingClause(normalizedMessage: string): boolean {
+	const trailingClause = sliceAfterFirst(normalizedMessage, /[,;]|\b(?:and|potom|then)\b/u);
+
+	if (trailingClause.length === 0) return false;
+
+	for (const token of tokenize(trailingClause)) {
+		if (
+			!SEARCH_SIGNALS.has(token) &&
+			!STATE_SIGNALS.has(token) &&
+			!GROUNDED_STATE_SIGNALS.has(token) &&
+			!HOME_SIGNALS.has(token) &&
+			!GENERAL_CONVERSATION_FILLERS.has(token)
+		) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
@@ -481,7 +518,7 @@ function getActionIntentTokens(
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;
 	}
 
-	const trailingCondition = normalizedMessage.search(/\b(?:if|kdyz|pokud|unless|when)\b/u);
+	const trailingCondition = normalizedMessage.search(CONDITION_PATTERN);
 
 	if (trailingCondition > 0) {
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
@@ -489,7 +526,7 @@ function getActionIntentTokens(
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 	}
 
-	if (/^(?:if|kdyz|pokud|unless|when)\b/u.test(normalizedMessage)) {
+	if (LEADING_CONDITION_PATTERN.test(normalizedMessage)) {
 		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\b(?:pak|potom|then)\b/u));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -64,6 +64,7 @@ const ACTION_SIGNALS = new Set([
 	'increase',
 	'lock',
 	'lower',
+	'make',
 	'open',
 	'raise',
 	'run',
@@ -168,6 +169,7 @@ const DEVICE_ACTION_SIGNALS = new Set([
 	'increase',
 	'lock',
 	'lower',
+	'make',
 	'nastav',
 	'odemkni',
 	'open',
@@ -285,9 +287,15 @@ export class BuddyToolSelectionService {
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
-		const hasConditionalAction = actionTokens !== null && /\b(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage);
+		const hasConditionalAction = actionTokens !== null && /\b(?:if|kdyz|pokud|unless|when)\b/u.test(normalizedMessage);
 		const hasTrailingReadClause = actionTokens !== null && READ_CLAUSE_PATTERN.test(normalizedMessage);
 		const questionEnd = normalizedMessage.indexOf('?');
+		const trailingQuestionClause = questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1).trim() : '';
+		const trailingQuestionTokens = tokenize(trailingQuestionClause);
+		const hasUnrecognizedTrailingIntent =
+			actionTokens === null &&
+			trailingQuestionClause.length > 0 &&
+			!isClearlyGeneralConversation(trailingQuestionClause, trailingQuestionTokens);
 		const hasStateFirstAction =
 			actionTokens !== null &&
 			questionEnd >= 0 &&
@@ -330,6 +338,10 @@ export class BuddyToolSelectionService {
 		}
 
 		if (hasUnrecognizedStateIntent) {
+			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
+		}
+
+		if (hasUnrecognizedTrailingIntent) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
 
@@ -424,7 +436,7 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 
 function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
-	if (/^how is\b/u.test(normalizedMessage)) return false;
+	if (/^(?:(?:how|who) is|tell me about)\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {
 		if (!GENERAL_CONVERSATION_SIGNALS.has(token) && !GENERAL_CONVERSATION_FILLERS.has(token)) return false;
@@ -469,7 +481,7 @@ function getActionIntentTokens(
 		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;
 	}
 
-	const trailingCondition = normalizedMessage.search(/\b(?:if|kdyz|pokud|when)\b/u);
+	const trailingCondition = normalizedMessage.search(/\b(?:if|kdyz|pokud|unless|when)\b/u);
 
 	if (trailingCondition > 0) {
 		const commandTokens = tokenize(normalizedMessage.slice(0, trailingCondition));
@@ -477,7 +489,7 @@ function getActionIntentTokens(
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
 	}
 
-	if (/^(?:if|kdyz|pokud|when)\b/u.test(normalizedMessage)) {
+	if (/^(?:if|kdyz|pokud|unless|when)\b/u.test(normalizedMessage)) {
 		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\b(?:pak|potom|then)\b/u));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -327,7 +327,7 @@ export class BuddyToolSelectionService {
 					hasTrailingReadClause ||
 					hasStateFirstAction ||
 					hasGroundedStateFirstAction ||
-					(message.includes('?') && hasHomeSignal)))
+					(message.includes('?') && hasHomeSignal && intersects(tokens, GROUNDED_STATE_SIGNALS))))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -239,6 +239,7 @@ export class BuddyToolSelectionService {
 		}
 
 		if (hasActionSignal) {
+			selected.add(SEARCH_HOME_TOOL_NAME);
 			this.selectActionTools(tokens, selected);
 		}
 

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -80,9 +80,21 @@ const ACTION_SIGNALS = new Set([
 	'zavri',
 ]);
 const ACTION_CLAUSE_PATTERN = new RegExp(
-	String.raw`(?:\band\b|\bthen\b|[,;])\s*(?:please\s+)?(?:${[...ACTION_SIGNALS].join('|')})\b`,
+	String.raw`(?:\ba\b|\band\b|\bpotom\b|\bthen\b|[,;])\s*(?:please\s+)?(?:${[...ACTION_SIGNALS].join('|')})\b`,
 	'u',
 );
+const GROUNDED_STATE_SIGNALS = new Set([
+	'active',
+	'closed',
+	'high',
+	'inactive',
+	'locked',
+	'low',
+	'off',
+	'on',
+	'open',
+	'unlocked',
+]);
 const HOME_SIGNALS = new Set([
 	'air',
 	'bathroom',
@@ -239,13 +251,14 @@ export class BuddyToolSelectionService {
 		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
-		const isStateExplanation = hasHomeSignal && /^explain (?:if|whether)\b/u.test(normalizedMessage);
+		const isStateExplanation =
+			hasHomeSignal &&
+			(/^explain (?:if|whether)\b/u.test(normalizedMessage) ||
+				(/^explain why\b/u.test(normalizedMessage) && intersects(tokens, GROUNDED_STATE_SIGNALS)));
 
 		if (
-			hasSearchSignal ||
-			hasStateSignal ||
 			isStateExplanation ||
-			(message.includes('?') && hasHomeSignal && !isGenericExplanation)
+			(!isGenericExplanation && (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
@@ -328,6 +341,7 @@ function isClearlyGeneralConversation(tokens: Set<string>): boolean {
 
 function isGenericHomeExplanation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, HOME_SIGNALS)) return false;
+	if (intersects(tokens, GROUNDED_STATE_SIGNALS)) return false;
 
 	return (
 		/^how (?:do|does) .+ work(?:s|ing)?\b/u.test(normalizedMessage) ||
@@ -371,6 +385,8 @@ function getActionIntentTokens(
 		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\bthen\b/u));
 
 		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
+
+		return new Set();
 	}
 
 	return tokens;

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,8 +91,10 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
-const CONDITION_PATTERN = /\b(?:as long as|if|kdyz|only if|pokud|provided(?: that)?|unless|when)\b/u;
-const LEADING_CONDITION_PATTERN = /^(?:as long as|if|kdyz|only if|pokud|provided(?: that)?|unless|when)\b/u;
+const CONDITION_PATTERN =
+	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
+const LEADING_CONDITION_PATTERN =
+	/^(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
 const GROUNDED_STATE_SIGNALS = new Set([
 	'active',
 	'closed',
@@ -452,7 +454,7 @@ function intersects(tokens: Set<string>, signals: Set<string>): boolean {
 
 function isClearlyGeneralConversation(normalizedMessage: string, tokens: Set<string>): boolean {
 	if (!intersects(tokens, GENERAL_CONVERSATION_SIGNALS)) return false;
-	if (tokens.size === 1 && tokens.has('morning')) return false;
+	if (tokens.size <= 2 && tokens.has('morning')) return false;
 	if (/^(?:(?:how|who) is|tell me about)\b/u.test(normalizedMessage)) return false;
 
 	for (const token of tokens) {

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -373,6 +373,7 @@ export class BuddyToolSelectionService {
 			hasStateReadSignal &&
 			actionTokens === null &&
 			!hasSearchSignal &&
+			!hasExplicitStateQuestion &&
 			(!message.includes('?') || UNKNOWN_ACTION_REQUEST_PATTERN.test(normalizedMessage)) &&
 			!/^(?:explain|tell)\b/u.test(normalizedMessage);
 		const hasUnknownModalRequest =
@@ -437,7 +438,6 @@ export class BuddyToolSelectionService {
 		if (hasUnrecognizedReadCompound) {
 			for (const name of BUILT_IN_TOOL_NAMES) selected.add(name);
 		}
-
 		if (
 			selected.size === 0 &&
 			!isGenericExplanation &&
@@ -615,7 +615,7 @@ function getActionIntentTokens(
 		const trailingClause = [
 			sliceAfterFirst(
 				questionBody,
-				/[,;]|\b(?:a|after|and|assuming(?: that)?|before|if not|if so|once|please|plus|potom|then|until|when|while)\b/u,
+				/[,;]|\b(?:a|after|and|assuming(?: that)?|before|if not|if so|once|plus|potom|then|until|when|while)\b/u,
 			),
 			questionEnd >= 0 ? normalizedMessage.slice(questionEnd + 1) : '',
 		].join(' ');

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -91,6 +91,7 @@ const ACTION_CLAUSE_PATTERN = new RegExp(
 	'u',
 );
 const READ_CLAUSE_PATTERN = /\b(?:a|and|potom|then)\s+(?:check|find|show|tell|what|whether|which)\b/u;
+const STATE_QUESTION_PATTERN = /^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u;
 const CONDITION_PATTERN =
 	/\b(?:after|as long as|as soon as|before|if|in case|jakmile|jestlize|kdyz|once|only if|pokud|provided(?: that)?|unless|when|whenever)\b/u;
 const LEADING_CONDITION_PATTERN =
@@ -318,6 +319,8 @@ export class BuddyToolSelectionService {
 			intersects(tokens, GROUNDED_STATE_SIGNALS) &&
 			/[,;]/u.test(normalizedMessage);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
+		const hasInterrogativeHomeQuestion =
+			hasHomeSignal && message.includes('?') && STATE_QUESTION_PATTERN.test(normalizedMessage);
 		const isGenericExplanation = isGenericHomeExplanation(normalizedMessage, tokens);
 		const hasUnrecognizedStateIntent =
 			hasStateSignal &&
@@ -341,6 +344,7 @@ export class BuddyToolSelectionService {
 					hasTrailingReadClause ||
 					hasStateFirstAction ||
 					hasGroundedStateFirstAction ||
+					hasInterrogativeHomeQuestion ||
 					(message.includes('?') && hasHomeSignal && intersects(tokens, GROUNDED_STATE_SIGNALS))))
 		) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
@@ -348,7 +352,11 @@ export class BuddyToolSelectionService {
 
 		if (actionTokens) {
 			selected.add(SEARCH_HOME_TOOL_NAME);
-			this.selectActionTools(actionTokens, selected, ACTION_CLAUSE_PATTERN.test(normalizedMessage));
+			this.selectActionTools(
+				actionTokens,
+				selected,
+				ACTION_CLAUSE_PATTERN.test(normalizedMessage) || hasUnknownTrailingClause(normalizedMessage),
+			);
 		}
 
 		if (hasUnrecognizedStateIntent) {
@@ -505,9 +513,10 @@ function getActionIntentTokens(
 	if (!intersects(tokens, ACTION_SIGNALS)) return null;
 
 	const isStateQuestion =
-		hasStateSignal &&
-		(/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage) ||
-			/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage));
+		(hasStateSignal &&
+			(STATE_QUESTION_PATTERN.test(normalizedMessage) ||
+				/^(?:please\s+)?tell\b.*\b(?:if|whether)\b/u.test(normalizedMessage))) ||
+		(STATE_QUESTION_PATTERN.test(normalizedMessage) && normalizedMessage.includes('?'));
 
 	if (isStateQuestion) {
 		const questionEnd = normalizedMessage.indexOf('?');

--- a/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
+++ b/apps/backend/src/modules/buddy/services/buddy-tool-selection.service.ts
@@ -232,16 +232,16 @@ export class BuddyToolSelectionService {
 		const selected = new Set<string>();
 		const hasSearchSignal = intersects(tokens, SEARCH_SIGNALS);
 		const hasStateSignal = intersects(tokens, STATE_SIGNALS);
-		const hasActionSignal = hasActionIntent(normalizedMessage, tokens, hasStateSignal);
+		const actionTokens = getActionIntentTokens(normalizedMessage, tokens, hasStateSignal);
 		const hasHomeSignal = intersects(tokens, HOME_SIGNALS);
 
 		if (hasSearchSignal || hasStateSignal || (message.includes('?') && hasHomeSignal)) {
 			for (const name of READ_TOOL_NAMES) selected.add(name);
 		}
 
-		if (hasActionSignal) {
+		if (actionTokens) {
 			selected.add(SEARCH_HOME_TOOL_NAME);
-			this.selectActionTools(tokens, selected);
+			this.selectActionTools(actionTokens, selected);
 		}
 
 		if (selected.size === 0 && (hasHomeSignal || !isClearlyGeneralConversation(tokens))) {
@@ -309,20 +309,39 @@ function isClearlyGeneralConversation(tokens: Set<string>): boolean {
 	return true;
 }
 
-function hasActionIntent(normalizedMessage: string, tokens: Set<string>, hasStateSignal: boolean): boolean {
-	if (!intersects(tokens, ACTION_SIGNALS)) return false;
+function getActionIntentTokens(
+	normalizedMessage: string,
+	tokens: Set<string>,
+	hasStateSignal: boolean,
+): Set<string> | null {
+	if (!intersects(tokens, ACTION_SIGNALS)) return null;
 
 	const isStateQuestion =
 		hasStateSignal &&
 		/^(?:are|do|does|how|is|what|which|where|was|were|je|jsou|jaka|jaky|ktere|kolik)\b/u.test(normalizedMessage);
 
-	if (!isStateQuestion) return true;
+	if (isStateQuestion) {
+		const questionEnd = normalizedMessage.indexOf('?');
+		const trailingClause =
+			questionEnd >= 0
+				? normalizedMessage.slice(questionEnd + 1)
+				: sliceAfterFirst(normalizedMessage, /\b(?:and|if not|if so|please|then)\b/u);
+		const trailingTokens = tokenize(trailingClause);
 
-	const questionEnd = normalizedMessage.indexOf('?');
+		return intersects(trailingTokens, ACTION_SIGNALS) ? trailingTokens : null;
+	}
 
-	if (questionEnd >= 0 && intersects(tokenize(normalizedMessage.slice(questionEnd + 1)), ACTION_SIGNALS)) return true;
+	if (/^(?:if|when)\b/u.test(normalizedMessage)) {
+		const commandTokens = tokenize(sliceAfterFirst(normalizedMessage, /[,;]|\bthen\b/u));
 
-	const conditionalClause = normalizedMessage.search(/\b(?:and|if not|if so|please|then)\b/u);
+		if (intersects(commandTokens, ACTION_SIGNALS)) return commandTokens;
+	}
 
-	return conditionalClause >= 0 && intersects(tokenize(normalizedMessage.slice(conditionalClause + 1)), ACTION_SIGNALS);
+	return tokens;
+}
+
+function sliceAfterFirst(value: string, delimiter: RegExp): string {
+	const match = delimiter.exec(value);
+
+	return match?.index === undefined ? '' : value.slice(match.index + match[0].length);
 }

--- a/tasks/plans/plan-buddy-adaptive-context.md
+++ b/tasks/plans/plan-buddy-adaptive-context.md
@@ -1566,7 +1566,10 @@ busy response leaves an ownerless nonterminal sequence capable of blocking later
       unscoped/global or canonical fallback. Per-conversation or global capacity exhaustion omits further action references
       instead of invalidating any reference that may be present in an in-flight prompt. Preserve existing non-Buddy mapping
       behavior and canonical UUID fallback.
-- [ ] Add tool selection support so unrelated schemas are not advertised on every turn.
+- [x] Add conservative deterministic selection for the initial built-in Buddy schemas so greetings, focused reads, and
+      explicit device/scene/space-lighting requests do not advertise unrelated tools. Preserve unknown extension tools and
+      treat schema selection only as a prompt-size optimization, never as authorization; full planner-driven domain and
+      action selection remains open in Phase 4.
 - [x] Register the initial read tools behind conversation-scoped action-reference containment: discovered canonical IDs
       remain valid for dependent reads but cannot authorize Buddy writes/triggers. This containment is not the complete
       server-held action-resolution proof from Section 5.4, which remains open.


### PR DESCRIPTION
## Summary

- add a deterministic selector for the five initial built-in Buddy tool schemas
- omit unrelated built-in schemas for greetings, focused reads, and explicit device, scene, or room-lighting requests
- preserve unknown extension tools and treat selection only as a prompt-size optimization, never authorization
- suppress empty tool payloads and scoped action-reference allocation when no schema is selected

## Safety boundary

This is conservative schema selection, not the complete Phase 4 planner or an access-control decision. Ambiguous home/action wording falls back to broader built-in sets, unknown extension tools remain advertised, and every emitted call still passes through the existing registry and provider validation.

## Validation

- Buddy Jest: 33 suites, 537 tests, 2 snapshots
- backend type-check
- focused ESLint and Prettier
- `git diff --check`
- GitHub CI: 12 checks passed

> 👍 Codex review passed on `8027ed992`.