### PR TITLE
feat(cross): adopt shelly v1 devices in one request

### DIFF
--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -289,6 +289,8 @@ export type DevicesModuleCreateDevicesBulkRemoveOperation = operations['create-d
 export type DevicesModuleCreateDevicesBulkUpdateOperation = operations['create-devices-module-devices-bulk-update'];
 
 export type DevicesShellyNgPluginCreateAdoptOperation = operations['create-devices-shelly-ng-plugin-adopt'];
+
+export type DevicesShellyV1PluginCreateAdoptOperation = operations['create-devices-shelly-v1-plugin-adopt'];
 export type DevicesModuleGetChannelOperation = operations['get-devices-module-channel'];
 export type DevicesModuleGetDeviceChannelOperation = operations['get-devices-module-device-channel'];
 export type DevicesModuleGetChannelsOperation = operations['get-devices-module-channels'];

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IWizardActionControl, IWizardFormControl, IWizardProgressControl } from '../../../modules/devices';
 import { DevicesModuleDeviceCategory } from '../../../openapi.constants';
-import { DEVICES_SHELLY_V1_PLUGIN_PREFIX, DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+import { DEVICES_SHELLY_V1_PLUGIN_PREFIX } from '../devices-shelly-v1.constants';
 import type { IShellyV1DiscoverySession } from '../schemas/devices.types';
 
 import { useDevicesWizard } from './useDevicesWizard';
@@ -11,6 +11,7 @@ const mockAdd = vi.fn();
 const mockEdit = vi.fn();
 const mockGet = vi.fn();
 const mockFindById = vi.fn();
+const mockFetch = vi.fn();
 
 const backendClient = {
 	GET: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock('../../../common', async () => {
 				add: mockAdd,
 				edit: mockEdit,
 				get: mockGet,
+				fetch: mockFetch,
 				findById: mockFindById,
 			}),
 		}),
@@ -422,15 +424,24 @@ describe('useDevicesWizard', () => {
 		await adapter.start();
 		await findControl<IWizardFormControl>(adapter.controls.value, 'manual').handler({ hostname: 'shelly-1.local', password: 'secret' });
 
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
+				data: [
+					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+				],
+			},
+			error: undefined,
+			response: { ok: true, status: 200 },
+		});
+
 		await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					password: 'secret',
-					hostname: 'shelly-1.local',
-				}),
-			})
+		const adopted = backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+		expect(adopted.body.data.devices[0]).toEqual(
+			expect.objectContaining({ password: 'secret', hostname: 'shelly-1.local' })
 		);
 	});
 
@@ -469,13 +480,26 @@ describe('useDevicesWizard', () => {
 		await adapter.start();
 		await findControl<IWizardFormControl>(adapter.controls.value, 'manual').handler({ hostname: 'shelly-1.local', password: 'wrong-password' });
 
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
+				data: [
+					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+				],
+			},
+			error: undefined,
+			response: { ok: true, status: 200 },
+		});
+
 		await adapter.adopt([{ key: 'shelly-1.local', name: 'Existing bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockEdit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.not.objectContaining({ password: expect.anything() }),
-			})
-		);
+		const adopted = backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+		// The wrong password was never cached, so nothing is sent for it. The
+		// backend omits a null password rather than clearing the stored one, so the
+		// correct on-disk password survives — which is the guarantee this protects.
+		expect(adopted.body.data.devices[0]!.password).toBeNull();
 	});
 
 	it('drops a manually entered password when the user rescans', async () => {
@@ -505,15 +529,23 @@ describe('useDevicesWizard', () => {
 		// not silently travel with the device into the next adoption.
 		await adapter.start();
 
+		backendClient.POST.mockResolvedValueOnce({
+			data: {
+				data: [
+					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+				],
+			},
+			error: undefined,
+			response: { ok: true, status: 200 },
+		});
+
 		await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					password: null,
-				}),
-			})
-		);
+		const adopted = backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+		expect(adopted.body.data.devices[0]!.password).toBeNull();
 	});
 
 	it('exposes a fresh session key on rescan so the shell drops the previous scan selections', async () => {
@@ -884,38 +916,57 @@ describe('useDevicesWizard', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(1);
 	});
 
-	it('adopts the selection handed over by the shell through the devices store', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+	// Adoption is one request for the whole selection. The create-or-update
+	// decision, and the race with the connector adopting a device on its own,
+	// now belong to the backend - see shelly-ng-adoption.service.spec.ts. What is
+	// tested here is what this composable is still responsible for: which devices
+	// it puts in the payload, and how it reads the answer back.
+	const arrangeAdoption = (results: unknown[]): void => {
 		backendClient.GET.mockResolvedValue({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		});
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({ data: { data: results }, error: undefined, response: { ok: true, status: 200 } });
+			}
+
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
+		});
+	};
+
+	const adoptCall = (): { body: { data: { devices: Record<string, unknown>[] } } } =>
+		backendClient.POST.mock.calls.find((call: unknown[]) => String(call[0]).includes('/devices/adopt'))![1] as {
+			body: { data: { devices: Record<string, unknown>[] } };
+		};
+
+	it('adopts the whole selection in a single request', async () => {
+		arrangeAdoption([
+			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith({
-			id: expect.any(String),
-			draft: false,
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_V1_TYPE,
-				category: DevicesModuleDeviceCategory.lighting,
+		const adoptCalls = backendClient.POST.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/devices/adopt'));
+
+		expect(adoptCalls).toHaveLength(1);
+		expect(adoptCall().body.data.devices).toEqual([
+			{
 				identifier: 'shelly1-aabbcc',
-				name: 'Bathroom heater',
-				password: null,
 				hostname: 'shelly-1.local',
-			}),
-		});
+				name: 'Kitchen relay',
+				category: DevicesModuleDeviceCategory.lighting,
+				password: null,
+			},
+		]);
 		expect(results).toEqual([
 			{
 				key: 'shelly-1.local',
-				name: 'Bathroom heater',
+				name: 'Kitchen relay',
 				identifier: 'shelly-1.local',
 				status: 'created',
 				error: null,
@@ -924,216 +975,139 @@ describe('useDevicesWizard', () => {
 		expect(adapter.results.value).toEqual(results);
 	});
 
+	it('never sends one request per device', async () => {
+		arrangeAdoption(
+			discoverySession.devices.map((device) => ({
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'created',
+				device_id: 'dev',
+				reason: null,
+			}))
+		);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		await adapter.adopt(
+			discoverySession.devices.map((device) => ({
+				key: device.hostname,
+				name: device.name ?? device.hostname,
+				category: DevicesModuleDeviceCategory.lighting,
+			}))
+		);
+
+		const adoptCalls = backendClient.POST.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/devices/adopt'));
+
+		expect(adoptCalls).toHaveLength(1);
+		expect(mockAdd).not.toHaveBeenCalled();
+		expect(mockEdit).not.toHaveBeenCalled();
+	});
+
 	it('adopts with the name and category the shell hands over, not the discovered ones', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+		arrangeAdoption([
+			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 		await adapter.adopt([{ key: 'shelly-1.local', name: 'Hallway light', category: DevicesModuleDeviceCategory.switcher }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					name: 'Hallway light',
-					category: DevicesModuleDeviceCategory.switcher,
-				}),
-			})
+		expect(adoptCall().body.data.devices[0]).toEqual(
+			expect.objectContaining({ name: 'Hallway light', category: DevicesModuleDeviceCategory.switcher })
 		);
 	});
 
 	it('falls back to the suggested name when the shell hands over a blank one', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
+		arrangeAdoption([
+			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 		await adapter.adopt([{ key: 'shelly-1.local', name: '   ', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					name: 'Bathroom heater',
-				}),
-			})
-		);
+		expect(adoptCall().body.data.devices[0]!.name).toBe('Bathroom heater');
 	});
 
-	it('updates an already registered device via edit instead of creating a duplicate', async () => {
-		const alreadyRegisteredSession: IShellyV1DiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-1',
-					registeredDeviceName: 'Existing bathroom heater',
-					registeredDeviceCategory: DevicesModuleDeviceCategory.lighting,
-				},
-			],
-		};
+	// The backend decides this, but the wizard still has to show it: a device the
+	// connector had already registered comes back as an update, not a failure.
+	it('reports back whatever outcome the backend returned for each device', async () => {
+		arrangeAdoption([
+			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'updated', device_id: 'dev-1', reason: null },
+		]);
 
-		backendClient.POST.mockResolvedValue({
-			data: { data: alreadyRegisteredSession },
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'updated', error: null }));
+	});
+
+	it('surfaces a per-device refusal without failing the rest', async () => {
+		arrangeAdoption([
+			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'failed', device_id: null, reason: 'Device is unreachable' },
+		]);
+
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed', error: 'Device is unreachable' }));
+	});
+
+	it('reports a failed outcome instead of throwing when the request itself fails', async () => {
+		backendClient.GET.mockResolvedValue({
+			data: { data: discoverySession },
 			response: { status: 200 },
 		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: alreadyRegisteredSession },
-			response: { status: 200 },
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({ data: undefined, error: { detail: 'boom' }, response: { ok: false, status: 500 } });
+			}
+
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
 		});
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
-		await adapter.adopt([{ key: 'shelly-1.local', name: 'Existing bathroom heater', category: DevicesModuleDeviceCategory.switcher }]);
 
