### PR TITLE
fix(admin): lift the oauth tabs out of the card and format its empty tables

### DIFF
--- a/apps/admin/src/modules/mcp/components/mcp-table-empty.spec.ts
+++ b/apps/admin/src/modules/mcp/components/mcp-table-empty.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { mount } from '@vue/test-utils';
+
+import McpTableEmpty from './mcp-table-empty.vue';
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../common', () => ({
+	IconWithChild: {
+		name: 'IconWithChild',
+		template: '<div><slot name="primary" /><slot name="secondary" /></div>',
+	},
+}));
+
+const mountEmpty = (props: Record<string, unknown>) =>
+	mount(McpTableEmpty, {
+		props: { icon: 'mdi:key-chain', loading: false, emptyLabel: 'nothing.here', ...props },
+		global: {
+			stubs: {
+				ElResult: { name: 'ElResult', template: '<div><slot name="icon" /><slot name="title" /><slot name="extra" /></div>' },
+				ElButton: { name: 'ElButton', template: '<button><slot name="icon" /><slot /></button>' },
+				ElText: { name: 'ElText', template: '<span><slot /></span>' },
+			},
+		},
+	});
+
+describe('McpTableEmpty', () => {
+	it('offers a retry when the load failed', () => {
+		const wrapper = mountEmpty({ failed: true });
+
+		// A failed load is not "nothing here" — without a retry the only way back
+		// is a full page reload.
+		expect(wrapper.find('[data-test-id="mcp-table-retry"]').exists()).toBe(true);
+		expect(wrapper.text()).toContain('mcpModule.messages.loadFailed');
+	});
+
+	it('emits a retry request', async () => {
+		const wrapper = mountEmpty({ failed: true });
+
+		await wrapper.find('[data-test-id="mcp-table-retry"]').trigger('click');
+
+		expect(wrapper.emitted('retry')).toHaveLength(1);
+	});
+
+	it('offers to clear filters when they are hiding everything', () => {
+		const wrapper = mountEmpty({ filtersActive: true });
+
+		expect(wrapper.find('[data-test-id="mcp-table-reset-filters"]').exists()).toBe(true);
+		expect(wrapper.find('[data-test-id="mcp-table-retry"]').exists()).toBe(false);
+	});
+
+	it('shows the plain empty message when nothing is wrong', () => {
+		const wrapper = mountEmpty({});
+
+		expect(wrapper.text()).toContain('nothing.here');
+		expect(wrapper.find('[data-test-id="mcp-table-retry"]').exists()).toBe(false);
+		expect(wrapper.find('[data-test-id="mcp-table-reset-filters"]').exists()).toBe(false);
+	});
+
+	it('prefers the failure state over the filter state', () => {
+		// Filters may well be active when a request fails; reporting "no matches"
+		// would send the user chasing a filter that is not the problem.
+		const wrapper = mountEmpty({ failed: true, filtersActive: true });
+
+		expect(wrapper.find('[data-test-id="mcp-table-retry"]').exists()).toBe(true);
+		expect(wrapper.find('[data-test-id="mcp-table-reset-filters"]').exists()).toBe(false);
+	});
+
+	it('shows neither affordance while loading', () => {
+		const wrapper = mountEmpty({ loading: true, failed: true });
+
+		expect(wrapper.find('[data-test-id="mcp-table-retry"]').exists()).toBe(false);
+	});
+});

--- a/apps/admin/src/modules/mcp/components/mcp-table-empty.types.ts
+++ b/apps/admin/src/modules/mcp/components/mcp-table-empty.types.ts
@@ -1,0 +1,10 @@
+export interface IMcpTableEmptyProps {
+	/** Glyph identifying the records the table holds, e.g. `mdi:key-chain`. */
+	icon: string;
+	loading: boolean;
+	/** Set when the last load failed, so the slot offers a retry instead of "nothing here". */
+	failed?: boolean;
+	/** Set when filters are narrowing the list, so the slot offers to clear them. */
+	filtersActive?: boolean;
+	emptyLabel: string;
+}

