### PR TITLE
fix(admin): plug memory leaks in timers, pollers and stores

### DIFF
--- a/apps/admin/src/app.main.spec.ts
+++ b/apps/admin/src/app.main.spec.ts
@@ -1,0 +1,85 @@
+import { nextTick } from 'vue';
+
+import mitt from 'mitt';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type VueWrapper, mount } from '@vue/test-utils';
+
+import AppMain from './app.main.vue';
+import { eventBusKey } from './common';
+
+vi.mock('vue-meta', () => ({
+	useMeta: () => undefined,
+}));
+
+// `app.main.vue` imports `vLoading` directly (`import { vLoading } from 'element-plus'`), so
+// `<script setup>` binds `v-loading` to that local import at compile time and never goes through
+// runtime directive resolution — a `global.directives` stub on `mount()` would never be consulted.
+// Mocking the module export is the only way to observe what value the directive receives. Keep the
+// rest of the real module intact: `./common` transitively pulls in other `element-plus` exports.
+vi.mock('element-plus', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('element-plus')>();
+
+	return {
+		...actual,
+		vLoading: (el: HTMLElement, binding: { value: unknown }): void => {
+			el.setAttribute('data-loading', String(binding.value));
+		},
+	};
+});
+
+describe('AppMain', (): void => {
+	let eventBus: ReturnType<typeof mitt>;
+	let wrapper: VueWrapper;
+
+	const overlayState = (): string | null => wrapper.find('[data-loading]').attributes('data-loading') ?? null;
+
+	beforeEach((): void => {
+		vi.useFakeTimers();
+
+		eventBus = mitt();
+
+		wrapper = mount(AppMain, {
+			global: {
+				provide: {
+					[eventBusKey as symbol]: eventBus,
+				},
+				stubs: {
+					metainfo: true,
+					'router-view': true,
+				},
+			},
+		});
+	});
+
+	afterEach((): void => {
+		wrapper.unmount();
+
+		vi.useRealTimers();
+	});
+
+	it('turns the overlay on for a numeric duration and off once it elapses', async (): Promise<void> => {
+		eventBus.emit('loadingOverlay', 5);
+		await nextTick();
+
+		expect(overlayState()).toBe('true');
+
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		expect(overlayState()).toBe('false');
+	});
+
+	it('a second timed overlay request does not strand a timer that later forces the overlay off', async (): Promise<void> => {
+		eventBus.emit('loadingOverlay', 10);
+		await vi.advanceTimersByTimeAsync(1_000);
+		eventBus.emit('loadingOverlay', 10); // re-arm before the first fires
+
+		await vi.advanceTimersByTimeAsync(10_000); // both original deadlines pass
+		eventBus.emit('loadingOverlay', true); // explicit ON
+
+		await vi.advanceTimersByTimeAsync(30_000);
+
+		// with the stranded-interval bug, the leftover interval keeps forcing this off
+		expect(overlayState()).toBe('true');
+	});
+});

--- a/apps/admin/src/app.main.vue
+++ b/apps/admin/src/app.main.vue
@@ -25,20 +25,27 @@ const eventBus = useEventBus();
 
 const loadingOverlay = ref<boolean>(false);
 
