### PR TITLE
feat(backend): expose Homey reconciliation metrics

### DIFF
--- a/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/controllers/homey-status.controller.spec.ts
@@ -22,6 +22,9 @@ describe('HomeyStatusController', () => {
 			lastInventorySyncAt: '2026-08-15T10:00:01.000Z',
 			lastEventAt: '2026-08-15T10:00:02.000Z',
 			reconnectCount: 1,
+			reconciliationCount: 4,
+			reconciliationFailureCount: 1,
+			lastReconciliationDurationMs: 125,
 			lastErrorCategory: null,
 			lastError: null,
 		});
@@ -42,6 +45,9 @@ describe('HomeyStatusController', () => {
 			last_inventory_sync_at: '2026-08-15T10:00:01.000Z',
 			last_event_at: '2026-08-15T10:00:02.000Z',
 			reconnect_count: 1,
+			reconciliation_count: 4,
+			reconciliation_failure_count: 1,
+			last_reconciliation_duration_ms: 125,
 			last_error_category: null,
 		});
 		expect(JSON.stringify(serialized)).not.toContain('api_key');

--- a/apps/backend/src/plugins/devices-homey/models/status.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/status.model.ts
@@ -102,6 +102,35 @@ export class HomeyStatusModel {
 	@Min(0)
 	reconnectCount: number;
 
+	@ApiProperty({
+		description: 'Authoritative inventory reconciliation attempts since the last explicit start',
+		name: 'reconciliation_count',
+	})
+	@Expose({ name: 'reconciliation_count' })
+	@IsInt()
+	@Min(0)
+	reconciliationCount: number;
+
+	@ApiProperty({
+		description: 'Authoritative inventory reconciliation attempts that failed since the last explicit start',
+		name: 'reconciliation_failure_count',
+	})
+	@Expose({ name: 'reconciliation_failure_count' })
+	@IsInt()
+	@Min(0)
+	reconciliationFailureCount: number;
+
+	@ApiPropertyOptional({
+		description: 'Duration of the latest authoritative inventory reconciliation in milliseconds',
+		nullable: true,
+		name: 'last_reconciliation_duration_ms',
+	})
+	@Expose({ name: 'last_reconciliation_duration_ms' })
+	@IsOptional()
+	@IsInt()
+	@Min(0)
+	lastReconciliationDurationMs: number | null;
+
 	@ApiPropertyOptional({
 		description: 'Normalized category for the current sanitized connector error',
 		enum: HomeyConnectorErrorCategory,

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -203,6 +203,9 @@ describe('HomeyService', () => {
 			lastInventorySyncAt: INITIAL_TIME.toISOString(),
 			lastEventAt: null,
 			reconnectCount: 0,
+			reconciliationCount: 1,
+			reconciliationFailureCount: 0,
+			lastReconciliationDurationMs: 0,
 			lastErrorCategory: null,
 		});
 
@@ -398,6 +401,9 @@ describe('HomeyService', () => {
 			degraded: true,
 			lastInventorySyncAt: '2026-08-15T10:10:00.000Z',
 			reconnectCount: 0,
+			reconciliationCount: 2,
+			reconciliationFailureCount: 0,
+			lastReconciliationDurationMs: 0,
 		});
 
 		await service.stop();
@@ -428,6 +434,8 @@ describe('HomeyService', () => {
 			degraded: false,
 			lastConnectedAt: '2026-08-15T10:00:01.000Z',
 			reconnectCount: 1,
+			reconciliationCount: 2,
+			reconciliationFailureCount: 0,
 			lastErrorCategory: null,
 		});
 
@@ -555,6 +563,11 @@ describe('HomeyService', () => {
 			await Promise.resolve();
 		}
 
+		expect(service.getStatus()).toMatchObject({
+			reconciliationCount: 2,
+			reconciliationFailureCount: 0,
+			lastReconciliationDurationMs: config.reconciliationInterval * 2,
+		});
 		expect(jest.getTimerCount()).toBe(1);
 
 		await service.stop();
@@ -601,6 +614,8 @@ describe('HomeyService', () => {
 		expect(service.getStatus().connectionState).toBe(HomeyConnectionState.RECONNECTING);
 		expect(service.getStatus()).toMatchObject({
 			lastInventorySyncAt: INITIAL_TIME.toISOString(),
+			reconciliationCount: 2,
+			reconciliationFailureCount: 1,
 			lastErrorCategory: HomeyConnectorErrorCategory.UNAVAILABLE,
 		});
 		expect(jest.getTimerCount()).toBe(1);
@@ -1001,6 +1016,9 @@ describe('HomeyService', () => {
 			lastInventorySyncAt: null,
 			lastEventAt: null,
 			reconnectCount: 0,
+			reconciliationCount: 0,
+			reconciliationFailureCount: 0,
+			lastReconciliationDurationMs: null,
 			lastErrorCategory: null,
 			lastError: null,
 		});

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -490,6 +490,30 @@ describe('HomeyService', () => {
 		await service.stop();
 	});
 
+	it('records startup metadata read failures as reconciliation attempts', async () => {
+		connector.getZones.mockImplementationOnce(() => {
+			jest.setSystemTime(new Date(INITIAL_TIME.getTime() + 125));
+
+			return Promise.reject(
+				new HomeyConnectorError(HomeyConnectorErrorCategory.UNAVAILABLE, HomeyConnectorOperation.GET_ZONES),
+			);
+		});
+
+		await service.start();
+
+		expect(service.getStatus()).toMatchObject({
+			connectionState: HomeyConnectionState.RECONNECTING,
+			reconciliationCount: 1,
+			reconciliationFailureCount: 1,
+			lastReconciliationDurationMs: 125,
+			lastInventorySyncAt: null,
+		});
+		expect(connector.subscribe.mock.calls).toHaveLength(0);
+		expect(connector.getDevices.mock.calls).toHaveLength(0);
+
+		await service.stop();
+	});
+
 	it('performs a targeted authoritative read for an event received during the startup snapshot', async () => {
 		const freshDevice = { ...staleDevice, available: false, availabilityMessage: 'Offline' };
 		connector.getDevice.mockResolvedValue(freshDevice);

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -273,26 +273,27 @@ export class HomeyService extends BaseManagedPluginService {
 		generation: number,
 		source: Extract<HomeyReconciliationSource, 'startup' | 'reconnect'>,
 	): Promise<HomeyConnectorError | null> {
-		this.systemInfo = await connector.getSystemInfo();
-		this.lastSystemInfo = this.systemInfo;
-		this.zones = await connector.getZones();
-		this.startupEvents = [];
 		let subscriptionFailure: HomeyConnectorError | null = null;
 
-		try {
-			this.unsubscribe = await connector.subscribe((event) => this.onConnectorEvent(connector, generation, event));
-		} catch (error) {
-			this.startupEvents = null;
+		await this.runInventoryReconciliation(source, async () => {
+			this.systemInfo = await connector.getSystemInfo();
+			this.lastSystemInfo = this.systemInfo;
+			this.zones = await connector.getZones();
+			this.startupEvents = [];
 
-			if (!this.isDegradableSubscriptionFailure(error)) {
-				throw error;
+			try {
+				this.unsubscribe = await connector.subscribe((event) => this.onConnectorEvent(connector, generation, event));
+			} catch (error) {
+				this.startupEvents = null;
+
+				if (!this.isDegradableSubscriptionFailure(error)) {
+					throw error;
+				}
+
+				subscriptionFailure = error;
 			}
 
-			subscriptionFailure = error;
-		}
-
-		await this.enqueueSynchronization(() =>
-			this.runInventoryReconciliation(source, async () => {
+			await this.enqueueSynchronization(async () => {
 				this.replaceDevices(await connector.getDevices());
 				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
 
@@ -301,8 +302,8 @@ export class HomeyService extends BaseManagedPluginService {
 				}
 
 				this.recordSuccessfulInventorySync(connector, generation);
-			}),
-		);
+			});
+		});
 
 		return subscriptionFailure;
 	}

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -29,6 +29,8 @@ import { HomeyStatusModel } from '../models/status.model';
 import { calculateHomeyReconnectDelay } from './homey-reconnect-backoff';
 import { HomeySynchronizationResult, HomeySynchronizerService } from './homey-synchronizer.service';
 
+type HomeyReconciliationSource = 'startup' | 'reconnect' | 'periodic';
+
 @Injectable()
 export class HomeyService extends BaseManagedPluginService {
 	private readonly logger = createExtensionLogger(DEVICES_HOMEY_PLUGIN_NAME, 'HomeyService');
@@ -59,6 +61,9 @@ export class HomeyService extends BaseManagedPluginService {
 	private lastInventorySyncAt: string | null = null;
 	private lastEventAt: string | null = null;
 	private lastErrorCategory: HomeyConnectorErrorCategory | null = null;
+	private reconciliationCount = 0;
+	private reconciliationFailureCount = 0;
+	private lastReconciliationDurationMs: number | null = null;
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -94,7 +99,7 @@ export class HomeyService extends BaseManagedPluginService {
 
 				await connector.connect();
 				this.recordSuccessfulConnection();
-				const subscriptionFailure = await this.synchronizeStartup(connector, generation);
+				const subscriptionFailure = await this.synchronizeStartup(connector, generation, 'startup');
 
 				this.state = 'started';
 
@@ -200,6 +205,9 @@ export class HomeyService extends BaseManagedPluginService {
 		status.lastInventorySyncAt = this.lastInventorySyncAt;
 		status.lastEventAt = this.lastEventAt;
 		status.reconnectCount = this.reconnectCount;
+		status.reconciliationCount = this.reconciliationCount;
+		status.reconciliationFailureCount = this.reconciliationFailureCount;
+		status.lastReconciliationDurationMs = this.lastReconciliationDurationMs;
 		status.lastErrorCategory = this.lastErrorCategory;
 		status.lastError = this.lastError;
 
@@ -260,7 +268,11 @@ export class HomeyService extends BaseManagedPluginService {
 		});
 	}
 
-	private async synchronizeStartup(connector: HomeyConnector, generation: number): Promise<HomeyConnectorError | null> {
+	private async synchronizeStartup(
+		connector: HomeyConnector,
+		generation: number,
+		source: Extract<HomeyReconciliationSource, 'startup' | 'reconnect'>,
+	): Promise<HomeyConnectorError | null> {
 		this.systemInfo = await connector.getSystemInfo();
 		this.lastSystemInfo = this.systemInfo;
 		this.zones = await connector.getZones();
@@ -279,16 +291,18 @@ export class HomeyService extends BaseManagedPluginService {
 			subscriptionFailure = error;
 		}
 
-		await this.enqueueSynchronization(async () => {
-			this.replaceDevices(await connector.getDevices());
-			this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
+		await this.enqueueSynchronization(() =>
+			this.runInventoryReconciliation(source, async () => {
+				this.replaceDevices(await connector.getDevices());
+				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot([...this.devices.values()]));
 
-			if (this.startupEvents) {
-				await this.reconcileStartupEvents(connector, generation);
-			}
+				if (this.startupEvents) {
+					await this.reconcileStartupEvents(connector, generation);
+				}
 
-			this.recordSuccessfulInventorySync(connector, generation);
-		});
+				this.recordSuccessfulInventorySync(connector, generation);
+			}),
+		);
 
 		return subscriptionFailure;
 	}
@@ -551,31 +565,33 @@ export class HomeyService extends BaseManagedPluginService {
 
 		await this.enqueueSynchronization(async () => {
 			try {
-				const [zonesResult, devicesResult] = await Promise.allSettled([connector.getZones(), connector.getDevices()]);
+				await this.runInventoryReconciliation('periodic', async () => {
+					const [zonesResult, devicesResult] = await Promise.allSettled([connector.getZones(), connector.getDevices()]);
 
-				if (zonesResult.status === 'rejected') {
-					throw zonesResult.reason as unknown;
-				}
+					if (zonesResult.status === 'rejected') {
+						throw zonesResult.reason as unknown;
+					}
 
-				if (devicesResult.status === 'rejected') {
-					throw devicesResult.reason as unknown;
-				}
+					if (devicesResult.status === 'rejected') {
+						throw devicesResult.reason as unknown;
+					}
 
-				if (!this.isCurrentGeneration(connector, generation)) {
-					return;
-				}
+					if (!this.isCurrentGeneration(connector, generation)) {
+						return;
+					}
 
-				this.zones = zonesResult.value;
-				this.replaceDevices(devicesResult.value);
-				this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot(devicesResult.value));
-				this.recordSuccessfulInventorySync(connector, generation);
+					this.zones = zonesResult.value;
+					this.replaceDevices(devicesResult.value);
+					this.recordSynchronizationResult(await this.synchronizer.synchronizeSnapshot(devicesResult.value));
+					this.recordSuccessfulInventorySync(connector, generation);
 
-				if (this.unsubscribe) {
-					this.markRuntimeHealthy(connector, generation);
-				} else {
-					this.connectionState = HomeyConnectionState.DEGRADED_POLLING;
-					this.healthy = false;
-				}
+					if (this.unsubscribe) {
+						this.markRuntimeHealthy(connector, generation);
+					} else {
+						this.connectionState = HomeyConnectionState.DEGRADED_POLLING;
+						this.healthy = false;
+					}
+				});
 			} catch (error) {
 				if (this.isCurrentGeneration(connector, generation)) {
 					this.handleRuntimeFailure(error, 'Homey inventory reconciliation failed', generation);
@@ -634,7 +650,7 @@ export class HomeyService extends BaseManagedPluginService {
 				this.connector = connector;
 				await connector.connect();
 				this.recordSuccessfulConnection();
-				const subscriptionFailure = await this.synchronizeStartup(connector, generation);
+				const subscriptionFailure = await this.synchronizeStartup(connector, generation, 'reconnect');
 
 				if (subscriptionFailure) {
 					this.markRuntimeDegraded(subscriptionFailure, generation);
@@ -769,6 +785,37 @@ export class HomeyService extends BaseManagedPluginService {
 		}
 	}
 
+	private async runInventoryReconciliation(
+		source: HomeyReconciliationSource,
+		operation: () => Promise<void>,
+	): Promise<void> {
+		const startedAt = Date.now();
+		this.reconciliationCount += 1;
+
+		try {
+			await operation();
+			this.lastReconciliationDurationMs = Math.max(0, Date.now() - startedAt);
+			this.logger.log('Homey inventory reconciliation completed', {
+				count: this.reconciliationCount,
+				deviceCount: this.devices.size,
+				durationMs: this.lastReconciliationDurationMs,
+				failureCount: this.reconciliationFailureCount,
+				source,
+			});
+		} catch (error) {
+			this.reconciliationFailureCount += 1;
+			this.lastReconciliationDurationMs = Math.max(0, Date.now() - startedAt);
+			this.logger.warn('Homey inventory reconciliation attempt failed', {
+				count: this.reconciliationCount,
+				durationMs: this.lastReconciliationDurationMs,
+				failureCount: this.reconciliationFailureCount,
+				source,
+			});
+
+			throw error;
+		}
+	}
+
 	private isCurrentGeneration(connector: HomeyConnector, generation: number): boolean {
 		return this.connector === connector && this.generation === generation;
 	}
@@ -871,6 +918,9 @@ export class HomeyService extends BaseManagedPluginService {
 		this.lastEventAt = null;
 		this.lastErrorCategory = null;
 		this.reconnectCount = 0;
+		this.reconciliationCount = 0;
+		this.reconciliationFailureCount = 0;
+		this.lastReconciliationDurationMs = null;
 	}
 
 	private recordSuccessfulConnection(): void {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -411,14 +411,22 @@ publish stale values. Removed or missing upstream devices become `lost` and no u
 
 ### Task 4.2: Implement reconciliation fallback
 
-- [ ] Reconcile all adopted devices immediately after every successful reconnect.
-- [ ] Reconcile inventory periodically at a conservative bounded interval.
-- [ ] Update current values, availability, renamed metadata where policy permits, and missing-upstream status.
-- [ ] Never delete orphaned Smart Panel devices automatically.
-- [ ] Prevent overlapping reconciliation runs and cap per-device errors.
-- [ ] Transition to `degraded_polling` when events are unavailable but reads succeed.
-- [ ] Expose reconciliation duration/count/failure metrics in status/logging.
-- [ ] Add fake-timer tests for scheduling, overlap prevention, reconnect, and shutdown.
+- [x] Reconcile all adopted devices immediately after every successful reconnect.
+- [x] Reconcile inventory periodically at a conservative bounded interval.
+- [x] Update current values, availability, renamed metadata where policy permits, and missing-upstream status.
+- [x] Never delete orphaned Smart Panel devices automatically.
+- [x] Prevent overlapping reconciliation runs and cap per-device errors.
+- [x] Transition to `degraded_polling` when events are unavailable but reads succeed.
+- [x] Expose reconciliation duration/count/failure metrics in status/logging.
+- [x] Add fake-timer tests for scheduling, overlap prevention, reconnect, and shutdown.
+
+Startup and every successful reconnect run a serialized authoritative snapshot before healthy state is published. A
+bounded configurable timer repeats that snapshot without overlap, and degraded event subscriptions retain the same
+read path in `degraded_polling`. Snapshot synchronization refreshes values and availability, marks missing upstream
+devices `lost`, isolates property failures into aggregate results, and has no local or upstream deletion path. Smart
+Panel names remain operator-owned, so upstream renames refresh inventory and discovery metadata without overwriting an
+adopted name. Status and sanitized structured logs expose attempt count, failed-attempt count, and latest duration;
+fake-timer coverage proves periodic scheduling, overlap prevention, reconnect reconciliation, and shutdown cleanup.
 
 ### Task 4.3: Implement Homey device control platform
 


### PR DESCRIPTION
## Summary

- expose Homey reconciliation attempt, failure, and duration metrics through the provider status API
- emit sanitized structured reconciliation summaries for startup, reconnect, and periodic inventory runs
- extend fake-timer coverage for polling, failed runs, reconnect reconciliation, overlap prevention, and elapsed duration
- complete Task 4.2 evidence while preserving operator-owned device names and the no-auto-delete policy

## Validation

- `pnpm exec jest --runInBand src/plugins/devices-homey` — 33 suites, 389 tests passed
- focused ESLint checks for changed backend files
- `pnpm run type-check`
- `pnpm run lint:api`
- Prettier and `git diff --check`

👍