### PR TITLE
feat(admin): rebuild the mcp clients list on the shared list pattern

### DIFF
--- a/apps/admin/src/modules/mcp/components/list-mcp-clients.types.ts
+++ b/apps/admin/src/modules/mcp/components/list-mcp-clients.types.ts
@@ -1,0 +1,13 @@
+import type { IMcpClientsSortBy } from '../composables/types';
+import type { IMcpClient } from '../schemas/client.types';
+
+export interface IListMcpClientsProps {
+	items: IMcpClient[];
+	totalRows: number;
+	sortBy: IMcpClientsSortBy | undefined;
+	sortDir: 'asc' | 'desc' | null;
+	paginateSize: number;
+	paginatePage: number;
+	loading: boolean;
+	filtersActive: boolean;
+}

--- a/apps/admin/src/modules/mcp/components/list-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/components/list-mcp-clients.vue
@@ -1,0 +1,151 @@
+<template>
+	<div
+		ref="wrapper"
+		class="flex-grow overflow-hidden"
+	>
+		<el-card
+			shadow="never"
+			class="max-h-full flex flex-col overflow-hidden box-border"
+			body-class="p-0! max-h-full overflow-hidden flex flex-col"
+		>
+			<mcp-clients-table
+				v-model:sort-by="sortBy"
+				v-model:sort-dir="sortDir"
+				:items="props.items"
+				:total-rows="props.totalRows"
+				:loading="props.loading"
+				:filters-active="props.filtersActive"
+				:table-height="tableHeight"
+				@edit="emit('edit', $event)"
+				@rotate="emit('rotate', $event)"
+				@revoke="emit('revoke', $event)"
+				@delete="emit('delete', $event)"
+				@reset-filters="emit('reset-filters')"
+				@selected-changes="onSelectionChange"
+			/>
+
+			<div
+				ref="paginator"
+				class="flex justify-center w-full py-4"
+			>
+				<el-pagination
+					v-model:current-page="paginatePage"
+					v-model:page-size="paginateSize"
+					:layout="isMDDevice ? 'total, sizes, prev, pager, next, jumper' : 'total, sizes, prev, pager, next'"
+					:total="props.totalRows"
+					@size-change="onPaginatePageSize"
+					@current-change="onPaginatePage"
+				/>
+			</div>
+		</el-card>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+import { ElCard, ElPagination } from 'element-plus';
+
+import { useBreakpoints } from '../../../common';
+import type { IMcpClientsSortBy } from '../composables/types';
+import type { IMcpClient } from '../schemas/client.types';
+
+import type { IListMcpClientsProps } from './list-mcp-clients.types';
+import McpClientsTable from './mcp-clients-table.vue';
+
+defineOptions({
+	name: 'ListMcpClients',
+});
+
+const props = defineProps<IListMcpClientsProps>();
+
+const emit = defineEmits<{
+	(e: 'edit', client: IMcpClient): void;
+	(e: 'rotate', client: IMcpClient): void;
+	(e: 'revoke', client: IMcpClient): void;
+	(e: 'delete', client: IMcpClient): void;
+	(e: 'reset-filters'): void;
+	(e: 'update:paginate-size', size: number): void;
+	(e: 'update:paginate-page', page: number): void;
+	(e: 'update:sort-by', by: IMcpClientsSortBy | undefined): void;
+	(e: 'update:sort-dir', dir: 'asc' | 'desc' | null): void;
+	(e: 'selected-changes', selected: IMcpClient[]): void;
+}>();
+
+const { isMDDevice } = useBreakpoints();
+
+let observer: ResizeObserver | null = null;
+
+const wrapper = ref<HTMLElement | null>(null);
+const paginator = ref<HTMLElement | null>(null);
+
+const sortBy = ref<IMcpClientsSortBy | undefined>(props.sortBy);
+const sortDir = ref<'asc' | 'desc' | null>(props.sortDir);
+const paginatePage = ref<number>(props.paginatePage);
+const paginateSize = ref<number>(props.paginateSize);
+
+const tableHeight = ref<number>(250);
+
+const onPaginatePageSize = (size: number): void => {
+	emit('update:paginate-size', size);
+};
+
+const onPaginatePage = (page: number): void => {
+	emit('update:paginate-page', page);
+};
+
+const onSelectionChange = (selected: IMcpClient[]): void => {
+	emit('selected-changes', selected);
+};
+
+onMounted((): void => {
+	if (!wrapper.value) {
+		return;
+	}
+
+	const updateHeight = (): void => {
+		tableHeight.value = wrapper.value!.clientHeight - (paginator.value?.clientHeight ?? 0);
+	};
+
+	if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+		observer = new ResizeObserver(updateHeight);
+		observer.observe(wrapper.value);
+	}
+
+	updateHeight();
+});
+
+onBeforeUnmount((): void => {
+	if (observer && wrapper.value) {
+		observer.unobserve(wrapper.value);
+	}
+});
+
+watch(
+	(): IMcpClientsSortBy | undefined => sortBy.value,
+	(val: IMcpClientsSortBy | undefined): void => {
+		emit('update:sort-by', val);
+	}
+);
+
+watch(
+	(): 'asc' | 'desc' | null => sortDir.value,
+	(val: 'asc' | 'desc' | null): void => {
+		emit('update:sort-dir', val);
+	}
+);
+
+watch(
+	(): number => props.paginatePage,
+	(val: number): void => {
+		paginatePage.value = val;
+	}
+);
+
+watch(
+	(): number => props.paginateSize,
+	(val: number): void => {
+		paginateSize.value = val;
+	}
+);
+</script>