-		expect(mockEdit).toHaveBeenCalledWith({
-			id: 'device-uuid-1',
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_V1_TYPE,
-				category: DevicesModuleDeviceCategory.switcher,
-				name: 'Existing bathroom heater',
-			}),
-		});
-		expect(mockAdd).not.toHaveBeenCalled();
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'updated',
-			}),
-		]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed' }));
 	});
 
-	it('falls back to update when create fails because the main service auto-adopted the device', async () => {
-		const racedSession: IShellyV1DiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-2',
-					registeredDeviceName: 'Auto-adopted heater',
-				},
-			],
-		};
+	// The refresh inside `adopt` can drop a device from the live session; the
+	// snapshot taken beforehand is what keeps the operator's choice adoptable.
+	it('adopts a device that the refresh inside adopt dropped from the session entirely', async () => {
+		backendClient.POST.mockImplementation((url: string) => {
+			if (url.includes('/devices/adopt')) {
+				return Promise.resolve({
+					data: {
+						data: [
+							{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+						],
+					},
+					error: undefined,
+					response: { ok: true, status: 200 },
+				});
+			}
 
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
+			return Promise.resolve({ data: { data: discoverySession }, response: { ok: true, status: 200 } });
 		});
-		// First refresh in adopt: still shows the snapshot's `ready` status.
-		// Second refresh (after add fails): shows the device now exists.
 		backendClient.GET.mockResolvedValueOnce({
 			data: { data: discoverySession },
 			response: { status: 200 },
 		}).mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-
-		mockAdd.mockRejectedValueOnce(new Error('Duplicate identifier'));
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-		await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(mockAdd).toHaveBeenCalledTimes(1);
-		expect(mockEdit).toHaveBeenCalledWith({
-			id: 'device-uuid-2',
-			data: expect.objectContaining({
-				type: DEVICES_SHELLY_V1_TYPE,
-				category: DevicesModuleDeviceCategory.lighting,
-				name: 'Bathroom heater',
-			}),
-		});
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('loads the device into the local store before editing if it was just auto-adopted', async () => {
-		const racedSession: IShellyV1DiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-fresh',
-					registeredDeviceName: 'Auto-adopted heater',
-				},
-			],
-		};
-
-		backendClient.POST.mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: racedSession },
-			response: { status: 200 },
-		});
-
-		// Device exists in the backend (already_registered) but not yet in the admin store —
-		// `devicesStore.edit` would otherwise reject the id.
-		mockFindById.mockReturnValue(null);
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-		await adapter.adopt([{ key: 'shelly-1.local', name: 'Auto-adopted heater', category: DevicesModuleDeviceCategory.switcher }]);
-
-		expect(mockGet).toHaveBeenCalledWith({ id: 'device-uuid-fresh' });
-		expect(mockEdit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				id: 'device-uuid-fresh',
-			})
-		);
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('still adopts a device the shell selected if the refresh inside adopt flips it to already_registered', async () => {
-		const racedSession: IShellyV1DiscoverySession = {
-			...discoverySession,
-			devices: [
-				{
-					...discoverySession.devices[0]!,
-					status: 'already_registered',
-					registeredDeviceId: 'device-uuid-in-flight',
-					registeredDeviceName: 'Auto-adopted heater',
-				},
-			],
-		};
-
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		// The refresh at the top of `adopt` reports the status flip.
-		backendClient.GET.mockResolvedValue({
-			data: { data: racedSession },
+			data: { data: { ...discoverySession, devices: [] } },
 			response: { status: 200 },
 		});
 
@@ -1141,85 +1115,10 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		// The user chose the device while it was still `ready`; the shell handed that intent over.
-		await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
 
-		expect(mockEdit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				id: 'device-uuid-in-flight',
-			})
-		);
-		expect(mockAdd).not.toHaveBeenCalled();
-		expect(adapter.results.value).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'updated',
-			}),
-		]);
-	});
-
-	it('adopts a device that the refresh inside adopt dropped from the session entirely', async () => {
-		// The refresh at the top of `adopt` can return a session that no longer lists the device
-		// — the scan expired it, or it stopped answering mDNS. The shell's selection carries only
-		// key / name / category, so without the pre-refresh descriptor snapshot we would lose the
-		// identifier and fail a device the user explicitly asked for.
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: emptySession },
-			response: { status: 200 },
-		});
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(mockAdd).toHaveBeenCalledWith(
-			expect.objectContaining({
-				data: expect.objectContaining({
-					identifier: 'shelly1-aabbcc',
-					name: 'Bathroom heater',
-					hostname: 'shelly-1.local',
-				}),
-			})
-		);
-		expect(results).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'created',
-			}),
-		]);
-	});
-
-	it('reports a failed outcome instead of throwing when adoption fails', async () => {
-		backendClient.POST.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-		backendClient.GET.mockResolvedValue({
-			data: { data: discoverySession },
-			response: { status: 200 },
-		});
-
-		mockAdd.mockRejectedValue(new Error('Backend refused the device'));
-
-		const adapter = useDevicesWizard();
-
-		await adapter.start();
-
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
-
-		expect(results).toEqual([
-			expect.objectContaining({
-				key: 'shelly-1.local',
-				status: 'failed',
-				error: 'Backend refused the device',
-			}),
-		]);
+		expect(adoptCall().body.data.devices[0]!.identifier).toBe('shelly1-aabbcc');
+		expect(results[0]).toEqual(expect.objectContaining({ status: 'created' }));
 	});
 
 	it('reports the discovered device count and scan progress through the progress control', async () => {

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -2,7 +2,6 @@ import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { orderBy } from 'natural-orderby';
-import { v4 as uuid } from 'uuid';
 
 import { useNow } from '@vueuse/core';
 
@@ -21,11 +20,12 @@ import {
 } from '../../../modules/devices';
 import {
 	type DevicesModuleDeviceCategory,
+	type DevicesShellyV1PluginCreateAdoptOperation,
 	type DevicesShellyV1PluginCreateDiscoveryManualOperation,
 	type DevicesShellyV1PluginCreateDiscoveryOperation,
 	type DevicesShellyV1PluginGetDiscoveryOperation,
 } from '../../../openapi.constants';
-import { DEVICES_SHELLY_V1_PLUGIN_NAME, DEVICES_SHELLY_V1_PLUGIN_PREFIX, DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+import { DEVICES_SHELLY_V1_PLUGIN_NAME, DEVICES_SHELLY_V1_PLUGIN_PREFIX } from '../devices-shelly-v1.constants';
 import { DevicesShellyV1ApiException, DevicesShellyV1ValidationException } from '../devices-shelly-v1.exceptions';
 import type { IShellyV1DiscoveryDevice, IShellyV1DiscoverySession } from '../schemas/devices.types';
 import { transformDeviceInfoRequest, transformDiscoverySessionResponse } from '../utils/devices.transformers';
@@ -397,7 +397,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			// `status: 'already_registered'` with `authentication.valid: false`. Storing it
 			// unconditionally would overwrite the correct on-disk password the next time the user
 			// hits Adopt — `adopt` reads `passwordByHostname[hostname]` and sends it straight to
-			// `updateRegistered`.
+			// the adoption endpoint.
 			if (password !== null && inspected?.authentication.valid !== false) {
 				passwordByHostname[hostname] = password;
 			}
@@ -476,56 +476,37 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 		},
 	]);
 
