### PR TITLE
feat(cross): give extensions a bulk-update endpoint

### DIFF
--- a/apps/admin/src/modules/extensions/composables/useExtensionActions.ts
+++ b/apps/admin/src/modules/extensions/composables/useExtensionActions.ts
@@ -85,31 +85,30 @@ export const useExtensionActions = (): IUseExtensionActions => {
 					type: 'info',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const extension of togglableExtensions) {
-				try {
-					await extensionsStore.update({
-						type: extension.type,
-						data: { enabled: true },
-					});
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('extensionsModule.messages.bulkEnabled', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('extensionsModule.messages.bulkEnableFailed', { count: failCount }));
-			}
 		} catch {
 			flashMessage.info(t('extensionsModule.messages.bulkEnableCanceled'));
+
+			return;
+		}
+
+		// One request for the whole selection. Sending one per extension tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await extensionsStore.bulkSetEnabled({
+				types: togglableExtensions.map((extension) => extension.type),
+				enabled: true,
+			});
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('extensionsModule.messages.bulkEnabled', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('extensionsModule.messages.bulkEnableFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('extensionsModule.messages.bulkEnableFailed', { count: togglableExtensions.length }));
 		}
 	};
 
@@ -132,31 +131,30 @@ export const useExtensionActions = (): IUseExtensionActions => {
 					type: 'warning',
 				}
 			);
-
-			let successCount = 0;
-			let failCount = 0;
-
-			for (const extension of togglableExtensions) {
-				try {
-					await extensionsStore.update({
-						type: extension.type,
-						data: { enabled: false },
-					});
-					successCount++;
-				} catch {
-					failCount++;
-				}
-			}
-
-			if (successCount > 0) {
-				flashMessage.success(t('extensionsModule.messages.bulkDisabled', { count: successCount }));
-			}
-
-			if (failCount > 0) {
-				flashMessage.error(t('extensionsModule.messages.bulkDisableFailed', { count: failCount }));
-			}
 		} catch {
 			flashMessage.info(t('extensionsModule.messages.bulkDisableCanceled'));
+
+			return;
+		}
+
+		// One request for the whole selection. Sending one per extension tripped the
+		// backend's shared rate limit once a selection went past thirty, which left
+		// the rest of the selection silently unprocessed.
+		try {
+			const result = await extensionsStore.bulkSetEnabled({
+				types: togglableExtensions.map((extension) => extension.type),
+				enabled: false,
+			});
+
+			if (result.succeeded.length > 0) {
+				flashMessage.success(t('extensionsModule.messages.bulkDisabled', { count: result.succeeded.length }));
+			}
+
+			if (result.failed.length > 0) {
+				flashMessage.error(t('extensionsModule.messages.bulkDisableFailed', { count: result.failed.length }));
+			}
+		} catch {
+			flashMessage.error(t('extensionsModule.messages.bulkDisableFailed', { count: togglableExtensions.length }));
 		}
 	};
 

--- a/apps/admin/src/modules/extensions/store/extensions.store.schemas.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.schemas.ts
@@ -23,6 +23,16 @@ export const ExtensionSchema = z.object({
 	links: ExtensionLinksSchema.optional(),
 });
 