-let overlayTimer: number;
+let overlayTimer: number | undefined;
 
 const hideOverlay = (): void => {
 	loadingOverlay.value = false;
 
-	window.clearInterval(overlayTimer);
+	window.clearTimeout(overlayTimer);
+
+	overlayTimer = undefined;
 };
 
 const overlayLoadingListener = (status?: unknown): void => {
 	if (typeof status === 'number') {
-		overlayTimer = window.setInterval(hideOverlay, status * 1000);
+		window.clearTimeout(overlayTimer);
+
+		overlayTimer = window.setTimeout(hideOverlay, status * 1000);
+
 		loadingOverlay.value = true;
 	} else if (typeof status === 'boolean') {
-		window.clearInterval(overlayTimer);
+		window.clearTimeout(overlayTimer);
+
+		overlayTimer = undefined;
 
 		loadingOverlay.value = status;
 	} else {
@@ -52,6 +59,8 @@ onBeforeMount((): void => {
 
 onBeforeUnmount((): void => {
 	eventBus.unregister('loadingOverlay', overlayLoadingListener);
+
+	window.clearTimeout(overlayTimer);
 });
 
 useMeta({

--- a/apps/admin/src/common/composables/useListQuery.spec.ts
+++ b/apps/admin/src/common/composables/useListQuery.spec.ts
@@ -1,7 +1,7 @@
 /*
 eslint-disable @typescript-eslint/no-explicit-any
 */
-import { nextTick, ref } from 'vue';
+import { effectScope, nextTick, ref } from 'vue';
 
 import { createPinia, setActivePinia } from 'pinia';
 
@@ -216,5 +216,37 @@ describe('useListQuery (composable)', () => {
 		await nextTick();
 
 		expect(routeQuery.value).toEqual({});
+	});
+
+	it('clears pending debounce timers when the wrapping scope is disposed', async () => {
+		const debounceMs = 150;
+
+		const patchSpy = vi.spyOn(fakeStore, 'patch');
+
+		const scope = effectScope();
+
+		const { filters } = scope.run(() =>
+			useListQuery({
+				key: 'k6',
+				filters: { schema: FilterSchema, defaults: defaultFilters },
+				pagination: { defaults: defaultPagination },
+				sort: { defaults: defaultSort },
+				syncQuery: true,
+				version: 1,
+				debounceMs,
+			})
+		)!;
+
+		filters.value.search = 'x';
+
+		// Let the debounce watcher run and schedule its `setTimeout` before disposing — otherwise
+		// there would be no pending timer for the disposal to actually clear.
+		await nextTick();
+
+		scope.stop();
+
+		await vi.advanceTimersByTimeAsync(debounceMs);
+
+		expect(patchSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/admin/src/common/composables/useListQuery.ts
+++ b/apps/admin/src/common/composables/useListQuery.ts
@@ -4,7 +4,7 @@ import { type LocationQueryRaw, useRoute, useRouter } from 'vue-router';
 import { isEqual } from 'lodash';
 import { z } from 'zod';
 
-import { tryOnMounted } from '@vueuse/core';
+import { tryOnMounted, tryOnScopeDispose } from '@vueuse/core';
 
 import { injectStoresManager } from '../services/store';
 import { listQueryStoreKey } from '../store/keys';
@@ -506,6 +506,14 @@ export function useListQuery<F extends z.ZodObject<AnyShape> | undefined, V exte
 			}, debounceMs);
 		});
 	}
+
+	tryOnScopeDispose((): void => {
+		// A pending debounce firing after unmount would patch the store or rewrite the URL
+		// for a view that no longer exists.
+		for (const timer of [tF, tS, tP, tV, qF, qS, qP, qV]) {
+			window.clearTimeout(timer);
+		}
+	});
 
 	// Hydrate URL once from store if no relevant keys present
 	tryOnMounted(() => {

--- a/apps/admin/src/common/composables/useSockets.spec.ts
+++ b/apps/admin/src/common/composables/useSockets.spec.ts
@@ -1,3 +1,5 @@
+import { effectScope } from 'vue';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useSockets } from './useSockets';
@@ -35,10 +37,14 @@ describe('useSockets', () => {
 
 	it('subscribes to connect and disconnect when called outside a component setup', () => {
 		// `useSockets` is called from `scenes.store.ts` — a Pinia store setup, which runs with no
-		// active component instance. Plain `onMounted` silently declines to register there (Vue
-		// only warns), so the listeners were never attached and `connected` / `active` on that
-		// instance stayed frozen at their initial values for the life of the app.
-		useSockets();
+		// active component instance but inside Pinia's own effect scope (`effectScope().run(setup)`).
+		// Plain `onMounted` silently declines to register there (Vue only warns), so the listeners
+		// were never attached and `connected` / `active` on that instance stayed frozen at their
+		// initial values for the life of the app. The effect scope is what makes the listeners safe
+		// to attach — see the "no scope at all" case below for the contrast.
+		const scope = effectScope();
+
+		scope.run(() => useSockets());
 
 		expect(mockOn).toHaveBeenCalledWith('connect', expect.any(Function));
 		expect(mockOn).toHaveBeenCalledWith('disconnect', expect.any(Function));
@@ -48,7 +54,9 @@ describe('useSockets', () => {
 		socketInstanceMock.connected = false;
 		socketInstanceMock.active = false;
 
-		const { connected, active } = useSockets();
+		const scope = effectScope();
+
+		const { connected, active } = scope.run(() => useSockets())!;
 
 		const onConnect = mockOn.mock.calls.find(([event]) => event === 'connect')?.[1] as () => void;
 		const onDisconnect = mockOn.mock.calls.find(([event]) => event === 'disconnect')?.[1] as () => void;
@@ -60,6 +68,24 @@ describe('useSockets', () => {
 		onDisconnect();
 		expect(connected.value).toBe(false);
 		expect(active.value).toBe(false);
+	});
+
+	it('does not attach listeners when there is no scope to release them', () => {
+		// Called bare — no component, no effectScope. `tryOnScopeDispose` would be a silent
+		// no-op here, so attaching listeners would leak them on the app-lifetime socket forever.
+		useSockets();
+
+		expect(mockOn).not.toHaveBeenCalled();
+	});
+
+	it('attaches and releases listeners inside a bare effect scope', () => {
+		const scope = effectScope();
+
+		scope.run(() => useSockets());
+		expect(mockOn).toHaveBeenCalledTimes(2);
+
+		scope.stop();
+		expect(mockOff).toHaveBeenCalledTimes(2);
 	});
 
 	it('still defers to the component lifecycle when called inside a component setup', async () => {

--- a/apps/admin/src/common/composables/useSockets.ts
+++ b/apps/admin/src/common/composables/useSockets.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { getCurrentScope, ref } from 'vue';
 
 import { v4 as uuid } from 'uuid';
 
@@ -24,6 +24,11 @@ export const useSockets = (): IUseSockets => {
 		active.value = false;
 	};
 
+	// Captured at call time — the same condition `tryOnScopeDispose` keys off. Without a
+	// scope the dispose hook is a silent no-op, so attaching listeners here would leak them
+	// on the app-lifetime socket.
+	const canDispose = getCurrentScope() !== undefined;
+
 	// `tryOnMounted`, not `onMounted`: this composable is also called from a Pinia store setup
 	// (`scenes_module-scenes`) and from composables that stores reach through, none of which run
 	// with an active component instance. Plain `onMounted` only warns and declines to register
@@ -35,8 +40,10 @@ export const useSockets = (): IUseSockets => {
 		connected.value = sockets.connected;
 		active.value = sockets.active;
 
-		sockets.on('connect', onConnect);
-		sockets.on('disconnect', onDisconnect);
+		if (canDispose) {
+			sockets.on('connect', onConnect);
+			sockets.on('disconnect', onDisconnect);
+		}
 	});
 
 	// Scope-based rather than `onBeforeUnmount` for the same reason, and because it is the

--- a/apps/admin/src/common/utils/first-load.utils.spec.ts
+++ b/apps/admin/src/common/utils/first-load.utils.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { markFirstLoad } from './first-load.utils';
+
+describe('markFirstLoad', () => {
+	it('pushes an id only once', () => {
+		const firstLoad: string[] = [];
+
+		markFirstLoad(firstLoad, 'a');
+		markFirstLoad(firstLoad, 'a');
+		markFirstLoad(firstLoad, 'b');
+
+		expect(firstLoad).toEqual(['a', 'b']);
+	});
+});

--- a/apps/admin/src/common/utils/first-load.utils.ts
+++ b/apps/admin/src/common/utils/first-load.utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Marks a related collection as loaded for the given parent id without letting repeated
+ * fetches grow the array: these markers are read with `includes()` from reactive computeds,
+ * so duplicates cost memory and O(n) time on every render.
+ */
+export const markFirstLoad = (firstLoad: string[], id: string): void => {
+	if (!firstLoad.includes(id)) {
+		firstLoad.push(id);
+	}
+};

--- a/apps/admin/src/common/utils/utils.ts
+++ b/apps/admin/src/common/utils/utils.ts
@@ -1,4 +1,5 @@
 export * from './api-error.utils';
+export * from './first-load.utils';
 export * from './format.utils';
 export * from './number.utils';
 export * from './objects.utils';

--- a/apps/admin/src/modules/dashboard/store/pages.store.ts
+++ b/apps/admin/src/modules/dashboard/store/pages.store.ts
@@ -4,7 +4,7 @@ import { type Pinia, type Store, defineStore } from 'pinia';
 
 import { isUndefined, omitBy } from 'lodash';
 
-import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, markFirstLoad, useBackend, useLogger } from '../../../common';
 import { MODULES_PREFIX } from '../../../app.constants';
 import type {
 	DashboardModuleGetPageOperation,
@@ -632,7 +632,7 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 			});
 		});
 
-		dataSourcesStore.firstLoad.push(page.id);
+		markFirstLoad(dataSourcesStore.firstLoad, page.id);
 	};
 
 	const insertTilesRelations = (page: IPage, tiles: ITileRes[]): void => {
@@ -658,10 +658,10 @@ export const usePages = defineStore<'dashboard_module-pages', PagesStoreSetup>('
 				});
 			});
 
-			dataSourcesStore.firstLoad.push(tile.id);
+			markFirstLoad(dataSourcesStore.firstLoad, tile.id);
 		});
 
-		tilesStore.firstLoad.push(page.id);
+		markFirstLoad(tilesStore.firstLoad, page.id);
 	};
 
 	// Reconnect refresh contract: the store itself says whether it holds anything worth

--- a/apps/admin/src/modules/dashboard/store/tiles.store.ts
+++ b/apps/admin/src/modules/dashboard/store/tiles.store.ts
@@ -4,7 +4,7 @@ import { type Pinia, type Store, defineStore } from 'pinia';
 
 import { isUndefined, omitBy } from 'lodash';
 
-import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, markFirstLoad, useBackend, useLogger } from '../../../common';
 import { MODULES_PREFIX } from '../../../app.constants';
 import type {
 	DashboardModuleGetTileOperation,
@@ -570,7 +570,7 @@ export const useTiles = defineStore<'dashboard_module-tiles', TilesStoreSetup>('
 			});
 		});
 
