### PR TITLE
feat(cross): describe config update payloads and redact plugin secrets

### DIFF
--- a/apps/admin/src/modules/config/components/components.ts
+++ b/apps/admin/src/modules/config/components/components.ts
@@ -1,5 +1,6 @@
 // ConfigLanguageForm, ConfigWeatherForm, ConfigSystemForm removed - these configs are now accessed via modules
 export { default as ConfigPlugin } from './config-pluign.vue';
 export { default as ConfigModule } from './config-module.vue';
+export { default as ConfigSecretInput } from './config-secret-input.vue';
 
 export * from './types';

--- a/apps/admin/src/modules/config/components/config-secret-input.spec.ts
+++ b/apps/admin/src/modules/config/components/config-secret-input.spec.ts
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils';
+import { ElButton, ElInput } from 'element-plus';
+import { describe, expect, it, vi } from 'vitest';
+
+import ConfigSecretInput from './config-secret-input.vue';
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+const factory = (props: Record<string, unknown> = {}) =>
+	mount(ConfigSecretInput, {
+		props,
+		global: {
+			components: { ElButton, ElInput },
+		},
+	});
+
+const emitted = (wrapper: ReturnType<typeof factory>): unknown[][] => (wrapper.emitted('update:modelValue') ?? []) as unknown[][];
+
+describe('ConfigSecretInput', () => {
+	it('offers no removal when nothing is stored', () => {
+		const wrapper = factory({ configured: false });
+
+		expect(wrapper.findComponent(ElInput).exists()).toBe(true);
+		expect(wrapper.findAllComponents(ElButton)).toHaveLength(0);
+	});
+
+	it('offers removal once the backend reports a stored value', () => {
+		const wrapper = factory({ configured: true });
+
+		expect(wrapper.text()).toContain('configModule.texts.secret.stored');
+		expect(wrapper.findComponent(ElButton).text()).toBe('configModule.buttons.removeSecret.title');
+	});
+
+	// The whole point of the control: the backend keeps a stored secret for an absent or blank
+	// field, so only an explicit `null` asks for it to go.
+	it('asks for removal with null', async () => {
+		const wrapper = factory({ configured: true });
+
+		await wrapper.findComponent(ElButton).trigger('click');
+
+		expect(emitted(wrapper)).toEqual([[null]]);
+	});
+
+	it('reverts a pending removal without submitting anything', async () => {
+		const wrapper = factory({ configured: true, modelValue: null });
+
+		expect(wrapper.text()).toContain('configModule.texts.secret.willBeRemoved');
+		// The field is out of the way while removal is pending, so nothing can be typed into a
+		// value that is on its way out.
+		expect(wrapper.findComponent(ElInput).exists()).toBe(false);
+
+		await wrapper.findComponent(ElButton).trigger('click');
+
+		expect(emitted(wrapper)).toEqual([[undefined]]);
+	});
+
+	it('submits what is typed', async () => {
+		const wrapper = factory({ configured: true });
+
+		await wrapper.findComponent(ElInput).setValue('a new secret');
+
+		expect(emitted(wrapper)).toEqual([['a new secret']]);
+	});
+
+	// Typing and then clearing again leaves the field exactly as it was found, and an untouched
+	// field must not be submitted at all - blanking one is not a way to remove a credential.
+	it('submits nothing for a field cleared back to blank', async () => {
+		const wrapper = factory({ configured: true, modelValue: 'half typed' });
+
+		await wrapper.findComponent(ElInput).setValue('');
+
+		expect(emitted(wrapper)).toEqual([[undefined]]);
+	});
+
+	it('renders the multi-line credentials as a textarea', () => {
+		const wrapper = factory({ type: 'textarea', rows: 4 });
+
+		expect(wrapper.findComponent(ElInput).props('type')).toBe('textarea');
+		expect(wrapper.findComponent(ElInput).props('rows')).toBe(4);
+	});
+});

--- a/apps/admin/src/modules/config/components/config-secret-input.types.ts
+++ b/apps/admin/src/modules/config/components/config-secret-input.types.ts
@@ -1,0 +1,15 @@
+export type IConfigSecretInputProps = {
+	/**
+	 * `undefined` leaves the stored value alone, a string replaces it, and `null` removes it.
+	 * Those are the backend's three cases, so the form field carries them directly.
+	 */
+	modelValue?: string | null;
+	/** Whether the backend reports a value is stored - it never sends the value itself. */
+	configured?: boolean;
+	/** `textarea` for the multi-line credentials; anything else is a masked single line. */
+	type?: 'password' | 'textarea';
+	rows?: number;
+	placeholder?: string;
+	name?: string;
+	disabled?: boolean;
+};

--- a/apps/admin/src/modules/config/components/config-secret-input.vue
+++ b/apps/admin/src/modules/config/components/config-secret-input.vue
@@ -1,0 +1,102 @@
+<template>
+	<div class="w-full">
+		<el-input
+			v-if="!markedForRemoval"
+			:model-value="modelValue ?? ''"
+			:placeholder="placeholder"
+			:name="name"
+			:type="type"
+			:rows="type === 'textarea' ? rows : undefined"
+			:show-password="type === 'password'"
+			:disabled="disabled"
+			@update:model-value="handleInput"
+		/>
+
+		<div
+			v-if="configured || markedForRemoval"
+			class="flex items-center justify-between gap-2 mt-1"
+		>
+			<span
+				v-if="markedForRemoval"
+				class="text-xs text-danger"
+			>
+				{{ t('configModule.texts.secret.willBeRemoved') }}
+			</span>
+			<span
+				v-else
+				class="text-xs text-gray-500"
+			>
+				{{ t('configModule.texts.secret.stored') }}
+			</span>
+
+			<el-button
+				v-if="markedForRemoval"
+				link
+				type="primary"
+				size="small"
+				:name="name ? `${name}-keep` : undefined"
+				@click="handleKeep"
+			>
+				{{ t('configModule.buttons.keepSecret.title') }}
+			</el-button>
+			<el-button
+				v-else
+				link
+				type="danger"
+				size="small"
+				:disabled="disabled"
+				:name="name ? `${name}-remove` : undefined"
+				@click="handleRemove"
+			>
+				{{ t('configModule.buttons.removeSecret.title') }}
+			</el-button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { ElButton, ElInput } from 'element-plus';
+
+import type { IConfigSecretInputProps } from './config-secret-input.types';
+
+defineOptions({
+	name: 'ConfigSecretInput',
+});
+
+const props = withDefaults(defineProps<IConfigSecretInputProps>(), {
+	modelValue: undefined,
+	configured: false,
+	type: 'password',
+	rows: 3,
+	placeholder: undefined,
+	name: undefined,
+	disabled: false,
+});
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: string | null | undefined): void;
+}>();
+
+const { t } = useI18n();
+
+// The backend answers a redacted secret with nothing at all, so the field always starts blank
+// and blank has to keep meaning "leave what is stored alone". Removing therefore needs a gesture
+// of its own, and `null` is the value the update carries for it.
+const markedForRemoval = computed<boolean>((): boolean => props.modelValue === null);
+
+const handleInput = (value: string): void => {
+	// Typed and then cleared again is untouched, not removed: it submits nothing.
+	emit('update:modelValue', value === '' ? undefined : value);
+};
+
+const handleRemove = (): void => {
+	emit('update:modelValue', null);
+};
+
+const handleKeep = (): void => {
+	emit('update:modelValue', undefined);
+};
+</script>

--- a/apps/admin/src/modules/config/components/types.ts
+++ b/apps/admin/src/modules/config/components/types.ts
@@ -1,2 +1,3 @@
 // Language, weather, and system form types removed - these configs are now accessed via modules
 export * from './config-pluign.types';
+export * from './config-secret-input.types';

--- a/apps/admin/src/modules/config/composables/useConfigPluginEditForm.spec.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPluginEditForm.spec.ts
@@ -161,7 +161,8 @@ describe('useConfigPluginEditForm', () => {
 	// about a credential once it has been saved.
 	describe('after a save', () => {
 		it('drops a stored secret and takes the configured flag from the response', async () => {
-			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig, apiKeyConfigured: false } });
+			const config = { ...mockConfig, apiKeyConfigured: false } as ITestConfigPluginSchema;
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config });
 
 			form.formEl.value = validatedForm();
 			form.model.apiKey = 'sk-typed-by-the-operator';
@@ -177,7 +178,8 @@ describe('useConfigPluginEditForm', () => {
 		});
 
 		it('clears a staged removal the backend has already carried out', async () => {
-			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig, apiKeyConfigured: true } });
+			const config = { ...mockConfig, apiKeyConfigured: true } as ITestConfigPluginSchema;
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config });
 
 			form.formEl.value = validatedForm();
 			// What the remove control stages: null is the one value that asks for a removal.
@@ -194,7 +196,8 @@ describe('useConfigPluginEditForm', () => {
 		});
 
 		it('leaves an ordinary field holding what the backend confirmed', async () => {
-			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig } });
+			const config = { ...mockConfig } as ITestConfigPluginSchema;
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config });
 
 			form.formEl.value = validatedForm();
 			form.model.value = 'Updated';

--- a/apps/admin/src/modules/config/composables/useConfigPluginEditForm.spec.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPluginEditForm.spec.ts
@@ -13,12 +13,17 @@ import { useConfigPluginEditForm } from './useConfigPluginEditForm';
 
 const TestConfigPluginSchema = ConfigPluginSchema.extend({
 	value: z.string(),
+	// A redacted secret: never in a response, which is what the reconciliation below is about.
+	apiKey: z.string().nullable().optional(),
+	apiKeyConfigured: z.boolean().optional(),
 });
 
 type ITestConfigPluginSchema = z.infer<typeof TestConfigPluginSchema>;
 
 const TestConfigPluginEditFormSchema = ConfigPluginEditFormSchema.extend({
 	value: z.string(),
+	apiKey: z.string().nullable().optional(),
+	apiKeyConfigured: z.boolean().optional(),
 });
 
 type ITestConfigPluginEditForm = z.infer<typeof TestConfigPluginEditFormSchema>;
@@ -98,8 +103,15 @@ vi.mock('./usePlugins', () => ({
 }));
 
 describe('useConfigPluginEditForm', () => {
+	const validatedForm = (): FormInstance =>
+		({
+			clearValidate: vi.fn(),
+			validate: vi.fn().mockResolvedValue(true),
+		}) as unknown as FormInstance;
+
 	beforeEach(() => {
 		mockEdit.mockClear();
+		mockEdit.mockResolvedValue({ type: 'test-plugin', value: 'test-value' });
 		mockSuccess.mockClear();
 		mockError.mockClear();
 	});
@@ -135,15 +147,63 @@ describe('useConfigPluginEditForm', () => {
 		const config = { ...mockConfig, draft: false };
 		const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config });
 
-		form.formEl.value = {
-			clearValidate: vi.fn(),
-			validate: vi.fn().mockResolvedValue(true),
-		} as unknown as FormInstance;
+		form.formEl.value = validatedForm();
 
 		await form.submit();
 
 		expect(mockEdit).toHaveBeenCalled();
 		expect(mockSuccess).toHaveBeenCalled();
 		expect(form.formResult.value).toBe(FormResult.OK);
+	});
+
+	// The model is the object that was submitted, not what the backend answered with, and a
+	// redacted secret is never in an answer. Reconciling the two is what keeps the form honest
+	// about a credential once it has been saved.
+	describe('after a save', () => {
+		it('drops a stored secret and takes the configured flag from the response', async () => {
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig, apiKeyConfigured: false } });
+
+			form.formEl.value = validatedForm();
+			form.model.apiKey = 'sk-typed-by-the-operator';
+
+			mockEdit.mockResolvedValueOnce({ type: 'test-plugin', value: 'test-value', apiKeyConfigured: true });
+
+			await form.submit();
+
+			// Left in place it would be sent again on the next save, and the field would still
+			// offer no way to remove the key it had just stored.
+			expect(form.model.apiKey).toBeUndefined();
+			expect(form.model.apiKeyConfigured).toBe(true);
+		});
+
+		it('clears a staged removal the backend has already carried out', async () => {
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig, apiKeyConfigured: true } });
+
+			form.formEl.value = validatedForm();
+			// What the remove control stages: null is the one value that asks for a removal.
+			form.model.apiKey = null;
+
+			mockEdit.mockResolvedValueOnce({ type: 'test-plugin', value: 'test-value', apiKeyConfigured: false });
+
+			await form.submit();
+			await nextTick();
+
+			expect(form.model.apiKey).toBeUndefined();
+			expect(form.model.apiKeyConfigured).toBe(false);
+			expect(form.formChanged.value).toBe(false);
+		});
+
+		it('leaves an ordinary field holding what the backend confirmed', async () => {
+			const form = useConfigPluginEditForm<ITestConfigPluginEditForm>({ config: { ...mockConfig } });
+
+			form.formEl.value = validatedForm();
+			form.model.value = 'Updated';
+
+			mockEdit.mockResolvedValueOnce({ type: 'test-plugin', value: 'Updated' });
+
+			await form.submit();
+
+			expect(form.model.value).toBe('Updated');
+		});
 	});
 });

--- a/apps/admin/src/modules/config/composables/useConfigPluginEditForm.ts
+++ b/apps/admin/src/modules/config/composables/useConfigPluginEditForm.ts
@@ -54,6 +54,30 @@ export const useConfigPluginEditForm = <TForm extends IConfigPluginEditForm = IC
 
 	const formChanged = ref<boolean>(false);
 