+export const ExtensionsBulkSetEnabledActionPayloadSchema = z.object({
+	types: z.array(z.string()).nonempty(),
+	enabled: z.boolean(),
+});
+
+export const ExtensionsBulkResultSchema = z.object({
+	succeeded: z.array(z.string()),
+	failed: z.array(z.object({ id: z.string(), reason: z.string() })),
+});
+
 export const ExtensionsUpdateActionPayloadSchema = z.object({
 	type: z.string(),
 	data: z.object({

--- a/apps/admin/src/modules/extensions/store/extensions.store.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.ts
@@ -11,10 +11,16 @@ import type {
 import { ExtensionKind } from '../extensions.constants';
 import { ExtensionsApiException, ExtensionsValidationException } from '../extensions.exceptions';
 
-import { ExtensionSchema, ExtensionsUpdateActionPayloadSchema } from './extensions.store.schemas';
+import {
+	ExtensionsBulkResultSchema,
+	ExtensionSchema,
+	ExtensionsUpdateActionPayloadSchema,
+} from './extensions.store.schemas';
 import type {
 	ExtensionsStoreSetup,
 	IExtension,
+	IExtensionsBulkResult,
+	IExtensionsBulkSetEnabledActionPayload,
 	IExtensionsFetchActionPayload,
 	IExtensionsGetActionPayload,
 	IExtensionsSetActionPayload,
@@ -256,6 +262,53 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 			}
 		};
 
+		/**
+		 * Enables or disables a selection in one request.
+		 *
+		 * The per-extension alternative was one request each, which the backend's
+		 * shared rate limit rejects past thirty. The outcome is reported per
+		 * extension because the backend still refuses individual ones for
+		 * individual reasons - a core extension above all.
+		 */
+		const bulkSetEnabled = async (payload: IExtensionsBulkSetEnabledActionPayload): Promise<IExtensionsBulkResult> => {
+			const types = payload.types.filter((type) => typeof data.value[type] !== 'undefined');
+
+			if (types.length === 0) {
+				return { succeeded: [], failed: [] };
+			}
+
+			semaphore.value.updating.push(...types);
+
+			try {
+				const { data: responseBody, error } = await backend.client.POST(
+					'/modules/extensions/extensions/bulk-update',
+					{ body: { data: { types, enabled: payload.enabled } } }
+				);
+
+				if (typeof error !== 'undefined' || typeof responseBody === 'undefined') {
+					throw new ExtensionsApiException('Received unexpected response.');
+				}
+
+				const result = ExtensionsBulkResultSchema.parse(responseBody.data);
+
+				// The response carries only the outcome, so the local records are
+				// nudged to the state the backend just confirmed instead of being
+				// re-fetched one by one - which would reintroduce the request storm
+				// this endpoint exists to remove.
+				for (const type of result.succeeded) {
+					const record = data.value[type];
+
+					if (typeof record !== 'undefined') {
+						data.value[type] = { ...record, enabled: payload.enabled };
+					}
+				}
+
+				return result;
+			} finally {
+				semaphore.value.updating = semaphore.value.updating.filter((item) => !types.includes(item));
+			}
+		};
+
 		return {
 			semaphore,
 			firstLoad,
@@ -270,6 +323,7 @@ export const useExtensions = defineStore<'extensions_module-extensions', Extensi
 			get,
 			fetch,
 			update,
+			bulkSetEnabled,
 		};
 	}
 );

--- a/apps/admin/src/modules/extensions/store/extensions.store.types.ts
+++ b/apps/admin/src/modules/extensions/store/extensions.store.types.ts
@@ -61,6 +61,18 @@ export interface IExtensionsUpdateActionPayload {
 	};
 }
 
+export interface IExtensionsBulkSetEnabledActionPayload {
+	types: IExtension['type'][];
+	enabled: boolean;
+}
+
+export interface IExtensionsBulkResult {
+	// Extensions are keyed by type rather than by a generated id, so the shared
+	// bulk result reports those types in its identifier field.
+	succeeded: IExtension['type'][];
+	failed: { id: IExtension['type']; reason: string }[];
+}
+
 export interface IExtensionsStoreActions {
 	firstLoadFinished: () => boolean;
 	getting: (type: IExtension['type']) => boolean;
@@ -72,6 +84,7 @@ export interface IExtensionsStoreActions {
 	get: (payload: IExtensionsGetActionPayload) => Promise<IExtension>;
 	fetch: (payload?: IExtensionsFetchActionPayload) => Promise<IExtension[]>;
 	update: (payload: IExtensionsUpdateActionPayload) => Promise<IExtension>;
+	bulkSetEnabled: (payload: IExtensionsBulkSetEnabledActionPayload) => Promise<IExtensionsBulkResult>;
 }
 
 export type ExtensionsStoreSetup = IExtensionsStoreState & IExtensionsStoreActions;

--- a/apps/backend/src/modules/extensions/controllers/extensions.controller.spec.ts
+++ b/apps/backend/src/modules/extensions/controllers/extensions.controller.spec.ts
@@ -9,6 +9,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { ExtensionKind } from '../extensions.constants';
 import { ExtensionModel } from '../models/extension.model';
+import { ExtensionsBulkService } from '../services/extensions-bulk.service';
 import { ExtensionsService } from '../services/extensions.service';
 
 import { ExtensionsController } from './extensions.controller';
@@ -28,6 +29,10 @@ describe('ExtensionsController', () => {
 		return { ...extension, ...overrides } as ExtensionModel;
 	};
 
+	const mockExtensionsBulkService = {
+		setEnabled: jest.fn().mockResolvedValue({ succeeded: [], failed: [] }),
+	};
+
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [ExtensionsController],
@@ -41,6 +46,10 @@ describe('ExtensionsController', () => {
 						findOne: jest.fn(),
 						updateEnabled: jest.fn(),
 					},
+				},
+				{
+					provide: ExtensionsBulkService,
+					useValue: mockExtensionsBulkService,
 				},
 			],
 		}).compile();
