### PR TITLE
fix(admin): align mcp client form with the shared form conventions

### DIFF
--- a/apps/admin/src/modules/mcp/locales/cs-CZ.json
+++ b/apps/admin/src/modules/mcp/locales/cs-CZ.json
@@ -15,7 +15,12 @@
     "addOrigin": "Přidat zdroj",
     "removeOrigin": "Odebrat zdroj",
     "copyEndpoint": "Kopírovat koncový bod",
-    "resetFilters": "Zrušit filtry"
+    "resetFilters": "Zrušit filtry",
+    "add": "Přidat",
+    "close": "Zavřít",
+    "discard": "Zahodit",
+    "yes": "Ano",
+    "no": "Ne"
   },
   "capabilities": {
     "read": {
@@ -120,7 +125,8 @@
     "revoke": "Odvolat aktuální přihlašovací údaje klienta {name}? Připojení klienti okamžitě ztratí přístup.",
     "delete": "Smazat klienta {name}? Jeho přihlašovací údaje budou odvolány a záznam klienta nebude možné obnovit.",
     "bulkRevoke": "Odvolat pověření pro {count} vybraných klientů?",
-    "bulkDelete": "Smazat {count} vybraných klientů?"
+    "bulkDelete": "Smazat {count} vybraných klientů?",
+    "discard": "Zahodit neuložené změny?"
   },
   "oauthConsent": {
     "title": "Povolit přístup MCP",
@@ -242,5 +248,8 @@
       "allRevoked": "Veškerý MCP OAuth přístup byl odvolán.",
       "revokeFailed": "Nepodařilo se odvolat OAuth autorizaci."
     }
+  },
+  "headings": {
+    "discard": "Zahodit změny"
   }
 }

--- a/apps/admin/src/modules/mcp/locales/de-DE.json
+++ b/apps/admin/src/modules/mcp/locales/de-DE.json
@@ -15,7 +15,12 @@
 		"addOrigin": "Origin hinzufügen",
 		"removeOrigin": "Origin entfernen",
 		"copyEndpoint": "Endpunkt kopieren",
-		"resetFilters": "Filter zurücksetzen"
+		"resetFilters": "Filter zurücksetzen",
+		"add": "Hinzufügen",
+		"close": "Schließen",
+		"discard": "Verwerfen",
+		"yes": "Ja",
+		"no": "Nein"
 	},
 	"capabilities": {
 		"read": {
@@ -120,7 +125,8 @@
 		"revoke": "Aktuelle Zugangsdaten für {name} widerrufen? Verbundene Clients verlieren sofort den Zugriff.",
 		"delete": "{name} löschen? Die Zugangsdaten werden widerrufen und der Client-Datensatz kann nicht wiederhergestellt werden.",
 		"bulkRevoke": "Anmeldedaten für {count} ausgewählte Clients widerrufen?",
-		"bulkDelete": "{count} ausgewählte Clients löschen?"
+		"bulkDelete": "{count} ausgewählte Clients löschen?",
+		"discard": "Nicht gespeicherte Änderungen verwerfen?"
 	},
 	"oauthConsent": {
 		"title": "MCP-Zugriff autorisieren",
@@ -242,5 +248,8 @@
 			"allRevoked": "Gesamter MCP-OAuth-Zugriff widerrufen.",
 			"revokeFailed": "OAuth-Autorisierung konnte nicht widerrufen werden."
 		}
+	},
+	"headings": {
+		"discard": "Änderungen verwerfen"
 	}
 }

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -15,7 +15,12 @@
 		"addOrigin": "Add origin",
 		"removeOrigin": "Remove origin",
 		"copyEndpoint": "Copy endpoint",
