### PR TITLE
feat(cross): synchronize adopted Homey device state

### DIFF
--- a/apps/backend/src/modules/devices/services/device-connectivity.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/device-connectivity.service.spec.ts
@@ -1,0 +1,63 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { ConnectionState } from '../devices.constants';
+import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
+
+import { ChannelsPropertiesService } from './channels.properties.service';
+import { ChannelsService } from './channels.service';
+import { DeviceConnectionStateService } from './device-connection-state.service';
+import { DeviceConnectivityService } from './device-connectivity.service';
+import { DevicesService } from './devices.service';
+
+describe('DeviceConnectivityService', () => {
+	const devicesService = { findOne: jest.fn() };
+	const channelsService = { findOneBy: jest.fn(), create: jest.fn() };
+	const channelsPropertiesService = { findOneBy: jest.fn(), create: jest.fn(), update: jest.fn() };
+	const deviceConnectionStateService = { readLatest: jest.fn(), write: jest.fn() };
+	const eventEmitter = { emit: jest.fn() };
+	let service: DeviceConnectivityService;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		service = new DeviceConnectivityService(
+			devicesService as unknown as DevicesService,
+			channelsService as unknown as ChannelsService,
+			channelsPropertiesService as unknown as ChannelsPropertiesService,
+			deviceConnectionStateService as unknown as DeviceConnectionStateService,
+			eventEmitter as unknown as EventEmitter2,
+		);
+	});
+
+	it('reports when the requested state could not be applied while preserving the legacy void method', async () => {
+		devicesService.findOne.mockResolvedValue(null);
+
+		await expect(service.trySetConnectionState('missing-device', { state: ConnectionState.CONNECTED })).resolves.toBe(
+			false,
+		);
+		await expect(service.setConnectionState('missing-device', { state: ConnectionState.CONNECTED })).resolves.toBe(
+			undefined,
+		);
+	});
+
+	it('reports an already-current persisted connection state as applied', async () => {
+		const device = Object.assign(new DeviceEntity(), { id: 'device-id' });
+		const channel = Object.assign(new ChannelEntity(), { id: 'channel-id' });
+		const property = Object.assign(new ChannelPropertyEntity(), {
+			id: 'property-id',
+			value: { value: ConnectionState.CONNECTED },
+		});
+		devicesService.findOne.mockResolvedValue(device);
+		channelsService.findOneBy.mockResolvedValue(channel);
+		channelsPropertiesService.findOneBy.mockResolvedValue(property);
+		deviceConnectionStateService.readLatest.mockResolvedValue({
+			online: true,
+			status: ConnectionState.CONNECTED,
+			lastChanged: null,
+		});
+
+		await expect(service.trySetConnectionState(device.id, { state: ConnectionState.CONNECTED })).resolves.toBe(true);
+		expect(channelsPropertiesService.update).not.toHaveBeenCalled();
+		expect(deviceConnectionStateService.write).not.toHaveBeenCalled();
+		expect(eventEmitter.emit).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/modules/devices/services/device-connectivity.service.ts
+++ b/apps/backend/src/modules/devices/services/device-connectivity.service.ts
@@ -32,11 +32,18 @@ export class DeviceConnectivityService {
 		deviceId: DeviceEntity['id'],
 		state: { state: ConnectionState; reason?: string; ts?: number },
 	): Promise<void> {
+		await this.trySetConnectionState(deviceId, state);
+	}
+
+	async trySetConnectionState(
+		deviceId: DeviceEntity['id'],
+		state: { state: ConnectionState; reason?: string; ts?: number },
+	): Promise<boolean> {
 		const device = await this.devicesService.findOne(deviceId);
 
 		if (!device) {
 			// Device not found - this can happen during initialization, just skip
-			return;
+			return false;
 		}
 
 		let channel: ChannelEntity;
@@ -48,12 +55,12 @@ export class DeviceConnectivityService {
 		} catch {
 			// Channel or property not found/created - this can happen during initialization
 			// Just skip setting connection state, it will be set later when channels are created
-			return;
+			return false;
 		}
 
 		if (!property) {
 			// Property not found - skip
-			return;
+			return false;
 		}
 
 		const last = property.value?.value;
@@ -70,7 +77,7 @@ export class DeviceConnectivityService {
 				changed = true;
 			} catch {
 				// Property may have been deleted or doesn't exist - skip
-				return;
+				return false;
 			}
 		}
 
@@ -84,7 +91,7 @@ export class DeviceConnectivityService {
 			}
 		} catch {
 			// Connection state service error - skip
-			return;
+			return false;
 		}
 
 		if (changed) {
@@ -95,6 +102,8 @@ export class DeviceConnectivityService {
 
 			this.eventEmitter.emit(EventType.DEVICE_CONNECTION_CHANGED, { device, state: state.state, reason: state.reason });
 		}
+
+		return true;
 	}
 
 	private async findOrCreateConnectionChannel(device: DeviceEntity, create: boolean): Promise<ChannelEntity> {

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -26,6 +26,7 @@ import { HomeyConnectionTestService } from './services/homey-connection-test.ser
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
 import { HomeyDeviceInventoryService } from './services/homey-device-inventory.service';
 import { HomeyMappingPreviewService } from './services/homey-mapping-preview.service';
+import { HomeySynchronizerService } from './services/homey-synchronizer.service';
 import { HomeyService } from './services/homey.service';
 
 describe('DevicesHomeyPlugin', () => {
@@ -98,6 +99,7 @@ describe('DevicesHomeyPlugin', () => {
 				HomeyMappingPreviewService,
 				HomeyAdoptionLockService,
 				HomeyDeviceAdoptionService,
+				HomeySynchronizerService,
 			]),
 		);
 		expect(providers).toContainEqual({

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -56,6 +56,7 @@ import { HomeyConnectionTestService } from './services/homey-connection-test.ser
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
 import { HomeyDeviceInventoryService } from './services/homey-device-inventory.service';
 import { HomeyMappingPreviewService } from './services/homey-mapping-preview.service';
+import { HomeySynchronizerService } from './services/homey-synchronizer.service';
 import { HomeyService } from './services/homey.service';
 
 @ApiTag({
@@ -92,6 +93,7 @@ import { HomeyService } from './services/homey.service';
 		HomeyMappingPreviewService,
 		HomeyAdoptionLockService,
 		HomeyDeviceAdoptionService,
+		HomeySynchronizerService,
 		HomeyService,
 	],
 	controllers: [
@@ -108,6 +110,7 @@ import { HomeyService } from './services/homey.service';
 		HomeyDeviceInventoryService,
 		HomeyMappingPreviewService,
 		HomeyDeviceAdoptionService,
+		HomeySynchronizerService,
 		HomeyService,
 	],
 })

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -1,0 +1,398 @@
+import {
+	ChannelCategory,
+	ConnectionState,
+	DataTypeType,
+	PermissionType,
+	PropertyCategory,
+} from '../../../modules/devices/devices.constants';
+import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
+import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from '../entities/devices-homey.entity';
+import { HomeyMappingLoaderService } from '../mappings/mapping-loader.service';
+import { HomeyMappingTransformerService } from '../mappings/mapping-transformer.service';
+import { ResolvedHomeyPropertyMapping } from '../mappings/mapping.types';
+import { HomeyCapabilityType, createHomeyCapability } from '../models/homey-capability.model';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+
+import { HomeySynchronizerService } from './homey-synchronizer.service';
+
+const powerMapping: ResolvedHomeyPropertyMapping = {
+	kind: 'properties',
+	source: 'builtin',
+	name: 'light-power',
+	priority: 100,
+	exclusive: false,
+	conflict: 'error',
+	match: {
+		classes: ['light'],
+		capabilityBaseIds: ['onoff'],
+		allCapabilities: [],
+		noneCapabilities: [],
+		driverIds: [],
+		manufacturers: [],
+		models: [],
+	},
+	property: {
+		channel: 'light',
+		category: PropertyCategory.ON,
+		dataType: DataTypeType.BOOL,
+		direction: 'bidirectional',
+	},
+};
+
+const stateMapping: ResolvedHomeyPropertyMapping = {
+	...powerMapping,
+	name: 'light-state-label',
+	property: {
+		...powerMapping.property,
+		category: PropertyCategory.STATE,
+		dataType: DataTypeType.STRING,
+		direction: 'read_only',
+		transform: { type: 'map', read: { true: 'on', false: 'off' } },
+	},
+};
+
+const brightnessMapping: ResolvedHomeyPropertyMapping = {
+	...powerMapping,
+	name: 'light-brightness',
+	match: { ...powerMapping.match, capabilityBaseIds: ['dim'] },
+	property: {
+		...powerMapping.property,
+		category: PropertyCategory.BRIGHTNESS,
+		dataType: DataTypeType.UCHAR,
+		transform: { type: 'scale', input_range: [0, 1], output_range: [0, 100], clamp: true },
+	},
+};
+
+function property(id: string, homeyCapabilityId: string, homeyMappingName: string): HomeyChannelPropertyEntity {
+	return Object.assign(new HomeyChannelPropertyEntity(), {
+		id,
+		identifier: `${homeyCapabilityId}::${homeyMappingName}`,
+		homeyCapabilityId,
+		homeyMappingName,
+		category: PropertyCategory.ON,
+		name: homeyMappingName,
+		permissions: [PermissionType.READ_ONLY],
+		dataType: DataTypeType.BOOL,
+		format: null,
+		invalid: null,
+		step: null,
+	});
+}
+
+function adoptedDevice(properties: HomeyChannelPropertyEntity[]): HomeyDeviceEntity {
+	const channel = Object.assign(new HomeyChannelEntity(), {
+		id: 'panel-channel',
+		identifier: 'light',
+		name: 'Light',
+		category: ChannelCategory.LIGHT,
+		properties,
+	});
+
+	return Object.assign(new HomeyDeviceEntity(), {
+		id: 'panel-device',
+		identifier: 'homey-light',
+		name: 'Light',
+		channels: [channel],
+	});
+}
+
+function homeyDevice(overrides: Partial<HomeyDevice> = {}): HomeyDevice {
+	return {
+		id: 'homey-light',
+		name: 'Light',
+		class: 'light',
+		zoneId: 'zone-living',
+		zoneName: 'Living room',
+		zonePath: ['Living room'],
+		available: true,
+		availabilityMessage: null,
+		driverId: 'homey:app:driver:light',
+		manufacturer: 'Example',
+		model: 'Light',
+		energy: null,
+		capabilities: [
+			createHomeyCapability({
+				id: 'onoff',
+				title: 'Power',
+				value: true,
+				type: HomeyCapabilityType.BOOLEAN,
+				unit: null,
+				minimum: null,
+				maximum: null,
+				step: null,
+				enumValues: [],
+				readable: true,
+				writable: true,
+				available: true,
+				lastUpdatedAt: '2026-08-21T10:00:00.000Z',
+			}),
+			createHomeyCapability({
+				id: 'dim',
+				title: 'Brightness',
+				value: 0.25,
+				type: HomeyCapabilityType.NUMBER,
+				unit: null,
+				minimum: 0,
+				maximum: 1,
+				step: 0.01,
+				enumValues: [],
+				readable: true,
+				writable: true,
+				available: true,
+				lastUpdatedAt: '2026-08-21T10:00:00.000Z',
+			}),
+		],
+		...overrides,
+	};
+}
+
+function capabilityEvent(
+	capabilityId: string,
+	value: boolean | number | string | null,
+	lastUpdatedAt: string | null,
+): Extract<HomeyEvent, { type: HomeyEventType.CAPABILITY_VALUE_CHANGED }> {
+	return {
+		type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+		deviceId: 'homey-light',
+		capabilityId,
+		value,
+		lastUpdatedAt,
+		occurredAt: lastUpdatedAt,
+		sequence: null,
+	};
+}
+
+describe('HomeySynchronizerService', () => {
+	let devicesService: jest.Mocked<Pick<DevicesService, 'findAll'>>;
+	let propertiesService: jest.Mocked<Pick<ChannelsPropertiesService, 'update'>>;
+	let connectivityService: jest.Mocked<Pick<DeviceConnectivityService, 'setConnectionState'>>;
+	let mappingLoader: jest.Mocked<Pick<HomeyMappingLoaderService, 'getPropertyMappings'>>;
+	let service: HomeySynchronizerService;
+	let powerProperty: HomeyChannelPropertyEntity;
+	let stateProperty: HomeyChannelPropertyEntity;
+	let brightnessProperty: HomeyChannelPropertyEntity;
+
+	beforeEach(() => {
+		powerProperty = property('property-power', 'onoff', powerMapping.name);
+		stateProperty = property('property-state', 'onoff', stateMapping.name);
+		brightnessProperty = property('property-brightness', 'dim', brightnessMapping.name);
+		devicesService = {
+			findAll: jest.fn().mockResolvedValue([adoptedDevice([powerProperty, stateProperty, brightnessProperty])]),
+		};
+		propertiesService = { update: jest.fn().mockResolvedValue(new HomeyChannelPropertyEntity()) };
+		connectivityService = { setConnectionState: jest.fn().mockResolvedValue(undefined) };
+		mappingLoader = {
+			getPropertyMappings: jest.fn().mockReturnValue([powerMapping, stateMapping, brightnessMapping]),
+		};
+		service = new HomeySynchronizerService(
+			devicesService as unknown as DevicesService,
+			propertiesService as unknown as ChannelsPropertiesService,
+			connectivityService as unknown as DeviceConnectivityService,
+			mappingLoader as unknown as HomeyMappingLoaderService,
+			new HomeyMappingTransformerService(),
+		);
+	});
+
+	it('indexes adopted full capability identities and applies the authoritative startup snapshot', async () => {
+		await expect(service.synchronizeSnapshot([homeyDevice()])).resolves.toEqual({
+			updated: 4,
+			ignored: 0,
+			failed: 0,
+		});
+
+		expect(devicesService.findAll).toHaveBeenCalledWith(DEVICES_HOMEY_TYPE);
+		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+			state: ConnectionState.CONNECTED,
+		});
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }],
+			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 25 }],
+		]);
+	});
+
+	it('marks missing and unavailable adopted devices without deleting them', async () => {
+		await service.synchronizeSnapshot([]);
+		await service.synchronizeSnapshot([homeyDevice({ available: false, availabilityMessage: 'Unavailable' })]);
+
+		expect(connectivityService.setConnectionState.mock.calls).toEqual([
+			['panel-device', { state: ConnectionState.LOST }],
+			['panel-device', { state: ConnectionState.DISCONNECTED }],
+		]);
+		expect(propertiesService.update).toHaveBeenCalledTimes(3);
+	});
+
+	it('does not publish a value for an unavailable capability', async () => {
+		const unavailable = homeyDevice({
+			capabilities: homeyDevice().capabilities.map((capability) =>
+				capability.id === 'onoff' ? { ...capability, available: false } : capability,
+			),
+		});
+
+		await service.synchronizeSnapshot([unavailable]);
+
+		expect(propertiesService.update).toHaveBeenCalledTimes(1);
+		expect(propertiesService.update).toHaveBeenCalledWith('property-brightness', {
+			type: DEVICES_HOMEY_TYPE,
+			value: 25,
+		});
+	});
+
+	it('preserves null as a valid normalized capability value', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', null, null)], new Map());
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: null }],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: null }],
+		]);
+	});
+
+	it('filters unknown devices, unmapped capabilities, and invalid runtime values', async () => {
+		await service.refreshIndex();
+
+		const invalid = { ...capabilityEvent('onoff', true, null), value: { leaked: true } } as unknown as HomeyEvent;
+		const result = await service.synchronizeEvents(
+			[
+				{ ...capabilityEvent('onoff', true, null), deviceId: 'unadopted' },
+				capabilityEvent('vendor_unknown', 1, null),
+				invalid,
+			],
+			new Map(),
+		);
+
+		expect(result).toEqual({ updated: 0, ignored: 3, failed: 0 });
+		expect(propertiesService.update).not.toHaveBeenCalled();
+		expect(connectivityService.setConnectionState).not.toHaveBeenCalled();
+	});
+
+	it('coalesces bursts by full property identity while preserving final selected order and value', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents(
+			[
+				capabilityEvent('onoff', true, '2026-08-21T10:01:00.000Z'),
+				capabilityEvent('dim', 0.5, '2026-08-21T10:01:01.000Z'),
+				capabilityEvent('onoff', false, '2026-08-21T10:01:02.000Z'),
+			],
+			new Map(),
+		);
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 50 }],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }],
+		]);
+	});
+
+	it('ignores duplicate and out-of-order timestamped capability events', async () => {
+		await service.refreshIndex();
+		const newest = capabilityEvent('onoff', true, '2026-08-21T10:02:00.000Z');
+
+		await service.synchronizeEvents([newest], new Map());
+		await service.synchronizeEvents([newest], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z')], new Map());
+
+		expect(propertiesService.update).toHaveBeenCalledTimes(2);
+		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
+			type: DEVICES_HOMEY_TYPE,
+			value: true,
+		});
+	});
+
+	it('updates availability and treats upstream removal as lost without a delete path', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+					deviceId: 'homey-light',
+					available: false,
+					availabilityMessage: 'Unavailable',
+					occurredAt: null,
+					sequence: null,
+				},
+				{
+					type: HomeyEventType.DEVICE_REMOVED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: null,
+				},
+			],
+			new Map(),
+		);
+
+		expect(connectivityService.setConnectionState.mock.calls).toEqual([
+			['panel-device', { state: ConnectionState.DISCONNECTED }],
+			['panel-device', { state: ConnectionState.LOST }],
+		]);
+		expect(devicesService).not.toHaveProperty('remove');
+	});
+
+	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {
+		await service.refreshIndex();
+		propertiesService.update.mockRejectedValueOnce(new Error('storage unavailable'));
+		const current = homeyDevice();
+		const result = await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_UPDATED,
+					deviceId: current.id,
+					occurredAt: null,
+					sequence: null,
+				},
+			],
+			new Map([[current.id, current]]),
+		);
+
+		expect(result).toEqual({ updated: 3, ignored: 0, failed: 1 });
+		expect(propertiesService.update).toHaveBeenCalledTimes(3);
+	});
+
+	it('rebuilds an invalidated index before processing later events', async () => {
+		await service.refreshIndex();
+		const replacement = property('replacement-power', 'onoff', powerMapping.name);
+		devicesService.findAll.mockResolvedValueOnce([adoptedDevice([replacement])]);
+		service.invalidateFromEntity();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], new Map());
+
+		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+		expect(propertiesService.update).toHaveBeenLastCalledWith('replacement-power', {
+			type: DEVICES_HOMEY_TYPE,
+			value: false,
+		});
+	});
+
+	it('repeats an in-flight refresh when the device structure changes during its database read', async () => {
+		let resolveInitial: (devices: HomeyDeviceEntity[]) => void = () => undefined;
+		const replacement = property('replacement-power', 'onoff', powerMapping.name);
+		devicesService.findAll
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveInitial = resolve;
+					}),
+			)
+			.mockResolvedValueOnce([adoptedDevice([replacement])]);
+
+		const refresh = service.refreshIndex();
+		await Promise.resolve();
+		service.invalidateFromEntity();
+		resolveInitial([adoptedDevice([powerProperty])]);
+		await refresh;
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], new Map());
+
+		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
+		expect(propertiesService.update).toHaveBeenCalledWith('replacement-power', {
+			type: DEVICES_HOMEY_TYPE,
+			value: false,
+		});
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -333,7 +333,7 @@ describe('HomeySynchronizerService', () => {
 		});
 	});
 
