### PR TITLE
fix(admin): read the oauth client identifier from the field the api sends

### DIFF
--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
@@ -15,9 +15,12 @@ vi.mock('../../../common', () => ({
 	snakeToCamel: (value: unknown): unknown => value,
 }));
 
+// Mirrors what the API sends: the public identifier travels as `client_id`,
+// which reaches the schema as `clientId`. The fixture previously used the
+// admin's own field name, so it agreed with the schema instead of testing it.
 const client = {
 	id: '10000000-0000-4000-8000-000000000001',
-	clientIdentifier: 'public-client-id',
+	clientId: 'public-client-id',
 	name: 'Codex',
 	redirectUris: ['http://127.0.0.1:1455/callback'],
 	maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
@@ -25,6 +28,9 @@ const client = {
 	createdAt: '2026-01-01T00:00:00.000Z',
 	updatedAt: null,
 };
+// What the schema yields once the wire field has been renamed.
+const parsedClient = (({ clientId, ...rest }) => ({ ...rest, clientIdentifier: clientId }))(client);
+
 const grant = {
 	id: '20000000-0000-4000-8000-000000000001',
 	clientId: client.id,
@@ -66,7 +72,7 @@ describe('useMcpOAuthManagement', () => {
 
 		await management.fetchAll();
 
-		expect(management.clients.value).toEqual([client]);
+		expect(management.clients.value).toEqual([parsedClient]);
 		expect(management.grants.value).toEqual([grant]);
 		expect(management.accessTokens.value).toEqual([accessToken]);
 		expect(management.refreshFamilies.value).toEqual([family]);
@@ -91,7 +97,7 @@ describe('useMcpOAuthManagement', () => {
 				},
 			},
 		});
-		expect(management.clients.value).toEqual([client]);
+		expect(management.clients.value).toEqual([parsedClient]);
 	});
 
 	it('removes a revoked refresh family and all access tokens issued from it', async () => {
@@ -124,10 +130,8 @@ describe('useMcpOAuthManagement', () => {
 		await management.revokeAll();
 
 		expect(backendClient.POST).toHaveBeenCalledWith('/modules/mcp/oauth/revoke-all', {});
-		expect(management.clients.value).toEqual([client]);
-		expect(management.grants.value).toEqual([
-			expect.objectContaining({ id: grant.id, active: false, revokedAt: expect.any(String) }),
-		]);
+		expect(management.clients.value).toEqual([parsedClient]);
+		expect(management.grants.value).toEqual([expect.objectContaining({ id: grant.id, active: false, revokedAt: expect.any(String) })]);
 		expect(management.accessTokens.value).toEqual([]);
 		expect(management.refreshFamilies.value).toEqual([]);
 	});

--- a/apps/admin/src/modules/mcp/schemas/mcp.schemas.spec.ts
+++ b/apps/admin/src/modules/mcp/schemas/mcp.schemas.spec.ts
@@ -7,8 +7,30 @@ import { McpConfigSchema, McpConfigUpdateReqSchema } from '../store/config.store
 
 import { McpCreateClientSchema } from './client.schemas';
 import { McpConfigEditFormSchema, McpOAuthPublicBaseUrlSchema, McpOriginSchema } from './config.schemas';
+import { McpOAuthClientSchema } from './oauth-management.schemas';
 
 describe('MCP admin schemas', () => {
+	it('reads the oauth client identifier from the field the api actually sends', () => {
+		// The backend exposes the public identifier as `client_id`, which reaches
+		// the schema as `clientId` after snake-to-camel. Expecting
+		// `clientIdentifier` made every client row fail to parse, and with it the
+		// whole OAuth page — all four tabs load in one `Promise.all`.
+		const parsed = McpOAuthClientSchema.parse({
+			id: '10000000-0000-4000-8000-000000000001',
+			clientId: 'codex-cli',
+			name: 'Codex',
+			redirectUris: ['https://example.test/callback'],
+			maximumScopes: [],
+			enabled: true,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: null,
+		});
+
+		// Kept as `clientIdentifier` in the admin: `clientId` means the internal
+		// record id on every other OAuth model, and reusing it here would collide.
+		expect(parsed.clientIdentifier).toBe('codex-cli');
+	});
+
 	const capabilityCombinations = [
 		[],
 		[McpCapability.read],

--- a/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
+++ b/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
@@ -6,16 +6,24 @@ const dateSchema = z.string().datetime({ offset: true });
 const nullableDateSchema = dateSchema.nullable().default(null);
 const scopeSchema = z.nativeEnum(McpOAuthScope);
 
-export const McpOAuthClientSchema = z.object({
-	id: z.string().uuid(),
-	clientIdentifier: z.string().min(1),
-	name: z.string().trim().min(1).max(100),
-	redirectUris: z.array(z.string().url()).min(1),
-	maximumScopes: z.array(scopeSchema),
-	enabled: z.boolean(),
-	createdAt: dateSchema,
-	updatedAt: nullableDateSchema,
-});
+/**
+ * The API sends the public identifier as `client_id`, which arrives here as
+ * `clientId`. It is renamed on the way in rather than adopted: `clientId` means
+ * the internal record id on the grant, access token and refresh family models,
+ * so carrying that name here would give one field two meanings.
+ */
+export const McpOAuthClientSchema = z
+	.object({
+		id: z.string().uuid(),
+		clientId: z.string().min(1),
+		name: z.string().trim().min(1).max(100),
+		redirectUris: z.array(z.string().url()).min(1),
+		maximumScopes: z.array(scopeSchema),
+		enabled: z.boolean(),
+		createdAt: dateSchema,
+		updatedAt: nullableDateSchema,
+	})
+	.transform(({ clientId, ...client }) => ({ ...client, clientIdentifier: clientId }));
 
 export const McpOAuthGrantSchema = z.object({
 	id: z.string().uuid(),

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.spec.ts
@@ -195,6 +195,20 @@ describe('ViewMcpOAuthManagement form conventions', () => {
 		expect(mocks.routerReplace).toHaveBeenCalledWith(expect.objectContaining({ query: expect.objectContaining({ tab: 'grants' }) }));
 	});
 
+	it('does not let a failed retry escape as an unhandled rejection', async () => {
+		mocks.fetchAll.mockRejectedValueOnce(new Error('still broken'));
+
+		const wrapper = mountForms();
+		const vm = wrapper.vm as unknown as { onRetry: () => void };
+
+		// `fetchAll` rethrows so callers can react; as an event handler that
+		// rejection has nowhere to go and Vue reports it as an unhandled error.
+		expect(() => vm.onRetry()).not.toThrow();
+		await flushPromises();
+
+		expect(mocks.fetchAll).toHaveBeenCalled();
+	});
+
 	it('labels the header create action the way the other list headers do', () => {
 		const wrapper = mountForms();
 

--- a/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
+++ b/apps/admin/src/modules/mcp/views/view-mcp-oauth-management.vue
@@ -152,7 +152,7 @@
 								:failed="error !== null"
 								:filters-active="clientsQuery.filtersActive.value"
 								empty-label="mcpModule.oauthManagement.empty.clients"
-								@retry="fetchAll"
+								@retry="onRetry"
 								@reset-filters="clientsQuery.resetFilter"
 							/>
 						</template>
@@ -249,7 +249,7 @@
 								:failed="error !== null"
 								:filters-active="grantsQuery.filtersActive.value"
 								empty-label="mcpModule.oauthManagement.empty.grants"
-								@retry="fetchAll"
+								@retry="onRetry"
 								@reset-filters="grantsQuery.resetFilter"
 							/>
 						</template>
@@ -330,7 +330,7 @@
 								:failed="error !== null"
 								:filters-active="accessTokensQuery.filtersActive.value"
 								empty-label="mcpModule.oauthManagement.empty.accessTokens"
-								@retry="fetchAll"
+								@retry="onRetry"
 								@reset-filters="accessTokensQuery.resetFilter"
 							/>
 						</template>
@@ -412,7 +412,7 @@
 								:failed="error !== null"
 								:filters-active="refreshFamiliesQuery.filtersActive.value"
 								empty-label="mcpModule.oauthManagement.empty.refreshFamilies"
-								@retry="fetchAll"
+								@retry="onRetry"
 								@reset-filters="refreshFamiliesQuery.resetFilter"
 							/>
 						</template>
@@ -980,6 +980,15 @@ const grantStatus = (grant: IMcpOAuthGrant): { key: 'active' | 'expired' | 'inac
 
 const canRevokeGrant = (grant: IMcpOAuthGrant): boolean => grant.revokedAt === null && new Date(grant.expiresAt).getTime() > Date.now();
 const canEditGrant = (grant: IMcpOAuthGrant): boolean => grant.active;
+
+// `fetchAll` records the failure and rethrows so callers can react. As an event
+// handler that rejection has nowhere to go, and Vue reports it as an unhandled
+// error — the state is already on screen, so swallowing it here is the point.
+const onRetry = (): void => {
+	fetchAll().catch(() => {
+		// Already surfaced by the table's failed state.
+	});
+};
 
 // El-table only draws the active sort arrow when it is told what the sort is;
 // without this the tabs looked unsorted while being sorted by client name.


### PR DESCRIPTION
## Problem

The OAuth page could not load at all. Reported as a `ZodError` on retry:

```
ZodError: [{ "expected": "string", "path": ["clientIdentifier"],
             "message": "Invalid input: expected string, received undefined" }]
```

The API exposes a client's public identifier as `client_id`:

```typescript
@Expose({ name: 'client_id' })
clientIdentifier: string;
```

which reaches the schema as `clientId` after snake-to-camel. The schema required `clientIdentifier`, so every client row failed to parse — and because all four tabs load in a single `Promise.all`, one bad row emptied the whole page.

Verified against the running instance:

```
keys: id, client_id, name, redirect_uris, maximum_scopes, enabled, created_at, updated_at
```

**This is what the "OAuth authorization data could not be loaded" message was reporting.** That message was turned into an in-table retry in #785 — but the underlying cause was this, not a transient failure.

## Change

The field is renamed on the way in rather than adopting the wire name. `clientId` means the **internal record id** on the grant, access token and refresh family models; carrying that name here would give one field two meanings across the module. The admin keeps `clientIdentifier`, so no consumer changes.

Grants, access tokens and refresh families were checked and already agree with their models.

## Why this was not caught

The composable's fixture used the admin's own field name:

```typescript
const client = { id: '…', clientIdentifier: 'public-client-id', … };
```

so it agreed with the schema instead of testing it against the API, and `snakeToCamel` was stubbed to identity. The test encoded the same wrong assumption as the code. The fixture now carries the shape the API actually returns, and a schema test asserts the mapping directly.

## Second bug in the same trace

Clicking **Retry** raised `Unhandled error during execution of component event handler`. `fetchAll` records the failure and rethrows so callers can react; bound straight to `@retry`, that rejection had nowhere to go. The retry now handles it — the failed state is already on screen, so there is nothing further to report.

## Tests

- Schema test asserting `clientId` is accepted and surfaces as `clientIdentifier`, verified failing first with the reported ZodError.
- Composable fixture corrected to the API shape, with assertions updated to the parsed result.
- View test that a rejected retry does not throw.

- Admin suite: 276 files, 2000 passed
- `vue-tsc` type-check clean
- eslint + prettier clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)