### PR TITLE
fix(backend): stop bulk endpoints leaking internals and crashing on an empty body

### DIFF
--- a/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
@@ -188,6 +188,57 @@ describe('runBulkOperation', () => {
 		});
 	});
 
+	// Even asking what a thrown value *is* runs code the thrower controls: a `Proxy`
+	// answers the prototype walk behind `instanceof` from a trap of its own. A throw
+	// there lands in the same catch block as everything else here, and would take the
+	// rest of the selection down with it.
+	it('survives a rejection that throws when its type is checked', async () => {
+		const hostile = new Proxy(
+			{},
+			{
+				getPrototypeOf: () => {
+					throw new Error('boom');
+				},
+			},
+		);
+
+		const perform = jest.fn().mockRejectedValueOnce(hostile).mockResolvedValueOnce(undefined);
+
+		const result = await runBulkOperation(['a', 'b'], perform, {
+			fallbackReason: 'Item could not be processed',
+			safeErrors: [ModuleRefusalError],
+			logger,
+		});
+
+		expect(result.succeeded).toEqual(['b']);
+		expect(result.failed).toEqual([{ id: 'a', reason: 'Item could not be processed' }]);
+		expect(perform).toHaveBeenCalledTimes(2);
+	});
+
+	it('still logs a rejection it cannot even describe', async () => {
+		const hostile = new Proxy(
+			{},
+			{
+				getPrototypeOf: () => {
+					throw new Error('boom');
+				},
+				ownKeys: () => {
+					throw new Error('boom');
+				},
+			},
+		);
+
+		const perform = jest.fn().mockRejectedValue(hostile);
+		const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+		await runBulkOperation(['a'], perform, {
+			fallbackReason: 'Item could not be processed',
+			logger,
+		});
+
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('id=a'), '<unreadable value>');
+	});
+
 	// A selection can carry the same item twice - two rows of one item in
 	// different groupings, for instance. Acting once keeps the caller's counts
 	// honest.

--- a/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
@@ -95,6 +95,35 @@ describe('runBulkOperation', () => {
 	// A selection can carry the same item twice - two rows of one item in
 	// different groupings, for instance. Acting once keeps the caller's counts
 	// honest.
+	// Describing the thrown value for the log must not itself throw. A
+	// null-prototype object has no conversion to a primitive at all, and
+	// `Symbol.toPrimitive` is code the thrower controls - either would escape the
+	// catch and abandon every item still to come, which is the one thing
+	// collecting failures per item exists to prevent.
+	it.each([
+		['an object with no prototype', (): unknown => Object.create(null)],
+		[
+			'an object that throws on conversion',
+			(): unknown => ({
+				[Symbol.toPrimitive]: () => {
+					throw new Error('boom');
+				},
+			}),
+		],
+	])('survives a rejection that cannot be converted to a string - %s', async (_label, makeValue) => {
+		const perform = jest.fn().mockRejectedValueOnce(makeValue()).mockResolvedValueOnce(undefined);
+
+		const result = await runBulkOperation(['a', 'b'], perform, {
+			fallbackReason: 'Item could not be processed',
+			logger,
+		});
+
+		// The later item still ran, which is what a throw here would have prevented.
+		expect(result.succeeded).toEqual(['b']);
+		expect(result.failed).toEqual([{ id: 'a', reason: 'Item could not be processed' }]);
+		expect(perform).toHaveBeenCalledTimes(2);
+	});
+
 	it('acts once on an item listed twice', async () => {
 		const perform = jest.fn().mockResolvedValue(undefined);
 

--- a/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
@@ -92,9 +92,6 @@ describe('runBulkOperation', () => {
 		expect(result.failed).toEqual([{ id: 'a', reason: 'Scene could not be removed' }]);
 	});
 
-	// A selection can carry the same item twice - two rows of one item in
-	// different groupings, for instance. Acting once keeps the caller's counts
-	// honest.
 	// Describing the thrown value for the log must not itself throw. A
 	// null-prototype object has no conversion to a primitive at all, and
 	// `Symbol.toPrimitive` is code the thrower controls - either would escape the
@@ -124,6 +121,76 @@ describe('runBulkOperation', () => {
 		expect(perform).toHaveBeenCalledTimes(2);
 	});
 
+	// An `Error` is no safer to read than any other thrown value: `message` and
+	// `stack` are ordinary properties on the exceptions raised here, but a getter
+	// that throws throws inside the catch block, which is exactly where a throw
+	// abandons the rest of the selection.
+	describe('an Error whose own accessors throw', () => {
+		const errorWithThrowingAccessor = (accessor: 'message' | 'stack'): Error => {
+			const error = new ModuleRefusalError('readable');
+
+			Object.defineProperty(error, accessor, {
+				get: () => {
+					throw new Error('boom');
+				},
+			});
+
+			return error;
+		};
+
+		it('does not abandon the remaining items when the message cannot be read', async () => {
+			const perform = jest
+				.fn()
+				.mockRejectedValueOnce(errorWithThrowingAccessor('message'))
+				.mockResolvedValueOnce(undefined);
+
+			const result = await runBulkOperation(['a', 'b'], perform, {
+				fallbackReason: 'Item could not be processed',
+				safeErrors: [ModuleRefusalError],
+				logger,
+			});
+
+			expect(result.succeeded).toEqual(['b']);
+			expect(result.failed).toEqual([{ id: 'a', reason: 'Item could not be processed' }]);
+			expect(perform).toHaveBeenCalledTimes(2);
+		});
+
+		// The logger formats an `Error` it is handed by reading `stack` first, so
+		// handing it the raw value would put the throwing accessor back in the path.
+		it('does not abandon the remaining items when the stack cannot be read', async () => {
+			const perform = jest
+				.fn()
+				.mockRejectedValueOnce(errorWithThrowingAccessor('stack'))
+				.mockResolvedValueOnce(undefined);
+
+			const result = await runBulkOperation(['a', 'b'], perform, {
+				fallbackReason: 'Item could not be processed',
+				logger,
+			});
+
+			expect(result.succeeded).toEqual(['b']);
+			expect(result.failed).toEqual([{ id: 'a', reason: 'Item could not be processed' }]);
+			expect(perform).toHaveBeenCalledTimes(2);
+		});
+
+		it('still logs the failure, describing what little could be read', async () => {
+			const error = errorWithThrowingAccessor('stack');
+			const perform = jest.fn().mockRejectedValue(error);
+
+			const logged = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+			await runBulkOperation(['a'], perform, {
+				fallbackReason: 'Item could not be processed',
+				logger,
+			});
+
+			expect(logged).toHaveBeenCalledWith('Bulk operation failed for id=a', 'readable');
+		});
+	});
+
+	// A selection can carry the same item twice - two rows of one item in
+	// different groupings, for instance. Acting once keeps the caller's counts
+	// honest.
 	it('acts once on an item listed twice', async () => {
 		const perform = jest.fn().mockResolvedValue(undefined);
 
@@ -198,7 +265,13 @@ describe('runBulkOperation', () => {
 			});
 
 			expect(errorSpy).toHaveBeenCalledTimes(1);
-			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('id=a'), error);
+			// The description rather than the value itself - the logger would otherwise
+			// read `stack` and `message` off it unguarded - but it still carries what
+			// was sanitized out of the response.
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('id=a'),
+				expect.stringContaining('SELECT * FROM users WHERE id = ?'),
+			);
 		});
 	});
 });