+	const markSaved = (): void => {
+		initialModel = deepClone<Reactive<TForm>>(toRaw(model));
+		formChanged.value = false;
+	};
+
+	/**
+	 * Replaces the model's contents with a configuration the backend has confirmed.
+	 *
+	 * Anything the answer does not carry is dropped rather than left in place: a redacted secret
+	 * is absent from every response, and absent is exactly what the model should end up holding.
+	 */
+	const reconcile = (saved: IConfigPlugin): void => {
+		const current = model as unknown as Record<string, unknown>;
+		const next = saved as unknown as Record<string, unknown>;
+
+		for (const key of Object.keys(current)) {
+			if (!(key in next)) {
+				delete current[key];
+			}
+		}
+
+		Object.assign(current, next);
+	};
+
 	const submit = async (): Promise<'saved'> => {
 		const errorMessage = messages && messages.error ? messages.error : t('configModule.messages.configPlugin.notEdited');
 
@@ -73,8 +97,10 @@ export const useConfigPluginEditForm = <TForm extends IConfigPluginEditForm = IC
 
 		formResult.value = FormResult.WORKING;
 
+		let saved: IConfigPlugin;
+
 		try {
-			await configPluginsStore.edit({
+			saved = await configPluginsStore.edit({
 				data: {
 					...parsedModel.data,
 					type: config.type,
@@ -94,13 +120,19 @@ export const useConfigPluginEditForm = <TForm extends IConfigPluginEditForm = IC
 			throw error;
 		}
 
+		// The model is still the object that was submitted, and a secret is never in what comes
+		// back. Left alone it would keep a saved credential in the field and send it again on the
+		// next save, keep announcing a removal that has already happened, and leave a key that was
+		// just stored with no way to remove it until the page is reloaded.
+		reconcile(saved);
+
+		markSaved();
+
 		formResult.value = FormResult.OK;
 
 		timer = window.setTimeout(clear, 2000);
 
 		flashMessage.success(t(messages && messages.success ? messages.success : 'configModule.messages.configPlugin.edited'));
-
-		formChanged.value = false;
 
 		return 'saved';
 	};
@@ -109,11 +141,6 @@ export const useConfigPluginEditForm = <TForm extends IConfigPluginEditForm = IC
 		window.clearTimeout(timer);
 
 		formResult.value = FormResult.NONE;
-	};
-
-	const markSaved = (): void => {
-		initialModel = deepClone<Reactive<TForm>>(toRaw(model));
-		formChanged.value = false;
 	};
 
 	watch(model, (): void => {

--- a/apps/admin/src/modules/config/locales/cs-CZ.json
+++ b/apps/admin/src/modules/config/locales/cs-CZ.json
@@ -145,6 +145,10 @@
 		"loadingModuleConfig": "Načítání konfigurace modulu...",
 		"misc": {
 			"confirmDiscard": "Máte neuložené změny. Opravdu je chcete zahodit?"
+		},
+		"secret": {
+			"stored": "Hodnota je uložena. Zadejte novou pro její nahrazení.",
+			"willBeRemoved": "Uložená hodnota bude po uložení odstraněna."
 		}
 	},
 	"fields": {
@@ -270,6 +274,12 @@
 		},
 		"no": {
 			"title": "Ne"
+		},
+		"removeSecret": {
+			"title": "Odstranit"
+		},
+		"keepSecret": {
+			"title": "Ponechat"
 		}
 	},
 	"languages": {

--- a/apps/admin/src/modules/config/locales/de-DE.json
+++ b/apps/admin/src/modules/config/locales/de-DE.json
@@ -145,6 +145,10 @@
 		"loadingModuleConfig": "Modul-Konfiguration wird geladen...",
 		"misc": {
 			"confirmDiscard": "Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?"
+		},
+		"secret": {
+			"stored": "Ein Wert ist gespeichert. Geben Sie einen neuen ein, um ihn zu ersetzen.",
+			"willBeRemoved": "Der gespeicherte Wert wird beim Speichern entfernt."
 		}
 	},
 	"fields": {
@@ -270,6 +274,12 @@
 		},
 		"no": {
 			"title": "Nein"
+		},
+		"removeSecret": {
+			"title": "Entfernen"
+		},
+		"keepSecret": {
+			"title": "Behalten"
 		}
 	},
 	"languages": {

--- a/apps/admin/src/modules/config/locales/en-US.json
+++ b/apps/admin/src/modules/config/locales/en-US.json
@@ -145,6 +145,10 @@
     "loadingModuleConfig": "Loading module config...",
     "misc": {
       "confirmDiscard": "You have unsaved changes. Are you sure you want to discard them?"
+    },
+    "secret": {
+      "stored": "A value is stored. Enter a new one to replace it.",
+      "willBeRemoved": "The stored value will be removed when you save."
     }
   },
   "fields": {
@@ -270,6 +274,12 @@
     },
     "no": {
       "title": "No"
+    },
+    "removeSecret": {
+      "title": "Remove"
+    },
+    "keepSecret": {
+      "title": "Keep it"
     }
   },
   "languages": {

--- a/apps/admin/src/modules/config/locales/es-ES.json
+++ b/apps/admin/src/modules/config/locales/es-ES.json
@@ -145,6 +145,10 @@
 		"loadingModuleConfig": "Cargando configuración del módulo...",
 		"misc": {
 			"confirmDiscard": "Tienes cambios sin guardar. ¿Estás seguro de que deseas descartarlos?"
+		},
+		"secret": {
+			"stored": "Hay un valor guardado. Introduce uno nuevo para reemplazarlo.",
+			"willBeRemoved": "El valor guardado se eliminará al guardar."
 		}
 	},
 	"fields": {
@@ -270,6 +274,12 @@
 		},
 		"no": {
 			"title": "No"
+		},
+		"removeSecret": {
+			"title": "Eliminar"
+		},
+		"keepSecret": {
+			"title": "Conservar"
 		}
 	},
 	"languages": {

--- a/apps/admin/src/modules/config/locales/pl-PL.json
+++ b/apps/admin/src/modules/config/locales/pl-PL.json
@@ -145,6 +145,10 @@
 		"loadingModuleConfig": "Ładowanie konfiguracji modułu...",
 		"misc": {
 			"confirmDiscard": "Masz niezapisane zmiany. Czy na pewno chcesz je odrzucić?"
+		},
+		"secret": {
+			"stored": "Wartość jest zapisana. Wprowadź nową, aby ją zastąpić.",
+			"willBeRemoved": "Zapisana wartość zostanie usunięta po zapisaniu."
 		}
 	},
 	"fields": {
@@ -270,6 +274,12 @@
 		},
 		"no": {
 			"title": "Nie"
+		},
+		"removeSecret": {
+			"title": "Usuń"
+		},
+		"keepSecret": {
+			"title": "Zachowaj"
 		}
 	},
 	"languages": {

--- a/apps/admin/src/modules/config/locales/sk-SK.json
+++ b/apps/admin/src/modules/config/locales/sk-SK.json
@@ -145,6 +145,10 @@
 		"loadingModuleConfig": "Načítavanie konfigurácie modulu...",
 		"misc": {
 			"confirmDiscard": "Máte neuložené zmeny. Naozaj ich chcete zahodiť?"
+		},
+		"secret": {
+			"stored": "Hodnota je uložená. Zadajte novú na jej nahradenie.",
+			"willBeRemoved": "Uložená hodnota sa po uložení odstráni."
 		}
 	},
 	"fields": {
@@ -270,6 +274,12 @@
 		},
 		"no": {
 			"title": "Nie"
+		},
+		"removeSecret": {
+			"title": "Odstrániť"
+		},
+		"keepSecret": {
+			"title": "Ponechať"
 		}
 	},
 	"languages": {

--- a/apps/admin/src/modules/system/system.constants.ts
+++ b/apps/admin/src/modules/system/system.constants.ts
@@ -25,14 +25,6 @@ export enum EventHandlerName {
 	INTERNAL_PLATFORM_ACTION = 'SystemModule.Internal.PlatformAction',
 }
 
-export enum HouseMode {
-	HOME = 'home',
-	AWAY = 'away',
-	NIGHT = 'night',
-}
-
-export type HouseModeType = HouseMode.HOME | HouseMode.AWAY | HouseMode.NIGHT;
-
 export enum FormResult {
 	NONE = 'none',
 	WORKING = 'working',

--- a/apps/admin/src/plugins/buddy-claude-setup-token/components/claude-setup-token-config-form.vue
+++ b/apps/admin/src/plugins/buddy-claude-setup-token/components/claude-setup-token-config-form.vue
@@ -30,12 +30,11 @@
 			:label="t('buddyClaudeSetupTokenPlugin.fields.config.accessToken.title')"
 			prop="accessToken"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.accessToken"
+				:configured="model.accessTokenConfigured"
 				:placeholder="t('buddyClaudeSetupTokenPlugin.fields.config.accessToken.placeholder')"
 				name="accessToken"
-				type="password"
-				show-password
 			/>
 		</el-form-item>
 
@@ -82,18 +81,9 @@
 import { reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import {
-	ElAlert,
-	ElForm,
-	ElFormItem,
-	ElInput,
-	ElOption,
-	ElSelect,
-	ElSwitch,
-	type FormRules,
-} from 'element-plus';
+import { ElAlert, ElForm, ElFormItem, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { BUDDY_CLAUDE_SETUP_TOKEN_MODELS } from '../buddy-claude-setup-token.models';
 import type { IClaudeSetupTokenConfigEditForm } from '../schemas/config.types';
 

--- a/apps/admin/src/plugins/buddy-claude-setup-token/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude-setup-token/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ClaudeSetupTokenConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored token" - the backend never sends it back.
+	// Absent or blank keeps the stored token and null removes it. The backend never sends
+	// the token back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	accessToken: z.string().nullable().optional(),
+	// What the backend answers with in place of the token. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	accessTokenConfigured: z.boolean().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-claude-setup-token/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude-setup-token/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ClaudeSetupTokenConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	accessToken: z.string().nullable(),
+	// Empty means "keep the stored token" - the backend never sends it back.
+	accessToken: z.string().nullable().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-claude-setup-token/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude-setup-token/store/config.store.schemas.ts
@@ -7,7 +7,12 @@ import { BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME } from '../buddy-claude-setup-toke
 type ApiConfig = BuddyClaudeSetupTokenPluginConfigSchema;
 
 export const ClaudeSetupTokenConfigSchema = ConfigPluginSchema.extend({
-	accessToken: z.string().trim().nullable(),
+	// The backend redacts the token on read and answers with
+	// accessTokenConfigured instead, so the stored config has no accessToken
+	// at all. It stays declared because the edit form writes a replacement
+	// into it before submitting.
+	accessToken: z.string().trim().nullable().optional(),
+	accessTokenConfigured: z.boolean().default(false),
 	model: z.string().trim().nullable(),
 });
 
@@ -25,7 +30,8 @@ export const ClaudeSetupTokenConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.
 export const ClaudeSetupTokenConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME),
-		access_token: z.string().trim().nullable(),
+		access_token: z.string().trim().nullable().optional(),
+		access_token_configured: z.boolean(),
 		model: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/buddy-claude/components/claude-config-form.vue
+++ b/apps/admin/src/plugins/buddy-claude/components/claude-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyClaudePlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('buddyClaudePlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyClaudePlugin.fields.config.apiKey.description') }}
@@ -71,9 +70,9 @@
 import { reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElForm, ElFormItem, ElInput, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
+import { ElAlert, ElForm, ElFormItem, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { BUDDY_CLAUDE_MODELS } from '../buddy-claude.models';
 import type { IClaudeConfigEditForm } from '../schemas/config.types';
 

--- a/apps/admin/src/plugins/buddy-claude/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ClaudeConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-claude/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ClaudeConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-claude/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-claude/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { BUDDY_CLAUDE_PLUGIN_NAME } from '../buddy-claude.constants';
 type ApiConfig = BuddyClaudePluginConfigSchema;
 
 export const ClaudeConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	model: z.string().trim().nullable(),
 });
 
@@ -25,7 +29,8 @@ export const ClaudeConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 export const ClaudeConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_CLAUDE_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		model: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/buddy-discord/components/discord-config-form.vue
+++ b/apps/admin/src/plugins/buddy-discord/components/discord-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyDiscordPlugin.fields.config.botToken.title')"
 			prop="botToken"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.botToken"
+				:configured="model.botTokenConfigured"
 				:placeholder="t('buddyDiscordPlugin.fields.config.botToken.placeholder')"
 				name="botToken"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyDiscordPlugin.fields.config.botToken.description') }}
@@ -144,7 +143,7 @@ import { useI18n } from 'vue-i18n';
 import { Icon } from '@iconify/vue';
 import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { useSpaces } from '../../../modules/spaces';
 import type { IDiscordConfigEditForm } from '../schemas/config.types';
 

--- a/apps/admin/src/plugins/buddy-discord/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-discord/schemas/config.schemas.ts
@@ -3,8 +3,13 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const DiscordConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored token" - the backend never sends it back.
+	// Absent or blank keeps the stored token and null removes it. The backend never sends
+	// the token back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	botToken: z.string().nullable().optional(),
+	// What the backend answers with in place of the token. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	botTokenConfigured: z.boolean().optional(),
 	guildId: z.string().nullable(),
 	generalChannelId: z.string().nullable(),
 	spaceChannelMappings: z.string().nullable(),

--- a/apps/admin/src/plugins/buddy-discord/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-discord/schemas/config.schemas.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const DiscordConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	botToken: z.string().nullable(),
+	// Empty means "keep the stored token" - the backend never sends it back.
+	botToken: z.string().nullable().optional(),
 	guildId: z.string().nullable(),
 	generalChannelId: z.string().nullable(),
 	spaceChannelMappings: z.string().nullable(),

--- a/apps/admin/src/plugins/buddy-discord/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-discord/store/config.store.schemas.ts
@@ -4,7 +4,11 @@ import { ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../module
 import { BUDDY_DISCORD_PLUGIN_NAME } from '../buddy-discord.constants';
 
 export const DiscordConfigSchema = ConfigPluginSchema.extend({
-	botToken: z.string().trim().nullable().default(null),
+	// The backend redacts the token on read and answers with botTokenConfigured
+	// instead, so the stored config has no botToken at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	botToken: z.string().trim().nullable().optional(),
+	botTokenConfigured: z.boolean().default(false),
 	guildId: z.string().trim().nullable().default(null),
 	generalChannelId: z.string().trim().nullable().default(null),
 	spaceChannelMappings: z.string().trim().nullable().default(null),

--- a/apps/admin/src/plugins/buddy-elevenlabs/components/elevenlabs-config-form.vue
+++ b/apps/admin/src/plugins/buddy-elevenlabs/components/elevenlabs-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyElevenlabsPlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('buddyElevenlabsPlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyElevenlabsPlugin.fields.config.apiKey.description') }}
@@ -64,7 +63,7 @@ import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElForm, ElFormItem, ElInput, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IElevenlabsConfigEditForm } from '../schemas/config.types';
 
 import type { IElevenlabsConfigFormProps } from './elevenlabs-config-form.types';

--- a/apps/admin/src/plugins/buddy-elevenlabs/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-elevenlabs/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ElevenlabsConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	voiceId: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-elevenlabs/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-elevenlabs/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const ElevenlabsConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	voiceId: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-elevenlabs/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-elevenlabs/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { BUDDY_ELEVENLABS_PLUGIN_NAME } from '../buddy-elevenlabs.constants';
 type ApiConfig = BuddyElevenlabsPluginConfigSchema;
 
 export const ElevenlabsConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	voiceId: z.string().trim().nullable(),
 });
 
@@ -25,7 +29,8 @@ export const ElevenlabsConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 export const ElevenlabsConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_ELEVENLABS_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		voice_id: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/buddy-openai-codex/components/openai-codex-config-form.vue
+++ b/apps/admin/src/plugins/buddy-openai-codex/components/openai-codex-config-form.vue
@@ -154,12 +154,11 @@
 					:label="t('buddyOpenaiCodexPlugin.fields.config.clientSecret.title')"
 					prop="clientSecret"
 				>
-					<el-input
+					<config-secret-input
 						v-model="model.clientSecret"
+						:configured="model.clientSecretConfigured"
 						:placeholder="t('buddyOpenaiCodexPlugin.fields.config.clientSecret.placeholder')"
 						name="clientSecret"
-						type="password"
-						show-password
 					/>
 				</el-form-item>
 
@@ -216,7 +215,7 @@ import { useBackend } from '../../../common';
 import { useFlashMessage } from '../../../common/composables/useFlashMessage';
 import { injectStoresManager } from '../../../common/services/store';
 import { PLUGINS_PREFIX } from '../../../app.constants';
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { configPluginsStoreKey } from '../../../modules/config/store/keys';
 import { BUDDY_OPENAI_CODEX_MODELS } from '../buddy-openai-codex.models';
 import { BUDDY_OPENAI_CODEX_PLUGIN_NAME, BUDDY_OPENAI_CODEX_PLUGIN_PREFIX } from '../buddy-openai-codex.constants';

--- a/apps/admin/src/plugins/buddy-openai-codex/components/openai-codex-config-form.vue
+++ b/apps/admin/src/plugins/buddy-openai-codex/components/openai-codex-config-form.vue
@@ -267,16 +267,20 @@ const callbackUrl = ref<string>('');
 const isLoadingUrl = ref<boolean>(false);
 const isExchanging = ref<boolean>(false);
 