--- a/apps/admin/src/modules/mcp/components/mcp-clients-table.types.ts
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-table.types.ts
@@ -1,0 +1,12 @@
+import type { IMcpClientsSortBy } from '../composables/types';
+import type { IMcpClient } from '../schemas/client.types';
+
+export interface IMcpClientsTableProps {
+	items: IMcpClient[];
+	totalRows: number;
+	sortBy: IMcpClientsSortBy | undefined;
+	sortDir: 'asc' | 'desc' | null;
+	loading: boolean;
+	filtersActive: boolean;
+	tableHeight?: number;
+}

--- a/apps/admin/src/modules/mcp/components/mcp-clients-table.vue
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-table.vue
@@ -1,0 +1,269 @@
+<template>
+	<el-table
+		v-loading="props.loading"
+		:element-loading-text="t('mcpModule.clients.loading')"
+		:data="props.items"
+		:default-sort="
+			typeof props.sortBy !== 'undefined' && props.sortDir !== null
+				? { prop: props.sortBy, order: props.sortDir === 'desc' ? 'descending' : 'ascending' }
+				: undefined
+		"
+		table-layout="fixed"
+		row-key="id"
+		class="flex-grow"
+		:style="{ maxHeight: props.tableHeight + 'px' }"
+		:max-height="props.tableHeight"
+		@sort-change="onSortData"
+		@selection-change="onSelectionChange"
+		@row-click="onRowClick"
+	>
+		<template #empty>
+			<div
+				v-if="props.loading"
+				class="h-full w-full leading-normal"
+			>
+				<el-result class="h-full w-full">
+					<template #icon>
+						<icon-with-child :size="80">
+							<template #primary>
+								<icon icon="mdi:robot-outline" />
+							</template>
+							<template #secondary>
+								<icon icon="mdi:database-refresh" />
+							</template>
+						</icon-with-child>
+					</template>
+				</el-result>
+			</div>
+
+			<div
+				v-else-if="props.filtersActive"
+				class="h-full w-full leading-normal"
+			>
+				<el-result class="h-full w-full">
+					<template #icon>
+						<icon-with-child :size="80">
+							<template #primary>
+								<icon icon="mdi:robot-outline" />
+							</template>
+							<template #secondary>
+								<icon icon="mdi:filter-remove" />
+							</template>
+						</icon-with-child>
+					</template>
+
+					<template #title>
+						{{ t('mcpModule.clients.noFilteredResults') }}
+					</template>
+
+					<template #extra>
+						<el-button
+							plain
+							@click="emit('reset-filters')"
+						>
+							{{ t('mcpModule.actions.resetFilters') }}
+						</el-button>
+					</template>
+				</el-result>
+			</div>
+
+			<div
+				v-else
+				class="h-full w-full leading-normal"
+			>
+				<el-result class="h-full w-full">
+					<template #icon>
+						<icon-with-child :size="80">
+							<template #primary>
+								<icon icon="mdi:robot-outline" />
+							</template>
+							<template #secondary>
+								<icon icon="mdi:information" />
+							</template>
+						</icon-with-child>
+					</template>
+
+					<template #title>
+						{{ t('mcpModule.clients.empty') }}
+					</template>
+				</el-result>
+			</div>
+		</template>
+
+		<el-table-column
+			v-if="isMDDevice"
+			type="selection"
+			fixed
+			:width="30"
+		/>
+
+		<el-table-column
+			:width="60"
+			align="center"
+		>
+			<template #default>
+				<el-icon :size="20">
+					<icon icon="mdi:robot-outline" />
+				</el-icon>
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			:label="t('mcpModule.clients.columns.name')"
+			prop="name"
+			sortable="custom"
+			:sort-orders="['ascending', 'descending']"
+			:min-width="200"
+		>
+			<template #default="scope">
+				<div class="font-600">{{ scope.row.name }}</div>
+				<el-text
+					size="small"
+					truncated
+				>
+					{{ scope.row.description || t('mcpModule.clients.noDescription') }}
+				</el-text>
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			:label="t('mcpModule.clients.columns.status')"
+			prop="status"
+			sortable="custom"
+			:sort-orders="['ascending', 'descending']"
+			:width="130"
+		>
+			<template #default="scope">
+				<el-tag :type="statusType(scope.row)">
+					{{ t(`mcpModule.status.${resolveMcpClientStatus(scope.row)}`) }}
+				</el-tag>
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			:label="t('mcpModule.clients.columns.capabilities')"
+			:min-width="180"
+		>
+			<template #default="scope">
+				<div class="flex flex-wrap gap-1">
+					<el-tag
+						v-for="capability in scope.row.capabilities"
+						:key="capability"
+						type="info"
+					>
+						{{ t(`mcpModule.capabilities.${capability}.title`) }}
+					</el-tag>
+					<span v-if="scope.row.capabilities.length === 0">{{ t('mcpModule.clients.none') }}</span>
+				</div>
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			v-if="isMDDevice"
+			:label="t('mcpModule.clients.columns.expires')"
+			prop="expires"
+			sortable="custom"
+			:sort-orders="['ascending', 'descending']"
+			:width="180"
+		>
+			<template #default="scope">
+				{{ formatNullableDate(scope.row.credentialExpiresAt) }}
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			v-if="isMDDevice"
+			:label="t('mcpModule.clients.columns.lastUsed')"
+			prop="lastUsed"
+			sortable="custom"
+			:sort-orders="['ascending', 'descending']"
+			:width="180"
+		>
+			<template #default="scope">
+				{{ formatNullableDate(scope.row.lastUsedAt) }}
+			</template>
+		</el-table-column>
+
+		<el-table-column
+			:width="320"
+			align="right"
+			fixed="right"
+		>
+			<template #default="scope">
+				<div @click.stop>
+					<mcp-client-actions
+						:client="scope.row"
+						@edit="emit('edit', $event)"
+						@rotate="emit('rotate', $event)"
+						@revoke="emit('revoke', $event)"
+						@delete="emit('delete', $event)"
+					/>
+				</div>
+			</template>
+		</el-table-column>
+	</el-table>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElIcon, ElResult, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import { IconWithChild, useBreakpoints } from '../../../common';
+import { resolveMcpClientStatus } from '../mcp.utils';
+import type { IMcpClient } from '../schemas/client.types';
+
+import McpClientActions from './mcp-client-actions.vue';
+import type { IMcpClientsTableProps } from './mcp-clients-table.types';
+
+defineOptions({
+	name: 'McpClientsTable',
+});
+
+const props = defineProps<IMcpClientsTableProps>();
+
+const emit = defineEmits<{
+	(e: 'edit', client: IMcpClient): void;
+	(e: 'rotate', client: IMcpClient): void;
+	(e: 'revoke', client: IMcpClient): void;
+	(e: 'delete', client: IMcpClient): void;
+	(e: 'reset-filters'): void;
+	(e: 'selected-changes', selected: IMcpClient[]): void;
+	(e: 'update:sort-by', by: IMcpClientsTableProps['sortBy']): void;
+	(e: 'update:sort-dir', dir: 'asc' | 'desc' | null): void;
+}>();
+
+const { t } = useI18n();
+
+const { isMDDevice } = useBreakpoints();
+
+const statusType = (client: IMcpClient): 'success' | 'warning' | 'danger' => {
+	switch (resolveMcpClientStatus(client)) {
+		case 'revoked':
+		case 'expired':
+			return 'danger';
+		case 'disabled':
+			return 'warning';
+		default:
+			return 'success';
+	}
+};
+
+const formatNullableDate = (value: string | null): string =>
+	value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)) : t('mcpModule.clients.never');
+
+const onSortData = ({ prop, order }: { prop: IMcpClientsTableProps['sortBy']; order: 'ascending' | 'descending' | null }): void => {
+	emit('update:sort-by', prop);
+	emit('update:sort-dir', order === null ? null : order === 'descending' ? 'desc' : 'asc');
+};
+
+const onSelectionChange = (selected: IMcpClient[]): void => {
+	emit('selected-changes', selected);
+};
+
+const onRowClick = (row: IMcpClient): void => {
+	emit('edit', row);
+};
+</script>

