### PR TITLE
perf(admin): cut allocation churn in config and property stores

### DIFF
--- a/apps/admin/src/modules/config/store/config-app.store.spec.ts
+++ b/apps/admin/src/modules/config/store/config-app.store.spec.ts
@@ -1,0 +1,163 @@
+import { type Ref, ref } from 'vue';
+
+import { createPinia, defineStore, setActivePinia } from 'pinia';
+
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useConfigApp } from './config-app.store';
+import type { IConfigModule } from './config-modules.store.types';
+import type { IConfigPlugin } from './config-plugins.store.types';
+import { configModulesStoreKey, configPluginsStoreKey } from './keys';
+
+const backendClient = {
+	GET: vi.fn(),
+};
+
+// Stand-ins for the real config-plugins/config-modules stores: this spec exercises `config-app`
+// store's own lazy-memoized `storeToRefs` wiring, not the sibling stores' business logic, so a store
+// matching their `{ data: Ref<...> }` shape (plus a `set` compatible with what `config-app.set()`
+// calls on them) is enough.
+const useFakePluginsStore = defineStore('test-config-plugins', () => {
+	const data: Ref<{ [key: string]: IConfigPlugin }> = ref({});
+
+	const set = (payload: { data: IConfigPlugin }): IConfigPlugin => {
+		data.value = { ...data.value, [payload.data.type]: payload.data };
+
+		return payload.data;
+	};
+
+	return { data, set };
+});
+
+const useFakeModulesStore = defineStore('test-config-modules', () => {
+	const data: Ref<{ [key: string]: IConfigModule }> = ref({});
+
+	const set = (payload: { data: IConfigModule }): IConfigModule => {
+		data.value = { ...data.value, [payload.data.type]: payload.data };
+
+		return payload.data;
+	};
+
+	return { data, set };
+});
+
+let pluginsStore: ReturnType<typeof useFakePluginsStore>;
+let modulesStore: ReturnType<typeof useFakeModulesStore>;
+
+const mockGetStore = vi.fn((key: symbol) => {
+	if (key === configPluginsStoreKey) {
+		return pluginsStore;
+	}
+
+	if (key === configModulesStoreKey) {
+		return modulesStore;
+	}
+
+	throw new Error('Unexpected store key requested in test');
+});
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: vi.fn(() => ({
+			client: backendClient,
+		})),
+		useLogger: vi.fn(() => ({
+			error: vi.fn(),
+			info: vi.fn(),
+			warning: vi.fn(),
+			log: vi.fn(),
+			debug: vi.fn(),
+		})),
+		getErrorReason: vi.fn(() => 'Some error'),
+		injectStoresManager: vi.fn(() => ({
+			getStore: mockGetStore,
+		})),
+	};
+});
+
+describe('ConfigApp Store', () => {
+	let store: ReturnType<typeof useConfigApp>;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+
+		pluginsStore = useFakePluginsStore();
+		modulesStore = useFakeModulesStore();
+
+		store = useConfigApp();
+
+		vi.clearAllMocks();
+	});
+
+	it('composes data from the seeded plugins and modules sibling stores', () => {
+		store.set({
+			data: {
+				path: '/config',
+				plugins: [{ type: 'plugin-a', enabled: true }],
+				modules: [{ type: 'module-a', enabled: true }],
+			},
+		});
+
+		expect(store.data).toEqual({
+			path: '/config',
+			plugins: [{ type: 'plugin-a', enabled: true }],
+			modules: [{ type: 'module-a', enabled: true }],
+		});
+	});
+
+	it('stays reactive to a later change on the plugins sibling store made outside config-app.set()', () => {
+		store.set({
+			data: {
+				path: '/config',
+				plugins: [{ type: 'plugin-a', enabled: true }],
+				modules: [],
+			},
+		});
+
+		// First read: this is what resolves (and, after the refactor, memoizes) the sibling refs.
+		expect(store.data?.plugins).toEqual([{ type: 'plugin-a', enabled: true }]);
+
+		// Something else touches the plugins store directly — e.g. its own set()/onEvent() — without
+		// going through config-app at all.
+		pluginsStore.data = { 'plugin-a': { type: 'plugin-a', enabled: false } };
+
+		// A later read must still reflect the sibling store's current data, proving the memoized ref
+		// is a live reactive proxy and not a one-time snapshot.
+		expect(store.data?.plugins).toEqual([{ type: 'plugin-a', enabled: false }]);
+	});
+
+	it('returns null before any data has been set', () => {
+		expect(store.data).toBeNull();
+	});
+
+	it('throws validation error when set with invalid data', () => {
+		expect(() =>
+			store.set({
+				data: { path: '', plugins: [], modules: [] },
+			})
+		).toThrow();
+	});
+
+	it('fetches app config and populates sibling stores', async () => {
+		(backendClient.GET as Mock).mockResolvedValue({
+			data: {
+				data: {
+					path: '/config',
+					plugins: [{ type: 'plugin-a', enabled: true }],
+					modules: [{ type: 'module-a', enabled: true }],
+				},
+			},
+			error: undefined,
+			response: { status: 200 },
+		});
+
+		const result = await store.get();
+
+		expect(result.path).toBe('/config');
+		expect(store.data?.plugins).toEqual([{ type: 'plugin-a', enabled: true }]);
+		expect(store.data?.modules).toEqual([{ type: 'module-a', enabled: true }]);
+	});
+});