-		"resetFilters": "Reset filters"
+		"resetFilters": "Reset filters",
+		"add": "Add",
+		"close": "Close",
+		"discard": "Discard",
+		"yes": "Yes",
+		"no": "No"
 	},
 	"capabilities": {
 		"read": {
@@ -120,7 +125,8 @@
 		"revoke": "Revoke the current credential for {name}? Connected clients will lose access immediately.",
 		"delete": "Delete {name}? Its credential will be revoked and the client record cannot be recovered.",
 		"bulkRevoke": "Revoke credentials for {count} selected clients?",
-		"bulkDelete": "Delete {count} selected clients?"
+		"bulkDelete": "Delete {count} selected clients?",
+		"discard": "Discard the unsaved changes?"
 	},
 	"oauthConsent": {
 		"title": "Authorize MCP access",
@@ -242,5 +248,8 @@
 		"deleteFailed": "MCP client could not be deleted.",
 		"bulkFailed": "{count} clients could not be updated.",
 		"bulkSucceeded": "{count} clients were updated."
+	},
+	"headings": {
+		"discard": "Discard changes"
 	}
 }

--- a/apps/admin/src/modules/mcp/locales/es-ES.json
+++ b/apps/admin/src/modules/mcp/locales/es-ES.json
@@ -15,7 +15,12 @@
     "addOrigin": "Añadir origen",
     "removeOrigin": "Eliminar origen",
     "copyEndpoint": "Copiar endpoint",
-    "resetFilters": "Restablecer filtros"
+    "resetFilters": "Restablecer filtros",
+    "add": "Añadir",
+    "close": "Cerrar",
+    "discard": "Descartar",
+    "yes": "Sí",
+    "no": "No"
   },
   "capabilities": {
     "read": {
@@ -120,7 +125,8 @@
     "revoke": "¿Revocar la credencial actual de {name}? Los clientes conectados perderán el acceso inmediatamente.",
     "delete": "¿Eliminar {name}? Su credencial se revocará y el registro del cliente no podrá recuperarse.",
     "bulkRevoke": "¿Revocar las credenciales de {count} clientes seleccionados?",
-    "bulkDelete": "¿Eliminar {count} clientes seleccionados?"
+    "bulkDelete": "¿Eliminar {count} clientes seleccionados?",
+    "discard": "¿Descartar los cambios sin guardar?"
   },
   "oauthConsent": {
     "title": "Autorizar acceso MCP",
@@ -242,5 +248,8 @@
       "allRevoked": "Todo el acceso OAuth de MCP revocado.",
       "revokeFailed": "No se pudo revocar la autorización OAuth."
     }
+  },
+  "headings": {
+    "discard": "Descartar cambios"
   }
 }

--- a/apps/admin/src/modules/mcp/locales/pl-PL.json
+++ b/apps/admin/src/modules/mcp/locales/pl-PL.json
@@ -15,7 +15,12 @@
     "addOrigin": "Dodaj źródło",
     "removeOrigin": "Usuń źródło",
     "copyEndpoint": "Kopiuj endpoint",
-    "resetFilters": "Resetuj filtry"
+    "resetFilters": "Resetuj filtry",
+    "add": "Dodaj",
+    "close": "Zamknij",
+    "discard": "Odrzuć",
+    "yes": "Tak",
+    "no": "Nie"
   },
   "capabilities": {
     "read": {
@@ -120,7 +125,8 @@
     "revoke": "Unieważnić bieżące poświadczenie klienta {name}? Połączeni klienci natychmiast utracą dostęp.",
     "delete": "Usunąć klienta {name}? Jego poświadczenie zostanie unieważnione, a rekordu klienta nie będzie można odzyskać.",
     "bulkRevoke": "Unieważnić poświadczenia dla {count} wybranych klientów?",
-    "bulkDelete": "Usunąć {count} wybranych klientów?"
+    "bulkDelete": "Usunąć {count} wybranych klientów?",
+    "discard": "Odrzucić niezapisane zmiany?"
   },
   "oauthConsent": {
     "title": "Autoryzuj dostęp MCP",
@@ -242,5 +248,8 @@
       "allRevoked": "Cofnięto cały dostęp OAuth MCP.",
       "revokeFailed": "Nie można było cofnąć autoryzacji OAuth."
     }
+  },
+  "headings": {
+    "discard": "Odrzuć zmiany"
   }
 }

