### PR TITLE
fix(admin): stop offering rows the backend will always refuse

### DIFF
--- a/apps/admin/src/modules/users/components/list-users.types.ts
+++ b/apps/admin/src/modules/users/components/list-users.types.ts
@@ -12,4 +12,7 @@ export interface IListUsersProps {
 	sortBy: 'username' | 'firstName' | 'lastName' | 'email' | 'role';
 	sortDir: 'ascending' | 'descending' | null;
 	loading: boolean;
+	// Forwarded to the table so the operator's own row cannot be selected for
+	// deletion; the view reads it from the session.
+	currentUserId?: string | null;
 }

--- a/apps/admin/src/modules/users/components/list-users.vue
+++ b/apps/admin/src/modules/users/components/list-users.vue
@@ -32,6 +32,7 @@
 				:loading="props.loading"
 				:filters-active="props.filtersActive"
 				:table-height="tableHeight"
+				:current-user-id="props.currentUserId"
 				@edit="onEdit"
 				@remove="onRemove"
 				@reset-filters="onResetFilters"

--- a/apps/admin/src/modules/users/components/users-table.spec.ts
+++ b/apps/admin/src/modules/users/components/users-table.spec.ts
@@ -20,6 +20,17 @@ vi.mock('vue-i18n', () => ({
 	}),
 }));
 
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		// The selection column is behind `v-if="isMDDevice"`, and jsdom reports a
+		// narrow viewport, so without this the column under test never renders.
+		useBreakpoints: () => ({ isMDDevice: true }),
+	};
+});
+
 describe('UsersTable', (): void => {
 	let wrapper: VueWrapper<UsersTableInstance>;
 
@@ -165,4 +176,43 @@ describe('UsersTable', (): void => {
 		expect(wrapper.emitted('remove')).toBeTruthy();
 		expect(wrapper.emitted('remove')?.[0]).toEqual(['1']);
 	});
+
+	// The backend refuses both of these, so offering them for selection only
+	// produces a failure the operator can do nothing about - and "select all"
+	// would always report one.
+	describe('protected rows', (): void => {
+		const selectableFor = (props: Partial<IUsersTableProps> = {}): ((row: IUser) => boolean) => {
+			createWrapper(props);
+
+			const column = wrapper.findAllComponents(ElTableColumn).find((c) => c.props('type') === 'selection');
+
+			return column!.props('selectable') as (row: IUser) => boolean;
+		};
+
+		it('does not let the owner account be selected', (): void => {
+			const isSelectable = selectableFor();
+
+			// usersMock[1] is the owner
+			expect(isSelectable(usersMock[1]!)).toBe(false);
+		});
+
+		it("does not let the operator select their own account", (): void => {
+			const isSelectable = selectableFor({ currentUserId: '1' });
+
+			expect(isSelectable(usersMock[0]!)).toBe(false);
+		});
+
+		it('lets any other account be selected', (): void => {
+			const isSelectable = selectableFor({ currentUserId: '2' });
+
+			expect(isSelectable(usersMock[0]!)).toBe(true);
+		});
+
+		it('selects normally when the current user is unknown', (): void => {
+			const isSelectable = selectableFor({ currentUserId: null });
+
+			expect(isSelectable(usersMock[0]!)).toBe(true);
+		});
+	});
+
 });

--- a/apps/admin/src/modules/users/components/users-table.types.ts
+++ b/apps/admin/src/modules/users/components/users-table.types.ts
@@ -10,4 +10,8 @@ export interface IUsersTableProps {
 	filters: IUsersFilter;
 	filtersActive: boolean;
 	tableHeight?: number;
+	// Who is looking. The operator's own row cannot be selected for deletion, and
+	// the table is presentational, so the identity is handed in rather than read
+	// from the session here.
+	currentUserId?: IUser['id'] | null;
 }

--- a/apps/admin/src/modules/users/components/users-table.vue
+++ b/apps/admin/src/modules/users/components/users-table.vue
@@ -96,6 +96,7 @@
 			v-if="isMDDevice"
 			type="selection"
 			:width="30"
+			:selectable="isSelectable"
 		/>
 
 		<el-table-column