@@ -138,6 +147,37 @@ describe('ExtensionsController', () => {
 
 			expect(result.data.enabled).toBe(true);
 			expect(extensionsService.updateEnabled).toHaveBeenCalledWith('devices-module', true);
+		});
+	});
+
+	describe('bulkUpdate', () => {
+		// Extensions are addressed by type, not by a generated id, so the selection
+		// travels as types all the way through.
+		it('hands the whole selection to the bulk service in one call', async () => {
+			const types = ['devices-shelly-ng-plugin', 'devices-wled-plugin'];
+
+			mockExtensionsBulkService.setEnabled.mockResolvedValue({ succeeded: types, failed: [] });
+
+			const response = await controller.bulkUpdate({ data: { types, enabled: true } } as never);
+
+			expect(mockExtensionsBulkService.setEnabled).toHaveBeenCalledTimes(1);
+			expect(mockExtensionsBulkService.setEnabled).toHaveBeenCalledWith(types, true);
+			expect(response.data.succeeded).toEqual(types);
+		});
+
+		it('reports a refusal in the response rather than throwing', async () => {
+			mockExtensionsBulkService.setEnabled.mockResolvedValue({
+				succeeded: ['devices-wled-plugin'],
+				failed: [{ id: 'devices-module', reason: 'Extension devices-module is not configurable' }],
+			});
+
+			const response = await controller.bulkUpdate({
+				data: { types: ['devices-wled-plugin', 'devices-module'], enabled: false },
+			} as never);
+
+			expect(response.data.failed).toEqual([
+				{ id: 'devices-module', reason: 'Extension devices-module is not configurable' },
+			]);
 		});
 	});
 });

