### PR TITLE
refactor(admin): validate mcp client responses against the generated contract

### DIFF
--- a/apps/admin/src/modules/mcp/composables/useMcpClients.spec.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClients.spec.ts
@@ -12,24 +12,42 @@ const backendClient = {
 	DELETE: vi.fn(),
 };
 
-vi.mock('../../../common', () => ({
-	useBackend: () => ({ client: backendClient }),
-	snakeToCamel: (value: unknown): unknown => value,
-}));
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual<typeof import('../../../common')>('../../../common');
 
+	// The real converter, so the fixture below can be the snake_case the API
+	// actually returns rather than a shape that merely matches the schema.
+	return { useBackend: () => ({ client: backendClient }), snakeToCamel: actual.snakeToCamel };
+});
+
+// Exactly what the API returns, per the generated OpenAPI types.
 const client = {
 	id: '10000000-0000-4000-8000-000000000001',
 	name: 'Test agent',
 	description: null,
 	enabled: true,
 	capabilities: [McpCapability.read],
-	createdById: null,
-	tokenId: '20000000-0000-4000-8000-000000000001',
-	credentialExpiresAt: '2030-01-01T00:00:00.000Z',
-	credentialRevoked: false,
-	lastUsedAt: null,
-	createdAt: '2026-01-01T00:00:00.000Z',
-	updatedAt: null,
+	created_by_id: null,
+	token_id: '20000000-0000-4000-8000-000000000001',
+	credential_expires_at: '2030-01-01T00:00:00.000Z',
+	credential_revoked: false,
+	last_used_at: null,
+	created_at: '2026-01-01T00:00:00.000Z',
+	updated_at: null,
+};
+const parsedClient = {
+	id: client.id,
+	name: client.name,
+	description: client.description,
+	enabled: client.enabled,
+	capabilities: client.capabilities,
+	createdById: client.created_by_id,
+	tokenId: client.token_id,
+	credentialExpiresAt: client.credential_expires_at,
+	credentialRevoked: client.credential_revoked,
+	lastUsedAt: client.last_used_at,
+	createdAt: client.created_at,
+	updatedAt: client.updated_at,
 };
 
 describe('useMcpClients', () => {
@@ -41,6 +59,29 @@ describe('useMcpClients', () => {
 
 		await expect(fetchClients()).rejects.toBeInstanceOf(McpApiException);
 		expect(error.value).toBeInstanceOf(McpApiException);
+	});
+
+	it('validates a listed client against the api contract', async () => {
+		backendClient.GET.mockResolvedValue({ data: { data: [client] }, response: { status: 200 } });
+
+		const { fetchClients, clients } = useMcpClients();
+
+		await fetchClients();
+
+		expect(clients.value).toEqual([parsedClient]);
+	});
+
+	it('rejects a listed client whose shape does not match the contract', async () => {
+		// A field the backend renames must be reported as a contract mismatch
+		// rather than reaching the store as a missing property.
+		const withoutRevoked: Record<string, unknown> = { ...client };
+		delete withoutRevoked.credential_revoked;
+
+		backendClient.GET.mockResolvedValue({ data: { data: [withoutRevoked] }, response: { status: 200 } });
+
+		const { fetchClients } = useMcpClients();
+
+		await expect(fetchClients()).rejects.toThrow();
 	});
 
 	it('creates a finite capability-scoped credential and stores its client', async () => {
@@ -68,6 +109,6 @@ describe('useMcpClients', () => {
 			},
 		});
 		expect(credential.token).toBe('one-time-secret');
-		expect(clients.value).toEqual([client]);
+		expect(clients.value).toEqual([parsedClient]);
 	});
 });

--- a/apps/admin/src/modules/mcp/composables/useMcpClients.ts
+++ b/apps/admin/src/modules/mcp/composables/useMcpClients.ts
@@ -3,13 +3,8 @@ import { type Ref, ref } from 'vue';
 import { snakeToCamel, useBackend } from '../../../common';
 import { MCP_MODULE_PREFIX } from '../mcp.constants';
 import { McpApiException } from '../mcp.exceptions';