@@ -256,6 +257,27 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const { isMDDevice } = useBreakpoints();
+
+/**
+ * The backend refuses to delete either of these, so offering them for selection
+ * only produces a failure the operator can do nothing about - and a bulk delete
+ * of "everything" would always report one.
+ *
+ * Same two rules the edit form already applies to the role field.
+ */
+const isSelectable = (row: IUser): boolean => {
+	// Users cannot delete their own account
+	if (typeof props.currentUserId === 'string' && props.currentUserId === row.id) {
+		return false;
+	}
+
+	// The owner account cannot be deleted
+	if (row.role === UsersModuleUserRole.owner) {
+		return false;
+	}
+
+	return true;
+};
 
 const noResults = computed<boolean>((): boolean => props.totalRows === 0);
 

--- a/apps/admin/src/modules/users/views/view-users.vue
+++ b/apps/admin/src/modules/users/views/view-users.vue
@@ -85,6 +85,7 @@
 			:total-rows="totalRows"
 			:loading="areLoading"
 			:filters-active="filtersActive"
+			:current-user-id="profile?.id ?? null"
 			@edit="onUserEdit"
 			@remove="onUserRemove"
 			@reset-filters="onResetFilters"
@@ -163,6 +164,7 @@ import { Icon } from '@iconify/vue';
 
 import { AppBar, AppBarButton, AppBarButtonAlign, AppBarHeading, AppBreadcrumbs, ViewError, ViewHeader, useBreakpoints } from '../../../common';
 import ListUsers from '../components/list-users.vue';
+import { useSession } from '../../auth/composables/composables';
 import { useUsersActions, useUsersDataSource } from '../composables/composables';
 import type { IUser } from '../store/users.store.types';
 import { RouteNames } from '../users.constants';