--- a/apps/admin/src/modules/mcp/locales/sk-SK.json
+++ b/apps/admin/src/modules/mcp/locales/sk-SK.json
@@ -15,7 +15,12 @@
     "addOrigin": "Pridať zdroj",
     "removeOrigin": "Odobrať zdroj",
     "copyEndpoint": "Kopírovať koncový bod",
-    "resetFilters": "Zrušiť filtre"
+    "resetFilters": "Zrušiť filtre",
+    "add": "Pridať",
+    "close": "Zavrieť",
+    "discard": "Zahodiť",
+    "yes": "Áno",
+    "no": "Nie"
   },
   "capabilities": {
     "read": {
@@ -120,7 +125,8 @@
     "revoke": "Odvolať aktuálne prihlasovacie údaje klienta {name}? Pripojení klienti okamžite stratia prístup.",
     "delete": "Odstrániť klienta {name}? Jeho prihlasovacie údaje budú odvolané a záznam klienta nebude možné obnoviť.",
     "bulkRevoke": "Odvolať poverenia pre {count} vybraných klientov?",
-    "bulkDelete": "Odstrániť {count} vybraných klientov?"
+    "bulkDelete": "Odstrániť {count} vybraných klientov?",
+    "discard": "Zahodiť neuložené zmeny?"
   },
   "oauthConsent": {
     "title": "Povoliť prístup MCP",
@@ -242,5 +248,8 @@
       "allRevoked": "Odobratý celý MCP OAuth prístup.",
       "revokeFailed": "Nepodarilo sa odobrať OAuth autorizáciu."
     }
+  },
+  "headings": {
+    "discard": "Zahodiť zmeny"
   }
 }

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -87,7 +87,25 @@ const mountView = () =>
 				// Render the drawer body so its contents can be asserted on.
 				ElDrawer: { name: 'ElDrawer', template: '<aside><slot /></aside>' },
 				ElScrollbar: { name: 'ElScrollbar', template: '<div><slot /></div>' },
-				ElForm: { name: 'ElForm', template: '<form><slot /></form>' },
+				// Rendered so button labels can be asserted on.
+				ElButton: {
+					name: 'ElButton',
+					props: { type: String, plain: Boolean, disabled: Boolean },
+					// `type` is deliberately not bound to the native attribute — doing so
+					// collides with the button's own `type` and reads back as "submit".
+					template: '<button :disabled="disabled"><slot name="icon" /><slot /></button>',
+				},
+				ElText: { name: 'ElText', template: '<span><slot /></span>' },
+				AppBar: { name: 'AppBar', template: '<div><slot name="heading" /><slot name="button-right" /></div>' },
+				AppBarHeading: { name: 'AppBarHeading', template: '<div><slot name="icon" /><slot name="title" /></div>' },
+				ElForm: {
+					name: 'ElForm',
+					template: '<form><slot /></form>',
+					methods: {
+						clearValidate: () => undefined,
+						validate: () => Promise.resolve(true),
+					},
+				},
 				ElFormItem: { name: 'ElFormItem', template: '<div><slot /></div>' },
 				// shallowMount would otherwise auto-stub this away and drop the
 				// header actions rendered into its `extra` slot.
