### PR TITLE
feat(cross): describe module configs in the spec and bind six to it

### DIFF
--- a/apps/admin/src/modules/buddy/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/buddy/store/config.store.schemas.ts
@@ -1,11 +1,11 @@
 import { type ZodType, z } from 'zod';
 
-import type { ConfigModuleModuleSchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
+import type { ConfigModuleBuddySchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { BUDDY_MODULE_NAME } from '../buddy.constants';
 
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleBuddySchema;
 
 // STORE STATE
 // ===========

--- a/apps/admin/src/modules/mcp/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/mcp/store/config.store.schemas.ts
@@ -1,10 +1,10 @@
 import { type ZodType, z } from 'zod';
 
-import type { ConfigModuleModuleSchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
+import type { ConfigModuleMcpSchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { MCP_MODULE_NAME, McpCapability } from '../mcp.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleMcpSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 export const McpConfigSchema = ConfigModuleSchema.extend({

--- a/apps/admin/src/modules/mdns/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/mdns/store/config.store.schemas.ts
@@ -1,13 +1,13 @@
 import { type ZodType, z } from 'zod';
 
 import type {
-	ConfigModuleModuleSchema,
+	ConfigModuleMdnsSchema,
 	ConfigModuleUpdateModuleSchema,
 } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { MDNS_MODULE_NAME } from '../mdns.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleMdnsSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE

--- a/apps/admin/src/modules/scenes/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/scenes/store/config.store.schemas.ts
@@ -1,13 +1,13 @@
 import { type ZodType, z } from 'zod';
 
 import type {
-	ConfigModuleModuleSchema,
+	ConfigModuleScenesSchema,
 	ConfigModuleUpdateModuleSchema,
 } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { SCENES_MODULE_NAME } from '../scenes.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleScenesSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE

--- a/apps/admin/src/modules/storage/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/storage/store/config.store.schemas.ts
@@ -1,13 +1,13 @@
 import { type ZodType, z } from 'zod';
 
 import type {
-	ConfigModuleModuleSchema,
+	ConfigModuleStorageSchema,
 	ConfigModuleUpdateModuleSchema,
 } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { STORAGE_MODULE_NAME } from '../storage.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleStorageSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE
@@ -34,6 +34,6 @@ export const StorageConfigResSchema: ZodType<ApiConfigModule> = ConfigModuleResS
 	z.object({
 		type: z.literal(STORAGE_MODULE_NAME),
 		primary_storage: z.string(),
-		fallback_storage: z.string().optional(),
+		fallback_storage: z.string(),
 	})
 );

--- a/apps/admin/src/modules/weather/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/weather/store/config.store.schemas.ts
@@ -1,13 +1,13 @@
 import { type ZodType, z } from 'zod';
 
 import type {
-	ConfigModuleModuleSchema,
+	ConfigModuleWeatherSchema,
 	ConfigModuleUpdateModuleSchema,
 } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { WEATHER_MODULE_NAME } from '../weather.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleWeatherSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -58,6 +58,20 @@ export type ConfigModuleAppSchema = components['schemas']['ConfigModuleDataApp']
 export type ConfigModulePluginSchema = components['schemas']['ConfigModuleDataPlugin'];
 export type ConfigModuleUpdatePluginSchema = components['schemas']['ConfigModuleUpdatePlugin'];
 export type ConfigModuleModuleSchema = components['schemas']['ConfigModuleDataModule'];
+
+export type ConfigModuleBuddySchema = components['schemas']['ConfigModuleDataBuddy'];
+
+
+export type ConfigModuleMcpSchema = components['schemas']['ConfigModuleDataMcp'];
+
+export type ConfigModuleMdnsSchema = components['schemas']['ConfigModuleDataMdns'];
+
+export type ConfigModuleScenesSchema = components['schemas']['ConfigModuleDataScenes'];
+
+export type ConfigModuleStorageSchema = components['schemas']['ConfigModuleDataStorage'];
+
+
+export type ConfigModuleWeatherSchema = components['schemas']['ConfigModuleDataWeather'];
 export type ConfigModuleUpdateModuleSchema = components['schemas']['ConfigModuleUpdateModule'];
 
 // MCP Module Schemas

--- a/apps/backend/src/modules/auth/auth.openapi.ts
+++ b/apps/backend/src/modules/auth/auth.openapi.ts
@@ -26,8 +26,11 @@ import {
 	TokensResponseModel,
 } from './models/auth-response.model';
 import { CheckModel, LoggedInModel, RefreshTokenModel, TokenPairModel } from './models/auth.model';
+import { AuthConfigModel } from './models/config.model';
 
 export const AUTH_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	AuthConfigModel,
 	// DTOs
 	CreateAccessTokenDto,
 	CreateRefreshTokenDto,

--- a/apps/backend/src/modules/dashboard/dashboard.openapi.ts
+++ b/apps/backend/src/modules/dashboard/dashboard.openapi.ts
@@ -5,6 +5,7 @@ import { CreateDataSourceDto } from './dto/create-data-source.dto';
 import { CreateTileDto } from './dto/create-tile.dto';
 import { UpdateDataSourceDto } from './dto/update-data-source.dto';
 import { UpdateTileDto } from './dto/update-tile.dto';
+import { DashboardConfigModel } from './models/config.model';
 import {
 	BulkResultResponseModel,
 	DataSourceResponseModel,
@@ -22,6 +23,8 @@ import {
 } from './models/dashboard.model';
 
 export const DASHBOARD_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	DashboardConfigModel,
 	// DTOs (abstract classes need type assertion)
 	CreateDataSourceDto,
 	CreateTileDto,

--- a/apps/backend/src/modules/devices/devices.openapi.ts
+++ b/apps/backend/src/modules/devices/devices.openapi.ts
@@ -8,6 +8,7 @@ import {
 	DeviceControlEntity,
 	DeviceEntity,
 } from './entities/devices.entity';
+import { DevicesConfigModel } from './models/config.model';
 import {
 	DeviceValidationResponseModel,
 	DeviceValidationResultModel,
@@ -53,6 +54,8 @@ import {
 } from './models/devices.model';
 
 export const DEVICES_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	DevicesConfigModel,
 	// Response models
 	BulkResultResponseModel,
 	DeviceResponseModel,

--- a/apps/backend/src/modules/displays/displays.openapi.ts
+++ b/apps/backend/src/modules/displays/displays.openapi.ts
@@ -4,6 +4,7 @@
 import { RegisterDisplayDto, ReqRegisterDisplayDto } from './dto/register-display.dto';
 import { ReqUpdateDisplayDto, UpdateDisplayDto } from './dto/update-display.dto';
 import { DisplayEntity } from './entities/displays.entity';
+import { DisplaysConfigModel } from './models/config.model';
 import {
 	BulkResultResponseModel,
 	DisplayRegistrationDataModel,
@@ -22,6 +23,8 @@ import {
 } from './models/displays-response.model';
 
 export const DISPLAYS_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	DisplaysConfigModel,
 	// DTOs
 	RegisterDisplayDto,
 	ReqRegisterDisplayDto,

--- a/apps/backend/src/modules/energy/energy.openapi.ts
+++ b/apps/backend/src/modules/energy/energy.openapi.ts
@@ -2,6 +2,7 @@
  * OpenAPI extra models for Energy module
  */
 import { EnergyDeltaEntity } from './entities/energy-delta.entity';
+import { EnergyConfigModel } from './models/config.model';
 import { EnergyBreakdownItemModel } from './models/energy-breakdown-item.model';
 import { EnergyDeltaItemModel } from './models/energy-delta.model';
 import {
@@ -20,6 +21,8 @@ import { EnergySummaryModel } from './models/energy-summary.model';
 import { EnergyTimeseriesPointModel } from './models/energy-timeseries-point.model';
 
 export const ENERGY_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	EnergyConfigModel,
 	// Response models
 	EnergySummaryResponseModel,
 	EnergyDeltasResponseModel,

--- a/apps/backend/src/modules/extensions/extensions.openapi.ts
+++ b/apps/backend/src/modules/extensions/extensions.openapi.ts
@@ -13,6 +13,7 @@ import {
 	ActionResultResponseModel,
 	ExtensionActionsResponseModel,
 } from './models/actions-response.model';
+import { ExtensionsConfigModel } from './models/config.model';
 import {
 	DiscoveredExtensionAdminModel,
 	DiscoveredExtensionBackendModel,
@@ -32,6 +33,8 @@ import {
 } from './models/service-status.model';
 
 export const EXTENSIONS_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	ExtensionsConfigModel,
 	ExtensionModel,
 	ExtensionLinksModel,
 	ExtensionResponseModel,

--- a/apps/backend/src/modules/scenes/scenes.openapi.ts
+++ b/apps/backend/src/modules/scenes/scenes.openapi.ts
@@ -2,6 +2,7 @@
  * OpenAPI extra models for Scenes module
  */
 import { SceneActionEntity, SceneEntity } from './entities/scenes.entity';
+import { ScenesConfigModel } from './models/config.model';
 import {
 	BulkResultResponseModel,
 	SceneActionResponseModel,
@@ -13,6 +14,8 @@ import {
 import { ActionExecutionResultModel, SceneExecutionResultModel } from './models/scenes.model';
 
 export const SCENES_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	ScenesConfigModel,
 	// Response models
 	BulkResultResponseModel,
 	SceneResponseModel,

--- a/apps/backend/src/modules/security/security.openapi.ts
+++ b/apps/backend/src/modules/security/security.openapi.ts
@@ -1,3 +1,4 @@
+import { SecurityConfigModel } from './models/config.model';
 import {
 	SecurityAlertAckAllResponseModel,
 	SecurityAlertAckModel,
@@ -8,6 +9,8 @@ import { SecurityStatusResponseModel } from './models/security-response.model';
 import { SecurityAlertModel, SecurityLastEventModel, SecurityStatusModel } from './models/security-status.model';
 
 export const SECURITY_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	SecurityConfigModel,
 	// Response models
 	SecurityStatusResponseModel,
 	SecurityAlertAckResponseModel,

--- a/apps/backend/src/modules/spaces/models/config.model.ts
+++ b/apps/backend/src/modules/spaces/models/config.model.ts
@@ -6,7 +6,7 @@ import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import { ModuleConfigModel } from '../../config/models/config.model';
 import { SPACES_MODULE_NAME } from '../spaces.constants';
 
-@ApiSchema({ name: 'SpacesModuleDataConfig' })
+@ApiSchema({ name: 'ConfigModuleDataSpaces' })
 export class SpacesConfigModel extends ModuleConfigModel {
 	@ApiProperty({
 		description: 'Module type',

--- a/apps/backend/src/modules/spaces/spaces.openapi.ts
+++ b/apps/backend/src/modules/spaces/spaces.openapi.ts
@@ -5,6 +5,7 @@ import { BulkAssignDto, ReqBulkAssignDto } from './dto/bulk-assign.dto';
 import { CreateSpaceDto, ReqCreateSpaceDto } from './dto/create-space.dto';
 import { ReqUpdateSpaceDto, UpdateSpaceDto } from './dto/update-space.dto';
 import { SpaceEntity } from './entities/space.entity';
+import { SpacesConfigModel } from './models/config.model';
 import {
 	BulkAssignmentDataModel,
 	BulkAssignmentResponseModel,
@@ -17,6 +18,8 @@ import {
 } from './models/spaces-response.model';
 
 export const SPACES_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	SpacesConfigModel,
 	// DTOs
 	CreateSpaceDto,
 	ReqCreateSpaceDto,

--- a/apps/backend/src/modules/storage/models/config.model.ts
+++ b/apps/backend/src/modules/storage/models/config.model.ts
@@ -27,6 +27,7 @@ export class StorageConfigModel extends ModuleConfigModel {
 	override enabled: boolean = true;
 
 	@ApiProperty({
+		name: 'primary_storage',
 		description: 'Primary storage plugin',
 		type: 'string',
 		example: 'influx-v1-plugin',
@@ -36,6 +37,7 @@ export class StorageConfigModel extends ModuleConfigModel {
 	primaryStorage: string = STORAGE_DEFAULT_PRIMARY;
 
 	@ApiProperty({
+		name: 'fallback_storage',
 		description: 'Fallback storage plugin (used when primary is unavailable)',
 		type: 'string',
 		example: 'memory-storage-plugin',

--- a/apps/backend/src/modules/users/users.openapi.ts
+++ b/apps/backend/src/modules/users/users.openapi.ts
@@ -2,9 +2,12 @@
  * OpenAPI extra models for Users module
  */
 import { UserEntity } from './entities/users.entity';
+import { UsersConfigModel } from './models/config.model';
 import { BulkResultResponseModel, UserResponseModel, UsersResponseModel } from './models/users-response.model';
 
 export const USERS_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	UsersConfigModel,
 	// Response models
 	BulkResultResponseModel,
 	UserResponseModel,

--- a/apps/backend/src/modules/weather/weather.openapi.ts
+++ b/apps/backend/src/modules/weather/weather.openapi.ts
@@ -3,6 +3,7 @@
  */
 import { WeatherLocationEntity } from './entities/locations.entity';
 import { LocationAlertsResponseModel, WeatherAlertModel } from './models/alert.model';
+import { WeatherConfigModel } from './models/config.model';
 import {
 	WeatherHistoryPointModel,
 	WeatherHistoryResponseModel,
@@ -34,6 +35,8 @@ import {
 } from './models/weather.model';
 
 export const WEATHER_SWAGGER_EXTRA_MODELS = [
+	// Module configuration
+	WeatherConfigModel,
 	// Response models
 	LocationWeatherResponseModel,
 	AllLocationsWeatherResponseModel,


### PR DESCRIPTION
Option A from the [findings write-up](https://claude.ai/code/artifact/9e134894-596c-467d-9410-1021deac9164).

Config endpoints declare their payload as `ConfigModuleDataModule` — `type` and `enabled`, nothing else — while **9 of 19 modules** return more than that. Plugins were already fine: each registers its config model and the admin binds its zod schema to the generated per-plugin type, so a backend rename is a compile error. Modules did neither.

## What this does

- **Registers 11 module config models** that were missing from the spec entirely
- **Binds 6 admin schemas** to their generated type instead of the two-field base: `buddy`, `mcp`, `mdns`, `scenes`, `storage`, `weather`

`ConfigModuleDataMcp` already existed with `oauth_enabled` on it — the admin just wasn't using it. That field gates the OAuth menu item from #790, and renaming it backend-side would have compiled cleanly and silently broken the menu. It now can't.

## The binding earned itself immediately

Turning it on surfaced real drift on three modules — which is the entire point:

| Module | What the binding caught |
|---|---|
| **storage** | admin declared `fallback_storage` **optional** in the response schema; the backend always sends it (default + `@IsString()`). Fixed here. |
| **displays** | `deployment_mode` re-declared as a zod string union against a generated enum |
| **system** | eleven enums re-declared the same way |

`displays` and `system` are deliberately left on the base. Their drift is per-field enum work, not a binding change, and mixing it in would bury this. Each needs the `z.nativeEnum(...)` treatment MCP already uses for `McpCapability`.

## Two spec defects found by registering

Both fixed here, both pre-existing:

**`ConfigModuleDataStorage` described camelCase.** `@Expose({ name: 'primary_storage' })` sets the wire name, but `@ApiProperty` publishes the TypeScript property name unless told otherwise — so the spec advertised `primaryStorage` / `fallbackStorage` while the endpoint has always sent snake_case. Any client generated from it would have read `undefined`.

**`spaces` broke the naming convention** — `SpacesModuleDataConfig` where every other module uses `ConfigModuleData{Name}`. Renamed while it was still absent from the spec and therefore free to change.

## Not included

`intents` and `platform` register nothing with Swagger at all — no `openapi.ts`, no registry call — so they need their own openapi module first, and neither has an admin config schema to bind. Left out rather than bundling new plumbing into a wiring change.

## Verification

| Check | Result |
|---|---|
| Backend | 390 suites, 4866 passed |
| Admin | 279 files, 2032 passed |
| `pnpm run type-check` (real) | clean |
| `lint:js` / `lint:api` / `lint:openapi` | pass |
| `ConfigModuleData*` schemas | 21, none camelCase |