--- a/apps/admin/src/modules/mcp/components/mcp-table-empty.vue
+++ b/apps/admin/src/modules/mcp/components/mcp-table-empty.vue
@@ -1,0 +1,107 @@
+<template>
+	<div class="h-full w-full leading-normal">
+		<el-result class="h-full w-full">
+			<template #icon>
+				<icon-with-child :size="80">
+					<template #primary>
+						<icon :icon="props.icon" />
+					</template>
+					<template #secondary>
+						<icon :icon="secondaryIcon" />
+					</template>
+				</icon-with-child>
+			</template>
+
+			<template
+				v-if="!props.loading"
+				#title
+			>
+				<el-text class="block">
+					{{ title }}
+				</el-text>
+			</template>
+
+			<template
+				v-if="!props.loading && (props.failed || props.filtersActive)"
+				#extra
+			>
+				<el-button
+					v-if="props.failed"
+					type="primary"
+					plain
+					data-test-id="mcp-table-retry"
+					@click="emit('retry')"
+				>
+					<template #icon>
+						<icon icon="mdi:refresh" />
+					</template>
+
+					{{ t('mcpModule.actions.retry') }}
+				</el-button>
+
+				<el-button
+					v-else
+					type="primary"
+					plain
+					data-test-id="mcp-table-reset-filters"
+					@click="emit('reset-filters')"
+				>
+					<template #icon>
+						<icon icon="mdi:filter-off" />
+					</template>
+
+					{{ t('mcpModule.actions.resetFilters') }}
+				</el-button>
+			</template>
+		</el-result>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElResult, ElText } from 'element-plus';
+
+import { Icon } from '@iconify/vue';
+
+import { IconWithChild } from '../../../common';
+
+import type { IMcpTableEmptyProps } from './mcp-table-empty.types';
+
+defineOptions({
+	name: 'McpTableEmpty',
+});
+
+const props = defineProps<IMcpTableEmptyProps>();
+
+const emit = defineEmits<{
+	(e: 'retry'): void;
+	(e: 'reset-filters'): void;
+}>();
+
+const { t } = useI18n();
+
+// A failed load outranks an active filter: filters are often set when a request
+// fails, and reporting "no matches" would send the user adjusting a filter that
+// is not the cause.
+const secondaryIcon = computed<string>((): string => {
+	if (props.loading) {
+		return 'mdi:database-refresh';
+	}
+
+	if (props.failed) {
+		return 'mdi:alert-circle';
+	}
+
+	return props.filtersActive ? 'mdi:filter-multiple' : 'mdi:information';
+});
+
+const title = computed<string>((): string => {
+	if (props.failed) {
+		return t('mcpModule.messages.loadFailed');
+	}
+
+	return props.filtersActive ? t('mcpModule.clients.noFilteredResults') : t(props.emptyLabel);
+});
+</script>

--- a/apps/admin/src/modules/mcp/locales/cs-CZ.json
+++ b/apps/admin/src/modules/mcp/locales/cs-CZ.json
@@ -20,7 +20,8 @@
     "close": "Zavřít",
     "discard": "Zahodit",
     "yes": "Ano",
