### PR TITLE
feat(cross): adopt shelly ng devices in one request

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -287,6 +287,8 @@ export type DevicesModuleDeleteDeviceOperation = operations['delete-devices-modu
 export type DevicesModuleCreateDevicesBulkRemoveOperation = operations['create-devices-module-devices-bulk-remove'];
 
 export type DevicesModuleCreateDevicesBulkUpdateOperation = operations['create-devices-module-devices-bulk-update'];
+
+export type DevicesShellyNgPluginCreateAdoptOperation = operations['create-devices-shelly-ng-plugin-adopt'];
 export type DevicesModuleGetChannelOperation = operations['get-devices-module-channel'];
 export type DevicesModuleGetDeviceChannelOperation = operations['get-devices-module-device-channel'];
 export type DevicesModuleGetChannelsOperation = operations['get-devices-module-channels'];

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IWizardActionControl, IWizardFormControl, IWizardProgressControl } from '../../../modules/devices';
 import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
-import { DEVICES_SHELLY_NG_PLUGIN_PREFIX, DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import { DEVICES_SHELLY_NG_PLUGIN_PREFIX } from '../devices-shelly-ng.constants';
 import type { IShellyNgDiscoverySession } from '../schemas/devices.types';
 
 import { useDevicesWizard } from './useDevicesWizard';
@@ -11,6 +11,7 @@ const mockAdd = vi.fn();
 const mockEdit = vi.fn();
 const mockGet = vi.fn();
 const mockFindById = vi.fn();
+const mockFetch = vi.fn();
 
 const backendClient = {
 	GET: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock('../../../common', async () => {
 				add: mockAdd,
 				edit: mockEdit,
 				get: mockGet,
+				fetch: mockFetch,
 				findById: mockFindById,
 			}),
 		}),
@@ -404,6 +406,14 @@ describe('useDevicesWizard', () => {
 		}).mockResolvedValueOnce({
 			data: { data: discoverySession },
 			response: { status: 200 },
+		})	.mockResolvedValueOnce({
+			data: {
+				data: [
+					{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+				],
+			},
+			error: undefined,
+			response: { ok: true, status: 200 },
 		});
 		backendClient.GET.mockResolvedValue({
 			data: { data: discoverySession },
@@ -417,13 +427,12 @@ describe('useDevicesWizard', () => {
 
 		await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					password: 'secret',
-					wifiAddress: '192.168.1.10',
-				}),
-			})
+		const adopted = backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+		expect(adopted.body.data.devices[0]).toEqual(
+			expect.objectContaining({ password: 'secret', hostname: '192.168.1.10' })
 		);
 	});
 
@@ -439,7 +448,15 @@ describe('useDevicesWizard', () => {
 			.mockResolvedValueOnce({
 				data: { data: discoverySession },
 				response: { status: 200 },
-			});
+			})		.mockResolvedValueOnce({
+			data: {
+				data: [
+					{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+				],
+			},
+			error: undefined,
+			response: { ok: true, status: 200 },
+		});
 		backendClient.GET.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
@@ -456,13 +473,11 @@ describe('useDevicesWizard', () => {
 
 		await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					password: null,
-				}),
-			})
-		);
+		const adopted = backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+		expect(adopted.body.data.devices[0]!.password).toBeNull();
 	});
 
 	it('exposes a fresh session key on rescan so the shell drops the previous scan selections', async () => {
@@ -859,15 +874,34 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 	});
 
-	it('adopts the selection handed over by the shell through the devices store', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+	// Adoption is one request for the whole selection. The create-or-update
+	// decision, and the race with the connector adopting a device on its own,
+	// now belong to the backend - see shelly-ng-adoption.service.spec.ts. What is
+	// tested here is what this composable is still responsible for: which devices
+	// it puts in the payload, and how it reads the answer back.
+	const arrangeAdoption = (results: unknown[]): void => {
 		backendClient.GET.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({ data: { data: results }, error: undefined, response: { ok: true, status: 200 } });
+			}
+
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
+		});
+	};
+
+	const adoptCall = (): { body: { data: { devices: Record<string, unknown>[] } } } =>
+		backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+	it('adopts the whole selection in a single request', async () => {
+		arrangeAdoption([
+			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
@@ -875,18 +909,18 @@ describe('useDevicesWizard', () => {
 
 		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith({
-			id: expect.any(String),
-			draft: false,
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_NG_TYPE,
-				category: DevicesModuleDeviceCategory.lighting,
+		const adoptCalls = backendClient.POST.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/devices/adopt'));
+
+		expect(adoptCalls).toHaveLength(1);
+		expect(adoptCall().body.data.devices).toEqual([
+			{
 				identifier: 'shellyplus1-aabbcc',
+				hostname: '192.168.1.10',
 				name: 'Kitchen relay',
+				category: DevicesModuleDeviceCategory.lighting,
 				password: null,
-				wifiAddress: '192.168.1.10',
-			}),
-		});
+			},
+		]);
 		expect(results).toEqual([
 			{
 				key: '192.168.1.10',
@@ -899,251 +933,139 @@ describe('useDevicesWizard', () => {
 		expect(adapter.results.value).toEqual(results);
 	});
 
+	it('never sends one request per device', async () => {
+		arrangeAdoption(
+			discoverySession.devices.map((device) => ({
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'created',
+				device_id: 'dev',
+				reason: null,
+			}))
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await adapter.adopt(
+			discoverySession.devices.map((device) => ({
+				key: device.hostname,
+				name: device.name ?? device.hostname,
+				category: DevicesModuleDeviceCategory.lighting,
+			}))
+		);
+
+		const adoptCalls = backendClient.POST.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/devices/adopt'));
+
+		expect(adoptCalls).toHaveLength(1);
+		expect(mockAdd).not.toHaveBeenCalled();
+		expect(mockEdit).not.toHaveBeenCalled();
+	});
+
 	it('adopts with the name and category the shell hands over, not the discovered ones', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+		arrangeAdoption([
+			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 		await adapter.adopt([{ key: '192.168.1.10', name: 'Hallway light', category: DevicesModuleDeviceCategory.switcher }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					name: 'Hallway light',
-					category: DevicesModuleDeviceCategory.switcher,
-				}),
-			})
+		expect(adoptCall().body.data.devices[0]).toEqual(
+			expect.objectContaining({ name: 'Hallway light', category: DevicesModuleDeviceCategory.switcher })
 		);
 	});
 
 	it('falls back to the suggested name when the shell hands over a blank one', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+		arrangeAdoption([
+			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 		await adapter.adopt([{ key: '192.168.1.10', name: '   ', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					name: 'Kitchen relay',
-				}),
-			})
-		);
+		expect(adoptCall().body.data.devices[0]!.name).toBe('Kitchen relay');
 	});
 
-	it('updates an already registered device via edit instead of creating a duplicate', async () => {
-		const alreadyRegisteredSession: IShellyNgDiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-1',
-					registeredDeviceName: 'Existing kitchen relay',
-					registeredDeviceCategory: DevicesModuleDeviceCategory.lighting,
-				},
-			],
-		};
+	// The backend decides this, but the wizard still has to show it: a device the
+	// connector had already registered comes back as an update, not a failure.
+	it('reports back whatever outcome the backend returned for each device', async () => {
+		arrangeAdoption([
+			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'updated', device_id: 'dev-1', reason: null },
+		]);
 
-		backendClient.POST.mockResolvedValue({
-			data: { data: alreadyRegisteredSession },
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'updated', error: null }));
+	});
+
+	it('surfaces a per-device refusal without failing the rest', async () => {
+		arrangeAdoption([
+			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'failed', device_id: null, reason: 'Device is unreachable' },
+		]);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed', error: 'Device is unreachable' }));
+	});
+
+	it('reports a failed outcome instead of throwing when the request itself fails', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: { data: discoverySession },
 			response: { status: 200 },
 		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: alreadyRegisteredSession },
-			response: { status: 200 },
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({ data: undefined, error: { detail: 'boom' }, response: { ok: false, status: 500 } });
+			}
+
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
 		});
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
-		await adapter.adopt([{ key: '192.168.1.10', name: 'Existing kitchen relay', category: DevicesModuleDeviceCategory.switcher }]);
 