-const isConnected = computed<boolean>(() => {
-	return !!(model.accessToken || model.refreshToken);
+const isConnected = computed<boolean>((): boolean => {
+	return !!(model.accessTokenConfigured || model.refreshTokenConfigured || model.accessToken || model.refreshToken);
 });
 
 const handleDisconnect = async (): Promise<void> => {
 	const prevAccessToken = model.accessToken;
 	const prevRefreshToken = model.refreshToken;
+	const prevAccessTokenConfigured = model.accessTokenConfigured;
+	const prevRefreshTokenConfigured = model.refreshTokenConfigured;
 
 	model.accessToken = null;
 	model.refreshToken = null;
+	model.accessTokenConfigured = false;
+	model.refreshTokenConfigured = false;
 	authorizeUrl.value = null;
 	callbackUrl.value = '';
 
@@ -288,6 +292,8 @@ const handleDisconnect = async (): Promise<void> => {
 		// Restore tokens so the UI stays consistent with the server
 		model.accessToken = prevAccessToken;
 		model.refreshToken = prevRefreshToken;
+		model.accessTokenConfigured = prevAccessTokenConfigured;
+		model.refreshTokenConfigured = prevRefreshTokenConfigured;
 
 		// submit() already shows its own error flash — don't duplicate it
 	}
@@ -371,6 +377,17 @@ const handleExchange = async (): Promise<void> => {
 
 			if (updatedConfig.refreshToken) {
 				model.refreshToken = updatedConfig.refreshToken as string;
+			}
+
+			// The backend redacts the actual secrets on read - the *Configured flags on the
+			// refetched config are where the truth about connection state now lives, so they
+			// take precedence over the (likely absent) token values above.
+			if (typeof updatedConfig.accessTokenConfigured === 'boolean') {
+				model.accessTokenConfigured = updatedConfig.accessTokenConfigured;
+			}
+
+			if (typeof updatedConfig.refreshTokenConfigured === 'boolean') {
+				model.refreshTokenConfigured = updatedConfig.refreshTokenConfigured;
 			}
 		}
 

--- a/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
@@ -4,8 +4,9 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const OpenAiCodexConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
 	clientId: z.string().nullable(),
-	clientSecret: z.string().nullable(),
-	accessToken: z.string().nullable(),
-	refreshToken: z.string().nullable(),
+	// Empty means "keep the stored value" - the backend never sends these back.
+	clientSecret: z.string().nullable().optional(),
+	accessToken: z.string().nullable().optional(),
+	refreshToken: z.string().nullable().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
@@ -4,12 +4,15 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const OpenAiCodexConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
 	clientId: z.string().nullable(),
-	// Empty means "keep the stored value" - the backend never sends these back.
+	// Absent or blank keeps the stored value and null removes it. The backend never sends
+	// these back, so the fields always start blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input. The two tokens have theirs in
+	// the connect/disconnect pair; the client secret uses the shared remove control.
 	clientSecret: z.string().nullable().optional(),
 	accessToken: z.string().nullable().optional(),
 	refreshToken: z.string().nullable().optional(),
-	// The backend redacts the secrets above on read and sends these booleans instead.
-	// Optional because the form can be constructed before a config has ever been read.
+	// What the backend answers with in place of the secrets above. Declared so the form
+	// knows what is stored; the update request schema drops them again.
 	clientSecretConfigured: z.boolean().optional(),
 	accessTokenConfigured: z.boolean().optional(),
 	refreshTokenConfigured: z.boolean().optional(),

--- a/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai-codex/schemas/config.schemas.ts
@@ -8,5 +8,10 @@ export const OpenAiCodexConfigEditFormSchema = ConfigPluginEditFormSchema.extend
 	clientSecret: z.string().nullable().optional(),
 	accessToken: z.string().nullable().optional(),
 	refreshToken: z.string().nullable().optional(),
+	// The backend redacts the secrets above on read and sends these booleans instead.
+	// Optional because the form can be constructed before a config has ever been read.
+	clientSecretConfigured: z.boolean().optional(),
+	accessTokenConfigured: z.boolean().optional(),
+	refreshTokenConfigured: z.boolean().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-openai-codex/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai-codex/store/config.store.schemas.ts
@@ -8,9 +8,16 @@ type ApiConfig = BuddyOpenaiCodexPluginConfigSchema;
 
 export const OpenAiCodexConfigSchema = ConfigPluginSchema.extend({
 	clientId: z.string().trim().nullable(),
-	clientSecret: z.string().trim().nullable(),
-	accessToken: z.string().trim().nullable(),
-	refreshToken: z.string().trim().nullable(),
+	// The backend redacts these on read and answers with the matching
+	// *Configured booleans instead, so the stored config has none of these
+	// values. They stay declared because the edit form writes replacements
+	// into them before submitting.
+	clientSecret: z.string().trim().nullable().optional(),
+	clientSecretConfigured: z.boolean().default(false),
+	accessToken: z.string().trim().nullable().optional(),
+	accessTokenConfigured: z.boolean().default(false),
+	refreshToken: z.string().trim().nullable().optional(),
+	refreshTokenConfigured: z.boolean().default(false),
 	model: z.string().trim().nullable(),
 });
 
@@ -32,9 +39,12 @@ export const OpenAiCodexConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSch
 	z.object({
 		type: z.literal(BUDDY_OPENAI_CODEX_PLUGIN_NAME),
 		client_id: z.string().trim().nullable(),
-		client_secret: z.string().trim().nullable(),
-		access_token: z.string().trim().nullable(),
-		refresh_token: z.string().trim().nullable(),
+		client_secret: z.string().trim().nullable().optional(),
+		client_secret_configured: z.boolean(),
+		access_token: z.string().trim().nullable().optional(),
+		access_token_configured: z.boolean(),
+		refresh_token: z.string().trim().nullable().optional(),
+		refresh_token_configured: z.boolean(),
 		model: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/buddy-openai/components/openai-config-form.vue
+++ b/apps/admin/src/plugins/buddy-openai/components/openai-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyOpenaiPlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('buddyOpenaiPlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyOpenaiPlugin.fields.config.apiKey.description') }}
@@ -71,9 +70,9 @@
 import { reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElForm, ElFormItem, ElInput, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
+import { ElAlert, ElForm, ElFormItem, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { BUDDY_OPENAI_MODELS } from '../buddy-openai.models';
 import type { IOpenAiConfigEditForm } from '../schemas/config.types';
 

--- a/apps/admin/src/plugins/buddy-openai/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const OpenAiConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-openai/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const OpenAiConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	model: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-openai/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-openai/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { BUDDY_OPENAI_PLUGIN_NAME } from '../buddy-openai.constants';
 type ApiConfig = BuddyOpenaiPluginConfigSchema;
 
 export const OpenAiConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	model: z.string().trim().nullable(),
 });
 
@@ -25,7 +29,8 @@ export const OpenAiConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 export const OpenAiConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_OPENAI_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		model: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/buddy-telegram/components/telegram-config-form.vue
+++ b/apps/admin/src/plugins/buddy-telegram/components/telegram-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyTelegramPlugin.fields.config.botToken.title')"
 			prop="botToken"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.botToken"
+				:configured="model.botTokenConfigured"
 				:placeholder="t('buddyTelegramPlugin.fields.config.botToken.placeholder')"
 				name="botToken"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyTelegramPlugin.fields.config.botToken.description') }}
@@ -63,7 +62,7 @@ import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElForm, ElFormItem, ElInput, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { ITelegramConfigEditForm } from '../schemas/config.types';
 
 import type { ITelegramConfigFormProps } from './telegram-config-form.types';

--- a/apps/admin/src/plugins/buddy-telegram/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-telegram/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const TelegramConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	botToken: z.string().nullable(),
+	// Empty means "keep the stored token" - the backend never sends it back.
+	botToken: z.string().nullable().optional(),
 	allowedUserIds: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-telegram/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-telegram/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const TelegramConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored token" - the backend never sends it back.
+	// Absent or blank keeps the stored token and null removes it. The backend never sends
+	// the token back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	botToken: z.string().nullable().optional(),
+	// What the backend answers with in place of the token. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	botTokenConfigured: z.boolean().optional(),
 	allowedUserIds: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-telegram/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-telegram/store/config.store.schemas.ts
@@ -4,7 +4,11 @@ import { ConfigPluginSchema, ConfigPluginUpdateReqSchema } from '../../../module
 import { BUDDY_TELEGRAM_PLUGIN_NAME } from '../buddy-telegram.constants';
 
 export const TelegramConfigSchema = ConfigPluginSchema.extend({
-	botToken: z.string().trim().nullable().default(null),
+	// The backend redacts the token on read and answers with botTokenConfigured
+	// instead, so the stored config has no botToken at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	botToken: z.string().trim().nullable().optional(),
+	botTokenConfigured: z.boolean().default(false),
 	allowedUserIds: z.string().trim().nullable().default(null),
 });
 

--- a/apps/admin/src/plugins/buddy-voiceai/components/voiceai-config-form.vue
+++ b/apps/admin/src/plugins/buddy-voiceai/components/voiceai-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('buddyVoiceaiPlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('buddyVoiceaiPlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('buddyVoiceaiPlugin.fields.config.apiKey.description') }}
@@ -64,7 +63,7 @@ import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElForm, ElFormItem, ElInput, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IVoiceaiConfigEditForm } from '../schemas/config.types';
 
 import type { IVoiceaiConfigFormProps } from './voiceai-config-form.types';

--- a/apps/admin/src/plugins/buddy-voiceai/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-voiceai/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const VoiceaiConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	voiceId: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-voiceai/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/buddy-voiceai/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const VoiceaiConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	voiceId: z.string().nullable(),
 });

--- a/apps/admin/src/plugins/buddy-voiceai/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/buddy-voiceai/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { BUDDY_VOICEAI_PLUGIN_NAME } from '../buddy-voiceai.constants';
 type ApiConfig = BuddyVoiceaiPluginConfigSchema;
 
 export const VoiceaiConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	voiceId: z.string().trim().nullable(),
 });
 
@@ -25,7 +29,8 @@ export const VoiceaiConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.and(
 export const VoiceaiConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(BUDDY_VOICEAI_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		voice_id: z.string().trim().nullable(),
 	})
 );

--- a/apps/admin/src/plugins/config-secrets.spec.ts
+++ b/apps/admin/src/plugins/config-secrets.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ZodTypeAny } from 'zod';
+
+// Every plugin's edit-form schema reaches for `ConfigPluginEditFormSchema` through the config
+// module's barrel, which pulls in the whole component tree behind it. Only that one export is
+// needed here, and it has a path of its own.
+vi.mock('../modules/config', async () => {
+	const schemas = await vi.importActual<typeof import('../modules/config/schemas/plugins.schemas')>('../modules/config/schemas/plugins.schemas');
+
+	return { ConfigPluginEditFormSchema: schemas.ConfigPluginEditFormSchema };
+});
+
+import { ClaudeSetupTokenConfigEditFormSchema } from './buddy-claude-setup-token/schemas/config.schemas';
+import { ClaudeSetupTokenConfigSchema } from './buddy-claude-setup-token/store/config.store.schemas';
+import { ClaudeConfigEditFormSchema } from './buddy-claude/schemas/config.schemas';
+import { ClaudeConfigSchema } from './buddy-claude/store/config.store.schemas';
+import { DiscordConfigEditFormSchema } from './buddy-discord/schemas/config.schemas';
+import { DiscordConfigSchema } from './buddy-discord/store/config.store.schemas';
+import { ElevenlabsConfigEditFormSchema } from './buddy-elevenlabs/schemas/config.schemas';
+import { ElevenlabsConfigSchema } from './buddy-elevenlabs/store/config.store.schemas';
+import { OpenAiCodexConfigEditFormSchema } from './buddy-openai-codex/schemas/config.schemas';
+import { OpenAiCodexConfigSchema } from './buddy-openai-codex/store/config.store.schemas';
+import { OpenAiConfigEditFormSchema } from './buddy-openai/schemas/config.schemas';
+import { OpenAiConfigSchema } from './buddy-openai/store/config.store.schemas';
+import { TelegramConfigEditFormSchema } from './buddy-telegram/schemas/config.schemas';
+import { TelegramConfigSchema } from './buddy-telegram/store/config.store.schemas';
+import { VoiceaiConfigEditFormSchema } from './buddy-voiceai/schemas/config.schemas';
+import { VoiceaiConfigSchema } from './buddy-voiceai/store/config.store.schemas';
+import { HomeAssistantConfigEditFormSchema } from './devices-home-assistant/schemas/config.schemas';
+import { HomeAssistantConfigSchema } from './devices-home-assistant/store/config.store.schemas';
+import { Zigbee2mqttConfigEditFormSchema } from './devices-zigbee2mqtt/schemas/config.schemas';
+import { Zigbee2mqttConfigSchema } from './devices-zigbee2mqtt/store/config.store.schemas';
+import { InfluxV1ConfigEditFormSchema } from './influx-v1/schemas/config.schemas';
+import { InfluxV1ConfigSchema } from './influx-v1/store/config.store.schemas';
+import { InfluxV2ConfigEditFormSchema } from './influx-v2/schemas/config.schemas';
+import { InfluxV2ConfigSchema } from './influx-v2/store/config.store.schemas';
+import { OpenWeatherMapOneCallConfigEditFormSchema } from './weather-openweathermap-onecall/schemas/config.schemas';
+import { OpenWeatherMapOneCallConfigSchema } from './weather-openweathermap-onecall/store/config.store.schemas';
+import { OpenWeatherMapConfigEditFormSchema } from './weather-openweathermap/schemas/config.schemas';
+import { OpenWeatherMapConfigSchema } from './weather-openweathermap/store/config.store.schemas';
+
+/**
+ * Every secret the backend redacts, and the two schemas a removal has to pass on its way out:
+ * the edit form's, and the store's. Mirrors the `secretFields` each plugin registers on the
+ * backend - a new registration there needs a row here.
+ */
+const REDACTED_SECRETS: { plugin: string; field: string; editForm: unknown; store: unknown }[] = [
+	{ plugin: 'buddy-claude', field: 'apiKey', editForm: ClaudeConfigEditFormSchema, store: ClaudeConfigSchema },
+	{
+		plugin: 'buddy-claude-setup-token',
+		field: 'accessToken',
+		editForm: ClaudeSetupTokenConfigEditFormSchema,
+		store: ClaudeSetupTokenConfigSchema,
+	},
+	{ plugin: 'buddy-discord', field: 'botToken', editForm: DiscordConfigEditFormSchema, store: DiscordConfigSchema },
+	{ plugin: 'buddy-elevenlabs', field: 'apiKey', editForm: ElevenlabsConfigEditFormSchema, store: ElevenlabsConfigSchema },
+	{ plugin: 'buddy-openai', field: 'apiKey', editForm: OpenAiConfigEditFormSchema, store: OpenAiConfigSchema },
+	{ plugin: 'buddy-openai-codex', field: 'clientSecret', editForm: OpenAiCodexConfigEditFormSchema, store: OpenAiCodexConfigSchema },
+	{ plugin: 'buddy-openai-codex', field: 'accessToken', editForm: OpenAiCodexConfigEditFormSchema, store: OpenAiCodexConfigSchema },
+	{ plugin: 'buddy-openai-codex', field: 'refreshToken', editForm: OpenAiCodexConfigEditFormSchema, store: OpenAiCodexConfigSchema },
+	{ plugin: 'buddy-telegram', field: 'botToken', editForm: TelegramConfigEditFormSchema, store: TelegramConfigSchema },
+	{ plugin: 'buddy-voiceai', field: 'apiKey', editForm: VoiceaiConfigEditFormSchema, store: VoiceaiConfigSchema },
+	{ plugin: 'devices-home-assistant', field: 'apiKey', editForm: HomeAssistantConfigEditFormSchema, store: HomeAssistantConfigSchema },
+	{ plugin: 'devices-zigbee2mqtt', field: 'mqtt.password', editForm: Zigbee2mqttConfigEditFormSchema, store: Zigbee2mqttConfigSchema },
+	{ plugin: 'devices-zigbee2mqtt', field: 'tls.key', editForm: Zigbee2mqttConfigEditFormSchema, store: Zigbee2mqttConfigSchema },
+	{ plugin: 'influx-v1', field: 'password', editForm: InfluxV1ConfigEditFormSchema, store: InfluxV1ConfigSchema },
+	{ plugin: 'influx-v2', field: 'token', editForm: InfluxV2ConfigEditFormSchema, store: InfluxV2ConfigSchema },
+	{ plugin: 'weather-openweathermap', field: 'apiKey', editForm: OpenWeatherMapConfigEditFormSchema, store: OpenWeatherMapConfigSchema },
+	{
+		plugin: 'weather-openweathermap-onecall',
+		field: 'apiKey',
+		editForm: OpenWeatherMapOneCallConfigEditFormSchema,
+		store: OpenWeatherMapOneCallConfigSchema,
+	},
+];
+
+/** Walks a dotted path into an object schema's shape, so a nested secret can be reached. */
+const fieldSchema = (schema: unknown, path: string): ZodTypeAny => {
+	return path.split('.').reduce<ZodTypeAny>((current, key) => {
+		const shape = (current as unknown as { shape?: Record<string, ZodTypeAny> }).shape;
+
+		expect(shape, `${path}: '${key}' is not reachable`).toBeDefined();
+		expect(shape![key], `${path}: '${key}' is not declared`).toBeDefined();
+
+		return shape![key];
+	}, schema as ZodTypeAny);
+};
+
+// The backend keeps a stored secret whenever the field is absent or blank and removes it only
+// for `null`, so `null` is the one value a form has to be able to put on the wire. It passes
+// through two schemas on the way, and neither rejects nor strips loudly - a secret declared
+// `z.string().optional()` simply makes removal impossible, which is how influx-v2 shipped.
+describe.each(REDACTED_SECRETS)('$plugin $field', ({ field, editForm, store }) => {
+	it('accepts null in the edit form schema, which is how a removal is expressed', () => {
+		expect(fieldSchema(editForm, field).safeParse(null).success).toBe(true);
+	});
+
+	it('accepts null in the store schema, which the edit merges through', () => {
+		expect(fieldSchema(store, field).safeParse(null).success).toBe(true);
+	});
+
+	// An untouched form leaves the field alone entirely, and that has to stay valid too -
+	// otherwise saving any other setting would fail on a secret nobody meant to change.
+	it('accepts an absent value, which is what an untouched form submits', () => {
+		expect(fieldSchema(editForm, field).safeParse(undefined).success).toBe(true);
+	});
+});