-    "no": "Ne"
+    "no": "Ne",
+    "retry": "Zkusit znovu"
   },
   "capabilities": {
     "read": {

--- a/apps/admin/src/modules/mcp/locales/de-DE.json
+++ b/apps/admin/src/modules/mcp/locales/de-DE.json
@@ -20,7 +20,8 @@
 		"close": "Schließen",
 		"discard": "Verwerfen",
 		"yes": "Ja",
-		"no": "Nein"
+		"no": "Nein",
+		"retry": "Erneut versuchen"
 	},
 	"capabilities": {
 		"read": {

--- a/apps/admin/src/modules/mcp/locales/en-US.json
+++ b/apps/admin/src/modules/mcp/locales/en-US.json
@@ -20,7 +20,8 @@
 		"close": "Close",
 		"discard": "Discard",
 		"yes": "Yes",
-		"no": "No"
+		"no": "No",
+		"retry": "Retry"
 	},
 	"capabilities": {
 		"read": {

--- a/apps/admin/src/modules/mcp/locales/es-ES.json
+++ b/apps/admin/src/modules/mcp/locales/es-ES.json
@@ -20,7 +20,8 @@
     "close": "Cerrar",
     "discard": "Descartar",
     "yes": "Sí",
-    "no": "No"
+    "no": "No",
+    "retry": "Reintentar"
   },
   "capabilities": {
     "read": {

--- a/apps/admin/src/modules/mcp/locales/pl-PL.json
+++ b/apps/admin/src/modules/mcp/locales/pl-PL.json
@@ -20,7 +20,8 @@
     "close": "Zamknij",
     "discard": "Odrzuć",
     "yes": "Tak",
-    "no": "Nie"
+    "no": "Nie",
+    "retry": "Ponów"
   },
   "capabilities": {
     "read": {

--- a/apps/admin/src/modules/mcp/locales/sk-SK.json
+++ b/apps/admin/src/modules/mcp/locales/sk-SK.json
@@ -20,7 +20,8 @@
     "close": "Zavrieť",
     "discard": "Zahodiť",
     "yes": "Áno",
-    "no": "Nie"
+    "no": "Nie",
+    "retry": "Skúsiť znova"
   },
   "capabilities": {
     "read": {

--- a/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-clients.spec.ts
@@ -54,9 +54,9 @@ vi.mock('../../../common', () => ({
 	}),
 	AppBar: { name: 'AppBar', template: '<div><slot name="heading" /><slot name="button-right" /></div>' },
 	AppBarHeading: {
-					name: 'AppBarHeading',
-					template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
-				},
+		name: 'AppBarHeading',
+		template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
+	},
 	AppBarButton: { name: 'AppBarButton', template: '<button><slot name="icon" /></button>' },
 	AppBarButtonAlign: { LEFT: 'left', RIGHT: 'right' },
 }));

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
@@ -43,9 +43,9 @@ vi.mock('../../../common', () => ({
 	useBreakpoints: () => ({ isLGDevice: ref(true), isMDDevice: ref(true) }),
 	AppBar: { name: 'AppBar', template: '<div><slot name="heading" /><slot name="button-right" /></div>' },
 	AppBarHeading: {
-					name: 'AppBarHeading',
-					template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
-				},
+		name: 'AppBarHeading',
+		template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
+	},
 	AppBarButton: { name: 'AppBarButton', template: '<button><slot name="icon" /></button>' },
 	AppBarButtonAlign: { LEFT: 'left', RIGHT: 'right' },
 }));
@@ -84,11 +84,16 @@ const formStubs = {
 		methods: { clearValidate: () => undefined, validate: () => Promise.resolve(true) },
 	},
 	ElFormItem: { name: 'ElFormItem', template: '<div><slot /></div>' },
+	ElTabs: { name: 'ElTabs', template: '<div><slot /></div>' },
+	ElTabPane: { name: 'ElTabPane', template: '<div><slot /></div>' },
+	ElCard: { name: 'ElCard', template: '<section><slot /></section>' },
+	ElTable: { name: 'ElTable', template: '<table><slot /><slot name="empty" /></table>' },
+	ElTableColumn: { name: 'ElTableColumn', template: '<td></td>' },
 	AppBar: { name: 'AppBar', template: '<div><slot name="heading" /><slot name="button-right" /></div>' },
 	AppBarHeading: {
-					name: 'AppBarHeading',
-					template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
-				},
+		name: 'AppBarHeading',
+		template: '<div><slot name="icon" /><slot name="title" /><slot name="subtitle" /></div>',
+	},
 	ViewHeader: { name: 'ViewHeader', template: '<header><slot name="extra" /></header>' },
 };
 
@@ -99,6 +104,35 @@ describe('ViewMcpOAuthManagement form conventions', () => {
 		vi.clearAllMocks();
 		vi.spyOn(ElMessageBox, 'confirm');
 		(ElMessageBox.confirm as Mock).mockReset().mockResolvedValue('confirm');
+	});
+
+	it('puts the tabs above the cards rather than inside one', () => {
+		const wrapper = mountForms();
+
+		const tabs = wrapper.findComponent({ name: 'ElTabs' });
+
+		expect(tabs.exists()).toBe(true);
+		// A card wrapping the tab strip is the layout this page had; every other
+		// tabbed view puts the tabs first and a card inside each pane.
+		expect(tabs.element.closest('section')).toBeNull();
+	});
+
+	it('gives every tab a card of its own', () => {
+		const wrapper = mountForms();
+
+		expect(wrapper.findAllComponents({ name: 'ElTabPane' })).toHaveLength(4);
+		expect(wrapper.findAllComponents({ name: 'McpTableEmpty' })).toHaveLength(4);
+	});
+
+	it('reports a load failure inside each table instead of as a page banner', () => {
+		const wrapper = mountForms();
+
+		for (const empty of wrapper.findAllComponents({ name: 'McpTableEmpty' })) {
+			// Bound to the load error, so the table offers a retry rather than the
+			// page carrying a dead-end alert.
+			expect(empty.props('failed')).toBe(false);
+			expect(empty.props('loading')).toBe(false);
+		}
 	});
 
 	it('labels the header create action the way the other list headers do', () => {

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
@@ -43,24 +43,20 @@
 			show-icon
 		/>
 
-		<el-alert
-			v-if="error"
-			type="error"
-			:title="t('mcpModule.oauthManagement.messages.loadFailed')"
-			:closable="false"
-			show-icon
-		/>
-
-		<el-card
-			v-loading="loading"
-			shadow="never"
+		<el-tabs
+			v-model="activeTab"
+			class="grow-1 overflow-hidden flex-1"
 		>
-			<el-tabs v-model="activeTab">
-				<el-tab-pane
-					name="clients"
-					:label="t('mcpModule.oauthManagement.tabs.clients')"
+			<el-tab-pane
+				name="clients"
+				:label="t('mcpModule.oauthManagement.tabs.clients')"
+			>
+				<el-card
+					shadow="never"
+					body-class="p-0!"
 				>
 					<el-table
+						v-loading="loading"
 						:data="clients"
 						row-key="id"
 					>
@@ -129,15 +125,29 @@
 								</el-button>
 							</template>
 						</el-table-column>
-						<template #empty>{{ t('mcpModule.oauthManagement.empty.clients') }}</template>
+						<template #empty>
+							<mcp-table-empty
+								icon="mdi:application-cog"
+								:loading="loading"
+								:failed="error !== null"
+								empty-label="mcpModule.oauthManagement.empty.clients"
+								@retry="fetchAll"
+							/>
+						</template>
 					</el-table>
-				</el-tab-pane>
+				</el-card>
+			</el-tab-pane>
 
-				<el-tab-pane
-					name="grants"
-					:label="t('mcpModule.oauthManagement.tabs.grants')"
+			<el-tab-pane
+				name="grants"
+				:label="t('mcpModule.oauthManagement.tabs.grants')"
+			>
+				<el-card
+					shadow="never"
+					body-class="p-0!"
 				>
 					<el-table
+						v-loading="loading"
 						:data="grants"
 						row-key="id"
 					>
@@ -190,15 +200,29 @@
 								</el-button>
 							</template>
 						</el-table-column>
-						<template #empty>{{ t('mcpModule.oauthManagement.empty.grants') }}</template>
+						<template #empty>
+							<mcp-table-empty
+								icon="mdi:key-chain"
+								:loading="loading"
+								:failed="error !== null"
+								empty-label="mcpModule.oauthManagement.empty.grants"
+								@retry="fetchAll"
+							/>
+						</template>
 					</el-table>
-				</el-tab-pane>
+				</el-card>
+			</el-tab-pane>
 
-				<el-tab-pane
-					name="accessTokens"
-					:label="t('mcpModule.oauthManagement.tabs.accessTokens')"
+			<el-tab-pane
+				name="accessTokens"
+				:label="t('mcpModule.oauthManagement.tabs.accessTokens')"
+			>
+				<el-card
+					shadow="never"
+					body-class="p-0!"
 				>
 					<el-table
+						v-loading="loading"
 						:data="accessTokens"
 						row-key="id"
 					>
@@ -235,15 +259,29 @@
 								</el-button>
 							</template>
 						</el-table-column>
-						<template #empty>{{ t('mcpModule.oauthManagement.empty.accessTokens') }}</template>
+						<template #empty>
+							<mcp-table-empty
+								icon="mdi:key"
+								:loading="loading"
+								:failed="error !== null"
+								empty-label="mcpModule.oauthManagement.empty.accessTokens"
+								@retry="fetchAll"
+							/>
+						</template>
 					</el-table>
-				</el-tab-pane>
+				</el-card>
+			</el-tab-pane>
 
-				<el-tab-pane
-					name="refreshFamilies"
-					:label="t('mcpModule.oauthManagement.tabs.refreshFamilies')"
+			<el-tab-pane
+				name="refreshFamilies"
+				:label="t('mcpModule.oauthManagement.tabs.refreshFamilies')"
+			>
+				<el-card
+					shadow="never"
+					body-class="p-0!"
 				>
 					<el-table
+						v-loading="loading"
 						:data="refreshFamilies"
 						row-key="id"
 					>
@@ -279,11 +317,19 @@
 								</el-button>
 							</template>
 						</el-table-column>
-						<template #empty>{{ t('mcpModule.oauthManagement.empty.refreshFamilies') }}</template>
+						<template #empty>
+							<mcp-table-empty
+								icon="mdi:key-link"
+								:loading="loading"
+								:failed="error !== null"
+								empty-label="mcpModule.oauthManagement.empty.refreshFamilies"
+								@retry="fetchAll"
+							/>
+						</template>
 					</el-table>
-				</el-tab-pane>
-			</el-tabs>
-		</el-card>
+				</el-card>
+			</el-tab-pane>
+		</el-tabs>
 	</div>
 
 	<el-drawer
@@ -563,6 +609,7 @@ import { isEqual } from 'lodash';
 import { Icon } from '@iconify/vue';
 
 import { AppBar, AppBarButton, AppBarButtonAlign, AppBarHeading, ViewHeader, useBreakpoints, useFlashMessage } from '../../../common';
+import McpTableEmpty from '../components/mcp-table-empty.vue';
 import { useMcpOAuthManagement } from '../composables/useMcpOAuthManagement';
 import { McpOAuthScope } from '../mcp.constants';
 import type { IMcpOAuthAccessToken, IMcpOAuthClient, IMcpOAuthGrant, IMcpOAuthRefreshFamily } from '../schemas/oauth-management.types';


### PR DESCRIPTION
## Problem

Three of the five reported OAuth-page defects:

> tabs have to be above the card where is card with table - example on route /extensions
> when no records to show the empty state has to be formatter and depends on the state - empty, empty with filter, failed - example devices list
> there is message: "OAuth authorization data could not be loaded." - this could be as no result component in table with posibility to refresh

## Changes

**Tabs above the card.** The tab strip sat inside a single card and all four tables shared one frame. Each pane now carries its own card, matching `/extensions`, and the loading indicator moves from the shared card onto the tables it actually describes.

**Formatted empty states.** Each table showed a bare sentence. New `mcp-table-empty` renders the `el-result` treatment the devices table uses and distinguishes four cases:

| State | Shows |
|---|---|
| loading | spinner glyph |
| failed | message + **Retry** |
| filtered to nothing | message + **Reset filters** |
| genuinely empty | plain message |

**Load failure moves into the table.** It was a banner above the page — it said what had gone wrong but offered no way out short of reloading. It now renders in the table that has no rows, with a retry wired to `fetchAll`.

## One ordering decision

A failed load **outranks** an active filter. Filters are frequently set when a request fails, and showing "no matches, reset your filters" would send the user adjusting a filter that is not the cause. There is a test pinning this precedence.

The reset-filters branch is unused for now — no OAuth tab has filters yet — but it is the same slot the filtering PR will use, so it is built and tested here rather than bolted on later.

## Tests

Six component tests (retry offered and emitted, reset offered, plain empty, failure-over-filter precedence, nothing while loading) and three view tests (tabs not inside a card, four panes each with a card and an empty component, failure bound per table).

Both key behaviours were mutation-checked: inverting the failure/filter precedence fails a test, and putting the tabs back inside a card fails another.

- Admin suite: 275 files, 1985 passed
- `vue-tsc` type-check clean
- eslint + prettier clean

Note: an earlier commit here reformatted two unrelated files that were already failing prettier; that was backed out so the diff stays on topic.

## Remaining

Per-tab search, sort and filters — the last of the five, and the large one. Agreed scope: search and sort on every tab, status filters only where a tab has a real status axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)