### PR TITLE
fix(admin): apply config changes announced over the socket

### DIFF
--- a/apps/admin/src/modules/config/config.module.ts
+++ b/apps/admin/src/modules/config/config.module.ts
@@ -16,12 +16,13 @@ import {
 	refreshLoadedStores,
 } from '../../common';
 
-import { CONFIG_MODULE_EVENT_PREFIX, CONFIG_MODULE_NAME, EventType } from './config.constants';
+import { CONFIG_MODULE_NAME } from './config.constants';
 import { locales } from './locales';
 import { ModuleRoutes } from './router';
 import { registerConfigModuleStore } from './store/config-modules.store';
 import { registerConfigPluginStore } from './store/config-plugins.store';
 import { configAppStoreKey, configModulesStoreKey, configPluginsStoreKey } from './store/keys';
+import { handleConfigChangeEvent } from './utils/config-change-event';
 import { registerConfigAppStore } from './store/stores';
 
 const configAdminModuleKey: ModuleInjectionKey<IModule> = Symbol('FB-Module-Config');
@@ -79,45 +80,9 @@ export default {
 			(): Promise<void> => refreshLoadedStores([configAppStore, configModulesStore, configPluginsStore])
 		);
 
-		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
-			if (!data?.event?.startsWith(CONFIG_MODULE_EVENT_PREFIX)) {
-				return;
-			}
-
-			if (data.payload === null || typeof data.payload !== 'object') {
-				return;
-			}
-
-			switch (data.event) {
-				case EventType.CONFIG_UPDATED:
-					// Language, weather, and system configs are now part of modules - handled via modules store
-					if ('plugins' in data.payload && Array.isArray(data.payload.plugins)) {
-						data.payload.plugins.forEach((plugin) => {
-							if (typeof plugin === 'object' && plugin !== null && 'type' in plugin && typeof plugin.type === 'string') {
-								configPluginsStore.onEvent({
-									type: plugin.type,
-									data: plugin,
-								});
-							}
-						});
-					}
-
-					if ('modules' in data.payload && Array.isArray(data.payload.modules)) {
-						data.payload.modules.forEach((module) => {
-							if (typeof module === 'object' && module !== null && 'type' in module && typeof module.type === 'string') {
-								configModulesStore.onEvent({
-									type: module.type,
-									data: module,
-								});
-							}
-						});
-					}
-					break;
-
-				default:
-					logger.warn('Unhandled config module event:', data.event);
-			}
-		});
+		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void =>
+			handleConfigChangeEvent(data, { configModulesStore, configPluginsStore, logger })
+		);
 
 		options.router.isReady().then(() => {
 			if (configPluginsStore.firstLoadFinished() === false) {

--- a/apps/admin/src/modules/config/utils/config-change-event.spec.ts
+++ b/apps/admin/src/modules/config/utils/config-change-event.spec.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventType } from '../config.constants';
+
+import { handleConfigChangeEvent } from './config-change-event';
+
+describe('handleConfigChangeEvent', (): void => {
+	const makeStore = () => ({ get: vi.fn((payload: { type: string }): Promise<unknown> => Promise.resolve(payload)) });
+
+	const makeLogger = () => ({
+		warn: vi.fn((message: string, ...args: unknown[]): void => void [message, args]),
+		error: vi.fn((message: string, ...args: unknown[]): void => void [message, args]),
+	});
+
+	let configModulesStore: ReturnType<typeof makeStore>;
+	let configPluginsStore: ReturnType<typeof makeStore>;
+	let logger: ReturnType<typeof makeLogger>;
+
+	const targets = () => ({ configModulesStore, configPluginsStore, logger });
+
+	beforeEach((): void => {
+		configModulesStore = makeStore();
+		configPluginsStore = makeStore();
+		logger = makeLogger();
+	});
+
+	// These two payloads are exactly what config.service.spec.ts pins the backend
+	// to emit. The handler previously read `payload.modules` / `payload.plugins`,
+	// arrays the backend has never sent, so every config change was dropped in
+	// silence and the admin only caught up on reload.
+	it('refetches the module whose config changed', (): void => {
+		handleConfigChangeEvent(
+			{ event: EventType.CONFIG_UPDATED, payload: { source: 'mock-module', type: 'module' } },
+			targets()
+		);
+
+		expect(configModulesStore.get).toHaveBeenCalledWith({ type: 'mock-module' });
+		expect(configPluginsStore.get).not.toHaveBeenCalled();
+	});
+
+	it('refetches the plugin whose config changed', (): void => {
+		handleConfigChangeEvent({ event: EventType.CONFIG_UPDATED, payload: { source: 'mock', type: 'plugin' } }, targets());
+
+		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'mock' });
+		expect(configModulesStore.get).not.toHaveBeenCalled();
+	});
+
+	// The whole point of the announcement carrying only a name: it reaches panel
+	// displays too, and plugin configs hold API keys and passwords.
+	it('never expects the configuration itself in the payload', (): void => {
+		handleConfigChangeEvent(
+			{
+				event: EventType.CONFIG_UPDATED,
+				payload: { source: 'devices-zigbee2mqtt-plugin', type: 'plugin', mqtt: { password: 'secret' } },
+			},
+			targets()
+		);
+
+		// Read back through the authenticated endpoint, not taken off the wire.
+		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'devices-zigbee2mqtt-plugin' });
+	});
+
+	it('ignores events from other modules', (): void => {
+		handleConfigChangeEvent({ event: 'DevicesModule.Device.Created', payload: { source: 'x', type: 'module' } }, targets());
+
+		expect(configModulesStore.get).not.toHaveBeenCalled();
+		expect(configPluginsStore.get).not.toHaveBeenCalled();
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('warns rather than throwing when the source is missing', (): void => {
+		handleConfigChangeEvent({ event: EventType.CONFIG_UPDATED, payload: { type: 'module' } }, targets());
+
+		expect(configModulesStore.get).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalled();
+	});
+
+	it('warns rather than guessing when the target type is unknown', (): void => {
+		handleConfigChangeEvent(
+			{ event: EventType.CONFIG_UPDATED, payload: { source: 'mock', type: 'something-else' } },
+			targets()
+		);
+
+		expect(configModulesStore.get).not.toHaveBeenCalled();
+		expect(configPluginsStore.get).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalled();
+	});
+
+	// A failed refetch must not surface as an unhandled rejection on the socket
+	// callback, which has no caller to catch it.
+	it('reports a failed refetch instead of rejecting', async (): Promise<void> => {
+		configModulesStore.get.mockRejectedValue(new Error('offline'));
+
+		handleConfigChangeEvent(
+			{ event: EventType.CONFIG_UPDATED, payload: { source: 'mock-module', type: 'module' } },
+			targets()
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(logger.error).toHaveBeenCalled();
+	});
+});

--- a/apps/admin/src/modules/config/utils/config-change-event.ts
+++ b/apps/admin/src/modules/config/utils/config-change-event.ts
@@ -1,0 +1,69 @@
+import { CONFIG_MODULE_EVENT_PREFIX, EventType } from '../config.constants';
+
+interface IConfigChangeEvent {
+	event: string;
+	payload: Record<string, unknown>;
+}
+
+interface IConfigChangeTargets {
+	configModulesStore: { get: (payload: { type: string }) => Promise<unknown> };
+	configPluginsStore: { get: (payload: { type: string }) => Promise<unknown> };
+	logger: { warn: (message: string, ...args: unknown[]) => void; error: (message: string, ...args: unknown[]) => void };
+}
+
+/**
+ * Reacts to the backend announcing that a module or plugin configuration
+ * changed.
+ *
+ * The announcement carries only *which* configuration changed - `{ source,
+ * type }` - not the configuration itself. That is deliberate: the event is
+ * broadcast to every connected client, panel displays included, and plugin
+ * configurations hold API keys, tokens and passwords. So the changed entry is
+ * refetched over the authenticated endpoint, which applies the redaction the
+ * socket cannot.
+ *
+ * Lives here rather than inline in the module installer so it can be tested:
+ * the previous version read `payload.modules` / `payload.plugins`, arrays the
+ * backend has never sent, so every configuration change was silently dropped
+ * and the admin only noticed one after a reload.
+ */
+export const handleConfigChangeEvent = (data: IConfigChangeEvent, targets: IConfigChangeTargets): void => {
+	const { configModulesStore, configPluginsStore, logger } = targets;
+
+	if (!data?.event?.startsWith(CONFIG_MODULE_EVENT_PREFIX)) {
+		return;
+	}
+
+	if (data.payload === null || typeof data.payload !== 'object') {
+		return;
+	}
+
+	switch (data.event) {
+		case EventType.CONFIG_UPDATED: {
+			const { source, type } = data.payload;
+
+			if (typeof source !== 'string' || source === '') {
+				logger.warn('Config change event carried no source:', data.payload);
+
+				break;
+			}
+
+			if (type === 'module') {
+				configModulesStore.get({ type: source }).catch((error: unknown): void => {
+					logger.error('Failed to refresh a module config after a change event', error);
+				});
+			} else if (type === 'plugin') {
+				configPluginsStore.get({ type: source }).catch((error: unknown): void => {
+					logger.error('Failed to refresh a plugin config after a change event', error);
+				});
+			} else {
+				logger.warn('Config change event carried an unknown target type:', String(type));
+			}
+
+			break;
+		}
+
+		default:
+			logger.warn('Unhandled config module event:', data.event);
+	}
+};


### PR DESCRIPTION
Fixes the bug you reported: toggling an extension applied only in the pinia store, so the menu kept showing modules that had just been disabled and device plugins kept their old state until a reload.

## What was actually broken

The socket round trip worked the entire way. The backend emits `ConfigModule.Configuration.Changed`, the gateway forwards it (it uses `onAny`, excluding only a few adapter prefixes), and the admin's handler recognised it.

Then it looked for `payload.modules` and `payload.plugins` — **arrays the backend has never sent** — matched neither, and fell through both branches doing nothing. Silently, because the `default:` branch only catches a different event name.

What the backend actually sends is `{ source, type }`, and it has been [pinned by `config.service.spec.ts`](https://github.com/FastyBird/smart-panel/blob/main/apps/backend/src/modules/config/services/config.service.spec.ts) since it was written:

```ts
expect(eventEmitter.emit).toHaveBeenCalledWith(EventType.CONFIG_UPDATED, {
    source: 'mock-module',
    type: 'module',
});
```

So the backend was right and tested; the admin was written against an imagined shape and had no test at all.

**It was never extensions-specific** — every config change from every source was dropped the same way: module edits, plugin edits, another admin session, a display.

## Why it refetches instead of reading the payload

My first plan was to put the changed config in the event, since the handler was already shaped for it. Checking who receives it stopped that:

| | |
|---|---|
| Plain broadcast (`server.emit`) reaches | **every** client, panel displays included |
| Plugins with secret config fields (`api_key`, `password`, `bot_token`, …) | **14** |
| Plugins declaring `secretFields`, so `toPublic()` redacts them | **1** (homey) |

Putting configs on that wire would have shipped 13 plugins' unredacted secrets to every display. So the event stays a name, and the admin refetches that one entry over the authenticated endpoint, which applies the redaction the socket cannot.

## Testability was the root cause

The handler lived inline in the module installer, where nothing tests it — no `.module.spec.ts` exists anywhere in the admin. That's how a completely inert handler survived. It's now a function with a spec; reinstating the old payload read fails **6 of 7** cases.

## Verification

| Check | Result |
|---|---|
| Admin | 279 files, 2032 passed |
| Backend | 390 suites, 4866 passed |
| `pnpm run type-check` (real) | clean |
| eslint (touched) | clean |
| Mutation-tested | original bug reinstated → 6 failures |

## Separate finding, not fixed here

**13 of 14 plugins holding secrets don't declare `secretFields`**, so `configSecrets.toPublic()` doesn't redact them on the REST read either. That's behind authentication rather than broadcast, so it's a much smaller exposure than the socket would have been — but it means the redaction mechanism is largely unwired. Worth its own change.