--- a/apps/admin/src/modules/config/store/config-app.store.ts
+++ b/apps/admin/src/modules/config/store/config-app.store.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { type Ref, computed, ref } from 'vue';
 
 import { type Pinia, type Store, defineStore, storeToRefs } from 'pinia';
 
@@ -20,6 +20,8 @@ import type {
 	IConfigAppStoreState,
 } from './config-app.store.types';
 import { transformConfigAppResponse } from './config-app.transformers';
+import type { IConfigModule } from './config-modules.store.types';
+import type { IConfigPlugin } from './config-plugins.store.types';
 import {
 	configModulesStoreKey,
 	configPluginsStoreKey,
@@ -41,12 +43,14 @@ export const useConfigApp = defineStore<'config-module_config_app', ConfigAppSto
 
 	const dataPartial = ref<Pick<IConfigApp, 'path'> | null>(null);
 
-	const data = computed<IConfigApp | null>((): IConfigApp | null => {
-		const configPluginsStore = storesManager.getStore(configPluginsStoreKey);
-		const configModulesStore = storesManager.getStore(configModulesStoreKey);
+	let pluginsData: Ref<{ [key: string]: IConfigPlugin }> | null = null;
+	let modulesData: Ref<{ [key: string]: IConfigModule }> | null = null;
 
-		const { data: plugins } = storeToRefs(configPluginsStore);
-		const { data: modules } = storeToRefs(configModulesStore);
+	const data = computed<IConfigApp | null>((): IConfigApp | null => {
+		// Resolved once: re-running storeToRefs here allocated a wrapper per store key on every
+		// evaluation and made this computed track both stores' entire surface.
+		pluginsData ??= storeToRefs(storesManager.getStore(configPluginsStoreKey)).data;
+		modulesData ??= storeToRefs(storesManager.getStore(configModulesStoreKey)).data;
 
 		if (dataPartial.value === null) {
 			return null;
@@ -55,8 +59,8 @@ export const useConfigApp = defineStore<'config-module_config_app', ConfigAppSto
 		return {
 			path: dataPartial.value.path,
 			// Language, weather, and system configs moved to modules (system-module, weather-module)
-			plugins: Object.values(plugins.value),
-			modules: Object.values(modules.value),
+			plugins: Object.values(pluginsData.value),
+			modules: Object.values(modulesData.value),
 		};
 	});
 

--- a/apps/admin/src/modules/devices/store/channels.properties.store.spec.ts
+++ b/apps/admin/src/modules/devices/store/channels.properties.store.spec.ts
@@ -1,0 +1,144 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { v4 as uuid } from 'uuid';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	DevicesModuleChannelPropertyCategory,
+	DevicesModuleChannelPropertyDataType,
+	DevicesModuleChannelPropertyPermissions,
+} from '../../../openapi.constants';
+import { DevicesValidationException } from '../devices.exceptions';
+
+import { useChannelsProperties } from './channels.properties.store';
+import { ChannelPropertySchema } from './channels.properties.store.schemas';
+import type {
+	IChannelPropertyRes,
+	IChannelsPropertiesOnEventActionPayload,
+	IChannelsPropertiesSetActionPayload,
+} from './channels.properties.store.types';
+import { transformChannelPropertyResponse } from './channels.properties.transformers';
+
+const backendClient = {
+	GET: vi.fn(),
+	POST: vi.fn(),
+	PATCH: vi.fn(),
+	DELETE: vi.fn(),
+};
+
+vi.mock('../../../common', async () => {
+	const actual = await vi.importActual('../../../common');
+
+	return {
+		...actual,
+		useBackend: vi.fn(() => ({
+			client: backendClient,
+		})),
+		useLogger: vi.fn(() => ({
+			error: vi.fn(),
+			info: vi.fn(),
+			warning: vi.fn(),
+			log: vi.fn(),
+			debug: vi.fn(),
+		})),
+		getErrorReason: vi.fn(() => 'Some error'),
+	};
+});
+
+// The plugin registry always answers "no element for this type" — this spec exercises the default
+// `ChannelPropertySchema` path, per the task brief.
+vi.mock('../composables/useChannelsPropertiesPlugins', () => ({
+	useChannelsPropertiesPlugins: () => ({
+		getElement: () => undefined,
+	}),
+}));
+
+const channelId = uuid();
+const propertyId = uuid();
+
+const rawResponse = (overrides: Partial<IChannelPropertyRes> = {}): IChannelPropertyRes => ({
+	id: propertyId,
+	type: 'some-property',
+	channel: channelId,
+	category: DevicesModuleChannelPropertyCategory.generic,
+	identifier: null,
+	name: 'Some channel property',
+	permissions: [DevicesModuleChannelPropertyPermissions.ro],
+	data_type: DevicesModuleChannelPropertyDataType.string,
+	format: null,
+	invalid: -1,
+	step: null,
+	value: { value: 'Some value', last_updated: null },
+	created_at: '2024-03-01T12:00:00Z',
+	updated_at: null,
+	...overrides,
+});
+
+describe('ChannelsProperties Store', () => {
+	let store: ReturnType<typeof useChannelsProperties>;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+
+		store = useChannelsProperties();
+
+		vi.clearAllMocks();
+	});
+
+	it('creates a new entry', () => {
+		const data = transformChannelPropertyResponse(rawResponse(), ChannelPropertySchema);
+
+		const result = store.set({ id: propertyId, data });
+
+		expect(result.name).toBe('Some channel property');
+		expect(store.findById(propertyId)?.name).toBe('Some channel property');
+	});
+
+	it('merges a partial update into an existing entry rather than replacing it wholesale', () => {
+		const initial = transformChannelPropertyResponse(rawResponse(), ChannelPropertySchema);
+
+		store.set({ id: propertyId, data: initial });
+
+		// A caller supplying only a subset of fields — the merge branch must fill the rest from what
+		// is already stored, not fail or drop them.
+		const partialUpdate = {
+			type: 'some-property',
+			name: 'Renamed property',
+		} as unknown as IChannelsPropertiesSetActionPayload['data'];
+
+		const result = store.set({ id: propertyId, data: partialUpdate });
+
+		expect(result.name).toBe('Renamed property');
+		expect(result.identifier).toBe(initial.identifier);
+		expect(result.permissions).toEqual(initial.permissions);
+		expect(result.channel).toBe(initial.channel);
+	});
+
+	it('produces the same entry via onEvent as via set() with equivalently transformed data', () => {
+		const dataFromTransform = transformChannelPropertyResponse(rawResponse(), ChannelPropertySchema);
+
+		const viaSet = store.set({ id: propertyId, data: dataFromTransform });
+
+		const otherId = uuid();
+		const rawForEvent = rawResponse({ id: otherId });
+
+		const eventPayload: IChannelsPropertiesOnEventActionPayload = {
+			id: otherId,
+			type: rawForEvent.type,
+			data: rawForEvent,
+		};
+
+		const viaEvent = store.onEvent(eventPayload);
+
+		expect(viaEvent).toEqual({ ...viaSet, id: otherId });
+	});
+
+	it('throws a validation exception for an invalid payload', () => {
+		expect(() =>
+			store.set({
+				id: uuid(),
+				data: { type: 'some-property' } as unknown as IChannelsPropertiesSetActionPayload['data'],
+			})
+		).toThrow(DevicesValidationException);
+	});
+});

--- a/apps/admin/src/modules/devices/store/channels.properties.store.ts
+++ b/apps/admin/src/modules/devices/store/channels.properties.store.ts
@@ -91,21 +91,9 @@ export const useChannelsProperties = defineStore<'devices_module-channels_proper
 
 		const pendingFetchPromises: Record<string, Promise<IChannelProperty[]>> = {};
 
-		const onEvent = (payload: IChannelsPropertiesOnEventActionPayload): IChannelProperty => {
-			const element = getPluginElement(payload.type);
-
-			return set({
-				id: payload.id,
-				data: transformChannelPropertyResponse(
-					payload.data as IChannelPropertyRes,
-					element?.schemas?.channelPropertySchema || ChannelPropertySchema
-				),
-			});
-		};
-
-		const set = (payload: IChannelsPropertiesSetActionPayload): IChannelProperty => {
-			const element = getPluginElement(payload.data.type);
-
+		// Shared by `set` and `onEvent` so a single incoming event scans the plugin registry once,
+		// not twice: each caller resolves `element` itself and hands it in here.
+		const applySet = (payload: IChannelsPropertiesSetActionPayload, element: ReturnType<typeof getPluginElement>): IChannelProperty => {
 			if (payload.id && data.value && payload.id in data.value) {
 				const parsed = (element?.schemas?.channelPropertySchema || ChannelPropertySchema).safeParse({ ...data.value[payload.id], ...payload.data });
 
@@ -130,6 +118,23 @@ export const useChannelsProperties = defineStore<'devices_module-channels_proper
 
 			return (data.value[parsed.data.id] = parsed.data);
 		};
+
+		const onEvent = (payload: IChannelsPropertiesOnEventActionPayload): IChannelProperty => {
+			const element = getPluginElement(payload.type);
+
+			return applySet(
+				{
+					id: payload.id,
+					data: transformChannelPropertyResponse(
+						payload.data as IChannelPropertyRes,
+						element?.schemas?.channelPropertySchema || ChannelPropertySchema
+					),
+				},
+				element
+			);
+		};
+
+		const set = (payload: IChannelsPropertiesSetActionPayload): IChannelProperty => applySet(payload, getPluginElement(payload.data.type));
 
 		const unset = (payload: IChannelsPropertiesUnsetActionPayload): void => {
 			if (!data.value) {


### PR DESCRIPTION
## Summary

Perf follow-up to the admin memory-leak audit (companion to the leak-fix PR; files are fully disjoint). Two hot paths allocated excessively on every evaluation/event:

- **`config-app.store.ts`**: the `data` computed re-ran `storeToRefs()` over the plugins and modules sibling stores on every evaluation — allocating a wrapper ref per store key each time and making the computed track both stores' entire surface. The sibling refs are now resolved lazily once (`??=` on first read) and reused; reactivity through the memoized refs is unchanged.
- **`channels.properties.store.ts`**: `set()` and `onEvent()` each scanned the plugin registry via `getPluginElement`, so a socket event scanned it twice. Both now delegate to a single `applySet(payload, element)` helper and resolve the plugin element exactly once per call. Signatures, merge semantics, and schema selection are unchanged.

## Testing

This is a pure refactor, locked in behavior-first: both new specs (`config-app.store.spec.ts`, `channels.properties.store.spec.ts`) were written against the **unrefactored** code and shown green, then kept green after the refactor. The config spec exercises real Pinia + real `storeToRefs` reactivity (only the store lookup is mocked); the properties spec covers set-create, set-update merge semantics, `onEvent`/`set` parity, and invalid-payload validation.

- Full admin unit suite: **281 files, 2041 tests, all passing** on this branch.
- Config + devices store suites: 76/76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
