### PR TITLE
fix(admin): hide mcp menu items when the module is disabled

### DIFF
--- a/apps/admin/src/modules/mcp/router/index.spec.ts
+++ b/apps/admin/src/modules/mcp/router/index.spec.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { UsersModuleUserRole } from '../../../openapi.constants';
-
-import { RouteNames } from '../mcp.constants';
+import { MCP_MODULE_NAME, RouteNames } from '../mcp.constants';
 
 import { ModuleRoutes } from './index';
 
@@ -12,6 +11,19 @@ describe('MCP routes', () => {
 			authenticated: true,
 			roles: [UsersModuleUserRole.admin, UsersModuleUserRole.owner],
 		});
+	});
+
+	it('tags every menu route with the module so the navigation can hide it when disabled', () => {
+		const menuRoutes = ModuleRoutes.filter(({ meta }) => meta?.menu !== undefined);
+
+		expect(menuRoutes.length).toBeGreaterThan(0);
+
+		// app-navigation only gates routes that declare `meta.module`; untagged
+		// routes fall through to "always visible", which left the MCP items in
+		// the menu while the module was disabled.
+		for (const route of menuRoutes) {
+			expect(route.meta?.module).toBe(MCP_MODULE_NAME);
+		}
 	});
 
 	it('registers consent as a hidden owner/admin route', () => {

--- a/apps/admin/src/modules/mcp/router/index.ts
+++ b/apps/admin/src/modules/mcp/router/index.ts
@@ -2,7 +2,7 @@ import type { RouteRecordRaw } from 'vue-router';
 
 import i18n from '../../../locales';
 import { UsersModuleUserRole } from '../../../openapi.constants';
-import { RouteNames } from '../mcp.constants';
+import { MCP_MODULE_NAME, RouteNames } from '../mcp.constants';
 
 export const ModuleRoutes: RouteRecordRaw[] = [
 	{
@@ -17,6 +17,7 @@ export const ModuleRoutes: RouteRecordRaw[] = [
 			title: () => i18n.global.t('mcpModule.menu.clients'),
 			icon: 'mdi:robot-outline',
 			menu: 6500,
+			module: MCP_MODULE_NAME,
 		},
 	},
 	{
@@ -31,6 +32,7 @@ export const ModuleRoutes: RouteRecordRaw[] = [
 			title: () => i18n.global.t('mcpModule.menu.oauth'),
 			icon: 'mdi:shield-key-outline',
 			menu: 6510,
+			module: MCP_MODULE_NAME,
 		},
 	},
 	{


### PR DESCRIPTION
## Problem

With `mcp-module` disabled, both MCP entries ("MCP Clients" and "MCP OAuth access") remained in the main navigation.

## Root cause

The gating mechanism already exists and is correct — `app-navigation.vue`:

```typescript
const moduleType = menuRoute.meta?.module as string | undefined;

if (!moduleType) return true;                              // untagged ⇒ always visible
if (!modulesLoaded.value) return configFetchFailed.value;

return isModuleEnabled(moduleType);
```

Routes are only gated if they declare `meta.module`. The MCP routes never did, so they fell through the `!moduleType` early return and stayed visible regardless of module state.

The `buddy` module already declares `module: BUDDY_MODULE_NAME` and is correctly hidden under the same conditions — so this aligns MCP with the existing convention rather than introducing one.

Confirmed against a running instance, where both modules are off:

```
buddy-module = false     ← correctly hidden
mcp-module   = false     ← still showed 2 menu items
```

## Change

Adds `module: MCP_MODULE_NAME` to the two menu-visible MCP routes. The consent route is intentionally untouched — it has no `menu` meta and is not a navigation entry.

## Tests

Adds a test asserting every menu-visible MCP route is tagged, so a future menu entry can't silently reintroduce the gap. Verified failing first (`expected undefined to be 'mcp-module'`).

- Admin suite: 271 files, 1934 passed
- `vue-tsc` type-check clean
- eslint + prettier clean

## Note

Other modules with menu entries (`config`, `dashboard`, `devices`, `displays`, `extensions`, `scenes`, `spaces`, `stats`, `system`, `users`, `weather`) also lack the tag. All are currently enabled, so there is no visible symptom, but any that become disableable would hit the same issue. Left out of this PR as it is not part of the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)