--- a/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.vue
+++ b/apps/admin/src/plugins/devices-home-assistant/components/home-assistant-config-form.vue
@@ -38,13 +38,14 @@
 			prop="apiKey"
 			:error="fieldErrors['apiKey']"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('devicesHomeAssistantPlugin.fields.config.apiKey.placeholder')"
 				:disabled="supervisorMode"
 				name="apiKey"
-				:rows="4"
 				type="textarea"
+				:rows="4"
 			/>
 		</el-form-item>
 
@@ -107,9 +108,9 @@
 import { computed, onMounted, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElAutocomplete, ElButton, ElForm, ElFormItem, ElInput, ElSwitch, ElTooltip, type FormRules } from 'element-plus';
+import { ElAlert, ElAutocomplete, ElButton, ElForm, ElFormItem, ElSwitch, ElTooltip, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { useDiscoveredInstances } from '../composables/useDiscoveredInstances';
 import type { IHomeAssistantConfigEditForm } from '../schemas/config.types';
 

--- a/apps/admin/src/plugins/devices-home-assistant/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/schemas/config.schemas.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const HomeAssistantConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	hostname: z.string(),
 });

--- a/apps/admin/src/plugins/devices-home-assistant/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/schemas/config.schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ConfigPluginEditFormSchema } from '../../../modules/config';
 
 export const HomeAssistantConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	hostname: z.string(),
 });

--- a/apps/admin/src/plugins/devices-home-assistant/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-home-assistant/store/config.store.schemas.ts
@@ -8,7 +8,11 @@ type ApiConfig = DevicesHomeAssistantPluginConfigSchema;
 type ApiUpdateConfig = DevicesHomeAssistantPluginUpdateConfigSchema;
 
 export const HomeAssistantConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nonempty().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nonempty().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	hostname: z.string().trim().nonempty(),
 	supervisorMode: z.boolean().default(false),
 });
@@ -27,7 +31,8 @@ export const HomeAssistantConfigUpdateReqSchema: ZodType<ApiUpdateConfig> = Conf
 export const HomeAssistantConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(DEVICES_HOME_ASSISTANT_PLUGIN_NAME),
-		api_key: z.string().trim().nonempty().nullable(),
+		api_key: z.string().trim().nonempty().nullable().optional(),
+		api_key_configured: z.boolean(),
 		hostname: z.string().trim().nonempty(),
 		supervisor_mode: z.boolean().default(false),
 	})

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-config-form.vue
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/components/zigbee2mqtt-config-form.vue
@@ -127,12 +127,11 @@
 						:label="t('devicesZigbee2mqttPlugin.fields.config.mqtt.password.title')"
 						prop="mqtt.password"
 					>
-						<el-input
+						<config-secret-input
 							v-model="model.mqtt.password"
-							type="password"
+							:configured="model.mqtt.passwordConfigured"
 							:placeholder="t('devicesZigbee2mqttPlugin.fields.config.mqtt.password.placeholder')"
 							name="mqttPassword"
-							show-password
 						/>
 					</el-form-item>
 				</el-col>
@@ -292,8 +291,9 @@
 					:label="t('devicesZigbee2mqttPlugin.fields.config.tls.key.title')"
 					prop="tls.key"
 				>
-					<el-input
+					<config-secret-input
 						v-model="model.tls.key"
+						:configured="model.tls.keyConfigured"
 						type="textarea"
 						:rows="3"
 						:placeholder="t('devicesZigbee2mqttPlugin.fields.config.tls.key.placeholder')"
@@ -469,7 +469,7 @@ import {
 	type FormRules,
 } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IZigbee2mqttConfigEditForm } from '../schemas/config.types';
 
 import type { IZigbee2mqttConfigFormProps } from './zigbee2mqtt-config-form.types';

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/config.schemas.ts
@@ -8,8 +8,13 @@ export const Zigbee2mqttConfigEditFormSchema = ConfigPluginEditFormSchema.extend
 		host: z.string().trim().min(1),
 		port: z.coerce.number().int().min(1).max(65535),
 		username: z.string().nullable(),
-		// Empty means "keep the stored password" - the backend never sends it back.
+		// Absent or blank keeps the stored password and null removes it. The backend never sends
+		// the password back, so the field always starts blank - which is why removing one needs a
+		// gesture of its own rather than just clearing the input.
 		password: z.string().nullable().optional(),
+		// What the backend answers with in place of the password. Declared so the form knows
+		// whether there is anything to remove; the update request schema drops it again.
+		passwordConfigured: z.boolean().optional(),
 		baseTopic: z.string().trim().min(1),
 		clientId: z.string().nullable(),
 		cleanSession: z.boolean(),
@@ -30,8 +35,13 @@ export const Zigbee2mqttConfigEditFormSchema = ConfigPluginEditFormSchema.extend
 		rejectUnauthorized: z.boolean(),
 		ca: z.string().nullable(),
 		cert: z.string().nullable(),
-		// Empty means "keep the stored key" - the backend never sends it back.
+		// Absent or blank keeps the stored key and null removes it. The backend never sends
+		// the key back, so the field always starts blank - which is why removing one needs a
+		// gesture of its own rather than just clearing the input.
 		key: z.string().nullable().optional(),
+		// What the backend answers with in place of the key. Declared so the form knows
+		// whether there is anything to remove; the update request schema drops it again.
+		keyConfigured: z.boolean().optional(),
 	}),
 	discovery: z.object({
 		autoAdd: z.boolean(),

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/schemas/config.schemas.ts
@@ -8,7 +8,8 @@ export const Zigbee2mqttConfigEditFormSchema = ConfigPluginEditFormSchema.extend
 		host: z.string().trim().min(1),
 		port: z.coerce.number().int().min(1).max(65535),
 		username: z.string().nullable(),
-		password: z.string().nullable(),
+		// Empty means "keep the stored password" - the backend never sends it back.
+		password: z.string().nullable().optional(),
 		baseTopic: z.string().trim().min(1),
 		clientId: z.string().nullable(),
 		cleanSession: z.boolean(),
@@ -29,7 +30,8 @@ export const Zigbee2mqttConfigEditFormSchema = ConfigPluginEditFormSchema.extend
 		rejectUnauthorized: z.boolean(),
 		ca: z.string().nullable(),
 		cert: z.string().nullable(),
-		key: z.string().nullable(),
+		// Empty means "keep the stored key" - the backend never sends it back.
+		key: z.string().nullable().optional(),
 	}),
 	discovery: z.object({
 		autoAdd: z.boolean(),

--- a/apps/admin/src/plugins/devices-zigbee2mqtt/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/devices-zigbee2mqtt/store/config.store.schemas.ts
@@ -13,7 +13,11 @@ export const Zigbee2mqttConfigSchema = ConfigPluginSchema.extend({
 		host: z.string(),
 		port: z.number(),
 		username: z.string().nullable(),
-		password: z.string().nullable(),
+		// The backend redacts the password on read and answers with passwordConfigured
+		// instead, so the stored config has no password at all. It stays declared
+		// because the edit form writes a replacement into it before submitting.
+		password: z.string().nullable().optional(),
+		passwordConfigured: z.boolean().default(false),
 		baseTopic: z.string(),
 		clientId: z.string().nullable(),
 		cleanSession: z.boolean(),
@@ -34,7 +38,11 @@ export const Zigbee2mqttConfigSchema = ConfigPluginSchema.extend({
 		rejectUnauthorized: z.boolean(),
 		ca: z.string().nullable(),
 		cert: z.string().nullable(),
-		key: z.string().nullable(),
+		// The backend redacts the key on read and answers with keyConfigured
+		// instead, so the stored config has no key at all. It stays declared
+		// because the edit form writes a replacement into it before submitting.
+		key: z.string().nullable().optional(),
+		keyConfigured: z.boolean().default(false),
 	}),
 	discovery: z.object({
 		autoAdd: z.boolean(),
@@ -99,7 +107,8 @@ export const Zigbee2mqttConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSch
 			host: z.string(),
 			port: z.number(),
 			username: z.string().nullable(),
-			password: z.string().nullable(),
+			password: z.string().nullable().optional(),
+			password_configured: z.boolean(),
 			base_topic: z.string(),
 			client_id: z.string().nullable(),
 			clean_session: z.boolean(),
@@ -120,7 +129,8 @@ export const Zigbee2mqttConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSch
 			reject_unauthorized: z.boolean(),
 			ca: z.string().nullable(),
 			cert: z.string().nullable(),
-			key: z.string().nullable(),
+			key: z.string().nullable().optional(),
+			key_configured: z.boolean(),
 		}),
 		discovery: z.object({
 			auto_add: z.boolean(),

--- a/apps/admin/src/plugins/influx-v1/components/influx-v1-config-form.vue
+++ b/apps/admin/src/plugins/influx-v1/components/influx-v1-config-form.vue
@@ -53,12 +53,11 @@
 			:label="t('influxV1Plugin.fields.config.password.title')"
 			prop="password"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.password"
+				:configured="model.passwordConfigured"
 				:placeholder="t('influxV1Plugin.fields.config.password.placeholder')"
 				name="password"
-				type="password"
-				show-password
 			/>
 		</el-form-item>
 	</el-form>
@@ -70,7 +69,7 @@ import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElDivider, ElForm, ElFormItem, ElInput, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IInfluxV1ConfigEditForm } from '../schemas/config.types';
 
 import type { IInfluxV1ConfigFormProps } from './influx-v1-config-form.types';

--- a/apps/admin/src/plugins/influx-v1/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/influx-v1/schemas/config.schemas.ts
@@ -6,5 +6,11 @@ export const InfluxV1ConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
 	host: z.string().min(1),
 	database: z.string().min(1),
 	username: z.string().nullable().optional(),
+	// Absent or blank keeps the stored password and null removes it. The backend never sends
+	// the password back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	password: z.string().nullable().optional(),
+	// What the backend answers with in place of the password. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	passwordConfigured: z.boolean().optional(),
 });

--- a/apps/admin/src/plugins/influx-v1/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/influx-v1/store/config.store.schemas.ts
@@ -19,6 +19,7 @@ type ApiConfig = {
 	database: string | null;
 	username?: string | null;
 	password?: string | null;
+	password_configured: boolean;
 };
 
 export const InfluxV1ConfigSchema = ConfigPluginSchema.extend({
@@ -26,6 +27,7 @@ export const InfluxV1ConfigSchema = ConfigPluginSchema.extend({
 	database: z.string().nullable(),
 	username: z.string().nullable().optional(),
 	password: z.string().nullable().optional(),
+	passwordConfigured: z.boolean().default(false),
 });
 
 // BACKEND API
@@ -48,5 +50,6 @@ export const InfluxV1ConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema
 		database: z.string().nullable(),
 		username: z.string().nullable().optional(),
 		password: z.string().nullable().optional(),
+		password_configured: z.boolean(),
 	})
 );

--- a/apps/admin/src/plugins/influx-v2/components/influx-v2-config-form.vue
+++ b/apps/admin/src/plugins/influx-v2/components/influx-v2-config-form.vue
@@ -53,12 +53,11 @@
 			:label="t('influxV2Plugin.fields.config.token.title')"
 			prop="token"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.token"
+				:configured="model.tokenConfigured"
 				:placeholder="t('influxV2Plugin.fields.config.token.placeholder')"
 				name="token"
-				type="password"
-				show-password
 			/>
 		</el-form-item>
 	</el-form>
@@ -70,7 +69,7 @@ import { useI18n } from 'vue-i18n';
 
 import { ElAlert, ElDivider, ElForm, ElFormItem, ElInput, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IInfluxV2ConfigEditForm } from '../schemas/config.types';
 
 import type { IInfluxV2ConfigFormProps } from './influx-v2-config-form.types';

--- a/apps/admin/src/plugins/influx-v2/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/influx-v2/schemas/config.schemas.ts
@@ -6,5 +6,11 @@ export const InfluxV2ConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
 	url: z.string().min(1),
 	org: z.string().min(1),
 	bucket: z.string().min(1),
-	token: z.string().optional(),
+	// Absent or blank keeps the stored token and null removes it. The backend never sends
+	// the token back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
+	token: z.string().nullable().optional(),
+	// What the backend answers with in place of the token. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	tokenConfigured: z.boolean().optional(),
 });

--- a/apps/admin/src/plugins/influx-v2/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/influx-v2/store/config.store.schemas.ts
@@ -7,7 +7,7 @@ type ApiUpdateConfig = {
 	type: typeof INFLUX_V2_PLUGIN_NAME;
 	enabled?: boolean;
 	url?: string;
-	token?: string;
+	token?: string | null;
 	org?: string;
 	bucket?: string;
 };
@@ -18,14 +18,16 @@ type ApiConfig = {
 	url: string;
 	org: string;
 	bucket: string;
-	token?: string;
+	token?: string | null;
+	token_configured: boolean;
 };
 
 export const InfluxV2ConfigSchema = ConfigPluginSchema.extend({
 	url: z.string(),
 	org: z.string(),
 	bucket: z.string(),
-	token: z.string().optional(),
+	token: z.string().nullable().optional(),
+	tokenConfigured: z.boolean().default(false),
 });
 
 // BACKEND API
@@ -35,7 +37,7 @@ export const InfluxV2ConfigUpdateReqSchema: ZodType<ApiUpdateConfig> = ConfigPlu
 	z.object({
 		type: z.literal(INFLUX_V2_PLUGIN_NAME),
 		url: z.string().optional(),
-		token: z.string().optional(),
+		token: z.string().nullable().optional(),
 		org: z.string().optional(),
 		bucket: z.string().optional(),
 	})
@@ -47,6 +49,7 @@ export const InfluxV2ConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema
 		url: z.string(),
 		org: z.string(),
 		bucket: z.string(),
-		token: z.string().optional(),
+		token: z.string().nullable().optional(),
+		token_configured: z.boolean(),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/components/openweathermap-onecall-config-form.vue
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/components/openweathermap-onecall-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('weatherOpenweathermapOnecallPlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('weatherOpenweathermapOnecallPlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('weatherOpenweathermapOnecallPlugin.fields.config.apiKey.description') }}
@@ -65,10 +64,10 @@
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElForm, ElFormItem, ElInput, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
+import { ElAlert, ElForm, ElFormItem, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 import type { z } from 'zod';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import { TemperatureUnit } from '../weather-openweathermap-onecall.constants';
 import type { OpenWeatherMapOneCallConfigEditFormSchema } from '../schemas/config.schemas';
 

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/schemas/config.schemas.ts
@@ -4,7 +4,12 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 import { TemperatureUnit } from '../weather-openweathermap-onecall.constants';
 
 export const OpenWeatherMapOneCallConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	unit: z.nativeEnum(TemperatureUnit),
 });

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/schemas/config.schemas.ts
@@ -4,6 +4,7 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 import { TemperatureUnit } from '../weather-openweathermap-onecall.constants';
 
 export const OpenWeatherMapOneCallConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	unit: z.nativeEnum(TemperatureUnit),
 });

--- a/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap-onecall/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { TemperatureUnit, WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../
 type ApiConfig = WeatherOpenweathermapOnecallPluginConfigSchema;
 
 export const OpenWeatherMapOneCallConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.celsius),
 });
 
