### PR TITLE
fix(backend): match the shelly device power component key casing

### DIFF
--- a/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/delegates/shelly-device.delegate.spec.ts
@@ -105,7 +105,7 @@ jest.mock('../devices-shelly-ng.constants', () => {
 				{ type: 'light', cls: Light, ids: [0] },
 				{ type: 'cover', cls: Cover, ids: [0] },
 				{ type: 'input', cls: Input, ids: [0] },
-				{ type: 'devicePower', cls: DevicePower, ids: [0] },
+				{ type: 'devicepower', cls: DevicePower, ids: [0] },
 				{ type: 'humidity', cls: Humidity, ids: [0] },
 				{ type: 'temperature', cls: Temperature, ids: [0] },
 				// POZOR: typ pro PM1 musí odpovídat ComponentType.PM1 v implementaci
@@ -122,7 +122,7 @@ jest.mock('../devices-shelly-ng.constants', () => {
 			COVER: 'cover',
 			PM1: 'pm1',
 			INPUT: 'input',
-			DEVICE_POWER: 'devicePower',
+			DEVICE_POWER: 'devicepower',
 			HUMIDITY: 'humidity',
 			TEMPERATURE: 'temperature',
 		},
@@ -143,7 +143,7 @@ describe('ShellyDeviceDelegate', () => {
 			['light:0', new Light('light:0')],
 			['cover:0', new Cover('cover:0')],
 			['input:0', new Input('input:0')],
-			['devicePower:0', new DevicePower('devicePower:0')],
+			['devicepower:0', new DevicePower('devicepower:0')],
 			['humidity:0', new Humidity('humidity:0')],
 			['temperature:0', new Temperature('temperature:0')],
 			// PM1 – klíč musí odpovídat type 'pm1'

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.spec.ts
@@ -1,4 +1,6 @@
-import { Em, Em1, Em1Data, EmData, Shelly3EmGen3, ShellyEmGen3, ShellyPro3Em, ShellyProEm } from 'shellies-ds9';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Shelly3EmGen3, ShellyEmGen3, ShellyPro3Em, ShellyProEm } from 'shellies-ds9';
 
 import { devicesSchema } from '../../spec/devices';
 
@@ -61,18 +63,40 @@ describe('Shelly NG energy meters', () => {
 		}
 	});
 
-	// ComponentType values are compared against the key prefix the device reports,
-	// so a value whose casing differs from the library's silently disables the
-	// whole component. `devicePower` is exactly that bug, still present.
-	it.each([
-		[ComponentType.EM, Em],
-		[ComponentType.EM_DATA, EmData],
-		[ComponentType.EM1, Em1],
-		[ComponentType.EM1_DATA, Em1Data],
-	])('uses the component key the library reports for %s', (type, cls) => {
-		const instance = new (cls as unknown as new (device: unknown, id: number) => { key: string })({}, 0);
+	// The delegate builds `${type}:${id}` and looks the component up by that key,
+	// and DeviceManagerService compares the type against the key prefix the device
+	// reports. A value whose casing differs from the library's therefore disables
+	// the component on both paths, silently.
+	it('declares every component type using the key the library reports', () => {
+		const instantiate = (cls: unknown): string => {
+			const ctor = cls as new (device: unknown, id: number) => { key: string };
 
-		expect(instance.key.split(':')[0]).toBe(String(type));
+			return new ctor({}, 0).key.split(':')[0];
+		};
+
+		const mismatches = new Set<string>();
+
+		for (const descriptor of Object.values(DESCRIPTORS)) {
+			for (const component of descriptor.components) {
+				const key = instantiate(component.cls);
+
+				if (key !== String(component.type)) {
+					mismatches.add(`${String(component.type)} != ${key}`);
+				}
+			}
+		}
+
+		expect([...mismatches]).toEqual([]);
+	});
+
+	// SystemSpec types are only ever compared against other descriptors - nothing
+	// looks a system component up by key - so ETHERNET declaring `ethernet` while
+	// the library uses `eth` is inert. Pinned so a future use of it as a lookup
+	// key has to confront this first.
+	it('never looks a system component up by key', () => {
+		const source = readFileSync(join(__dirname, 'delegates', 'shelly-device.delegate.ts'), 'utf8');
+
+		expect(source).not.toContain('DESCRIPTOR.system');
 	});
 
 	it('only assigns categories whose device spec permits the electrical channels', () => {

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.constants.ts
@@ -117,7 +117,9 @@ export enum ComponentType {
 	RGBW = 'rgbw',
 	CCT = 'cct',
 	INPUT = 'input',
-	DEVICE_POWER = 'devicePower',
+	// Component keys are the library's lower-cased class names; the delegate and
+	// DeviceManagerService both match on them, so the casing has to be exact.
+	DEVICE_POWER = 'devicepower',
 	HUMIDITY = 'humidity',
 	TEMPERATURE = 'temperature',
 	PM1 = 'pm1',

--- a/apps/backend/src/plugins/devices-shelly-ng/mappings/definitions/sensors.yaml
+++ b/apps/backend/src/plugins/devices-shelly-ng/mappings/definitions/sensors.yaml
@@ -74,7 +74,7 @@ mappings:
     description: "Shelly device power component mapped as battery channel"
     priority: 100
     match:
-      component_type: devicePower
+      component_type: devicepower
     channels:
       - identifier: "devicePower:{key}"
         name: "Battery: {key}"

--- a/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/device-manager.service.spec.ts
@@ -41,6 +41,18 @@ const mockChannelsPropertiesService = {
 const mockMappingLoaderService = {
 	findMatchingMapping: jest.fn().mockImplementation((context: any) => {
 		// Return a valid mapping for switch components
+		if (context.componentType === 'devicepower') {
+			return {
+				channels: [
+					{
+						identifier: `devicePower:${context.componentKey}`,
+						name: `Battery: ${context.componentKey}`,
+						category: ChannelCategory.BATTERY,
+						properties: [],
+					},
+				],
+			};
+		}
 		if (context.componentType === 'switch') {
 			return {
 				channels: [
@@ -621,6 +633,84 @@ describe('DeviceManagerService energy meters', () => {
 		expect(identifiers.some((identifier: string) => identifier.endsWith(':total'))).toBe(false);
 
 		expect(propertiesOf('power:1').find((prop: any) => prop.category === PropertyCategory.POWER)?.value).toBe(200);
+	});
+});
+
+describe('DeviceManagerService battery devices', () => {
+	// The component type is matched against the key prefix the device reports,
+	// which is lower-case. While the constant read `devicePower` this branch never
+	// ran, so battery devices such as the Plus H&T got no battery channel at all.
+	test('a devicepower component produces a battery channel', async () => {
+		const svc = makeService();
+		const device = { id: 'db-ht-1', password: null, category: DeviceCategory.SENSOR } as any;
+
+		mockDevicesService.findOne.mockResolvedValue(device);
+
+		jest.spyOn<any, any>(svc as any, 'getSpecification').mockReturnValue({
+			models: ['SNSN-0013A'],
+			system: [{ type: 'wifi' }],
+		});
+
+		mockRpc.getDeviceInfo.mockResolvedValue({
+			id: 'shelly-ht',
+			mac: 'mac',
+			model: 'SNSN-0013A',
+			fw_id: 'fw',
+			ver: '1.2.3',
+			app: 'app',
+			auth_en: false,
+			auth_domain: null,
+			discoverable: true,
+			key: 'key',
+			batch: 'batch',
+			fw_sbits: 'sbits',
+		} as any);
+
+		mockRpc.getComponents.mockResolvedValue([{ key: 'devicepower:0', config: {}, status: {} }] as any);
+		mockRpc.getSystemConfig.mockResolvedValue({
+			device: { name: 'Hall sensor', eco_mode: false, mac: 'mac', fw_id: 'fw', discoverable: true },
+			location: { tz: null, lat: null, lon: null },
+			debug: { mqtt: { enabled: false }, websocket: { enabled: false }, udp: { addr: null } },
+			rpc_udp: { dst_addr: '', listen_port: null },
+			sntp: { server: '' },
+			cfg_rev: 1,
+		} as any);
+		mockRpc.getWifiStatus.mockResolvedValue({ rssi: -70 } as any);
+		mockRpc.getDevicePowerStatus.mockResolvedValue({
+			id: 0,
+			battery: { V: 5.9, percent: 88 },
+			external: { present: false },
+		} as any);
+
+		mockChannelsService.findOneBy.mockResolvedValue(null);
+		mockChannelsService.findAll.mockResolvedValue([]);
+
+		let channelCounter = 0;
+		mockChannelsService.create.mockImplementation(async (dto: any) => ({ id: `ch_${++channelCounter}`, ...dto }));
+		mockChannelsService.update.mockImplementation(async (id: string, dto: any) => ({ id, ...dto }));
+
+		mockChannelsPropertiesService.findOneBy.mockResolvedValue(null);
+		let propCounter = 0;
+		mockChannelsPropertiesService.create.mockImplementation(async (channelId: string, dto: any) => ({
+			id: `p_${++propCounter}`,
+			channel: channelId,
+			...dto,
+		}));
+		mockChannelsPropertiesService.update.mockImplementation(async (id: string, dto: any) => ({ id, ...dto }));
+
+		await svc.createOrUpdate(device.id);
+
+		const battery = mockChannelsService.create.mock.calls
+			.map((call: any[]) => call[0])
+			.find((dto: any) => dto?.category === ChannelCategory.BATTERY);
+
+		expect(battery).toBeTruthy();
+
+		const percentage = mockChannelsPropertiesService.create.mock.calls
+			.map((call: any[]) => call[1])
+			.find((dto: any) => dto?.category === PropertyCategory.PERCENTAGE);
+
+		expect(percentage?.value).toBe(88);
 	});
 });
 


### PR DESCRIPTION
Follow-up to #792, where this surfaced.

## The bug

`ComponentType.DEVICE_POWER` read `devicePower`. The component key is the library's **lower-cased** class name — `devicepower` — and both runtime paths match on that key:

| Path | Builds / compares | Actual key | |
|---|---|---|---|
| `ShellyDeviceDelegate` → `hasComponent()` | `devicePower:0` | `devicepower:0` | ✗ skipped |
| `DeviceManagerService` branch | `'devicePower'` | `'devicepower'` | ✗ never runs |
| YAML via `resolveComponentType()` | lower-cases first | — | ✓ fine |

Net effect: **battery-powered devices got no battery channel**. Only `SHELLYPLUSHT` declares the component, so the Plus H&T is the device affected.

Verified by constructing the component rather than reading docs:

```
DevicePower  -> key = "devicepower:0"
```

## Scope

I audited every `ComponentType` against the library rather than fixing only the one I noticed. Exactly one live mismatch:

```
MISMATCH  DEVICE_POWER  declared="devicePower"  library="devicepower"
MISMATCH  ETHERNET      declared="ethernet"     library="eth"
```

`ETHERNET` is **not** a live bug — it appears only in `SystemSpec`, which is compared against other descriptors; nothing looks a system component up by key, and the delegate never iterates `DESCRIPTOR.system`. Left alone, and pinned by a test so a future key-based use has to confront it.

## No migration

The constant has read `devicePower` since the plugin was first added (`8c0e6d30b`, the only commit to touch it). The component has therefore never bound, no channel was ever created under either spelling, and there is nothing to migrate. Channel identifiers stay `devicePower:{key}` to match the two hard-coded sites that read them back — `device-manager.service.ts:1438,1463` and `delegates-manager.service.ts:1563`.

The YAML `component_type` is corrected too. That one is cosmetic — `resolveComponentType()` lower-cases before lookup — but the file should state what the device actually reports.

## Tests were agreeing with the bug

Both existing tests were self-consistent fictions:

- `shelly-device.delegate.spec.ts` built its component map with `devicePower:0`, matching the wrong constant on both sides.
- `device-manager.service.spec.ts` mocked `DEVICE_POWER: 'devicepower'` — lower-cased — which is precisely what made its branch reachable and hid the production defect.

Both now use the key the library produces. Added:

- a guard that instantiates **every** declared component and compares its key to the declared type, so the next mismatch fails loudly;
- an outcome test that a `devicepower:0` component yields a `BATTERY` channel carrying `PERCENTAGE`.

## Verification

| Check | Result |
|---|---|
| Backend suite | 379 suites, 4800 passed |
| `tsc --noEmit` | clean |
| eslint + prettier (touched) | clean |

Written test-first: the guard failed with `"devicePower != devicepower"` before the change. Re-introducing the old value fails the guard, and mocking it back to `devicePower` fails the battery test.

No physical Plus H&T here, so the key is verified against the library, not hardware.