### PR TITLE
fix(infra): ignore the generated mcp oauth provider key material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_modules/
 var/data/config.yaml
 var/data/extensions.manifest.json
 var/data/extensions.ts
+var/data/.mcp-oauth-provider.json
 var/backups/
 var/buddy/
 var/db/database.sqlite


### PR DESCRIPTION
## Summary

Enabling the MCP OAuth provider writes `var/data/.mcp-oauth-provider.json`, which contains the provider's **RSA private key** (`d, p, q, dp, dq, qi`) and both **cookie signing keys**. Git was not ignoring it.

`.gitignore` enumerates the runtime files under `var/data/` individually:

```
var/data/config.yaml
var/data/extensions.manifest.json
var/data/extensions.ts
```

This artifact was written later and never added to that list, so it showed up as untracked. On an instance with OAuth enabled, a `git add -A` would commit the signing keys.

Found while verifying #790 against a local instance with `oauth_enabled: true` — the file appeared in `git status` right after the provider bootstrapped.

## Change

One line, matching the surrounding per-file style:

```
var/data/.mcp-oauth-provider.json
```

## Nothing has leaked

Verified before opening this:

| Check | Result |
|---|---|
| `git log --all -- '**/.mcp-oauth-provider.json'` | no commits |
| private JWK material (`"kty":"RSA"`) across last 200 commits | none found |
| `git check-ignore` after the change | ignored |

So this is preventive only; no key rotation or history rewrite is needed.

## Notes

Kept deliberately narrow rather than ignoring `var/data/` wholesale, since `.gitkeep` and `seed/**` are tracked there and the file-by-file convention is already established.