@@ -179,6 +181,8 @@ const props = defineProps<IViewUsersProps>();
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
+
+const { profile } = useSession();
 
 useMeta({
 	title: t('usersModule.meta.users.list.title'),

--- a/apps/admin/src/modules/weather/components/locations-table.spec.ts
+++ b/apps/admin/src/modules/weather/components/locations-table.spec.ts
@@ -1,0 +1,117 @@
+import { type ComponentPublicInstance } from 'vue';
+
+import { ElTableColumn } from 'element-plus';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { VueWrapper, mount } from '@vue/test-utils';
+
+import type { IWeatherLocation } from '../store/locations.store.types';
+
+import type { ILocationsTableProps } from './locations-table.types';
+import LocationsTable from './locations-table.vue';
+
+type LocationsTableInstance = ComponentPublicInstance<ILocationsTableProps>;
+
+vi.mock('vue-i18n', () => ({
+	createI18n: () => ({ global: { locale: { value: 'en-US' }, getLocaleMessage: () => ({}), setLocaleMessage: () => {} } }),
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		// The selection column is behind `v-if="isMDDevice"`, and jsdom reports a
+		// narrow viewport, so without this the column under test never renders.
+		useBreakpoints: () => ({ isMDDevice: true }),
+	};
+});
+
+describe('LocationsTable', (): void => {
+	let wrapper: VueWrapper<LocationsTableInstance>;
+
+	const locationsMock: IWeatherLocation[] = [
+		{
+			id: 'primary-location',
+			draft: false,
+			type: 'weather-open-meteo',
+			name: 'Prague',
+			order: 0,
+			createdAt: new Date(),
+			updatedAt: null,
+		} as IWeatherLocation,
+		{
+			id: 'other-location',
+			draft: false,
+			type: 'weather-open-meteo',
+			name: 'Brno',
+			order: 1,
+			createdAt: new Date(),
+			updatedAt: null,
+		} as IWeatherLocation,
+	];
+
+	const createWrapper = (props: Partial<ILocationsTableProps> = {}): void => {
+		wrapper = mount(LocationsTable, {
+			props: {
+				items: locationsMock,
+				totalRows: locationsMock.length,
+				loading: false,
+				filtersActive: false,
+				sortBy: 'name',
+				sortDir: 'ascending',
+				tableHeight: 400,
+				filters: { search: undefined, types: [], primary: 'all' },
+				primaryLocationId: 'primary-location',
+				weatherByLocation: {},
+				temperatureUnit: 'celsius',
+				weatherFetchCompleted: true,
+				...props,
+			} as ILocationsTableProps,
+			global: {
+				// These render plugin metadata and live weather from stores, which the
+				// selection predicate has nothing to do with.
+				stubs: {
+					LocationsTableColumnPlugin: true,
+					LocationsTableColumnWeather: true,
+				},
+			},
+		});
+	};
+
+	const selectablePredicate = (): ((row: IWeatherLocation) => boolean) => {
+		const column = wrapper.findAllComponents(ElTableColumn).find((c) => c.props('type') === 'selection');
+
+		return column!.props('selectable') as (row: IWeatherLocation) => boolean;
+	};
+
+	afterEach((): void => {
+		wrapper.unmount();
+	});
+
+	// The backend refuses to delete the primary location and says to reassign it
+	// first, so offering it for selection only produces a failure the operator can
+	// do nothing about - and "select all" would always report one.
+	describe('protected rows', (): void => {
+		it('does not let the primary location be selected', (): void => {
+			createWrapper();
+
+			expect(selectablePredicate()(locationsMock[0]!)).toBe(false);
+		});
+
+		it('lets any other location be selected', (): void => {
+			createWrapper();
+
+			expect(selectablePredicate()(locationsMock[1]!)).toBe(true);
+		});
+
+		it('selects normally when no primary location is configured', (): void => {
+			createWrapper({ primaryLocationId: null });
+
+			expect(selectablePredicate()(locationsMock[0]!)).toBe(true);
+		});
+	});
+});

--- a/apps/admin/src/modules/weather/components/locations-table.vue
+++ b/apps/admin/src/modules/weather/components/locations-table.vue
@@ -96,6 +96,7 @@
 			v-if="isMDDevice"
 			type="selection"
 			:width="30"
+			:selectable="isSelectable"
 		/>
 
 		<el-table-column
@@ -263,6 +264,15 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const { isMDDevice } = useBreakpoints();
+
+/**
+ * The backend refuses to delete the primary location - it says to reassign the
+ * primary first - so offering it for selection only produces a failure the
+ * operator can do nothing about, and "select all" would always report one.
+ *
+ * The row already renders a Primary tag from the same prop.
+ */
+const isSelectable = (row: IWeatherLocation): boolean => row.id !== props.primaryLocationId;
 
 const innerFilters = useVModel(props, 'filters', emit);
 


### PR DESCRIPTION
Follow-up to the bulk work. The users and locations tables let **every** visible row be selected — including the ones the backend refuses to delete:

- the operator's own account
- the owner account
- the configured primary weather location

So the ordinary "select all → delete" ended in *"Failed to remove 2 user(s)"* with no indication of which two, or that the refusal was correct rather than a fault. The information already existed on the wire — the backend answers with `'The owner account cannot be deleted'` and `'Cannot delete the primary weather location. Please set a different primary location first.'` — the UI simply discarded it.

Both tables now pass `:selectable` on the selection column, so those rows can't be picked and the failure doesn't arise. Element Plus honours the predicate for select-all too.

## Neither predicate is new knowledge

That's what makes this a gap rather than a feature:

- `user-edit-form.vue` already disables the role field with *exactly* these two rules ("is this me", "is this the owner")
- `locations-table.vue` already renders a **Primary** tag from the very prop the predicate needs

They had just never been applied to the selection column.

## One design note

The current user's id is passed down **from the view** rather than read from the session inside the table. Three reasons: the tables are presentational, the locations table already receives `primaryLocationId` the same way, and reaching for the session two levels down broke both components' specs at mount — I tried it in the table, then in the list, before putting it where the store access already lives.

The backend checks are untouched. A row can become protected while the list is open, so this removes the *predictable* failure, not the guarantee.

## Verification

| Check | Result |
|---|---|
| Admin | 278 files, 2024 passed |
| `pnpm run type-check` (real) | clean |
| eslint (touched) | clean |
| Mutation-tested | owner rule, self rule, primary rule — all caught |

`locations-table.spec.ts` is new — the weather module had no component specs. Both specs mock `useBreakpoints`, because the selection column sits behind `v-if="isMDDevice"` and jsdom reports a narrow viewport, so without it the column under test never renders and the assertions would have passed against nothing.