-	it('updates availability and treats upstream removal as lost without a delete path', async () => {
+	it('coalesces availability and removal to the final lost state without a delete path', async () => {
 		await service.refreshIndex();
 
 		await service.synchronizeEvents(
@@ -357,7 +357,6 @@ describe('HomeySynchronizerService', () => {
 		);
 
 		expect(connectivityService.setConnectionState.mock.calls).toEqual([
-			['panel-device', { state: ConnectionState.DISCONNECTED }],
 			['panel-device', { state: ConnectionState.LOST }],
 		]);
 		expect(devicesService).not.toHaveProperty('remove');
@@ -425,6 +424,26 @@ describe('HomeySynchronizerService', () => {
 			state: ConnectionState.CONNECTED,
 		});
 		expect(propertiesService.update).not.toHaveBeenCalled();
+	});
+
+	it('filters a stale removal before callers mutate their inventory cache', async () => {
+		await service.refreshIndex();
+		const update: HomeyEvent = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: 'homey-light',
+			occurredAt: null,
+			sequence: 2,
+		};
+		const removal: HomeyEvent = {
+			type: HomeyEventType.DEVICE_REMOVED,
+			deviceId: 'homey-light',
+			occurredAt: null,
+			sequence: 1,
+		};
+
+		expect(service.filterEvents([update, removal])).toEqual([update]);
+		await service.synchronizeEvents([update], new Map([['homey-light', homeyDevice()]]));
+		expect(service.filterEvents([removal])).toEqual([]);
 	});
 
 	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -393,8 +393,9 @@ describe('HomeySynchronizerService', () => {
 		};
 		const stale = { ...available, available: false, availabilityMessage: 'Offline', sequence: 1 };
 
-		await service.synchronizeEvents([available, stale], new Map());
-		await service.synchronizeEvents([stale], new Map());
+		const currentDevices = new Map([['homey-light', homeyDevice()]]);
+		await service.synchronizeEvents([available, stale], currentDevices);
+		await service.synchronizeEvents([stale], currentDevices);
 
 		expect(connectivityService.trySetConnectionState).toHaveBeenCalledTimes(1);
 		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
@@ -414,9 +415,10 @@ describe('HomeySynchronizerService', () => {
 			sequence: 2,
 		};
 
-		await service.synchronizeEvents([event], new Map());
-		await service.synchronizeEvents([event], new Map());
-		await service.synchronizeEvents([event], new Map());
+		const currentDevices = new Map([['homey-light', homeyDevice()]]);
+		await service.synchronizeEvents([event], currentDevices);
+		await service.synchronizeEvents([event], currentDevices);
+		await service.synchronizeEvents([event], currentDevices);
 
 		expect(connectivityService.trySetConnectionState).toHaveBeenCalledTimes(2);
 	});
@@ -501,6 +503,40 @@ describe('HomeySynchronizerService', () => {
 		};
 
 		expect(service.filterEvents([update, availability])).toEqual([update, availability]);
+	});
+
+	it('does not resurrect an adopted device from availability when authoritative inventory omits it', async () => {
+		await service.synchronizeSnapshot([]);
+		connectivityService.trySetConnectionState.mockClear();
+
+		await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+					deviceId: 'homey-light',
+					available: true,
+					availabilityMessage: null,
+					occurredAt: null,
+					sequence: 2,
+				},
+			],
+			new Map(),
+		);
+
+		expect(connectivityService.trySetConnectionState).not.toHaveBeenCalled();
+	});
+
+	it('commits zone-triggered snapshot event ordering from fresh values', async () => {
+		const current = homeyDevice({
+			capabilities: homeyDevice().capabilities.map((capability) => ({ ...capability, lastUpdatedAt: null })),
+		});
+		const event = capabilityEvent('onoff', false, null, 2);
+
+		await service.synchronizeSnapshot([current], [event]);
+		propertiesService.update.mockClear();
+		await service.synchronizeEvents([{ ...event, value: false, sequence: 1 }], new Map());
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
 	});
 
 	it('commits buffered startup ordering after applying fresh targeted readback', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -466,6 +466,53 @@ describe('HomeySynchronizerService', () => {
 		expect(propertiesService.update).not.toHaveBeenCalled();
 	});
 
+	it('preserves a numeric device watermark across an unsequenced device event', async () => {
+		await service.refreshIndex();
+		const currentDevices = new Map([['homey-light', homeyDevice()]]);
+
+		await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+					deviceId: 'homey-light',
+					available: true,
+					availabilityMessage: null,
+					occurredAt: null,
+					sequence: 2,
+				},
+			],
+			currentDevices,
+		);
+		await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_UPDATED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: null,
+				},
+			],
+			currentDevices,
+		);
+		connectivityService.trySetConnectionState.mockClear();
+
+		await service.synchronizeEvents(
+			[
+				{
+					type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+					deviceId: 'homey-light',
+					available: false,
+					availabilityMessage: 'Delayed',
+					occurredAt: null,
+					sequence: 1,
+				},
+			],
+			currentDevices,
+		);
+
+		expect(connectivityService.trySetConnectionState).not.toHaveBeenCalled();
+	});
+
 	it('filters a stale removal before callers mutate their inventory cache', async () => {
 		await service.refreshIndex();
 		const update: HomeyEvent = {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -582,6 +582,24 @@ describe('HomeySynchronizerService', () => {
 		expect(connectivityService.trySetConnectionState).not.toHaveBeenCalled();
 	});
 
+	it('carries a lifecycle refresh sequence into the fresh capability values', async () => {
+		const current = homeyDevice({
+			capabilities: homeyDevice().capabilities.map((capability) => ({ ...capability, lastUpdatedAt: null })),
+		});
+		const update: HomeyEvent = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: 'homey-light',
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		await service.synchronizeDevices([current], [], [update]);
+		propertiesService.update.mockClear();
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
+	});
+
 	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {
 		await service.refreshIndex();
 		propertiesService.update.mockRejectedValueOnce(new Error('storage unavailable'));

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -167,6 +167,10 @@ function capabilityEvent(
 	};
 }
 
+function inventory(device: HomeyDevice = homeyDevice()): ReadonlyMap<string, HomeyDevice> {
+	return new Map([[device.id, device]]);
+}
+
 describe('HomeySynchronizerService', () => {
 	let devicesService: jest.Mocked<Pick<DevicesService, 'findAll'>>;
 	let propertiesService: jest.Mocked<Pick<ChannelsPropertiesService, 'update'>>;
@@ -246,7 +250,7 @@ describe('HomeySynchronizerService', () => {
 	it('preserves null as a valid normalized capability value', async () => {
 		await service.refreshIndex();
 
-		await service.synchronizeEvents([capabilityEvent('onoff', null, null)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', null, null)], inventory());
 
 		expect(propertiesService.update.mock.calls).toEqual([
 			['property-power', { type: DEVICES_HOMEY_TYPE, value: null }],
@@ -264,7 +268,7 @@ describe('HomeySynchronizerService', () => {
 				capabilityEvent('vendor_unknown', 1, null),
 				invalid,
 			],
-			new Map(),
+			inventory(),
 		);
 
 		expect(result).toEqual({ updated: 0, ignored: 3, failed: 0 });
@@ -281,7 +285,7 @@ describe('HomeySynchronizerService', () => {
 				capabilityEvent('dim', 0.5, '2026-08-21T10:01:01.000Z'),
 				capabilityEvent('onoff', false, '2026-08-21T10:01:02.000Z'),
 			],
-			new Map(),
+			inventory(),
 		);
 
 		expect(propertiesService.update.mock.calls).toEqual([
@@ -295,9 +299,9 @@ describe('HomeySynchronizerService', () => {
 		await service.refreshIndex();
 		const newest = capabilityEvent('onoff', true, '2026-08-21T10:02:00.000Z');
 
-		await service.synchronizeEvents([newest], new Map());
-		await service.synchronizeEvents([newest], new Map());
-		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z')], new Map());
+		await service.synchronizeEvents([newest], inventory());
+		await service.synchronizeEvents([newest], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z')], inventory());
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(2);
 		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
@@ -311,7 +315,7 @@ describe('HomeySynchronizerService', () => {
 
 		await service.synchronizeEvents(
 			[capabilityEvent('onoff', false, null, 2), capabilityEvent('onoff', true, null, 1)],
-			new Map(),
+			inventory(),
 		);
 
 		expect(propertiesService.update.mock.calls).toEqual([
@@ -323,8 +327,8 @@ describe('HomeySynchronizerService', () => {
 	it('rejects an older numeric sequence received in a later batch', async () => {
 		await service.refreshIndex();
 
-		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], new Map());
-		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], inventory());
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(2);
 		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
@@ -333,10 +337,47 @@ describe('HomeySynchronizerService', () => {
 		});
 	});
 
+	it('blocks older capability events after a newer write failure and allows an equal-order retry', async () => {
+		await service.refreshIndex();
+		propertiesService.update.mockRejectedValueOnce(new Error('storage unavailable'));
+		const newest = capabilityEvent('onoff', true, null, 2);
+
+		await service.synchronizeEvents([newest], inventory());
+		propertiesService.update.mockClear();
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], inventory());
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
+
+		await service.synchronizeEvents([newest], inventory());
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }],
+		]);
+	});
+
+	it('rejects capability events missing from authoritative inventory or unavailable upstream', async () => {
+		await service.synchronizeSnapshot([]);
+		propertiesService.update.mockClear();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 2)], new Map());
+		await service.synchronizeEvents(
+			[capabilityEvent('onoff', false, null, 3)],
+			inventory(
+				homeyDevice({
+					capabilities: homeyDevice().capabilities.map((capability) =>
+						capability.id === 'onoff' ? { ...capability, available: false } : capability,
+					),
+				}),
+			),
+		);
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
+	});
+
 	it('preserves a numeric sequence watermark across an unsequenced snapshot', async () => {
 		await service.refreshIndex();
 
-		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], inventory());
 		await service.synchronizeSnapshot([
 			homeyDevice({
 				capabilities: homeyDevice().capabilities.map((capability) => ({
@@ -347,7 +388,7 @@ describe('HomeySynchronizerService', () => {
 		]);
 		propertiesService.update.mockClear();
 
-		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], inventory());
 
 		expect(propertiesService.update).not.toHaveBeenCalled();
 	});
@@ -581,7 +622,7 @@ describe('HomeySynchronizerService', () => {
 
 		await service.synchronizeSnapshot([current], [event]);
 		propertiesService.update.mockClear();
-		await service.synchronizeEvents([{ ...event, value: false, sequence: 1 }], new Map());
+		await service.synchronizeEvents([{ ...event, value: false, sequence: 1 }], inventory(current));
 
 		expect(propertiesService.update).not.toHaveBeenCalled();
 	});
@@ -622,7 +663,7 @@ describe('HomeySynchronizerService', () => {
 					sequence: 1,
 				},
 			],
-			new Map(),
+			inventory(current),
 		);
 
 		expect(propertiesService.update).not.toHaveBeenCalled();
@@ -642,7 +683,7 @@ describe('HomeySynchronizerService', () => {
 
 		await service.synchronizeDevices([current], [], [update]);
 		propertiesService.update.mockClear();
-		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], inventory(current));
 
 		expect(propertiesService.update).not.toHaveBeenCalled();
 	});
@@ -673,7 +714,7 @@ describe('HomeySynchronizerService', () => {
 		devicesService.findAll.mockResolvedValueOnce([adoptedDevice([replacement])]);
 		service.invalidateFromEntity();
 
-		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], inventory());
 
 		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
 		expect(propertiesService.update).toHaveBeenLastCalledWith('replacement-power', {
@@ -699,7 +740,7 @@ describe('HomeySynchronizerService', () => {
 		service.invalidateFromEntity();
 		resolveInitial([adoptedDevice([powerProperty])]);
 		await refresh;
-		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], inventory());
 
 		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
 		expect(propertiesService.update).toHaveBeenCalledWith('replacement-power', {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -170,7 +170,7 @@ function capabilityEvent(
 describe('HomeySynchronizerService', () => {
 	let devicesService: jest.Mocked<Pick<DevicesService, 'findAll'>>;
 	let propertiesService: jest.Mocked<Pick<ChannelsPropertiesService, 'update'>>;
-	let connectivityService: jest.Mocked<Pick<DeviceConnectivityService, 'setConnectionState'>>;
+	let connectivityService: jest.Mocked<Pick<DeviceConnectivityService, 'trySetConnectionState'>>;
 	let mappingLoader: jest.Mocked<Pick<HomeyMappingLoaderService, 'getPropertyMappings'>>;
 	let service: HomeySynchronizerService;
 	let powerProperty: HomeyChannelPropertyEntity;
@@ -185,7 +185,7 @@ describe('HomeySynchronizerService', () => {
 			findAll: jest.fn().mockResolvedValue([adoptedDevice([powerProperty, stateProperty, brightnessProperty])]),
 		};
 		propertiesService = { update: jest.fn().mockResolvedValue(new HomeyChannelPropertyEntity()) };
-		connectivityService = { setConnectionState: jest.fn().mockResolvedValue(undefined) };
+		connectivityService = { trySetConnectionState: jest.fn().mockResolvedValue(true) };
 		mappingLoader = {
 			getPropertyMappings: jest.fn().mockReturnValue([powerMapping, stateMapping, brightnessMapping]),
 		};
@@ -206,7 +206,7 @@ describe('HomeySynchronizerService', () => {
 		});
 
 		expect(devicesService.findAll).toHaveBeenCalledWith(DEVICES_HOMEY_TYPE);
-		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
 			state: ConnectionState.CONNECTED,
 		});
 		expect(propertiesService.update.mock.calls).toEqual([
@@ -220,7 +220,7 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeSnapshot([]);
 		await service.synchronizeSnapshot([homeyDevice({ available: false, availabilityMessage: 'Unavailable' })]);
 
-		expect(connectivityService.setConnectionState.mock.calls).toEqual([
+		expect(connectivityService.trySetConnectionState.mock.calls).toEqual([
 			['panel-device', { state: ConnectionState.LOST }],
 			['panel-device', { state: ConnectionState.DISCONNECTED }],
 		]);
@@ -269,7 +269,7 @@ describe('HomeySynchronizerService', () => {
 
 		expect(result).toEqual({ updated: 0, ignored: 3, failed: 0 });
 		expect(propertiesService.update).not.toHaveBeenCalled();
-		expect(connectivityService.setConnectionState).not.toHaveBeenCalled();
+		expect(connectivityService.trySetConnectionState).not.toHaveBeenCalled();
 	});
 
 	it('coalesces bursts by full property identity while preserving final selected order and value', async () => {
@@ -356,7 +356,7 @@ describe('HomeySynchronizerService', () => {
 			new Map(),
 		);
 
-		expect(connectivityService.setConnectionState.mock.calls).toEqual([
+		expect(connectivityService.trySetConnectionState.mock.calls).toEqual([
 			['panel-device', { state: ConnectionState.LOST }],
 		]);
 		expect(devicesService).not.toHaveProperty('remove');
@@ -377,10 +377,29 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([available, stale], new Map());
 		await service.synchronizeEvents([stale], new Map());
 
-		expect(connectivityService.setConnectionState).toHaveBeenCalledTimes(1);
-		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledTimes(1);
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
 			state: ConnectionState.CONNECTED,
 		});
+	});
+
+	it('retries an equal-sequence device event until connectivity is actually applied', async () => {
+		await service.refreshIndex();
+		connectivityService.trySetConnectionState.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+		const event: HomeyEvent = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'homey-light',
+			available: false,
+			availabilityMessage: 'Offline',
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		await service.synchronizeEvents([event], new Map());
+		await service.synchronizeEvents([event], new Map());
+		await service.synchronizeEvents([event], new Map());
+
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledTimes(2);
 	});
 
 	it('shares device ordering across availability, add, update, and removal events', async () => {
@@ -419,8 +438,8 @@ describe('HomeySynchronizerService', () => {
 			new Map([['homey-light', homeyDevice()]]),
 		);
 
-		expect(connectivityService.setConnectionState).toHaveBeenCalledTimes(1);
-		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledTimes(1);
+		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
 			state: ConnectionState.CONNECTED,
 		});
 		expect(propertiesService.update).not.toHaveBeenCalled();
@@ -444,6 +463,49 @@ describe('HomeySynchronizerService', () => {
 		expect(service.filterEvents([update, removal])).toEqual([update]);
 		await service.synchronizeEvents([update], new Map([['homey-light', homeyDevice()]]));
 		expect(service.filterEvents([removal])).toEqual([]);
+	});
+
+	it('commits buffered startup ordering after applying fresh targeted readback', async () => {
+		const current = homeyDevice({
+			capabilities: homeyDevice().capabilities.map((capability) => ({ ...capability, lastUpdatedAt: null })),
+		});
+		const capability: HomeyEvent = {
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: 'homey-light',
+			capabilityId: 'onoff',
+			value: false,
+			lastUpdatedAt: null,
+			occurredAt: null,
+			sequence: 2,
+		};
+		const availability: HomeyEvent = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'homey-light',
+			available: false,
+			availabilityMessage: 'Stale event payload',
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		await service.synchronizeDevices([current], [], [capability, availability]);
+		propertiesService.update.mockClear();
+		connectivityService.trySetConnectionState.mockClear();
+
+		await service.synchronizeEvents(
+			[
+				{ ...capability, value: false, sequence: 1 },
+				{
+					type: HomeyEventType.DEVICE_REMOVED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: 1,
+				},
+			],
+			new Map(),
+		);
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
+		expect(connectivityService.trySetConnectionState).not.toHaveBeenCalled();
 	});
 
 	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -384,6 +384,49 @@ describe('HomeySynchronizerService', () => {
 		});
 	});
 
+	it('shares device ordering across availability, add, update, and removal events', async () => {
+		await service.refreshIndex();
+		const available: HomeyEvent = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'homey-light',
+			available: true,
+			availabilityMessage: null,
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		await service.synchronizeEvents(
+			[
+				available,
+				{
+					type: HomeyEventType.DEVICE_ADDED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: 1,
+				},
+				{
+					type: HomeyEventType.DEVICE_UPDATED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: 1,
+				},
+				{
+					type: HomeyEventType.DEVICE_REMOVED,
+					deviceId: 'homey-light',
+					occurredAt: null,
+					sequence: 1,
+				},
+			],
+			new Map([['homey-light', homeyDevice()]]),
+		);
+
+		expect(connectivityService.setConnectionState).toHaveBeenCalledTimes(1);
+		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+			state: ConnectionState.CONNECTED,
+		});
+		expect(propertiesService.update).not.toHaveBeenCalled();
+	});
+
 	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {
 		await service.refreshIndex();
 		propertiesService.update.mockRejectedValueOnce(new Error('storage unavailable'));

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -333,6 +333,25 @@ describe('HomeySynchronizerService', () => {
 		});
 	});
 
+	it('preserves a numeric sequence watermark across an unsequenced snapshot', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], new Map());
+		await service.synchronizeSnapshot([
+			homeyDevice({
+				capabilities: homeyDevice().capabilities.map((capability) => ({
+					...capability,
+					lastUpdatedAt: null,
+				})),
+			}),
+		]);
+		propertiesService.update.mockClear();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
+
+		expect(propertiesService.update).not.toHaveBeenCalled();
+	});
+
 	it('coalesces availability and removal to the final lost state without a delete path', async () => {
 		await service.refreshIndex();
 
@@ -463,6 +482,25 @@ describe('HomeySynchronizerService', () => {
 		expect(service.filterEvents([update, removal])).toEqual([update]);
 		await service.synchronizeEvents([update], new Map([['homey-light', homeyDevice()]]));
 		expect(service.filterEvents([removal])).toEqual([]);
+	});
+
+	it('retains a refresh event before a newer availability event for the same device', () => {
+		const update: HomeyEvent = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: 'homey-light',
+			occurredAt: null,
+			sequence: 1,
+		};
+		const availability: HomeyEvent = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'homey-light',
+			available: false,
+			availabilityMessage: 'Offline',
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		expect(service.filterEvents([update, availability])).toEqual([update, availability]);
 	});
 
 	it('commits buffered startup ordering after applying fresh targeted readback', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -154,6 +154,7 @@ function capabilityEvent(
 	capabilityId: string,
 	value: boolean | number | string | null,
 	lastUpdatedAt: string | null,
+	sequence: string | number | null = null,
 ): Extract<HomeyEvent, { type: HomeyEventType.CAPABILITY_VALUE_CHANGED }> {
 	return {
 		type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
@@ -162,7 +163,7 @@ function capabilityEvent(
 		value,
 		lastUpdatedAt,
 		occurredAt: lastUpdatedAt,
-		sequence: null,
+		sequence,
 	};
 }
 
@@ -297,6 +298,33 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([newest], new Map());
 		await service.synchronizeEvents([newest], new Map());
 		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z')], new Map());
+
+		expect(propertiesService.update).toHaveBeenCalledTimes(2);
+		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
+			type: DEVICES_HOMEY_TYPE,
+			value: true,
+		});
+	});
+
+	it('prefers numeric event sequence over arrival order within a burst', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents(
+			[capabilityEvent('onoff', false, null, 2), capabilityEvent('onoff', true, null, 1)],
+			new Map(),
+		);
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }],
+		]);
+	});
+
+	it('rejects an older numeric sequence received in a later batch', async () => {
+		await service.refreshIndex();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', true, null, 2)], new Map());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], new Map());
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(2);
 		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -363,6 +363,27 @@ describe('HomeySynchronizerService', () => {
 		expect(devicesService).not.toHaveProperty('remove');
 	});
 
+	it('rejects stale availability sequences within one batch and across later batches', async () => {
+		await service.refreshIndex();
+		const available: Extract<HomeyEvent, { type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED }> = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: 'homey-light',
+			available: true,
+			availabilityMessage: null,
+			occurredAt: null,
+			sequence: 2,
+		};
+		const stale = { ...available, available: false, availabilityMessage: 'Offline', sequence: 1 };
+
+		await service.synchronizeEvents([available, stale], new Map());
+		await service.synchronizeEvents([stale], new Map());
+
+		expect(connectivityService.setConnectionState).toHaveBeenCalledTimes(1);
+		expect(connectivityService.setConnectionState).toHaveBeenCalledWith('panel-device', {
+			state: ConnectionState.CONNECTED,
+		});
+	});
+
 	it('uses the refreshed device after a device update event and isolates per-property failures', async () => {
 		await service.refreshIndex();
 		propertiesService.update.mockRejectedValueOnce(new Error('storage unavailable'));

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -130,7 +130,7 @@ export class HomeySynchronizerService {
 		await this.ensureIndex();
 		const result = this.emptyResult();
 
-		for (const event of this.coalesceEvents(events)) {
+		for (const event of this.filterEvents(events)) {
 			if (!this.isValidEvent(event)) {
 				result.ignored += 1;
 				continue;
@@ -154,15 +154,12 @@ export class HomeySynchronizerService {
 						break;
 					}
 
-					const applied = await this.setConnectionState(
+					await this.setConnectionState(
 						context.adopted.id,
 						event.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 						result,
 					);
-
-					if (applied) {
-						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
-					}
+					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
 					break;
 				}
 				case HomeyEventType.DEVICE_ADDED:
@@ -174,17 +171,13 @@ export class HomeySynchronizerService {
 					}
 
 					const current = currentDevices.get(event.deviceId);
-					let applied: boolean;
-
 					if (current === undefined) {
-						applied = await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
+						await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
 					} else {
-						applied = await this.synchronizeDevice(current, result);
+						await this.synchronizeDevice(current, result);
 					}
 
-					if (applied) {
-						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
-					}
+					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
 					break;
 				}
 				case HomeyEventType.DEVICE_REMOVED: {
@@ -194,9 +187,8 @@ export class HomeySynchronizerService {
 						break;
 					}
 
-					if (await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result)) {
-						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
-					}
+					await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
+					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
 					break;
 				}
 				case HomeyEventType.ZONE_ADDED:
@@ -208,6 +200,21 @@ export class HomeySynchronizerService {
 		}
 
 		return result;
+	}
+
+	filterEvents(events: readonly HomeyEvent[]): HomeyEvent[] {
+		return this.coalesceEvents(events).filter((event) => {
+			if (!this.isDeviceEvent(event)) {
+				return true;
+			}
+
+			const previousOrder = this.lastAppliedDeviceOrder.get(event.deviceId);
+
+			return (
+				previousOrder === undefined ||
+				this.isNewerOrder(this.createOrder(event.sequence, event.occurredAt), previousOrder)
+			);
+		});
 	}
 
 	reset(): void {
@@ -292,15 +299,15 @@ export class HomeySynchronizerService {
 		this.indexDirty = this.indexGeneration !== generation;
 	}
 
-	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<boolean> {
+	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<void> {
 		const adopted = this.adoptedDevices.get(device.id);
 
 		if (adopted === undefined) {
 			result.ignored += 1;
-			return false;
+			return;
 		}
 
-		const connectionStateApplied = await this.setConnectionState(
+		await this.setConnectionState(
 			adopted.id,
 			device.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 			result,
@@ -314,8 +321,6 @@ export class HomeySynchronizerService {
 
 			await this.synchronizeCapability(device.id, capability, result);
 		}
-
-		return connectionStateApplied;
 	}
 
 	private async synchronizeCapability(
@@ -379,67 +384,71 @@ export class HomeySynchronizerService {
 		panelDeviceId: string,
 		state: ConnectionState,
 		result: MutableSynchronizationResult,
-	): Promise<boolean> {
+	): Promise<void> {
 		try {
 			await this.deviceConnectivityService.setConnectionState(panelDeviceId, { state });
 			result.updated += 1;
-			return true;
 		} catch {
 			result.failed += 1;
 			this.logger.warn('Could not update an adopted Homey device connection state', { resource: panelDeviceId });
-			return false;
 		}
 	}
 
 	private coalesceEvents(events: readonly HomeyEvent[]): HomeyEvent[] {
 		const selectedCapabilityIndexes = new Map<string, number>();
+		const selectedDeviceIndexes = new Map<string, number>();
 
 		for (let index = 0; index < events.length; index += 1) {
 			const event = events[index];
 
-			if (event.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
-				continue;
-			}
+			if (event.type === HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+				const key = `${event.deviceId}\u0000${event.capabilityId}`;
+				const selectedIndex = selectedCapabilityIndexes.get(key);
 
-			const key = `${event.deviceId}\u0000${event.capabilityId}`;
-			const selectedIndex = selectedCapabilityIndexes.get(key);
+				if (selectedIndex === undefined || this.isLaterEvent(event, events[selectedIndex])) {
+					selectedCapabilityIndexes.set(key, index);
+				}
+			} else if (this.isDeviceEvent(event)) {
+				const selectedIndex = selectedDeviceIndexes.get(event.deviceId);
 
-			if (selectedIndex === undefined || this.isLaterCapabilityEvent(event, events[selectedIndex])) {
-				selectedCapabilityIndexes.set(key, index);
+				if (selectedIndex === undefined || this.isLaterEvent(event, events[selectedIndex])) {
+					selectedDeviceIndexes.set(event.deviceId, index);
+				}
 			}
 		}
 
 		return events.filter((event, index) => {
-			if (event.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
-				return true;
+			if (event.type === HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+				return selectedCapabilityIndexes.get(`${event.deviceId}\u0000${event.capabilityId}`) === index;
 			}
 
-			return selectedCapabilityIndexes.get(`${event.deviceId}\u0000${event.capabilityId}`) === index;
+			return !this.isDeviceEvent(event) || selectedDeviceIndexes.get(event.deviceId) === index;
 		});
 	}
 
-	private isLaterCapabilityEvent(
-		candidate: Extract<HomeyEvent, { type: HomeyEventType.CAPABILITY_VALUE_CHANGED }>,
-		current: HomeyEvent,
-	): boolean {
-		if (current.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
-			return true;
-		}
-
+	private isLaterEvent(candidate: HomeyEvent, current: HomeyEvent): boolean {
 		const sequenceComparison = this.compareSequences(candidate.sequence, current.sequence);
 
 		if (sequenceComparison !== null) {
 			return sequenceComparison > 0;
 		}
 
-		const candidateTimestamp = this.parseTimestamp(candidate.lastUpdatedAt ?? candidate.occurredAt);
-		const currentTimestamp = this.parseTimestamp(current.lastUpdatedAt ?? current.occurredAt);
+		const candidateTimestamp = this.eventTimestamp(candidate);
+		const currentTimestamp = this.eventTimestamp(current);
 
 		if (candidateTimestamp !== null && currentTimestamp !== null && candidateTimestamp !== currentTimestamp) {
 			return candidateTimestamp > currentTimestamp;
 		}
 
 		return true;
+	}
+
+	private eventTimestamp(event: HomeyEvent): number | null {
+		return this.parseTimestamp(
+			event.type === HomeyEventType.CAPABILITY_VALUE_CHANGED
+				? (event.lastUpdatedAt ?? event.occurredAt)
+				: event.occurredAt,
+		);
 	}
 
 	private isNewerOrder(candidate: HomeyEventOrder, current: HomeyEventOrder): boolean {
@@ -486,6 +495,24 @@ export class HomeySynchronizerService {
 		}
 
 		return { adopted, order };
+	}
+
+	private isDeviceEvent(
+		event: HomeyEvent,
+	): event is Exclude<
+		HomeyEvent,
+		| Extract<HomeyEvent, { type: HomeyEventType.CAPABILITY_VALUE_CHANGED }>
+		| Extract<
+				HomeyEvent,
+				{ type: HomeyEventType.ZONE_ADDED | HomeyEventType.ZONE_UPDATED | HomeyEventType.ZONE_REMOVED }
+		  >
+	> {
+		return (
+			event.type === HomeyEventType.DEVICE_AVAILABILITY_CHANGED ||
+			event.type === HomeyEventType.DEVICE_ADDED ||
+			event.type === HomeyEventType.DEVICE_UPDATED ||
+			event.type === HomeyEventType.DEVICE_REMOVED
+		);
 	}
 
 	private compareSequences(candidate: string | number | null, current: string | number | null): number | null {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -448,6 +448,27 @@ export class HomeySynchronizerService {
 				continue;
 			}
 
+			if (event.type === HomeyEventType.DEVICE_ADDED || event.type === HomeyEventType.DEVICE_UPDATED) {
+				const current = currentDevices.get(event.deviceId);
+
+				if (current !== undefined) {
+					for (const capability of current.capabilities) {
+						if (!capability.readable || capability.available === false) {
+							continue;
+						}
+
+						await this.synchronizeCapabilityValue(
+							event.deviceId,
+							capability.id,
+							capability.value,
+							event.sequence === null ? event.occurredAt : null,
+							event.sequence,
+							result,
+						);
+					}
+				}
+			}
+
 			const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
 
 			if (context !== null) {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -45,6 +45,7 @@ export class HomeySynchronizerService {
 	private adoptedDevices = new Map<string, HomeyDeviceEntity>();
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
 	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
+	private lastAppliedAvailabilityOrder = new Map<string, HomeyEventOrder>();
 	private arrivalOrder = 0;
 	private indexDirty = true;
 	private indexRefresh: Promise<void> | null = null;
@@ -154,11 +155,23 @@ export class HomeySynchronizerService {
 						break;
 					}
 
-					await this.setConnectionState(
+					const order = this.createOrder(event.sequence, event.occurredAt);
+					const previousOrder = this.lastAppliedAvailabilityOrder.get(event.deviceId);
+
+					if (previousOrder !== undefined && !this.isNewerOrder(order, previousOrder)) {
+						result.ignored += 1;
+						break;
+					}
+
+					const applied = await this.setConnectionState(
 						adopted.id,
 						event.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 						result,
 					);
+
+					if (applied) {
+						this.lastAppliedAvailabilityOrder.set(event.deviceId, order);
+					}
 					break;
 				}
 				case HomeyEventType.DEVICE_ADDED:
@@ -203,6 +216,7 @@ export class HomeySynchronizerService {
 		this.adoptedDevices.clear();
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
+		this.lastAppliedAvailabilityOrder.clear();
 		this.arrivalOrder = 0;
 		this.indexDirty = true;
 		this.indexGeneration += 1;
@@ -334,11 +348,7 @@ export class HomeySynchronizerService {
 			return;
 		}
 
-		const order: HomeyEventOrder = {
-			sequence,
-			timestamp: this.parseTimestamp(updatedAt),
-			arrival: ++this.arrivalOrder,
-		};
+		const order = this.createOrder(sequence, updatedAt);
 
 		for (const binding of bindings) {
 			const previousOrder = this.lastAppliedOrder.get(binding.property.id);
@@ -369,13 +379,15 @@ export class HomeySynchronizerService {
 		panelDeviceId: string,
 		state: ConnectionState,
 		result: MutableSynchronizationResult,
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
 			await this.deviceConnectivityService.setConnectionState(panelDeviceId, { state });
 			result.updated += 1;
+			return true;
 		} catch {
 			result.failed += 1;
 			this.logger.warn('Could not update an adopted Homey device connection state', { resource: panelDeviceId });
+			return false;
 		}
 	}
 
@@ -442,6 +454,14 @@ export class HomeySynchronizerService {
 		}
 
 		return candidate.arrival > current.arrival;
+	}
+
+	private createOrder(sequence: string | number | null, updatedAt: string | null): HomeyEventOrder {
+		return {
+			sequence,
+			timestamp: this.parseTimestamp(updatedAt),
+			arrival: ++this.arrivalOrder,
+		};
 	}
 
 	private compareSequences(candidate: string | number | null, current: string | number | null): number | null {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -386,7 +386,7 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				});
-				this.lastAppliedOrder.set(binding.property.id, order);
+				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(order, previousOrder));
 				result.updated += 1;
 			} catch {
 				result.failed += 1;
@@ -465,7 +465,7 @@ export class HomeySynchronizerService {
 
 	private coalesceEvents(events: readonly HomeyEvent[]): HomeyEvent[] {
 		const selectedCapabilityIndexes = new Map<string, number>();
-		const selectedDeviceIndexes = new Map<string, number>();
+		const selectedDeviceIndexes = new Map<string, { latest: number; latestRefresh: number | null }>();
 
 		for (let index = 0; index < events.length; index += 1) {
 			const event = events[index];
@@ -478,11 +478,19 @@ export class HomeySynchronizerService {
 					selectedCapabilityIndexes.set(key, index);
 				}
 			} else if (this.isDeviceEvent(event)) {
-				const selectedIndex = selectedDeviceIndexes.get(event.deviceId);
+				const selected = selectedDeviceIndexes.get(event.deviceId);
+				const isRefresh = event.type === HomeyEventType.DEVICE_ADDED || event.type === HomeyEventType.DEVICE_UPDATED;
+				const latest =
+					selected === undefined || this.isLaterEvent(event, events[selected.latest]) ? index : selected.latest;
+				const latestRefresh = !isRefresh
+					? (selected?.latestRefresh ?? null)
+					: selected?.latestRefresh === null || selected?.latestRefresh === undefined
+						? index
+						: this.isLaterEvent(event, events[selected.latestRefresh])
+							? index
+							: selected.latestRefresh;
 
-				if (selectedIndex === undefined || this.isLaterEvent(event, events[selectedIndex])) {
-					selectedDeviceIndexes.set(event.deviceId, index);
-				}
+				selectedDeviceIndexes.set(event.deviceId, { latest, latestRefresh });
 			}
 		}
 
@@ -491,8 +499,31 @@ export class HomeySynchronizerService {
 				return selectedCapabilityIndexes.get(`${event.deviceId}\u0000${event.capabilityId}`) === index;
 			}
 
-			return !this.isDeviceEvent(event) || selectedDeviceIndexes.get(event.deviceId) === index;
+			if (!this.isDeviceEvent(event)) {
+				return true;
+			}
+
+			const selected = selectedDeviceIndexes.get(event.deviceId);
+
+			if (selected === undefined || selected.latest === index) {
+				return true;
+			}
+
+			return (
+				selected.latestRefresh === index && events[selected.latest].type === HomeyEventType.DEVICE_AVAILABILITY_CHANGED
+			);
 		});
+	}
+
+	private preserveSequenceWatermark(
+		order: HomeyEventOrder,
+		previousOrder: HomeyEventOrder | undefined,
+	): HomeyEventOrder {
+		if (order.sequence !== null || typeof previousOrder?.sequence !== 'number') {
+			return order;
+		}
+
+		return { ...order, sequence: previousOrder.sequence };
 	}
 
 	private isLaterEvent(candidate: HomeyEvent, current: HomeyEvent): boolean {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -33,12 +33,19 @@ interface MutableSynchronizationResult {
 	failed: number;
 }
 
+interface HomeyEventOrder {
+	readonly sequence: string | number | null;
+	readonly timestamp: number | null;
+	readonly arrival: number;
+}
+
 @Injectable()
 export class HomeySynchronizerService {
 	private readonly logger = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'Synchronizer');
 	private adoptedDevices = new Map<string, HomeyDeviceEntity>();
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
-	private lastAppliedAt = new Map<string, number>();
+	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
+	private arrivalOrder = 0;
 	private indexDirty = true;
 	private indexRefresh: Promise<void> | null = null;
 	private indexGeneration = 0;
@@ -135,6 +142,7 @@ export class HomeySynchronizerService {
 						event.capabilityId,
 						event.value,
 						event.lastUpdatedAt ?? event.occurredAt,
+						event.sequence,
 						result,
 					);
 					break;
@@ -194,7 +202,8 @@ export class HomeySynchronizerService {
 	reset(): void {
 		this.adoptedDevices.clear();
 		this.propertiesByDeviceCapability.clear();
-		this.lastAppliedAt.clear();
+		this.lastAppliedOrder.clear();
+		this.arrivalOrder = 0;
 		this.indexDirty = true;
 		this.indexGeneration += 1;
 	}
@@ -305,6 +314,7 @@ export class HomeySynchronizerService {
 			capability.id,
 			capability.value,
 			capability.lastUpdatedAt,
+			null,
 			result,
 		);
 	}
@@ -314,6 +324,7 @@ export class HomeySynchronizerService {
 		capabilityId: string,
 		value: HomeyCapabilityValue,
 		updatedAt: string | null,
+		sequence: string | number | null,
 		result: MutableSynchronizationResult,
 	): Promise<void> {
 		const bindings = this.propertiesByDeviceCapability.get(homeyDeviceId)?.get(capabilityId);
@@ -323,11 +334,16 @@ export class HomeySynchronizerService {
 			return;
 		}
 
-		for (const binding of bindings) {
-			const timestamp = this.parseTimestamp(updatedAt);
-			const previousTimestamp = this.lastAppliedAt.get(binding.property.id);
+		const order: HomeyEventOrder = {
+			sequence,
+			timestamp: this.parseTimestamp(updatedAt),
+			arrival: ++this.arrivalOrder,
+		};
 
-			if (timestamp !== null && previousTimestamp !== undefined && timestamp <= previousTimestamp) {
+		for (const binding of bindings) {
+			const previousOrder = this.lastAppliedOrder.get(binding.property.id);
+
+			if (previousOrder !== undefined && !this.isNewerOrder(order, previousOrder)) {
 				result.ignored += 1;
 				continue;
 			}
@@ -338,9 +354,7 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				});
-				if (timestamp !== null) {
-					this.lastAppliedAt.set(binding.property.id, timestamp);
-				}
+				this.lastAppliedOrder.set(binding.property.id, order);
 				result.updated += 1;
 			} catch {
 				result.failed += 1;
@@ -400,10 +414,46 @@ export class HomeySynchronizerService {
 			return true;
 		}
 
+		const sequenceComparison = this.compareSequences(candidate.sequence, current.sequence);
+
+		if (sequenceComparison !== null) {
+			return sequenceComparison > 0;
+		}
+
 		const candidateTimestamp = this.parseTimestamp(candidate.lastUpdatedAt ?? candidate.occurredAt);
 		const currentTimestamp = this.parseTimestamp(current.lastUpdatedAt ?? current.occurredAt);
 
-		return candidateTimestamp === null || currentTimestamp === null || candidateTimestamp >= currentTimestamp;
+		if (candidateTimestamp !== null && currentTimestamp !== null && candidateTimestamp !== currentTimestamp) {
+			return candidateTimestamp > currentTimestamp;
+		}
+
+		return true;
+	}
+
+	private isNewerOrder(candidate: HomeyEventOrder, current: HomeyEventOrder): boolean {
+		const sequenceComparison = this.compareSequences(candidate.sequence, current.sequence);
+
+		if (sequenceComparison !== null) {
+			return sequenceComparison > 0;
+		}
+
+		if (candidate.timestamp !== null && current.timestamp !== null) {
+			return candidate.timestamp > current.timestamp;
+		}
+
+		return candidate.arrival > current.arrival;
+	}
+
+	private compareSequences(candidate: string | number | null, current: string | number | null): number | null {
+		if (typeof candidate === 'number' && typeof current === 'number') {
+			return Math.sign(candidate - current);
+		}
+
+		if (typeof candidate === 'string' && typeof current === 'string' && candidate === current) {
+			return 0;
+		}
+
+		return null;
 	}
 
 	private isValidEvent(event: HomeyEvent): boolean {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -46,6 +46,7 @@ export class HomeySynchronizerService {
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
 	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
 	private lastAppliedDeviceOrder = new Map<string, HomeyEventOrder>();
+	private lastObservedDeviceOrder = new Map<string, HomeyEventOrder>();
 	private arrivalOrder = 0;
 	private indexDirty = true;
 	private indexRefresh: Promise<void> | null = null;
@@ -104,21 +105,33 @@ export class HomeySynchronizerService {
 	async synchronizeDevices(
 		devices: readonly HomeyDevice[],
 		missingDeviceIds: readonly string[] = [],
+		readbackEvents: readonly HomeyEvent[] = [],
 	): Promise<HomeySynchronizationResult> {
 		await this.ensureIndex();
 		const result = this.emptyResult();
+		const connectionStateApplied = new Map<string, boolean>();
 
 		for (const device of devices) {
-			await this.synchronizeDevice(device, result);
+			connectionStateApplied.set(device.id, await this.synchronizeDevice(device, result));
 		}
 
 		for (const homeyDeviceId of missingDeviceIds) {
 			const adopted = this.adoptedDevices.get(homeyDeviceId);
 
 			if (adopted !== undefined) {
-				await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+				connectionStateApplied.set(
+					homeyDeviceId,
+					await this.setConnectionState(adopted.id, ConnectionState.LOST, result),
+				);
 			}
 		}
+
+		await this.commitReadbackOrder(
+			readbackEvents,
+			new Map(devices.map((device) => [device.id, device])),
+			connectionStateApplied,
+			result,
+		);
 
 		return result;
 	}
@@ -154,12 +167,12 @@ export class HomeySynchronizerService {
 						break;
 					}
 
-					await this.setConnectionState(
+					const applied = await this.setConnectionState(
 						context.adopted.id,
 						event.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 						result,
 					);
-					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
+					this.recordDeviceOrder(event.deviceId, context.order, applied);
 					break;
 				}
 				case HomeyEventType.DEVICE_ADDED:
@@ -171,13 +184,14 @@ export class HomeySynchronizerService {
 					}
 
 					const current = currentDevices.get(event.deviceId);
+					let applied: boolean;
 					if (current === undefined) {
-						await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
+						applied = await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
 					} else {
-						await this.synchronizeDevice(current, result);
+						applied = await this.synchronizeDevice(current, result);
 					}
 
-					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
+					this.recordDeviceOrder(event.deviceId, context.order, applied);
 					break;
 				}
 				case HomeyEventType.DEVICE_REMOVED: {
@@ -187,8 +201,8 @@ export class HomeySynchronizerService {
 						break;
 					}
 
-					await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
-					this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
+					const applied = await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
+					this.recordDeviceOrder(event.deviceId, context.order, applied);
 					break;
 				}
 				case HomeyEventType.ZONE_ADDED:
@@ -208,11 +222,11 @@ export class HomeySynchronizerService {
 				return true;
 			}
 
-			const previousOrder = this.lastAppliedDeviceOrder.get(event.deviceId);
+			const previousOrder = this.lastObservedDeviceOrder.get(event.deviceId);
 
 			return (
 				previousOrder === undefined ||
-				this.isNewerOrder(this.createOrder(event.sequence, event.occurredAt), previousOrder)
+				this.compareOrders(this.createOrder(event.sequence, event.occurredAt), previousOrder) >= 0
 			);
 		});
 	}
@@ -222,6 +236,7 @@ export class HomeySynchronizerService {
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
 		this.lastAppliedDeviceOrder.clear();
+		this.lastObservedDeviceOrder.clear();
 		this.arrivalOrder = 0;
 		this.indexDirty = true;
 		this.indexGeneration += 1;
@@ -299,15 +314,15 @@ export class HomeySynchronizerService {
 		this.indexDirty = this.indexGeneration !== generation;
 	}
 
-	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<void> {
+	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<boolean> {
 		const adopted = this.adoptedDevices.get(device.id);
 
 		if (adopted === undefined) {
 			result.ignored += 1;
-			return;
+			return false;
 		}
 
-		await this.setConnectionState(
+		const connectionStateApplied = await this.setConnectionState(
 			adopted.id,
 			device.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 			result,
@@ -321,6 +336,8 @@ export class HomeySynchronizerService {
 
 			await this.synchronizeCapability(device.id, capability, result);
 		}
+
+		return connectionStateApplied;
 	}
 
 	private async synchronizeCapability(
@@ -380,18 +397,70 @@ export class HomeySynchronizerService {
 		}
 	}
 
+	private async commitReadbackOrder(
+		events: readonly HomeyEvent[],
+		currentDevices: ReadonlyMap<string, HomeyDevice>,
+		connectionStateApplied: ReadonlyMap<string, boolean>,
+		result: MutableSynchronizationResult,
+	): Promise<void> {
+		for (const event of this.filterEvents(events)) {
+			if (!this.isValidEvent(event)) {
+				result.ignored += 1;
+				continue;
+			}
+
+			if (event.type === HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+				const capability = currentDevices
+					.get(event.deviceId)
+					?.capabilities.find((candidate) => candidate.id === event.capabilityId);
+
+				if (capability === undefined || !capability.readable || capability.available === false) {
+					result.ignored += 1;
+					continue;
+				}
+
+				await this.synchronizeCapabilityValue(
+					event.deviceId,
+					event.capabilityId,
+					capability.value,
+					null,
+					event.sequence,
+					result,
+				);
+				continue;
+			}
+
+			if (!this.isDeviceEvent(event)) {
+				continue;
+			}
+
+			const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
+
+			if (context !== null) {
+				this.recordDeviceOrder(event.deviceId, context.order, connectionStateApplied.get(event.deviceId) === true);
+			}
+		}
+	}
+
 	private async setConnectionState(
 		panelDeviceId: string,
 		state: ConnectionState,
 		result: MutableSynchronizationResult,
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
-			await this.deviceConnectivityService.setConnectionState(panelDeviceId, { state });
-			result.updated += 1;
+			const applied = await this.deviceConnectivityService.trySetConnectionState(panelDeviceId, { state });
+
+			if (applied) {
+				result.updated += 1;
+				return true;
+			}
 		} catch {
-			result.failed += 1;
-			this.logger.warn('Could not update an adopted Homey device connection state', { resource: panelDeviceId });
+			// The fixed failure path below handles both thrown and explicit not-applied outcomes.
 		}
+
+		result.failed += 1;
+		this.logger.warn('Could not update an adopted Homey device connection state', { resource: panelDeviceId });
+		return false;
 	}
 
 	private coalesceEvents(events: readonly HomeyEvent[]): HomeyEvent[] {
@@ -452,17 +521,21 @@ export class HomeySynchronizerService {
 	}
 
 	private isNewerOrder(candidate: HomeyEventOrder, current: HomeyEventOrder): boolean {
+		return this.compareOrders(candidate, current) > 0;
+	}
+
+	private compareOrders(candidate: HomeyEventOrder, current: HomeyEventOrder): number {
 		const sequenceComparison = this.compareSequences(candidate.sequence, current.sequence);
 
 		if (sequenceComparison !== null) {
-			return sequenceComparison > 0;
+			return sequenceComparison;
 		}
 
 		if (candidate.timestamp !== null && current.timestamp !== null) {
-			return candidate.timestamp > current.timestamp;
+			return Math.sign(candidate.timestamp - current.timestamp);
 		}
 
-		return candidate.arrival > current.arrival;
+		return Math.sign(candidate.arrival - current.arrival);
 	}
 
 	private createOrder(sequence: string | number | null, updatedAt: string | null): HomeyEventOrder {
@@ -495,6 +568,14 @@ export class HomeySynchronizerService {
 		}
 
 		return { adopted, order };
+	}
+
+	private recordDeviceOrder(homeyDeviceId: string, order: HomeyEventOrder, applied: boolean): void {
+		this.lastObservedDeviceOrder.set(homeyDeviceId, order);
+
+		if (applied) {
+			this.lastAppliedDeviceOrder.set(homeyDeviceId, order);
+		}
 	}
 
 	private isDeviceEvent(

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -637,10 +637,16 @@ export class HomeySynchronizerService {
 	}
 
 	private recordDeviceOrder(homeyDeviceId: string, order: HomeyEventOrder, applied: boolean): void {
-		this.lastObservedDeviceOrder.set(homeyDeviceId, order);
+		this.lastObservedDeviceOrder.set(
+			homeyDeviceId,
+			this.preserveSequenceWatermark(order, this.lastObservedDeviceOrder.get(homeyDeviceId)),
+		);
 
 		if (applied) {
-			this.lastAppliedDeviceOrder.set(homeyDeviceId, order);
+			this.lastAppliedDeviceOrder.set(
+				homeyDeviceId,
+				this.preserveSequenceWatermark(order, this.lastAppliedDeviceOrder.get(homeyDeviceId)),
+			);
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -45,6 +45,7 @@ export class HomeySynchronizerService {
 	private adoptedDevices = new Map<string, HomeyDeviceEntity>();
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
 	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
+	private lastObservedOrder = new Map<string, HomeyEventOrder>();
 	private lastAppliedDeviceOrder = new Map<string, HomeyEventOrder>();
 	private lastObservedDeviceOrder = new Map<string, HomeyEventOrder>();
 	private arrivalOrder = 0;
@@ -160,14 +161,29 @@ export class HomeySynchronizerService {
 
 			switch (event.type) {
 				case HomeyEventType.CAPABILITY_VALUE_CHANGED:
-					await this.synchronizeCapabilityValue(
-						event.deviceId,
-						event.capabilityId,
-						event.value,
-						event.lastUpdatedAt ?? event.occurredAt,
-						event.sequence,
-						result,
-					);
+					{
+						const currentCapability = currentDevices
+							.get(event.deviceId)
+							?.capabilities.find((capability) => capability.id === event.capabilityId);
+
+						if (
+							currentCapability === undefined ||
+							!currentCapability.readable ||
+							currentCapability.available === false
+						) {
+							result.ignored += 1;
+							break;
+						}
+
+						await this.synchronizeCapabilityValue(
+							event.deviceId,
+							event.capabilityId,
+							event.value,
+							event.lastUpdatedAt ?? event.occurredAt,
+							event.sequence,
+							result,
+						);
+					}
 					break;
 				case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
 					if (!currentDevices.has(event.deviceId)) {
@@ -249,6 +265,7 @@ export class HomeySynchronizerService {
 		this.adoptedDevices.clear();
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
+		this.lastObservedOrder.clear();
 		this.lastAppliedDeviceOrder.clear();
 		this.lastObservedDeviceOrder.clear();
 		this.arrivalOrder = 0;
@@ -387,12 +404,19 @@ export class HomeySynchronizerService {
 		const order = this.createOrder(sequence, updatedAt);
 
 		for (const binding of bindings) {
+			const previousObservedOrder = this.lastObservedOrder.get(binding.property.id);
 			const previousOrder = this.lastAppliedOrder.get(binding.property.id);
 
-			if (previousOrder !== undefined && !this.isNewerOrder(order, previousOrder)) {
+			if (
+				(previousObservedOrder !== undefined && this.compareOrders(order, previousObservedOrder) < 0) ||
+				(previousOrder !== undefined && !this.isNewerOrder(order, previousOrder))
+			) {
 				result.ignored += 1;
 				continue;
 			}
+
+			const observedOrder = this.preserveSequenceWatermark(order, previousObservedOrder);
+			this.lastObservedOrder.set(binding.property.id, observedOrder);
 
 			try {
 				const transformed = this.transformer.read(binding.mapping, value);
@@ -400,7 +424,7 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				});
-				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(order, previousOrder));
+				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(observedOrder, previousOrder));
 				result.updated += 1;
 			} catch {
 				result.failed += 1;

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -1,0 +1,454 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { createExtensionLogger } from '../../../common/logger';
+import { ConnectionState, EventType } from '../../../modules/devices/devices.constants';
+import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
+import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
+import { DevicesService } from '../../../modules/devices/services/devices.service';
+import { DEVICES_HOMEY_PLUGIN_NAME, DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
+import { HomeyChannelPropertyEntity, HomeyDeviceEntity } from '../entities/devices-homey.entity';
+import { HomeyMappingLoaderService } from '../mappings/mapping-loader.service';
+import { HomeyMappingTransformerService } from '../mappings/mapping-transformer.service';
+import { ResolvedHomeyPropertyMapping } from '../mappings/mapping.types';
+import { HomeyCapability, HomeyCapabilityValue } from '../models/homey-capability.model';
+import { HomeyDevice } from '../models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
+
+interface HomeyIndexedProperty {
+	readonly panelDeviceId: string;
+	readonly property: HomeyChannelPropertyEntity;
+	readonly mapping: ResolvedHomeyPropertyMapping;
+}
+
+export interface HomeySynchronizationResult {
+	readonly updated: number;
+	readonly ignored: number;
+	readonly failed: number;
+}
+
+interface MutableSynchronizationResult {
+	updated: number;
+	ignored: number;
+	failed: number;
+}
+
+@Injectable()
+export class HomeySynchronizerService {
+	private readonly logger = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'Synchronizer');
+	private adoptedDevices = new Map<string, HomeyDeviceEntity>();
+	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
+	private lastAppliedAt = new Map<string, number>();
+	private indexDirty = true;
+	private indexRefresh: Promise<void> | null = null;
+	private indexGeneration = 0;
+
+	constructor(
+		private readonly devicesService: DevicesService,
+		private readonly channelsPropertiesService: ChannelsPropertiesService,
+		private readonly deviceConnectivityService: DeviceConnectivityService,
+		private readonly mappingLoader: HomeyMappingLoaderService,
+		private readonly transformer: HomeyMappingTransformerService,
+	) {}
+
+	@OnEvent(EventType.DEVICE_CREATED)
+	@OnEvent(EventType.DEVICE_UPDATED)
+	@OnEvent(EventType.DEVICE_DELETED)
+	@OnEvent(EventType.CHANNEL_CREATED)
+	@OnEvent(EventType.CHANNEL_UPDATED)
+	@OnEvent(EventType.CHANNEL_DELETED)
+	@OnEvent(EventType.CHANNEL_PROPERTY_CREATED)
+	@OnEvent(EventType.CHANNEL_PROPERTY_UPDATED)
+	@OnEvent(EventType.CHANNEL_PROPERTY_DELETED)
+	invalidateFromEntity(): void {
+		this.invalidateIndex();
+	}
+
+	invalidateIndex(): void {
+		this.indexDirty = true;
+		this.indexGeneration += 1;
+	}
+
+	async refreshIndex(): Promise<void> {
+		this.invalidateIndex();
+		await this.ensureIndex();
+	}
+
+	async synchronizeSnapshot(devices: readonly HomeyDevice[]): Promise<HomeySynchronizationResult> {
+		await this.refreshIndex();
+		const upstreamDevices = new Map(devices.map((device) => [device.id, device]));
+		const result = this.emptyResult();
+
+		for (const [homeyDeviceId, adopted] of this.adoptedDevices) {
+			const upstream = upstreamDevices.get(homeyDeviceId);
+
+			if (upstream === undefined) {
+				await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+				continue;
+			}
+
+			await this.synchronizeDevice(upstream, result);
+		}
+
+		return result;
+	}
+
+	async synchronizeDevices(
+		devices: readonly HomeyDevice[],
+		missingDeviceIds: readonly string[] = [],
+	): Promise<HomeySynchronizationResult> {
+		await this.ensureIndex();
+		const result = this.emptyResult();
+
+		for (const device of devices) {
+			await this.synchronizeDevice(device, result);
+		}
+
+		for (const homeyDeviceId of missingDeviceIds) {
+			const adopted = this.adoptedDevices.get(homeyDeviceId);
+
+			if (adopted !== undefined) {
+				await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+			}
+		}
+
+		return result;
+	}
+
+	async synchronizeEvents(
+		events: readonly HomeyEvent[],
+		currentDevices: ReadonlyMap<string, HomeyDevice>,
+	): Promise<HomeySynchronizationResult> {
+		await this.ensureIndex();
+		const result = this.emptyResult();
+
+		for (const event of this.coalesceEvents(events)) {
+			if (!this.isValidEvent(event)) {
+				result.ignored += 1;
+				continue;
+			}
+
+			switch (event.type) {
+				case HomeyEventType.CAPABILITY_VALUE_CHANGED:
+					await this.synchronizeCapabilityValue(
+						event.deviceId,
+						event.capabilityId,
+						event.value,
+						event.lastUpdatedAt ?? event.occurredAt,
+						result,
+					);
+					break;
+				case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
+					const adopted = this.adoptedDevices.get(event.deviceId);
+
+					if (adopted === undefined) {
+						result.ignored += 1;
+						break;
+					}
+
+					await this.setConnectionState(
+						adopted.id,
+						event.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
+						result,
+					);
+					break;
+				}
+				case HomeyEventType.DEVICE_ADDED:
+				case HomeyEventType.DEVICE_UPDATED: {
+					const current = currentDevices.get(event.deviceId);
+
+					if (current === undefined) {
+						const adopted = this.adoptedDevices.get(event.deviceId);
+						if (adopted === undefined) {
+							result.ignored += 1;
+						} else {
+							await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+						}
+						break;
+					}
+
+					await this.synchronizeDevice(current, result);
+					break;
+				}
+				case HomeyEventType.DEVICE_REMOVED: {
+					const adopted = this.adoptedDevices.get(event.deviceId);
+
+					if (adopted === undefined) {
+						result.ignored += 1;
+					} else {
+						await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+					}
+					break;
+				}
+				case HomeyEventType.ZONE_ADDED:
+				case HomeyEventType.ZONE_UPDATED:
+				case HomeyEventType.ZONE_REMOVED:
+					result.ignored += 1;
+					break;
+			}
+		}
+
+		return result;
+	}
+
+	reset(): void {
+		this.adoptedDevices.clear();
+		this.propertiesByDeviceCapability.clear();
+		this.lastAppliedAt.clear();
+		this.indexDirty = true;
+		this.indexGeneration += 1;
+	}
+
+	private async ensureIndex(): Promise<void> {
+		if (!this.indexDirty) {
+			return;
+		}
+
+		if (this.indexRefresh !== null) {
+			await this.indexRefresh;
+			if (this.indexDirty) {
+				await this.ensureIndex();
+			}
+			return;
+		}
+
+		this.indexRefresh = this.rebuildIndex();
+
+		try {
+			await this.indexRefresh;
+		} finally {
+			this.indexRefresh = null;
+		}
+
+		if (this.indexDirty) {
+			await this.ensureIndex();
+		}
+	}
+
+	private async rebuildIndex(): Promise<void> {
+		const generation = this.indexGeneration;
+		const mappings = new Map(this.mappingLoader.getPropertyMappings().map((mapping) => [mapping.name, mapping]));
+		const devices = await this.devicesService.findAll<HomeyDeviceEntity>(DEVICES_HOMEY_TYPE);
+		const adoptedDevices = new Map<string, HomeyDeviceEntity>();
+		const propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
+
+		for (const device of devices) {
+			if (device.identifier === null || !device.enabled) {
+				continue;
+			}
+
+			adoptedDevices.set(device.identifier, device);
+			const capabilities = new Map<string, HomeyIndexedProperty[]>();
+
+			for (const channel of device.channels ?? []) {
+				for (const candidate of channel.properties ?? []) {
+					const property = candidate as HomeyChannelPropertyEntity;
+
+					if (
+						candidate.type !== DEVICES_HOMEY_TYPE ||
+						typeof property.homeyCapabilityId !== 'string' ||
+						typeof property.homeyMappingName !== 'string'
+					) {
+						continue;
+					}
+
+					const mapping = mappings.get(property.homeyMappingName);
+					if (mapping === undefined || mapping.property.direction === 'write_only') {
+						continue;
+					}
+
+					const bindings = capabilities.get(property.homeyCapabilityId) ?? [];
+					bindings.push({ panelDeviceId: device.id, property, mapping });
+					capabilities.set(property.homeyCapabilityId, bindings);
+				}
+			}
+
+			propertiesByDeviceCapability.set(device.identifier, capabilities);
+		}
+
+		this.adoptedDevices = adoptedDevices;
+		this.propertiesByDeviceCapability = propertiesByDeviceCapability;
+		this.indexDirty = this.indexGeneration !== generation;
+	}
+
+	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<void> {
+		const adopted = this.adoptedDevices.get(device.id);
+
+		if (adopted === undefined) {
+			result.ignored += 1;
+			return;
+		}
+
+		await this.setConnectionState(
+			adopted.id,
+			device.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
+			result,
+		);
+
+		for (const capability of device.capabilities) {
+			if (!capability.readable || capability.available === false) {
+				result.ignored += 1;
+				continue;
+			}
+
+			await this.synchronizeCapability(device.id, capability, result);
+		}
+	}
+
+	private async synchronizeCapability(
+		homeyDeviceId: string,
+		capability: HomeyCapability,
+		result: MutableSynchronizationResult,
+	): Promise<void> {
+		await this.synchronizeCapabilityValue(
+			homeyDeviceId,
+			capability.id,
+			capability.value,
+			capability.lastUpdatedAt,
+			result,
+		);
+	}
+
+	private async synchronizeCapabilityValue(
+		homeyDeviceId: string,
+		capabilityId: string,
+		value: HomeyCapabilityValue,
+		updatedAt: string | null,
+		result: MutableSynchronizationResult,
+	): Promise<void> {
+		const bindings = this.propertiesByDeviceCapability.get(homeyDeviceId)?.get(capabilityId);
+
+		if (bindings === undefined || bindings.length === 0 || !this.isCapabilityValue(value)) {
+			result.ignored += 1;
+			return;
+		}
+
+		for (const binding of bindings) {
+			const timestamp = this.parseTimestamp(updatedAt);
+			const previousTimestamp = this.lastAppliedAt.get(binding.property.id);
+
+			if (timestamp !== null && previousTimestamp !== undefined && timestamp <= previousTimestamp) {
+				result.ignored += 1;
+				continue;
+			}
+
+			try {
+				const transformed = this.transformer.read(binding.mapping, value);
+				await this.channelsPropertiesService.update(binding.property.id, {
+					type: DEVICES_HOMEY_TYPE,
+					value: transformed,
+				});
+				if (timestamp !== null) {
+					this.lastAppliedAt.set(binding.property.id, timestamp);
+				}
+				result.updated += 1;
+			} catch {
+				result.failed += 1;
+				this.logger.warn('Ignored a Homey capability update that could not be mapped or persisted', {
+					resource: binding.property.id,
+				});
+			}
+		}
+	}
+
+	private async setConnectionState(
+		panelDeviceId: string,
+		state: ConnectionState,
+		result: MutableSynchronizationResult,
+	): Promise<void> {
+		try {
+			await this.deviceConnectivityService.setConnectionState(panelDeviceId, { state });
+			result.updated += 1;
+		} catch {
+			result.failed += 1;
+			this.logger.warn('Could not update an adopted Homey device connection state', { resource: panelDeviceId });
+		}
+	}
+
+	private coalesceEvents(events: readonly HomeyEvent[]): HomeyEvent[] {
+		const selectedCapabilityIndexes = new Map<string, number>();
+
+		for (let index = 0; index < events.length; index += 1) {
+			const event = events[index];
+
+			if (event.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+				continue;
+			}
+
+			const key = `${event.deviceId}\u0000${event.capabilityId}`;
+			const selectedIndex = selectedCapabilityIndexes.get(key);
+
+			if (selectedIndex === undefined || this.isLaterCapabilityEvent(event, events[selectedIndex])) {
+				selectedCapabilityIndexes.set(key, index);
+			}
+		}
+
+		return events.filter((event, index) => {
+			if (event.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+				return true;
+			}
+
+			return selectedCapabilityIndexes.get(`${event.deviceId}\u0000${event.capabilityId}`) === index;
+		});
+	}
+
+	private isLaterCapabilityEvent(
+		candidate: Extract<HomeyEvent, { type: HomeyEventType.CAPABILITY_VALUE_CHANGED }>,
+		current: HomeyEvent,
+	): boolean {
+		if (current.type !== HomeyEventType.CAPABILITY_VALUE_CHANGED) {
+			return true;
+		}
+
+		const candidateTimestamp = this.parseTimestamp(candidate.lastUpdatedAt ?? candidate.occurredAt);
+		const currentTimestamp = this.parseTimestamp(current.lastUpdatedAt ?? current.occurredAt);
+
+		return candidateTimestamp === null || currentTimestamp === null || candidateTimestamp >= currentTimestamp;
+	}
+
+	private isValidEvent(event: HomeyEvent): boolean {
+		switch (event.type) {
+			case HomeyEventType.CAPABILITY_VALUE_CHANGED:
+				return (
+					typeof event.deviceId === 'string' &&
+					event.deviceId.length > 0 &&
+					typeof event.capabilityId === 'string' &&
+					event.capabilityId.length > 0 &&
+					this.isCapabilityValue(event.value)
+				);
+			case HomeyEventType.DEVICE_AVAILABILITY_CHANGED:
+				return typeof event.deviceId === 'string' && event.deviceId.length > 0 && typeof event.available === 'boolean';
+			case HomeyEventType.DEVICE_ADDED:
+			case HomeyEventType.DEVICE_UPDATED:
+			case HomeyEventType.DEVICE_REMOVED:
+				return typeof event.deviceId === 'string' && event.deviceId.length > 0;
+			case HomeyEventType.ZONE_ADDED:
+			case HomeyEventType.ZONE_UPDATED:
+			case HomeyEventType.ZONE_REMOVED:
+				return typeof event.zoneId === 'string' && event.zoneId.length > 0;
+		}
+	}
+
+	private isCapabilityValue(value: unknown): value is HomeyCapabilityValue {
+		return (
+			value === null ||
+			typeof value === 'boolean' ||
+			typeof value === 'string' ||
+			(typeof value === 'number' && Number.isFinite(value))
+		);
+	}
+
+	private parseTimestamp(value: string | null): number | null {
+		if (value === null) {
+			return null;
+		}
+
+		const timestamp = Date.parse(value);
+
+		return Number.isFinite(timestamp) ? timestamp : null;
+	}
+
+	private emptyResult(): MutableSynchronizationResult {
+		return { updated: 0, ignored: 0, failed: 0 };
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -45,7 +45,7 @@ export class HomeySynchronizerService {
 	private adoptedDevices = new Map<string, HomeyDeviceEntity>();
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
 	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
-	private lastAppliedAvailabilityOrder = new Map<string, HomeyEventOrder>();
+	private lastAppliedDeviceOrder = new Map<string, HomeyEventOrder>();
 	private arrivalOrder = 0;
 	private indexDirty = true;
 	private indexRefresh: Promise<void> | null = null;
@@ -148,56 +148,54 @@ export class HomeySynchronizerService {
 					);
 					break;
 				case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
-					const adopted = this.adoptedDevices.get(event.deviceId);
+					const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
 
-					if (adopted === undefined) {
-						result.ignored += 1;
-						break;
-					}
-
-					const order = this.createOrder(event.sequence, event.occurredAt);
-					const previousOrder = this.lastAppliedAvailabilityOrder.get(event.deviceId);
-
-					if (previousOrder !== undefined && !this.isNewerOrder(order, previousOrder)) {
-						result.ignored += 1;
+					if (context === null) {
 						break;
 					}
 
 					const applied = await this.setConnectionState(
-						adopted.id,
+						context.adopted.id,
 						event.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 						result,
 					);
 
 					if (applied) {
-						this.lastAppliedAvailabilityOrder.set(event.deviceId, order);
+						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
 					}
 					break;
 				}
 				case HomeyEventType.DEVICE_ADDED:
 				case HomeyEventType.DEVICE_UPDATED: {
-					const current = currentDevices.get(event.deviceId);
+					const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
 
-					if (current === undefined) {
-						const adopted = this.adoptedDevices.get(event.deviceId);
-						if (adopted === undefined) {
-							result.ignored += 1;
-						} else {
-							await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
-						}
+					if (context === null) {
 						break;
 					}
 
-					await this.synchronizeDevice(current, result);
+					const current = currentDevices.get(event.deviceId);
+					let applied: boolean;
+
+					if (current === undefined) {
+						applied = await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result);
+					} else {
+						applied = await this.synchronizeDevice(current, result);
+					}
+
+					if (applied) {
+						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
+					}
 					break;
 				}
 				case HomeyEventType.DEVICE_REMOVED: {
-					const adopted = this.adoptedDevices.get(event.deviceId);
+					const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
 
-					if (adopted === undefined) {
-						result.ignored += 1;
-					} else {
-						await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+					if (context === null) {
+						break;
+					}
+
+					if (await this.setConnectionState(context.adopted.id, ConnectionState.LOST, result)) {
+						this.lastAppliedDeviceOrder.set(event.deviceId, context.order);
 					}
 					break;
 				}
@@ -216,7 +214,7 @@ export class HomeySynchronizerService {
 		this.adoptedDevices.clear();
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
-		this.lastAppliedAvailabilityOrder.clear();
+		this.lastAppliedDeviceOrder.clear();
 		this.arrivalOrder = 0;
 		this.indexDirty = true;
 		this.indexGeneration += 1;
@@ -294,15 +292,15 @@ export class HomeySynchronizerService {
 		this.indexDirty = this.indexGeneration !== generation;
 	}
 
-	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<void> {
+	private async synchronizeDevice(device: HomeyDevice, result: MutableSynchronizationResult): Promise<boolean> {
 		const adopted = this.adoptedDevices.get(device.id);
 
 		if (adopted === undefined) {
 			result.ignored += 1;
-			return;
+			return false;
 		}
 
-		await this.setConnectionState(
+		const connectionStateApplied = await this.setConnectionState(
 			adopted.id,
 			device.available ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED,
 			result,
@@ -316,6 +314,8 @@ export class HomeySynchronizerService {
 
 			await this.synchronizeCapability(device.id, capability, result);
 		}
+
+		return connectionStateApplied;
 	}
 
 	private async synchronizeCapability(
@@ -462,6 +462,30 @@ export class HomeySynchronizerService {
 			timestamp: this.parseTimestamp(updatedAt),
 			arrival: ++this.arrivalOrder,
 		};
+	}
+
+	private prepareDeviceEvent(
+		homeyDeviceId: string,
+		sequence: string | number | null,
+		occurredAt: string | null,
+		result: MutableSynchronizationResult,
+	): { readonly adopted: HomeyDeviceEntity; readonly order: HomeyEventOrder } | null {
+		const adopted = this.adoptedDevices.get(homeyDeviceId);
+
+		if (adopted === undefined) {
+			result.ignored += 1;
+			return null;
+		}
+
+		const order = this.createOrder(sequence, occurredAt);
+		const previousOrder = this.lastAppliedDeviceOrder.get(homeyDeviceId);
+
+		if (previousOrder !== undefined && !this.isNewerOrder(order, previousOrder)) {
+			result.ignored += 1;
+			return null;
+		}
+
+		return { adopted, order };
 	}
 
 	private compareSequences(candidate: string | number | null, current: string | number | null): number | null {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -83,21 +83,30 @@ export class HomeySynchronizerService {
 		await this.ensureIndex();
 	}
 
-	async synchronizeSnapshot(devices: readonly HomeyDevice[]): Promise<HomeySynchronizationResult> {
+	async synchronizeSnapshot(
+		devices: readonly HomeyDevice[],
+		readbackEvents: readonly HomeyEvent[] = [],
+	): Promise<HomeySynchronizationResult> {
 		await this.refreshIndex();
 		const upstreamDevices = new Map(devices.map((device) => [device.id, device]));
 		const result = this.emptyResult();
+		const connectionStateApplied = new Map<string, boolean>();
 
 		for (const [homeyDeviceId, adopted] of this.adoptedDevices) {
 			const upstream = upstreamDevices.get(homeyDeviceId);
 
 			if (upstream === undefined) {
-				await this.setConnectionState(adopted.id, ConnectionState.LOST, result);
+				connectionStateApplied.set(
+					homeyDeviceId,
+					await this.setConnectionState(adopted.id, ConnectionState.LOST, result),
+				);
 				continue;
 			}
 
-			await this.synchronizeDevice(upstream, result);
+			connectionStateApplied.set(homeyDeviceId, await this.synchronizeDevice(upstream, result));
 		}
+
+		await this.commitReadbackOrder(readbackEvents, upstreamDevices, connectionStateApplied, result);
 
 		return result;
 	}
@@ -161,6 +170,11 @@ export class HomeySynchronizerService {
 					);
 					break;
 				case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
+					if (!currentDevices.has(event.deviceId)) {
+						result.ignored += 1;
+						break;
+					}
+
 					const context = this.prepareDeviceEvent(event.deviceId, event.sequence, event.occurredAt, result);
 
 					if (context === null) {

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -647,6 +647,40 @@ describe('HomeyService', () => {
 		await service.stop();
 	});
 
+	it('keeps a pending reconnect after locally processed capability traffic', async () => {
+		await service.start();
+		connector.getDevice.mockRejectedValueOnce(
+			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
+		);
+
+		await emitLiveEvent({
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: 1,
+		});
+		await emitLiveEvent({
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: staleDevice.id,
+			capabilityId: 'onoff',
+			value: true,
+			lastUpdatedAt: null,
+			occurredAt: null,
+			sequence: 2,
+		});
+
+		expect(connector.getDevice.mock.calls).toHaveLength(1);
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.RECONNECTING,
+			healthy: false,
+			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
+			lastError: 'Homey connection is temporarily unavailable',
+		});
+		expect(jest.getTimerCount()).toBe(1);
+
+		await service.stop();
+	});
+
 	it('does not retry authentication failures encountered while reconnecting', async () => {
 		const rejectedConnector = createConnectorMock(() => undefined, jest.fn());
 		rejectedConnector.connect.mockRejectedValue(

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -325,8 +325,47 @@ describe('HomeyService', () => {
 		await flushMicrotasks();
 
 		expect(synchronizer.filterEvents).toHaveBeenCalledWith([update, removal]);
-		expect(synchronizer.synchronizeEvents).toHaveBeenCalledWith([update], expect.any(Map));
+		expect(synchronizer.synchronizeDevices).toHaveBeenCalledWith([staleDevice], [], [update]);
+		expect(synchronizer.synchronizeEvents).not.toHaveBeenCalled();
 		expect(service.getInventorySnapshot()).toStrictEqual([staleDevice]);
+
+		await service.stop();
+	});
+
+	it('applies a targeted refresh independently when a newer availability event arrived first', async () => {
+		await service.start();
+		synchronizer.synchronizeDevices.mockClear();
+		synchronizer.synchronizeEvents.mockClear();
+		const freshDevice = {
+			...staleDevice,
+			capabilities: staleDevice.capabilities.map((capability) =>
+				capability.id === 'onoff' ? { ...capability, value: false } : capability,
+			),
+		};
+		connector.getDevice.mockResolvedValueOnce(freshDevice);
+		const availability: HomeyEvent = {
+			type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+			deviceId: staleDevice.id,
+			available: false,
+			availabilityMessage: 'Offline',
+			occurredAt: null,
+			sequence: 2,
+		};
+		const delayedUpdate: HomeyEvent = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: 1,
+		};
+
+		void listener?.(availability);
+		void listener?.(delayedUpdate);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
+
+		expect(connector.getDevice.mock.calls).toContainEqual([staleDevice.id]);
+		expect(synchronizer.synchronizeDevices).toHaveBeenCalledWith([freshDevice], [], [availability, delayedUpdate]);
+		expect(synchronizer.synchronizeEvents).not.toHaveBeenCalled();
 
 		await service.stop();
 	});
@@ -849,16 +888,31 @@ describe('HomeyService', () => {
 		await service.start();
 		connector.getZones.mockClear();
 		connector.getDevices.mockClear();
-
-		await emitLiveEvent({
+		synchronizer.synchronizeSnapshot.mockClear();
+		const zoneEvent: HomeyEvent = {
 			type: HomeyEventType.ZONE_UPDATED,
 			zoneId: zones[0].id,
 			occurredAt: null,
-			sequence: null,
-		});
+			sequence: 1,
+		};
+		const capabilityEvent: HomeyEvent = {
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: staleDevice.id,
+			capabilityId: 'onoff',
+			value: false,
+			lastUpdatedAt: null,
+			occurredAt: null,
+			sequence: 2,
+		};
+
+		void listener?.(zoneEvent);
+		void listener?.(capabilityEvent);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
 
 		expect(connector.getZones.mock.calls).toHaveLength(1);
 		expect(connector.getDevices.mock.calls).toHaveLength(1);
+		expect(synchronizer.synchronizeSnapshot).toHaveBeenCalledWith([staleDevice], [zoneEvent, capabilityEvent]);
 
 		await service.stop();
 	});

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -92,7 +92,10 @@ describe('HomeyService', () => {
 	let connector: jest.Mocked<HomeyConnector>;
 	let connectorFactory: jest.Mocked<HomeyConnectorFactory>;
 	let synchronizer: jest.Mocked<
-		Pick<HomeySynchronizerService, 'synchronizeSnapshot' | 'synchronizeDevices' | 'synchronizeEvents' | 'reset'>
+		Pick<
+			HomeySynchronizerService,
+			'filterEvents' | 'synchronizeSnapshot' | 'synchronizeDevices' | 'synchronizeEvents' | 'reset'
+		>
 	>;
 	let listener: HomeyEventListener | null;
 	let unsubscribe: jest.Mock;
@@ -117,6 +120,7 @@ describe('HomeyService', () => {
 		}, unsubscribe);
 		connectorFactory = { create: jest.fn().mockReturnValue(connector) };
 		synchronizer = {
+			filterEvents: jest.fn((events) => [...events]),
 			synchronizeSnapshot: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
 			synchronizeDevices: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
 			synchronizeEvents: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
@@ -295,6 +299,34 @@ describe('HomeyService', () => {
 		expect(synchronizer.synchronizeEvents).toHaveBeenCalledTimes(1);
 		expect(synchronizer.synchronizeEvents).toHaveBeenCalledWith([first, final], expect.any(Map));
 		expect(connector.getDevice.mock.calls).toHaveLength(0);
+
+		await service.stop();
+	});
+
+	it('filters stale device events before mutating the inventory cache', async () => {
+		await service.start();
+		const update: HomeyEvent = {
+			type: HomeyEventType.DEVICE_UPDATED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: 2,
+		};
+		const removal: HomeyEvent = {
+			type: HomeyEventType.DEVICE_REMOVED,
+			deviceId: staleDevice.id,
+			occurredAt: null,
+			sequence: 1,
+		};
+		synchronizer.filterEvents.mockReturnValueOnce([update]);
+
+		void listener?.(update);
+		void listener?.(removal);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
+
+		expect(synchronizer.filterEvents).toHaveBeenCalledWith([update, removal]);
+		expect(synchronizer.synchronizeEvents).toHaveBeenCalledWith([update], expect.any(Map));
+		expect(service.getInventorySnapshot()).toStrictEqual([staleDevice]);
 
 		await service.stop();
 	});

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -466,7 +466,20 @@ describe('HomeyService', () => {
 		);
 		expect(connector.getDevice.mock.calls).toContainEqual([staleDevice.id]);
 		expect(synchronizer.synchronizeSnapshot).toHaveBeenCalledWith([staleDevice]);
-		expect(synchronizer.synchronizeDevices).toHaveBeenCalledWith([freshDevice], []);
+		expect(synchronizer.synchronizeDevices).toHaveBeenCalledWith(
+			[freshDevice],
+			[],
+			[
+				{
+					type: HomeyEventType.DEVICE_AVAILABILITY_CHANGED,
+					deviceId: staleDevice.id,
+					available: false,
+					availabilityMessage: 'Offline',
+					occurredAt: null,
+					sequence: null,
+				},
+			],
+		);
 		expect(synchronizer.synchronizeSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
 			synchronizer.synchronizeDevices.mock.invocationCallOrder[0],
 		);

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -17,10 +17,11 @@ import {
 import { HomeyInventoryUnavailableError } from '../errors/homey-inventory.error';
 import { HomeyConfigModel } from '../models/config.model';
 import { HomeyDevice } from '../models/homey-device.model';
-import { HomeyEventType } from '../models/homey-event.model';
+import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
 import { HomeySystemInfo } from '../models/homey-system-info.model';
 import { HomeyZone } from '../models/homey-zone.model';
 
+import { HomeySynchronizerService } from './homey-synchronizer.service';
 import { HomeyService } from './homey.service';
 
 const INITIAL_TIME = new Date('2026-08-15T10:00:00.000Z');
@@ -90,6 +91,9 @@ describe('HomeyService', () => {
 	let configService: jest.Mocked<Pick<ConfigService, 'getPluginConfig'>>;
 	let connector: jest.Mocked<HomeyConnector>;
 	let connectorFactory: jest.Mocked<HomeyConnectorFactory>;
+	let synchronizer: jest.Mocked<
+		Pick<HomeySynchronizerService, 'synchronizeSnapshot' | 'synchronizeDevices' | 'synchronizeEvents' | 'reset'>
+	>;
 	let listener: HomeyEventListener | null;
 	let unsubscribe: jest.Mock;
 	let service: HomeyService;
@@ -112,13 +116,29 @@ describe('HomeyService', () => {
 			listener = nextListener;
 		}, unsubscribe);
 		connectorFactory = { create: jest.fn().mockReturnValue(connector) };
-		service = new HomeyService(configService as unknown as ConfigService, connectorFactory);
+		synchronizer = {
+			synchronizeSnapshot: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
+			synchronizeDevices: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
+			synchronizeEvents: jest.fn().mockResolvedValue({ updated: 0, ignored: 0, failed: 0 }),
+			reset: jest.fn(),
+		};
+		service = new HomeyService(
+			configService as unknown as ConfigService,
+			synchronizer as unknown as HomeySynchronizerService,
+			connectorFactory,
+		);
 	});
 
 	afterEach(() => {
 		jest.useRealTimers();
 		jest.restoreAllMocks();
 	});
+
+	async function emitLiveEvent(event: HomeyEvent): Promise<void> {
+		void listener?.(event);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
+	}
 
 	it('exposes the managed connector identity and starts stopped', () => {
 		expect(service.pluginName).toBe(DEVICES_HOMEY_PLUGIN_NAME);
@@ -226,7 +246,7 @@ describe('HomeyService', () => {
 		connect.resolve();
 		await start;
 		jest.setSystemTime(new Date('2026-08-15T10:01:00.000Z'));
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.DEVICE_UPDATED,
 			deviceId: staleDevice.id,
 			occurredAt: null,
@@ -248,6 +268,35 @@ describe('HomeyService', () => {
 		disconnect.resolve();
 		await stop;
 		expect(service.getStatus().serviceState).toBe('stopped');
+	});
+
+	it('batches live capability bursts without issuing a targeted read for each value event', async () => {
+		await service.start();
+		connector.getDevice.mockClear();
+		synchronizer.synchronizeEvents.mockClear();
+		const first: HomeyEvent = {
+			type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+			deviceId: staleDevice.id,
+			capabilityId: 'dim',
+			value: 0.25,
+			lastUpdatedAt: '2026-08-15T10:01:00.000Z',
+			occurredAt: '2026-08-15T10:01:00.000Z',
+			sequence: null,
+		};
+		const final: HomeyEvent = { ...first, value: 0.5, lastUpdatedAt: '2026-08-15T10:01:01.000Z' };
+
+		void listener?.(first);
+		void listener?.(final);
+
+		expect(synchronizer.synchronizeEvents).not.toHaveBeenCalled();
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
+
+		expect(synchronizer.synchronizeEvents).toHaveBeenCalledTimes(1);
+		expect(synchronizer.synchronizeEvents).toHaveBeenCalledWith([first, final], expect.any(Map));
+		expect(connector.getDevice.mock.calls).toHaveLength(0);
+
+		await service.stop();
 	});
 
 	it('keeps authoritative inventory available in degraded polling mode', async () => {
@@ -384,6 +433,11 @@ describe('HomeyService', () => {
 			connector.getDevices.mock.invocationCallOrder[0],
 		);
 		expect(connector.getDevice.mock.calls).toContainEqual([staleDevice.id]);
+		expect(synchronizer.synchronizeSnapshot).toHaveBeenCalledWith([staleDevice]);
+		expect(synchronizer.synchronizeDevices).toHaveBeenCalledWith([freshDevice], []);
+		expect(synchronizer.synchronizeSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+			synchronizer.synchronizeDevices.mock.invocationCallOrder[0],
+		);
 		expect(await service.isHealthy()).toBe(true);
 
 		await service.stop();
@@ -487,7 +541,7 @@ describe('HomeyService', () => {
 			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
 		);
 
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.DEVICE_UPDATED,
 			deviceId: staleDevice.id,
 			occurredAt: null,
@@ -538,7 +592,7 @@ describe('HomeyService', () => {
 			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
 		);
 
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.DEVICE_UPDATED,
 			deviceId: staleDevice.id,
 			occurredAt: null,
@@ -578,10 +632,10 @@ describe('HomeyService', () => {
 			sequence: null,
 		} as const;
 
-		await listener?.(event);
+		await emitLiveEvent(event);
 		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
 
-		await listener?.(event);
+		await emitLiveEvent(event);
 		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.CONNECTED);
 		expect(jest.getTimerCount()).toBe(1);
 
@@ -604,7 +658,7 @@ describe('HomeyService', () => {
 			new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_DEVICE),
 		);
 
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.DEVICE_UPDATED,
 			deviceId: staleDevice.id,
 			occurredAt: null,
@@ -629,7 +683,7 @@ describe('HomeyService', () => {
 			new HomeyConnectorError(HomeyConnectorErrorCategory.AUTHENTICATION, HomeyConnectorOperation.GET_DEVICE),
 		);
 
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.DEVICE_UPDATED,
 			deviceId: staleDevice.id,
 			occurredAt: null,
@@ -654,7 +708,10 @@ describe('HomeyService', () => {
 			sequence: null,
 		} as const;
 
-		await Promise.all([listener?.(event), listener?.(event)]);
+		void listener?.(event);
+		void listener?.(event);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
 
 		expect(jest.getTimerCount()).toBe(1);
 		expect(connectorFactory.create.mock.calls).toHaveLength(1);
@@ -680,7 +737,7 @@ describe('HomeyService', () => {
 			sequence: null,
 		} as const;
 
-		await listener?.(event);
+		await emitLiveEvent(event);
 
 		let rejectRead: (error: Error) => void = () => undefined;
 		connector.getDevice.mockImplementationOnce(
@@ -689,7 +746,9 @@ describe('HomeyService', () => {
 					rejectRead = reject;
 				}),
 		);
-		const activeReconciliation = listener?.(event);
+		void listener?.(event);
+		await jest.advanceTimersByTimeAsync(0);
+		await flushMicrotasks();
 
 		await jest.advanceTimersByTimeAsync(1000);
 
@@ -697,8 +756,6 @@ describe('HomeyService', () => {
 		expect(connector.disconnect.mock.calls).toHaveLength(0);
 
 		rejectRead(new Error('in-flight read ended'));
-		await activeReconciliation;
-
 		for (let index = 0; index < 10; index += 1) {
 			await Promise.resolve();
 		}
@@ -714,7 +771,7 @@ describe('HomeyService', () => {
 		connector.getZones.mockClear();
 		connector.getDevices.mockClear();
 
-		await listener?.({
+		await emitLiveEvent({
 			type: HomeyEventType.ZONE_UPDATED,
 			zoneId: zones[0].id,
 			occurredAt: null,
@@ -768,7 +825,10 @@ describe('HomeyService', () => {
 	});
 
 	it('fails safely when the production connector factory is not registered', async () => {
-		service = new HomeyService(configService as unknown as ConfigService);
+		service = new HomeyService(
+			configService as unknown as ConfigService,
+			synchronizer as unknown as HomeySynchronizerService,
+		);
 
 		await expect(service.start()).rejects.toThrow('Homey service failed to start');
 		expect(service.getStatus()).toMatchObject({

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -340,8 +340,11 @@ export class HomeyService extends BaseManagedPluginService {
 	private flushLiveEvents(connector: HomeyConnector, generation: number, events: readonly HomeyEvent[]): Promise<void> {
 		return this.enqueueSynchronization(async () => {
 			try {
-				await this.reconcileEvents(connector, generation, events);
-				this.markRuntimeHealthy(connector, generation);
+				const authoritativeTraffic = await this.reconcileEvents(connector, generation, events);
+
+				if (authoritativeTraffic) {
+					this.markRuntimeHealthy(connector, generation);
+				}
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
 					this.handleRuntimeFailure(error, 'Homey event synchronization failed', generation);
@@ -356,19 +359,28 @@ export class HomeyService extends BaseManagedPluginService {
 		generation: number,
 		events: readonly HomeyEvent[],
 		authoritativeReadback = false,
-	): Promise<void> {
+	): Promise<boolean> {
 		if (!this.isCurrentGeneration(connector, generation)) {
-			return;
+			return false;
 		}
 
 		const containsZoneEvent = events.some((event) => this.isZoneEvent(event));
 
 		let inventoryReplaced = false;
+		let authoritativeTraffic = false;
 
 		if (containsZoneEvent) {
-			this.zones = await connector.getZones();
-			this.replaceDevices(await connector.getDevices());
+			const zones = await connector.getZones();
+			const devices = await connector.getDevices();
+
+			if (!this.isCurrentGeneration(connector, generation)) {
+				return false;
+			}
+
+			this.zones = zones;
+			this.replaceDevices(devices);
 			inventoryReplaced = true;
+			authoritativeTraffic = true;
 		}
 
 		const deviceIds = [...new Set(events.flatMap((event) => ('deviceId' in event ? [event.deviceId] : [])))];
@@ -380,8 +392,10 @@ export class HomeyService extends BaseManagedPluginService {
 				const device = await connector.getDevice(deviceId);
 
 				if (!this.isCurrentGeneration(connector, generation)) {
-					return;
+					return false;
 				}
+
+				authoritativeTraffic = true;
 
 				if (device) {
 					this.devices.set(device.id, device);
@@ -393,7 +407,8 @@ export class HomeyService extends BaseManagedPluginService {
 			}
 		} else {
 			for (const event of events) {
-				await this.updateInventoryFromEvent(connector, generation, event);
+				authoritativeTraffic =
+					(await this.updateInventoryFromEvent(connector, generation, event)) || authoritativeTraffic;
 			}
 		}
 
@@ -409,20 +424,22 @@ export class HomeyService extends BaseManagedPluginService {
 			}
 			this.lastEventAt = this.now();
 		}
+
+		return authoritativeTraffic;
 	}
 
 	private async updateInventoryFromEvent(
 		connector: HomeyConnector,
 		generation: number,
 		event: HomeyEvent,
-	): Promise<void> {
+	): Promise<boolean> {
 		switch (event.type) {
 			case HomeyEventType.DEVICE_ADDED:
 			case HomeyEventType.DEVICE_UPDATED: {
 				const device = await connector.getDevice(event.deviceId);
 
 				if (!this.isCurrentGeneration(connector, generation)) {
-					return;
+					return false;
 				}
 
 				if (device === null) {
@@ -430,11 +447,11 @@ export class HomeyService extends BaseManagedPluginService {
 				} else {
 					this.devices.set(device.id, device);
 				}
-				return;
+				return true;
 			}
 			case HomeyEventType.DEVICE_REMOVED:
 				this.devices.delete(event.deviceId);
-				return;
+				return false;
 			case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
 				const device = this.devices.get(event.deviceId);
 
@@ -445,13 +462,13 @@ export class HomeyService extends BaseManagedPluginService {
 						availabilityMessage: event.availabilityMessage,
 					});
 				}
-				return;
+				return false;
 			}
 			case HomeyEventType.CAPABILITY_VALUE_CHANGED: {
 				const device = this.devices.get(event.deviceId);
 
 				if (device === undefined) {
-					return;
+					return false;
 				}
 
 				this.devices.set(event.deviceId, {
@@ -462,12 +479,12 @@ export class HomeyService extends BaseManagedPluginService {
 							: capability,
 					),
 				});
-				return;
+				return false;
 			}
 			case HomeyEventType.ZONE_ADDED:
 			case HomeyEventType.ZONE_UPDATED:
 			case HomeyEventType.ZONE_REMOVED:
-				return;
+				return false;
 		}
 	}
 

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -27,6 +27,7 @@ import { HomeyZone } from '../models/homey-zone.model';
 import { HomeyStatusModel } from '../models/status.model';
 
 import { calculateHomeyReconnectDelay } from './homey-reconnect-backoff';
+import { HomeySynchronizationResult, HomeySynchronizerService } from './homey-synchronizer.service';
 
 @Injectable()
 export class HomeyService extends BaseManagedPluginService {
@@ -52,6 +53,8 @@ export class HomeyService extends BaseManagedPluginService {
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private reconnectAttempt = 0;
 	private reconnectCount = 0;
+	private liveEvents: HomeyEvent[] = [];
+	private liveEventFlush: ReturnType<typeof setImmediate> | null = null;
 	private lastConnectedAt: string | null = null;
 	private lastInventorySyncAt: string | null = null;
 	private lastEventAt: string | null = null;
@@ -59,6 +62,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 	constructor(
 		private readonly configService: ConfigService,
+		private readonly synchronizer: HomeySynchronizerService,
 		@Optional()
 		@Inject(HOMEY_CONNECTOR_FACTORY)
 		private readonly connectorFactory: HomeyConnectorFactory | null = null,
@@ -277,6 +281,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 		await this.enqueueSynchronization(async () => {
 			this.replaceDevices(await connector.getDevices());
+			this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
 
 			if (this.startupEvents) {
 				await this.reconcileStartupEvents(connector, generation);
@@ -296,18 +301,18 @@ export class HomeyService extends BaseManagedPluginService {
 			const events = this.startupEvents.slice(cursor);
 			cursor += events.length;
 			pass += 1;
-			await this.reconcileEvents(connector, generation, events);
+			await this.reconcileEvents(connector, generation, events, true);
 		}
 
 		const remainingEvents = this.startupEvents?.slice(cursor) ?? [];
 		this.startupEvents = null;
 
 		if (remainingEvents.length > 0) {
-			await this.reconcileEvents(connector, generation, remainingEvents);
+			await this.reconcileEvents(connector, generation, remainingEvents, true);
 		}
 	}
 
-	private onConnectorEvent(connector: HomeyConnector, generation: number, event: HomeyEvent): Promise<void> | void {
+	private onConnectorEvent(connector: HomeyConnector, generation: number, event: HomeyEvent): void {
 		if (!this.isCurrentGeneration(connector, generation)) {
 			return;
 		}
@@ -318,9 +323,24 @@ export class HomeyService extends BaseManagedPluginService {
 			return;
 		}
 
+		this.liveEvents.push(event);
+
+		if (this.liveEventFlush !== null) {
+			return;
+		}
+
+		this.liveEventFlush = setImmediate(() => {
+			this.liveEventFlush = null;
+			const events = this.liveEvents;
+			this.liveEvents = [];
+			void this.flushLiveEvents(connector, generation, events);
+		});
+	}
+
+	private flushLiveEvents(connector: HomeyConnector, generation: number, events: readonly HomeyEvent[]): Promise<void> {
 		return this.enqueueSynchronization(async () => {
 			try {
-				await this.reconcileEvents(connector, generation, [event]);
+				await this.reconcileEvents(connector, generation, events);
 				this.markRuntimeHealthy(connector, generation);
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
@@ -335,6 +355,7 @@ export class HomeyService extends BaseManagedPluginService {
 		connector: HomeyConnector,
 		generation: number,
 		events: readonly HomeyEvent[],
+		authoritativeReadback = false,
 	): Promise<void> {
 		if (!this.isCurrentGeneration(connector, generation)) {
 			return;
@@ -342,29 +363,111 @@ export class HomeyService extends BaseManagedPluginService {
 
 		const containsZoneEvent = events.some((event) => this.isZoneEvent(event));
 
+		let inventoryReplaced = false;
+
 		if (containsZoneEvent) {
 			this.zones = await connector.getZones();
 			this.replaceDevices(await connector.getDevices());
+			inventoryReplaced = true;
 		}
 
 		const deviceIds = [...new Set(events.flatMap((event) => ('deviceId' in event ? [event.deviceId] : [])))];
+		const refreshedDevices: HomeyDevice[] = [];
+		const missingDeviceIds: string[] = [];
 
-		for (const deviceId of deviceIds) {
-			const device = await connector.getDevice(deviceId);
+		if (authoritativeReadback) {
+			for (const deviceId of deviceIds) {
+				const device = await connector.getDevice(deviceId);
 
-			if (!this.isCurrentGeneration(connector, generation)) {
-				return;
+				if (!this.isCurrentGeneration(connector, generation)) {
+					return;
+				}
+
+				if (device) {
+					this.devices.set(device.id, device);
+					refreshedDevices.push(device);
+				} else {
+					this.devices.delete(deviceId);
+					missingDeviceIds.push(deviceId);
+				}
 			}
-
-			if (device) {
-				this.devices.set(device.id, device);
-			} else {
-				this.devices.delete(deviceId);
+		} else {
+			for (const event of events) {
+				await this.updateInventoryFromEvent(connector, generation, event);
 			}
 		}
 
 		if (events.length > 0 && this.isCurrentGeneration(connector, generation)) {
+			if (inventoryReplaced) {
+				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
+			} else if (authoritativeReadback) {
+				this.recordSynchronizationResult(
+					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds),
+				);
+			} else {
+				this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(events, this.devices));
+			}
 			this.lastEventAt = this.now();
+		}
+	}
+
+	private async updateInventoryFromEvent(
+		connector: HomeyConnector,
+		generation: number,
+		event: HomeyEvent,
+	): Promise<void> {
+		switch (event.type) {
+			case HomeyEventType.DEVICE_ADDED:
+			case HomeyEventType.DEVICE_UPDATED: {
+				const device = await connector.getDevice(event.deviceId);
+
+				if (!this.isCurrentGeneration(connector, generation)) {
+					return;
+				}
+
+				if (device === null) {
+					this.devices.delete(event.deviceId);
+				} else {
+					this.devices.set(device.id, device);
+				}
+				return;
+			}
+			case HomeyEventType.DEVICE_REMOVED:
+				this.devices.delete(event.deviceId);
+				return;
+			case HomeyEventType.DEVICE_AVAILABILITY_CHANGED: {
+				const device = this.devices.get(event.deviceId);
+
+				if (device !== undefined) {
+					this.devices.set(event.deviceId, {
+						...device,
+						available: event.available,
+						availabilityMessage: event.availabilityMessage,
+					});
+				}
+				return;
+			}
+			case HomeyEventType.CAPABILITY_VALUE_CHANGED: {
+				const device = this.devices.get(event.deviceId);
+
+				if (device === undefined) {
+					return;
+				}
+
+				this.devices.set(event.deviceId, {
+					...device,
+					capabilities: device.capabilities.map((capability) =>
+						capability.id === event.capabilityId
+							? { ...capability, value: event.value, lastUpdatedAt: event.lastUpdatedAt }
+							: capability,
+					),
+				});
+				return;
+			}
+			case HomeyEventType.ZONE_ADDED:
+			case HomeyEventType.ZONE_UPDATED:
+			case HomeyEventType.ZONE_REMOVED:
+				return;
 		}
 	}
 
@@ -420,6 +523,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 				this.zones = zonesResult.value;
 				this.replaceDevices(devicesResult.value);
+				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot(devicesResult.value));
 				this.recordSuccessfulInventorySync(connector, generation);
 
 				if (this.unsubscribe) {
@@ -541,6 +645,7 @@ export class HomeyService extends BaseManagedPluginService {
 	private async cleanupRuntime(): Promise<boolean> {
 		this.clearReconciliationTimer();
 		this.clearReconnectTimer();
+		this.clearLiveEventFlush();
 		this.startupEvents = null;
 		const unsubscribe = this.unsubscribe;
 		const connector = this.connector;
@@ -557,6 +662,7 @@ export class HomeyService extends BaseManagedPluginService {
 		}
 
 		await this.synchronizationTail;
+		this.synchronizer.reset();
 
 		if (connector) {
 			try {
@@ -592,13 +698,31 @@ export class HomeyService extends BaseManagedPluginService {
 		}
 	}
 
+	private clearLiveEventFlush(): void {
+		if (this.liveEventFlush !== null) {
+			clearImmediate(this.liveEventFlush);
+			this.liveEventFlush = null;
+		}
+
+		this.liveEvents = [];
+	}
+
 	private hasRuntimeResources(): boolean {
 		return (
 			this.connector !== null ||
 			this.unsubscribe !== null ||
 			this.reconciliationTimer !== null ||
-			this.reconnectTimer !== null
+			this.reconnectTimer !== null ||
+			this.liveEventFlush !== null
 		);
+	}
+
+	private recordSynchronizationResult(result: HomeySynchronizationResult): void {
+		if (result.failed > 0) {
+			this.logger.warn('Homey synchronization completed with isolated property failures', {
+				failed: result.failed,
+			});
+		}
 	}
 
 	private isCurrentGeneration(connector: HomeyConnector, generation: number): boolean {

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -387,9 +387,18 @@ export class HomeyService extends BaseManagedPluginService {
 		const refreshedDevices: HomeyDevice[] = [];
 		const missingDeviceIds: string[] = [];
 		const selectedEvents = inventoryReplaced || authoritativeReadback ? events : this.synchronizer.filterEvents(events);
+		const targetedDeviceIds = new Set(
+			authoritativeReadback
+				? deviceIds
+				: selectedEvents.flatMap((event) =>
+						event.type === HomeyEventType.DEVICE_ADDED || event.type === HomeyEventType.DEVICE_UPDATED
+							? [event.deviceId]
+							: [],
+					),
+		);
 
-		if (authoritativeReadback) {
-			for (const deviceId of deviceIds) {
+		if (!inventoryReplaced) {
+			for (const deviceId of targetedDeviceIds) {
 				const device = await connector.getDevice(deviceId);
 
 				if (!this.isCurrentGeneration(connector, generation)) {
@@ -406,8 +415,12 @@ export class HomeyService extends BaseManagedPluginService {
 					missingDeviceIds.push(deviceId);
 				}
 			}
-		} else if (!inventoryReplaced) {
+
 			for (const event of selectedEvents) {
+				if ('deviceId' in event && targetedDeviceIds.has(event.deviceId)) {
+					continue;
+				}
+
 				authoritativeTraffic =
 					(await this.updateInventoryFromEvent(connector, generation, event)) || authoritativeTraffic;
 			}
@@ -415,11 +428,24 @@ export class HomeyService extends BaseManagedPluginService {
 
 		if (events.length > 0 && this.isCurrentGeneration(connector, generation)) {
 			if (inventoryReplaced) {
-				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
-			} else if (authoritativeReadback) {
 				this.recordSynchronizationResult(
-					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds, events),
+					await this.synchronizer.synchronizeSnapshot([...this.devices.values()], events),
 				);
+			} else if (targetedDeviceIds.size > 0) {
+				const readbackEvents = selectedEvents.filter(
+					(event) => 'deviceId' in event && targetedDeviceIds.has(event.deviceId),
+				);
+				this.recordSynchronizationResult(
+					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds, readbackEvents),
+				);
+
+				const remainingEvents = selectedEvents.filter(
+					(event) => !('deviceId' in event) || !targetedDeviceIds.has(event.deviceId),
+				);
+
+				if (remainingEvents.length > 0) {
+					this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(remainingEvents, this.devices));
+				}
 			} else if (selectedEvents.length > 0) {
 				this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(selectedEvents, this.devices));
 			}

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -418,7 +418,7 @@ export class HomeyService extends BaseManagedPluginService {
 				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
 			} else if (authoritativeReadback) {
 				this.recordSynchronizationResult(
-					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds),
+					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds, events),
 				);
 			} else if (selectedEvents.length > 0) {
 				this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(selectedEvents, this.devices));

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -386,6 +386,7 @@ export class HomeyService extends BaseManagedPluginService {
 		const deviceIds = [...new Set(events.flatMap((event) => ('deviceId' in event ? [event.deviceId] : [])))];
 		const refreshedDevices: HomeyDevice[] = [];
 		const missingDeviceIds: string[] = [];
+		const selectedEvents = inventoryReplaced || authoritativeReadback ? events : this.synchronizer.filterEvents(events);
 
 		if (authoritativeReadback) {
 			for (const deviceId of deviceIds) {
@@ -405,8 +406,8 @@ export class HomeyService extends BaseManagedPluginService {
 					missingDeviceIds.push(deviceId);
 				}
 			}
-		} else {
-			for (const event of events) {
+		} else if (!inventoryReplaced) {
+			for (const event of selectedEvents) {
 				authoritativeTraffic =
 					(await this.updateInventoryFromEvent(connector, generation, event)) || authoritativeTraffic;
 			}
@@ -419,8 +420,8 @@ export class HomeyService extends BaseManagedPluginService {
 				this.recordSynchronizationResult(
 					await this.synchronizer.synchronizeDevices(refreshedDevices, missingDeviceIds),
 				);
-			} else {
-				this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(events, this.devices));
+			} else if (selectedEvents.length > 0) {
+				this.recordSynchronizationResult(await this.synchronizer.synchronizeEvents(selectedEvents, this.devices));
 			}
 			this.lastEventAt = this.now();
 		}

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -392,14 +392,22 @@ are documented in `docs/homey-adoption-persistence.md`.
 
 **Proposed service:** `services/homey-synchronizer.service.ts`
 
-- [ ] Maintain an index from adopted Homey device/full capability IDs to Smart Panel properties.
-- [ ] Subscribe through the active connector before the authoritative initial inventory reconciliation; buffer/serialize events through the startup barrier so a snapshot cannot overwrite a newer event.
-- [ ] Validate/filter events and ignore unadopted or unmapped capabilities.
-- [ ] Transform values and update properties through the standard Devices service path.
-- [ ] Update whole-device/capability availability when corresponding events arrive.
-- [ ] Coalesce bursts per property while preserving the final order/value.
-- [ ] Avoid feedback loops when a command confirmation event returns.
-- [ ] Add tests for unknown devices, unknown capabilities, duplicate/out-of-order events, bursts, invalid values, unsubscribe, and a capability change during the startup snapshot/subscription boundary.
+- [x] Maintain an index from adopted Homey device/full capability IDs to Smart Panel properties.
+- [x] Subscribe through the active connector before the authoritative initial inventory reconciliation; buffer/serialize events through the startup barrier so a snapshot cannot overwrite a newer event.
+- [x] Validate/filter events and ignore unadopted or unmapped capabilities.
+- [x] Transform values and update properties through the standard Devices service path.
+- [x] Update whole-device/capability availability when corresponding events arrive.
+- [x] Coalesce bursts per property while preserving the final order/value.
+- [x] Avoid feedback loops when a command confirmation event returns.
+- [x] Add tests for unknown devices, unknown capabilities, duplicate/out-of-order events, bursts, invalid values, unsubscribe, and a capability change during the startup snapshot/subscription boundary.
+
+`HomeySynchronizerService` rebuilds its mapping index from provider-scoped adopted entities and invalidates it on generic
+device/channel/property structure events. Startup subscribes first, applies the inventory snapshot, and then performs
+fresh targeted reads for every upstream device touched while the barrier was active. Live capability batches retain the
+newest timestamped value per full capability ID, apply every intentional mapping fan-out through the normal property
+service, and never call the connector, so confirmation events cannot feed back into command transport. Device
+availability maps to generic connection state; unavailable capabilities remain in the normalized inventory but do not
+publish stale values. Removed or missing upstream devices become `lost` and no upstream or local deletion path is used.
 
 ### Task 4.2: Implement reconciliation fallback
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -113,11 +113,11 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [x] Mapping preview returns category, channels, properties, identifiers, values, access, conversions, and warnings.
 - [x] Single and batch adoption are idempotent and return per-device outcomes.
 - [x] Adoption reuses generic device/channel/property identifiers without a migration, or an incremental migration is added if evidence shows one is required.
-- [ ] Initial reconciliation populates current values and availability for adopted devices.
-- [ ] Subscriptions are established before the authoritative initial reconciliation, and a tested startup barrier prevents snapshot/event races from losing the newest value.
-- [ ] Real-time Homey events update only adopted, mapped properties.
+- [x] Initial reconciliation populates current values and availability for adopted devices.
+- [x] Subscriptions are established before the authoritative initial reconciliation, and a tested startup barrier prevents snapshot/event races from losing the newest value.
+- [x] Real-time Homey events update only adopted, mapped properties.
 - [ ] Reconnect performs a full reconciliation and bounded periodic reconciliation repairs missed events.
-- [ ] A missing upstream device is marked unavailable/orphaned but never automatically deleted.
+- [x] A missing upstream device is marked unavailable/orphaned but never automatically deleted.
 - [ ] Writable property commands validate and transform values, use the full capability ID, and await authoritative confirmation.
 - [ ] A missing confirmation triggers at most one targeted read before returning a timeout/error.
 


### PR DESCRIPTION
## Summary

- add a provider-scoped Homey synchronizer for adopted device, capability, and property mappings
- preserve startup event ordering with authoritative readback and batch live capability events
- propagate mapped values and device availability without deleting missing adopted devices or feeding events back into command transport
- filter cache mutations and property updates through one sequence/timestamp/arrival ordering decision
- retain separate observed and applied capability/device watermarks across failures, retries, and unsequenced events
- carry lifecycle refresh watermarks into fresh readable capability values across all authoritative snapshot paths
- preserve distinct refresh and availability effects while coalescing duplicate device events
- reject availability and capability traffic for devices absent from authoritative inventory
- retry connectivity until it is actually applied and preserve reconnect recovery until authoritative connector reads succeed
- record Task 4.1 implementation evidence in the Homey plan and feature checklist

## Validation

- `pnpm exec jest --runInBand src/plugins/devices-homey src/modules/devices/services/device-connectivity.service.spec.ts` — 34 suites, 391 tests passed
- `pnpm run type-check`
- `pnpm run build`
- focused ESLint and Prettier checks
- `git diff --check`
