### PR TITLE
fix(admin): bind the displays and system configs to their generated types

### DIFF
--- a/apps/admin/src/modules/displays/displays.constants.ts
+++ b/apps/admin/src/modules/displays/displays.constants.ts
@@ -1,8 +1,14 @@
+import { DisplaysModuleDeploymentMode } from '../../openapi.constants';
+
 export const DISPLAYS_MODULE_PREFIX = 'displays';
 
 export const DISPLAYS_MODULE_NAME = 'displays-module';
 
 export const DISPLAYS_MODULE_EVENT_PREFIX = 'DisplaysModule.';
+
+export const DeploymentMode = DisplaysModuleDeploymentMode;
+
+export type DeploymentMode = DisplaysModuleDeploymentMode;
 
 export enum EventType {
 	DISPLAY_CREATED = 'DisplaysModule.Display.Created',

--- a/apps/admin/src/modules/displays/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/displays/store/config.store.schemas.ts
@@ -1,13 +1,10 @@
 import { type ZodType, z } from 'zod';
 
-import type {
-	ConfigModuleModuleSchema,
-	ConfigModuleUpdateModuleSchema,
-} from '../../../openapi.constants';
+import type { ConfigModuleDisplaysSchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
-import { DISPLAYS_MODULE_NAME } from '../displays.constants';
+import { DISPLAYS_MODULE_NAME, DeploymentMode } from '../displays.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleDisplaysSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE
@@ -15,7 +12,7 @@ type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 export const DisplaysConfigSchema = ConfigModuleSchema.extend({
 	type: z.literal(DISPLAYS_MODULE_NAME),
-	deploymentMode: z.enum(['standalone', 'all-in-one', 'combined']),
+	deploymentMode: z.nativeEnum(DeploymentMode),
 	permitJoinDurationMs: z.number().int().min(1000),
 });
 
@@ -25,7 +22,7 @@ export const DisplaysConfigSchema = ConfigModuleSchema.extend({
 export const DisplaysConfigUpdateReqSchema: ZodType<ApiConfigUpdateModule> = ConfigModuleUpdateReqSchema.and(
 	z.object({
 		type: z.literal(DISPLAYS_MODULE_NAME),
-		deployment_mode: z.enum(['standalone', 'all-in-one', 'combined']).optional(),
+		deployment_mode: z.nativeEnum(DeploymentMode).optional(),
 		permit_join_duration_ms: z.number().int().min(1000).optional(),
 	})
 );
@@ -33,7 +30,7 @@ export const DisplaysConfigUpdateReqSchema: ZodType<ApiConfigUpdateModule> = Con
 export const DisplaysConfigResSchema: ZodType<ApiConfigModule> = ConfigModuleResSchema.and(
 	z.object({
 		type: z.literal(DISPLAYS_MODULE_NAME),
-		deployment_mode: z.enum(['standalone', 'all-in-one', 'combined']),
+		deployment_mode: z.nativeEnum(DeploymentMode),
 		permit_join_duration_ms: z.number().int().min(1000),
 	})
 );

--- a/apps/admin/src/modules/system/store/config.store.schemas.ts
+++ b/apps/admin/src/modules/system/store/config.store.schemas.ts
@@ -1,13 +1,22 @@
 import { type ZodType, z } from 'zod';
 
-import type {
-	ConfigModuleModuleSchema,
-	ConfigModuleUpdateModuleSchema,
+import type { ConfigModuleSystemSchema, ConfigModuleUpdateModuleSchema } from '../../../openapi.constants';
+import {
+	SystemModuleDistanceUnit,
+	SystemModuleHouseMode,
+	SystemModuleLanguage,
+	SystemModuleLogEntryType,
+	SystemModuleNumberFormat,
+	SystemModulePrecipitationUnit,
+	SystemModulePressureUnit,
+	SystemModuleTimeFormat,
+	SystemModuleWindSpeedUnit,
+	TemperatureUnit,
 } from '../../../openapi.constants';
 import { ConfigModuleResSchema, ConfigModuleSchema, ConfigModuleUpdateReqSchema } from '../../config/store/config-modules.store.schemas';
 import { SYSTEM_MODULE_NAME } from '../system.constants';
 
-type ApiConfigModule = ConfigModuleModuleSchema;
+type ApiConfigModule = ConfigModuleSystemSchema;
 type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 // STORE STATE
@@ -15,52 +24,56 @@ type ApiConfigUpdateModule = ConfigModuleUpdateModuleSchema;
 
 export const SystemConfigSchema = ConfigModuleSchema.extend({
 	type: z.literal(SYSTEM_MODULE_NAME),
-	language: z.enum(['en_US', 'cs_CZ', 'de_DE', 'es_ES', 'pl_PL', 'sk_SK']),
+	language: z.nativeEnum(SystemModuleLanguage),
 	timezone: z.string(),
-	timeFormat: z.enum(['12h', '24h']),
-	numberFormat: z.enum(['comma_dot', 'dot_comma', 'space_comma', 'none']),
-	temperatureUnit: z.enum(['celsius', 'fahrenheit']),
-	windSpeedUnit: z.enum(['ms', 'kmh', 'mph', 'knots']),
-	pressureUnit: z.enum(['hpa', 'mbar', 'inhg', 'mmhg']),
-	precipitationUnit: z.enum(['mm', 'inches']),
-	distanceUnit: z.enum(['km', 'miles', 'meters', 'feet']),
-	logLevels: z.array(z.enum(['silent', 'verbose', 'debug', 'trace', 'log', 'info', 'success', 'warn', 'error', 'fail', 'fatal'])),
-	houseMode: z.enum(['home', 'away', 'night']),
+	timeFormat: z.nativeEnum(SystemModuleTimeFormat),
+	numberFormat: z.nativeEnum(SystemModuleNumberFormat),
+	temperatureUnit: z.nativeEnum(TemperatureUnit),
+	windSpeedUnit: z.nativeEnum(SystemModuleWindSpeedUnit),
+	pressureUnit: z.nativeEnum(SystemModulePressureUnit),
+	precipitationUnit: z.nativeEnum(SystemModulePrecipitationUnit),
+	distanceUnit: z.nativeEnum(SystemModuleDistanceUnit),
+	logLevels: z.array(z.nativeEnum(SystemModuleLogEntryType)),
+	houseMode: z.nativeEnum(SystemModuleHouseMode),
+	onboardingCompleted: z.boolean().default(false),
 });
 
 // BACKEND API
 // ===========
 
+// onboarding_completed is deliberately absent - the backend accepts it, but the config
+// form never offers it and the onboarding module flips the flag through its own endpoint.
 export const SystemConfigUpdateReqSchema: ZodType<ApiConfigUpdateModule> = ConfigModuleUpdateReqSchema.and(
 	z.object({
 		type: z.literal(SYSTEM_MODULE_NAME),
-		language: z.enum(['en_US', 'cs_CZ', 'de_DE', 'es_ES', 'pl_PL', 'sk_SK']).optional(),
+		language: z.nativeEnum(SystemModuleLanguage).optional(),
 		timezone: z.string().optional(),
-		time_format: z.enum(['12h', '24h']).optional(),
-		number_format: z.enum(['comma_dot', 'dot_comma', 'space_comma', 'none']).optional(),
-		temperature_unit: z.enum(['celsius', 'fahrenheit']).optional(),
-		wind_speed_unit: z.enum(['ms', 'kmh', 'mph', 'knots']).optional(),
-		pressure_unit: z.enum(['hpa', 'mbar', 'inhg', 'mmhg']).optional(),
-		precipitation_unit: z.enum(['mm', 'inches']).optional(),
-		distance_unit: z.enum(['km', 'miles', 'meters', 'feet']).optional(),
-		log_levels: z.array(z.enum(['silent', 'verbose', 'debug', 'trace', 'log', 'info', 'success', 'warn', 'error', 'fail', 'fatal'])).optional(),
-		house_mode: z.enum(['home', 'away', 'night']).optional(),
+		time_format: z.nativeEnum(SystemModuleTimeFormat).optional(),
+		number_format: z.nativeEnum(SystemModuleNumberFormat).optional(),
+		temperature_unit: z.nativeEnum(TemperatureUnit).optional(),
+		wind_speed_unit: z.nativeEnum(SystemModuleWindSpeedUnit).optional(),
+		pressure_unit: z.nativeEnum(SystemModulePressureUnit).optional(),
+		precipitation_unit: z.nativeEnum(SystemModulePrecipitationUnit).optional(),
+		distance_unit: z.nativeEnum(SystemModuleDistanceUnit).optional(),
+		log_levels: z.array(z.nativeEnum(SystemModuleLogEntryType)).optional(),
+		house_mode: z.nativeEnum(SystemModuleHouseMode).optional(),
 	})
 );
 
 export const SystemConfigResSchema: ZodType<ApiConfigModule> = ConfigModuleResSchema.and(
 	z.object({
 		type: z.literal(SYSTEM_MODULE_NAME),
-		language: z.enum(['en_US', 'cs_CZ', 'de_DE', 'es_ES', 'pl_PL', 'sk_SK']),
+		language: z.nativeEnum(SystemModuleLanguage),
 		timezone: z.string(),
-		time_format: z.enum(['12h', '24h']),
-		number_format: z.enum(['comma_dot', 'dot_comma', 'space_comma', 'none']),
-		temperature_unit: z.enum(['celsius', 'fahrenheit']),
-		wind_speed_unit: z.enum(['ms', 'kmh', 'mph', 'knots']),
-		pressure_unit: z.enum(['hpa', 'mbar', 'inhg', 'mmhg']),
-		precipitation_unit: z.enum(['mm', 'inches']),
-		distance_unit: z.enum(['km', 'miles', 'meters', 'feet']),
-		log_levels: z.array(z.enum(['silent', 'verbose', 'debug', 'trace', 'log', 'info', 'success', 'warn', 'error', 'fail', 'fatal'])),
-		house_mode: z.enum(['home', 'away', 'night']),
+		time_format: z.nativeEnum(SystemModuleTimeFormat),
+		number_format: z.nativeEnum(SystemModuleNumberFormat),
+		temperature_unit: z.nativeEnum(TemperatureUnit),
+		wind_speed_unit: z.nativeEnum(SystemModuleWindSpeedUnit),
+		pressure_unit: z.nativeEnum(SystemModulePressureUnit),
+		precipitation_unit: z.nativeEnum(SystemModulePrecipitationUnit),
+		distance_unit: z.nativeEnum(SystemModuleDistanceUnit),
+		log_levels: z.array(z.nativeEnum(SystemModuleLogEntryType)),
+		house_mode: z.nativeEnum(SystemModuleHouseMode),
+		onboarding_completed: z.boolean(),
 	})
 );

--- a/apps/admin/src/openapi.constants.ts
+++ b/apps/admin/src/openapi.constants.ts
@@ -61,6 +61,7 @@ export type ConfigModuleModuleSchema = components['schemas']['ConfigModuleDataMo
 
 export type ConfigModuleBuddySchema = components['schemas']['ConfigModuleDataBuddy'];
 
+export type ConfigModuleDisplaysSchema = components['schemas']['ConfigModuleDataDisplays'];
 
 export type ConfigModuleMcpSchema = components['schemas']['ConfigModuleDataMcp'];
 
@@ -70,6 +71,7 @@ export type ConfigModuleScenesSchema = components['schemas']['ConfigModuleDataSc
 
 export type ConfigModuleStorageSchema = components['schemas']['ConfigModuleDataStorage'];
 
+export type ConfigModuleSystemSchema = components['schemas']['ConfigModuleDataSystem'];
 
 export type ConfigModuleWeatherSchema = components['schemas']['ConfigModuleDataWeather'];
 export type ConfigModuleUpdateModuleSchema = components['schemas']['ConfigModuleUpdateModule'];
@@ -93,6 +95,7 @@ export type DisplaysModuleUpdateDisplaySchema = components['schemas']['DisplaysM
 export type DisplaysModuleRegisterDisplaySchema = components['schemas']['DisplaysModuleRegisterDisplay'];
 export type DisplaysModuleRegistrationSchema = components['schemas']['DisplaysModuleDataRegistration'];
 export type DisplaysModuleLongLiveTokenSchema = components['schemas']['AuthModuleDataLongLiveToken'];
+export { ConfigModuleDataDisplaysDeployment_mode as DisplaysModuleDeploymentMode } from './openapi';
 
 // System Module Schemas
 export type SystemModuleCreateLogEntrySchema = components['schemas']['SystemModuleCreateLogEntry'];
@@ -514,6 +517,25 @@ export { SystemModuleCreateLogEntrySource as SystemModuleLogEntrySource } from '
 export { SystemModuleCreateLogEntryType as SystemModuleLogEntryType } from './openapi';
 
 export { SystemModuleDataSystemInfoNetwork_mode as SystemModuleNetworkMode } from './openapi';
+
+export { ConfigModuleDataSystemLanguage as SystemModuleLanguage } from './openapi';
+
+export { ConfigModuleDataSystemTime_format as SystemModuleTimeFormat } from './openapi';
+
+export { ConfigModuleDataSystemHouse_mode as SystemModuleHouseMode } from './openapi';
+
+// The unit and number-format enums are deduped by the generator onto the displays
+// update DTO, which declares the same members. Temperature already has an alias -
+// TemperatureUnit, used by the weather plugins - so only five are aliased here.
+export { DisplaysModuleUpdateDisplayNumber_format as SystemModuleNumberFormat } from './openapi';
+
+export { DisplaysModuleUpdateDisplayWind_speed_unit as SystemModuleWindSpeedUnit } from './openapi';
+
+export { DisplaysModuleUpdateDisplayPressure_unit as SystemModulePressureUnit } from './openapi';
+
+export { DisplaysModuleUpdateDisplayPrecipitation_unit as SystemModulePrecipitationUnit } from './openapi';
+
+export { DisplaysModuleUpdateDisplayDistance_unit as SystemModuleDistanceUnit } from './openapi';
 
 // Scenes Module Types
 // ====================


### PR DESCRIPTION
Completes what #806 started. Both modules were left on the two-field base because they re-declared generated enums as zod string unions, so binding them produced a type error per field — drift worth fixing on its own rather than buried in a wiring change.

Both now use `z.nativeEnum` on the generated enum, aliased in the module's own constants the way MCP already does for `McpCapability`.

## The names had to be read, not guessed

`--dedupe-enums` points five of the ten system fields at *another* module's DTO:

| field | generated type |
|---|---|
| `language` | `ConfigModuleDataSystemLanguage` |
| `number_format` | `DisplaysModuleUpdateDisplayNumber_format` |
| `temperature_unit` | `DisplaysModuleUpdateDisplayTemperature_unit` |
| `wind_speed_unit` | `DisplaysModuleUpdateDisplayWind_speed_unit` |
| `log_levels` | `SystemModuleCreateLogEntryType[]` |

## What the binding caught

**No value drift.** All ten literal lists matched their generated enum exactly — `log_levels` included, where I'd expected a mismatch across eleven members. Same spelling, same order.

**`onboarding_completed` was missing from the admin entirely.** It's `required` on `ConfigModuleDataSystem`, the backend declares it with a default so the response always carries it, and the admin's transformer — `snakeToCamel` then `safeParse` — was **silently stripping it on every read**. Zero occurrences in the admin on `main`.

It's now in the response and store-state schemas. Deliberately *not* in the update schema: the edit form parses through a non-strict zod object that would strip it anyway, and the onboarding module owns the flag via its own endpoint, so nothing in the admin could populate it.

## Verified live, not just green

Trusting a passing type-check would prove nothing here, so each binding was mutated:

| Mutation | Result |
|---|---|
| Remove `onboarding_completed` from the response schema | fails type-check |
| Add a member to `house_mode` in the **response** schema | fails type-check |
| Same edit in the **store-state** schema | passes — only the response carries `ZodType<…>` |

That last row is worth knowing: the binding protects the response contract specifically. The store-state and update schemas are unguarded.

## Verification

| Check | Result |
|---|---|
| Admin | 279 files, 2032 passed |
| Backend | 390 suites, 4866 passed |
| `pnpm run type-check` (real, serial) | clean |
| eslint (touched) | clean |

## Left for later, deliberately

- `modules/system/schemas/config.schemas.ts` and `modules/displays/schemas/config.schemas.ts` still re-declare the same enums as string unions for form validation. Nothing binds them, so drift there stays invisible. Values currently agree.
- `system.constants.ts` hand-declares `HouseMode` / `HouseModeType`, both **completely unused** — a dead duplicate of the generated enum.
- `PATCH /config/module/{module}` is undescribed for **13 of 17** modules: their update DTOs are annotated but never added to `SWAGGER_EXTRA_MODELS`, the same gap #806 closed on the read side. Its own change.