@@ -25,7 +29,8 @@ export const OpenWeatherMapOneCallConfigUpdateReqSchema= ConfigPluginUpdateReqSc
 export const OpenWeatherMapOneCallConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		unit: z.nativeEnum(TemperatureUnit),
 	})
 );

--- a/apps/admin/src/plugins/weather-openweathermap/components/openweathermap-config-form.vue
+++ b/apps/admin/src/plugins/weather-openweathermap/components/openweathermap-config-form.vue
@@ -29,12 +29,11 @@
 			:label="t('weatherOpenweathermapPlugin.fields.config.apiKey.title')"
 			prop="apiKey"
 		>
-			<el-input
+			<config-secret-input
 				v-model="model.apiKey"
+				:configured="model.apiKeyConfigured"
 				:placeholder="t('weatherOpenweathermapPlugin.fields.config.apiKey.placeholder')"
 				name="apiKey"
-				type="password"
-				show-password
 			/>
 			<div class="text-xs text-gray-500 mt-1">
 				{{ t('weatherOpenweathermapPlugin.fields.config.apiKey.description') }}
@@ -65,9 +64,9 @@
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ElAlert, ElForm, ElFormItem, ElInput, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
+import { ElAlert, ElForm, ElFormItem, ElOption, ElSelect, ElSwitch, type FormRules } from 'element-plus';
 
-import { FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
+import { ConfigSecretInput, FormResult, type FormResultType, Layout, useConfigPluginEditForm } from '../../../modules/config';
 import type { IOpenWeatherMapConfigEditForm } from '../schemas/config.types';
 import { TemperatureUnit } from '../weather-openweathermap.constants';
 

--- a/apps/admin/src/plugins/weather-openweathermap/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/schemas/config.schemas.ts
@@ -4,6 +4,7 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 import { TemperatureUnit } from '../weather-openweathermap.constants';
 
 export const OpenWeatherMapConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	apiKey: z.string().nullable(),
+	// Empty means "keep the stored key" - the backend never sends it back.
+	apiKey: z.string().nullable().optional(),
 	unit: z.nativeEnum(TemperatureUnit),
 });

--- a/apps/admin/src/plugins/weather-openweathermap/schemas/config.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/schemas/config.schemas.ts
@@ -4,7 +4,12 @@ import { ConfigPluginEditFormSchema } from '../../../modules/config';
 import { TemperatureUnit } from '../weather-openweathermap.constants';
 
 export const OpenWeatherMapConfigEditFormSchema = ConfigPluginEditFormSchema.extend({
-	// Empty means "keep the stored key" - the backend never sends it back.
+	// Absent or blank keeps the stored key and null removes it. The backend never sends
+	// the key back, so the field always starts blank - which is why removing one needs a
+	// gesture of its own rather than just clearing the input.
 	apiKey: z.string().nullable().optional(),
+	// What the backend answers with in place of the key. Declared so the form knows
+	// whether there is anything to remove; the update request schema drops it again.
+	apiKeyConfigured: z.boolean().optional(),
 	unit: z.nativeEnum(TemperatureUnit),
 });