--- a/apps/backend/src/modules/extensions/controllers/extensions.controller.ts
+++ b/apps/backend/src/modules/extensions/controllers/extensions.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, HttpCode, Param, Patch, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
 import {
@@ -9,9 +9,15 @@ import {
 } from '../../swagger/decorators/api-documentation.decorator';
 import { Roles } from '../../users/guards/roles.guard';
 import { UserRole } from '../../users/users.constants';
+import { ReqBulkUpdateExtensionsDto } from '../dto/bulk-extensions.dto';
 import { ReqUpdateExtensionDto } from '../dto/update-extension.dto';
 import { EXTENSIONS_MODULE_API_TAG_NAME, EXTENSIONS_MODULE_NAME } from '../extensions.constants';
-import { ExtensionResponseModel, ExtensionsResponseModel } from '../models/extensions-response.model';
+import {
+	BulkResultResponseModel,
+	ExtensionResponseModel,
+	ExtensionsResponseModel,
+} from '../models/extensions-response.model';
+import { ExtensionsBulkService } from '../services/extensions-bulk.service';
 import { ExtensionsService } from '../services/extensions.service';
 
 @ApiTags(EXTENSIONS_MODULE_API_TAG_NAME)
@@ -19,7 +25,10 @@ import { ExtensionsService } from '../services/extensions.service';
 export class ExtensionsController {
 	private readonly logger = createExtensionLogger(EXTENSIONS_MODULE_NAME, 'ExtensionsController');
 
-	constructor(private readonly extensionsService: ExtensionsService) {}
+	constructor(
+		private readonly extensionsService: ExtensionsService,
+		private readonly extensionsBulkService: ExtensionsBulkService,
+	) {}
 
 	@Get()
 	@Roles(UserRole.OWNER, UserRole.ADMIN)
@@ -108,6 +117,26 @@ export class ExtensionsController {
 
 		const response = new ExtensionResponseModel();
 		response.data = extension;
+
+		return response;
+	}
+
+	@ApiOperation({
+		operationId: 'create-extensions-module-extensions-bulk-update',
+		summary: 'Enable or disable several extensions',
+		description:
+			'Sets the enabled state of every extension in the supplied selection. Each extension is processed independently, so one that can not be updated - a core extension, or an unknown type - is reported in the response rather than aborting the rest of the selection. This exists so that acting on a large selection is one request instead of one per extension. Requires owner or admin role.',
+	})
+	@ApiBody({ type: ReqBulkUpdateExtensionsDto, description: 'The extensions to update and the state to set' })
+	@ApiSuccessResponse(BulkResultResponseModel, 'Returns which extensions were updated and which were not')
+	@ApiBadRequestResponse('Invalid request data')
+	@Post('bulk-update')
+	@Roles(UserRole.OWNER, UserRole.ADMIN)
+	@HttpCode(200)
+	async bulkUpdate(@Body() body: ReqBulkUpdateExtensionsDto): Promise<BulkResultResponseModel> {
+		const response = new BulkResultResponseModel();
+
+		response.data = await this.extensionsBulkService.setEnabled(body.data.types, body.data.enabled);
 
 		return response;
 	}

--- a/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.ts
+++ b/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.ts
@@ -1,0 +1,51 @@
+import { Expose, Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsString, ValidateNested } from 'class-validator';
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+
+/**
+ * A bulk request replaces one HTTP round trip per item, so the cap is what
+ * stops a single call from turning into unbounded work.
+ */
+export const BULK_EXTENSIONS_MAX_TYPES = 500;
+
+@ApiSchema({ name: 'ExtensionsModuleBulkUpdateExtensions' })
+export class BulkUpdateExtensionsDto {
+	/**
+	 * Extensions are addressed by their type, not by a generated id - the single
+	 * update route is `PATCH /extensions/:type` - so the selection travels as
+	 * types and the outcome is reported against the same strings.
+	 */
+	@ApiProperty({
+		description: 'Types of the extensions to update',
+		type: 'array',
+		items: { type: 'string' },
+		example: ['devices-shelly-ng-plugin'],
+	})
+	@Expose()
+	@IsArray({ message: '[{"field":"types","reason":"Types must be an array."}]' })
+	@ArrayNotEmpty({ message: '[{"field":"types","reason":"At least one extension type is required."}]' })
+	@ArrayMaxSize(BULK_EXTENSIONS_MAX_TYPES, {
+		message: `[{"field":"types","reason":"At most ${BULK_EXTENSIONS_MAX_TYPES} extension types can be sent in one request."}]`,
+	})
+	@IsString({ each: true, message: '[{"field":"types","reason":"Each extension type must be a string."}]' })
+	types: string[];
+
+	@ApiProperty({
+		description: 'Whether the listed extensions should be enabled',
+		type: 'boolean',
+		example: true,
+	})
+	@Expose()
+	@IsBoolean({ message: '[{"field":"enabled","reason":"Enabled must be a boolean value."}]' })
+	enabled: boolean;
+}
+
+@ApiSchema({ name: 'ExtensionsModuleReqBulkUpdateExtensions' })
+export class ReqBulkUpdateExtensionsDto {
+	@ApiProperty({ description: 'Bulk update data', type: () => BulkUpdateExtensionsDto })
+	@Expose()
+	@ValidateNested()
+	@Type(() => BulkUpdateExtensionsDto)
+	data: BulkUpdateExtensionsDto;
+}

--- a/apps/backend/src/modules/extensions/extensions.module.ts
+++ b/apps/backend/src/modules/extensions/extensions.module.ts
@@ -29,6 +29,7 @@ import { ExtensionsConfigModel } from './models/config.model';
 import { ExtensionsStatsProvider } from './providers/extensions-stats.provider';
 import { ActionAuditService } from './services/action-audit.service';
 import { ExtensionActionRegistryService } from './services/extension-action-registry.service';
+import { ExtensionsBulkService } from './services/extensions-bulk.service';
 import { ExtensionsService } from './services/extensions.service';
 import { ModuleResetService } from './services/module-reset.service';
 import { PluginServiceManagerService } from './services/plugin-service-manager.service';
@@ -43,6 +44,7 @@ import { PluginServiceManagerService } from './services/plugin-service-manager.s
 	imports: [NestConfigModule, StatsModule],
 	controllers: [ExtensionsController, DiscoveredExtensionsController, ServicesController, ActionsController],
 	providers: [
+		ExtensionsBulkService,
 		ModuleResetService,
 		PluginServiceManagerService,
 		ExtensionActionRegistryService,

--- a/apps/backend/src/modules/extensions/extensions.openapi.ts
+++ b/apps/backend/src/modules/extensions/extensions.openapi.ts
@@ -20,7 +20,11 @@ import {
 } from './models/discovered-extension.model';
 import { DiscoveredExtensionsResponseModel } from './models/discovered-extensions-response.model';
 import { ExtensionLinksModel, ExtensionModel } from './models/extension.model';
-import { ExtensionResponseModel, ExtensionsResponseModel } from './models/extensions-response.model';
+import {
+	BulkResultResponseModel,
+	ExtensionResponseModel,
+	ExtensionsResponseModel,
+} from './models/extensions-response.model';
 import {
 	ServiceStatusModel,
 	ServiceStatusResponseModel,
@@ -32,6 +36,7 @@ export const EXTENSIONS_SWAGGER_EXTRA_MODELS = [
 	ExtensionLinksModel,
 	ExtensionResponseModel,
 	ExtensionsResponseModel,
+	BulkResultResponseModel,
 	ReqUpdateExtensionDto,
 	UpdateExtensionDataDto,
 	// Action models

--- a/apps/backend/src/modules/extensions/models/extensions-response.model.ts
+++ b/apps/backend/src/modules/extensions/models/extensions-response.model.ts
@@ -3,6 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
 import { BaseSuccessResponseModel } from '../../api/models/api-response.model';
+import { BulkResultModel } from '../../api/models/bulk.model';
 
 import { ExtensionModel } from './extension.model';
 
@@ -29,4 +30,17 @@ export class ExtensionResponseModel extends BaseSuccessResponseModel<ExtensionMo
 	@Expose()
 	@Type(() => ExtensionModel)
 	declare data: ExtensionModel;
+}
+
+/**
+ * Response wrapper for the outcome of a bulk operation
+ */
+@ApiSchema({ name: 'ExtensionsModuleResBulkResult' })
+export class BulkResultResponseModel extends BaseSuccessResponseModel<BulkResultModel> {
+	@ApiProperty({
+		description: 'The actual data payload returned by the API',
+		type: () => BulkResultModel,
+	})
+	@Expose()
+	declare data: BulkResultModel;
 }

--- a/apps/backend/src/modules/extensions/services/extensions-bulk.service.spec.ts
+++ b/apps/backend/src/modules/extensions/services/extensions-bulk.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ExtensionsBulkService } from './extensions-bulk.service';
+import { ExtensionsService } from './extensions.service';
+
+describe('ExtensionsBulkService', () => {
+	let service: ExtensionsBulkService;
+	let extensionsService: { updateEnabled: jest.Mock };
+
+	beforeEach(async () => {
+		extensionsService = { updateEnabled: jest.fn().mockResolvedValue(undefined) };
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [ExtensionsBulkService, { provide: ExtensionsService, useValue: extensionsService }],
+		}).compile();
+
+		service = module.get<ExtensionsBulkService>(ExtensionsBulkService);
+	});
+
+	it('sets the requested state on every extension in the selection', async () => {
+		const result = await service.setEnabled(['devices-wled-plugin', 'devices-shelly-ng-plugin'], true);
+
+		expect(result.succeeded).toEqual(['devices-wled-plugin', 'devices-shelly-ng-plugin']);
+		expect(result.failed).toEqual([]);
+		expect(extensionsService.updateEnabled).toHaveBeenCalledWith('devices-wled-plugin', true);
+		expect(extensionsService.updateEnabled).toHaveBeenCalledWith('devices-shelly-ng-plugin', true);
+	});
+
+	// The outcome is keyed by extension type, since that is how the single update
+	// endpoint addresses them too - there is no generated id to report against.
+	it('reports the failing extension by its type', async () => {
+		extensionsService.updateEnabled.mockImplementation((type: string) =>
+			type === 'devices-module'
+				? Promise.reject(new Error('Extension devices-module is not configurable'))
+				: Promise.resolve(),
+		);
+
+		const result = await service.setEnabled(['devices-wled-plugin', 'devices-module'], false);
+
+		expect(result.succeeded).toEqual(['devices-wled-plugin']);
+		expect(result.failed).toEqual([{ id: 'devices-module', reason: 'Extension devices-module is not configurable' }]);
+	});
+
+	// A core extension refusing must not take the rest of the selection with it -
+	// the admin's "disable all" is a set of independent intents.
+	it('keeps going after a core extension refuses', async () => {
+		extensionsService.updateEnabled.mockImplementation((type: string) =>
+			type === 'core' ? Promise.reject(new Error('Extension core is not configurable')) : Promise.resolve(),
+		);
+
+		const result = await service.setEnabled(['a', 'core', 'b'], false);
+
+		expect(result.succeeded).toEqual(['a', 'b']);
+		expect(extensionsService.updateEnabled).toHaveBeenCalledTimes(3);
+	});
+
+	it('passes the enabled flag through unchanged', async () => {
+		await service.setEnabled(['a'], false);
+
+		expect(extensionsService.updateEnabled).toHaveBeenCalledWith('a', false);
+	});
+});

--- a/apps/backend/src/modules/extensions/services/extensions-bulk.service.ts
+++ b/apps/backend/src/modules/extensions/services/extensions-bulk.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { BulkResultModel } from '../../api/models/bulk.model';
+import { runBulkOperation } from '../../api/utils/bulk.utils';
+import { EXTENSIONS_MODULE_NAME } from '../extensions.constants';
+
+import { ExtensionsService } from './extensions.service';
+
+/**
+ * Runs an extension operation across a selection in a single request.
+ *
+ * The per-extension semantics, including each refusal, are meant to be
+ * identical to the single-extension endpoint - see runBulkOperation for why the
+ * work is still performed one extension at a time.
+ *
+ * Unlike the other bulk endpoints, the selection is keyed by extension type
+ * rather than by a generated id, matching `PATCH /extensions/:type`.
+ */
+@Injectable()
+export class ExtensionsBulkService {
+	private readonly logger = createExtensionLogger(EXTENSIONS_MODULE_NAME, 'ExtensionsBulkService');
+
+	constructor(private readonly extensionsService: ExtensionsService) {}
+
+	async setEnabled(types: string[], enabled: boolean): Promise<BulkResultModel> {
+		const result = await runBulkOperation(
+			types,
+			// The service raises for an unknown extension, for one that cannot be
+			// toggled - a core extension - and for a config the update would
+			// invalidate. Each reason is worth reading, and runBulkOperation carries
+			// it through per item.
+			async (type) => {
+				await this.extensionsService.updateEnabled(type, enabled);
+			},
+			'Extension could not be updated',
+		);
+
+		this.logger.debug(
+			`Bulk enabled=${String(enabled)} finished succeeded=${result.succeeded.length} failed=${result.failed.length}`,
+		);
+
+		return result;
+	}
+}


### PR DESCRIPTION
Last of the three. Completes the bulk unification.

Extensions was left until last because it's the one resource the shared shape doesn't fit cleanly: extensions are addressed by **type**, not by a generated id, matching `PATCH /extensions/:type`.

```
POST /modules/extensions/extensions/bulk-update
  { "data": { "types": ["devices-wled-plugin"], "enabled": true } }

→ { "data": { "succeeded": [...], "failed": [{ "id": "...", "reason": "..." }] } }
```

So the request carries `types` rather than `ids` — the module's own vocabulary — and the shared result reports those same strings back. This is precisely why `CommonDataBulkResult` was defined over **plain strings rather than UUIDs** in #798: extensions was the case it had to leave room for, and it did.

## Why per-item reasons matter more here than elsewhere

`updateEnabled` already refuses three distinct things: an unknown type, an extension that can't be toggled (a core one), and a config the change would invalidate. All three now surface per item rather than one 4xx discarding the selection.

That's not theoretical for this module — bulk enable/disable is exactly where a core extension gets swept up in a wider selection. The composable keeps its existing pre-filter to togglable extensions, so the common case still sends nothing the backend will refuse; the per-item reasons cover what the filter can't know (an extension whose state changed since the list was loaded).

`@Roles(OWNER, ADMIN)` matches the single update route, so the bulk form isn't a way around it.

## The unification, complete

All eight bulk endpoints now answer with the same `CommonDataBulkResult` and run on the shared `runBulkOperation`:

| | |
|---|---|
| `bulk-remove` | devices, scenes, displays, spaces, pages, users, weather locations |
| `bulk-update` | devices, scenes, **extensions** |

## Verification

| Check | Result |
|---|---|
| Backend | 390 suites, 4864 passed |
| Admin | 277 files, 2017 passed |
| `pnpm run type-check` (admin, real) | clean |
| `lint:js` / `lint:api` / `lint:openapi` | all pass |
| Mutation-tested | swallowing refusals, ignoring the `enabled` flag — both caught |

Verified structurally as well: the store action issues exactly one POST, and both composable paths split confirm-from-work with an early return on cancel.