--- a/apps/admin/src/modules/mcp/composables/schemas.ts
+++ b/apps/admin/src/modules/mcp/composables/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+import { McpCapability } from '../mcp.constants';
+
+export const McpClientsFilterSchema = z.object({
+	search: z.string().optional(),
+	status: z.enum(['all', 'active', 'revoked', 'expired']).default('all'),
+	enabled: z.enum(['all', 'enabled', 'disabled']).default('all'),
+	capabilities: z.array(z.nativeEnum(McpCapability)),
+});

--- a/apps/admin/src/modules/mcp/composables/types.ts
+++ b/apps/admin/src/modules/mcp/composables/types.ts
@@ -1,0 +1,24 @@
+import type { ComputedRef, Ref } from 'vue';
+
+import type { z } from 'zod';
+
+import type { IMcpClient } from '../schemas/client.types';
+
+import type { McpClientsFilterSchema } from './schemas';
+
+export type IMcpClientsFilter = z.infer<typeof McpClientsFilterSchema>;
+
+export type IMcpClientsSortBy = 'name' | 'status' | 'expires' | 'lastUsed';
+
+export interface IUseMcpClientsDataSource {
+	clients: ComputedRef<IMcpClient[]>;
+	clientsPaginated: ComputedRef<IMcpClient[]>;
+	totalRows: ComputedRef<number>;
+	filters: Ref<IMcpClientsFilter>;
+	filtersActive: ComputedRef<boolean>;
+	sortBy: Ref<IMcpClientsSortBy | undefined>;
+	sortDir: Ref<'asc' | 'desc' | null>;
+	paginateSize: Ref<number>;
+	paginatePage: Ref<number>;
+	resetFilter: () => void;
+}

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
@@ -1,0 +1,135 @@
+import { ref } from 'vue';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { McpCapability } from '../mcp.constants';
+import type { IMcpClient } from '../schemas/client.types';
+
+import { defaultMcpClientsFilter, defaultMcpClientsSort, useMcpClientsDataSource } from './useMcpClientsDataSource';
+
+const build = (overrides: Partial<IMcpClient> & Pick<IMcpClient, 'id' | 'name'>): IMcpClient =>
+	({
+		description: null,
+		enabled: true,
+		capabilities: [McpCapability.read],
+		createdById: null,
+		tokenId: null,
+		credentialExpiresAt: null,
+		credentialRevoked: false,
+		lastUsedAt: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: null,
+		...overrides,
+	}) as unknown as IMcpClient;
+
+const active = build({ id: '1', name: 'Charlie', lastUsedAt: '2026-03-01T00:00:00.000Z' });
+const revoked = build({ id: '2', name: 'alpha', credentialRevoked: true });
+const expired = build({ id: '3', name: 'Bravo', credentialExpiresAt: '2020-01-01T00:00:00.000Z' });
+const disabled = build({ id: '4', name: 'delta', enabled: false, capabilities: [McpCapability.write] });
+
+const clients = ref<IMcpClient[]>([active, revoked, expired, disabled]);
+
+const mockFilters = ref({ ...defaultMcpClientsFilter });
+const mockPagination = ref<{ page?: number; size?: number }>({ page: 1, size: 25 });
+const mockSort = ref([defaultMcpClientsSort]);
+
+vi.mock('../../../common', () => ({
+	useListQuery: vi.fn(() => ({
+		filters: mockFilters,
+		pagination: mockPagination,
+		sort: mockSort,
+		viewMode: ref('table'),
+		reset: vi.fn(() => {
+			mockFilters.value = { ...defaultMcpClientsFilter };
+		}),
+	})),
+}));
+
+describe('useMcpClientsDataSource', () => {
+	beforeEach(() => {
+		mockFilters.value = { ...defaultMcpClientsFilter };
+		mockPagination.value = { page: 1, size: 25 };
+		mockSort.value = [defaultMcpClientsSort];
+		clients.value = [active, revoked, expired, disabled];
+	});
+
+	it('returns every client when no filter is applied', () => {
+		const { clients: result, totalRows } = useMcpClientsDataSource(clients);
+
+		expect(result.value).toHaveLength(4);
+		expect(totalRows.value).toBe(4);
+	});
+
+	it('sorts by name case-insensitively rather than by raw code point', () => {
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		expect(result.value.map((client) => client.name)).toEqual(['alpha', 'Bravo', 'Charlie', 'delta']);
+	});
+
+	it('matches the search term against name and description', () => {
+		clients.value = [build({ id: '5', name: 'Kitchen agent', description: 'reads the oven' }), active];
+		mockFilters.value = { ...defaultMcpClientsFilter, search: 'oven' };
+
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		expect(result.value.map((client) => client.id)).toEqual(['5']);
+	});
+
+	it.each([
+		['revoked', '2'],
+		['expired', '3'],
+		['active', '1'],
+	])('filters by the %s status', (status, expectedId) => {
+		mockFilters.value = { ...defaultMcpClientsFilter, status: status as 'revoked' | 'expired' | 'active' };
+
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		expect(result.value.map((client) => client.id)).toEqual([expectedId]);
+	});
+
+	it('treats a disabled client as disabled rather than active', () => {
+		mockFilters.value = { ...defaultMcpClientsFilter, status: 'active' };
+
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		expect(result.value.map((client) => client.id)).not.toContain('4');
+	});
+
+	it('filters by capability', () => {
+		mockFilters.value = { ...defaultMcpClientsFilter, capabilities: [McpCapability.write] };
+
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		expect(result.value.map((client) => client.id)).toEqual(['4']);
+	});
+
+	it('reports filters as active only once one differs from the default', () => {
+		const { filtersActive } = useMcpClientsDataSource(clients);
+
+		expect(filtersActive.value).toBe(false);
+
+		mockFilters.value = { ...defaultMcpClientsFilter, status: 'revoked' };
+
+		expect(filtersActive.value).toBe(true);
+	});
+
+	it('paginates the filtered rows', () => {
+		mockPagination.value = { page: 1, size: 2 };
+
+		const { clientsPaginated, totalRows } = useMcpClientsDataSource(clients);
+
+		expect(clientsPaginated.value).toHaveLength(2);
+		// The count drives the pager, so it must describe the whole filtered set.
+		expect(totalRows.value).toBe(4);
+	});
+
+	it('sorts clients with no expiry last when sorting by expiry ascending', () => {
+		mockSort.value = [{ by: 'expires', dir: 'asc' }];
+
+		const { clients: result } = useMcpClientsDataSource(clients);
+
+		// Only the expired client carries a date; the rest never expire and must
+		// not be presented as expiring soonest.
+		expect(result.value[0]?.id).toBe('3');
+	});
+});

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
@@ -1,0 +1,180 @@
+import { type Ref, computed, ref, watch } from 'vue';
+
+import { isEqual } from 'lodash';
+import { orderBy } from 'natural-orderby';
+
+import { type ISortEntry, useListQuery } from '../../../common';
+import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { resolveMcpClientStatus } from '../mcp.utils';
+import type { IMcpClient } from '../schemas/client.types';
+
+import { McpClientsFilterSchema } from './schemas';
+import type { IMcpClientsFilter, IUseMcpClientsDataSource } from './types';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 25;
+
+export const defaultMcpClientsFilter: IMcpClientsFilter = {
+	search: undefined,
+	status: 'all',
+	enabled: 'all',
+	capabilities: [],
+};
+
+export const defaultMcpClientsSort: ISortEntry = {
+	by: 'name',
+	dir: 'asc',
+};
+
+/**
+ * Clients are held in a ref owned by `useMcpClients`, not in a store, so the
+ * list is passed in rather than fetched again here — calling the composable a
+ * second time would otherwise produce a second, unsynchronised list.
+ */
+export const useMcpClientsDataSource = (clients: Ref<IMcpClient[]>): IUseMcpClientsDataSource => {
+	const {
+		filters,
+		sort,
+		pagination,
+		reset: resetFilter,
+	} = useListQuery<typeof McpClientsFilterSchema>({
+		key: `${MCP_MODULE_NAME}:clients:list`,
+		filters: {
+			schema: McpClientsFilterSchema,
+			defaults: defaultMcpClientsFilter,
+		},
+		sort: {
+			defaults: [defaultMcpClientsSort],
+		},
+		pagination: {
+			defaults: {
+				page: DEFAULT_PAGE,
+				size: DEFAULT_PAGE_SIZE,
+			},
+		},
+		syncQuery: true,
+		version: 1,
+	});
+
+	const filtersActive = computed<boolean>((): boolean => {
+		return (
+			filters.value.search !== defaultMcpClientsFilter.search ||
+			filters.value.status !== defaultMcpClientsFilter.status ||
+			filters.value.enabled !== defaultMcpClientsFilter.enabled ||
+			!isEqual(filters.value.capabilities, defaultMcpClientsFilter.capabilities)
+		);
+	});
+
+	const paginateSize = ref<number>(pagination.value.size || DEFAULT_PAGE_SIZE);
+
+	const paginatePage = ref<number>(pagination.value.page || DEFAULT_PAGE);
+
+	const sortBy = ref<'name' | 'status' | 'expires' | 'lastUsed' | undefined>(
+		sort.value.length > 0 ? (sort.value[0]?.by as 'name' | 'status' | 'expires' | 'lastUsed') : undefined
+	);
+
+	const sortDir = ref<'asc' | 'desc' | null>(sort.value.length > 0 ? (sort.value[0]?.dir ?? null) : null);
+
+	const matchesFilters = (client: IMcpClient): boolean => {
+		const search = filters.value.search?.trim().toLowerCase();
+
+		if (typeof search !== 'undefined' && search !== '') {
+			const haystack = `${client.name} ${client.description ?? ''}`.toLowerCase();
+
+			if (!haystack.includes(search)) {
+				return false;
+			}
+		}
+
+		if (filters.value.status !== 'all' && resolveMcpClientStatus(client) !== filters.value.status) {
+			return false;
+		}
+
+		if (filters.value.enabled !== 'all' && client.enabled !== (filters.value.enabled === 'enabled')) {
+			return false;
+		}
+
+		if (
+			filters.value.capabilities.length > 0 &&
+			!filters.value.capabilities.some((capability: McpCapability) => client.capabilities.includes(capability))
+		) {
+			return false;
+		}
+
+		return true;
+	};
+
+	const sortValue = (client: IMcpClient): string | number => {
+		switch (sortBy.value) {
+			case 'status':
+				return resolveMcpClientStatus(client);
+			case 'expires':
+				// Nulls sort last ascending — a credential with no expiry is not
+				// "expiring soonest".
+				return client.credentialExpiresAt === null ? Number.MAX_SAFE_INTEGER : new Date(client.credentialExpiresAt).getTime();
+			case 'lastUsed':
+				return client.lastUsedAt === null ? 0 : new Date(client.lastUsedAt).getTime();
+			default:
+				return client.name;
+		}
+	};
+
+	const clientsFiltered = computed<IMcpClient[]>((): IMcpClient[] => {
+		return orderBy<IMcpClient>(
+			clients.value.filter(matchesFilters),
+			[(client: IMcpClient) => sortValue(client)],
+			[sortDir.value === 'desc' ? 'desc' : 'asc']
+		);
+	});
+
+	const clientsPaginated = computed<IMcpClient[]>((): IMcpClient[] => {
+		const start = (paginatePage.value - 1) * paginateSize.value;
+
+		return clientsFiltered.value.slice(start, start + paginateSize.value);
+	});
+
+	// Counts what the list is showing, so the pager cannot disagree with the rows.
+	const totalRows = computed<number>((): number => clientsFiltered.value.length);
+
+	watch(
+		(): { page?: number; size?: number } => pagination.value,
+		(val: { page?: number; size?: number }): void => {
+			paginatePage.value = val.page ?? DEFAULT_PAGE;
+			paginateSize.value = val.size ?? DEFAULT_PAGE_SIZE;
+		}
+	);
+
+	watch(
+		(): ISortEntry[] => sort.value,
+		(val: ISortEntry[]): void => {
+			sortBy.value = val.length > 0 ? (val[0]?.by as 'name' | 'status' | 'expires' | 'lastUsed') : undefined;
+			sortDir.value = val.length > 0 ? (val[0]?.dir ?? null) : null;
+		}
+	);
+
+	// A filter change can leave the pager past the end of the new result set.
+	watch(
+		(): number => totalRows.value,
+		(val: number): void => {
+			const lastPage = Math.max(1, Math.ceil(val / paginateSize.value));
+
+			if (paginatePage.value > lastPage) {
+				paginatePage.value = lastPage;
+				pagination.value = { ...pagination.value, page: lastPage };
+			}
+		}
+	);
+
+	return {
+		clients: clientsFiltered,
+		clientsPaginated,
+		totalRows,
+		filters,
+		filtersActive,
+		sortBy,
+		sortDir,
+		paginateSize,
+		paginatePage,
+		resetFilter,
+	};
+};