-		dataSourcesStore.firstLoad.push(tile.id);
+		markFirstLoad(dataSourcesStore.firstLoad, tile.id);
 	};
 
 	return {

--- a/apps/admin/src/modules/devices/store/channels.store.ts
+++ b/apps/admin/src/modules/devices/store/channels.store.ts
@@ -4,7 +4,7 @@ import { type Pinia, type Store, defineStore } from 'pinia';
 
 import { isUndefined, omitBy } from 'lodash';
 
-import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, markFirstLoad, useBackend, useLogger } from '../../../common';
 import { MODULES_PREFIX } from '../../../app.constants';
 import type {
 	DevicesModuleGetChannelOperation,
@@ -647,7 +647,7 @@ export const useChannels = defineStore<'devices_module-channels', ChannelsStoreS
 			});
 		});
 
-		channelsControlsStore.firstLoad.push(channel.id);
+		markFirstLoad(channelsControlsStore.firstLoad, channel.id);
 	};
 
 	const insertChannelPropertiesRelations = (channel: IChannel, properties: IChannelPropertyRes[]): void => {
@@ -662,7 +662,7 @@ export const useChannels = defineStore<'devices_module-channels', ChannelsStoreS
 			});
 		});
 
-		channelsPropertiesStore.firstLoad.push(channel.id);
+		markFirstLoad(channelsPropertiesStore.firstLoad, channel.id);
 	};
 
 	return {

--- a/apps/admin/src/modules/devices/store/devices.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.spec.ts
@@ -3,8 +3,14 @@ import { createPinia, setActivePinia } from 'pinia';
 import { v4 as uuid } from 'uuid';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DevicesModuleDeviceCategory, DevicesModuleDeviceConnectionStatus, DevicesModuleDevicesHiddenFilter } from '../../../openapi.constants';
+import {
+	DevicesModuleChannelCategory,
+	DevicesModuleDeviceCategory,
+	DevicesModuleDeviceConnectionStatus,
+	DevicesModuleDevicesHiddenFilter,
+} from '../../../openapi.constants';
 
+import type { IChannelRes } from './channels.store.types';
 import { useDevices } from './devices.store';
 import type { IDeviceRes } from './devices.store.types';
 
@@ -15,16 +21,42 @@ const mockBackendClient = {
 	DELETE: vi.fn(),
 };
 
-// Permissive: this spec exercises `fetch()`'s dedup/staleness handling and the bulk actions' own
-// bookkeeping, not what ends up in the related controls/channels stores, so every key gets the same
-// push-able, no-op stub. `findForDevice` answers empty because the cascade's fan-out is the channels
-// store's concern; what matters here is that the cascade runs for the right devices.
-const mockGetStore = vi.fn(() => ({
-	firstLoad: [] as string[],
-	set: vi.fn(),
-	unset: vi.fn(),
-	findForDevice: vi.fn(() => []),
-}));
+type RelationStoreStub = {
+	firstLoad: string[];
+	set: Mock;
+	unset: Mock;
+	findForDevice: Mock;
+};
+
+// Keyed by store symbol and kept for the life of a test, mirroring the real `storesManager`, which
+// hands back the very same store instance on every `getStore()` call rather than a fresh one. That
+// identity is what the cross-store `firstLoad` dedup regression below depends on: it only sees
+// duplicates pile up if the array a first `fetch()` pushed into is the same array a second `fetch()`
+// pushes into. Otherwise permissive: this spec exercises `fetch()`'s dedup/staleness handling and the
+// bulk actions' own bookkeeping, not the full shape of what ends up in the related controls/channels
+// stores, so every key gets the same push-able, no-op `set`/`unset` stub. `findForDevice` answers
+// empty because the cascade's fan-out is the channels store's concern; what matters here is that the
+// cascade runs for the right devices.
+const relationStores = new Map<symbol, RelationStoreStub>();
+
+const mockGetStore = vi.fn((key: symbol): RelationStoreStub => {
+	const existing = relationStores.get(key);
+
+	if (existing) {
+		return existing;
+	}
+
+	const created: RelationStoreStub = {
+		firstLoad: [],
+		set: vi.fn(),
+		unset: vi.fn(),
+		findForDevice: vi.fn(() => []),
+	};
+
+	relationStores.set(key, created);
+
+	return created;
+});
 
 vi.mock('../../../common', async () => {
 	const utils = await vi.importActual('../../../common/utils/utils');
@@ -90,6 +122,22 @@ const deviceFixture = (name: string): IDeviceRes =>
 		channels: [],
 	}) as unknown as IDeviceRes;
 
+const channelFixture = (deviceId: string, name: string): IChannelRes =>
+	({
+		id: uuid(),
+		type: 'some-channel',
+		device: deviceId,
+		category: DevicesModuleChannelCategory.generic,
+		identifier: null,
+		name,
+		description: null,
+		parent: null,
+		created_at: '2024-03-01T12:00:00Z',
+		updated_at: null,
+		controls: [],
+		properties: [],
+	}) as unknown as IChannelRes;
+
 describe('Devices Store', () => {
 	let store: ReturnType<typeof useDevices>;
 
@@ -98,6 +146,7 @@ describe('Devices Store', () => {
 
 		store = useDevices();
 
+		relationStores.clear();
 		vi.clearAllMocks();
 	});
 
@@ -397,6 +446,31 @@ describe('Devices Store', () => {
 		await olderFetch;
 
 		expect(store.fetching()).toBe(false);
+	});
+
+	// Cross-store relation bookkeeping — `devicesControlsStore.firstLoad`, `channelsStore.firstLoad`,
+	// `channelsControlsStore.firstLoad`, `channelsPropertiesStore.firstLoad` — is written on every
+	// `fetch()`, including a plain reconnect refresh of devices and channels the stores already hold.
+	// A naive push would grow those arrays without bound across repeated fetches of the same rows.
+	it('does not accumulate duplicate ids in cross-store firstLoad markers across repeated fetches', async () => {
+		const deviceOne = deviceFixture('device-1');
+		const deviceTwo = deviceFixture('device-2');
+
+		deviceOne.channels = [channelFixture(deviceOne.id, 'channel-1')];
+		deviceTwo.channels = [channelFixture(deviceTwo.id, 'channel-2')];
+
+		mockBackendClient.GET.mockResolvedValue({ data: { data: [deviceOne, deviceTwo] } });
+
+		await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+		await store.fetch({ hidden: DevicesModuleDevicesHiddenFilter.all });
+
+		// Guards the regression test itself: if nothing populated `relationStores`, the loop below
+		// would pass vacuously without ever having exercised the cascade.
+		expect(relationStores.size).toBeGreaterThan(0);
+
+		for (const relationStore of relationStores.values()) {
+			expect(relationStore.firstLoad.length).toBe(new Set(relationStore.firstLoad).size);
+		}
 	});
 
 	// `edit()` merges the whole cached record into the object it validates, so schema defaults (e.g.

--- a/apps/admin/src/modules/devices/store/devices.store.ts
+++ b/apps/admin/src/modules/devices/store/devices.store.ts
@@ -5,7 +5,7 @@ import { type Pinia, type Store, defineStore } from 'pinia';
 import { isUndefined, omitBy, pick } from 'lodash';
 
 import { MODULES_PREFIX } from '../../../app.constants';
-import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, markFirstLoad, useBackend, useLogger } from '../../../common';
 import type {
 	DevicesModuleCreateDeviceOperation,
 	DevicesModuleCreateDevicesBulkRemoveOperation,
@@ -887,7 +887,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 			});
 		});
 
