### PR TITLE
feat(backend): add Homey MVP mapping catalog

### DIFF
--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -15,6 +15,7 @@ import { DEVICES_HOMEY_PLUGIN_SWAGGER_EXTRA_MODELS } from './devices-homey.opena
 import { DevicesHomeyPlugin } from './devices-homey.plugin';
 import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
 import { HomeyMappingLoaderService } from './mappings/mapping-loader.service';
+import { HomeyMappingTransformerService } from './mappings/mapping-transformer.service';
 import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-storage.service';
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
@@ -84,6 +85,7 @@ describe('DevicesHomeyPlugin', () => {
 				HomeyLocalConnectorFactory,
 				HomeyConnectionTestService,
 				HomeyMappingLoaderService,
+				HomeyMappingTransformerService,
 				HomeyPropertyMappingStorageService,
 			]),
 		);

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -43,6 +43,7 @@ import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateHomeyDeviceDto } from './dto/update-device.dto';
 import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './entities/devices-homey.entity';
 import { HomeyMappingLoaderService } from './mappings/mapping-loader.service';
+import { HomeyMappingTransformerService } from './mappings/mapping-transformer.service';
 import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-storage.service';
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
@@ -72,11 +73,17 @@ import { HomeyService } from './services/homey.service';
 		},
 		HomeyConnectionTestService,
 		HomeyMappingLoaderService,
+		HomeyMappingTransformerService,
 		HomeyPropertyMappingStorageService,
 		HomeyService,
 	],
 	controllers: [HomeyStatusController, HomeyTestConnectionController],