@@ -117,11 +135,11 @@ describe('ViewMcpClients', () => {
 		// Every other list header in the admin uses `type="primary" plain`
 		// for its add action; MCP rendered a solid primary, which reads as a
 		// different control.
-		const create = wrapper.find('[data-test-id="create-mcp-client"]');
+		const create = wrapper.findAllComponents({ name: 'ElButton' }).find((candidate) => candidate.attributes('data-test-id') === 'create-mcp-client');
 
-		expect(create.exists()).toBe(true);
-		expect(create.attributes('type')).toBe('primary');
-		expect(create.attributes('plain')).toBeDefined();
+		expect(create).toBeDefined();
+		expect(create?.props('type')).toBe('primary');
+		expect(create?.props('plain')).toBe(true);
 	});
 
 	it('hosts the client form in a drawer rather than a dialog', () => {
@@ -182,6 +200,81 @@ describe('ViewMcpClients', () => {
 
 		expect(ElMessageBox.confirm).not.toHaveBeenCalled();
 		expect(mocks.deleteClient).not.toHaveBeenCalled();
+	});
+
+	it('labels the header action the way the other list headers do', () => {
+		const wrapper = mountView();
+
+		// Other modules label this "Add"; "Create client" was MCP-only phrasing.
+		expect(wrapper.find('[data-test-id="create-mcp-client"]').text()).toContain('mcpModule.actions.add');
+	});
+
+	it('renders the drawer heading through el-text so it picks up the bar styling', () => {
+		const wrapper = mountView();
+
+		// `.app-bar-heading__title > span` is what colours the heading; a bare
+		// text node in the title slot never matches it.
+		const heading = wrapper.findComponent({ name: 'AppBarHeading' });
+
+		expect(heading.exists()).toBe(true);
+		expect(heading.findComponent({ name: 'ElText' }).exists()).toBe(true);
+	});
+
+	it('keeps save disabled until the form changes', async () => {
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientFormChanged: boolean; clientForm: { name: string } };
+
+		vm.openCreate();
+		await nextTick();
+
+		expect(vm.clientFormChanged).toBe(false);
+
+		vm.clientForm.name = 'Something';
+		await nextTick();
+
+		expect(vm.clientFormChanged).toBe(true);
+	});
+
+	it('offers close on an untouched form and discard once it changed', async () => {
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string } };
+
+		vm.openCreate();
+		await nextTick();
+
+		expect(wrapper.find('[data-test-id="cancel-mcp-client-form"]').text()).toContain('mcpModule.actions.close');
+
+		vm.clientForm.name = 'Something';
+		await nextTick();
+
+		expect(wrapper.find('[data-test-id="cancel-mcp-client-form"]').text()).toContain('mcpModule.actions.discard');
+	});
+
+	it('asks to confirm before discarding a changed form', async () => {
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string }; onCancelClientForm: () => Promise<void> };
+
+		vm.openCreate();
+		vm.clientForm.name = 'Something';
+		await nextTick();
+
+		await vm.onCancelClientForm();
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
+	});
+
+	it('closes without confirming when nothing was edited', async () => {
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; onCancelClientForm: () => Promise<void> };
+
+		vm.openCreate();
+		await nextTick();
+
+		await vm.onCancelClientForm();
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).not.toHaveBeenCalled();
 	});
 
 	it('requires confirmation before revoking a credential', async () => {

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -85,7 +85,7 @@ const mountView = () =>
 			stubs: {
 				ElCard: { name: 'ElCard', template: '<section><slot name="header" /><slot /></section>' },
 				// Render the drawer body so its contents can be asserted on.
-				ElDrawer: { name: 'ElDrawer', template: '<aside><slot /></aside>' },
+				ElDrawer: { name: 'ElDrawer', props: ['beforeClose'], template: '<aside><slot /></aside>' },
 				ElScrollbar: { name: 'ElScrollbar', template: '<div><slot /></div>' },
 				// Rendered so button labels can be asserted on.
 				ElButton: {
@@ -118,7 +118,9 @@ describe('ViewMcpClients', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.spyOn(ElMessageBox, 'confirm');
-		(ElMessageBox.confirm as Mock).mockResolvedValue('confirm');
+		// `clearAllMocks` leaves any queued `…Once` implementation in place, which
+		// would leak a rejection into the next test.
+		(ElMessageBox.confirm as Mock).mockReset().mockResolvedValue('confirm');
 	});
 
 	it('renders the shared list component rather than a bespoke table', () => {
@@ -252,13 +254,13 @@ describe('ViewMcpClients', () => {
 
 	it('asks to confirm before discarding a changed form', async () => {
 		const wrapper = mountView();
-		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string }; onCancelClientForm: () => Promise<void> };
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string }; onCloseClientForm: () => Promise<void> };
 
 		vm.openCreate();
 		vm.clientForm.name = 'Something';
 		await nextTick();
 
-		await vm.onCancelClientForm();
+		await vm.onCloseClientForm();
 		await flushPromises();
 
 		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
@@ -266,15 +268,59 @@ describe('ViewMcpClients', () => {
 
 	it('closes without confirming when nothing was edited', async () => {
 		const wrapper = mountView();
-		const vm = wrapper.vm as unknown as { openCreate: () => void; onCancelClientForm: () => Promise<void> };
+		const vm = wrapper.vm as unknown as { openCreate: () => void; onCloseClientForm: () => Promise<void> };
 
 		vm.openCreate();
 		await nextTick();
 
-		await vm.onCancelClientForm();
+		await vm.onCloseClientForm();
 		await flushPromises();
 
 		expect(ElMessageBox.confirm).not.toHaveBeenCalled();
+	});
+
+	it('guards the drawer close event, not just the footer button', async () => {
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string } };
+
+		vm.openCreate();
+		vm.clientForm.name = 'Something';
+		await nextTick();
+
+		// Closing via the drawer itself — overlay click, escape, its own close
+		// button — must run the same guard as the footer action, otherwise the
+		// edits vanish without a word.
+		const drawer = wrapper.findComponent({ name: 'ElDrawer' });
+		const beforeClose = drawer.props('beforeClose') as (done: () => void) => Promise<void>;
+
+		expect(typeof beforeClose).toBe('function');
+
+		const done = vi.fn();
+		await beforeClose(done);
+		await flushPromises();
+
+		expect(ElMessageBox.confirm).toHaveBeenCalledOnce();
+		expect(done).toHaveBeenCalledOnce();
+	});
+
+	it('keeps the drawer open when the discard confirmation is dismissed', async () => {
+		(ElMessageBox.confirm as Mock).mockRejectedValueOnce('cancel');
+
+		const wrapper = mountView();
+		const vm = wrapper.vm as unknown as { openCreate: () => void; clientForm: { name: string } };
+
+		vm.openCreate();
+		vm.clientForm.name = 'Something';
+		await nextTick();
+
+		const drawer = wrapper.findComponent({ name: 'ElDrawer' });
+		const beforeClose = drawer.props('beforeClose') as (done: () => void) => Promise<void>;
+
+		const done = vi.fn();
+		await beforeClose(done);
+		await flushPromises();
+
+		expect(done).not.toHaveBeenCalled();
 	});
 
 	it('requires confirmation before revoking a credential', async () => {

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
@@ -82,6 +82,7 @@
 		:show-close="false"
 		:with-header="false"
 		:size="isLGDevice ? '40%' : '100%'"
+		:before-close="onCloseClientForm"
 		data-test-id="mcp-client-form-drawer"
 		@closed="resetClientForm"
 	>
@@ -105,7 +106,7 @@
 					<app-bar-button
 						:align="AppBarButtonAlign.RIGHT"
 						class="mr-2"
-						@click="showClientDialog = false"
+						@click="() => onCloseClientForm()"
 					>
 						<template #icon>
 							<el-icon>
@@ -202,7 +203,7 @@
 						link
 						class="mr-2"
 						data-test-id="cancel-mcp-client-form"
-						@click="onCancelClientForm"
+						@click="() => onCloseClientForm()"
 					>
 						{{ clientFormChanged ? t('mcpModule.actions.discard') : t('mcpModule.actions.close') }}
 					</el-button>
@@ -366,7 +367,15 @@ const resetClientForm = (): void => {
 	initialClientForm.value = snapshotClientForm();
 };
 
-const onCancelClientForm = async (): Promise<void> => {
+/**
+ * Guards every route out of the drawer — the footer action, the close button in
+ * its bar, and the drawer's own `before-close` (overlay click and escape). All
+ * three have to run the same check, or the edits disappear without a word.
+ *
+ * `done` is supplied only by `before-close`; withholding it leaves the drawer
+ * open when the confirmation is dismissed.
+ */
+const onCloseClientForm = async (done?: () => void): Promise<void> => {
 	if (clientFormChanged.value) {
 		try {
 			await ElMessageBox.confirm(t('mcpModule.confirm.discard'), t('mcpModule.headings.discard'), {
@@ -380,6 +389,8 @@ const onCancelClientForm = async (): Promise<void> => {
 	}
 
 	showClientDialog.value = false;
+
+	done?.();
 };
 
 const openCreate = (): void => {

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.vue
@@ -16,7 +16,7 @@
 					<icon icon="mdi:plus" />
 				</template>
 
-				{{ t('mcpModule.actions.create') }}
+				{{ t('mcpModule.actions.add') }}
 			</el-button>
 		</template>
 	</view-header>
@@ -94,7 +94,9 @@
 						</template>
 
 						<template #title>
-							{{ editingClient ? t('mcpModule.clientForm.editTitle') : t('mcpModule.clientForm.createTitle') }}
+							<el-text truncated>
+								{{ editingClient ? t('mcpModule.clientForm.editTitle') : t('mcpModule.clientForm.createTitle') }}
+							</el-text>
 						</template>
 					</app-bar-heading>
 				</template>
@@ -199,17 +201,20 @@
 					<el-button
 						link
 						class="mr-2"
-						@click="showClientDialog = false"
+						data-test-id="cancel-mcp-client-form"
+						@click="onCancelClientForm"
 					>
-						{{ t('mcpModule.actions.cancel') }}
+						{{ clientFormChanged ? t('mcpModule.actions.discard') : t('mcpModule.actions.close') }}
 					</el-button>
 
 					<el-button
 						type="primary"
 						:loading="saving"
+						:disabled="saving || !clientFormChanged"
+						data-test-id="save-mcp-client-form"
 						@click="saveClient"
 					>
-						{{ editingClient ? t('mcpModule.actions.save') : t('mcpModule.actions.create') }}
+						{{ t('mcpModule.actions.save') }}
 					</el-button>
 				</div>
 			</div>
@@ -277,9 +282,11 @@ import {
 	ElMessageBox,
 	ElScrollbar,
 	ElSwitch,
+	ElText,
 	type FormInstance,
 	type FormRules,
 } from 'element-plus';
+import { isEqual } from 'lodash';
 
 import { Icon } from '@iconify/vue';
 
@@ -332,6 +339,22 @@ const clientRules = reactive<FormRules>({
 	expiresInDays: [{ required: true, type: 'number', min: 1, max: MCP_MAX_TOKEN_EXPIRATION_DAYS, message: t('mcpModule.clientForm.expiryRequired') }],
 });
 
+type ClientFormSnapshot = { name: string; description: string; enabled: boolean; capabilities: McpCapability[]; expiresInDays: number };
+
+const snapshotClientForm = (): ClientFormSnapshot => ({
+	name: clientForm.name,
+	description: clientForm.description,
+	enabled: clientForm.enabled,
+	capabilities: [...clientForm.capabilities],
+	expiresInDays: clientForm.expiresInDays,
+});
+
+// Taken whenever the drawer opens, so "changed" means changed since it opened
+// rather than merely non-empty.
+const initialClientForm = ref<ClientFormSnapshot>(snapshotClientForm());
+
+const clientFormChanged = computed<boolean>((): boolean => !isEqual(snapshotClientForm(), initialClientForm.value));
+
 const resetClientForm = (): void => {
 	editingClient.value = null;
 	clientForm.name = '';
@@ -340,6 +363,23 @@ const resetClientForm = (): void => {
 	clientForm.capabilities = [];
 	clientForm.expiresInDays = MCP_DEFAULT_TOKEN_EXPIRATION_DAYS;
 	clientFormEl.value?.clearValidate();
+	initialClientForm.value = snapshotClientForm();
+};
+
+const onCancelClientForm = async (): Promise<void> => {
+	if (clientFormChanged.value) {
+		try {
+			await ElMessageBox.confirm(t('mcpModule.confirm.discard'), t('mcpModule.headings.discard'), {
+				confirmButtonText: t('mcpModule.actions.yes'),
+				cancelButtonText: t('mcpModule.actions.no'),
+				type: 'warning',
+			});
+		} catch {
+			return;
+		}
+	}
+
+	showClientDialog.value = false;
 };
 
 const openCreate = (): void => {
@@ -353,6 +393,7 @@ const openEdit = (client: IMcpClient): void => {
 	clientForm.description = client.description ?? '';
 	clientForm.enabled = client.enabled;
 	clientForm.capabilities = [...client.capabilities];
+	initialClientForm.value = snapshotClientForm();
 	showClientDialog.value = true;
 };
 


### PR DESCRIPTION
## Problem

Six ways the MCP client form differed from how the rest of the admin presents an add/edit form:

> the mcp clients uses "Create client" other modules uses "Add" · action buttons in the add/edit mcp client also uses different labels · the save button should be disabled if no form change · the edit/add cancel button is dynamic - close if no changes, cancel if anything changed · the edit/add if form is changed it have to ask for discard confirmation · edit/add drawer header text color is wrong

## Changes

| | Before | Now |
|---|---|---|
| header action | "Create client" | "Add" |
| primary button | "Create" on add, "Save" on edit | "Save" throughout |
| save enabled | always | only once the form changed |
| secondary button | always "Cancel" | "Close" until edited, then "Discard" |
| leaving a changed form | silently discarded | confirms first |
| drawer heading colour | default text colour | picks up the bar styling |

"Changed" is measured against a snapshot taken when the drawer opens, so it means *changed since opening* rather than merely non-empty — otherwise editing a client would count as changed the moment it loaded.

## The heading colour

Worth recording, since the cause is not obvious. `app-bar-heading` renders two different DOM shapes:

- **teleported** (what the devices views use): the title goes through `el-text`, producing `<h1 class="app-bar-heading__title"><span>…`
- **inline** (what this drawer uses): with no subtitle slot the title is emitted as a bare text node

The stylesheet colours the heading via `.app-bar-heading__title > span { color: var(--el-color-white) }`, which only matches the first shape — so the inline title kept its default colour against the coloured bar.

Devices always teleports, but that targets a fixed `#app-bar-heading` id and `layout-default.vue` already renders one, so a non-routed drawer cannot teleport unambiguously. The title is therefore wrapped in `el-text` to produce the same DOM the stylesheet expects.

## Tests

Six new view tests, all verified failing first: the header label, the heading rendering through `el-text`, save disabled until changed, the close/discard label swap, confirmation on discarding a changed form, and closing without confirmation when untouched.

Two testing notes for reviewers, both bugs in my first attempt rather than in the component:

- the `ElButton` stub initially bound `type` onto the native `<button>`, which collides with the element's own `type` and reads back as `"submit"`; it now asserts on the component prop
- `shallowMount` auto-stubs `AppBarHeading` and drops its slots, so the heading assertion passed judgement on an empty stub until the component was stubbed explicitly

- Admin suite: 274 files, 1968 passed
- `vue-tsc` type-check clean
- eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)