### PR TITLE
feat(cross): give the remaining modules a bulk-remove endpoint

### DIFF
--- a/apps/admin/src/modules/dashboard/composables/usePagesActions.ts
+++ b/apps/admin/src/modules/dashboard/composables/usePagesActions.ts
@@ -83,28 +83,26 @@ export const usePagesActions = (): IUsePagesActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const page of pages) {
-				try {
-					await pagesStore.remove({ id: page.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('dashboardModule.messages.pages.bulkRemoved', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('dashboardModule.messages.pages.bulkRemoveFailed', { count: failCount }));
-			}
 		} catch {
 			// User cancelled - do nothing
+			return;
+		}
+
+		// One request for the whole selection. Sending one per page tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await pagesStore.bulkRemove({ ids: pages.map((page) => page.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('dashboardModule.messages.pages.bulkRemoved', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('dashboardModule.messages.pages.bulkRemoveFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('dashboardModule.messages.pages.bulkRemoveFailed', { count: pages.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/dashboard/store/pages.store.schemas.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.schemas.ts
@@ -131,6 +131,15 @@ export const PagesRemoveActionPayloadSchema = z.object({
 	id: ItemIdSchema,
 });
 
+export const PagesBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(ItemIdSchema).nonempty(),
+});
+
+export const PagesBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 // BACKEND API
 // ===========
 

--- a/apps/admin/src/modules/dashboard/store/pages.store.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.ts
@@ -28,6 +28,7 @@ import {
 	PageSchema,
 	PageUpdateReqSchema,
 	PagesAddActionPayloadSchema,
+	PagesBulkResultSchema,
 	PagesEditActionPayloadSchema,
 } from './pages.store.schemas';
 import type {
@@ -36,6 +37,8 @@ import type {
 	IPageRes,
 	IPageUpdateReq,
 	IPagesAddActionPayload,
+	IPagesBulkRemoveActionPayload,
+	IPagesBulkResult,
 	IPagesEditActionPayload,
 	IPagesGetActionPayload,
 	IPagesOnEventActionPayload,
@@ -509,18 +512,7 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 				});
 
 				if (response.status === 204) {
-					const tilesStore = storesManager.getStore(tilesStoreKey);
-					const dataSourcesStore = storesManager.getStore(dataSourcesStoreKey);
-
-					dataSourcesStore.unset({ parent: { type: 'page', id: payload.id } });
-
-					const tiles = tilesStore.findForParent('page', payload.id);
-
-					tiles.forEach((tile) => {
-						dataSourcesStore.unset({ parent: { type: 'tile', id: tile.id } });
-					});
-
-					tilesStore.unset({ parent: { type: 'page', id: payload.id } });
+					purgeLocally(payload.id);
 
 					return true;
 				}
@@ -541,6 +533,90 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 		}
 
 		return true;
+	};
+
+	/**
+	 * Drops the tiles and data sources that hang off a page.
+	 *
+	 * `remove` did this inline; the bulk path needs the same cascade for each
+	 * page the backend confirmed, so it lives here rather than being written out
+	 * twice with a chance of drifting apart.
+	 */
+	const purgeLocally = (id: IPage['id']): void => {
+		const tilesStore = storesManager.getStore(tilesStoreKey);
+		const dataSourcesStore = storesManager.getStore(dataSourcesStoreKey);
+
+		dataSourcesStore.unset({ parent: { type: 'page', id } });
+
+		const tiles = tilesStore.findForParent('page', id);
+
+		tiles.forEach((tile) => {
+			dataSourcesStore.unset({ parent: { type: 'tile', id: tile.id } });
+		});
+
+		tilesStore.unset({ parent: { type: 'page', id } });
+	};
+
+	/**
+	 * Removes a selection in one request.
+	 *
+	 * The per-page alternative was one request each, which the backend's shared
+	 * rate limit rejects past thirty - so a large selection failed halfway
+	 * through with no way to tell which half. The outcome is reported per page
+	 * because the backend still refuses individual pages for individual reasons.
+	 */
+	const bulkRemove = async (payload: IPagesBulkRemoveActionPayload): Promise<IPagesBulkResult> => {
+		// Drafts were never sent to the backend, so they are dropped here and
+		// counted as done rather than handed to an endpoint that would correctly
+		// report them as unknown.
+		const drafts: string[] = [];
+		const persisted: string[] = [];
+
+		for (const id of payload.ids) {
+			const record = data.value[id];
+
+			if (record === undefined) {
+				continue;
+			}
+
+			(record.draft ? drafts : persisted).push(id);
+		}
+
+		for (const id of drafts) {
+			unset({ id });
+			purgeLocally(id);
+		}
+
+		if (persisted.length === 0) {
+			return { succeeded: drafts, failed: [] };
+		}
+
+		semaphore.value.deleting.push(...persisted);
+
+		try {
+			const { data: responseBody, error } = await backend.client.POST(`/${MODULES_PREFIX}/${DASHBOARD_MODULE_PREFIX}/pages/bulk-remove`, {
+				body: { data: { ids: persisted } },
+			});
+
+			if (typeof error !== 'undefined' || typeof responseBody === 'undefined') {
+				throw new DashboardApiException('Received unexpected response.');
+			}
+
+			const result = PagesBulkResultSchema.parse(responseBody.data);
+
+			// Removing a page cascades to its tiles and data sources on the backend,
+			// so the same cascade is applied locally for every page it confirmed.
+			for (const id of result.succeeded) {
+				unset({ id });
+				purgeLocally(id);
+			}
+
+			return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+		} catch (e) {
+			throw new DashboardApiException('Failed to remove pages.', null, e as Error);
+		} finally {
+			semaphore.value.deleting = semaphore.value.deleting.filter((item) => !persisted.includes(item));
+		}
 	};
 
 	const insertDataSourceRelations = (page: IPage, dataSources: IDataSourceRes[]): void => {
@@ -614,6 +690,7 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 		edit,
 		save,
 		remove,
+		bulkRemove,
 	};
 });
 

--- a/apps/admin/src/modules/dashboard/store/pages.store.types.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.types.ts
@@ -10,6 +10,8 @@ import {
 	PageSchema,
 	PageUpdateReqSchema,
 	PagesAddActionPayloadSchema,
+	PagesBulkRemoveActionPayloadSchema,
+	PagesBulkResultSchema,
 	PagesEditActionPayloadSchema,
 	PagesGetActionPayloadSchema,
 	PagesOnSetActionPayloadSchema,
@@ -46,6 +48,10 @@ export type IPagesSaveActionPayload = z.infer<typeof PagesSaveActionPayloadSchem
 
 export type IPagesRemoveActionPayload = z.infer<typeof PagesRemoveActionPayloadSchema>;
 
+export type IPagesBulkRemoveActionPayload = z.infer<typeof PagesBulkRemoveActionPayloadSchema>;
+
+export type IPagesBulkResult = z.infer<typeof PagesBulkResultSchema>;
+
 // STORE
 // =====
 
@@ -72,6 +78,7 @@ export interface IPagesStoreActions {
 	edit: (payload: IPagesEditActionPayload) => Promise<IPage>;
 	save: (payload: IPagesSaveActionPayload) => Promise<IPage>;
 	remove: (payload: IPagesRemoveActionPayload) => Promise<boolean>;
+	bulkRemove: (payload: IPagesBulkRemoveActionPayload) => Promise<IPagesBulkResult>;
 	isLoaded: () => boolean;
 	refresh: () => Promise<unknown>;
 }

--- a/apps/admin/src/modules/displays/composables/useDisplaysActions.ts
+++ b/apps/admin/src/modules/displays/composables/useDisplaysActions.ts
@@ -58,28 +58,26 @@ export const useDisplaysActions = (): IUseDisplaysActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const display of displays) {
-				try {
-					await displaysStore.remove({ id: display.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('displaysModule.messages.bulkRemoved', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('displaysModule.messages.bulkRemoveFailed', { count: failCount }));
-			}
 		} catch {
 			// User cancelled - do nothing
+			return;
+		}
+
+		// One request for the whole selection. Sending one per display tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await displaysStore.bulkRemove({ ids: displays.map((display) => display.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('displaysModule.messages.bulkRemoved', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('displaysModule.messages.bulkRemoveFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('displaysModule.messages.bulkRemoveFailed', { count: displays.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/displays/store/displays.store.schemas.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.schemas.ts
@@ -195,6 +195,15 @@ export const DisplaysSaveActionPayloadSchema = z.object({
 	id: DisplayIdSchema,
 });
 
+export const DisplaysBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(DisplayIdSchema).nonempty(),
+});
+
+export const DisplaysBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 export const DisplaysRemoveActionPayloadSchema = z.object({
 	id: DisplayIdSchema,
 });

--- a/apps/admin/src/modules/displays/store/displays.store.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.ts
@@ -9,13 +9,15 @@ import { MODULES_PREFIX } from '../../../app.constants';
 import { DISPLAYS_MODULE_PREFIX } from '../displays.constants';
 import { DisplaysApiException, DisplaysException, DisplaysValidationException } from '../displays.exceptions';
 
-import { DisplaySchema, DisplaysAddActionPayloadSchema, DisplaysEditActionPayloadSchema } from './displays.store.schemas';
+import { DisplaySchema, DisplaysAddActionPayloadSchema, DisplaysBulkResultSchema, DisplaysEditActionPayloadSchema } from './displays.store.schemas';
 import type {
 	DisplaysStoreSetup,
 	IDisplay,
 	IDisplayRes,
 	IDisplayToken,
 	IDisplaysAddActionPayload,
+	IDisplaysBulkRemoveActionPayload,
+	IDisplaysBulkResult,
 	IDisplaysEditActionPayload,
 	IDisplaysGetActionPayload,
 	IDisplaysOnEventActionPayload,
@@ -440,6 +442,64 @@ export const useDisplays = defineStore<'displays_module-displays', DisplaysStore
 		return true;
 	};
 