-		expect(mockEdit).toHaveBeenCalledWith({
-			id: 'device-uuid-1',
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_NG_TYPE,
-				category: DevicesModuleDeviceCategory.switcher,
-				name: 'Existing kitchen relay',
-			}),
-		});
-		expect(mockAdd).not.toHaveBeenCalled();
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'updated',
-			}),
-		]);
+		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed' }));
 	});
 
-	it('falls back to update when create fails because the main service auto-adopted the device', async () => {
-		const racedSession: IShellyNgDiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-2',
-					registeredDeviceName: 'Auto-adopted relay',
-				},
-			],
-		};
+	// The refresh inside `adopt` can drop a device from the live session; the
+	// snapshot taken beforehand is what keeps the operator's choice adoptable.
+	it('adopts a device that the refresh inside adopt dropped from the session entirely', async () => {
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({
+					data: {
+						data: [
+							{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+						],
+					},
+					error: undefined,
+					response: { ok: true, status: 200 },
+				});
+			}
 
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
 		});
-		// First refresh in adopt: still shows the snapshot's `ready` status.
-		// Second refresh (after add fails): shows the device now exists.
 		backendClient.GET.mockResolvedValueOnce({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		}).mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-
-		mockAdd.mockRejectedValueOnce(new Error('Duplicate identifier'));
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-		await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(mockAdd).toHaveBeenCalledTimes(1);
-		expect(mockEdit).toHaveBeenCalledWith({
-			id: 'device-uuid-2',
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_NG_TYPE,
-				category: DevicesModuleDeviceCategory.lighting,
-				name: 'Kitchen relay',
-			}),
-		});
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('loads the device into the local store before editing if it was just auto-adopted', async () => {
-		const racedSession: IShellyNgDiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-fresh',
-					registeredDeviceName: 'Auto-adopted relay',
-				},
-			],
-		};
-
-		backendClient.POST.mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-
-		// Device exists in the backend (already_registered) but not yet in the admin store —
-		// `devicesStore.edit` would otherwise reject the id.
-		mockFindById.mockReturnValue(null);
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-		await adapter.adopt([{ key: '192.168.1.10', name: 'Auto-adopted relay', category: DevicesModuleDeviceCategory.switcher }]);
-
-		expect(mockGet).toHaveBeenCalledWith({ id: 'device-uuid-fresh' });
-		expect(mockEdit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				id: 'device-uuid-fresh',
-			})
-		);
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('still adopts a device the shell selected if the refresh inside adopt flips it to already_registered', async () => {
-		const racedSession: IShellyNgDiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-in-flight',
-					registeredDeviceName: 'Auto-adopted relay',
-				},
-			],
-		};
-
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		// The refresh at the top of `adopt` reports the status flip.
-		backendClient.GET.mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-
-		// The user chose the device while it was still `ready`; the shell handed that intent over.
-		await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(mockEdit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				id: 'device-uuid-in-flight',
-			})
-		);
-		expect(mockAdd).not.toHaveBeenCalled();
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('adopts a device that the refresh inside adopt dropped from the session entirely', async () => {
-		// The refresh at the top of `adopt` can return a session that no longer lists the device
-		// — the scan expired it, or it stopped answering mDNS. The shell's selection carries only
-		// key / name / category, so without the pre-refresh descriptor snapshot we would lose the
-		// identifier and fail a device the user explicitly asked for.
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: emptySession },
+			data: { data: { ...discoverySession, devices: [] } },
 			response: { status: 200 },
 		});
 
