### PR TITLE
refactor(cross): align the shelly adoption result with the other plugins

### DIFF
--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.spec.ts
@@ -409,7 +409,7 @@ describe('useDevicesWizard', () => {
 		})	.mockResolvedValueOnce({
 			data: {
 				data: [
-					{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+					{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 				],
 			},
 			error: undefined,
@@ -451,7 +451,7 @@ describe('useDevicesWizard', () => {
 			})		.mockResolvedValueOnce({
 			data: {
 				data: [
-					{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+					{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 				],
 			},
 			error: undefined,
@@ -900,7 +900,7 @@ describe('useDevicesWizard', () => {
 
 	it('adopts the whole selection in a single request', async () => {
 		arrangeAdoption([
-			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -937,10 +937,10 @@ describe('useDevicesWizard', () => {
 		arrangeAdoption(
 			discoverySession.devices.map((device) => ({
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name ?? device.hostname,
 				status: 'created',
+				error: null,
 				device_id: 'dev',
-				reason: null,
 			}))
 		);
 
@@ -965,7 +965,7 @@ describe('useDevicesWizard', () => {
 
 	it('adopts with the name and category the shell hands over, not the discovered ones', async () => {
 		arrangeAdoption([
-			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -980,7 +980,7 @@ describe('useDevicesWizard', () => {
 
 	it('falls back to the suggested name when the shell hands over a blank one', async () => {
 		arrangeAdoption([
-			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -995,7 +995,7 @@ describe('useDevicesWizard', () => {
 	// connector had already registered comes back as an update, not a failure.
 	it('reports back whatever outcome the backend returned for each device', async () => {
 		arrangeAdoption([
-			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'updated', device_id: 'dev-1', reason: null },
+			{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'updated', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -1009,7 +1009,7 @@ describe('useDevicesWizard', () => {
 
 	it('surfaces a per-device refusal without failing the rest', async () => {
 		arrangeAdoption([
-			{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'failed', device_id: null, reason: 'Device is unreachable' },
+			{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'failed', error: 'Device is unreachable', device_id: null },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -1051,7 +1051,7 @@ describe('useDevicesWizard', () => {
 				return Promise.resolve({
 					data: {
 						data: [
-							{ hostname: '192.168.1.10', identifier: 'shellyplus1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+							{ hostname: '192.168.1.10', name: 'Kitchen relay', status: 'created', error: null, device_id: 'dev-1' },
 						],
 					},
 					error: undefined,

--- a/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-ng/composables/useDevicesWizard.ts
@@ -538,13 +538,11 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				}
 
 				for (const result of responseBody.data) {
-					const requested = payload.find((item) => item.hostname === result.hostname);
-
 					outcomes.push({
 						hostname: result.hostname,
-						name: requested?.name ?? result.hostname,
+						name: result.name,
 						status: result.status,
-						error: result.reason,
+						error: result.error,
 					});
 				}
 

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.spec.ts
@@ -427,7 +427,7 @@ describe('useDevicesWizard', () => {
 		backendClient.POST.mockResolvedValueOnce({
 			data: {
 				data: [
-					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+					{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 				],
 			},
 			error: undefined,
@@ -483,7 +483,7 @@ describe('useDevicesWizard', () => {
 		backendClient.POST.mockResolvedValueOnce({
 			data: {
 				data: [
-					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+					{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 				],
 			},
 			error: undefined,
@@ -532,7 +532,7 @@ describe('useDevicesWizard', () => {
 		backendClient.POST.mockResolvedValueOnce({
 			data: {
 				data: [
-					{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+					{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 				],
 			},
 			error: undefined,
@@ -942,14 +942,14 @@ describe('useDevicesWizard', () => {
 
 	it('adopts the whole selection in a single request', async () => {
 		arrangeAdoption([
-			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
 		const adoptCalls = backendClient.POST.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/devices/adopt'));
 
@@ -958,7 +958,7 @@ describe('useDevicesWizard', () => {
 			{
 				identifier: 'shelly1-aabbcc',
 				hostname: 'shelly-1.local',
-				name: 'Kitchen relay',
+				name: 'Bathroom heater',
 				category: DevicesModuleDeviceCategory.lighting,
 				password: null,
 			},
@@ -966,7 +966,7 @@ describe('useDevicesWizard', () => {
 		expect(results).toEqual([
 			{
 				key: 'shelly-1.local',
-				name: 'Kitchen relay',
+				name: 'Bathroom heater',
 				identifier: 'shelly-1.local',
 				status: 'created',
 				error: null,
@@ -979,10 +979,10 @@ describe('useDevicesWizard', () => {
 		arrangeAdoption(
 			discoverySession.devices.map((device) => ({
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name ?? device.hostname,
 				status: 'created',
+				error: null,
 				device_id: 'dev',
-				reason: null,
 			}))
 		);
 
@@ -1007,7 +1007,7 @@ describe('useDevicesWizard', () => {
 
 	it('adopts with the name and category the shell hands over, not the discovered ones', async () => {
 		arrangeAdoption([
-			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -1022,7 +1022,7 @@ describe('useDevicesWizard', () => {
 
 	it('falls back to the suggested name when the shell hands over a blank one', async () => {
 		arrangeAdoption([
-			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+			{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
@@ -1037,28 +1037,28 @@ describe('useDevicesWizard', () => {
 	// connector had already registered comes back as an update, not a failure.
 	it('reports back whatever outcome the backend returned for each device', async () => {
 		arrangeAdoption([
-			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'updated', device_id: 'dev-1', reason: null },
+			{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'updated', error: null, device_id: 'dev-1' },
 		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(results[0]).toEqual(expect.objectContaining({ status: 'updated', error: null }));
 	});
 
 	it('surfaces a per-device refusal without failing the rest', async () => {
 		arrangeAdoption([
-			{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'failed', device_id: null, reason: 'Device is unreachable' },
+			{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'failed', error: 'Device is unreachable', device_id: null },
 		]);
 
 		const adapter = useDevicesWizard();
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed', error: 'Device is unreachable' }));
 	});
@@ -1080,7 +1080,7 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(results[0]).toEqual(expect.objectContaining({ status: 'failed' }));
 	});
@@ -1093,7 +1093,7 @@ describe('useDevicesWizard', () => {
 				return Promise.resolve({
 					data: {
 						data: [
-							{ hostname: 'shelly-1.local', identifier: 'shelly1-aabbcc', status: 'created', device_id: 'dev-1', reason: null },
+							{ hostname: 'shelly-1.local', name: 'Bathroom heater', status: 'created', error: null, device_id: 'dev-1' },
 						],
 					},
 					error: undefined,
@@ -1115,7 +1115,7 @@ describe('useDevicesWizard', () => {
 
 		await adapter.start();
 
-		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Kitchen relay', category: DevicesModuleDeviceCategory.lighting }]);
+		const results = await adapter.adopt([{ key: 'shelly-1.local', name: 'Bathroom heater', category: DevicesModuleDeviceCategory.lighting }]);
 
 		expect(adoptCall().body.data.devices[0]!.identifier).toBe('shelly1-aabbcc');
 		expect(results[0]).toEqual(expect.objectContaining({ status: 'created' }));

--- a/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-shelly-v1/composables/useDevicesWizard.ts
@@ -551,13 +551,11 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 				}
 
 				for (const result of responseBody.data) {
-					const requested = payload.find((item) => item.hostname === result.hostname);
-
 					outcomes.push({
 						hostname: result.hostname,
-						name: requested?.name ?? result.hostname,
+						name: result.name,
 						status: result.status,
-						error: result.reason,
+						error: result.error,
 					});
 				}
 

--- a/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/controllers/shelly-ng-devices.controller.spec.ts
@@ -282,10 +282,10 @@ describe('ShellyNgDevicesController', () => {
 			adoptionService.adopt.mockResolvedValue([
 				{
 					hostname: '192.168.1.10',
-					identifier: 'shellyplus1-aabbcc',
+					name: 'Kitchen light',
 					status: 'created',
+					error: null,
 					deviceId: 'dev-1',
-					reason: null,
 				},
 			]);
 

--- a/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/models/shelly-ng.model.ts
@@ -593,6 +593,9 @@ export class ShellyNgMappingReloadModel {
  * Adoption is a set of independent intents, so the outcome is reported per
  * device: one device refusing must not discard the rest of the selection, and
  * the wizard shows the operator exactly which ones landed.
+ *
+ * The field set matches the other device plugins' adoption results (WLED,
+ * Zigbee2MQTT, Home Assistant) so a wizard reads the same answer everywhere.
  */
 @ApiSchema({ name: 'DevicesShellyNgPluginDataAdoptionResult' })
 export class ShellyNgAdoptionResultModel {
@@ -605,12 +608,12 @@ export class ShellyNgAdoptionResultModel {
 	hostname: string;
 
 	@ApiProperty({
-		description: 'Shelly device identifier',
+		description: 'Name the device was adopted under',
 		type: 'string',
-		example: 'shellyplus1pm-441793ad07bc',
+		example: 'Kitchen light',
 	})
 	@Expose()
-	identifier: string;
+	name: string;
 
 	@ApiProperty({
 		description:
@@ -623,6 +626,15 @@ export class ShellyNgAdoptionResultModel {
 	status: 'created' | 'updated' | 'failed';
 
 	@ApiProperty({
+		description: 'Why this device could not be adopted',
+		type: 'string',
+		nullable: true,
+		example: 'Device could not be adopted',
+	})
+	@Expose()
+	error: string | null;
+
+	@ApiProperty({
 		name: 'device_id',
 		description: 'Identifier of the resulting device, when there is one',
 		type: 'string',
@@ -632,13 +644,4 @@ export class ShellyNgAdoptionResultModel {
 	})
 	@Expose({ name: 'device_id' })
 	deviceId: string | null;
-
-	@ApiProperty({
-		description: 'Why this device could not be adopted',
-		type: 'string',
-		nullable: true,
-		example: 'Device could not be adopted',
-	})
-	@Expose()
-	reason: string | null;
 }

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.spec.ts
@@ -85,7 +85,7 @@ describe('ShellyNgAdoptionService', () => {
 		const [outcome] = await service.adopt([selection()]);
 
 		expect(outcome.status).toBe('failed');
-		expect(outcome.reason).toBe('Device could not be created');
+		expect(outcome.error).toBe('Device could not be created');
 		expect(outcome.deviceId).toBeNull();
 	});
 

--- a/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-ng/services/shelly-ng-adoption.service.ts
@@ -12,10 +12,10 @@ export type ShellyNgAdoptionStatus = 'created' | 'updated' | 'failed';
 
 export interface ShellyNgAdoptionOutcome {
 	hostname: string;
-	identifier: string;
+	name: string;
 	status: ShellyNgAdoptionStatus;
+	error: string | null;
 	deviceId: string | null;
-	reason: string | null;
 }
 
 /**
@@ -73,10 +73,10 @@ export class ShellyNgAdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'created',
+				error: null,
 				deviceId: created.id,
-				reason: null,
 			};
 		} catch (error) {
 			// The connector may have adopted this device between the lookup above
@@ -98,10 +98,10 @@ export class ShellyNgAdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'failed',
+				error: err.message.length > 0 ? err.message : 'Device could not be adopted',
 				deviceId: null,
-				reason: err.message.length > 0 ? err.message : 'Device could not be adopted',
 			};
 		}
 	}
@@ -121,10 +121,10 @@ export class ShellyNgAdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'updated',
+				error: null,
 				deviceId: existing.id,
-				reason: null,
 			};
 		} catch (error) {
 			const err = error as Error;
@@ -136,10 +136,10 @@ export class ShellyNgAdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'failed',
+				error: err.message.length > 0 ? err.message : 'Device could not be updated',
 				deviceId: existing.id,
-				reason: err.message.length > 0 ? err.message : 'Device could not be updated',
 			};
 		}
 	}

--- a/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/controllers/shelly-v1-devices.controller.spec.ts
@@ -184,10 +184,10 @@ describe('ShellyV1DevicesController', () => {
 			adoptionService.adopt.mockResolvedValue([
 				{
 					hostname: '192.168.1.100',
-					identifier: 'shelly1-a4cf12df3b21',
+					name: 'Kitchen light',
 					status: 'created',
+					error: null,
 					deviceId: 'dev-1',
-					reason: null,
 				},
 			]);
 

--- a/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/models/shelly-v1.model.ts
@@ -390,6 +390,9 @@ export class ShellyV1DiscoverySessionModel {
  * Adoption is a set of independent intents, so the outcome is reported per
  * device: one device refusing must not discard the rest of the selection, and
  * the wizard shows the operator exactly which ones landed.
+ *
+ * The field set matches the other device plugins' adoption results (WLED,
+ * Zigbee2MQTT, Home Assistant) so a wizard reads the same answer everywhere.
  */
 @ApiSchema({ name: 'DevicesShellyV1PluginDataAdoptionResult' })
 export class ShellyV1AdoptionResultModel {
@@ -402,12 +405,12 @@ export class ShellyV1AdoptionResultModel {
 	hostname: string;
 
 	@ApiProperty({
-		description: 'Shelly device identifier',
+		description: 'Name the device was adopted under',
 		type: 'string',
-		example: 'shelly1-a4cf12df3b21',
+		example: 'Kitchen light',
 	})
 	@Expose()
-	identifier: string;
+	name: string;
 
 	@ApiProperty({
 		description:
@@ -420,6 +423,15 @@ export class ShellyV1AdoptionResultModel {
 	status: 'created' | 'updated' | 'failed';
 
 	@ApiProperty({
+		description: 'Why this device could not be adopted',
+		type: 'string',
+		nullable: true,
+		example: 'Device could not be adopted',
+	})
+	@Expose()
+	error: string | null;
+
+	@ApiProperty({
 		name: 'device_id',
 		description: 'Identifier of the resulting device, when there is one',
 		type: 'string',
@@ -429,13 +441,4 @@ export class ShellyV1AdoptionResultModel {
 	})
 	@Expose({ name: 'device_id' })
 	deviceId: string | null;
-
-	@ApiProperty({
-		description: 'Why this device could not be adopted',
-		type: 'string',
-		nullable: true,
-		example: 'Device could not be adopted',
-	})
-	@Expose()
-	reason: string | null;
 }

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.spec.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.spec.ts
@@ -85,7 +85,7 @@ describe('ShellyV1AdoptionService', () => {
 		const [outcome] = await service.adopt([selection()]);
 
 		expect(outcome.status).toBe('failed');
-		expect(outcome.reason).toBe('Device could not be created');
+		expect(outcome.error).toBe('Device could not be created');
 		expect(outcome.deviceId).toBeNull();
 	});
 

--- a/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.ts
+++ b/apps/backend/src/plugins/devices-shelly-v1/services/shelly-v1-adoption.service.ts
@@ -12,10 +12,10 @@ export type ShellyV1AdoptionStatus = 'created' | 'updated' | 'failed';
 
 export interface ShellyV1AdoptionOutcome {
 	hostname: string;
-	identifier: string;
+	name: string;
 	status: ShellyV1AdoptionStatus;
+	error: string | null;
 	deviceId: string | null;
-	reason: string | null;
 }
 
 /**
@@ -73,10 +73,10 @@ export class ShellyV1AdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'created',
+				error: null,
 				deviceId: created.id,
-				reason: null,
 			};
 		} catch (error) {
 			// The connector may have adopted this device between the lookup above
@@ -98,10 +98,10 @@ export class ShellyV1AdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'failed',
+				error: err.message.length > 0 ? err.message : 'Device could not be adopted',
 				deviceId: null,
-				reason: err.message.length > 0 ? err.message : 'Device could not be adopted',
 			};
 		}
 	}
@@ -121,10 +121,10 @@ export class ShellyV1AdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'updated',
+				error: null,
 				deviceId: existing.id,
-				reason: null,
 			};
 		} catch (error) {
 			const err = error as Error;
@@ -136,10 +136,10 @@ export class ShellyV1AdoptionService {
 
 			return {
 				hostname: device.hostname,
-				identifier: device.identifier,
+				name: device.name,
 				status: 'failed',
+				error: err.message.length > 0 ? err.message : 'Device could not be updated',
 				deviceId: existing.id,
-				reason: err.message.length > 0 ? err.message : 'Device could not be updated',
 			};
 		}
 	}


### PR DESCRIPTION
Follow-up to #795 / #796. Came out of asking whether the rate limit could bite other device wizards — it can't, but checking showed the pattern already existed in three plugins and I'd built a fourth variant instead of following it.

## The divergence

WLED, Zigbee2MQTT and Home Assistant all return the same adoption result shape:

```
{ <key>, name, status: 'created'|'updated'|'failed', error, device_id }
```

Shelly returned `reason` instead of `error`, omitted `name`, and carried an extra `identifier`. `shelly-ng.model.ts` ended up with **both spellings in one file** — `error` on the discovery model (line 409), `reason` on the adoption one.

| | Before | After |
|---|---|---|
| failure text | `reason` | `error` |
| adopted name | *(absent)* | `name` |
| extra key | `identifier` | *(dropped)* |

`identifier` had no consumer — the wizard keys on hostname, and two devices can't share one.

## A latent test defect this surfaced

The admin used to derive the name with `requested?.name ?? result.hostname` — looking the requested name back up by hostname. That lookup meant a test could assert **any** name and pass, because the wizard echoed back whatever was requested and a wrong name compared equal to itself.

It was hiding a real inconsistency: the **V1 wizard spec asserted the NG fixture's device name** (`'Kitchen relay'` rather than `'Bathroom heater'`) in seven places — my own copy-paste from #796. Now that `name` comes from the response, the fixture and the assertion have to agree. Fixed.

## Verification

| Check | Result |
|---|---|
| Backend | 382 suites, 4827 passed |
| Admin | 277 files, 2012 passed |
| `pnpm run type-check` (admin, real) | clean |
| `tsc --noEmit` (backend) | clean |
| eslint + prettier (touched) | clean |

The type-checker did most of the work here — every call site of the changed interface failed to compile until updated, which is why this is a low-risk rename.

No behaviour change. The endpoints are four days old and only the two wizards consume them, so there is nothing to deprecate.