--- a/apps/admin/src/modules/mcp/locales/cs-CZ.json
+++ b/apps/admin/src/modules/mcp/locales/cs-CZ.json
@@ -14,7 +14,8 @@
     "done": "Hotovo",
     "addOrigin": "Přidat zdroj",
     "removeOrigin": "Odebrat zdroj",
-    "copyEndpoint": "Kopírovat koncový bod"
+    "copyEndpoint": "Kopírovat koncový bod",
+    "resetFilters": "Zrušit filtry"
   },
   "capabilities": {
     "read": {
@@ -80,7 +81,9 @@
     "empty": "Dosud nebyli vytvořeni žádní klienti MCP.",
     "none": "Žádné",
     "never": "Nikdy",
-    "noDescription": "Bez popisu"
+    "noDescription": "Bez popisu",
+    "loading": "Načítání MCP klientů…",
+    "noFilteredResults": "Žádný MCP klient neodpovídá zvoleným filtrům."
   },
   "clientForm": {
     "createTitle": "Vytvořit klienta MCP",

--- a/apps/admin/src/modules/mcp/locales/de-DE.json
+++ b/apps/admin/src/modules/mcp/locales/de-DE.json
@@ -14,7 +14,8 @@
 		"done": "Fertig",
 		"addOrigin": "Origin hinzufügen",
 		"removeOrigin": "Origin entfernen",
-		"copyEndpoint": "Endpunkt kopieren"
+		"copyEndpoint": "Endpunkt kopieren",
+		"resetFilters": "Filter zurücksetzen"
 	},
 	"capabilities": {
 		"read": {
@@ -80,7 +81,9 @@
 		"empty": "Es wurden noch keine MCP-Clients erstellt.",
 		"none": "Keine",
 		"never": "Nie",
-		"noDescription": "Keine Beschreibung"
+		"noDescription": "Keine Beschreibung",
+		"loading": "MCP-Clients werden geladen…",
+		"noFilteredResults": "Kein MCP-Client entspricht den aktuellen Filtern."
 	},
 	"clientForm": {
 		"createTitle": "MCP-Client erstellen",

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -14,7 +14,8 @@
 		"done": "Done",
 		"addOrigin": "Add origin",
 		"removeOrigin": "Remove origin",
-		"copyEndpoint": "Copy endpoint"
+		"copyEndpoint": "Copy endpoint",
+		"resetFilters": "Reset filters"
 	},
 	"capabilities": {
 		"read": {
@@ -80,7 +81,9 @@
 		"empty": "No MCP clients have been created.",
 		"none": "None",
 		"never": "Never",
-		"noDescription": "No description"
+		"noDescription": "No description",
+		"loading": "Loading MCP clients…",
+		"noFilteredResults": "No MCP client matches the current filters."
 	},
 	"clientForm": {
 		"createTitle": "Create MCP client",

--- a/apps/admin/src/modules/mcp/locales/es-ES.json
+++ b/apps/admin/src/modules/mcp/locales/es-ES.json
@@ -14,7 +14,8 @@
     "done": "Listo",
     "addOrigin": "Añadir origen",
     "removeOrigin": "Eliminar origen",
-    "copyEndpoint": "Copiar endpoint"
+    "copyEndpoint": "Copiar endpoint",
+    "resetFilters": "Restablecer filtros"
   },
   "capabilities": {
     "read": {
@@ -80,7 +81,9 @@
     "empty": "Todavía no se ha creado ningún cliente MCP.",
     "none": "Ninguna",
     "never": "Nunca",
-    "noDescription": "Sin descripción"
+    "noDescription": "Sin descripción",
+    "loading": "Cargando clientes MCP…",
+    "noFilteredResults": "Ningún cliente MCP coincide con los filtros actuales."
   },
   "clientForm": {
     "createTitle": "Crear cliente MCP",

--- a/apps/admin/src/modules/mcp/locales/pl-PL.json
+++ b/apps/admin/src/modules/mcp/locales/pl-PL.json
@@ -14,7 +14,8 @@
     "done": "Gotowe",
     "addOrigin": "Dodaj źródło",
     "removeOrigin": "Usuń źródło",
-    "copyEndpoint": "Kopiuj endpoint"
+    "copyEndpoint": "Kopiuj endpoint",
+    "resetFilters": "Resetuj filtry"
   },
   "capabilities": {
     "read": {
@@ -80,7 +81,9 @@
     "empty": "Nie utworzono jeszcze żadnych klientów MCP.",
     "none": "Brak",
     "never": "Nigdy",
-    "noDescription": "Bez opisu"
+    "noDescription": "Bez opisu",
+    "loading": "Ładowanie klientów MCP…",
+    "noFilteredResults": "Żaden klient MCP nie pasuje do bieżących filtrów."
   },
   "clientForm": {
     "createTitle": "Utwórz klienta MCP",

--- a/apps/admin/src/modules/mcp/locales/sk-SK.json
+++ b/apps/admin/src/modules/mcp/locales/sk-SK.json
@@ -14,7 +14,8 @@
     "done": "Hotovo",
     "addOrigin": "Pridať zdroj",
     "removeOrigin": "Odobrať zdroj",
-    "copyEndpoint": "Kopírovať koncový bod"
+    "copyEndpoint": "Kopírovať koncový bod",
+    "resetFilters": "Zrušiť filtre"
   },
   "capabilities": {
     "read": {
@@ -80,7 +81,9 @@
     "empty": "Zatiaľ neboli vytvorení žiadni klienti MCP.",
     "none": "Žiadne",
     "never": "Nikdy",
-    "noDescription": "Bez popisu"
+    "noDescription": "Bez popisu",
+    "loading": "Načítavanie MCP klientov…",
+    "noFilteredResults": "Žiadny MCP klient nezodpovedá zvoleným filtrom."
   },
   "clientForm": {
     "createTitle": "Vytvoriť klienta MCP",

--- a/apps/admin/src/modules/mcp/mcp.utils.ts
+++ b/apps/admin/src/modules/mcp/mcp.utils.ts
@@ -9,3 +9,30 @@ export const resolveMcpEndpoint = (location: Pick<Location, 'origin' | 'pathname
 
 export const isCapabilitySubset = (granted: McpCapability[], ceiling: McpCapability[]): boolean =>
 	granted.every((capability) => ceiling.includes(capability));
+
+export type McpClientStatus = 'active' | 'disabled' | 'expired' | 'revoked';
+
+/**
+ * Single definition of a client's effective state, shared by the status column
+ * and the status filter so a row can never be labelled one thing and matched by
+ * another.
+ */
+export const resolveMcpClientStatus = (client: {
+	enabled: boolean;
+	credentialRevoked: boolean;
+	credentialExpiresAt: string | null;
+}): McpClientStatus => {
+	if (client.credentialRevoked) {
+		return 'revoked';
+	}
+
+	if (client.credentialExpiresAt !== null && new Date(client.credentialExpiresAt).getTime() <= Date.now()) {
+		return 'expired';
+	}
+
+	if (!client.enabled) {
+		return 'disabled';
+	}
+
+	return 'active';
+};

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -44,7 +44,14 @@ vi.mock('vue-i18n', () => ({
 vi.mock('../../../common', () => ({
 	ViewHeader: { name: 'ViewHeader', template: '<header><slot name="extra" /></header>' },
 	useFlashMessage: () => ({ success: mocks.flashSuccess, error: mocks.flashError }),
-	useBreakpoints: () => ({ isLGDevice: ref(true) }),
+	useBreakpoints: () => ({ isLGDevice: ref(true), isMDDevice: ref(true) }),
+	useListQuery: () => ({
+		filters: ref({ search: undefined, status: 'all', enabled: 'all', capabilities: [] }),
+		sort: ref([{ by: 'name', dir: 'asc' }]),
+		pagination: ref({ page: 1, size: 25 }),
+		viewMode: ref('table'),
+		reset: vi.fn(),
+	}),
 	AppBar: { name: 'AppBar', template: '<div><slot name="heading" /><slot name="button-right" /></div>' },
 	AppBarHeading: { name: 'AppBarHeading', template: '<div><slot name="icon" /><slot name="title" /></div>' },
 	AppBarButton: { name: 'AppBarButton', template: '<button><slot name="icon" /></button>' },
@@ -96,11 +103,12 @@ describe('ViewMcpClients', () => {
 		(ElMessageBox.confirm as Mock).mockResolvedValue('confirm');
 	});
 
-	it('renders dedicated desktop and mobile client layouts', () => {
+	it('renders the shared list component rather than a bespoke table', () => {
 		const wrapper = mountView();
 
-		expect(wrapper.find('.mcp-client-table-wrap').exists()).toBe(true);
-		expect(wrapper.find('.mcp-client-cards').exists()).toBe(true);
+		// The separate desktop table and mobile card markup were replaced by the
+		// list/table pair every other module uses, which handles both viewports.
+		expect(wrapper.findComponent({ name: 'ListMcpClients' }).exists()).toBe(true);
 	});
 
 	it('renders the header create action as a plain primary button', () => {
@@ -136,10 +144,10 @@ describe('ViewMcpClients', () => {
 
 	it('requires confirmation before revoking a credential', async () => {
 		const wrapper = mountView();
-		const actions = wrapper.findAllComponents({ name: 'McpClientActions' });
+		const list = wrapper.findComponent({ name: 'ListMcpClients' });
 
-		expect(actions.length).toBeGreaterThan(0);
-		actions[0]?.vm.$emit('revoke', client);
+		expect(list.exists()).toBe(true);
+		list.vm.$emit('revoke', client);
 		await nextTick();
 		await flushPromises();
 

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
@@ -58,130 +58,21 @@
 			show-icon
 		/>
 
-		<div class="mcp-client-table-wrap">
-			<el-table
-				v-loading="loading"
-				:data="clients"
-				class="mcp-client-table"
-				row-key="id"
-			>
-				<el-table-column
-					prop="name"
-					:label="t('mcpModule.clients.columns.name')"
-					min-width="190"
-				>
-					<template #default="scope">
-						<div class="font-600">{{ scope.row.name }}</div>
-						<div class="text-sm text-gray-500">{{ scope.row.description || t('mcpModule.clients.noDescription') }}</div>
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('mcpModule.clients.columns.status')"
-					width="120"
-				>
-					<template #default="scope">
-						<el-tag :type="status(scope.row).type">
-							{{ t(`mcpModule.status.${status(scope.row).key}`) }}
-						</el-tag>
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('mcpModule.clients.columns.capabilities')"
-					min-width="210"
-				>
-					<template #default="scope">
-						<div class="flex flex-wrap gap-1">
-							<el-tag
-								v-for="capability in scope.row.capabilities"
-								:key="capability"
-								type="info"
-							>
-								{{ t(`mcpModule.capabilities.${capability}.title`) }}
-							</el-tag>
-							<span v-if="scope.row.capabilities.length === 0">{{ t('mcpModule.clients.none') }}</span>
-						</div>
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('mcpModule.clients.columns.expires')"
-					width="180"
-				>
-					<template #default="scope">
-						{{ formatNullableDate(scope.row.credentialExpiresAt) }}
-					</template>
-				</el-table-column>
-				<el-table-column
-					:label="t('mcpModule.clients.columns.lastUsed')"
-					width="180"
-				>
-					<template #default="scope">
-						{{ formatNullableDate(scope.row.lastUsedAt) }}
-					</template>
-				</el-table-column>
-				<el-table-column
-					fixed="right"
-					:label="t('mcpModule.clients.columns.actions')"
-					:width="320"
-					align="right"
-				>
-					<template #default="scope">
-						<mcp-client-actions
-							:client="scope.row"
-							@edit="openEdit"
-							@rotate="openRotate"
-							@revoke="confirmRevoke"
-							@delete="confirmDelete"
-						/>
-					</template>
-				</el-table-column>
-				<template #empty>
-					{{ t('mcpModule.clients.empty') }}
-				</template>
-			</el-table>
-		</div>
-
-		<div
-			v-loading="loading"
-			class="mcp-client-cards"
-		>
-			<el-card
-				v-for="cardClient in clients"
-				:key="cardClient.id"
-				shadow="never"
-			>
-				<div class="flex justify-between gap-2 mb-2">
-					<div>
-						<div class="font-600">{{ cardClient.name }}</div>
-						<div class="text-sm text-gray-500">{{ cardClient.description || t('mcpModule.clients.noDescription') }}</div>
-					</div>
-					<el-tag :type="status(cardClient).type">{{ t(`mcpModule.status.${status(cardClient).key}`) }}</el-tag>
-				</div>
-				<div class="flex flex-wrap gap-1 mb-3">
-					<el-tag
-						v-for="capability in cardClient.capabilities"
-						:key="capability"
-						type="info"
-					>
-						{{ t(`mcpModule.capabilities.${capability}.title`) }}
-					</el-tag>
-				</div>
-				<div class="text-sm mb-1">{{ t('mcpModule.clients.columns.expires') }}: {{ formatNullableDate(cardClient.credentialExpiresAt) }}</div>
-				<div class="text-sm mb-3">{{ t('mcpModule.clients.columns.lastUsed') }}: {{ formatNullableDate(cardClient.lastUsedAt) }}</div>
-				<mcp-client-actions
-					:client="cardClient"
-					@edit="openEdit"
-					@rotate="openRotate"
-					@revoke="confirmRevoke"
-					@delete="confirmDelete"
-				/>
-			</el-card>
-			<div
-				v-if="!loading && clients.length === 0"
-				class="text-center text-gray-500 py-6"
-			>
-				{{ t('mcpModule.clients.empty') }}
-			</div>
-		</div>
+		<list-mcp-clients
+			v-model:sort-by="sortBy"
+			v-model:sort-dir="sortDir"
+			v-model:paginate-size="paginateSize"
+			v-model:paginate-page="paginatePage"
+			:items="clientsPaginated"
+			:total-rows="totalRows"
+			:loading="loading"
+			:filters-active="filtersActive"
+			@edit="openEdit"
+			@rotate="openRotate"
+			@revoke="confirmRevoke"
+			@delete="confirmDelete"
+			@reset-filters="resetFilter"
+		/>
 	</div>
 
 	<el-drawer
@@ -384,21 +275,18 @@ import {
 	ElMessageBox,
 	ElScrollbar,
 	ElSwitch,
-	ElTable,
-	ElTableColumn,
-	ElTag,
 	type FormInstance,
 	type FormRules,
-	vLoading,
 } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
 
 import { AppBar, AppBarButton, AppBarButtonAlign, AppBarHeading, ViewHeader, useBreakpoints, useFlashMessage } from '../../../common';
 import { useConfigModule } from '../../config/composables/useConfigModule';
-import McpClientActions from '../components/mcp-client-actions.vue';
+import ListMcpClients from '../components/list-mcp-clients.vue';
 import McpTokenDialog from '../components/mcp-token-dialog.vue';
 import { useMcpClients } from '../composables/useMcpClients';
+import { useMcpClientsDataSource } from '../composables/useMcpClientsDataSource';
 import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, MCP_MAX_TOKEN_EXPIRATION_DAYS, MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
 import { isCapabilitySubset, resolveMcpEndpoint } from '../mcp.utils';
 import type { IMcpClient } from '../schemas/client.types';
@@ -410,6 +298,7 @@ const { t } = useI18n();
 const flashMessage = useFlashMessage();
 const { isLGDevice } = useBreakpoints();
 const { clients, loading, error, fetchClients, createClient, updateClient, rotateClient, revokeClient, deleteClient } = useMcpClients();
+const { clientsPaginated, totalRows, filtersActive, sortBy, sortDir, paginateSize, paginatePage, resetFilter } = useMcpClientsDataSource(clients);
 const { configModule, fetchConfigModule } = useConfigModule({ type: MCP_MODULE_NAME });
 
 const capabilityOptions = Object.values(McpCapability);
@@ -562,16 +451,6 @@ const confirmDelete = async (client: IMcpClient): Promise<void> => {
 	}
 };
 
-const status = (client: IMcpClient): { key: string; type: 'success' | 'warning' | 'danger' | 'info' } => {
-	if (client.credentialRevoked) return { key: 'revoked', type: 'danger' };
-	if (client.credentialExpiresAt && new Date(client.credentialExpiresAt).getTime() <= Date.now()) return { key: 'expired', type: 'danger' };
-	if (!client.enabled) return { key: 'disabled', type: 'warning' };
-	return { key: 'active', type: 'success' };
-};
-
-const formatNullableDate = (value: string | null): string =>
-	value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)) : t('mcpModule.clients.never');
-
 const copyEndpoint = async (): Promise<void> => {
 	try {
 		await navigator.clipboard.writeText(endpointUrl);
@@ -594,33 +473,12 @@ onMounted(async (): Promise<void> => {
 	gap: 16px;
 	margin: 16px;
 	min-width: 0;
-}
-
-.mcp-client-table-wrap {
-	overflow-x: auto;
-}
-
-.mcp-client-table {
-	min-width: 1050px;
-}
-
-.mcp-client-cards {
-	display: none;
-	flex-direction: column;
-	gap: 12px;
+	overflow: hidden;
 }
 
 @media (max-width: 767px) {
 	.mcp-clients-page {
 		margin: 8px;
-	}
-
-	.mcp-client-table-wrap {
-		display: none;
-	}
-
-	.mcp-client-cards {
-		display: flex;
 	}
 }
 </style>


### PR DESCRIPTION
## Problem

The MCP clients page did not follow the list-view structure the rest of the admin shares. Reported as:

> the table design is different than for example devices, missing row icon, row checkbox, table border, table sorting, bulk actions, label for column actions should not be there. and also whole filter/search system/component is missing. The views must follow the rules of other views

It rendered a hand-rolled `el-table` next to a duplicate card layout for small screens, with no sorting, no selection, no pagination and no card around the table.

## Change

Rebuilt on the same pieces the devices module uses:

| Piece | Added |
|---|---|
| `useMcpClientsDataSource` | filtering, sorting and pagination over the shared `useListQuery` |
| `mcp-clients-table.vue` | selection column, row icon, sortable columns, loading / empty / no-match states |
| `list-mcp-clients.vue` | card around the table plus its pager, with the table-height observer |

Also: the actions column header label is gone, matching the other tables, and the status derivation moved into `resolveMcpClientStatus` so the status column and the status filter cannot disagree.

## Notes on two decisions

**The data source takes the client list as an argument** rather than calling `useMcpClients()` itself. Clients live in a `ref` owned by that composable rather than in a Pinia store, so calling it a second time would produce a second, unsynchronised list — unlike the devices data source, which can safely reach for its store.

**The separate mobile card layout is removed.** The devices table hides lower-priority columns below `md` instead of maintaining a second layout, so conforming means dropping the cards rather than keeping both. The table hides `expires` and `lastUsed`, and the selection column, on small viewports.

## Tests

- New data-source spec, 11 cases: search, each status, capability filter, `filtersActive`, pagination, case-insensitive name sort, and null-expiry ordering.
- Verified the spec is not vacuous by mutating the implementation: breaking null-expiry sorting fails 1 test, removing the status filter fails 4.
- View spec updated for the new structure — the layout assertion now checks the shared list component, and the revoke-confirmation test drives the event from it.

- Admin suite: 1953 passed
- `vue-tsc` type-check clean
- eslint clean; prettier clean on all touched files

## Still to come

Filters/search and bulk actions build directly on this and follow in the next PR. The selection column is wired and already emits `selected-changes`, so the bulk-action bar has something to bind to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)