### PR TITLE
fix(backend): copy spaces intent specs into the build

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -6,7 +6,7 @@
     "deleteOutDir": true,
     "assets": [
       {
-        "include": "modules/spaces/spec/definitions/**/*.yaml",
+        "include": "plugins/spaces-home-control/spec/definitions/**/*.yaml",
         "outDir": "dist"
       },
       {

--- a/apps/backend/src/nest-cli-assets.spec.ts
+++ b/apps/backend/src/nest-cli-assets.spec.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+
+/**
+ * `nest build` only copies non-TS files listed under `compilerOptions.assets`.
+ * A glob that no longer matches anything is silent — the build succeeds and the
+ * files are simply missing from `dist`, so the failure only surfaces at runtime
+ * as whatever consumes them degrading. That is how the spaces intent catalog
+ * ended up loading zero intents in every built artifact after its YAML moved.
+ */
+describe('nest-cli asset globs', () => {
+	const backendRoot = resolve(__dirname, '..');
+	const sourceRoot = join(backendRoot, 'src');
+
+	const nestCli = JSON.parse(readFileSync(join(backendRoot, 'nest-cli.json'), 'utf8')) as {
+		compilerOptions?: { assets?: ({ include?: string } | string)[] };
+	};
+
+	const includes = (nestCli.compilerOptions?.assets ?? [])
+		.map((asset) => (typeof asset === 'string' ? asset : asset.include))
+		.filter((include): include is string => typeof include === 'string');
+
+	const collectFiles = (dir: string): string[] => {
+		if (!existsSync(dir)) {
+			return [];
+		}
+
+		return readdirSync(dir).flatMap((entry) => {
+			const full = join(dir, entry);
+
+			return statSync(full).isDirectory() ? collectFiles(full) : [full];
+		});
+	};
+
+	const matches = (include: string): string[] => {
+		// Every glob in this project is `<dir>/**/*.<ext>`; anything else is
+		// treated as a literal path so an unsupported shape can't pass silently.
+		const [base, pattern] = include.split('/**/');
+
+		if (pattern === undefined) {
+			return existsSync(join(sourceRoot, include)) ? [include] : [];
+		}
+
+		const extension = pattern.replace(/^\*/, '');
+
+		return collectFiles(join(sourceRoot, base)).filter((file) => file.endsWith(extension));
+	};
+
+	it('declares at least one asset glob', () => {
+		expect(includes.length).toBeGreaterThan(0);
+	});
+
+	it.each(includes)('resolves %s to at least one file under src', (include) => {
+		expect(matches(include)).not.toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Problem

Every backend start logs six errors and an empty intent catalog:

```
[IntentSpecLoader] Failed to load builtin enums - intent catalog will be incomplete
[IntentSpecLoader] Failed to load builtin lighting intents
[IntentSpecLoader] Failed to load builtin climate intents
[IntentSpecLoader] Failed to load builtin lighting modes
[IntentSpecLoader] Failed to load builtin covers modes
[IntentSpecLoader] Failed to load builtin suggestions
[IntentSpecLoader] Loaded specs: 0 lighting intents, 0 climate intents, 0 lighting modes, 0 covers modes, 0 suggestion rules
```

Anything driven by the intent catalog is silently inert. This affects **production builds too**, not just local dev.

## Root cause

`nest build` copies non-TS files only when they match `compilerOptions.assets` in `nest-cli.json`. Commit `c0a4809aa` relocated the intent spec loader and its YAML catalog from `modules/spaces/spec/definitions` to `plugins/spaces-home-control/spec/definitions`, but the asset glob was not updated:

```json
"include": "modules/spaces/spec/definitions/**/*.yaml"
```

That path no longer exists, so the glob matched nothing. `IntentSpecLoader` resolves `join(__dirname, 'definitions')` — i.e. `dist/plugins/spaces-home-control/spec/definitions` — which was never populated.

A stale glob is silent: the build still succeeds and only the runtime degrades.

## Change

One line — the glob now points at the current location.

## Verification

Built and ran the compiled artifact (on a spare port, so as not to disturb a running instance):

```
dist/plugins/spaces-home-control/spec/definitions/
  climate-intents.yaml  covers-modes.yaml  enums.yaml
  lighting-intents.yaml lighting-modes.yaml suggestions.yaml

[IntentSpecLoader] Loaded specs: 11 lighting intents, 4 climate intents,
                  4 lighting modes, 4 covers modes, 3 suggestion rules
```

`Failed to load builtin` count: **6 -> 0**.

## Tests

Because the failure mode is a *silent* build-config drift that no unit test would otherwise catch, this adds a check that every declared asset glob resolves to at least one file under `src`. Verified it fails on the current config with exactly one failing case — the spaces glob — while the other eleven pass, so it pins the whole class rather than this single instance.

- Backend unit suite: 377 suites, 4779 passed, 2 skipped
- eslint clean

`nest-cli.json` is not prettier-clean, but it already wasn't before this change and the project's `pretty:check` only covers `src/**/*.ts` and `test/**/*.ts`, so it is deliberately left untouched rather than reformatted into unrelated diff noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)