### PR TITLE
fix(backend): raise throttle ceiling for shelly discovery polling

### DIFF
--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
@@ -9,6 +9,7 @@ handling of Jest mocks, which ESLint rules flag unnecessarily.
 */
 import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { THROTTLER_LIMIT, THROTTLER_TTL } from '@nestjs/throttler/dist/throttler.constants';
 
 import { MappingLoaderService } from '../mappings';
 import { DeviceManagerService } from '../services/device-manager.service';
@@ -114,6 +115,22 @@ describe('ShellyNgDevicesController', () => {
 			discoveryService.get.mockReturnValue(null);
 
 			expect(() => controller.getDiscovery('missing')).toThrow(NotFoundException);
+		});
+
+		it('raises the throttle ceiling for the polled discovery session route', () => {
+			// The wizard polls this route once per second for the whole scan, so
+			// the default 30 req/60s budget is exhausted mid-scan and every later
+			// request — including device adoption — is rejected with 429.
+			const limit = Reflect.getMetadata(
+				`${THROTTLER_LIMIT}default`,
+				ShellyNgDevicesController.prototype.getDiscovery,
+			) as number | undefined;
+			const ttl = Reflect.getMetadata(`${THROTTLER_TTL}default`, ShellyNgDevicesController.prototype.getDiscovery) as
+				| number
+				| undefined;
+
+			expect(ttl).toBe(60_000);
+			expect(limit).toBeGreaterThanOrEqual(120);
 		});
 
 		it('adds manual device lookup to a discovery session', async () => {

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
@@ -2,6 +2,7 @@ import { validate } from 'class-validator';
 
 import { Body, Controller, Get, NotFoundException, Param, Post, UnprocessableEntityException } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
 import { toInstance } from '../../../common/utils/transform.utils';
@@ -74,6 +75,12 @@ export class ShellyNgDevicesController {
 	@ApiSuccessResponse(ShellyNgDiscoverySessionResponseModel, 'Shelly NG discovery session was successfully retrieved.')
 	@ApiNotFoundResponse('Discovery session could not be found')
 	@ApiInternalServerErrorResponse('Internal server error')
+	// The wizard polls this route once per second for the duration of a scan, so
+	// the default 30 req/60s budget is spent before the scan finishes and every
+	// later request — including adopting the discovered devices — gets a 429.
+	// Reading a discovery session is an in-memory lookup with no I/O, so a higher
+	// ceiling costs nothing while still bounding abuse.
+	@Throttle({ default: { limit: 240, ttl: 60000 } })
 	@Get('discovery/:id')
 	getDiscovery(@Param('id') id: string): ShellyNgDiscoverySessionResponseModel {
 		const session = this.discoveryService.get(id);


### PR DESCRIPTION
## Problem

Reported as: *"shelly wizard — on step 2 — if i select all devices, for example 50, and click done, it fails on rate limit — too many requests."*

Investigation showed the device count is **not** the main cause.

## Root cause

Two independent contributors, and the dominant one is polling:

| Cause | Arithmetic | Effect |
|---|---|---|
| Discovery polling at 1 Hz (`POLL_INTERVAL_MS = 1_000`) | 30 polls in 30s vs a 30 req/60s budget | quota exhausted **during the scan** |
| Per-device adoption requests | 50 devices = 50 requests | exceeds 30 on its own |

The wizard polls `GET /plugins/devices-shelly-ng/devices/discovery/:id` once per second for the duration of a scan (`duration: 30`). The global throttler is `{ ttl: 60000, limit: 30 }`, and `DisplayAwareThrottlerGuard` only bypasses it for tokens whose `type` is `DISPLAY` — an admin user token falls through to the default. So the quota is gone before the user reaches step 2, and adoption then fails regardless of how many devices were selected.

Measured on a running instance before the change — the default limit is exactly as configured:

```
first 429 at request #: 31
```

## Change

Gives the polled route its own ceiling via `@Throttle`, matching the per-route override pattern `auth.controller.ts` already uses (which tightens rather than loosens). Reading a discovery session is an in-memory lookup with no I/O, so the higher ceiling costs nothing.

## Verification

After the change, against the running instance:

```
45 consecutive polls → 45× 404   (unknown session, no 429)
```

Negative control — unrelated routes are unaffected:

```
GET /modules/devices/devices → first 429 at request #: 31
```

## Tests

Adds a test asserting the route carries a raised ceiling, verified failing first (`Expected: 60000, Received: undefined`).

- Backend unit suite: 376 suites, 4768 passed, 2 skipped
- eslint + prettier clean

## Not addressed here

Adoption still issues one request per device, so a batch larger than 30 can exhaust the default budget even with polling fixed. That half is deliberately excluded: adoption goes through the **shared** `POST /modules/devices/devices` and `PATCH /modules/devices/devices/{id}` routes rather than any wizard-specific endpoint, so raising its limit would loosen device writes for every client. Worth deciding separately — a bulk-adopt endpoint (following the `/bulk` convention in the spaces module) would fix it without weakening the shared routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)