-	exports: [HomeyMappingLoaderService, HomeyPropertyMappingStorageService, HomeyService],
+	exports: [
+		HomeyMappingLoaderService,
+		HomeyMappingTransformerService,
+		HomeyPropertyMappingStorageService,
+		HomeyService,
+	],
 })
 export class DevicesHomeyPlugin implements OnModuleInit {
 	constructor(

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -17,9 +17,11 @@ both have the same `name`; otherwise it is added. Resolution is deterministic: p
 built-in source, then mapping name. Invalid user files are isolated and ignored as a whole, while an invalid built-in
 file prevents the plugin from starting.
 
-Matches use exact Homey `class` values and capability base IDs. Optional `driver_ids`, `manufacturers`, and `models`
-may narrow a descriptor but should not be used for generic mappings. Property matching derives the base ID from the
-first dot only, while every resolved property binding retains the original full capability ID for reads and writes.
+Matches use exact Homey `class` values and capability base IDs. Optional `all_capabilities` and `none_capabilities`
+constraints let a property mapping require or exclude companion capabilities so the resulting Smart Panel channel is
+structurally complete. Optional `driver_ids`, `manufacturers`, and `models` may narrow a descriptor but should not be
+used for generic mappings. Property matching derives the base ID from the first dot only, while every resolved property
+binding retains the original full capability ID for reads and writes.
 
 Every descriptor supports:
 
@@ -27,14 +29,18 @@ Every descriptor supports:
 - `exclusive`: the highest-priority exclusive match suppresses other matches of that kind;
 - `conflict`: `first`, `warn`, or `error` for equal-priority mappings targeting the same output;
 - property `direction`: `read_only`, `write_only`, or `bidirectional`;
-- property unit/range expectations and inline `scale`, `map`, `boolean`, `clamp`, or `round` transforms.
+- property unit/range expectations and inline `scale`, `map`, `boolean`, `clamp`, `round`, `constant`, `threshold`, or
+  `thresholds` transforms.
 
 Map transforms must declare a `read` table for read-capable directions and an explicit `write` table for writable
 directions. Bidirectional maps require both tables; the loader never guesses an inverse from potentially non-injective
 read values.
 
+`constant`, `threshold`, and `thresholds` are read-only derived transforms. Constants can supply a required static
+property even when the source capability has no current value; a threshold derives one of two values, while strictly
+descending thresholds derive a band from a numeric source.
 The JSON schema rejects unknown keys and malformed structures. Semantic validation additionally rejects unknown Smart
-Panel enum values, inverted ranges, and degenerate transformations.
+Panel enum values, inverted ranges, degenerate transformations, and writable use of derived transforms.
 
 ## Built-in MVP catalog
 
@@ -59,6 +65,17 @@ Two relative Homey controls need a deterministic projection into Smart Panel's p
 These projections are reversible and clamped, but they describe normalized travel rather than device-reported physical
 calibration. Mapping preview must present that conversion metadata so an operator can override it for hardware with a
 narrower or inverted range.
+
+Smart Panel's thermostat contract keeps child-lock state on the `thermostat` channel and climate targets on complete
+`heater` and `cooler` channels. Homey's standard `thermostat_mode` supplies the required power/status projections when
+no separate activity capability exists. The Task 4.3 command platform must coalesce paired heater/cooler power changes
+into one `thermostat_mode` write instead of sending the two projected bindings independently.
+
+The battery channel is emitted only when `measure_battery` exists. When Homey also exposes `alarm_battery`, that alarm
+maps directly to the required status; otherwise status is derived as `low` at or below 20 percent and `ok` above it.
+Alarm-only devices do not produce an invalid percentage-less battery channel. Window-covering classes provide their
+required `type` through a read-only constant projection; the generic class defaults to `roller` and remains replaceable
+by an operator override.
 
 `HomeyMappingTransformerService` is the single read/write execution path for inline transforms. It rejects forbidden
 directions, invalid target types, and unmapped enum values with fixed errors that never include the rejected value.

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -21,7 +21,10 @@ Matches use exact Homey `class` values and capability base IDs. Optional `all_ca
 constraints let a property mapping require or exclude companion capabilities so the resulting Smart Panel channel is
 structurally complete. Optional `driver_ids`, `manufacturers`, and `models` may narrow a descriptor but should not be
 used for generic mappings. Property matching derives the base ID from the first dot only, while every resolved property
-binding retains the original full capability ID for reads and writes.
+binding retains the original full capability ID for reads and writes. When repeated capability instances would target
+the same static channel property, resolution selects the unsuffixed primary instance, or the lexically first full ID
+when no primary exists. Additional instances remain discoverable upstream but are not collapsed into duplicate Smart
+Panel properties.
 
 Every descriptor supports:
 
@@ -70,6 +73,10 @@ Smart Panel's thermostat contract keeps child-lock state on the `thermostat` cha
 `heater` and `cooler` channels. Homey's standard `thermostat_mode` supplies the required power/status projections when
 no separate activity capability exists. The Task 4.3 command platform must coalesce paired heater/cooler power changes
 into one `thermostat_mode` write instead of sending the two projected bindings independently.
+
+Thermostat device eligibility requires `measure_temperature`, `target_temperature`, and `thermostat_mode` together.
+Partial target-only or mode-only devices stay unsupported instead of losing their control or producing incomplete
+climate channels.
 
 The battery channel is emitted only when `measure_battery` exists. When Homey also exposes `alarm_battery`, that alarm
 maps directly to the required status; otherwise status is derived as `low` at or below 20 percent and `ok` above it.

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -69,15 +69,16 @@ These projections are reversible and clamped, but they describe normalized trave
 calibration. Mapping preview must present that conversion metadata so an operator can override it for hardware with a
 narrower or inverted range.
 
-Smart Panel's thermostat contract keeps child-lock state on the `thermostat` channel and projects Homey's single target
-onto one complete `heater` channel. Homey's standard `thermostat_mode` supplies the required power/status projections
-when no separate activity capability exists. The generic mapping deliberately does not create an independent cooler
-setpoint, because both would write the same Homey `target_temperature`; a user override may replace the heater
-projection for cooling-only hardware.
+Smart Panel's heater contract requires `status` to mean actual heating activity. Homey's standard `thermostat_mode`
+reports only the configured mode and has no standard activity capability, so the built-in catalog deliberately does not
+fabricate a heater channel or project `target_temperature`. Those capabilities remain visible in Homey inventory and
+mapping preview. A user mapping may add one heater or cooler projection for a device with a verified driver-specific
+activity signal; it must not use `thermostat_mode` itself as `status`.
 
 Thermostat device eligibility requires `measure_temperature`, `target_temperature`, and `thermostat_mode` together.
-Partial target-only or mode-only devices stay unsupported instead of losing their control or producing incomplete
-climate channels.
+Partial target-only or mode-only devices stay unsupported, while complete standard devices receive read-only
+temperature and thermostat identity channels until an actual activity signal can support a structurally complete
+control channel.
 
 The battery channel is emitted only when `measure_battery` exists and the selected Smart Panel device contract permits
 that channel. Thermostats are excluded because their current contract does not accept battery channels. When Homey also

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -35,3 +35,32 @@ read values.
 
 The JSON schema rejects unknown keys and malformed structures. Semantic validation additionally rejects unknown Smart
 Panel enum values, inverted ranges, and degenerate transformations.
+
+## Built-in MVP catalog
+
+The built-in catalog covers standardized Homey power, lighting, climate, environment, safety/contact, energy, battery,
+lock, and window-covering capabilities. The committed SHS 13.4.0 golden fixtures directly exercise power, dimming,
+hue, saturation, relative light temperature, measured temperature and humidity, luminance, battery percentage,
+instantaneous/cumulative energy, cover state/position, and repeated suffixed capabilities.
+
+The captured household did not expose every standardized capability. Tests for `target_temperature`,
+`thermostat_mode`, `measure_pressure`, `measure_co2`, `alarm_motion`, `alarm_contact`, `alarm_smoke`, `alarm_co`,
+`locked`, and `windowcoverings_tilt_set` therefore use clearly named published-contract devices, not fixtures that claim
+live provenance. Their scalar types, ranges, access, and enum values were checked against Athom's public
+[`node-homey-lib`](https://github.com/athombv/node-homey-lib/tree/aa72cd285caff479c68cfdfe1347053eca06c20f/assets/capability/capabilities)
+capability definitions on 2026-08-20. Live evidence gaps remain recorded in the fixture manifest and
+`docs/homey-shs-compatibility.md`.
+
+Two relative Homey controls need a deterministic projection into Smart Panel's physical-unit properties:
+
+- `light_temperature` maps Homey's cool-to-warm `0..1` travel to `6500..2000 K`.
+- `windowcoverings_tilt_set` maps Homey's closed-to-open `0..1` travel to Smart Panel's full `-90..90°` tilt travel.
+
+These projections are reversible and clamped, but they describe normalized travel rather than device-reported physical
+calibration. Mapping preview must present that conversion metadata so an operator can override it for hardware with a
+narrower or inverted range.
+
+`HomeyMappingTransformerService` is the single read/write execution path for inline transforms. It rejects forbidden
+directions, invalid target types, and unmapped enum values with fixed errors that never include the rejected value.
+Scale transforms preserve fractional Homey command values on inverse writes while normalizing integer Smart Panel
+properties only on reads.

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -79,11 +79,12 @@ Thermostat device eligibility requires `measure_temperature`, `target_temperatur
 Partial target-only or mode-only devices stay unsupported instead of losing their control or producing incomplete
 climate channels.
 
-The battery channel is emitted only when `measure_battery` exists. When Homey also exposes `alarm_battery`, that alarm
-maps directly to the required status; otherwise status is derived as `low` at or below 20 percent and `ok` above it.
-Alarm-only devices do not produce an invalid percentage-less battery channel. Window-covering classes provide their
-required `type` through a read-only constant projection; the generic class defaults to `roller` and remains replaceable
-by an operator override.
+The battery channel is emitted only when `measure_battery` exists and the selected Smart Panel device contract permits
+that channel. Thermostats are excluded because their current contract does not accept battery channels. When Homey also
+exposes `alarm_battery`, that alarm maps directly to the required status; otherwise status is derived as `low` at or
+below 20 percent and `ok` above it. Alarm-only devices do not produce an invalid percentage-less battery channel.
+Window-covering classes provide their required `type` through a read-only constant projection; the generic class
+defaults to `roller` and remains replaceable by an operator override.
 
 `HomeyMappingTransformerService` is the single read/write execution path for inline transforms. It rejects forbidden
 directions, invalid target types, and unmapped enum values with fixed errors that never include the rejected value.

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -69,10 +69,11 @@ These projections are reversible and clamped, but they describe normalized trave
 calibration. Mapping preview must present that conversion metadata so an operator can override it for hardware with a
 narrower or inverted range.
 
-Smart Panel's thermostat contract keeps child-lock state on the `thermostat` channel and climate targets on complete
-`heater` and `cooler` channels. Homey's standard `thermostat_mode` supplies the required power/status projections when
-no separate activity capability exists. The Task 4.3 command platform must coalesce paired heater/cooler power changes
-into one `thermostat_mode` write instead of sending the two projected bindings independently.
+Smart Panel's thermostat contract keeps child-lock state on the `thermostat` channel and projects Homey's single target
+onto one complete `heater` channel. Homey's standard `thermostat_mode` supplies the required power/status projections
+when no separate activity capability exists. The generic mapping deliberately does not create an independent cooler
+setpoint, because both would write the same Homey `target_temperature`; a user override may replace the heater
+projection for cooling-only hardware.
 
 Thermostat device eligibility requires `measure_temperature`, `target_temperature`, and `thermostat_mode` together.
 Partial target-only or mode-only devices stay unsupported instead of losing their control or producing incomplete

--- a/apps/backend/src/plugins/devices-homey/mappings/README.md
+++ b/apps/backend/src/plugins/devices-homey/mappings/README.md
@@ -69,6 +69,11 @@ These projections are reversible and clamped, but they describe normalized trave
 calibration. Mapping preview must present that conversion metadata so an operator can override it for hardware with a
 narrower or inverted range.
 
+Homey's `windowcoverings_state` is retained as the open/close/stop command source, but it is not treated as live motion:
+captured SHS evidence retains `down` after the covering has reached position `0`. The built-in status therefore derives
+`closed` and `opened` from position endpoints and reports intermediate positions as `stopped`. A driver-specific mapping
+may add `opening` or `closing` only when it has a verified live motion signal.
+
 Smart Panel's heater contract requires `status` to mean actual heating activity. Homey's standard `thermostat_mode`
 reports only the configured mode and has no standard activity capability, so the built-in catalog deliberately does not
 fabricate a heater channel or project `target_temperature`. Those capabilities remain visible in Homey inventory and

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -174,7 +174,7 @@ mappings:
   - name: battery
     priority: 100
     match:
-      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      classes: [sensor, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
       all_capabilities: [measure_battery]
     channel:
       identifier: battery

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -61,16 +61,6 @@ mappings:
       category: heater
       name: Heating
 
-  - name: thermostat-cooler
-    priority: 200
-    match:
-      classes: [thermostat]
-      all_capabilities: [target_temperature, thermostat_mode]
-    channel:
-      identifier: cooler
-      category: cooler
-      name: Cooling
-
   - name: measured-temperature
     priority: 100
     match:

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -1,3 +1,192 @@
 version: 1
 kind: channels
-mappings: []
+mappings:
+  - name: light
+    priority: 200
+    match:
+      classes: [light]
+      all_capabilities: [onoff]
+    channel:
+      identifier: light
+      category: light
+      name: Light
+
+  - name: outlet
+    priority: 200
+    match:
+      classes: [socket]
+      all_capabilities: [onoff]
+    channel:
+      identifier: outlet
+      category: outlet
+      name: Outlet
+
+  - name: generic-switch
+    priority: 100
+    match:
+      classes: [other]
+      all_capabilities: [onoff]
+    channel:
+      identifier: switcher
+      category: switcher
+      name: Switch
+
+  - name: thermostat-temperature
+    priority: 200
+    match:
+      classes: [thermostat]
+      all_capabilities: [measure_temperature]
+    channel:
+      identifier: temperature
+      category: temperature
+      name: Current temperature
+
+  - name: thermostat-control
+    priority: 200
+    match:
+      classes: [thermostat]
+      any_capabilities: [target_temperature, thermostat_mode]
+    channel:
+      identifier: thermostat
+      category: thermostat
+      name: Thermostat
+
+  - name: measured-temperature
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [measure_temperature]
+    channel:
+      identifier: temperature
+      category: temperature
+      name: Temperature
+
+  - name: measured-humidity
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [measure_humidity]
+    channel:
+      identifier: humidity
+      category: humidity
+      name: Humidity
+
+  - name: measured-pressure
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [measure_pressure]
+    channel:
+      identifier: pressure
+      category: pressure
+      name: Pressure
+
+  - name: measured-luminance
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [measure_luminance]
+    channel:
+      identifier: illuminance
+      category: illuminance
+      name: Illuminance
+
+  - name: measured-carbon-dioxide
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [measure_co2]
+    channel:
+      identifier: carbon-dioxide
+      category: carbon_dioxide
+      name: Carbon dioxide
+
+  - name: motion-alarm
+    priority: 100
+    match:
+      classes: [sensor, lock]
+      all_capabilities: [alarm_motion]
+    channel:
+      identifier: motion
+      category: motion
+      name: Motion
+
+  - name: contact-alarm
+    priority: 100
+    match:
+      classes: [sensor, lock]
+      all_capabilities: [alarm_contact]
+    channel:
+      identifier: contact
+      category: contact
+      name: Contact
+
+  - name: smoke-alarm
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [alarm_smoke]
+    channel:
+      identifier: smoke
+      category: smoke
+      name: Smoke
+
+  - name: carbon-monoxide-alarm
+    priority: 100
+    match:
+      classes: [sensor]
+      all_capabilities: [alarm_co]
+    channel:
+      identifier: carbon-monoxide
+      category: carbon_monoxide
+      name: Carbon monoxide
+
+  - name: electrical-power
+    priority: 100
+    match:
+      classes: [light, socket]
+      all_capabilities: [measure_power]
+    channel:
+      identifier: electrical-power
+      category: electrical_power
+      name: Electrical power
+
+  - name: electrical-energy
+    priority: 100
+    match:
+      classes: [light, socket]
+      all_capabilities: [meter_power]
+    channel:
+      identifier: electrical-energy
+      category: electrical_energy
+      name: Electrical energy
+
+  - name: battery
+    priority: 100
+    match:
+      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      any_capabilities: [measure_battery, alarm_battery]
+    channel:
+      identifier: battery
+      category: battery
+      name: Battery
+
+  - name: lock
+    priority: 200
+    match:
+      classes: [lock]
+      all_capabilities: [locked]
+    channel:
+      identifier: lock
+      category: lock
+      name: Lock
+
+  - name: window-covering
+    priority: 200
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      all_capabilities: [windowcoverings_state, windowcoverings_set]
+    channel:
+      identifier: window-covering
+      category: window_covering
+      name: Window covering

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -45,7 +45,7 @@ mappings:
     priority: 200
     match:
       classes: [thermostat]
-      any_capabilities: [target_temperature, thermostat_mode]
+      all_capabilities: [target_temperature, thermostat_mode]
     channel:
       identifier: thermostat
       category: thermostat

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -51,6 +51,26 @@ mappings:
       category: thermostat
       name: Thermostat
 
+  - name: thermostat-heater
+    priority: 200
+    match:
+      classes: [thermostat]
+      all_capabilities: [target_temperature, thermostat_mode]
+    channel:
+      identifier: heater
+      category: heater
+      name: Heating
+
+  - name: thermostat-cooler
+    priority: 200
+    match:
+      classes: [thermostat]
+      all_capabilities: [target_temperature, thermostat_mode]
+    channel:
+      identifier: cooler
+      category: cooler
+      name: Cooling
+
   - name: measured-temperature
     priority: 100
     match:
@@ -165,7 +185,7 @@ mappings:
     priority: 100
     match:
       classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
-      any_capabilities: [measure_battery, alarm_battery]
+      all_capabilities: [measure_battery]
     channel:
       identifier: battery
       category: battery

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/channels.yaml
@@ -51,16 +51,6 @@ mappings:
       category: thermostat
       name: Thermostat
 
-  - name: thermostat-heater
-    priority: 200
-    match:
-      classes: [thermostat]
-      all_capabilities: [target_temperature, thermostat_mode]
-    channel:
-      identifier: heater
-      category: heater
-      name: Heating
-
   - name: measured-temperature
     priority: 100
     match:

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
@@ -62,7 +62,6 @@ mappings:
         - alarm_smoke
         - alarm_co
         - measure_battery
-        - alarm_battery
     device:
       category: sensor
 

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
@@ -2,12 +2,11 @@ version: 1
 kind: devices
 mappings:
   - name: thermostat
-    description: Homey thermostat with a target temperature or standardized thermostat mode
+    description: Homey thermostat with the complete standardized temperature and mode contract
     priority: 300
     match:
       classes: [thermostat]
-      all_capabilities: [measure_temperature]
-      any_capabilities: [target_temperature, thermostat_mode]
+      all_capabilities: [measure_temperature, target_temperature, thermostat_mode]
     device:
       category: thermostat
 

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/devices.yaml
@@ -1,3 +1,77 @@
 version: 1
 kind: devices
-mappings: []
+mappings:
+  - name: thermostat
+    description: Homey thermostat with a target temperature or standardized thermostat mode
+    priority: 300
+    match:
+      classes: [thermostat]
+      all_capabilities: [measure_temperature]
+      any_capabilities: [target_temperature, thermostat_mode]
+    device:
+      category: thermostat
+
+  - name: lock
+    description: Homey lock exposing the standardized writable lock state
+    priority: 300
+    match:
+      classes: [lock]
+      all_capabilities: [locked]
+    device:
+      category: lock
+
+  - name: window-covering
+    description: Homey window covering with state, position, or tilt control
+    priority: 300
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      all_capabilities: [windowcoverings_state, windowcoverings_set]
+    device:
+      category: window_covering
+
+  - name: light
+    description: Homey light with a power or lighting capability
+    priority: 250
+    match:
+      classes: [light]
+      all_capabilities: [onoff]
+    device:
+      category: lighting
+
+  - name: outlet
+    description: Homey socket with standardized power control
+    priority: 250
+    match:
+      classes: [socket]
+      all_capabilities: [onoff]
+    device:
+      category: outlet
+
+  - name: sensor
+    description: Homey environmental, safety, contact, or battery sensor
+    priority: 200
+    match:
+      classes: [sensor]
+      any_capabilities:
+        - measure_temperature
+        - measure_humidity
+        - measure_pressure
+        - measure_luminance
+        - measure_co2
+        - alarm_motion
+        - alarm_contact
+        - alarm_smoke
+        - alarm_co
+        - measure_battery
+        - alarm_battery
+    device:
+      category: sensor
+
+  - name: generic-switch
+    description: Homey generic device exposing standardized power control
+    priority: 100
+    match:
+      classes: [other]
+      all_capabilities: [onoff]
+    device:
+      category: switcher

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -332,7 +332,7 @@ mappings:
   - name: battery-level
     priority: 100
     match:
-      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      classes: [sensor, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
       capability_base_ids: [measure_battery]
     property:
       channel: battery
@@ -345,7 +345,7 @@ mappings:
   - name: battery-alarm
     priority: 100
     match:
-      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      classes: [sensor, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
       capability_base_ids: [alarm_battery]
       all_capabilities: [measure_battery]
     property:
@@ -361,7 +361,7 @@ mappings:
     description: Derive the required Smart Panel status when Homey exposes only a battery percentage
     priority: 100
     match:
-      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      classes: [sensor, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
       capability_base_ids: [measure_battery]
       none_capabilities: [alarm_battery]
     property:

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -150,20 +150,6 @@ mappings:
       unit: °C
       range: { minimum: 4, maximum: 35, step: 0.1 }
 
-  - name: thermostat-cooler-target-temperature
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [target_temperature]
-      all_capabilities: [thermostat_mode]
-    property:
-      channel: cooler
-      category: temperature
-      data_type: float
-      direction: bidirectional
-      unit: °C
-      range: { minimum: 4, maximum: 35, step: 0.1 }
-
   - name: thermostat-heater-on
     description: Project Homey's standard thermostat mode onto Smart Panel's heater power state
     priority: 200
@@ -196,39 +182,6 @@ mappings:
       transform:
         type: map
         read: { auto: true, heat: true, cool: false, 'off': false }
-
-  - name: thermostat-cooler-on
-    description: Project Homey's standard thermostat mode onto Smart Panel's cooler power state
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [thermostat_mode]
-      all_capabilities: [target_temperature]
-    property:
-      channel: cooler
-      category: on
-      data_type: bool
-      direction: bidirectional
-      transform:
-        type: map
-        read: { auto: true, heat: false, cool: true, 'off': false }
-        write: { 'true': cool, 'false': 'off' }
-
-  - name: thermostat-cooler-status
-    description: Use Homey's configured mode as the available activity fallback
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [thermostat_mode]
-      all_capabilities: [target_temperature]
-    property:
-      channel: cooler
-      category: status
-      data_type: bool
-      direction: read_only
-      transform:
-        type: map
-        read: { auto: true, heat: false, cool: true, 'off': false }
 
   - name: humidity
     priority: 100

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -136,34 +136,99 @@ mappings:
       unit: °C
       range: { minimum: 0, maximum: 100, step: 0.1 }
 
-  - name: thermostat-target-temperature
+  - name: thermostat-heater-target-temperature
     priority: 200
     match:
       classes: [thermostat]
       capability_base_ids: [target_temperature]
+      all_capabilities: [thermostat_mode]
     property:
-      channel: thermostat
+      channel: heater
       category: temperature
       data_type: float
       direction: bidirectional
       unit: °C
       range: { minimum: 4, maximum: 35, step: 0.1 }
 
-  - name: thermostat-mode
-    description: Standard Homey thermostat modes verified from the published capability contract
+  - name: thermostat-cooler-target-temperature
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [target_temperature]
+      all_capabilities: [thermostat_mode]
+    property:
+      channel: cooler
+      category: temperature
+      data_type: float
+      direction: bidirectional
+      unit: °C
+      range: { minimum: 4, maximum: 35, step: 0.1 }
+
+  - name: thermostat-heater-on
+    description: Project Homey's standard thermostat mode onto Smart Panel's heater power state
     priority: 200
     match:
       classes: [thermostat]
       capability_base_ids: [thermostat_mode]
+      all_capabilities: [target_temperature]
     property:
-      channel: thermostat
-      category: mode
-      data_type: enum
+      channel: heater
+      category: on
+      data_type: bool
       direction: bidirectional
       transform:
         type: map
-        read: { auto: auto, heat: heat, cool: cool, 'off': 'off' }
-        write: { auto: auto, heat: heat, cool: cool, 'off': 'off' }
+        read: { auto: true, heat: true, cool: false, 'off': false }
+        write: { 'true': heat, 'false': 'off' }
+
+  - name: thermostat-heater-status
+    description: Use Homey's configured mode as the available activity fallback
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [thermostat_mode]
+      all_capabilities: [target_temperature]
+    property:
+      channel: heater
+      category: status
+      data_type: bool
+      direction: read_only
+      transform:
+        type: map
+        read: { auto: true, heat: true, cool: false, 'off': false }
+
+  - name: thermostat-cooler-on
+    description: Project Homey's standard thermostat mode onto Smart Panel's cooler power state
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [thermostat_mode]
+      all_capabilities: [target_temperature]
+    property:
+      channel: cooler
+      category: on
+      data_type: bool
+      direction: bidirectional
+      transform:
+        type: map
+        read: { auto: true, heat: false, cool: true, 'off': false }
+        write: { 'true': cool, 'false': 'off' }
+
+  - name: thermostat-cooler-status
+    description: Use Homey's configured mode as the available activity fallback
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [thermostat_mode]
+      all_capabilities: [target_temperature]
+    property:
+      channel: cooler
+      category: status
+      data_type: bool
+      direction: read_only
+      transform:
+        type: map
+        read: { auto: true, heat: false, cool: true, 'off': false }
 
   - name: humidity
     priority: 100
@@ -208,6 +273,25 @@ mappings:
       direction: read_only
       unit: lx
       range: { minimum: 0, maximum: 100000, step: 0.1 }
+
+  - name: illuminance-level
+    description: Derive Smart Panel's required illuminance band from the measured lux value
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_luminance]
+    property:
+      channel: illuminance
+      category: level
+      data_type: enum
+      direction: read_only
+      transform:
+        type: thresholds
+        thresholds:
+          - { minimum: 1000, value: bright }
+          - { minimum: 100, value: moderate }
+          - { minimum: 10, value: dusky }
+        default: dark
 
   - name: carbon-dioxide
     priority: 100
@@ -310,6 +394,7 @@ mappings:
     match:
       classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
       capability_base_ids: [alarm_battery]
+      all_capabilities: [measure_battery]
     property:
       channel: battery
       category: status
@@ -319,16 +404,49 @@ mappings:
         type: map
         read: { 'false': ok, 'true': low }
 
-  - name: lock-state
+  - name: battery-status-from-level
+    description: Derive the required Smart Panel status when Homey exposes only a battery percentage
+    priority: 100
+    match:
+      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [measure_battery]
+      none_capabilities: [alarm_battery]
+    property:
+      channel: battery
+      category: status
+      data_type: enum
+      direction: read_only
+      transform:
+        type: threshold
+        threshold: 20
+        less_than_or_equal: low
+        greater_than: ok
+
+  - name: lock-on
     priority: 200
     match:
       classes: [lock]
       capability_base_ids: [locked]
     property:
       channel: lock
-      category: locked
+      category: on
       data_type: bool
       direction: bidirectional
+
+  - name: lock-status
+    priority: 200
+    match:
+      classes: [lock]
+      capability_base_ids: [locked]
+    property:
+      channel: lock
+      category: status
+      data_type: enum
+      direction: bidirectional
+      transform:
+        type: map
+        read: { 'true': locked, 'false': unlocked }
+        write: { locked: true, unlocked: false }
 
   - name: window-covering-status
     description: Homey movement state to Smart Panel operational status
@@ -378,6 +496,67 @@ mappings:
         input_range: [0, 1]
         output_range: [0, 100]
         clamp: true
+
+  - name: window-covering-type-generic
+    description: Default Homey's generic window-covering class to Smart Panel's roller presentation
+    priority: 200
+    match:
+      classes: [windowcoverings]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: type
+      data_type: enum
+      direction: read_only
+      transform: { type: constant, value: roller }
+
+  - name: window-covering-type-curtain
+    priority: 200
+    match:
+      classes: [curtain]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: type
+      data_type: enum
+      direction: read_only
+      transform: { type: constant, value: curtain }
+
+  - name: window-covering-type-blind
+    priority: 200
+    match:
+      classes: [blinds]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: type
+      data_type: enum
+      direction: read_only
+      transform: { type: constant, value: blind }
+
+  - name: window-covering-type-sunshade
+    priority: 200
+    match:
+      classes: [sunshade]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: type
+      data_type: enum
+      direction: read_only
+      transform: { type: constant, value: outdoor_blind }
+
+  - name: window-covering-type-shutter
+    priority: 200
+    match:
+      classes: [shutterblinds]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: type
+      data_type: enum
+      direction: read_only
+      transform: { type: constant, value: shutter }
 
   - name: window-covering-tilt
     description: Homey normalized closed-to-open tilt travel to Smart Panel full angular travel

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -136,53 +136,6 @@ mappings:
       unit: °C
       range: { minimum: 0, maximum: 100, step: 0.1 }
 
-  - name: thermostat-heater-target-temperature
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [target_temperature]
-      all_capabilities: [thermostat_mode]
-    property:
-      channel: heater
-      category: temperature
-      data_type: float
-      direction: bidirectional
-      unit: °C
-      range: { minimum: 4, maximum: 35, step: 0.1 }
-
-  - name: thermostat-heater-on
-    description: Project Homey's standard thermostat mode onto Smart Panel's heater power state
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [thermostat_mode]
-      all_capabilities: [target_temperature]
-    property:
-      channel: heater
-      category: on
-      data_type: bool
-      direction: bidirectional
-      transform:
-        type: map
-        read: { auto: true, heat: true, cool: false, 'off': false }
-        write: { 'true': heat, 'false': 'off' }
-
-  - name: thermostat-heater-status
-    description: Use Homey's configured mode as the available activity fallback
-    priority: 200
-    match:
-      classes: [thermostat]
-      capability_base_ids: [thermostat_mode]
-      all_capabilities: [target_temperature]
-    property:
-      channel: heater
-      category: status
-      data_type: bool
-      direction: read_only
-      transform:
-        type: map
-        read: { auto: true, heat: true, cool: false, 'off': false }
-
   - name: humidity
     priority: 100
     match:

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -355,19 +355,22 @@ mappings:
         write: { locked: true, unlocked: false }
 
   - name: window-covering-status
-    description: Homey movement state to Smart Panel operational status
+    description: Derive stable endpoint status from Homey's normalized position
     priority: 200
     match:
       classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
-      capability_base_ids: [windowcoverings_state]
+      capability_base_ids: [windowcoverings_set]
     property:
       channel: window-covering
       category: status
       data_type: enum
       direction: read_only
       transform:
-        type: map
-        read: { up: opening, idle: stopped, down: closing }
+        type: thresholds
+        thresholds:
+          - { minimum: 1, value: opened }
+          - { minimum: 0.000001, value: stopped }
+        default: closed
 
   - name: window-covering-command
     description: Smart Panel open, close, and stop commands to Homey's standardized state capability

--- a/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
+++ b/apps/backend/src/plugins/devices-homey/mappings/definitions/properties.yaml
@@ -1,3 +1,399 @@
 version: 1
 kind: properties
-mappings: []
+mappings:
+  - name: light-power
+    priority: 200
+    match:
+      classes: [light]
+      capability_base_ids: [onoff]
+    property:
+      channel: light
+      category: on
+      data_type: bool
+      direction: bidirectional
+
+  - name: outlet-power
+    priority: 200
+    match:
+      classes: [socket]
+      capability_base_ids: [onoff]
+    property:
+      channel: outlet
+      category: on
+      data_type: bool
+      direction: bidirectional
+
+  - name: generic-switch-power
+    priority: 100
+    match:
+      classes: [other]
+      capability_base_ids: [onoff]
+    property:
+      channel: switcher
+      category: on
+      data_type: bool
+      direction: bidirectional
+
+  - name: light-brightness
+    description: Homey normalized dim level to Smart Panel percentage
+    priority: 200
+    match:
+      classes: [light]
+      capability_base_ids: [dim]
+    property:
+      channel: light
+      category: brightness
+      data_type: uchar
+      direction: bidirectional
+      unit: '%'
+      range: { minimum: 0, maximum: 100, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [0, 100]
+        clamp: true
+
+  - name: light-hue
+    description: Homey normalized hue to Smart Panel degrees
+    priority: 200
+    match:
+      classes: [light]
+      capability_base_ids: [light_hue]
+    property:
+      channel: light
+      category: hue
+      data_type: ushort
+      direction: bidirectional
+      unit: deg
+      range: { minimum: 0, maximum: 360, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [0, 360]
+        clamp: true
+
+  - name: light-saturation
+    description: Homey normalized saturation to Smart Panel percentage
+    priority: 200
+    match:
+      classes: [light]
+      capability_base_ids: [light_saturation]
+    property:
+      channel: light
+      category: saturation
+      data_type: uchar
+      direction: bidirectional
+      unit: '%'
+      range: { minimum: 0, maximum: 100, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [0, 100]
+        clamp: true
+
+  - name: light-color-temperature
+    description: Homey's warm-relative 0..1 scale to the Smart Panel Kelvin control range
+    priority: 200
+    match:
+      classes: [light]
+      capability_base_ids: [light_temperature]
+    property:
+      channel: light
+      category: color_temperature
+      data_type: ushort
+      direction: bidirectional
+      unit: K
+      range: { minimum: 2000, maximum: 6500, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [6500, 2000]
+        clamp: true
+
+  - name: sensor-temperature
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_temperature]
+    property:
+      channel: temperature
+      category: temperature
+      data_type: float
+      direction: read_only
+      unit: °C
+      range: { minimum: 0, maximum: 100, step: 0.1 }
+
+  - name: thermostat-current-temperature
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [measure_temperature]
+    property:
+      channel: temperature
+      category: temperature
+      data_type: float
+      direction: read_only
+      unit: °C
+      range: { minimum: 0, maximum: 100, step: 0.1 }
+
+  - name: thermostat-target-temperature
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [target_temperature]
+    property:
+      channel: thermostat
+      category: temperature
+      data_type: float
+      direction: bidirectional
+      unit: °C
+      range: { minimum: 4, maximum: 35, step: 0.1 }
+
+  - name: thermostat-mode
+    description: Standard Homey thermostat modes verified from the published capability contract
+    priority: 200
+    match:
+      classes: [thermostat]
+      capability_base_ids: [thermostat_mode]
+    property:
+      channel: thermostat
+      category: mode
+      data_type: enum
+      direction: bidirectional
+      transform:
+        type: map
+        read: { auto: auto, heat: heat, cool: cool, 'off': 'off' }
+        write: { auto: auto, heat: heat, cool: cool, 'off': 'off' }
+
+  - name: humidity
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_humidity]
+    property:
+      channel: humidity
+      category: humidity
+      data_type: uchar
+      direction: read_only
+      unit: '%'
+      range: { minimum: 0, maximum: 100, step: 1 }
+
+  - name: pressure
+    description: Homey millibar to Smart Panel kilopascal
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_pressure]
+    property:
+      channel: pressure
+      category: pressure
+      data_type: float
+      direction: read_only
+      unit: kPa
+      range: { minimum: 0, maximum: 32767, step: 0.1 }
+      transform:
+        type: scale
+        input_range: [0, 10]
+        output_range: [0, 1]
+
+  - name: illuminance
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_luminance]
+    property:
+      channel: illuminance
+      category: illuminance
+      data_type: float
+      direction: read_only
+      unit: lx
+      range: { minimum: 0, maximum: 100000, step: 0.1 }
+
+  - name: carbon-dioxide
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [measure_co2]
+    property:
+      channel: carbon-dioxide
+      category: concentration
+      data_type: float
+      direction: read_only
+      unit: ppm
+      range: { minimum: 0, maximum: 100000, step: 1 }
+
+  - name: motion
+    priority: 100
+    match:
+      classes: [sensor, lock]
+      capability_base_ids: [alarm_motion]
+    property:
+      channel: motion
+      category: detected
+      data_type: bool
+      direction: read_only
+
+  - name: contact
+    priority: 100
+    match:
+      classes: [sensor, lock]
+      capability_base_ids: [alarm_contact]
+    property:
+      channel: contact
+      category: detected
+      data_type: bool
+      direction: read_only
+
+  - name: smoke
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [alarm_smoke]
+    property:
+      channel: smoke
+      category: detected
+      data_type: bool
+      direction: read_only
+
+  - name: carbon-monoxide
+    priority: 100
+    match:
+      classes: [sensor]
+      capability_base_ids: [alarm_co]
+    property:
+      channel: carbon-monoxide
+      category: detected
+      data_type: bool
+      direction: read_only
+
+  - name: instantaneous-power
+    priority: 100
+    match:
+      classes: [light, socket]
+      capability_base_ids: [measure_power]
+    property:
+      channel: electrical-power
+      category: power
+      data_type: float
+      direction: read_only
+      unit: W
+      range: { minimum: 0, maximum: 10000, step: 0.1 }
+
+  - name: accumulated-energy
+    priority: 100
+    match:
+      classes: [light, socket]
+      capability_base_ids: [meter_power]
+    property:
+      channel: electrical-energy
+      category: consumption
+      data_type: float
+      direction: read_only
+      unit: kWh
+      range: { minimum: 0, step: 0.001 }
+
+  - name: battery-level
+    priority: 100
+    match:
+      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [measure_battery]
+    property:
+      channel: battery
+      category: percentage
+      data_type: uchar
+      direction: read_only
+      unit: '%'
+      range: { minimum: 0, maximum: 100, step: 1 }
+
+  - name: battery-alarm
+    priority: 100
+    match:
+      classes: [sensor, thermostat, lock, windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [alarm_battery]
+    property:
+      channel: battery
+      category: status
+      data_type: enum
+      direction: read_only
+      transform:
+        type: map
+        read: { 'false': ok, 'true': low }
+
+  - name: lock-state
+    priority: 200
+    match:
+      classes: [lock]
+      capability_base_ids: [locked]
+    property:
+      channel: lock
+      category: locked
+      data_type: bool
+      direction: bidirectional
+
+  - name: window-covering-status
+    description: Homey movement state to Smart Panel operational status
+    priority: 200
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [windowcoverings_state]
+    property:
+      channel: window-covering
+      category: status
+      data_type: enum
+      direction: read_only
+      transform:
+        type: map
+        read: { up: opening, idle: stopped, down: closing }
+
+  - name: window-covering-command
+    description: Smart Panel open, close, and stop commands to Homey's standardized state capability
+    priority: 200
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [windowcoverings_state]
+    property:
+      channel: window-covering
+      category: command
+      data_type: enum
+      direction: write_only
+      transform:
+        type: map
+        write: { open: up, close: down, stop: idle }
+
+  - name: window-covering-position
+    description: Homey normalized closed-to-open position to Smart Panel percentage
+    priority: 200
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [windowcoverings_set]
+    property:
+      channel: window-covering
+      category: position
+      data_type: uchar
+      direction: bidirectional
+      unit: '%'
+      range: { minimum: 0, maximum: 100, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [0, 100]
+        clamp: true
+
+  - name: window-covering-tilt
+    description: Homey normalized closed-to-open tilt travel to Smart Panel full angular travel
+    priority: 200
+    match:
+      classes: [windowcoverings, curtain, blinds, sunshade, shutterblinds]
+      capability_base_ids: [windowcoverings_tilt_set]
+    property:
+      channel: window-covering
+      category: tilt
+      data_type: float
+      direction: bidirectional
+      unit: °
+      range: { minimum: -90, maximum: 90, step: 1 }
+      transform:
+        type: scale
+        input_range: [0, 1]
+        output_range: [-90, 90]
+        clamp: true

--- a/apps/backend/src/plugins/devices-homey/mappings/homey-mapping.error.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/homey-mapping.error.ts
@@ -7,3 +7,14 @@ export class HomeyMappingConfigurationError extends Error {
 		this.name = 'HomeyMappingConfigurationError';
 	}
 }
+
+export class HomeyMappingValueError extends Error {
+	constructor(
+		readonly mappingName: string,
+		readonly direction: 'read' | 'write',
+		readonly reason: string,
+	) {
+		super(`Homey mapping '${mappingName}' could not transform a ${direction} value: ${reason}`);
+		this.name = 'HomeyMappingValueError';
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/index.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/index.ts
@@ -1,5 +1,6 @@
 export * from './homey-mapping.error';
 export * from './mapping-loader.service';
+export * from './mapping-transformer.service';
 export * from './mapping.constants';
 export * from './mapping.types';
 export * from './property-mapping-storage.service';

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
@@ -157,21 +157,31 @@ describe('HomeyMappingLoaderService', () => {
 		});
 	});
 
-	it('matches suffixed capabilities by base ID while preserving both full IDs', () => {
+	it('matches suffixed capabilities by base ID and selects one full ID deterministically', () => {
 		writeBuiltin('properties', [propertyDefinition()]);
 		service.loadAllMappings();
 
 		const resolution = service.resolvePropertyMappings(createDevice());
 
 		expect(resolution.conflicts).toEqual([]);
-		expect(resolution.mappings.map((binding) => binding.capabilityBaseId)).toEqual([
-			'measure_temperature',
-			'measure_temperature',
-		]);
-		expect(resolution.mappings.map((binding) => binding.capabilityId)).toEqual([
-			'measure_temperature.inside',
-			'measure_temperature.outside',
-		]);
+		expect(resolution.mappings.map((binding) => binding.capabilityBaseId)).toEqual(['measure_temperature']);
+		expect(resolution.mappings.map((binding) => binding.capabilityId)).toEqual(['measure_temperature.inside']);
+	});
+
+	it('prefers the unsuffixed primary capability over repeated instances', () => {
+		writeBuiltin('properties', [propertyDefinition()]);
+		service.loadAllMappings();
+
+		const resolution = service.resolvePropertyMappings(
+			createDevice({
+				capabilities: [
+					createCapability('measure_temperature.suffix', 18),
+					createCapability('measure_temperature', 21.5),
+				],
+			}),
+		);
+
+		expect(resolution.mappings.map((binding) => binding.capabilityId)).toEqual(['measure_temperature']);
 	});
 
 	it('replaces a built-in descriptor with a same-name user override', () => {

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.spec.ts
@@ -331,6 +331,40 @@ describe('HomeyMappingLoaderService', () => {
 		expect(service.resolveDeviceMappings(createDevice({ manufacturer: 'Different vendor' })).mappings).toHaveLength(0);
 	});
 
+	it('applies required and excluded device capability filters to property mappings', () => {
+		writeBuiltin('properties', [
+			propertyDefinition({
+				match: {
+					classes: ['sensor'],
+					capability_base_ids: ['measure_temperature'],
+					all_capabilities: ['measure_humidity'],
+					none_capabilities: ['alarm_temperature'],
+				},
+			}),
+		]);
+		service.loadAllMappings();
+
+		expect(service.resolvePropertyMappings(createDevice()).mappings).toHaveLength(0);
+		expect(
+			service.resolvePropertyMappings(
+				createDevice({
+					capabilities: [createCapability('measure_temperature', 21.5), createCapability('measure_humidity', 45)],
+				}),
+			).mappings,
+		).toHaveLength(1);
+		expect(
+			service.resolvePropertyMappings(
+				createDevice({
+					capabilities: [
+						createCapability('measure_temperature', 21.5),
+						createCapability('measure_humidity', 45),
+						createCapability('alarm_temperature', 0),
+					],
+				}),
+			).mappings,
+		).toHaveLength(0);
+	});
+
 	it('isolates semantically invalid ranges and transforms in user overrides', () => {
 		writeBuiltin('properties', [propertyDefinition()]);
 		writeUser('properties', [
@@ -425,5 +459,48 @@ describe('HomeyMappingLoaderService', () => {
 			'read-map',
 			'write-map',
 		]);
+	});
+
+	it.each([
+		{ type: 'constant', value: 'static' },
+		{ type: 'threshold', threshold: 20, less_than_or_equal: 'low', greater_than: 'ok' },
+		{ type: 'thresholds', thresholds: [{ minimum: 20, value: 'high' }], default: 'low' },
+	])('rejects the read-derived $type transform on a writable property', (transform) => {
+		writeBuiltin('properties', [
+			propertyDefinition({
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'float',
+					direction: 'bidirectional',
+					transform,
+				},
+			}),
+		]);
+
+		expect(() => service.loadAllMappings()).toThrow(HomeyMappingConfigurationError);
+	});
+
+	it('rejects unordered multi-threshold transforms', () => {
+		writeBuiltin('properties', [
+			propertyDefinition({
+				property: {
+					channel: 'temperature',
+					category: 'temperature',
+					data_type: 'enum',
+					direction: 'read_only',
+					transform: {
+						type: 'thresholds',
+						thresholds: [
+							{ minimum: 10, value: 'low' },
+							{ minimum: 20, value: 'high' },
+						],
+						default: 'none',
+					},
+				},
+			}),
+		]);
+
+		expect(() => service.loadAllMappings()).toThrow(HomeyMappingConfigurationError);
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
@@ -317,6 +317,8 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 			match: {
 				classes: [...propertyDefinition.match.classes],
 				capabilityBaseIds: [...propertyDefinition.match.capability_base_ids],
+				allCapabilities: [...(propertyDefinition.match.all_capabilities ?? [])],
+				noneCapabilities: [...(propertyDefinition.match.none_capabilities ?? [])],
 				driverIds: [...(propertyDefinition.match.driver_ids ?? [])],
 				manufacturers: [...(propertyDefinition.match.manufacturers ?? [])],
 				models: [...(propertyDefinition.match.models ?? [])],
@@ -375,6 +377,28 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 				throw new Error(`map transform requires a write table for ${direction} direction`);
 			}
 		}
+
+		if (transform?.type === 'constant' && direction !== 'read_only') {
+			throw new Error('constant transform requires read_only direction');
+		}
+
+		if (transform?.type === 'threshold' && direction !== 'read_only') {
+			throw new Error('threshold transform requires read_only direction');
+		}
+
+		if (transform?.type === 'thresholds') {
+			if (direction !== 'read_only') {
+				throw new Error('thresholds transform requires read_only direction');
+			}
+
+			if (
+				transform.thresholds.some(
+					(entry, index) => index > 0 && entry.minimum >= transform.thresholds[index - 1].minimum,
+				)
+			) {
+				throw new Error('thresholds transform minimums must be strictly descending');
+			}
+		}
 	}
 
 	private resolveEnum<TEnum extends Record<string, string>>(
@@ -403,7 +427,16 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 	}
 
 	private matchesPropertyDevice(mapping: ResolvedHomeyPropertyMapping, device: HomeyDevice): boolean {
-		return mapping.match.classes.includes(device.class) && this.matchesNarrowingFilters(mapping.match, device);
+		if (!mapping.match.classes.includes(device.class) || !this.matchesNarrowingFilters(mapping.match, device)) {
+			return false;
+		}
+
+		const capabilityBaseIds = new Set(device.capabilities.map((capability) => capability.baseId));
+
+		return (
+			mapping.match.allCapabilities.every((baseId) => capabilityBaseIds.has(baseId)) &&
+			mapping.match.noneCapabilities.every((baseId) => !capabilityBaseIds.has(baseId))
+		);
 	}
 
 	private matchesNarrowingFilters(

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-loader.service.ts
@@ -253,7 +253,33 @@ export class HomeyMappingLoaderService implements OnModuleInit {
 			conflicts.push(...resolution.conflicts);
 		}
 
-		return { mappings: bindings, conflicts };
+		return { mappings: this.selectPrimaryPropertyBindings(bindings), conflicts };
+	}
+
+	private selectPrimaryPropertyBindings(
+		bindings: readonly ResolvedHomeyPropertyBinding[],
+	): ResolvedHomeyPropertyBinding[] {
+		const selected = new Map<string, ResolvedHomeyPropertyBinding>();
+
+		for (const binding of bindings) {
+			const current = selected.get(binding.mapping.name);
+			if (current === undefined || this.compareCapabilityInstances(binding, current) < 0) {
+				selected.set(binding.mapping.name, binding);
+			}
+		}
+
+		return [...selected.values()];
+	}
+
+	private compareCapabilityInstances(left: ResolvedHomeyPropertyBinding, right: ResolvedHomeyPropertyBinding): number {
+		const leftIsPrimary = left.capabilityId === left.capabilityBaseId;
+		const rightIsPrimary = right.capabilityId === right.capabilityBaseId;
+
+		if (leftIsPrimary !== rightIsPrimary) {
+			return leftIsPrimary ? -1 : 1;
+		}
+
+		return left.capabilityId < right.capabilityId ? -1 : left.capabilityId > right.capabilityId ? 1 : 0;
 	}
 
 	private applyUserOverrides(

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.spec.ts
@@ -17,6 +17,8 @@ const mapping = (
 	match: {
 		classes: ['sensor'],
 		capabilityBaseIds: ['test'],
+		allCapabilities: [],
+		noneCapabilities: [],
 		driverIds: [],
 		manufacturers: [],
 		models: [],
@@ -87,6 +89,46 @@ describe('HomeyMappingTransformerService', () => {
 		expect(service.read(mapping({ type: 'clamp', minimum: 0, maximum: 10 }), 12)).toBe(10);
 		expect(service.read(mapping({ type: 'round', precision: 2 }), 1.236)).toBe(1.24);
 		expect(service.read(mapping({ type: 'round', precision: 2 }), null)).toBeNull();
+	});
+
+	it('emits constants even when the source capability value is null', () => {
+		const definition = mapping(
+			{ type: 'constant', value: 'roller' },
+			{ dataType: DataTypeType.ENUM, direction: 'read_only' },
+		);
+
+		expect(service.read(definition, null)).toBe('roller');
+	});
+
+	it('derives values on both sides of an inclusive numeric threshold', () => {
+		const definition = mapping(
+			{ type: 'threshold', threshold: 20, less_than_or_equal: 'low', greater_than: 'ok' },
+			{ dataType: DataTypeType.ENUM, direction: 'read_only' },
+		);
+
+		expect(service.read(definition, 0)).toBe('low');
+		expect(service.read(definition, 20)).toBe('low');
+		expect(service.read(definition, 21)).toBe('ok');
+	});
+
+	it('derives an ordered band value with a below-minimum default', () => {
+		const definition = mapping(
+			{
+				type: 'thresholds',
+				thresholds: [
+					{ minimum: 1000, value: 'bright' },
+					{ minimum: 100, value: 'moderate' },
+					{ minimum: 10, value: 'dusky' },
+				],
+				default: 'dark',
+			},
+			{ dataType: DataTypeType.ENUM, direction: 'read_only' },
+		);
+
+		expect(service.read(definition, 1000)).toBe('bright');
+		expect(service.read(definition, 999)).toBe('moderate');
+		expect(service.read(definition, 10)).toBe('dusky');
+		expect(service.read(definition, 9)).toBe('dark');
 	});
 
 	it('fails closed for forbidden directions and incompatible panel values', () => {

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.spec.ts
@@ -1,0 +1,116 @@
+import { DataTypeType, PropertyCategory } from '../../../modules/devices/devices.constants';
+
+import { HomeyMappingValueError } from './homey-mapping.error';
+import { HomeyMappingTransformerService } from './mapping-transformer.service';
+import { HomeyTransformDefinition, ResolvedHomeyPropertyMapping } from './mapping.types';
+
+const mapping = (
+	transform: HomeyTransformDefinition | undefined,
+	overrides: Partial<ResolvedHomeyPropertyMapping['property']> = {},
+): ResolvedHomeyPropertyMapping => ({
+	kind: 'properties',
+	source: 'builtin',
+	name: 'test-mapping',
+	priority: 100,
+	exclusive: false,
+	conflict: 'error',
+	match: {
+		classes: ['sensor'],
+		capabilityBaseIds: ['test'],
+		driverIds: [],
+		manufacturers: [],
+		models: [],
+	},
+	property: {
+		channel: 'test',
+		category: PropertyCategory.GENERIC,
+		dataType: DataTypeType.FLOAT,
+		direction: 'bidirectional',
+		transform,
+		...overrides,
+	},
+});
+
+describe('HomeyMappingTransformerService', () => {
+	const service = new HomeyMappingTransformerService();
+
+	it('scales and clamps reads while applying the exact inverse on writes', () => {
+		const definition = mapping(
+			{ type: 'scale', input_range: [0, 1], output_range: [0, 100], clamp: true },
+			{ dataType: DataTypeType.UCHAR },
+		);
+
+		expect(service.read(definition, 0.245)).toBe(25);
+		expect(service.read(definition, 2)).toBe(100);
+		expect(service.write(definition, 25)).toBe(0.25);
+		expect(service.write(definition, 200)).toBe(1);
+	});
+
+	it('supports descending ranges without losing inverse precision', () => {
+		const definition = mapping(
+			{ type: 'scale', input_range: [0, 1], output_range: [6500, 2000], clamp: true },
+			{ dataType: DataTypeType.USHORT },
+		);
+
+		expect(service.read(definition, 0.5)).toBe(4250);
+		expect(service.write(definition, 4250)).toBe(0.5);
+	});
+
+	it('uses explicit direction-specific maps and rejects unknown values', () => {
+		const definition = mapping(
+			{
+				type: 'map',
+				read: { up: 'opening', idle: 'stopped' },
+				write: { opening: 'up', stopped: 'idle' },
+			},
+			{ dataType: DataTypeType.ENUM },
+		);
+
+		expect(service.read(definition, 'up')).toBe('opening');
+		expect(service.write(definition, 'stopped')).toBe('idle');
+		expect(() => service.read(definition, 'down')).toThrow(HomeyMappingValueError);
+		expect(() => service.write(definition, 'closed')).toThrow(HomeyMappingValueError);
+	});
+
+	it('converts only declared boolean representations', () => {
+		const definition = mapping(
+			{ type: 'boolean', true_value: 'enabled', false_value: 'disabled', invert: true },
+			{ dataType: DataTypeType.BOOL },
+		);
+
+		expect(service.read(definition, 'enabled')).toBe(false);
+		expect(service.write(definition, false)).toBe('enabled');
+		expect(() => service.read(definition, 'unknown')).toThrow(HomeyMappingValueError);
+	});
+
+	it('supports clamp and round transforms and preserves null', () => {
+		expect(service.read(mapping({ type: 'clamp', minimum: 0, maximum: 10 }), 12)).toBe(10);
+		expect(service.read(mapping({ type: 'round', precision: 2 }), 1.236)).toBe(1.24);
+		expect(service.read(mapping({ type: 'round', precision: 2 }), null)).toBeNull();
+	});
+
+	it('fails closed for forbidden directions and incompatible panel values', () => {
+		const readOnly = mapping(undefined, { dataType: DataTypeType.BOOL, direction: 'read_only' });
+
+		expect(() => service.write(readOnly, true)).toThrow(HomeyMappingValueError);
+		expect(() => service.read(readOnly, 'true')).toThrow(HomeyMappingValueError);
+	});
+
+	it('never includes the rejected value in transformation errors', () => {
+		const secretLikeSentinel = 'secret-sentinel-value';
+		const definition = mapping(
+			{ type: 'map', read: { known: 'mapped' }, write: { mapped: 'known' } },
+			{
+				dataType: DataTypeType.ENUM,
+			},
+		);
+
+		try {
+			service.read(definition, secretLikeSentinel);
+			throw new Error('Expected the unknown value to fail');
+		} catch (error) {
+			expect(error).toBeInstanceOf(HomeyMappingValueError);
+			expect((error as Error).message).not.toContain(secretLikeSentinel);
+		}
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.ts
@@ -49,11 +49,14 @@ export class HomeyMappingTransformerService {
 		direction: HomeyTransformDirection,
 		value: HomeyMappingScalar,
 	): HomeyMappingScalar {
-		if (value === null || mapping.property.transform === undefined) {
+		if (mapping.property.transform === undefined) {
 			return value;
 		}
 
 		const transform = mapping.property.transform;
+		if (value === null && transform.type !== 'constant') {
+			return value;
+		}
 
 		switch (transform.type) {
 			case 'scale':
@@ -66,6 +69,16 @@ export class HomeyMappingTransformerService {
 				return this.clamp(mapping, direction, transform.minimum, transform.maximum, value);
 			case 'round':
 				return this.round(mapping, direction, transform.precision ?? 0, value);
+			case 'constant':
+				return transform.value;
+			case 'threshold':
+				return this.requireFiniteNumber(mapping, direction, value) <= transform.threshold
+					? transform.less_than_or_equal
+					: transform.greater_than;
+			case 'thresholds': {
+				const numericValue = this.requireFiniteNumber(mapping, direction, value);
+				return transform.thresholds.find((entry) => numericValue >= entry.minimum)?.value ?? transform.default;
+			}
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping-transformer.service.ts
@@ -1,0 +1,209 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataTypeType } from '../../../modules/devices/devices.constants';
+import { HomeyCapabilityValue } from '../models/homey-capability.model';
+
+import { HomeyMappingValueError } from './homey-mapping.error';
+import { HomeyMappingScalar, HomeyTransformDefinition, ResolvedHomeyPropertyMapping } from './mapping.types';
+
+type HomeyTransformDirection = 'read' | 'write';
+
+const INTEGER_DATA_TYPES = new Set<DataTypeType>([
+	DataTypeType.CHAR,
+	DataTypeType.UCHAR,
+	DataTypeType.SHORT,
+	DataTypeType.USHORT,
+	DataTypeType.INT,
+	DataTypeType.UINT,
+]);
+
+@Injectable()
+export class HomeyMappingTransformerService {
+	read(mapping: ResolvedHomeyPropertyMapping, value: HomeyCapabilityValue): HomeyMappingScalar {
+		this.assertDirection(mapping, 'read');
+		const transformed = this.transform(mapping, 'read', value);
+
+		return this.normalizePanelValue(mapping, transformed);
+	}
+
+	write(mapping: ResolvedHomeyPropertyMapping, value: HomeyMappingScalar): HomeyCapabilityValue {
+		this.assertDirection(mapping, 'write');
+		this.assertPanelValue(mapping, 'write', value);
+
+		return this.transform(mapping, 'write', value);
+	}
+
+	private assertDirection(mapping: ResolvedHomeyPropertyMapping, direction: HomeyTransformDirection): void {
+		const allowed =
+			mapping.property.direction === 'bidirectional' ||
+			(direction === 'read' && mapping.property.direction === 'read_only') ||
+			(direction === 'write' && mapping.property.direction === 'write_only');
+
+		if (!allowed) {
+			throw this.error(mapping, direction, `mapping direction is ${mapping.property.direction}`);
+		}
+	}
+
+	private transform(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		value: HomeyMappingScalar,
+	): HomeyMappingScalar {
+		if (value === null || mapping.property.transform === undefined) {
+			return value;
+		}
+
+		const transform = mapping.property.transform;
+
+		switch (transform.type) {
+			case 'scale':
+				return this.scale(mapping, direction, transform, value);
+			case 'map':
+				return this.map(mapping, direction, transform, value);
+			case 'boolean':
+				return this.boolean(mapping, direction, transform, value);
+			case 'clamp':
+				return this.clamp(mapping, direction, transform.minimum, transform.maximum, value);
+			case 'round':
+				return this.round(mapping, direction, transform.precision ?? 0, value);
+		}
+	}
+
+	private scale(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		transform: Extract<HomeyTransformDefinition, { type: 'scale' }>,
+		value: HomeyMappingScalar,
+	): number {
+		const numericValue = this.requireFiniteNumber(mapping, direction, value);
+		const inputRange = direction === 'read' ? transform.input_range : transform.output_range;
+		const outputRange = direction === 'read' ? transform.output_range : transform.input_range;
+		const boundedValue = transform.clamp
+			? Math.max(Math.min(inputRange[0], inputRange[1]), Math.min(Math.max(inputRange[0], inputRange[1]), numericValue))
+			: numericValue;
+		const ratio = (boundedValue - inputRange[0]) / (inputRange[1] - inputRange[0]);
+		const result = outputRange[0] + ratio * (outputRange[1] - outputRange[0]);
+
+		return Object.is(result, -0) ? 0 : result;
+	}
+
+	private map(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		transform: Extract<HomeyTransformDefinition, { type: 'map' }>,
+		value: HomeyMappingScalar,
+	): HomeyMappingScalar {
+		const table = direction === 'read' ? transform.read : transform.write;
+		const key = String(value);
+
+		if (table === undefined || !Object.hasOwn(table, key)) {
+			throw this.error(mapping, direction, 'value is not present in the explicit map table');
+		}
+
+		return table[key];
+	}
+
+	private boolean(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		transform: Extract<HomeyTransformDefinition, { type: 'boolean' }>,
+		value: HomeyMappingScalar,
+	): HomeyMappingScalar {
+		if (direction === 'read') {
+			if (value !== transform.true_value && value !== transform.false_value) {
+				throw this.error(mapping, direction, 'value does not match either declared boolean representation');
+			}
+
+			const result = value === transform.true_value;
+			return transform.invert === true ? !result : result;
+		}
+
+		if (typeof value !== 'boolean') {
+			throw this.error(mapping, direction, 'expected a boolean panel value');
+		}
+
+		const result = transform.invert === true ? !value : value;
+		return result ? transform.true_value : transform.false_value;
+	}
+
+	private clamp(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		minimum: number,
+		maximum: number,
+		value: HomeyMappingScalar,
+	): number {
+		return Math.max(minimum, Math.min(maximum, this.requireFiniteNumber(mapping, direction, value)));
+	}
+
+	private round(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		precision: number,
+		value: HomeyMappingScalar,
+	): number {
+		const factor = 10 ** precision;
+		return Math.round(this.requireFiniteNumber(mapping, direction, value) * factor) / factor;
+	}
+
+	private normalizePanelValue(mapping: ResolvedHomeyPropertyMapping, value: HomeyMappingScalar): HomeyMappingScalar {
+		if (value === null || mapping.property.dataType === DataTypeType.UNKNOWN) {
+			return value;
+		}
+
+		if (INTEGER_DATA_TYPES.has(mapping.property.dataType)) {
+			return Math.round(this.requireFiniteNumber(mapping, 'read', value));
+		}
+
+		this.assertPanelValue(mapping, 'read', value);
+		return value;
+	}
+
+	private assertPanelValue(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		value: HomeyMappingScalar,
+	): void {
+		if (value === null || mapping.property.dataType === DataTypeType.UNKNOWN) {
+			return;
+		}
+
+		const valid = (() => {
+			switch (mapping.property.dataType) {
+				case DataTypeType.BOOL:
+					return typeof value === 'boolean';
+				case DataTypeType.FLOAT:
+					return typeof value === 'number' && Number.isFinite(value);
+				case DataTypeType.STRING:
+				case DataTypeType.ENUM:
+					return typeof value === 'string';
+				default:
+					return INTEGER_DATA_TYPES.has(mapping.property.dataType) && Number.isInteger(value);
+			}
+		})();
+
+		if (!valid) {
+			throw this.error(mapping, direction, `value does not match ${mapping.property.dataType} data type`);
+		}
+	}
+
+	private requireFiniteNumber(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		value: HomeyMappingScalar,
+	): number {
+		if (typeof value !== 'number' || !Number.isFinite(value)) {
+			throw this.error(mapping, direction, 'expected a finite number');
+		}
+
+		return value;
+	}
+
+	private error(
+		mapping: ResolvedHomeyPropertyMapping,
+		direction: HomeyTransformDirection,
+		reason: string,
+	): HomeyMappingValueError {
+		return new HomeyMappingValueError(mapping.name, direction, reason);
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mapping.types.ts
@@ -33,6 +33,8 @@ export interface HomeyDeviceMatchDefinition {
 export interface HomeyPropertyMatchDefinition {
 	classes: string[];
 	capability_base_ids: string[];
+	all_capabilities?: string[];
+	none_capabilities?: string[];
 	driver_ids?: string[];
 	manufacturers?: string[];
 	models?: string[];
@@ -99,12 +101,36 @@ export interface HomeyRoundTransformDefinition {
 	precision?: number;
 }
 
+export interface HomeyConstantTransformDefinition {
+	type: 'constant';
+	value: HomeyMappingScalar;
+}
+
+export interface HomeyThresholdTransformDefinition {
+	type: 'threshold';
+	threshold: number;
+	less_than_or_equal: HomeyMappingScalar;
+	greater_than: HomeyMappingScalar;
+}
+
+export interface HomeyThresholdsTransformDefinition {
+	type: 'thresholds';
+	thresholds: Array<{
+		minimum: number;
+		value: HomeyMappingScalar;
+	}>;
+	default: HomeyMappingScalar;
+}
+
 export type HomeyTransformDefinition =
 	| HomeyScaleTransformDefinition
 	| HomeyMapTransformDefinition
 	| HomeyBooleanTransformDefinition
 	| HomeyClampTransformDefinition
-	| HomeyRoundTransformDefinition;
+	| HomeyRoundTransformDefinition
+	| HomeyConstantTransformDefinition
+	| HomeyThresholdTransformDefinition
+	| HomeyThresholdsTransformDefinition;
 
 export interface HomeyPropertyMappingDefinition extends HomeyMappingDefinitionBase {
 	match: HomeyPropertyMatchDefinition;
@@ -142,6 +168,8 @@ export interface ResolvedHomeyDeviceMatch {
 export interface ResolvedHomeyPropertyMatch {
 	classes: readonly string[];
 	capabilityBaseIds: readonly string[];
+	allCapabilities: readonly string[];
+	noneCapabilities: readonly string[];
 	driverIds: readonly string[];
 	manufacturers: readonly string[];
 	models: readonly string[];

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -1,0 +1,213 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { HomeyCapabilityType, HomeyCapabilityValue, createHomeyCapability } from '../models/homey-capability.model';
+import { HomeyDevice } from '../models/homey-device.model';
+
+import { HomeyMappingLoaderService } from './mapping-loader.service';
+import { HomeyMappingTransformerService } from './mapping-transformer.service';
+import { ResolvedHomeyPropertyBinding } from './mapping.types';
+
+const EXPECTED_FIXTURE_ROOT = resolve(__dirname, '../__fixtures__/expected/v1/devices');
+
+const readDeviceFixture = (name: string): HomeyDevice =>
+	JSON.parse(readFileSync(resolve(EXPECTED_FIXTURE_ROOT, `${name}.json`), 'utf8')) as HomeyDevice;
+
+const capability = (
+	id: string,
+	value: HomeyCapabilityValue,
+	options: { writable?: boolean; unit?: string; minimum?: number; maximum?: number } = {},
+) =>
+	createHomeyCapability({
+		id,
+		title: id,
+		value,
+		type:
+			typeof value === 'boolean'
+				? HomeyCapabilityType.BOOLEAN
+				: typeof value === 'number'
+					? HomeyCapabilityType.NUMBER
+					: HomeyCapabilityType.ENUM,
+		unit: options.unit ?? null,
+		minimum: options.minimum ?? null,
+		maximum: options.maximum ?? null,
+		step: null,
+		enumValues: [],
+		readable: true,
+		writable: options.writable ?? false,
+		available: true,
+		lastUpdatedAt: null,
+	});
+
+const publishedContractDevice = (deviceClass: string, capabilities: HomeyDevice['capabilities']): HomeyDevice => ({
+	id: `published-${deviceClass}`,
+	name: `Published ${deviceClass} contract`,
+	class: deviceClass,
+	zoneId: null,
+	zoneName: null,
+	zonePath: [],
+	available: true,
+	availabilityMessage: null,
+	driverId: null,
+	manufacturer: null,
+	model: null,
+	energy: null,
+	capabilities,
+});
+
+describe('Homey MVP mapping catalog', () => {
+	const loader = new HomeyMappingLoaderService();
+	const transformer = new HomeyMappingTransformerService();
+
+	const bindingsByName = (device: HomeyDevice): Map<string, ResolvedHomeyPropertyBinding> => {
+		const resolution = loader.resolvePropertyMappings(device);
+		expect(resolution.conflicts).toStrictEqual([]);
+
+		return new Map(resolution.mappings.map((binding) => [binding.mapping.name, binding]));
+	};
+
+	const read = (bindings: Map<string, ResolvedHomeyPropertyBinding>, name: string, value: HomeyCapabilityValue) => {
+		const binding = bindings.get(name);
+		expect(binding).toBeDefined();
+
+		return transformer.read(binding.mapping, value);
+	};
+
+	const write = (bindings: Map<string, ResolvedHomeyPropertyBinding>, name: string, value: HomeyCapabilityValue) => {
+		const binding = bindings.get(name);
+		expect(binding).toBeDefined();
+
+		return transformer.write(binding.mapping, value);
+	};
+
+	beforeAll(() => {
+		loader.loadAllMappings();
+	});
+
+	it('loads the complete built-in catalog without ambiguity', () => {
+		expect(loader.getDeviceMappings()).toHaveLength(7);
+		expect(loader.getChannelMappings()).toHaveLength(19);
+		expect(loader.getPropertyMappings()).toHaveLength(28);
+	});
+
+	it('maps the captured light fixture and applies inverse lighting transformations', () => {
+		const device = readDeviceFixture('light');
+		const bindings = bindingsByName(device);
+
+		expect(loader.resolveDeviceMappings(device)).toMatchObject({
+			conflicts: [],
+			mappings: [expect.objectContaining({ deviceCategory: DeviceCategory.LIGHTING })],
+		});
+		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).toStrictEqual([
+			'light',
+		]);
+		expect(read(bindings, 'light-power', false)).toBe(false);
+		expect(read(bindings, 'light-brightness', 0.24)).toBe(24);
+		expect(write(bindings, 'light-brightness', 24)).toBe(0.24);
+		expect(read(bindings, 'light-hue', 0.87)).toBe(313);
+		expect(write(bindings, 'light-hue', 180)).toBe(0.5);
+		expect(read(bindings, 'light-saturation', 0.95)).toBe(95);
+		expect(write(bindings, 'light-saturation', 95)).toBe(0.95);
+		expect(read(bindings, 'light-color-temperature', 0.01)).toBe(6455);
+		expect(write(bindings, 'light-color-temperature', 6455)).toBeCloseTo(0.01, 12);
+	});
+
+	it('maps captured outlet, energy, and repeated full capability IDs', () => {
+		const outlet = readDeviceFixture('switch');
+		const bindings = bindingsByName(outlet);
+
+		expect(loader.resolveDeviceMappings(outlet).mappings[0]?.deviceCategory).toBe(DeviceCategory.OUTLET);
+		expect(read(bindings, 'outlet-power', false)).toBe(false);
+		expect(read(bindings, 'instantaneous-power', 0)).toBe(0);
+		expect(read(bindings, 'accumulated-energy', 58.03)).toBe(58.03);
+
+		const repeated = loader.resolvePropertyMappings(readDeviceFixture('repeated-capabilities'));
+		const energyBindings = repeated.mappings.filter((binding) => binding.mapping.name === 'accumulated-energy');
+		expect(energyBindings.map((binding) => binding.capabilityId)).toStrictEqual([
+			'meter_power',
+			'meter_power.capability-suffix-000007',
+		]);
+	});
+
+	it('maps captured environmental and battery values', () => {
+		const device = readDeviceFixture('sensor-air-quality');
+		const bindings = bindingsByName(device);
+
+		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.SENSOR);
+		expect(read(bindings, 'battery-level', 100)).toBe(100);
+		expect(read(bindings, 'humidity', 28.65)).toBe(29);
+		expect(read(bindings, 'sensor-temperature', 30.6)).toBe(30.6);
+		expect(read(bindings, 'illuminance', 1)).toBe(1);
+	});
+
+	it('maps the captured cover and preserves open, close, stop, and position semantics', () => {
+		const device = readDeviceFixture('cover');
+		const bindings = bindingsByName(device);
+
+		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.WINDOW_COVERING);
+		expect(read(bindings, 'window-covering-status', 'down')).toBe('closing');
+		expect(write(bindings, 'window-covering-command', 'open')).toBe('up');
+		expect(write(bindings, 'window-covering-command', 'close')).toBe('down');
+		expect(write(bindings, 'window-covering-command', 'stop')).toBe('idle');
+		expect(read(bindings, 'window-covering-position', 0)).toBe(0);
+		expect(write(bindings, 'window-covering-position', 45)).toBe(0.45);
+	});
+
+	it('maps published thermostat modes and target temperature without claiming live fixture provenance', () => {
+		const device = publishedContractDevice('thermostat', [
+			capability('measure_temperature', 21.5, { unit: '°C' }),
+			capability('target_temperature', 22.5, { unit: '°C', writable: true, minimum: 4, maximum: 35 }),
+			capability('thermostat_mode', 'heat', { writable: true }),
+		]);
+		const bindings = bindingsByName(device);
+
+		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.THERMOSTAT);
+		expect(read(bindings, 'thermostat-current-temperature', 21.5)).toBe(21.5);
+		expect(read(bindings, 'thermostat-target-temperature', 22.5)).toBe(22.5);
+		expect(write(bindings, 'thermostat-target-temperature', 19.5)).toBe(19.5);
+		expect(['auto', 'heat', 'cool', 'off']).toStrictEqual(
+			['auto', 'heat', 'cool', 'off'].map((mode) => read(bindings, 'thermostat-mode', mode)),
+		);
+		expect(write(bindings, 'thermostat-mode', 'cool')).toBe('cool');
+	});
+
+	it('maps published environment and safety capability contracts', () => {
+		const device = publishedContractDevice('sensor', [
+			capability('measure_pressure', 1013, { unit: 'mbar' }),
+			capability('measure_co2', 850, { unit: 'ppm' }),
+			capability('alarm_motion', true),
+			capability('alarm_contact', false),
+			capability('alarm_smoke', true),
+			capability('alarm_co', false),
+			capability('alarm_battery', true),
+		]);
+		const bindings = bindingsByName(device);
+
+		expect(read(bindings, 'pressure', 1013)).toBeCloseTo(101.3, 12);
+		expect(read(bindings, 'carbon-dioxide', 850)).toBe(850);
+		expect(read(bindings, 'motion', true)).toBe(true);
+		expect(read(bindings, 'contact', false)).toBe(false);
+		expect(read(bindings, 'smoke', true)).toBe(true);
+		expect(read(bindings, 'carbon-monoxide', false)).toBe(false);
+		expect(read(bindings, 'battery-alarm', true)).toBe('low');
+	});
+
+	it('maps published lock and tilt contracts with inverse control values', () => {
+		const lock = publishedContractDevice('lock', [capability('locked', true, { writable: true })]);
+		const lockBindings = bindingsByName(lock);
+		expect(loader.resolveDeviceMappings(lock).mappings[0]?.deviceCategory).toBe(DeviceCategory.LOCK);
+		expect(read(lockBindings, 'lock-state', true)).toBe(true);
+		expect(write(lockBindings, 'lock-state', false)).toBe(false);
+
+		const cover = publishedContractDevice('windowcoverings', [
+			capability('windowcoverings_state', 'idle', { writable: true }),
+			capability('windowcoverings_set', 0.5, { writable: true, minimum: 0, maximum: 1 }),
+			capability('windowcoverings_tilt_set', 0.5, { writable: true, minimum: 0, maximum: 1 }),
+		]);
+		const coverBindings = bindingsByName(cover);
+		expect(loader.resolveDeviceMappings(cover).mappings[0]?.deviceCategory).toBe(DeviceCategory.WINDOW_COVERING);
+		expect(read(coverBindings, 'window-covering-tilt', 0.5)).toBe(0);
+		expect(write(coverBindings, 'window-covering-tilt', 45)).toBe(0.75);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { DeviceCategory } from '../../../modules/devices/devices.constants';
+import { getRequiredProperties } from '../../../modules/devices/utils/schema.utils';
 import { HomeyCapabilityType, HomeyCapabilityValue, createHomeyCapability } from '../models/homey-capability.model';
 import { HomeyDevice } from '../models/homey-device.model';
 
@@ -81,19 +82,33 @@ describe('Homey MVP mapping catalog', () => {
 		return transformer.write(binding.mapping, value);
 	};
 
+	const expectMappedChannelsComplete = (device: HomeyDevice): void => {
+		const channels = loader.resolveChannelMappings(device).mappings;
+		const properties = loader.resolvePropertyMappings(device).mappings;
+
+		for (const channel of channels) {
+			const mappedCategories = properties
+				.filter((binding) => binding.mapping.property.channel === channel.channel.identifier)
+				.map((binding) => binding.mapping.property.category);
+
+			expect(mappedCategories).toEqual(expect.arrayContaining(getRequiredProperties(channel.channel.category)));
+		}
+	};
+
 	beforeAll(() => {
 		loader.loadAllMappings();
 	});
 
 	it('loads the complete built-in catalog without ambiguity', () => {
 		expect(loader.getDeviceMappings()).toHaveLength(7);
-		expect(loader.getChannelMappings()).toHaveLength(19);
-		expect(loader.getPropertyMappings()).toHaveLength(28);
+		expect(loader.getChannelMappings()).toHaveLength(21);
+		expect(loader.getPropertyMappings()).toHaveLength(40);
 	});
 
 	it('maps the captured light fixture and applies inverse lighting transformations', () => {
 		const device = readDeviceFixture('light');
 		const bindings = bindingsByName(device);
+		expectMappedChannelsComplete(device);
 
 		expect(loader.resolveDeviceMappings(device)).toMatchObject({
 			conflicts: [],
@@ -116,6 +131,7 @@ describe('Homey MVP mapping catalog', () => {
 	it('maps captured outlet, energy, and repeated full capability IDs', () => {
 		const outlet = readDeviceFixture('switch');
 		const bindings = bindingsByName(outlet);
+		expectMappedChannelsComplete(outlet);
 
 		expect(loader.resolveDeviceMappings(outlet).mappings[0]?.deviceCategory).toBe(DeviceCategory.OUTLET);
 		expect(read(bindings, 'outlet-power', false)).toBe(false);
@@ -133,19 +149,24 @@ describe('Homey MVP mapping catalog', () => {
 	it('maps captured environmental and battery values', () => {
 		const device = readDeviceFixture('sensor-air-quality');
 		const bindings = bindingsByName(device);
+		expectMappedChannelsComplete(device);
 
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.SENSOR);
 		expect(read(bindings, 'battery-level', 100)).toBe(100);
+		expect(read(bindings, 'battery-status-from-level', 100)).toBe('ok');
 		expect(read(bindings, 'humidity', 28.65)).toBe(29);
 		expect(read(bindings, 'sensor-temperature', 30.6)).toBe(30.6);
 		expect(read(bindings, 'illuminance', 1)).toBe(1);
+		expect(read(bindings, 'illuminance-level', 1)).toBe('dark');
 	});
 
 	it('maps the captured cover and preserves open, close, stop, and position semantics', () => {
 		const device = readDeviceFixture('cover');
 		const bindings = bindingsByName(device);
+		expectMappedChannelsComplete(device);
 
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.WINDOW_COVERING);
+		expect(read(bindings, 'window-covering-type-generic', null)).toBe('roller');
 		expect(read(bindings, 'window-covering-status', 'down')).toBe('closing');
 		expect(write(bindings, 'window-covering-command', 'open')).toBe('up');
 		expect(write(bindings, 'window-covering-command', 'close')).toBe('down');
@@ -161,15 +182,28 @@ describe('Homey MVP mapping catalog', () => {
 			capability('thermostat_mode', 'heat', { writable: true }),
 		]);
 		const bindings = bindingsByName(device);
+		expectMappedChannelsComplete(device);
 
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.THERMOSTAT);
 		expect(read(bindings, 'thermostat-current-temperature', 21.5)).toBe(21.5);
-		expect(read(bindings, 'thermostat-target-temperature', 22.5)).toBe(22.5);
-		expect(write(bindings, 'thermostat-target-temperature', 19.5)).toBe(19.5);
-		expect(['auto', 'heat', 'cool', 'off']).toStrictEqual(
-			['auto', 'heat', 'cool', 'off'].map((mode) => read(bindings, 'thermostat-mode', mode)),
-		);
-		expect(write(bindings, 'thermostat-mode', 'cool')).toBe('cool');
+		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).toStrictEqual([
+			'cooler',
+			'heater',
+			'temperature',
+			'thermostat',
+		]);
+		expect(read(bindings, 'thermostat-heater-target-temperature', 22.5)).toBe(22.5);
+		expect(write(bindings, 'thermostat-heater-target-temperature', 19.5)).toBe(19.5);
+		expect(read(bindings, 'thermostat-cooler-target-temperature', 22.5)).toBe(22.5);
+		expect(write(bindings, 'thermostat-cooler-target-temperature', 19.5)).toBe(19.5);
+		expect(read(bindings, 'thermostat-heater-on', 'heat')).toBe(true);
+		expect(read(bindings, 'thermostat-heater-on', 'cool')).toBe(false);
+		expect(write(bindings, 'thermostat-heater-on', true)).toBe('heat');
+		expect(read(bindings, 'thermostat-heater-status', 'off')).toBe(false);
+		expect(read(bindings, 'thermostat-cooler-on', 'cool')).toBe(true);
+		expect(read(bindings, 'thermostat-cooler-on', 'heat')).toBe(false);
+		expect(write(bindings, 'thermostat-cooler-on', true)).toBe('cool');
+		expect(read(bindings, 'thermostat-cooler-status', 'auto')).toBe(true);
 	});
 
 	it('maps published environment and safety capability contracts', () => {
@@ -180,9 +214,11 @@ describe('Homey MVP mapping catalog', () => {
 			capability('alarm_contact', false),
 			capability('alarm_smoke', true),
 			capability('alarm_co', false),
+			capability('measure_battery', 15),
 			capability('alarm_battery', true),
 		]);
 		const bindings = bindingsByName(device);
+		expectMappedChannelsComplete(device);
 
 		expect(read(bindings, 'pressure', 1013)).toBeCloseTo(101.3, 12);
 		expect(read(bindings, 'carbon-dioxide', 850)).toBe(850);
@@ -191,14 +227,27 @@ describe('Homey MVP mapping catalog', () => {
 		expect(read(bindings, 'smoke', true)).toBe(true);
 		expect(read(bindings, 'carbon-monoxide', false)).toBe(false);
 		expect(read(bindings, 'battery-alarm', true)).toBe('low');
+		expect(bindings.has('battery-status-from-level')).toBe(false);
+	});
+
+	it('does not emit an incomplete battery channel for an alarm-only device', () => {
+		const device = publishedContractDevice('sensor', [capability('alarm_battery', true)]);
+
+		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).not.toContain(
+			'battery',
+		);
+		expect(bindingsByName(device).size).toBe(0);
 	});
 
 	it('maps published lock and tilt contracts with inverse control values', () => {
 		const lock = publishedContractDevice('lock', [capability('locked', true, { writable: true })]);
 		const lockBindings = bindingsByName(lock);
+		expectMappedChannelsComplete(lock);
 		expect(loader.resolveDeviceMappings(lock).mappings[0]?.deviceCategory).toBe(DeviceCategory.LOCK);
-		expect(read(lockBindings, 'lock-state', true)).toBe(true);
-		expect(write(lockBindings, 'lock-state', false)).toBe(false);
+		expect(read(lockBindings, 'lock-on', true)).toBe(true);
+		expect(write(lockBindings, 'lock-on', false)).toBe(false);
+		expect(read(lockBindings, 'lock-status', true)).toBe('locked');
+		expect(write(lockBindings, 'lock-status', 'unlocked')).toBe(false);
 
 		const cover = publishedContractDevice('windowcoverings', [
 			capability('windowcoverings_state', 'idle', { writable: true }),
@@ -206,7 +255,9 @@ describe('Homey MVP mapping catalog', () => {
 			capability('windowcoverings_tilt_set', 0.5, { writable: true, minimum: 0, maximum: 1 }),
 		]);
 		const coverBindings = bindingsByName(cover);
+		expectMappedChannelsComplete(cover);
 		expect(loader.resolveDeviceMappings(cover).mappings[0]?.deviceCategory).toBe(DeviceCategory.WINDOW_COVERING);
+		expect(read(coverBindings, 'window-covering-type-generic', null)).toBe('roller');
 		expect(read(coverBindings, 'window-covering-tilt', 0.5)).toBe(0);
 		expect(write(coverBindings, 'window-covering-tilt', 45)).toBe(0.75);
 	});

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -255,6 +255,7 @@ describe('Homey MVP mapping catalog', () => {
 	it('does not emit an incomplete battery channel for an alarm-only device', () => {
 		const device = publishedContractDevice('sensor', [capability('alarm_battery', true)]);
 
+		expect(loader.resolveDeviceMappings(device).mappings).toStrictEqual([]);
 		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).not.toContain(
 			'battery',
 		);

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -140,10 +140,17 @@ describe('Homey MVP mapping catalog', () => {
 
 		const repeated = loader.resolvePropertyMappings(readDeviceFixture('repeated-capabilities'));
 		const energyBindings = repeated.mappings.filter((binding) => binding.mapping.name === 'accumulated-energy');
-		expect(energyBindings.map((binding) => binding.capabilityId)).toStrictEqual([
-			'meter_power',
-			'meter_power.capability-suffix-000007',
-		]);
+		expect(energyBindings.map((binding) => binding.capabilityId)).toStrictEqual(['meter_power']);
+	});
+
+	it('selects primary light controls instead of collapsing repeated instances onto one channel', () => {
+		const resolution = loader.resolvePropertyMappings(readDeviceFixture('energy-meter'));
+		const lightPower = resolution.mappings.filter((binding) => binding.mapping.name === 'light-power');
+		const brightness = resolution.mappings.filter((binding) => binding.mapping.name === 'light-brightness');
+
+		expect(resolution.conflicts).toStrictEqual([]);
+		expect(lightPower.map((binding) => binding.capabilityId)).toStrictEqual(['onoff']);
+		expect(brightness.map((binding) => binding.capabilityId)).toStrictEqual(['dim']);
 	});
 
 	it('maps captured environmental and battery values', () => {
@@ -204,6 +211,21 @@ describe('Homey MVP mapping catalog', () => {
 		expect(read(bindings, 'thermostat-cooler-on', 'heat')).toBe(false);
 		expect(write(bindings, 'thermostat-cooler-on', true)).toBe('cool');
 		expect(read(bindings, 'thermostat-cooler-status', 'auto')).toBe(true);
+	});
+
+	it('does not classify an incomplete target-only thermostat as adoptable', () => {
+		const device = publishedContractDevice('thermostat', [
+			capability('measure_temperature', 21.5, { unit: '°C' }),
+			capability('target_temperature', 22.5, { unit: '°C', writable: true }),
+		]);
+
+		expect(loader.resolveDeviceMappings(device).mappings).toStrictEqual([]);
+		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).toStrictEqual([
+			'temperature',
+		]);
+		expect(loader.resolvePropertyMappings(device).mappings.map((binding) => binding.mapping.name)).toStrictEqual([
+			'thermostat-current-temperature',
+		]);
 	});
 
 	it('maps published environment and safety capability contracts', () => {

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -101,8 +101,8 @@ describe('Homey MVP mapping catalog', () => {
 
 	it('loads the complete built-in catalog without ambiguity', () => {
 		expect(loader.getDeviceMappings()).toHaveLength(7);
-		expect(loader.getChannelMappings()).toHaveLength(21);
-		expect(loader.getPropertyMappings()).toHaveLength(40);
+		expect(loader.getChannelMappings()).toHaveLength(20);
+		expect(loader.getPropertyMappings()).toHaveLength(37);
 	});
 
 	it('maps the captured light fixture and applies inverse lighting transformations', () => {
@@ -194,23 +194,21 @@ describe('Homey MVP mapping catalog', () => {
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.THERMOSTAT);
 		expect(read(bindings, 'thermostat-current-temperature', 21.5)).toBe(21.5);
 		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).toStrictEqual([
-			'cooler',
 			'heater',
 			'temperature',
 			'thermostat',
 		]);
 		expect(read(bindings, 'thermostat-heater-target-temperature', 22.5)).toBe(22.5);
 		expect(write(bindings, 'thermostat-heater-target-temperature', 19.5)).toBe(19.5);
-		expect(read(bindings, 'thermostat-cooler-target-temperature', 22.5)).toBe(22.5);
-		expect(write(bindings, 'thermostat-cooler-target-temperature', 19.5)).toBe(19.5);
 		expect(read(bindings, 'thermostat-heater-on', 'heat')).toBe(true);
 		expect(read(bindings, 'thermostat-heater-on', 'cool')).toBe(false);
 		expect(write(bindings, 'thermostat-heater-on', true)).toBe('heat');
 		expect(read(bindings, 'thermostat-heater-status', 'off')).toBe(false);
-		expect(read(bindings, 'thermostat-cooler-on', 'cool')).toBe(true);
-		expect(read(bindings, 'thermostat-cooler-on', 'heat')).toBe(false);
-		expect(write(bindings, 'thermostat-cooler-on', true)).toBe('cool');
-		expect(read(bindings, 'thermostat-cooler-status', 'auto')).toBe(true);
+		expect(
+			loader
+				.resolvePropertyMappings(device)
+				.mappings.filter((binding) => binding.capabilityId === 'target_temperature'),
+		).toHaveLength(1);
 	});
 
 	it('does not classify an incomplete target-only thermostat as adoptable', () => {

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -101,8 +101,8 @@ describe('Homey MVP mapping catalog', () => {
 
 	it('loads the complete built-in catalog without ambiguity', () => {
 		expect(loader.getDeviceMappings()).toHaveLength(7);
-		expect(loader.getChannelMappings()).toHaveLength(20);
-		expect(loader.getPropertyMappings()).toHaveLength(37);
+		expect(loader.getChannelMappings()).toHaveLength(19);
+		expect(loader.getPropertyMappings()).toHaveLength(34);
 	});
 
 	it('maps the captured light fixture and applies inverse lighting transformations', () => {
@@ -182,7 +182,7 @@ describe('Homey MVP mapping catalog', () => {
 		expect(write(bindings, 'window-covering-position', 45)).toBe(0.45);
 	});
 
-	it('maps published thermostat modes and target temperature without claiming live fixture provenance', () => {
+	it('does not fabricate thermostat activity from the configured mode', () => {
 		const device = publishedContractDevice('thermostat', [
 			capability('measure_temperature', 21.5, { unit: '°C' }),
 			capability('target_temperature', 22.5, { unit: '°C', writable: true, minimum: 4, maximum: 35 }),
@@ -196,23 +196,14 @@ describe('Homey MVP mapping catalog', () => {
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.THERMOSTAT);
 		expect(read(bindings, 'thermostat-current-temperature', 21.5)).toBe(21.5);
 		expect(loader.resolveChannelMappings(device).mappings.map((mapping) => mapping.channel.identifier)).toStrictEqual([
-			'heater',
 			'temperature',
 			'thermostat',
 		]);
-		expect(read(bindings, 'thermostat-heater-target-temperature', 22.5)).toBe(22.5);
-		expect(write(bindings, 'thermostat-heater-target-temperature', 19.5)).toBe(19.5);
-		expect(read(bindings, 'thermostat-heater-on', 'heat')).toBe(true);
-		expect(read(bindings, 'thermostat-heater-on', 'cool')).toBe(false);
-		expect(write(bindings, 'thermostat-heater-on', true)).toBe('heat');
-		expect(read(bindings, 'thermostat-heater-status', 'off')).toBe(false);
+		expect(bindings.has('thermostat-heater-target-temperature')).toBe(false);
+		expect(bindings.has('thermostat-heater-on')).toBe(false);
+		expect(bindings.has('thermostat-heater-status')).toBe(false);
 		expect(bindings.has('battery-level')).toBe(false);
 		expect(bindings.has('battery-alarm')).toBe(false);
-		expect(
-			loader
-				.resolvePropertyMappings(device)
-				.mappings.filter((binding) => binding.capabilityId === 'target_temperature'),
-		).toHaveLength(1);
 	});
 
 	it('does not classify an incomplete target-only thermostat as adoptable', () => {

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -187,6 +187,8 @@ describe('Homey MVP mapping catalog', () => {
 			capability('measure_temperature', 21.5, { unit: '°C' }),
 			capability('target_temperature', 22.5, { unit: '°C', writable: true, minimum: 4, maximum: 35 }),
 			capability('thermostat_mode', 'heat', { writable: true }),
+			capability('measure_battery', 80),
+			capability('alarm_battery', false),
 		]);
 		const bindings = bindingsByName(device);
 		expectMappedChannelsComplete(device);
@@ -204,6 +206,8 @@ describe('Homey MVP mapping catalog', () => {
 		expect(read(bindings, 'thermostat-heater-on', 'cool')).toBe(false);
 		expect(write(bindings, 'thermostat-heater-on', true)).toBe('heat');
 		expect(read(bindings, 'thermostat-heater-status', 'off')).toBe(false);
+		expect(bindings.has('battery-level')).toBe(false);
+		expect(bindings.has('battery-alarm')).toBe(false);
 		expect(
 			loader
 				.resolvePropertyMappings(device)

--- a/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/mvp-mappings.spec.ts
@@ -174,7 +174,10 @@ describe('Homey MVP mapping catalog', () => {
 
 		expect(loader.resolveDeviceMappings(device).mappings[0]?.deviceCategory).toBe(DeviceCategory.WINDOW_COVERING);
 		expect(read(bindings, 'window-covering-type-generic', null)).toBe('roller');
-		expect(read(bindings, 'window-covering-status', 'down')).toBe('closing');
+		expect(bindings.get('window-covering-status')?.capabilityId).toBe('windowcoverings_set');
+		expect(read(bindings, 'window-covering-status', 0)).toBe('closed');
+		expect(read(bindings, 'window-covering-status', 1)).toBe('opened');
+		expect(read(bindings, 'window-covering-status', 0.5)).toBe('stopped');
 		expect(write(bindings, 'window-covering-command', 'open')).toBe('up');
 		expect(write(bindings, 'window-covering-command', 'close')).toBe('down');
 		expect(write(bindings, 'window-covering-command', 'stop')).toBe('idle');

--- a/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/mappings/property-mapping-storage.service.spec.ts
@@ -13,6 +13,8 @@ const mapping: ResolvedHomeyPropertyMapping = {
 	match: {
 		classes: ['sensor'],
 		capabilityBaseIds: ['measure_temperature'],
+		allCapabilities: [],
+		noneCapabilities: [],
 		driverIds: [],
 		manufacturers: [],
 		models: [],

--- a/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
+++ b/apps/backend/src/plugins/devices-homey/mappings/schema/mapping-schema.json
@@ -47,6 +47,8 @@
       "properties": {
         "classes": { "$ref": "#/definitions/uniqueStrings" },
         "capability_base_ids": { "$ref": "#/definitions/uniqueStrings" },
+        "all_capabilities": { "$ref": "#/definitions/uniqueStrings" },
+        "none_capabilities": { "$ref": "#/definitions/uniqueStrings" },
         "driver_ids": { "$ref": "#/definitions/uniqueStrings" },
         "manufacturers": { "$ref": "#/definitions/uniqueStrings" },
         "models": { "$ref": "#/definitions/uniqueStrings" }
@@ -185,6 +187,48 @@
             "precision": { "type": "integer", "minimum": 0, "maximum": 12 }
           },
           "required": ["type"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "constant" },
+            "value": { "$ref": "#/definitions/scalar" }
+          },
+          "required": ["type", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "threshold" },
+            "threshold": { "type": "number" },
+            "less_than_or_equal": { "$ref": "#/definitions/scalar" },
+            "greater_than": { "$ref": "#/definitions/scalar" }
+          },
+          "required": ["type", "threshold", "less_than_or_equal", "greater_than"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "thresholds" },
+            "thresholds": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "minimum": { "type": "number" },
+                  "value": { "$ref": "#/definitions/scalar" }
+                },
+                "required": ["minimum", "value"],
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "default": { "$ref": "#/definitions/scalar" }
+          },
+          "required": ["type", "thresholds", "default"],
           "additionalProperties": false
         }
       ]

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -394,6 +394,7 @@ metadata remains visible to mapping preview and user overrides.
 - [ ] Resolve the property mapping and full capability ID.
 - [ ] Validate writable access, value type, enum/range, and device availability.
 - [ ] Apply the inverse transformation.
+- [ ] Coalesce paired heater/cooler power projections into one Homey `thermostat_mode` command.
 - [ ] Serialize writes per device/capability.
 - [ ] Send the command through the connector with a bounded timeout.
 - [ ] Await a matching event as authoritative confirmation.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -293,7 +293,9 @@ remain supported. Revisit only after a Homey-specific identity and restart-stabl
 
 - [x] Power: `onoff`.
 - [x] Lighting: `dim`, hue, saturation, and temperature.
-- [x] Climate: measured temperature, target temperature, and verified thermostat modes.
+- [x] Climate: measured temperature and complete thermostat identity.
+- [ ] Climate control: project target temperature and mode only with a verified actual-activity signal; Homey's standard
+      `thermostat_mode` is configuration, not heater/cooler activity.
 - [x] Environment: humidity, pressure, luminance, and CO2.
 - [x] Safety/contact: motion, contact, smoke, carbon monoxide.
 - [x] Energy: instantaneous power and accumulated energy.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -394,7 +394,6 @@ metadata remains visible to mapping preview and user overrides.
 - [ ] Resolve the property mapping and full capability ID.
 - [ ] Validate writable access, value type, enum/range, and device availability.
 - [ ] Apply the inverse transformation.
-- [ ] Coalesce paired heater/cooler power projections into one Homey `thermostat_mode` command.
 - [ ] Serialize writes per device/capability.
 - [ ] Send the command through the connector with a bounded timeout.
 - [ ] Await a matching event as authoritative confirmation.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -291,16 +291,21 @@ remain supported. Revisit only after a Homey-specific identity and restart-stabl
 
 ### Task 3.2: Add MVP mapping definitions
 
-- [ ] Power: `onoff`.
-- [ ] Lighting: `dim`, hue, saturation, and temperature.
-- [ ] Climate: measured temperature, target temperature, and verified thermostat modes.
-- [ ] Environment: humidity, pressure, luminance, and CO2.
-- [ ] Safety/contact: motion, contact, smoke, carbon monoxide.
-- [ ] Energy: instantaneous power and accumulated energy.
-- [ ] Battery: level and low-battery alarm.
-- [ ] Lock: state/control when writable.
-- [ ] Covers: state, position, tilt, open/close/stop behavior after fixture validation.
-- [ ] Add representative fixture tests for each mapping family and inverse transformation.
+- [x] Power: `onoff`.
+- [x] Lighting: `dim`, hue, saturation, and temperature.
+- [x] Climate: measured temperature, target temperature, and verified thermostat modes.
+- [x] Environment: humidity, pressure, luminance, and CO2.
+- [x] Safety/contact: motion, contact, smoke, carbon monoxide.
+- [x] Energy: instantaneous power and accumulated energy.
+- [x] Battery: level and low-battery alarm.
+- [x] Lock: state/control when writable.
+- [x] Covers: state, position, tilt, open/close/stop behavior after fixture validation.
+- [x] Add representative fixture tests for each mapping family and inverse transformation.
+
+Live SHS 13.4.0 fixtures cover the capability families present in the captured inventory. Known inventory gaps use
+explicitly named published-contract test devices derived from Athom's public capability definitions; they do not claim
+live provenance. Relative light-temperature and cover-tilt projections are reversible defaults whose conversion
+metadata remains visible to mapping preview and user overrides.
 
 ### Task 3.3: Implement device inventory/discovery service and API
 


### PR DESCRIPTION
## Summary

- add the built-in Homey MVP device, channel, and property mapping catalog
- add fail-closed read/write transformations with reversible scaling and explicit enum maps
- cover live SHS fixtures plus clearly separated Athom published-contract gaps
- complete and document Homey implementation-plan Task 3.2

## Verification

- 22 Homey unit suites: 240 tests passed
- 7 Homey compatibility-spike suites: 122 tests passed
- backend type-check passed
- backend build passed
- targeted lint, formatting, and diff checks passed
- full backend lint has no errors; it retains two pre-existing Buddy floating-promise warnings

## Provenance

The committed SHS 13.4.0 fixtures exercise the capability families present in the captured inventory. Missing live shapes are tested as explicitly named published-contract devices based on Athom node-homey-lib definitions and do not claim live provenance.