### PR TITLE
fix(infra): probe the real health route in container healthchecks

### DIFF
--- a/apps/backend/src/modules/system/health-endpoint-contract.spec.ts
+++ b/apps/backend/src/modules/system/health-endpoint-contract.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+import { API_PREFIX, MODULES_PREFIX } from '../../app.constants';
+
+import { SYSTEM_MODULE_PREFIX } from './system.constants';
+
+/**
+ * The container health probes hard-code the health route. When they drift from
+ * the route the app actually serves, the probe just 404s forever: the server
+ * container never reports healthy, and anything gated on `service_healthy`
+ * (the admin container) never starts. Nothing fails loudly, so pin the two
+ * together here.
+ */
+describe('health endpoint deployment contract', () => {
+	// src/modules/system -> src -> apps/backend -> apps -> repo root
+	const repoRoot = resolve(__dirname, '../../../../..');
+
+	// `main.ts` sets a global prefix and URI versioning with `defaultVersion: '1'`,
+	// so Nest serves `/{prefix}/v1/...`. The system controller is mounted at
+	// `system` inside the system module, exposing `health`.
+	const healthPath = `/${API_PREFIX}/v1/${MODULES_PREFIX}/${SYSTEM_MODULE_PREFIX}/system/health`;
+
+	const probes = ['docker/dev/docker-compose.yml', 'docker/prod/docker-compose.yml', 'docker/prod/Dockerfile'];
+
+	it.each(probes)('%s probes the health route the app serves', (file) => {
+		const contents = readFileSync(join(repoRoot, file), 'utf8');
+
+		// Guard against the stale `/api/system/health` shape that skips the
+		// version segment and the modules prefix.
+		expect(contents).toContain(healthPath);
+	});
+});

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     ports:
       - "${BACKEND_PORT:-3000}:3000"
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/api/system/health', r => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))\""]
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/api/v1/modules/system/system/health', r => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))\""]
       interval: 10s
       timeout: 5s
       retries: 30

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -114,7 +114,7 @@ EXPOSE 3000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-	CMD wget -qO- http://localhost:${FB_BACKEND_PORT}/api/system/health || exit 1
+	CMD wget -qO- http://localhost:${FB_BACKEND_PORT}/api/v1/modules/system/system/health || exit 1
 
 # Use tini for proper signal handling
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       FB_CONFIG_PATH: /data/config
       FB_ADMIN_UI_PATH: /app/static
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/system/health"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/v1/modules/system/system/health"]
       interval: 30s
       timeout: 10s
       start_period: 30s


### PR DESCRIPTION
## Problem

All three container health probes request a route that does not exist:

```
docker/dev/docker-compose.yml   → /api/system/health
docker/prod/docker-compose.yml  → /api/system/health
docker/prod/Dockerfile          → /api/system/health
```

`main.ts` applies a global `api` prefix **and** URI versioning (`defaultVersion: '1'`), and the controller is mounted inside the system module, so the served route is `/api/v1/modules/system/system/health`.

Verified against a running instance:

```
/api/system/health                    404
/api/v1/modules/system/system/health  200
```

## Impact

The probe never succeeds, so the container never reports healthy.

This is worst in **dev compose**, where the admin service is gated on it:

```yaml
depends_on:
  server:
    condition: service_healthy
```

The server never becomes healthy, so `admin` never starts — `docker compose -f docker/dev/docker-compose.yml up` cannot bring up a working stack.

## Change

Points all three probes at the real route.

## Tests

The probes hard-code a path that nothing else validates, which is how it drifted. Adds a test that composes the expected route from the app's own constants (`API_PREFIX`, `MODULES_PREFIX`, `SYSTEM_MODULE_PREFIX`) and asserts each probe contains it — so renaming a prefix or moving the controller fails loudly instead of silently breaking container orchestration.

Verified failing first for the right reason (`Expected substring: "/api/v1/modules/system/system/health"`), not merely erroring.

- Backend unit suite: 378 suites, 4783 passed, 2 skipped
- eslint + prettier clean

## Note on scope

The defect is in `docker/**`, hence `infra`. The accompanying test lives under `apps/backend/` because that is where the jest suite and the prefix constants are — it guards the infra config rather than testing backend behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)