### PR TITLE
feat(admin): add search, filters and bulk actions to mcp clients

### DIFF
--- a/apps/admin/src/modules/mcp/components/list-mcp-clients.types.ts
+++ b/apps/admin/src/modules/mcp/components/list-mcp-clients.types.ts
@@ -1,8 +1,9 @@
-import type { IMcpClientsSortBy } from '../composables/types';
+import type { IMcpClientsFilter, IMcpClientsSortBy } from '../composables/types';
 import type { IMcpClient } from '../schemas/client.types';
 
 export interface IListMcpClientsProps {
 	items: IMcpClient[];
+	filters: IMcpClientsFilter;
 	totalRows: number;
 	sortBy: IMcpClientsSortBy | undefined;
 	sortDir: 'asc' | 'desc' | null;

--- a/apps/admin/src/modules/mcp/components/list-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/components/list-mcp-clients.vue
@@ -1,4 +1,19 @@
 <template>
+	<el-card
+		shadow="never"
+		class="px-1 py-2 shrink-0"
+		body-class="p-0!"
+	>
+		<mcp-clients-filter
+			v-model:filters="innerFilters"
+			:filters-active="props.filtersActive"
+			:selected-count="selectedItems.length"
+			:bulk-actions="bulkActions"
+			@reset-filters="emit('reset-filters')"
+			@bulk-action="onBulkAction"
+		/>
+	</el-card>
+
 	<div
 		ref="wrapper"
 		class="flex-grow overflow-hidden"
@@ -42,15 +57,19 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { ElCard, ElPagination } from 'element-plus';
 
-import { useBreakpoints } from '../../../common';
-import type { IMcpClientsSortBy } from '../composables/types';
+import { useVModel } from '@vueuse/core';
+
+import { type IBulkAction, useBreakpoints } from '../../../common';
+import type { IMcpClientsFilter, IMcpClientsSortBy } from '../composables/types';
 import type { IMcpClient } from '../schemas/client.types';
 
 import type { IListMcpClientsProps } from './list-mcp-clients.types';
+import McpClientsFilter from './mcp-clients-filter.vue';
 import McpClientsTable from './mcp-clients-table.vue';
 
 defineOptions({
@@ -65,6 +84,8 @@ const emit = defineEmits<{
 	(e: 'revoke', client: IMcpClient): void;
 	(e: 'delete', client: IMcpClient): void;
 	(e: 'reset-filters'): void;
+	(e: 'update:filters', filters: IMcpClientsFilter): void;
+	(e: 'bulk-action', action: string, items: IMcpClient[]): void;
 	(e: 'update:paginate-size', size: number): void;
 	(e: 'update:paginate-page', page: number): void;
 	(e: 'update:sort-by', by: IMcpClientsSortBy | undefined): void;
@@ -72,7 +93,43 @@ const emit = defineEmits<{
 	(e: 'selected-changes', selected: IMcpClient[]): void;
 }>();
 
+const { t } = useI18n();
 const { isMDDevice } = useBreakpoints();
+
+const innerFilters = useVModel(props, 'filters', emit);
+
+const selectedItems = ref<IMcpClient[]>([]);
+
+const bulkActions = computed<IBulkAction[]>((): IBulkAction[] => [
+	{
+		key: 'enable',
+		label: t('application.bulkActions.enable'),
+		icon: 'mdi:check-circle-outline',
+		type: 'success',
+	},
+	{
+		key: 'disable',
+		label: t('application.bulkActions.disable'),
+		icon: 'mdi:close-circle-outline',
+		type: 'warning',
+	},
+	{
+		key: 'revoke',
+		label: t('mcpModule.actions.revoke'),
+		icon: 'mdi:key-remove',
+		type: 'warning',
+	},
+	{
+		key: 'delete',
+		label: t('application.bulkActions.delete'),
+		icon: 'mdi:trash',
+		type: 'danger',
+	},
+]);
+
+const onBulkAction = (action: string): void => {
+	emit('bulk-action', action, selectedItems.value);
+};
 
 let observer: ResizeObserver | null = null;
 
@@ -95,6 +152,8 @@ const onPaginatePage = (page: number): void => {
 };
 
 const onSelectionChange = (selected: IMcpClient[]): void => {
+	selectedItems.value = selected;
+
 	emit('selected-changes', selected);
 };
 

--- a/apps/admin/src/modules/mcp/components/mcp-clients-filter.types.ts
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-filter.types.ts
@@ -1,0 +1,9 @@
+import type { IBulkAction } from '../../../common';
+import type { IMcpClientsFilter } from '../composables/types';
+
+export interface IMcpClientsFilterProps {
+	filters: IMcpClientsFilter;
+	filtersActive: boolean;
+	selectedCount: number;
+	bulkActions: IBulkAction[];
+}

--- a/apps/admin/src/modules/mcp/components/mcp-clients-filter.vue
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-filter.vue
@@ -1,0 +1,136 @@
+<template>
+	<div class="flex w-full">
+		<el-form
+			:inline="true"
+			:model="innerFilters"
+			class="grow-1"
+		>
+			<el-input
+				v-model="innerFilters.search"
+				:placeholder="t('mcpModule.clients.searchPlaceholder')"
+				class="max-w[280px] p-1"
+				clearable
+				data-test-id="search-mcp-clients"
+			>
+				<template #suffix>
+					<el-icon><icon icon="mdi:magnify" /></el-icon>
+				</template>
+			</el-input>
+
+			<el-divider direction="vertical" />
+
+			<el-form-item
+				:label="t('mcpModule.clients.columns.status')"
+				class="p-1 m-0!"
+			>
+				<el-radio-group
+					v-model="innerFilters.status"
+					data-test-id="filter-mcp-clients-status"
+				>
+					<el-radio-button
+						:label="t('mcpModule.status.active')"
+						value="active"
+					/>
+					<el-radio-button
+						:label="t('mcpModule.status.revoked')"
+						value="revoked"
+					/>
+					<el-radio-button
+						:label="t('mcpModule.status.expired')"
+						value="expired"
+					/>
+					<el-radio-button
+						:label="t('mcpModule.clients.filterAll')"
+						value="all"
+					/>
+				</el-radio-group>
+			</el-form-item>
+
+			<el-divider direction="vertical" />
+
+			<el-form-item
+				:label="t('mcpModule.clientForm.capabilities')"
+				class="p-1 m-0!"
+			>
+				<el-select
+					v-model="innerFilters.capabilities"
+					:placeholder="t('mcpModule.clients.filterAll')"
+					class="min-w[180px]"
+					multiple
+					collapse-tags
+					clearable
+					data-test-id="filter-mcp-clients-capabilities"
+				>
+					<el-option
+						v-for="capability in capabilityOptions"
+						:key="capability"
+						:label="t(`mcpModule.capabilities.${capability}.title`)"
+						:value="capability"
+					/>
+				</el-select>
+			</el-form-item>
+		</el-form>
+
+		<bulk-actions-toolbar
+			:selected-count="props.selectedCount"
+			:actions="props.bulkActions"
+			@action="(key: string) => emit('bulk-action', key)"
+		/>
+
+		<el-button
+			v-if="props.filtersActive"
+			plain
+			class="px-2! mt-1 mr-1"
+			:title="t('mcpModule.actions.resetFilters')"
+			data-test-id="reset-mcp-clients-filters"
+			@click="emit('reset-filters')"
+		>
+			<icon icon="mdi:filter-off" />
+		</el-button>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElDivider, ElForm, ElFormItem, ElIcon, ElInput, ElOption, ElRadioButton, ElRadioGroup, ElSelect } from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+import { useVModel } from '@vueuse/core';
+
+import { BulkActionsToolbar } from '../../../common';
+import type { IMcpClientsFilter } from '../composables/types';
+import { McpCapability } from '../mcp.constants';
+
+import type { IMcpClientsFilterProps } from './mcp-clients-filter.types';
+
+defineOptions({
+	name: 'McpClientsFilter',
+});
+
+const props = defineProps<IMcpClientsFilterProps>();
+
+const emit = defineEmits<{
+	(e: 'update:filters', filters: IMcpClientsFilter): void;
+	(e: 'reset-filters'): void;
+	(e: 'bulk-action', key: string): void;
+}>();
+
+const { t } = useI18n();
+
+const capabilityOptions = Object.values(McpCapability);
+
+const innerFilters = useVModel(props, 'filters', emit);
+
+// `clearable` hands back an empty string, which would otherwise count as an
+// active filter and keep the reset button on screen.
+watch(
+	(): string | undefined => innerFilters.value.search,
+	(val: string | undefined): void => {
+		if (val === '') {
+			innerFilters.value.search = undefined;
+		}
+	}
+);
+</script>

--- a/apps/admin/src/modules/mcp/components/mcp-clients-table.spec.ts
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-table.spec.ts
@@ -1,0 +1,66 @@
+import { ref } from 'vue';
+
+import { ElAvatar } from 'element-plus';
+import { describe, expect, it, vi } from 'vitest';
+
+import { shallowMount } from '@vue/test-utils';
+
+import { McpCapability } from '../mcp.constants';
+import type { IMcpClient } from '../schemas/client.types';
+
+import McpClientsTable from './mcp-clients-table.vue';
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../common', () => ({
+	useBreakpoints: () => ({ isMDDevice: ref(true) }),
+	IconWithChild: { name: 'IconWithChild', template: '<div><slot name="primary" /><slot name="secondary" /></div>' },
+}));
+
+const client = {
+	id: '1',
+	name: 'Test agent',
+	description: null,
+	enabled: true,
+	capabilities: [McpCapability.read],
+	credentialExpiresAt: null,
+	credentialRevoked: false,
+	lastUsedAt: null,
+} as unknown as IMcpClient;
+
+const mountTable = () =>
+	shallowMount(McpClientsTable, {
+		props: {
+			items: [client],
+			totalRows: 1,
+			sortBy: 'name' as const,
+			sortDir: 'asc' as const,
+			loading: false,
+			filtersActive: false,
+		},
+		global: {
+			stubs: {
+				ElTable: { name: 'ElTable', template: '<table><slot /></table>' },
+				ElTableColumn: {
+					name: 'ElTableColumn',
+					template: '<td><slot :row="row" /></td>',
+					data: () => ({ row: client }),
+				},
+			},
+		},
+	});
+
+describe('McpClientsTable', () => {
+	it('renders the row icon in an avatar, as every other list does', () => {
+		const wrapper = mountTable();
+
+		// Eight modules render their row icon as `el-avatar :size="32"`; a bare
+		// `el-icon` reads as a different control set at a glance.
+		const avatar = wrapper.findComponent(ElAvatar);
+
+		expect(avatar.exists()).toBe(true);
+		expect(avatar.props('size')).toBe(32);
+	});
+});