@@ -1153,48 +1075,8 @@ describe('useDevicesWizard', () => {
 
 		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					identifier: 'shellyplus1-aabbcc',
-					name: 'Kitchen relay',
-					wifiAddress: '192.168.1.10',
-				}),
-			})
-		);
-		expect(results).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'created',
-			}),
-		]);
-	});
-
-	it('reports a failed outcome instead of throwing when adoption fails', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-
-		mockAdd.mockRejectedValue(new Error('Backend refused the device'));
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-
-		const results = await adapter.adopt([{ key: '192.168.1.10', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(results).toEqual([
-			expect.objectContaining({
-				key: '192.168.1.10',
-				status: 'failed',
-				error: 'Backend refused the device',
-			}),
-		]);
+		expect(adoptCall().body.data.devices[0]!.identifier).toBe('shellyplus1-aabbcc');
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'created' }));
 	});
 
 	it('reports the discovered device count and scan progress through the progress control', async () => {

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -2,7 +2,6 @@ import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { orderBy } from 'natural-orderby';
-import { v4 as uuid } from 'uuid';
 
 import { useNow } from '@vueuse/core';
 
@@ -21,11 +20,12 @@ import {
 } from '../../../modules/devices';
 import {
 	type DevicesModuleDeviceCategory,
+	type DevicesShellyNgPluginCreateAdoptOperation,
 	type DevicesShellyNgPluginCreateDiscoveryManualOperation,
 	type DevicesShellyNgPluginCreateDiscoveryOperation,
 	type DevicesShellyNgPluginGetDiscoveryOperation,
 } from '../../../openapi.constants';
-import { DEVICES_SHELLY_NG_PLUGIN_NAME, DEVICES_SHELLY_NG_PLUGIN_PREFIX, DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import { DEVICES_SHELLY_NG_PLUGIN_NAME, DEVICES_SHELLY_NG_PLUGIN_PREFIX } from '../devices-shelly-ng.constants';
 import { DevicesShellyNgApiException, DevicesShellyNgValidationException } from '../devices-shelly-ng.exceptions';
 import type { IShellyNgDiscoveryDevice, IShellyNgDiscoverySession } from '../schemas/devices.types';
 import { transformDeviceInfoRequest, transformDiscoverySessionResponse } from '../utils/devices.transformers';
@@ -463,56 +463,37 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		},
 	]);
 
