### PR TITLE
fix(backend): answer 422 when a weather location deletion is refused

### DIFF
--- a/apps/backend/src/modules/weather/controllers/locations.controller.spec.ts
+++ b/apps/backend/src/modules/weather/controllers/locations.controller.spec.ts
@@ -18,7 +18,7 @@ import { WeatherLocationEntity } from '../entities/locations.entity';
 import { LocationsBulkService } from '../services/locations-bulk.service';
 import { LocationsTypeMapperService } from '../services/locations-type-mapper.service';
 import { LocationsService } from '../services/locations.service';
-import { WeatherException } from '../weather.exceptions';
+import { WeatherException, WeatherValidationException } from '../weather.exceptions';
 
 import { LocationsController } from './locations.controller';
 
@@ -221,6 +221,37 @@ describe('LocationsController', () => {
 			jest.spyOn(service, 'findOne').mockResolvedValue(null);
 
 			await expect(controller.remove('non-existent-id')).rejects.toThrow(NotFoundException);
+		});
+
+		// Refusing the primary location is policy, not a fault, and the message says
+		// which location to reassign first. Unmapped it escaped as a 500, which told
+		// the operator the server broke rather than what to do about it.
+		it('answers 422 with the reason when the primary location is refused', async () => {
+			jest
+				.spyOn(service, 'remove')
+				.mockRejectedValue(
+					new WeatherValidationException(
+						'Cannot delete the primary weather location. Please set a different primary location first.',
+					),
+				);
+
+			const result = controller.remove(mockLocation.id);
+
+			await expect(result).rejects.toBeInstanceOf(UnprocessableEntityException);
+			await expect(result).rejects.toThrow(
+				'Cannot delete the primary weather location. Please set a different primary location first.',
+			);
+		});
+
+		it('lets an unexpected failure through rather than dressing it as a refusal', async () => {
+			jest.spyOn(service, 'remove').mockRejectedValue(new Error('database is on fire'));
+
+			const result = controller.remove(mockLocation.id);
+
+			// Asserting the message alone is not enough: wrapping *everything* in a 422
+			// would carry the same message through and satisfy it.
+			await expect(result).rejects.not.toBeInstanceOf(UnprocessableEntityException);
+			await expect(result).rejects.toThrow('database is on fire');
 		});
 	});
 });

--- a/apps/backend/src/modules/weather/controllers/locations.controller.ts
+++ b/apps/backend/src/modules/weather/controllers/locations.controller.ts
@@ -44,7 +44,7 @@ import { LocationsBulkService } from '../services/locations-bulk.service';
 import { LocationTypeMapping, LocationsTypeMapperService } from '../services/locations-type-mapper.service';
 import { LocationsService } from '../services/locations.service';
 import { WEATHER_MODULE_API_TAG_NAME, WEATHER_MODULE_NAME, WEATHER_MODULE_PREFIX } from '../weather.constants';
-import { WeatherException } from '../weather.exceptions';
+import { WeatherException, WeatherValidationException } from '../weather.exceptions';
 
 @ApiTags(WEATHER_MODULE_API_TAG_NAME)
 @Controller('locations')
@@ -302,6 +302,7 @@ export class LocationsController {
 	@ApiNoContentResponse({ description: 'Location deleted successfully' })
 	@ApiBadRequestResponse('Invalid UUID format')
 	@ApiNotFoundResponse('Location not found')
+	@ApiUnprocessableEntityResponse('Location could not be deleted')
 	@ApiInternalServerErrorResponse('Internal server error')
 	@Delete(':id')
 	@HttpCode(204)
@@ -310,7 +311,18 @@ export class LocationsController {
 
 		const location = await this.getOneOrThrow(id);
 
-		await this.locationsService.remove(location.id);
+		try {
+			await this.locationsService.remove(location.id);
+		} catch (error) {
+			// Refusing to delete the primary location is a deliberate policy, and the
+			// message says which location to reassign first. Unmapped it escaped as a
+			// 500, telling the operator the server broke rather than what to do.
+			if (error instanceof WeatherValidationException) {
+				throw new UnprocessableEntityException(error.message);
+			}
+
+			throw error;
+		}
 
 		this.logger.debug(`Successfully deleted location id=${id}`);
 	}


### PR DESCRIPTION
`LocationsService.remove` refuses to delete the configured primary location, with a message that says exactly what to do:

> Cannot delete the primary weather location. Please set a different primary location first.

But `DELETE /weather/locations/:id` never mapped `WeatherValidationException`, so it escaped unhandled and the operator got a **500** — the server reporting that it broke, rather than telling them how to proceed. The reason was discarded on the way out.

Now mapped to 422 the same way the create and update routes in that controller already map theirs, carrying the reason through instead of replacing it with a generic line.

Found while adding the bulk endpoint in #799 — the bulk form reported this correctly, per item, while the single route didn't. It was pre-existing, so I kept it out of that change.

## Verification

| Check | Result |
|---|---|
| Backend | 390 suites, 4866 passed |
| `lint:js` / `lint:api` / `lint:openapi` | pass |

Two tests: the refusal answers 422 with its reason intact, and an unexpected failure still propagates rather than being dressed up as a refusal.

Worth noting on the second one — my first version asserted only the message, and a mutation that wrapped **every** error in a 422 still passed it, since the message carries through either way. It now asserts the type too, and the mutation fails.