-import {
-	McpClientCredentialSchema,
-	McpClientSchema,
-	McpCreateClientSchema,
-	McpRotateClientSchema,
-	McpUpdateClientSchema,
-} from '../schemas/client.schemas';
+import { McpClientCredentialSchema, McpCreateClientSchema, McpRotateClientSchema, McpUpdateClientSchema } from '../schemas/client.schemas';
+import { transformMcpClient } from '../schemas/client.transformers';
 import type { IMcpClient, IMcpClientCredential, IMcpCreateClient, IMcpRotateClient, IMcpUpdateClient } from '../schemas/client.types';
 
 interface IUseMcpClients {
@@ -53,7 +48,7 @@ export const useMcpClients = (): IUseMcpClients => {
 
 			if (!data) throw new McpApiException('Failed to load MCP clients.', response.status);
 
-			clients.value = data.data.map((client) => McpClientSchema.parse(snakeToCamel(client)));
+			clients.value = data.data.map((client) => transformMcpClient(client));
 
 			return clients.value;
 		} catch (caught) {
@@ -94,7 +89,7 @@ export const useMcpClients = (): IUseMcpClients => {
 
 		if (!data) throw new McpApiException('Failed to update MCP client.', response.status);
 
-		return setClient(McpClientSchema.parse(snakeToCamel(data.data)));
+		return setClient(transformMcpClient(data.data));
 	};
 
 	const rotateClient = async (id: string, payload: IMcpRotateClient): Promise<IMcpClientCredential> => {
@@ -117,7 +112,7 @@ export const useMcpClients = (): IUseMcpClients => {
 
 		if (!data) throw new McpApiException('Failed to revoke MCP client.', response.status);
 
-		return setClient(McpClientSchema.parse(snakeToCamel(data.data)));
+		return setClient(transformMcpClient(data.data));
 	};
 
 	const deleteClient = async (id: string): Promise<void> => {

--- a/apps/admin/src/modules/mcp/schemas/client.schemas.ts
+++ b/apps/admin/src/modules/mcp/schemas/client.schemas.ts
@@ -1,6 +1,9 @@
-import { z } from 'zod';
+import { type ZodType, z } from 'zod';
 
+import type { McpModuleClientSchema } from '../../../openapi.constants';
 import { MCP_DEFAULT_TOKEN_EXPIRATION_DAYS, MCP_MAX_TOKEN_EXPIRATION_DAYS, McpCapability } from '../mcp.constants';
+
+type ApiClient = McpModuleClientSchema;
 
 const nullableDateSchema = z.string().datetime({ offset: true }).nullable().default(null);
 
@@ -40,4 +43,24 @@ export const McpRotateClientSchema = z.object({
 export const McpClientCredentialSchema = z.object({
 	client: McpClientSchema,
 	token: z.string().min(1),
+});
+
+/**
+ * The wire shape, bound to the type generated from the backend's OpenAPI spec,
+ * so a field the backend renames stops compiling here rather than emptying the
+ * list at runtime.
+ */
+export const McpClientResSchema: ZodType<ApiClient> = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	description: z.string().nullable(),
+	enabled: z.boolean(),
+	capabilities: z.array(z.nativeEnum(McpCapability)),
+	created_by_id: z.string().nullable(),
+	token_id: z.string().nullable(),
+	credential_expires_at: z.string().nullable(),
+	credential_revoked: z.boolean(),
+	last_used_at: z.string().nullable(),
+	created_at: z.string(),
+	updated_at: z.string().nullable(),
 });

--- a/apps/admin/src/modules/mcp/schemas/client.transformers.ts
+++ b/apps/admin/src/modules/mcp/schemas/client.transformers.ts
@@ -1,0 +1,30 @@
+import { type ZodType, z } from 'zod';
+
+import { snakeToCamel } from '../../../common';
+import { McpApiException } from '../mcp.exceptions';
+
+import { McpClientResSchema, McpClientSchema } from './client.schemas';
+import type { IMcpClient } from './client.types';
+
+/**
+ * Validates a record against the wire shape generated from the backend's
+ * OpenAPI spec before converting it, so a renamed field is reported as the
+ * contract mismatch it is rather than as a missing property further along.
+ */
+const transform = <TRes, TOut>(item: unknown, resSchema: ZodType<TRes>, schema: z.ZodTypeAny, label: string): TOut => {
+	const wire = resSchema.safeParse(item);
+
+	if (!wire.success) {
+		throw new McpApiException(`Received ${label} does not match the API contract.`);
+	}
+
+	const parsed = schema.safeParse(snakeToCamel(wire.data as Record<string, unknown>));
+
+	if (!parsed.success) {
+		throw new McpApiException(`Failed to validate received ${label}.`);
+	}
+
+	return parsed.data as TOut;
+};
+
+export const transformMcpClient = (item: unknown): IMcpClient => transform(item, McpClientResSchema, McpClientSchema, 'MCP client');


### PR DESCRIPTION
## Why

#788 bound the MCP **OAuth** responses to the generated OpenAPI types. This does the same for the **clients** endpoints, so no MCP response is parsed without being checked against the contract first.

## Audit result

I swept the admin for the same gap before writing this, and the outcome is narrower than expected — most modules already do it:

| | Res schemas | bound |
|---|---|---|
| config, dashboard, scenes, stats, system, weather | 3/3/4/1/4/5 | all |
| devices | 9 | 8 (one declared inline) |
| **mcp** | 5 | 5 after #788 — but clients had **no** Res layer at all |

Modules that never convert responses (`extensions`, `intents`, `spaces`) hold only internal schemas and need nothing. Where a module has no `ResSchema`, the binding is carried by the transformer's typed input instead — e.g. `transformConfigAppResponse(response: IConfigAppRes)` — so the compile-time link is intact there.

**MCP clients was the only remaining response path with no binding of either kind.**

## Change

- `McpClientResSchema: ZodType<ApiClient>` — the wire shape, checked against `McpModuleDataClient` at compile time.
- `transformMcpClient` validates a record against it, then `snakeToCamel`s it into the schema the admin works with.
- `fetchClients`, `updateClient` and `revokeClient` go through it.

Renaming a field in the response schema now fails `vue-tsc` (verified: exit 2) rather than emptying the list at runtime.

## The tests were the real hole

The fixture was camelCase with `snakeToCamel` stubbed to identity, so it agreed with the schema instead of testing it — and neither of the two existing tests reached the parse at all: one covers a failed request, the other goes through the credential schema. The transformer was entirely uncovered.

It now carries the snake_case the API returns, runs through the **real** converter, and is covered by two new tests: one asserting a valid record converts correctly, one asserting a record missing a contract field is rejected rather than reaching the store half-formed.

- Admin suite: 276 files, 2002 passed
- `vue-tsc` type-check clean
- eslint clean; prettier clean on every touched file

## Correction to an earlier claim

While auditing I reported that 183 of 224 `ModuleData` schemas omit `id`/`created_at`. **That was wrong** — an artefact of two buggy scans. The spec declares them correctly (`McpModuleDataClient` has all 12 properties, matching the live API). There is no backend spec defect; no action needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)