+	/**
+	 * Removes a selection in one request.
+	 *
+	 * The per-display alternative was one request each, which the backend's shared
+	 * rate limit rejects past thirty - so a large selection failed halfway through
+	 * with no way to tell which half. The outcome is reported per display because
+	 * the backend still refuses individual displays for individual reasons.
+	 */
+	const bulkRemove = async (payload: IDisplaysBulkRemoveActionPayload): Promise<IDisplaysBulkResult> => {
+		// Drafts were never sent to the backend, so they are dropped here and
+		// counted as done rather than handed to an endpoint that would correctly
+		// report them as unknown.
+		const drafts: string[] = [];
+		const persisted: string[] = [];
+
+		for (const id of payload.ids) {
+			const record = data.value[id];
+
+			if (record === undefined) {
+				continue;
+			}
+
+			(record.draft ? drafts : persisted).push(id);
+		}
+
+		for (const id of drafts) {
+			unset({ id });
+		}
+
+		if (persisted.length === 0) {
+			return { succeeded: drafts, failed: [] };
+		}
+
+		semaphore.value.deleting.push(...persisted);
+
+		try {
+			const { data: responseData, error } = await backend.client.POST(`/${MODULES_PREFIX}/${DISPLAYS_MODULE_PREFIX}/displays/bulk-remove`, {
+				body: { data: { ids: persisted } },
+			});
+
+			if (typeof error !== 'undefined' || typeof responseData === 'undefined') {
+				throw new DisplaysApiException('Received unexpected response.');
+			}
+
+			const result = DisplaysBulkResultSchema.parse(responseData.data);
+
+			for (const id of result.succeeded) {
+				unset({ id });
+			}
+
+			return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+		} catch (e) {
+			throw new DisplaysApiException('Failed to remove displays.', null, e as Error);
+		} finally {
+			semaphore.value.deleting = semaphore.value.deleting.filter((item) => !persisted.includes(item));
+		}
+	};
+
 	const getTokens = async (payload: IDisplaysGetActionPayload): Promise<IDisplayToken[]> => {
 		try {
 			const {
@@ -539,6 +599,7 @@ export const useDisplays = defineStore<'displays_module-displays', DisplaysStore
 		edit,
 		save,
 		remove,
+		bulkRemove,
 		getTokens,
 		revokeToken,
 		refreshTokensForDisplay,

--- a/apps/admin/src/modules/displays/store/displays.store.types.ts
+++ b/apps/admin/src/modules/displays/store/displays.store.types.ts
@@ -11,6 +11,8 @@ import {
 	DisplayTokenResSchema,
 	DisplayUpdateReqSchema,
 	DisplaysAddActionPayloadSchema,
+	DisplaysBulkRemoveActionPayloadSchema,
+	DisplaysBulkResultSchema,
 	DisplaysEditActionPayloadSchema,
 	DisplaysGetActionPayloadSchema,
 	DisplaysOnEventActionPayloadSchema,
@@ -48,6 +50,10 @@ export type IDisplaysEditActionPayload = z.infer<typeof DisplaysEditActionPayloa
 
 export type IDisplaysSaveActionPayload = z.infer<typeof DisplaysSaveActionPayloadSchema>;
 
+export type IDisplaysBulkRemoveActionPayload = z.infer<typeof DisplaysBulkRemoveActionPayloadSchema>;
+
+export type IDisplaysBulkResult = z.infer<typeof DisplaysBulkResultSchema>;
+
 export type IDisplaysRemoveActionPayload = z.infer<typeof DisplaysRemoveActionPayloadSchema>;
 
 export type IDisplaysRevokeTokenActionPayload = z.infer<typeof DisplaysRevokeTokenActionPayloadSchema>;
@@ -79,6 +85,7 @@ export interface IDisplaysStoreActions {
 	edit: (payload: IDisplaysEditActionPayload) => Promise<IDisplay>;
 	save: (payload: IDisplaysSaveActionPayload) => Promise<IDisplay>;
 	remove: (payload: IDisplaysRemoveActionPayload) => Promise<boolean>;
+	bulkRemove: (payload: IDisplaysBulkRemoveActionPayload) => Promise<IDisplaysBulkResult>;
 	getTokens: (payload: IDisplaysGetActionPayload) => Promise<IDisplayToken[]>;
 	revokeToken: (payload: IDisplaysRevokeTokenActionPayload) => Promise<boolean>;
 	refreshTokensForDisplay: (payload: IDisplaysGetActionPayload) => void;

--- a/apps/admin/src/modules/spaces/composables/useSpacesActions.spec.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpacesActions.spec.ts
@@ -1,3 +1,4 @@
+import { ElMessageBox } from 'element-plus';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SpaceRoomCategory, SpaceType } from '../spaces.constants';
@@ -32,6 +33,7 @@ const mockFindById = vi.fn((id: string) => {
 });
 
 const mockRemove = vi.fn();
+const mockBulkRemove = vi.fn();
 
 const mockSuccess = vi.fn();
 const mockError = vi.fn();
@@ -64,6 +66,7 @@ vi.mock('../../../common', async () => {
 			getStore: () => ({
 				findById: mockFindById,
 				remove: mockRemove,
+				bulkRemove: mockBulkRemove,
 			}),
 		}),
 		useFlashMessage: () => ({
@@ -108,25 +111,41 @@ describe('useSpacesActions', () => {
 	});
 
 	describe('bulkRemove', () => {
+		beforeEach(() => {
+			mockBulkRemove.mockResolvedValue({ succeeded: [], failed: [] });
+		});
+
 		it('does nothing when spaces array is empty', async () => {
 			const { bulkRemove } = useSpacesActions();
 
 			await bulkRemove([]);
 
-			expect(mockRemove).not.toHaveBeenCalled();
+			expect(mockBulkRemove).not.toHaveBeenCalled();
 		});
 
-		it('calls remove for each space when confirmed', async () => {
+		it('sends the whole selection in one call when confirmed', async () => {
 			const { bulkRemove } = useSpacesActions();
 
 			await bulkRemove([mockSpace1, mockSpace2]);
 
-			expect(mockRemove).toHaveBeenCalledTimes(2);
-			expect(mockRemove).toHaveBeenCalledWith({ id: 'space-1' });
-			expect(mockRemove).toHaveBeenCalledWith({ id: 'space-2' });
+			expect(mockBulkRemove).toHaveBeenCalledTimes(1);
+			expect(mockBulkRemove).toHaveBeenCalledWith({ ids: ['space-1', 'space-2'] });
+		});
+
+		it('does not call the store when the confirmation is cancelled', async () => {
+			vi.mocked(ElMessageBox.confirm).mockRejectedValueOnce(new Error('cancel'));
+
+			const { bulkRemove } = useSpacesActions();
+
+			await bulkRemove([mockSpace1, mockSpace2]);
+
+			expect(mockBulkRemove).not.toHaveBeenCalled();
+			expect(mockError).not.toHaveBeenCalled();
 		});
 
 		it('shows success message after bulk removing', async () => {
+			mockBulkRemove.mockResolvedValue({ succeeded: ['space-1', 'space-2'], failed: [] });
+
 			const { bulkRemove } = useSpacesActions();
 
 			await bulkRemove([mockSpace1, mockSpace2]);
@@ -135,11 +154,7 @@ describe('useSpacesActions', () => {
 		});
 
 		it('shows error message when some removes fail', async () => {
-			mockRemove.mockImplementation(({ id }) => {
-				if (id === 'space-2') {
-					throw new Error('Failed to remove');
-				}
-			});
+			mockBulkRemove.mockResolvedValue({ succeeded: ['space-1'], failed: [{ id: 'space-2', reason: 'Failed to remove' }] });
 
 			const { bulkRemove } = useSpacesActions();
 
@@ -147,6 +162,17 @@ describe('useSpacesActions', () => {
 
 			expect(mockSuccess).toHaveBeenCalled();
 			expect(mockError).toHaveBeenCalledWith(expect.stringContaining('spacesModule.messages.bulkRemoveFailed'));
+		});
+
+		it('reports a failed request as failed rather than cancelled', async () => {
+			mockBulkRemove.mockRejectedValue(new Error('Request failed'));
+
+			const { bulkRemove } = useSpacesActions();
+
+			await bulkRemove([mockSpace1, mockSpace2]);
+
+			expect(mockError).toHaveBeenCalledWith(expect.stringContaining('spacesModule.messages.bulkRemoveFailed'));
+			expect(mockInfo).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/admin/src/modules/spaces/composables/useSpacesActions.ts
+++ b/apps/admin/src/modules/spaces/composables/useSpacesActions.ts
@@ -74,28 +74,26 @@ export const useSpacesActions = (): IUseSpacesActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const space of spaces) {
-				try {
-					await spacesStore.remove({ id: space.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('spacesModule.messages.bulkRemoved', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('spacesModule.messages.bulkRemoveFailed', { count: failCount }));
-			}
 		} catch {
 			// User cancelled - do nothing
+			return;
+		}
+
+		// One request for the whole selection. Sending one per space tripped the backend's shared rate
+		// limit once a selection went past thirty, which left the rest of the selection silently
+		// unprocessed.
+		try {
+			const result = await spacesStore.bulkRemove({ ids: spaces.map((space) => space.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('spacesModule.messages.bulkRemoved', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('spacesModule.messages.bulkRemoveFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('spacesModule.messages.bulkRemoveFailed', { count: spaces.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/spaces/store/spaces.store.schemas.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.schemas.ts
@@ -45,3 +45,12 @@ export const SpaceEditSchema = z.object({
 	displayOrder: z.number().int().min(0).optional(),
 	statusWidgets: z.array(StatusWidgetSchema).nullable().optional(),
 });
+
+export const SpacesBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(z.string().uuid()).nonempty(),
+});
+
+export const SpacesBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});

--- a/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
@@ -9,6 +9,7 @@ import { useSpacesStore } from './spaces.store';
 
 const backendClient = {
 	GET: vi.fn(),
+	POST: vi.fn(),
 };
 
 vi.mock('../../../common', async () => {
@@ -115,5 +116,55 @@ describe('Spaces store', () => {
 		expect(store.findAll()).toHaveLength(1);
 		expect(store.findById(removedId)).toBeNull();
 		expect(store.findById(keptId)).not.toBeNull();
+	});
+
+	describe('bulkRemove', () => {
+		const seed = async (): Promise<void> => {
+			backendClient.GET.mockResolvedValueOnce({
+				data: { data: [spaceResponse(keptId, 'Kept'), spaceResponse(removedId, 'Removed')] },
+				error: undefined,
+			});
+
+			await store.fetch();
+		};
+
+		it('sends the whole selection in one request and drops what the backend removed', async () => {
+			await seed();
+
+			backendClient.POST.mockResolvedValueOnce({ data: { data: { succeeded: [removedId], failed: [] } }, error: undefined });
+
+			const result = await store.bulkRemove({ ids: [keptId, removedId] });
+
+			expect(backendClient.POST).toHaveBeenCalledTimes(1);
+			expect(backendClient.POST).toHaveBeenCalledWith('/modules/spaces/spaces/bulk-remove', {
+				body: { data: { ids: [keptId, removedId] } },
+			});
+			expect(result).toEqual({ succeeded: [removedId], failed: [] });
+			expect(store.findById(removedId)).toBeNull();
+			expect(store.findById(keptId)).not.toBeNull();
+		});
+
+		it('drops drafts locally and never asks the backend about them', async () => {
+			await seed();
+
+			store.set({ id: removedId, data: { draft: true } });
+
+			const result = await store.bulkRemove({ ids: [removedId] });
+
+			expect(backendClient.POST).not.toHaveBeenCalled();
+			expect(result).toEqual({ succeeded: [removedId], failed: [] });
+			expect(store.findById(removedId)).toBeNull();
+		});
+
+		it('reports a rejected request as a failure and keeps the selection', async () => {
+			await seed();
+
+			backendClient.POST.mockResolvedValueOnce({ data: undefined, error: { message: 'Nope' } });
+
+			await expect(store.bulkRemove({ ids: [keptId] })).rejects.toThrow('Failed to remove spaces');
+
+			expect(store.findById(keptId)).not.toBeNull();
+			expect(store.semaphore.deleting).not.toContain(keptId);
+		});
 	});
 });

--- a/apps/admin/src/modules/spaces/store/spaces.store.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.ts
@@ -9,7 +9,17 @@ import { SPACES_MODULE_PREFIX } from '../spaces.constants';
 
 import { SpacesApiException } from '../spaces.exceptions';
 
-import type { ISpace, ISpaceCreateData, ISpaceEditData, ISpacesStateSemaphore, ISpacesStoreActions, ISpacesStoreState } from './spaces.store.types';
+import { SpacesBulkResultSchema } from './spaces.store.schemas';
+import type {
+	ISpace,
+	ISpaceCreateData,
+	ISpaceEditData,
+	ISpacesBulkRemoveActionPayload,
+	ISpacesBulkResult,
+	ISpacesStateSemaphore,
+	ISpacesStoreActions,
+	ISpacesStoreState,
+} from './spaces.store.types';
 import { type ApiSpace, transformSpaceCreateRequest, transformSpaceEditRequest, transformSpaceResponse } from './spaces.transformers';
 
 type SpacesStoreSetup = ISpacesStoreState & ISpacesStoreActions;
@@ -247,6 +257,64 @@ export const useSpacesStore = defineStore<'spaces_module-spaces', SpacesStoreSet
 		}
 	};
 
+	/**
+	 * Removes a selection in one request.
+	 *
+	 * The per-space alternative was one request each, which the backend's shared rate limit rejects past
+	 * thirty - so a large selection failed halfway through with no way to tell which half. The outcome is
+	 * reported per space because the backend still refuses individual spaces for individual reasons.
+	 */
+	const bulkRemove = async (payload: ISpacesBulkRemoveActionPayload): Promise<ISpacesBulkResult> => {
+		// Drafts were never sent to the backend, so they are dropped here and counted as done rather than
+		// handed to an endpoint that would correctly report them as unknown.
+		const drafts: string[] = [];
+		const persisted: string[] = [];
+
+		for (const id of payload.ids) {
+			const existing = findById(id);
+
+			if (!existing) {
+				continue;
+			}
+
+			(existing.draft ? drafts : persisted).push(id);
+		}
+
+		for (const id of drafts) {
+			unset({ id });
+		}
+
+		if (persisted.length === 0) {
+			return { succeeded: drafts, failed: [] };
+		}
+
+		semaphore.value.deleting.push(...persisted);
+
+		try {
+			const { data: responseData, error } = await backend.client.POST(`/${MODULES_PREFIX}/${SPACES_MODULE_PREFIX}/spaces/bulk-remove`, {
+				body: {
+					data: { ids: persisted },
+				},
+			});
+
+			if (error || !responseData) {
+				throw new SpacesApiException('Received unexpected response');
+			}
+
+			const result = SpacesBulkResultSchema.parse(responseData.data);
+
+			for (const id of result.succeeded) {
+				unset({ id });
+			}
+
+			return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+		} catch (e) {
+			throw new SpacesApiException('Failed to remove spaces', null, e as Error);
+		} finally {
+			semaphore.value.deleting = semaphore.value.deleting.filter((id) => !persisted.includes(id));
+		}
+	};
+
 	const set = (payload: { id: ISpace['id']; data: Partial<ISpace> }): void => {
 		const existing = data.value[payload.id];
 		if (existing) {
@@ -288,6 +356,7 @@ export const useSpacesStore = defineStore<'spaces_module-spaces', SpacesStoreSet
 		edit,
 		save,
 		remove,
+		bulkRemove,
 		set,
 		unset,
 		onEvent,

--- a/apps/admin/src/modules/spaces/store/spaces.store.types.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.types.ts
@@ -1,6 +1,10 @@
 import type { Ref } from 'vue';
 
+import type { z } from 'zod';
+
 import type { IStatusWidget, SpaceRoomCategory, SpaceType, SpaceZoneCategory } from '../spaces.constants';
+
+import type { SpacesBulkRemoveActionPayloadSchema, SpacesBulkResultSchema } from './spaces.store.schemas';
 
 export interface ISpace {
 	id: string;
@@ -43,6 +47,10 @@ export interface ISpaceCreateData {
 	statusWidgets?: IStatusWidget[] | null;
 }
 
+export type ISpacesBulkRemoveActionPayload = z.infer<typeof SpacesBulkRemoveActionPayloadSchema>;
+
+export type ISpacesBulkResult = z.infer<typeof SpacesBulkResultSchema>;
+
 export interface ISpacesStoreState {
 	data: Ref<{ [key: ISpace['id']]: ISpace }>;
 	semaphore: Ref<ISpacesStateSemaphore>;
@@ -72,6 +80,7 @@ export interface ISpacesStoreActions {
 	edit: (payload: { id: ISpace['id']; data: ISpaceEditData }) => Promise<ISpace>;
 	save: (payload: { id: ISpace['id'] }) => Promise<ISpace>;
 	remove: (payload: { id: ISpace['id'] }) => Promise<void>;
+	bulkRemove: (payload: ISpacesBulkRemoveActionPayload) => Promise<ISpacesBulkResult>;
 	set: (payload: { id: ISpace['id']; data: Partial<ISpace> }) => void;
 	unset: (payload: { id: ISpace['id'] }) => void;
 	onEvent: (payload: { id: ISpace['id']; data: Record<string, unknown> }) => void;

--- a/apps/admin/src/modules/users/composables/useUsersActions.ts
+++ b/apps/admin/src/modules/users/composables/useUsersActions.ts
@@ -79,28 +79,26 @@ export const useUsersActions = (): IUseUsersActions => {
 				cancelButtonText: t('usersModule.buttons.no.title'),
 				type: 'warning',
 			});
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const user of users) {
-				try {
-					await usersStore.remove({ id: user.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('usersModule.messages.bulkRemoved', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('usersModule.messages.bulkRemoveFailed', { count: failCount }));
-			}
 		} catch {
 			// User cancelled - do nothing
+			return;
+		}
+
+		// One request for the whole selection. Sending one per user tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await usersStore.bulkRemove({ ids: users.map((user) => user.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('usersModule.messages.bulkRemoved', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('usersModule.messages.bulkRemoveFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('usersModule.messages.bulkRemoveFailed', { count: users.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/users/store/users.store.schemas.ts
+++ b/apps/admin/src/modules/users/store/users.store.schemas.ts
@@ -145,6 +145,15 @@ export const UsersSaveActionPayloadSchema = z.object({
 	id: UserIdSchema,
 });
 
+export const UsersBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(UserIdSchema).nonempty(),
+});
+
+export const UsersBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 export const UsersRemoveActionPayloadSchema = z.object({
 	id: UserIdSchema,
 });

--- a/apps/admin/src/modules/users/store/users.store.ts
+++ b/apps/admin/src/modules/users/store/users.store.ts
@@ -16,11 +16,13 @@ import type {
 import { USERS_MODULE_PREFIX } from '../users.constants';
 import { UsersApiException, UsersException, UsersValidationException } from '../users.exceptions';
 
-import { UserSchema, UsersAddActionPayloadSchema, UsersEditActionPayloadSchema } from './users.store.schemas';
+import { UserSchema, UsersAddActionPayloadSchema, UsersBulkResultSchema, UsersEditActionPayloadSchema } from './users.store.schemas';
 import type {
 	IUser,
 	IUserRes,
 	IUsersAddActionPayload,
+	IUsersBulkRemoveActionPayload,
+	IUsersBulkResult,
 	IUsersEditActionPayload,
 	IUsersGetActionPayload,
 	IUsersOnEventActionPayload,
@@ -436,6 +438,65 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 		return true;
 	};
 
+	/**
+	 * Removes a selection in one request.
+	 *
+	 * The per-user alternative was one request each, which the backend's shared
+	 * rate limit rejects past thirty - so a large selection failed halfway
+	 * through with no way to tell which half. The outcome is reported per user
+	 * because the backend still refuses individual users for individual reasons,
+	 * the caller's own account and the owner account above all.
+	 */
+	const bulkRemove = async (payload: IUsersBulkRemoveActionPayload): Promise<IUsersBulkResult> => {
+		// Drafts were never sent to the backend, so they are dropped here and
+		// counted as done rather than handed to an endpoint that would correctly
+		// report them as unknown.
+		const drafts: string[] = [];
+		const persisted: string[] = [];
+
+		for (const id of payload.ids) {
+			const record = data.value[id];
+
+			if (typeof record === 'undefined') {
+				continue;
+			}
+
+			(record.draft ? drafts : persisted).push(id);
+		}
+
+		for (const id of drafts) {
+			unset({ id });
+		}
+
+		if (persisted.length === 0) {
+			return { succeeded: drafts, failed: [] };
+		}
+
+		semaphore.value.deleting.push(...persisted);
+
+		try {
+			const { data: responseBody, error } = await backend.client.POST(`/${MODULES_PREFIX}/${USERS_MODULE_PREFIX}/users/bulk-remove`, {
+				body: { data: { ids: persisted } },
+			});
+
+			if (typeof error !== 'undefined' || typeof responseBody === 'undefined') {
+				throw new UsersApiException('Received unexpected response.');
+			}
+
+			const result = UsersBulkResultSchema.parse(responseBody.data);
+
+			for (const id of result.succeeded) {
+				unset({ id });
+			}
+
+			return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+		} catch (e) {
+			throw new UsersApiException('Failed to remove users.', null, e as Error);
+		} finally {
+			semaphore.value.deleting = semaphore.value.deleting.filter((item) => !persisted.includes(item));
+		}
+	};
+
 	// Reconnect refresh contract: the store itself says whether it holds anything worth
 	// re-reading, so the caller never has to guess from a flag it does not maintain.
 	const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
@@ -462,6 +523,7 @@ export const useUsers = defineStore<'users_module-users', UsersStoreSetup>('user
 		edit,
 		save,
 		remove,
+		bulkRemove,
 	};
 });
 

--- a/apps/admin/src/modules/users/store/users.store.types.ts
+++ b/apps/admin/src/modules/users/store/users.store.types.ts
@@ -10,6 +10,8 @@ import {
 	UserSchema,
 	UserUpdateReqSchema,
 	UsersAddActionPayloadSchema,
+	UsersBulkRemoveActionPayloadSchema,
+	UsersBulkResultSchema,
 	UsersEditActionPayloadSchema,
 	UsersGetActionPayloadSchema,
 	UsersOnEventActionPayloadSchema,
@@ -44,6 +46,10 @@ export type IUsersEditActionPayload = z.infer<typeof UsersEditActionPayloadSchem
 
 export type IUsersSaveActionPayload = z.infer<typeof UsersSaveActionPayloadSchema>;
 
+export type IUsersBulkRemoveActionPayload = z.infer<typeof UsersBulkRemoveActionPayloadSchema>;
+
+export type IUsersBulkResult = z.infer<typeof UsersBulkResultSchema>;
+
 export type IUsersRemoveActionPayload = z.infer<typeof UsersRemoveActionPayloadSchema>;
 
 // STORE
@@ -72,6 +78,7 @@ export interface IUsersStoreActions {
 	edit: (payload: IUsersEditActionPayload) => Promise<IUser>;
 	save: (payload: IUsersSaveActionPayload) => Promise<IUser>;
 	remove: (payload: IUsersRemoveActionPayload) => Promise<boolean>;
+	bulkRemove: (payload: IUsersBulkRemoveActionPayload) => Promise<IUsersBulkResult>;
 	isLoaded: () => boolean;
 	refresh: () => Promise<unknown>;
 }

--- a/apps/admin/src/modules/weather/composables/useLocationsActions.ts
+++ b/apps/admin/src/modules/weather/composables/useLocationsActions.ts
@@ -79,28 +79,27 @@ export const useLocationsActions = (): IUseWeatherLocationsActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const location of locations) {
-				try {
-					await locationsStore.remove({ id: location.id });
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('weatherModule.messages.locations.bulkDeleted', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('weatherModule.messages.locations.bulkDeleteFailed', { count: failCount }));
-			}
 		} catch {
 			flashMessage.info(t('weatherModule.messages.locations.bulkDeleteCanceled'));
+
+			return;
+		}
+
+		// One request for the whole selection. Sending one per location tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await locationsStore.bulkRemove({ ids: locations.map((location) => location.id) });
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('weatherModule.messages.locations.bulkDeleted', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('weatherModule.messages.locations.bulkDeleteFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('weatherModule.messages.locations.bulkDeleteFailed', { count: locations.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/weather/store/locations.store.schemas.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.schemas.ts
@@ -96,6 +96,15 @@ export const WeatherLocationsSaveActionPayloadSchema = z.object({
 	id: ItemIdSchema,
 });
 
+export const WeatherLocationsBulkRemoveActionPayloadSchema = z.object({
+	ids: z.array(ItemIdSchema).nonempty(),
+});
+
+export const WeatherLocationsBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 export const WeatherLocationsRemoveActionPayloadSchema = z.object({
 	id: ItemIdSchema,
 });

--- a/apps/admin/src/modules/weather/store/locations.store.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.ts
@@ -12,6 +12,7 @@ import { WeatherApiException, WeatherValidationException } from '../weather.exce
 import {
 	WeatherLocationSchema,
 	WeatherLocationsAddActionPayloadSchema,
+	WeatherLocationsBulkResultSchema,
 	WeatherLocationsEditActionPayloadSchema,
 } from './locations.store.schemas';
 import type {
@@ -26,6 +27,8 @@ import type {
 	IWeatherLocationsEditActionPayload,
 	IWeatherLocationsSaveActionPayload,
 	IWeatherLocationsRemoveActionPayload,
+	IWeatherLocationsBulkRemoveActionPayload,
+	IWeatherLocationsBulkResult,
 	IWeatherLocationsStoreState,
 	IWeatherLocationsStoreActions,
 	WeatherLocationsStoreSetup,
@@ -486,6 +489,68 @@ export const useWeatherLocations = defineStore<'weather_module-locations', Weath
 			}
 		};
 
+		/**
+		 * Removes a selection in one request.
+		 *
+		 * The per-location alternative was one request each, which the backend's
+		 * shared rate limit rejects past thirty - so a large selection failed
+		 * halfway through with no way to tell which half. The outcome is reported
+		 * per location because the backend still refuses individual locations for
+		 * individual reasons, the configured primary one above all.
+		 */
+		const bulkRemove = async (
+			payload: IWeatherLocationsBulkRemoveActionPayload
+		): Promise<IWeatherLocationsBulkResult> => {
+			// Drafts were never sent to the backend, so they are dropped here and
+			// counted as done rather than handed to an endpoint that would correctly
+			// report them as unknown.
+			const drafts: string[] = [];
+			const persisted: string[] = [];
+
+			for (const id of payload.ids) {
+				const record = data.value[id];
+
+				if (typeof record === 'undefined') {
+					continue;
+				}
+
+				(record.draft ? drafts : persisted).push(id);
+			}
+
+			for (const id of drafts) {
+				unset({ id });
+			}
+
+			if (persisted.length === 0) {
+				return { succeeded: drafts, failed: [] };
+			}
+
+			semaphore.value.deleting.push(...persisted);
+
+			try {
+				const { data: responseBody, error } = await backend.client.POST(
+					`/${MODULES_PREFIX}/${WEATHER_MODULE_PREFIX}/locations/bulk-remove`,
+					{ body: { data: { ids: persisted } } }
+				);
+
+				if (typeof error !== 'undefined' || typeof responseBody === 'undefined') {
+					throw new WeatherApiException('Received unexpected response.');
+				}
+
+				const result = WeatherLocationsBulkResultSchema.parse(responseBody.data);
+
+				for (const id of result.succeeded) {
+					unset({ id });
+				}
+
+				return { succeeded: [...drafts, ...result.succeeded], failed: result.failed };
+			} catch (error: unknown) {
+				throw new WeatherApiException('Failed to remove locations.', null, error as Error);
+			} finally {
+				semaphore.value.deleting = semaphore.value.deleting.filter((item) => !persisted.includes(item));
+			}
+		};
+
 		// Reconnect refresh contract: the store itself says whether it holds anything worth
 		// re-reading, so the caller never has to guess from a flag it does not maintain.
 		const isLoaded = (): boolean => firstLoadFinished() || findAll().length > 0;
@@ -512,6 +577,7 @@ export const useWeatherLocations = defineStore<'weather_module-locations', Weath
 			edit,
 			save,
 			remove,
+			bulkRemove,
 		};
 	}
 );

--- a/apps/admin/src/modules/weather/store/locations.store.types.ts
+++ b/apps/admin/src/modules/weather/store/locations.store.types.ts
@@ -13,6 +13,8 @@ import type {
 	WeatherLocationsAddActionPayloadSchema,
 	WeatherLocationsEditActionPayloadSchema,
 	WeatherLocationsSaveActionPayloadSchema,
+	WeatherLocationsBulkRemoveActionPayloadSchema,
+	WeatherLocationsBulkResultSchema,
 	WeatherLocationsRemoveActionPayloadSchema,
 	WeatherLocationResSchema,
 	WeatherLocationCreateReqSchema,
@@ -44,6 +46,10 @@ export type IWeatherLocationsAddActionPayload = z.infer<typeof WeatherLocationsA
 export type IWeatherLocationsEditActionPayload = z.infer<typeof WeatherLocationsEditActionPayloadSchema>;
 
 export type IWeatherLocationsSaveActionPayload = z.infer<typeof WeatherLocationsSaveActionPayloadSchema>;
+
+export type IWeatherLocationsBulkRemoveActionPayload = z.infer<typeof WeatherLocationsBulkRemoveActionPayloadSchema>;
+
+export type IWeatherLocationsBulkResult = z.infer<typeof WeatherLocationsBulkResultSchema>;
 
 export type IWeatherLocationsRemoveActionPayload = z.infer<typeof WeatherLocationsRemoveActionPayloadSchema>;
 
@@ -89,6 +95,7 @@ export interface IWeatherLocationsStoreActions {
 	edit: (payload: IWeatherLocationsEditActionPayload) => Promise<IWeatherLocation>;
 	save: (payload: IWeatherLocationsSaveActionPayload) => Promise<IWeatherLocation>;
 	remove: (payload: IWeatherLocationsRemoveActionPayload) => Promise<boolean>;
+	bulkRemove: (payload: IWeatherLocationsBulkRemoveActionPayload) => Promise<IWeatherLocationsBulkResult>;
 	isLoaded: () => boolean;
 	refresh: () => Promise<unknown>;
 }

--- a/apps/backend/src/modules/dashboard/controllers/pages.controller.spec.ts
+++ b/apps/backend/src/modules/dashboard/controllers/pages.controller.spec.ts
@@ -20,6 +20,7 @@ import { CreatePageDto } from '../dto/create-page.dto';
 import { UpdatePageDto } from '../dto/update-page.dto';
 import { PageEntity } from '../entities/dashboard.entity';
 import { DataSourcesTypeMapperService } from '../services/data-source-type-mapper.service';
+import { PagesBulkService } from '../services/pages-bulk.service';
 import { PagesTypeMapperService } from '../services/pages-type-mapper.service';
 import { PagesService } from '../services/pages.service';
 import { TilesTypeMapperService } from '../services/tiles-type-mapper.service';
@@ -151,6 +152,12 @@ describe('PagesController', () => {
 						create: jest.fn().mockResolvedValue(toInstance(MockPageEntity, mockPageOne)),
 						update: jest.fn().mockResolvedValue(toInstance(MockPageEntity, mockPageOne)),
 						remove: jest.fn().mockResolvedValue(undefined),
+					},
+				},
+				{
+					provide: PagesBulkService,
+					useValue: {
+						remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
 					},
 				},
 			],

--- a/apps/backend/src/modules/dashboard/controllers/pages.controller.ts
+++ b/apps/backend/src/modules/dashboard/controllers/pages.controller.ts
@@ -33,10 +33,12 @@ import {
 } from '../../swagger/decorators/api-documentation.decorator';
 import { DASHBOARD_MODULE_API_TAG_NAME, DASHBOARD_MODULE_NAME, DASHBOARD_MODULE_PREFIX } from '../dashboard.constants';
 import { DashboardException } from '../dashboard.exceptions';
+import { ReqBulkRemovePagesDto } from '../dto/bulk-pages.dto';
 import { CreatePageDto, ReqCreatePageDto } from '../dto/create-page.dto';
 import { ReqUpdatePageDto, UpdatePageDto } from '../dto/update-page.dto';
 import { PageEntity } from '../entities/dashboard.entity';
-import { PageResponseModel, PagesResponseModel } from '../models/dashboard-response.model';
+import { BulkResultResponseModel, PageResponseModel, PagesResponseModel } from '../models/dashboard-response.model';
+import { PagesBulkService } from '../services/pages-bulk.service';
 import { PageTypeMapping, PagesTypeMapperService } from '../services/pages-type-mapper.service';
 import { PagesService } from '../services/pages.service';
 
@@ -48,6 +50,7 @@ export class PagesController {
 	constructor(
 		private readonly pagesService: PagesService,
 		private readonly pagesMapperService: PagesTypeMapperService,
+		private readonly pagesBulkService: PagesBulkService,
 	) {}
 
 	// Pages
@@ -302,6 +305,27 @@ export class PagesController {
 		await this.pagesService.remove(page.id);
 
 		this.logger.debug(`Successfully deleted page id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [DASHBOARD_MODULE_API_TAG_NAME],
+		summary: 'Remove several pages',
+		description:
+			'Removes every page in the supplied selection. Each page is processed independently, so a page that can not be removed is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per page.',
+		operationId: 'create-dashboard-module-pages-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemovePagesDto, description: 'The pages to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which pages were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('bulk-remove')
+	@HttpCode(200)
+	async bulkRemove(@Body() body: ReqBulkRemovePagesDto): Promise<BulkResultResponseModel> {
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.pagesBulkService.remove(body.data.ids);
+
+		return response;
 	}
 
 	private async getOneOrThrow(id: string): Promise<PageEntity> {

--- a/apps/backend/src/modules/dashboard/dashboard.module.ts
+++ b/apps/backend/src/modules/dashboard/dashboard.module.ts
@@ -35,6 +35,7 @@ import { DataSourcesService } from './services/data-sources.service';
 import { ModuleResetService } from './services/module-reset.service';
 import { PageCreateBuilderRegistryService } from './services/page-create-builder-registry.service';
 import { PageRelationsLoaderRegistryService } from './services/page-relations-loader-registry.service';
+import { PagesBulkService } from './services/pages-bulk.service';
 import { PagesTypeMapperService } from './services/pages-type-mapper.service';
 import { PagesService } from './services/pages.service';
 import { TileCreateBuilderRegistryService } from './services/tile-create-builder-registry.service';
@@ -60,6 +61,7 @@ import { TileTypeConstraintValidator } from './validators/tile-type-constraint.v
 	],
 	providers: [
 		PagesService,
+		PagesBulkService,
 		TilesService,
 		DataSourcesService,
 		PagesTypeMapperService,

--- a/apps/backend/src/modules/dashboard/dashboard.openapi.ts
+++ b/apps/backend/src/modules/dashboard/dashboard.openapi.ts
@@ -6,6 +6,7 @@ import { CreateTileDto } from './dto/create-tile.dto';
 import { UpdateDataSourceDto } from './dto/update-data-source.dto';
 import { UpdateTileDto } from './dto/update-tile.dto';
 import {
+	BulkResultResponseModel,
 	DataSourceResponseModel,
 	DataSourcesResponseModel,
 	PageResponseModel,
@@ -27,6 +28,7 @@ export const DASHBOARD_SWAGGER_EXTRA_MODELS = [
 	UpdateDataSourceDto,
 	UpdateTileDto,
 	// Response models
+	BulkResultResponseModel,
 	PageResponseModel,
 	PagesResponseModel,
 	TileResponseModel,

--- a/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.ts
+++ b/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.ts
@@ -1,0 +1,37 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_PAGES_MAX_IDS = 500;
+
+@ApiSchema({ name: 'DashboardModuleBulkRemovePages' })
+export class BulkRemovePagesDto {
+	@ApiProperty({
+		description: 'Identifiers of the pages to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one page identifier is required."}]' })
+	@ArrayMaxSize(BULK_PAGES_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_PAGES_MAX_IDS} page identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each page identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'DashboardModuleReqBulkRemovePages' })
+export class ReqBulkRemovePagesDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemovePagesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemovePagesDto)
+	data: BulkRemovePagesDto;
+}

--- a/apps/backend/src/modules/dashboard/models/dashboard-response.model.ts
+++ b/apps/backend/src/modules/dashboard/models/dashboard-response.model.ts
@@ -3,6 +3,7 @@ import { Expose } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 import { DataSourceEntity, PageEntity, TileEntity } from '../entities/dashboard.entity';
 
 /**
@@ -84,4 +85,17 @@ export class DataSourcesResponseModel extends BaseSuccessResponseModel<DataSourc
 	})
 	@Expose()
 	declare data: DataSourceEntity[];
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'DashboardModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/dashboard/services/pages-bulk.service.spec.ts
+++ b/apps/backend/src/modules/dashboard/services/pages-bulk.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PagesBulkService } from './pages-bulk.service';
+import { PagesService } from './pages.service';
+
+describe('PagesBulkService', () => {
+	let service: PagesBulkService;
+	let pagesService: { remove: jest.Mock };
+
+	beforeEach(async () => {
+		pagesService = {
+			remove: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [PagesBulkService, { provide: PagesService, useValue: pagesService }],
+		}).compile();
+
+		service = module.get<PagesBulkService>(PagesBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every page in the selection', async () => {
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(pagesService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// A page the module refuses to delete - a missing one - explains why, and
+		// that explanation is more use to the operator than "failed".
+		it('carries the service refusal through as the reason', async () => {
+			pagesService.remove.mockImplementation((id: string) =>
+				id === 'b' ? Promise.reject(new Error('Requested page does not exist')) : Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Requested page does not exist' }]);
+		});
+	});
+});

--- a/apps/backend/src/modules/dashboard/services/pages-bulk.service.ts
+++ b/apps/backend/src/modules/dashboard/services/pages-bulk.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { DASHBOARD_MODULE_NAME } from '../dashboard.constants';
+
+import { PagesService } from './pages.service';
+
+/**
+ * Runs a page operation across a selection in a single request.
+ *
+ * The per-page semantics, including each refusal, are meant to be identical to
+ * the single-page endpoints - see runBulkOperation for why the work is still
+ * performed one page at a time.
+ */
+@Injectable()
+export class PagesBulkService {
+	private readonly logger = createExtensionLogger(DASHBOARD_MODULE_NAME, 'PagesBulkService');
+
+	constructor(private readonly pagesService: PagesService) {}
+
+	async remove(ids: string[]): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			ids,
+			// The service raises for a missing page with a reason worth reading, and
+			// runBulkOperation carries that through per item.
+			(id) => this.pagesService.remove(id),
+			'Page could not be removed',
+		);
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+}

--- a/apps/backend/src/modules/displays/controllers/displays.controller.spec.ts
+++ b/apps/backend/src/modules/displays/controllers/displays.controller.spec.ts
@@ -17,6 +17,7 @@ import { TokensService } from '../../auth/services/tokens.service';
 import { ConnectionState, HomeMode } from '../displays.constants';
 import { DisplaysNotFoundException } from '../displays.exceptions';
 import { DisplayEntity } from '../entities/displays.entity';
+import { DisplaysBulkService } from '../services/displays-bulk.service';
 import { DisplaysService } from '../services/displays.service';
 import { HomeResolutionService } from '../services/home-resolution.service';
 import { PermitJoinService } from '../services/permit-join.service';
@@ -28,6 +29,7 @@ describe('DisplaysController', () => {
 	let controller: DisplaysController;
 	let service: DisplaysService;
 	let tokensService: TokensService;
+	let bulkService: DisplaysBulkService;
 
 	const mockDisplay: DisplayEntity = {
 		id: uuid().toString(),
@@ -165,6 +167,12 @@ describe('DisplaysController', () => {
 					},
 				},
 				{
+					provide: DisplaysBulkService,
+					useValue: {
+						remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+					},
+				},
+				{
 					provide: EventEmitter2,
 					useValue: {
 						emit: jest.fn(),
@@ -176,6 +184,7 @@ describe('DisplaysController', () => {
 		controller = module.get<DisplaysController>(DisplaysController);
 		service = module.get<DisplaysService>(DisplaysService);
 		tokensService = module.get<TokensService>(TokensService);
+		bulkService = module.get<DisplaysBulkService>(DisplaysBulkService);
 	});
 
 	afterEach(() => {
@@ -350,6 +359,37 @@ describe('DisplaysController', () => {
 			jest.spyOn(service, 'getOneOrThrow').mockRejectedValue(new DisplaysNotFoundException('Display not found'));
 
 			await expect(controller.revokeToken('non-existent-id')).rejects.toThrow(DisplaysNotFoundException);
+		});
+	});
+
+	describe('bulkRemove', () => {
+		it('should hand the whole selection to the bulk service in one call', async () => {
+			const ids = [uuid().toString(), uuid().toString(), uuid().toString()];
+
+			jest.spyOn(bulkService, 'remove').mockResolvedValue({ succeeded: ids, failed: [] });
+
+			const result = await controller.bulkRemove({ data: { ids } });
+
+			expect(bulkService.remove).toHaveBeenCalledTimes(1);
+			expect(bulkService.remove).toHaveBeenCalledWith(ids);
+			expect(result.data.succeeded).toEqual(ids);
+		});
+
+		// A display the backend refused belongs in the response, not in an
+		// exception: the rest of the selection went through and the caller has to
+		// be able to say so.
+		it('should report refusals in the response rather than throwing', async () => {
+			const ids = [uuid().toString(), uuid().toString()];
+
+			jest.spyOn(bulkService, 'remove').mockResolvedValue({
+				succeeded: [ids[0]],
+				failed: [{ id: ids[1], reason: 'Requested display does not exist' }],
+			});
+
+			const result = await controller.bulkRemove({ data: { ids } });
+
+			expect(result.data.succeeded).toEqual([ids[0]]);
+			expect(result.data.failed).toEqual([{ id: ids[1], reason: 'Requested display does not exist' }]);
 		});
 	});
 });

--- a/apps/backend/src/modules/displays/controllers/displays.controller.ts
+++ b/apps/backend/src/modules/displays/controllers/displays.controller.ts
@@ -13,7 +13,7 @@ import {
 	Req,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { TokenOwnerType } from '../../auth/auth.constants';
@@ -22,6 +22,7 @@ import { TokensService } from '../../auth/services/tokens.service';
 import {
 	ApiBadRequestResponse,
 	ApiForbiddenResponse,
+	ApiInternalServerErrorResponse,
 	ApiNotFoundResponse,
 	ApiSuccessResponse,
 	ApiUnprocessableEntityResponse,
@@ -29,8 +30,10 @@ import {
 import { Roles } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
 import { DISPLAYS_MODULE_API_TAG_NAME, DISPLAYS_MODULE_NAME, DeploymentMode, EventType } from '../displays.constants';
+import { ReqBulkRemoveDisplaysDto } from '../dto/bulk-displays.dto';
 import { ReqUpdateDisplayDto } from '../dto/update-display.dto';
 import {
+	BulkResultResponseModel,
 	DisplayResponseModel,
 	DisplayTokenRefreshDataModel,
 	DisplayTokenRefreshResponseModel,
@@ -41,6 +44,7 @@ import {
 	PermitJoinStatusDataModel,
 	PermitJoinStatusResponseModel,
 } from '../models/displays-response.model';
+import { DisplaysBulkService } from '../services/displays-bulk.service';
 import { DisplaysService } from '../services/displays.service';
 import { HomeResolutionService } from '../services/home-resolution.service';
 import { PermitJoinService } from '../services/permit-join.service';
@@ -57,6 +61,7 @@ export class DisplaysController {
 		private readonly registrationService: RegistrationService,
 		private readonly permitJoinService: PermitJoinService,
 		private readonly homeResolutionService: HomeResolutionService,
+		private readonly displaysBulkService: DisplaysBulkService,
 		private readonly eventEmitter: EventEmitter2,
 	) {}
 
@@ -290,6 +295,30 @@ export class DisplaysController {
 		await this.displaysService.remove(id);
 
 		this.logger.debug(`Successfully removed display with id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [DISPLAYS_MODULE_API_TAG_NAME],
+		summary: 'Remove several displays',
+		description:
+			'Removes every display in the supplied selection. Each display is processed independently, so a display that can not be removed is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per display. Requires owner or admin role.',
+		operationId: 'create-displays-module-displays-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemoveDisplaysDto, description: 'The displays to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which displays were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Roles(UserRole.OWNER, UserRole.ADMIN)
+	@Post('bulk-remove')
+	@HttpCode(200)
+	async bulkRemove(@Body() body: ReqBulkRemoveDisplaysDto): Promise<BulkResultResponseModel> {
+		this.logger.debug(`Removing ${body.data.ids.length} display(s)`);
+
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.displaysBulkService.remove(body.data.ids);
+
+		return response;
 	}
 
 	@Get(':id/tokens')

--- a/apps/backend/src/modules/displays/displays.module.ts
+++ b/apps/backend/src/modules/displays/displays.module.ts
@@ -28,6 +28,7 @@ import { RegistrationGuard } from './guards/registration.guard';
 import { WebsocketExchangeListener } from './listeners/websocket-exchange.listener';
 import { DisplaysConfigModel } from './models/config.model';
 import { DisplayConnectionStateService } from './services/display-connection-state.service';
+import { DisplaysBulkService } from './services/displays-bulk.service';
 import { DisplaysService } from './services/displays.service';
 import { HomeResolutionService } from './services/home-resolution.service';
 import { DisplaysModuleResetService } from './services/module-reset.service';
@@ -53,6 +54,7 @@ import { DisplayExistsConstraint } from './validators/display-exists-constraint.
 	controllers: [DisplaysController, RegistrationController],
 	providers: [
 		DisplaysService,
+		DisplaysBulkService,
 		RegistrationService,
 		DisplaysModuleResetService,
 		DisplayExistsConstraint,
@@ -67,6 +69,7 @@ import { DisplayExistsConstraint } from './validators/display-exists-constraint.
 	],
 	exports: [
 		DisplaysService,
+		DisplaysBulkService,
 		DisplaysModuleResetService,
 		DisplayExistsConstraint,
 		PermitJoinService,

--- a/apps/backend/src/modules/displays/displays.openapi.ts
+++ b/apps/backend/src/modules/displays/displays.openapi.ts
@@ -5,6 +5,7 @@ import { RegisterDisplayDto, ReqRegisterDisplayDto } from './dto/register-displa
 import { ReqUpdateDisplayDto, UpdateDisplayDto } from './dto/update-display.dto';
 import { DisplayEntity } from './entities/displays.entity';
 import {
+	BulkResultResponseModel,
 	DisplayRegistrationDataModel,
 	DisplayRegistrationResponseModel,
 	DisplayResponseModel,
@@ -27,6 +28,7 @@ export const DISPLAYS_SWAGGER_EXTRA_MODELS = [
 	UpdateDisplayDto,
 	ReqUpdateDisplayDto,
 	// Response models
+	BulkResultResponseModel,
 	DisplayResponseModel,
 	DisplaysResponseModel,
 	DisplayRegistrationDataModel,

--- a/apps/backend/src/modules/displays/dto/bulk-displays.dto.ts
+++ b/apps/backend/src/modules/displays/dto/bulk-displays.dto.ts
@@ -1,0 +1,37 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_DISPLAYS_MAX_IDS = 500;
+
+@ApiSchema({ name: 'DisplaysModuleBulkRemoveDisplays' })
+export class BulkRemoveDisplaysDto {
+	@ApiProperty({
+		description: 'Identifiers of the displays to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one display identifier is required."}]' })
+	@ArrayMaxSize(BULK_DISPLAYS_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_DISPLAYS_MAX_IDS} display identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each display identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'DisplaysModuleReqBulkRemoveDisplays' })
+export class ReqBulkRemoveDisplaysDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveDisplaysDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemoveDisplaysDto)
+	data: BulkRemoveDisplaysDto;
+}

--- a/apps/backend/src/modules/displays/models/displays-response.model.ts
+++ b/apps/backend/src/modules/displays/models/displays-response.model.ts
@@ -3,6 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 import { LongLiveTokenEntity } from '../../auth/entities/auth.entity';
 import { DisplayEntity } from '../entities/displays.entity';
 
@@ -275,4 +276,17 @@ export class RegistrationStatusResponseModel extends BaseSuccessResponseModel<Re
 	@Expose()
 	@Type(() => RegistrationStatusDataModel)
 	declare data: RegistrationStatusDataModel;
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'DisplaysModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/displays/services/displays-bulk.service.spec.ts
+++ b/apps/backend/src/modules/displays/services/displays-bulk.service.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DisplaysBulkService } from './displays-bulk.service';
+import { DisplaysService } from './displays.service';
+
+describe('DisplaysBulkService', () => {
+	let service: DisplaysBulkService;
+	let displaysService: { remove: jest.Mock };
+
+	beforeEach(async () => {
+		displaysService = {
+			remove: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [DisplaysBulkService, { provide: DisplaysService, useValue: displaysService }],
+		}).compile();
+
+		service = module.get<DisplaysBulkService>(DisplaysBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every display in the selection', async () => {
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(displaysService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// A display the module refuses to delete - one that is no longer there -
+		// explains why, and that explanation is more use to the operator than
+		// "failed".
+		it('carries the service refusal through as the reason', async () => {
+			displaysService.remove.mockImplementation((id: string) =>
+				id === 'b' ? Promise.reject(new Error('Requested display does not exist')) : Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Requested display does not exist' }]);
+		});
+	});
+});

--- a/apps/backend/src/modules/displays/services/displays-bulk.service.ts
+++ b/apps/backend/src/modules/displays/services/displays-bulk.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { DISPLAYS_MODULE_NAME } from '../displays.constants';
+
+import { DisplaysService } from './displays.service';
+
+/**
+ * Runs a display operation across a selection in a single request.
+ *
+ * The per-display semantics, including each refusal, are meant to be identical
+ * to the single-display endpoints - see runBulkOperation for why the work is
+ * still performed one display at a time.
+ */
+@Injectable()
+export class DisplaysBulkService {
+	private readonly logger = createExtensionLogger(DISPLAYS_MODULE_NAME, 'DisplaysBulkService');
+
+	constructor(private readonly displaysService: DisplaysService) {}
+
+	async remove(ids: string[]): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			ids,
+			// The service raises for a display that is not there with a reason worth
+			// reading, and runBulkOperation carries that through per item.
+			(id) => this.displaysService.remove(id),
+			'Display could not be removed',
+		);
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+}

--- a/apps/backend/src/modules/spaces/controllers/spaces.controller.spec.ts
+++ b/apps/backend/src/modules/spaces/controllers/spaces.controller.spec.ts
@@ -16,9 +16,11 @@ import { DevicesNotAllowedException } from '../../devices/devices.exceptions';
 import { DeviceEntity } from '../../devices/entities/devices.entity';
 import { DisplayEntity } from '../../displays/entities/displays.entity';
 import { ReqBulkAssignDto } from '../dto/bulk-assign.dto';
+import { ReqBulkRemoveSpacesDto } from '../dto/bulk-spaces.dto';
 import { ReqCreateSpaceDto } from '../dto/create-space.dto';
 import { ReqUpdateSpaceDto } from '../dto/update-space.dto';
 import { SpaceEntity } from '../entities/space.entity';
+import { SpacesBulkService } from '../services/spaces-bulk.service';
 import { SpacesService } from '../services/spaces.service';
 import { SpaceType } from '../spaces.constants';
 import { SpacesNotFoundException, SpacesValidationException } from '../spaces.exceptions';
@@ -28,6 +30,7 @@ import { SpacesController } from './spaces.controller';
 describe('SpacesController', () => {
 	let controller: SpacesController;
 	let spacesService: SpacesService;
+	let spacesBulkService: SpacesBulkService;
 
 	const mockSpace: SpaceEntity = {
 		id: uuid().toString(),
@@ -76,11 +79,18 @@ describe('SpacesController', () => {
 						bulkAssign: jest.fn().mockResolvedValue({ devicesAssigned: 2, displaysAssigned: 1 }),
 					},
 				},
+				{
+					provide: SpacesBulkService,
+					useValue: {
+						remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+					},
+				},
 			],
 		}).compile();
 
 		controller = module.get<SpacesController>(SpacesController);
 		spacesService = module.get<SpacesService>(SpacesService);
+		spacesBulkService = module.get<SpacesBulkService>(SpacesBulkService);
 	});
 
 	it('should be defined', () => {
@@ -239,6 +249,24 @@ describe('SpacesController', () => {
 			jest.spyOn(spacesService, 'remove').mockRejectedValue(new SpacesNotFoundException('Not found'));
 
 			await expect(controller.remove('non-existent-id')).rejects.toThrow(SpacesNotFoundException);
+		});
+	});
+
+	describe('bulkRemove', () => {
+		it('should return the per-space outcome of the removal', async () => {
+			const removed = uuid();
+			const refused = uuid();
+
+			jest.spyOn(spacesBulkService, 'remove').mockResolvedValue({
+				succeeded: [removed],
+				failed: [{ id: refused, reason: 'Requested space does not exist' }],
+			});
+
+			const result = await controller.bulkRemove({ data: { ids: [removed, refused] } } as ReqBulkRemoveSpacesDto);
+
+			expect(result.data.succeeded).toEqual([removed]);
+			expect(result.data.failed).toEqual([{ id: refused, reason: 'Requested space does not exist' }]);
+			expect(spacesBulkService.remove).toHaveBeenCalledWith([removed, refused]);
 		});
 	});
 

--- a/apps/backend/src/modules/spaces/controllers/spaces.controller.ts
+++ b/apps/backend/src/modules/spaces/controllers/spaces.controller.ts
@@ -19,6 +19,7 @@ import { DevicesResponseModel } from '../../devices/models/devices-response.mode
 import { DisplaysResponseModel } from '../../displays/models/displays-response.model';
 import {
 	ApiBadRequestResponse,
+	ApiInternalServerErrorResponse,
 	ApiNotFoundResponse,
 	ApiSuccessResponse,
 	ApiUnprocessableEntityResponse,
@@ -26,14 +27,17 @@ import {
 import { Roles } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
 import { ReqBulkAssignDto } from '../dto/bulk-assign.dto';
+import { ReqBulkRemoveSpacesDto } from '../dto/bulk-spaces.dto';
 import { ReqCreateSpaceDto } from '../dto/create-space.dto';
 import { ReqUpdateSpaceDto } from '../dto/update-space.dto';
 import {
 	BulkAssignmentResponseModel,
 	BulkAssignmentResultDataModel,
+	BulkResultResponseModel,
 	SpaceResponseModel,
 	SpacesResponseModel,
 } from '../models/spaces-response.model';
+import { SpacesBulkService } from '../services/spaces-bulk.service';
 import { SpacesService } from '../services/spaces.service';
 import { SPACES_MODULE_API_TAG_NAME, SPACES_MODULE_NAME } from '../spaces.constants';
 
@@ -42,7 +46,10 @@ import { SPACES_MODULE_API_TAG_NAME, SPACES_MODULE_NAME } from '../spaces.consta
 export class SpacesController {
 	private readonly logger = createExtensionLogger(SPACES_MODULE_NAME, 'SpacesController');
 
-	constructor(private readonly spacesService: SpacesService) {}
+	constructor(
+		private readonly spacesService: SpacesService,
+		private readonly spacesBulkService: SpacesBulkService,
+	) {}
 
 	@Get()
 	@ApiOperation({
@@ -196,6 +203,32 @@ export class SpacesController {
 		await this.spacesService.remove(id);
 
 		this.logger.debug(`Successfully removed space with id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [SPACES_MODULE_API_TAG_NAME],
+		summary: 'Remove several spaces',
+		description:
+			'Removes every space in the supplied selection. Each space is processed independently, so a space that can not be removed is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per space. Requires owner or admin role.',
+		operationId: 'create-spaces-module-spaces-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemoveSpacesDto, description: 'The spaces to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which spaces were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('bulk-remove')
+	// The single delete is owner/admin only, so the bulk form has to be too - without
+	// this the endpoint would be a way around that check.
+	@Roles(UserRole.OWNER, UserRole.ADMIN)
+	@HttpCode(200)
+	async bulkRemove(@Body() body: ReqBulkRemoveSpacesDto): Promise<BulkResultResponseModel> {
+		this.logger.debug(`Incoming request to remove ${body.data.ids.length} space(s)`);
+
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.spacesBulkService.remove(body.data.ids);
+
+		return response;
 	}
 
 	@Get(':id/devices')

--- a/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.ts
+++ b/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.ts
@@ -1,0 +1,37 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_SPACES_MAX_IDS = 500;
+
+@ApiSchema({ name: 'SpacesModuleBulkRemoveSpaces' })
+export class BulkRemoveSpacesDto {
+	@ApiProperty({
+		description: 'Identifiers of the spaces to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one space identifier is required."}]' })
+	@ArrayMaxSize(BULK_SPACES_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_SPACES_MAX_IDS} space identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each space identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'SpacesModuleReqBulkRemoveSpaces' })
+export class ReqBulkRemoveSpacesDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveSpacesDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemoveSpacesDto)
+	data: BulkRemoveSpacesDto;
+}

--- a/apps/backend/src/modules/spaces/models/spaces-response.model.ts
+++ b/apps/backend/src/modules/spaces/models/spaces-response.model.ts
@@ -3,6 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 import { SpaceEntity } from '../entities/space.entity';
 import { ALL_SPACE_CATEGORIES, SpaceRoomCategory, SpaceZoneCategory } from '../spaces.constants';
 
@@ -103,6 +104,19 @@ export class BulkAssignmentResponseModel extends BaseSuccessResponseModel<BulkAs
 	@Expose()
 	@Type(() => BulkAssignmentResultDataModel)
 	declare data: BulkAssignmentResultDataModel;
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'SpacesModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }
 
 // ================================

--- a/apps/backend/src/modules/spaces/services/spaces-bulk.service.spec.ts
+++ b/apps/backend/src/modules/spaces/services/spaces-bulk.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { SpacesNotFoundException } from '../spaces.exceptions';
+
+import { SpacesBulkService } from './spaces-bulk.service';
+import { SpacesService } from './spaces.service';
+
+describe('SpacesBulkService', () => {
+	let service: SpacesBulkService;
+	let spacesService: { remove: jest.Mock };
+
+	beforeEach(async () => {
+		spacesService = {
+			remove: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [SpacesBulkService, { provide: SpacesService, useValue: spacesService }],
+		}).compile();
+
+		service = module.get<SpacesBulkService>(SpacesBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every space in the selection', async () => {
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(spacesService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// A space the module refuses to remove - one that is already gone - explains
+		// why, and that explanation is more use to the operator than "failed". The
+		// refusal is an HttpException rather than a plain Error, so this also pins
+		// that its message is what reaches the caller.
+		it('carries the service refusal through as the reason', async () => {
+			spacesService.remove.mockImplementation((id: string) =>
+				id === 'b' ? Promise.reject(new SpacesNotFoundException('Requested space does not exist')) : Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Requested space does not exist' }]);
+		});
+	});
+});

--- a/apps/backend/src/modules/spaces/services/spaces-bulk.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces-bulk.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { SPACES_MODULE_NAME } from '../spaces.constants';
+
+import { SpacesService } from './spaces.service';
+
+/**
+ * Removes a selection of spaces in a single request.
+ *
+ * The per-space semantics, including each refusal, are meant to be identical to
+ * the single-space endpoint - see runBulkOperation for why the work is still
+ * performed one space at a time.
+ */
+@Injectable()
+export class SpacesBulkService {
+	private readonly logger = createExtensionLogger(SPACES_MODULE_NAME, 'SpacesBulkService');
+
+	constructor(private readonly spacesService: SpacesService) {}
+
+	async remove(ids: string[]): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			ids,
+			// The service raises for a missing space with a reason worth reading, and
+			// runBulkOperation carries that through per item.
+			(id) => this.spacesService.remove(id),
+			'Space could not be removed',
+		);
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+}

--- a/apps/backend/src/modules/spaces/spaces.module.ts
+++ b/apps/backend/src/modules/spaces/spaces.module.ts
@@ -31,6 +31,7 @@ import { SpacesModuleResetService } from './services/module-reset.service';
 import { SpaceCreateBuilderRegistryService } from './services/space-create-builder-registry.service';
 import { SpaceRelationsLoaderRegistryService } from './services/space-relations-loader-registry.service';
 import { SpaceRolesTypeMapperService } from './services/space-roles-type-mapper.service';
+import { SpacesBulkService } from './services/spaces-bulk.service';
 import { SpacesTypeMapperService } from './services/spaces-type-mapper.service';
 import { SpacesService } from './services/spaces.service';
 import { SPACES_MODULE_API_TAG_DESCRIPTION, SPACES_MODULE_API_TAG_NAME, SPACES_MODULE_NAME } from './spaces.constants';
@@ -72,6 +73,7 @@ import { SPACES_SWAGGER_EXTRA_MODELS } from './spaces.openapi';
 	controllers: [SpacesController, SpacesDomainController],
 	providers: [
 		SpacesService,
+		SpacesBulkService,
 		SpacesTypeMapperService,
 		SpaceRolesTypeMapperService,
 		SpaceCreateBuilderRegistryService,
@@ -80,6 +82,7 @@ import { SPACES_SWAGGER_EXTRA_MODELS } from './spaces.openapi';
 	],
 	exports: [
 		SpacesService,
+		SpacesBulkService,
 		SpacesTypeMapperService,
 		SpaceRolesTypeMapperService,
 		SpaceCreateBuilderRegistryService,

--- a/apps/backend/src/modules/spaces/spaces.openapi.ts
+++ b/apps/backend/src/modules/spaces/spaces.openapi.ts
@@ -9,6 +9,7 @@ import {
 	BulkAssignmentDataModel,
 	BulkAssignmentResponseModel,
 	BulkAssignmentResultDataModel,
+	BulkResultResponseModel,
 	CategoryTemplateDataModel,
 	CategoryTemplatesResponseModel,
 	SpaceResponseModel,
@@ -29,6 +30,7 @@ export const SPACES_SWAGGER_EXTRA_MODELS = [
 	BulkAssignmentDataModel,
 	BulkAssignmentResultDataModel,
 	BulkAssignmentResponseModel,
+	BulkResultResponseModel,
 	CategoryTemplateDataModel,
 	CategoryTemplatesResponseModel,
 	// Entities

--- a/apps/backend/src/modules/users/controllers/users.controller.spec.ts
+++ b/apps/backend/src/modules/users/controllers/users.controller.spec.ts
@@ -16,6 +16,7 @@ import { AuthenticatedRequest } from '../../auth/guards/auth.guard';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserEntity } from '../entities/users.entity';
+import { UsersBulkService } from '../services/users-bulk.service';
 import { UsersService } from '../services/users.service';
 import { USERS_MODULE_PREFIX, UserRole } from '../users.constants';
 
@@ -49,6 +50,10 @@ describe('UsersController', () => {
 		findByEmail: jest.fn().mockResolvedValue(null),
 	};
 
+	const mockUsersBulkService = {
+		remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+	};
+
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UsersController],
@@ -56,6 +61,10 @@ describe('UsersController', () => {
 				{
 					provide: UsersService,
 					useValue: mockUserService,
+				},
+				{
+					provide: UsersBulkService,
+					useValue: mockUsersBulkService,
 				},
 			],
 		}).compile();
@@ -170,6 +179,40 @@ describe('UsersController', () => {
 			await expect(controller.remove('invalid-id', requestMock as unknown as AuthenticatedRequest)).rejects.toThrow(
 				NotFoundException,
 			);
+		});
+	});
+
+	// The two delete protections live in this controller, not in UsersService, so
+	// the bulk route has to hand the caller down for the self-deletion rule to
+	// survive at all. Without this, passing `null` there would disable that
+	// protection with every service-level test still green.
+	describe('bulkRemove', () => {
+		it('hands the authenticated user down so the self-deletion rule still applies', async () => {
+			const ids = [uuid().toString(), uuid().toString()];
+
+			await controller.bulkRemove(
+				{ data: { ids } } as never,
+				{
+					auth: { type: 'user', id: 'caller-id' },
+				} as never,
+			);
+
+			expect(mockUsersBulkService.remove).toHaveBeenCalledWith(ids, 'caller-id');
+		});
+
+		// A long-lived token acts as its owner, which is how the single delete
+		// route resolves it too.
+		it('resolves a long-lived token to its owner', async () => {
+			const ids = [uuid().toString()];
+
+			await controller.bulkRemove(
+				{ data: { ids } } as never,
+				{
+					auth: { type: 'token', ownerId: 'owner-id' },
+				} as never,
+			);
+
+			expect(mockUsersBulkService.remove).toHaveBeenCalledWith(ids, 'owner-id');
 		});
 	});
 });

--- a/apps/backend/src/modules/users/controllers/users.controller.ts
+++ b/apps/backend/src/modules/users/controllers/users.controller.ts
@@ -5,6 +5,7 @@ import {
 	Controller,
 	Delete,
 	Get,
+	HttpCode,
 	NotFoundException,
 	Param,
 	ParseUUIDPipe,
@@ -14,7 +15,7 @@ import {
 	Res,
 	UnprocessableEntityException,
 } from '@nestjs/common';
-import { ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { setLocationHeader } from '../../api/utils/location-header.utils';
@@ -27,11 +28,13 @@ import {
 	ApiSuccessResponse,
 	ApiUnprocessableEntityResponse,
 } from '../../swagger/decorators/api-documentation.decorator';
+import { ReqBulkRemoveUsersDto } from '../dto/bulk-users.dto';
 import { ReqCreateUserDto } from '../dto/create-user.dto';
 import { ReqUpdateUserDto } from '../dto/update-user.dto';
 import { UserEntity } from '../entities/users.entity';
 import { Roles } from '../guards/roles.guard';
-import { UserResponseModel, UsersResponseModel } from '../models/users-response.model';
+import { BulkResultResponseModel, UserResponseModel, UsersResponseModel } from '../models/users-response.model';
+import { UsersBulkService } from '../services/users-bulk.service';
 import { UsersService } from '../services/users.service';
 import { USERS_MODULE_API_TAG_NAME, USERS_MODULE_NAME, USERS_MODULE_PREFIX, UserRole } from '../users.constants';
 
@@ -40,7 +43,10 @@ import { USERS_MODULE_API_TAG_NAME, USERS_MODULE_NAME, USERS_MODULE_PREFIX, User
 export class UsersController {
 	private readonly logger = createExtensionLogger(USERS_MODULE_NAME, 'UsersController');
 
-	constructor(private readonly usersService: UsersService) {}
+	constructor(
+		private readonly usersService: UsersService,
+		private readonly usersBulkService: UsersBulkService,
+	) {}
 
 	@ApiOperation({
 		tags: [USERS_MODULE_API_TAG_NAME],
@@ -296,6 +302,36 @@ export class UsersController {
 		await this.usersService.remove(user.id);
 
 		this.logger.debug(`Successfully deleted user id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [USERS_MODULE_API_TAG_NAME],
+		summary: 'Remove several users',
+		description:
+			'Removes every user in the supplied selection. Each user is processed independently, so a user that can not be removed - the account of the caller, or the owner account - is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per user.',
+		operationId: 'create-users-module-users-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemoveUsersDto, description: 'The users to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which users were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Roles(UserRole.OWNER, UserRole.ADMIN)
+	@Post('bulk-remove')
+	@HttpCode(200)
+	async bulkRemove(
+		@Body() body: ReqBulkRemoveUsersDto,
+		@Req() req: AuthenticatedRequest,
+	): Promise<BulkResultResponseModel> {
+		const { auth } = req;
+
+		// Resolve the authenticated user's ID (works for both access tokens and long-live tokens)
+		const authenticatedUserId = auth?.type === 'user' ? auth.id : auth?.type === 'token' ? auth.ownerId : null;
+
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.usersBulkService.remove(body.data.ids, authenticatedUserId);
+
+		return response;
 	}
 
 	private async getOneOrThrow(id: string): Promise<UserEntity> {

--- a/apps/backend/src/modules/users/dto/bulk-users.dto.ts
+++ b/apps/backend/src/modules/users/dto/bulk-users.dto.ts
@@ -1,0 +1,37 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_USERS_MAX_IDS = 500;
+
+@ApiSchema({ name: 'UsersModuleBulkRemoveUsers' })
+export class BulkRemoveUsersDto {
+	@ApiProperty({
+		description: 'Identifiers of the users to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one user identifier is required."}]' })
+	@ArrayMaxSize(BULK_USERS_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_USERS_MAX_IDS} user identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each user identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'UsersModuleReqBulkRemoveUsers' })
+export class ReqBulkRemoveUsersDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveUsersDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemoveUsersDto)
+	data: BulkRemoveUsersDto;
+}

--- a/apps/backend/src/modules/users/models/users-response.model.ts
+++ b/apps/backend/src/modules/users/models/users-response.model.ts
@@ -3,6 +3,7 @@ import { Expose } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 import { UserEntity } from '../entities/users.entity';
 
 /**
@@ -30,4 +31,17 @@ export class UsersResponseModel extends BaseSuccessResponseModel<UserEntity[]> {
 	})
 	@Expose()
 	declare data: UserEntity[];
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'UsersModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/users/services/users-bulk.service.spec.ts
+++ b/apps/backend/src/modules/users/services/users-bulk.service.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { UserEntity } from '../entities/users.entity';
+import { UserRole } from '../users.constants';
+import { UsersNotFoundException } from '../users.exceptions';
+
+import { UsersBulkService } from './users-bulk.service';
+import { UsersService } from './users.service';
+
+describe('UsersBulkService', () => {
+	let service: UsersBulkService;
+	let usersService: { getOneOrThrow: jest.Mock; remove: jest.Mock };
+
+	const mockUser = (id: string, role: UserRole = UserRole.USER): UserEntity => ({
+		id,
+		isHidden: false,
+		username: `user-${id}`,
+		password: 'hashedpassword',
+		email: null,
+		firstName: null,
+		lastName: null,
+		role,
+		language: null,
+		createdAt: new Date(),
+		updatedAt: null,
+	});
+
+	beforeEach(async () => {
+		usersService = {
+			getOneOrThrow: jest.fn().mockImplementation((id: string) => Promise.resolve(mockUser(id))),
+			remove: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [UsersBulkService, { provide: UsersService, useValue: usersService }],
+		}).compile();
+
+		service = module.get<UsersBulkService>(UsersBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every user in the selection', async () => {
+			const result = await service.remove(['a', 'b', 'c'], null);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(usersService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// An account that is not there explains itself, and that explanation is more
+		// use to the operator than "failed".
+		it('carries the service refusal through as the reason', async () => {
+			usersService.getOneOrThrow.mockImplementation((id: string) =>
+				id === 'b'
+					? Promise.reject(new UsersNotFoundException('Requested user does not exist'))
+					: Promise.resolve(mockUser(id)),
+			);
+
+			const result = await service.remove(['a', 'b', 'c'], null);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Requested user does not exist' }]);
+		});
+
+		// The single delete endpoint refuses both of these, so the bulk endpoint has
+		// to refuse them too - otherwise it is a way around the protection.
+		it('refuses to remove the account of the caller', async () => {
+			const result = await service.remove(['a', 'b'], 'b');
+
+			expect(result.succeeded).toEqual(['a']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'You cannot delete your own account' }]);
+			expect(usersService.remove).toHaveBeenCalledTimes(1);
+			expect(usersService.remove).toHaveBeenCalledWith('a');
+		});
+
+		it('refuses to remove the owner account', async () => {
+			usersService.getOneOrThrow.mockImplementation((id: string) =>
+				Promise.resolve(mockUser(id, id === 'b' ? UserRole.OWNER : UserRole.USER)),
+			);
+
+			const result = await service.remove(['a', 'b'], null);
+
+			expect(result.succeeded).toEqual(['a']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'The owner account cannot be deleted' }]);
+			expect(usersService.remove).toHaveBeenCalledTimes(1);
+			expect(usersService.remove).toHaveBeenCalledWith('a');
+		});
+	});
+});

--- a/apps/backend/src/modules/users/services/users-bulk.service.ts
+++ b/apps/backend/src/modules/users/services/users-bulk.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { USERS_MODULE_NAME, UserRole } from '../users.constants';
+
+import { UsersService } from './users.service';
+
+/**
+ * Runs a user operation across a selection in a single request.
+ *
+ * The per-user semantics, including each refusal, are meant to be identical to
+ * the single-user endpoints - see runBulkOperation for why the work is still
+ * performed one user at a time.
+ */
+@Injectable()
+export class UsersBulkService {
+	private readonly logger = createExtensionLogger(USERS_MODULE_NAME, 'UsersBulkService');
+
+	constructor(private readonly usersService: UsersService) {}
+
+	/**
+	 * @param authenticatedUserId Who is asking. The single delete endpoint refuses
+	 *   to remove the caller's own account, so the caller has to travel with the
+	 *   selection for that rule to survive the move to bulk.
+	 */
+	async remove(ids: string[], authenticatedUserId: string | null): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			ids,
+			async (id) => {
+				// The service raises for a missing user with a reason worth reading, and
+				// the account is needed anyway for the two refusals the single delete
+				// endpoint enforces - going through bulk must not be a way around them.
+				const user = await this.usersService.getOneOrThrow(id);
+
+				if (authenticatedUserId !== null && authenticatedUserId === user.id) {
+					throw new Error('You cannot delete your own account');
+				}
+
+				if (user.role === UserRole.OWNER) {
+					throw new Error('The owner account cannot be deleted');
+				}
+
+				await this.usersService.remove(user.id);
+			},
+			'User could not be removed',
+		);
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+}

--- a/apps/backend/src/modules/users/users.module.ts
+++ b/apps/backend/src/modules/users/users.module.ts
@@ -19,6 +19,7 @@ import { RolesGuard } from './guards/roles.guard';
 import { UsersConfigModel } from './models/config.model';
 import { ModuleResetService } from './services/module-reset.service';
 import { UserLifecycleMutationRegistryService } from './services/user-lifecycle-mutation-registry.service';
+import { UsersBulkService } from './services/users-bulk.service';
 import { UsersSeederService } from './services/users-seeder.service';
 import { UsersService } from './services/users.service';
 import { USERS_MODULE_API_TAG_DESCRIPTION, USERS_MODULE_API_TAG_NAME, USERS_MODULE_NAME } from './users.constants';
@@ -34,6 +35,7 @@ import { UserExistsConstraintValidator } from './validators/user-exists-constrai
 	imports: [TypeOrmModule.forFeature([UserEntity]), SwaggerModule, SeedModule],
 	providers: [
 		UsersService,
+		UsersBulkService,
 		UserExistsConstraintValidator,
 		ListUsersCommand,
 		{

--- a/apps/backend/src/modules/users/users.openapi.ts
+++ b/apps/backend/src/modules/users/users.openapi.ts
@@ -2,10 +2,11 @@
  * OpenAPI extra models for Users module
  */
 import { UserEntity } from './entities/users.entity';
-import { UserResponseModel, UsersResponseModel } from './models/users-response.model';
+import { BulkResultResponseModel, UserResponseModel, UsersResponseModel } from './models/users-response.model';
 
 export const USERS_SWAGGER_EXTRA_MODELS = [
 	// Response models
+	BulkResultResponseModel,
 	UserResponseModel,
 	UsersResponseModel,
 	// Entities

--- a/apps/backend/src/modules/weather/controllers/locations.controller.spec.ts
+++ b/apps/backend/src/modules/weather/controllers/locations.controller.spec.ts
@@ -15,6 +15,7 @@ import { toInstance } from '../../../common/utils/transform.utils';
 import { CreateLocationDto } from '../dto/create-location.dto';
 import { UpdateLocationDto } from '../dto/update-location.dto';
 import { WeatherLocationEntity } from '../entities/locations.entity';
+import { LocationsBulkService } from '../services/locations-bulk.service';
 import { LocationsTypeMapperService } from '../services/locations-type-mapper.service';
 import { LocationsService } from '../services/locations.service';
 import { WeatherException } from '../weather.exceptions';
@@ -53,6 +54,12 @@ describe('LocationsController', () => {
 						create: jest.fn().mockResolvedValue(toInstance(WeatherLocationEntity, mockLocation)),
 						update: jest.fn().mockResolvedValue(toInstance(WeatherLocationEntity, mockLocation)),
 						remove: jest.fn().mockResolvedValue(undefined),
+					},
+				},
+				{
+					provide: LocationsBulkService,
+					useValue: {
+						remove: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
 					},
 				},
 			],

--- a/apps/backend/src/modules/weather/controllers/locations.controller.ts
+++ b/apps/backend/src/modules/weather/controllers/locations.controller.ts
@@ -31,10 +31,16 @@ import {
 	ApiSuccessResponse,
 	ApiUnprocessableEntityResponse,
 } from '../../swagger/decorators/api-documentation.decorator';
+import { ReqBulkRemoveLocationsDto } from '../dto/bulk-locations.dto';
 import { CreateLocationDto, ReqCreateLocationDto } from '../dto/create-location.dto';
 import { ReqUpdateLocationDto, UpdateLocationDto } from '../dto/update-location.dto';
 import { WeatherLocationEntity } from '../entities/locations.entity';
-import { LocationResponseModel, LocationsResponseModel } from '../models/locations-response.model';
+import {
+	BulkResultResponseModel,
+	LocationResponseModel,
+	LocationsResponseModel,
+} from '../models/locations-response.model';
+import { LocationsBulkService } from '../services/locations-bulk.service';
 import { LocationTypeMapping, LocationsTypeMapperService } from '../services/locations-type-mapper.service';
 import { LocationsService } from '../services/locations.service';
 import { WEATHER_MODULE_API_TAG_NAME, WEATHER_MODULE_NAME, WEATHER_MODULE_PREFIX } from '../weather.constants';
@@ -48,6 +54,7 @@ export class LocationsController {
 	constructor(
 		private readonly locationsService: LocationsService,
 		private readonly locationsMapperService: LocationsTypeMapperService,
+		private readonly locationsBulkService: LocationsBulkService,
 	) {}
 
 	@ApiOperation({
@@ -306,6 +313,27 @@ export class LocationsController {
 		await this.locationsService.remove(location.id);
 
 		this.logger.debug(`Successfully deleted location id=${id}`);
+	}
+
+	@ApiOperation({
+		tags: [WEATHER_MODULE_API_TAG_NAME],
+		summary: 'Remove several locations',
+		description:
+			'Removes every location in the supplied selection. Each location is processed independently, so a location that can not be removed is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per location.',
+		operationId: 'create-weather-module-locations-bulk-remove',
+	})
+	@ApiBody({ type: ReqBulkRemoveLocationsDto, description: 'The locations to remove' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which locations were removed and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@ApiInternalServerErrorResponse('Internal server error')
+	@Post('bulk-remove')
+	@HttpCode(200)
+	async bulkRemove(@Body() body: ReqBulkRemoveLocationsDto): Promise<BulkResultResponseModel> {
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.locationsBulkService.remove(body.data.ids);
+
+		return response;
 	}
 
 	private async getOneOrThrow(id: string): Promise<WeatherLocationEntity> {

--- a/apps/backend/src/modules/weather/dto/bulk-locations.dto.ts
+++ b/apps/backend/src/modules/weather/dto/bulk-locations.dto.ts
@@ -1,0 +1,37 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_LOCATIONS_MAX_IDS = 500;
+
+@ApiSchema({ name: 'WeatherModuleBulkRemoveLocations' })
+export class BulkRemoveLocationsDto {
+	@ApiProperty({
+		description: 'Identifiers of the locations to remove',
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"ids","reason":"Ids must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"ids","reason":"At least one location identifier is required."}]' })
+	@ArrayMaxSize(BULK_LOCATIONS_MAX_IDS, {
+		message: `[{"field":"ids","reason":"At most ${BULK_LOCATIONS_MAX_IDS} location identifiers can be sent in one request."}]`,
+	})
+	@IsUUID('4', { each: true, message: '[{"field":"ids","reason":"Each location identifier must be a valid UUID."}]' })
+	ids: string[];
+}
+
+@ApiSchema({ name: 'WeatherModuleReqBulkRemoveLocations' })
+export class ReqBulkRemoveLocationsDto {
+	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveLocationsDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkRemoveLocationsDto)
+	data: BulkRemoveLocationsDto;
+}

--- a/apps/backend/src/modules/weather/models/locations-response.model.ts
+++ b/apps/backend/src/modules/weather/models/locations-response.model.ts
@@ -3,6 +3,7 @@ import { Expose } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 import { WeatherLocationEntity } from '../entities/locations.entity';
 
 /**
@@ -30,4 +31,17 @@ export class LocationsResponseModel extends BaseSuccessResponseModel<WeatherLoca
 	})
 	@Expose()
 	declare data: WeatherLocationEntity[];
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'WeatherModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/weather/services/locations-bulk.service.spec.ts
+++ b/apps/backend/src/modules/weather/services/locations-bulk.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { WeatherValidationException } from '../weather.exceptions';
+
+import { LocationsBulkService } from './locations-bulk.service';
+import { LocationsService } from './locations.service';
+
+describe('LocationsBulkService', () => {
+	let service: LocationsBulkService;
+	let locationsService: { remove: jest.Mock };
+
+	beforeEach(async () => {
+		locationsService = {
+			remove: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [LocationsBulkService, { provide: LocationsService, useValue: locationsService }],
+		}).compile();
+
+		service = module.get<LocationsBulkService>(LocationsBulkService);
+	});
+
+	describe('remove', () => {
+		it('removes every location in the selection', async () => {
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'b', 'c']);
+			expect(result.failed).toEqual([]);
+			expect(locationsService.remove).toHaveBeenCalledTimes(3);
+		});
+
+		// A location the module refuses to delete - a missing one - explains why,
+		// and that explanation is more use to the operator than "failed".
+		it('carries the service refusal through as the reason', async () => {
+			locationsService.remove.mockImplementation((id: string) =>
+				id === 'b' ? Promise.reject(new Error('Location does not exist')) : Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'b', 'c']);
+
+			expect(result.succeeded).toEqual(['a', 'c']);
+			expect(result.failed).toEqual([{ id: 'b', reason: 'Location does not exist' }]);
+		});
+
+		// The primary location is protected by the single-location delete, so the
+		// bulk path must report that refusal rather than delete around it.
+		it('reports the primary location the service protects', async () => {
+			locationsService.remove.mockImplementation((id: string) =>
+				id === 'primary'
+					? Promise.reject(
+							new WeatherValidationException(
+								'Cannot delete the primary weather location. Please set a different primary location first.',
+							),
+						)
+					: Promise.resolve(),
+			);
+
+			const result = await service.remove(['a', 'primary']);
+
+			expect(result.succeeded).toEqual(['a']);
+			expect(result.failed).toEqual([
+				{
+					id: 'primary',
+					reason: 'Cannot delete the primary weather location. Please set a different primary location first.',
+				},
+			]);
+		});
+	});
+});

--- a/apps/backend/src/modules/weather/services/locations-bulk.service.ts
+++ b/apps/backend/src/modules/weather/services/locations-bulk.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { WEATHER_MODULE_NAME } from '../weather.constants';
+
+import { LocationsService } from './locations.service';
+
+/**
+ * Runs a location operation across a selection in a single request.
+ *
+ * The per-location semantics, including each refusal, are meant to be identical
+ * to the single-location endpoints - see runBulkOperation for why the work is
+ * still performed one location at a time.
+ */
+@Injectable()
+export class LocationsBulkService {
+	private readonly logger = createExtensionLogger(WEATHER_MODULE_NAME, 'LocationsBulkService');
+
+	constructor(private readonly locationsService: LocationsService) {}
+
+	async remove(ids: string[]): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			ids,
+			// The service raises for a missing location, and for the primary one it
+			// refuses to delete, with a reason worth reading; runBulkOperation
+			// carries that through per item.
+			(id) => this.locationsService.remove(id),
+			'Location could not be removed',
+		);
+
+		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
+
+		return result;
+	}
+}

--- a/apps/backend/src/modules/weather/weather.module.ts
+++ b/apps/backend/src/modules/weather/weather.module.ts
@@ -17,6 +17,7 @@ import { WeatherController } from './controllers/weather.controller';
 import { UpdateWeatherConfigDto } from './dto/update-config.dto';
 import { WeatherLocationEntity } from './entities/locations.entity';
 import { WeatherConfigModel } from './models/config.model';
+import { LocationsBulkService } from './services/locations-bulk.service';
 import { LocationsTypeMapperService } from './services/locations-type-mapper.service';
 import { LocationsService } from './services/locations.service';
 import { WeatherModuleResetService } from './services/module-reset.service';
@@ -42,6 +43,7 @@ import { WEATHER_SWAGGER_EXTRA_MODELS } from './weather.openapi';
 	providers: [
 		WeatherService,
 		LocationsService,
+		LocationsBulkService,
 		LocationsTypeMapperService,
 		WeatherProviderRegistryService,
 		WeatherHistoryService,

--- a/apps/backend/src/modules/weather/weather.openapi.ts
+++ b/apps/backend/src/modules/weather/weather.openapi.ts
@@ -9,7 +9,11 @@ import {
 	WeatherStatisticsModel,
 	WeatherStatisticsResponseModel,
 } from './models/history.model';
-import { LocationResponseModel, LocationsResponseModel } from './models/locations-response.model';
+import {
+	BulkResultResponseModel,
+	LocationResponseModel,
+	LocationsResponseModel,
+} from './models/locations-response.model';
 import {
 	AllLocationsWeatherResponseModel,
 	LocationCurrentResponseModel,
@@ -41,6 +45,7 @@ export const WEATHER_SWAGGER_EXTRA_MODELS = [
 	WeatherStatisticsResponseModel,
 	LocationResponseModel,
 	LocationsResponseModel,
+	BulkResultResponseModel,
 	// Data models
 	WindModel,
 	WeatherModel,


### PR DESCRIPTION
Second of three. Extends the shared bulk shape from #798 to **displays, spaces, dashboard pages, users and weather locations**.

```
POST /modules/{resource}/bulk-remove  { data: { ids } }
→ { data: { succeeded, failed: [{ id, reason }] } }
```

All seven bulk endpoints now `$ref` the same `CommonDataBulkResult`, and every bulk service runs on the shared `runBulkOperation`, so per-item semantics are defined once:

```
DashboardModuleResBulkResult  DevicesModuleResBulkResult   DisplaysModuleResBulkResult
ScenesModuleResBulkResult     SpacesModuleResBulkResult    UsersModuleResBulkResult
WeatherModuleResBulkResult
   all -> #/components/schemas/CommonDataBulkResult
```

## Two modules needed more than a copy

**Users — this one mattered.** Its two delete protections live in the **controller**, not the service:

```
You cannot delete your own account
The owner account cannot be deleted
```

A bulk service that simply delegated to `usersService.remove()` — which is what every other module does — would have given any administrator a way to **delete the owner account** by routing through bulk. `UsersBulkService.remove` therefore takes the authenticated caller as a second argument and enforces both rules itself; the route resolves the caller exactly as the single delete does, long-lived tokens included.

The wiring is tested, not just the rules. Replacing the caller with `null` at the route disabled self-deletion protection while **every service-level test stayed green** — so there are now two tests pinning the hand-off itself.

**Weather.** Same question, opposite answer: its primary-location guard is in the *service*, so bulk inherits it and the refusal surfaces per item.

## Authorization parity

Where a module gates its single delete on a role, the bulk route carries the same `@Roles` — otherwise it would be a way around that check.

| Module | single DELETE | bulk-remove |
|---|---|---|
| displays, spaces, users | `@Roles(OWNER, ADMIN)` | `@Roles(OWNER, ADMIN)` |
| weather, dashboard, scenes, devices | ungated | ungated |

## Other module-specific findings

- **pages** — removal cascades to tiles and data-sources, so the store's cascade is now shared between `remove` and `bulkRemove` rather than written twice, as devices already does.
- **spaces** — deletion *detaches* children and unassigns devices/displays rather than refusing, so not-found is its only refusal path.
- **pages/users/weather/displays/spaces** stores are plain objects, not scenes' `Map` — each action matches its own store.

The #794 composable fix applies to all five: the confirmation prompt and the work shared one `try`, so an API failure surfaced as "canceled".

## Verification

| Check | Result |
|---|---|
| Backend | 389 suites, 4858 passed |
| Admin | 277 files, 2017 passed |
| `pnpm run type-check` (admin, real, serial) | clean |
| `lint:js` / `lint:api` / `lint:openapi` | all pass |
| Mutation-tested | owner guard, self-deletion guard, controller hand-off — all caught |

Verified structurally rather than by report: every one of the five store actions issues **exactly one** POST with no HTTP call inside any loop, and all seven composables split confirm-from-work with an early return on cancel.

## Found along the way, deliberately not fixed here

- **`DELETE /weather/locations/:id` returns 500**, not 422, when refusing the primary location — the route doesn't catch `WeatherValidationException`. Pre-existing; the new bulk endpoint reports it properly.
- **No `:selectable` on any admin table.** Users and weather both let you select rows the backend will always refuse (your own account, the owner, the primary location), so "select all → delete" reliably yields an unexplained "N failed" — while the backend already sends usable prose the UI discards.
- **CLAUDE.md says print width 120**, but `apps/admin/prettier.config.mjs` sets **150** (backend is 120). That mismatch is why so many admin files are permanently `prettier --check` dirty.
- **`defaultSemaphore` is shared by reference** across ~13 admin stores (`ref(defaultSemaphore)`, no copy). Harmless with one pinia instance; leaks between tests.