-	const updateRegistered = async (
-		id: string,
-		{ name, category, password }: { name: string; category: DevicesModuleDeviceCategory; password: string | null }
-	): Promise<void> => {
-		const data: { type: string; name: string; category: DevicesModuleDeviceCategory; password?: string } = {
-			type: DEVICES_SHELLY_V1_TYPE,
-			name,
-			category,
-		};
-
-		if (password !== null) {
-			data.password = password;
-		}
-
-		// `devicesStore.edit` requires the device to be present in the local store. When the
-		// main connector auto-adopts a device after the wizard's snapshot was taken, the new
-		// row may not be in the admin store yet — pull it in first so the edit can land.
-		if (devicesStore.findById(id) === null) {
-			await devicesStore.get({ id });
-		}
-
-		await devicesStore.edit({ id, data });
-	};
-
 	const adopt = async (selection: IWizardAdoptSelection[]): Promise<IWizardResult[]> => {
 		formResult.value = FormResult.WORKING;
 
 		// Snapshot the descriptors BEFORE refreshing. The shell already captured the user's
 		// intent (name / category) in `selection`, but the refresh below can drop a device from
-		// the live list entirely, and we still need its identifier and registration state to
-		// adopt the device the user chose.
+		// the live list entirely, and we still need its identifier to adopt the device the user
+		// chose.
 		const snapshot = devices.value.slice();
 
-		// Refresh once so we see any device the main service auto-adopted between scan and adoption.
-		// Lets us route those through `edit` instead of getting a duplicate-identifier error from `add`.
 		if (session.value !== null) {
 			try {
 				await refreshDiscovery();
 			} catch {
-				// Stale snapshot is fine — the per-device fallback below still handles late races.
+				// Stale snapshot is fine — the identifiers we need are already in hand.
 			}
 		}
 
 		const outcomes: IShellyV1WizardAdoptionResult[] = [];
+		const payload: {
+			identifier: string;
+			hostname: string;
+			name: string;
+			category: DevicesModuleDeviceCategory;
+			password?: string | null;
+		}[] = [];
 
 		for (const item of selection) {
 			const device =
 				devices.value.find((candidate) => candidate.hostname === item.key) ?? snapshot.find((candidate) => candidate.hostname === item.key);
 
-			if (device === undefined) {
+			if (device === undefined || device.identifier === null) {
 				outcomes.push({
 					hostname: item.key,
 					name: item.name,
@@ -536,84 +517,58 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				continue;
 			}
 
-			// The shell already trims and defaults the name, but a blank one must never reach
-			// the backend — fall back to the same chain that seeded the field.
-			const name = item.name.trim() || suggestedNameFor(device);
-			const category = item.category;
-			const password = passwordByHostname[device.hostname] ?? null;
+			payload.push({
+				identifier: device.identifier,
+				hostname: device.hostname,
+				// The shell already trims and defaults the name, but a blank one must never reach
+				// the backend — fall back to the same chain that seeded the field.
+				name: item.name.trim() || suggestedNameFor(device),
+				category: item.category,
+				password: passwordByHostname[device.hostname] ?? null,
+			});
+		}
 
+		if (payload.length > 0) {
+			// One request for the whole selection. Sending one per device tripped the backend's
+			// shared rate limit past thirty devices, and left this composable racing the
+			// connector's own auto-adoption — which the backend now settles against current
+			// state instead of a snapshot taken here.
 			try {
-				if (device.status === 'already_registered' && device.registeredDeviceId !== null) {
-					await updateRegistered(device.registeredDeviceId, { name, category, password });
+				const { data: responseBody, error, response } = await backend.client.POST(
+					`/${PLUGINS_PREFIX}/${DEVICES_SHELLY_V1_PLUGIN_PREFIX}/devices/adopt`,
+					{ body: { data: { devices: payload } } }
+				);
 
-					outcomes.push({
-						hostname: device.hostname,
-						name,
-						status: 'updated',
-						error: null,
-					});
+				if (typeof responseBody === 'undefined' || !response.ok) {
+					const errorReason = error
+						? getErrorReason<DevicesShellyV1PluginCreateAdoptOperation>(
+								error,
+								t('devicesShellyV1Plugin.messages.wizard.adoptionNotCreated')
+							)
+						: t('devicesShellyV1Plugin.messages.wizard.adoptionNotCreated');
 
-					continue;
+					throw new DevicesShellyV1ApiException(errorReason, response.status);
 				}
 
-				const id = uuid().toString();
-
-				try {
-					await devicesStore.add({
-						id,
-						draft: false,
-						data: {
-							id,
-							type: DEVICES_SHELLY_V1_TYPE,
-							category,
-							identifier: device.identifier,
-							name,
-							description: null,
-							enabled: true,
-							password,
-							hostname: device.hostname,
-						},
-					});
+				for (const result of responseBody.data) {
+					const requested = payload.find((item) => item.hostname === result.hostname);
 
 					outcomes.push({
-						hostname: device.hostname,
-						name,
-						status: 'created',
-						error: null,
+						hostname: result.hostname,
+						name: requested?.name ?? result.hostname,
+						status: result.status,
+						error: result.reason,
 					});
-				} catch (createError: unknown) {
-					// The device may have been auto-created by the main shelly-v1 service after the discovery
-					// snapshot was taken. Re-poll, and if it now shows as already_registered, fall back to update.
-					try {
-						await refreshDiscovery();
-					} catch {
-						// ignore — handled below
-					}
-
-					const refreshed = devices.value.find((candidate) => candidate.hostname === device.hostname);
-
-					if (refreshed?.status === 'already_registered' && refreshed.registeredDeviceId !== null) {
-						await updateRegistered(refreshed.registeredDeviceId, { name, category, password });
-
-						outcomes.push({
-							hostname: device.hostname,
-							name,
-							status: 'updated',
-							error: null,
-						});
-
-						continue;
-					}
-
-					throw createError;
 				}
+
+				await devicesStore.fetch();
 			} catch (error: unknown) {
-				outcomes.push({
-					hostname: device.hostname,
-					name,
-					status: 'failed',
-					error: error instanceof Error ? error.message : t('devicesShellyV1Plugin.messages.wizard.adoptionNotCreated'),
-				});
+				const reason =
+					error instanceof Error ? error.message : t('devicesShellyV1Plugin.messages.wizard.adoptionNotCreated');
+
+				for (const item of payload) {
+					outcomes.push({ hostname: item.hostname, name: item.name, status: 'failed', error: reason });
+				}
 			}
 		}
 

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
@@ -10,6 +10,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { DevicesShellyV1Exception } from '../devices-shelly-v1.exceptions';
 import { ShellyV1DeviceInfoModel } from '../models/shelly-v1.model';
+import { ShellyV1AdoptionService } from '../services/shelly-v1-adoption.service';
 import { ShellyV1DiscoveryService } from '../services/shelly-v1-discovery.service';
 import { ShellyV1ProbeService } from '../services/shelly-v1-probe.service';
 
@@ -18,6 +19,7 @@ import { ShellyV1DevicesController } from './shelly-v1-devices.controller';
 describe('ShellyV1DevicesController', () => {
 	let controller: ShellyV1DevicesController;
 	let probeService: jest.Mocked<ShellyV1ProbeService>;
+	let adoptionService: jest.Mocked<ShellyV1AdoptionService>;
 
 	beforeAll(() => {});
 
@@ -32,16 +34,22 @@ describe('ShellyV1DevicesController', () => {
 			manual: jest.fn(),
 		};
 
+		const adoptionServiceMock: Partial<jest.Mocked<ShellyV1AdoptionService>> = {
+			adopt: jest.fn(),
+		};
+
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [ShellyV1DevicesController],
 			providers: [
 				{ provide: ShellyV1ProbeService, useValue: probeServiceMock },
 				{ provide: ShellyV1DiscoveryService, useValue: discoveryServiceMock },
+				{ provide: ShellyV1AdoptionService, useValue: adoptionServiceMock },
 			],
 		}).compile();
 
 		controller = module.get(ShellyV1DevicesController);
 		probeService = module.get(ShellyV1ProbeService) as jest.Mocked<ShellyV1ProbeService>;
+		adoptionService = module.get(ShellyV1AdoptionService) as jest.Mocked<ShellyV1AdoptionService>;
 	});
 
 	afterEach(() => {
@@ -158,6 +166,36 @@ describe('ShellyV1DevicesController', () => {
 			expect(firstDevice).toHaveProperty('categories');
 			expect(Array.isArray(firstDevice.models)).toBe(true);
 			expect(Array.isArray(firstDevice.categories)).toBe(true);
+		});
+	});
+
+	describe('POST /devices/adopt', () => {
+		it('hands the whole selection to the adoption service in one call', async () => {
+			const devices = [
+				{
+					identifier: 'shelly1-a4cf12df3b21',
+					hostname: '192.168.1.100',
+					name: 'Kitchen light',
+					category: 'lighting',
+					password: null,
+				},
+			];
+
+			adoptionService.adopt.mockResolvedValue([
+				{
+					hostname: '192.168.1.100',
+					identifier: 'shelly1-a4cf12df3b21',
+					status: 'created',
+					deviceId: 'dev-1',
+					reason: null,
+				},
+			]);
+
+			const response = await controller.adopt({ data: { devices } } as never);
+
+			expect(adoptionService.adopt).toHaveBeenCalledTimes(1);
+			expect(adoptionService.adopt).toHaveBeenCalledWith(devices);
+			expect(response.data[0]?.status).toBe('created');
 		});
 	});
 });

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.ts
@@ -18,8 +18,10 @@ import {
 	DEVICES_SHELLY_V1_PLUGIN_NAME,
 } from '../devices-shelly-v1.constants';
 import { DevicesShellyV1Exception } from '../devices-shelly-v1.exceptions';
+import { ReqAdoptDevicesDto } from '../dto/adopt-devices.dto';
 import { DevicesShellyV1PluginReqGetInfo } from '../dto/shelly-v1-probe.dto';
 import {
+	ShellyV1AdoptionResponseModel,
 	ShellyV1DeviceInfoResponseModel,
 	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
@@ -29,6 +31,7 @@ import {
 	ShellyV1DiscoverySessionModel,
 	ShellyV1SupportedDeviceModel,
 } from '../models/shelly-v1.model';
+import { ShellyV1AdoptionService } from '../services/shelly-v1-adoption.service';
 import { ShellyV1DiscoveryService } from '../services/shelly-v1-discovery.service';
 import { ShellyV1ProbeService } from '../services/shelly-v1-probe.service';
 
@@ -43,6 +46,7 @@ export class ShellyV1DevicesController {
 	constructor(
 		private readonly probeService: ShellyV1ProbeService,
 		private readonly discoveryService: ShellyV1DiscoveryService,
+		private readonly adoptionService: ShellyV1AdoptionService,
 	) {}
 
 	@ApiOperation({
@@ -234,6 +238,28 @@ export class ShellyV1DevicesController {
 
 		const response = new ShellyV1SupportedDevicesResponseModel();
 		response.data = devices;
+
+		return response;
+	}
+
+	@ApiOperation({
+		tags: [DEVICES_SHELLY_V1_PLUGIN_API_TAG_NAME],
+		summary: 'Adopt discovered Shelly V1 devices',
+		description:
+			'Adopts a selection of discovered devices in a single request. Each device is adopted independently and its outcome reported separately, so one device that can not be adopted does not discard the rest of the selection. A device the connector has already registered on its own is updated rather than reported as a conflict.',
+		operationId: 'create-devices-shelly-v1-plugin-adopt',
+	})
+	@ApiBody({ type: ReqAdoptDevicesDto, description: 'The devices to adopt' })
+	@ApiSuccessResponse(ShellyV1AdoptionResponseModel, 'Returns the outcome for each device in the selection')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('adopt')
+	async adopt(@Body() body: ReqAdoptDevicesDto): Promise<ShellyV1AdoptionResponseModel> {
+		this.logger.debug(`Incoming request to adopt ${body.data.devices.length} device(s)`);
+
+		const response = new ShellyV1AdoptionResponseModel();
+
+		response.data = await this.adoptionService.adopt(body.data.devices);
 
 		return response;
 	}

--- a/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.openapi.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Devices Shelly V1 plugin
  */
+import { AdoptDeviceDto, AdoptDevicesDto } from './dto/adopt-devices.dto';
 import { CreateShellyV1ChannelPropertyDto } from './dto/create-channel-property.dto';
 import { CreateShellyV1ChannelDto } from './dto/create-channel.dto';
 import { CreateShellyV1DeviceDto } from './dto/create-device.dto';
@@ -19,11 +20,13 @@ import {
 } from './entities/devices-shelly-v1.entity';
 import { ShellyV1ConfigModel, ShellyV1DiscoveryConfigModel, ShellyV1TimeoutsConfigModel } from './models/config.model';
 import {
+	ShellyV1AdoptionResponseModel,
 	ShellyV1DeviceInfoResponseModel,
 	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 } from './models/shelly-v1-response.model';
 import {
+	ShellyV1AdoptionResultModel,
 	ShellyV1DeviceInfoModel,
 	ShellyV1DiscoveryDeviceAuthenticationModel,
 	ShellyV1DiscoveryDeviceModel,
@@ -42,11 +45,15 @@ export const DEVICES_SHELLY_V1_PLUGIN_SWAGGER_EXTRA_MODELS = [
 	ShellyV1UpdatePluginConfigDto,
 	ShellyV1UpdatePluginConfigDiscoveryDto,
 	ShellyV1UpdatePluginConfigTimeoutsDto,
+	AdoptDeviceDto,
+	AdoptDevicesDto,
 	// Response models
+	ShellyV1AdoptionResponseModel,
 	ShellyV1DeviceInfoResponseModel,
 	ShellyV1DiscoverySessionResponseModel,
 	ShellyV1SupportedDevicesResponseModel,
 	// Data models
+	ShellyV1AdoptionResultModel,
 	ShellyV1SupportedDeviceModel,
 	ShellyV1DeviceInfoModel,
 	ShellyV1DiscoveryDeviceAuthenticationModel,

--- a/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/devices-shelly-v1.plugin.ts
@@ -47,6 +47,7 @@ import { ShellyV1ConfigModel } from './models/config.model';
 import { ShellyV1DevicePlatform } from './platforms/shelly-v1.device.platform';
 import { DeviceMapperService } from './services/device-mapper.service';
 import { ShelliesAdapterService } from './services/shellies-adapter.service';
+import { ShellyV1AdoptionService } from './services/shelly-v1-adoption.service';
 import { ShellyV1DiscoveryService } from './services/shelly-v1-discovery.service';
 import { ShellyV1HttpClientService } from './services/shelly-v1-http-client.service';
 import { ShellyV1ProbeService } from './services/shelly-v1-probe.service';
@@ -72,6 +73,7 @@ import { DeviceEntitySubscriber } from './subscribers/device-entity.subscriber';
 		ShellyV1HttpClientService,
 		ShellyV1ProbeService,
 		ShellyV1DiscoveryService,
+		ShellyV1AdoptionService,
 		ShellyV1DevicePlatform,
 		ShellyV1Service,
 		DeviceEntitySubscriber,

--- a/apps/backend/src/plugins/devices-shelly-v1/dto/adopt-devices.dto.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/dto/adopt-devices.dto.ts
@@ -1,0 +1,89 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+
+/**
+ * A whole discovery result can be adopted at once, and a large installation
+ * discovers a lot of devices, so the cap only guards against a request that
+ * could not have come from the wizard.
+ */
+export const ADOPT_DEVICES_MAX = 500;
+
+@ApiSchema({ name: 'DevicesShellyV1PluginAdoptDevice' })
+export class AdoptDeviceDto {
+	@ApiProperty({
+		description: 'Shelly device identifier as reported by the device itself',
+		type: 'string',
+		example: 'shelly1-a4cf12df3b21',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"identifier","reason":"Identifier must be a valid string."}]' })
+	identifier: string;
+
+	@ApiProperty({
+		description: 'Address the device was discovered on',
+		type: 'string',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"hostname","reason":"Hostname must be a valid string."}]' })
+	hostname: string;
+
+	@ApiProperty({
+		description: 'Name to give the adopted device',
+		type: 'string',
+		example: 'Kitchen light',
+	})
+	@Expose()
+	@IsString({ message: '[{"field":"name","reason":"Name must be a valid string."}]' })
+	name: string;
+
+	@ApiProperty({
+		description: 'Category to assign to the adopted device',
+		enum: DeviceCategory,
+		example: DeviceCategory.LIGHTING,
+	})
+	@Expose()
+	@IsEnum(DeviceCategory, { message: '[{"field":"category","reason":"Category must be a valid device category."}]' })
+	category: DeviceCategory;
+
+	@ApiPropertyOptional({
+		description: 'Password for a device with authentication enabled',
+		type: 'string',
+		nullable: true,
+		example: 'password123',
+	})
+	@Expose()
+	@IsOptional()
+	@IsString({ message: '[{"field":"password","reason":"Password must be a valid string."}]' })
+	password?: string | null = null;
+}
+
+@ApiSchema({ name: 'DevicesShellyV1PluginAdoptDevices' })
+export class AdoptDevicesDto {
+	@ApiProperty({
+		description: 'Devices to adopt',
+		type: () => [AdoptDeviceDto],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"devices","reason":"Devices must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"devices","reason":"At least one device is required."}]' })
+	@ArrayMaxSize(ADOPT_DEVICES_MAX, {
+		message: `[{"field":"devices","reason":"At most ${ADOPT_DEVICES_MAX} devices can be adopted in one request."}]`,
+	})
+	@ValidateNested({ each: true })
+	@Type(() => AdoptDeviceDto)
+	devices: AdoptDeviceDto[];
+}
+
+@ApiSchema({ name: 'DevicesShellyV1PluginReqAdoptDevices' })
+export class ReqAdoptDevicesDto {
+	@ApiProperty({ description: 'Adoption data', type: () => AdoptDevicesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => AdoptDevicesDto)
+	data: AdoptDevicesDto;
+}

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1-response.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1-response.model.ts
@@ -5,6 +5,7 @@ import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 import { BaseSuccessResponseModel } from '../../../modules/api/models/api-response.model';
 
 import {
+	ShellyV1AdoptionResultModel,
 	ShellyV1DeviceInfoModel,
 	ShellyV1DiscoverySessionModel,
 	ShellyV1SupportedDeviceModel,
@@ -48,4 +49,18 @@ export class ShellyV1DiscoverySessionResponseModel extends BaseSuccessResponseMo
 	})
 	@Expose()
 	declare data: ShellyV1DiscoverySessionModel;
+}
+
+/**
+ * Response wrapper for the per-device outcome of an adoption request
+ */
+@ApiSchema({ name: 'DevicesShellyV1PluginResAdoption' })
+export class ShellyV1AdoptionResponseModel extends BaseSuccessResponseModel<ShellyV1AdoptionResultModel[]> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: 'array',
+		items: { $ref: getSchemaPath(ShellyV1AdoptionResultModel) },
+	})
+	@Expose()
+	declare data: ShellyV1AdoptionResultModel[];
 }

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
@@ -383,3 +383,59 @@ export class ShellyV1DiscoverySessionModel {
 	@Type(() => ShellyV1DiscoveryDeviceModel)
 	devices: ShellyV1DiscoveryDeviceModel[];
 }
+
+/**
+ * What happened to one device in an adoption request.
+ *
+ * Adoption is a set of independent intents, so the outcome is reported per
+ * device: one device refusing must not discard the rest of the selection, and
+ * the wizard shows the operator exactly which ones landed.
+ */
+@ApiSchema({ name: 'DevicesShellyV1PluginDataAdoptionResult' })
+export class ShellyV1AdoptionResultModel {
+	@ApiProperty({
+		description: 'Address the device was discovered on',
+		type: 'string',
+		example: '192.168.1.100',
+	})
+	@Expose()
+	hostname: string;
+
+	@ApiProperty({
+		description: 'Shelly device identifier',
+		type: 'string',
+		example: 'shelly1-a4cf12df3b21',
+	})
+	@Expose()
+	identifier: string;
+
+	@ApiProperty({
+		description:
+			'Whether the device was newly created, or updated because it was already registered - including when the connector adopted it on its own while the wizard was open',
+		type: 'string',
+		enum: ['created', 'updated', 'failed'],
+		example: 'created',
+	})
+	@Expose()
+	status: 'created' | 'updated' | 'failed';
+
+	@ApiProperty({
+		name: 'device_id',
+		description: 'Identifier of the resulting device, when there is one',
+		type: 'string',
+		format: 'uuid',
+		nullable: true,
+		example: 'f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6',
+	})
+	@Expose({ name: 'device_id' })
+	deviceId: string | null;
+
+	@ApiProperty({
+		description: 'Why this device could not be adopted',
+		type: 'string',
+		nullable: true,
+		example: 'Device could not be adopted',
+	})
+	@Expose()
+	reason: string | null;
+}

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+import { AdoptDeviceDto } from '../dto/adopt-devices.dto';
+import { ShellyV1DeviceEntity } from '../entities/devices-shelly-v1.entity';
+
+import { ShellyV1AdoptionService } from './shelly-v1-adoption.service';
+
+describe('ShellyV1AdoptionService', () => {
+	let service: ShellyV1AdoptionService;
+	let devicesService: { findOneBy: jest.Mock; create: jest.Mock; update: jest.Mock };
+
+	const selection = (overrides: Partial<AdoptDeviceDto> = {}): AdoptDeviceDto =>
+		({
+			identifier: 'shelly1-a4cf12df3b21',
+			hostname: '192.168.1.100',
+			name: 'Kitchen light',
+			category: DeviceCategory.LIGHTING,
+			password: null,
+			...overrides,
+		}) as AdoptDeviceDto;
+
+	beforeEach(async () => {
+		devicesService = {
+			findOneBy: jest.fn().mockResolvedValue(null),
+			create: jest.fn().mockImplementation(() => Promise.resolve({ id: 'new-device' } as ShellyV1DeviceEntity)),
+			update: jest.fn().mockImplementation(() => Promise.resolve({ id: 'existing' } as ShellyV1DeviceEntity)),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [ShellyV1AdoptionService, { provide: DevicesService, useValue: devicesService }],
+		}).compile();
+
+		service = module.get<ShellyV1AdoptionService>(ShellyV1AdoptionService);
+	});
+
+	it('creates a device that is not registered yet', async () => {
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('created');
+		expect(outcome.deviceId).toBe('new-device');
+		expect(devicesService.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: DEVICES_SHELLY_V1_TYPE,
+				identifier: 'shelly1-a4cf12df3b21',
+				name: 'Kitchen light',
+				category: DeviceCategory.LIGHTING,
+				hostname: '192.168.1.100',
+			}),
+		);
+	});
+
+	it('updates a device the connector already registered', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyV1DeviceEntity);
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('updated');
+		expect(outcome.deviceId).toBe('existing');
+		expect(devicesService.create).not.toHaveBeenCalled();
+		expect(devicesService.update).toHaveBeenCalledWith('existing', expect.objectContaining({ name: 'Kitchen light' }));
+	});
+
+	// The whole point of adopting here rather than in the browser: the connector
+	// can register a device between the lookup and the create, and the answer is
+	// a local re-read instead of the browser re-polling discovery.
+	it('treats a device the connector registered mid-request as an update', async () => {
+		devicesService.findOneBy
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce({ id: 'raced-in' } as ShellyV1DeviceEntity);
+		devicesService.create.mockRejectedValue(new Error('UNIQUE constraint failed: devices.identifier'));
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('updated');
+		expect(outcome.deviceId).toBe('raced-in');
+		expect(devicesService.update).toHaveBeenCalledWith('raced-in', expect.anything());
+	});
+
+	it('reports a genuine create failure with its reason', async () => {
+		devicesService.create.mockRejectedValue(new Error('Device could not be created'));
+
+		const [outcome] = await service.adopt([selection()]);
+
+		expect(outcome.status).toBe('failed');
+		expect(outcome.reason).toBe('Device could not be created');
+		expect(outcome.deviceId).toBeNull();
+	});
+
+	// A blank password means the operator did not type one this session, not that
+	// the stored one should be discarded.
+	it('leaves a stored password alone when none was supplied', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyV1DeviceEntity);
+
+		await service.adopt([selection({ password: null })]);
+
+		// The key has to be absent, not present-and-null: `expect.anything()` does
+		// not match null, so an `objectContaining` assertion here would pass either
+		// way and prove nothing.
+		const [, dto] = devicesService.update.mock.calls[0] as [string, Record<string, unknown>];
+
+		expect(Object.keys(dto)).not.toContain('password');
+	});
+
+	it('sends a password the operator did supply', async () => {
+		devicesService.findOneBy.mockResolvedValue({ id: 'existing' } as ShellyV1DeviceEntity);
+
+		await service.adopt([selection({ password: 'hunter2' })]);
+
+		expect(devicesService.update).toHaveBeenCalledWith('existing', expect.objectContaining({ password: 'hunter2' }));
+	});
+
+	it('adopts the rest of the selection after one device fails', async () => {
+		devicesService.create.mockImplementation((dto: { identifier: string }) =>
+			dto.identifier === 'bad' ? Promise.reject(new Error('nope')) : Promise.resolve({ id: dto.identifier }),
+		);
+
+		const outcomes = await service.adopt([
+			selection({ identifier: 'first' }),
+			selection({ identifier: 'bad' }),
+			selection({ identifier: 'last' }),
+		]);
+
+		expect(outcomes.map((outcome) => outcome.status)).toEqual(['created', 'failed', 'created']);
+	});
+});

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.ts
@@ -1,0 +1,150 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_SHELLY_V1_PLUGIN_NAME, DEVICES_SHELLY_V1_TYPE } from '../devices-shelly-v1.constants';
+import { AdoptDeviceDto } from '../dto/adopt-devices.dto';
+import { CreateShellyV1DeviceDto } from '../dto/create-device.dto';
+import { UpdateShellyV1DeviceDto } from '../dto/update-device.dto';
+import { ShellyV1DeviceEntity } from '../entities/devices-shelly-v1.entity';
+
+export type ShellyV1AdoptionStatus = 'created' | 'updated' | 'failed';
+
+export interface ShellyV1AdoptionOutcome {
+	hostname: string;
+	identifier: string;
+	status: ShellyV1AdoptionStatus;
+	deviceId: string | null;
+	reason: string | null;
+}
+
+/**
+ * Adopts discovered devices.
+ *
+ * This used to run in the browser, one request per device, which the shared
+ * request limit rejected once a selection went past thirty. It also had to cope
+ * with the connector adopting a device on its own between the discovery scan
+ * and the adoption - the browser could only notice that by failing a create,
+ * re-polling discovery and retrying as an update.
+ *
+ * Running here removes that: the connector's auto-adoption and this adoption
+ * are the same process writing to the same table, so a device that already
+ * exists is simply found, and the create/update decision is made against
+ * current state rather than against a snapshot the browser took earlier.
+ */
+@Injectable()
+export class ShellyV1AdoptionService {
+	private readonly logger = createExtensionLogger(DEVICES_SHELLY_V1_PLUGIN_NAME, 'ShellyV1AdoptionService');
+
+	constructor(private readonly devicesService: DevicesService) {}
+
+	async adopt(devices: AdoptDeviceDto[]): Promise<ShellyV1AdoptionOutcome[]> {
+		const outcomes: ShellyV1AdoptionOutcome[] = [];
+
+		for (const device of devices) {
+			outcomes.push(await this.adoptOne(device));
+		}
+
+		this.logger.debug(
+			`Adoption finished created=${outcomes.filter((outcome) => outcome.status === 'created').length} ` +
+				`updated=${outcomes.filter((outcome) => outcome.status === 'updated').length} ` +
+				`failed=${outcomes.filter((outcome) => outcome.status === 'failed').length}`,
+		);
+
+		return outcomes;
+	}
+
+	private async adoptOne(device: AdoptDeviceDto): Promise<ShellyV1AdoptionOutcome> {
+		const existing = await this.findByIdentifier(device.identifier);
+
+		if (existing !== null) {
+			return this.update(device, existing);
+		}
+
+		try {
+			const created = await this.devicesService.create<ShellyV1DeviceEntity, CreateShellyV1DeviceDto>({
+				type: DEVICES_SHELLY_V1_TYPE,
+				category: device.category,
+				identifier: device.identifier,
+				name: device.name,
+				password: device.password ?? null,
+				hostname: device.hostname,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'created',
+				deviceId: created.id,
+				reason: null,
+			};
+		} catch (error) {
+			// The connector may have adopted this device between the lookup above
+			// and the create. It is the same race the connector itself handles, and
+			// the answer is the same: look again, and treat a device that now exists
+			// as an update rather than a failure.
+			const raced = await this.findByIdentifier(device.identifier);
+
+			if (raced !== null) {
+				return this.update(device, raced);
+			}
+
+			const err = error as Error;
+
+			this.logger.error(`Failed to adopt device identifier=${device.identifier}`, {
+				message: err.message,
+				stack: err.stack,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'failed',
+				deviceId: null,
+				reason: err.message.length > 0 ? err.message : 'Device could not be adopted',
+			};
+		}
+	}
+
+	private async update(device: AdoptDeviceDto, existing: ShellyV1DeviceEntity): Promise<ShellyV1AdoptionOutcome> {
+		try {
+			await this.devicesService.update<ShellyV1DeviceEntity, UpdateShellyV1DeviceDto>(existing.id, {
+				type: DEVICES_SHELLY_V1_TYPE,
+				name: device.name,
+				category: device.category,
+				// A blank password field means "leave what is stored" rather than
+				// "clear it" - the wizard only knows a password the operator typed
+				// during this session.
+				...(device.password === null || typeof device.password === 'undefined' ? {} : { password: device.password }),
+				hostname: device.hostname,
+			} as UpdateShellyV1DeviceDto);
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'updated',
+				deviceId: existing.id,
+				reason: null,
+			};
+		} catch (error) {
+			const err = error as Error;
+
+			this.logger.error(`Failed to update adopted device identifier=${device.identifier}`, {
+				message: err.message,
+				stack: err.stack,
+			});
+
+			return {
+				hostname: device.hostname,
+				identifier: device.identifier,
+				status: 'failed',
+				deviceId: existing.id,
+				reason: err.message.length > 0 ? err.message : 'Device could not be updated',
+			};
+		}
+	}
+
+	private async findByIdentifier(identifier: string): Promise<ShellyV1DeviceEntity | null> {
+		return await this.devicesService.findOneBy<ShellyV1DeviceEntity>('identifier', identifier, DEVICES_SHELLY_V1_TYPE);
+	}
+}


### PR DESCRIPTION
Mirrors #795 for the Gen1 wizard, which had the identical defect: one request per device, rejected by the shared 30-per-minute limit past thirty, plus the create → re-poll discovery → update dance to cope with the connector adopting a device between the scan and the adoption.

```
POST /plugins/devices-shelly-v1/devices/adopt
  { "data": { "devices": [
      { "identifier": "…", "hostname": "…", "name": "…", "category": "…", "password": null }
  ] } }

→ { "data": [
      { "hostname": "…", "identifier": "…", "status": "created|updated|failed",
        "device_id": "…", "reason": null }
  ] }
```

Same reasoning as #795: adoption and the connector's auto-adoption are now the same process writing the same table, so the race is gone rather than handled.

## Where V1 genuinely differs

Mostly mechanical, but two things are not:

**The address field.** Gen1 devices carry a plain `hostname`; NG splits WiFi and Ethernet and takes `wifiAddress`. Mutation-tested — sourcing `hostname` from the wrong field fails the create assertion.

**A protection NG doesn't have.** A password the operator typed that the inspect step reported invalid is never cached, so a later Adopt can't overwrite the correct stored one — the bug fixed in `45750b9fb`. That guarantee still holds under the new design, via two independent steps: the wizard sends `null` for an uncached password, and the backend omits a null rather than clearing what is stored.

Its test was using the same vacuous pattern I hit in #795 — `expect.not.objectContaining({ password: expect.anything() })` passes whether the key is absent *or* present-and-null. It now asserts the sent value directly.

## Verification

| Check | Result |
|---|---|
| Backend | 382 suites, 4827 passed |
| Admin | 277 files, 2012 passed |
| `pnpm run type-check` (admin, real) | clean |
| `tsc --noEmit` (backend) | clean |
| eslint + prettier (touched) | clean |
| Mutation-tested | hostname-vs-identifier caught |

## Remaining

Stage 3's last piece: bulk actions for the other eight modules — scenes, displays, spaces, extensions, pages, users, weather locations (13 actions). Those follow the `bulk-remove` / `bulk-update` shape merged in #794, so it is repetition of a reviewed pattern rather than new design.