### PR TITLE
fix(admin): stop the spaces semaphore leaking between store instances

### DIFF
--- a/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.spec.ts
@@ -167,4 +167,30 @@ describe('Spaces store', () => {
 			expect(store.semaphore.deleting).not.toContain(keptId);
 		});
 	});
+
+
+	// The semaphore used to be `{ ...defaultSemaphore }` - a spread that copies the
+	// object but not its arrays - so a push leaked onto the module-level constant
+	// and the next pinia started with it. This pins that a fresh store starts clean
+	// even after a previous one has pushed.
+	describe('semaphore isolation', () => {
+		it('does not carry semaphore state into the next store instance', () => {
+			// Reach the semaphore the way an in-flight action does, then leave it as a
+			// completed action would.
+			store.semaphore.deleting.push(removedId);
+			store.semaphore.deleting = store.semaphore.deleting.filter((id) => id !== removedId);
+
+			store.semaphore.creating.push(keptId);
+
+			setActivePinia(createPinia());
+
+			const fresh = useSpacesStore();
+
+			expect(fresh.semaphore.deleting).toEqual([]);
+			expect(fresh.semaphore.creating).toEqual([]);
+			expect(fresh.semaphore.updating).toEqual([]);
+			expect(fresh.semaphore.fetching.item).toEqual([]);
+		});
+	});
+
 });

--- a/apps/admin/src/modules/spaces/store/spaces.store.ts
+++ b/apps/admin/src/modules/spaces/store/spaces.store.ts
@@ -24,7 +24,17 @@ import { type ApiSpace, transformSpaceCreateRequest, transformSpaceEditRequest, 
 
 type SpacesStoreSetup = ISpacesStoreState & ISpacesStoreActions;
 
-const defaultSemaphore: ISpacesStateSemaphore = {
+/**
+ * Built fresh per store rather than shared, so the arrays cannot outlive one
+ * pinia instance.
+ *
+ * The previous `{ ...defaultSemaphore }` looked safe but was the one shape that
+ * leaked: the spread copies the object, not the arrays, so `push` mutated the
+ * module-level constant while the reassignment in each `finally` replaced the
+ * property only on the copy. Anything pushed stayed on the constant, and the
+ * next pinia - the next test - started with it.
+ */
+const createSemaphore = (): ISpacesStateSemaphore => ({
 	fetching: {
 		items: false,
 		item: [],
@@ -32,13 +42,13 @@ const defaultSemaphore: ISpacesStateSemaphore = {
 	creating: [],
 	updating: [],
 	deleting: [],
-};
+});
 
 export const useSpacesStore = defineStore<'spaces_module-spaces', SpacesStoreSetup>('spaces_module-spaces', (): SpacesStoreSetup => {
 	const backend = useBackend();
 
 	const data = ref<{ [key: ISpace['id']]: ISpace }>({});
-	const semaphore = ref({ ...defaultSemaphore });
+	const semaphore = ref<ISpacesStateSemaphore>(createSemaphore());
 	const firstLoad = ref<boolean>(false);
 
 	const firstLoadFinished = (): boolean => firstLoad.value;


### PR DESCRIPTION
Last of the findings from the bulk work. The result inverts what it looked like at first, so the investigation is the interesting part.

## The bug

The spaces store built its semaphore as `ref({ ...defaultSemaphore })`. The spread copies the **object** but not the **arrays inside it**, so:

1. `push` mutates the module-level constant's array
2. the reassignment in each `finally` (`semaphore.value.deleting = …filter(…)`) replaces the property only on the *copy*

Whatever had been pushed stayed on the constant, and the next pinia — in practice, the next test — started with it.

Now built per store, so nothing outlives one pinia.

## Why it's one store and not thirty

My first read was that this was repo-wide: **30 stores** initialise a semaphore from a module-level constant, 29 of them passing it to `ref()` *by reference*, which looks worse. It isn't:

| Shape | Stores | Leaks? |
|---|---|---|
| `ref(defaultSemaphore)` | 29 | **no** — `semaphore.value` *is* the constant, so the reassignment writes the filtered array back onto it and it clears itself |
| `ref({ ...defaultSemaphore })` | 1 (spaces) | **yes** — the copy breaks that write-back |

So the safer-looking spread was the faulty one, and the blunt-looking by-reference version is fine. Verified by reducing both to a few lines and running them, rather than reasoning about it.

## What I deliberately did not do

Those 29 are only *accidentally* safe — they depend on every cleanup reassigning rather than splicing. All 110 cleanups currently reassign, so there's nothing to fix today, but a single `.splice()` would reintroduce this everywhere at once. Converting all 29 to a factory would be robust, but it's 29 files of churn against a latent risk, so I left them and recorded the dependency here instead. Say the word if you'd rather have the belt-and-braces version.

## Verification

| Check | Result |
|---|---|
| Admin | 278 files, 2025 passed |
| `pnpm run type-check` (real) | clean |
| eslint (touched) | clean |
| Mutation-tested | reverting to the spread fails the new test |

Found by a subagent during #799 — its first spaces store test made a later one see a stale `deleting` entry, and it scoped its assertion around the problem rather than papering over it.