### PR TITLE
feat(admin): hide the mcp oauth pages while oauth is disabled

### DIFF
--- a/apps/admin/src/common/components/app-navigation.spec.ts
+++ b/apps/admin/src/common/components/app-navigation.spec.ts
@@ -29,6 +29,11 @@ vi.mock('../composables/useMenu', () => ({
 				children: [],
 			},
 			{
+				name: 'flagged',
+				meta: { title: 'Flagged', icon: 'mdi:flag', module: 'mcp-module', moduleFlag: 'oauthEnabled' },
+				children: [],
+			},
+			{
 				name: 'settings',
 				meta: { title: 'Settings', icon: 'mdi:cog' },
 				children: [
@@ -42,7 +47,7 @@ vi.mock('../composables/useMenu', () => ({
 
 vi.mock('../../modules/config/composables/useConfigModules', () => ({
 	useConfigModules: vi.fn(() => ({
-		configModules: { value: [] },
+		configModules: { value: [{ type: 'mcp-module', enabled: true, oauthEnabled: false }] },
 		areLoading: { value: false },
 		loaded: { value: true },
 		enabled: () => true,
@@ -102,6 +107,13 @@ describe('AppNavigation', () => {
 
 	it('renders correctly', () => {
 		expect(wrapper.exists()).toBe(true);
+	});
+
+	it('hides a menu item whose module flag is off', () => {
+		// The module is enabled, but the feature the route depends on is not, so
+		// the page could only ever be empty.
+		expect(wrapper.text()).not.toContain('Flagged');
+		expect(wrapper.text()).toContain('Dashboard');
 	});
 
 	it('displays menu items', () => {

--- a/apps/admin/src/common/components/app-navigation.vue
+++ b/apps/admin/src/common/components/app-navigation.vue
@@ -164,7 +164,7 @@ const ns = useNamespace('app-navigation');
 
 const { isMDDevice } = useBreakpoints();
 const { mainMenuItems } = useMenu();
-const { enabled: isModuleEnabled, loaded: modulesLoaded, fetchConfigModules } = useConfigModules();
+const { configModules, enabled: isModuleEnabled, loaded: modulesLoaded, fetchConfigModules } = useConfigModules();
 
 const accountManager = injectAccountManager();
 
@@ -187,7 +187,17 @@ const visibleMenuItems = computed(() => {
 			// If fetch failed, show all as degraded fallback
 			if (!modulesLoaded.value) return configFetchFailed.value;
 
-			return isModuleEnabled(moduleType);
+			if (!isModuleEnabled(moduleType)) return false;
+
+			// Some routes depend on a feature within an otherwise enabled module —
+			// the page exists but has nothing to show while the feature is off.
+			const moduleFlag = menuRoute.meta?.moduleFlag as string | undefined;
+
+			if (!moduleFlag) return true;
+
+			const moduleConfig = configModules.value.find((module) => module.type === moduleType) as Record<string, unknown> | undefined;
+
+			return moduleConfig?.[moduleFlag] === true;
 		})
 	);
 });

--- a/apps/admin/src/modules/mcp/mcp.module.ts
+++ b/apps/admin/src/modules/mcp/mcp.module.ts
@@ -5,13 +5,15 @@ import { defaultsDeep } from 'lodash';
 
 import { RouteNames as AppRouteNames } from '../../app.constants';
 import type { IModuleOptions } from '../../app.types';
-import { type IModule, type ModuleInjectionKey, injectModulesManager } from '../../common';
+import { type IModule, type ModuleInjectionKey, injectModulesManager, injectRouterGuard, injectStoresManager } from '../../common';
 import { CONFIG_MODULE_MODULE_TYPE, CONFIG_MODULE_NAME } from '../config';
+import { configModulesStoreKey } from '../config/store/keys';
 
 import { McpConfigForm } from './components/components';
 import { locales } from './locales';
 import { MCP_MODULE_NAME } from './mcp.constants';
 import { ModuleRoutes } from './router';
+import oauthEnabledGuard from './router/guards/oauth-enabled.guard';
 import { McpConfigEditFormSchema } from './schemas/config.schemas';
 import { McpConfigSchema, McpConfigUpdateReqSchema } from './store/config.store.schemas';
 
@@ -49,6 +51,15 @@ export default {
 			modules: [CONFIG_MODULE_NAME],
 			isCore: true,
 		});
+
+		const storesManager = injectStoresManager(app);
+		const routerGuard = injectRouterGuard(app);
+
+		// Consulted for both the menu and navigation, so the OAuth pages are
+		// hidden and unreachable while the provider is switched off.
+		routerGuard.register(
+			oauthEnabledGuard(() => storesManager.getStore(configModulesStoreKey).findByType(MCP_MODULE_NAME) as { oauthEnabled?: boolean } | null)
+		);
 
 		const rootRoute = options.router.getRoutes().find((route) => route.name === AppRouteNames.ROOT);
 

--- a/apps/admin/src/modules/mcp/router/guards/oauth-enabled.guard.spec.ts
+++ b/apps/admin/src/modules/mcp/router/guards/oauth-enabled.guard.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RouteNames as AppRouteNames } from '../../../../app.constants';
+import { RouteNames } from '../../mcp.constants';
+
+import oauthEnabledGuard from './oauth-enabled.guard';
+
+const route = (name: string) => ({ name }) as never;
+
+describe('oauthEnabledGuard', () => {
+	it('lets unrelated routes through untouched', () => {
+		const guard = oauthEnabledGuard(() => ({ oauthEnabled: false }));
+
+		expect(guard(undefined, route(RouteNames.CLIENTS))).toBe(true);
+		expect(guard(undefined, route('some-other-route'))).toBe(true);
+	});
+
+	it('allows the oauth routes while oauth is enabled', () => {
+		const guard = oauthEnabledGuard(() => ({ oauthEnabled: true }));
+
+		expect(guard(undefined, route(RouteNames.OAUTH_MANAGEMENT))).toBe(true);
+		expect(guard(undefined, route(RouteNames.OAUTH_CONSENT))).toBe(true);
+	});
+
+	it('redirects the oauth routes away while oauth is disabled', () => {
+		// The provider's endpoints are not mounted when oauth is off, so the page
+		// can only ever show empty tables and the consent flow cannot complete.
+		const guard = oauthEnabledGuard(() => ({ oauthEnabled: false }));
+
+		expect(guard(undefined, route(RouteNames.OAUTH_MANAGEMENT))).toEqual({ name: AppRouteNames.ROOT });
+		expect(guard(undefined, route(RouteNames.OAUTH_CONSENT))).toEqual({ name: AppRouteNames.ROOT });
+	});
+
+	it('does not redirect before the module config has loaded', () => {
+		// A deep link can arrive before the config fetch resolves; bouncing the
+		// user away on a value that is merely not known yet would be wrong.
+		const guard = oauthEnabledGuard(() => null);
+
+		expect(guard(undefined, route(RouteNames.OAUTH_MANAGEMENT))).toBe(true);
+	});
+
+	it('reads the flag fresh on every call', () => {
+		const read = vi.fn().mockReturnValueOnce({ oauthEnabled: false }).mockReturnValueOnce({ oauthEnabled: true });
+		const guard = oauthEnabledGuard(read);
+
+		expect(guard(undefined, route(RouteNames.OAUTH_MANAGEMENT))).toEqual({ name: AppRouteNames.ROOT });
+		// Toggling the flag in settings must take effect without a reload.
+		expect(guard(undefined, route(RouteNames.OAUTH_MANAGEMENT))).toBe(true);
+	});
+});

--- a/apps/admin/src/modules/mcp/router/guards/oauth-enabled.guard.ts
+++ b/apps/admin/src/modules/mcp/router/guards/oauth-enabled.guard.ts
@@ -1,0 +1,45 @@
+import type { RouteLocationRaw, RouteRecordRaw } from 'vue-router';
+
+import { RouteNames as AppRouteNames } from '../../../../app.constants';
+import type { IAppUser } from '../../../../app.types';
+import { RouteNames } from '../../mcp.constants';
+
+type RouteGuard = (appUser: IAppUser | undefined, route: RouteRecordRaw) => Error | boolean | RouteLocationRaw;
+
+/** Only the flag matters here; the rest of the module config is irrelevant. */
+type OAuthFlag = { oauthEnabled?: boolean } | null;
+
+const OAUTH_ROUTES: string[] = [RouteNames.OAUTH_MANAGEMENT, RouteNames.OAUTH_CONSENT];
+
+/**
+ * Keeps the OAuth pages out of reach while the provider is switched off.
+ *
+ * `oauth_enabled` decides whether the backend mounts the provider's endpoints
+ * at all — with it off, grants, access tokens and refresh families can never be
+ * created and the consent flow cannot complete, so the pages could only ever
+ * show empty tables.
+ *
+ * The flag is read through a callback rather than captured, so toggling it in
+ * settings takes effect without a reload. Registered with the shared router
+ * guard, which is consulted both when building the menu and when navigating,
+ * so one registration hides the item and blocks the URL.
+ */
+const oauthEnabledGuard =
+	(readConfig: () => OAuthFlag): RouteGuard =>
+	(_appUser: IAppUser | undefined, route: RouteRecordRaw): Error | boolean | RouteLocationRaw => {
+		if (typeof route.name !== 'string' || !OAUTH_ROUTES.includes(route.name)) {
+			return true;
+		}
+
+		const config = readConfig();
+
+		// Not loaded yet — a deep link can arrive before the config fetch
+		// resolves, and redirecting on an unknown value would be wrong.
+		if (config === null) {
+			return true;
+		}
+
+		return config.oauthEnabled === true ? true : { name: AppRouteNames.ROOT };
+	};
+
+export default oauthEnabledGuard;

--- a/apps/admin/src/modules/mcp/router/index.spec.ts
+++ b/apps/admin/src/modules/mcp/router/index.spec.ts
@@ -26,6 +26,15 @@ describe('MCP routes', () => {
 		}
 	});
 
+	it('gates the oauth menu route on the oauth feature flag', () => {
+		const route = ModuleRoutes.find(({ name }) => name === RouteNames.OAUTH_MANAGEMENT);
+
+		// Module-enabled alone is not enough: the provider can be off inside an
+		// enabled module, leaving the page with nothing to show.
+		expect(route?.meta?.module).toBe(MCP_MODULE_NAME);
+		expect(route?.meta?.moduleFlag).toBe('oauthEnabled');
+	});
+
 	it('registers consent as a hidden owner/admin route', () => {
 		const route = ModuleRoutes.find(({ name }) => name === RouteNames.OAUTH_CONSENT);
 

--- a/apps/admin/src/modules/mcp/router/index.ts
+++ b/apps/admin/src/modules/mcp/router/index.ts
@@ -33,6 +33,9 @@ export const ModuleRoutes: RouteRecordRaw[] = [
 			icon: 'mdi:shield-key-outline',
 			menu: 6510,
 			module: MCP_MODULE_NAME,
+			// The provider's endpoints are not mounted while this is off, so the
+			// page would have nothing to show.
+			moduleFlag: 'oauthEnabled',
 		},
 	},
 	{


### PR DESCRIPTION
## Why

The grants, access tokens and refresh families tabs were empty and there was no obvious way to populate them. The cause is not the UI: `oauth_enabled` is `false`, and `McpOAuthLifecycleService.onApplicationBootstrap` reads it directly:

```typescript
if (!config.enabled || !config.oauthEnabled) {
    this.routeGate.closeInternal();
    this.runtime.deactivateInternal();
    return;
}
```

With the route gate closed the provider's endpoints are never mounted, so no client can authorize. All three of those records are artefacts of a completed authorization — the admin API exposes only `GET` and `revoke` for them, by design — so with OAuth off the page can only ever show empty tables, and the consent route cannot complete either.

The clients tab is the exception, and that is correct: pre-registering a client is admin bookkeeping that works regardless of whether the provider runs.

## Change

A guard registered with the shared router guard, which is consulted **both** when the menu is built (`useMenu` → `buildRouteTree`) and when navigating (`router.beforeEach` in `app.main.ts`). One registration therefore hides the menu item *and* makes the URL unreachable, mirroring how a disabled module already hides its items.

Covers `OAUTH_MANAGEMENT` and `OAUTH_CONSENT`; every other route passes through untouched.

## Two details

**The flag is read through a callback, not captured at registration.** Guards are registered once at install, so capturing the value would freeze it — toggling OAuth in settings has to take effect without a reload.

**An unloaded config counts as "allow".** A deep link can arrive before the config fetch resolves; redirecting on a value that is merely unknown would bounce the user out of a page they are entitled to. The menu side is already covered here, since the item carries `meta.module` and is hidden while config loads.

## Tests

Five cases, verified failing first: unrelated routes untouched, both OAuth routes allowed when enabled, both redirected when disabled, no redirect before config loads, and the flag re-read on every call so a toggle applies immediately.

Also checked against the running backend that the config endpoint really exposes the flag — `oauth_enabled: false` reaches the store as `oauthEnabled`. Had it not, the guard would have hidden the page even with OAuth on.

- Admin suite: 277 files, 2007 passed
- `vue-tsc` type-check clean
- eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)