### PR TITLE
fix(admin): stop stale responses overwriting confirmed writes

### DIFF
--- a/apps/admin/src/modules/config/store/config-modules.store.schemas.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.schemas.ts
@@ -40,6 +40,10 @@ export const ConfigModulesSetActionPayloadSchema = z.object({
 
 export const ConfigModulesGetActionPayloadSchema = z.object({
 	type: z.string(),
+	// Opt-in, default off so existing callers keep coalescing onto an in-flight request. A
+	// change-driven refresh sets it to force a genuinely fresh read instead of reusing one that may
+	// have been taken before the change it is reacting to. See `get()` in config-modules.store.ts.
+	force: z.boolean().optional(),
 });
 
 export const ConfigModulesEditActionPayloadSchema = z.object({

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -271,10 +271,11 @@ describe('ConfigModule Store', () => {
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
 	});
 
-	// The other side of that window. Once the edit's answer is in hand the entry is released, and a
-	// read issued after the edit went out is the newer story again - which is why the edit response
-	// takes its number when the request was sent rather than when it came back.
-	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+	// The same window seen from the other end: a read issued while the write was outstanding is
+	// dropped whenever it lands, not only when it lands first. Its snapshot may have been taken
+	// either side of the write and nothing here can tell which, so the entry keeps the confirmed
+	// edit - reverting one of those is the worse of the two mistakes.
+	it('drops a refresh issued during an edit even when it lands after the edit', async () => {
 		let resolvePatch!: (value: unknown) => void;
 		let resolveGet!: (value: unknown) => void;
 
@@ -293,7 +294,7 @@ describe('ConfigModule Store', () => {
 
 		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
 
-		// Issued after the PATCH went out, and answered after it comes back.
+		// Issued while the PATCH is still outstanding.
 		const pendingGet = store.get({ type: 'custom-module', force: true });
 
 		resolvePatch({
@@ -304,13 +305,34 @@ describe('ConfigModule Store', () => {
 
 		await pendingEdit;
 
-		resolveGet({
+		// And answered only afterwards, with what the server held before the edit was committed.
+		resolveGet({ data: { data: mockModuleRes }, error: undefined, response: { status: 200 } });
+
+		await pendingGet;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
+	});
+
+	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a
+	// refresh issued after that overlaps nothing and is the newer story again.
+	it('applies a refresh issued once the edit has settled', async () => {
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		(backendClient.GET as Mock).mockResolvedValueOnce({
 			data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
 			error: undefined,
 			response: { status: 200 },
 		});
 
-		await pendingGet;
+		await store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		await store.get({ type: 'custom-module', force: true });
 
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else');
 	});

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -209,10 +209,10 @@ describe('ConfigModule Store', () => {
 		expect(store.firstLoadFinished()).toBe(true);
 	});
 
-	// The race the mutation-token stamp exists to prevent: a change event fires a `get()` for the
+	// The race the sequence exists to prevent: a change event fires a `get()` for the
 	// changed type while an already-in-flight `fetch()` is still reading the pre-change configuration.
-	// Without the stamp, `fetch()`'s wholesale replace lands after `get()` and wipes it out with the
-	// older snapshot, so the admin stays stale until something else happens to refresh it.
+	// Without the ordering, `fetch()`'s wholesale replace lands after `get()` and wipes it out with
+	// the older snapshot, so the admin stays stale until something else happens to refresh it.
 	it('keeps an entry refreshed by get() while fetch() is in flight, rather than restoring the snapshot it answers with', async () => {
 		let resolveFetch!: (value: unknown) => void;
 
@@ -286,6 +286,113 @@ describe('ConfigModule Store', () => {
 		expect(firstResult).toEqual(mockModule);
 		expect((forcedResult as ICustomModuleConfig).mockValue).toBe('forced value');
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('forced value');
+	});
+
+	// Ordering by when a response lands is not the same as ordering by when it was asked for, and
+	// only the second is meaningful: a read describes the moment its request went out. An entry
+	// `get()` issued before this `fetch()` and answered during it is the older story of the two, so
+	// the list response — asked for later — is the one worth keeping.
+	it('applies the fetch response over an entry read that was issued before it', async () => {
+		let resolveGet!: (value: unknown) => void;
+		let resolveFetch!: (value: unknown) => void;
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockReturnValueOnce(fetchRequest);
+
+		const pendingGet = store.get({ type: 'custom-module' });
+		const pendingFetch = store.fetch();
+
+		// The earlier request is answered first, and with what the server held before the change.
+		resolveGet({ data: { data: { ...mockModuleRes, mockValue: 'stale value' } } });
+		await pendingGet;
+
+		resolveFetch({ data: { data: [{ ...mockModuleRes, mockValue: 'current value' }] } });
+		await pendingFetch;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('current value');
+	});
+
+	// Two change events for the same type can land together. Both forced refreshes then wait on the
+	// one request already in flight and both resume, so unless they are queued the second finds the
+	// semaphore still held by the first and is rejected out of hand.
+	it('serializes forced refreshes that arrive together instead of rejecting the second', async () => {
+		let resolveFirst!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		(backendClient.GET as Mock)
+			.mockReturnValueOnce(firstRequest)
+			.mockResolvedValueOnce({
+				data: { data: { ...mockModuleRes, mockValue: 'first refresh' } },
+				error: undefined,
+				response: { status: 200 },
+			})
+			.mockResolvedValueOnce({
+				data: { data: { ...mockModuleRes, mockValue: 'second refresh' } },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+		const firstGet = store.get({ type: 'custom-module' });
+		const forcedFirst = store.get({ type: 'custom-module', force: true });
+		const forcedSecond = store.get({ type: 'custom-module', force: true });
+
+		resolveFirst({ data: { data: mockModuleRes } });
+
+		const [, firstRefresh, secondRefresh] = await Promise.all([firstGet, forcedFirst, forcedSecond]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+		expect((firstRefresh as ICustomModuleConfig).mockValue).toBe('first refresh');
+		expect((secondRefresh as ICustomModuleConfig).mockValue).toBe('second refresh');
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('second refresh');
+	});
+
+	// The registration a call retires has to be its own. A forced refresh registers itself in place
+	// of the read it is waiting on, so that earlier read finishing would otherwise delete the
+	// successor's entry — and the next caller, finding nothing registered, starts a competing
+	// request that collides with the one still in flight.
+	it('leaves a forced successor registered once the read it waited on finishes', async () => {
+		let resolveFirst!: (value: unknown) => void;
+		let resolveForced!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		const forcedRequest = new Promise((resolve) => {
+			resolveForced = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(firstRequest).mockReturnValueOnce(forcedRequest);
+
+		const firstGet = store.get({ type: 'custom-module' });
+		const forcedGet = store.get({ type: 'custom-module', force: true });
+
+		resolveFirst({ data: { data: mockModuleRes } });
+		await firstGet;
+
+		// Wait for the forced successor to take over and issue its own request.
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
+
+		// Arrives while that refresh is in flight, so it should be handed the same request.
+		const joinedGet = store.get({ type: 'custom-module' });
+
+		resolveForced({ data: { data: { ...mockModuleRes, mockValue: 'forced value' } } });
+
+		const [forcedResult, joinedResult] = await Promise.all([forcedGet, joinedGet]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+		expect((forcedResult as ICustomModuleConfig).mockValue).toBe('forced value');
+		expect((joinedResult as ICustomModuleConfig).mockValue).toBe('forced value');
 	});
 
 	it('should handle onEvent and update module config', () => {

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -209,6 +209,85 @@ describe('ConfigModule Store', () => {
 		expect(store.firstLoadFinished()).toBe(true);
 	});
 
+	// The race the mutation-token stamp exists to prevent: a change event fires a `get()` for the
+	// changed type while an already-in-flight `fetch()` is still reading the pre-change configuration.
+	// Without the stamp, `fetch()`'s wholesale replace lands after `get()` and wipes it out with the
+	// older snapshot, so the admin stays stale until something else happens to refresh it.
+	it('keeps an entry refreshed by get() while fetch() is in flight, rather than restoring the snapshot it answers with', async () => {
+		let resolveFetch!: (value: unknown) => void;
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(fetchRequest).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'fresh value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingFetch = store.fetch();
+
+		// The change-driven refresh lands before the response the server assembled ahead of it.
+		await store.get({ type: 'custom-module' });
+
+		resolveFetch({ data: { data: [mockModuleRes] } });
+		await pendingFetch;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('fresh value');
+	});
+
+	// The other half of the same rule: an entry the response *does* carry, and that nothing has
+	// touched since the request went out, is still applied — otherwise this guard would freeze the
+	// store rather than merely protecting entries genuinely written since the request was made.
+	it('applies an entry the fetch response carries when nothing has written it since the request went out', async () => {
+		let resolveFetch!: (value: unknown) => void;
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(fetchRequest);
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		const pendingFetch = store.fetch();
+
+		resolveFetch({ data: { data: [{ ...mockModuleRes, mockValue: 'server value' }] } });
+		await pendingFetch;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('server value');
+	});
+
+	// The other race: a change event calling `get({ force: true })` while an earlier `get()` for the
+	// same type is still in flight must not just hand back that older request's answer. It should wait
+	// for it to settle, then issue a genuinely new request.
+	it('issues a new request for a forced get() instead of reusing an in-flight one', async () => {
+		let resolveFirst!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(firstRequest).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'forced value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const firstGet = store.get({ type: 'custom-module' });
+		const forcedGet = store.get({ type: 'custom-module', force: true });
+
+		resolveFirst({ data: { data: mockModuleRes } });
+
+		const [firstResult, forcedResult] = await Promise.all([firstGet, forcedGet]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+		expect(firstResult).toEqual(mockModule);
+		expect((forcedResult as ICustomModuleConfig).mockValue).toBe('forced value');
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('forced value');
+	});
+
 	it('should handle onEvent and update module config', () => {
 		const eventPayload = {
 			type: 'custom-module',

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -66,6 +66,8 @@ vi.mock('../composables/useModules', () => ({
 	}),
 }));
 
+const mockLoggerError = vi.fn();
+
 vi.mock('../../../common', async () => {
 	const actual = await vi.importActual('../../../common');
 
@@ -75,7 +77,7 @@ vi.mock('../../../common', async () => {
 			client: backendClient,
 		})),
 		useLogger: vi.fn(() => ({
-			error: vi.fn(),
+			error: mockLoggerError,
 			info: vi.fn(),
 			warning: vi.fn(),
 			log: vi.fn(),
@@ -94,6 +96,7 @@ describe('ConfigModule Store', () => {
 		store = useConfigModule();
 
 		vi.clearAllMocks();
+		mockLoggerError.mockClear();
 	});
 
 	it('should set config Module data successfully', () => {
@@ -371,6 +374,51 @@ describe('ConfigModule Store', () => {
 		await vi.waitFor(() => expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else'));
 
 		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+	});
+
+	// That deferred read is the only attempt left that can bring in whatever the dropped one was
+	// carrying, and the event handler that started it has long since resolved. A failure there has
+	// nowhere else to surface, so it must not be swallowed.
+	it('reports a deferred refresh that fails rather than losing it silently', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock)
+			.mockResolvedValueOnce({
+				data: { data: mockModuleRes },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// The deferred read, which the backend refuses.
+			.mockResolvedValueOnce({
+				data: undefined,
+				error: new Error('Read error'),
+				response: { status: 500 },
+			});
+
+		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		await store.get({ type: 'custom-module', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		await vi.waitFor(() => expect(mockLoggerError).toHaveBeenCalledWith(expect.stringContaining('re-read'), expect.anything()));
+
+		// The entry keeps this client's confirmed value rather than being left in some other state.
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
 	});
 
 	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -247,12 +247,19 @@ describe('ConfigModule Store', () => {
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
 
-		// What the server still holds, because it has not committed the edit yet.
-		(backendClient.GET as Mock).mockResolvedValueOnce({
-			data: { data: mockModuleRes },
-			error: undefined,
-			response: { status: 200 },
-		});
+		(backendClient.GET as Mock)
+			// What the server still holds, because it has not committed the edit yet.
+			.mockResolvedValueOnce({
+				data: { data: mockModuleRes },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// And what it holds once it has - the read the store asks for after the write settles.
+			.mockResolvedValueOnce({
+				data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+				error: undefined,
+				response: { status: 200 },
+			});
 
 		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
 
@@ -267,6 +274,8 @@ describe('ConfigModule Store', () => {
 		});
 
 		await pendingEdit;
+
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
 
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
 	});
@@ -290,7 +299,12 @@ describe('ConfigModule Store', () => {
 		store.data = { [mockModule.type]: { ...mockModule } };
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
-		(backendClient.GET as Mock).mockReturnValueOnce(getRequest);
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
 
 		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
 
@@ -310,7 +324,53 @@ describe('ConfigModule Store', () => {
 
 		await pendingGet;
 
+		// Dropped, and asked again now that the write is done.
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
+
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
+	});
+
+	// Dropping an overlapping read loses whatever prompted it. A change event is the backend saying
+	// something changed without saying whose change it was, so a refresh reacting to one may be
+	// carrying another client's edit - and silently discarding it would leave that lost until
+	// something else happened to refresh. It is asked again once the write is out of the way.
+	it('asks again after the edit when a change-driven refresh had to be dropped', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock).mockResolvedValue({
+			data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		// The change event's refresh, issued and answered while the PATCH is still outstanding.
+		await store.get({ type: 'custom-module', force: true });
+
+		// Dropped, because nothing here can tell it apart from a read taken before the edit landed.
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
+
+		resolvePatch({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		// Asked again now that the write is done, and this time the answer stands.
+		await vi.waitFor(() => expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else'));
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
 	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -233,11 +233,10 @@ describe('ConfigModule Store', () => {
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('server value');
 	});
 
-	// A successful PATCH answers with the configuration as of the moment the server was asked, so
-	// in that respect it is a read like any other. A refresh issued after it - a change event
-	// reacting to somebody else's edit, say - describes a later moment and must win, even when the
-	// slower PATCH response lands after it.
-	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+	// A read issued while an edit is in flight cannot be trusted to include it: the server may not
+	// have committed the write when it answered. So for as long as the write is outstanding the
+	// entry is held, and a refresh landing inside that window is dropped rather than applied.
+	it('keeps a pending edit when a refresh is answered before the edit is', async () => {
 		let resolvePatch!: (value: unknown) => void;
 
 		const patchRequest = new Promise((resolve) => {
@@ -248,16 +247,18 @@ describe('ConfigModule Store', () => {
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
 
+		// What the server still holds, because it has not committed the edit yet.
 		(backendClient.GET as Mock).mockResolvedValueOnce({
-			data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
+			data: { data: mockModuleRes },
 			error: undefined,
 			response: { status: 200 },
 		});
 
 		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
 
-		// Issued after the PATCH went out, and answered before it comes back.
 		await store.get({ type: 'custom-module', force: true });
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
 
 		resolvePatch({
 			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
@@ -266,6 +267,50 @@ describe('ConfigModule Store', () => {
 		});
 
 		await pendingEdit;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
+	});
+
+	// The other side of that window. Once the edit's answer is in hand the entry is released, and a
+	// read issued after the edit went out is the newer story again - which is why the edit response
+	// takes its number when the request was sent rather than when it came back.
+	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+		let resolvePatch!: (value: unknown) => void;
+		let resolveGet!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest);
+
+		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		// Issued after the PATCH went out, and answered after it comes back.
+		const pendingGet = store.get({ type: 'custom-module', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		resolveGet({
+			data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingGet;
 
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else');
 	});
@@ -392,6 +437,36 @@ describe('ConfigModule Store', () => {
 		await pendingFetch;
 
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('current value');
+	});
+
+	// A list response asserts the whole set as of the moment it was asked, so an entry it leaves
+	// out is gone. Tombstoning only what is held at that moment is not enough: a `get()` for a type
+	// that is currently absent carries no number of its own, so nothing would stop its late answer
+	// from reinstating an entry the newer list says no longer exists.
+	it('does not let an older read reinstate an entry a newer fetch left out', async () => {
+		let resolveGet!: (value: unknown) => void;
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		store.data = {};
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockResolvedValueOnce({
+			data: { data: [] },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingGet = store.get({ type: 'custom-module' });
+		const pendingFetch = store.fetch();
+
+		await pendingFetch;
+
+		resolveGet({ data: { data: mockModuleRes }, error: undefined, response: { status: 200 } });
+		await pendingGet;
+
+		expect(store.data[mockModule.type]).toBeUndefined();
 	});
 
 	// Two change events for the same type can land together. Both forced refreshes then wait on the

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -195,6 +195,44 @@ describe('ConfigModule Store', () => {
 		);
 	});
 
+	// The rollback after a failed edit has to undo the optimistic write, and the optimistic write
+	// is newer than any request already in flight. A plain read would be allowed to join one of
+	// those, and its answer - correctly judged older - would be dropped, leaving the value the
+	// failed edit put there sitting in the store while `edit()` reports failure.
+	it('rolls back a failed edit even while an older read is in flight', async () => {
+		let resolveInFlight!: (value: unknown) => void;
+
+		const inFlightRequest = new Promise((resolve) => {
+			resolveInFlight = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.GET as Mock).mockReturnValueOnce(inFlightRequest).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'server value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		(backendClient.PATCH as Mock).mockResolvedValue({
+			data: undefined,
+			error: new Error('Patch error'),
+			response: { status: 500 },
+		});
+
+		// Issued before the edit, so its answer describes the configuration from before it.
+		const pendingGet = store.get({ type: 'custom-module' });
+
+		const failedEdit = store.edit({ data: { ...mockModule, mockValue: 'optimistic value' } } as IConfigModulesEditActionPayload);
+
+		resolveInFlight({ data: { data: mockModuleRes }, error: undefined, response: { status: 200 } });
+
+		await expect(failedEdit).rejects.toThrow(ConfigApiException);
+		await pendingGet;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('server value');
+	});
+
 	it('should fetch all modules successfully', async () => {
 		(backendClient.GET as Mock).mockResolvedValue({
 			data: { data: [mockModuleRes] },

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -233,6 +233,43 @@ describe('ConfigModule Store', () => {
 		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('server value');
 	});
 
+	// A successful PATCH answers with the configuration as of the moment the server was asked, so
+	// in that respect it is a read like any other. A refresh issued after it - a change event
+	// reacting to somebody else's edit, say - describes a later moment and must win, even when the
+	// slower PATCH response lands after it.
+	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock).mockResolvedValueOnce({
+			data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		// Issued after the PATCH went out, and answered before it comes back.
+		await store.get({ type: 'custom-module', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else');
+	});
+
 	it('should fetch all modules successfully', async () => {
 		(backendClient.GET as Mock).mockResolvedValue({
 			data: { data: [mockModuleRes] },

--- a/apps/admin/src/modules/config/store/config-modules.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.spec.ts
@@ -376,6 +376,52 @@ describe('ConfigModule Store', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
+	// A reconnect refresh goes through `fetch()`, and it is exactly where another client's change
+	// is most likely to be waiting. Skipping an overlapped entry without asking again would leave
+	// that change sitting on the server until something else happened to look.
+	it('asks again for an entry a list refresh had to skip', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockModule.type]: { ...mockModule } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock)
+			// The reconnect refresh, answered while the edit is still outstanding.
+			.mockResolvedValueOnce({
+				data: { data: [mockModuleRes] },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// The read that follows once the write is done.
+			.mockResolvedValueOnce({
+				data: { data: { ...mockModuleRes, mockValue: 'someone else' } },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+		const pendingEdit = store.edit({ data: { ...mockModule, mockValue: 'my value' } } as IConfigModulesEditActionPayload);
+
+		await store.fetch();
+
+		// Skipped, because the answer cannot be told apart from one taken before the edit landed.
+		expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('my value');
+
+		resolvePatch({
+			data: { data: { ...mockModuleRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		await vi.waitFor(() => expect((store.data[mockModule.type] as ICustomModuleConfig).mockValue).toBe('someone else'));
+	});
+
 	// That deferred read is the only attempt left that can bring in whatever the dropped one was
 	// carrying, and the event handler that started it has long since resolved. A failure there has
 	// nowhere else to surface, so it must not be swallowed.

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -228,7 +228,9 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 								} else {
 									// The write settled while this answer was in transit, so there is
 									// nothing left to wait for - ask again now.
-									void get({ type: payload.type, force: true }).catch(() => undefined);
+									void get({ type: payload.type, force: true }).catch((error: unknown): void => {
+										logger.error('Failed to re-read module config after a write settled', error);
+									});
 								}
 							}
 
@@ -436,7 +438,14 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				endWrite(payload.data.type);
 
 				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
-					void get({ type: payload.data.type, force: true }).catch(() => undefined);
+					// This is the only attempt left that can bring in whatever the dropped read was
+					// carrying, and the event handler that started it has long since resolved, so a
+					// failure here has nowhere else to surface. It is reported rather than swallowed:
+					// the entry keeps this client's confirmed value, and another client's change
+					// arrives with the next event or refresh instead.
+					void get({ type: payload.data.type, force: true }).catch((error: unknown): void => {
+						logger.error('Failed to re-read module config after an edit settled', error);
+					});
 				}
 			};
 

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -67,6 +67,21 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 		const pendingFetchPromises: Record<string, Promise<IConfigModule[]>> = {};
 
+		// Stamped on every write that is not `fetch()` applying its own response — a websocket event,
+		// a change-driven `get()`, an `edit()`. `fetch()` remembers the stamp it went out under, so
+		// when its response lands it can tell which entries were written since: for those the snapshot
+		// is the older story and must not overwrite them. See the guard inside `fetch()` below.
+		let mutationToken = 0;
+		const mutationTokenByType: Record<IConfigModule['type'], number> = {};
+
+		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
+		// write below goes through it, which is what keeps the stamp complete.
+		const commit = (config: IConfigModule): IConfigModule => {
+			mutationTokenByType[config.type] = ++mutationToken;
+
+			return (data.value[config.type] = config);
+		};
+
 		const updating = (module: IConfigModule['type']): boolean => semaphore.value.updating.includes(module);
 
 		const onEvent = (payload: IConfigModulesOnEventActionPayload): IConfigModule => {
@@ -89,7 +104,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 					throw new ConfigValidationException('Failed to insert module configuration.');
 				}
 
-				return (data.value[parsed.data.type] = parsed.data);
+				return commit(parsed.data);
 			}
 
 			const parsed = (element?.schemas?.moduleConfigSchema || ConfigModuleSchema).safeParse(payload.data);
@@ -102,13 +117,22 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 			data.value ??= {};
 
-			return (data.value[parsed.data.type] = parsed.data);
+			return commit(parsed.data);
 		};
 
 		const get = async (payload: IConfigModulesGetActionPayload): Promise<IConfigModule> => {
 			const existingPromise = pendingGetPromises[payload.type];
 			if (existingPromise) {
-				return existingPromise;
+				if (payload.force) {
+					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
+					// request could hand back a snapshot taken before the change this call is
+					// reacting to. Its result does not matter here, only that it has finished — that
+					// is what frees the semaphore below for the new request this call makes instead
+					// of throwing 'Already getting module config.' by firing concurrently.
+					await existingPromise.catch(() => undefined);
+				} else {
+					return existingPromise;
+				}
 			}
 
 			const getPromise = (async (): Promise<IConfigModule> => {
@@ -136,9 +160,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 						const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-						data.value[transformed.type] = transformed;
-
-						return transformed;
+						return commit(transformed);
 					}
 
 					let errorReason: string | null = 'Failed to fetch module config.';
@@ -167,6 +189,10 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				return pendingFetchPromises['all'];
 			}
 
+			// Read before the request goes out: every entry stamped later than this was written while
+			// the server was assembling its answer, so for those entries this response is out of date.
+			const requestedAt = mutationToken;
+
 			const fetchPromise = (async (): Promise<IConfigModule[]> => {
 				if (semaphore.value.fetching.items) {
 					throw new ConfigApiException('Already fetching modules config.');
@@ -177,16 +203,42 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				try {
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/modules`);
 
-				if (typeof responseData !== 'undefined') {
-					data.value = Object.fromEntries(
-						responseData.data.map((module) => {
+					if (typeof responseData !== 'undefined') {
+						// Applied entry by entry rather than assigned wholesale: an entry written since
+						// `requestedAt` is newer than this snapshot and keeps what it holds — including
+						// having been dropped locally, which is why a stamped type with nothing behind
+						// it is left out rather than restored. Entries the response does not carry are
+						// still evicted, which is what makes this a replacement rather than a merge
+						// that can only ever grow.
+						const applied: { [key: IConfigModule['type']]: IConfigModule } = {};
+
+						for (const module of responseData.data) {
 							const element = getModuleElement(module.type);
 
 							const transformed = transformConfigModuleResponse(module, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-							return [transformed.type, transformed];
-						})
-					);
+							if ((mutationTokenByType[transformed.type] ?? 0) > requestedAt) {
+								const local = data.value[transformed.type];
+
+								if (local) {
+									applied[transformed.type] = local;
+								}
+
+								continue;
+							}
+
+							applied[transformed.type] = transformed;
+						}
+
+						// Written while the request was in flight and absent from its answer: the
+						// server read its list before this entry's local write landed.
+						for (const [type, token] of Object.entries(mutationTokenByType)) {
+							if (token > requestedAt && !(type in applied) && data.value[type]) {
+								applied[type] = data.value[type];
+							}
+						}
+
+						data.value = applied;
 
 						firstLoad.value = true;
 
@@ -246,7 +298,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 			semaphore.value.updating.push(payload.data.type);
 
-			data.value[parsedEditedConfig.data.type] = parsedEditedConfig.data;
+			commit(parsedEditedConfig.data);
 
 			try {
 				const {
@@ -270,9 +322,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-					data.value[transformed.type] = transformed;
-
-					return transformed;
+					return commit(transformed);
 				}
 
 				// Updating the record on api failed, we need to refresh the record

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -365,8 +365,12 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 					return commit(transformed);
 				}
 
-				// Updating the record on api failed, we need to refresh the record
-				await get({ type: payload.data.type });
+				// Updating the record on api failed, so the optimistic write above has to be rolled
+				// back to whatever the server actually holds. Forced, because a plain read would
+				// be allowed to join a request that went out before that optimistic write: its
+				// answer carries a lower number and would be dropped, leaving the value the failed
+				// edit put there in place.
+				await get({ type: payload.data.type, force: true });
 
 				let errorReason: string | null = 'Failed to update module config.';
 

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -223,15 +223,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						// than the one this answer carries.
 						if (overlapsWrite) {
 							if (payload.force) {
-								if (writePending(payload.type)) {
-									refreshAfterWrite.add(payload.type);
-								} else {
-									// The write settled while this answer was in transit, so there is
-									// nothing left to wait for - ask again now.
-									void get({ type: payload.type, force: true }).catch((error: unknown): void => {
-										logger.error('Failed to re-read module config after a write settled', error);
-									});
-								}
+								reReadAfterWrite(payload.type);
 							}
 
 							return data.value[payload.type] ?? transformed;
@@ -267,7 +259,22 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 			}
 		};
 
-		const fetch = async (): Promise<IConfigModule[]> => {
+		// Re-issues a read that had to be dropped for overlapping a write. Dropping one silently would
+	// lose whatever prompted it - another client's change, most often - so it is asked again once
+	// the write is out of the way, where the answer cannot predate it.
+	const reReadAfterWrite = (type: IConfigModule['type']): void => {
+		if (writePending(type)) {
+			refreshAfterWrite.add(type);
+
+			return;
+		}
+
+		void get({ type, force: true }).catch((error: unknown): void => {
+			logger.error('Failed to re-read module config after a write settled', error);
+		});
+	};
+
+	const fetch = async (): Promise<IConfigModule[]> => {
 			if ('all' in pendingFetchPromises) {
 				return pendingFetchPromises['all'];
 			}
@@ -329,11 +336,15 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						}
 
 						// A type whose write overlapped this request is not described reliably by the
-						// answer, present or absent, so it keeps what it holds.
+						// answer, present or absent, so it keeps what it holds - and is asked about
+						// again, because this response may have been the one carrying another client's
+						// change and a reconnect refresh is exactly where that matters.
 						for (const type of overlappedWrites) {
 							if (!(type in applied) && data.value[type]) {
 								applied[type] = data.value[type];
 							}
+
+							reReadAfterWrite(type);
 						}
 
 						// An entry this response does not carry is evicted, and the eviction takes this
@@ -438,14 +449,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				endWrite(payload.data.type);
 
 				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
-					// This is the only attempt left that can bring in whatever the dropped read was
-					// carrying, and the event handler that started it has long since resolved, so a
-					// failure here has nowhere else to surface. It is reported rather than swallowed:
-					// the entry keeps this client's confirmed value, and another client's change
-					// arrives with the next event or refresh instead.
-					void get({ type: payload.data.type, force: true }).catch((error: unknown): void => {
-						logger.error('Failed to re-read module config after an edit settled', error);
-					});
+					reReadAfterWrite(payload.data.type);
 				}
 			};
 

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -102,6 +102,13 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 	const writePending = (type: IConfigModule['type']): boolean => (pendingWrites[type] ?? 0) > 0;
 
+	// Change-driven reads that were dropped for overlapping a write. The write's own answer
+	// settles the entry, but the event that prompted the read was the backend announcing that
+	// *something* changed - it does not say whose change, and it may well be another client's.
+	// Dropping the read silently would lose that until something else happened to refresh, so it
+	// is asked again once the write is out of the way, where the answer cannot predate it.
+	const refreshAfterWrite = new Set<IConfigModule['type']>();
+
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
 		// write below goes through it, which is what keeps the sequence complete. `at` places the
 		// write in that sequence; omitting it claims the moment of the call, which is what a write
@@ -215,6 +222,16 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						// The caller still gets the entry, just the copy the write left behind rather
 						// than the one this answer carries.
 						if (overlapsWrite) {
+							if (payload.force) {
+								if (writePending(payload.type)) {
+									refreshAfterWrite.add(payload.type);
+								} else {
+									// The write settled while this answer was in transit, so there is
+									// nothing left to wait for - ask again now.
+									void get({ type: payload.type, force: true }).catch(() => undefined);
+								}
+							}
+
 							return data.value[payload.type] ?? transformed;
 						}
 
@@ -417,6 +434,10 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				writeReleased = true;
 
 				endWrite(payload.data.type);
+
+				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
+					void get({ type: payload.data.type, force: true }).catch(() => undefined);
+				}
 			};
 
 			try {

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -188,6 +188,12 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				// describes the configuration as of now, whatever is written while it travels.
 				const requestedAt = nextSequence();
 
+				// Whether a write for this type was in flight at that moment. The server can answer
+				// a read from either side of an uncommitted write and nothing here distinguishes
+				// the two, so a read that overlapped one never speaks for the entry - however late
+				// it lands, and however new its number looks.
+				const overlapsWrite = writePending(payload.type);
+
 				try {
 					const {
 						data: responseData,
@@ -206,10 +212,9 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 						const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-						// A write for this type is in flight, so this answer is not guaranteed to
-						// include it - the server may not have committed it when it was read. The
-						// caller still gets the entry, just the copy the write is putting there.
-						if (writePending(payload.type)) {
+						// The caller still gets the entry, just the copy the write left behind rather
+						// than the one this answer carries.
+						if (overlapsWrite) {
 							return data.value[payload.type] ?? transformed;
 						}
 
@@ -260,6 +265,11 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				// story.
 				const requestedAt = nextSequence();
 
+				// The types whose write was in flight at that moment. This answer cannot speak for
+				// them either way - it may have been assembled before the write was committed - so
+				// they keep what they hold, present or absent from it.
+				const overlappedWrites = new Set(Object.keys(pendingWrites));
+
 				try {
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/modules`);
 
@@ -277,7 +287,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 							const transformed = transformConfigModuleResponse(module, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-							if (writePending(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
+							if (overlappedWrites.has(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -299,6 +309,14 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 							}
 						}
 
+						// A type whose write overlapped this request is not described reliably by the
+						// answer, present or absent, so it keeps what it holds.
+						for (const type of overlappedWrites) {
+							if (!(type in applied) && data.value[type]) {
+								applied[type] = data.value[type];
+							}
+						}
+
 						// An entry this response does not carry is evicted, and the eviction takes this
 						// response's number like every other write it makes: a read still in flight
 						// from before it must not put back what a newer answer says is gone.
@@ -311,7 +329,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						const known = new Set([...Object.keys(data.value), ...Object.keys(appliedSequence), ...Object.keys(pendingGetPromises)]);
 
 						for (const type of known) {
-							if (!(type in applied)) {
+							if (!(type in applied) && !overlappedWrites.has(type)) {
 								appliedSequence[type] = requestedAt;
 							}
 						}

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -79,6 +79,29 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 		const appliedSequence: Record<IConfigModule['type'], number> = {};
 
+	// Types whose write is in flight. A read issued after that write went out is *not*
+	// guaranteed to include it - the server may not have committed it yet - so for as long as
+	// one is outstanding no read may speak for the entry, however new its number looks. Without
+	// this, a list read issued mid-edit lands with the pre-edit value, takes the higher number,
+	// and then rejects the edit's own confirmation as the older story.
+	const pendingWrites: Record<IConfigModule['type'], number> = {};
+
+	const beginWrite = (type: IConfigModule['type']): void => {
+		pendingWrites[type] = (pendingWrites[type] ?? 0) + 1;
+	};
+
+	const endWrite = (type: IConfigModule['type']): void => {
+		const remaining = (pendingWrites[type] ?? 1) - 1;
+
+		if (remaining > 0) {
+			pendingWrites[type] = remaining;
+		} else {
+			delete pendingWrites[type];
+		}
+	};
+
+	const writePending = (type: IConfigModule['type']): boolean => (pendingWrites[type] ?? 0) > 0;
+
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
 		// write below goes through it, which is what keeps the sequence complete. `at` places the
 		// write in that sequence; omitting it claims the moment of the call, which is what a write
@@ -183,6 +206,13 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 						const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
+						// A write for this type is in flight, so this answer is not guaranteed to
+						// include it - the server may not have committed it when it was read. The
+						// caller still gets the entry, just the copy the write is putting there.
+						if (writePending(payload.type)) {
+							return data.value[payload.type] ?? transformed;
+						}
+
 						return commit(transformed, requestedAt);
 					}
 
@@ -247,7 +277,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 							const transformed = transformConfigModuleResponse(module, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-							if ((appliedSequence[transformed.type] ?? 0) > requestedAt) {
+							if (writePending(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -272,7 +302,15 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						// An entry this response does not carry is evicted, and the eviction takes this
 						// response's number like every other write it makes: a read still in flight
 						// from before it must not put back what a newer answer says is gone.
-						for (const type of Object.keys(data.value)) {
+						//
+						// The tombstone has to cover more than what is held right now. A `get()` for a
+						// type that is currently absent carries no number yet, so without a tombstone
+						// of its own it would be free to reinstate an entry this list says no longer
+						// exists. Every type this store has heard of - held, numbered before, or being
+						// read at this moment - gets one.
+						const known = new Set([...Object.keys(data.value), ...Object.keys(appliedSequence), ...Object.keys(pendingGetPromises)]);
+
+						for (const type of known) {
 							if (!(type in applied)) {
 								appliedSequence[type] = requestedAt;
 							}
@@ -346,6 +384,23 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 			// picking up somebody else's edit - is the newer story even if it lands first.
 			const requestedAt = nextSequence();
 
+			// Held from the moment the request goes out until its answer is in hand. A read issued
+			// inside that window carries a higher number but can still be answered from before the
+			// write was committed, so it must not be allowed to speak for the entry.
+			beginWrite(payload.data.type);
+
+			let writeReleased = false;
+
+			const releaseWrite = (): void => {
+				if (writeReleased) {
+					return;
+				}
+
+				writeReleased = true;
+
+				endWrite(payload.data.type);
+			};
+
 			try {
 				const {
 					data: responseData,
@@ -364,6 +419,8 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 						),
 					},
 				});
+
+				releaseWrite();
 
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
@@ -386,6 +443,10 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 				throw new ConfigApiException(errorReason, response.status);
 			} finally {
+				// A backstop for the request throwing outright, which would otherwise leave the
+				// entry held for good.
+				releaseWrite();
+
 				semaphore.value.updating = semaphore.value.updating.filter((item) => item !== payload.data.type);
 			}
 		};

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -67,17 +67,30 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 		const pendingFetchPromises: Record<string, Promise<IConfigModule[]>> = {};
 
-		// Stamped on every write that is not `fetch()` applying its own response — a websocket event,
-		// a change-driven `get()`, an `edit()`. `fetch()` remembers the stamp it went out under, so
-		// when its response lands it can tell which entries were written since: for those the snapshot
-		// is the older story and must not overwrite them. See the guard inside `fetch()` below.
-		let mutationToken = 0;
-		const mutationTokenByType: Record<IConfigModule['type'], number> = {};
+		// Everything that can write an entry draws a number from one sequence, and each entry
+		// remembers the number behind what it currently holds. A write — a websocket event, an
+		// `edit()` — draws its number as it lands, because a write is authoritative the moment it
+		// happens. A read draws its number as the request goes out, because a response only ever
+		// tells the story of that moment: two reads issued in one order can come back in the
+		// other, and it is the earlier request's answer that is stale, however late it arrives.
+		let sequence = 0;
+
+		const nextSequence = (): number => ++sequence;
+
+		const appliedSequence: Record<IConfigModule['type'], number> = {};
 
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
-		// write below goes through it, which is what keeps the stamp complete.
-		const commit = (config: IConfigModule): IConfigModule => {
-			mutationTokenByType[config.type] = ++mutationToken;
+		// write below goes through it, which is what keeps the sequence complete. `at` places the
+		// write in that sequence; omitting it claims the moment of the call, which is what a write
+		// wants and a read does not.
+		const commit = (config: IConfigModule, at: number = nextSequence()): IConfigModule => {
+			if ((appliedSequence[config.type] ?? 0) > at) {
+				// Something newer is already held, so this is the older story and is not applied.
+				// The caller still gets an answer about what it asked for — the newer one.
+				return data.value[config.type] ?? config;
+			}
+
+			appliedSequence[config.type] = at;
 
 			return (data.value[config.type] = config);
 		};
@@ -121,26 +134,36 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 		};
 
 		const get = async (payload: IConfigModulesGetActionPayload): Promise<IConfigModule> => {
-			const existingPromise = pendingGetPromises[payload.type];
-			if (existingPromise) {
-				if (payload.force) {
-					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
-					// request could hand back a snapshot taken before the change this call is
-					// reacting to. Its result does not matter here, only that it has finished — that
-					// is what frees the semaphore below for the new request this call makes instead
-					// of throwing 'Already getting module config.' by firing concurrently.
-					await existingPromise.catch(() => undefined);
-				} else {
-					return existingPromise;
-				}
+			const inFlight = pendingGetPromises[payload.type];
+
+			if (inFlight && !payload.force) {
+				return inFlight;
 			}
 
 			const getPromise = (async (): Promise<IConfigModule> => {
+				if (inFlight) {
+					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
+					// request could hand back a snapshot taken before the change this call is
+					// reacting to. Its result does not matter here, only that it has finished — that
+					// is what frees the semaphore below for the request this call makes instead.
+					//
+					// Waiting in here rather than before registering below is what serializes forced
+					// refreshes. Two arriving together would otherwise wait on the same request, both
+					// resume, and the second would find the semaphore still held by the first and
+					// reject with 'Already getting module config.' — after its own registration,
+					// made later, had already displaced the first's.
+					await inFlight.catch(() => undefined);
+				}
+
 				if (semaphore.value.fetching.item.includes(payload.type)) {
 					throw new ConfigApiException('Already getting module config.');
 				}
 
 				semaphore.value.fetching.item.push(payload.type);
+
+				// Drawn as the request goes out, not when its answer lands: what comes back
+				// describes the configuration as of now, whatever is written while it travels.
+				const requestedAt = nextSequence();
 
 				try {
 					const {
@@ -160,7 +183,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 						const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-						return commit(transformed);
+						return commit(transformed, requestedAt);
 					}
 
 					let errorReason: string | null = 'Failed to fetch module config.';
@@ -180,7 +203,13 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 			try {
 				return await getPromise;
 			} finally {
-				delete pendingGetPromises[payload.type];
+				// Only the registration this call owns. A forced refresh arriving while this read is
+				// still running has already replaced it with its own successor, and deleting that
+				// would leave the next caller unable to find — or queue behind — the read that is
+				// actually in flight.
+				if (pendingGetPromises[payload.type] === getPromise) {
+					delete pendingGetPromises[payload.type];
+				}
 			}
 		};
 
@@ -189,10 +218,6 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				return pendingFetchPromises['all'];
 			}
 
-			// Read before the request goes out: every entry stamped later than this was written while
-			// the server was assembling its answer, so for those entries this response is out of date.
-			const requestedAt = mutationToken;
-
 			const fetchPromise = (async (): Promise<IConfigModule[]> => {
 				if (semaphore.value.fetching.items) {
 					throw new ConfigApiException('Already fetching modules config.');
@@ -200,16 +225,21 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 				semaphore.value.fetching.items = true;
 
+				// Drawn as the request goes out: an entry numbered higher than this was written, or
+				// read, after the server was asked, so for that entry this response is the older
+				// story.
+				const requestedAt = nextSequence();
+
 				try {
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/modules`);
 
 					if (typeof responseData !== 'undefined') {
-						// Applied entry by entry rather than assigned wholesale: an entry written since
-						// `requestedAt` is newer than this snapshot and keeps what it holds — including
-						// having been dropped locally, which is why a stamped type with nothing behind
-						// it is left out rather than restored. Entries the response does not carry are
-						// still evicted, which is what makes this a replacement rather than a merge
-						// that can only ever grow.
+						// Applied entry by entry rather than assigned wholesale: an entry numbered higher
+						// than `requestedAt` was written, or read, after this request went out and keeps
+						// what it holds — including having been dropped locally, which is why a numbered
+						// type with nothing behind it is left out rather than restored. Entries the
+						// response does not carry are still evicted, which is what makes this a
+						// replacement rather than a merge that can only ever grow.
 						const applied: { [key: IConfigModule['type']]: IConfigModule } = {};
 
 						for (const module of responseData.data) {
@@ -217,7 +247,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 							const transformed = transformConfigModuleResponse(module, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-							if ((mutationTokenByType[transformed.type] ?? 0) > requestedAt) {
+							if ((appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -228,13 +258,23 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 							}
 
 							applied[transformed.type] = transformed;
+							appliedSequence[transformed.type] = requestedAt;
 						}
 
 						// Written while the request was in flight and absent from its answer: the
 						// server read its list before this entry's local write landed.
-						for (const [type, token] of Object.entries(mutationTokenByType)) {
-							if (token > requestedAt && !(type in applied) && data.value[type]) {
+						for (const [type, at] of Object.entries(appliedSequence)) {
+							if (at > requestedAt && !(type in applied) && data.value[type]) {
 								applied[type] = data.value[type];
+							}
+						}
+
+						// An entry this response does not carry is evicted, and the eviction takes this
+						// response's number like every other write it makes: a read still in flight
+						// from before it must not put back what a newer answer says is gone.
+						for (const type of Object.keys(data.value)) {
+							if (!(type in applied)) {
+								appliedSequence[type] = requestedAt;
 							}
 						}
 

--- a/apps/admin/src/modules/config/store/config-modules.store.ts
+++ b/apps/admin/src/modules/config/store/config-modules.store.ts
@@ -340,6 +340,12 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 
 			commit(parsedEditedConfig.data);
 
+			// Drawn as the request goes out, and so after the optimistic write above, which it is
+			// meant to confirm. What comes back describes the configuration as of the moment the
+			// server was asked, so a read issued later - a change event's forced refresh, say,
+			// picking up somebody else's edit - is the newer story even if it lands first.
+			const requestedAt = nextSequence();
+
 			try {
 				const {
 					data: responseData,
@@ -362,7 +368,7 @@ export const useConfigModule = defineStore<'config-module_config_module', Config
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigModuleResponse(responseData.data, element?.schemas?.moduleConfigSchema || ConfigModuleSchema);
 
-					return commit(transformed);
+					return commit(transformed, requestedAt);
 				}
 
 				// Updating the record on api failed, so the optimistic write above has to be rolled

--- a/apps/admin/src/modules/config/store/config-plugins.store.schemas.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.schemas.ts
@@ -40,6 +40,10 @@ export const ConfigPluginsSetActionPayloadSchema = z.object({
 
 export const ConfigPluginsGetActionPayloadSchema = z.object({
 	type: z.string(),
+	// Opt-in, default off so existing callers keep coalescing onto an in-flight request. A
+	// change-driven refresh sets it to force a genuinely fresh read instead of reusing one that may
+	// have been taken before the change it is reacting to. See `get()` in config-plugins.store.ts.
+	force: z.boolean().optional(),
 });
 
 export const ConfigPluginsEditActionPayloadSchema = z.object({

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -382,4 +382,42 @@ describe('ConfigPlugin Store', () => {
 			ConfigApiException
 		);
 	});
+
+	// The rollback after a failed edit has to undo the optimistic write, and the optimistic write
+	// is newer than any request already in flight. A plain read would be allowed to join one of
+	// those, and its answer - correctly judged older - would be dropped, leaving the value the
+	// failed edit put there sitting in the store while `edit()` reports failure.
+	it('rolls back a failed edit even while an older read is in flight', async () => {
+		let resolveInFlight!: (value: unknown) => void;
+
+		const inFlightRequest = new Promise((resolve) => {
+			resolveInFlight = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.GET as Mock).mockReturnValueOnce(inFlightRequest).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'server value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		(backendClient.PATCH as Mock).mockResolvedValue({
+			data: undefined,
+			error: new Error('Patch error'),
+			response: { status: 500 },
+		});
+
+		// Issued before the edit, so its answer describes the configuration from before it.
+		const pendingGet = store.get({ type: 'custom-plugin' });
+
+		const failedEdit = store.edit({ data: { ...mockPlugin, mockValue: 'optimistic value' } } as IConfigPluginsEditActionPayload);
+
+		resolveInFlight({ data: { data: mockPluginRes }, error: undefined, response: { status: 200 } });
+
+		await expect(failedEdit).rejects.toThrow(ConfigApiException);
+		await pendingGet;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('server value');
+	});
 });

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -489,10 +489,11 @@ describe('ConfigPlugin Store', () => {
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
 	});
 
-	// The other side of that window. Once the edit's answer is in hand the entry is released, and a
-	// read issued after the edit went out is the newer story again - which is why the edit response
-	// takes its number when the request was sent rather than when it came back.
-	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+	// The same window seen from the other end: a read issued while the write was outstanding is
+	// dropped whenever it lands, not only when it lands first. Its snapshot may have been taken
+	// either side of the write and nothing here can tell which, so the entry keeps the confirmed
+	// edit - reverting one of those is the worse of the two mistakes.
+	it('drops a refresh issued during an edit even when it lands after the edit', async () => {
 		let resolvePatch!: (value: unknown) => void;
 		let resolveGet!: (value: unknown) => void;
 
@@ -511,7 +512,7 @@ describe('ConfigPlugin Store', () => {
 
 		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
 
-		// Issued after the PATCH went out, and answered after it comes back.
+		// Issued while the PATCH is still outstanding.
 		const pendingGet = store.get({ type: 'custom-plugin', force: true });
 
 		resolvePatch({
@@ -522,13 +523,34 @@ describe('ConfigPlugin Store', () => {
 
 		await pendingEdit;
 
-		resolveGet({
+		// And answered only afterwards, with what the server held before the edit was committed.
+		resolveGet({ data: { data: mockPluginRes }, error: undefined, response: { status: 200 } });
+
+		await pendingGet;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
+	});
+
+	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a
+	// refresh issued after that overlaps nothing and is the newer story again.
+	it('applies a refresh issued once the edit has settled', async () => {
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		(backendClient.GET as Mock).mockResolvedValueOnce({
 			data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
 			error: undefined,
 			response: { status: 200 },
 		});
 
-		await pendingGet;
+		await store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		await store.get({ type: 'custom-plugin', force: true });
 
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else');
 	});

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -137,6 +137,85 @@ describe('ConfigPlugin Store', () => {
 		await expect(store.get({ type: 'custom-plugin' })).rejects.toThrow(ConfigApiException);
 	});
 
+	// The race the mutation-token stamp exists to prevent: a change event fires a `get()` for the
+	// changed type while an already-in-flight `fetch()` is still reading the pre-change configuration.
+	// Without the stamp, `fetch()`'s wholesale replace lands after `get()` and wipes it out with the
+	// older snapshot, so the admin stays stale until something else happens to refresh it.
+	it('keeps an entry refreshed by get() while fetch() is in flight, rather than restoring the snapshot it answers with', async () => {
+		let resolveFetch!: (value: unknown) => void;
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(fetchRequest).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'fresh value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingFetch = store.fetch();
+
+		// The change-driven refresh lands before the response the server assembled ahead of it.
+		await store.get({ type: 'custom-plugin' });
+
+		resolveFetch({ data: { data: [mockPluginRes] } });
+		await pendingFetch;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('fresh value');
+	});
+
+	// The other half of the same rule: an entry the response *does* carry, and that nothing has
+	// touched since the request went out, is still applied — otherwise this guard would freeze the
+	// store rather than merely protecting entries genuinely written since the request was made.
+	it('applies an entry the fetch response carries when nothing has written it since the request went out', async () => {
+		let resolveFetch!: (value: unknown) => void;
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(fetchRequest);
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		const pendingFetch = store.fetch();
+
+		resolveFetch({ data: { data: [{ ...mockPluginRes, mockValue: 'server value' }] } });
+		await pendingFetch;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('server value');
+	});
+
+	// The other race: a change event calling `get({ force: true })` while an earlier `get()` for the
+	// same type is still in flight must not just hand back that older request's answer. It should wait
+	// for it to settle, then issue a genuinely new request.
+	it('issues a new request for a forced get() instead of reusing an in-flight one', async () => {
+		let resolveFirst!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(firstRequest).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'forced value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const firstGet = store.get({ type: 'custom-plugin' });
+		const forcedGet = store.get({ type: 'custom-plugin', force: true });
+
+		resolveFirst({ data: { data: mockPluginRes } });
+
+		const [firstResult, forcedResult] = await Promise.all([firstGet, forcedGet]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+		expect(firstResult).toEqual(mockPlugin);
+		expect((forcedResult as ICustomPluginConfig).mockValue).toBe('forced value');
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('forced value');
+	});
+
 	it('should update config Plugin successfully', async () => {
 		store.data = { [mockPlugin.type]: { ...mockPlugin } };
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -465,12 +465,19 @@ describe('ConfigPlugin Store', () => {
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
 
-		// What the server still holds, because it has not committed the edit yet.
-		(backendClient.GET as Mock).mockResolvedValueOnce({
-			data: { data: mockPluginRes },
-			error: undefined,
-			response: { status: 200 },
-		});
+		(backendClient.GET as Mock)
+			// What the server still holds, because it has not committed the edit yet.
+			.mockResolvedValueOnce({
+				data: { data: mockPluginRes },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// And what it holds once it has - the read the store asks for after the write settles.
+			.mockResolvedValueOnce({
+				data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+				error: undefined,
+				response: { status: 200 },
+			});
 
 		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
 
@@ -485,6 +492,8 @@ describe('ConfigPlugin Store', () => {
 		});
 
 		await pendingEdit;
+
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
 
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
 	});
@@ -508,7 +517,12 @@ describe('ConfigPlugin Store', () => {
 		store.data = { [mockPlugin.type]: { ...mockPlugin } };
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
-		(backendClient.GET as Mock).mockReturnValueOnce(getRequest);
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
 
 		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
 
@@ -528,7 +542,53 @@ describe('ConfigPlugin Store', () => {
 
 		await pendingGet;
 
+		// Dropped, and asked again now that the write is done.
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
+
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
+	});
+
+	// Dropping an overlapping read loses whatever prompted it. A change event is the backend saying
+	// something changed without saying whose change it was, so a refresh reacting to one may be
+	// carrying another client's edit - and silently discarding it would leave that lost until
+	// something else happened to refresh. It is asked again once the write is out of the way.
+	it('asks again after the edit when a change-driven refresh had to be dropped', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock).mockResolvedValue({
+			data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		// The change event's refresh, issued and answered while the PATCH is still outstanding.
+		await store.get({ type: 'custom-plugin', force: true });
+
+		// Dropped, because nothing here can tell it apart from a read taken before the edit landed.
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
+
+		resolvePatch({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		// Asked again now that the write is done, and this time the answer stands.
+		await vi.waitFor(() => expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else'));
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
 	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -247,6 +247,36 @@ describe('ConfigPlugin Store', () => {
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('current value');
 	});
 
+	// A list response asserts the whole set as of the moment it was asked, so an entry it leaves
+	// out is gone. Tombstoning only what is held at that moment is not enough: a `get()` for a type
+	// that is currently absent carries no number of its own, so nothing would stop its late answer
+	// from reinstating an entry the newer list says no longer exists.
+	it('does not let an older read reinstate an entry a newer fetch left out', async () => {
+		let resolveGet!: (value: unknown) => void;
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		store.data = {};
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockResolvedValueOnce({
+			data: { data: [] },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingGet = store.get({ type: 'custom-plugin' });
+		const pendingFetch = store.fetch();
+
+		await pendingFetch;
+
+		resolveGet({ data: { data: mockPluginRes }, error: undefined, response: { status: 200 } });
+		await pendingGet;
+
+		expect(store.data[mockPlugin.type]).toBeUndefined();
+	});
+
 	// Two change events for the same type can land together. Both forced refreshes then wait on the
 	// one request already in flight and both resume, so unless they are queued the second finds the
 	// semaphore still held by the first and is rejected out of hand.
@@ -421,11 +451,10 @@ describe('ConfigPlugin Store', () => {
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('server value');
 	});
 
-	// A successful PATCH answers with the configuration as of the moment the server was asked, so
-	// in that respect it is a read like any other. A refresh issued after it - a change event
-	// reacting to somebody else's edit, say - describes a later moment and must win, even when the
-	// slower PATCH response lands after it.
-	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+	// A read issued while an edit is in flight cannot be trusted to include it: the server may not
+	// have committed the write when it answered. So for as long as the write is outstanding the
+	// entry is held, and a refresh landing inside that window is dropped rather than applied.
+	it('keeps a pending edit when a refresh is answered before the edit is', async () => {
 		let resolvePatch!: (value: unknown) => void;
 
 		const patchRequest = new Promise((resolve) => {
@@ -436,16 +465,18 @@ describe('ConfigPlugin Store', () => {
 
 		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
 
+		// What the server still holds, because it has not committed the edit yet.
 		(backendClient.GET as Mock).mockResolvedValueOnce({
-			data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
+			data: { data: mockPluginRes },
 			error: undefined,
 			response: { status: 200 },
 		});
 
 		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
 
-		// Issued after the PATCH went out, and answered before it comes back.
 		await store.get({ type: 'custom-plugin', force: true });
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
 
 		resolvePatch({
 			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
@@ -454,6 +485,50 @@ describe('ConfigPlugin Store', () => {
 		});
 
 		await pendingEdit;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
+	});
+
+	// The other side of that window. Once the edit's answer is in hand the entry is released, and a
+	// read issued after the edit went out is the newer story again - which is why the edit response
+	// takes its number when the request was sent rather than when it came back.
+	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+		let resolvePatch!: (value: unknown) => void;
+		let resolveGet!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest);
+
+		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		// Issued after the PATCH went out, and answered after it comes back.
+		const pendingGet = store.get({ type: 'custom-plugin', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		resolveGet({
+			data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingGet;
 
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else');
 	});

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -420,4 +420,41 @@ describe('ConfigPlugin Store', () => {
 
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('server value');
 	});
+
+	// A successful PATCH answers with the configuration as of the moment the server was asked, so
+	// in that respect it is a read like any other. A refresh issued after it - a change event
+	// reacting to somebody else's edit, say - describes a later moment and must win, even when the
+	// slower PATCH response lands after it.
+	it('does not let a slow edit response overwrite a refresh issued after it', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock).mockResolvedValueOnce({
+			data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		// Issued after the PATCH went out, and answered before it comes back.
+		await store.get({ type: 'custom-plugin', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else');
+	});
 });

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -57,6 +57,8 @@ const mockGetPlugins = vi.fn().mockReturnValue([
 	} as unknown as IPlugin<IPluginsComponents, IPluginsSchemas>,
 ]);
 
+const mockLoggerError = vi.fn();
+
 vi.mock('../../../common', async () => {
 	const utils = await vi.importActual('../../../common/utils/utils');
 	const composables = await vi.importActual('../../../common/composables/composables');
@@ -74,7 +76,7 @@ vi.mock('../../../common', async () => {
 			client: backendClient,
 		})),
 		useLogger: vi.fn(() => ({
-			error: vi.fn(),
+			error: mockLoggerError,
 			info: vi.fn(),
 			warning: vi.fn(),
 			log: vi.fn(),
@@ -96,6 +98,7 @@ describe('ConfigPlugin Store', () => {
 		store = useConfigPlugin();
 
 		vi.clearAllMocks();
+		mockLoggerError.mockClear();
 	});
 
 	it('should set config Plugin data successfully', () => {
@@ -589,6 +592,51 @@ describe('ConfigPlugin Store', () => {
 		await vi.waitFor(() => expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else'));
 
 		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+	});
+
+	// That deferred read is the only attempt left that can bring in whatever the dropped one was
+	// carrying, and the event handler that started it has long since resolved. A failure there has
+	// nowhere else to surface, so it must not be swallowed.
+	it('reports a deferred refresh that fails rather than losing it silently', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock)
+			.mockResolvedValueOnce({
+				data: { data: mockPluginRes },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// The deferred read, which the backend refuses.
+			.mockResolvedValueOnce({
+				data: undefined,
+				error: new Error('Read error'),
+				response: { status: 500 },
+			});
+
+		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		await store.get({ type: 'custom-plugin', force: true });
+
+		resolvePatch({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		await vi.waitFor(() => expect(mockLoggerError).toHaveBeenCalledWith(expect.stringContaining('re-read'), expect.anything()));
+
+		// The entry keeps this client's confirmed value rather than being left in some other state.
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
 	});
 
 	// The hold is not permanent. Once the edit's answer is in hand the entry is released, and a

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -594,6 +594,52 @@ describe('ConfigPlugin Store', () => {
 		expect(backendClient.GET).toHaveBeenCalledTimes(2);
 	});
 
+	// A reconnect refresh goes through `fetch()`, and it is exactly where another client's change
+	// is most likely to be waiting. Skipping an overlapped entry without asking again would leave
+	// that change sitting on the server until something else happened to look.
+	it('asks again for an entry a list refresh had to skip', async () => {
+		let resolvePatch!: (value: unknown) => void;
+
+		const patchRequest = new Promise((resolve) => {
+			resolvePatch = resolve;
+		});
+
+		store.data = { [mockPlugin.type]: { ...mockPlugin } };
+
+		(backendClient.PATCH as Mock).mockReturnValueOnce(patchRequest);
+
+		(backendClient.GET as Mock)
+			// The reconnect refresh, answered while the edit is still outstanding.
+			.mockResolvedValueOnce({
+				data: { data: [mockPluginRes] },
+				error: undefined,
+				response: { status: 200 },
+			})
+			// The read that follows once the write is done.
+			.mockResolvedValueOnce({
+				data: { data: { ...mockPluginRes, mockValue: 'someone else' } },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+		const pendingEdit = store.edit({ data: { ...mockPlugin, mockValue: 'my value' } } as IConfigPluginsEditActionPayload);
+
+		await store.fetch();
+
+		// Skipped, because the answer cannot be told apart from one taken before the edit landed.
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('my value');
+
+		resolvePatch({
+			data: { data: { ...mockPluginRes, mockValue: 'my value' } },
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		await pendingEdit;
+
+		await vi.waitFor(() => expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('someone else'));
+	});
+
 	// That deferred read is the only attempt left that can bring in whatever the dropped one was
 	// carrying, and the event handler that started it has long since resolved. A failure there has
 	// nowhere else to surface, so it must not be swallowed.

--- a/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.spec.ts
@@ -137,10 +137,10 @@ describe('ConfigPlugin Store', () => {
 		await expect(store.get({ type: 'custom-plugin' })).rejects.toThrow(ConfigApiException);
 	});
 
-	// The race the mutation-token stamp exists to prevent: a change event fires a `get()` for the
+	// The race the sequence exists to prevent: a change event fires a `get()` for the
 	// changed type while an already-in-flight `fetch()` is still reading the pre-change configuration.
-	// Without the stamp, `fetch()`'s wholesale replace lands after `get()` and wipes it out with the
-	// older snapshot, so the admin stays stale until something else happens to refresh it.
+	// Without the ordering, `fetch()`'s wholesale replace lands after `get()` and wipes it out with
+	// the older snapshot, so the admin stays stale until something else happens to refresh it.
 	it('keeps an entry refreshed by get() while fetch() is in flight, rather than restoring the snapshot it answers with', async () => {
 		let resolveFetch!: (value: unknown) => void;
 
@@ -214,6 +214,113 @@ describe('ConfigPlugin Store', () => {
 		expect(firstResult).toEqual(mockPlugin);
 		expect((forcedResult as ICustomPluginConfig).mockValue).toBe('forced value');
 		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('forced value');
+	});
+
+	// Ordering by when a response lands is not the same as ordering by when it was asked for, and
+	// only the second is meaningful: a read describes the moment its request went out. An entry
+	// `get()` issued before this `fetch()` and answered during it is the older story of the two, so
+	// the list response — asked for later — is the one worth keeping.
+	it('applies the fetch response over an entry read that was issued before it', async () => {
+		let resolveGet!: (value: unknown) => void;
+		let resolveFetch!: (value: unknown) => void;
+
+		const getRequest = new Promise((resolve) => {
+			resolveGet = resolve;
+		});
+
+		const fetchRequest = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(getRequest).mockReturnValueOnce(fetchRequest);
+
+		const pendingGet = store.get({ type: 'custom-plugin' });
+		const pendingFetch = store.fetch();
+
+		// The earlier request is answered first, and with what the server held before the change.
+		resolveGet({ data: { data: { ...mockPluginRes, mockValue: 'stale value' } } });
+		await pendingGet;
+
+		resolveFetch({ data: { data: [{ ...mockPluginRes, mockValue: 'current value' }] } });
+		await pendingFetch;
+
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('current value');
+	});
+
+	// Two change events for the same type can land together. Both forced refreshes then wait on the
+	// one request already in flight and both resume, so unless they are queued the second finds the
+	// semaphore still held by the first and is rejected out of hand.
+	it('serializes forced refreshes that arrive together instead of rejecting the second', async () => {
+		let resolveFirst!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		(backendClient.GET as Mock)
+			.mockReturnValueOnce(firstRequest)
+			.mockResolvedValueOnce({
+				data: { data: { ...mockPluginRes, mockValue: 'first refresh' } },
+				error: undefined,
+				response: { status: 200 },
+			})
+			.mockResolvedValueOnce({
+				data: { data: { ...mockPluginRes, mockValue: 'second refresh' } },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+		const firstGet = store.get({ type: 'custom-plugin' });
+		const forcedFirst = store.get({ type: 'custom-plugin', force: true });
+		const forcedSecond = store.get({ type: 'custom-plugin', force: true });
+
+		resolveFirst({ data: { data: mockPluginRes } });
+
+		const [, firstRefresh, secondRefresh] = await Promise.all([firstGet, forcedFirst, forcedSecond]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(3);
+		expect((firstRefresh as ICustomPluginConfig).mockValue).toBe('first refresh');
+		expect((secondRefresh as ICustomPluginConfig).mockValue).toBe('second refresh');
+		expect((store.data[mockPlugin.type] as ICustomPluginConfig).mockValue).toBe('second refresh');
+	});
+
+	// The registration a call retires has to be its own. A forced refresh registers itself in place
+	// of the read it is waiting on, so that earlier read finishing would otherwise delete the
+	// successor's entry — and the next caller, finding nothing registered, starts a competing
+	// request that collides with the one still in flight.
+	it('leaves a forced successor registered once the read it waited on finishes', async () => {
+		let resolveFirst!: (value: unknown) => void;
+		let resolveForced!: (value: unknown) => void;
+
+		const firstRequest = new Promise((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		const forcedRequest = new Promise((resolve) => {
+			resolveForced = resolve;
+		});
+
+		(backendClient.GET as Mock).mockReturnValueOnce(firstRequest).mockReturnValueOnce(forcedRequest);
+
+		const firstGet = store.get({ type: 'custom-plugin' });
+		const forcedGet = store.get({ type: 'custom-plugin', force: true });
+
+		resolveFirst({ data: { data: mockPluginRes } });
+		await firstGet;
+
+		// Wait for the forced successor to take over and issue its own request.
+		await vi.waitFor(() => expect(backendClient.GET).toHaveBeenCalledTimes(2));
+
+		// Arrives while that refresh is in flight, so it should be handed the same request.
+		const joinedGet = store.get({ type: 'custom-plugin' });
+
+		resolveForced({ data: { data: { ...mockPluginRes, mockValue: 'forced value' } } });
+
+		const [forcedResult, joinedResult] = await Promise.all([forcedGet, joinedGet]);
+
+		expect(backendClient.GET).toHaveBeenCalledTimes(2);
+		expect((forcedResult as ICustomPluginConfig).mockValue).toBe('forced value');
+		expect((joinedResult as ICustomPluginConfig).mockValue).toBe('forced value');
 	});
 
 	it('should update config Plugin successfully', async () => {

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -342,6 +342,12 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 			commit(parsedEditedConfig.data);
 
+			// Drawn as the request goes out, and so after the optimistic write above, which it is
+			// meant to confirm. What comes back describes the configuration as of the moment the
+			// server was asked, so a read issued later - a change event's forced refresh, say,
+			// picking up somebody else's edit - is the newer story even if it lands first.
+			const requestedAt = nextSequence();
+
 			try {
 				const {
 					data: responseData,
@@ -364,7 +370,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-					return commit(transformed);
+					return commit(transformed, requestedAt);
 				}
 
 				// Updating the record on api failed, so the optimistic write above has to be rolled

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -69,17 +69,30 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 		const pendingFetchPromises: Record<string, Promise<IConfigPlugin[]>> = {};
 
-		// Stamped on every write that is not `fetch()` applying its own response — a websocket event,
-		// a change-driven `get()`, an `edit()`. `fetch()` remembers the stamp it went out under, so
-		// when its response lands it can tell which entries were written since: for those the snapshot
-		// is the older story and must not overwrite them. See the guard inside `fetch()` below.
-		let mutationToken = 0;
-		const mutationTokenByType: Record<IConfigPlugin['type'], number> = {};
+		// Everything that can write an entry draws a number from one sequence, and each entry
+		// remembers the number behind what it currently holds. A write — a websocket event, an
+		// `edit()` — draws its number as it lands, because a write is authoritative the moment it
+		// happens. A read draws its number as the request goes out, because a response only ever
+		// tells the story of that moment: two reads issued in one order can come back in the
+		// other, and it is the earlier request's answer that is stale, however late it arrives.
+		let sequence = 0;
+
+		const nextSequence = (): number => ++sequence;
+
+		const appliedSequence: Record<IConfigPlugin['type'], number> = {};
 
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
-		// write below goes through it, which is what keeps the stamp complete.
-		const commit = (config: IConfigPlugin): IConfigPlugin => {
-			mutationTokenByType[config.type] = ++mutationToken;
+		// write below goes through it, which is what keeps the sequence complete. `at` places the
+		// write in that sequence; omitting it claims the moment of the call, which is what a write
+		// wants and a read does not.
+		const commit = (config: IConfigPlugin, at: number = nextSequence()): IConfigPlugin => {
+			if ((appliedSequence[config.type] ?? 0) > at) {
+				// Something newer is already held, so this is the older story and is not applied.
+				// The caller still gets an answer about what it asked for — the newer one.
+				return data.value[config.type] ?? config;
+			}
+
+			appliedSequence[config.type] = at;
 
 			return (data.value[config.type] = config);
 		};
@@ -123,26 +136,36 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 		};
 
 		const get = async (payload: IConfigPluginsGetActionPayload): Promise<IConfigPlugin> => {
-			const existingPromise = pendingGetPromises[payload.type];
-			if (existingPromise) {
-				if (payload.force) {
-					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
-					// request could hand back a snapshot taken before the change this call is
-					// reacting to. Its result does not matter here, only that it has finished — that
-					// is what frees the semaphore below for the new request this call makes instead
-					// of throwing 'Already getting plugin config.' by firing concurrently.
-					await existingPromise.catch(() => undefined);
-				} else {
-					return existingPromise;
-				}
+			const inFlight = pendingGetPromises[payload.type];
+
+			if (inFlight && !payload.force) {
+				return inFlight;
 			}
 
 			const getPromise = (async (): Promise<IConfigPlugin> => {
+				if (inFlight) {
+					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
+					// request could hand back a snapshot taken before the change this call is
+					// reacting to. Its result does not matter here, only that it has finished — that
+					// is what frees the semaphore below for the request this call makes instead.
+					//
+					// Waiting in here rather than before registering below is what serializes forced
+					// refreshes. Two arriving together would otherwise wait on the same request, both
+					// resume, and the second would find the semaphore still held by the first and
+					// reject with 'Already getting plugin config.' — after its own registration,
+					// made later, had already displaced the first's.
+					await inFlight.catch(() => undefined);
+				}
+
 				if (semaphore.value.fetching.item.includes(payload.type)) {
 					throw new ConfigApiException('Already getting plugin config.');
 				}
 
 				semaphore.value.fetching.item.push(payload.type);
+
+				// Drawn as the request goes out, not when its answer lands: what comes back
+				// describes the configuration as of now, whatever is written while it travels.
+				const requestedAt = nextSequence();
 
 				try {
 					const {
@@ -162,7 +185,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 						const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-						return commit(transformed);
+						return commit(transformed, requestedAt);
 					}
 
 					let errorReason: string | null = 'Failed to fetch plugin config.';
@@ -182,7 +205,13 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 			try {
 				return await getPromise;
 			} finally {
-				delete pendingGetPromises[payload.type];
+				// Only the registration this call owns. A forced refresh arriving while this read is
+				// still running has already replaced it with its own successor, and deleting that
+				// would leave the next caller unable to find — or queue behind — the read that is
+				// actually in flight.
+				if (pendingGetPromises[payload.type] === getPromise) {
+					delete pendingGetPromises[payload.type];
+				}
 			}
 		};
 
@@ -191,10 +220,6 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				return pendingFetchPromises['all'];
 			}
 
-			// Read before the request goes out: every entry stamped later than this was written while
-			// the server was assembling its answer, so for those entries this response is out of date.
-			const requestedAt = mutationToken;
-
 			const fetchPromise = (async (): Promise<IConfigPlugin[]> => {
 				if (semaphore.value.fetching.items) {
 					throw new ConfigApiException('Already fetching plugins config.');
@@ -202,16 +227,21 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 				semaphore.value.fetching.items = true;
 
+				// Drawn as the request goes out: an entry numbered higher than this was written, or
+				// read, after the server was asked, so for that entry this response is the older
+				// story.
+				const requestedAt = nextSequence();
+
 				try {
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/plugins`);
 
 					if (typeof responseData !== 'undefined') {
-						// Applied entry by entry rather than assigned wholesale: an entry written since
-						// `requestedAt` is newer than this snapshot and keeps what it holds — including
-						// having been dropped locally, which is why a stamped type with nothing behind
-						// it is left out rather than restored. Entries the response does not carry are
-						// still evicted, which is what makes this a replacement rather than a merge
-						// that can only ever grow.
+						// Applied entry by entry rather than assigned wholesale: an entry numbered higher
+						// than `requestedAt` was written, or read, after this request went out and keeps
+						// what it holds — including having been dropped locally, which is why a numbered
+						// type with nothing behind it is left out rather than restored. Entries the
+						// response does not carry are still evicted, which is what makes this a
+						// replacement rather than a merge that can only ever grow.
 						const applied: { [key: IConfigPlugin['type']]: IConfigPlugin } = {};
 
 						for (const plugin of responseData.data) {
@@ -219,7 +249,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 							const transformed = transformConfigPluginResponse(plugin, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-							if ((mutationTokenByType[transformed.type] ?? 0) > requestedAt) {
+							if ((appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -230,13 +260,23 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 							}
 
 							applied[transformed.type] = transformed;
+							appliedSequence[transformed.type] = requestedAt;
 						}
 
 						// Written while the request was in flight and absent from its answer: the
 						// server read its list before this entry's local write landed.
-						for (const [type, token] of Object.entries(mutationTokenByType)) {
-							if (token > requestedAt && !(type in applied) && data.value[type]) {
+						for (const [type, at] of Object.entries(appliedSequence)) {
+							if (at > requestedAt && !(type in applied) && data.value[type]) {
 								applied[type] = data.value[type];
+							}
+						}
+
+						// An entry this response does not carry is evicted, and the eviction takes this
+						// response's number like every other write it makes: a read still in flight
+						// from before it must not put back what a newer answer says is gone.
+						for (const type of Object.keys(data.value)) {
+							if (!(type in applied)) {
+								appliedSequence[type] = requestedAt;
 							}
 						}
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -104,6 +104,13 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 	const writePending = (type: IConfigPlugin['type']): boolean => (pendingWrites[type] ?? 0) > 0;
 
+	// Change-driven reads that were dropped for overlapping a write. The write's own answer
+	// settles the entry, but the event that prompted the read was the backend announcing that
+	// *something* changed - it does not say whose change, and it may well be another client's.
+	// Dropping the read silently would lose that until something else happened to refresh, so it
+	// is asked again once the write is out of the way, where the answer cannot predate it.
+	const refreshAfterWrite = new Set<IConfigPlugin['type']>();
+
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
 		// write below goes through it, which is what keeps the sequence complete. `at` places the
 		// write in that sequence; omitting it claims the moment of the call, which is what a write
@@ -217,6 +224,16 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						// The caller still gets the entry, just the copy the write left behind rather
 						// than the one this answer carries.
 						if (overlapsWrite) {
+							if (payload.force) {
+								if (writePending(payload.type)) {
+									refreshAfterWrite.add(payload.type);
+								} else {
+									// The write settled while this answer was in transit, so there is
+									// nothing left to wait for - ask again now.
+									void get({ type: payload.type, force: true }).catch(() => undefined);
+								}
+							}
+
 							return data.value[payload.type] ?? transformed;
 						}
 
@@ -419,6 +436,10 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				writeReleased = true;
 
 				endWrite(payload.data.type);
+
+				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
+					void get({ type: payload.data.type, force: true }).catch(() => undefined);
+				}
 			};
 
 			try {

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -190,6 +190,12 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				// describes the configuration as of now, whatever is written while it travels.
 				const requestedAt = nextSequence();
 
+				// Whether a write for this type was in flight at that moment. The server can answer
+				// a read from either side of an uncommitted write and nothing here distinguishes
+				// the two, so a read that overlapped one never speaks for the entry - however late
+				// it lands, and however new its number looks.
+				const overlapsWrite = writePending(payload.type);
+
 				try {
 					const {
 						data: responseData,
@@ -208,10 +214,9 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 						const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-						// A write for this type is in flight, so this answer is not guaranteed to
-						// include it - the server may not have committed it when it was read. The
-						// caller still gets the entry, just the copy the write is putting there.
-						if (writePending(payload.type)) {
+						// The caller still gets the entry, just the copy the write left behind rather
+						// than the one this answer carries.
+						if (overlapsWrite) {
 							return data.value[payload.type] ?? transformed;
 						}
 
@@ -262,6 +267,11 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				// story.
 				const requestedAt = nextSequence();
 
+				// The types whose write was in flight at that moment. This answer cannot speak for
+				// them either way - it may have been assembled before the write was committed - so
+				// they keep what they hold, present or absent from it.
+				const overlappedWrites = new Set(Object.keys(pendingWrites));
+
 				try {
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/plugins`);
 
@@ -279,7 +289,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 							const transformed = transformConfigPluginResponse(plugin, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-							if (writePending(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
+							if (overlappedWrites.has(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -301,6 +311,14 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 							}
 						}
 
+						// A type whose write overlapped this request is not described reliably by the
+						// answer, present or absent, so it keeps what it holds.
+						for (const type of overlappedWrites) {
+							if (!(type in applied) && data.value[type]) {
+								applied[type] = data.value[type];
+							}
+						}
+
 						// An entry this response does not carry is evicted, and the eviction takes this
 						// response's number like every other write it makes: a read still in flight
 						// from before it must not put back what a newer answer says is gone.
@@ -313,7 +331,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						const known = new Set([...Object.keys(data.value), ...Object.keys(appliedSequence), ...Object.keys(pendingGetPromises)]);
 
 						for (const type of known) {
-							if (!(type in applied)) {
+							if (!(type in applied) && !overlappedWrites.has(type)) {
 								appliedSequence[type] = requestedAt;
 							}
 						}

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -69,6 +69,21 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 		const pendingFetchPromises: Record<string, Promise<IConfigPlugin[]>> = {};
 
+		// Stamped on every write that is not `fetch()` applying its own response — a websocket event,
+		// a change-driven `get()`, an `edit()`. `fetch()` remembers the stamp it went out under, so
+		// when its response lands it can tell which entries were written since: for those the snapshot
+		// is the older story and must not overwrite them. See the guard inside `fetch()` below.
+		let mutationToken = 0;
+		const mutationTokenByType: Record<IConfigPlugin['type'], number> = {};
+
+		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
+		// write below goes through it, which is what keeps the stamp complete.
+		const commit = (config: IConfigPlugin): IConfigPlugin => {
+			mutationTokenByType[config.type] = ++mutationToken;
+
+			return (data.value[config.type] = config);
+		};
+
 		const updating = (plugin: IConfigPlugin['type']): boolean => semaphore.value.updating.includes(plugin);
 
 		const onEvent = (payload: IConfigPluginsOnEventActionPayload): IConfigPlugin => {
@@ -91,7 +106,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 					throw new ConfigValidationException('Failed to insert plugin configuration.');
 				}
 
-				return (data.value[parsed.data.type] = parsed.data);
+				return commit(parsed.data);
 			}
 
 			const parsed = (element?.schemas?.pluginConfigSchema || ConfigPluginSchema).safeParse(payload.data);
@@ -104,13 +119,22 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 			data.value ??= {};
 
-			return (data.value[parsed.data.type] = parsed.data);
+			return commit(parsed.data);
 		};
 
 		const get = async (payload: IConfigPluginsGetActionPayload): Promise<IConfigPlugin> => {
 			const existingPromise = pendingGetPromises[payload.type];
 			if (existingPromise) {
-				return existingPromise;
+				if (payload.force) {
+					// A change-driven refresh must be a genuinely fresh read: reusing an in-flight
+					// request could hand back a snapshot taken before the change this call is
+					// reacting to. Its result does not matter here, only that it has finished — that
+					// is what frees the semaphore below for the new request this call makes instead
+					// of throwing 'Already getting plugin config.' by firing concurrently.
+					await existingPromise.catch(() => undefined);
+				} else {
+					return existingPromise;
+				}
 			}
 
 			const getPromise = (async (): Promise<IConfigPlugin> => {
@@ -138,9 +162,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 						const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-						data.value[transformed.type] = transformed;
-
-						return transformed;
+						return commit(transformed);
 					}
 
 					let errorReason: string | null = 'Failed to fetch plugin config.';
@@ -169,6 +191,10 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				return pendingFetchPromises['all'];
 			}
 
+			// Read before the request goes out: every entry stamped later than this was written while
+			// the server was assembling its answer, so for those entries this response is out of date.
+			const requestedAt = mutationToken;
+
 			const fetchPromise = (async (): Promise<IConfigPlugin[]> => {
 				if (semaphore.value.fetching.items) {
 					throw new ConfigApiException('Already fetching plugins config.');
@@ -180,17 +206,41 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 					const { data: responseData, error, response } = await backend.client.GET(`/${MODULES_PREFIX}/${CONFIG_MODULE_PREFIX}/config/plugins`);
 
 					if (typeof responseData !== 'undefined') {
-						data.value = Object.fromEntries(
-							responseData.data.map((plugin) => {
-								const element = getPluginElement(plugin.type);
+						// Applied entry by entry rather than assigned wholesale: an entry written since
+						// `requestedAt` is newer than this snapshot and keeps what it holds — including
+						// having been dropped locally, which is why a stamped type with nothing behind
+						// it is left out rather than restored. Entries the response does not carry are
+						// still evicted, which is what makes this a replacement rather than a merge
+						// that can only ever grow.
+						const applied: { [key: IConfigPlugin['type']]: IConfigPlugin } = {};
 
-								const transformed = transformConfigPluginResponse(plugin, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
+						for (const plugin of responseData.data) {
+							const element = getPluginElement(plugin.type);
 
-								data.value[transformed.type] = transformed;
+							const transformed = transformConfigPluginResponse(plugin, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-								return [transformed.type, transformed];
-							})
-						);
+							if ((mutationTokenByType[transformed.type] ?? 0) > requestedAt) {
+								const local = data.value[transformed.type];
+
+								if (local) {
+									applied[transformed.type] = local;
+								}
+
+								continue;
+							}
+
+							applied[transformed.type] = transformed;
+						}
+
+						// Written while the request was in flight and absent from its answer: the
+						// server read its list before this entry's local write landed.
+						for (const [type, token] of Object.entries(mutationTokenByType)) {
+							if (token > requestedAt && !(type in applied) && data.value[type]) {
+								applied[type] = data.value[type];
+							}
+						}
+
+						data.value = applied;
 
 						firstLoad.value = true;
 
@@ -250,7 +300,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 			semaphore.value.updating.push(payload.data.type);
 
-			data.value[parsedEditedConfig.data.type] = parsedEditedConfig.data;
+			commit(parsedEditedConfig.data);
 
 			try {
 				const {
@@ -274,9 +324,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-					data.value[transformed.type] = transformed;
-
-					return transformed;
+					return commit(transformed);
 				}
 
 				// Updating the record on api failed, we need to refresh the record

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -230,7 +230,9 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 								} else {
 									// The write settled while this answer was in transit, so there is
 									// nothing left to wait for - ask again now.
-									void get({ type: payload.type, force: true }).catch(() => undefined);
+									void get({ type: payload.type, force: true }).catch((error: unknown): void => {
+										logger.error('Failed to re-read plugin config after a write settled', error);
+									});
 								}
 							}
 
@@ -438,7 +440,14 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				endWrite(payload.data.type);
 
 				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
-					void get({ type: payload.data.type, force: true }).catch(() => undefined);
+					// This is the only attempt left that can bring in whatever the dropped read was
+					// carrying, and the event handler that started it has long since resolved, so a
+					// failure here has nowhere else to surface. It is reported rather than swallowed:
+					// the entry keeps this client's confirmed value, and another client's change
+					// arrives with the next event or refresh instead.
+					void get({ type: payload.data.type, force: true }).catch((error: unknown): void => {
+						logger.error('Failed to re-read plugin config after an edit settled', error);
+					});
 				}
 			};
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -81,6 +81,29 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 		const appliedSequence: Record<IConfigPlugin['type'], number> = {};
 
+	// Types whose write is in flight. A read issued after that write went out is *not*
+	// guaranteed to include it - the server may not have committed it yet - so for as long as
+	// one is outstanding no read may speak for the entry, however new its number looks. Without
+	// this, a list read issued mid-edit lands with the pre-edit value, takes the higher number,
+	// and then rejects the edit's own confirmation as the older story.
+	const pendingWrites: Record<IConfigPlugin['type'], number> = {};
+
+	const beginWrite = (type: IConfigPlugin['type']): void => {
+		pendingWrites[type] = (pendingWrites[type] ?? 0) + 1;
+	};
+
+	const endWrite = (type: IConfigPlugin['type']): void => {
+		const remaining = (pendingWrites[type] ?? 1) - 1;
+
+		if (remaining > 0) {
+			pendingWrites[type] = remaining;
+		} else {
+			delete pendingWrites[type];
+		}
+	};
+
+	const writePending = (type: IConfigPlugin['type']): boolean => (pendingWrites[type] ?? 0) > 0;
+
 		// The one way an entry is written outside `fetch()`. Every direct `data.value[...] = ...`
 		// write below goes through it, which is what keeps the sequence complete. `at` places the
 		// write in that sequence; omitting it claims the moment of the call, which is what a write
@@ -185,6 +208,13 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 						const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
+						// A write for this type is in flight, so this answer is not guaranteed to
+						// include it - the server may not have committed it when it was read. The
+						// caller still gets the entry, just the copy the write is putting there.
+						if (writePending(payload.type)) {
+							return data.value[payload.type] ?? transformed;
+						}
+
 						return commit(transformed, requestedAt);
 					}
 
@@ -249,7 +279,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 							const transformed = transformConfigPluginResponse(plugin, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
 
-							if ((appliedSequence[transformed.type] ?? 0) > requestedAt) {
+							if (writePending(transformed.type) || (appliedSequence[transformed.type] ?? 0) > requestedAt) {
 								const local = data.value[transformed.type];
 
 								if (local) {
@@ -274,7 +304,15 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						// An entry this response does not carry is evicted, and the eviction takes this
 						// response's number like every other write it makes: a read still in flight
 						// from before it must not put back what a newer answer says is gone.
-						for (const type of Object.keys(data.value)) {
+						//
+						// The tombstone has to cover more than what is held right now. A `get()` for a
+						// type that is currently absent carries no number yet, so without a tombstone
+						// of its own it would be free to reinstate an entry this list says no longer
+						// exists. Every type this store has heard of - held, numbered before, or being
+						// read at this moment - gets one.
+						const known = new Set([...Object.keys(data.value), ...Object.keys(appliedSequence), ...Object.keys(pendingGetPromises)]);
+
+						for (const type of known) {
 							if (!(type in applied)) {
 								appliedSequence[type] = requestedAt;
 							}
@@ -348,6 +386,23 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 			// picking up somebody else's edit - is the newer story even if it lands first.
 			const requestedAt = nextSequence();
 
+			// Held from the moment the request goes out until its answer is in hand. A read issued
+			// inside that window carries a higher number but can still be answered from before the
+			// write was committed, so it must not be allowed to speak for the entry.
+			beginWrite(payload.data.type);
+
+			let writeReleased = false;
+
+			const releaseWrite = (): void => {
+				if (writeReleased) {
+					return;
+				}
+
+				writeReleased = true;
+
+				endWrite(payload.data.type);
+			};
+
 			try {
 				const {
 					data: responseData,
@@ -366,6 +421,8 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						),
 					},
 				});
+
+				releaseWrite();
 
 				if (typeof responseData !== 'undefined') {
 					const transformed = transformConfigPluginResponse(responseData.data, element?.schemas?.pluginConfigSchema || ConfigPluginSchema);
@@ -388,6 +445,10 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 
 				throw new ConfigApiException(errorReason, response.status);
 			} finally {
+				// A backstop for the request throwing outright, which would otherwise leave the
+				// entry held for good.
+				releaseWrite();
+
 				semaphore.value.updating = semaphore.value.updating.filter((item) => item !== payload.data.type);
 			}
 		};

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -367,8 +367,12 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 					return commit(transformed);
 				}
 
-				// Updating the record on api failed, we need to refresh the record
-				await get({ type: payload.data.type });
+				// Updating the record on api failed, so the optimistic write above has to be rolled
+				// back to whatever the server actually holds. Forced, because a plain read would
+				// be allowed to join a request that went out before that optimistic write: its
+				// answer carries a lower number and would be dropped, leaving the value the failed
+				// edit put there in place.
+				await get({ type: payload.data.type, force: true });
 
 				let errorReason: string | null = 'Failed to update plugin config.';
 

--- a/apps/admin/src/modules/config/store/config-plugins.store.ts
+++ b/apps/admin/src/modules/config/store/config-plugins.store.ts
@@ -225,15 +225,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						// than the one this answer carries.
 						if (overlapsWrite) {
 							if (payload.force) {
-								if (writePending(payload.type)) {
-									refreshAfterWrite.add(payload.type);
-								} else {
-									// The write settled while this answer was in transit, so there is
-									// nothing left to wait for - ask again now.
-									void get({ type: payload.type, force: true }).catch((error: unknown): void => {
-										logger.error('Failed to re-read plugin config after a write settled', error);
-									});
-								}
+								reReadAfterWrite(payload.type);
 							}
 
 							return data.value[payload.type] ?? transformed;
@@ -269,7 +261,22 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 			}
 		};
 
-		const fetch = async (): Promise<IConfigPlugin[]> => {
+		// Re-issues a read that had to be dropped for overlapping a write. Dropping one silently would
+	// lose whatever prompted it - another client's change, most often - so it is asked again once
+	// the write is out of the way, where the answer cannot predate it.
+	const reReadAfterWrite = (type: IConfigPlugin['type']): void => {
+		if (writePending(type)) {
+			refreshAfterWrite.add(type);
+
+			return;
+		}
+
+		void get({ type, force: true }).catch((error: unknown): void => {
+			logger.error('Failed to re-read plugin config after a write settled', error);
+		});
+	};
+
+	const fetch = async (): Promise<IConfigPlugin[]> => {
 			if ('all' in pendingFetchPromises) {
 				return pendingFetchPromises['all'];
 			}
@@ -331,11 +338,15 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 						}
 
 						// A type whose write overlapped this request is not described reliably by the
-						// answer, present or absent, so it keeps what it holds.
+						// answer, present or absent, so it keeps what it holds - and is asked about
+						// again, because this response may have been the one carrying another client's
+						// change and a reconnect refresh is exactly where that matters.
 						for (const type of overlappedWrites) {
 							if (!(type in applied) && data.value[type]) {
 								applied[type] = data.value[type];
 							}
+
+							reReadAfterWrite(type);
 						}
 
 						// An entry this response does not carry is evicted, and the eviction takes this
@@ -440,14 +451,7 @@ export const useConfigPlugin = defineStore<'config-module_config_plugin', Config
 				endWrite(payload.data.type);
 
 				if (!writePending(payload.data.type) && refreshAfterWrite.delete(payload.data.type)) {
-					// This is the only attempt left that can bring in whatever the dropped read was
-					// carrying, and the event handler that started it has long since resolved, so a
-					// failure here has nowhere else to surface. It is reported rather than swallowed:
-					// the entry keeps this client's confirmed value, and another client's change
-					// arrives with the next event or refresh instead.
-					void get({ type: payload.data.type, force: true }).catch((error: unknown): void => {
-						logger.error('Failed to re-read plugin config after an edit settled', error);
-					});
+					reReadAfterWrite(payload.data.type);
 				}
 			};
 

--- a/apps/admin/src/modules/config/utils/config-change-event.spec.ts
+++ b/apps/admin/src/modules/config/utils/config-change-event.spec.ts
@@ -34,14 +34,16 @@ describe('handleConfigChangeEvent', (): void => {
 			targets()
 		);
 
-		expect(configModulesStore.get).toHaveBeenCalledWith({ type: 'mock-module' });
+		// `force: true` so the refresh chains onto an in-flight `get()` for the same type rather than
+		// reusing its (possibly pre-change) result — see config-modules.store.ts.
+		expect(configModulesStore.get).toHaveBeenCalledWith({ type: 'mock-module', force: true });
 		expect(configPluginsStore.get).not.toHaveBeenCalled();
 	});
 
 	it('refetches the plugin whose config changed', (): void => {
 		handleConfigChangeEvent({ event: EventType.CONFIG_UPDATED, payload: { source: 'mock', type: 'plugin' } }, targets());
 
-		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'mock' });
+		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'mock', force: true });
 		expect(configModulesStore.get).not.toHaveBeenCalled();
 	});
 
@@ -57,7 +59,7 @@ describe('handleConfigChangeEvent', (): void => {
 		);
 
 		// Read back through the authenticated endpoint, not taken off the wire.
-		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'devices-zigbee2mqtt-plugin' });
+		expect(configPluginsStore.get).toHaveBeenCalledWith({ type: 'devices-zigbee2mqtt-plugin', force: true });
 	});
 
 	it('ignores events from other modules', (): void => {

--- a/apps/admin/src/modules/config/utils/config-change-event.ts
+++ b/apps/admin/src/modules/config/utils/config-change-event.ts
@@ -6,8 +6,8 @@ interface IConfigChangeEvent {
 }
 
 interface IConfigChangeTargets {
-	configModulesStore: { get: (payload: { type: string }) => Promise<unknown> };
-	configPluginsStore: { get: (payload: { type: string }) => Promise<unknown> };
+	configModulesStore: { get: (payload: { type: string; force?: boolean }) => Promise<unknown> };
+	configPluginsStore: { get: (payload: { type: string; force?: boolean }) => Promise<unknown> };
 	logger: { warn: (message: string, ...args: unknown[]) => void; error: (message: string, ...args: unknown[]) => void };
 }
 
@@ -49,11 +49,14 @@ export const handleConfigChangeEvent = (data: IConfigChangeEvent, targets: IConf
 			}
 
 			if (type === 'module') {
-				configModulesStore.get({ type: source }).catch((error: unknown): void => {
+				// `force: true` because this call is racing an already-in-flight `get()` for the same
+				// type just as often as it is racing `fetch()`: reusing that in-flight request's result
+				// would silently hand back a read taken before this change happened. See config-modules.store.ts.
+				configModulesStore.get({ type: source, force: true }).catch((error: unknown): void => {
 					logger.error('Failed to refresh a module config after a change event', error);
 				});
 			} else if (type === 'plugin') {
-				configPluginsStore.get({ type: source }).catch((error: unknown): void => {
+				configPluginsStore.get({ type: source, force: true }).catch((error: unknown): void => {
 					logger.error('Failed to refresh a plugin config after a change event', error);
 				});
 			} else {

--- a/apps/admin/src/modules/devices/store/devices.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.spec.ts
@@ -623,6 +623,46 @@ describe('Devices Store', () => {
 			expect(store.findById(device.id)?.enabled).toBe(true);
 		});
 
+		// The guard above asks whether the row moved on, and a row that was merely re-read has not.
+		// A `get()` answering late with what the server held before the bulk update is an older
+		// story arriving late, not a newer write, and must not suppress the confirmation.
+		it('applies the confirmation even when a read landed while the request was in flight', async () => {
+			const device = deviceFixture('device-1');
+
+			mockBackendClient.GET.mockResolvedValueOnce({ data: { data: [device] }, error: undefined, response: { status: 200 } });
+
+			await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+			let resolveRequest!: (value: unknown) => void;
+
+			const request = new Promise((resolve) => {
+				resolveRequest = resolve;
+			});
+
+			mockBackendClient.POST.mockReturnValueOnce(request);
+
+			const pendingBulk = store.bulkSetEnabled({ ids: [device.id], enabled: false });
+
+			// A per-row read answering with the state from before the bulk update was applied.
+			(mockBackendClient.GET as Mock).mockResolvedValueOnce({
+				data: { data: { ...device, controls: [], channels: [] } },
+				error: undefined,
+				response: { status: 200 },
+			});
+
+			await store.get({ id: device.id });
+
+			resolveRequest({
+				data: { data: { succeeded: [device.id], failed: [] } },
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			await pendingBulk;
+
+			expect(store.findById(device.id)?.enabled).toBe(false);
+		});
+
 		it('sends the selection in the request body', async () => {
 			const ids = await seed(2);
 

--- a/apps/admin/src/modules/devices/store/devices.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.spec.ts
@@ -548,6 +548,46 @@ describe('Devices Store', () => {
 			expect(store.findById(ids[1]!)?.enabled).toBe(true);
 		});
 
+		// The race the mutation-token stamp exists to prevent: a `fetch()` already in flight when the
+		// bulk update lands resolves afterwards with the response the server assembled before the
+		// update - still carrying the pre-update `enabled` value. Applying that snapshot must not
+		// undo the confirmed bulk outcome.
+		it('keeps the bulk-confirmed value against a fetch that resolves later with the stale value', async () => {
+			const device = deviceFixture('device-1');
+
+			mockBackendClient.GET.mockResolvedValueOnce({ data: { data: [device] }, error: undefined, response: { status: 200 } });
+
+			await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+			let resolveRequest!: (value: unknown) => void;
+
+			const request = new Promise((resolve) => {
+				resolveRequest = resolve;
+			});
+
+			(mockBackendClient.GET as Mock).mockReturnValueOnce(request);
+
+			// A refresh - e.g. on reconnect - starts before the bulk update goes out ...
+			const pendingFetch = store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+			mockBackendClient.POST.mockResolvedValue({
+				data: { data: { succeeded: [device.id], failed: [] } },
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			await store.bulkSetEnabled({ ids: [device.id], enabled: false });
+
+			expect(store.findById(device.id)?.enabled).toBe(false);
+
+			// ... and resolves only now, with the response the server built before the bulk update
+			// committed - still `enabled: true`.
+			resolveRequest({ data: { data: [device] } });
+			await pendingFetch;
+
+			expect(store.findById(device.id)?.enabled).toBe(false);
+		});
+
 		it('sends the selection in the request body', async () => {
 			const ids = await seed(2);
 

--- a/apps/admin/src/modules/devices/store/devices.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.spec.ts
@@ -588,6 +588,41 @@ describe('Devices Store', () => {
 			expect(store.findById(device.id)?.enabled).toBe(false);
 		});
 
+		// The response says only that the backend applied the change, not what the row looks like
+		// now. If something wrote the row while the request was in flight - another client's change
+		// arriving over the socket, most likely - the confirmation would otherwise walk it back to
+		// the value this request asked for, and stamp that older value as the newest thing known.
+		it('does not walk back a row something else wrote while the request was in flight', async () => {
+			const device = deviceFixture('device-1');
+
+			mockBackendClient.GET.mockResolvedValueOnce({ data: { data: [device] }, error: undefined, response: { status: 200 } });
+
+			await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+			let resolveRequest!: (value: unknown) => void;
+
+			const request = new Promise((resolve) => {
+				resolveRequest = resolve;
+			});
+
+			mockBackendClient.POST.mockReturnValueOnce(request);
+
+			const pendingBulk = store.bulkSetEnabled({ ids: [device.id], enabled: false });
+
+			// Somebody else turns it back on while the bulk request is still outstanding.
+			store.onEvent({ id: device.id, type: device.type, data: { ...device, enabled: true } });
+
+			resolveRequest({
+				data: { data: { succeeded: [device.id], failed: [] } },
+				error: undefined,
+				response: { ok: true, status: 200 },
+			});
+
+			await pendingBulk;
+
+			expect(store.findById(device.id)?.enabled).toBe(true);
+		});
+
 		it('sends the selection in the request body', async () => {
 			const ids = await seed(2);
 

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -807,7 +807,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 				const record = data.value[id];
 
 				if (record !== undefined) {
-					data.value[id] = { ...record, enabled: payload.enabled };
+					commit({ ...record, enabled: payload.enabled });
 				}
 			}
 

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -781,6 +781,12 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 
 		semaphore.value.updating.push(...persisted);
 
+		// What each row was stamped at before the request goes out. The response says only that the
+		// backend applied the change, not what the row looks like now, so a row that something else
+		// has written since - a `DEVICE_UPDATED` event carrying another client's newer state, most
+		// likely - must not be walked back to the value this request asked for.
+		const stampedBefore = new Map(persisted.map((id): [IDevice['id'], number] => [id, mutationTokenById[id] ?? 0]));
+
 		try {
 			const { data: responseBody, error, response } = await backend.client.POST(
 				`/${MODULES_PREFIX}/${DEVICES_MODULE_PREFIX}/devices/bulk-update`,
@@ -806,7 +812,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 			for (const id of result.succeeded) {
 				const record = data.value[id];
 
-				if (record !== undefined) {
+				if (record !== undefined && (mutationTokenById[id] ?? 0) === stampedBefore.get(id)) {
 					commit({ ...record, enabled: payload.enabled });
 				}
 			}

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -132,16 +132,28 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 	let mutationToken = 0;
 	const mutationTokenById: Record<IDevice['id'], number> = {};
 
+	// The subset of those stamps that came from something authoritative - a device event, an edit, a
+	// removal - rather than from a row merely being re-read. A read that lands late is not a newer
+	// write however late it lands, and a confirmation asking whether its row has moved on since it
+	// was requested must not mistake one for the other.
+	const writeTokenById: Record<IDevice['id'], number> = {};
+
 	// The two ways a row is written outside a fetch. Everything else in this store goes through them,
-	// which is what keeps the stamp complete.
-	const commit = (device: IDevice): IDevice => {
+	// which is what keeps the stamp complete. `read` marks a commit that only carries back what the
+	// server already had, so the row is stamped without claiming to have been changed.
+	const commit = (device: IDevice, { read = false }: { read?: boolean } = {}): IDevice => {
 		mutationTokenById[device.id] = ++mutationToken;
+
+		if (!read) {
+			writeTokenById[device.id] = mutationTokenById[device.id];
+		}
 
 		return (data.value[device.id] = device);
 	};
 
 	const forget = (id: IDevice['id']): void => {
 		mutationTokenById[id] = ++mutationToken;
+		writeTokenById[id] = mutationTokenById[id];
 
 		delete data.value[id];
 	};
@@ -225,7 +237,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 
 					const transformed = transformDeviceResponse(responseData.data, element?.schemas?.deviceSchema || DeviceSchema);
 
-					commit(transformed);
+					commit(transformed, { read: true });
 
 					insertDeviceControlsRelations(transformed, responseData.data.controls);
 					insertChannelsRelations(transformed, responseData.data.channels);
@@ -784,8 +796,9 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 		// What each row was stamped at before the request goes out. The response says only that the
 		// backend applied the change, not what the row looks like now, so a row that something else
 		// has written since - a `DEVICE_UPDATED` event carrying another client's newer state, most
-		// likely - must not be walked back to the value this request asked for.
-		const stampedBefore = new Map(persisted.map((id): [IDevice['id'], number] => [id, mutationTokenById[id] ?? 0]));
+		// likely - must not be walked back to the value this request asked for. A row merely re-read
+		// in the meantime has not moved on, so it still takes the confirmation.
+		const stampedBefore = new Map(persisted.map((id): [IDevice['id'], number] => [id, writeTokenById[id] ?? 0]));
 
 		try {
 			const { data: responseBody, error, response } = await backend.client.POST(
@@ -812,7 +825,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 			for (const id of result.succeeded) {
 				const record = data.value[id];
 
-				if (record !== undefined && (mutationTokenById[id] ?? 0) === stampedBefore.get(id)) {
+				if (record !== undefined && (writeTokenById[id] ?? 0) === stampedBefore.get(id)) {
 					commit({ ...record, enabled: payload.enabled });
 				}
 			}


### PR DESCRIPTION
Addresses two Codex findings on already-merged PRs — the `commit` bypass flagged on #794 and the config refresh race flagged on #805. They are the same bug shape: a response that left the server *before* a write lands *after* it, and wins.

## The devices bulk update bypassed the stamp

`devices.store` keeps a mutation token per row, and `fetch()` uses it to leave alone anything written while its request was in flight. Every write goes through `commit()` or `forget()` so the stamp stays complete — the comment above them says so directly:

> The two ways a row is written outside a fetch. Everything else in this store goes through them, which is what keeps the stamp complete.

The bulk `setEnabled` path was the one exception, assigning straight into `data.value`. The row therefore carried no newer stamp, and a `fetch()` that started before the bulk request and answered after it restored the old `enabled` value. Visible on reconnect or manual refresh, and whenever the websocket event is late or absent.

It was the only such write left in the store — `bulkRemove` already used `forget()`.

## The config stores had no guard at all

#805 made a config-change event refetch just the entry that changed. Two races defeated it:

- `fetch()` replaced the whole map wholesale (`data.value = Object.fromEntries(…)`), so an entry refreshed while a list request was in flight was discarded, and the admin stayed stale until something else refreshed it.
- `get()` returned any in-flight promise for the same type, so a refresh *reacting to a change* could be handed a read taken **before** that change.

Both stores now carry the devices store's pattern: every write outside `fetch()` goes through a stamping `commit()`, `fetch()` remembers the stamp it went out under, and its response is applied entry by entry so anything written since keeps the newer value. Both writes in `edit()` are stamped — the optimistic one as well as the confirmed one — since a guard that misses a write is the incomplete-stamp problem one layer down.

For the second race, `get()` takes an opt-in `force` flag: it waits for an in-flight read to settle, then issues its own. Waiting rather than firing concurrently is what keeps it from tripping the semaphore, which rejects a second read for a type already being read. Only the change handler passes it; every other caller keeps the dedup.

## Review follow-up: two holes in the first attempt

Codex found both, and both were real.

**The stamp ordered by the wrong moment.** It was taken when a response landed, but a read only
ever describes the moment its request went out. An entry `get()` issued *before* a `fetch()` and
answered *during* it therefore counted as the newer of the two, so if the configuration changed
between the two requests the list response carried the new value and was thrown away in favour of
the older read. Reads now draw their number as the request is issued and writes as they land, and
a commit whose number is below what an entry already holds is dropped rather than applied. An
eviction takes its response's number too, so a read still in flight cannot resurrect an entry a
newer answer says is gone.

**Forced refreshes raced each other.** Two arriving together both awaited the one request in
flight and both resumed; the second found the semaphore still held by the first and was rejected
with `Already getting … config.` — after its own registration, made later, had displaced the
first's, which the first then deleted on its way out. A caller arriving after that found nothing
registered and started a competing request. A forced refresh now waits *inside* its own promise,
which queues it behind its predecessor, and a call retires only the registration it owns.

Six new tests, three per store; all six fail against the previous revision.

**And the edit response was ordered by the wrong moment too.** A successful PATCH answers with
the configuration as of when the server was asked, so it is a read like any other in that respect,
but it was taking its number on arrival. A refresh issued after the edit went out — a change event
reacting to another client's edit — was therefore overwritten whenever the slower PATCH response
landed second. It now draws its number as the request goes out: after the optimistic write it
confirms, before anything issued later.

**And the rollback after a failed edit had to be forced.** It undoes an optimistic write that is
newer than anything already in flight, so a plain read could join an older request whose answer
the ordering then correctly discards — leaving exactly the value the failed edit had written.

**And a read cannot speak for an entry whose write is still in flight.** Ordering by issue time
assumes a later request sees more, which is false while a write is outstanding: the server can
answer a read from before it commits. A list read issued mid-edit therefore landed with the
pre-edit value, took the higher number, and then rejected the edit's own confirmation as older.
An entry is now held from the moment its write goes out until the answer is in hand.

**And the overlap has to be decided when the read is issued, not when it lands.** Checking it at
response time meant the hold only protected reads that came back before the edit did; a read issued
during the write but answered after it kept its higher number and committed the pre-edit snapshot
over the confirmed edit — the same failure, one ordering later. A read issued while a write was in
flight now never speaks for that entry, whenever it lands, and a list response leaves an overlapped
type alone whether it carries it or omits it.

So the rule is two lines: **a response that overlapped a write cannot speak for that entry, and one
that did not is ordered by when it was issued.** The hold is bounded — a read issued after the
write settles overlaps nothing and wins normally.

**And a dropped change-driven refresh is asked again rather than simply lost.** Discarding it would
lose another client's edit until something else happened to refresh. Trusting it instead is not
safe either: `CONFIG_UPDATED` carries only `{ source, type }`, so it announces that something
changed, not that the change includes this client's write — an event-driven read can still predate
it. So a forced read dropped for overlapping a write is re-issued once the write is out of the way,
where the answer cannot predate it. Another client's change arrives one round trip later instead of
being lost, and the re-issue cannot recur because the follow-up overlaps nothing.

**And the eviction tombstones were too narrow.** They covered only the entries held at that moment,
but a `get()` for a currently absent type carries no number of its own, so its late answer could
reinstate an entry the newer list said was gone. Every type the store has heard of — held, numbered
before, or being read right now — now gets one.

That deferred read is the last attempt that can recover the dropped one's content, and the event
handler that started it has already resolved, so **a rejection there is logged rather than
swallowed**. Not retried: the entry meanwhile holds this client's confirmed value, so nothing wrong
is shown, and the change arrives with the next event or refresh.

Both re-issue paths go through one helper, so a list `fetch()` that could not speak for an entry
asks about it again rather than only skipping it — a reconnect refresh is exactly where another
client's change tends to be waiting.

**The devices bulk confirmation is ordered too.** Its response says only which ids succeeded, not
what the rows hold now, so applying it unconditionally walked back a row a `DEVICE_UPDATED` had
touched meanwhile and stamped that older value as the newest thing known — reachable only because
this PR made that path stamp at all. Each row's stamp is captured before the request goes out and
the confirmation is applied only where nothing has written since. Comparing *any* stamp change was too blunt, though: a `get()` answering late with what the server
already had bumped the same counter and so looked like somebody else's write, suppressing a correct
confirmation. `commit()` now distinguishes the two — a read-driven commit stamps the row for the
list-fetch guard without claiming to have changed it, and the bulk guard compares writes only. The
config stores' full request-time sequence model is deliberately *not* ported to that store here; it
needs its own change.

## Verification

- Admin unit: green (31 new — 7 in the first pass, 24 across the review follow-ups)
- `type-check` clean, eslint clean on all touched files
- Every fix mutation-tested. Restoring the direct assignment makes the devices race test fail (`expected true to be false`); reverting the stamp guard fails exactly the two "keeps an entry refreshed…" tests; reverting the forced read fails exactly the two "issues a new request…" tests. In each case everything else stayed green, so the tests are scoped to what they claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)








