### PR TITLE
refactor(admin): validate mcp oauth responses against the generated contract

### DIFF
--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.spec.ts
@@ -10,54 +10,92 @@ const backendClient = {
 	PATCH: vi.fn(),
 };
 
-vi.mock('../../../common', () => ({
-	useBackend: () => ({ client: backendClient }),
-	snakeToCamel: (value: unknown): unknown => value,
-}));
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual<typeof import('../../../common')>('../../../common');
 
-// Mirrors what the API sends: the public identifier travels as `client_id`,
-// which reaches the schema as `clientId`. The fixture previously used the
-// admin's own field name, so it agreed with the schema instead of testing it.
+	// The real converter, so the fixtures below can be the snake_case the API
+	// actually returns rather than a shape that merely matches the schema.
+	return { useBackend: () => ({ client: backendClient }), snakeToCamel: actual.snakeToCamel };
+});
+
+// Exactly what the API returns, per the generated OpenAPI types.
 const client = {
 	id: '10000000-0000-4000-8000-000000000001',
-	clientId: 'public-client-id',
+	client_id: 'public-client-id',
 	name: 'Codex',
-	redirectUris: ['http://127.0.0.1:1455/callback'],
-	maximumScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+	redirect_uris: ['http://127.0.0.1:1455/callback'],
+	maximum_scopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
 	enabled: true,
-	createdAt: '2026-01-01T00:00:00.000Z',
-	updatedAt: null,
+	created_at: '2026-01-01T00:00:00.000Z',
+	updated_at: null,
 };