-		devicesControlsStore.firstLoad.push(device.id);
+		markFirstLoad(devicesControlsStore.firstLoad, device.id);
 	};
 
 	const insertChannelsRelations = (device: IDevice, channels: IChannelRes[]): void => {
@@ -910,7 +910,7 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 				});
 			});
 
-			channelsControlsStore.firstLoad.push(channel.id);
+			markFirstLoad(channelsControlsStore.firstLoad, channel.id);
 
 			channel.properties.forEach((property) => {
 				const element = getChannelsPropertiesPluginElement(property.type);
@@ -921,10 +921,10 @@ export const useDevices = defineStore<'devices_module-devices', DevicesStoreSetu
 				});
 			});
 
-			channelsPropertiesStore.firstLoad.push(channel.id);
+			markFirstLoad(channelsPropertiesStore.firstLoad, channel.id);
 		});
 
-		channelsStore.firstLoad.push(device.id);
+		markFirstLoad(channelsStore.firstLoad, device.id);
 	};
 
 	// Reconnect refresh contract: the store itself says whether it holds anything worth

--- a/apps/admin/src/modules/onboarding/composables/useOnboardingStatus.spec.ts
+++ b/apps/admin/src/modules/onboarding/composables/useOnboardingStatus.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useOnboardingStatus } from './useOnboardingStatus';
+
+const mockGet = vi.fn();
+
+// Mocked at the composable's own file, not the '../../../common' barrel: ensure
+// all call sites see the same stub.
+vi.mock('../../../common/composables/useBackend', () => ({
+	useBackend: () => ({ client: { GET: mockGet } }),
+}));
+
+describe('useOnboardingStatus', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGet.mockResolvedValue({ data: { data: {} }, error: undefined });
+	});
+
+	it('returns the same computed instances on every call (the router guard calls this per navigation)', () => {
+		const first = useOnboardingStatus();
+		const second = useOnboardingStatus();
+
+		expect(first.needsOnboarding).toBe(second.needsOnboarding);
+		expect(first.isOnboardingCompleted).toBe(second.isOnboardingCompleted);
+	});
+});