-	const updateRegistered = async (
-		id: string,
-		{ name, category, password }: { name: string; category: DevicesModuleDeviceCategory; password: string | null }
-	): Promise<void> => {
-		const data: { type: string; name: string; category: DevicesModuleDeviceCategory; password?: string } = {
-			type: DEVICES_SHELLY_NG_TYPE,
-			name,
-			category,
-		};
-
-		if (password !== null) {
-			data.password = password;
-		}
-
-		// `devicesStore.edit` requires the device to be present in the local store. When the
-		// main connector auto-adopts a device after the wizard's snapshot was taken, the new
-		// row may not be in the admin store yet — pull it in first so the edit can land.
-		if (devicesStore.findById(id) === null) {
-			await devicesStore.get({ id });
-		}
-
-		await devicesStore.edit({ id, data });
-	};
-
 	const adopt = async (selection: IWizardAdoptSelection[]): Promise<IWizardResult[]> => {
 		formResult.value = FormResult.WORKING;
 
 		// Snapshot the descriptors BEFORE refreshing. The shell already captured the user's
 		// intent (name / category) in `selection`, but the refresh below can drop a device from
-		// the live list entirely, and we still need its identifier and registration state to
-		// adopt the device the user chose.
+		// the live list entirely, and we still need its identifier to adopt the device the user
+		// chose.
 		const snapshot = devices.value.slice();
 
-		// Refresh once so we see any device the main service auto-adopted between scan and adoption.
-		// Lets us route those through `edit` instead of getting a duplicate-identifier error from `add`.
 		if (session.value !== null) {
 			try {
 				await refreshDiscovery();
 			} catch {
-				// Stale snapshot is fine — the per-device fallback below still handles late races.
+				// Stale snapshot is fine — the identifiers we need are already in hand.
 			}
 		}
 
 		const outcomes: IShellyNgWizardAdoptionResult[] = [];
+		const payload: {
+			identifier: string;
+			hostname: string;
+			name: string;
+			category: DevicesModuleDeviceCategory;
+			password?: string | null;
+		}[] = [];
 
 		for (const item of selection) {
 			const device =
 				devices.value.find((candidate) => candidate.hostname === item.key) ?? snapshot.find((candidate) => candidate.hostname === item.key);
 
-			if (device === undefined) {
+			if (device === undefined || device.identifier === null) {
 				outcomes.push({
 					hostname: item.key,
 					name: item.name,
@@ -523,84 +504,58 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				continue;
 			}
 
-			// The shell already trims and defaults the name, but a blank one must never reach
-			// the backend — fall back to the same chain that seeded the field.
-			const name = item.name.trim() || suggestedNameFor(device);
-			const category = item.category;
-			const password = passwordByHostname[device.hostname] ?? null;
+			payload.push({
+				identifier: device.identifier,
+				hostname: device.hostname,
+				// The shell already trims and defaults the name, but a blank one must never reach
+				// the backend — fall back to the same chain that seeded the field.
+				name: item.name.trim() || suggestedNameFor(device),
+				category: item.category,
+				password: passwordByHostname[device.hostname] ?? null,
+			});
+		}
 
+		if (payload.length > 0) {
+			// One request for the whole selection. Sending one per device tripped the backend's
+			// shared rate limit past thirty devices, and left this composable racing the
+			// connector's own auto-adoption — which the backend now settles against current
+			// state instead of a snapshot taken here.
 			try {
-				if (device.status === 'already_registered' && device.registeredDeviceId !== null) {
-					await updateRegistered(device.registeredDeviceId, { name, category, password });
+				const { data: responseBody, error, response } = await backend.client.POST(
+					`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_NG_PLUGIN_PREFIX}/devices/adopt`,
+					{ body: { data: { devices: payload } } }
+				);
 
-					outcomes.push({
-						hostname: device.hostname,
-						name,
-						status: 'updated',
-						error: null,
-					});
+				if (typeof responseBody === 'undefined' || !response.ok) {
+					const errorReason = error
+						? getErrorReason<DevicesShellyNgPluginCreateAdoptOperation>(
+								error,
+								t('devicesShellyNgPlugin.messages.wizard.adoptionNotCreated')
+							)
+						: t('devicesShellyNgPlugin.messages.wizard.adoptionNotCreated');
 
-					continue;
+					throw new DevicesShellyNgApiException(errorReason, response.status);
 				}
 
-				const id = uuid().toString();
-
-				try {
-					await devicesStore.add({
-						id,
-						draft: false,
-						data: {
-							id,
-							type: DEVICES_SHELLY_NG_TYPE,
-							category,
-							identifier: device.identifier,
-							name,
-							description: null,
-							enabled: true,
-							password,
-							wifiAddress: device.hostname,
-						},
-					});
+				for (const result of responseBody.data) {
+					const requested = payload.find((item) => item.hostname === result.hostname);
 
 					outcomes.push({
-						hostname: device.hostname,
-						name,
-						status: 'created',
-						error: null,
+						hostname: result.hostname,
+						name: requested?.name ?? result.hostname,
+						status: result.status,
+						error: result.reason,
 					});
-				} catch (createError: unknown) {
-					// The device may have been auto-created by the main shelly-ng service after the discovery
-					// snapshot was taken. Re-poll, and if it now shows as already_registered, fall back to update.
-					try {
-						await refreshDiscovery();
-					} catch {
-						// ignore — handled below
-					}
-
-					const refreshed = devices.value.find((candidate) => candidate.hostname === device.hostname);
-
-					if (refreshed?.status === 'already_registered' && refreshed.registeredDeviceId !== null) {
-						await updateRegistered(refreshed.registeredDeviceId, { name, category, password });
-
-						outcomes.push({
-							hostname: device.hostname,
-							name,
-							status: 'updated',
-							error: null,
-						});
-
-						continue;
-					}
-
-					throw createError;
 				}
+
+				await devicesStore.fetch();
 			} catch (error: unknown) {
-				outcomes.push({
-					hostname: device.hostname,
-					name,
-					status: 'failed',
-					error: error instanceof Error ? error.message : t('devicesShellyNgPlugin.messages.wizard.adoptionNotCreated'),
-				});
+				const reason =
+					error instanceof Error ? error.message : t('devicesShellyNgPlugin.messages.wizard.adoptionNotCreated');
+
+				for (const item of payload) {
+					outcomes.push({ hostname: item.hostname, name: item.name, status: 'failed', error: reason });
+				}
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
@@ -13,6 +13,7 @@ import { THROTTLER_LIMIT, THROTTLER_TTL } from '@nestjs/throttler/dist/throttler
 
 import { MappingLoaderService } from '../mappings';
 import { DeviceManagerService } from '../services/device-manager.service';
+import { ShellyNgAdoptionService } from '../services/shelly-ng-adoption.service';
 import { ShellyNgDiscoveryService } from '../services/shelly-ng-discovery.service';
 
 import { ShellyNgDevicesController } from './shelly-ng-devices.controller';
@@ -50,6 +51,7 @@ describe('ShellyNgDevicesController', () => {
 	let controller: ShellyNgDevicesController;
 	let deviceManager: jest.Mocked<DeviceManagerService>;
 	let discoveryService: jest.Mocked<ShellyNgDiscoveryService>;
+	let adoptionService: jest.Mocked<ShellyNgAdoptionService>;
 
 	beforeAll(() => {});
 
@@ -62,12 +64,16 @@ describe('ShellyNgDevicesController', () => {
 			get: jest.fn(),
 			manual: jest.fn(),
 		};
+		const adoptionServiceMock: Partial<jest.Mocked<ShellyNgAdoptionService>> = {
+			adopt: jest.fn(),
+		};
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [ShellyNgDevicesController],
 			providers: [
 				{ provide: DeviceManagerService, useValue: deviceManagerMock },
 				{ provide: ShellyNgDiscoveryService, useValue: discoveryServiceMock },
+				{ provide: ShellyNgAdoptionService, useValue: adoptionServiceMock },
 				{
 					provide: MappingLoaderService,
 					useValue: {
@@ -81,6 +87,7 @@ describe('ShellyNgDevicesController', () => {
 		controller = module.get(ShellyNgDevicesController);
 		deviceManager = module.get(DeviceManagerService) as jest.Mocked<DeviceManagerService>;
 		discoveryService = module.get(ShellyNgDiscoveryService) as jest.Mocked<ShellyNgDiscoveryService>;
+		adoptionService = module.get(ShellyNgAdoptionService) as jest.Mocked<ShellyNgAdoptionService>;
 	});
 
 	describe('Shelly NG discovery endpoints', () => {
@@ -257,6 +264,37 @@ describe('ShellyNgDevicesController', () => {
 			expect(groups).toContain('SHELLYPLUS1');
 			expect(groups).toContain('SHELLYDIMMER');
 			expect(groups).not.toContain('BROKEN');
+		});
+	});
+
+	describe('Shelly NG adoption endpoint', () => {
+		it('hands the whole selection to the adoption service in one call', async () => {
+			const devices = [
+				{
+					identifier: 'shellyplus1-aabbcc',
+					hostname: '192.168.1.10',
+					name: 'Kitchen relay',
+					category: 'lighting',
+					password: null,
+				},
+			];
+
+			adoptionService.adopt.mockResolvedValue([
+				{
+					hostname: '192.168.1.10',
+					identifier: 'shellyplus1-aabbcc',
+					status: 'created',
+					deviceId: 'dev-1',
+					reason: null,
+				},
+			]);
+
+			const response = await controller.adopt({ data: { devices } } as never);
+
+			expect(adoptionService.adopt).toHaveBeenCalledTimes(1);
+			expect(adoptionService.adopt).toHaveBeenCalledWith(devices);
+			expect(response.data).toHaveLength(1);
+			expect(response.data[0]?.status).toBe('created');
 		});
 	});
 });

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.ts
@@ -19,9 +19,11 @@ import {
 	DEVICES_SHELLY_NG_PLUGIN_NAME,
 } from '../devices-shelly-ng.constants';
 import { DevicesShellyNgException } from '../devices-shelly-ng.exceptions';
+import { ReqAdoptDevicesDto } from '../dto/adopt-devices.dto';
 import { DevicesShellyNgPluginReqGetInfo } from '../dto/shelly-ng-get-info.dto';
 import { MappingLoaderService } from '../mappings';
 import {
+	ShellyNgAdoptionResponseModel,
 	ShellyNgDeviceInfoResponseModel,
 	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
@@ -29,6 +31,7 @@ import {
 } from '../models/shelly-ng-response.model';
 import { ShellyNgDeviceInfoModel, ShellyNgSupportedDeviceModel } from '../models/shelly-ng.model';
 import { DeviceManagerService } from '../services/device-manager.service';
+import { ShellyNgAdoptionService } from '../services/shelly-ng-adoption.service';
 import { ShellyNgDiscoveryService } from '../services/shelly-ng-discovery.service';
 
 @ApiTags(DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME)
@@ -43,6 +46,7 @@ export class ShellyNgDevicesController {
 		private readonly deviceManagerService: DeviceManagerService,
 		private readonly mappingLoaderService: MappingLoaderService,
 		private readonly discoveryService: ShellyNgDiscoveryService,
+		private readonly adoptionService: ShellyNgAdoptionService,
 	) {}
 
 	@ApiOperation({
@@ -312,5 +316,27 @@ export class ShellyNgDevicesController {
 
 			throw new UnprocessableEntityException('Failed to reload mapping configurations');
 		}
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_NG_PLUGIN_API_TAG_NAME],
+		summary: 'Adopt discovered Shelly NG devices',
+		description:
+			'Adopts a selection of discovered devices in a single request. Each device is adopted independently and its outcome reported separately, so one device that can not be adopted does not discard the rest of the selection. A device the connector has already registered on its own is updated rather than reported as a conflict.',
+		operationId: 'create-devices-shelly-ng-plugin-adopt',
+	})
+	@ApiBody({ type: ReqAdoptDevicesDto, description: 'The devices to adopt' })
+	@ApiSuccessResponse(ShellyNgAdoptionResponseModel, 'Returns the outcome for each device in the selection')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('adopt')
+	async adopt(@Body() body: ReqAdoptDevicesDto): Promise<ShellyNgAdoptionResponseModel> {
+		this.logger.debug(`Incoming request to adopt ${body.data.devices.length} device(s)`);
+
+		const response = new ShellyNgAdoptionResponseModel();
+
+		response.data = await this.adoptionService.adopt(body.data.devices);
+
+		return response;
 	}
 }

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.openapi.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Devices Shelly NG plugin
  */
+import { AdoptDeviceDto, AdoptDevicesDto } from './dto/adopt-devices.dto';
 import { CreateShellyNgChannelPropertyDto } from './dto/create-channel-property.dto';
 import { CreateShellyNgChannelDto } from './dto/create-channel.dto';
 import { CreateShellyNgDeviceDto } from './dto/create-device.dto';
@@ -19,12 +20,14 @@ import {
 } from './entities/devices-shelly-ng.entity';
 import { ShellyNgConfigModel, ShellyNgMdnsConfigModel, ShellyNgWebsocketsConfigModel } from './models/config.model';
 import {
+	ShellyNgAdoptionResponseModel,
 	ShellyNgDeviceInfoResponseModel,
 	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
 	ShellyNgSupportedDevicesResponseModel,
 } from './models/shelly-ng-response.model';
 import {
+	ShellyNgAdoptionResultModel,
 	ShellyNgDeviceInfoAuthenticationModel,
 	ShellyNgDeviceInfoComponentModel,
 	ShellyNgDeviceInfoModel,
@@ -49,12 +52,16 @@ export const DEVICES_SHELLY_NG_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	ShellyNgUpdatePluginConfigDto,
 	ShellyNgUpdatePluginConfigMdnsDto,
 	ShellyNgUpdatePluginConfigWebsocketsDto,
+	AdoptDeviceDto,
+	AdoptDevicesDto,
 	// Response models
+	ShellyNgAdoptionResponseModel,
 	ShellyNgDeviceInfoResponseModel,
 	ShellyNgDiscoverySessionResponseModel,
 	ShellyNgMappingReloadResponseModel,
 	ShellyNgSupportedDevicesResponseModel,
 	// Data models
+	ShellyNgAdoptionResultModel,
 	ShellyNgDiscoveryDeviceAuthenticationModel,
 	ShellyNgDiscoveryDeviceModel,
 	ShellyNgDiscoverySessionModel,

--- a/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/devices-shelly-ng.plugin.ts
@@ -57,6 +57,7 @@ import { ShellyNgDevicePlatform } from './platforms/shelly-ng.device.platform';
 import { DatabaseDiscovererService } from './services/database-discoverer.service';
 import { DeviceAddressService } from './services/device-address.service';
 import { DeviceManagerService } from './services/device-manager.service';
+import { ShellyNgAdoptionService } from './services/shelly-ng-adoption.service';
 import { ShellyNgDiscoveryService } from './services/shelly-ng-discovery.service';
 import { ShellyNgService } from './services/shelly-ng.service';
 import { ShellyRpcClientService } from './services/shelly-rpc-client.service';
@@ -92,6 +93,7 @@ import { DeviceEntitySubscriber } from './subscribers/device-entity.subscriber';
 		DelegatesManagerService,
 		DeviceManagerService,
 		ShellyNgDiscoveryService,
+		ShellyNgAdoptionService,
 		ShellyNgService,
 		ShellyWsServerService,
 		ShellyNgDevicePlatform,

--- a/apps/backend/src/plugins/devices-shelly-ng/dto/adopt-devices.dto.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/dto/adopt-devices.dto.ts
@@ -1,0 +1,89 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+/**
+ * A whole discovery result can be adopted at once, and a large installation
+ * discovers a lot of devices, so the cap only guards against a request that
+ * could not have come from the wizard.
+ */
+export const ADOPT_DEVICES_MAX = 500;
+
+@ApiSchema({ name: 'DevicesShellyNgPluginAdoptDevice' })
+export class AdoptDeviceDto {
+	@ApiProperty({
+		description: 'Shelly device identifier as reported by the device itself',
+		type: 'string',
+		example: 'shellyplus1pm-441793ad07bc',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"identifier","reason":"Identifier must be a valid string."}]' })
+	identifier: string;
+
+	@ApiProperty({
+		description: 'Address the device was discovered on',
+		type: 'string',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"hostname","reason":"Hostname must be a valid string."}]' })
+	hostname: string;
+
+	@ApiProperty({
+		description: 'Name to give the adopted device',
+		type: 'string',
+		example: 'Kitchen light',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"name","reason":"Name must be a valid string."}]' })
+	name: string;
+
+	@ApiProperty({
+		description: 'Category to assign to the adopted device',
+		enum: DeviceCategory,
+		example: DeviceCategory.LIGHTING,
+	})
+	@Expose()
+	@IsEnum(DeviceCategory, { message: '[{"field":"category","reason":"Category must be a valid device category."}]' })
+	category: DeviceCategory;
+
+	@ApiPropertyOptional({
+		description: 'Password for a device with authentication enabled',
+		type: 'string',
+		nullable: true,
+		example: 'password123',
+	})
+	@Expose()
+	@IsOptional()
+	@IsString({ message: '[{"field":"password","reason":"Password must be a valid string."}]' })
+	password?: string | null = null;
+}
+
+@ApiSchema({ name: 'DevicesShellyNgPluginAdoptDevices' })
+export class AdoptDevicesDto {
+	@ApiProperty({
+		description: 'Devices to adopt',
+		type: () => [AdoptDeviceDto],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"devices","reason":"Devices must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"devices","reason":"At least one device is required."}]' })
+	@ArrayMaxSize(ADOPT_DEVICES_MAX, {
+		message: `[{"field":"devices","reason":"At most ${ADOPT_DEVICES_MAX} devices can be adopted in one request."}]`,
+	})
+	@ValidateNested({ each: true })
+	@Type(() => AdoptDeviceDto)
+	devices: AdoptDeviceDto[];
+}
+
+@ApiSchema({ name: 'DevicesShellyNgPluginReqAdoptDevices' })
+export class ReqAdoptDevicesDto {
+	@ApiProperty({ description: 'Adoption data', type: () => AdoptDevicesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => AdoptDevicesDto)
+	data: AdoptDevicesDto;
+}

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng-response.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng-response.model.ts
@@ -5,6 +5,7 @@ import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 
 import {
+	ShellyNgAdoptionResultModel,
 	ShellyNgDeviceInfoModel,
 	ShellyNgDiscoverySessionModel,
 	ShellyNgMappingReloadModel,
@@ -62,4 +63,18 @@ export class ShellyNgMappingReloadResponseModel extends BaseSuccessResponseModel
 	})
 	@Expose()
 	declare data: ShellyNgMappingReloadModel;
+}
+
+/**
+ * Response wrapper for the per-device outcome of an adoption request
+ */
+@ApiSchema({ name: 'DevicesShellyNgPluginResAdoption' })
+export class ShellyNgAdoptionResponseModel extends BaseSuccessResponseModel<ShellyNgAdoptionResultModel[]> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: 'array',
+		items: { $ref: getSchemaPath(ShellyNgAdoptionResultModel) },
+	})
+	@Expose()
+	declare data: ShellyNgAdoptionResultModel[];
 }

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
@@ -586,3 +586,59 @@ export class ShellyNgMappingReloadModel {
 	@Type(() => ShellyNgMappingReloadStatsModel)
 	reloadStats: ShellyNgMappingReloadStatsModel;
 }
+
+/**
+ * What happened to one device in an adoption request.
+ *
+ * Adoption is a set of independent intents, so the outcome is reported per
+ * device: one device refusing must not discard the rest of the selection, and
+ * the wizard shows the operator exactly which ones landed.
+ */
+@ApiSchema({ name: 'DevicesShellyNgPluginDataAdoptionResult' })
+export class ShellyNgAdoptionResultModel {
+	@ApiProperty({
+		description: 'Address the device was discovered on',
+		type: 'string',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	hostname: string;
+
+	@ApiProperty({
+		description: 'Shelly device identifier',
+		type: 'string',
+		example: 'shellyplus1pm-441793ad07bc',
+	})
+	@Expose()
+	identifier: string;
+
+	@ApiProperty({
+		description:
+			'Whether the device was newly created, or updated because it was already registered - including when the connector adopted it on its own while the wizard was open',
+		type: 'string',
+		enum: ['created', 'updated', 'failed'],
+		example: 'created',
+	})
+	@Expose()
+	status: 'created' | 'updated' | 'failed';
+
+	@ApiProperty({
+		name: 'device_id',
+		description: 'Identifier of the resulting device, when there is one',
+		type: 'string',
+		format: 'uuid',
+		nullable: true,
+		example: 'f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6',
+	})
+	@Expose({ name: 'device_id' })
+	deviceId: string | null;
+
+	@ApiProperty({
+		description: 'Why this device could not be adopted',
+		type: 'string',
+		nullable: true,
+		example: 'Device could not be adopted',
+	})
+	@Expose()
+	reason: string | null;
+}

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import { AdoptDeviceDto } from '../dto/adopt-devices.dto';
+import { ShellyNgDeviceEntity } from '../entities/devices-shelly-ng.entity';
+
+import { ShellyNgAdoptionService } from './shelly-ng-adoption.service';
+
+describe('ShellyNgAdoptionService', () => {
+	let service: ShellyNgAdoptionService;
+	let devicesService: { findOneBy: jest.Mock; create: jest.Mock; update: jest.Mock };
+
+	const selection = (overrides: Partial<AdoptDeviceDto> = {}): AdoptDeviceDto =>
+		({
+			identifier: 'shellyplus1pm-441793ad07bc',
+			hostname: '192.168.1.100',
+			name: 'Kitchen light',
+			category: DeviceCategory.LIGHTING,
+			password: null,
+			...overrides,
+		}) as AdoptDeviceDto;
+
+	beforeEach(async () => {
+		devicesService = {
+			findOneBy: jest.fn().mockResolvedValue(null),
+			create: jest.fn().mockImplementation(() => Promise.resolve({ id: 'new-device' } as ShellyNgDeviceEntity)),
+			update: jest.fn().mockImplementation(() => Promise.resolve({ id: 'existing' } as ShellyNgDeviceEntity)),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [ShellyNgAdoptionService, { provide: DevicesService, useValue: devicesService }],
+		}).compile();
+
+		service = module.get<ShellyNgAdoptionService>(ShellyNgAdoptionService);
+	});
+
+	it('creates a device that is not registered yet', async () => {
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('created');
+		expect(outcome.deviceId).toBe('new-device');
+		expect(devicesService.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: DEVICES_SHELLY_NG_TYPE,
+				identifier: 'shellyplus1pm-441793ad07bc',
+				name: 'Kitchen light',
+				category: DeviceCategory.LIGHTING,
+				wifiAddress: '192.168.1.100',
+			}),
+		);
+	});
+
+	it('updates a device the connector already registered', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyNgDeviceEntity);
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('updated');
+		expect(outcome.deviceId).toBe('existing');
+		expect(devicesService.create).not.toHaveBeenCalled();
+		expect(devicesService.update).toHaveBeenCalledWith('existing', expect.objectContaining({ name: 'Kitchen light' }));
+	});
+
+	// The whole point of adopting here rather than in the browser: the connector
+	// can register a device between the lookup and the create, and the answer is
+	// a local re-read instead of the browser re-polling discovery.
+	it('treats a device the connector registered mid-request as an update', async () => {
+		devicesService.findOneBy
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce({ id: 'raced-in' } as ShellyNgDeviceEntity);
+		devicesService.create.mockRejectedValue(new Error('UNIQUE constraint failed: devices.identifier'));
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('updated');
+		expect(outcome.deviceId).toBe('raced-in');
+		expect(devicesService.update).toHaveBeenCalledWith('raced-in', expect.anything());
+	});
+
+	it('reports a genuine create failure with its reason', async () => {
+		devicesService.create.mockRejectedValue(new Error('Device could not be created'));
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('failed');
+		expect(outcome.reason).toBe('Device could not be created');
+		expect(outcome.deviceId).toBeNull();
+	});
+
+	// A blank password means the operator did not type one this session, not that
+	// the stored one should be discarded.
+	it('leaves a stored password alone when none was supplied', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyNgDeviceEntity);
+
+		await service.adopt([selection({ password: null })]);
+
+		// The key has to be absent, not present-and-null: `expect.anything()` does
+		// not match null, so an `objectContaining` assertion here would pass either
+		// way and prove nothing.
+		const [, dto] = devicesService.update.mock.calls[0] as [string, Record<string, unknown>];
+
+		expect(Object.keys(dto)).not.toContain('password');
+	});
+
+	it('sends a password the operator did supply', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyNgDeviceEntity);
+
+		await service.adopt([selection({ password: 'hunter2' })]);
+
+		expect(devicesService.update).toHaveBeenCalledWith('existing', expect.objectContaining({ password: 'hunter2' }));
+	});
+
+	it('adopts the rest of the selection after one device fails', async () => {
+		devicesService.create.mockImplementation((dto: { identifier: string }) =>
+			dto.identifier === 'bad' ? Promise.reject(new Error('nope')) : Promise.resolve({ id: dto.identifier }),
+		);
+
+		const outcomes = await service.adopt([
+			selection({ identifier: 'first' }),
+			selection({ identifier: 'bad' }),
+			selection({ identifier: 'last' }),
+		]);
+
+		expect(outcomes.map((outcome) => outcome.status)).toEqual(['created', 'failed', 'created']);
+	});
+});

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.ts
@@ -1,0 +1,150 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_SHELLY_NG_PLUGIN_NAME, DEVICES_SHELLY_NG_TYPE } from '../devices-shelly-ng.constants';
+import { AdoptDeviceDto } from '../dto/adopt-devices.dto';
+import { CreateShellyNgDeviceDto } from '../dto/create-device.dto';
+import { UpdateShellyNgDeviceDto } from '../dto/update-device.dto';
+import { ShellyNgDeviceEntity } from '../entities/devices-shelly-ng.entity';
+
+export type ShellyNgAdoptionStatus = 'created' | 'updated' | 'failed';
+
+export interface ShellyNgAdoptionOutcome {
+	hostname: string;
+	identifier: string;
+	status: ShellyNgAdoptionStatus;
+	deviceId: string | null;
+	reason: string | null;
+}
+
+/**
+ * Adopts discovered devices.
+ *
+ * This used to run in the browser, one request per device, which the shared
+ * request limit rejected once a selection went past thirty. It also had to cope
+ * with the connector adopting a device on its own between the discovery scan
+ * and the adoption - the browser could only notice that by failing a create,
+ * re-polling discovery and retrying as an update.
+ *
+ * Running here removes that: the connector's auto-adoption and this adoption
+ * are the same process writing to the same table, so a device that already
+ * exists is simply found, and the create/update decision is made against
+ * current state rather than against a snapshot the browser took earlier.
+ */
+@Injectable()
+export class ShellyNgAdoptionService {
+	private readonly logger = createExtensionLogger(DEVICES_SHELLY_NG_PLUGIN_NAME, 'ShellyNgAdoptionService');
+
+	constructor(private readonly devicesService: DevicesService) {}
+
+	async adopt(devices: AdoptDeviceDto[]): Promise<ShellyNgAdoptionOutcome[]> {
+		const outcomes: ShellyNgAdoptionOutcome[] = [];
+
+		for (const device of devices) {
+			outcomes.push(await this.adoptOne(device));
+		}
+
+		this.logger.debug(
+			`Adoption finished created=${outcomes.filter((outcome) => outcome.status === 'created').length} ` +
+				`updated=${outcomes.filter((outcome) => outcome.status === 'updated').length} ` +
+				`failed=${outcomes.filter((outcome) => outcome.status === 'failed').length}`,
+		);
+
+		return outcomes;
+	}
+
+	private async adoptOne(device: AdoptDeviceDto): Promise<ShellyNgAdoptionOutcome> {
+		const existing = await this.findByIdentifier(device.identifier);
+
+		if (existing !== null) {
+			return this.update(device, existing);
+		}
+
+		try {
+			const created = await this.devicesService.create<ShellyNgDeviceEntity, CreateShellyNgDeviceDto>({
+				type: DEVICES_SHELLY_NG_TYPE,
+				category: device.category,
+				identifier: device.identifier,
+				name: device.name,
+				password: device.password ?? null,
+				wifiAddress: device.hostname,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'created',
+				deviceId: created.id,
+				reason: null,
+			};
+		} catch (error) {
+			// The connector may have adopted this device between the lookup above
+			// and the create. It is the same race the connector itself handles, and
+			// the answer is the same: look again, and treat a device that now exists
+			// as an update rather than a failure.
+			const raced = await this.findByIdentifier(device.identifier);
+
+			if (raced !== null) {
+				return this.update(device, raced);
+			}
+
+			const err = error as Error;
+
+			this.logger.error(`Failed to adopt device identifier=${device.identifier}`, {
+				message: err.message,
+				stack: err.stack,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'failed',
+				deviceId: null,
+				reason: err.message.length > 0 ? err.message : 'Device could not be adopted',
+			};
+		}
+	}
+
+	private async update(device: AdoptDeviceDto, existing: ShellyNgDeviceEntity): Promise<ShellyNgAdoptionOutcome> {
+		try {
+			await this.devicesService.update<ShellyNgDeviceEntity, UpdateShellyNgDeviceDto>(existing.id, {
+				type: DEVICES_SHELLY_NG_TYPE,
+				name: device.name,
+				category: device.category,
+				// A blank password field means "leave what is stored" rather than
+				// "clear it" - the wizard only knows a password the operator typed
+				// during this session.
+				...(device.password === null || typeof device.password === 'undefined' ? {} : { password: device.password }),
+				wifiAddress: device.hostname,
+			} as UpdateShellyNgDeviceDto);
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'updated',
+				deviceId: existing.id,
+				reason: null,
+			};
+		} catch (error) {
+			const err = error as Error;
+
+			this.logger.error(`Failed to update adopted device identifier=${device.identifier}`, {
+				message: err.message,
+				stack: err.stack,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'failed',
+				deviceId: existing.id,
+				reason: err.message.length > 0 ? err.message : 'Device could not be updated',
+			};
+		}
+	}
+
+	private async findByIdentifier(identifier: string): Promise<ShellyNgDeviceEntity | null> {
+		return await this.devicesService.findOneBy<ShellyNgDeviceEntity>('identifier', identifier, DEVICES_SHELLY_NG_TYPE);
+	}
+}


### PR DESCRIPTION
Stage 2 of 3, following #794.

## The problem

The wizard adopted **one device per request**, so the shared 30-per-minute limit rejected the tail of any selection past thirty.

It also carried a race: the connector can adopt a device on its own between the scan and the adoption. The browser could only detect that by failing a create, **re-polling discovery**, and retrying as a PATCH — more requests, on the path that was already over budget.

## The endpoint

```
POST /plugins/devices-shelly-ng/devices/adopt
  { "data": { "devices": [
      { "identifier": "…", "hostname": "…", "name": "…", "category": "…", "password": null }
  ] } }

→ { "data": [
      { "hostname": "…", "identifier": "…", "status": "created|updated|failed",
        "device_id": "…", "reason": null }
  ] }
```

## The race stops existing

This is the reason for putting it in the plugin rather than adding a generic bulk create. The connector's auto-adoption and this adoption are now **the same process writing the same table**, so a device that already exists is simply found, and create-or-update is decided against current state instead of a snapshot the browser took minutes earlier.

The narrow window that remains — the connector inserting between the lookup and the create — is answered by a local re-read, the same fallback [the connector itself already uses](https://github.com/FastyBird/smart-panel/blob/main/apps/backend/src/plugins/devices-shelly-ng/delegates/delegates-manager.service.ts#L218). No discovery re-poll, no round trip.

Outcome is per device, so one refusal doesn't discard the rest and the wizard still shows exactly which ones landed.

One behaviour worth naming: a blank password means the operator didn't type one *this session*, so it is **omitted** rather than sent as `null` — sending null would clear a stored password.

## What stayed in the wizard

The pre-refresh snapshot (which keeps a device adoptable even when the refresh drops it from the session) and the name/category the shell captured. `updateRegistered` and the client-side `uuid` are gone along with the logic that needed them.

Wizard tests covering create-or-update and the auto-adoption race moved to `shelly-ng-adoption.service.spec.ts`, where the behaviour now lives.

## A verification correction

While doing this I found that **`vue-tsc --noEmit -p tsconfig.json` checks nothing** in this repo — `tsconfig.json` is solution-style with `"files": []`, so without `--build` it silently passes. The real command is `pnpm run type-check`.

I had reported "vue-tsc clean" on #790 and #794 using the no-op form; that check was hollow. I've now run the real one across the whole project — it is clean, so those two are fine, but the claim was not evidence at the time. Everything below uses `pnpm run type-check`.

It immediately caught two real errors here: a missing import, and a `@ApiProperty({ items: { type: 'object' } })` on the adopt DTO that generated `{ [x: string]: undefined }` in the admin client. The DTO now references the item schema properly.

## Verification

| Check | Result |
|---|---|
| Backend | 381 suites, 4819 passed |
| Admin | 277 files, 2013 passed |
| `pnpm run type-check` (admin, real) | clean |
| `tsc --noEmit` (backend) | clean |
| eslint + prettier (touched) | clean |
| Mutation-tested | 3 mutations, all caught |

Mutations: race re-lookup removed; password always sent; (plus one that initially **passed** — see below).

**A test that was vacuous:** `expect.not.objectContaining({ password: expect.anything() })` passes whether the key is absent *or* present-and-null, because `expect.anything()` does not match `null`. The mutation exposed it. It now asserts key absence directly.

## Next

Stage 3: Shelly V1 has the same wizard, then the remaining eight modules' bulk actions.