-// What the schema yields once the wire field has been renamed.
-const parsedClient = (({ clientId, ...rest }) => ({ ...rest, clientIdentifier: clientId }))(client);
+const parsedClient = {
+	id: client.id,
+	clientIdentifier: client.client_id,
+	name: client.name,
+	redirectUris: client.redirect_uris,
+	maximumScopes: client.maximum_scopes,
+	enabled: client.enabled,
+	createdAt: client.created_at,
+	updatedAt: client.updated_at,
+};
 
 const grant = {
 	id: '20000000-0000-4000-8000-000000000001',
-	clientId: client.id,
-	clientName: client.name,
-	approvedById: '30000000-0000-4000-8000-000000000001',
-	approvedScopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
-	expiresAt: '2030-01-01T00:00:00.000Z',
-	revokedAt: null,
+	client_id: client.id,
+	client_name: client.name,
+	approved_by_id: '30000000-0000-4000-8000-000000000001',
+	approved_scopes: [McpOAuthScope.READ, McpOAuthScope.OFFLINE_ACCESS],
+	expires_at: '2030-01-01T00:00:00.000Z',
+	revoked_at: null,
 	active: true,
-	createdAt: '2026-01-01T00:00:00.000Z',
+	created_at: '2026-01-01T00:00:00.000Z',
+};
+const parsedGrant = {
+	id: grant.id,
+	clientId: grant.client_id,
+	clientName: grant.client_name,
+	approvedById: grant.approved_by_id,
+	approvedScopes: grant.approved_scopes,
+	expiresAt: grant.expires_at,
+	revokedAt: grant.revoked_at,
+	active: grant.active,
+	createdAt: grant.created_at,
 };
 const family = {
 	id: '40000000-0000-4000-8000-000000000001',
-	clientId: client.id,
-	clientName: client.name,
-	grantId: grant.id,
-	expiresAt: '2030-01-01T00:00:00.000Z',
-	activeTokenCount: 1,
+	client_id: client.id,
+	client_name: client.name,
+	grant_id: grant.id,
+	expires_at: '2030-01-01T00:00:00.000Z',
+	active_token_count: 1,
 };
 const accessToken = {
 	id: '50000000-0000-4000-8000-000000000001',
-	clientId: client.id,
-	clientName: client.name,
-	grantId: grant.id,
-	refreshFamilyId: family.id,
+	client_id: client.id,
+	client_name: client.name,
+	grant_id: grant.id,
+	refresh_family_id: family.id,
 	scopes: [McpOAuthScope.READ],
-	expiresAt: '2030-01-01T00:00:00.000Z',
+	expires_at: '2030-01-01T00:00:00.000Z',
+};
+
+const parsedFamily = {
+	id: family.id,
+	clientId: family.client_id,
+	clientName: family.client_name,
+	grantId: family.grant_id,
+	expiresAt: family.expires_at,
+	activeTokenCount: family.active_token_count,
+};
+const parsedAccessToken = {
+	id: accessToken.id,
+	clientId: accessToken.client_id,
+	clientName: accessToken.client_name,
+	grantId: accessToken.grant_id,
+	refreshFamilyId: accessToken.refresh_family_id,
+	scopes: accessToken.scopes,
+	expiresAt: accessToken.expires_at,
 };
 
 describe('useMcpOAuthManagement', () => {
@@ -73,9 +111,9 @@ describe('useMcpOAuthManagement', () => {
 		await management.fetchAll();
 
 		expect(management.clients.value).toEqual([parsedClient]);
-		expect(management.grants.value).toEqual([grant]);
-		expect(management.accessTokens.value).toEqual([accessToken]);
-		expect(management.refreshFamilies.value).toEqual([family]);
+		expect(management.grants.value).toEqual([parsedGrant]);
+		expect(management.accessTokens.value).toEqual([parsedAccessToken]);
+		expect(management.refreshFamilies.value).toEqual([parsedFamily]);
 	});
 
 	it('pre-registers a public client through the generated API contract', async () => {
@@ -84,16 +122,16 @@ describe('useMcpOAuthManagement', () => {
 
 		await management.createClient({
 			name: client.name,
-			redirectUris: client.redirectUris,
-			maximumScopes: client.maximumScopes,
+			redirectUris: parsedClient.redirectUris,
+			maximumScopes: parsedClient.maximumScopes,
 		});
 
 		expect(backendClient.POST).toHaveBeenCalledWith('/modules/mcp/oauth/clients', {
 			body: {
 				data: {
 					name: client.name,
-					redirect_uris: client.redirectUris,
-					maximum_scopes: client.maximumScopes,
+					redirect_uris: client.redirect_uris,
+					maximum_scopes: client.maximum_scopes,
 				},
 			},
 		});
@@ -137,7 +175,9 @@ describe('useMcpOAuthManagement', () => {
 	});
 
 	it('updates a grant through the reduction-only generated API contract', async () => {
-		const reduced = { ...grant, approvedScopes: [McpOAuthScope.READ] };
+		// The API echoes the updated record back in its own snake_case shape.
+		const reduced = { ...grant, approved_scopes: [McpOAuthScope.READ] };
+		const parsedReduced = { ...parsedGrant, approvedScopes: [McpOAuthScope.READ] };
 		backendClient.GET.mockResolvedValueOnce({ data: { data: [client] }, response: { status: 200 } })
 			.mockResolvedValueOnce({ data: { data: [grant] }, response: { status: 200 } })
 			.mockResolvedValueOnce({ data: { data: [accessToken] }, response: { status: 200 } })
@@ -152,6 +192,6 @@ describe('useMcpOAuthManagement', () => {
 			params: { path: { id: grant.id } },
 			body: { data: { approved_scopes: [McpOAuthScope.READ] } },
 		});
-		expect(management.grants.value).toEqual([reduced]);
+		expect(management.grants.value).toEqual([parsedReduced]);
 	});
 });

--- a/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpOAuthManagement.ts
@@ -1,17 +1,15 @@
 import { type Ref, ref } from 'vue';
 
-import { snakeToCamel, useBackend } from '../../../common';
+import { useBackend } from '../../../common';
 import { MCP_MODULE_PREFIX } from '../mcp.constants';
 import { McpApiException } from '../mcp.exceptions';
+import { McpOAuthCreateClientSchema, McpOAuthUpdateClientSchema, McpOAuthUpdateGrantSchema } from '../schemas/oauth-management.schemas';
 import {
-	McpOAuthAccessTokenSchema,
-	McpOAuthClientSchema,
-	McpOAuthCreateClientSchema,
-	McpOAuthGrantSchema,
-	McpOAuthRefreshFamilySchema,
-	McpOAuthUpdateClientSchema,
-	McpOAuthUpdateGrantSchema,
-} from '../schemas/oauth-management.schemas';
+	transformOAuthAccessToken,
+	transformOAuthClient,
+	transformOAuthGrant,
+	transformOAuthRefreshFamily,
+} from '../schemas/oauth-management.transformers';
 import type {
 	IMcpOAuthAccessToken,
 	IMcpOAuthClient,
@@ -79,10 +77,10 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 				throw new McpApiException('Failed to load MCP OAuth authorization data.', status);
 			}
 
-			clients.value = clientsResult.data.data.map((item) => McpOAuthClientSchema.parse(snakeToCamel(item)));
-			grants.value = grantsResult.data.data.map((item) => McpOAuthGrantSchema.parse(snakeToCamel(item)));
-			accessTokens.value = accessResult.data.data.map((item) => McpOAuthAccessTokenSchema.parse(snakeToCamel(item)));
-			refreshFamilies.value = familiesResult.data.data.map((item) => McpOAuthRefreshFamilySchema.parse(snakeToCamel(item)));
+			clients.value = clientsResult.data.data.map(transformOAuthClient);
+			grants.value = grantsResult.data.data.map(transformOAuthGrant);
+			accessTokens.value = accessResult.data.data.map(transformOAuthAccessToken);
+			refreshFamilies.value = familiesResult.data.data.map(transformOAuthRefreshFamily);
 		} catch (caught) {
 			error.value = caught instanceof Error ? caught : new Error('Failed to load MCP OAuth authorization data.');
 			throw error.value;
@@ -113,7 +111,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 
 		if (!data) throw new McpApiException('Failed to create MCP OAuth client.', response.status);
 
-		return setClient(McpOAuthClientSchema.parse(snakeToCamel(data.data)));
+		return setClient(transformOAuthClient(data.data));
 	};
 
 	const updateClient = async (id: string, payload: IMcpOAuthUpdateClient): Promise<IMcpOAuthClient> => {
@@ -131,7 +129,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 
 		if (!data) throw new McpApiException('Failed to update MCP OAuth client.', response.status);
 
-		return setClient(McpOAuthClientSchema.parse(snakeToCamel(data.data)));
+		return setClient(transformOAuthClient(data.data));
 	};
 
 	const revokeClient = async (id: string): Promise<IMcpOAuthClient> => {
@@ -139,7 +137,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 
 		if (!data) throw new McpApiException('Failed to disable MCP OAuth client.', response.status);
 
-		const client = setClient(McpOAuthClientSchema.parse(snakeToCamel(data.data)));
+		const client = setClient(transformOAuthClient(data.data));
 		grants.value = grants.value.map((grant) =>
 			grant.clientId === id ? { ...grant, active: false, revokedAt: grant.revokedAt ?? new Date().toISOString() } : grant
 		);
@@ -154,7 +152,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 
 		if (!data) throw new McpApiException('Failed to revoke MCP OAuth grant.', response.status);
 
-		const grant = McpOAuthGrantSchema.parse(snakeToCamel(data.data));
+		const grant = transformOAuthGrant(data.data);
 		grants.value = grants.value.map((item) => (item.id === id ? grant : item));
 		accessTokens.value = accessTokens.value.filter((token) => token.grantId !== id);
 		refreshFamilies.value = refreshFamilies.value.filter((family) => family.grantId !== id);
@@ -171,7 +169,7 @@ export const useMcpOAuthManagement = (): IUseMcpOAuthManagement => {
 
 		if (!data) throw new McpApiException('Failed to update MCP OAuth grant.', response.status);
 
-		const grant = McpOAuthGrantSchema.parse(snakeToCamel(data.data));
+		const grant = transformOAuthGrant(data.data);
 		grants.value = grants.value.map((item) => (item.id === id ? grant : item));
 
 		return grant;

--- a/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
+++ b/apps/admin/src/modules/mcp/schemas/oauth-management.schemas.ts
@@ -1,6 +1,17 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
+import type {
+	McpModuleOAuthAccessTokenSchema,
+	McpModuleOAuthClientSchema,
+	McpModuleOAuthGrantSchema,
+	McpModuleOAuthRefreshFamilySchema,
+} from '../../../openapi.constants';
 import { McpOAuthScope } from '../mcp.constants';
+
+type ApiOAuthClient = McpModuleOAuthClientSchema;
+type ApiOAuthGrant = McpModuleOAuthGrantSchema;
+type ApiOAuthAccessToken = McpModuleOAuthAccessTokenSchema;
+type ApiOAuthRefreshFamily = McpModuleOAuthRefreshFamilySchema;
 
 const dateSchema = z.string().datetime({ offset: true });
 const nullableDateSchema = dateSchema.nullable().default(null);
@@ -66,4 +77,52 @@ export const McpOAuthUpdateClientSchema = McpOAuthCreateClientSchema.partial();
 
 export const McpOAuthUpdateGrantSchema = z.object({
 	approvedScopes: z.array(scopeSchema).min(1),
+});
+
+/**
+ * The wire shapes, bound to the types generated from the backend's OpenAPI
+ * spec. These exist so a field the backend renames stops compiling here rather
+ * than failing at runtime as an empty page — which is exactly how the public
+ * client identifier drifted from `client_id` to `clientIdentifier` unnoticed.
+ */
+export const McpOAuthClientResSchema: ZodType<ApiOAuthClient> = z.object({
+	id: z.string().uuid(),
+	client_id: z.string().min(1),
+	name: z.string(),
+	redirect_uris: z.array(z.string()),
+	maximum_scopes: z.array(scopeSchema),
+	enabled: z.boolean(),
+	created_at: z.string(),
+	updated_at: z.string().nullable(),
+});
+
+export const McpOAuthGrantResSchema: ZodType<ApiOAuthGrant> = z.object({
+	id: z.string().uuid(),
+	client_id: z.string(),
+	client_name: z.string(),
+	approved_by_id: z.string().nullable(),
+	approved_scopes: z.array(scopeSchema),
+	expires_at: z.string(),
+	revoked_at: z.string().nullable(),
+	active: z.boolean(),
+	created_at: z.string(),
+});
+
+export const McpOAuthAccessTokenResSchema: ZodType<ApiOAuthAccessToken> = z.object({
+	id: z.string().uuid(),
+	client_id: z.string(),
+	client_name: z.string(),
+	grant_id: z.string(),
+	refresh_family_id: z.string().nullable(),
+	scopes: z.array(scopeSchema),
+	expires_at: z.string(),
+});
+
+export const McpOAuthRefreshFamilyResSchema: ZodType<ApiOAuthRefreshFamily> = z.object({
+	id: z.string().uuid(),
+	client_id: z.string(),
+	client_name: z.string(),
+	grant_id: z.string(),
+	expires_at: z.string(),
+	active_token_count: z.number(),
 });

--- a/apps/admin/src/modules/mcp/schemas/oauth-management.transformers.ts
+++ b/apps/admin/src/modules/mcp/schemas/oauth-management.transformers.ts
@@ -1,0 +1,49 @@
+import { type ZodType, z } from 'zod';
+
+import { snakeToCamel } from '../../../common';
+import { McpApiException } from '../mcp.exceptions';
+
+import {
+	McpOAuthAccessTokenResSchema,
+	McpOAuthAccessTokenSchema,
+	McpOAuthClientResSchema,
+	McpOAuthClientSchema,
+	McpOAuthGrantResSchema,
+	McpOAuthGrantSchema,
+	McpOAuthRefreshFamilyResSchema,
+	McpOAuthRefreshFamilySchema,
+} from './oauth-management.schemas';
+import type { IMcpOAuthAccessToken, IMcpOAuthClient, IMcpOAuthGrant, IMcpOAuthRefreshFamily } from './oauth-management.types';
+
+/**
+ * Validates a record against the wire shape generated from the backend's
+ * OpenAPI spec before converting it, so a field the backend renames is
+ * reported as the mismatch it is rather than surfacing as a missing property
+ * further along.
+ */
+const transform = <TRes, TOut>(item: unknown, resSchema: ZodType<TRes>, schema: ZodType<TOut> | z.ZodTypeAny, label: string): TOut => {
+	const wire = resSchema.safeParse(item);
+
+	if (!wire.success) {
+		throw new McpApiException(`Received ${label} does not match the API contract.`);
+	}
+
+	const parsed = (schema as z.ZodTypeAny).safeParse(snakeToCamel(wire.data as Record<string, unknown>));
+
+	if (!parsed.success) {
+		throw new McpApiException(`Failed to validate received ${label}.`);
+	}
+
+	return parsed.data as TOut;
+};
+
+export const transformOAuthClient = (item: unknown): IMcpOAuthClient =>
+	transform(item, McpOAuthClientResSchema, McpOAuthClientSchema, 'OAuth client');
+
+export const transformOAuthGrant = (item: unknown): IMcpOAuthGrant => transform(item, McpOAuthGrantResSchema, McpOAuthGrantSchema, 'OAuth grant');
+
+export const transformOAuthAccessToken = (item: unknown): IMcpOAuthAccessToken =>
+	transform(item, McpOAuthAccessTokenResSchema, McpOAuthAccessTokenSchema, 'OAuth access token');
+
+export const transformOAuthRefreshFamily = (item: unknown): IMcpOAuthRefreshFamily =>
+	transform(item, McpOAuthRefreshFamilyResSchema, McpOAuthRefreshFamilySchema, 'OAuth refresh family');

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -66,6 +66,10 @@ export type McpModuleClientCredentialSchema = components['schemas']['McpModuleDa
 export type McpModuleCreateClientSchema = components['schemas']['McpModuleCreateClient'];
 export type McpModuleUpdateClientSchema = components['schemas']['McpModuleUpdateClient'];
 export type McpModuleRotateClientTokenSchema = components['schemas']['McpModuleRotateClientToken'];
+export type McpModuleOAuthClientSchema = components['schemas']['McpModuleDataOAuthClient'];
+export type McpModuleOAuthGrantSchema = components['schemas']['McpModuleDataOAuthGrant'];
+export type McpModuleOAuthAccessTokenSchema = components['schemas']['McpModuleDataOAuthAccessToken'];
+export type McpModuleOAuthRefreshFamilySchema = components['schemas']['McpModuleDataOAuthRefreshFamily'];
 export { McpModuleCreateClientCapabilities as McpModuleCapability } from './openapi';
 export { McpModuleCreateOAuthClientMaximum_scopes as McpModuleOAuthScope } from './openapi';
 


### PR DESCRIPTION
## Why

#787 fixed a field name. This removes the conditions that let it drift.

The MCP OAuth schemas were hand-written and bound to nothing, so nothing related them to what the backend actually sends. The devices module already solves this — its schemas are declared against the types generated from the OpenAPI spec — and MCP simply never adopted it.

## The gap

| | devices | MCP OAuth (before) |
|---|---|---|
| response schema typed against generated OpenAPI type | `DeviceResSchema: ZodType<ApiDevice>` | — |
| transformer validating the wire shape | `transformDeviceResponse` | — |
| generated types re-exported | yes | only `McpModuleOAuthScope` |

The generated types existed all along (`McpModuleDataOAuthClient` and friends) — `openapi.constants.ts`, which is maintained by hand, just never re-exported them, so there was nothing for the schemas to bind to.

## Change

- Re-export the four generated OAuth types.
- Declare `McpOAuth*ResSchema: ZodType<Api*>` for each record — the snake_case wire shape, checked against the generated type at compile time.
- Add transformers that validate a record against the wire shape, then `snakeToCamel` it into the schema the admin works with.
- `fetchAll`, `createClient`, `updateClient` and `updateGrant` all go through them, so every response the store accepts is validated.

## The guard is real

Reintroducing the original drift — renaming `client_id` back to `client_identifier` in the response schema — now fails `vue-tsc`:

```
typecheck exit=2   (1 error)
```

That is the whole point: the mismatch is a build failure rather than an empty page.

## Why the old tests did not catch it

The composable's fixtures were camelCase and `snakeToCamel` was stubbed to identity, so they fed the schemas exactly what the schemas expected. The tests agreed with the code instead of testing it against the API.

They now carry the snake_case the API returns, run through the **real** converter, and assert against the converted result — so a fixture can no longer be quietly written to match a wrong schema.

- Admin suite: 276 files, 2000 passed
- `vue-tsc` type-check clean
- eslint clean; prettier clean on every touched file

## Scope

MCP OAuth only — where the bug was. The MCP **clients** schema was checked against both the generated type and the live API and matches, but it is bound to nothing either, so the same drift is possible there and in any other module that skipped this. Worth a sweep; deliberately not folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)