--- a/apps/admin/src/modules/onboarding/composables/useOnboardingStatus.ts
+++ b/apps/admin/src/modules/onboarding/composables/useOnboardingStatus.ts
@@ -17,6 +17,12 @@ const lastFetched = ref<number | null>(null);
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+// Hoisted to module scope: the onboarding router guard calls the composable on every
+// navigation with no active effect scope, so per-call computeds would be created outside
+// any owner. The refs they read are module singletons anyway.
+const needsOnboarding = computed(() => status.value !== null && !status.value.hasOwner);
+const isOnboardingCompleted = computed(() => status.value?.onboardingCompleted ?? false);
+
 /**
  * Standalone cache invalidation — safe to call outside Vue setup context.
  * Use this when you need to clear the onboarding status cache from services
@@ -29,9 +35,6 @@ export const invalidateOnboardingStatus = (): void => {
 
 export const useOnboardingStatus = () => {
 	const backend = useBackend();
-
-	const needsOnboarding = computed(() => status.value !== null && !status.value.hasOwner);
-	const isOnboardingCompleted = computed(() => status.value?.onboardingCompleted ?? false);
 
 	const fetchStatus = async (force = false): Promise<IOnboardingStatus | null> => {
 		if (!force && status.value && lastFetched.value) {

--- a/apps/admin/src/modules/system/composables/useSystemLogsDataSource.spec.ts
+++ b/apps/admin/src/modules/system/composables/useSystemLogsDataSource.spec.ts
@@ -1,0 +1,102 @@
+import { type Ref, effectScope, nextTick, ref } from 'vue';
+
+import { createPinia, setActivePinia } from 'pinia';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { injectStoresManager, useListQuery } from '../../../common';
+
+import { useSystemLogsDataSource } from './useSystemLogsDataSource';
+
+vi.mock('../../../common', () => ({
+	injectStoresManager: vi.fn(),
+	useListQuery: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+
+describe('useSystemLogsDataSource', () => {
+	let mockStore: {
+		findAll: ReturnType<typeof vi.fn>;
+		fetch: ReturnType<typeof vi.fn>;
+		semaphore: Ref<{ fetching: { items: boolean } }>;
+		firstLoad: Ref<boolean>;
+		hasMore: Ref<boolean>;
+		nextCursor: Ref<string | undefined>;
+	};
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+
+		mockFetch.mockReset().mockResolvedValue([]);
+
+		mockStore = {
+			findAll: vi.fn(() => []),
+			fetch: mockFetch,
+			semaphore: ref({ fetching: { items: false } }),
+			firstLoad: ref(true),
+			hasMore: ref(false),
+			nextCursor: ref(undefined),
+		};
+
+		(injectStoresManager as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+			getStore: () => mockStore,
+		});
+
+		(useListQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+			filters: ref({ search: undefined, levels: [], sources: [], tag: undefined }),
+			reset: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('clears the live poll when the owning scope is disposed', async () => {
+		vi.useFakeTimers();
+
+		const scope = effectScope();
+		let live!: Ref<boolean>;
+
+		scope.run(() => {
+			({ live } = useSystemLogsDataSource({ syncQuery: false }));
+		});
+
+		live.value = true;
+		await nextTick();
+
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+
+		scope.stop();
+
+		await vi.advanceTimersByTimeAsync(9000);
+		expect(mockFetch).toHaveBeenCalledTimes(1); // no further ticks after dispose
+
+		vi.useRealTimers();
+	});
+
+	it('skips a live tick while a fetch is already in flight', async () => {
+		vi.useFakeTimers();
+
+		mockStore.semaphore.value.fetching.items = true;
+
+		const scope = effectScope();
+		let live!: Ref<boolean>;
+
+		scope.run(() => {
+			({ live } = useSystemLogsDataSource({ syncQuery: false }));
+		});
+
+		live.value = true;
+		await nextTick();
+
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(mockFetch).not.toHaveBeenCalled();
+
+		scope.stop();
+
+		vi.useRealTimers();
+	});
+});

--- a/apps/admin/src/modules/system/composables/useSystemLogsDataSource.spec.ts
+++ b/apps/admin/src/modules/system/composables/useSystemLogsDataSource.spec.ts
@@ -95,6 +95,12 @@ describe('useSystemLogsDataSource', () => {
 		await vi.advanceTimersByTimeAsync(3000);
 		expect(mockFetch).not.toHaveBeenCalled();
 
+		mockStore.semaphore.value.fetching.items = false;
+
+		await vi.advanceTimersByTimeAsync(3000);
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+
 		scope.stop();
 
 		vi.useRealTimers();

--- a/apps/admin/src/modules/system/composables/useSystemLogsDataSource.ts
+++ b/apps/admin/src/modules/system/composables/useSystemLogsDataSource.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue';
+import { computed, onScopeDispose, ref, watch } from 'vue';
 
 import { storeToRefs } from 'pinia';
 
@@ -104,10 +104,27 @@ export const useSystemLogsDataSource = (props?: IUseSystemLogsDataSourceProps): 
 			}
 
 			if (on) {
-				timer = setInterval(() => logsStore.fetch({ append: true }), 3000);
+				timer = setInterval((): void => {
+					// A slow backend must not stack overlapping requests, and a failed tick
+					// simply retries on the next one.
+					if (semaphore.value.fetching.items) {
+						return;
+					}
+
+					logsStore.fetch({ append: true }).catch((): void => undefined);
+				}, 3000);
 			}
 		}
 	);
+
+	// Clean up timer when composable scope is disposed
+	onScopeDispose((): void => {
+		if (timer) {
+			clearInterval(timer);
+
+			timer = null;
+		}
+	});
 
 	return {
 		systemLogs,

--- a/apps/admin/src/modules/system/composables/useSystemLogsDataSource.ts
+++ b/apps/admin/src/modules/system/composables/useSystemLogsDataSource.ts
@@ -55,7 +55,7 @@ export const useSystemLogsDataSource = (props?: IUseSystemLogsDataSourceProps): 
 		return logsStore
 			.findAll()
 			.sort((a, b): number => {
-				return new Date(b.ts).getTime() - new Date(a.ts).getTime();
+				return Date.parse(b.ts) - Date.parse(a.ts);
 			})
 			.filter(
 				(logEntry) =>

--- a/apps/admin/src/modules/system/composables/useUpdateStatus.spec.ts
+++ b/apps/admin/src/modules/system/composables/useUpdateStatus.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUpdateStatus } from './useUpdateStatus';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+// Mirrors useSystemActions.spec.ts: mock the barrel and keep everything else real, only
+// swapping useBackend for a stub the tests can drive.
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: () => ({
+			client: { GET: mockGet, POST: mockPost },
+		}),
+	};
+});
+
+describe('useUpdateStatus', () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+		mockPost.mockReset();
+		mockPost.mockResolvedValue({ data: { data: {} }, error: undefined });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('stops a poll that never reaches a terminal status after the absolute deadline', async () => {
+		vi.useFakeTimers();
+
+		// each tick answers successfully with a non-terminal status
+		mockGet.mockResolvedValue({ data: { data: { status: 'installing', progress_percent: 10 } }, error: undefined });
+
+		const { installUpdate, status } = useUpdateStatus();
+
+		await installUpdate();
+
+		await vi.advanceTimersByTimeAsync(31 * 60 * 1000);
+
+		expect(status.value).toBe('failed');
+
+		// no further requests after the deadline
+		const calls = mockGet.mock.calls.length;
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(mockGet.mock.calls.length).toBe(calls);
+
+		vi.useRealTimers();
+	});
+
+	it('stops the poll once the backend reports a complete status', async () => {
+		vi.useFakeTimers();
+
+		mockGet
+			.mockResolvedValueOnce({ data: { data: { status: 'installing', progress_percent: 10 } }, error: undefined })
+			.mockResolvedValueOnce({ data: { data: { status: 'complete', progress_percent: 100 } }, error: undefined });
+
+		const { installUpdate, status } = useUpdateStatus();
+
+		await installUpdate();
+
+		// two ticks at the 4s poll interval
+		await vi.advanceTimersByTimeAsync(8_000);
+
+		expect(status.value).toBe('complete');
+
+		vi.useRealTimers();
+	});
+});

--- a/apps/admin/src/modules/system/composables/useUpdateStatus.ts
+++ b/apps/admin/src/modules/system/composables/useUpdateStatus.ts
@@ -36,7 +36,11 @@ const waitingForRestart = ref<boolean>(false);
 // Polling handle for reconnection detection after service restart
 let reconnectPollTimer: ReturnType<typeof setInterval> | null = null;
 const RECONNECT_POLL_INTERVAL_MS = 4_000;
-const RECONNECT_POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes max
+const RECONNECT_POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes max unreachable gap
+// A backend stuck reporting a non-terminal status must not keep the poll alive forever:
+// every successful response resets the unreachable timeout, so without an absolute
+// ceiling the interval outlives navigation for as long as the tab does.
+const RECONNECT_POLL_MAX_LIFETIME_MS = 30 * 60 * 1000;
 
 // Simulated progress ticker during backend restart gap
 let progressTickTimer: ReturnType<typeof setInterval> | null = null;
@@ -222,13 +226,16 @@ export const useUpdateStatus = (): IUseUpdateStatus => {
 		// Capture the version we're updating TO before the poll overwrites it
 		const targetVersion = latestVersion.value;
 
-		let lastSuccessAt = Date.now();
+		const startedAt = Date.now();
+
+		let lastSuccessAt = startedAt;
 
 		reconnectPollTimer = setInterval(async () => {
-			// Timeout only applies to the reconnection gap (backend unreachable).
+			// Timeout only applies to the reconnection gap (backend unreachable); the
+			// absolute ceiling applies regardless of how healthily the backend answers.
 			// Reset the timer on every successful response so slow-but-active
 			// updates aren't incorrectly marked as failed.
-			if (Date.now() - lastSuccessAt > RECONNECT_POLL_TIMEOUT_MS) {
+			if (Date.now() - lastSuccessAt > RECONNECT_POLL_TIMEOUT_MS || Date.now() - startedAt > RECONNECT_POLL_MAX_LIFETIME_MS) {
 				stopReconnectPoll();
 				waitingForRestart.value = false;
 				installing.value = false;

--- a/apps/admin/src/modules/system/services/system-logs-reporter.service.spec.ts
+++ b/apps/admin/src/modules/system/services/system-logs-reporter.service.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SystemLogsReporterService } from './system-logs-reporter.service';
+
+describe('SystemLogsReporterService', () => {
+	let logger: { addReporter: ReturnType<typeof vi.fn>; removeReporter: ReturnType<typeof vi.fn> };
+	let store: { add: ReturnType<typeof vi.fn> };
+	let i18n: { global: { locale: string } };
+
+	beforeEach(() => {
+		logger = { addReporter: vi.fn(), removeReporter: vi.fn() };
+		store = { add: vi.fn() };
+		i18n = { global: { locale: 'en' } };
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('start is idempotent: one reporter, one listener pair, however often it is called', () => {
+		const addListener = vi.spyOn(window, 'addEventListener');
+
+		const service = new SystemLogsReporterService(logger as never, store as never, i18n as never);
+
+		service.start();
+		service.start();
+		service.start();
+
+		expect(logger.addReporter).toHaveBeenCalledTimes(1);
+		expect(addListener.mock.calls.filter(([event]) => event === 'beforeunload' || event === 'pagehide')).toHaveLength(2);
+	});
+
+	it('start works again after dispose', () => {
+		const service = new SystemLogsReporterService(logger as never, store as never, i18n as never);
+
+		service.start();
+		service.dispose();
+		service.start();
+
+		expect(logger.addReporter).toHaveBeenCalledTimes(2);
+		expect(logger.removeReporter).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/admin/src/modules/system/services/system-logs-reporter.service.ts
+++ b/apps/admin/src/modules/system/services/system-logs-reporter.service.ts
@@ -70,6 +70,11 @@ export class SystemLogsReporterService {
 	) {}
 
 	start(): void {
+		// Re-entry must not stack window listeners or duplicate consola reporters.
+		if (this.reporter) {
+			return;
+		}
+
 		if (typeof window !== 'undefined') {
 			this.onUnload = () => {
 				if (this.queue.length) {

--- a/apps/admin/src/modules/system/store/logs-entries.store.spec.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.spec.ts
@@ -100,17 +100,56 @@ describe('LogsEntries Store', () => {
 		expect(store.findById(makeLogEntryId(1004))).not.toBeNull();
 	});
 
-	it('never prunes when appending a paginated page (afterId set)', async () => {
-		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(0, 999, { has_more: true, next_cursor: makeLogEntryId(999) }));
+	// Real afterId pagination is the user scrolling further back into history: the paginated page
+	// is always OLDER than whatever's already in the store, never newer.
+	it('never prunes when paging in older entries (afterId set)', async () => {
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(10, 1009, { has_more: true, next_cursor: makeLogEntryId(10) }));
 
 		await store.fetch({ append: true });
 
 		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES);
 
-		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(1000, 1009, { has_more: false }));
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(0, 9, { has_more: false }));
 
-		await store.fetch({ afterId: makeLogEntryId(999), append: true });
+		await store.fetch({ afterId: makeLogEntryId(10), append: true });
+
+		// The paginated page (indices 0-9) is older than everything already in the store
+		// (indices 10-1009). Appending it pushes the map over the cap, but afterId exempts
+		// this fetch from pruning.
+		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES + 10);
+		expect(store.findById(makeLogEntryId(0))).not.toBeNull();
+	});
+
+	it('prunes previously paged-in older entries on the next live append once the cap is exceeded', async () => {
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(10, 1009, { has_more: true, next_cursor: makeLogEntryId(10) }));
+
+		await store.fetch({ append: true });
+
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(0, 9, { has_more: false }));
+
+		await store.fetch({ afterId: makeLogEntryId(10), append: true });
 
 		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES + 10);
+		expect(store.findById(makeLogEntryId(0))).not.toBeNull();
+
+		// The live poller ticks again (no afterId). This newest page doesn't overlap what's
+		// already in the store, so the merge is unambiguously over the cap by 30, and the 30
+		// oldest entries -- indices 0-29, which fully contain the page paged in above -- are pruned.
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(1010, 1029, { has_more: false }));
+
+		await store.fetch({ append: true });
+
+		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES);
+
+		// The entire paginated-in older page is gone.
+		expect(store.findById(makeLogEntryId(0))).toBeNull();
+		expect(store.findById(makeLogEntryId(9))).toBeNull();
+
+		// Exact cutoff: index 29 is dropped, index 30 is the oldest survivor.
+		expect(store.findById(makeLogEntryId(29))).toBeNull();
+		expect(store.findById(makeLogEntryId(30))).not.toBeNull();
+
+		// The newest entries from this live tick are retained.
+		expect(store.findById(makeLogEntryId(1029))).not.toBeNull();
 	});
 });

--- a/apps/admin/src/modules/system/store/logs-entries.store.spec.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.spec.ts
@@ -1,0 +1,116 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SystemModuleLogEntrySource, SystemModuleLogEntryType } from '../../../openapi.constants';
+
+import { MAX_LIVE_LOG_ENTRIES, useLogsEntries } from './logs-entries.store';
+
+const backendClient = {
+	GET: vi.fn(),
+};
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: () => ({
+			client: backendClient,
+		}),
+		useLogger: vi.fn(() => ({
+			error: vi.fn(),
+			info: vi.fn(),
+			warning: vi.fn(),
+			log: vi.fn(),
+			debug: vi.fn(),
+		})),
+		getErrorReason: () => 'Some error',
+	};
+});
+
+// Crockford's base32 alphabet (excludes I, L, O, U), matching the ULID charset the store's schema expects.
+const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+const encodeBase32 = (value: number): string => {
+	let encoded = '';
+	let remaining = value;
+
+	do {
+		encoded = ULID_ALPHABET[remaining % 32] + encoded;
+		remaining = Math.floor(remaining / 32);
+	} while (remaining > 0);
+
+	return encoded;
+};
+
+// A deterministic, distinct, valid-looking ULID per index so entries are cheap to generate in bulk.
+const makeLogEntryId = (index: number): string => encodeBase32(index).padStart(26, '0');
+
+const BASE_TS = Date.parse('2026-01-01T00:00:00.000Z');
+
+// Later index => later timestamp, so "newest by ts" and "highest index" are interchangeable in assertions.
+const makeLogEntryRes = (index: number) => ({
+	id: makeLogEntryId(index),
+	ts: new Date(BASE_TS + index * 1000).toISOString(),
+	ingested_at: new Date(BASE_TS + index * 1000).toISOString(),
+	source: SystemModuleLogEntrySource.backend,
+	level: 6,
+	type: SystemModuleLogEntryType.info,
+	message: `entry-${index}`,
+	user: {},
+	context: {},
+});
+
+const makeLogsResponse = (fromIndex: number, toIndex: number, metadata: { has_more: boolean; next_cursor?: string }) => ({
+	data: {
+		data: Array.from({ length: toIndex - fromIndex + 1 }, (_, i) => makeLogEntryRes(fromIndex + i)),
+		metadata,
+	},
+	error: undefined,
+	response: { status: 200 },
+});
+
+describe('LogsEntries Store', () => {
+	let store: ReturnType<typeof useLogsEntries>;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+
+		store = useLogsEntries();
+
+		vi.clearAllMocks();
+	});
+
+	it('caps retained entries at MAX_LIVE_LOG_ENTRIES and keeps the newest by ts when appending without a cursor', async () => {
+		(backendClient.GET as Mock)
+			.mockResolvedValueOnce(makeLogsResponse(0, 599, { has_more: true, next_cursor: makeLogEntryId(599) }))
+			.mockResolvedValueOnce(makeLogsResponse(600, 1004, { has_more: false }));
+
+		await store.fetch({ append: true });
+		await store.fetch({ append: true });
+
+		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES);
+
+		// 1005 distinct entries appended over the cap by 5: the 5 oldest (indices 0-4) are pruned,
+		// the newest 1000 (indices 5-1004) survive.
+		expect(store.findById(makeLogEntryId(0))).toBeNull();
+		expect(store.findById(makeLogEntryId(4))).toBeNull();
+		expect(store.findById(makeLogEntryId(5))).not.toBeNull();
+		expect(store.findById(makeLogEntryId(1004))).not.toBeNull();
+	});
+
+	it('never prunes when appending a paginated page (afterId set)', async () => {
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(0, 999, { has_more: true, next_cursor: makeLogEntryId(999) }));
+
+		await store.fetch({ append: true });
+
+		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES);
+
+		(backendClient.GET as Mock).mockResolvedValueOnce(makeLogsResponse(1000, 1009, { has_more: false }));
+
+		await store.fetch({ afterId: makeLogEntryId(999), append: true });
+
+		expect(Object.keys(store.data).length).toBe(MAX_LIVE_LOG_ENTRIES + 10);
+	});
+});

--- a/apps/admin/src/modules/system/store/logs-entries.store.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.ts
@@ -152,7 +152,7 @@ export const useLogsEntries = defineStore<'system_module-logs', LogsEntriesStore
 
 						if (!payload.afterId && Object.keys(merged).length > MAX_LIVE_LOG_ENTRIES) {
 							const newest = Object.values(merged)
-								.sort((a, b): number => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+								.sort((a, b): number => Date.parse(b.ts) - Date.parse(a.ts))
 								.slice(0, MAX_LIVE_LOG_ENTRIES);
 
 							data.value = Object.fromEntries(newest.map((logEntry) => [logEntry.id, logEntry]));

--- a/apps/admin/src/modules/system/store/logs-entries.store.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.ts
@@ -31,8 +31,9 @@ import type {
 import { transformLogEntryCreateRequest, transformLogEntryResponse } from './logs-entries.transformers';
 
 // A live tail re-reads the newest page every few seconds forever; cap what it retains so a
-// long-running tab stays bounded. Cursor pagination (afterId) keeps everything the user
-// explicitly paged to.
+// long-running tab stays bounded. A cursor-paginated fetch (afterId set) never prunes on its
+// own, but the next live append (no afterId) caps the whole map to the newest
+// MAX_LIVE_LOG_ENTRIES by ts — including entries paged in earlier that fall outside that window.
 export const MAX_LIVE_LOG_ENTRIES = 1000;
 
 const defaultSemaphore: ILogsEntriesStateSemaphore = {

--- a/apps/admin/src/modules/system/store/logs-entries.store.ts
+++ b/apps/admin/src/modules/system/store/logs-entries.store.ts
@@ -30,6 +30,11 @@ import type {
 } from './logs-entries.store.types';
 import { transformLogEntryCreateRequest, transformLogEntryResponse } from './logs-entries.transformers';
 
+// A live tail re-reads the newest page every few seconds forever; cap what it retains so a
+// long-running tab stays bounded. Cursor pagination (afterId) keeps everything the user
+// explicitly paged to.
+export const MAX_LIVE_LOG_ENTRIES = 1000;
+
 const defaultSemaphore: ILogsEntriesStateSemaphore = {
 	fetching: {
 		items: false,
@@ -141,7 +146,21 @@ export const useLogsEntries = defineStore<'system_module-logs', LogsEntriesStore
 						})
 					);
 
-					data.value = payload?.append ? { ...data.value, ...transformed } : transformed;
+					if (payload?.append) {
+						const merged = { ...data.value, ...transformed };
+
+						if (!payload.afterId && Object.keys(merged).length > MAX_LIVE_LOG_ENTRIES) {
+							const newest = Object.values(merged)
+								.sort((a, b): number => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+								.slice(0, MAX_LIVE_LOG_ENTRIES);
+
+							data.value = Object.fromEntries(newest.map((logEntry) => [logEntry.id, logEntry]));
+						} else {
+							data.value = merged;
+						}
+					} else {
+						data.value = transformed;
+					}
 
 					firstLoad.value = true;
 

--- a/apps/admin/src/modules/system/system.module.ts
+++ b/apps/admin/src/modules/system/system.module.ts
@@ -114,6 +114,10 @@ export default {
 		// Events emitted while the browser was suspended are gone for good - re-read what we hold.
 		dataRefreshRegistry.register(systemAdminModuleKey, (): Promise<void> => refreshLoadedStores([systemInfoStore, throttleStatusStore]));
 
+		if (typeof window !== 'undefined' && isTest) {
+			systemLogsReporter.start();
+		}
+
 		sockets.on('event', (data: { event: string; payload: Record<string, unknown>; metadata: object }): void => {
 			if (!data?.event?.startsWith(SYSTEM_MODULE_EVENT_PREFIX)) {
 				return;
@@ -199,10 +203,6 @@ export default {
 
 				default:
 					logger.warn('Unhandled system module event:', data.event);
-			}
-
-			if (typeof window !== 'undefined' && isTest) {
-				systemLogsReporter.start();
 			}
 		});
 	},

--- a/apps/admin/src/plugins/pages-cards/store/cards.store.ts
+++ b/apps/admin/src/plugins/pages-cards/store/cards.store.ts
@@ -4,7 +4,7 @@ import { type Pinia, type Store, defineStore } from 'pinia';
 
 import { isUndefined, omitBy } from 'lodash';
 
-import { getErrorReason, injectStoresManager, useBackend, useLogger } from '../../../common';
+import { getErrorReason, injectStoresManager, markFirstLoad, useBackend, useLogger } from '../../../common';
 import { PLUGINS_PREFIX } from '../../../app.constants';
 import {
 	DashboardApiException,
@@ -544,7 +544,7 @@ export const useCards = defineStore<'pages_cards_plugin-cards', CardsStoreSetup>
 			});
 		});
 
-		dataSourcesStore.firstLoad.push(card.id);
+		markFirstLoad(dataSourcesStore.firstLoad, card.id);
 	};
 
 	const insertTilesRelations = (card: ICard, tiles: ITileRes[]): void => {
@@ -570,10 +570,10 @@ export const useCards = defineStore<'pages_cards_plugin-cards', CardsStoreSetup>
 				});
 			});
 
-			dataSourcesStore.firstLoad.push(tile.id);
+			markFirstLoad(dataSourcesStore.firstLoad, tile.id);
 		});
 
-		tilesStore.firstLoad.push(card.id);
+		markFirstLoad(tilesStore.firstLoad, card.id);
 	};
 
 	return {

--- a/apps/admin/src/plugins/pages-tiles/components/page-configure.vue
+++ b/apps/admin/src/plugins/pages-tiles/components/page-configure.vue
@@ -379,6 +379,8 @@ const pageChanged = ref<boolean>(false);
 
 let changeTimeout: ReturnType<typeof setTimeout>;
 
+let initTimeout: ReturnType<typeof setTimeout> | undefined;
+
 const onTileRemove = (id: ITile['id']): void => {
 	const el = document.querySelector(`.grid-stack-item[gs-id="${id}"]`);
 
@@ -780,13 +782,16 @@ onMounted((): void => {
 
 	window.addEventListener('resize', updateSquareCells);
 
-	setTimeout(() => {
+	initTimeout = setTimeout(() => {
 		initialized.value = true;
 	}, 500);
 });
 
 onBeforeUnmount((): void => {
 	window.removeEventListener('resize', updateSquareCells);
+
+	clearTimeout(changeTimeout);
+	clearTimeout(initTimeout);
 
 	destroyGrids();
 });

--- a/apps/admin/src/plugins/spaces-home-control/components/space-media-activities-dialog.vue
+++ b/apps/admin/src/plugins/spaces-home-control/components/space-media-activities-dialog.vue
@@ -772,20 +772,8 @@ const onDialogOpen = async (): Promise<void> => {
 	autoSaveReady.value = true;
 };
 
-onBeforeUnmount((): void => {
-	// Unmount without the close flow (route change) must not leave debounced saves
-	// firing against a destroyed component's state.
-	for (const timer of pendingSaves.values()) {
-		clearTimeout(timer);
-	}
-
-	pendingSaves.clear();
-});
-
-const onClose = async (): Promise<void> => {
-	autoSaveReady.value = false;
-
-	// Flush pending debounced saves so no edits are lost
+// Flush pending debounced saves and any dirty forms so no edits are lost
+const flushPendingSaves = (): Promise<void>[] => {
 	const flushPromises: Promise<void>[] = [];
 	const flushedKeys = new Set<string>();
 
@@ -804,7 +792,20 @@ const onClose = async (): Promise<void> => {
 		}
 	}
 
-	await Promise.allSettled(flushPromises);
+	return flushPromises;
+};
+
+onBeforeUnmount((): void => {
+	// Unmount without the close flow (route change) must not leave debounce timers
+	// behind — flush the edits immediately instead of discarding them; the save
+	// promises safely outlive the component.
+	void Promise.allSettled(flushPendingSaves());
+});
+
+const onClose = async (): Promise<void> => {
+	autoSaveReady.value = false;
+
+	await Promise.allSettled(flushPendingSaves());
 
 	emit('bindings-changed');
 	visible.value = false;

--- a/apps/admin/src/plugins/spaces-home-control/components/space-media-activities-dialog.vue
+++ b/apps/admin/src/plugins/spaces-home-control/components/space-media-activities-dialog.vue
@@ -353,7 +353,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, reactive, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { Icon } from '@iconify/vue';
@@ -771,6 +771,16 @@ const onDialogOpen = async (): Promise<void> => {
 	await nextTick();
 	autoSaveReady.value = true;
 };
+
+onBeforeUnmount((): void => {
+	// Unmount without the close flow (route change) must not leave debounced saves
+	// firing against a destroyed component's state.
+	for (const timer of pendingSaves.values()) {
+		clearTimeout(timer);
+	}
+
+	pendingSaves.clear();
+});
 
 const onClose = async (): Promise<void> => {
 	autoSaveReady.value = false;


### PR DESCRIPTION
## Summary

Fixes the memory leaks found by the admin memory-leak audit (triggered by a Chrome crash + slowdown against the local dev server). Seven leak fixes, each implemented test-first and independently reviewed:

- **System logs live tail** (the most likely crash cause): the 3 s poll timer now dies with its effect scope instead of surviving component unmount, ticks are skipped while a fetch is in flight, and the live entries store is capped at `MAX_LIVE_LOG_ENTRIES = 1000` (pruned newest-first by `ts` on live appends; a cursor-paged history append doesn't self-prune, the next live tick does).
- **Cross-store `firstLoad` markers**: new `markFirstLoad` util dedupes the 13 cross-store push sites in the devices/channels/pages/tiles/cards stores that previously grew the arrays unboundedly on every relation refresh.
- **Update reconnect poll**: the poll that waits for the backend to come back after an update now has an absolute 30-minute deadline alongside the last-success timeout, so it can't spin forever.
- **Loading overlay timer**: the auto-hide timeout in `app.main.vue` is now a tracked one-shot — cleared on re-arm, on boolean emits, in `hideOverlay`, and on unmount.
- **Test logs reporter**: `start()` is idempotent and is invoked once at module setup instead of on every socket event (test-env only; production behavior unchanged).
- **Onboarding status computeds**: hoisted to module scope — the router guard calls the composable on every navigation with no effect scope, so the per-call computeds were created without an owner.
- **Stray timers + scopeless socket listeners**: `useSockets` no longer attaches listeners it could never release when called without an effect scope; `useListQuery` clears its eight debounce timers on scope dispose; the pages-tiles grid view and the media activities dialog clear their pending timeouts on unmount.

A final whole-branch review then trimmed allocation churn in the new prune sort (`Date.parse` instead of per-comparison `Date` objects) and hardened the skip-tick test.

## Behavior note

The reconnect poll's absolute deadline is a deliberate trade-off: an update that legitimately takes longer than 30 minutes will now surface as **failed** in the admin UI even if it later completes. Previously the poll ran unbounded, which is the leak this fixes.

## Testing

- Full admin unit suite: **286 files, 2049 tests, all passing** (run twice: after task 7 and again after the final-review fix wave).
- Every fix carries its own spec, written test-first (RED→GREEN verified per task); the two SFC timer fixes mirror the already-tested pages-cards sibling pattern and are intentionally untested.
- Type-check and eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