--- a/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
+++ b/apps/admin/src/plugins/weather-openweathermap/store/config.store.schemas.ts
@@ -7,7 +7,11 @@ import { TemperatureUnit, WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-
 type ApiConfig = WeatherOpenweathermapPluginConfigSchema;
 
 export const OpenWeatherMapConfigSchema = ConfigPluginSchema.extend({
-	apiKey: z.string().trim().nullable(),
+	// The backend redacts the key on read and answers with apiKeyConfigured
+	// instead, so the stored config has no apiKey at all. It stays declared
+	// because the edit form writes a replacement into it before submitting.
+	apiKey: z.string().trim().nullable().optional(),
+	apiKeyConfigured: z.boolean().default(false),
 	unit: z.nativeEnum(TemperatureUnit).default(TemperatureUnit.celsius),
 });
 
@@ -25,7 +29,8 @@ export const OpenWeatherMapConfigUpdateReqSchema= ConfigPluginUpdateReqSchema.an
 export const OpenWeatherMapConfigResSchema: ZodType<ApiConfig> = ConfigPluginResSchema.and(
 	z.object({
 		type: z.literal(WEATHER_OPENWEATHERMAP_PLUGIN_NAME),
-		api_key: z.string().trim().nullable(),
+		api_key: z.string().trim().nullable().optional(),
+		api_key_configured: z.boolean(),
 		unit: z.nativeEnum(TemperatureUnit),
 	})
 );

--- a/apps/backend/src/common/utils/transform.utils.spec.ts
+++ b/apps/backend/src/common/utils/transform.utils.spec.ts
@@ -1,4 +1,4 @@
-import { clampNumber } from './transform.utils';
+import { clampNumber, readSubmittedValue } from './transform.utils';
 
 describe('clampNumber', () => {
 	test('returns value when within bounds', () => {
@@ -25,5 +25,31 @@ describe('clampNumber', () => {
 	test('returns NaN when input is NaN (matches current implementation)', () => {
 		const result = clampNumber(NaN, 0, 10);
 		expect(Number.isNaN(result)).toBe(true);
+	});
+});
+
+describe('readSubmittedValue', () => {
+	test('prefers the wire name', () => {
+		expect(readSubmittedValue({ api_key: 'wire', apiKey: 'camel' }, 'api_key', 'apiKey')).toBe('wire');
+	});
+
+	test('falls back to the camelCase spelling', () => {
+		expect(readSubmittedValue({ apiKey: 'camel' }, 'api_key', 'apiKey')).toBe('camel');
+	});
+
+	// The distinction the whole helper exists for: `a ?? b` reads a submitted null as absent,
+	// and for a secret the two mean opposite things - remove it, or leave it alone.
+	test('keeps an explicit null distinct from an absent field', () => {
+		expect(readSubmittedValue({ api_key: null }, 'api_key', 'apiKey')).toBeNull();
+		expect(readSubmittedValue({}, 'api_key', 'apiKey')).toBeUndefined();
+	});
+
+	test('reads a null under the camelCase spelling too', () => {
+		expect(readSubmittedValue({ apiKey: null }, 'api_key', 'apiKey')).toBeNull();
+	});
+
+	test('answers undefined for anything that is not an object', () => {
+		expect(readSubmittedValue(null, 'api_key', 'apiKey')).toBeUndefined();
+		expect(readSubmittedValue('nonsense', 'api_key', 'apiKey')).toBeUndefined();
 	});
 });

--- a/apps/backend/src/common/utils/transform.utils.ts
+++ b/apps/backend/src/common/utils/transform.utils.ts
@@ -29,6 +29,34 @@ export function toInstance<T, V>(cls: ClassConstructor<T>, plain: V[] | V, optio
 	});
 }
 
+/**
+ * Reads a submitted field that may arrive under either its wire name or its camelCase
+ * spelling, keeping an explicit `null` distinct from an absent field.
+ *
+ * `obj.wire_name ?? obj.camelName` cannot express that difference: a submitted `null` is
+ * nullish, so it falls through to the other spelling and comes back `undefined` - which
+ * every consumer downstream reads as "not submitted". For a secret that is the difference
+ * between removing a stored credential and silently keeping it, and the removal is the case
+ * that fails silently.
+ */
+export const readSubmittedValue = <T>(obj: unknown, wireName: string, camelName: string): T | null | undefined => {
+	if (obj === null || typeof obj !== 'object') {
+		return undefined;
+	}
+
+	const source = obj as Record<string, unknown>;
+
+	if (wireName in source) {
+		return source[wireName] as T | null;
+	}
+
+	if (camelName in source) {
+		return source[camelName] as T | null;
+	}
+
+	return undefined;
+};
+
 export const clampNumber = (number: number, min: number, max: number): number => {
 	return Math.max(min, Math.min(max, Number(number)));
 };

--- a/apps/backend/src/modules/auth/auth.openapi.ts
+++ b/apps/backend/src/modules/auth/auth.openapi.ts
@@ -7,6 +7,7 @@ import {
 	CreateRefreshTokenDto,
 	ReqCreateTokenDto,
 } from './dto/create-token.dto';
+import { UpdateAuthConfigDto } from './dto/update-config.dto';
 import {
 	ReqUpdateTokenDto,
 	UpdateAccessTokenDto,
@@ -40,6 +41,7 @@ export const AUTH_SWAGGER_EXTRA_MODELS = [
 	UpdateRefreshTokenDto,
 	UpdateLongLiveTokenDto,
 	ReqUpdateTokenDto,
+	UpdateAuthConfigDto,
 	// Response models
 	ProfileResponseModel,
 	LoginResponseModel,

--- a/apps/backend/src/modules/buddy/buddy.openapi.ts
+++ b/apps/backend/src/modules/buddy/buddy.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Buddy module
  */
+import { UpdateBuddyConfigDto } from './dto/update-config.dto';
 import { BuddyConversationEntity } from './entities/buddy-conversation.entity';
 import { BuddyMessageEntity } from './entities/buddy-message.entity';
 import { BuddyConfigModel } from './models/config.model';
@@ -31,6 +32,7 @@ export const BUDDY_SWAGGER_EXTRA_MODELS = [
 	BuddyMessageEntity,
 	// Config model
 	BuddyConfigModel,
+	UpdateBuddyConfigDto,
 	// Response models
 	ConversationResponseModel,
 	ConversationsResponseModel,

--- a/apps/backend/src/modules/dashboard/dashboard.openapi.ts
+++ b/apps/backend/src/modules/dashboard/dashboard.openapi.ts
@@ -3,6 +3,7 @@
  */
 import { CreateDataSourceDto } from './dto/create-data-source.dto';
 import { CreateTileDto } from './dto/create-tile.dto';
+import { UpdateDashboardConfigDto } from './dto/update-config.dto';
 import { UpdateDataSourceDto } from './dto/update-data-source.dto';
 import { UpdateTileDto } from './dto/update-tile.dto';
 import { DashboardConfigModel } from './models/config.model';
@@ -30,6 +31,7 @@ export const DASHBOARD_SWAGGER_EXTRA_MODELS = [
 	CreateTileDto,
 	UpdateDataSourceDto,
 	UpdateTileDto,
+	UpdateDashboardConfigDto,
 	// Response models
 	BulkResultResponseModel,
 	PageResponseModel,

--- a/apps/backend/src/modules/devices/devices.openapi.ts
+++ b/apps/backend/src/modules/devices/devices.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Devices module
  */
+import { UpdateDevicesConfigDto } from './dto/update-config.dto';
 import {
 	ChannelControlEntity,
 	ChannelEntity,
@@ -56,6 +57,7 @@ import {
 export const DEVICES_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	DevicesConfigModel,
+	UpdateDevicesConfigDto,
 	// Response models
 	BulkResultResponseModel,
 	DeviceResponseModel,

--- a/apps/backend/src/modules/displays/displays.openapi.ts
+++ b/apps/backend/src/modules/displays/displays.openapi.ts
@@ -2,6 +2,7 @@
  * OpenAPI extra models for Displays module
  */
 import { RegisterDisplayDto, ReqRegisterDisplayDto } from './dto/register-display.dto';
+import { UpdateDisplaysConfigDto } from './dto/update-config.dto';
 import { ReqUpdateDisplayDto, UpdateDisplayDto } from './dto/update-display.dto';
 import { DisplayEntity } from './entities/displays.entity';
 import { DisplaysConfigModel } from './models/config.model';
@@ -30,6 +31,7 @@ export const DISPLAYS_SWAGGER_EXTRA_MODELS = [
 	ReqRegisterDisplayDto,
 	UpdateDisplayDto,
 	ReqUpdateDisplayDto,
+	UpdateDisplaysConfigDto,
 	// Response models
 	BulkResultResponseModel,
 	DisplayResponseModel,

--- a/apps/backend/src/modules/energy/energy.openapi.ts
+++ b/apps/backend/src/modules/energy/energy.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Energy module
  */
+import { UpdateEnergyConfigDto } from './dto/update-config.dto';
 import { EnergyDeltaEntity } from './entities/energy-delta.entity';
 import { EnergyConfigModel } from './models/config.model';
 import { EnergyBreakdownItemModel } from './models/energy-breakdown-item.model';
@@ -23,6 +24,7 @@ import { EnergyTimeseriesPointModel } from './models/energy-timeseries-point.mod
 export const ENERGY_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	EnergyConfigModel,
+	UpdateEnergyConfigDto,
 	// Response models
 	EnergySummaryResponseModel,
 	EnergyDeltasResponseModel,

--- a/apps/backend/src/modules/extensions/dto/update-config.dto.ts
+++ b/apps/backend/src/modules/extensions/dto/update-config.dto.ts
@@ -5,7 +5,7 @@ import { ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
 import { UpdateModuleConfigDto } from '../../config/dto/config.dto';
 
-@ApiSchema({ name: 'ExtensionsModuleUpdateExtensionsConfig' })
+@ApiSchema({ name: 'ConfigModuleUpdateExtensions' })
 export class UpdateExtensionsConfigDto extends UpdateModuleConfigDto {
 	@ApiPropertyOptional({
 		description: 'Module enabled state',

--- a/apps/backend/src/modules/extensions/extensions.openapi.ts
+++ b/apps/backend/src/modules/extensions/extensions.openapi.ts
@@ -1,4 +1,5 @@
 import { ExecuteActionDataDto, ReqExecuteActionDto } from './dto/execute-action.dto';
+import { UpdateExtensionsConfigDto } from './dto/update-config.dto';
 import { ReqUpdateExtensionDto, UpdateExtensionDataDto } from './dto/update-extension.dto';
 import {
 	ActionExecutionRecordModel,
@@ -35,6 +36,7 @@ import {
 export const EXTENSIONS_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	ExtensionsConfigModel,
+	UpdateExtensionsConfigDto,
 	ExtensionModel,
 	ExtensionLinksModel,
 	ExtensionResponseModel,

--- a/apps/backend/src/modules/scenes/scenes.openapi.ts
+++ b/apps/backend/src/modules/scenes/scenes.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Scenes module
  */
+import { UpdateScenesConfigDto } from './dto/update-config.dto';
 import { SceneActionEntity, SceneEntity } from './entities/scenes.entity';
 import { ScenesConfigModel } from './models/config.model';
 import {
@@ -16,6 +17,7 @@ import { ActionExecutionResultModel, SceneExecutionResultModel } from './models/
 export const SCENES_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	ScenesConfigModel,
+	UpdateScenesConfigDto,
 	// Response models
 	BulkResultResponseModel,
 	SceneResponseModel,

--- a/apps/backend/src/modules/security/security.openapi.ts
+++ b/apps/backend/src/modules/security/security.openapi.ts
@@ -1,3 +1,4 @@
+import { UpdateSecurityConfigDto } from './dto/update-config.dto';
 import { SecurityConfigModel } from './models/config.model';
 import {
 	SecurityAlertAckAllResponseModel,
@@ -11,6 +12,7 @@ import { SecurityAlertModel, SecurityLastEventModel, SecurityStatusModel } from 
 export const SECURITY_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	SecurityConfigModel,
+	UpdateSecurityConfigDto,
 	// Response models
 	SecurityStatusResponseModel,
 	SecurityAlertAckResponseModel,

--- a/apps/backend/src/modules/spaces/dto/update-config.dto.ts
+++ b/apps/backend/src/modules/spaces/dto/update-config.dto.ts
@@ -6,7 +6,7 @@ import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import { UpdateModuleConfigDto } from '../../config/dto/config.dto';
 import { SPACES_MODULE_NAME } from '../spaces.constants';
 
-@ApiSchema({ name: 'SpacesModuleUpdateConfig' })
+@ApiSchema({ name: 'ConfigModuleUpdateSpaces' })
 export class UpdateSpacesConfigDto extends UpdateModuleConfigDto {
 	@ApiProperty({
 		description: 'Module type',

--- a/apps/backend/src/modules/spaces/spaces.openapi.ts
+++ b/apps/backend/src/modules/spaces/spaces.openapi.ts
@@ -3,6 +3,7 @@
  */
 import { BulkAssignDto, ReqBulkAssignDto } from './dto/bulk-assign.dto';
 import { CreateSpaceDto, ReqCreateSpaceDto } from './dto/create-space.dto';
+import { UpdateSpacesConfigDto } from './dto/update-config.dto';
 import { ReqUpdateSpaceDto, UpdateSpaceDto } from './dto/update-space.dto';
 import { SpaceEntity } from './entities/space.entity';
 import { SpacesConfigModel } from './models/config.model';
@@ -27,6 +28,7 @@ export const SPACES_SWAGGER_EXTRA_MODELS = [
 	ReqUpdateSpaceDto,
 	BulkAssignDto,
 	ReqBulkAssignDto,
+	UpdateSpacesConfigDto,
 	// Response models
 	SpaceResponseModel,
 	SpacesResponseModel,

--- a/apps/backend/src/modules/system/models/config.model.ts
+++ b/apps/backend/src/modules/system/models/config.model.ts
@@ -132,6 +132,7 @@ export class SystemConfigModel extends ModuleConfigModel {
 		name: 'log_levels',
 		description: 'Array of enabled log levels',
 		type: 'array',
+		minItems: 1,
 		items: {
 			type: 'string',
 			enum: Object.values(LogLevelType),

--- a/apps/backend/src/modules/users/users.openapi.ts
+++ b/apps/backend/src/modules/users/users.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Users module
  */
+import { UpdateUsersConfigDto } from './dto/update-config.dto';
 import { UserEntity } from './entities/users.entity';
 import { UsersConfigModel } from './models/config.model';
 import { BulkResultResponseModel, UserResponseModel, UsersResponseModel } from './models/users-response.model';
@@ -8,6 +9,7 @@ import { BulkResultResponseModel, UserResponseModel, UsersResponseModel } from '
 export const USERS_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	UsersConfigModel,
+	UpdateUsersConfigDto,
 	// Response models
 	BulkResultResponseModel,
 	UserResponseModel,

--- a/apps/backend/src/modules/weather/weather.openapi.ts
+++ b/apps/backend/src/modules/weather/weather.openapi.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI extra models for Weather module
  */
+import { UpdateWeatherConfigDto } from './dto/update-config.dto';
 import { WeatherLocationEntity } from './entities/locations.entity';
 import { LocationAlertsResponseModel, WeatherAlertModel } from './models/alert.model';
 import { WeatherConfigModel } from './models/config.model';
@@ -37,6 +38,7 @@ import {
 export const WEATHER_SWAGGER_EXTRA_MODELS = [
 	// Module configuration
 	WeatherConfigModel,
+	UpdateWeatherConfigDto,
 	// Response models
 	LocationWeatherResponseModel,
 	AllLocationsWeatherResponseModel,

--- a/apps/backend/src/plugins/buddy-claude-setup-token/buddy-claude-setup-token.plugin.ts
+++ b/apps/backend/src/plugins/buddy-claude-setup-token/buddy-claude-setup-token.plugin.ts
@@ -46,6 +46,13 @@ export class BuddyClaudeSetupTokenPlugin implements OnModuleInit {
 			type: BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME,
 			class: BuddyClaudeSetupTokenConfigModel,
 			configDto: UpdateBuddyClaudeSetupTokenConfigDto,
+			secretFields: [
+				{
+					path: 'access_token',
+					configuredPath: 'access_token_configured',
+					inputPaths: ['accessToken'],
+				},
+			],
 		});
 
 		this.providerRegistry.register(this.claudeSetupTokenProvider);

--- a/apps/backend/src/plugins/buddy-claude-setup-token/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-claude-setup-token/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_CLAUDE_SETUP_TOKEN_PLUGIN_NAME } from '../buddy-claude-setup-token.constants';
 
@@ -36,8 +37,8 @@ export class UpdateBuddyClaudeSetupTokenConfigDto extends UpdatePluginConfigDto 
 	})
 	@Expose({ name: 'access_token' })
 	@Transform(
-		({ obj }: { obj: { access_token?: string | null; accessToken?: string | null } }) => {
-			const raw = obj.access_token ?? obj.accessToken;
+		({ obj }) => {
+			const raw = readSubmittedValue<string>(obj, 'access_token', 'accessToken');
 
 			return typeof raw === 'string' ? raw.replace(/\s+/g, '') || null : raw;
 		},

--- a/apps/backend/src/plugins/buddy-claude-setup-token/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-claude-setup-token/models/config.model.ts
@@ -25,10 +25,12 @@ export class BuddyClaudeSetupTokenConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'Setup token obtained from claude setup-token command',
+		description:
+			'Setup token obtained from claude setup-token command. This value is accepted on write and never returned.',
 		name: 'access_token',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'access_token' })
 	@Transform(
@@ -42,6 +44,15 @@ export class BuddyClaudeSetupTokenConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	accessToken: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Claude setup token is configured',
+		name: 'access_token_configured',
+	})
+	@Expose({ name: 'access_token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	accessTokenConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Model name to use (e.g. claude-sonnet-4-20250514)',

--- a/apps/backend/src/plugins/buddy-claude/buddy-claude.plugin.ts
+++ b/apps/backend/src/plugins/buddy-claude/buddy-claude.plugin.ts
@@ -45,6 +45,13 @@ export class BuddyClaudePlugin implements OnModuleInit {
 			type: BUDDY_CLAUDE_PLUGIN_NAME,
 			class: BuddyClaudeConfigModel,
 			configDto: UpdateBuddyClaudeConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		this.providerRegistry.register(this.claudeProvider);

--- a/apps/backend/src/plugins/buddy-claude/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-claude/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_CLAUDE_PLUGIN_NAME } from '../buddy-claude.constants';
 
@@ -35,9 +36,7 @@ export class UpdateBuddyClaudeConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/buddy-claude/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-claude/models/config.model.ts
@@ -25,10 +25,11 @@ export class BuddyClaudeConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'Anthropic API key',
+		description: 'Anthropic API key. This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'api_key' })
 	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
@@ -37,6 +38,15 @@ export class BuddyClaudeConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an Anthropic API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Model name to use (e.g. claude-sonnet-4-20250514)',

--- a/apps/backend/src/plugins/buddy-discord/buddy-discord.plugin.ts
+++ b/apps/backend/src/plugins/buddy-discord/buddy-discord.plugin.ts
@@ -46,6 +46,13 @@ export class BuddyDiscordPlugin implements OnModuleInit {
 			type: BUDDY_DISCORD_PLUGIN_NAME,
 			class: BuddyDiscordConfigModel,
 			configDto: UpdateBuddyDiscordConfigDto,
+			secretFields: [
+				{
+					path: 'bot_token',
+					configuredPath: 'bot_token_configured',
+					inputPaths: ['botToken'],
+				},
+			],
 		});
 
 		for (const model of BUDDY_DISCORD_PLUGIN_SWAGGER_EXTRA_MODELS) {

--- a/apps/backend/src/plugins/buddy-discord/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-discord/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_DISCORD_PLUGIN_NAME } from '../buddy-discord.constants';
 
@@ -35,10 +36,7 @@ export class UpdateBuddyDiscordConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'bot_token' })
-	@Transform(
-		({ obj }: { obj: { bot_token?: string | null; botToken?: string | null } }) => obj.bot_token ?? obj.botToken,
-		{ toClassOnly: true },
-	)
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'bot_token', 'botToken'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"bot_token","reason":"Bot token must be a string."}]' })
 	botToken?: string | null;

--- a/apps/backend/src/plugins/buddy-discord/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-discord/models/config.model.ts
@@ -25,10 +25,12 @@ export class BuddyDiscordConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'Discord Bot Token from the Discord Developer Portal',
+		description:
+			'Discord Bot Token from the Discord Developer Portal. This value is accepted on write and never returned.',
 		name: 'bot_token',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'bot_token' })
 	@Transform(
@@ -38,6 +40,15 @@ export class BuddyDiscordConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	botToken: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Discord Bot Token is configured',
+		name: 'bot_token_configured',
+	})
+	@Expose({ name: 'bot_token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	botTokenConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Discord Guild (server) ID',

--- a/apps/backend/src/plugins/buddy-elevenlabs/buddy-elevenlabs.plugin.ts
+++ b/apps/backend/src/plugins/buddy-elevenlabs/buddy-elevenlabs.plugin.ts
@@ -50,6 +50,13 @@ export class BuddyElevenlabsPlugin implements OnModuleInit {
 			type: BUDDY_ELEVENLABS_PLUGIN_NAME,
 			class: BuddyElevenlabsConfigModel,
 			configDto: UpdateBuddyElevenlabsConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		this.sttProviderRegistry.register(this.elevenlabsSttProvider);

--- a/apps/backend/src/plugins/buddy-elevenlabs/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-elevenlabs/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_ELEVENLABS_PLUGIN_NAME } from '../buddy-elevenlabs.constants';
 
@@ -35,9 +36,7 @@ export class UpdateBuddyElevenlabsConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/buddy-elevenlabs/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-elevenlabs/models/config.model.ts
@@ -25,10 +25,11 @@ export class BuddyElevenlabsConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'ElevenLabs API key',
+		description: 'ElevenLabs API key. This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'api_key' })
 	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
@@ -37,6 +38,15 @@ export class BuddyElevenlabsConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an ElevenLabs API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'ElevenLabs voice ID (e.g. 21m00Tcm4TlvDq8ikWAM for Rachel)',

--- a/apps/backend/src/plugins/buddy-openai-codex/buddy-openai-codex.plugin.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/buddy-openai-codex.plugin.ts
@@ -47,6 +47,23 @@ export class BuddyOpenaiCodexPlugin implements OnModuleInit {
 			type: BUDDY_OPENAI_CODEX_PLUGIN_NAME,
 			class: BuddyOpenaiCodexConfigModel,
 			configDto: UpdateBuddyOpenaiCodexConfigDto,
+			secretFields: [
+				{
+					path: 'client_secret',
+					configuredPath: 'client_secret_configured',
+					inputPaths: ['clientSecret'],
+				},
+				{
+					path: 'access_token',
+					configuredPath: 'access_token_configured',
+					inputPaths: ['accessToken'],
+				},
+				{
+					path: 'refresh_token',
+					configuredPath: 'refresh_token_configured',
+					inputPaths: ['refreshToken'],
+				},
+			],
 		});
 
 		this.providerRegistry.register(this.openAiCodexProvider);

--- a/apps/backend/src/plugins/buddy-openai-codex/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_OPENAI_CODEX_PLUGIN_NAME } from '../buddy-openai-codex.constants';
 
@@ -50,11 +51,7 @@ export class UpdateBuddyOpenaiCodexConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'client_secret' })
-	@Transform(
-		({ obj }: { obj: { client_secret?: string | null; clientSecret?: string | null } }) =>
-			obj.client_secret ?? obj.clientSecret,
-		{ toClassOnly: true },
-	)
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'client_secret', 'clientSecret'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"client_secret","reason":"Client secret must be a string."}]' })
 	clientSecret?: string | null;
@@ -66,11 +63,7 @@ export class UpdateBuddyOpenaiCodexConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'access_token' })
-	@Transform(
-		({ obj }: { obj: { access_token?: string | null; accessToken?: string | null } }) =>
-			obj.access_token ?? obj.accessToken,
-		{ toClassOnly: true },
-	)
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'access_token', 'accessToken'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"access_token","reason":"Access token must be a string."}]' })
 	accessToken?: string | null;
@@ -82,11 +75,7 @@ export class UpdateBuddyOpenaiCodexConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'refresh_token' })
-	@Transform(
-		({ obj }: { obj: { refresh_token?: string | null; refreshToken?: string | null } }) =>
-			obj.refresh_token ?? obj.refreshToken,
-		{ toClassOnly: true },
-	)
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'refresh_token', 'refreshToken'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"refresh_token","reason":"Refresh token must be a string."}]' })
 	refreshToken?: string | null;

--- a/apps/backend/src/plugins/buddy-openai-codex/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-openai-codex/models/config.model.ts
@@ -40,10 +40,11 @@ export class BuddyOpenaiCodexConfigModel extends PluginConfigModel {
 	clientId: string | null = null;
 
 	@ApiPropertyOptional({
-		description: 'OAuth client secret',
+		description: 'OAuth client secret. This value is accepted on write and never returned.',
 		name: 'client_secret',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'client_secret' })
 	@Transform(
@@ -55,11 +56,21 @@ export class BuddyOpenaiCodexConfigModel extends PluginConfigModel {
 	@IsString()
 	clientSecret: string | null = null;
 
+	@ApiProperty({
+		description: 'Whether an OAuth client secret is configured',
+		name: 'client_secret_configured',
+	})
+	@Expose({ name: 'client_secret_configured' })
+	@IsOptional()
+	@IsBoolean()
+	clientSecretConfigured?: boolean;
+
 	@ApiPropertyOptional({
-		description: 'OAuth access token',
+		description: 'OAuth access token. This value is accepted on write and never returned.',
 		name: 'access_token',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'access_token' })
 	@Transform(
@@ -71,11 +82,21 @@ export class BuddyOpenaiCodexConfigModel extends PluginConfigModel {
 	@IsString()
 	accessToken: string | null = null;
 
+	@ApiProperty({
+		description: 'Whether an OAuth access token is configured',
+		name: 'access_token_configured',
+	})
+	@Expose({ name: 'access_token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	accessTokenConfigured?: boolean;
+
 	@ApiPropertyOptional({
-		description: 'OAuth refresh token',
+		description: 'OAuth refresh token. This value is accepted on write and never returned.',
 		name: 'refresh_token',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'refresh_token' })
 	@Transform(
@@ -86,6 +107,15 @@ export class BuddyOpenaiCodexConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	refreshToken: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an OAuth refresh token is configured',
+		name: 'refresh_token_configured',
+	})
+	@Expose({ name: 'refresh_token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	refreshTokenConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Model name to use (e.g. codex-mini)',

--- a/apps/backend/src/plugins/buddy-openai/buddy-openai.plugin.ts
+++ b/apps/backend/src/plugins/buddy-openai/buddy-openai.plugin.ts
@@ -54,6 +54,13 @@ export class BuddyOpenaiPlugin implements OnModuleInit {
 			type: BUDDY_OPENAI_PLUGIN_NAME,
 			class: BuddyOpenaiConfigModel,
 			configDto: UpdateBuddyOpenaiConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		this.llmProviderRegistry.register(this.openAiProvider);

--- a/apps/backend/src/plugins/buddy-openai/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-openai/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_OPENAI_PLUGIN_NAME } from '../buddy-openai.constants';
 
@@ -35,9 +36,7 @@ export class UpdateBuddyOpenaiConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/buddy-openai/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-openai/models/config.model.ts
@@ -25,10 +25,11 @@ export class BuddyOpenaiConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'OpenAI API key',
+		description: 'OpenAI API key. This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'api_key' })
 	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
@@ -37,6 +38,15 @@ export class BuddyOpenaiConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an OpenAI API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Model name to use (e.g. gpt-4o, gpt-4o-mini)',

--- a/apps/backend/src/plugins/buddy-telegram/buddy-telegram.plugin.ts
+++ b/apps/backend/src/plugins/buddy-telegram/buddy-telegram.plugin.ts
@@ -46,6 +46,13 @@ export class BuddyTelegramPlugin implements OnModuleInit {
 			type: BUDDY_TELEGRAM_PLUGIN_NAME,
 			class: BuddyTelegramConfigModel,
 			configDto: UpdateBuddyTelegramConfigDto,
+			secretFields: [
+				{
+					path: 'bot_token',
+					configuredPath: 'bot_token_configured',
+					inputPaths: ['botToken'],
+				},
+			],
 		});
 
 		for (const model of BUDDY_TELEGRAM_PLUGIN_SWAGGER_EXTRA_MODELS) {

--- a/apps/backend/src/plugins/buddy-telegram/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-telegram/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_TELEGRAM_PLUGIN_NAME } from '../buddy-telegram.constants';
 
@@ -35,10 +36,7 @@ export class UpdateBuddyTelegramConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'bot_token' })
-	@Transform(
-		({ obj }: { obj: { bot_token?: string | null; botToken?: string | null } }) => obj.bot_token ?? obj.botToken,
-		{ toClassOnly: true },
-	)
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'bot_token', 'botToken'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"bot_token","reason":"Bot token must be a string."}]' })
 	botToken?: string | null;

--- a/apps/backend/src/plugins/buddy-telegram/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-telegram/models/config.model.ts
@@ -25,10 +25,11 @@ export class BuddyTelegramConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'Telegram Bot API token (from @BotFather)',
+		description: 'Telegram Bot API token (from @BotFather). This value is accepted on write and never returned.',
 		name: 'bot_token',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'bot_token' })
 	@Transform(
@@ -38,6 +39,15 @@ export class BuddyTelegramConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	botToken: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Telegram Bot API token is configured',
+		name: 'bot_token_configured',
+	})
+	@Expose({ name: 'bot_token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	botTokenConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Comma-separated list of Telegram user IDs allowed to interact with the bot (empty = allow all)',

--- a/apps/backend/src/plugins/buddy-voiceai/buddy-voiceai.plugin.ts
+++ b/apps/backend/src/plugins/buddy-voiceai/buddy-voiceai.plugin.ts
@@ -46,6 +46,13 @@ export class BuddyVoiceaiPlugin implements OnModuleInit {
 			type: BUDDY_VOICEAI_PLUGIN_NAME,
 			class: BuddyVoiceaiConfigModel,
 			configDto: UpdateBuddyVoiceaiConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		this.ttsProviderRegistry.register(this.voiceaiTtsProvider);

--- a/apps/backend/src/plugins/buddy-voiceai/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/buddy-voiceai/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { BUDDY_VOICEAI_PLUGIN_NAME } from '../buddy-voiceai.constants';
 
@@ -35,9 +36,7 @@ export class UpdateBuddyVoiceaiConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/buddy-voiceai/models/config.model.ts
+++ b/apps/backend/src/plugins/buddy-voiceai/models/config.model.ts
@@ -25,10 +25,11 @@ export class BuddyVoiceaiConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'Voice.ai API key',
+		description: 'Voice.ai API key. This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		nullable: true,
+		writeOnly: true,
 	})
 	@Expose({ name: 'api_key' })
 	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
@@ -37,6 +38,15 @@ export class BuddyVoiceaiConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Voice.ai API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiPropertyOptional({
 		description: 'Voice.ai voice ID',

--- a/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/devices-home-assistant.plugin.ts
@@ -159,6 +159,13 @@ export class DevicesHomeAssistantPlugin {
 			type: DEVICES_HOME_ASSISTANT_PLUGIN_NAME,
 			class: HomeAssistantConfigModel,
 			configDto: HomeAssistantUpdatePluginConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		this.devicesMapper.registerMapping<

--- a/apps/backend/src/plugins/devices-home-assistant/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-home-assistant/models/config.model.ts
@@ -18,9 +18,10 @@ export class HomeAssistantConfigModel extends PluginConfigModel {
 	type: string = DEVICES_HOME_ASSISTANT_PLUGIN_NAME;
 
 	@ApiPropertyOptional({
-		description: 'Home Assistant API key for authentication',
+		description: 'Home Assistant API key for authentication. This value is accepted on write and never returned.',
 		type: 'string',
 		example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+		writeOnly: true,
 		nullable: true,
 		name: 'api_key',
 	})
@@ -28,6 +29,15 @@ export class HomeAssistantConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether a Home Assistant API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiProperty({
 		description: 'Home Assistant hostname or IP address',

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/devices-zigbee2mqtt.plugin.ts
@@ -114,6 +114,16 @@ export class DevicesZigbee2mqttPlugin {
 			type: DEVICES_ZIGBEE2MQTT_PLUGIN_NAME,
 			class: Zigbee2mqttConfigModel,
 			configDto: Zigbee2mqttUpdatePluginConfigDto,
+			secretFields: [
+				{
+					path: 'mqtt.password',
+					configuredPath: 'mqtt.password_configured',
+				},
+				{
+					path: 'tls.key',
+					configuredPath: 'tls.key_configured',
+				},
+			],
 		});
 
 		// Register device type mapper

--- a/apps/backend/src/plugins/devices-zigbee2mqtt/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-zigbee2mqtt/models/config.model.ts
@@ -56,11 +56,21 @@ export class Z2mMqttConfigModel {
 	@IsOptional()
 	@IsString()
 	@ApiPropertyOptional({
-		description: 'MQTT password for authentication',
+		description: 'MQTT password for authentication. This value is accepted on write and never returned.',
+		writeOnly: true,
 		nullable: true,
 		example: null,
 	})
 	password: string | null = null;
+
+	@Expose({ name: 'password_configured' })
+	@IsOptional()
+	@IsBoolean()
+	@ApiProperty({
+		description: 'Whether an MQTT password is configured',
+		name: 'password_configured',
+	})
+	passwordConfigured?: boolean;
 
 	@Expose({ name: 'base_topic' })
 	@IsString()
@@ -170,11 +180,21 @@ export class Z2mTlsConfigModel {
 	@IsOptional()
 	@IsString()
 	@ApiPropertyOptional({
-		description: 'Client private key content or path',
+		description: 'Client private key content or path. This value is accepted on write and never returned.',
+		writeOnly: true,
 		nullable: true,
 		example: null,
 	})
 	key: string | null = null;
+
+	@Expose({ name: 'key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	@ApiProperty({
+		description: 'Whether a TLS client private key is configured',
+		name: 'key_configured',
+	})
+	keyConfigured?: boolean;
 }
 
 /**

--- a/apps/backend/src/plugins/influx-v1/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/influx-v1/dto/update-config.dto.ts
@@ -50,10 +50,11 @@ export class UpdateInfluxV1ConfigDto extends UpdatePluginConfigDto {
 	@ApiPropertyOptional({
 		description: 'InfluxDB password for authentication.',
 		type: 'string',
+		nullable: true,
 		example: 'secret',
 	})
 	@Expose()
 	@IsOptional()
 	@IsString({ message: '[{"field":"password","reason":"Password must be a valid string."}]' })
-	password?: string;
+	password?: string | null;
 }

--- a/apps/backend/src/plugins/influx-v1/influx-v1.plugin.ts
+++ b/apps/backend/src/plugins/influx-v1/influx-v1.plugin.ts
@@ -30,6 +30,12 @@ export class InfluxV1Plugin implements OnModuleInit {
 			type: INFLUX_V1_PLUGIN_NAME,
 			class: InfluxV1ConfigModel,
 			configDto: UpdateInfluxV1ConfigDto,
+			secretFields: [
+				{
+					path: 'password',
+					configuredPath: 'password_configured',
+				},
+			],
 		});
 
 		for (const model of INFLUX_V1_SWAGGER_EXTRA_MODELS) {

--- a/apps/backend/src/plugins/influx-v1/models/config.model.ts
+++ b/apps/backend/src/plugins/influx-v1/models/config.model.ts
@@ -55,12 +55,22 @@ export class InfluxV1ConfigModel extends PluginConfigModel {
 	username?: string;
 
 	@ApiPropertyOptional({
-		description: 'InfluxDB password for authentication',
+		description: 'InfluxDB password for authentication. This value is accepted on write and never returned.',
 		type: 'string',
 		example: 'secret',
+		writeOnly: true,
 	})
 	@Expose()
 	@IsOptional()
 	@IsString()
 	password?: string;
+
+	@ApiProperty({
+		description: 'Whether an InfluxDB password is configured',
+		name: 'password_configured',
+	})
+	@Expose({ name: 'password_configured' })
+	@IsOptional()
+	@IsBoolean()
+	passwordConfigured?: boolean;
 }

--- a/apps/backend/src/plugins/influx-v2/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/influx-v2/dto/update-config.dto.ts
@@ -30,12 +30,13 @@ export class UpdateInfluxV2ConfigDto extends UpdatePluginConfigDto {
 	@ApiPropertyOptional({
 		description: 'InfluxDB v2 API token for authentication.',
 		type: 'string',
+		nullable: true,
 		example: 'my-token',
 	})
 	@Expose()
 	@IsOptional()
 	@IsString({ message: '[{"field":"token","reason":"Token must be a valid string."}]' })
-	token?: string;
+	token?: string | null;
 
 	@ApiPropertyOptional({
 		description: 'InfluxDB v2 organization name.',

--- a/apps/backend/src/plugins/influx-v2/influx-v2.plugin.spec.ts
+++ b/apps/backend/src/plugins/influx-v2/influx-v2.plugin.spec.ts
@@ -1,0 +1,85 @@
+import { plainToInstance } from 'class-transformer';
+
+import { ConfigSecretField } from '../../modules/config/interfaces/config-secret.interface';
+import { ConfigSecretsService } from '../../modules/config/services/config-secrets.service';
+import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
+import { ExtensionsService } from '../../modules/extensions/services/extensions.service';
+import { PluginServiceManagerService } from '../../modules/extensions/services/plugin-service-manager.service';
+import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
+
+import { INFLUX_V2_PLUGIN_NAME } from './influx-v2.constants';
+import { InfluxV2Plugin } from './influx-v2.plugin';
+import { InfluxV2ConfigModel } from './models/config.model';
+import { InfluxV2ManagedService } from './services/influx-v2-managed.service';
+
+describe('InfluxV2Plugin', () => {
+	const registeredMapping = (): { secretFields?: readonly ConfigSecretField[] } => {
+		let captured: { secretFields?: readonly ConfigSecretField[] } | undefined;
+
+		const pluginsMapperService = {
+			registerMapping: jest.fn((mapping: { secretFields?: readonly ConfigSecretField[] }): void => {
+				captured = mapping;
+			}),
+		};
+		const managedService = { pluginName: INFLUX_V2_PLUGIN_NAME, serviceId: 'storage' };
+
+		new InfluxV2Plugin(
+			pluginsMapperService as unknown as PluginsTypeMapperService,
+			{ register: jest.fn() } as unknown as SwaggerModelsRegistryService,
+			{ registerPluginMetadata: jest.fn() } as unknown as ExtensionsService,
+			managedService as unknown as InfluxV2ManagedService,
+			{ register: jest.fn() } as unknown as PluginServiceManagerService,
+		).onModuleInit();
+
+		if (!captured) {
+			throw new Error('InfluxV2Plugin registered no config mapping');
+		}
+
+		return captured;
+	};
+
+	// The v2 token is an authentication credential, and every other storage and
+	// buddy plugin declares its credential. This one was missed because the
+	// original survey grepped for `api_key` / `password` / `*_token` and the bare
+	// name `token` matched none of them, so `GET /config/plugins` returned it.
+	//
+	// Asserted through ConfigSecretsService rather than against the literal
+	// registration, because a declared-but-wrong `path` fails silently: the
+	// service calls instanceToPlain() before every lookup, so a path that does
+	// not match the serialized wire name redacts nothing and looks identical to
+	// declaring no secret at all.
+	it('keeps the API token out of the public config', () => {
+		const config = plainToInstance(InfluxV2ConfigModel, {
+			type: INFLUX_V2_PLUGIN_NAME,
+			url: 'http://localhost:8086',
+			token: 'super-secret-token',
+			org: 'fastybird',
+			bucket: 'smart-panel',
+		});
+
+		const publicConfig = new ConfigSecretsService().toPublic(
+			config,
+			registeredMapping().secretFields,
+		) as unknown as Record<string, unknown>;
+
+		expect(publicConfig).not.toHaveProperty('token');
+		expect(publicConfig.token_configured).toBe(true);
+		expect(JSON.stringify(publicConfig)).not.toContain('super-secret-token');
+	});
+
+	it('reports an absent token as not configured', () => {
+		const config = plainToInstance(InfluxV2ConfigModel, {
+			type: INFLUX_V2_PLUGIN_NAME,
+			url: 'http://localhost:8086',
+			org: 'fastybird',
+			bucket: 'smart-panel',
+		});
+
+		const publicConfig = new ConfigSecretsService().toPublic(
+			config,
+			registeredMapping().secretFields,
+		) as unknown as Record<string, unknown>;
+
+		expect(publicConfig.token_configured).toBe(false);
+	});
+});

--- a/apps/backend/src/plugins/influx-v2/influx-v2.plugin.ts
+++ b/apps/backend/src/plugins/influx-v2/influx-v2.plugin.ts
@@ -30,6 +30,12 @@ export class InfluxV2Plugin implements OnModuleInit {
 			type: INFLUX_V2_PLUGIN_NAME,
 			class: InfluxV2ConfigModel,
 			configDto: UpdateInfluxV2ConfigDto,
+			secretFields: [
+				{
+					path: 'token',
+					configuredPath: 'token_configured',
+				},
+			],
 		});
 
 		for (const model of INFLUX_V2_SWAGGER_EXTRA_MODELS) {

--- a/apps/backend/src/plugins/influx-v2/models/config.model.ts
+++ b/apps/backend/src/plugins/influx-v2/models/config.model.ts
@@ -41,14 +41,24 @@ export class InfluxV2ConfigModel extends PluginConfigModel {
 	url: string = INFLUXDB_V2_DEFAULT_URL;
 
 	@ApiPropertyOptional({
-		description: 'InfluxDB v2 API token for authentication',
+		description: 'InfluxDB v2 API token for authentication. This value is accepted on write and never returned.',
 		type: 'string',
 		example: 'my-token',
+		writeOnly: true,
 	})
 	@Expose()
 	@IsOptional()
 	@IsString()
 	token?: string;
+
+	@ApiProperty({
+		description: 'Whether an InfluxDB v2 API token is configured',
+		name: 'token_configured',
+	})
+	@Expose({ name: 'token_configured' })
+	@IsOptional()
+	@IsBoolean()
+	tokenConfigured?: boolean;
 
 	@ApiProperty({
 		description: 'InfluxDB v2 organization name',

--- a/apps/backend/src/plugins/plugin-secret-removal.spec.ts
+++ b/apps/backend/src/plugins/plugin-secret-removal.spec.ts
@@ -1,0 +1,132 @@
+import { toInstance } from '../common/utils/transform.utils';
+import { ConfigSecretsService } from '../modules/config/services/config-secrets.service';
+
+import { UpdateBuddyClaudeSetupTokenConfigDto } from './buddy-claude-setup-token/dto/update-config.dto';
+import { UpdateBuddyClaudeConfigDto } from './buddy-claude/dto/update-config.dto';
+import { UpdateBuddyDiscordConfigDto } from './buddy-discord/dto/update-config.dto';
+import { UpdateBuddyElevenlabsConfigDto } from './buddy-elevenlabs/dto/update-config.dto';
+import { UpdateBuddyOpenaiCodexConfigDto } from './buddy-openai-codex/dto/update-config.dto';
+import { UpdateBuddyOpenaiConfigDto } from './buddy-openai/dto/update-config.dto';
+import { BuddyOpenaiConfigModel } from './buddy-openai/models/config.model';
+import { UpdateBuddyTelegramConfigDto } from './buddy-telegram/dto/update-config.dto';
+import { UpdateBuddyVoiceaiConfigDto } from './buddy-voiceai/dto/update-config.dto';
+import { HomeAssistantUpdatePluginConfigDto } from './devices-home-assistant/dto/update-config.dto';
+import { HomeyUpdatePluginConfigDto } from './devices-homey/dto/update-config.dto';
+import { Zigbee2mqttUpdatePluginConfigDto } from './devices-zigbee2mqtt/dto/update-config.dto';
+import { UpdateInfluxV1ConfigDto } from './influx-v1/dto/update-config.dto';
+import { UpdateInfluxV2ConfigDto } from './influx-v2/dto/update-config.dto';
+import { UpdateOpenWeatherMapOneCallConfigDto } from './weather-openweathermap-onecall/dto/update-config.dto';
+import { UpdateOpenWeatherMapConfigDto } from './weather-openweathermap/dto/update-config.dto';
+
+/**
+ * Every redacted secret, named by the wire field a client submits and the property the update
+ * DTO exposes it as. Mirrors the `secretFields` each plugin registers - a new registration
+ * there wants a row here.
+ */
+/**
+ * `devices-home-assistant` declares its secret with a `= null` class default, so an absent field
+ * arrives as `null` rather than `undefined`. Harmless, because `resolveUpdate()` decides from the
+ * submitted body rather than from the DTO, but it means this one row cannot make the
+ * absent-is-not-null assertion the others do.
+ */
+const DEFAULTS_TO_NULL = 'devices-home-assistant';
+
+const SECRETS: { label: string; dto: object; submit: Record<string, unknown>; read: (instance: object) => unknown }[] =
+	[
+		['buddy-claude', UpdateBuddyClaudeConfigDto, 'api_key', 'apiKey'],
+		['buddy-claude-setup-token', UpdateBuddyClaudeSetupTokenConfigDto, 'access_token', 'accessToken'],
+		['buddy-discord', UpdateBuddyDiscordConfigDto, 'bot_token', 'botToken'],
+		['buddy-elevenlabs', UpdateBuddyElevenlabsConfigDto, 'api_key', 'apiKey'],
+		['buddy-openai', UpdateBuddyOpenaiConfigDto, 'api_key', 'apiKey'],
+		['buddy-openai-codex client secret', UpdateBuddyOpenaiCodexConfigDto, 'client_secret', 'clientSecret'],
+		['buddy-openai-codex access token', UpdateBuddyOpenaiCodexConfigDto, 'access_token', 'accessToken'],
+		['buddy-openai-codex refresh token', UpdateBuddyOpenaiCodexConfigDto, 'refresh_token', 'refreshToken'],
+		['buddy-telegram', UpdateBuddyTelegramConfigDto, 'bot_token', 'botToken'],
+		['buddy-voiceai', UpdateBuddyVoiceaiConfigDto, 'api_key', 'apiKey'],
+		['devices-home-assistant', HomeAssistantUpdatePluginConfigDto, 'api_key', 'api_key'],
+		['devices-homey', HomeyUpdatePluginConfigDto, 'api_key', 'apiKey'],
+		['influx-v1', UpdateInfluxV1ConfigDto, 'password', 'password'],
+		['influx-v2', UpdateInfluxV2ConfigDto, 'token', 'token'],
+		['weather-openweathermap', UpdateOpenWeatherMapConfigDto, 'api_key', 'apiKey'],
+		['weather-openweathermap-onecall', UpdateOpenWeatherMapOneCallConfigDto, 'api_key', 'apiKey'],
+	].map(([label, dto, wire, property]) => ({
+		label: label as string,
+		dto: dto as object,
+		submit: { [wire as string]: null },
+		read: (instance: object): unknown => (instance as Record<string, unknown>)[property as string],
+	}));
+
+const instantiate = (dto: object, plain: Record<string, unknown>): object =>
+	toInstance(dto as new () => object, plain, { excludeExtraneousValues: false });
+
+// `resolveUpdate()` keeps a stored secret whenever the submitted field is absent or blank and
+// removes it only for `null`. So `null` has to survive the DTO, and survive it as `null` rather
+// than as "absent" - the two are indistinguishable downstream, and one of them means the
+// opposite of what the operator asked for.
+describe('an explicit null on a redacted secret', () => {
+	describe.each(SECRETS)('$label', ({ label, dto, submit, read }) => {
+		it('reaches the update DTO as null rather than as an absent field', () => {
+			expect(read(instantiate(dto, submit))).toBeNull();
+		});
+
+		it('is still distinguishable from a field that was never submitted', () => {
+			if (label === DEFAULTS_TO_NULL) {
+				return;
+			}
+
+			expect(read(instantiate(dto, {}))).toBeUndefined();
+		});
+	});
+
+	// The nested pair, which the flat table cannot describe.
+	it('reaches the zigbee2mqtt DTO as null on both nested secrets', () => {
+		const instance = instantiate(Zigbee2mqttUpdatePluginConfigDto, {
+			mqtt: { password: null },
+			tls: { key: null },
+		}) as {
+			mqtt?: { password?: string | null };
+			tls?: { key?: string | null };
+		};
+
+		expect(instance.mqtt?.password).toBeNull();
+		expect(instance.tls?.key).toBeNull();
+	});
+});
+
+// The chain that actually broke: `resolveUpdate()` decided correctly, and then the decision was
+// handed straight back through the DTO, which turned the `null` into an absent field again. The
+// merge that followed therefore kept the credential while the API reported a successful removal.
+describe('removing a stored secret end to end', () => {
+	const secrets = new ConfigSecretsService();
+	const fields = [{ path: 'api_key', configuredPath: 'api_key_configured', inputPaths: ['apiKey'] }];
+
+	const stored = (): BuddyOpenaiConfigModel =>
+		toInstance(BuddyOpenaiConfigModel, { type: 'buddy-openai', enabled: true, api_key: 'sk-stored', model: 'gpt-4o' });
+
+	const applyUpdate = (submitted: Record<string, unknown>): BuddyOpenaiConfigModel => {
+		const existing = stored();
+		const instance = instantiate(UpdateBuddyOpenaiConfigDto, submitted);
+
+		// The two steps `ConfigService.resolvePluginConfigUpdate()` performs, in order.
+		const resolved = secrets.resolveUpdate(existing, instance, submitted, fields);
+		const reInstanced = instantiate(UpdateBuddyOpenaiConfigDto, resolved as Record<string, unknown>);
+
+		return toInstance(BuddyOpenaiConfigModel, secrets.merge(existing, { type: 'buddy-openai', ...reInstanced }));
+	};
+
+	it('leaves nothing stored when the secret is submitted as null', () => {
+		expect(applyUpdate({ type: 'buddy-openai', api_key: null }).apiKey).toBeNull();
+	});
+
+	it('replaces what is stored when a new secret is submitted', () => {
+		expect(applyUpdate({ type: 'buddy-openai', api_key: 'sk-replacement' }).apiKey).toBe('sk-replacement');
+	});
+
+	it('keeps what is stored when the secret is not submitted at all', () => {
+		expect(applyUpdate({ type: 'buddy-openai', model: 'gpt-4o-mini' }).apiKey).toBe('sk-stored');
+	});
+
+	it('keeps what is stored when the secret is submitted blank', () => {
+		expect(applyUpdate({ type: 'buddy-openai', api_key: '' }).apiKey).toBe('sk-stored');
+	});
+});

--- a/apps/backend/src/plugins/weather-openweathermap-onecall/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/weather-openweathermap-onecall/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { TemperatureUnitType } from '../../../modules/system/system.constants';
 import { WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME } from '../weather-openweathermap-onecall.constants';
@@ -37,9 +38,7 @@ export class UpdateOpenWeatherMapOneCallConfigDto extends UpdatePluginConfigDto 
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/weather-openweathermap-onecall/models/config.model.ts
+++ b/apps/backend/src/plugins/weather-openweathermap-onecall/models/config.model.ts
@@ -26,10 +26,12 @@ export class OpenWeatherMapOneCallConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'OpenWeatherMap One Call API 3.0 key (requires subscription)',
+		description:
+			'OpenWeatherMap One Call API 3.0 key (requires subscription). This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		example: 'your-api-key-here',
+		writeOnly: true,
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
@@ -39,6 +41,15 @@ export class OpenWeatherMapOneCallConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an OpenWeatherMap One Call API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiProperty({
 		description: 'Temperature unit',

--- a/apps/backend/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.plugin.ts
+++ b/apps/backend/src/plugins/weather-openweathermap-onecall/weather-openweathermap-onecall.plugin.ts
@@ -73,6 +73,13 @@ export class WeatherOpenweathermapOnecallPlugin implements OnModuleInit {
 			type: WEATHER_OPENWEATHERMAP_ONECALL_PLUGIN_NAME,
 			class: OpenWeatherMapOneCallConfigModel,
 			configDto: UpdateOpenWeatherMapOneCallConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		// Register location type mapping

--- a/apps/backend/src/plugins/weather-openweathermap/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/weather-openweathermap/dto/update-config.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
+import { readSubmittedValue } from '../../../common/utils/transform.utils';
 import { UpdatePluginConfigDto } from '../../../modules/config/dto/config.dto';
 import { TemperatureUnitType } from '../../../modules/system/system.constants';
 import { WEATHER_OPENWEATHERMAP_PLUGIN_NAME } from '../weather-openweathermap.constants';
@@ -37,9 +38,7 @@ export class UpdateOpenWeatherMapConfigDto extends UpdatePluginConfigDto {
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
-	@Transform(({ obj }: { obj: { api_key?: string | null; apiKey?: string | null } }) => obj.api_key ?? obj.apiKey, {
-		toClassOnly: true,
-	})
+	@Transform(({ obj }) => readSubmittedValue<string>(obj, 'api_key', 'apiKey'), { toClassOnly: true })
 	@IsOptional()
 	@IsString({ message: '[{"field":"api_key","reason":"API key must be a string."}]' })
 	apiKey?: string | null;

--- a/apps/backend/src/plugins/weather-openweathermap/models/config.model.ts
+++ b/apps/backend/src/plugins/weather-openweathermap/models/config.model.ts
@@ -26,10 +26,11 @@ export class OpenWeatherMapConfigModel extends PluginConfigModel {
 	enabled: boolean = false;
 
 	@ApiPropertyOptional({
-		description: 'OpenWeatherMap API key',
+		description: 'OpenWeatherMap API key. This value is accepted on write and never returned.',
 		name: 'api_key',
 		type: 'string',
 		example: 'your-api-key-here',
+		writeOnly: true,
 		nullable: true,
 	})
 	@Expose({ name: 'api_key' })
@@ -39,6 +40,15 @@ export class OpenWeatherMapConfigModel extends PluginConfigModel {
 	@IsOptional()
 	@IsString()
 	apiKey: string | null = null;
+
+	@ApiProperty({
+		description: 'Whether an OpenWeatherMap API key is configured',
+		name: 'api_key_configured',
+	})
+	@Expose({ name: 'api_key_configured' })
+	@IsOptional()
+	@IsBoolean()
+	apiKeyConfigured?: boolean;
 
 	@ApiProperty({
 		description: 'Temperature unit',

--- a/apps/backend/src/plugins/weather-openweathermap/weather-openweathermap.plugin.ts
+++ b/apps/backend/src/plugins/weather-openweathermap/weather-openweathermap.plugin.ts
@@ -65,6 +65,13 @@ export class WeatherOpenweathermapPlugin implements OnModuleInit {
 			type: WEATHER_OPENWEATHERMAP_PLUGIN_NAME,
 			class: OpenWeatherMapConfigModel,
 			configDto: UpdateOpenWeatherMapConfigDto,
+			secretFields: [
+				{
+					path: 'api_key',
+					configuredPath: 'api_key_configured',
+					inputPaths: ['apiKey'],
+				},
+			],
 		});
 
 		// Register location type mapping


### PR DESCRIPTION
Three related gaps, all surfaced while binding module configs in #806 / #807.

## 1 · `PATCH /config/module/{module}` was undescribed

#806 registered every module's config *model* so the read side appears in the spec. The write side was never done — the update DTOs are annotated but never registered.

Registers the update DTO for **12 modules**, so `ConfigModuleUpdate<Name>` now exists for all of them rather than just `mcp`, `mdns`, `storage`, `system`. The spec goes from 4 to 18 `ConfigModuleUpdate*` schemas.

Two of those DTOs broke the convention the other sixteen follow — `ExtensionsModuleUpdateExtensionsConfig` and `SpacesModuleUpdateConfig`. Renamed while still absent from the spec and therefore free to change, exactly as `ConfigModuleDataSpaces` was in #806.

`intents` is excluded: it registers nothing with Swagger at all, so it needs its own openapi module first.

## 2 · Plugin secrets weren't actually being redacted

`ConfigService` redacts on read via `configSecrets.toPublic(config, mapping.secretFields)` — but only for fields a plugin declares. **14 plugins hold credentials in config and exactly one declared them.** For the other 13, `secretFields` was `undefined`, `toPublic` defaulted to `[]`, the redaction loop never ran, and `GET /config/plugins` returned the raw value.

Concretely, for `buddy-discord` the response now carries `bot_token_configured: true` and **no `bot_token` key at all**.

**The paths are wire names, not property names.** `ConfigSecretsService` calls `instanceToPlain()` before every lookup, so a camelCase path matches nothing and leaves the secret exposed — a failure indistinguishable from not declaring it. Every one of the 15 declared paths was checked against the `@Expose` name that produces it, including the nested `mqtt.password` and `tls.key`.

**Only credentials are listed.** Identifiers deliberately aren't:

| Included | Excluded, and why |
|---|---|
| `bot_token`, `api_key`, `access_token`, `refresh_token`, `client_secret`, `password` | `guild_id`, channel ids, `allowed_user_ids` — identifiers and ACL data |
| `mqtt.password`, `tls.key` | `mqtt.username`; `tls.ca` / `tls.cert` — public certificate material |
| | `client_id` — the Codex OAuth controller already accepts it as a `@Public()` query parameter |

## 3 · Two small corrections

- `logLevels` has `@ArrayNotEmpty()` but the spec emitted no `minItems`, so no generated client knew an empty array is rejected. Added.
- The admin declared a `HouseMode` enum and `HouseModeType` that **nothing referenced** — left behind when #807 moved that field onto the generated enum. Removed.

## 4 · Review follow-up: removing a credential

Codex flagged that redaction took away the only way to delete a stored secret, and it was right.
The backend keeps what it holds whenever the field is absent or blank, and removes it only for
`null`. That rule is what makes an untouched form safe — the field always loads blank, because the
secret is never sent back — but it also means blanking the input cannot mean "delete", and no form
had any other gesture. Every plugin could replace a key from then on; none could remove one.

A shared `ConfigSecretInput` carries that gesture. When the backend reports something is stored it
offers **Remove**, which stages `null` and says the value will go when the form is saved, with a
**Keep it** to take it back. Typing and then clearing again submits nothing at all, so blanking a
field still is not a way to delete a credential. It is wired into the fourteen forms holding a
redacted secret, including the two that are textareas rather than masked inputs
(`devices-home-assistant.api_key`, `devices-zigbee2mqtt.tls.key`). `devices-homey` has no admin
form, and the Codex OAuth tokens keep their existing connect/disconnect pair — only its
`client_secret` gains the control.

Wiring it exposed a gap on the two plugins nobody had checked: **influx-v1 and influx-v2 were never
given the `_configured` field on the admin side at all**, so neither could tell whether a value was
stored, and influx-v2's `token` was not even nullable — a removal would have been rejected before
it left the browser. Both are fixed, and a table-driven test now pins, for every redacted secret,
that `null` survives both the edit-form and the store schema and that an absent value stays valid.
It fails on exactly the influx-v2 shape.

## 5 · Review follow-up: the removal was a no-op

The remove control put `null` on the wire, `resolveUpdate()` read it correctly — and then nothing
happened. Reproduced through the real pipeline, with `sk-stored` held and `{ api_key: null }`
submitted:

| step | result |
|---|---|
| DTO instance from the request | `apiKey` **absent** |
| `resolveUpdate()` | `{ api_key: null }` — correct, a removal |
| re-instanced by `resolvePluginConfigUpdate()` | `apiKey` **absent** again |
| merge | `api_key: 'sk-stored'` — the credential survives |

`obj.api_key ?? obj.apiKey` cannot express "explicitly null": `null` is nullish, so it falls
through to the other spelling and returns `undefined`, which everything downstream reads as "not
submitted". **12 secrets across 10 DTOs** were written that way and all 12 lost it. The five
written without it (`devices-home-assistant`, `devices-homey`, `devices-zigbee2mqtt` ×2,
`influx-v1`, `influx-v2`) were already correct.

All 12 now read through a shared `readSubmittedValue(obj, wireName, camelName)`, which tests for
presence rather than nullishness. The same four steps now end in `apiKey: null`. This also repairs
the Codex **Disconnect** action, which had the same defect and never cleared its tokens.

Two tests guard it — a table over every redacted secret, and an end-to-end one over the
resolve/re-instance/merge chain covering removal, replacement, an absent field and a blank one.
Restoring the `??` on a single DTO fails both.

## Verification

| Check | Result |
|---|---|
| Backend | 392 suites, 4910 passed |
| Admin | 281 files, 2090 passed (+58) |
| `pnpm run type-check` (real) | clean |
| `lint:js` / `lint:api` / `lint:openapi` | pass |
| `ConfigModuleUpdate*` schemas | 4 → 18 |
| Every secret path matched to its `@Expose` name | 15/15 |
| Every redacted secret accepts `null` end to end | 17/17 admin, 17/17 backend |