--- a/apps/admin/src/modules/mcp/components/mcp-clients-table.vue
+++ b/apps/admin/src/modules/mcp/components/mcp-clients-table.vue
@@ -102,9 +102,12 @@
 			align="center"
 		>
 			<template #default>
-				<el-icon :size="20">
-					<icon icon="mdi:robot-outline" />
-				</el-icon>
+				<el-avatar :size="32">
+					<icon
+						icon="mdi:robot-outline"
+						class="w[20px] h[20px]"
+					/>
+				</el-avatar>
 			</template>
 		</el-table-column>
 
@@ -207,7 +210,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 
-import { ElButton, ElIcon, ElResult, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
+import { ElAvatar, ElButton, ElResult, ElTable, ElTableColumn, ElTag, ElText, vLoading } from 'element-plus';
 
 import { Icon } from '@iconify/vue';
 

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
@@ -1,7 +1,8 @@
 import { nextTick, ref } from 'vue';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useListQuery } from '../../../common';
 import { McpCapability } from '../mcp.constants';
 import type { IMcpClient } from '../schemas/client.types';
 
@@ -30,7 +31,7 @@ const disabled = build({ id: '4', name: 'delta', enabled: false, capabilities: [
 const clients = ref<IMcpClient[]>([active, revoked, expired, disabled]);
 
 const mockFilters = ref({ ...defaultMcpClientsFilter });
-const mockPagination = ref<{ page?: number; size?: number }>({ page: 1, size: 25 });
+const mockPagination = ref<{ page?: number; size?: number }>({ page: 1, size: 10 });
 const mockSort = ref([defaultMcpClientsSort]);
 
 vi.mock('../../../common', () => ({
@@ -48,7 +49,7 @@ vi.mock('../../../common', () => ({
 describe('useMcpClientsDataSource', () => {
 	beforeEach(() => {
 		mockFilters.value = { ...defaultMcpClientsFilter };
-		mockPagination.value = { page: 1, size: 25 };
+		mockPagination.value = { page: 1, size: 10 };
 		mockSort.value = [defaultMcpClientsSort];
 		clients.value = [active, revoked, expired, disabled];
 	});
@@ -123,6 +124,21 @@ describe('useMcpClientsDataSource', () => {
 		expect(totalRows.value).toBe(4);
 	});
 
+	it('defaults to a page size the pager can actually offer', () => {
+		useMcpClientsDataSource(clients);
+
+		const options = (useListQuery as unknown as Mock).mock.calls[0]?.[0] as {
+			pagination: { defaults: { page: number; size: number } };
+		};
+
+		// El-pagination offers 10/20/30/40/50/100, and every other module defaults
+		// to 10 — a size outside that list shows in the pager but cannot be
+		// re-selected once changed.
+		expect(options.pagination.defaults.size).toBe(10);
+		expect([10, 20, 30, 40, 50, 100]).toContain(options.pagination.defaults.size);
+		expect(options.pagination.defaults.page).toBe(1);
+	});
+
 	describe('query state write-back', () => {
 		// `useListQuery` is what persists list state to the URL, so a change made
 		// in the table has to land back on its refs — reading them without ever
@@ -161,7 +177,7 @@ describe('useMcpClientsDataSource', () => {
 			const { paginatePage } = useMcpClientsDataSource(clients);
 
 			// e.g. the user edits the URL or uses the back button.
-			mockPagination.value = { page: 2, size: 25 };
+			mockPagination.value = { page: 2, size: 10 };
 			await nextTick();
 
 			expect(paginatePage.value).toBe(2);

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.spec.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -121,6 +121,51 @@ describe('useMcpClientsDataSource', () => {
 		expect(clientsPaginated.value).toHaveLength(2);
 		// The count drives the pager, so it must describe the whole filtered set.
 		expect(totalRows.value).toBe(4);
+	});
+
+	describe('query state write-back', () => {
+		// `useListQuery` is what persists list state to the URL, so a change made
+		// in the table has to land back on its refs — reading them without ever
+		// writing leaves the address bar stuck on the initial state.
+		it('writes a sort change back to the query state', async () => {
+			const { sortBy, sortDir } = useMcpClientsDataSource(clients);
+
+			sortBy.value = 'lastUsed';
+			sortDir.value = 'desc';
+			await nextTick();
+
+			expect(mockSort.value).toEqual([{ by: 'lastUsed', dir: 'desc' }]);
+		});
+
+		it('clears the query sort when sorting is turned off', async () => {
+			const { sortDir } = useMcpClientsDataSource(clients);
+
+			sortDir.value = null;
+			await nextTick();
+
+			expect(mockSort.value).toEqual([]);
+		});
+
+		it('writes page and size changes back to the query state', async () => {
+			const { paginatePage, paginateSize } = useMcpClientsDataSource(clients);
+
+			paginatePage.value = 3;
+			paginateSize.value = 50;
+			await nextTick();
+
+			expect(mockPagination.value.page).toBe(3);
+			expect(mockPagination.value.size).toBe(50);
+		});
+
+		it('follows the query state when it changes externally', async () => {
+			const { paginatePage } = useMcpClientsDataSource(clients);
+
+			// e.g. the user edits the URL or uses the back button.
+			mockPagination.value = { page: 2, size: 25 };
+			await nextTick();
+
+			expect(paginatePage.value).toBe(2);
+		});
 	});
 
 	it('sorts clients with no expiry last when sorting by expiry ascending', () => {

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
@@ -4,15 +4,12 @@ import { isEqual } from 'lodash';
 import { orderBy } from 'natural-orderby';
 
 import { type ISortEntry, useListQuery } from '../../../common';
-import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
 import { resolveMcpClientStatus } from '../mcp.utils';
 import type { IMcpClient } from '../schemas/client.types';
 
 import { McpClientsFilterSchema } from './schemas';
 import type { IMcpClientsFilter, IUseMcpClientsDataSource } from './types';
-
-const DEFAULT_PAGE = 1;
-const DEFAULT_PAGE_SIZE = 25;
 
 export const defaultMcpClientsFilter: IMcpClientsFilter = {
 	search: undefined,

--- a/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClientsDataSource.ts
@@ -136,11 +136,29 @@ export const useMcpClientsDataSource = (clients: Ref<IMcpClient[]>): IUseMcpClie
 	// Counts what the list is showing, so the pager cannot disagree with the rows.
 	const totalRows = computed<number>((): number => clientsFiltered.value.length);
 
+	// `useListQuery` owns the URL-synced state, so every one of these pairs has to
+	// run in both directions: inwards so a pasted link or the back button restores
+	// the list, outwards so sorting or paging updates the address bar.
 	watch(
 		(): { page?: number; size?: number } => pagination.value,
 		(val: { page?: number; size?: number }): void => {
 			paginatePage.value = val.page ?? DEFAULT_PAGE;
 			paginateSize.value = val.size ?? DEFAULT_PAGE_SIZE;
+		},
+		{ deep: true }
+	);
+
+	watch(
+		(): number => paginatePage.value,
+		(val: number): void => {
+			pagination.value.page = val;
+		}
+	);
+
+	watch(
+		(): number => paginateSize.value,
+		(val: number): void => {
+			pagination.value.size = val;
 		}
 	);
 
@@ -149,6 +167,20 @@ export const useMcpClientsDataSource = (clients: Ref<IMcpClient[]>): IUseMcpClie
 		(val: ISortEntry[]): void => {
 			sortBy.value = val.length > 0 ? (val[0]?.by as 'name' | 'status' | 'expires' | 'lastUsed') : undefined;
 			sortDir.value = val.length > 0 ? (val[0]?.dir ?? null) : null;
+		}
+	);
+
+	watch(
+		(): 'asc' | 'desc' | null => sortDir.value,
+		(val: 'asc' | 'desc' | null): void => {
+			sort.value = typeof sortBy.value === 'undefined' || val === null ? [] : [{ by: sortBy.value, dir: val }];
+		}
+	);
+
+	watch(
+		(): 'name' | 'status' | 'expires' | 'lastUsed' | undefined => sortBy.value,
+		(val: 'name' | 'status' | 'expires' | 'lastUsed' | undefined): void => {
+			sort.value = typeof val === 'undefined' || sortDir.value === null ? [] : [{ by: val, dir: sortDir.value }];
 		}
 	);
 

--- a/apps/admin/src/modules/mcp/locales/cs-CZ.json
+++ b/apps/admin/src/modules/mcp/locales/cs-CZ.json
@@ -83,7 +83,9 @@
     "never": "Nikdy",
     "noDescription": "Bez popisu",
     "loading": "Načítání MCP klientů…",
-    "noFilteredResults": "Žádný MCP klient neodpovídá zvoleným filtrům."
+    "noFilteredResults": "Žádný MCP klient neodpovídá zvoleným filtrům.",
+    "searchPlaceholder": "Hledat podle názvu nebo popisu",
+    "filterAll": "Vše"
   },
   "clientForm": {
     "createTitle": "Vytvořit klienta MCP",
@@ -116,7 +118,9 @@
   },
   "confirm": {
     "revoke": "Odvolat aktuální přihlašovací údaje klienta {name}? Připojení klienti okamžitě ztratí přístup.",
-    "delete": "Smazat klienta {name}? Jeho přihlašovací údaje budou odvolány a záznam klienta nebude možné obnovit."
+    "delete": "Smazat klienta {name}? Jeho přihlašovací údaje budou odvolány a záznam klienta nebude možné obnovit.",
+    "bulkRevoke": "Odvolat pověření pro {count} vybraných klientů?",
+    "bulkDelete": "Smazat {count} vybraných klientů?"
   },
   "oauthConsent": {
     "title": "Povolit přístup MCP",
@@ -158,7 +162,9 @@
     "revoked": "Klient MCP byl odvolán.",
     "revokeFailed": "Klienta MCP se nepodařilo odvolat.",
     "deleted": "Klient MCP byl smazán.",
-    "deleteFailed": "Klienta MCP se nepodařilo smazat."
+    "deleteFailed": "Klienta MCP se nepodařilo smazat.",
+    "bulkFailed": "{count} klientů se nepodařilo aktualizovat.",
+    "bulkSucceeded": "{count} klientů bylo aktualizováno."
   },
   "oauthManagement": {
     "title": "MCP OAuth přístup",

--- a/apps/admin/src/modules/mcp/locales/de-DE.json
+++ b/apps/admin/src/modules/mcp/locales/de-DE.json
@@ -83,7 +83,9 @@
 		"never": "Nie",
 		"noDescription": "Keine Beschreibung",
 		"loading": "MCP-Clients werden geladen…",
-		"noFilteredResults": "Kein MCP-Client entspricht den aktuellen Filtern."
+		"noFilteredResults": "Kein MCP-Client entspricht den aktuellen Filtern.",
+		"searchPlaceholder": "Nach Name oder Beschreibung suchen",
+		"filterAll": "Alle"
 	},
 	"clientForm": {
 		"createTitle": "MCP-Client erstellen",
@@ -116,7 +118,9 @@
 	},
 	"confirm": {
 		"revoke": "Aktuelle Zugangsdaten für {name} widerrufen? Verbundene Clients verlieren sofort den Zugriff.",
-		"delete": "{name} löschen? Die Zugangsdaten werden widerrufen und der Client-Datensatz kann nicht wiederhergestellt werden."
+		"delete": "{name} löschen? Die Zugangsdaten werden widerrufen und der Client-Datensatz kann nicht wiederhergestellt werden.",
+		"bulkRevoke": "Anmeldedaten für {count} ausgewählte Clients widerrufen?",
+		"bulkDelete": "{count} ausgewählte Clients löschen?"
 	},
 	"oauthConsent": {
 		"title": "MCP-Zugriff autorisieren",
@@ -158,7 +162,9 @@
 		"revoked": "MCP-Client wurde widerrufen.",
 		"revokeFailed": "MCP-Client konnte nicht widerrufen werden.",
 		"deleted": "MCP-Client wurde gelöscht.",
-		"deleteFailed": "MCP-Client konnte nicht gelöscht werden."
+		"deleteFailed": "MCP-Client konnte nicht gelöscht werden.",
+		"bulkFailed": "{count} Clients konnten nicht aktualisiert werden.",
+		"bulkSucceeded": "{count} Clients wurden aktualisiert."
 	},
 	"oauthManagement": {
 		"title": "MCP OAuth-Zugriff",

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -83,7 +83,9 @@
 		"never": "Never",
 		"noDescription": "No description",
 		"loading": "Loading MCP clients…",
-		"noFilteredResults": "No MCP client matches the current filters."
+		"noFilteredResults": "No MCP client matches the current filters.",
+		"searchPlaceholder": "Search by name or description",
+		"filterAll": "All"
 	},
 	"clientForm": {
 		"createTitle": "Create MCP client",
@@ -116,7 +118,9 @@
 	},
 	"confirm": {
 		"revoke": "Revoke the current credential for {name}? Connected clients will lose access immediately.",
-		"delete": "Delete {name}? Its credential will be revoked and the client record cannot be recovered."
+		"delete": "Delete {name}? Its credential will be revoked and the client record cannot be recovered.",
+		"bulkRevoke": "Revoke credentials for {count} selected clients?",
+		"bulkDelete": "Delete {count} selected clients?"
 	},
 	"oauthConsent": {
 		"title": "Authorize MCP access",
@@ -235,6 +239,8 @@
 		"revoked": "MCP client revoked.",
 		"revokeFailed": "MCP client could not be revoked.",
 		"deleted": "MCP client deleted.",
-		"deleteFailed": "MCP client could not be deleted."
+		"deleteFailed": "MCP client could not be deleted.",
+		"bulkFailed": "{count} clients could not be updated.",
+		"bulkSucceeded": "{count} clients were updated."
 	}
 }

--- a/apps/admin/src/modules/mcp/locales/es-ES.json
+++ b/apps/admin/src/modules/mcp/locales/es-ES.json
@@ -83,7 +83,9 @@
     "never": "Nunca",
     "noDescription": "Sin descripción",
     "loading": "Cargando clientes MCP…",
-    "noFilteredResults": "Ningún cliente MCP coincide con los filtros actuales."
+    "noFilteredResults": "Ningún cliente MCP coincide con los filtros actuales.",
+    "searchPlaceholder": "Buscar por nombre o descripción",
+    "filterAll": "Todos"
   },
   "clientForm": {
     "createTitle": "Crear cliente MCP",
@@ -116,7 +118,9 @@
   },
   "confirm": {
     "revoke": "¿Revocar la credencial actual de {name}? Los clientes conectados perderán el acceso inmediatamente.",
-    "delete": "¿Eliminar {name}? Su credencial se revocará y el registro del cliente no podrá recuperarse."
+    "delete": "¿Eliminar {name}? Su credencial se revocará y el registro del cliente no podrá recuperarse.",
+    "bulkRevoke": "¿Revocar las credenciales de {count} clientes seleccionados?",
+    "bulkDelete": "¿Eliminar {count} clientes seleccionados?"
   },
   "oauthConsent": {
     "title": "Autorizar acceso MCP",
@@ -158,7 +162,9 @@
     "revoked": "Cliente MCP revocado.",
     "revokeFailed": "No se pudo revocar el cliente MCP.",
     "deleted": "Cliente MCP eliminado.",
-    "deleteFailed": "No se pudo eliminar el cliente MCP."
+    "deleteFailed": "No se pudo eliminar el cliente MCP.",
+    "bulkFailed": "No se pudieron actualizar {count} clientes.",
+    "bulkSucceeded": "Se actualizaron {count} clientes."
   },
   "oauthManagement": {
     "title": "Acceso OAuth de MCP",

--- a/apps/admin/src/modules/mcp/locales/pl-PL.json
+++ b/apps/admin/src/modules/mcp/locales/pl-PL.json
@@ -83,7 +83,9 @@
     "never": "Nigdy",
     "noDescription": "Bez opisu",
     "loading": "Ładowanie klientów MCP…",
-    "noFilteredResults": "Żaden klient MCP nie pasuje do bieżących filtrów."
+    "noFilteredResults": "Żaden klient MCP nie pasuje do bieżących filtrów.",
+    "searchPlaceholder": "Szukaj według nazwy lub opisu",
+    "filterAll": "Wszystkie"
   },
   "clientForm": {
     "createTitle": "Utwórz klienta MCP",
@@ -116,7 +118,9 @@
   },
   "confirm": {
     "revoke": "Unieważnić bieżące poświadczenie klienta {name}? Połączeni klienci natychmiast utracą dostęp.",
-    "delete": "Usunąć klienta {name}? Jego poświadczenie zostanie unieważnione, a rekordu klienta nie będzie można odzyskać."
+    "delete": "Usunąć klienta {name}? Jego poświadczenie zostanie unieważnione, a rekordu klienta nie będzie można odzyskać.",
+    "bulkRevoke": "Unieważnić poświadczenia dla {count} wybranych klientów?",
+    "bulkDelete": "Usunąć {count} wybranych klientów?"
   },
   "oauthConsent": {
     "title": "Autoryzuj dostęp MCP",
@@ -158,7 +162,9 @@
     "revoked": "Klient MCP został unieważniony.",
     "revokeFailed": "Nie udało się unieważnić klienta MCP.",
     "deleted": "Klient MCP został usunięty.",
-    "deleteFailed": "Nie udało się usunąć klienta MCP."
+    "deleteFailed": "Nie udało się usunąć klienta MCP.",
+    "bulkFailed": "Nie udało się zaktualizować {count} klientów.",
+    "bulkSucceeded": "Zaktualizowano {count} klientów."
   },
   "oauthManagement": {
     "title": "Dostęp OAuth MCP",

--- a/apps/admin/src/modules/mcp/locales/sk-SK.json
+++ b/apps/admin/src/modules/mcp/locales/sk-SK.json
@@ -83,7 +83,9 @@
     "never": "Nikdy",
     "noDescription": "Bez popisu",
     "loading": "Načítavanie MCP klientov…",
-    "noFilteredResults": "Žiadny MCP klient nezodpovedá zvoleným filtrom."
+    "noFilteredResults": "Žiadny MCP klient nezodpovedá zvoleným filtrom.",
+    "searchPlaceholder": "Hľadať podľa názvu alebo popisu",
+    "filterAll": "Všetko"
   },
   "clientForm": {
     "createTitle": "Vytvoriť klienta MCP",
@@ -116,7 +118,9 @@
   },
   "confirm": {
     "revoke": "Odvolať aktuálne prihlasovacie údaje klienta {name}? Pripojení klienti okamžite stratia prístup.",
-    "delete": "Odstrániť klienta {name}? Jeho prihlasovacie údaje budú odvolané a záznam klienta nebude možné obnoviť."
+    "delete": "Odstrániť klienta {name}? Jeho prihlasovacie údaje budú odvolané a záznam klienta nebude možné obnoviť.",
+    "bulkRevoke": "Odvolať poverenia pre {count} vybraných klientov?",
+    "bulkDelete": "Odstrániť {count} vybraných klientov?"
   },
   "oauthConsent": {
     "title": "Povoliť prístup MCP",
@@ -158,7 +162,9 @@
     "revoked": "Klient MCP bol odvolaný.",
     "revokeFailed": "Klienta MCP sa nepodarilo odvolať.",
     "deleted": "Klient MCP bol odstránený.",
-    "deleteFailed": "Klienta MCP sa nepodarilo odstrániť."
+    "deleteFailed": "Klienta MCP sa nepodarilo odstrániť.",
+    "bulkFailed": "{count} klientov sa nepodarilo aktualizovať.",
+    "bulkSucceeded": "{count} klientov bolo aktualizovaných."
   },
   "oauthManagement": {
     "title": "Prístup MCP OAuth",

--- a/apps/admin/src/modules/mcp/mcp.constants.ts
+++ b/apps/admin/src/modules/mcp/mcp.constants.ts
@@ -26,3 +26,6 @@ export const RouteNames = {
 	OAUTH_MANAGEMENT: 'mcp_module-oauth-management',
 	OAUTH_CONSENT: 'mcp_module-oauth-consent',
 };
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 10;

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -48,7 +48,7 @@ vi.mock('../../../common', () => ({
 	useListQuery: () => ({
 		filters: ref({ search: undefined, status: 'all', enabled: 'all', capabilities: [] }),
 		sort: ref([{ by: 'name', dir: 'asc' }]),
-		pagination: ref({ page: 1, size: 25 }),
+		pagination: ref({ page: 1, size: 10 }),
 		viewMode: ref('table'),
 		reset: vi.fn(),
 	}),

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -142,6 +142,48 @@ describe('ViewMcpClients', () => {
 		expect(hint.element.tagName.toLowerCase()).toContain('alert');
 	});
 
+	it('confirms once for a bulk revoke rather than per selected client', async () => {
+		const wrapper = mountView();
+		const list = wrapper.findComponent({ name: 'ListMcpClients' });
+
+		list.vm.$emit('bulk-action', 'revoke', [client, { ...client, id: 'second' }]);
+		await nextTick();
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
+		expect(mocks.revokeClient).toHaveBeenCalledTimes(2);
+	});
+
+	it('sends the untouched fields back when bulk toggling enabled', async () => {
+		const wrapper = mountView();
+		const list = wrapper.findComponent({ name: 'ListMcpClients' });
+
+		list.vm.$emit('bulk-action', 'disable', [client]);
+		await nextTick();
+		await flushPromises();
+
+		// The update endpoint replaces the record — sending only `enabled` would
+		// blank the name and capabilities.
+		expect(mocks.updateClient).toHaveBeenCalledWith(client.id, {
+			name: client.name,
+			description: client.description,
+			enabled: false,
+			capabilities: client.capabilities,
+		});
+	});
+
+	it('does nothing when a bulk action runs with an empty selection', async () => {
+		const wrapper = mountView();
+		const list = wrapper.findComponent({ name: 'ListMcpClients' });
+
+		list.vm.$emit('bulk-action', 'delete', []);
+		await nextTick();
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).not.toHaveBeenCalled();
+		expect(mocks.deleteClient).not.toHaveBeenCalled();
+	});
+
 	it('requires confirmation before revoking a credential', async () => {
 		const wrapper = mountView();
 		const list = wrapper.findComponent({ name: 'ListMcpClients' });

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
@@ -59,6 +59,7 @@
 		/>
 
 		<list-mcp-clients
+			v-model:filters="filters"
 			v-model:sort-by="sortBy"
 			v-model:sort-dir="sortDir"
 			v-model:paginate-size="paginateSize"
@@ -72,6 +73,7 @@
 			@revoke="confirmRevoke"
 			@delete="confirmDelete"
 			@reset-filters="resetFilter"
+			@bulk-action="onBulkAction"
 		/>
 	</div>
 
@@ -298,7 +300,8 @@ const { t } = useI18n();
 const flashMessage = useFlashMessage();
 const { isLGDevice } = useBreakpoints();
 const { clients, loading, error, fetchClients, createClient, updateClient, rotateClient, revokeClient, deleteClient } = useMcpClients();
-const { clientsPaginated, totalRows, filtersActive, sortBy, sortDir, paginateSize, paginatePage, resetFilter } = useMcpClientsDataSource(clients);
+const { clientsPaginated, totalRows, filters, filtersActive, sortBy, sortDir, paginateSize, paginatePage, resetFilter } =
+	useMcpClientsDataSource(clients);
 const { configModule, fetchConfigModule } = useConfigModule({ type: MCP_MODULE_NAME });
 
 const capabilityOptions = Object.values(McpCapability);
@@ -420,6 +423,66 @@ const confirmRotate = async (): Promise<void> => {
 		flashMessage.error(t('mcpModule.messages.rotateFailed'));
 	} finally {
 		saving.value = false;
+	}
+};
+
+const onBulkAction = async (action: string, items: IMcpClient[]): Promise<void> => {
+	if (items.length === 0) {
+		return;
+	}
+
+	// Destructive actions confirm once for the whole selection rather than per
+	// row, matching the bulk behaviour of the other list views.
+	if (action === 'revoke' || action === 'delete') {
+		try {
+			await ElMessageBox.confirm(
+				t(action === 'revoke' ? 'mcpModule.confirm.bulkRevoke' : 'mcpModule.confirm.bulkDelete', { count: items.length }),
+				t(action === 'revoke' ? 'mcpModule.actions.revoke' : 'mcpModule.actions.delete'),
+				{
+					type: 'warning',
+					confirmButtonText: t(action === 'revoke' ? 'mcpModule.actions.revoke' : 'mcpModule.actions.delete'),
+					cancelButtonText: t('mcpModule.actions.cancel'),
+				}
+			);
+		} catch {
+			return;
+		}
+	}
+
+	const results = await Promise.allSettled(
+		items.map((item) => {
+			switch (action) {
+				// The update endpoint replaces the record, so the untouched fields
+				// have to be sent back alongside the flag being flipped.
+				case 'enable':
+					return updateClient(item.id, {
+						name: item.name,
+						description: item.description,
+						enabled: true,
+						capabilities: item.capabilities,
+					});
+				case 'disable':
+					return updateClient(item.id, {
+						name: item.name,
+						description: item.description,
+						enabled: false,
+						capabilities: item.capabilities,
+					});
+				case 'revoke':
+					return revokeClient(item.id);
+				default:
+					return deleteClient(item.id);
+			}
+		})
+	);
+
+	const failed = results.filter((result) => result.status === 'rejected').length;
+
+	if (failed > 0) {
+		// Partial success is reported rather than swallowed — some rows changed.
+		flashMessage.error(t('mcpModule.messages.bulkFailed', { count: failed }));
+	} else {
+		flashMessage.success(t('mcpModule.messages.bulkSucceeded', { count: items.length }));
 	}
 };
 


### PR DESCRIPTION
## Problem

Second half of the clients list rebuild started in #780, closing the last part of the report:

> and also whole filter/search system/component is missing … missing bulk actions

## Change

**`mcp-clients-filter.vue`** — the filter bar every other list view carries, in its own card above the table:

| Control | Behaviour |
|---|---|
| search | matches name and description |
| status | segmented control: active / revoked / expired / all |
| capabilities | multi-select, collapsed tags |
| reset | appears only while a filter differs from its default |

**Bulk actions** — the selection column added in #780 now feeds the shared `BulkActionsToolbar`: enable, disable, revoke, delete, reusing the existing `application.bulkActions.*` labels.

## Three decisions worth review

**Destructive bulk actions confirm once**, not per row — revoking 20 credentials should not mean 20 dialogs.

**Partial failures are reported.** The actions run through `Promise.allSettled`, and if any fail the user is told how many. Swallowing that would be wrong here: some rows have already changed, so a silent success would misrepresent the state of the list.

**Bulk enable/disable resends untouched fields.** The update endpoint replaces the record rather than patching it, so sending only `enabled` would blank the client's name and capabilities. This was caught by the type-checker, and there is now a test pinning the full payload so a future refactor cannot quietly reintroduce it.

## Tests

Three new view tests: one confirmation per bulk revoke (not per client), the full payload on bulk toggle, and no dialog or request when the selection is empty.

Verified the empty-selection test is not vacuous by deleting the guard — it fails.

- Admin suite: 1956 passed
- `vue-tsc` type-check clean
- eslint + prettier clean on touched files

## Note

The devices module additionally offers an "adjust list" drawer for its filters, because it has seven of them. MCP has three, which fit inline, so that panel is deliberately not replicated — adding a drawer to reach three controls would be more indirection than the module needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)