### PR TITLE
fix(admin): read nested scalar for shelly device model lookup

### DIFF
--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDeviceEditForm.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDeviceEditForm.spec.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { StoreInjectionKey } from '../../../common';
 import { DevicesValidationException, FormResult, channelsPropertiesStoreKey, channelsStoreKey, devicesStoreKey } from '../../../modules/devices';
-import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { DevicesModuleChannelCategory, DevicesModuleChannelPropertyCategory, DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import type { IShellyNgDevice } from '../store/devices.store.types';
 
 import { useDeviceEditForm } from './useDeviceEditForm';
@@ -31,6 +31,9 @@ const mockDevice = {
 
 const mockEdit = vi.fn();
 const mockSave = vi.fn();
+
+const mockFindForDevice = vi.fn();
+const mockFindForChannel = vi.fn();
 
 const mockSuccess = vi.fn();
 const mockError = vi.fn();
@@ -63,11 +66,11 @@ vi.mock('../../../common', async () => {
 					};
 				} else if (key === channelsStoreKey) {
 					return {
-						findForDevice: vi.fn(),
+						findForDevice: mockFindForDevice,
 					};
 				} else if (key === channelsPropertiesStoreKey) {
 					return {
-						findForChannel: vi.fn(),
+						findForChannel: mockFindForChannel,
 					};
 				} else {
 					throw new Error('Unknown key');
@@ -98,6 +101,40 @@ describe('useDeviceEditForm', () => {
 		mockSave.mockClear();
 		mockSuccess.mockClear();
 		mockError.mockClear();
+		mockFindForDevice.mockReset().mockReturnValue([]);
+		mockFindForChannel.mockReset().mockReturnValue([]);
+	});
+
+	it('derives category options from the stored model property value', () => {
+		const channelId = uuid().toString();
+
+		mockFindForDevice.mockReturnValue([{ id: channelId, category: DevicesModuleChannelCategory.device_information }]);
+		// The channels-properties store normalizes every value into
+		// `{ value, lastUpdated, trend }` — never a bare scalar.
+		mockFindForChannel.mockReturnValue([
+			{
+				id: uuid().toString(),
+				category: DevicesModuleChannelPropertyCategory.model,
+				value: { value: 'SNSW-001P16EU', lastUpdated: null, trend: null },
+			},
+		]);
+
+		const form = useDeviceEditForm({ device: mockDevice });
+
+		form.supportedDevices.value = [
+			{
+				group: 'shelly-plus-1pm',
+				name: 'Shelly Plus 1PM',
+				models: ['SNSW-001P16EU'],
+				categories: [DevicesModuleDeviceCategory.outlet, DevicesModuleDeviceCategory.lighting],
+				components: [],
+				system: [],
+			},
+		] as unknown as typeof form.supportedDevices.value;
+
+		expect(form.categoriesOptions.value.map((option) => option.value)).toEqual(
+			expect.arrayContaining([DevicesModuleDeviceCategory.outlet, DevicesModuleDeviceCategory.lighting])
+		);
 	});
 
 	it('initializes model with device data', () => {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDeviceEditForm.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDeviceEditForm.ts
@@ -65,7 +65,11 @@ export const useDeviceEditForm = ({ device, messages }: IUseDeviceEditFormProps)
 		if (channel !== undefined) {
 			const property = channelsPropertiesStore.findForChannel(channel.id).find((p) => p.category === DevicesModuleChannelPropertyCategory.model);
 
-			return typeof property?.value === 'string' ? property?.value : undefined;
+			// Property values are normalized by the store into
+			// `{ value, lastUpdated, trend }`, so the scalar is nested.
+			const value = property?.value?.value;
+
+			return typeof value === 'string' ? value : undefined;
 		}
 
 		return undefined;

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDeviceEditForm.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDeviceEditForm.spec.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { StoreInjectionKey } from '../../../common';
 import { DevicesValidationException, FormResult, channelsPropertiesStoreKey, channelsStoreKey, devicesStoreKey } from '../../../modules/devices';
-import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
+import { DevicesModuleChannelCategory, DevicesModuleChannelPropertyCategory, DevicesModuleDeviceCategory } from '../../../openapi.constants';
 import type { IShellyV1Device } from '../store/devices.store.types';
 
 import { useDeviceEditForm } from './useDeviceEditForm';
@@ -27,6 +27,9 @@ const mockDevice = {
 
 const mockEdit = vi.fn();
 const mockSave = vi.fn();
+
+const mockFindForDevice = vi.fn();
+const mockFindForChannel = vi.fn();
 
 const mockSuccess = vi.fn();
 const mockError = vi.fn();
@@ -59,11 +62,11 @@ vi.mock('../../../common', async () => {
 					};
 				} else if (key === channelsStoreKey) {
 					return {
-						findForDevice: vi.fn(),
+						findForDevice: mockFindForDevice,
 					};
 				} else if (key === channelsPropertiesStoreKey) {
 					return {
-						findForChannel: vi.fn(),
+						findForChannel: mockFindForChannel,
 					};
 				} else {
 					throw new Error('Unknown key');
@@ -94,6 +97,38 @@ describe('useDeviceEditForm', () => {
 		mockSave.mockClear();
 		mockSuccess.mockClear();
 		mockError.mockClear();
+		mockFindForDevice.mockReset().mockReturnValue([]);
+		mockFindForChannel.mockReset().mockReturnValue([]);
+	});
+
+	it('derives category options from the stored model property value', () => {
+		const channelId = uuid().toString();
+
+		mockFindForDevice.mockReturnValue([{ id: channelId, category: DevicesModuleChannelCategory.device_information }]);
+		// The channels-properties store normalizes every value into
+		// `{ value, lastUpdated, trend }` — never a bare scalar.
+		mockFindForChannel.mockReturnValue([
+			{
+				id: uuid().toString(),
+				category: DevicesModuleChannelPropertyCategory.model,
+				value: { value: 'SHSW-1', lastUpdated: null, trend: null },
+			},
+		]);
+
+		const form = useDeviceEditForm({ device: mockDevice });
+
+		form.supportedDevices.value = [
+			{
+				group: 'shelly-1',
+				name: 'Shelly 1',
+				models: ['SHSW-1'],
+				categories: [DevicesModuleDeviceCategory.outlet, DevicesModuleDeviceCategory.lighting],
+			},
+		] as unknown as typeof form.supportedDevices.value;
+
+		expect(form.categoriesOptions.value.map((option) => option.value)).toEqual(
+			expect.arrayContaining([DevicesModuleDeviceCategory.outlet, DevicesModuleDeviceCategory.lighting])
+		);
 	});
 
 	it('initializes model with device data', () => {

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDeviceEditForm.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDeviceEditForm.ts
@@ -55,7 +55,11 @@ export const useDeviceEditForm = ({ device, messages }: IUseDeviceEditFormProps)
 		if (channel !== undefined) {
 			const property = channelsPropertiesStore.findForChannel(channel.id).find((p) => p.category === DevicesModuleChannelPropertyCategory.model);
 
-			return typeof property?.value === 'string' ? property?.value : undefined;
+			// Property values are normalized by the store into
+			// `{ value, lastUpdated, trend }`, so the scalar is nested.
+			const value = property?.value?.value;
+
+			return typeof value === 'string' ? value : undefined;
 		}
 
 		return undefined;


### PR DESCRIPTION
## Problem

Editing a Shelly device in the admin showed a **category select with no options**, so changing a device's category (e.g. outlet → light) was impossible. This was previously a working feature.

## Root cause

`deviceModel` resolves the device's hardware model from the `model` channel property:

```typescript
return typeof property?.value === 'string' ? property?.value : undefined;
```

But the channels-properties store normalizes every property value into an object — see `channels.properties.store.schemas.ts`:

```typescript
value: z.object({ value, lastUpdated, trend }).nullable()
```

So `property.value` is **never** a string. The guard always returned `undefined`, `deviceGroup` always resolved to `null`, and `categoriesOptions` was always `[]`. This was unconditional, not data-dependent.

Confirmed against a running instance — the API serves the nested shape:

```
model => {"value":"SNSW-001P16EU","last_updated":"...","trend":null}
```

while `models` on the supported-device groups holds `["SNSW-001P16EU", ...]`, so the lookup would have matched had the scalar been read correctly.

Both `devices-shelly-ng` and `devices-shelly-v1` carried the identical guard, so both are fixed.

## Tests

Neither composable had any coverage of `categoriesOptions`, which is how this shipped. Adds a test per plugin that mocks the store with the **real normalized shape** and asserts the options are derived. Both were verified failing first (`expected [] to deeply equal ArrayContaining ["outlet", "lighting"]`) — for v1 the fix was stashed to confirm the test genuinely catches the bug.

- Admin suite: 271 files, 1933 passed
- `vue-tsc` type-check clean
- eslint + prettier clean on all four touched files

## Note

This is one of two symptoms reported together; the other — Shelly devices "not fully recognized, some channels missing" during discovery — is a separate backend concern and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)