### PR TITLE
feat(cross): add bulk device endpoints and use them for bulk actions

### DIFF
--- a/apps/admin/src/modules/devices/composables/useDevicesActions.ts
+++ b/apps/admin/src/modules/devices/composables/useDevicesActions.ts
@@ -83,28 +83,26 @@ export const useDevicesActions = (): IUseDevicesActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const device of devices) {
-				try {
-					await devicesStore.remove({ id: device.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('devicesModule.messages.devices.bulkRemoved', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('devicesModule.messages.devices.bulkRemoveFailed', { count: failCount }));
-			}
 		} catch {
 			// User cancelled - do nothing
+			return;
+		}
+
+		// One request for the whole selection. Sending one per device tripped the
+		// backend's shared rate limit once a selection went past thirty, which
+		// left the rest of the selection silently unprocessed.
+		try {
+			const result = await devicesStore.bulkRemove({ ids: devices.map((device) => device.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('devicesModule.messages.devices.bulkRemoved', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('devicesModule.messages.devices.bulkRemoveFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('devicesModule.messages.devices.bulkRemoveFailed', { count: devices.length }));
 		}
 	};
 
@@ -123,34 +121,25 @@ export const useDevicesActions = (): IUseDevicesActions => {
 					type: 'info',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const device of devices) {
-				try {
-					await devicesStore.edit({
-						id: device.id,
-						data: {
-							type: device.type,
-							enabled: true,
-						},
-					});
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('devicesModule.messages.devices.bulkEnabled', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('devicesModule.messages.devices.bulkEnableFailed', { count: failCount }));
-			}
 		} catch {
 			flashMessage.info(t('devicesModule.messages.devices.bulkEnableCanceled'));
+
+			return;
+		}
+
+		// See bulkRemove: one request for the whole selection.
+		try {
+			const result = await devicesStore.bulkSetEnabled({ ids: devices.map((device) => device.id), enabled: true });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('devicesModule.messages.devices.bulkEnabled', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('devicesModule.messages.devices.bulkEnableFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('devicesModule.messages.devices.bulkEnableFailed', { count: devices.length }));
 		}
 	};
 
@@ -169,34 +158,25 @@ export const useDevicesActions = (): IUseDevicesActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const device of devices) {
-				try {
-					await devicesStore.edit({
-						id: device.id,
-						data: {
-							type: device.type,
-							enabled: false,
-						},
-					});
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('devicesModule.messages.devices.bulkDisabled', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('devicesModule.messages.devices.bulkDisableFailed', { count: failCount }));
-			}
 		} catch {
 			flashMessage.info(t('devicesModule.messages.devices.bulkDisableCanceled'));
+
+			return;
+		}
+
+		// See bulkRemove: one request for the whole selection.
+		try {
+			const result = await devicesStore.bulkSetEnabled({ ids: devices.map((device) => device.id), enabled: false });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('devicesModule.messages.devices.bulkDisabled', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('devicesModule.messages.devices.bulkDisableFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('devicesModule.messages.devices.bulkDisableFailed', { count: devices.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/devices/store/devices.store.schemas.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.schemas.ts
@@ -161,6 +161,20 @@ export const DevicesRemoveActionPayloadSchema = z.object({
 	id: ItemIdSchema,
 });
 
+export const DevicesBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(ItemIdSchema).nonempty(),
+});
+
+export const DevicesBulkSetEnabledActionPayloadSchema = z.object({
+	ids: z.array(ItemIdSchema).nonempty(),
+	enabled: z.boolean(),
+});
+
+export const DevicesBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 export const DevicesAddZoneActionPayloadSchema = z.object({
 	id: ItemIdSchema,
 	zoneId: z.string().uuid(),

--- a/apps/admin/src/modules/devices/store/devices.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.spec.ts
@@ -15,12 +15,15 @@ const mockBackendClient = {
 	DELETE: vi.fn(),
 };
 
-// Permissive: this spec only exercises `fetch()`'s own dedup/staleness handling, not what ends up in
-// the related controls/channels stores, so every key gets the same push-able, no-op-set stub.
+// Permissive: this spec exercises `fetch()`'s dedup/staleness handling and the bulk actions' own
+// bookkeeping, not what ends up in the related controls/channels stores, so every key gets the same
+// push-able, no-op stub. `findForDevice` answers empty because the cascade's fan-out is the channels
+// store's concern; what matters here is that the cascade runs for the right devices.
 const mockGetStore = vi.fn(() => ({
 	firstLoad: [] as string[],
 	set: vi.fn(),
 	unset: vi.fn(),
+	findForDevice: vi.fn(() => []),
 }));
 
 vi.mock('../../../common', async () => {
@@ -469,4 +472,113 @@ describe('Devices Store', () => {
 			expect(requestInit.body.data.room_id).toBe(null);
 		});
 	});
+
+	describe('bulk actions', () => {
+		const seed = async (count: number): Promise<string[]> => {
+			const records = Array.from({ length: count }, (_, index) => deviceFixture(`Device ${index}`));
+
+			mockBackendClient.GET.mockResolvedValue({
+				data: { data: records },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+			await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+			return records.map((record) => record.id);
+		};
+
+		// The whole point of the endpoint: a selection is one request, not one per
+		// device. Sending one each tripped the backend's 30-per-minute limit and
+		// left the tail of a large selection unprocessed.
+		it('removes a large selection with a single request', async () => {
+			const ids = await seed(45);
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: { data: { succeeded: ids, failed: [] } },
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			const result = await store.bulkRemove({ ids: [ids[0]!, ...ids.slice(1)] });
+
+			expect(mockBackendClient.POST).toHaveBeenCalledTimes(1);
+			expect(mockBackendClient.DELETE).not.toHaveBeenCalled();
+			expect(result.succeeded).toHaveLength(45);
+			expect(store.findAll()).toHaveLength(0);
+		});
+
+		it('keeps a device the backend refused', async () => {
+			const ids = await seed(3);
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: {
+					data: {
+						succeeded: [ids[0]!, ids[2]!],
+						failed: [{ id: ids[1]!, reason: 'Device is hidden' }],
+					},
+				},
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			const result = await store.bulkRemove({ ids: [ids[0]!, ids[1]!, ids[2]!] });
+
+			expect(result.failed).toEqual([{ id: ids[1], reason: 'Device is hidden' }]);
+			expect(store.findAll().map((device) => device.id)).toEqual([ids[1]]);
+		});
+
+		it('sets the enabled state locally for the devices the backend confirmed', async () => {
+			const ids = await seed(2);
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: {
+					data: { succeeded: [ids[0]!], failed: [{ id: ids[1]!, reason: 'Device could not be updated' }] },
+				},
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			await store.bulkSetEnabled({ ids: [ids[0]!, ids[1]!], enabled: false });
+
+			expect(mockBackendClient.POST).toHaveBeenCalledTimes(1);
+			expect(store.findById(ids[0]!)?.enabled).toBe(false);
+			// Untouched: the backend did not accept this one, so the row must keep
+			// showing the state the backend still holds.
+			expect(store.findById(ids[1]!)?.enabled).toBe(true);
+		});
+
+		it('sends the selection in the request body', async () => {
+			const ids = await seed(2);
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: { data: { succeeded: ids, failed: [] } },
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			await store.bulkSetEnabled({ ids: [ids[0]!, ids[1]!], enabled: true });
+
+			expect(mockBackendClient.POST).toHaveBeenCalledWith(
+				expect.stringContaining('bulk-update'),
+				expect.objectContaining({ body: { data: { ids, enabled: true } } })
+			);
+		});
+
+		it('raises when the request itself fails', async () => {
+			const ids = await seed(2);
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: undefined,
+				error: { detail: 'nope' },
+				response: { ok: false, status: 500 },
+			});
+
+			await expect(store.bulkRemove({ ids: [ids[0]!, ids[1]!] })).rejects.toThrow();
+
+			// Nothing was confirmed, so nothing may be dropped from the cache.
+			expect(store.findAll()).toHaveLength(2);
+		});
+	});
+
 });

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -8,6 +8,8 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
 import type {
 	DevicesModuleCreateDeviceOperation,
+	DevicesModuleCreateDevicesBulkRemoveOperation,
+	DevicesModuleCreateDevicesBulkUpdateOperation,
 	DevicesModuleDeleteDeviceOperation,
 	DevicesModuleGetDeviceOperation,
 	DevicesModuleGetDevicesOperation,
@@ -31,6 +33,7 @@ import {
 	DeviceSchema,
 	DeviceUpdateReqSchema,
 	DevicesAddActionPayloadSchema,
+	DevicesBulkResultSchema,
 	DevicesEditActionPayloadSchema,
 } from './devices.store.schemas';
 import type {
@@ -41,6 +44,9 @@ import type {
 	IDeviceUpdateReq,
 	IDevicesAddActionPayload,
 	IDevicesAddZoneActionPayload,
+	IDevicesBulkRemoveActionPayload,
+	IDevicesBulkResult,
+	IDevicesBulkSetEnabledActionPayload,
 	IDevicesEditActionPayload,
 	IDevicesFetchActionPayload,
 	IDevicesGetActionPayload,
@@ -647,22 +653,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 				});
 
 				if (response.status === 204) {
-					const devicesControlsStore = storesManager.getStore(devicesControlsStoreKey);
-
-					devicesControlsStore.unset({ deviceId: payload.id });
-
-					const channelsStore = storesManager.getStore(channelsStoreKey);
-					const channelsControlsStore = storesManager.getStore(channelsControlsStoreKey);
-					const channelsPropertiesStore = storesManager.getStore(channelsPropertiesStoreKey);
-
-					const channels = channelsStore.findForDevice(payload.id);
-
-					channels.forEach((channel) => {
-						channelsControlsStore.unset({ channelId: channel.id });
-						channelsPropertiesStore.unset({ channelId: channel.id });
-					});
-
-					channelsStore.unset({ deviceId: payload.id });
+					purgeLocally(payload.id);
 
 					return true;
 				}
@@ -683,6 +674,147 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 		}
 
 		return true;
+	};
+
+	/**
+	 * Drops a device from this store and every store that hangs off it.
+	 *
+	 * `remove` did this inline; the bulk paths need the same cascade for each
+	 * device the backend confirmed, so it lives here rather than being written
+	 * out twice with a chance of drifting apart.
+	 */
+	const purgeLocally = (id: IDevice['id']): void => {
+		const devicesControlsStore = storesManager.getStore(devicesControlsStoreKey);
+
+		devicesControlsStore.unset({ deviceId: id });
+
+		const channelsStore = storesManager.getStore(channelsStoreKey);
+		const channelsControlsStore = storesManager.getStore(channelsControlsStoreKey);
+		const channelsPropertiesStore = storesManager.getStore(channelsPropertiesStoreKey);
+
+		const channels = channelsStore.findForDevice(id);
+
+		channels.forEach((channel) => {
+			channelsControlsStore.unset({ channelId: channel.id });
+			channelsPropertiesStore.unset({ channelId: channel.id });
+		});
+
+		channelsStore.unset({ deviceId: id });
+	};
+
+	/**
+	 * Removes a selection in one request.
+	 *
+	 * The per-device alternative was one request each, which the backend's
+	 * shared rate limit rejects past thirty - so a large selection failed
+	 * halfway through with no way to tell which half. The outcome is reported
+	 * per device because the backend still refuses individual devices for
+	 * individual reasons.
+	 */
+	const bulkRemove = async (payload: IDevicesBulkRemoveActionPayload): Promise<IDevicesBulkResult> => {
+		// Drafts were never sent to the backend, so they are dropped here and
+		// counted as done rather than being handed to an endpoint that would
+		// correctly report them as unknown.
+		const drafts: string[] = [];
+		const persisted: string[] = [];
+
+		for (const id of payload.ids) {
+			const record = data.value[id];
+
+			if (record === undefined) {
+				continue;
+			}
+
+			(record.draft ? drafts : persisted).push(id);
+		}
+
+		for (const id of drafts) {
+			forget(id);
+			purgeLocally(id);
+		}
+
+		if (persisted.length === 0) {
+			return { succeeded: drafts, failed: [] };
+		}
+
+		semaphore.value.deleting.push(...persisted);
+
+		try {
+			const { data: responseBody, error, response } = await backend.client.POST(
+				`/${MODULES_PREFIX}/${DEVICES_MODULE_PREFIX}/devices/bulk-remove`,
+				{ body: { data: { ids: persisted } } }
+			);
+
+			if (typeof responseBody === 'undefined' || !response.ok) {
+				let errorReason: string | null = 'Remove devices failed.';
+
+				if (error) {
+					errorReason = getErrorReason<DevicesModuleCreateDevicesBulkRemoveOperation>(error, errorReason);
+				}
+
+				throw new DevicesApiException(errorReason, response.status);
+			}
+
+			const result = DevicesBulkResultSchema.parse(responseBody.data);
+
+			for (const id of result.succeeded) {
+				forget(id);
+				purgeLocally(id);
+			}
+
+			return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+		} finally {
+			semaphore.value.deleting = semaphore.value.deleting.filter((item) => !persisted.includes(item));
+		}
+	};
+
+	/**
+	 * Enables or disables a selection in one request. Same reasoning as
+	 * `bulkRemove`.
+	 */
+	const bulkSetEnabled = async (payload: IDevicesBulkSetEnabledActionPayload): Promise<IDevicesBulkResult> => {
+		const persisted = payload.ids.filter((id) => data.value[id] !== undefined && !data.value[id]!.draft);
+
+		if (persisted.length === 0) {
+			return { succeeded: [], failed: [] };
+		}
+
+		semaphore.value.updating.push(...persisted);
+
+		try {
+			const { data: responseBody, error, response } = await backend.client.POST(
+				`/${MODULES_PREFIX}/${DEVICES_MODULE_PREFIX}/devices/bulk-update`,
+				{ body: { data: { ids: persisted, enabled: payload.enabled } } }
+			);
+
+			if (typeof responseBody === 'undefined' || !response.ok) {
+				let errorReason: string | null = 'Update devices failed.';
+
+				if (error) {
+					errorReason = getErrorReason<DevicesModuleCreateDevicesBulkUpdateOperation>(error, errorReason);
+				}
+
+				throw new DevicesApiException(errorReason, response.status);
+			}
+
+			const result = DevicesBulkResultSchema.parse(responseBody.data);
+
+			// The response carries only the outcome, so the local records are
+			// nudged to the state the backend just confirmed instead of being
+			// re-fetched one by one - which would reintroduce the request storm
+			// this endpoint exists to remove.
+			for (const id of result.succeeded) {
+				const record = data.value[id];
+
+				if (record !== undefined) {
+					data.value[id] = { ...record, enabled: payload.enabled };
+				}
+			}
+
+			return result;
+		} finally {
+			semaphore.value.updating = semaphore.value.updating.filter((item) => !persisted.includes(item));
+		}
 	};
 
 	const addZone = async (payload: IDevicesAddZoneActionPayload): Promise<IDevice> => {
@@ -826,6 +958,8 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 		edit,
 		save,
 		remove,
+		bulkRemove,
+		bulkSetEnabled,
 		addZone,
 		removeZone,
 	};

--- a/apps/admin/src/modules/devices/store/devices.store.types.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.types.ts
@@ -11,6 +11,9 @@ import {
 	DeviceUpdateReqSchema,
 	DevicesAddActionPayloadSchema,
 	DevicesAddZoneActionPayloadSchema,
+	DevicesBulkRemoveActionPayloadSchema,
+	DevicesBulkResultSchema,
+	DevicesBulkSetEnabledActionPayloadSchema,
 	DevicesEditActionPayloadSchema,
 	DevicesFetchActionPayloadSchema,
 	DevicesGetActionPayloadSchema,
@@ -51,6 +54,12 @@ export type IDevicesSaveActionPayload = z.infer<typeof DevicesSaveActionPayloadS
 
 export type IDevicesRemoveActionPayload = z.infer<typeof DevicesRemoveActionPayloadSchema>;
 
+export type IDevicesBulkRemoveActionPayload = z.infer<typeof DevicesBulkRemoveActionPayloadSchema>;
+
+export type IDevicesBulkSetEnabledActionPayload = z.infer<typeof DevicesBulkSetEnabledActionPayloadSchema>;
+
+export type IDevicesBulkResult = z.infer<typeof DevicesBulkResultSchema>;
+
 export type IDevicesAddZoneActionPayload = z.infer<typeof DevicesAddZoneActionPayloadSchema>;
 
 export type IDevicesRemoveZoneActionPayload = z.infer<typeof DevicesRemoveZoneActionPayloadSchema>;
@@ -81,6 +90,8 @@ export interface IDevicesStoreActions {
 	edit: (payload: IDevicesEditActionPayload) => Promise<IDevice>;
 	save: (payload: IDevicesSaveActionPayload) => Promise<IDevice>;
 	remove: (payload: IDevicesRemoveActionPayload) => Promise<boolean>;
+	bulkRemove: (payload: IDevicesBulkRemoveActionPayload) => Promise<IDevicesBulkResult>;
+	bulkSetEnabled: (payload: IDevicesBulkSetEnabledActionPayload) => Promise<IDevicesBulkResult>;
 	addZone: (payload: IDevicesAddZoneActionPayload) => Promise<IDevice>;
 	removeZone: (payload: IDevicesRemoveZoneActionPayload) => Promise<IDevice>;
 	isLoaded: () => boolean;

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -283,6 +283,10 @@ export type DevicesModuleGetDevicesOperation = operations['get-devices-module-de
 export type DevicesModuleCreateDeviceOperation = operations['create-devices-module-device'];
 export type DevicesModuleUpdateDeviceOperation = operations['update-devices-module-device'];
 export type DevicesModuleDeleteDeviceOperation = operations['delete-devices-module-device'];
+
+export type DevicesModuleCreateDevicesBulkRemoveOperation = operations['create-devices-module-devices-bulk-remove'];
+
+export type DevicesModuleCreateDevicesBulkUpdateOperation = operations['create-devices-module-devices-bulk-update'];
 export type DevicesModuleGetChannelOperation = operations['get-devices-module-channel'];
 export type DevicesModuleGetDeviceChannelOperation = operations['get-devices-module-device-channel'];
 export type DevicesModuleGetChannelsOperation = operations['get-devices-module-channels'];

--- a/apps/backend/src/modules/devices/controllers/devices.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.controller.spec.ts
@@ -20,6 +20,7 @@ import { UpdateDeviceDto } from '../dto/update-device.dto';
 import { DeviceEntity } from '../entities/devices.entity';
 import { DeviceValidationService } from '../services/device-validation.service';
 import { DeviceZonesService } from '../services/device-zones.service';
+import { DevicesBulkService } from '../services/devices-bulk.service';
 import { DevicesTypeMapperService } from '../services/devices-type-mapper.service';
 import { DevicesService } from '../services/devices.service';
 
@@ -29,6 +30,7 @@ describe('DevicesController', () => {
 	let controller: DevicesController;
 	let service: DevicesService;
 	let deviceZonesService: DeviceZonesService;
+	let bulkService: DevicesBulkService;
 	let mapper: DevicesTypeMapperService;
 
 	const mockDevice = {
@@ -99,12 +101,20 @@ describe('DevicesController', () => {
 						getDeviceZones: jest.fn().mockResolvedValue([]),
 					},
 				},
+				{
+					provide: DevicesBulkService,
+					useValue: {
+						remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+						setEnabled: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+					},
+				},
 			],
 		}).compile();
 
 		controller = module.get<DevicesController>(DevicesController);
 		service = module.get<DevicesService>(DevicesService);
 		deviceZonesService = module.get<DeviceZonesService>(DeviceZonesService);
+		bulkService = module.get<DevicesBulkService>(DevicesBulkService);
 		mapper = module.get<DevicesTypeMapperService>(DevicesTypeMapperService);
 	});
 
@@ -254,6 +264,47 @@ describe('DevicesController', () => {
 
 			expect(result).toBeUndefined();
 			expect(service.remove).toHaveBeenCalledWith(mockDevice.id);
+		});
+	});
+
+	describe('Bulk', () => {
+		it('hands the whole selection to the bulk service in one call', async () => {
+			const ids = [uuid().toString(), uuid().toString(), uuid().toString()];
+
+			jest.spyOn(bulkService, 'remove').mockResolvedValue({ succeeded: ids, failed: [] });
+
+			const result = await controller.bulkRemove({ data: { ids } });
+
+			expect(bulkService.remove).toHaveBeenCalledTimes(1);
+			expect(bulkService.remove).toHaveBeenCalledWith(ids);
+			expect(result.data.succeeded).toEqual(ids);
+		});
+
+		// A device the backend refused belongs in the response, not in an
+		// exception: the rest of the selection went through and the caller has to
+		// be able to say so.
+		it('reports refusals in the response rather than throwing', async () => {
+			const ids = [uuid().toString(), uuid().toString()];
+
+			jest.spyOn(bulkService, 'remove').mockResolvedValue({
+				succeeded: [ids[0]],
+				failed: [{ id: ids[1], reason: 'Device is hidden' }],
+			});
+
+			const result = await controller.bulkRemove({ data: { ids } });
+
+			expect(result.data.succeeded).toEqual([ids[0]]);
+			expect(result.data.failed).toEqual([{ id: ids[1], reason: 'Device is hidden' }]);
+		});
+
+		it('passes the requested enabled state through', async () => {
+			const ids = [uuid().toString()];
+
+			jest.spyOn(bulkService, 'setEnabled').mockResolvedValue({ succeeded: ids, failed: [] });
+
+			await controller.bulkUpdate({ data: { ids, enabled: false } });
+
+			expect(bulkService.setEnabled).toHaveBeenCalledWith(ids, false);
 		});
 	});
 });

--- a/apps/backend/src/modules/devices/controllers/devices.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.controller.ts
@@ -45,14 +45,16 @@ import {
 	DevicesNotFoundException,
 	DevicesValidationException,
 } from '../devices.exceptions';
+import { ReqBulkRemoveDevicesDto, ReqBulkUpdateDevicesDto } from '../dto/bulk-devices.dto';
 import { CreateDeviceDto, ReqCreateDeviceDto } from '../dto/create-device.dto';
 import { ListDevicesQueryDto } from '../dto/list-devices-query.dto';
 import { ReqUpdateDeviceDto, UpdateDeviceDto } from '../dto/update-device.dto';
 import { DeviceEntity } from '../entities/devices.entity';
 import { DeviceValidationResponseModel, DevicesValidationResponseModel } from '../models/device-validation.model';
-import { DeviceResponseModel, DevicesResponseModel } from '../models/devices-response.model';
+import { BulkResultResponseModel, DeviceResponseModel, DevicesResponseModel } from '../models/devices-response.model';
 import { DeviceValidationService } from '../services/device-validation.service';
 import { DeviceZonesService } from '../services/device-zones.service';
+import { DevicesBulkService } from '../services/devices-bulk.service';
 import { DeviceTypeMapping, DevicesTypeMapperService } from '../services/devices-type-mapper.service';
 import { DevicesService } from '../services/devices.service';
 
@@ -66,6 +68,7 @@ export class DevicesController {
 		private readonly devicesMapperService: DevicesTypeMapperService,
 		private readonly deviceValidationService: DeviceValidationService,
 		private readonly deviceZonesService: DeviceZonesService,
+		private readonly devicesBulkService: DevicesBulkService,
 	) {}
 
 	@ApiOperation({
@@ -424,6 +427,52 @@ export class DevicesController {
 		await this.devicesService.remove(device.id);
 
 		this.logger.debug(`Successfully deleted device id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_MODULE_API_TAG_NAME],
+		summary: 'Remove several devices',
+		description:
+			'Removes every device in the supplied selection. Each device is processed independently, so a device that can not be removed is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per device.',
+		operationId: 'create-devices-module-devices-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemoveDevicesDto, description: 'The devices to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which devices were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('bulk-remove')
+	@HttpCode(200)
+	async bulkRemove(@Body() body: ReqBulkRemoveDevicesDto): Promise<BulkResultResponseModel> {
+		this.logger.debug(`Incoming request to remove ${body.data.ids.length} device(s)`);
+
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.devicesBulkService.remove(body.data.ids);
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_MODULE_API_TAG_NAME],
+		summary: 'Enable or disable several devices',
+		description:
+			'Sets the enabled state of every device in the supplied selection. Each device is processed independently, so a device that can not be updated is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per device.',
+		operationId: 'create-devices-module-devices-bulk-update',
+	})
+	@ApiBody({ type: ReqBulkUpdateDevicesDto, description: 'The devices to update and the state to set' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which devices were updated and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('bulk-update')
+	@HttpCode(200)
+	async bulkUpdate(@Body() body: ReqBulkUpdateDevicesDto): Promise<BulkResultResponseModel> {
+		this.logger.debug(`Incoming request to update ${body.data.ids.length} device(s)`);
+
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.devicesBulkService.setEnabled(body.data.ids, body.data.enabled);
+
+		return response;
 	}
 
 	@ApiOperation({

--- a/apps/backend/src/modules/devices/devices.module.ts
+++ b/apps/backend/src/modules/devices/devices.module.ts
@@ -61,6 +61,7 @@ import { DeviceProvisionQueueService } from './services/device-provision-queue.s
 import { DeviceStructureLockService } from './services/device-structure-lock.service';
 import { DeviceValidationService } from './services/device-validation.service';
 import { DeviceZonesService } from './services/device-zones.service';
+import { DevicesBulkService } from './services/devices-bulk.service';
 import { DevicesSeederService } from './services/devices-seeder.service';
 import { DevicesTypeMapperService } from './services/devices-type-mapper.service';
 import { DevicesControlsService } from './services/devices.controls.service';
@@ -113,6 +114,7 @@ import { DeviceNotHiddenConstraintValidator } from './validators/device-not-hidd
 		ChannelsTypeMapperService,
 		ChannelsPropertiesTypeMapperService,
 		DevicesService,
+		DevicesBulkService,
 		DevicesControlsService,
 		DeviceZonesService,
 		ChannelsService,
@@ -155,6 +157,7 @@ import { DeviceNotHiddenConstraintValidator } from './validators/device-not-hidd
 	],
 	exports: [
 		DevicesService,
+		DevicesBulkService,
 		DevicesControlsService,
 		DeviceZonesService,
 		ChannelsService,

--- a/apps/backend/src/modules/devices/devices.openapi.ts
+++ b/apps/backend/src/modules/devices/devices.openapi.ts
@@ -22,6 +22,7 @@ import {
 	DevicesModuleDeviceCategory,
 } from './models/devices-enums.model';
 import {
+	BulkResultResponseModel,
 	ChannelControlResponseModel,
 	ChannelControlsResponseModel,
 	ChannelPropertiesResponseModel,
@@ -37,6 +38,8 @@ import {
 	PropertyTimeseriesResponseModel,
 } from './models/devices-response.model';
 import {
+	BulkFailureModel,
+	BulkResultModel,
 	ChannelPropertySpecModel,
 	ChannelSpecModel,
 	DeviceChannelSpecModel,
@@ -53,6 +56,7 @@ import {
 
 export const DEVICES_SWAGGER_EXTRA_MODELS = [
 	// Response models
+	BulkResultResponseModel,
 	DeviceResponseModel,
 	DevicesResponseModel,
 	ChannelResponseModel,
@@ -75,6 +79,8 @@ export const DEVICES_SWAGGER_EXTRA_MODELS = [
 	ValidationSummaryModel,
 	ValidationIssueModel,
 	// Data models
+	BulkResultModel,
+	BulkFailureModel,
 	DeviceChannelSpecModel,
 	DeviceSpecModel,
 	ChannelPropertySpecModel,

--- a/apps/backend/src/modules/devices/dto/bulk-devices.dto.ts
+++ b/apps/backend/src/modules/devices/dto/bulk-devices.dto.ts
@@ -1,0 +1,75 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work. It is deliberately
+ * generous - the point of these endpoints is that a selection of several
+ * hundred devices goes through in one request.
+ */
+export const BULK_DEVICES_MAX_IDS = 500;
+
+@ApiSchema({ name: 'DevicesModuleBulkRemoveDevices' })
+export class BulkRemoveDevicesDto {
+	@ApiProperty({
+		description: 'Identifiers of the devices to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one device identifier is required."}]' })
+	@ArrayMaxSize(BULK_DEVICES_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_DEVICES_MAX_IDS} device identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each device identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'DevicesModuleReqBulkRemoveDevices' })
+export class ReqBulkRemoveDevicesDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveDevicesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemoveDevicesDto)
+	data: BulkRemoveDevicesDto;
+}
+
+@ApiSchema({ name: 'DevicesModuleBulkUpdateDevices' })
+export class BulkUpdateDevicesDto {
+	@ApiProperty({
+		description: 'Identifiers of the devices to update',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one device identifier is required."}]' })
+	@ArrayMaxSize(BULK_DEVICES_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_DEVICES_MAX_IDS} device identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each device identifier must be a valid UUID."}]' })
+	ids: string[];
+
+	@ApiProperty({
+		description: 'Whether the listed devices should be enabled',
+		type: 'boolean',
+		example: true,
+	})
+	@Expose()
+	@IsBoolean({ message: '[{"field":"enabled","reason":"Enabled must be a boolean value."}]' })
+	enabled: boolean;
+}
+
+@ApiSchema({ name: 'DevicesModuleReqBulkUpdateDevices' })
+export class ReqBulkUpdateDevicesDto {
+	@ApiProperty({ description: 'Bulk update data', type: () => BulkUpdateDevicesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkUpdateDevicesDto)
+	data: BulkUpdateDevicesDto;
+}

--- a/apps/backend/src/modules/devices/models/devices-response.model.ts
+++ b/apps/backend/src/modules/devices/models/devices-response.model.ts
@@ -11,7 +11,7 @@ import {
 	DeviceEntity,
 } from '../entities/devices.entity';
 
-import { PropertyTimeseriesModel } from './devices.model';
+import { BulkResultModel, PropertyTimeseriesModel } from './devices.model';
 
 /**
  * Response wrapper for DeviceEntity
@@ -186,4 +186,17 @@ export class PropertyTimeseriesResponseModel extends BaseSuccessResponseModel<Pr
 	})
 	@Expose()
 	declare data: PropertyTimeseriesModel;
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'DevicesModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/devices/models/devices.model.ts
+++ b/apps/backend/src/modules/devices/models/devices.model.ts
@@ -614,3 +614,54 @@ export class PropertyTimeseriesModel {
 	@ValidateNested({ each: true })
 	points: TimeseriesPointModel[];
 }
+
+/**
+ * One item of a bulk operation that did not go through.
+ *
+ * A bulk call replaces a sequence of individual requests, each of which could
+ * previously fail on its own, so the outcome has to stay per item: a device
+ * refused because it is hidden must not sink the rest of the selection.
+ */
+@ApiSchema({ name: 'DevicesModuleDataBulkFailure' })
+export class BulkFailureModel {
+	@ApiProperty({
+		description: 'Identifier of the device that could not be processed',
+		type: 'string',
+		format: 'uuid',
+		example: 'f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6',
+	})
+	@Expose()
+	id: string;
+
+	@ApiProperty({
+		description: 'Why this device could not be processed',
+		type: 'string',
+		example: 'Device not found',
+	})
+	@Expose()
+	reason: string;
+}
+
+/**
+ * Outcome of a bulk operation.
+ */
+@ApiSchema({ name: 'DevicesModuleDataBulkResult' })
+export class BulkResultModel {
+	@ApiProperty({
+		description: 'Identifiers of the devices that were processed successfully',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	succeeded: string[];
+
+	@ApiProperty({
+		description: 'Devices that could not be processed, each with its reason',
+		type: 'array',
+		items: { $ref: getSchemaPath(BulkFailureModel) },
+	})
+	@Expose()
+	@Type(() => BulkFailureModel)
+	failed: BulkFailureModel[];
+}

--- a/apps/backend/src/modules/devices/services/devices-bulk.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices-bulk.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { UpdateDeviceDto } from '../dto/update-device.dto';
+import { DeviceEntity } from '../entities/devices.entity';
+
+import { DevicesBulkService } from './devices-bulk.service';
+import { DevicesTypeMapperService } from './devices-type-mapper.service';
+import { DevicesService } from './devices.service';
+
+describe('DevicesBulkService', () => {
+	let service: DevicesBulkService;
+	let devicesService: { findOne: jest.Mock; remove: jest.Mock; update: jest.Mock };
+	let mapperService: { getMapping: jest.Mock };
+
+	const device = (id: string, type = 'mock-type'): DeviceEntity => ({ id, type }) as DeviceEntity;
+
+	beforeEach(async () => {
+		devicesService = {
+			findOne: jest.fn(),
+			remove: jest.fn().mockResolvedValue(undefined),
+			update: jest.fn().mockResolvedValue(undefined),
+		};
+
+		mapperService = {
+			getMapping: jest.fn().mockReturnValue({ updateDto: UpdateDeviceDto }),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				DevicesBulkService,
+				{ provide: DevicesService, useValue: devicesService },
+				{ provide: DevicesTypeMapperService, useValue: mapperService },
+			],
+		}).compile();
+
+		service = module.get<DevicesBulkService>(DevicesBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every device in the selection', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(devicesService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// The per-item endpoints each failed on their own; collapsing them into one
+		// request must not turn one refusal into a lost selection.
+		it('keeps going after a device fails and reports it', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
+			devicesService.remove.mockImplementation((id: string) =>
+				id === 'b' ? Promise.reject(new Error('Device is hidden and can not be removed')) : Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Device is hidden and can not be removed' }]);
+		});
+
+		it('reports an unknown device instead of throwing', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(id === 'gone' ? null : device(id)));
+
+			const result = await service.remove(['a', 'gone']);
+
+			expect(result.succeeded).toEqual(['a']);
+			expect(result.failed).toEqual([{ id: 'gone', reason: 'Requested device does not exist' }]);
+			expect(devicesService.remove).toHaveBeenCalledTimes(1);
+		});
+
+		it('acts once on a device listed twice', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
+
+			const result = await service.remove(['a', 'a', 'b']);
+
+			expect(result.succeeded).toEqual(['a', 'b']);
+			expect(devicesService.remove).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('setEnabled', () => {
+		it('updates every device in the selection', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
+
+			const result = await service.setEnabled(['a', 'b'], false);
+
+			expect(result.succeeded).toEqual(['a', 'b']);
+			expect(result.failed).toEqual([]);
+			expect(devicesService.update).toHaveBeenCalledTimes(2);
+			expect(devicesService.update).toHaveBeenCalledWith('a', expect.objectContaining({ enabled: false }));
+		});
+
+		// The type comes from the stored device, never the request, so a caller
+		// cannot route a device through another type's update rules.
+		it('resolves the update dto from the stored device type', async () => {
+			devicesService.findOne.mockResolvedValue(device('a', 'devices-shelly-ng'));
+
+			await service.setEnabled(['a'], true);
+
+			expect(mapperService.getMapping).toHaveBeenCalledWith('devices-shelly-ng');
+		});
+
+		it('reports a device whose type has no registered mapping', async () => {
+			devicesService.findOne.mockResolvedValue(device('a', 'gone-plugin'));
+			mapperService.getMapping.mockImplementation(() => {
+				throw new Error('no mapping');
+			});
+
+			const result = await service.setEnabled(['a'], true);
+
+			expect(result.succeeded).toEqual([]);
+			expect(result.failed).toEqual([{ id: 'a', reason: 'Unsupported device type: gone-plugin' }]);
+			expect(devicesService.update).not.toHaveBeenCalled();
+		});
+
+		it('carries the refusal reason back rather than a generic message', async () => {
+			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
+			devicesService.update.mockRejectedValue(new Error('Hidden device placement is immutable'));
+
+			const result = await service.setEnabled(['a'], true);
+
+			expect(result.failed).toEqual([{ id: 'a', reason: 'Hidden device placement is immutable' }]);
+		});
+	});
+});

--- a/apps/backend/src/modules/devices/services/devices-bulk.service.ts
+++ b/apps/backend/src/modules/devices/services/devices-bulk.service.ts
@@ -1,0 +1,162 @@
+import { validate } from 'class-validator';
+
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { toInstance } from '../../../common/utils/transform.utils';
+import { DEVICES_MODULE_NAME } from '../devices.constants';
+import { CreateDeviceDto } from '../dto/create-device.dto';
+import { UpdateDeviceDto } from '../dto/update-device.dto';
+import { DeviceEntity } from '../entities/devices.entity';
+import { BulkFailureModel, BulkResultModel } from '../models/devices.model';
+
+import { DeviceTypeMapping, DevicesTypeMapperService } from './devices-type-mapper.service';
+import { DevicesService } from './devices.service';
+
+/**
+ * Runs a device operation across a selection in a single request.
+ *
+ * These endpoints exist because the per-item alternative was a request per
+ * device, which the shared 30-per-minute throttle rejects once a selection goes
+ * past thirty. Collapsing the round trips is the whole point, so the work is
+ * still performed one device at a time here - the semantics of each operation,
+ * including its per-device refusals, are meant to be identical to the single
+ * endpoints. What changes is the transport, not the behaviour.
+ *
+ * Failures are collected rather than thrown: a selection is a set of
+ * independent intents, and one hidden device refusing to move must not discard
+ * the other forty-nine.
+ */
+@Injectable()
+export class DevicesBulkService {
+	private readonly logger = createExtensionLogger(DEVICES_MODULE_NAME, 'DevicesBulkService');
+
+	constructor(
+		private readonly devicesService: DevicesService,
+		private readonly devicesMapperService: DevicesTypeMapperService,
+	) {}
+
+	async remove(ids: string[]): Promise<BulkResultModel> {
+		const result = this.emptyResult();
+
+		for (const id of this.unique(ids)) {
+			const device = await this.devicesService.findOne(id);
+
+			if (!device) {
+				this.fail(result, id, 'Requested device does not exist');
+
+				continue;
+			}
+
+			try {
+				await this.devicesService.remove(device.id);
+
+				result.succeeded.push(device.id);
+			} catch (error) {
+				this.fail(result, id, this.reasonFor(error, 'Device could not be removed'));
+			}
+		}
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+
+	async setEnabled(ids: string[], enabled: boolean): Promise<BulkResultModel> {
+		const result = this.emptyResult();
+
+		for (const id of this.unique(ids)) {
+			const device = await this.devicesService.findOne(id);
+
+			if (!device) {
+				this.fail(result, id, 'Requested device does not exist');
+
+				continue;
+			}
+
+			let mapping: DeviceTypeMapping<DeviceEntity, CreateDeviceDto, UpdateDeviceDto>;
+
+			try {
+				mapping = this.devicesMapperService.getMapping<DeviceEntity, CreateDeviceDto, UpdateDeviceDto>(device.type);
+			} catch {
+				this.fail(result, id, `Unsupported device type: ${device.type}`);
+
+				continue;
+			}
+
+			// The single update endpoint routes the body through the type owner's own
+			// update DTO, so a plugin that constrains its devices keeps that say here
+			// too. The type comes from the stored device rather than the request, for
+			// the same reason it does there.
+			const dtoInstance = toInstance(
+				mapping.updateDto,
+				{ type: device.type, enabled },
+				{
+					excludeExtraneousValues: false,
+				},
+			);
+
+			const errors = await validate(dtoInstance, {
+				whitelist: true,
+				forbidNonWhitelisted: true,
+				stopAtFirstError: false,
+			});
+
+			if (errors.length > 0) {
+				this.fail(result, id, 'Device could not be updated');
+
+				continue;
+			}
+
+			try {
+				await this.devicesService.update(device.id, dtoInstance);
+
+				result.succeeded.push(device.id);
+			} catch (error) {
+				this.fail(result, id, this.reasonFor(error, 'Device could not be updated'));
+			}
+		}
+
+		this.logger.debug(
+			`Bulk enabled=${String(enabled)} finished succeeded=${result.succeeded.length} failed=${result.failed.length}`,
+		);
+
+		return result;
+	}
+
+	/**
+	 * A selection can carry the same device twice - two rows of the same device
+	 * in different groupings, for instance. Acting once and reporting once keeps
+	 * the counts the caller shows honest.
+	 */
+	private unique(ids: string[]): string[] {
+		return [...new Set(ids)];
+	}
+
+	private emptyResult(): BulkResultModel {
+		const result = new BulkResultModel();
+
+		result.succeeded = [];
+		result.failed = [];
+
+		return result;
+	}
+
+	private fail(result: BulkResultModel, id: string, reason: string): void {
+		const failure = new BulkFailureModel();
+
+		failure.id = id;
+		failure.reason = reason;
+
+		result.failed.push(failure);
+	}
+
+	/**
+	 * Refusals that carry an explanation - a hidden device's placement, a type
+	 * owner rejecting a state - are worth passing back, the same way the single
+	 * endpoints translate them instead of answering "try again later".
+	 */
+	private reasonFor(error: unknown, fallback: string): string {
+		return error instanceof Error && error.message.length > 0 ? error.message : fallback;
+	}
+}


### PR DESCRIPTION
First of three, per the agreed rollout. Fixes the reported ">30 devices" failure.

## The problem

Every bulk action was a loop issuing one request per device:

| Site | Requests |
|---|---|
| `bulkRemove` | N × `DELETE /devices/{id}` |
| `bulkEnable` / `bulkDisable` | N × `PATCH /devices/{id}` |

`ThrottlerModule.forRoot([{ ttl: 60000, limit: 30 }])` allows 30 requests a minute, shared across all device writes. A selection past thirty was rejected partway through and the tail went silently unprocessed — the user saw "some of them worked".

## The endpoints

```
POST /modules/devices/devices/bulk-remove   { "data": { "ids": [...] } }
POST /modules/devices/devices/bulk-update   { "data": { "ids": [...], "enabled": false } }
```

Both answer with the outcome **per device**, not a single verdict:

```json
{ "data": {
    "succeeded": ["…"],
    "failed": [{ "id": "…", "reason": "Device is hidden" }]
} }
```

A selection is a set of independent intents — one device refusing (a hidden device whose placement is immutable, a type owner rejecting a state) must not discard the other forty-nine. It is also what keeps the admin's existing "N removed, M failed" message honest; a single-verdict response would have regressed it.

Shape follows the existing `POST /spaces/:id/assign` precedent: `POST` + verb in path, body wrapped in `data`.

## Semantics are unchanged

`DevicesBulkService` still processes one device at a time. Each update goes through the owning type's own update DTO, resolved from the **stored** device type rather than the request — so a caller cannot route a device through another type's rules, and a plugin that constrains its devices keeps that say. Only the transport changed.

## Two corrections found along the way

- The composable wrapped **both** the confirmation prompt and the work in one `try`, so an API failure surfaced as "canceled". Those are now separate, and a real failure reads as one.
- Drafts were being handed to the backend, which would correctly report them as unknown. They never existed server-side, so they are now dropped locally and counted as done.

The local-cleanup cascade that `remove` performed inline is now shared with the bulk paths rather than written out twice with a chance of drifting.

## Verification

| Check | Result |
|---|---|
| Backend | 380 suites, 4811 passed |
| Admin | 277 files, 2014 passed |
| `tsc` / `vue-tsc` | clean |
| eslint (touched files) | clean |
| Mutation-tested | 5 mutations, all caught |

Mutations used: dedupe dropped; generic reason substituted for the real one; loop stopped at first failure; cascade applied to all requested ids instead of confirmed ones; `enabled` applied to all requested ids instead of confirmed ones.

`spec/api/v1/openapi.json` and `apps/admin/src/openapi.ts` are gitignored and regenerate in CI; `openapi.constants.ts` is hand-maintained and carries the two new operation types.

Two admin files still fail `prettier --check`, both **already failing on `main`** — left alone rather than reformatting untouched lines. `eslint` is what CI gates on and is clean.

## Not in this PR

- **Shelly NG + V1 wizard `adopt`** — the fiddliest path: `POST`-or-`PATCH` per device with a re-poll race fallback. Needs a bulk create reporting per-item outcome.
- **The other eight modules** — scenes, displays, spaces, extensions, pages, users, weather locations (13 bulk actions total).