### PR TITLE
fix(backend): preserve simulator category payload fields

### DIFF
--- a/apps/backend/src/plugins/simulator/controllers/simulator.controller.spec.ts
+++ b/apps/backend/src/plugins/simulator/controllers/simulator.controller.spec.ts
@@ -29,6 +29,24 @@ describe('SimulatorController', () => {
 		jest.clearAllMocks();
 	});
 
+	it('serializes device categories with their identifier and name preserved', () => {
+		const response = controller.getCategories();
+
+		expect(response.data.length).toBeGreaterThan(0);
+
+		// Regression: the response model exposed `data` without `@Type`, so
+		// `excludeExtraneousValues` stripped every nested category down to an
+		// empty object and the admin wizard rendered options with no value.
+		for (const category of response.data) {
+			expect(typeof category.category).toBe('string');
+			expect(category.category.length).toBeGreaterThan(0);
+			expect(typeof category.name).toBe('string');
+			expect(category.name.length).toBeGreaterThan(0);
+		}
+
+		expect(response.data.map((category) => category.category)).toContain(DeviceCategory.LIGHTING);
+	});
+
 	it('returns the persisted device when initial connectivity setup fails', async () => {
 		const dto = {
 			category: DeviceCategory.LIGHTING,

--- a/apps/backend/src/plugins/simulator/models/simulator-response.model.ts
+++ b/apps/backend/src/plugins/simulator/models/simulator-response.model.ts
@@ -1,4 +1,4 @@
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -59,6 +59,7 @@ export class DeviceCategoriesResponseModel extends BaseSuccessResponseModel<Devi
 		items: { type: 'object' },
 	})
 	@Expose()
+	@Type(() => DeviceCategoryModel)
 	declare data: DeviceCategoryModel[];
 }
 


### PR DESCRIPTION
## Problem

The simulator device generation wizard rendered a category select whose options all bound `undefined`, and emitted one `Invalid prop: type check failed for prop "value"` warning per category (32 of them). The select was unusable — no category could be picked.

## Root cause

`DeviceCategoriesResponseModel.data` was decorated with `@Expose()` but had no `@Type()` declaration:

```typescript
@Expose()
declare data: DeviceCategoryModel[];
```

`SimulatorController.getCategories()` serializes via `toInstance(..., { excludeExtraneousValues: true })`. Without `@Type`, class-transformer cannot map the nested plain objects onto `DeviceCategoryModel`, so it strips them entirely.

Observed against a running instance before the fix:

```
count: 32
first 3 items: [[],[],[]]
```

After:

```
count: 32
first 3: [{"category":"generic","name":"Generic","description":""}, ...]
```

## Change

Declares the nested element type so the category identifier, name and description survive serialization. Two lines of production code.

## Tests

Adds a regression test asserting every serialized category carries a non-empty `category` and `name`. Verified it fails on the previous code (`expected "string", received "undefined"`) before the fix.

- Backend unit suite: 376 suites, 4763 passed, 2 skipped
- eslint + prettier clean on both touched files

## Follow-ups (deliberately not in this PR)

- The `@ApiProperty` for this field still declares `items: { type: 'object' }`, so the generated OpenAPI schema is untyped and the admin has to cast the response. Tightening it changes the API contract and regenerates the spec, so it belongs in its own PR.
- The endpoint offers the `generic` category, which is reportedly not usable by plugins. Same defect appears in the Shelly wizard. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)