### PR TITLE
fix(backend): map shelly outlet switches to an outlet channel

### DIFF
--- a/apps/backend/src/plugins/devices-shelly-ng/mappings/definitions/switches.yaml
+++ b/apps/backend/src/plugins/devices-shelly-ng/mappings/definitions/switches.yaml
@@ -11,7 +11,7 @@ transformers:
     false_value: false
 
 mappings:
-  # Switch as Switcher (default for SWITCHER, OUTLET, PUMP devices)
+  # Switch as Switcher (default for SWITCHER and PUMP devices)
   - name: switch_as_switcher
     description: "Shelly switch component mapped as switcher channel"
     priority: 100
@@ -20,12 +20,33 @@ mappings:
         - component_type: switch
         - any_of:
             - device_category: SWITCHER
-            - device_category: OUTLET
             - device_category: PUMP
     channels:
       - identifier: "switch:{key}"
         name: "Switch: {key}"
         category: SWITCHER
+        properties:
+          - shelly_property: output
+            panel:
+              identifier: ON
+              data_type: BOOL
+            transformer: boolean_state
+
+  # Switch as Outlet (for OUTLET category)
+  # The devices spec permits only outlet / device_information / electrical_*
+  # channels on an outlet device, so a switcher channel here would produce a
+  # device structure that fails validation.
+  - name: switch_as_outlet
+    description: "Shelly switch component mapped as outlet channel"
+    priority: 100
+    match:
+      all_of:
+        - component_type: switch
+        - device_category: OUTLET
+    channels:
+      - identifier: "switch:{key}"
+        name: "Outlet: {key}"
+        category: OUTLET
         properties:
           - shelly_property: output
             panel:

--- a/apps/backend/src/plugins/devices-shelly-ng/mappings/mapping-loader.integration.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/mappings/mapping-loader.integration.spec.ts
@@ -426,6 +426,33 @@ mappings:
 		});
 	});
 
+	describe('Built-in switch mappings', () => {
+		// No user mappings are written here, so only the shipped definitions load.
+		beforeEach(() => {
+			service.loadAllMappings();
+		});
+
+		it.each([
+			[DeviceCategory.OUTLET, ChannelCategory.OUTLET],
+			[DeviceCategory.SWITCHER, ChannelCategory.SWITCHER],
+			[DeviceCategory.PUMP, ChannelCategory.SWITCHER],
+			[DeviceCategory.LIGHTING, ChannelCategory.LIGHT],
+		])('maps a switch component on a %s device to a %s channel', (deviceCategory, expectedChannel) => {
+			const context: MappingContext = {
+				componentType: ComponentType.SWITCH,
+				componentKey: 0,
+				deviceCategory,
+			};
+
+			const result = service.findMatchingMapping(context);
+
+			// The devices spec allows an `outlet` device to carry only
+			// outlet / device_information / electrical_* channels, so emitting a
+			// SWITCHER channel for it produced an unadoptable device structure.
+			expect(result?.channels[0]?.category).toBe(expectedChannel);
+		});
+	});
+
 	describe('Path Traversal Protection', () => {
 		it('should validate paths and prevent traversal', () => {
 			// This test verifies that path validation is working


### PR DESCRIPTION
## Problem

Automatic Shelly NG discovery produced device structures that the devices spec rejects. Reported as: *"device in category outlet, has a channel switcher — this combination is not allowed by the devices spec. When opened by user, is not able to re-adopt the device."*

This is on the **default path**, not an edge case. Discovery pre-fills the category from the model descriptor:

```typescript
suggestedCategory: categories.length > 0 ? categories[0] : null,
```

and `categories[0]` is `outlet` for the whole Plus/Pro 1PM family.

## Root cause

`switches.yaml` matched `OUTLET` but hardcoded the channel category:

```yaml
- any_of:
    - device_category: SWITCHER
    - device_category: OUTLET    # matched
    - device_category: PUMP
channels:
  - category: SWITCHER           # always SWITCHER
```

Per `spec/devices/devices.yaml`, an `outlet` device may carry only `outlet`, `device_information`, `electrical_energy` and `electrical_power`. `switcher` is not permitted — so every outlet-suggested device was adopted invalid.

Only `outlet` is affected. `switcher` and `pump` both legitimately permit a `switcher` channel, so their behaviour is unchanged.

Measured against a real install (35 Shelly NG + 8 v1 devices):

| device category | channel category | count | valid |
|---|---|---|---|
| lighting | light | 33 | ✅ |
| switcher | switcher | 26 | ✅ |
| **outlet** | **switcher** | **19** | ❌ |
| outlet | outlet | 5 | ✅ |

## Change

Splits the rule so `OUTLET` produces an `OUTLET` channel. Both channel categories require the same `on` bool property, so the property mapping is unchanged.

This matches what the **shelly v1 plugin already does** (`devices-shelly-v1/services/device-mapper.service.ts:765-767`):

```typescript
[DeviceCategory.OUTLET]:   ChannelCategory.OUTLET,
[DeviceCategory.SWITCHER]: ChannelCategory.SWITCHER,
[DeviceCategory.PUMP]:     ChannelCategory.SWITCHER,
```

so NG was the outlier; this aligns the two plugins.

## Tests

Adds a table-driven test over the **shipped** definitions (not temp fixtures) covering all four switch-bearing categories. Verified failing first — and only the OUTLET row failed (`Expected: "outlet", Received: "switcher"`), confirming SWITCHER/PUMP/LIGHTING were already correct and are not regressed.

- Backend unit suite: 376 suites, 4767 passed, 2 skipped
- eslint + prettier clean

## Scope

Mapping only, by request — no migration. Existing devices keep their current channels until re-adopted.

Two related findings from the same investigation are **not** addressed here:

- The `temperature_sensor` rule in `sensors.yaml` has no `device_category` guard, so it adds a `temperature` channel to devices whose category disallows it (9 more invalid channels in the sample). Left as-is deliberately — it yields an unsupported channel rather than the outlet/switcher conflict.
- Shelly **EM** devices have no catalog entry at all (0 of 41 groups), which is why they are unrecognized, fall back to `generic`, and cannot be re-adopted. That needs device definitions authored, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)