--- a/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.spec.ts
@@ -1,10 +1,31 @@
+import { ExtensionLoggerService, createExtensionLogger } from '../../../common/logger';
+
 import { runBulkOperation } from './bulk.utils';
 
+// Stands in for a module's own exception type - one of `safeErrors` - the
+// deliberate, user-facing refusal a single-item endpoint would also translate
+// into a response.
+class ModuleRefusalError extends Error {}
+
+// Stands in for a failure nobody declared safe: a TypeORM error, a
+// subscriber, or a plugin hook, none of which were ever meant to reach a
+// client verbatim.
+class QueryFailedError extends Error {}
+
 describe('runBulkOperation', () => {
+	let logger: ExtensionLoggerService;
+
+	beforeEach(() => {
+		logger = createExtensionLogger('test-module', 'TestComponent');
+	});
+
 	it('reports every item that went through', async () => {
 		const perform = jest.fn().mockResolvedValue(undefined);
 
-		const result = await runBulkOperation(['a', 'b', 'c'], perform);
+		const result = await runBulkOperation(['a', 'b', 'c'], perform, {
+			fallbackReason: 'Item could not be processed',
+			logger,
+		});
 
 		expect(result.succeeded).toEqual(['a', 'b', 'c']);
 		expect(result.failed).toEqual([]);
@@ -18,10 +39,14 @@ describe('runBulkOperation', () => {
 		const perform = jest
 			.fn()
 			.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Item is hidden')) : Promise.resolve(),
+				id === 'b' ? Promise.reject(new ModuleRefusalError('Item is hidden')) : Promise.resolve(),
 			);
 
-		const result = await runBulkOperation(['a', 'b', 'c'], perform);
+		const result = await runBulkOperation(['a', 'b', 'c'], perform, {
+			fallbackReason: 'Item could not be processed',
+			safeErrors: [ModuleRefusalError],
+			logger,
+		});
 
 		expect(result.succeeded).toEqual(['a', 'c']);
 		expect(result.failed).toEqual([{ id: 'b', reason: 'Item is hidden' }]);
@@ -29,19 +54,28 @@ describe('runBulkOperation', () => {
 	});
 
 	// Refusals that carry an explanation are worth passing back, the same way the
-	// single-item endpoints translate them instead of answering "try again later".
-	it('reports the thrown message as the reason', async () => {
-		const perform = jest.fn().mockRejectedValue(new Error('Placement is immutable'));
+	// single-item endpoints translate them instead of answering "try again later" -
+	// but only once the error is named as one the caller is willing to show.
+	it('forwards the message of a declared safe error', async () => {
+		const perform = jest.fn().mockRejectedValue(new ModuleRefusalError('Placement is immutable'));
 
-		const result = await runBulkOperation(['a'], perform);
+		const result = await runBulkOperation(['a'], perform, {
+			fallbackReason: 'Item could not be processed',
+			safeErrors: [ModuleRefusalError],
+			logger,
+		});
 
 		expect(result.failed).toEqual([{ id: 'a', reason: 'Placement is immutable' }]);
 	});
 
-	it('falls back to the supplied reason when the failure carries no message', async () => {
-		const perform = jest.fn().mockRejectedValue(new Error(''));
+	it('falls back to the supplied reason when a safe failure carries no message', async () => {
+		const perform = jest.fn().mockRejectedValue(new ModuleRefusalError(''));
 
-		const result = await runBulkOperation(['a'], perform, 'Scene could not be removed');
+		const result = await runBulkOperation(['a'], perform, {
+			fallbackReason: 'Scene could not be removed',
+			safeErrors: [ModuleRefusalError],
+			logger,
+		});
 
 		expect(result.failed).toEqual([{ id: 'a', reason: 'Scene could not be removed' }]);
 	});
@@ -49,7 +83,11 @@ describe('runBulkOperation', () => {
 	it('falls back for a rejection that is not an Error at all', async () => {
 		const perform = jest.fn().mockRejectedValue('just a string');
 
-		const result = await runBulkOperation(['a'], perform, 'Scene could not be removed');
+		const result = await runBulkOperation(['a'], perform, {
+			fallbackReason: 'Scene could not be removed',
+			safeErrors: [ModuleRefusalError],
+			logger,
+		});
 
 		expect(result.failed).toEqual([{ id: 'a', reason: 'Scene could not be removed' }]);
 	});
@@ -60,7 +98,10 @@ describe('runBulkOperation', () => {
 	it('acts once on an item listed twice', async () => {
 		const perform = jest.fn().mockResolvedValue(undefined);
 
-		const result = await runBulkOperation(['a', 'a', 'b'], perform);
+		const result = await runBulkOperation(['a', 'a', 'b'], perform, {
+			fallbackReason: 'Item could not be processed',
+			logger,
+		});
 
 		expect(result.succeeded).toEqual(['a', 'b']);
 		expect(perform).toHaveBeenCalledTimes(2);
@@ -69,7 +110,7 @@ describe('runBulkOperation', () => {
 	it('answers an empty selection with an empty result', async () => {
 		const perform = jest.fn();
 
-		const result = await runBulkOperation([], perform);
+		const result = await runBulkOperation([], perform, { fallbackReason: 'Item could not be processed', logger });
 
 		expect(result).toEqual({ succeeded: [], failed: [] });
 		expect(perform).not.toHaveBeenCalled();
@@ -88,8 +129,47 @@ describe('runBulkOperation', () => {
 			order.push(`end:${id}`);
 		});
 
-		await runBulkOperation(['a', 'b'], perform);
+		await runBulkOperation(['a', 'b'], perform, { fallbackReason: 'Item could not be processed', logger });
 
 		expect(order).toEqual(['start:a', 'end:a', 'start:b', 'end:b']);
+	});
+
+	// The leak this option exists to close: an internal failure must never reach
+	// a 200 response body verbatim, even though it is still an instance of
+	// `Error` and even though older code forwarded any `Error` message.
+	describe('an error that is not declared safe', () => {
+		it('is reported as the fallback reason, not its own message', async () => {
+			const perform = jest.fn().mockRejectedValue(new QueryFailedError('SELECT * FROM users WHERE id = ?'));
+
+			const result = await runBulkOperation(['a'], perform, {
+				fallbackReason: 'Item could not be processed',
+				safeErrors: [ModuleRefusalError],
+				logger,
+			});
+
+			expect(result.failed).toEqual([{ id: 'a', reason: 'Item could not be processed' }]);
+
+			// Assert the raw text is genuinely gone from what a client would receive,
+			// not merely that the reason happens to equal the fallback string.
+			const serialized = JSON.stringify(result);
+
+			expect(serialized).not.toContain('SELECT');
+			expect(serialized).not.toContain('users');
+		});
+
+		it('is logged server-side, so the failure leaves a trace somewhere', async () => {
+			const error = new QueryFailedError('SELECT * FROM users WHERE id = ?');
+			const perform = jest.fn().mockRejectedValue(error);
+			const errorSpy = jest.spyOn(logger, 'error');
+
+			await runBulkOperation(['a'], perform, {
+				fallbackReason: 'Item could not be processed',
+				safeErrors: [ModuleRefusalError],
+				logger,
+			});
+
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('id=a'), error);
+		});
 	});
 });

--- a/apps/backend/src/modules/api/utils/bulk.utils.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.ts
@@ -42,46 +42,67 @@ const readMessage = (error: Error): string | undefined => {
 };
 
 /**
+ * Answers whether a thrown value is one of the types the caller declared safe,
+ * without the question itself being able to throw.
+ *
+ * `instanceof` walks the value's prototype chain, and a `Proxy` answers that
+ * walk from a `getPrototypeOf` trap it controls. A throw there is a throw inside
+ * the catch block, which is the one thing that must not happen: anything not
+ * recognisably safe is reported as the fallback reason anyway, so refusing to
+ * classify a hostile value costs nothing.
+ */
+const isSafeError = (value: unknown, safeErrors: readonly SafeErrorClass[]): value is Error => {
+	try {
+		return safeErrors.some((SafeError) => value instanceof SafeError);
+	} catch {
+		return false;
+	}
+};
+
+/**
  * Describes a thrown value for the log, without the description itself being
  * able to throw.
  *
  * Nothing about a thrown value is safe to touch unguarded. `String(value)` runs
  * code the thrower controls - a `Symbol.toPrimitive`, or on a null-prototype
- * object no conversion at all - and an `Error` is no better: `message` and
- * `stack` are plain properties on the exceptions raised here, but a getter that
- * throws is a getter that throws inside the catch block, escaping it and
- * abandoning every item still to come. Collecting failures per item exists
- * precisely so one bad item cannot do that, so every read below is guarded.
+ * object no conversion at all. An `Error` is no better: `message` and `stack`
+ * are plain properties on the exceptions raised here, but a getter that throws
+ * is a getter that throws inside the catch block. Even asking what the value
+ * *is* can throw, from a `Proxy`'s `getPrototypeOf` trap. A throw here would
+ * escape the catch and abandon every item still to come, which is precisely what
+ * collecting failures per item exists to prevent - so each read is guarded for
+ * the sake of a better description, and the whole is guarded so that failing to
+ * describe the value at all is still an answer.
  */
 const describeThrown = (value: unknown): string => {
-	if (typeof value === 'string') {
-		return value;
-	}
-
-	if (value instanceof Error) {
-		try {
-			const { stack } = value;
-
-			if (typeof stack === 'string' && stack.length > 0) {
-				return stack;
-			}
-		} catch {
-			// Falls through to the message, which is guarded in turn.
+	try {
+		if (typeof value === 'string') {
+			return value;
 		}
 
-		return readMessage(value) ?? '<unreadable Error>';
-	}
+		if (value instanceof Error) {
+			try {
+				const { stack } = value;
 
-	if (value === undefined) {
-		return 'undefined';
-	}
+				if (typeof stack === 'string' && stack.length > 0) {
+					return stack;
+				}
+			} catch {
+				// Falls through to the message, which is guarded in turn.
+			}
 
-	try {
+			return readMessage(value) ?? '<unreadable Error>';
+		}
+
+		if (value === undefined) {
+			return 'undefined';
+		}
+
 		// Covers null, numbers and booleans too, and renders an object's fields
 		// rather than the `[object Object]` a plain conversion would produce.
-		return JSON.stringify(value) ?? `<unreadable ${typeof value}>`;
+		return JSON.stringify(value) ?? '<unreadable value>';
 	} catch {
-		return `<unreadable ${typeof value}>`;
+		return '<unreadable value>';
 	}
 };
 
@@ -133,8 +154,7 @@ export const runBulkOperation = async (
 
 			failure.id = id;
 
-			const isSafe = safeErrors.some((SafeError) => error instanceof SafeError);
-			const safeMessage = isSafe && error instanceof Error ? readMessage(error) : undefined;
+			const safeMessage = isSafeError(error, safeErrors) ? readMessage(error) : undefined;
 
 			if (typeof safeMessage === 'string') {
 				failure.reason = safeMessage;

--- a/apps/backend/src/modules/api/utils/bulk.utils.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.ts
@@ -1,4 +1,31 @@
+import { ExtensionLoggerService } from '../../../common/logger';
 import { BulkFailureModel, BulkResultModel } from '../models/bulk.model';
+
+/**
+ * A constructor for an `Error` subclass, used to name which thrown types are
+ * safe to forward to the client.
+ */
+type SafeErrorClass = new (...args: unknown[]) => Error;
+
+export interface RunBulkOperationOptions {
+	/** Reason reported for a failure whose message is not safe to forward. */
+	fallbackReason: string;
+	/**
+	 * Error constructors whose message is safe to return to the client - the
+	 * module's own exception types, the deliberate refusals a single-item
+	 * endpoint would also translate into a response. Anything thrown that is
+	 * not an instance of one of these is treated as unexpected and reported as
+	 * `fallbackReason` instead, so a TypeORM error, a subscriber, or a plugin
+	 * hook never forwards internal detail into the response. Defaults to none,
+	 * so an operation that forgets to declare any leaks nothing.
+	 */
+	safeErrors?: SafeErrorClass[];
+	/**
+	 * Records an unexpected failure server-side. Sanitizing that failure out of
+	 * the response would otherwise be the only trace it happened at all.
+	 */
+	logger: ExtensionLoggerService;
+}
 
 /**
  * Runs one operation across a selection and reports the outcome per item.
@@ -15,14 +42,24 @@ import { BulkFailureModel, BulkResultModel } from '../models/bulk.model';
  * @param ids Identifiers to act on. Duplicates are acted on once, so the counts
  *   the caller reports stay honest when a selection lists the same item twice.
  * @param perform Runs the operation for one identifier. Throwing marks that
- *   item failed; the thrown message becomes the reported reason, so refusals
- *   that carry an explanation keep it.
+ *   item failed. The thrown message becomes the reported reason only when the
+ *   error is an instance of one of `options.safeErrors` - the refusals that
+ *   carry an explanation worth keeping. Anything else is logged server-side
+ *   through `options.logger` and reported as `options.fallbackReason` instead,
+ *   so an unexpected failure never forwards its raw message to the client.
+ * @param options.fallbackReason Reason reported for a failure whose message is
+ *   not safe to forward.
+ * @param options.safeErrors Error constructors whose message is safe to
+ *   forward to the client.
+ * @param options.logger Records an unexpected failure server-side.
  */
 export const runBulkOperation = async (
 	ids: string[],
 	perform: (id: string) => Promise<void>,
-	fallbackReason = 'Item could not be processed',
+	options: RunBulkOperationOptions,
 ): Promise<BulkResultModel> => {
+	const { fallbackReason, safeErrors = [], logger } = options;
+
 	const result = new BulkResultModel();
 
 	result.succeeded = [];
@@ -37,7 +74,16 @@ export const runBulkOperation = async (
 			const failure = new BulkFailureModel();
 
 			failure.id = id;
-			failure.reason = error instanceof Error && error.message.length > 0 ? error.message : fallbackReason;
+
+			const isSafe = safeErrors.some((SafeError) => error instanceof SafeError);
+
+			if (isSafe && error instanceof Error && error.message.length > 0) {
+				failure.reason = error.message;
+			} else {
+				logger.error(`Bulk operation failed for id=${id}`, error instanceof Error ? error : String(error));
+
+				failure.reason = fallbackReason;
+			}
 
 			result.failed.push(failure);
 		}

--- a/apps/backend/src/modules/api/utils/bulk.utils.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.ts
@@ -28,6 +28,35 @@ export interface RunBulkOperationOptions {
 }
 
 /**
+ * Describes a thrown non-Error for the log, without the description itself
+ * being able to throw.
+ *
+ * `String(value)` runs code the thrower controls - a `Symbol.toPrimitive`, or
+ * on a null-prototype object no conversion at all - and a throw here would
+ * escape the catch, abandoning every item still to come. Collecting failures
+ * per item exists precisely so one bad item cannot do that. It also renders
+ * anything object-shaped as a useless `[object Object]`, so the fields are
+ * serialized instead where that is possible.
+ */
+const describeThrown = (value: unknown): string => {
+	if (value === undefined) {
+		return 'undefined';
+	}
+
+	if (typeof value === 'string') {
+		return value;
+	}
+
+	try {
+		// Covers null, numbers and booleans too, and renders an object's fields
+		// rather than the `[object Object]` a plain conversion would produce.
+		return JSON.stringify(value) ?? `<unreadable ${typeof value}>`;
+	} catch {
+		return `<unreadable ${typeof value}>`;
+	}
+};
+
+/**
  * Runs one operation across a selection and reports the outcome per item.
  *
  * Bulk endpoints exist because the per-item alternative was a request each,
@@ -80,7 +109,7 @@ export const runBulkOperation = async (
 			if (isSafe && error instanceof Error && error.message.length > 0) {
 				failure.reason = error.message;
 			} else {
-				logger.error(`Bulk operation failed for id=${id}`, error instanceof Error ? error : String(error));
+				logger.error(`Bulk operation failed for id=${id}`, error instanceof Error ? error : describeThrown(error));
 
 				failure.reason = fallbackReason;
 			}

--- a/apps/backend/src/modules/api/utils/bulk.utils.ts
+++ b/apps/backend/src/modules/api/utils/bulk.utils.ts
@@ -28,23 +28,52 @@ export interface RunBulkOperationOptions {
 }
 
 /**
- * Describes a thrown non-Error for the log, without the description itself
- * being able to throw.
+ * Reads a thrown `Error`'s own message, or `undefined` when there is nothing
+ * readable there.
+ */
+const readMessage = (error: Error): string | undefined => {
+	try {
+		const { message } = error;
+
+		return typeof message === 'string' && message.length > 0 ? message : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * Describes a thrown value for the log, without the description itself being
+ * able to throw.
  *
- * `String(value)` runs code the thrower controls - a `Symbol.toPrimitive`, or
- * on a null-prototype object no conversion at all - and a throw here would
- * escape the catch, abandoning every item still to come. Collecting failures
- * per item exists precisely so one bad item cannot do that. It also renders
- * anything object-shaped as a useless `[object Object]`, so the fields are
- * serialized instead where that is possible.
+ * Nothing about a thrown value is safe to touch unguarded. `String(value)` runs
+ * code the thrower controls - a `Symbol.toPrimitive`, or on a null-prototype
+ * object no conversion at all - and an `Error` is no better: `message` and
+ * `stack` are plain properties on the exceptions raised here, but a getter that
+ * throws is a getter that throws inside the catch block, escaping it and
+ * abandoning every item still to come. Collecting failures per item exists
+ * precisely so one bad item cannot do that, so every read below is guarded.
  */
 const describeThrown = (value: unknown): string => {
-	if (value === undefined) {
-		return 'undefined';
-	}
-
 	if (typeof value === 'string') {
 		return value;
+	}
+
+	if (value instanceof Error) {
+		try {
+			const { stack } = value;
+
+			if (typeof stack === 'string' && stack.length > 0) {
+				return stack;
+			}
+		} catch {
+			// Falls through to the message, which is guarded in turn.
+		}
+
+		return readMessage(value) ?? '<unreadable Error>';
+	}
+
+	if (value === undefined) {
+		return 'undefined';
 	}
 
 	try {
@@ -105,11 +134,15 @@ export const runBulkOperation = async (
 			failure.id = id;
 
 			const isSafe = safeErrors.some((SafeError) => error instanceof SafeError);
+			const safeMessage = isSafe && error instanceof Error ? readMessage(error) : undefined;
 
-			if (isSafe && error instanceof Error && error.message.length > 0) {
-				failure.reason = error.message;
+			if (typeof safeMessage === 'string') {
+				failure.reason = safeMessage;
 			} else {
-				logger.error(`Bulk operation failed for id=${id}`, error instanceof Error ? error : describeThrown(error));
+				// The description, never the value: the logger's own formatter reads
+				// `stack` and `message` off an `Error` it is handed, which would put an
+				// unguarded accessor right back into the path this catch has to survive.
+				logger.error(`Bulk operation failed for id=${id}`, describeThrown(error));
 
 				failure.reason = fallbackReason;
 			}

--- a/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.spec.ts
+++ b/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.spec.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemovePagesDto } from './bulk-pages.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkRemovePagesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemovePagesDto });
+
+describe('ReqBulkRemovePagesDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.ts
+++ b/apps/backend/src/modules/dashboard/dto/bulk-pages.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemovePagesDto {
 export class ReqBulkRemovePagesDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemovePagesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemovePagesDto)
 	data: BulkRemovePagesDto;

--- a/apps/backend/src/modules/dashboard/services/pages-bulk.service.spec.ts
+++ b/apps/backend/src/modules/dashboard/services/pages-bulk.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DashboardNotFoundException } from '../dashboard.exceptions';
+
 import { PagesBulkService } from './pages-bulk.service';
 import { PagesService } from './pages.service';
 
@@ -32,7 +34,9 @@ describe('PagesBulkService', () => {
 		// that explanation is more use to the operator than "failed".
 		it('carries the service refusal through as the reason', async () => {
 			pagesService.remove.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Requested page does not exist')) : Promise.resolve(),
+				id === 'b'
+					? Promise.reject(new DashboardNotFoundException('Requested page does not exist'))
+					: Promise.resolve(),
 			);
 
 			const result = await service.remove(['a', 'b', 'c']);

--- a/apps/backend/src/modules/dashboard/services/pages-bulk.service.ts
+++ b/apps/backend/src/modules/dashboard/services/pages-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { DASHBOARD_MODULE_NAME } from '../dashboard.constants';
+import { DashboardException } from '../dashboard.exceptions';
 
 import { PagesService } from './pages.service';
 
@@ -26,7 +27,7 @@ export class PagesBulkService {
 			// The service raises for a missing page with a reason worth reading, and
 			// runBulkOperation carries that through per item.
 			(id) => this.pagesService.remove(id),
-			'Page could not be removed',
+			{ fallbackReason: 'Page could not be removed', safeErrors: [DashboardException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);

--- a/apps/backend/src/modules/devices/dto/bulk-devices.dto.spec.ts
+++ b/apps/backend/src/modules/devices/dto/bulk-devices.dto.spec.ts
@@ -1,0 +1,52 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveDevicesDto, ReqBulkUpdateDevicesDto } from './bulk-devices.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRemoveRequest = (value: unknown): Promise<ReqBulkRemoveDevicesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveDevicesDto });
+
+const transformUpdateRequest = (value: unknown): Promise<ReqBulkUpdateDevicesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkUpdateDevicesDto });
+
+describe('ReqBulkRemoveDevicesDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRemoveRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRemoveRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRemoveRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});
+
+describe('ReqBulkUpdateDevicesDto', () => {
+	it('accepts a valid bulk update payload', async () => {
+		const request = await transformUpdateRequest({
+			data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'], enabled: true },
+		});
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+		expect(request.data.enabled).toBe(true);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformUpdateRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformUpdateRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/devices/dto/bulk-devices.dto.ts
+++ b/apps/backend/src/modules/devices/dto/bulk-devices.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -33,6 +33,7 @@ export class BulkRemoveDevicesDto {
 export class ReqBulkRemoveDevicesDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveDevicesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveDevicesDto)
 	data: BulkRemoveDevicesDto;
@@ -69,6 +70,7 @@ export class BulkUpdateDevicesDto {
 export class ReqBulkUpdateDevicesDto {
 	@ApiProperty({ description: 'Bulk update data', type: () => BulkUpdateDevicesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk update data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkUpdateDevicesDto)
 	data: BulkUpdateDevicesDto;

--- a/apps/backend/src/modules/devices/services/devices-bulk.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/devices-bulk.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DevicesNotAllowedException } from '../devices.exceptions';
 import { UpdateDeviceDto } from '../dto/update-device.dto';
 import { DeviceEntity } from '../entities/devices.entity';
 
@@ -52,7 +53,9 @@ describe('DevicesBulkService', () => {
 		it('keeps going after a device fails and reports it', async () => {
 			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
 			devicesService.remove.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Device is hidden and can not be removed')) : Promise.resolve(),
+				id === 'b'
+					? Promise.reject(new DevicesNotAllowedException('Device is hidden and can not be removed'))
+					: Promise.resolve(),
 			);
 
 			const result = await service.remove(['a', 'b', 'c']);
@@ -118,7 +121,7 @@ describe('DevicesBulkService', () => {
 
 		it('carries the refusal reason back rather than a generic message', async () => {
 			devicesService.findOne.mockImplementation((id: string) => Promise.resolve(device(id)));
-			devicesService.update.mockRejectedValue(new Error('Hidden device placement is immutable'));
+			devicesService.update.mockRejectedValue(new DevicesNotAllowedException('Hidden device placement is immutable'));
 
 			const result = await service.setEnabled(['a'], true);
 

--- a/apps/backend/src/modules/devices/services/devices-bulk.service.ts
+++ b/apps/backend/src/modules/devices/services/devices-bulk.service.ts
@@ -7,6 +7,7 @@ import { toInstance } from '../../../common/utils/transform.utils';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
+import { DevicesException, DevicesNotFoundException, DevicesValidationException } from '../devices.exceptions';
 import { CreateDeviceDto } from '../dto/create-device.dto';
 import { UpdateDeviceDto } from '../dto/update-device.dto';
 import { DeviceEntity } from '../entities/devices.entity';
@@ -38,7 +39,7 @@ export class DevicesBulkService {
 
 				await this.devicesService.remove(device.id);
 			},
-			'Device could not be removed',
+			{ fallbackReason: 'Device could not be removed', safeErrors: [DevicesException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
@@ -57,7 +58,7 @@ export class DevicesBulkService {
 				try {
 					mapping = this.devicesMapperService.getMapping<DeviceEntity, CreateDeviceDto, UpdateDeviceDto>(device.type);
 				} catch {
-					throw new Error(`Unsupported device type: ${device.type}`);
+					throw new DevicesException(`Unsupported device type: ${device.type}`);
 				}
 
 				// The single update endpoint routes the body through the type owner's
@@ -77,12 +78,12 @@ export class DevicesBulkService {
 				});
 
 				if (errors.length > 0) {
-					throw new Error('Device could not be updated');
+					throw new DevicesValidationException('Device could not be updated');
 				}
 
 				await this.devicesService.update(device.id, dtoInstance);
 			},
-			'Device could not be updated',
+			{ fallbackReason: 'Device could not be updated', safeErrors: [DevicesException], logger: this.logger },
 		);
 
 		this.logger.debug(
@@ -96,7 +97,7 @@ export class DevicesBulkService {
 		const device = await this.devicesService.findOne(id);
 
 		if (!device) {
-			throw new Error('Requested device does not exist');
+			throw new DevicesNotFoundException('Requested device does not exist');
 		}
 
 		return device;

--- a/apps/backend/src/modules/displays/dto/bulk-displays.dto.spec.ts
+++ b/apps/backend/src/modules/displays/dto/bulk-displays.dto.spec.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveDisplaysDto } from './bulk-displays.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkRemoveDisplaysDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveDisplaysDto });
+
+describe('ReqBulkRemoveDisplaysDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/displays/dto/bulk-displays.dto.ts
+++ b/apps/backend/src/modules/displays/dto/bulk-displays.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemoveDisplaysDto {
 export class ReqBulkRemoveDisplaysDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveDisplaysDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveDisplaysDto)
 	data: BulkRemoveDisplaysDto;

--- a/apps/backend/src/modules/displays/services/displays-bulk.service.spec.ts
+++ b/apps/backend/src/modules/displays/services/displays-bulk.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DisplaysNotFoundException } from '../displays.exceptions';
+
 import { DisplaysBulkService } from './displays-bulk.service';
 import { DisplaysService } from './displays.service';
 
@@ -33,7 +35,9 @@ describe('DisplaysBulkService', () => {
 		// "failed".
 		it('carries the service refusal through as the reason', async () => {
 			displaysService.remove.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Requested display does not exist')) : Promise.resolve(),
+				id === 'b'
+					? Promise.reject(new DisplaysNotFoundException('Requested display does not exist'))
+					: Promise.resolve(),
 			);
 
 			const result = await service.remove(['a', 'b', 'c']);

--- a/apps/backend/src/modules/displays/services/displays-bulk.service.ts
+++ b/apps/backend/src/modules/displays/services/displays-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { DISPLAYS_MODULE_NAME } from '../displays.constants';
+import { DisplaysNotFoundException } from '../displays.exceptions';
 
 import { DisplaysService } from './displays.service';
 
@@ -26,7 +27,11 @@ export class DisplaysBulkService {
 			// The service raises for a display that is not there with a reason worth
 			// reading, and runBulkOperation carries that through per item.
 			(id) => this.displaysService.remove(id),
-			'Display could not be removed',
+			{
+				fallbackReason: 'Display could not be removed',
+				safeErrors: [DisplaysNotFoundException],
+				logger: this.logger,
+			},
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);

--- a/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.spec.ts
+++ b/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.spec.ts
@@ -1,0 +1,31 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkUpdateExtensionsDto } from './bulk-extensions.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkUpdateExtensionsDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkUpdateExtensionsDto });
+
+describe('ReqBulkUpdateExtensionsDto', () => {
+	it('accepts a valid bulk update payload', async () => {
+		const request = await transformRequest({ data: { types: ['devices-shelly-ng-plugin'], enabled: true } });
+
+		expect(request.data.types).toEqual(['devices-shelly-ng-plugin']);
+		expect(request.data.enabled).toBe(true);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.ts
+++ b/apps/backend/src/modules/extensions/dto/bulk-extensions.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsString, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsDefined, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -45,6 +45,7 @@ export class BulkUpdateExtensionsDto {
 export class ReqBulkUpdateExtensionsDto {
 	@ApiProperty({ description: 'Bulk update data', type: () => BulkUpdateExtensionsDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk update data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkUpdateExtensionsDto)
 	data: BulkUpdateExtensionsDto;

--- a/apps/backend/src/modules/extensions/services/extensions-bulk.service.spec.ts
+++ b/apps/backend/src/modules/extensions/services/extensions-bulk.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { ExtensionNotConfigurableException } from '../extensions.exceptions';
+
 import { ExtensionsBulkService } from './extensions-bulk.service';
 import { ExtensionsService } from './extensions.service';
 
@@ -30,22 +32,22 @@ describe('ExtensionsBulkService', () => {
 	// endpoint addresses them too - there is no generated id to report against.
 	it('reports the failing extension by its type', async () => {
 		extensionsService.updateEnabled.mockImplementation((type: string) =>
-			type === 'devices-module'
-				? Promise.reject(new Error('Extension devices-module is not configurable'))
-				: Promise.resolve(),
+			type === 'devices-module' ? Promise.reject(new ExtensionNotConfigurableException(type)) : Promise.resolve(),
 		);
 
 		const result = await service.setEnabled(['devices-wled-plugin', 'devices-module'], false);
 
 		expect(result.succeeded).toEqual(['devices-wled-plugin']);
-		expect(result.failed).toEqual([{ id: 'devices-module', reason: 'Extension devices-module is not configurable' }]);
+		expect(result.failed).toEqual([
+			{ id: 'devices-module', reason: "Extension 'devices-module' does not support enable/disable configuration." },
+		]);
 	});
 
 	// A core extension refusing must not take the rest of the selection with it -
 	// the admin's "disable all" is a set of independent intents.
 	it('keeps going after a core extension refuses', async () => {
 		extensionsService.updateEnabled.mockImplementation((type: string) =>
-			type === 'core' ? Promise.reject(new Error('Extension core is not configurable')) : Promise.resolve(),
+			type === 'core' ? Promise.reject(new ExtensionNotConfigurableException(type)) : Promise.resolve(),
 		);
 
 		const result = await service.setEnabled(['a', 'core', 'b'], false);

--- a/apps/backend/src/modules/extensions/services/extensions-bulk.service.ts
+++ b/apps/backend/src/modules/extensions/services/extensions-bulk.service.ts
@@ -4,6 +4,11 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { EXTENSIONS_MODULE_NAME } from '../extensions.constants';
+import {
+	ExtensionConfigValidationException,
+	ExtensionNotConfigurableException,
+	ExtensionNotFoundException,
+} from '../extensions.exceptions';
 
 import { ExtensionsService } from './extensions.service';
 
@@ -33,7 +38,11 @@ export class ExtensionsBulkService {
 			async (type) => {
 				await this.extensionsService.updateEnabled(type, enabled);
 			},
-			'Extension could not be updated',
+			{
+				fallbackReason: 'Extension could not be updated',
+				safeErrors: [ExtensionNotFoundException, ExtensionNotConfigurableException, ExtensionConfigValidationException],
+				logger: this.logger,
+			},
 		);
 
 		this.logger.debug(

--- a/apps/backend/src/modules/scenes/dto/bulk-scenes.dto.spec.ts
+++ b/apps/backend/src/modules/scenes/dto/bulk-scenes.dto.spec.ts
@@ -1,0 +1,52 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveScenesDto, ReqBulkUpdateScenesDto } from './bulk-scenes.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRemoveRequest = (value: unknown): Promise<ReqBulkRemoveScenesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveScenesDto });
+
+const transformUpdateRequest = (value: unknown): Promise<ReqBulkUpdateScenesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkUpdateScenesDto });
+
+describe('ReqBulkRemoveScenesDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRemoveRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRemoveRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRemoveRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});
+
+describe('ReqBulkUpdateScenesDto', () => {
+	it('accepts a valid bulk update payload', async () => {
+		const request = await transformUpdateRequest({
+			data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'], enabled: true },
+		});
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+		expect(request.data.enabled).toBe(true);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformUpdateRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformUpdateRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/scenes/dto/bulk-scenes.dto.ts
+++ b/apps/backend/src/modules/scenes/dto/bulk-scenes.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsBoolean, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemoveScenesDto {
 export class ReqBulkRemoveScenesDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveScenesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveScenesDto)
 	data: BulkRemoveScenesDto;
@@ -67,6 +68,7 @@ export class BulkUpdateScenesDto {
 export class ReqBulkUpdateScenesDto {
 	@ApiProperty({ description: 'Bulk update data', type: () => BulkUpdateScenesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk update data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkUpdateScenesDto)
 	data: BulkUpdateScenesDto;

--- a/apps/backend/src/modules/scenes/services/scenes-bulk.service.spec.ts
+++ b/apps/backend/src/modules/scenes/services/scenes-bulk.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { ScenesNotEditableException, ScenesNotFoundException } from '../scenes.exceptions';
+
 import { ScenesBulkService } from './scenes-bulk.service';
 import { ScenesService } from './scenes.service';
 
@@ -33,7 +35,9 @@ describe('ScenesBulkService', () => {
 		// and that explanation is more use to the operator than "failed".
 		it('carries the service refusal through as the reason', async () => {
 			scenesService.remove.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Scene with id=b cannot be deleted.')) : Promise.resolve(),
+				id === 'b'
+					? Promise.reject(new ScenesNotEditableException('Scene with id=b cannot be deleted.'))
+					: Promise.resolve(),
 			);
 
 			const result = await service.remove(['a', 'b', 'c']);
@@ -64,7 +68,7 @@ describe('ScenesBulkService', () => {
 		});
 
 		it('reports a scene the service refused', async () => {
-			scenesService.update.mockRejectedValue(new Error('Scene with id=a was not found.'));
+			scenesService.update.mockRejectedValue(new ScenesNotFoundException('Scene with id=a was not found.'));
 
 			const result = await service.setEnabled(['a'], true);
 

--- a/apps/backend/src/modules/scenes/services/scenes-bulk.service.ts
+++ b/apps/backend/src/modules/scenes/services/scenes-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger/extension-logger.s
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { SCENES_MODULE_NAME } from '../scenes.constants';
+import { ScenesException } from '../scenes.exceptions';
 
 import { ScenesService } from './scenes.service';
 
@@ -26,7 +27,7 @@ export class ScenesBulkService {
 			// The service raises for a missing or non-deletable scene with a reason
 			// worth reading, and runBulkOperation carries that through per item.
 			(id) => this.scenesService.remove(id),
-			'Scene could not be removed',
+			{ fallbackReason: 'Scene could not be removed', safeErrors: [ScenesException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);
@@ -40,7 +41,7 @@ export class ScenesBulkService {
 			async (id) => {
 				await this.scenesService.update(id, { enabled });
 			},
-			'Scene could not be updated',
+			{ fallbackReason: 'Scene could not be updated', safeErrors: [ScenesException], logger: this.logger },
 		);
 
 		this.logger.debug(

--- a/apps/backend/src/modules/spaces/dto/bulk-assign.dto.spec.ts
+++ b/apps/backend/src/modules/spaces/dto/bulk-assign.dto.spec.ts
@@ -1,0 +1,40 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkAssignDto } from './bulk-assign.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkAssignDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkAssignDto });
+
+describe('ReqBulkAssignDto', () => {
+	it('accepts a valid bulk assignment payload', async () => {
+		const request = await transformRequest({ data: { device_ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.deviceIds).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+
+	// The inner shape allows both device_ids and display_ids to be omitted, so an
+	// explicit but empty envelope is a different case from an absent one - it is
+	// still a defined object and must keep passing.
+	it('still accepts an explicitly empty data object', async () => {
+		const request = await transformRequest({ data: {} });
+
+		expect(request.data.deviceIds).toBeUndefined();
+		expect(request.data.displayIds).toBeUndefined();
+	});
+});

--- a/apps/backend/src/modules/spaces/dto/bulk-assign.dto.ts
+++ b/apps/backend/src/modules/spaces/dto/bulk-assign.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsArray, IsOptional, IsUUID, ValidateNested } from 'class-validator';
+import { IsArray, IsDefined, IsOptional, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger';
 
@@ -46,6 +46,7 @@ export class ReqBulkAssignDto {
 		type: () => BulkAssignDto,
 	})
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk assignment data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkAssignDto)
 	data: BulkAssignDto;

--- a/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.spec.ts
+++ b/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.spec.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveSpacesDto } from './bulk-spaces.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkRemoveSpacesDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveSpacesDto });
+
+describe('ReqBulkRemoveSpacesDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.ts
+++ b/apps/backend/src/modules/spaces/dto/bulk-spaces.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemoveSpacesDto {
 export class ReqBulkRemoveSpacesDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveSpacesDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveSpacesDto)
 	data: BulkRemoveSpacesDto;

--- a/apps/backend/src/modules/spaces/services/spaces-bulk.service.ts
+++ b/apps/backend/src/modules/spaces/services/spaces-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { SPACES_MODULE_NAME } from '../spaces.constants';
+import { SpacesNotFoundException } from '../spaces.exceptions';
 
 import { SpacesService } from './spaces.service';
 
@@ -26,7 +27,7 @@ export class SpacesBulkService {
 			// The service raises for a missing space with a reason worth reading, and
 			// runBulkOperation carries that through per item.
 			(id) => this.spacesService.remove(id),
-			'Space could not be removed',
+			{ fallbackReason: 'Space could not be removed', safeErrors: [SpacesNotFoundException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);

--- a/apps/backend/src/modules/users/dto/bulk-users.dto.spec.ts
+++ b/apps/backend/src/modules/users/dto/bulk-users.dto.spec.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveUsersDto } from './bulk-users.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkRemoveUsersDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveUsersDto });
+
+describe('ReqBulkRemoveUsersDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/users/dto/bulk-users.dto.ts
+++ b/apps/backend/src/modules/users/dto/bulk-users.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemoveUsersDto {
 export class ReqBulkRemoveUsersDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveUsersDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveUsersDto)
 	data: BulkRemoveUsersDto;

--- a/apps/backend/src/modules/users/services/users-bulk.service.ts
+++ b/apps/backend/src/modules/users/services/users-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { USERS_MODULE_NAME, UserRole } from '../users.constants';
+import { UsersException, UsersNotAllowedException } from '../users.exceptions';
 
 import { UsersService } from './users.service';
 
@@ -35,16 +36,16 @@ export class UsersBulkService {
 				const user = await this.usersService.getOneOrThrow(id);
 
 				if (authenticatedUserId !== null && authenticatedUserId === user.id) {
-					throw new Error('You cannot delete your own account');
+					throw new UsersNotAllowedException('You cannot delete your own account');
 				}
 
 				if (user.role === UserRole.OWNER) {
-					throw new Error('The owner account cannot be deleted');
+					throw new UsersNotAllowedException('The owner account cannot be deleted');
 				}
 
 				await this.usersService.remove(user.id);
 			},
-			'User could not be removed',
+			{ fallbackReason: 'User could not be removed', safeErrors: [UsersException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);

--- a/apps/backend/src/modules/users/users.exceptions.ts
+++ b/apps/backend/src/modules/users/users.exceptions.ts
@@ -18,3 +18,10 @@ export class UsersValidationException extends UsersException {
 		this.name = 'UsersValidationException';
 	}
 }
+
+export class UsersNotAllowedException extends UsersException {
+	constructor(message: string) {
+		super(message);
+		this.name = 'UsersNotAllowedException';
+	}
+}

--- a/apps/backend/src/modules/weather/dto/bulk-locations.dto.spec.ts
+++ b/apps/backend/src/modules/weather/dto/bulk-locations.dto.spec.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+
+import { ReqBulkRemoveLocationsDto } from './bulk-locations.dto';
+
+// Same options as the global pipe registered in main.ts.
+const pipe = new ValidationPipe({
+	transform: true,
+	whitelist: true,
+	forbidNonWhitelisted: true,
+	transformOptions: { enableImplicitConversion: true },
+});
+
+const transformRequest = (value: unknown): Promise<ReqBulkRemoveLocationsDto> =>
+	pipe.transform(value, { type: 'body', metatype: ReqBulkRemoveLocationsDto });
+
+describe('ReqBulkRemoveLocationsDto', () => {
+	it('accepts a valid bulk removal payload', async () => {
+		const request = await transformRequest({ data: { ids: ['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6'] } });
+
+		expect(request.data.ids).toEqual(['f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6']);
+	});
+
+	it('rejects an empty request body with a 400 instead of leaving data undefined', async () => {
+		await expect(transformRequest({})).rejects.toThrow(BadRequestException);
+	});
+
+	it('rejects a null data envelope', async () => {
+		await expect(transformRequest({ data: null })).rejects.toThrow(BadRequestException);
+	});
+});

--- a/apps/backend/src/modules/weather/dto/bulk-locations.dto.ts
+++ b/apps/backend/src/modules/weather/dto/bulk-locations.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsDefined, IsUUID, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 
@@ -31,6 +31,7 @@ export class BulkRemoveLocationsDto {
 export class ReqBulkRemoveLocationsDto {
 	@ApiProperty({ description: 'Bulk removal data', type: () => BulkRemoveLocationsDto })
 	@Expose()
+	@IsDefined({ message: '[{"field":"data","reason":"Bulk removal data is required."}]' })
 	@ValidateNested()
 	@Type(() => BulkRemoveLocationsDto)
 	data: BulkRemoveLocationsDto;

--- a/apps/backend/src/modules/weather/services/locations-bulk.service.spec.ts
+++ b/apps/backend/src/modules/weather/services/locations-bulk.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { WeatherValidationException } from '../weather.exceptions';
+import { WeatherNotFoundException, WeatherValidationException } from '../weather.exceptions';
 
 import { LocationsBulkService } from './locations-bulk.service';
 import { LocationsService } from './locations.service';
@@ -34,7 +34,7 @@ describe('LocationsBulkService', () => {
 		// and that explanation is more use to the operator than "failed".
 		it('carries the service refusal through as the reason', async () => {
 			locationsService.remove.mockImplementation((id: string) =>
-				id === 'b' ? Promise.reject(new Error('Location does not exist')) : Promise.resolve(),
+				id === 'b' ? Promise.reject(new WeatherNotFoundException('Location does not exist')) : Promise.resolve(),
 			);
 
 			const result = await service.remove(['a', 'b', 'c']);

--- a/apps/backend/src/modules/weather/services/locations-bulk.service.ts
+++ b/apps/backend/src/modules/weather/services/locations-bulk.service.ts
@@ -4,6 +4,7 @@ import { createExtensionLogger } from '../../../common/logger';
 import { BulkResultModel } from '../../api/models/bulk.model';
 import { runBulkOperation } from '../../api/utils/bulk.utils';
 import { WEATHER_MODULE_NAME } from '../weather.constants';
+import { WeatherException } from '../weather.exceptions';
 
 import { LocationsService } from './locations.service';
 
@@ -27,7 +28,7 @@ export class LocationsBulkService {
 			// refuses to delete, with a reason worth reading; runBulkOperation
 			// carries that through per item.
 			(id) => this.locationsService.remove(id),
-			'Location could not be removed',
+			{ fallbackReason: 'Location could not be removed', safeErrors: [WeatherException], logger: this.logger },
 		);
 
 		this.logger.debug(`Bulk removal finished succeeded=${result.succeeded.length} failed=${result.failed.length}`);


### PR DESCRIPTION
Addresses two Codex findings on already-merged PRs: the raw-error-message leak flagged on #794, and the empty-envelope 500 flagged on #799. Both live in the shared bulk plumbing, so they are fixed together.

## Unexpected errors were returned to the client

`runBulkOperation` reported `error.message` for **any** thrown `Error`, inside a **200** response. A TypeORM failure, a subscriber, or a plugin hook therefore put its raw message — SQL, schema, filesystem paths — into the response body. The single-item endpoints never behave this way: they translate their module's own exception into a fixed sentence and let anything else become a sanitized 500. Since #798 centralised the helper, this applied to all ten bulk endpoints across eight modules.

**The obvious fix would have been wrong.** "Only forward module exceptions" sounds right, but the bulk services raised their deliberate refusals as plain `Error`s — `'The owner account cannot be deleted'`, `'Unsupported device type: …'` — so keying on an exception base would have dropped exactly the messages worth keeping and forwarded nothing useful. Fifteen such strings are pinned by existing specs.

So the callers now declare what is safe instead of the helper inferring it:

```ts
runBulkOperation(ids, perform, {
    fallbackReason: 'Device could not be removed',
    safeErrors: [DevicesException],
    logger: this.logger,
})
```

`safeErrors` defaults to empty, so an operation that declares nothing leaks nothing rather than everything. The refusals the bulk services raise themselves became their module's exception type — **no message text changed** — and each call site whitelists the base its underlying service actually throws, chosen by reading those services rather than assuming.

Unexpected failures are now **logged**. Sanitizing one out of the response would otherwise leave no trace it happened at all, which is much of why this went unnoticed.

## An empty body was a 500, not a 400

`@ValidateNested()` has nothing to validate when `data` is absent, and nothing else required it, so `{}` passed the pipe and the controllers then dereferenced `body.data.ids`. Verified against the app's real pipe configuration:

| body | before |
|---|---|
| `{}` | accepted → `body.data` undefined → **500** |
| `{ data: {} }` | 400 |
| `{ data: { ids: [] } }` | 400 |
| valid | accepted |

Only the missing envelope slipped through. `@IsDefined()` is added to all eleven wrappers, with a spec per DTO file — none existed, and the single controller spec that touches a bulk DTO calls the method directly, bypassing validation entirely, so it could never have caught this.

`bulk-assign` still accepts `{ data: {} }`: both of its inner arrays are optional by design. A test pins that, so the two cases stay distinguishable.

## Verification

- Backend unit: **401 suites / 4925 tests**, green
- `lint:js` (0 errors), `lint:api`, `lint:openapi` all pass
- Both fixes mutation-tested. Restoring the unconditional `error.message` makes the leak test fail on the raw SQL text and the logging assertion fail; removing an `@IsDefined()` makes that DTO's empty-body test fail while its siblings stay green.

## Review follow-up: guarding the reads inside the catch

Codex followed up that `String(error)` was only half the problem, and it was right. Guarding the
non-`Error` conversion left `error.message` read directly on the safe path, and the raw value
handed to `ExtensionLoggerService`, whose formatter evaluates `context.stack || context.message`.
An `Error` subclass with a throwing `message` or `stack` accessor therefore still threw inside the
catch, escaped it, and abandoned every item still to come — the exact failure the first fix was
meant to close.

Both reads now go through a guard and only the resulting string reaches the logger. Four new tests
cover it, and all four fail against the previous revision.

**And the classification was still unguarded.** `error instanceof SafeError` walks the value's
prototype chain, which a `Proxy` answers from a `getPrototypeOf` trap it controls, so a hostile
rejection threw out of the catch before reaching any of the guarded reads. I had considered this
while writing the previous fix and judged it too exotic to guard — the wrong call, given the whole
purpose of the helper is that no single item can abandon the rest of the selection. `isSafeError()`
now answers behind a guard and `describeThrown()` has an outer one, so failing to describe a value
is still an answer rather than a throw.

## A note on the third finding

Codex also flagged, on #794, that a `findOne` rejection escapes per-item handling in `devices-bulk.service.ts`. That was **correct for the code it reviewed** — at #794's head the lookup sat outside the `try`, so a transient read failure would have aborted the whole bulk after earlier items had already committed.

It is already fixed, though not deliberately: #798 extracted `runBulkOperation` and moved the lookup inside the `perform` callback, which the helper wraps in `try`/`catch`. A rejecting `findOne` is now recorded as a per-item failure and the remaining items still run. Nothing more is needed here; noted so the finding does not get re-raised as outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


