### PR TITLE
docs(docs): record that admin uses a print width of 150

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Note: `apps/admin/src/openapi.constants.ts` is manually maintained (exports from
 ### TypeScript (Backend & Admin)
 
 - **Indentation**: tabs (not spaces)
-- **Print width**: 120 characters
+- **Print width**: 120 characters, except `apps/admin` which is 150 (see each app's `prettier.config.mjs`)
 - **Quotes**: single quotes
 - **Semicolons**: always
 - **Trailing commas**: always on multiline


### PR DESCRIPTION
One line. CLAUDE.md stated print width 120 flatly; the actual configs are:

| Package | `printWidth` |
|---|---|
| `apps/backend` | 120 |
| `apps/testing` | 120 |
| `packages/extension-sdk` | 120 |
| **`apps/admin`** | **150** |

This matters more than a docs nit. The admin source is hand-wrapped near 120, so prettier considers most of it unformatted — which is why `pretty:check` fails there on files nobody has touched, and why running `--write` on a single admin file reflows lines unrelated to the change being made.

I hit that earlier in this session: reformatting two untouched files and having to back it out. Knowing the real number makes the behaviour legible instead of looking like neglect.

Not changing either config — that's a separate decision about which number the admin should actually use.