### PR TITLE
feat(backend): recognise shelly energy meters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_modules/
 var/data/config.yaml
 var/data/extensions.manifest.json
 var/data/extensions.ts
+var/data/.mcp-oauth-provider.json
 var/backups/
 var/buddy/
 var/db/database.sqlite

--- a/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.ts
@@ -4,6 +4,10 @@ import {
 	Cover,
 	Device,
 	DevicePower,
+	Em,
+	Em1,
+	Em1Data,
+	EmData,
 	Humidity,
 	Input,
 	Light,
@@ -38,7 +42,11 @@ type SupportedComponent =
 	| DevicePower
 	| Humidity
 	| Temperature
-	| Pm1;
+	| Pm1
+	| Em
+	| EmData
+	| Em1
+	| Em1Data;
 
 export class ShellyDeviceDelegate extends EventEmitter2 {
 	private readonly logger: ExtensionLoggerService = createExtensionLogger(

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.spec.ts
@@ -1,0 +1,112 @@
+import { Em, Em1, Em1Data, EmData, Shelly3EmGen3, ShellyEmGen3, ShellyPro3Em, ShellyProEm } from 'shellies-ds9';
+
+import { devicesSchema } from '../../spec/devices';
+
+import { ComponentType, DESCRIPTORS } from './devices-shelly-ng.constants';
+
+const findDescriptor = (model: string) =>
+	Object.values(DESCRIPTORS).find((descriptor) => descriptor.models.includes(model.toUpperCase())) ?? null;
+
+describe('Shelly NG energy meters', () => {
+	// A model missing from DESCRIPTORS is rejected outright by
+	// DeviceManagerService with "Provided device is not supported", which is what
+	// made every EM model unadoptable.
+	it.each([
+		['SPEM-002CEBEU50', 'Shelly Pro EM'],
+		['SPEM-003CEBEU', 'Shelly Pro 3EM'],
+		['SPEM-003CEBEU400', 'Shelly Pro 3EM-400'],
+		['SPEM-003CEBEU63', 'Shelly Pro 3EM-3CT63'],
+		['S3EM-002CXCEU', 'Shelly EM Gen3'],
+		['S3EM-003CXCEU63', 'Shelly 3EM-63 G3'],
+	])('resolves %s to a descriptor', (model) => {
+		expect(findDescriptor(model)).not.toBeNull();
+	});
+
+	it('keeps the model strings in step with the library', () => {
+		// The descriptors reference the library constants directly, so this only
+		// fails if a library upgrade renames a model we hard-coded above.
+		expect([
+			ShellyProEm.model.toUpperCase(),
+			ShellyPro3Em.model.toUpperCase(),
+			ShellyEmGen3.model.toUpperCase(),
+			Shelly3EmGen3.model.toUpperCase(),
+		]).toEqual(['SPEM-002CEBEU50', 'SPEM-003CEBEU', 'S3EM-002CXCEU', 'S3EM-003CXCEU63']);
+	});
+
+	it('declares the three-phase and per-phase components for the 3EM models', () => {
+		for (const model of ['SPEM-003CEBEU', 'S3EM-003CXCEU63']) {
+			const descriptor = findDescriptor(model);
+
+			const byType = new Map(descriptor.components.map((component) => [component.type, component.ids]));
+
+			// Both profiles are declared: the device reports only the set matching
+			// the profile it currently runs.
+			expect(byType.get(ComponentType.EM)).toEqual([0]);
+			expect(byType.get(ComponentType.EM_DATA)).toEqual([0]);
+			expect(byType.get(ComponentType.EM1)).toEqual([0, 1, 2]);
+			expect(byType.get(ComponentType.EM1_DATA)).toEqual([0, 1, 2]);
+		}
+	});
+
+	it('declares two meters and a relay for the single-phase models', () => {
+		for (const model of ['SPEM-002CEBEU50', 'S3EM-002CXCEU']) {
+			const descriptor = findDescriptor(model);
+
+			const byType = new Map(descriptor.components.map((component) => [component.type, component.ids]));
+
+			expect(byType.get(ComponentType.EM1)).toEqual([0, 1]);
+			expect(byType.get(ComponentType.EM1_DATA)).toEqual([0, 1]);
+			expect(byType.get(ComponentType.SWITCH)).toEqual([0]);
+			expect(byType.has(ComponentType.EM)).toBe(false);
+		}
+	});
+
+	// ComponentType values are compared against the key prefix the device reports,
+	// so a value whose casing differs from the library's silently disables the
+	// whole component. `devicePower` is exactly that bug, still present.
+	it.each([
+		[ComponentType.EM, Em],
+		[ComponentType.EM_DATA, EmData],
+		[ComponentType.EM1, Em1],
+		[ComponentType.EM1_DATA, Em1Data],
+	])('uses the component key the library reports for %s', (type, cls) => {
+		const instance = new (cls as unknown as new (device: unknown, id: number) => { key: string })({}, 0);
+
+		expect(instance.key.split(':')[0]).toBe(String(type));
+	});
+
+	it('only assigns categories whose device spec permits the electrical channels', () => {
+		const models = [
+			'SPEM-002CEBEU50',
+			'SPEM-003CEBEU',
+			'SPEM-003CEBEU400',
+			'SPEM-003CEBEU63',
+			'S3EM-002CXCEU',
+			'S3EM-003CXCEU63',
+		];
+
+		for (const model of models) {
+			const descriptor = findDescriptor(model);
+
+			expect(descriptor.categories.length).toBeGreaterThan(0);
+
+			for (const category of descriptor.categories) {
+				const channels = (devicesSchema as Record<string, { channels: Record<string, unknown> }>)[category]?.channels;
+
+				// A category that forbids these channels - `generic` does - produces a
+				// device that fails spec validation once the meter reports.
+				expect(Object.keys(channels ?? {})).toEqual(expect.arrayContaining(['electrical_power', 'electrical_energy']));
+			}
+		}
+	});
+
+	it('defaults the relay models to a category that keeps the relay mappable', () => {
+		for (const model of ['SPEM-002CEBEU50', 'S3EM-002CXCEU']) {
+			const descriptor = findDescriptor(model);
+
+			// Discovery adopts categories[0]; SENSOR would leave switch:0 unmapped
+			// because the sensor spec permits no outlet or switcher channel.
+			expect(descriptor.categories[0]).toBe('switcher');
+		}
+	});
+});

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.ts
@@ -2,6 +2,10 @@ import {
 	Cct,
 	Cover,
 	DevicePower,
+	Em,
+	Em1,
+	Em1Data,
+	EmData,
 	Ethernet,
 	Humidity,
 	Input,
@@ -21,9 +25,11 @@ import {
 	Shelly2LGen3,
 	Shelly2PmGen3,
 	Shelly2PmGen4,
+	Shelly3EmGen3,
 	ShellyDaliDimmerGen3,
 	ShellyDimmerGen3,
 	ShellyDimmerPmGen3,
+	ShellyEmGen3,
 	ShellyI4Gen3,
 	ShellyOutdoorPlugSGen3,
 	ShellyPlugAzGen3,
@@ -64,12 +70,16 @@ import {
 	ShellyPro2Rev1,
 	ShellyPro2Rev2,
 	ShellyPro3,
+	ShellyPro3Em,
+	ShellyPro3Em3CT63,
+	ShellyPro3Em400,
 	ShellyPro4Pm,
 	ShellyPro4PmV2,
 	ShellyProDimmer,
 	ShellyProDimmer1Pm,
 	ShellyProDimmer2Pm,
 	ShellyProDualCoverPm,
+	ShellyProEm,
 	ShellyProRGBWPm,
 	Switch,
 	Temperature,
@@ -111,6 +121,10 @@ export enum ComponentType {
 	HUMIDITY = 'humidity',
 	TEMPERATURE = 'temperature',
 	PM1 = 'pm1',
+	EM = 'em',
+	EM_DATA = 'emdata',
+	EM1 = 'em1',
+	EM1_DATA = 'em1data',
 	WIFI = 'wifi',
 	ETHERNET = 'ethernet',
 }
@@ -139,7 +153,11 @@ export type ComponentSpec =
 	| { type: ComponentType.DEVICE_POWER; cls: Ctor<DevicePower>; ids: number[] }
 	| { type: ComponentType.HUMIDITY; cls: Ctor<Humidity>; ids: number[] }
 	| { type: ComponentType.TEMPERATURE; cls: Ctor<Temperature>; ids: number[] }
-	| { type: ComponentType.PM1; cls: Ctor<Pm1>; ids: number[] };
+	| { type: ComponentType.PM1; cls: Ctor<Pm1>; ids: number[] }
+	| { type: ComponentType.EM; cls: Ctor<Em>; ids: number[] }
+	| { type: ComponentType.EM_DATA; cls: Ctor<EmData>; ids: number[] }
+	| { type: ComponentType.EM1; cls: Ctor<Em1>; ids: number[] }
+	| { type: ComponentType.EM1_DATA; cls: Ctor<Em1Data>; ids: number[] };
 
 export type SystemSpec =
 	| { type: ComponentType.WIFI; cls: Ctor<WiFi> }
@@ -505,6 +523,45 @@ export const DESCRIPTORS: Record<string, DeviceDescriptor> = {
 		],
 		categories: [DeviceCategory.LIGHTING],
 	},
+	// Energy meters expose their CTs under two mutually exclusive profiles: the
+	// `triphase` profile reports a single three-phase `em` component, while
+	// `monophase` reports one `em1` per phase. Both are declared here because the
+	// profile is only known once the device reports its live components.
+	SHELLYPROEM: {
+		name: ShellyProEm.modelName,
+		models: [ShellyProEm.model.toUpperCase()],
+		components: [
+			{ type: ComponentType.SWITCH, cls: Switch, ids: [0] },
+			{ type: ComponentType.EM1, cls: Em1, ids: [0, 1] },
+			{ type: ComponentType.EM1_DATA, cls: Em1Data, ids: [0, 1] },
+		],
+		system: [
+			{ type: ComponentType.WIFI, cls: WiFi },
+			{ type: ComponentType.ETHERNET, cls: Ethernet },
+		],
+		// The relay makes SWITCHER the more capable default: it still permits the
+		// electrical channels, whereas SENSOR would leave the relay unmapped.
+		categories: [DeviceCategory.SWITCHER, DeviceCategory.OUTLET, DeviceCategory.SENSOR],
+	},
+	SHELLYPRO3EM: {
+		name: ShellyPro3Em.modelName,
+		models: [
+			ShellyPro3Em.model.toUpperCase(),
+			ShellyPro3Em400.model.toUpperCase(),
+			ShellyPro3Em3CT63.model.toUpperCase(),
+		],
+		components: [
+			{ type: ComponentType.EM, cls: Em, ids: [0] },
+			{ type: ComponentType.EM_DATA, cls: EmData, ids: [0] },
+			{ type: ComponentType.EM1, cls: Em1, ids: [0, 1, 2] },
+			{ type: ComponentType.EM1_DATA, cls: Em1Data, ids: [0, 1, 2] },
+		],
+		system: [
+			{ type: ComponentType.WIFI, cls: WiFi },
+			{ type: ComponentType.ETHERNET, cls: Ethernet },
+		],
+		categories: [DeviceCategory.SENSOR],
+	},
 	SHELLY1GEN3: {
 		name: Shelly1Gen3.modelName,
 		models: [Shelly1Gen3.model.toUpperCase()],
@@ -687,6 +744,29 @@ export const DESCRIPTORS: Record<string, DeviceDescriptor> = {
 		],
 		system: [{ type: ComponentType.WIFI, cls: WiFi }],
 		categories: [DeviceCategory.LIGHTING],
+	},
+	SHELLYEMGEN3: {
+		name: ShellyEmGen3.modelName,
+		models: [ShellyEmGen3.model.toUpperCase()],
+		components: [
+			{ type: ComponentType.SWITCH, cls: Switch, ids: [0] },
+			{ type: ComponentType.EM1, cls: Em1, ids: [0, 1] },
+			{ type: ComponentType.EM1_DATA, cls: Em1Data, ids: [0, 1] },
+		],
+		system: [{ type: ComponentType.WIFI, cls: WiFi }],
+		categories: [DeviceCategory.SWITCHER, DeviceCategory.OUTLET, DeviceCategory.SENSOR],
+	},
+	SHELLY3EMGEN3: {
+		name: Shelly3EmGen3.modelName,
+		models: [Shelly3EmGen3.model.toUpperCase()],
+		components: [
+			{ type: ComponentType.EM, cls: Em, ids: [0] },
+			{ type: ComponentType.EM_DATA, cls: EmData, ids: [0] },
+			{ type: ComponentType.EM1, cls: Em1, ids: [0, 1, 2] },
+			{ type: ComponentType.EM1_DATA, cls: Em1Data, ids: [0, 1, 2] },
+		],
+		system: [{ type: ComponentType.WIFI, cls: WiFi }],
+		categories: [DeviceCategory.SENSOR],
 	},
 	SHELLY1GEN4: {
 		name: Shelly1Gen4.modelName,

--- a/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.spec.ts
@@ -89,6 +89,13 @@ const mockRpc = {
 
 	getPm1Config: jest.fn(),
 	getPm1Status: jest.fn(),
+
+	getEmConfig: jest.fn(),
+	getEmStatus: jest.fn(),
+	getEmDataStatus: jest.fn(),
+	getEm1Config: jest.fn(),
+	getEm1Status: jest.fn(),
+	getEm1DataStatus: jest.fn(),
 } as unknown as jest.Mocked<ShellyRpcClientService>;
 
 jest.mock('../../../spec/channels', () => {
@@ -123,6 +130,7 @@ jest.mock('../../../spec/channels', () => {
 		[ChannelCategory.ELECTRICAL_ENERGY]: {
 			properties: {
 				[PropertyCategory.CONSUMPTION]: { ...common(), data_type: 'number' as any },
+				[PropertyCategory.GRID_EXPORT]: { ...common(), data_type: 'number' as any },
 			},
 		},
 		[ChannelCategory.ELECTRICAL_POWER]: {
@@ -130,6 +138,7 @@ jest.mock('../../../spec/channels', () => {
 				[PropertyCategory.POWER]: { ...common(), data_type: 'number' as any },
 				[PropertyCategory.VOLTAGE]: { ...common(), data_type: 'number' as any },
 				[PropertyCategory.CURRENT]: { ...common(), data_type: 'number' as any },
+				[PropertyCategory.FREQUENCY]: { ...common(), data_type: 'number' as any },
 			},
 		},
 		[ChannelCategory.LIGHT]: {
@@ -177,6 +186,10 @@ jest.mock('../devices-shelly-ng.constants', () => ({
 		HUMIDITY: 'humidity',
 		TEMPERATURE: 'temperature',
 		PM: 'pm1',
+		EM: 'em',
+		EM_DATA: 'emdata',
+		EM1: 'em1',
+		EM1_DATA: 'em1data',
 		WIFI: 'wifi',
 		ETHERNET: 'ethernet',
 	},
@@ -400,6 +413,214 @@ describe('DeviceManagerService.createOrUpdate', () => {
 		// Switch ON property was created with 'output' value
 		const onCall = mockChannelsPropertiesService.create.mock.calls.find((c) => c[1]?.category === PropertyCategory.ON);
 		expect(onCall).toBeTruthy();
+	});
+});
+
+describe('DeviceManagerService energy meters', () => {
+	const baseDeviceInfo = {
+		id: 'shelly-dev-id',
+		mac: 'mac',
+		model: 'SPEM-003CEBEU',
+		fw_id: 'fw',
+		ver: '1.2.3',
+		app: 'app',
+		auth_en: false,
+		auth_domain: null,
+		discoverable: true,
+		key: 'key',
+		batch: 'batch',
+		fw_sbits: 'sbits',
+	};
+
+	const arrange = (svc: any, components: { key: string }[]) => {
+		jest.spyOn<any, any>(svc, 'getSpecification').mockReturnValue({
+			models: ['SPEM-003CEBEU'],
+			system: [{ type: 'wifi' }],
+		});
+
+		mockRpc.getDeviceInfo.mockResolvedValue(baseDeviceInfo as any);
+		mockRpc.getComponents.mockResolvedValue(components.map((c) => ({ ...c, config: {}, status: {} })) as any);
+		mockRpc.getSystemConfig.mockResolvedValue({
+			device: { name: 'Main meter', eco_mode: false, mac: 'mac', fw_id: 'fw', discoverable: true },
+			location: { tz: null, lat: null, lon: null },
+			debug: { mqtt: { enabled: false }, websocket: { enabled: false }, udp: { addr: null } },
+			rpc_udp: { dst_addr: '', listen_port: null },
+			sntp: { server: '' },
+			cfg_rev: 1,
+		} as any);
+		mockRpc.getWifiStatus.mockResolvedValue({ rssi: -55 } as any);
+
+		mockChannelsService.findOneBy.mockResolvedValue(null);
+		mockChannelsService.findAll.mockResolvedValue([]);
+
+		let channelCounter = 0;
+		mockChannelsService.create.mockImplementation(async (dto: any) => ({ id: `ch_${++channelCounter}`, ...dto }));
+		mockChannelsService.update.mockImplementation(async (id: string, dto: any) => ({ id, ...dto }));
+
+		let propCounter = 0;
+		mockChannelsPropertiesService.findOneBy.mockResolvedValue(null);
+		mockChannelsPropertiesService.create.mockImplementation(async (channelId: string, dto: any) => ({
+			id: `p_${++propCounter}`,
+			channel: channelId,
+			...dto,
+		}));
+		mockChannelsPropertiesService.update.mockImplementation(async (id: string, dto: any) => ({ id, ...dto }));
+	};
+
+	const createdChannels = () =>
+		mockChannelsService.create.mock.calls.map((call: any[]) => call[0]).filter((dto: any) => dto?.identifier);
+
+	const propertiesOf = (identifier: string) => {
+		const index = mockChannelsService.create.mock.calls.findIndex((call: any[]) => call[0]?.identifier === identifier);
+
+		if (index === -1) {
+			return [];
+		}
+
+		const channelId = `ch_${index + 1}`;
+
+		return mockChannelsPropertiesService.create.mock.calls
+			.filter((call: any[]) => call[0] === channelId)
+			.map((call: any[]) => call[1]);
+	};
+
+	test('three-phase meter creates a channel per phase plus the device-reported total', async () => {
+		const svc = makeService();
+		const device = { id: 'db-em-1', password: null, category: DeviceCategory.SENSOR } as any;
+
+		mockDevicesService.findOne.mockResolvedValue(device);
+		arrange(svc, [{ key: 'em:0' }, { key: 'emdata:0' }]);
+
+		mockRpc.getEmConfig.mockResolvedValue({ id: 0, name: null } as any);
+		mockRpc.getEmStatus.mockResolvedValue({
+			id: 0,
+			a_current: 1.1,
+			a_voltage: 231,
+			a_act_power: 250,
+			a_freq: 50,
+			b_current: 2.2,
+			b_voltage: 232,
+			b_act_power: 500,
+			b_freq: 50,
+			c_current: 3.3,
+			c_voltage: 233,
+			c_act_power: 750,
+			c_freq: 50,
+			n_current: null,
+			total_current: 6.6,
+			total_act_power: 1500,
+		} as any);
+		mockRpc.getEmDataStatus.mockResolvedValue({
+			id: 0,
+			a_total_act_energy: 10,
+			a_total_act_ret_energy: 1,
+			b_total_act_energy: 20,
+			b_total_act_ret_energy: 2,
+			c_total_act_energy: 30,
+			c_total_act_ret_energy: 3,
+			total_act: 60,
+			total_act_ret: 6,
+		} as any);
+
+		await svc.createOrUpdate(device.id);
+
+		const identifiers = createdChannels().map((dto: any) => dto.identifier);
+
+		expect(identifiers).toEqual(
+			expect.arrayContaining([
+				'power:0:a',
+				'power:0:b',
+				'power:0:c',
+				'power:0:total',
+				'energy:0:a',
+				'energy:0:b',
+				'energy:0:c',
+				'energy:0:total',
+			]),
+		);
+
+		// The total comes straight from the meter, never summed by us.
+		const total = propertiesOf('power:0:total');
+
+		expect(total.find((prop: any) => prop.category === PropertyCategory.POWER)?.value).toBe(1500);
+
+		// Phase B carries the full instantaneous set the spec allows.
+		expect(
+			propertiesOf('power:0:b')
+				.map((prop: any) => prop.category)
+				.sort(),
+		).toEqual(
+			[PropertyCategory.CURRENT, PropertyCategory.FREQUENCY, PropertyCategory.POWER, PropertyCategory.VOLTAGE].sort(),
+		);
+
+		// Returned energy is the only spec property that can carry it.
+		expect(propertiesOf('energy:0:c').find((prop: any) => prop.category === PropertyCategory.GRID_EXPORT)?.value).toBe(
+			3,
+		);
+	});
+
+	test('a phase with no CT attached is skipped rather than written without its required power', async () => {
+		const svc = makeService();
+		const device = { id: 'db-em-2', password: null, category: DeviceCategory.SENSOR } as any;
+
+		mockDevicesService.findOne.mockResolvedValue(device);
+		arrange(svc, [{ key: 'em:0' }]);
+
+		mockRpc.getEmConfig.mockResolvedValue({ id: 0, name: null } as any);
+		mockRpc.getEmStatus.mockResolvedValue({
+			id: 0,
+			a_current: 1.1,
+			a_voltage: 231,
+			a_act_power: 250,
+			a_freq: 50,
+			b_current: null,
+			b_voltage: null,
+			b_act_power: null,
+			b_freq: null,
+			c_current: null,
+			c_voltage: null,
+			c_act_power: null,
+			c_freq: null,
+			n_current: null,
+			total_current: 1.1,
+			total_act_power: 250,
+		} as any);
+
+		await svc.createOrUpdate(device.id);
+
+		const identifiers = createdChannels().map((dto: any) => dto.identifier);
+
+		expect(identifiers).toContain('power:0:a');
+		expect(identifiers).not.toContain('power:0:b');
+		expect(identifiers).not.toContain('power:0:c');
+	});
+
+	test('single-phase meters create one channel per em1 component', async () => {
+		const svc = makeService();
+		const device = { id: 'db-em-3', password: null, category: DeviceCategory.SWITCHER } as any;
+
+		mockDevicesService.findOne.mockResolvedValue(device);
+		arrange(svc, [{ key: 'em1:0' }, { key: 'em1:1' }, { key: 'em1data:0' }, { key: 'em1data:1' }]);
+
+		mockRpc.getEm1Config.mockImplementation(async (_host: string, id: number) => ({ id, name: null }) as any);
+		mockRpc.getEm1Status.mockImplementation(
+			async (_host: string, id: number) =>
+				({ id, current: 1 + id, voltage: 230, act_power: 100 * (id + 1), freq: 50 }) as any,
+		);
+		mockRpc.getEm1DataStatus.mockImplementation(
+			async (_host: string, id: number) => ({ id, total_act_energy: 10 * (id + 1), total_act_ret_energy: id }) as any,
+		);
+
+		await svc.createOrUpdate(device.id);
+
+		const identifiers = createdChannels().map((dto: any) => dto.identifier);
+
+		expect(identifiers).toEqual(expect.arrayContaining(['power:0', 'power:1', 'energy:0', 'energy:1']));
+
+		// No three-phase channels: this profile has no `em` component at all.
+		expect(identifiers.some((identifier: string) => identifier.endsWith(':total'))).toBe(false);
+
+		expect(propertiesOf('power:1').find((prop: any) => prop.category === PropertyCategory.POWER)?.value).toBe(200);
 	});
 });
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.ts
@@ -1779,6 +1779,302 @@ export class DeviceManagerService {
 							resource: device.id,
 						});
 					}
+				} else if (type === String(ComponentType.EM)) {
+					const tasks = ids.map((key) =>
+						limit(async () => {
+							const [emConfig, emStatus] = await retry(
+								() =>
+									withTimeout(
+										Promise.all([
+											this.shellyRpcClientService.getEmConfig(host, key, { password }),
+											this.shellyRpcClientService.getEmStatus(host, key, { password }),
+										]),
+										this.timeoutSec * 1000,
+										`EM.GetConfig+EM.GetStatus - ${key}`,
+									),
+								{ retries: 2, baseMs: 300, factor: 2 },
+							).catch((err: Error) => {
+								this.logger.error(`Failed load for em=${key} on device=${device.id}`, {
+									resource: device.id,
+									message: err.message,
+									stack: err.stack,
+								});
+
+								throw err;
+							});
+
+							const label = emConfig.name ?? `Meter: ${key}`;
+
+							const phases = [
+								{
+									id: 'a',
+									power: emStatus.a_act_power,
+									voltage: emStatus.a_voltage,
+									current: emStatus.a_current,
+									frequency: emStatus.a_freq,
+								},
+								{
+									id: 'b',
+									power: emStatus.b_act_power,
+									voltage: emStatus.b_voltage,
+									current: emStatus.b_current,
+									frequency: emStatus.b_freq,
+								},
+								{
+									id: 'c',
+									power: emStatus.c_act_power,
+									voltage: emStatus.c_voltage,
+									current: emStatus.c_current,
+									frequency: emStatus.c_freq,
+								},
+							];
+
+							for (const phase of phases) {
+								const channel = await this.ensureMeterChannel(
+									device,
+									ChannelCategory.ELECTRICAL_POWER,
+									`power:${key}:${phase.id}`,
+									`${label} - phase ${phase.id.toUpperCase()}`,
+									[
+										{ category: PropertyCategory.POWER, identifier: `${phase.id}_act_power`, value: phase.power },
+										{ category: PropertyCategory.VOLTAGE, identifier: `${phase.id}_voltage`, value: phase.voltage },
+										{ category: PropertyCategory.CURRENT, identifier: `${phase.id}_current`, value: phase.current },
+										{ category: PropertyCategory.FREQUENCY, identifier: `${phase.id}_freq`, value: phase.frequency },
+									],
+								);
+
+								if (channel) {
+									channelsIds.push(channel.id);
+								}
+							}
+
+							const total = await this.ensureMeterChannel(
+								device,
+								ChannelCategory.ELECTRICAL_POWER,
+								`power:${key}:total`,
+								`${label} - total`,
+								[
+									{ category: PropertyCategory.POWER, identifier: 'total_act_power', value: emStatus.total_act_power },
+									{ category: PropertyCategory.CURRENT, identifier: 'total_current', value: emStatus.total_current },
+								],
+							);
+
+							if (total) {
+								channelsIds.push(total.id);
+							}
+						}),
+					);
+
+					const settled = await Promise.allSettled(tasks);
+
+					const failed = settled.filter((r) => r.status === 'rejected').length;
+
+					if (failed) {
+						this.logger.warn(`${failed}/${ids.length} em component(s) failed for device=${device.id}`, {
+							resource: device.id,
+						});
+					}
+				} else if (type === String(ComponentType.EM_DATA)) {
+					const tasks = ids.map((key) =>
+						limit(async () => {
+							const emDataStatus = await retry(
+								() =>
+									withTimeout(
+										this.shellyRpcClientService.getEmDataStatus(host, key, { password }),
+										this.timeoutSec * 1000,
+										`EMData.GetStatus - ${key}`,
+									),
+								{ retries: 2, baseMs: 300, factor: 2 },
+							).catch((err: Error) => {
+								this.logger.error(`Failed load for emdata=${key} on device=${device.id}`, {
+									resource: device.id,
+									message: err.message,
+									stack: err.stack,
+								});
+
+								throw err;
+							});
+
+							const phases = [
+								{
+									id: 'a',
+									consumption: emDataStatus.a_total_act_energy,
+									returned: emDataStatus.a_total_act_ret_energy,
+								},
+								{
+									id: 'b',
+									consumption: emDataStatus.b_total_act_energy,
+									returned: emDataStatus.b_total_act_ret_energy,
+								},
+								{
+									id: 'c',
+									consumption: emDataStatus.c_total_act_energy,
+									returned: emDataStatus.c_total_act_ret_energy,
+								},
+							];
+
+							for (const phase of phases) {
+								const channel = await this.ensureMeterChannel(
+									device,
+									ChannelCategory.ELECTRICAL_ENERGY,
+									`energy:${key}:${phase.id}`,
+									`Consumption: ${key} - phase ${phase.id.toUpperCase()}`,
+									[
+										{
+											category: PropertyCategory.CONSUMPTION,
+											identifier: `${phase.id}_total_act_energy`,
+											value: phase.consumption,
+										},
+										{
+											category: PropertyCategory.GRID_EXPORT,
+											identifier: `${phase.id}_total_act_ret_energy`,
+											value: phase.returned,
+										},
+									],
+								);
+
+								if (channel) {
+									channelsIds.push(channel.id);
+								}
+							}
+
+							const total = await this.ensureMeterChannel(
+								device,
+								ChannelCategory.ELECTRICAL_ENERGY,
+								`energy:${key}:total`,
+								`Consumption: ${key} - total`,
+								[
+									{ category: PropertyCategory.CONSUMPTION, identifier: 'total_act', value: emDataStatus.total_act },
+									{
+										category: PropertyCategory.GRID_EXPORT,
+										identifier: 'total_act_ret',
+										value: emDataStatus.total_act_ret,
+									},
+								],
+							);
+
+							if (total) {
+								channelsIds.push(total.id);
+							}
+						}),
+					);
+
+					const settled = await Promise.allSettled(tasks);
+
+					const failed = settled.filter((r) => r.status === 'rejected').length;
+
+					if (failed) {
+						this.logger.warn(`${failed}/${ids.length} emdata component(s) failed for device=${device.id}`, {
+							resource: device.id,
+						});
+					}
+				} else if (type === String(ComponentType.EM1)) {
+					const tasks = ids.map((key) =>
+						limit(async () => {
+							const [em1Config, em1Status] = await retry(
+								() =>
+									withTimeout(
+										Promise.all([
+											this.shellyRpcClientService.getEm1Config(host, key, { password }),
+											this.shellyRpcClientService.getEm1Status(host, key, { password }),
+										]),
+										this.timeoutSec * 1000,
+										`EM1.GetConfig+EM1.GetStatus - ${key}`,
+									),
+								{ retries: 2, baseMs: 300, factor: 2 },
+							).catch((err: Error) => {
+								this.logger.error(`Failed load for em1=${key} on device=${device.id}`, {
+									resource: device.id,
+									message: err.message,
+									stack: err.stack,
+								});
+
+								throw err;
+							});
+
+							const channel = await this.ensureMeterChannel(
+								device,
+								ChannelCategory.ELECTRICAL_POWER,
+								`power:${key}`,
+								em1Config.name ?? `Power: ${key}`,
+								[
+									{ category: PropertyCategory.POWER, identifier: 'act_power', value: em1Status.act_power },
+									{ category: PropertyCategory.VOLTAGE, identifier: 'voltage', value: em1Status.voltage },
+									{ category: PropertyCategory.CURRENT, identifier: 'current', value: em1Status.current },
+									{ category: PropertyCategory.FREQUENCY, identifier: 'freq', value: em1Status.freq },
+								],
+							);
+
+							if (channel) {
+								channelsIds.push(channel.id);
+							}
+						}),
+					);
+
+					const settled = await Promise.allSettled(tasks);
+
+					const failed = settled.filter((r) => r.status === 'rejected').length;
+
+					if (failed) {
+						this.logger.warn(`${failed}/${ids.length} em1 component(s) failed for device=${device.id}`, {
+							resource: device.id,
+						});
+					}
+				} else if (type === String(ComponentType.EM1_DATA)) {
+					const tasks = ids.map((key) =>
+						limit(async () => {
+							const em1DataStatus = await retry(
+								() =>
+									withTimeout(
+										this.shellyRpcClientService.getEm1DataStatus(host, key, { password }),
+										this.timeoutSec * 1000,
+										`EM1Data.GetStatus - ${key}`,
+									),
+								{ retries: 2, baseMs: 300, factor: 2 },
+							).catch((err: Error) => {
+								this.logger.error(`Failed load for em1data=${key} on device=${device.id}`, {
+									resource: device.id,
+									message: err.message,
+									stack: err.stack,
+								});
+
+								throw err;
+							});
+
+							const channel = await this.ensureMeterChannel(
+								device,
+								ChannelCategory.ELECTRICAL_ENERGY,
+								`energy:${key}`,
+								`Consumption: ${key}`,
+								[
+									{
+										category: PropertyCategory.CONSUMPTION,
+										identifier: 'total_act_energy',
+										value: em1DataStatus.total_act_energy,
+									},
+									{
+										category: PropertyCategory.GRID_EXPORT,
+										identifier: 'total_act_ret_energy',
+										value: em1DataStatus.total_act_ret_energy,
+									},
+								],
+							);
+
+							if (channel) {
+								channelsIds.push(channel.id);
+							}
+						}),
+					);
+
+					const settled = await Promise.allSettled(tasks);
+
+					const failed = settled.filter((r) => r.status === 'rejected').length;
+
+					if (failed) {
+						this.logger.warn(`${failed}/${ids.length} em1data component(s) failed for device=${device.id}`, {
+							resource: device.id,
+						});
+					}
 				}
 			}
 
@@ -2183,6 +2479,43 @@ export class DeviceManagerService {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Creates one electrical channel from an energy-meter reading.
+	 *
+	 * The first reading is the one the devices spec marks required - `power` for
+	 * ELECTRICAL_POWER, `consumption` for ELECTRICAL_ENERGY. A meter reports
+	 * `null` for a phase whose CT is not connected, so when that value is absent
+	 * the channel is skipped entirely rather than written without its required
+	 * property, which would fail spec validation.
+	 */
+	private async ensureMeterChannel(
+		device: ShellyNgDeviceEntity,
+		category: ChannelCategory.ELECTRICAL_POWER | ChannelCategory.ELECTRICAL_ENERGY,
+		identifier: string,
+		name: string,
+		readings: { category: PropertyCategory; identifier: string; value: number | null | undefined }[],
+	): Promise<ShellyNgChannelEntity | null> {
+		const [required, ...optional] = readings;
+
+		if (!required || required.value === null || typeof required.value === 'undefined') {
+			return null;
+		}
+
+		const channel = await this.ensureChannel(device, 'identifier', identifier, category, name);
+
+		await this.ensureProperty(channel, required.category, 'identifier', required.identifier, required.value);
+
+		for (const reading of optional) {
+			if (reading.value === null || typeof reading.value === 'undefined') {
+				continue;
+			}
+
+			await this.ensureProperty(channel, reading.category, 'identifier', reading.identifier, reading.value);
+		}
+
+		return channel;
 	}
 
 	private async ensureElectricalEnergy(

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-rpc-client.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-rpc-client.service.ts
@@ -430,6 +430,82 @@ export interface Pm1Status {
 	errors: string[];
 }
 
+export interface EmConfig {
+	id: number;
+	name: string | null;
+	phase_selector?: 'a' | 'b' | 'c' | 'all';
+	ct_type?: string;
+}
+
+/**
+ * Three-phase energy meter, reported by devices running the `triphase` profile.
+ * Every measurement is nullable: a phase with no CT attached reports `null`
+ * rather than omitting the field.
+ */
+export interface EmStatus {
+	id: number;
+	a_current: number | null;
+	a_voltage: number | null;
+	a_act_power: number | null;
+	a_freq: number | null;
+	b_current: number | null;
+	b_voltage: number | null;
+	b_act_power: number | null;
+	b_freq: number | null;
+	c_current: number | null;
+	c_voltage: number | null;
+	c_act_power: number | null;
+	c_freq: number | null;
+	n_current: number | null;
+	total_current: number | null;
+	total_act_power: number | null;
+	errors?: string[];
+}
+
+export interface Em1Config {
+	id: number;
+	name: string | null;
+	reverse?: boolean;
+	ct_type?: string;
+}
+
+/**
+ * Single-phase energy meter, reported by devices running the `monophase`
+ * profile and by the two-channel EM models.
+ */
+export interface Em1Status {
+	id: number;
+	current: number | null;
+	voltage: number | null;
+	act_power: number | null;
+	freq?: number | null;
+	errors?: string[];
+}
+
+/**
+ * Cumulative counters for the three-phase meter. Unlike the instantaneous
+ * readings these are plain numbers, so absence of a phase shows up as 0.
+ */
+export interface EmDataStatus {
+	id: number;
+	a_total_act_energy: number;
+	a_total_act_ret_energy: number;
+	b_total_act_energy: number;
+	b_total_act_ret_energy: number;
+	c_total_act_energy: number;
+	c_total_act_ret_energy: number;
+	total_act: number;
+	total_act_ret: number;
+	errors?: string[];
+}
+
+export interface Em1DataStatus {
+	id: number;
+	total_act_energy: number;
+	total_act_ret_energy: number;
+	errors?: string[];
+}
+
 export interface DeviceComponentsResponse {
 	components: DeviceComponent[];
 	cfg_rev: number;
@@ -657,6 +733,54 @@ export class ShellyRpcClientService {
 		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
 	): Promise<Pm1Status> {
 		return this.call<Pm1Status>(host, 'PM1.GetStatus', { id }, options);
+	}
+
+	getEmConfig(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<EmConfig> {
+		return this.call<EmConfig>(host, 'EM.GetConfig', { id }, options);
+	}
+
+	getEmStatus(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<EmStatus> {
+		return this.call<EmStatus>(host, 'EM.GetStatus', { id }, options);
+	}
+
+	getEmDataStatus(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<EmDataStatus> {
+		return this.call<EmDataStatus>(host, 'EMData.GetStatus', { id }, options);
+	}
+
+	getEm1Config(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<Em1Config> {
+		return this.call<Em1Config>(host, 'EM1.GetConfig', { id }, options);
+	}
+
+	getEm1Status(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<Em1Status> {
+		return this.call<Em1Status>(host, 'EM1.GetStatus', { id }, options);
+	}
+
+	getEm1DataStatus(
+		host: string,
+		id: number,
+		options?: { password?: string | null; https?: boolean; timeoutSec?: number },
+	): Promise<Em1DataStatus> {
+		return this.call<Em1DataStatus>(host, 'EM1Data.GetStatus', { id }, options);
 	}
 
 	/**


### PR DESCRIPTION
Fixes the Shelly EM defects from the bug round: not recognized, missing channels, cannot re-adopt, falls back to generic.

## Root cause

One line, `device-manager.service.ts:178`:

```
Provided device is not supported hostname=… model=…
```

`getSpecification()` returns `null` for any model absent from `DESCRIPTORS`, and **every** EM model was absent. Adoption aborts there, which is why all four symptoms appeared together.

This needed nothing from the Shelly docs — the `shellies-ds9` fork already models the hardware. Six device classes and the `Em` / `Em1` / `EmData` / `Em1Data` components were present and simply never wired in:

| Device | Model | Components |
|---|---|---|
| Shelly Pro EM | `SPEM-002CEBEU50` | switch:0, em1:0-1, em1data:0-1 |
| Shelly Pro 3EM | `SPEM-003CEBEU` | em:0, emdata:0, em1:0-2, em1data:0-2 |
| Shelly Pro 3EM-400 | `SPEM-003CEBEU400` | ″ |
| Shelly Pro 3EM-3CT63 | `SPEM-003CEBEU63` | ″ |
| Shelly EM Gen3 | `S3EM-002CXCEU` | switch:0, em1:0-1, em1data:0-1 |
| Shelly 3EM-63 G3 | `S3EM-003CXCEU63` | em:0, emdata:0, em1:0-2, em1data:0-2 |

## Channel layout

The 3EM models expose the same three CTs under two **mutually exclusive** profiles. Both component sets are declared; only the set the device actually reports materialises.

**`triphase`** — one `em` component carrying per-phase and total fields:

```
power:0:a  power:0:b  power:0:c  power:0:total
energy:0:a energy:0:b energy:0:c energy:0:total
```

**`monophase`**, and the two-CT models — one `em1` per phase:

```
power:0 power:1   energy:0 energy:1
```

The total is read from the meter's own `total_act_power` / `total_act`, never summed here.

## Spec correctness

Two traps, both guarded by tests:

- **Unconnected CT.** A phase with no CT reports `null`. `power` and `consumption` are *required* by the devices spec, so that phase is skipped entirely rather than written as a channel that fails validation.
- **Device category.** `generic` permits neither electrical channel — the fallback's real damage. Every assigned category is asserted against `devicesSchema` to permit both. The two models with a relay default to `SWITCHER`, which still allows the electrical channels; `SENSOR` would leave `switch:0` unmapped, since the sensor spec has no outlet or switcher channel.

Property identifiers keep the Shelly field names (`a_act_power`, `total_act_ret_energy`, …) so a value stays traceable to its source field.

## Deviations from the original plan

- **No `energy-meter.yaml`.** The YAML mapping layer is only consulted for the nine component types that build a `MappingContext`; PM1 already bypasses it and creates channels directly. EM channel categories never depend on device category, so a mapping file would be dead weight — `power.yaml`'s `pm1_power_monitor` rule is already unreachable for the same reason.
- **Apparent power and power factor dropped**, as agreed — no channel property accepts them.

## Found in passing, not fixed here

`ComponentType.DEVICE_POWER` is `'devicePower'`, but the library's key is `'devicepower'` (verified by constructing the component). Since the type is compared against the reported key prefix, DevicePower never matches — battery devices such as Plus HT get no battery channel. `device-manager.service.spec.ts` mocks the constant *lowercased*, which is what has been hiding it. Left for its own PR; the new casing test documents the trap.

## Verification

| Check | Result |
|---|---|
| Backend suite | 379 suites, 4801 passed |
| `tsc --noEmit` | clean |
| eslint + prettier (touched files) | clean |
| Mutation-tested | 5 mutations, all caught |

Mutations used: null-skip removed from `ensureMeterChannel`; total sourced from phase A; `SENSOR` promoted ahead of `SWITCHER`; `GENERIC` category; `emdata` → `emData` casing.

Not exercised against physical hardware — I have no EM device. The status shapes are typed from the library's own attribute definitions.