### PR TITLE
test(cross): verify Homey panel compatibility

### DIFF
--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
@@ -133,6 +133,7 @@ describe('ChannelsPropertiesController', () => {
 					provide: PropertyCommandService,
 					useValue: {
 						processApiPropertyCommand: jest.fn().mockResolvedValue(undefined),
+						usesAuthoritativePropertyReadback: jest.fn().mockResolvedValue(false),
 					},
 				},
 			],
@@ -234,7 +235,37 @@ describe('ChannelsPropertiesController', () => {
 			expect(channelsPropertiesService.update).toHaveBeenCalledWith(mockChannelProperty.id, updateDto);
 		});
 
-		it('should dispatch a command value without persisting an optimistic measurement', async () => {
+		it('should persist a command value for a command-only platform', async () => {
+			const updateDto: UpdateChannelPropertyDto = {
+				type: 'mock',
+				value: 'command-state',
+			};
+
+			jest.spyOn(mapper, 'getMapping').mockReturnValue({
+				type: 'mock',
+				class: ChannelPropertyEntity,
+				createDto: CreateChannelPropertyDto,
+				updateDto: UpdateChannelPropertyDto,
+			});
+			jest
+				.spyOn(channelsService, 'findOne')
+				.mockResolvedValue(Object.assign(toInstance(ChannelEntity, mockChannel), { device: mockDevice }));
+
+			await controller.update(mockChannel.id, mockChannelProperty.id, { data: updateDto });
+
+			expect(channelsPropertiesService.update).toHaveBeenCalledWith(
+				mockChannelProperty.id,
+				expect.objectContaining({ type: 'mock', value: 'command-state' }),
+			);
+			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
+				mockDevice.id,
+				mockChannel.id,
+				mockChannelProperty.id,
+				'command-state',
+			);
+		});
+
+		it('should not persist a command value for an authoritative-readback platform', async () => {
 			const updateDto: UpdateChannelPropertyDto = {
 				type: 'mock',
 				value: 'reported-later',
@@ -249,6 +280,7 @@ describe('ChannelsPropertiesController', () => {
 			jest
 				.spyOn(channelsService, 'findOne')
 				.mockResolvedValue(Object.assign(toInstance(ChannelEntity, mockChannel), { device: mockDevice }));
+			jest.spyOn(propertyCommandService, 'usesAuthoritativePropertyReadback').mockResolvedValue(true);
 
 			await controller.update(mockChannel.id, mockChannelProperty.id, { data: updateDto });
 

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
@@ -288,6 +288,11 @@ describe('ChannelsPropertiesController', () => {
 				mockChannelProperty.id,
 				expect.objectContaining({ type: 'mock', value: undefined }),
 			);
+			expect(propertyCommandService.usesAuthoritativePropertyReadback).toHaveBeenCalledWith(
+				mockDevice,
+				expect.objectContaining({ id: mockChannelProperty.id }),
+				expect.objectContaining({ type: 'mock', value: 'reported-later' }),
+			);
 			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
 				mockDevice.id,
 				mockChannel.id,

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.spec.ts
@@ -37,6 +37,7 @@ describe('ChannelsPropertiesController', () => {
 	let channelsService: ChannelsService;
 	let channelsPropertiesService: ChannelsPropertiesService;
 	let mapper: ChannelsPropertiesTypeMapperService;
+	let propertyCommandService: PropertyCommandService;
 	let propertyTimeseriesService: PropertyTimeseriesService;
 
 	const mockDevice = {
@@ -143,6 +144,7 @@ describe('ChannelsPropertiesController', () => {
 		channelsService = module.get<ChannelsService>(ChannelsService);
 		channelsPropertiesService = module.get<ChannelsPropertiesService>(ChannelsPropertiesService);
 		mapper = module.get<ChannelsPropertiesTypeMapperService>(ChannelsPropertiesTypeMapperService);
+		propertyCommandService = module.get<PropertyCommandService>(PropertyCommandService);
 		propertyTimeseriesService = module.get<PropertyTimeseriesService>(PropertyTimeseriesService);
 	});
 
@@ -230,6 +232,36 @@ describe('ChannelsPropertiesController', () => {
 
 			expect(result.data).toEqual(toInstance(ChannelPropertyEntity, mockChannelProperty));
 			expect(channelsPropertiesService.update).toHaveBeenCalledWith(mockChannelProperty.id, updateDto);
+		});
+
+		it('should dispatch a command value without persisting an optimistic measurement', async () => {
+			const updateDto: UpdateChannelPropertyDto = {
+				type: 'mock',
+				value: 'reported-later',
+			};
+
+			jest.spyOn(mapper, 'getMapping').mockReturnValue({
+				type: 'mock',
+				class: ChannelPropertyEntity,
+				createDto: CreateChannelPropertyDto,
+				updateDto: UpdateChannelPropertyDto,
+			});
+			jest
+				.spyOn(channelsService, 'findOne')
+				.mockResolvedValue(Object.assign(toInstance(ChannelEntity, mockChannel), { device: mockDevice }));
+
+			await controller.update(mockChannel.id, mockChannelProperty.id, { data: updateDto });
+
+			expect(channelsPropertiesService.update).toHaveBeenCalledWith(
+				mockChannelProperty.id,
+				expect.objectContaining({ type: 'mock', value: undefined }),
+			);
+			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
+				mockDevice.id,
+				mockChannel.id,
+				mockChannelProperty.id,
+				'reported-later',
+			);
 		});
 
 		it('should delete a property', async () => {

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
@@ -371,17 +371,20 @@ export class ChannelsPropertiesController {
 			throw ValidationExceptionFactory.createException(errors);
 		}
 
+		const commandValue = dtoInstance.value;
+		dtoInstance.value = undefined;
+
 		try {
 			const updatedProperty = await this.channelsPropertiesService.update(property.id, dtoInstance);
 
 			this.logger.debug(`Successfully updated property id=${updatedProperty.id} for channelId=${channel.id}`);
 
 			// If value was provided, send command to the physical device (fire-and-forget)
-			if (typeof updateDto.data.value !== 'undefined' && updateDto.data.value !== null) {
+			if (typeof commandValue !== 'undefined' && commandValue !== null) {
 				const deviceId = typeof channel.device === 'string' ? channel.device : channel.device.id;
 
 				this.propertyCommandService
-					.processApiPropertyCommand(deviceId, channel.id, updatedProperty.id, updateDto.data.value)
+					.processApiPropertyCommand(deviceId, channel.id, updatedProperty.id, commandValue)
 					.catch((err: Error) => {
 						this.logger.error(`Failed to send device command for property id=${updatedProperty.id}: ${err.message}`);
 					});

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
@@ -372,10 +372,15 @@ export class ChannelsPropertiesController {
 		}
 
 		const commandValue = dtoInstance.value;
+		const effectivePropertyUpdate = { ...dtoInstance };
 		if (
 			typeof commandValue !== 'undefined' &&
 			commandValue !== null &&
-			(await this.propertyCommandService.usesAuthoritativePropertyReadback(channel.device, property))
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(
+				channel.device,
+				property,
+				effectivePropertyUpdate,
+			))
 		) {
 			dtoInstance.value = undefined;
 		}

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
@@ -372,7 +372,13 @@ export class ChannelsPropertiesController {
 		}
 
 		const commandValue = dtoInstance.value;
-		dtoInstance.value = undefined;
+		if (
+			typeof commandValue !== 'undefined' &&
+			commandValue !== null &&
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(channel.device))
+		) {
+			dtoInstance.value = undefined;
+		}
 
 		try {
 			const updatedProperty = await this.channelsPropertiesService.update(property.id, dtoInstance);

--- a/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/channels.properties.controller.ts
@@ -375,7 +375,7 @@ export class ChannelsPropertiesController {
 		if (
 			typeof commandValue !== 'undefined' &&
 			commandValue !== null &&
-			(await this.propertyCommandService.usesAuthoritativePropertyReadback(channel.device))
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(channel.device, property))
 		) {
 			dtoInstance.value = undefined;
 		}

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
@@ -39,6 +39,7 @@ describe('DevicesChannelsPropertiesController', () => {
 	let channelsService: ChannelsService;
 	let channelsPropertiesService: ChannelsPropertiesService;
 	let mapper: ChannelsPropertiesTypeMapperService;
+	let propertyCommandService: PropertyCommandService;
 	let propertyTimeseriesService: PropertyTimeseriesService;
 
 	const mockDevice = {
@@ -156,6 +157,7 @@ describe('DevicesChannelsPropertiesController', () => {
 		channelsService = module.get<ChannelsService>(ChannelsService);
 		channelsPropertiesService = module.get<ChannelsPropertiesService>(ChannelsPropertiesService);
 		mapper = module.get<ChannelsPropertiesTypeMapperService>(ChannelsPropertiesTypeMapperService);
+		propertyCommandService = module.get<PropertyCommandService>(PropertyCommandService);
 		propertyTimeseriesService = module.get<PropertyTimeseriesService>(PropertyTimeseriesService);
 	});
 
@@ -252,6 +254,33 @@ describe('DevicesChannelsPropertiesController', () => {
 
 			expect(result.data).toEqual(toInstance(ChannelPropertyEntity, mockChannelProperty));
 			expect(channelsPropertiesService.update).toHaveBeenCalledWith(mockChannelProperty.id, updateDto);
+		});
+
+		it('should dispatch a command value without persisting an optimistic measurement', async () => {
+			const updateDto: UpdateChannelPropertyDto = {
+				type: 'mock',
+				value: 'reported-later',
+			};
+
+			jest.spyOn(mapper, 'getMapping').mockReturnValue({
+				type: 'mock',
+				class: ChannelPropertyEntity,
+				createDto: CreateChannelPropertyDto,
+				updateDto: UpdateChannelPropertyDto,
+			});
+
+			await controller.update(mockDevice.id, mockChannel.id, mockChannelProperty.id, { data: updateDto });
+
+			expect(channelsPropertiesService.update).toHaveBeenCalledWith(
+				mockChannelProperty.id,
+				expect.objectContaining({ type: 'mock', value: undefined }),
+			);
+			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
+				mockDevice.id,
+				mockChannel.id,
+				mockChannelProperty.id,
+				'reported-later',
+			);
 		});
 
 		it('should delete a property', async () => {

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
@@ -304,6 +304,11 @@ describe('DevicesChannelsPropertiesController', () => {
 				mockChannelProperty.id,
 				expect.objectContaining({ type: 'mock', value: undefined }),
 			);
+			expect(propertyCommandService.usesAuthoritativePropertyReadback).toHaveBeenCalledWith(
+				expect.objectContaining({ id: mockDevice.id }),
+				expect.objectContaining({ id: mockChannelProperty.id }),
+				expect.objectContaining({ type: 'mock', value: 'reported-later' }),
+			);
 			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
 				mockDevice.id,
 				mockChannel.id,

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.spec.ts
@@ -145,6 +145,7 @@ describe('DevicesChannelsPropertiesController', () => {
 					provide: PropertyCommandService,
 					useValue: {
 						processApiPropertyCommand: jest.fn().mockResolvedValue(undefined),
+						usesAuthoritativePropertyReadback: jest.fn().mockResolvedValue(false),
 					},
 				},
 			],
@@ -256,7 +257,34 @@ describe('DevicesChannelsPropertiesController', () => {
 			expect(channelsPropertiesService.update).toHaveBeenCalledWith(mockChannelProperty.id, updateDto);
 		});
 
-		it('should dispatch a command value without persisting an optimistic measurement', async () => {
+		it('should persist a command value for a command-only platform', async () => {
+			const updateDto: UpdateChannelPropertyDto = {
+				type: 'mock',
+				value: 'command-state',
+			};
+
+			jest.spyOn(mapper, 'getMapping').mockReturnValue({
+				type: 'mock',
+				class: ChannelPropertyEntity,
+				createDto: CreateChannelPropertyDto,
+				updateDto: UpdateChannelPropertyDto,
+			});
+
+			await controller.update(mockDevice.id, mockChannel.id, mockChannelProperty.id, { data: updateDto });
+
+			expect(channelsPropertiesService.update).toHaveBeenCalledWith(
+				mockChannelProperty.id,
+				expect.objectContaining({ type: 'mock', value: 'command-state' }),
+			);
+			expect(propertyCommandService.processApiPropertyCommand).toHaveBeenCalledWith(
+				mockDevice.id,
+				mockChannel.id,
+				mockChannelProperty.id,
+				'command-state',
+			);
+		});
+
+		it('should not persist a command value for an authoritative-readback platform', async () => {
 			const updateDto: UpdateChannelPropertyDto = {
 				type: 'mock',
 				value: 'reported-later',
@@ -268,6 +296,7 @@ describe('DevicesChannelsPropertiesController', () => {
 				createDto: CreateChannelPropertyDto,
 				updateDto: UpdateChannelPropertyDto,
 			});
+			jest.spyOn(propertyCommandService, 'usesAuthoritativePropertyReadback').mockResolvedValue(true);
 
 			await controller.update(mockDevice.id, mockChannel.id, mockChannelProperty.id, { data: updateDto });
 

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
@@ -405,7 +405,13 @@ export class DevicesChannelsPropertiesController {
 		}
 
 		const commandValue = dtoInstance.value;
-		dtoInstance.value = undefined;
+		if (
+			typeof commandValue !== 'undefined' &&
+			commandValue !== null &&
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(device))
+		) {
+			dtoInstance.value = undefined;
+		}
 
 		try {
 			const updatedProperty = await this.channelsPropertiesService.update(property.id, dtoInstance);

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
@@ -405,10 +405,11 @@ export class DevicesChannelsPropertiesController {
 		}
 
 		const commandValue = dtoInstance.value;
+		const effectivePropertyUpdate = { ...dtoInstance };
 		if (
 			typeof commandValue !== 'undefined' &&
 			commandValue !== null &&
-			(await this.propertyCommandService.usesAuthoritativePropertyReadback(device, property))
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(device, property, effectivePropertyUpdate))
 		) {
 			dtoInstance.value = undefined;
 		}

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
@@ -404,6 +404,9 @@ export class DevicesChannelsPropertiesController {
 			throw ValidationExceptionFactory.createException(errors);
 		}
 
+		const commandValue = dtoInstance.value;
+		dtoInstance.value = undefined;
+
 		try {
 			const updatedProperty = await this.channelsPropertiesService.update(property.id, dtoInstance);
 
@@ -412,9 +415,9 @@ export class DevicesChannelsPropertiesController {
 			);
 
 			// If value was provided, send command to the physical device (fire-and-forget)
-			if (typeof updateDto.data.value !== 'undefined' && updateDto.data.value !== null) {
+			if (typeof commandValue !== 'undefined' && commandValue !== null) {
 				this.propertyCommandService
-					.processApiPropertyCommand(device.id, channel.id, updatedProperty.id, updateDto.data.value)
+					.processApiPropertyCommand(device.id, channel.id, updatedProperty.id, commandValue)
 					.catch((err: Error) => {
 						this.logger.error(`Failed to send device command for property id=${updatedProperty.id}: ${err.message}`);
 					});

--- a/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
+++ b/apps/backend/src/modules/devices/controllers/devices.channels.properties.controller.ts
@@ -408,7 +408,7 @@ export class DevicesChannelsPropertiesController {
 		if (
 			typeof commandValue !== 'undefined' &&
 			commandValue !== null &&
-			(await this.propertyCommandService.usesAuthoritativePropertyReadback(device))
+			(await this.propertyCommandService.usesAuthoritativePropertyReadback(device, property))
 		) {
 			dtoInstance.value = undefined;
 		}

--- a/apps/backend/src/modules/devices/platforms/device.platform.ts
+++ b/apps/backend/src/modules/devices/platforms/device.platform.ts
@@ -14,5 +14,7 @@ export interface IDevicePlatform {
 
 	getCommandTimeoutMs?(commandCount: number): number;
 
+	usesAuthoritativePropertyReadback?(): boolean;
+
 	getType(): string;
 }

--- a/apps/backend/src/modules/devices/platforms/device.platform.ts
+++ b/apps/backend/src/modules/devices/platforms/device.platform.ts
@@ -14,7 +14,7 @@ export interface IDevicePlatform {
 
 	getCommandTimeoutMs?(commandCount: number): number;
 
-	usesAuthoritativePropertyReadback?(): boolean;
+	usesAuthoritativePropertyReadback?(property: ChannelPropertyEntity): boolean;
 
 	getType(): string;
 }

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -1206,6 +1206,7 @@ describe('ChannelsPropertiesService', () => {
 				expect.objectContaining({ id: mockChannelProperty.id }),
 				'new value',
 				storageBinding,
+				undefined,
 			);
 			expect(propertyValueService.write).not.toHaveBeenCalled();
 			expect(eventEmitter.emit).toHaveBeenCalledWith(
@@ -1248,6 +1249,7 @@ describe('ChannelsPropertiesService', () => {
 				'new value',
 				null,
 				beforeValuePersistence,
+				undefined,
 			);
 			expect(propertyValueService.writeStrictWithState).not.toHaveBeenCalled();
 			expect(eventEmitter.emit).toHaveBeenCalledWith(

--- a/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.spec.ts
@@ -1180,6 +1180,38 @@ describe('ChannelsPropertiesService', () => {
 			expect(removalEntered).toBe(true);
 		});
 
+		it('resolves a value timestamp inside the serialized update before persistence', async () => {
+			const property = toInstance(MockChannelProperty, mockChannelProperty);
+			const valueTimestamp = new Date('2026-08-24T10:00:00.000Z');
+			const resolveValueTimestamp = jest.fn().mockReturnValue(valueTimestamp);
+			jest.spyOn(mapper, 'getMapping').mockReturnValue({
+				type: 'mock',
+				class: MockChannelProperty,
+				createDto: CreateMockChannelPropertyDto,
+				updateDto: UpdateMockChannelPropertyDto,
+			});
+			jest.spyOn(dataSource, 'getRepository').mockReturnValue(repository);
+			jest.spyOn(channelsPropertiesService, 'getOneOrThrow').mockResolvedValue(property);
+			jest.spyOn(repository, 'save').mockResolvedValue(property);
+			propertyValueService.write.mockResolvedValue(true);
+
+			await channelsPropertiesService.update(
+				property.id,
+				{ type: 'mock', value: 'new value' } as UpdateMockChannelPropertyDto,
+				{ resolveValueTimestamp },
+			);
+
+			expect(resolveValueTimestamp).toHaveBeenCalledTimes(1);
+			expect(propertyValueService.write).toHaveBeenCalledWith(
+				expect.objectContaining({ id: property.id }),
+				'new value',
+				valueTimestamp,
+			);
+			expect(resolveValueTimestamp.mock.invocationCallOrder[0]).toBeLessThan(
+				propertyValueService.write.mock.invocationCallOrder[0],
+			);
+		});
+
 		it('uses strict value persistence when the caller requires retry-safe storage', async () => {
 			const storageBinding = {} as StorageBackendBinding;
 			jest.spyOn(mapper, 'getMapping').mockReturnValue({

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -110,6 +110,7 @@ export interface ChannelPropertyUpdateOptions {
 	comparePersistedValue?: boolean;
 	expectedPersistedState?: PropertyValueState | null;
 	beforeValuePersistence?: () => Promise<void>;
+	valueTimestamp?: Date;
 }
 
 @Injectable()
@@ -859,6 +860,7 @@ export class ChannelsPropertiesService {
 						updateDto.value,
 						options.expectedPersistedState ?? null,
 						options.beforeValuePersistence,
+						options.valueTimestamp,
 					);
 					valueChanged = result.changed;
 					persistedValueState = result.state;
@@ -868,11 +870,12 @@ export class ChannelsPropertiesService {
 						raw,
 						updateDto.value,
 						options.storageBinding,
+						options.valueTimestamp,
 					);
 					valueChanged = result.changed;
 					persistedValueState = result.state;
 				} else {
-					valueChanged = await this.propertyValueService.write(raw, updateDto.value);
+					valueChanged = await this.propertyValueService.write(raw, updateDto.value, options.valueTimestamp);
 				}
 			}
 			const strictValueEventEmitted = options.strictValuePersistence === true && valueChanged;

--- a/apps/backend/src/modules/devices/services/channels.properties.service.ts
+++ b/apps/backend/src/modules/devices/services/channels.properties.service.ts
@@ -111,6 +111,7 @@ export interface ChannelPropertyUpdateOptions {
 	expectedPersistedState?: PropertyValueState | null;
 	beforeValuePersistence?: () => Promise<void>;
 	valueTimestamp?: Date;
+	resolveValueTimestamp?: () => Date;
 }
 
 @Injectable()
@@ -844,23 +845,22 @@ export class ChannelsPropertiesService {
 
 			// Track if value actually changed
 			//
-			// Deliberately not mirroring create()'s refusal above for a projected property. Here the value
-			// has a second, legitimate meaning: both property controllers dispatch it to the device's own
-			// platform right after this returns, and for a virtual device that platform forwards it to the
-			// source's — so the request is coherent and rejecting it would remove the only way to command a
-			// virtual device over REST. It is only the optimistic local echo into the source's series that is
-			// not coherent, and PropertyValueService.write() drops exactly that, leaving the source's own
-			// report to record what the hardware actually did.
+			// Deliberately not mirroring create()'s refusal above for a projected property. Service-level
+			// updates can carry provider measurements, while the REST controllers remove command values and
+			// dispatch them through PropertyCommandService instead. A projected property still owns no series,
+			// so PropertyValueService.write() drops any value here and leaves the source's own report to record
+			// what the hardware actually did.
 			let valueChanged = false;
 			let persistedValueState: PropertyValueState | null = null;
 			if (typeof updateDto.value !== 'undefined') {
+				const valueTimestamp = options.resolveValueTimestamp?.() ?? options.valueTimestamp;
 				if (options.strictValuePersistence && options.comparePersistedValue) {
 					const result = await this.propertyValueService.writeStrictIfPersistedDifferent(
 						raw,
 						updateDto.value,
 						options.expectedPersistedState ?? null,
 						options.beforeValuePersistence,
-						options.valueTimestamp,
+						valueTimestamp,
 					);
 					valueChanged = result.changed;
 					persistedValueState = result.state;
@@ -870,12 +870,12 @@ export class ChannelsPropertiesService {
 						raw,
 						updateDto.value,
 						options.storageBinding,
-						options.valueTimestamp,
+						valueTimestamp,
 					);
 					valueChanged = result.changed;
 					persistedValueState = result.state;
 				} else {
-					valueChanged = await this.propertyValueService.write(raw, updateDto.value, options.valueTimestamp);
+					valueChanged = await this.propertyValueService.write(raw, updateDto.value, valueTimestamp);
 				}
 			}
 			const strictValueEventEmitted = options.strictValuePersistence === true && valueChanged;

--- a/apps/backend/src/modules/devices/services/platform.registry.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/platform.registry.service.spec.ts
@@ -8,7 +8,7 @@ handling of Jest mocks, which ESLint rules flag unnecessarily.
 import { Logger } from '@nestjs/common';
 
 import { INTENT_CLEANUP_INTERVAL } from '../../intents/intents.constants';
-import { DeviceEntity } from '../entities/devices.entity';
+import { ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
 import { IDevicePlatform } from '../platforms/device.platform';
 
 import { PlatformRegistryService } from './platform.registry.service';
@@ -87,13 +87,14 @@ describe('PlatformRegistryService', () => {
 	it('should require platforms to opt into authoritative property readback', () => {
 		service.register(mockPlatform);
 		const device = { type: 'mock-platform' } as DeviceEntity;
+		const property = {} as ChannelPropertyEntity;
 
-		expect(service.usesAuthoritativePropertyReadback(device)).toBe(false);
+		expect(service.usesAuthoritativePropertyReadback(device, property)).toBe(false);
 
 		service = new PlatformRegistryService();
 		service.register({ ...mockPlatform, usesAuthoritativePropertyReadback: () => true });
 
-		expect(service.usesAuthoritativePropertyReadback(device)).toBe(true);
+		expect(service.usesAuthoritativePropertyReadback(device, property)).toBe(true);
 	});
 
 	it('should extend an intent TTL by registered platform completion windows', () => {

--- a/apps/backend/src/modules/devices/services/platform.registry.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/platform.registry.service.spec.ts
@@ -84,6 +84,18 @@ describe('PlatformRegistryService', () => {
 		expect(platforms).toEqual(['mock-platform']);
 	});
 
+	it('should require platforms to opt into authoritative property readback', () => {
+		service.register(mockPlatform);
+		const device = { type: 'mock-platform' } as DeviceEntity;
+
+		expect(service.usesAuthoritativePropertyReadback(device)).toBe(false);
+
+		service = new PlatformRegistryService();
+		service.register({ ...mockPlatform, usesAuthoritativePropertyReadback: () => true });
+
+		expect(service.usesAuthoritativePropertyReadback(device)).toBe(true);
+	});
+
 	it('should extend an intent TTL by registered platform completion windows', () => {
 		const timedPlatform = { ...mockPlatform, getCommandTimeoutMs: jest.fn((count: number) => count * 10000) };
 		service.register(timedPlatform);

--- a/apps/backend/src/modules/devices/services/platform.registry.service.ts
+++ b/apps/backend/src/modules/devices/services/platform.registry.service.ts
@@ -63,6 +63,10 @@ export class PlatformRegistryService {
 		return hasCustomTimeout ? completionWindowMs + defaultTtlMs + INTENT_CLEANUP_INTERVAL : defaultTtlMs;
 	}
 
+	usesAuthoritativePropertyReadback(device: DeviceEntity): boolean {
+		return this.get(device)?.usesAuthoritativePropertyReadback?.() ?? false;
+	}
+
 	list(): string[] {
 		return Object.keys(this.platforms);
 	}

--- a/apps/backend/src/modules/devices/services/platform.registry.service.ts
+++ b/apps/backend/src/modules/devices/services/platform.registry.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { createExtensionLogger } from '../../../common/logger/extension-logger.service';
 import { INTENT_CLEANUP_INTERVAL } from '../../intents/intents.constants';
 import { DEVICES_MODULE_NAME } from '../devices.constants';
-import { DeviceEntity } from '../entities/devices.entity';
+import { ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
 import { IDevicePlatform } from '../platforms/device.platform';
 
 export interface DevicePlatformCommandBudget {
@@ -63,8 +63,8 @@ export class PlatformRegistryService {
 		return hasCustomTimeout ? completionWindowMs + defaultTtlMs + INTENT_CLEANUP_INTERVAL : defaultTtlMs;
 	}
 
-	usesAuthoritativePropertyReadback(device: DeviceEntity): boolean {
-		return this.get(device)?.usesAuthoritativePropertyReadback?.() ?? false;
+	usesAuthoritativePropertyReadback(device: DeviceEntity, property: ChannelPropertyEntity): boolean {
+		return this.get(device)?.usesAuthoritativePropertyReadback?.(property) ?? false;
 	}
 
 	list(): string[] {

--- a/apps/backend/src/modules/devices/services/property-command.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.spec.ts
@@ -20,6 +20,7 @@ import {
 	PropertyCategory,
 } from '../devices.constants';
 import { PropertyCommandDto } from '../dto/property-command.dto';
+import { UpdateChannelPropertyDto } from '../dto/update-channel-property.dto';
 import { ChannelEntity, ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
 import { PropertyValueState } from '../models/property-value-state.model';
 import { IDevicePlatform } from '../platforms/device.platform';
@@ -184,6 +185,7 @@ describe('PropertyCommandService', () => {
 					useValue: {
 						get: jest.fn(),
 						getCommandTtlMs: jest.fn().mockReturnValue(DEFAULT_TTL_DEVICE_COMMAND),
+						usesAuthoritativePropertyReadback: jest.fn().mockReturnValue(false),
 					},
 				},
 				{
@@ -231,6 +233,28 @@ describe('PropertyCommandService', () => {
 			},
 		],
 	};
+
+	it('evaluates authoritative readback against the merged property update', async () => {
+		const device = toInstance(MockDevice, mockDevice);
+		const property = toInstance(MockChannelProperty, { ...mockChannelProperty, mockValue: 'readable' });
+		const update = {
+			type: 'mock',
+			value: true,
+			mockValue: 'write-only',
+		} as UpdateChannelPropertyDto & { mockValue: string };
+		const readbackSpy = jest
+			.spyOn(platformRegistryService, 'usesAuthoritativePropertyReadback')
+			.mockImplementation((_device, effectiveProperty) => {
+				expect(effectiveProperty).toBeInstanceOf(MockChannelProperty);
+				expect((effectiveProperty as MockChannelProperty).mockValue).toBe('write-only');
+				expect(property.mockValue).toBe('readable');
+
+				return false;
+			});
+
+		await expect(service.usesAuthoritativePropertyReadback(device, property, update)).resolves.toBe(false);
+		expect(readbackSpy).toHaveBeenCalledWith(device, expect.objectContaining({ value: true }));
+	});
 
 	it('should validate and process a valid command', async () => {
 		jest.spyOn(devicesService, 'findOne').mockResolvedValue(toInstance(MockDevice, mockDevice));

--- a/apps/backend/src/modules/devices/services/property-command.service.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.ts
@@ -13,6 +13,7 @@ import { ClientUserDto } from '../../websocket/dto/client-user.dto';
 import { WebsocketNotAllowedException } from '../../websocket/websocket.exceptions';
 import { ConnectionState, DEVICES_MODULE_NAME, PermissionType } from '../devices.constants';
 import { PropertyCommandDto, PropertyCommandValueDto } from '../dto/property-command.dto';
+import { DeviceEntity } from '../entities/devices.entity';
 import { IDevicePropertyData } from '../platforms/device.platform';
 import { PropertyCommandValue, validatePropertyCommandValue } from '../utils/property-command-value.utils';
 
@@ -410,5 +411,11 @@ export class PropertyCommandService {
 
 			this.logger.warn(`[API Command] Failed for deviceId=${deviceId}: ${reason}`);
 		}
+	}
+
+	async usesAuthoritativePropertyReadback(device: DeviceEntity | string): Promise<boolean> {
+		const resolvedDevice = typeof device === 'string' ? await this.devicesService.findOne(device) : device;
+
+		return resolvedDevice !== null && this.platformRegistryService.usesAuthoritativePropertyReadback(resolvedDevice);
 	}
 }

--- a/apps/backend/src/modules/devices/services/property-command.service.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.ts
@@ -13,6 +13,7 @@ import { ClientUserDto } from '../../websocket/dto/client-user.dto';
 import { WebsocketNotAllowedException } from '../../websocket/websocket.exceptions';
 import { ConnectionState, DEVICES_MODULE_NAME, PermissionType } from '../devices.constants';
 import { PropertyCommandDto, PropertyCommandValueDto } from '../dto/property-command.dto';
+import { UpdateChannelPropertyDto } from '../dto/update-channel-property.dto';
 import { ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
 import { IDevicePropertyData } from '../platforms/device.platform';
 import { PropertyCommandValue, validatePropertyCommandValue } from '../utils/property-command-value.utils';
@@ -416,12 +417,16 @@ export class PropertyCommandService {
 	async usesAuthoritativePropertyReadback(
 		device: DeviceEntity | string,
 		property: ChannelPropertyEntity,
+		update?: UpdateChannelPropertyDto,
 	): Promise<boolean> {
 		const resolvedDevice = typeof device === 'string' ? await this.devicesService.findOne(device) : device;
+		const effectiveProperty = update
+			? (Object.setPrototypeOf({ ...property, ...update }, Reflect.getPrototypeOf(property)) as ChannelPropertyEntity)
+			: property;
 
 		return (
 			resolvedDevice !== null &&
-			this.platformRegistryService.usesAuthoritativePropertyReadback(resolvedDevice, property)
+			this.platformRegistryService.usesAuthoritativePropertyReadback(resolvedDevice, effectiveProperty)
 		);
 	}
 }

--- a/apps/backend/src/modules/devices/services/property-command.service.ts
+++ b/apps/backend/src/modules/devices/services/property-command.service.ts
@@ -13,7 +13,7 @@ import { ClientUserDto } from '../../websocket/dto/client-user.dto';
 import { WebsocketNotAllowedException } from '../../websocket/websocket.exceptions';
 import { ConnectionState, DEVICES_MODULE_NAME, PermissionType } from '../devices.constants';
 import { PropertyCommandDto, PropertyCommandValueDto } from '../dto/property-command.dto';
-import { DeviceEntity } from '../entities/devices.entity';
+import { ChannelPropertyEntity, DeviceEntity } from '../entities/devices.entity';
 import { IDevicePropertyData } from '../platforms/device.platform';
 import { PropertyCommandValue, validatePropertyCommandValue } from '../utils/property-command-value.utils';
 
@@ -413,9 +413,15 @@ export class PropertyCommandService {
 		}
 	}
 
-	async usesAuthoritativePropertyReadback(device: DeviceEntity | string): Promise<boolean> {
+	async usesAuthoritativePropertyReadback(
+		device: DeviceEntity | string,
+		property: ChannelPropertyEntity,
+	): Promise<boolean> {
 		const resolvedDevice = typeof device === 'string' ? await this.devicesService.findOne(device) : device;
 
-		return resolvedDevice !== null && this.platformRegistryService.usesAuthoritativePropertyReadback(resolvedDevice);
+		return (
+			resolvedDevice !== null &&
+			this.platformRegistryService.usesAuthoritativePropertyReadback(resolvedDevice, property)
+		);
 	}
 }

--- a/apps/backend/src/modules/devices/services/property-value.service.spec.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.spec.ts
@@ -84,6 +84,27 @@ describe('PropertyValueService', () => {
 			]);
 		});
 
+		it('preserves a provider measurement timestamp in storage and cache', async () => {
+			const property = {
+				id: 'timestamped-property-id',
+				dataType: DataTypeType.INT,
+				invalid: null,
+				format: null,
+				step: null,
+			} as ChannelPropertyEntity;
+			const measuredAt = new Date('2026-08-24T10:01:02.345Z');
+
+			await expect(service.write(property, 42, measuredAt)).resolves.toBe(true);
+
+			expect(storageService.writePoints).toHaveBeenCalledWith([expect.objectContaining({ timestamp: measuredAt })]);
+			expect(await service.readLatest(property)).toEqual(
+				expect.objectContaining({
+					value: 42,
+					lastUpdated: measuredAt.toISOString(),
+				}),
+			);
+		});
+
 		it('does not cache a strict value until storage persists it', async () => {
 			const property = {
 				id: 'strict-property-id',

--- a/apps/backend/src/modules/devices/services/property-value.service.ts
+++ b/apps/backend/src/modules/devices/services/property-value.service.ts
@@ -113,10 +113,15 @@ export class PropertyValueService {
 	 * Write property value to storage
 	 * @returns true if value changed, false if value was the same or invalid
 	 */
-	async write(property: ChannelPropertyEntity, value: string | boolean | number | null): Promise<boolean> {
+	async write(
+		property: ChannelPropertyEntity,
+		value: string | boolean | number | null,
+		valueTimestamp?: Date,
+	): Promise<boolean> {
 		const key = this.valueSourceRegistry.resolve(property);
 
-		return (await this.withValueLock(key, () => this.writeInternal(property, value, false))).changed;
+		return (await this.withValueLock(key, () => this.writeInternal(property, value, false, undefined, valueTimestamp)))
+			.changed;
 	}
 
 	/**
@@ -136,10 +141,11 @@ export class PropertyValueService {
 		property: ChannelPropertyEntity,
 		value: string | boolean | number | null,
 		storageBinding?: StorageBackendBinding,
+		valueTimestamp?: Date,
 	): Promise<PropertyValueWriteResult> {
 		const key = this.valueSourceRegistry.resolve(property);
 
-		return this.withValueLock(key, () => this.writeInternal(property, value, true, storageBinding));
+		return this.withValueLock(key, () => this.writeInternal(property, value, true, storageBinding, valueTimestamp));
 	}
 
 	async writeStrictIfPersistedDifferent(
@@ -147,6 +153,7 @@ export class PropertyValueService {
 		value: string | boolean | number | null,
 		expectedPersistedState: PropertyValueState | null,
 		beforeWrite?: () => Promise<void>,
+		valueTimestamp?: Date,
 	): Promise<PropertyValueWriteResult> {
 		const key = this.valueSourceRegistry.resolve(property);
 
@@ -165,7 +172,7 @@ export class PropertyValueService {
 			}
 			await valueLease.assertOwned();
 
-			return this.writeInternal(property, value, true, latest.storageBinding);
+			return this.writeInternal(property, value, true, latest.storageBinding, valueTimestamp);
 		});
 	}
 
@@ -174,6 +181,7 @@ export class PropertyValueService {
 		value: string | boolean | number | null,
 		strict: boolean,
 		storageBinding?: StorageBackendBinding,
+		valueTimestamp?: Date,
 	): Promise<PropertyValueWriteResult> {
 		const key = this.valueSourceRegistry.resolve(property);
 
@@ -220,7 +228,7 @@ export class PropertyValueService {
 		const cached = this.valuesMap.get(key);
 		if (!strict && cached && cached.value === value) {
 			// no change → skip storage write, but refresh lastUpdated so freshness stays accurate
-			cached.lastUpdated = new Date().toISOString();
+			cached.lastUpdated = (valueTimestamp ?? new Date()).toISOString();
 			this.bumpCacheVersion(key);
 			return { changed: false, state: cached };
 		}
@@ -262,7 +270,7 @@ export class PropertyValueService {
 				return { changed: false, state: null };
 		}
 
-		const timestamp = new Date();
+		const timestamp = valueTimestamp ?? new Date();
 		const now = timestamp.toISOString();
 		const point = {
 			measurement: 'property_value',

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
@@ -226,7 +226,16 @@ describe('HomeyDevicePlatform', () => {
 		);
 
 		expect(platform.getCommandTimeoutMs(2)).toBe(HOMEY_COMMAND_MAX_DURATION_MS * 2);
-		expect(platform.usesAuthoritativePropertyReadback()).toBe(true);
+		expect(
+			platform.usesAuthoritativePropertyReadback(
+				Object.assign(new HomeyChannelPropertyEntity(), { permissions: [PermissionType.READ_WRITE] }),
+			),
+		).toBe(true);
+		expect(
+			platform.usesAuthoritativePropertyReadback(
+				Object.assign(new HomeyChannelPropertyEntity(), { permissions: [PermissionType.WRITE_ONLY] }),
+			),
+		).toBe(false);
 	});
 
 	it.each(commandCases)('transforms and sends a validated $label command', async (command) => {

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
@@ -226,16 +226,35 @@ describe('HomeyDevicePlatform', () => {
 		);
 
 		expect(platform.getCommandTimeoutMs(2)).toBe(HOMEY_COMMAND_MAX_DURATION_MS * 2);
-		expect(
-			platform.usesAuthoritativePropertyReadback(
-				Object.assign(new HomeyChannelPropertyEntity(), { permissions: [PermissionType.READ_WRITE] }),
-			),
-		).toBe(true);
-		expect(
-			platform.usesAuthoritativePropertyReadback(
-				Object.assign(new HomeyChannelPropertyEntity(), { permissions: [PermissionType.WRITE_ONLY] }),
-			),
-		).toBe(false);
+	});
+
+	it('reports authoritative readback from the current resolved property mapping', () => {
+		const readableMapping = mapping(commandCases[0]);
+		const writeOnlyMapping = mapping(commandCases.find((command) => command.label === 'cover command'));
+		const platform = new HomeyDevicePlatform(
+			{} as HomeyService,
+			{
+				getPropertyMappings: () => [readableMapping, writeOnlyMapping],
+			} as unknown as HomeyMappingLoaderService,
+			{} as HomeyMappingTransformerService,
+		);
+		const property = Object.assign(new HomeyChannelPropertyEntity(), {
+			homeyCapabilityId: 'capability.main',
+			homeyMappingName: readableMapping.name,
+			permissions: [PermissionType.WRITE_ONLY],
+		});
+
+		expect(platform.usesAuthoritativePropertyReadback(property)).toBe(true);
+
+		property.homeyMappingName = writeOnlyMapping.name;
+		property.permissions = [PermissionType.READ_WRITE];
+		expect(platform.usesAuthoritativePropertyReadback(property)).toBe(false);
+
+		property.homeyMappingName = 'removed-mapping';
+		expect(platform.usesAuthoritativePropertyReadback(property)).toBe(false);
+
+		property.homeyCapabilityId = null;
+		expect(platform.usesAuthoritativePropertyReadback(property)).toBe(false);
 	});
 
 	it.each(commandCases)('transforms and sends a validated $label command', async (command) => {

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.spec.ts
@@ -226,6 +226,7 @@ describe('HomeyDevicePlatform', () => {
 		);
 
 		expect(platform.getCommandTimeoutMs(2)).toBe(HOMEY_COMMAND_MAX_DURATION_MS * 2);
+		expect(platform.usesAuthoritativePropertyReadback()).toBe(true);
 	});
 
 	it.each(commandCases)('transforms and sends a validated $label command', async (command) => {

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
@@ -49,6 +49,10 @@ export class HomeyDevicePlatform implements IDevicePlatform {
 		return Math.max(0, commandCount) * HOMEY_COMMAND_MAX_DURATION_MS;
 	}
 
+	usesAuthoritativePropertyReadback(): boolean {
+		return true;
+	}
+
 	process(update: HomeyDevicePropertyData): Promise<boolean> {
 		return this.processBatch([update]);
 	}

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { createExtensionLogger } from '../../../common/logger';
 import { PermissionType } from '../../../modules/devices/devices.constants';
+import { ChannelPropertyEntity } from '../../../modules/devices/entities/devices.entity';
 import { IDevicePlatform, IDevicePropertyData } from '../../../modules/devices/platforms/device.platform';
 import { validatePropertyCommandValue } from '../../../modules/devices/utils/property-command-value.utils';
 import {
@@ -49,8 +50,8 @@ export class HomeyDevicePlatform implements IDevicePlatform {
 		return Math.max(0, commandCount) * HOMEY_COMMAND_MAX_DURATION_MS;
 	}
 
-	usesAuthoritativePropertyReadback(): boolean {
-		return true;
+	usesAuthoritativePropertyReadback(property: ChannelPropertyEntity): boolean {
+		return property.permissions.includes(PermissionType.READ_WRITE);
 	}
 
 	process(update: HomeyDevicePropertyData): Promise<boolean> {

--- a/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
+++ b/apps/backend/src/plugins/devices-homey/platforms/homey-device.platform.ts
@@ -51,7 +51,19 @@ export class HomeyDevicePlatform implements IDevicePlatform {
 	}
 
 	usesAuthoritativePropertyReadback(property: ChannelPropertyEntity): boolean {
-		return property.permissions.includes(PermissionType.READ_WRITE);
+		if (
+			!(property instanceof HomeyChannelPropertyEntity) ||
+			typeof property.homeyCapabilityId !== 'string' ||
+			typeof property.homeyMappingName !== 'string'
+		) {
+			return false;
+		}
+
+		const mapping = this.mappingLoader
+			.getPropertyMappings()
+			.find((candidate) => candidate.name === property.homeyMappingName);
+
+		return mapping !== undefined && mapping.property.direction !== 'write_only';
 	}
 
 	process(update: HomeyDevicePropertyData): Promise<boolean> {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -20,6 +20,13 @@ import { HomeyEvent, HomeyEventType } from '../models/homey-event.model';
 
 import { HomeySynchronizerService } from './homey-synchronizer.service';
 
+const BACKEND_RECEIVED_AT = '2026-08-24T10:00:00.000Z';
+const BACKEND_RECEIVED_AT_MS = new Date(BACKEND_RECEIVED_AT).getTime();
+
+function backendValueTimestamp(offset = 0): { valueTimestamp: Date } {
+	return { valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + offset) };
+}
+
 const powerMapping: ResolvedHomeyPropertyMapping = {
 	kind: 'properties',
 	source: 'builtin',
@@ -188,6 +195,7 @@ describe('HomeySynchronizerService', () => {
 	let brightnessProperty: HomeyChannelPropertyEntity;
 
 	beforeEach(() => {
+		jest.spyOn(Date, 'now').mockReturnValue(BACKEND_RECEIVED_AT_MS);
 		powerProperty = property('property-power', 'onoff', powerMapping.name);
 		stateProperty = property('property-state', 'onoff', stateMapping.name);
 		brightnessProperty = property('property-brightness', 'dim', brightnessMapping.name);
@@ -217,6 +225,10 @@ describe('HomeySynchronizerService', () => {
 		);
 	});
 
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('indexes adopted full capability identities and applies the authoritative startup snapshot', async () => {
 		await expect(service.synchronizeSnapshot([homeyDevice()])).resolves.toEqual({
 			updated: 4,
@@ -233,7 +245,7 @@ describe('HomeySynchronizerService', () => {
 		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
 			state: ConnectionState.CONNECTED,
 		});
-		const valueTimestamp = { valueTimestamp: new Date('2026-08-21T10:00:00.000Z') };
+		const valueTimestamp = backendValueTimestamp();
 		expect(propertiesService.update.mock.calls).toEqual([
 			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, valueTimestamp],
 			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, valueTimestamp],
@@ -296,7 +308,7 @@ describe('HomeySynchronizerService', () => {
 				type: DEVICES_HOMEY_TYPE,
 				value: 25,
 			},
-			{ valueTimestamp: new Date('2026-08-21T10:00:00.000Z') },
+			backendValueTimestamp(),
 		);
 	});
 
@@ -306,27 +318,26 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([capabilityEvent('onoff', null, null)], inventory());
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: null }],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: null }],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: null }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: null }, backendValueTimestamp()],
 		]);
 	});
 
-	it('passes the originating Homey event timestamp to value persistence', async () => {
+	it('orders by Homey event metadata while persisting backend receive timestamps', async () => {
 		await service.refreshIndex();
-		const measuredAt = '2026-08-24T10:01:02.345Z';
+		const futureProviderTimestamp = '2027-08-24T10:00:00.000Z';
+		const pastProviderTimestamp = '2025-08-24T10:00:00.000Z';
 
-		await service.synchronizeEvents([capabilityEvent('onoff', false, measuredAt)], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, futureProviderTimestamp, 1)], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', true, pastProviderTimestamp, 2)], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, '2028-08-24T10:00:00.000Z', 1)], inventory());
 
-		expect(propertiesService.update).toHaveBeenCalledWith(
-			'property-power',
-			{ type: DEVICES_HOMEY_TYPE, value: false },
-			{ valueTimestamp: new Date(measuredAt) },
-		);
-		expect(propertiesService.update).toHaveBeenCalledWith(
-			'property-state',
-			{ type: DEVICES_HOMEY_TYPE, value: 'off' },
-			{ valueTimestamp: new Date(measuredAt) },
-		);
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp(1)],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, backendValueTimestamp(1)],
+		]);
 	});
 
 	it('reports whether a capability has a readable property binding', async () => {
@@ -375,21 +386,9 @@ describe('HomeySynchronizerService', () => {
 		);
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			[
-				'property-brightness',
-				{ type: DEVICES_HOMEY_TYPE, value: 50 },
-				{ valueTimestamp: new Date('2026-08-21T10:01:01.000Z') },
-			],
-			[
-				'property-power',
-				{ type: DEVICES_HOMEY_TYPE, value: false },
-				{ valueTimestamp: new Date('2026-08-21T10:01:02.000Z') },
-			],
-			[
-				'property-state',
-				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
-				{ valueTimestamp: new Date('2026-08-21T10:01:02.000Z') },
-			],
+			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 50 }, backendValueTimestamp()],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
 		]);
 	});
 
@@ -408,7 +407,7 @@ describe('HomeySynchronizerService', () => {
 				type: DEVICES_HOMEY_TYPE,
 				value: true,
 			},
-			{ valueTimestamp: new Date('2026-08-21T10:02:00.000Z') },
+			backendValueTimestamp(),
 		);
 	});
 
@@ -421,8 +420,8 @@ describe('HomeySynchronizerService', () => {
 		);
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
 		]);
 	});
 
@@ -435,10 +434,14 @@ describe('HomeySynchronizerService', () => {
 		const rejected = await service.synchronizeEvents([stale], inventory());
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(2);
-		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
-			type: DEVICES_HOMEY_TYPE,
-			value: true,
-		});
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-power',
+			{
+				type: DEVICES_HOMEY_TYPE,
+				value: true,
+			},
+			backendValueTimestamp(),
+		);
 		expect(accepted.acceptedEvents).toEqual([newest]);
 		expect(rejected.acceptedEvents).toEqual([]);
 	});
@@ -452,18 +455,10 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([capabilityEvent('onoff', false, secondTimestamp, 2)], inventory());
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, { valueTimestamp: new Date(firstTimestamp) }],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, { valueTimestamp: new Date(firstTimestamp) }],
-			[
-				'property-power',
-				{ type: DEVICES_HOMEY_TYPE, value: false },
-				{ valueTimestamp: new Date('2026-08-21T10:02:00.001Z') },
-			],
-			[
-				'property-state',
-				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
-				{ valueTimestamp: new Date('2026-08-21T10:02:00.001Z') },
-			],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, backendValueTimestamp()],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp(1)],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp(1)],
 		]);
 	});
 
@@ -471,7 +466,7 @@ describe('HomeySynchronizerService', () => {
 		await service.refreshIndex();
 		await service.synchronizeEvents([capabilityEvent('onoff', true, '2026-08-21T10:02:00.000Z', 1)], inventory());
 
-		const durableTimestamp = '2026-08-21T10:03:00.000Z';
+		const durableTimestamp = new Date(BACKEND_RECEIVED_AT_MS + 60_000).toISOString();
 		powerProperty.value = new PropertyValueState(true, durableTimestamp);
 		stateProperty.value = new PropertyValueState('on', durableTimestamp);
 		service.reset();
@@ -484,19 +479,19 @@ describe('HomeySynchronizerService', () => {
 			[
 				'property-power',
 				{ type: DEVICES_HOMEY_TYPE, value: false },
-				{ valueTimestamp: new Date('2026-08-21T10:03:00.001Z') },
+				{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 60_001) },
 			],
 			[
 				'property-state',
 				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
-				{ valueTimestamp: new Date('2026-08-21T10:03:00.001Z') },
+				{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 60_001) },
 			],
 		]);
 	});
 
 	it('includes local property writes in the persistence watermark', async () => {
 		await service.refreshIndex();
-		const commandTimestamp = '2026-08-21T10:04:00.000Z';
+		const commandTimestamp = new Date(BACKEND_RECEIVED_AT_MS + 120_000).toISOString();
 		powerProperty.value = new PropertyValueState(true, commandTimestamp);
 		service.recordPersistedPropertyValue(powerProperty);
 
@@ -505,7 +500,7 @@ describe('HomeySynchronizerService', () => {
 		expect(propertiesService.update).toHaveBeenCalledWith(
 			'property-power',
 			{ type: DEVICES_HOMEY_TYPE, value: false },
-			{ valueTimestamp: new Date('2026-08-21T10:04:00.001Z') },
+			{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 120_001) },
 		);
 	});
 
@@ -537,7 +532,7 @@ describe('HomeySynchronizerService', () => {
 		const retried = await service.synchronizeEvents([newest], inventory());
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp()],
 		]);
 		expect(retried.acceptedEvents).toEqual([newest]);
 	});
@@ -906,10 +901,14 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], inventory());
 
 		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
-		expect(propertiesService.update).toHaveBeenLastCalledWith('replacement-power', {
-			type: DEVICES_HOMEY_TYPE,
-			value: false,
-		});
+		expect(propertiesService.update).toHaveBeenLastCalledWith(
+			'replacement-power',
+			{
+				type: DEVICES_HOMEY_TYPE,
+				value: false,
+			},
+			backendValueTimestamp(),
+		);
 	});
 
 	it('repeats an in-flight refresh when the device structure changes during its database read', async () => {
@@ -932,9 +931,13 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([capabilityEvent('onoff', false, null)], inventory());
 
 		expect(devicesService.findAll).toHaveBeenCalledTimes(2);
-		expect(propertiesService.update).toHaveBeenCalledWith('replacement-power', {
-			type: DEVICES_HOMEY_TYPE,
-			value: false,
-		});
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'replacement-power',
+			{
+				type: DEVICES_HOMEY_TYPE,
+				value: false,
+			},
+			backendValueTimestamp(),
+		);
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -5,6 +5,7 @@ import {
 	PermissionType,
 	PropertyCategory,
 } from '../../../modules/devices/devices.constants';
+import { PropertyValueState } from '../../../modules/devices/models/property-value-state.model';
 import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
 import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
@@ -462,6 +463,33 @@ describe('HomeySynchronizerService', () => {
 				'property-state',
 				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
 				{ valueTimestamp: new Date('2026-08-21T10:02:00.001Z') },
+			],
+		]);
+	});
+
+	it('rebuilds persistence watermarks from loaded values after reset', async () => {
+		await service.refreshIndex();
+		await service.synchronizeEvents([capabilityEvent('onoff', true, '2026-08-21T10:02:00.000Z', 1)], inventory());
+
+		const durableTimestamp = '2026-08-21T10:03:00.000Z';
+		powerProperty.value = new PropertyValueState(true, durableTimestamp);
+		stateProperty.value = new PropertyValueState('on', durableTimestamp);
+		service.reset();
+		propertiesService.update.mockClear();
+		await service.refreshIndex();
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z', 2)], inventory());
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			[
+				'property-power',
+				{ type: DEVICES_HOMEY_TYPE, value: false },
+				{ valueTimestamp: new Date('2026-08-21T10:03:00.001Z') },
+			],
+			[
+				'property-state',
+				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
+				{ valueTimestamp: new Date('2026-08-21T10:03:00.001Z') },
 			],
 		]);
 	});

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -494,6 +494,21 @@ describe('HomeySynchronizerService', () => {
 		]);
 	});
 
+	it('includes local property writes in the persistence watermark', async () => {
+		await service.refreshIndex();
+		const commandTimestamp = '2026-08-21T10:04:00.000Z';
+		powerProperty.value = new PropertyValueState(true, commandTimestamp);
+		service.recordPersistedPropertyValue(powerProperty);
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z', 1)], inventory());
+
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-power',
+			{ type: DEVICES_HOMEY_TYPE, value: false },
+			{ valueTimestamp: new Date('2026-08-21T10:04:00.001Z') },
+		);
+	});
+
 	it('rejects a conflicting capability value at an already-applied order', async () => {
 		await service.refreshIndex();
 		const applied = capabilityEvent('onoff', true, null, 2);

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -6,7 +6,10 @@ import {
 	PropertyCategory,
 } from '../../../modules/devices/devices.constants';
 import { PropertyValueState } from '../../../modules/devices/models/property-value-state.model';
-import { ChannelsPropertiesService } from '../../../modules/devices/services/channels.properties.service';
+import {
+	ChannelPropertyUpdateOptions,
+	ChannelsPropertiesService,
+} from '../../../modules/devices/services/channels.properties.service';
 import { DeviceConnectivityService } from '../../../modules/devices/services/device-connectivity.service';
 import { DevicesService } from '../../../modules/devices/services/devices.service';
 import { DEVICES_HOMEY_TYPE } from '../devices-homey.constants';
@@ -23,8 +26,8 @@ import { HomeySynchronizerService } from './homey-synchronizer.service';
 const BACKEND_RECEIVED_AT = '2026-08-24T10:00:00.000Z';
 const BACKEND_RECEIVED_AT_MS = new Date(BACKEND_RECEIVED_AT).getTime();
 
-function backendValueTimestamp(offset = 0): { valueTimestamp: Date } {
-	return { valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + offset) };
+function backendValueTimestamp(): { resolveValueTimestamp: jest.AsymmetricMatcher } {
+	return { resolveValueTimestamp: expect.any(Function) as unknown as jest.AsymmetricMatcher };
 }
 
 const powerMapping: ResolvedHomeyPropertyMapping = {
@@ -193,16 +196,27 @@ describe('HomeySynchronizerService', () => {
 	let powerProperty: HomeyChannelPropertyEntity;
 	let stateProperty: HomeyChannelPropertyEntity;
 	let brightnessProperty: HomeyChannelPropertyEntity;
+	let persistedValueTimestamps: Date[];
 
 	beforeEach(() => {
 		jest.spyOn(Date, 'now').mockReturnValue(BACKEND_RECEIVED_AT_MS);
+		persistedValueTimestamps = [];
 		powerProperty = property('property-power', 'onoff', powerMapping.name);
 		stateProperty = property('property-state', 'onoff', stateMapping.name);
 		brightnessProperty = property('property-brightness', 'dim', brightnessMapping.name);
 		devicesService = {
 			findAll: jest.fn().mockResolvedValue([adoptedDevice([powerProperty, stateProperty, brightnessProperty])]),
 		};
-		propertiesService = { update: jest.fn().mockResolvedValue(new HomeyChannelPropertyEntity()) };
+		propertiesService = {
+			update: jest.fn().mockImplementation((_id: string, _dto: unknown, options?: ChannelPropertyUpdateOptions) => {
+				const valueTimestamp = options?.resolveValueTimestamp?.();
+				if (valueTimestamp !== undefined) {
+					persistedValueTimestamps.push(valueTimestamp);
+				}
+
+				return Promise.resolve(new HomeyChannelPropertyEntity());
+			}),
+		};
 		connectivityService = { trySetConnectionState: jest.fn().mockResolvedValue(true) };
 		mappingLoader = {
 			getPropertyMappings: jest.fn().mockReturnValue([powerMapping, stateMapping, brightnessMapping]),
@@ -335,8 +349,14 @@ describe('HomeySynchronizerService', () => {
 		expect(propertiesService.update.mock.calls).toEqual([
 			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
 			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp(1)],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, backendValueTimestamp(1)],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, backendValueTimestamp()],
+		]);
+		expect(persistedValueTimestamps).toEqual([
+			new Date(BACKEND_RECEIVED_AT_MS),
+			new Date(BACKEND_RECEIVED_AT_MS),
+			new Date(BACKEND_RECEIVED_AT_MS + 1),
+			new Date(BACKEND_RECEIVED_AT_MS + 1),
 		]);
 	});
 
@@ -457,8 +477,14 @@ describe('HomeySynchronizerService', () => {
 		expect(propertiesService.update.mock.calls).toEqual([
 			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, backendValueTimestamp()],
 			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, backendValueTimestamp()],
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp(1)],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp(1)],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
+		]);
+		expect(persistedValueTimestamps).toEqual([
+			new Date(BACKEND_RECEIVED_AT_MS),
+			new Date(BACKEND_RECEIVED_AT_MS),
+			new Date(BACKEND_RECEIVED_AT_MS + 1),
+			new Date(BACKEND_RECEIVED_AT_MS + 1),
 		]);
 	});
 
@@ -471,21 +497,18 @@ describe('HomeySynchronizerService', () => {
 		stateProperty.value = new PropertyValueState('on', durableTimestamp);
 		service.reset();
 		propertiesService.update.mockClear();
+		persistedValueTimestamps.length = 0;
 		await service.refreshIndex();
 
 		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z', 2)], inventory());
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			[
-				'property-power',
-				{ type: DEVICES_HOMEY_TYPE, value: false },
-				{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 60_001) },
-			],
-			[
-				'property-state',
-				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
-				{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 60_001) },
-			],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }, backendValueTimestamp()],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }, backendValueTimestamp()],
+		]);
+		expect(persistedValueTimestamps).toEqual([
+			new Date(BACKEND_RECEIVED_AT_MS + 60_001),
+			new Date(BACKEND_RECEIVED_AT_MS + 60_001),
 		]);
 	});
 
@@ -500,8 +523,30 @@ describe('HomeySynchronizerService', () => {
 		expect(propertiesService.update).toHaveBeenCalledWith(
 			'property-power',
 			{ type: DEVICES_HOMEY_TYPE, value: false },
-			{ valueTimestamp: new Date(BACKEND_RECEIVED_AT_MS + 120_001) },
+			backendValueTimestamp(),
 		);
+		expect(persistedValueTimestamps[0]).toEqual(new Date(BACKEND_RECEIVED_AT_MS + 120_001));
+	});
+
+	it('resolves the persistence watermark after entering the serialized update', async () => {
+		await service.refreshIndex();
+		propertiesService.update.mockImplementationOnce(
+			(_id: string, _dto: unknown, options?: ChannelPropertyUpdateOptions) => {
+				const commandTimestamp = new Date(BACKEND_RECEIVED_AT_MS + 30_000).toISOString();
+				powerProperty.value = new PropertyValueState(true, commandTimestamp);
+				service.recordPersistedPropertyValue(powerProperty);
+				const valueTimestamp = options?.resolveValueTimestamp?.();
+				if (valueTimestamp !== undefined) {
+					persistedValueTimestamps.push(valueTimestamp);
+				}
+
+				return Promise.resolve(new HomeyChannelPropertyEntity());
+			},
+		);
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, null, 1)], inventory());
+
+		expect(persistedValueTimestamps[0]).toEqual(new Date(BACKEND_RECEIVED_AT_MS + 30_001));
 	});
 
 	it('rejects a conflicting capability value at an already-applied order', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -442,6 +442,30 @@ describe('HomeySynchronizerService', () => {
 		expect(rejected.acceptedEvents).toEqual([]);
 	});
 
+	it('persists newer sequences at a monotonic effective timestamp', async () => {
+		await service.refreshIndex();
+		const firstTimestamp = '2026-08-21T10:02:00.000Z';
+		const secondTimestamp = '2026-08-21T10:01:00.000Z';
+
+		await service.synchronizeEvents([capabilityEvent('onoff', true, firstTimestamp, 1)], inventory());
+		await service.synchronizeEvents([capabilityEvent('onoff', false, secondTimestamp, 2)], inventory());
+
+		expect(propertiesService.update.mock.calls).toEqual([
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, { valueTimestamp: new Date(firstTimestamp) }],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, { valueTimestamp: new Date(firstTimestamp) }],
+			[
+				'property-power',
+				{ type: DEVICES_HOMEY_TYPE, value: false },
+				{ valueTimestamp: new Date('2026-08-21T10:02:00.001Z') },
+			],
+			[
+				'property-state',
+				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
+				{ valueTimestamp: new Date('2026-08-21T10:02:00.001Z') },
+			],
+		]);
+	});
+
 	it('rejects a conflicting capability value at an already-applied order', async () => {
 		await service.refreshIndex();
 		const applied = capabilityEvent('onoff', true, null, 2);

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.spec.ts
@@ -232,10 +232,11 @@ describe('HomeySynchronizerService', () => {
 		expect(connectivityService.trySetConnectionState).toHaveBeenCalledWith('panel-device', {
 			state: ConnectionState.CONNECTED,
 		});
+		const valueTimestamp = { valueTimestamp: new Date('2026-08-21T10:00:00.000Z') };
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }],
-			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 25 }],
+			['property-power', { type: DEVICES_HOMEY_TYPE, value: true }, valueTimestamp],
+			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'on' }, valueTimestamp],
+			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 25 }, valueTimestamp],
 		]);
 	});
 
@@ -288,10 +289,14 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeSnapshot([unavailable]);
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(1);
-		expect(propertiesService.update).toHaveBeenCalledWith('property-brightness', {
-			type: DEVICES_HOMEY_TYPE,
-			value: 25,
-		});
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-brightness',
+			{
+				type: DEVICES_HOMEY_TYPE,
+				value: 25,
+			},
+			{ valueTimestamp: new Date('2026-08-21T10:00:00.000Z') },
+		);
 	});
 
 	it('preserves null as a valid normalized capability value', async () => {
@@ -303,6 +308,24 @@ describe('HomeySynchronizerService', () => {
 			['property-power', { type: DEVICES_HOMEY_TYPE, value: null }],
 			['property-state', { type: DEVICES_HOMEY_TYPE, value: null }],
 		]);
+	});
+
+	it('passes the originating Homey event timestamp to value persistence', async () => {
+		await service.refreshIndex();
+		const measuredAt = '2026-08-24T10:01:02.345Z';
+
+		await service.synchronizeEvents([capabilityEvent('onoff', false, measuredAt)], inventory());
+
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-power',
+			{ type: DEVICES_HOMEY_TYPE, value: false },
+			{ valueTimestamp: new Date(measuredAt) },
+		);
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-state',
+			{ type: DEVICES_HOMEY_TYPE, value: 'off' },
+			{ valueTimestamp: new Date(measuredAt) },
+		);
 	});
 
 	it('reports whether a capability has a readable property binding', async () => {
@@ -351,9 +374,21 @@ describe('HomeySynchronizerService', () => {
 		);
 
 		expect(propertiesService.update.mock.calls).toEqual([
-			['property-brightness', { type: DEVICES_HOMEY_TYPE, value: 50 }],
-			['property-power', { type: DEVICES_HOMEY_TYPE, value: false }],
-			['property-state', { type: DEVICES_HOMEY_TYPE, value: 'off' }],
+			[
+				'property-brightness',
+				{ type: DEVICES_HOMEY_TYPE, value: 50 },
+				{ valueTimestamp: new Date('2026-08-21T10:01:01.000Z') },
+			],
+			[
+				'property-power',
+				{ type: DEVICES_HOMEY_TYPE, value: false },
+				{ valueTimestamp: new Date('2026-08-21T10:01:02.000Z') },
+			],
+			[
+				'property-state',
+				{ type: DEVICES_HOMEY_TYPE, value: 'off' },
+				{ valueTimestamp: new Date('2026-08-21T10:01:02.000Z') },
+			],
 		]);
 	});
 
@@ -366,10 +401,14 @@ describe('HomeySynchronizerService', () => {
 		await service.synchronizeEvents([capabilityEvent('onoff', false, '2026-08-21T10:01:00.000Z')], inventory());
 
 		expect(propertiesService.update).toHaveBeenCalledTimes(2);
-		expect(propertiesService.update).toHaveBeenCalledWith('property-power', {
-			type: DEVICES_HOMEY_TYPE,
-			value: true,
-		});
+		expect(propertiesService.update).toHaveBeenCalledWith(
+			'property-power',
+			{
+				type: DEVICES_HOMEY_TYPE,
+				value: true,
+			},
+			{ valueTimestamp: new Date('2026-08-21T10:02:00.000Z') },
+		);
 	});
 
 	it('prefers numeric event sequence over arrival order within a burst', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -549,8 +549,17 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				};
-				const valueTimestamp = this.createValueTimestamp(binding.property.id, receivedTimestamp);
-				await this.channelsPropertiesService.update(binding.property.id, updateDto, { valueTimestamp });
+				let valueTimestamp: Date | undefined;
+				await this.channelsPropertiesService.update(binding.property.id, updateDto, {
+					resolveValueTimestamp: () => {
+						valueTimestamp = this.createValueTimestamp(binding.property.id, receivedTimestamp);
+
+						return valueTimestamp;
+					},
+				});
+				if (valueTimestamp === undefined) {
+					throw new Error('Homey value timestamp was not resolved before persistence');
+				}
 				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(observedOrder, previousOrder));
 				this.lastAppliedValues.set(binding.property.id, value);
 				this.lastPersistedValueTimestamp.set(binding.property.id, valueTimestamp.getTime());

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -483,6 +483,8 @@ export class HomeySynchronizerService {
 		}
 
 		const order = this.createOrder(sequence, updatedAt);
+		const observedTimestamp = this.parseTimestamp(updatedAt);
+		const valueTimestamp = observedTimestamp === null ? undefined : new Date(observedTimestamp);
 		let allBindingsApplied = true;
 
 		for (const binding of bindings) {
@@ -513,10 +515,15 @@ export class HomeySynchronizerService {
 
 			try {
 				const transformed = this.transformer.read(binding.mapping, value);
-				await this.channelsPropertiesService.update(binding.property.id, {
+				const updateDto = {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
-				});
+				};
+				if (valueTimestamp === undefined) {
+					await this.channelsPropertiesService.update(binding.property.id, updateDto);
+				} else {
+					await this.channelsPropertiesService.update(binding.property.id, updateDto, { valueTimestamp });
+				}
 				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(observedOrder, previousOrder));
 				this.lastAppliedValues.set(binding.property.id, value);
 				result.updated += 1;

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -337,7 +337,6 @@ export class HomeySynchronizerService {
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
 		this.lastAppliedValues.clear();
-		this.lastPersistedValueTimestamp.clear();
 		this.lastObservedOrder.clear();
 		this.lastAppliedDeviceOrder.clear();
 		this.lastObservedDeviceOrder.clear();
@@ -378,6 +377,7 @@ export class HomeySynchronizerService {
 		const devices = await this.devicesService.findAll<HomeyDeviceEntity>(DEVICES_HOMEY_TYPE);
 		const adoptedDevices = new Map<string, HomeyDeviceEntity>();
 		const propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
+		const persistedValueTimestamps = new Map<string, number>();
 
 		for (const device of devices) {
 			if (device.identifier === null || !device.enabled) {
@@ -404,6 +404,16 @@ export class HomeySynchronizerService {
 						continue;
 					}
 
+					const loadedTimestamp = this.parseTimestamp(property.value?.lastUpdated ?? null);
+					const currentTimestamp = this.lastPersistedValueTimestamp.get(property.id);
+					const persistedTimestamp =
+						loadedTimestamp === null
+							? currentTimestamp
+							: Math.max(loadedTimestamp, currentTimestamp ?? loadedTimestamp);
+					if (persistedTimestamp !== undefined) {
+						persistedValueTimestamps.set(property.id, persistedTimestamp);
+					}
+
 					const bindings = capabilities.get(property.homeyCapabilityId) ?? [];
 					bindings.push({ panelDeviceId: device.id, property, mapping });
 					capabilities.set(property.homeyCapabilityId, bindings);
@@ -415,6 +425,7 @@ export class HomeySynchronizerService {
 
 		this.adoptedDevices = adoptedDevices;
 		this.propertiesByDeviceCapability = propertiesByDeviceCapability;
+		this.lastPersistedValueTimestamp = persistedValueTimestamps;
 		this.indexDirty = this.indexGeneration !== generation;
 	}
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -514,7 +514,7 @@ export class HomeySynchronizerService {
 		}
 
 		const order = this.createOrder(sequence, updatedAt);
-		const observedTimestamp = this.parseTimestamp(updatedAt);
+		const receivedTimestamp = Date.now();
 		let allBindingsApplied = true;
 
 		for (const binding of bindings) {
@@ -549,15 +549,11 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				};
-				const valueTimestamp = this.createValueTimestamp(binding.property.id, observedTimestamp);
-				if (valueTimestamp === undefined) {
-					await this.channelsPropertiesService.update(binding.property.id, updateDto);
-				} else {
-					await this.channelsPropertiesService.update(binding.property.id, updateDto, { valueTimestamp });
-				}
+				const valueTimestamp = this.createValueTimestamp(binding.property.id, receivedTimestamp);
+				await this.channelsPropertiesService.update(binding.property.id, updateDto, { valueTimestamp });
 				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(observedOrder, previousOrder));
 				this.lastAppliedValues.set(binding.property.id, value);
-				this.lastPersistedValueTimestamp.set(binding.property.id, valueTimestamp?.getTime() ?? Date.now());
+				this.lastPersistedValueTimestamp.set(binding.property.id, valueTimestamp.getTime());
 				result.updated += 1;
 			} catch {
 				result.failed += 1;
@@ -790,16 +786,10 @@ export class HomeySynchronizerService {
 		};
 	}
 
-	private createValueTimestamp(propertyId: string, observedTimestamp: number | null): Date | undefined {
+	private createValueTimestamp(propertyId: string, receivedTimestamp: number): Date {
 		const previousTimestamp = this.lastPersistedValueTimestamp.get(propertyId);
-
-		if (observedTimestamp === null && previousTimestamp === undefined) {
-			return undefined;
-		}
-
-		const candidateTimestamp = observedTimestamp ?? Date.now();
 		const effectiveTimestamp =
-			previousTimestamp === undefined ? candidateTimestamp : Math.max(candidateTimestamp, previousTimestamp + 1);
+			previousTimestamp === undefined ? receivedTimestamp : Math.max(receivedTimestamp, previousTimestamp + 1);
 
 		return new Date(effectiveTimestamp);
 	}

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -75,6 +75,7 @@ export class HomeySynchronizerService {
 	private propertiesByDeviceCapability = new Map<string, Map<string, HomeyIndexedProperty[]>>();
 	private lastAppliedOrder = new Map<string, HomeyEventOrder>();
 	private lastAppliedValues = new Map<string, HomeyCapabilityValue>();
+	private lastPersistedValueTimestamp = new Map<string, number>();
 	private lastObservedOrder = new Map<string, HomeyEventOrder>();
 	private lastAppliedDeviceOrder = new Map<string, HomeyEventOrder>();
 	private lastObservedDeviceOrder = new Map<string, HomeyEventOrder>();
@@ -336,6 +337,7 @@ export class HomeySynchronizerService {
 		this.propertiesByDeviceCapability.clear();
 		this.lastAppliedOrder.clear();
 		this.lastAppliedValues.clear();
+		this.lastPersistedValueTimestamp.clear();
 		this.lastObservedOrder.clear();
 		this.lastAppliedDeviceOrder.clear();
 		this.lastObservedDeviceOrder.clear();
@@ -484,7 +486,6 @@ export class HomeySynchronizerService {
 
 		const order = this.createOrder(sequence, updatedAt);
 		const observedTimestamp = this.parseTimestamp(updatedAt);
-		const valueTimestamp = observedTimestamp === null ? undefined : new Date(observedTimestamp);
 		let allBindingsApplied = true;
 
 		for (const binding of bindings) {
@@ -519,6 +520,7 @@ export class HomeySynchronizerService {
 					type: DEVICES_HOMEY_TYPE,
 					value: transformed,
 				};
+				const valueTimestamp = this.createValueTimestamp(binding.property.id, observedTimestamp);
 				if (valueTimestamp === undefined) {
 					await this.channelsPropertiesService.update(binding.property.id, updateDto);
 				} else {
@@ -526,6 +528,7 @@ export class HomeySynchronizerService {
 				}
 				this.lastAppliedOrder.set(binding.property.id, this.preserveSequenceWatermark(observedOrder, previousOrder));
 				this.lastAppliedValues.set(binding.property.id, value);
+				this.lastPersistedValueTimestamp.set(binding.property.id, valueTimestamp?.getTime() ?? Date.now());
 				result.updated += 1;
 			} catch {
 				result.failed += 1;
@@ -756,6 +759,20 @@ export class HomeySynchronizerService {
 			timestamp: this.parseTimestamp(updatedAt),
 			arrival: ++this.arrivalOrder,
 		};
+	}
+
+	private createValueTimestamp(propertyId: string, observedTimestamp: number | null): Date | undefined {
+		const previousTimestamp = this.lastPersistedValueTimestamp.get(propertyId);
+
+		if (observedTimestamp === null && previousTimestamp === undefined) {
+			return undefined;
+		}
+
+		const candidateTimestamp = observedTimestamp ?? Date.now();
+		const effectiveTimestamp =
+			previousTimestamp === undefined ? candidateTimestamp : Math.max(candidateTimestamp, previousTimestamp + 1);
+
+		return new Date(effectiveTimestamp);
 	}
 
 	private prepareDeviceEvent(

--- a/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-synchronizer.service.ts
@@ -105,6 +105,24 @@ export class HomeySynchronizerService {
 		this.invalidateIndex();
 	}
 
+	@OnEvent(EventType.CHANNEL_PROPERTY_VALUE_SET)
+	recordPersistedPropertyValue(property: HomeyChannelPropertyEntity): void {
+		if (property.type !== DEVICES_HOMEY_TYPE) {
+			return;
+		}
+
+		const timestamp = this.parseTimestamp(property.value?.lastUpdated ?? null);
+		if (timestamp === null) {
+			return;
+		}
+
+		const previousTimestamp = this.lastPersistedValueTimestamp.get(property.id);
+		this.lastPersistedValueTimestamp.set(
+			property.id,
+			previousTimestamp === undefined ? timestamp : Math.max(timestamp, previousTimestamp),
+		);
+	}
+
 	invalidateIndex(): void {
 		this.indexDirty = true;
 		this.indexGeneration += 1;

--- a/apps/panel/lib/modules/devices/controllers/channels/light.dart
+++ b/apps/panel/lib/modules/devices/controllers/channels/light.dart
@@ -267,20 +267,7 @@ class LightChannelController {
   /// Set power state with optimistic UI.
   void setPower(bool value) {
     final prop = channel.onProp;
-
-    _controlState.setPending(deviceId, channel.id, prop.id, value);
-
-    _devicesService.setPropertyValue(prop.id, value).then((success) {
-      if (success) {
-        _controlState.setSettling(deviceId, channel.id, prop.id);
-      } else {
-        _controlState.clear(deviceId, channel.id, prop.id);
-        _onError?.call(prop.id, Exception('Failed to set power'));
-      }
-    }).catchError((error) {
-      _controlState.clear(deviceId, channel.id, prop.id);
-      _onError?.call(prop.id, error);
-    });
+    _runPropertyCommand(prop.id, value, 'Failed to set power');
   }
 
   /// Toggle power state with optimistic UI.
@@ -293,19 +280,7 @@ class LightChannelController {
     final prop = channel.brightnessProp;
     if (prop == null) return;
 
-    _controlState.setPending(deviceId, channel.id, prop.id, value);
-
-    _devicesService.setPropertyValue(prop.id, value).then((success) {
-      if (success) {
-        _controlState.setSettling(deviceId, channel.id, prop.id);
-      } else {
-        _controlState.clear(deviceId, channel.id, prop.id);
-        _onError?.call(prop.id, Exception('Failed to set brightness'));
-      }
-    }).catchError((error) {
-      _controlState.clear(deviceId, channel.id, prop.id);
-      _onError?.call(prop.id, error);
-    });
+    _runPropertyCommand(prop.id, value, 'Failed to set brightness');
   }
 
   /// Set color white level with optimistic UI.
@@ -313,19 +288,7 @@ class LightChannelController {
     final prop = channel.colorWhiteProp;
     if (prop == null) return;
 
-    _controlState.setPending(deviceId, channel.id, prop.id, value);
-
-    _devicesService.setPropertyValue(prop.id, value).then((success) {
-      if (success) {
-        _controlState.setSettling(deviceId, channel.id, prop.id);
-      } else {
-        _controlState.clear(deviceId, channel.id, prop.id);
-        _onError?.call(prop.id, Exception('Failed to set color white'));
-      }
-    }).catchError((error) {
-      _controlState.clear(deviceId, channel.id, prop.id);
-      _onError?.call(prop.id, error);
-    });
+    _runPropertyCommand(prop.id, value, 'Failed to set color white');
   }
 
   /// Set color temperature in Kelvin with optimistic UI.
@@ -333,19 +296,7 @@ class LightChannelController {
     final prop = channel.temperatureProp;
     if (prop == null) return;
 
-    _controlState.setPending(deviceId, channel.id, prop.id, value);
-
-    _devicesService.setPropertyValue(prop.id, value).then((success) {
-      if (success) {
-        _controlState.setSettling(deviceId, channel.id, prop.id);
-      } else {
-        _controlState.clear(deviceId, channel.id, prop.id);
-        _onError?.call(prop.id, Exception('Failed to set color temperature'));
-      }
-    }).catchError((error) {
-      _controlState.clear(deviceId, channel.id, prop.id);
-      _onError?.call(prop.id, error);
-    });
+    _runPropertyCommand(prop.id, value, 'Failed to set color temperature');
   }
 
   /// Set RGB color with optimistic UI using group API.
@@ -377,12 +328,15 @@ class LightChannelController {
         ),
       ],
     );
+    final commandGeneration =
+        _controlState.getGroupState(deviceId, colorGroupId)?.generation;
 
     Future.wait([
       _devicesService.setPropertyValue(redProp.id, red),
       _devicesService.setPropertyValue(greenProp.id, green),
       _devicesService.setPropertyValue(blueProp.id, blue),
     ]).then((results) {
+      if (!_isCurrentGroupGeneration(commandGeneration)) return;
       if (results.every((success) => success)) {
         _controlState.setGroupSettling(deviceId, colorGroupId);
       } else {
@@ -390,6 +344,7 @@ class LightChannelController {
         _onError?.call(redProp.id, Exception('Failed to set RGB color'));
       }
     }).catchError((error) {
+      if (!_isCurrentGroupGeneration(commandGeneration)) return;
       _controlState.clearGroup(deviceId, colorGroupId);
       _onError?.call(redProp.id, error);
     });
@@ -435,6 +390,8 @@ class LightChannelController {
 
     // 1. Set pending state FIRST (before starting API calls)
     _controlState.setGroupPending(deviceId, colorGroupId, properties);
+    final commandGeneration =
+        _controlState.getGroupState(deviceId, colorGroupId)?.generation;
 
     // 2. Start API calls AFTER pending state is set
     final futures = <Future<bool>>[];
@@ -449,6 +406,7 @@ class LightChannelController {
     }
 
     Future.wait(futures).then((results) {
+      if (!_isCurrentGroupGeneration(commandGeneration)) return;
       if (results.every((success) => success)) {
         _controlState.setGroupSettling(deviceId, colorGroupId);
       } else {
@@ -456,6 +414,7 @@ class LightChannelController {
         _onError?.call(firstPropId!, Exception('Failed to set HSV color'));
       }
     }).catchError((error) {
+      if (!_isCurrentGroupGeneration(commandGeneration)) return;
       _controlState.clearGroup(deviceId, colorGroupId);
       _onError?.call(firstPropId!, error);
     });
@@ -481,6 +440,52 @@ class LightChannelController {
   // ===========================================================================
   // PRIVATE HELPERS
   // ===========================================================================
+
+  void _runPropertyCommand(
+    String propertyId,
+    dynamic value,
+    String failureMessage,
+  ) {
+    _controlState.setPending(deviceId, channel.id, propertyId, value);
+    final commandGeneration = _controlState
+        .getState(deviceId, channel.id, propertyId)
+        ?.generation;
+
+    _devicesService.setPropertyValue(propertyId, value).then((success) {
+      if (!_isCurrentPropertyGeneration(propertyId, commandGeneration)) return;
+      if (success) {
+        _controlState.setSettling(deviceId, channel.id, propertyId);
+      } else {
+        _controlState.clear(deviceId, channel.id, propertyId);
+        _onError?.call(propertyId, Exception(failureMessage));
+      }
+    }).catchError((error) {
+      if (!_isCurrentPropertyGeneration(propertyId, commandGeneration)) return;
+      _controlState.clear(deviceId, channel.id, propertyId);
+      _onError?.call(propertyId, error);
+    });
+  }
+
+  bool _isCurrentPropertyGeneration(
+    String propertyId,
+    Object? commandGeneration,
+  ) {
+    return commandGeneration != null &&
+        identical(
+          _controlState
+              .getState(deviceId, channel.id, propertyId)
+              ?.generation,
+          commandGeneration,
+        );
+  }
+
+  bool _isCurrentGroupGeneration(Object? commandGeneration) {
+    return commandGeneration != null &&
+        identical(
+          _controlState.getGroupState(deviceId, colorGroupId)?.generation,
+          commandGeneration,
+        );
+  }
 
   bool _isAnyColorPropertyLocked() {
     final redProp = channel.colorRedProp;

--- a/apps/panel/lib/modules/devices/models/control_state.dart
+++ b/apps/panel/lib/modules/devices/models/control_state.dart
@@ -53,13 +53,18 @@ class DeviceControlState {
   /// Timestamp when this state was created.
   final DateTime createdAt;
 
-  const DeviceControlState({
+  /// Stable local identity for one optimistic command generation.
+  /// Preserved across pending, settling, and mixed transitions.
+  final Object generation;
+
+  DeviceControlState({
     this.state = DeviceControlUIState.idle,
     this.properties = const [],
     this.settlingTimer,
     this.settlingStartedAt,
     required this.createdAt,
-  });
+    Object? generation,
+  }) : generation = generation ?? Object();
 
   /// Create a copy with updated fields.
   DeviceControlState copyWith({
@@ -80,6 +85,7 @@ class DeviceControlState {
           ? null
           : (settlingStartedAt ?? this.settlingStartedAt),
       createdAt: createdAt,
+      generation: generation,
     );
   }
 
@@ -166,6 +172,7 @@ class DeviceControlState {
       state: DeviceControlUIState.mixed,
       properties: properties,
       createdAt: createdAt,
+      generation: generation,
     );
   }
 

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -262,19 +262,18 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         }
 
         if (propertyState?.isSettling ?? false) {
-          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
-            _deferredPropertySnapshots.remove(propertyKey);
-            controlState.clear(newDevice.id, channel.id, property.id);
-          } else {
-            _deferPropertySnapshot(
-              propertyKey,
-              newDevice.id,
-              channel.id,
-              property.id,
-              propertyState!.generation,
-              actualValue,
-            );
-          }
+          // A matching provider snapshot received after acknowledgment can
+          // still be a delayed event from an older ABA command. Keep the
+          // newest snapshot generation-scoped for the full settling window so
+          // subsequent delayed events cannot update an unprotected UI.
+          _deferPropertySnapshot(
+            propertyKey,
+            newDevice.id,
+            channel.id,
+            property.id,
+            propertyState!.generation,
+            actualValue,
+          );
           continue;
         }
 

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -183,17 +183,32 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
   }
 
-  void _checkConvergence(LightingDeviceView device) {
+  void _checkConvergence(
+    LightingDeviceView oldDevice,
+    LightingDeviceView newDevice,
+  ) {
     final controlState = _deviceControlStateService;
     if (controlState == null) return;
 
-    for (final channel in device.lightChannels) {
+    final oldValues = <String, dynamic>{
+      for (final channel in oldDevice.lightChannels)
+        for (final property in channel.properties)
+          '${channel.id}:${property.id}': property.value?.value,
+    };
+    final changedProperties = <String>{};
+
+    for (final channel in newDevice.lightChannels) {
       for (final property in channel.properties) {
+        final propertyKey = '${channel.id}:${property.id}';
         final actualValue = property.value?.value;
-        if (actualValue == null) continue;
+        if (actualValue == null || oldValues[propertyKey] == actualValue) {
+          continue;
+        }
+
+        changedProperties.add(propertyKey);
 
         controlState.checkPropertyConvergence(
-          device.id,
+          newDevice.id,
           channel.id,
           property.id,
           actualValue,
@@ -202,13 +217,23 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
 
     final colorState = controlState.getGroupState(
-      device.id,
+      newDevice.id,
       LightChannelController.colorGroupId,
     );
     if (colorState != null && (colorState.isSettling || colorState.isMixed)) {
-      // A new authoritative device snapshot supersedes the grouped optimistic
-      // color values, whether it confirms them or reports an external change.
-      controlState.clearGroup(device.id, LightChannelController.colorGroupId);
+      final colorChanged = colorState.properties.any(
+        (property) => changedProperties.contains(
+          '${property.channelId}:${property.propertyId}',
+        ),
+      );
+      if (colorChanged) {
+        // A changed authoritative color value supersedes the grouped
+        // optimistic values, whether it confirms or overrides them.
+        controlState.clearGroup(
+          newDevice.id,
+          LightChannelController.colorGroupId,
+        );
+      }
     }
   }
 
@@ -216,7 +241,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   void didUpdateWidget(covariant LightingDeviceDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget._device, widget._device)) {
-      _checkConvergence(widget._device);
+      _checkConvergence(oldWidget._device, widget._device);
     }
     _initController();
   }

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -282,7 +282,10 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
       for (final property in colorState.properties) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
-        if (changedProperties.contains(propertyKey)) {
+        final actualValue = newValues[propertyKey];
+        final correlatedUpdate = colorState.isPending ||
+            _valuesConverged(property.desiredValue, actualValue);
+        if (changedProperties.contains(propertyKey) && correlatedUpdate) {
           _authoritativeColorUpdates.add(propertyKey);
         }
       }

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -53,6 +53,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   final Map<String, _DeferredPropertySnapshot>
       _deferredPropertySnapshots = {};
   Object? _trackedColorGeneration;
+  final Set<String> _baselineColorMatches = {};
   final Set<String> _authoritativeColorUpdates = {};
   final Set<String> _postAckColorMatches = {};
   final Set<String> _postAckColorDivergences = {};
@@ -293,6 +294,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
     if (colorState == null) {
       _trackedColorGeneration = null;
+      _baselineColorMatches.clear();
       _authoritativeColorUpdates.clear();
       _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
@@ -300,10 +302,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
 
     if (!identical(_trackedColorGeneration, colorState.generation)) {
-      _trackedColorGeneration = colorState.generation;
-      _authoritativeColorUpdates.clear();
-      _postAckColorMatches.clear();
-      _postAckColorDivergences.clear();
+      _trackColorGeneration(colorState, newDevice);
     }
 
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
@@ -325,6 +324,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           // before acknowledgment it may be delayed state from the previous
           // color. Accept a complete divergent set only after settling expires.
           _authoritativeColorUpdates.remove(propertyKey);
+          _baselineColorMatches.remove(propertyKey);
           _postAckColorMatches.remove(propertyKey);
           _postAckColorDivergences.add(propertyKey);
         }
@@ -372,16 +372,14 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
     if (colorState == null) {
       _trackedColorGeneration = null;
+      _baselineColorMatches.clear();
       _authoritativeColorUpdates.clear();
       _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
       return;
     }
     if (!identical(_trackedColorGeneration, colorState.generation)) {
-      _trackedColorGeneration = colorState.generation;
-      _authoritativeColorUpdates.clear();
-      _postAckColorMatches.clear();
-      _postAckColorDivergences.clear();
+      _trackColorGeneration(colorState, widget._device);
       return;
     }
     if (!colorState.isSettling && !colorState.isMixed) return;
@@ -417,6 +415,33 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
   }
 
+  void _trackColorGeneration(
+    DeviceControlState colorState,
+    LightingDeviceView device,
+  ) {
+    _trackedColorGeneration = colorState.generation;
+    _baselineColorMatches.clear();
+    _authoritativeColorUpdates.clear();
+    _postAckColorMatches.clear();
+    _postAckColorDivergences.clear();
+
+    final currentValues = <String, dynamic>{
+      for (final channel in device.lightChannels)
+        for (final property in channel.properties)
+          '${channel.id}:${property.id}': property.value?.value,
+    };
+    for (final property in colorState.properties) {
+      final propertyKey = '${property.channelId}:${property.propertyId}';
+      if (currentValues.containsKey(propertyKey) &&
+          _valuesConverged(
+            property.desiredValue,
+            currentValues[propertyKey],
+          )) {
+        _baselineColorMatches.add(propertyKey);
+      }
+    }
+  }
+
   void _clearColorStateIfComplete(
     DeviceControlStateService controlState,
     String deviceId,
@@ -429,7 +454,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       final propertyKey = '${property.channelId}:${property.propertyId}';
       if (!actualValues.containsKey(propertyKey)) return false;
 
-      return _postAckColorMatches.contains(propertyKey) &&
+      return (_baselineColorMatches.contains(propertyKey) ||
+              _postAckColorMatches.contains(propertyKey)) &&
           _valuesConverged(
             property.desiredValue,
             actualValues[propertyKey],
@@ -440,9 +466,11 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           final propertyKey = '${property.channelId}:${property.propertyId}';
           return actualValues.containsKey(propertyKey) &&
               (_authoritativeColorUpdates.contains(propertyKey) ||
+                  _baselineColorMatches.contains(propertyKey) ||
                   _postAckColorDivergences.contains(propertyKey));
         });
-    if ((_authoritativeColorUpdates.isEmpty &&
+    if ((_baselineColorMatches.isEmpty &&
+            _authoritativeColorUpdates.isEmpty &&
             _postAckColorDivergences.isEmpty) ||
         (!colorComplete && !divergentComplete)) {
       return;
@@ -453,6 +481,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       LightChannelController.colorGroupId,
     );
     _trackedColorGeneration = null;
+    _baselineColorMatches.clear();
     _authoritativeColorUpdates.clear();
     _postAckColorMatches.clear();
     _postAckColorDivergences.clear();

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -50,6 +50,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   final DevicesService _devicesService = locator<DevicesService>();
   DeviceControlStateService? _deviceControlStateService;
   LightingDeviceController? _controller;
+  final Map<String, _DeferredPropertyDivergence>
+      _deferredPropertyDivergences = {};
   Object? _trackedColorGeneration;
   final Set<String> _authoritativeColorUpdates = {};
 
@@ -180,6 +182,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   }
 
   void _onControlStateChanged() {
+    _consumeDeferredDivergences();
     if (mounted && !_isAnyDragging) {
       setState(() {});
     }
@@ -232,15 +235,26 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           property.id,
         );
         if (propertyState?.isPending ?? false) {
-          // While the command generation is pending, only its requested value
-          // can confirm it. Divergent updates may still belong to the previous
-          // generation; command failure or the settling phase handles them.
           if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
+            _deferredPropertyDivergences.remove(propertyKey);
             controlState.clear(newDevice.id, channel.id, property.id);
+          } else {
+            // The event may arrive before the command acknowledgment. Retain
+            // it for this generation, but do not accept divergence until the
+            // controller moves that generation into settling.
+            _deferredPropertyDivergences[propertyKey] =
+                _DeferredPropertyDivergence(
+              deviceId: newDevice.id,
+              channelId: channel.id,
+              propertyId: property.id,
+              generation: propertyState!.generation,
+              actualValue: actualValue,
+            );
           }
           continue;
         }
 
+        _deferredPropertyDivergences.remove(propertyKey);
         controlState.checkPropertyConvergence(
           newDevice.id,
           channel.id,
@@ -268,41 +282,102 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
       for (final property in colorState.properties) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
-        final belongsToActiveCommand = !colorState.isPending ||
-            _valuesConverged(
-              property.desiredValue,
-              newValues[propertyKey],
-            );
-        if (changedProperties.contains(propertyKey) &&
-            belongsToActiveCommand) {
+        if (changedProperties.contains(propertyKey)) {
           _authoritativeColorUpdates.add(propertyKey);
         }
       }
 
-      final colorComplete = colorState.properties.every((property) {
-        final propertyKey = '${property.channelId}:${property.propertyId}';
-        if (!newValues.containsKey(propertyKey)) return false;
-
-        final desired = property.desiredValue;
-        final actual = newValues[propertyKey];
-        if (colorState.isPending) {
-          return _valuesConverged(desired, actual);
-        }
-        return _authoritativeColorUpdates.contains(propertyKey) ||
-            _valuesConverged(desired, actual);
-      });
-      if (_authoritativeColorUpdates.isNotEmpty && colorComplete) {
-        // Pending commands clear only on requested-value confirmation. Once
-        // their generation is acknowledged and settling, a complete divergent
-        // set is authoritative too (for example device-side quantization).
-        controlState.clearGroup(
-          newDevice.id,
-          LightChannelController.colorGroupId,
-        );
-        _trackedColorGeneration = null;
-        _authoritativeColorUpdates.clear();
-      }
+      _clearColorStateIfComplete(
+        controlState,
+        newDevice.id,
+        colorState,
+        newValues,
+      );
     }
+  }
+
+  void _consumeDeferredDivergences() {
+    final controlState = _deviceControlStateService;
+    if (controlState == null) return;
+
+    for (final entry in _deferredPropertyDivergences.entries.toList()) {
+      final divergence = entry.value;
+      final state = controlState.getState(
+        divergence.deviceId,
+        divergence.channelId,
+        divergence.propertyId,
+      );
+      if (state == null ||
+          !identical(state.generation, divergence.generation)) {
+        _deferredPropertyDivergences.remove(entry.key);
+        continue;
+      }
+      if (!state.isSettling && !state.isMixed) continue;
+
+      _deferredPropertyDivergences.remove(entry.key);
+      controlState.checkPropertyConvergence(
+        divergence.deviceId,
+        divergence.channelId,
+        divergence.propertyId,
+        divergence.actualValue,
+      );
+    }
+
+    final colorState = controlState.getGroupState(
+      widget._device.id,
+      LightChannelController.colorGroupId,
+    );
+    if (colorState == null) {
+      _trackedColorGeneration = null;
+      _authoritativeColorUpdates.clear();
+      return;
+    }
+    if (!identical(_trackedColorGeneration, colorState.generation)) {
+      _trackedColorGeneration = colorState.generation;
+      _authoritativeColorUpdates.clear();
+      return;
+    }
+    if (!colorState.isSettling && !colorState.isMixed) return;
+
+    final currentValues = <String, dynamic>{
+      for (final channel in widget._device.lightChannels)
+        for (final property in channel.properties)
+          '${channel.id}:${property.id}': property.value?.value,
+    };
+    _clearColorStateIfComplete(
+      controlState,
+      widget._device.id,
+      colorState,
+      currentValues,
+    );
+  }
+
+  void _clearColorStateIfComplete(
+    DeviceControlStateService controlState,
+    String deviceId,
+    DeviceControlState colorState,
+    Map<String, dynamic> actualValues,
+  ) {
+    final colorComplete = colorState.properties.every((property) {
+      final propertyKey = '${property.channelId}:${property.propertyId}';
+      if (!actualValues.containsKey(propertyKey)) return false;
+
+      final converged = _valuesConverged(
+        property.desiredValue,
+        actualValues[propertyKey],
+      );
+      return colorState.isPending
+          ? converged
+          : _authoritativeColorUpdates.contains(propertyKey) || converged;
+    });
+    if (_authoritativeColorUpdates.isEmpty || !colorComplete) return;
+
+    controlState.clearGroup(
+      deviceId,
+      LightChannelController.colorGroupId,
+    );
+    _trackedColorGeneration = null;
+    _authoritativeColorUpdates.clear();
   }
 
   @override
@@ -942,6 +1017,22 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       ],
     );
   }
+}
+
+class _DeferredPropertyDivergence {
+  final String deviceId;
+  final String channelId;
+  final String propertyId;
+  final Object generation;
+  final dynamic actualValue;
+
+  const _DeferredPropertyDivergence({
+    required this.deviceId,
+    required this.channelId,
+    required this.propertyId,
+    required this.generation,
+    required this.actualValue,
+  });
 }
 
 // --------------------------------------------------------------------------

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -195,13 +195,17 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         for (final property in channel.properties)
           '${channel.id}:${property.id}': property.value?.value,
     };
+    final newValues = <String, dynamic>{};
     final changedProperties = <String>{};
 
     for (final channel in newDevice.lightChannels) {
       for (final property in channel.properties) {
         final propertyKey = '${channel.id}:${property.id}';
         final actualValue = property.value?.value;
-        if (actualValue == null || oldValues[propertyKey] == actualValue) {
+        if (actualValue == null) continue;
+
+        newValues[propertyKey] = actualValue;
+        if (oldValues[propertyKey] == actualValue) {
           continue;
         }
 
@@ -226,9 +230,20 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           '${property.channelId}:${property.propertyId}',
         ),
       );
-      if (colorChanged) {
-        // A changed authoritative color value supersedes the grouped
-        // optimistic values, whether it confirms or overrides them.
+      final colorConverged = colorState.properties.every((property) {
+        final propertyKey = '${property.channelId}:${property.propertyId}';
+        if (!newValues.containsKey(propertyKey)) return false;
+
+        final desired = property.desiredValue;
+        final actual = newValues[propertyKey];
+        if (desired is num && actual is num) {
+          return (desired - actual).abs() <= 0.5;
+        }
+        return desired == actual;
+      });
+      if (colorChanged && colorConverged) {
+        // Keep grouped optimism until every authoritative component has
+        // arrived; Homey may emit RGB/HSV property changes separately.
         controlState.clearGroup(
           newDevice.id,
           LightChannelController.colorGroupId,

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -248,16 +248,30 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
             _deferredPropertyDivergences.remove(propertyKey);
             controlState.clear(newDevice.id, channel.id, property.id);
           } else {
-            // The event may arrive before the command acknowledgment. Retain
-            // it for this generation, but do not accept divergence until the
-            // controller moves that generation into settling.
-            _deferredPropertyDivergences[propertyKey] =
-                _DeferredPropertyDivergence(
-              deviceId: newDevice.id,
-              channelId: channel.id,
-              propertyId: property.id,
-              generation: propertyState!.generation,
-              actualValue: actualValue,
+            _deferPropertyDivergence(
+              propertyKey,
+              newDevice.id,
+              channel.id,
+              property.id,
+              propertyState!.generation,
+              actualValue,
+            );
+          }
+          continue;
+        }
+
+        if (propertyState?.isSettling ?? false) {
+          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
+            _deferredPropertyDivergences.remove(propertyKey);
+            controlState.clear(newDevice.id, channel.id, property.id);
+          } else {
+            _deferPropertyDivergence(
+              propertyKey,
+              newDevice.id,
+              channel.id,
+              property.id,
+              propertyState!.generation,
+              actualValue,
             );
           }
           continue;
@@ -298,15 +312,13 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           continue;
         }
         final actualValue = newValues[propertyKey];
-        if (colorState.isPending ||
-            _valuesConverged(property.desiredValue, actualValue)) {
+        if (_valuesConverged(property.desiredValue, actualValue)) {
           _authoritativeColorUpdates.add(propertyKey);
           _postAckColorDivergences.remove(propertyKey);
         } else {
-          // A post-ack divergent snapshot cannot be assigned to this command
-          // immediately: it may be delayed state from the previous color.
-          // Retain the latest authoritative component and accept a complete
-          // divergent set only if the settling window expires.
+          // Divergence cannot be assigned to this command immediately: even
+          // before acknowledgment it may be delayed state from the previous
+          // color. Accept a complete divergent set only after settling expires.
           _postAckColorDivergences.add(propertyKey);
         }
       }
@@ -336,7 +348,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         _deferredPropertyDivergences.remove(entry.key);
         continue;
       }
-      if (!state.isSettling && !state.isMixed) continue;
+      if (!state.isMixed) continue;
 
       _deferredPropertyDivergences.remove(entry.key);
       controlState.checkPropertyConvergence(
@@ -375,6 +387,24 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       widget._device.id,
       colorState,
       currentValues,
+    );
+  }
+
+  void _deferPropertyDivergence(
+    String propertyKey,
+    String deviceId,
+    String channelId,
+    String propertyId,
+    Object generation,
+    dynamic actualValue,
+  ) {
+    _deferredPropertyDivergences[propertyKey] =
+        _DeferredPropertyDivergence(
+      deviceId: deviceId,
+      channelId: channelId,
+      propertyId: propertyId,
+      generation: generation,
+      actualValue: actualValue,
     );
   }
 

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -109,6 +109,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
 
     try {
       _deviceControlStateService = locator<DeviceControlStateService>();
+      _reconcileExistingControlState(_deviceControlStateService!);
       _deviceControlStateService?.addListener(_onControlStateChanged);
     } catch (e) {
       if (kDebugMode) {
@@ -198,6 +199,92 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       return (desired - actual).abs() <= 0.5;
     }
     return desired == actual;
+  }
+
+  void _reconcileExistingControlState(
+    DeviceControlStateService controlState,
+  ) {
+    final currentValues = <String, dynamic>{};
+    final currentLastUpdated = <String, DateTime?>{};
+
+    for (final channel in widget._device.lightChannels) {
+      for (final property in channel.properties) {
+        final propertyKey = '${channel.id}:${property.id}';
+        final actualValue = property.value?.value;
+        currentValues[propertyKey] = actualValue;
+        currentLastUpdated[propertyKey] = property.lastUpdated;
+        if (property.lastUpdated == null) continue;
+
+        final state = controlState.getState(
+          widget._device.id,
+          channel.id,
+          property.id,
+        );
+        if ((state?.isPending ?? false) ||
+            (state?.isSettling ?? false)) {
+          _deferPropertySnapshot(
+            propertyKey,
+            widget._device.id,
+            channel.id,
+            property.id,
+            state!.generation,
+            actualValue,
+          );
+        } else if (state?.isMixed ?? false) {
+          controlState.checkPropertyConvergence(
+            widget._device.id,
+            channel.id,
+            property.id,
+            actualValue,
+          );
+        }
+      }
+    }
+
+    final colorState = controlState.getGroupState(
+      widget._device.id,
+      LightChannelController.colorGroupId,
+    );
+    if (colorState == null ||
+        (!colorState.isPending &&
+            !colorState.isSettling &&
+            !colorState.isMixed)) {
+      return;
+    }
+
+    _trackColorGeneration(
+      colorState,
+      widget._device,
+      captureBaseline: false,
+    );
+    for (final property in colorState.properties) {
+      final propertyKey = '${property.channelId}:${property.propertyId}';
+      if (currentLastUpdated[propertyKey] == null ||
+          !currentValues.containsKey(propertyKey)) {
+        continue;
+      }
+      if (_valuesConverged(
+        property.desiredValue,
+        currentValues[propertyKey],
+      )) {
+        _authoritativeColorUpdates.add(propertyKey);
+        if (!colorState.isPending) {
+          _postAckColorMatches.add(propertyKey);
+        }
+        _postAckColorDivergences.remove(propertyKey);
+      } else {
+        _baselineColorMatches.remove(propertyKey);
+        _authoritativeColorUpdates.remove(propertyKey);
+        _postAckColorMatches.remove(propertyKey);
+        _postAckColorDivergences.add(propertyKey);
+      }
+    }
+    _clearColorStateIfComplete(
+      controlState,
+      widget._device.id,
+      colorState,
+      currentValues,
+    );
   }
 
   void _checkConvergence(
@@ -516,6 +603,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   void _trackColorGeneration(
     DeviceControlState colorState,
     LightingDeviceView device,
+    {bool captureBaseline = true}
   ) {
     _trackedColorGeneration = colorState.generation;
     _baselineColorMatches.clear();
@@ -528,6 +616,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         for (final property in channel.properties)
           '${channel.id}:${property.id}': property.value?.value,
     };
+    if (!captureBaseline) return;
+
     for (final property in colorState.properties) {
       final propertyKey = '${property.channelId}:${property.propertyId}';
       if (currentValues.containsKey(propertyKey) &&

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -204,16 +204,25 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         for (final property in channel.properties)
           '${channel.id}:${property.id}': property.value?.value,
     };
+    final oldLastUpdated = <String, DateTime?>{
+      for (final channel in oldDevice.lightChannels)
+        for (final property in channel.properties)
+          '${channel.id}:${property.id}': property.lastUpdated,
+    };
     final newValues = <String, dynamic>{};
+    final newLastUpdated = <String, DateTime?>{};
     final changedProperties = <String>{};
 
     for (final channel in newDevice.lightChannels) {
       for (final property in channel.properties) {
         final propertyKey = '${channel.id}:${property.id}';
         final actualValue = property.value?.value;
+        final actualLastUpdated = property.lastUpdated;
         newValues[propertyKey] = actualValue;
+        newLastUpdated[propertyKey] = actualLastUpdated;
         if (oldValues.containsKey(propertyKey) &&
-            oldValues[propertyKey] == actualValue) {
+            oldValues[propertyKey] == actualValue &&
+            oldLastUpdated[propertyKey] == actualLastUpdated) {
           continue;
         }
 
@@ -224,6 +233,13 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           channel.id,
           property.id,
         );
+        if (propertyState != null &&
+            actualLastUpdated != null &&
+            actualLastUpdated.isBefore(propertyState.createdAt)) {
+          // A delayed event from an earlier command must not confirm or
+          // override the currently active optimistic generation.
+          continue;
+        }
         if (propertyState?.isPending ?? false) {
           // Homey synchronizes the authoritative capability event before the
           // command acknowledgment resolves. A changed value is authoritative
@@ -260,7 +276,11 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
       for (final property in colorState.properties) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
-        if (changedProperties.contains(propertyKey)) {
+        final lastUpdated = newLastUpdated[propertyKey];
+        final belongsToActiveCommand = lastUpdated == null ||
+            !lastUpdated.isBefore(colorState.createdAt);
+        if (changedProperties.contains(propertyKey) &&
+            belongsToActiveCommand) {
           _authoritativeColorUpdates.add(propertyKey);
         }
       }

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -183,9 +183,41 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
   }
 
+  void _checkConvergence(LightingDeviceView device) {
+    final controlState = _deviceControlStateService;
+    if (controlState == null) return;
+
+    for (final channel in device.lightChannels) {
+      for (final property in channel.properties) {
+        final actualValue = property.value?.value;
+        if (actualValue == null) continue;
+
+        controlState.checkPropertyConvergence(
+          device.id,
+          channel.id,
+          property.id,
+          actualValue,
+        );
+      }
+    }
+
+    final colorState = controlState.getGroupState(
+      device.id,
+      LightChannelController.colorGroupId,
+    );
+    if (colorState != null && (colorState.isSettling || colorState.isMixed)) {
+      // A new authoritative device snapshot supersedes the grouped optimistic
+      // color values, whether it confirms them or reports an external change.
+      controlState.clearGroup(device.id, LightChannelController.colorGroupId);
+    }
+  }
+
   @override
   void didUpdateWidget(covariant LightingDeviceDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget._device, widget._device)) {
+      _checkConvergence(widget._device);
+    }
     _initController();
   }
 
@@ -1271,4 +1303,3 @@ Color _sampleGradient(List<Color> colors, double t) {
   final localT = (t * segments - segment).clamp(0.0, 1.0);
   return Color.lerp(colors[segment], colors[segment + 1], localT)!;
 }
-

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -50,6 +50,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   final DevicesService _devicesService = locator<DevicesService>();
   DeviceControlStateService? _deviceControlStateService;
   LightingDeviceController? _controller;
+  DateTime? _trackedColorStateCreatedAt;
+  final Set<String> _authoritativeColorUpdates = {};
 
   // Selected channel index for multi-channel devices
   int _selectedChannelIndex = 0;
@@ -209,10 +211,9 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       for (final property in channel.properties) {
         final propertyKey = '${channel.id}:${property.id}';
         final actualValue = property.value?.value;
-        if (actualValue == null) continue;
-
         newValues[propertyKey] = actualValue;
-        if (oldValues[propertyKey] == actualValue) {
+        if (oldValues.containsKey(propertyKey) &&
+            oldValues[propertyKey] == actualValue) {
           continue;
         }
 
@@ -225,11 +226,10 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         );
         if (propertyState?.isPending ?? false) {
           // Homey synchronizes the authoritative capability event before the
-          // command acknowledgment resolves. Consume a matching value now so
-          // the later setSettling call is a harmless no-op.
-          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
-            controlState.clear(newDevice.id, channel.id, property.id);
-          }
+          // command acknowledgment resolves. A changed value is authoritative
+          // confirmation or divergence, including null, so the later
+          // setSettling call must be a harmless no-op.
+          controlState.clear(newDevice.id, channel.id, property.id);
           continue;
         }
 
@@ -246,28 +246,44 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       newDevice.id,
       LightChannelController.colorGroupId,
     );
-    if (colorState != null &&
-        (colorState.isPending || colorState.isSettling || colorState.isMixed)) {
-      final colorChanged = colorState.properties.any(
-        (property) => changedProperties.contains(
-          '${property.channelId}:${property.propertyId}',
-        ),
-      );
-      final colorConverged = colorState.properties.every((property) {
+    if (colorState == null) {
+      _trackedColorStateCreatedAt = null;
+      _authoritativeColorUpdates.clear();
+      return;
+    }
+
+    if (_trackedColorStateCreatedAt != colorState.createdAt) {
+      _trackedColorStateCreatedAt = colorState.createdAt;
+      _authoritativeColorUpdates.clear();
+    }
+
+    if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
+      for (final property in colorState.properties) {
+        final propertyKey = '${property.channelId}:${property.propertyId}';
+        if (changedProperties.contains(propertyKey)) {
+          _authoritativeColorUpdates.add(propertyKey);
+        }
+      }
+
+      final colorComplete = colorState.properties.every((property) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
         if (!newValues.containsKey(propertyKey)) return false;
 
         final desired = property.desiredValue;
         final actual = newValues[propertyKey];
-        return _valuesConverged(desired, actual);
+        return _authoritativeColorUpdates.contains(propertyKey) ||
+            _valuesConverged(desired, actual);
       });
-      if (colorChanged && colorConverged) {
+      if (_authoritativeColorUpdates.isNotEmpty && colorComplete) {
         // Keep grouped optimism until every authoritative component has
-        // arrived; Homey may emit RGB/HSV property changes separately.
+        // arrived or was already at its desired value. A complete divergent
+        // set is authoritative too (for example device-side quantization).
         controlState.clearGroup(
           newDevice.id,
           LightChannelController.colorGroupId,
         );
+        _trackedColorStateCreatedAt = null;
+        _authoritativeColorUpdates.clear();
       }
     }
   }

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -54,6 +54,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       _deferredPropertySnapshots = {};
   Object? _trackedColorGeneration;
   final Set<String> _authoritativeColorUpdates = {};
+  final Set<String> _postAckColorMatches = {};
   final Set<String> _postAckColorDivergences = {};
 
   // Selected channel index for multi-channel devices
@@ -293,6 +294,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState == null) {
       _trackedColorGeneration = null;
       _authoritativeColorUpdates.clear();
+      _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
       return;
     }
@@ -300,6 +302,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (!identical(_trackedColorGeneration, colorState.generation)) {
       _trackedColorGeneration = colorState.generation;
       _authoritativeColorUpdates.clear();
+      _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
     }
 
@@ -313,11 +316,16 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         final actualValue = newValues[propertyKey];
         if (_valuesConverged(property.desiredValue, actualValue)) {
           _authoritativeColorUpdates.add(propertyKey);
+          if (!colorState.isPending) {
+            _postAckColorMatches.add(propertyKey);
+          }
           _postAckColorDivergences.remove(propertyKey);
         } else {
           // Divergence cannot be assigned to this command immediately: even
           // before acknowledgment it may be delayed state from the previous
           // color. Accept a complete divergent set only after settling expires.
+          _authoritativeColorUpdates.remove(propertyKey);
+          _postAckColorMatches.remove(propertyKey);
           _postAckColorDivergences.add(propertyKey);
         }
       }
@@ -365,12 +373,14 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState == null) {
       _trackedColorGeneration = null;
       _authoritativeColorUpdates.clear();
+      _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
       return;
     }
     if (!identical(_trackedColorGeneration, colorState.generation)) {
       _trackedColorGeneration = colorState.generation;
       _authoritativeColorUpdates.clear();
+      _postAckColorMatches.clear();
       _postAckColorDivergences.clear();
       return;
     }
@@ -413,28 +423,24 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     DeviceControlState colorState,
     Map<String, dynamic> actualValues,
   ) {
+    if (colorState.isPending) return;
+
     final colorComplete = colorState.properties.every((property) {
       final propertyKey = '${property.channelId}:${property.propertyId}';
       if (!actualValues.containsKey(propertyKey)) return false;
 
-      final converged = _valuesConverged(
-        property.desiredValue,
-        actualValues[propertyKey],
-      );
-      return colorState.isPending
-          ? converged
-          : _authoritativeColorUpdates.contains(propertyKey) || converged;
+      return _postAckColorMatches.contains(propertyKey) &&
+          _valuesConverged(
+            property.desiredValue,
+            actualValues[propertyKey],
+          );
     });
     final divergentComplete = colorState.isMixed &&
         colorState.properties.every((property) {
           final propertyKey = '${property.channelId}:${property.propertyId}';
           return actualValues.containsKey(propertyKey) &&
               (_authoritativeColorUpdates.contains(propertyKey) ||
-                  _postAckColorDivergences.contains(propertyKey) ||
-                  _valuesConverged(
-                    property.desiredValue,
-                    actualValues[propertyKey],
-                  ));
+                  _postAckColorDivergences.contains(propertyKey));
         });
     if ((_authoritativeColorUpdates.isEmpty &&
             _postAckColorDivergences.isEmpty) ||
@@ -448,6 +454,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
     _trackedColorGeneration = null;
     _authoritativeColorUpdates.clear();
+    _postAckColorMatches.clear();
     _postAckColorDivergences.clear();
   }
 

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -183,6 +183,13 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
   }
 
+  bool _valuesConverged(dynamic desired, dynamic actual) {
+    if (desired is num && actual is num) {
+      return (desired - actual).abs() <= 0.5;
+    }
+    return desired == actual;
+  }
+
   void _checkConvergence(
     LightingDeviceView oldDevice,
     LightingDeviceView newDevice,
@@ -211,6 +218,21 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
 
         changedProperties.add(propertyKey);
 
+        final propertyState = controlState.getState(
+          newDevice.id,
+          channel.id,
+          property.id,
+        );
+        if (propertyState?.isPending ?? false) {
+          // Homey synchronizes the authoritative capability event before the
+          // command acknowledgment resolves. Consume a matching value now so
+          // the later setSettling call is a harmless no-op.
+          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
+            controlState.clear(newDevice.id, channel.id, property.id);
+          }
+          continue;
+        }
+
         controlState.checkPropertyConvergence(
           newDevice.id,
           channel.id,
@@ -224,7 +246,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       newDevice.id,
       LightChannelController.colorGroupId,
     );
-    if (colorState != null && (colorState.isSettling || colorState.isMixed)) {
+    if (colorState != null &&
+        (colorState.isPending || colorState.isSettling || colorState.isMixed)) {
       final colorChanged = colorState.properties.any(
         (property) => changedProperties.contains(
           '${property.channelId}:${property.propertyId}',
@@ -236,10 +259,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
 
         final desired = property.desiredValue;
         final actual = newValues[propertyKey];
-        if (desired is num && actual is num) {
-          return (desired - actual).abs() <= 0.5;
-        }
-        return desired == actual;
+        return _valuesConverged(desired, actual);
       });
       if (colorChanged && colorConverged) {
         // Keep grouped optimism until every authoritative component has

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -54,6 +54,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       _deferredPropertyDivergences = {};
   Object? _trackedColorGeneration;
   final Set<String> _authoritativeColorUpdates = {};
+  final Set<String> _postAckColorDivergences = {};
 
   // Selected channel index for multi-channel devices
   int _selectedChannelIndex = 0;
@@ -213,6 +214,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           '${channel.id}:${property.id}': property.lastUpdated,
     };
     final newValues = <String, dynamic>{};
+    final newLastUpdated = <String, DateTime?>{};
     final changedProperties = <String>{};
 
     for (final channel in newDevice.lightChannels) {
@@ -221,6 +223,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         final actualValue = property.value?.value;
         final actualLastUpdated = property.lastUpdated;
         newValues[propertyKey] = actualValue;
+        newLastUpdated[propertyKey] = actualLastUpdated;
         if (oldValues.containsKey(propertyKey) &&
             oldValues[propertyKey] == actualValue &&
             oldLastUpdated[propertyKey] == actualLastUpdated) {
@@ -234,6 +237,12 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           channel.id,
           property.id,
         );
+        if (actualLastUpdated == null) {
+          // ChannelPropertiesRepository emits a local optimistic copy without
+          // measurement metadata before dispatching the command. It is UI
+          // feedback, not provider confirmation.
+          continue;
+        }
         if (propertyState?.isPending ?? false) {
           if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
             _deferredPropertyDivergences.remove(propertyKey);
@@ -271,22 +280,34 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState == null) {
       _trackedColorGeneration = null;
       _authoritativeColorUpdates.clear();
+      _postAckColorDivergences.clear();
       return;
     }
 
     if (!identical(_trackedColorGeneration, colorState.generation)) {
       _trackedColorGeneration = colorState.generation;
       _authoritativeColorUpdates.clear();
+      _postAckColorDivergences.clear();
     }
 
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
       for (final property in colorState.properties) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
+        if (newLastUpdated[propertyKey] == null ||
+            !changedProperties.contains(propertyKey)) {
+          continue;
+        }
         final actualValue = newValues[propertyKey];
-        final correlatedUpdate = colorState.isPending ||
-            _valuesConverged(property.desiredValue, actualValue);
-        if (changedProperties.contains(propertyKey) && correlatedUpdate) {
+        if (colorState.isPending ||
+            _valuesConverged(property.desiredValue, actualValue)) {
           _authoritativeColorUpdates.add(propertyKey);
+          _postAckColorDivergences.remove(propertyKey);
+        } else {
+          // A post-ack divergent snapshot cannot be assigned to this command
+          // immediately: it may be delayed state from the previous color.
+          // Retain the latest authoritative component and accept a complete
+          // divergent set only if the settling window expires.
+          _postAckColorDivergences.add(propertyKey);
         }
       }
 
@@ -333,11 +354,13 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     if (colorState == null) {
       _trackedColorGeneration = null;
       _authoritativeColorUpdates.clear();
+      _postAckColorDivergences.clear();
       return;
     }
     if (!identical(_trackedColorGeneration, colorState.generation)) {
       _trackedColorGeneration = colorState.generation;
       _authoritativeColorUpdates.clear();
+      _postAckColorDivergences.clear();
       return;
     }
     if (!colorState.isSettling && !colorState.isMixed) return;
@@ -373,7 +396,22 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           ? converged
           : _authoritativeColorUpdates.contains(propertyKey) || converged;
     });
-    if (_authoritativeColorUpdates.isEmpty || !colorComplete) return;
+    final divergentComplete = colorState.isMixed &&
+        colorState.properties.every((property) {
+          final propertyKey = '${property.channelId}:${property.propertyId}';
+          return actualValues.containsKey(propertyKey) &&
+              (_authoritativeColorUpdates.contains(propertyKey) ||
+                  _postAckColorDivergences.contains(propertyKey) ||
+                  _valuesConverged(
+                    property.desiredValue,
+                    actualValues[propertyKey],
+                  ));
+        });
+    if ((_authoritativeColorUpdates.isEmpty &&
+            _postAckColorDivergences.isEmpty) ||
+        (!colorComplete && !divergentComplete)) {
+      return;
+    }
 
     controlState.clearGroup(
       deviceId,
@@ -381,6 +419,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
     _trackedColorGeneration = null;
     _authoritativeColorUpdates.clear();
+    _postAckColorDivergences.clear();
   }
 
   @override

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -447,7 +447,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     DeviceControlState colorState,
     Map<String, dynamic> actualValues,
   ) {
-    if (colorState.isPending) return;
+    if (colorState.isPending || colorState.isSettling) return;
 
     final colorComplete = colorState.properties.every((property) {
       final propertyKey = '${property.channelId}:${property.propertyId}';

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -50,8 +50,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   final DevicesService _devicesService = locator<DevicesService>();
   DeviceControlStateService? _deviceControlStateService;
   LightingDeviceController? _controller;
-  final Map<String, _DeferredPropertyDivergence>
-      _deferredPropertyDivergences = {};
+  final Map<String, _DeferredPropertySnapshot>
+      _deferredPropertySnapshots = {};
   Object? _trackedColorGeneration;
   final Set<String> _authoritativeColorUpdates = {};
   final Set<String> _postAckColorDivergences = {};
@@ -183,7 +183,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   }
 
   void _onControlStateChanged() {
-    _consumeDeferredDivergences();
+    _consumeDeferredSnapshots();
     if (mounted && !_isAnyDragging) {
       setState(() {});
     }
@@ -244,28 +244,27 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           continue;
         }
         if (propertyState?.isPending ?? false) {
-          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
-            _deferredPropertyDivergences.remove(propertyKey);
-            controlState.clear(newDevice.id, channel.id, property.id);
-          } else {
-            _deferPropertyDivergence(
-              propertyKey,
-              newDevice.id,
-              channel.id,
-              property.id,
-              propertyState!.generation,
-              actualValue,
-            );
-          }
+          // A provider snapshot received before this command is acknowledged
+          // may belong to an older command generation, even when its value
+          // matches (for example on -> off -> on). Keep it associated with
+          // this generation, but never let it complete pending state.
+          _deferPropertySnapshot(
+            propertyKey,
+            newDevice.id,
+            channel.id,
+            property.id,
+            propertyState!.generation,
+            actualValue,
+          );
           continue;
         }
 
         if (propertyState?.isSettling ?? false) {
           if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
-            _deferredPropertyDivergences.remove(propertyKey);
+            _deferredPropertySnapshots.remove(propertyKey);
             controlState.clear(newDevice.id, channel.id, property.id);
           } else {
-            _deferPropertyDivergence(
+            _deferPropertySnapshot(
               propertyKey,
               newDevice.id,
               channel.id,
@@ -277,7 +276,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           continue;
         }
 
-        _deferredPropertyDivergences.remove(propertyKey);
+        _deferredPropertySnapshots.remove(propertyKey);
         controlState.checkPropertyConvergence(
           newDevice.id,
           channel.id,
@@ -332,30 +331,30 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     }
   }
 
-  void _consumeDeferredDivergences() {
+  void _consumeDeferredSnapshots() {
     final controlState = _deviceControlStateService;
     if (controlState == null) return;
 
-    for (final entry in _deferredPropertyDivergences.entries.toList()) {
-      final divergence = entry.value;
+    for (final entry in _deferredPropertySnapshots.entries.toList()) {
+      final snapshot = entry.value;
       final state = controlState.getState(
-        divergence.deviceId,
-        divergence.channelId,
-        divergence.propertyId,
+        snapshot.deviceId,
+        snapshot.channelId,
+        snapshot.propertyId,
       );
       if (state == null ||
-          !identical(state.generation, divergence.generation)) {
-        _deferredPropertyDivergences.remove(entry.key);
+          !identical(state.generation, snapshot.generation)) {
+        _deferredPropertySnapshots.remove(entry.key);
         continue;
       }
       if (!state.isMixed) continue;
 
-      _deferredPropertyDivergences.remove(entry.key);
+      _deferredPropertySnapshots.remove(entry.key);
       controlState.checkPropertyConvergence(
-        divergence.deviceId,
-        divergence.channelId,
-        divergence.propertyId,
-        divergence.actualValue,
+        snapshot.deviceId,
+        snapshot.channelId,
+        snapshot.propertyId,
+        snapshot.actualValue,
       );
     }
 
@@ -390,7 +389,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     );
   }
 
-  void _deferPropertyDivergence(
+  void _deferPropertySnapshot(
     String propertyKey,
     String deviceId,
     String channelId,
@@ -398,8 +397,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     Object generation,
     dynamic actualValue,
   ) {
-    _deferredPropertyDivergences[propertyKey] =
-        _DeferredPropertyDivergence(
+    _deferredPropertySnapshots[propertyKey] =
+        _DeferredPropertySnapshot(
       deviceId: deviceId,
       channelId: channelId,
       propertyId: propertyId,
@@ -1091,14 +1090,14 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   }
 }
 
-class _DeferredPropertyDivergence {
+class _DeferredPropertySnapshot {
   final String deviceId;
   final String channelId;
   final String propertyId;
   final Object generation;
   final dynamic actualValue;
 
-  const _DeferredPropertyDivergence({
+  const _DeferredPropertySnapshot({
     required this.deviceId,
     required this.channelId,
     required this.propertyId,

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -50,7 +50,7 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   final DevicesService _devicesService = locator<DevicesService>();
   DeviceControlStateService? _deviceControlStateService;
   LightingDeviceController? _controller;
-  DateTime? _trackedColorStateCreatedAt;
+  Object? _trackedColorGeneration;
   final Set<String> _authoritativeColorUpdates = {};
 
   // Selected channel index for multi-channel devices
@@ -210,7 +210,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           '${channel.id}:${property.id}': property.lastUpdated,
     };
     final newValues = <String, dynamic>{};
-    final newLastUpdated = <String, DateTime?>{};
     final changedProperties = <String>{};
 
     for (final channel in newDevice.lightChannels) {
@@ -219,7 +218,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         final actualValue = property.value?.value;
         final actualLastUpdated = property.lastUpdated;
         newValues[propertyKey] = actualValue;
-        newLastUpdated[propertyKey] = actualLastUpdated;
         if (oldValues.containsKey(propertyKey) &&
             oldValues[propertyKey] == actualValue &&
             oldLastUpdated[propertyKey] == actualLastUpdated) {
@@ -233,19 +231,13 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           channel.id,
           property.id,
         );
-        if (propertyState != null &&
-            actualLastUpdated != null &&
-            actualLastUpdated.isBefore(propertyState.createdAt)) {
-          // A delayed event from an earlier command must not confirm or
-          // override the currently active optimistic generation.
-          continue;
-        }
         if (propertyState?.isPending ?? false) {
-          // Homey synchronizes the authoritative capability event before the
-          // command acknowledgment resolves. A changed value is authoritative
-          // confirmation or divergence, including null, so the later
-          // setSettling call must be a harmless no-op.
-          controlState.clear(newDevice.id, channel.id, property.id);
+          // While the command generation is pending, only its requested value
+          // can confirm it. Divergent updates may still belong to the previous
+          // generation; command failure or the settling phase handles them.
+          if (_valuesConverged(propertyState?.desiredValue, actualValue)) {
+            controlState.clear(newDevice.id, channel.id, property.id);
+          }
           continue;
         }
 
@@ -263,22 +255,24 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       LightChannelController.colorGroupId,
     );
     if (colorState == null) {
-      _trackedColorStateCreatedAt = null;
+      _trackedColorGeneration = null;
       _authoritativeColorUpdates.clear();
       return;
     }
 
-    if (_trackedColorStateCreatedAt != colorState.createdAt) {
-      _trackedColorStateCreatedAt = colorState.createdAt;
+    if (!identical(_trackedColorGeneration, colorState.generation)) {
+      _trackedColorGeneration = colorState.generation;
       _authoritativeColorUpdates.clear();
     }
 
     if (colorState.isPending || colorState.isSettling || colorState.isMixed) {
       for (final property in colorState.properties) {
         final propertyKey = '${property.channelId}:${property.propertyId}';
-        final lastUpdated = newLastUpdated[propertyKey];
-        final belongsToActiveCommand = lastUpdated == null ||
-            !lastUpdated.isBefore(colorState.createdAt);
+        final belongsToActiveCommand = !colorState.isPending ||
+            _valuesConverged(
+              property.desiredValue,
+              newValues[propertyKey],
+            );
         if (changedProperties.contains(propertyKey) &&
             belongsToActiveCommand) {
           _authoritativeColorUpdates.add(propertyKey);
@@ -291,18 +285,21 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
 
         final desired = property.desiredValue;
         final actual = newValues[propertyKey];
+        if (colorState.isPending) {
+          return _valuesConverged(desired, actual);
+        }
         return _authoritativeColorUpdates.contains(propertyKey) ||
             _valuesConverged(desired, actual);
       });
       if (_authoritativeColorUpdates.isNotEmpty && colorComplete) {
-        // Keep grouped optimism until every authoritative component has
-        // arrived or was already at its desired value. A complete divergent
+        // Pending commands clear only on requested-value confirmation. Once
+        // their generation is acknowledged and settling, a complete divergent
         // set is authoritative too (for example device-side quantization).
         controlState.clearGroup(
           newDevice.id,
           LightChannelController.colorGroupId,
         );
-        _trackedColorStateCreatedAt = null;
+        _trackedColorGeneration = null;
         _authoritativeColorUpdates.clear();
       }
     }
@@ -408,14 +405,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         }
 
         controller.setBrightness(value);
-
-        if (prop != null) {
-          _deviceControlStateService?.setSettling(
-            controller.deviceId,
-            controller.channel.id,
-            prop.id,
-          );
-        }
       },
     );
   }
@@ -454,14 +443,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         }
 
         controller.setColorTemperature(value);
-
-        if (prop != null) {
-          _deviceControlStateService?.setSettling(
-            controller.deviceId,
-            controller.channel.id,
-            prop.id,
-          );
-        }
       },
     );
   }
@@ -547,13 +528,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         }
 
         controller.setColor(color);
-
-        if (colorProperties.isNotEmpty) {
-          _deviceControlStateService?.setGroupSettling(
-            deviceId,
-            LightChannelController.colorGroupId,
-          );
-        }
       },
     );
   }
@@ -592,14 +566,6 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         }
 
         controller.setColorWhite(value);
-
-        if (prop != null) {
-          _deviceControlStateService?.setSettling(
-            controller.deviceId,
-            controller.channel.id,
-            prop.id,
-          );
-        }
       },
     );
   }

--- a/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
+++ b/apps/panel/lib/modules/devices/presentation/device_details/lighting.dart
@@ -52,6 +52,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
   LightingDeviceController? _controller;
   final Map<String, _DeferredPropertySnapshot>
       _deferredPropertySnapshots = {};
+  final Map<String, Object> _trackedPropertyGenerations = {};
+  final Map<String, Object> _baselinePropertyMatches = {};
   Object? _trackedColorGeneration;
   final Set<String> _baselineColorMatches = {};
   final Set<String> _authoritativeColorUpdates = {};
@@ -239,11 +241,21 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
           channel.id,
           property.id,
         );
+        if (propertyState == null) {
+          _trackedPropertyGenerations.remove(propertyKey);
+          _baselinePropertyMatches.remove(propertyKey);
+        }
         if (actualLastUpdated == null) {
           // ChannelPropertiesRepository emits a local optimistic copy without
           // measurement metadata before dispatching the command. It is UI
           // feedback, not provider confirmation.
           continue;
+        }
+        final baselineGeneration = _baselinePropertyMatches[propertyKey];
+        if (propertyState != null &&
+            identical(baselineGeneration, propertyState.generation) &&
+            !_valuesConverged(propertyState.desiredValue, actualValue)) {
+          _baselinePropertyMatches.remove(propertyKey);
         }
         if (propertyState?.isPending ?? false) {
           // A provider snapshot received before this command is acknowledged
@@ -342,6 +354,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
     final controlState = _deviceControlStateService;
     if (controlState == null) return;
 
+    _trackPropertyGenerations(controlState);
+
     for (final entry in _deferredPropertySnapshots.entries.toList()) {
       final snapshot = entry.value;
       final state = controlState.getState(
@@ -364,6 +378,8 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
         snapshot.actualValue,
       );
     }
+
+    _clearBaselinePropertyStates(controlState);
 
     final colorState = controlState.getGroupState(
       widget._device.id,
@@ -394,6 +410,89 @@ class _LightingDeviceDetailState extends State<LightingDeviceDetail> {
       colorState,
       currentValues,
     );
+  }
+
+  void _trackPropertyGenerations(
+    DeviceControlStateService controlState,
+  ) {
+    final activePropertyKeys = <String>{};
+
+    for (final channel in widget._device.lightChannels) {
+      for (final property in channel.properties) {
+        final propertyKey = '${channel.id}:${property.id}';
+        activePropertyKeys.add(propertyKey);
+        final state = controlState.getState(
+          widget._device.id,
+          channel.id,
+          property.id,
+        );
+        if (state == null) {
+          _trackedPropertyGenerations.remove(propertyKey);
+          _baselinePropertyMatches.remove(propertyKey);
+          continue;
+        }
+        if (identical(
+          _trackedPropertyGenerations[propertyKey],
+          state.generation,
+        )) {
+          continue;
+        }
+
+        _trackedPropertyGenerations[propertyKey] = state.generation;
+        _baselinePropertyMatches.remove(propertyKey);
+        if (state.isPending &&
+            _valuesConverged(
+              state.desiredValue,
+              property.value?.value,
+            )) {
+          _baselinePropertyMatches[propertyKey] = state.generation;
+        }
+      }
+    }
+
+    for (final propertyKey in _trackedPropertyGenerations.keys.toList()) {
+      if (!activePropertyKeys.contains(propertyKey)) {
+        _trackedPropertyGenerations.remove(propertyKey);
+        _baselinePropertyMatches.remove(propertyKey);
+        _deferredPropertySnapshots.remove(propertyKey);
+      }
+    }
+  }
+
+  void _clearBaselinePropertyStates(
+    DeviceControlStateService controlState,
+  ) {
+    for (final channel in widget._device.lightChannels) {
+      for (final property in channel.properties) {
+        final propertyKey = '${channel.id}:${property.id}';
+        final state = controlState.getState(
+          widget._device.id,
+          channel.id,
+          property.id,
+        );
+        if (state == null ||
+            !state.isMixed ||
+            _deferredPropertySnapshots.containsKey(propertyKey) ||
+            !identical(
+              _baselinePropertyMatches[propertyKey],
+              state.generation,
+            ) ||
+            !_valuesConverged(
+              state.desiredValue,
+              property.value?.value,
+            )) {
+          continue;
+        }
+
+        _trackedPropertyGenerations.remove(propertyKey);
+        _baselinePropertyMatches.remove(propertyKey);
+        controlState.clear(
+          widget._device.id,
+          channel.id,
+          property.id,
+        );
+      }
+    }
   }
 
   void _deferPropertySnapshot(

--- a/apps/panel/lib/modules/devices/services/device_control_state.service.dart
+++ b/apps/panel/lib/modules/devices/services/device_control_state.service.dart
@@ -207,6 +207,7 @@ class DeviceControlStateService extends ChangeNotifier {
         _onSettlingTimeout(key);
       }),
       createdAt: currentState.createdAt,
+      generation: currentState.generation,
     );
 
     if (kDebugMode) {
@@ -471,6 +472,7 @@ class DeviceControlStateService extends ChangeNotifier {
       settlingTimer: timer,
       settlingStartedAt: DateTime.now(),
       createdAt: currentState.createdAt,
+      generation: currentState.generation,
     );
 
     if (kDebugMode) {
@@ -670,6 +672,7 @@ class DeviceControlStateService extends ChangeNotifier {
       state: DeviceControlUIState.mixed,
       properties: currentState!.properties,
       createdAt: currentState.createdAt,
+      generation: currentState.generation,
     );
 
     if (kDebugMode) {

--- a/apps/panel/test/modules/devices/controllers/channels/light_channel_controller_test.dart
+++ b/apps/panel/test/modules/devices/controllers/channels/light_channel_controller_test.dart
@@ -29,6 +29,8 @@ void main() {
     late MockDevicesService mockDevicesService;
     late LightChannelView lightChannel;
     late LightChannelController controller;
+    late Map<String, DeviceControlState> propertyStates;
+    DeviceControlState? groupState;
 
     const deviceId = 'device-123';
     const channelId = 'channel-456';
@@ -45,6 +47,52 @@ void main() {
     setUp(() {
       mockControlState = MockDeviceControlStateService();
       mockDevicesService = MockDevicesService();
+      propertyStates = {};
+      groupState = null;
+
+      when(
+        () => mockControlState.setPending(
+          any(),
+          any(),
+          any(),
+          any(),
+          silent: any(named: 'silent'),
+        ),
+      ).thenAnswer((invocation) {
+        final propertyId = invocation.positionalArguments[2] as String;
+        propertyStates[propertyId] = DeviceControlState(
+          createdAt: DateTime.now(),
+        ).toPending([
+          PropertyConfig(
+            channelId: invocation.positionalArguments[1] as String,
+            propertyId: propertyId,
+            desiredValue: invocation.positionalArguments[3],
+          ),
+        ]);
+      });
+      when(
+        () => mockControlState.getState(any(), any(), any()),
+      ).thenAnswer(
+        (invocation) =>
+            propertyStates[invocation.positionalArguments[2] as String],
+      );
+      when(
+        () => mockControlState.setGroupPending(
+          any(),
+          any(),
+          any(),
+          silent: any(named: 'silent'),
+        ),
+      ).thenAnswer((invocation) {
+        groupState = DeviceControlState(
+          createdAt: DateTime.now(),
+        ).toPending(
+          invocation.positionalArguments[2] as List<PropertyConfig>,
+        );
+      });
+      when(
+        () => mockControlState.getGroupState(any(), any()),
+      ).thenAnswer((_) => groupState);
 
       // Create test channel with RGB properties
       lightChannel = LightChannelView(
@@ -239,12 +287,6 @@ void main() {
     group('commands', () {
       test('setPower calls setPending and then setSettling after API call',
           () async {
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              onPropId,
-              false,
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(onPropId, false))
             .thenAnswer((_) async => true);
         when(() => mockControlState.setSettling(
@@ -277,12 +319,6 @@ void main() {
       test('togglePower toggles current power state', () {
         when(() => mockControlState.isLocked(deviceId, channelId, onPropId))
             .thenReturn(false);
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              onPropId,
-              false, // Toggle from true to false
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(onPropId, false))
             .thenAnswer((_) async => true);
         when(() => mockControlState.setSettling(
@@ -302,12 +338,6 @@ void main() {
       });
 
       test('setBrightness calls setPending and then setSettling', () async {
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              brightnessPropId,
-              50,
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(brightnessPropId, 50))
             .thenAnswer((_) async => true);
         when(() => mockControlState.setSettling(
@@ -338,11 +368,6 @@ void main() {
 
       test('setColorRGB calls setGroupPending and then setGroupSettling',
           () async {
-        when(() => mockControlState.setGroupPending(
-              deviceId,
-              LightChannelController.colorGroupId,
-              any(),
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(colorRedPropId, 100))
             .thenAnswer((_) async => true);
         when(() => mockDevicesService.setPropertyValue(colorGreenPropId, 150))
@@ -377,11 +402,6 @@ void main() {
       });
 
       test('setColor with RGB light calls setColorRGB', () async {
-        when(() => mockControlState.setGroupPending(
-              deviceId,
-              LightChannelController.colorGroupId,
-              any(),
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(colorRedPropId, 128))
             .thenAnswer((_) async => true);
         when(() => mockDevicesService.setPropertyValue(colorGreenPropId, 64))
@@ -430,12 +450,6 @@ void main() {
           },
         );
 
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              onPropId,
-              false,
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(onPropId, false))
             .thenAnswer((_) async => false);
         when(() => mockControlState.clear(
@@ -472,12 +486,6 @@ void main() {
           },
         );
 
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              brightnessPropId,
-              50,
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(brightnessPropId, 50))
             .thenAnswer((_) async => false);
         when(() => mockControlState.clear(
@@ -514,11 +522,6 @@ void main() {
           },
         );
 
-        when(() => mockControlState.setGroupPending(
-              deviceId,
-              LightChannelController.colorGroupId,
-              any(),
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(colorRedPropId, 100))
             .thenAnswer((_) async => false);
         when(() => mockDevicesService.setPropertyValue(colorGreenPropId, 150))
@@ -557,12 +560,6 @@ void main() {
           },
         );
 
-        when(() => mockControlState.setPending(
-              deviceId,
-              channelId,
-              onPropId,
-              false,
-            )).thenReturn(null);
         when(() => mockDevicesService.setPropertyValue(onPropId, false))
             .thenAnswer((_) => Future.error(Exception('Network error')));
         when(() => mockControlState.clear(

--- a/apps/panel/test/modules/devices/services/device_control_state_service_test.dart
+++ b/apps/panel/test/modules/devices/services/device_control_state_service_test.dart
@@ -121,6 +121,48 @@ void main() {
           'test-value',
         );
       });
+
+      test('preserves command generation through settling and mixed states', () {
+        fakeAsync((async) {
+          service.setPending('device-1', 'channel-1', 'property-1', 10);
+          final pendingGeneration = service
+              .getState('device-1', 'channel-1', 'property-1')!
+              .generation;
+
+          service.setSettling('device-1', 'channel-1', 'property-1');
+          expect(
+            identical(
+              service
+                  .getState('device-1', 'channel-1', 'property-1')!
+                  .generation,
+              pendingGeneration,
+            ),
+            isTrue,
+          );
+
+          async.elapse(const Duration(milliseconds: 900));
+          expect(
+            identical(
+              service
+                  .getState('device-1', 'channel-1', 'property-1')!
+                  .generation,
+              pendingGeneration,
+            ),
+            isTrue,
+          );
+
+          service.setPending('device-1', 'channel-1', 'property-1', 20);
+          expect(
+            identical(
+              service
+                  .getState('device-1', 'channel-1', 'property-1')!
+                  .generation,
+              pendingGeneration,
+            ),
+            isFalse,
+          );
+        });
+      });
     });
 
     group('timer expiration', () {

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -769,6 +769,19 @@ void main() {
           controlState.isSettling(deviceId, lightChannelId, propertyId),
           isTrue,
         );
+
+        updateHost(() {
+          renderedDevice =
+              _buildRepresentativeDevice('lighting', lightOn: false)
+                  as LightingDeviceView;
+        });
+        await tester.pump();
+
+        expect(
+          controlState.isSettling(deviceId, lightChannelId, propertyId),
+          isTrue,
+          reason: 'an equivalent rebuilt snapshot is not confirmation',
+        );
         expect(socket.lastEvent, DevicesModuleConstants.setPropertyEvent);
         expect(socket.lastHandler, DevicesModuleEventHandlerName.setProperty);
         expect(socket.lastData, {

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -909,7 +909,7 @@ void main() {
       },
     );
 
-    testWidgets('accepts an authoritative null as lighting divergence', (
+    testWidgets('accepts a settled authoritative null as lighting divergence', (
       tester,
     ) async {
       tester.view.physicalSize = const Size(1280, 800);
@@ -939,6 +939,7 @@ void main() {
       );
 
       controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      controlState.setSettling(deviceId, lightChannelId, propertyId);
       final authoritativeEventAt = controlState
           .getState(deviceId, lightChannelId, propertyId)!
           .createdAt
@@ -1136,8 +1137,8 @@ void main() {
         deviceId,
         LightChannelController.colorGroupId,
       )!;
-      final previousCommandEventAt = activeState.createdAt.subtract(
-        const Duration(milliseconds: 1),
+      final previousCommandEventAt = activeState.createdAt.add(
+        const Duration(days: 365),
       );
 
       updateHost(() {
@@ -1154,11 +1155,11 @@ void main() {
             .getGroupState(deviceId, LightChannelController.colorGroupId)
             ?.isPending,
         isTrue,
-        reason: 'events predating the active generation belong to its predecessor',
+        reason: 'provider clock skew must not make stale values confirm the active generation',
       );
 
-      final activeCommandEventAt = activeState.createdAt.add(
-        const Duration(milliseconds: 1),
+      final activeCommandEventAt = activeState.createdAt.subtract(
+        const Duration(days: 365),
       );
       updateHost(() {
         renderedDevice = _buildRepresentativeDevice(
@@ -1177,6 +1178,70 @@ void main() {
         isNull,
       );
       expect(tester.takeException(), isNull);
+    });
+
+    test('ignores completion from an older color command generation', () async {
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      final devicesService = locator<DevicesService>() as _MockDevicesService;
+      reset(devicesService);
+      final completions = List.generate(6, (_) => Completer<bool>());
+      var commandCall = 0;
+      when(
+        () => devicesService.setPropertyValue(any(), any()),
+      ).thenAnswer((_) => completions[commandCall++].future);
+      final controller = LightingDeviceController(
+        device: _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [0, 0, 0],
+        ) as LightingDeviceView,
+        controlState: controlState,
+        devicesService: devicesService,
+      ).light;
+
+      controller.setColorRGB(10, 20, 30);
+      final firstGeneration = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      )!;
+      controller.setColorRGB(40, 50, 60);
+      final secondGeneration = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      )!;
+      expect(identical(secondGeneration, firstGeneration), isFalse);
+
+      for (final completion in completions.take(3)) {
+        completion.complete(false);
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      final afterFirstCompletion = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      expect(identical(afterFirstCompletion, secondGeneration), isTrue);
+      expect(afterFirstCompletion?.isPending, isTrue);
+
+      for (final completion in completions.skip(3)) {
+        completion.complete(true);
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      final afterSecondCompletion = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      expect(
+        identical(
+          afterSecondCompletion?.generation,
+          secondGeneration.generation,
+        ),
+        isTrue,
+      );
+      expect(afterSecondCompletion?.isSettling, isTrue);
     });
   });
 }

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -660,9 +660,14 @@ void main() {
   });
 
   group('Homey state and control pipeline', () {
-    test(
+    testWidgets(
       'drives optimistic control to authoritative Homey state without credentials',
-      () async {
+      (tester) async {
+        tester.view.physicalSize = const Size(1280, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
         final apiClient = DevicesModuleClient(
           Dio(),
           baseUrl: 'http://localhost',
@@ -709,18 +714,35 @@ void main() {
           isFalse,
         );
 
-        final controlState = DeviceControlStateService();
-        addTearDown(controlState.dispose);
-        final devicesService = _MockDevicesService();
+        final controlState = locator<DeviceControlStateService>();
+        controlState.clearForDevice(deviceId);
+        addTearDown(() => controlState.clearForDevice(deviceId));
+        final devicesService = locator<DevicesService>() as _MockDevicesService;
+        reset(devicesService);
         final commandResult = Completer<bool>();
         when(
           () => devicesService.setPropertyValue(propertyId, true),
         ).thenAnswer((_) => commandResult.future);
 
+        var renderedDevice =
+            _buildRepresentativeDevice('lighting', lightOn: false)
+                as LightingDeviceView;
+        late StateSetter updateHost;
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                updateHost = setState;
+                return LightingDeviceDetail(device: renderedDevice);
+              },
+            ),
+          ),
+        );
+
         final controller = LightingDeviceController(
-          device:
-              _buildRepresentativeDevice('lighting', lightOn: false)
-                  as LightingDeviceView,
+          device: renderedDevice,
           controlState: controlState,
           devicesService: devicesService,
         );
@@ -736,9 +758,11 @@ void main() {
         expect(pending?.desiredValue, isTrue);
         expect(controller.isOn, isTrue);
 
-        final sent = await propertiesRepository.setValue(propertyId, true);
-        commandResult.complete(sent);
-        await Future<void>.delayed(Duration.zero);
+        final sent = await tester.runAsync(
+          () => propertiesRepository.setValue(propertyId, true),
+        );
+        commandResult.complete(sent!);
+        await tester.pump();
 
         expect(sent, isTrue);
         expect(
@@ -782,25 +806,19 @@ void main() {
             (synchronized.value as BooleanValueType).value;
         expect(authoritativeValue, isTrue);
 
-        controlState.checkPropertyConvergence(
-          deviceId,
-          lightChannelId,
-          propertyId,
-          authoritativeValue,
-        );
+        updateHost(() {
+          renderedDevice =
+              _buildRepresentativeDevice('lighting', lightOn: true)
+                  as LightingDeviceView;
+        });
+        await tester.pump();
 
         expect(
           controlState.getState(deviceId, lightChannelId, propertyId),
           isNull,
         );
-        final synchronizedController = LightingDeviceController(
-          device:
-              _buildRepresentativeDevice('lighting', lightOn: true)
-                  as LightingDeviceView,
-          controlState: controlState,
-          devicesService: devicesService,
-        );
-        expect(synchronizedController.isOn, isTrue);
+        expect(find.byType(LightingDeviceDetail), findsOneWidget);
+        expect(tester.takeException(), isNull);
       },
     );
   });

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -804,13 +804,14 @@ void main() {
         final sent = await tester.runAsync(
           () => propertiesRepository.setValue(propertyId, true),
         );
-        commandResult.complete(sent!);
-        await tester.pump();
 
         expect(sent, isTrue);
         expect(
-          controlState.isSettling(deviceId, lightChannelId, propertyId),
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isPending,
           isTrue,
+          reason: 'the Homey event arrives before the command acknowledgment',
         );
 
         updateHost(() {
@@ -821,7 +822,9 @@ void main() {
         await tester.pump();
 
         expect(
-          controlState.isSettling(deviceId, lightChannelId, propertyId),
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isPending,
           isTrue,
           reason: 'an equivalent rebuilt snapshot is not confirmation',
         );
@@ -872,6 +875,15 @@ void main() {
         expect(
           controlState.getState(deviceId, lightChannelId, propertyId),
           isNull,
+        );
+
+        commandResult.complete(sent!);
+        await tester.pump();
+
+        expect(
+          controlState.getState(deviceId, lightChannelId, propertyId),
+          isNull,
+          reason: 'the later acknowledgment must not reopen confirmed state',
         );
         expect(find.byType(LightingDeviceDetail), findsOneWidget);
         expect(tester.takeException(), isNull);

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -961,6 +961,64 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('retains pre-ack lighting divergence for settling', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightOn: false)
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightOn: null,
+          lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isPending,
+        isTrue,
+        reason: 'divergence must wait for this generation acknowledgment',
+      );
+
+      controlState.setSettling(deviceId, lightChannelId, propertyId);
+      await tester.pump();
+
+      expect(
+        controlState.getState(deviceId, lightChannelId, propertyId),
+        isNull,
+        reason: 'the retained divergence is authoritative after acknowledgment',
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('waits for every authoritative grouped color component', (
       tester,
     ) async {
@@ -1050,6 +1108,91 @@ void main() {
           lightRgbLastUpdated: [firstEventAt, secondEventAt, secondEventAt],
         ) as LightingDeviceView;
       });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('retains pre-ack grouped color divergence for settling', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [5, 15, 25],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isPending,
+        isTrue,
+      );
+
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
       await tester.pump();
 
       expect(

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1344,6 +1344,149 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('reconciles a single-property snapshot after remount', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LightingDeviceDetail(
+            device: _buildRepresentativeDevice(
+              'lighting',
+              lightOn: false,
+            ) as LightingDeviceView,
+          ),
+        ),
+      );
+      controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      controlState.setSettling(deviceId, lightChannelId, propertyId);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isMixed,
+        isTrue,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LightingDeviceDetail(
+            device: _buildRepresentativeDevice(
+              'lighting',
+              lightOn: true,
+              lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+            ) as LightingDeviceView,
+          ),
+        ),
+      );
+
+      expect(
+        controlState.getState(deviceId, lightChannelId, propertyId),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('reconciles a grouped color snapshot after remount', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LightingDeviceDetail(
+            device: _buildRepresentativeDevice(
+              'lighting',
+              lightRgb: const [0, 0, 0],
+            ) as LightingDeviceView,
+          ),
+        ),
+      );
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isMixed,
+        isTrue,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LightingDeviceDetail(
+            device: _buildRepresentativeDevice(
+              'lighting',
+              lightRgb: const [10, 20, 30],
+              lightRgbLastUpdated: List.filled(
+                3,
+                DateTime.utc(2026, 8, 24, 10, 1),
+              ),
+            ) as LightingDeviceView,
+          ),
+        ),
+      );
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('ignores grouped repository echoes as color confirmation', (
       tester,
     ) async {

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1405,6 +1405,14 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'post-ack color remains protected while settling',
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
@@ -1464,6 +1472,18 @@ void main() {
       )!;
       final thirdGeneration = thirdState.generation;
 
+      for (var index = 6; index < 9; index++) {
+        commandResults[index].complete(true);
+      }
+      await tester.pump();
+
+      final settling = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      expect(settling?.isSettling, isTrue);
+      expect(identical(settling?.generation, thirdGeneration), isTrue);
+
       updateHost(() {
         renderedDevice = _buildRepresentativeDevice(
           'lighting',
@@ -1476,24 +1496,33 @@ void main() {
       });
       await tester.pump();
 
-      final stillPending = controlState.getGroupState(
-        deviceId,
-        LightChannelController.colorGroupId,
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'stale matching color cannot clear the settling generation',
       );
-      expect(stillPending?.isPending, isTrue);
-      expect(identical(stillPending?.generation, thirdGeneration), isTrue);
 
-      for (var index = 6; index < 9; index++) {
-        commandResults[index].complete(true);
-      }
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [40, 50, 60],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+          ),
+        ) as LightingDeviceView;
+      });
       await tester.pump();
 
-      final settling = controlState.getGroupState(
-        deviceId,
-        LightChannelController.colorGroupId,
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'delayed intermediate color remains behind the group lock',
       );
-      expect(settling?.isSettling, isTrue);
-      expect(identical(settling?.generation, thirdGeneration), isTrue);
 
       for (var index = 0; index < 6; index++) {
         commandResults[index].complete(true);
@@ -1517,19 +1546,27 @@ void main() {
           lightRgb: const [10, 20, 30],
           lightRgbLastUpdated: List.filled(
             3,
-            DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+            DateTime.utc(2026, 8, 24, 10, 1, 0, 2),
           ),
         ) as LightingDeviceView;
       });
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'latest color snapshot remains protected until timeout',
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
         ),
         isNull,
-        reason: 'only post-ack color snapshots confirm immediately',
+        reason: 'settling consumes the newest grouped color snapshot',
       );
       expect(tester.takeException(), isNull);
     });
@@ -1626,6 +1663,13 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
@@ -1704,12 +1748,20 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'unchanged components remain protected while settling',
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
         ),
         isNull,
-        reason: 'unchanged components do not receive Homey capability events',
+        reason: 'unchanged components do not require Homey capability events',
       );
       expect(tester.takeException(), isNull);
     });
@@ -1893,6 +1945,13 @@ void main() {
       });
       await tester.pump();
 
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
       expect(
         controlState.getGroupState(
           deviceId,
@@ -2110,6 +2169,13 @@ void main() {
       });
       await tester.pump();
 
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
       expect(
         controlState.getGroupState(
           deviceId,

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1,7 +1,13 @@
 import 'package:dio/dio.dart';
+import 'package:event_bus/event_bus.dart';
 import 'package:fastybird_smart_panel/api/devices_module/devices_module_client.dart';
+import 'package:fastybird_smart_panel/app/locator.dart';
 import 'package:fastybird_smart_panel/core/services/command_dispatch.dart';
+import 'package:fastybird_smart_panel/core/services/screen.dart';
 import 'package:fastybird_smart_panel/core/services/socket.dart';
+import 'package:fastybird_smart_panel/core/services/visual_density.dart';
+import 'package:fastybird_smart_panel/l10n/app_localizations.dart';
+import 'package:fastybird_smart_panel/modules/config/module.dart';
 import 'package:fastybird_smart_panel/modules/devices/constants.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/channel.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/device.dart';
@@ -15,7 +21,11 @@ import 'package:fastybird_smart_panel/modules/devices/presentation/device_detail
 import 'package:fastybird_smart_panel/modules/devices/repositories/channel_properties.dart';
 import 'package:fastybird_smart_panel/modules/devices/repositories/channels.dart';
 import 'package:fastybird_smart_panel/modules/devices/repositories/devices.dart';
+import 'package:fastybird_smart_panel/modules/devices/service.dart';
+import 'package:fastybird_smart_panel/modules/devices/services/device_control_state.service.dart';
+import 'package:fastybird_smart_panel/modules/devices/services/property_timeseries.dart';
 import 'package:fastybird_smart_panel/modules/devices/types/values.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/view.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/channels/electrical_energy.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/channels/electrical_power.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/channels/light.dart';
@@ -28,14 +38,20 @@ import 'package:fastybird_smart_panel/modules/devices/views/devices/lock.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/devices/sensor.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/devices/thermostat.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/devices/window_covering.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/view.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/properties/consumption.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/properties/on.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/properties/power.dart';
 import 'package:fastybird_smart_panel/modules/devices/views/properties/temperature.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/properties/view.dart';
+import 'package:fastybird_smart_panel/modules/displays/repositories/display.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 const homeyType = 'devices-homey';
 const deviceId = '046f5102-1a8b-4e7d-a70e-20fe1fa836b1';
+const deviceInformationChannelId = '375c48c4-d939-4267-b7e1-a8bfc4710fc2';
 const lightChannelId = '7833d7c9-250c-46e6-9c27-438ac92f0a39';
 const temperatureChannelId = '00f25c17-488b-44db-a413-59c31bd1803c';
 const thermostatChannelId = '5f59626d-5b9a-4207-a195-c959a4467f50';
@@ -45,6 +61,11 @@ const powerChannelId = '26673bf2-63f4-44e1-8476-28ccca1c78d0';
 const energyChannelId = '625b095a-5c13-47f0-89aa-837056eda993';
 const propertyId = '80aa6c9c-918c-4751-af94-837a689f31dc';
 const secondPropertyId = '349ebbb0-bce1-4248-982e-a320b91dfd5b';
+const thirdPropertyId = '2a0c26f9-0c56-4fc8-83f9-e24469035a1d';
+const fourthPropertyId = 'c3119230-cfd9-4bbe-896d-322bd68bfa63';
+const manufacturerPropertyId = '4b649dac-fb01-40db-9d26-69f75b6079dc';
+const modelPropertyId = '0c631313-c94d-4de2-9455-0d87ff6b5743';
+const serialNumberPropertyId = '4bbd00b7-87ff-44f5-a69f-fddf72d2c356';
 
 Map<String, dynamic> _deviceJson(
   String category, {
@@ -136,53 +157,303 @@ class _FakeSocketService extends SocketService {
   }
 }
 
+class _MockDevicesService extends Mock implements DevicesService {}
+
+class _MockPropertyTimeseriesService extends Mock
+    implements PropertyTimeseriesService {}
+
+class _MockDisplayRepository extends Mock implements DisplayRepository {}
+
+class _MockConfigModuleService extends Mock implements ConfigModuleService {}
+
+ChannelPropertyView _buildProperty({
+  required String id,
+  required String channel,
+  required String category,
+  required String dataType,
+  required dynamic value,
+  List<String> permissions = const ['ro'],
+  List<dynamic>? format,
+  String? unit,
+}) => buildChannelPropertyView(
+  buildChannelPropertyModel(
+    homeyType,
+    _propertyJson(
+      id: id,
+      channel: channel,
+      category: category,
+      dataType: dataType,
+      value: value,
+      permissions: permissions,
+      capabilityId: 'fixture_$category',
+      mappingName: 'fixture-$category',
+      format: format,
+      unit: unit,
+    ),
+  ),
+);
+
+ChannelView _buildChannel(
+  String id,
+  String category,
+  List<ChannelPropertyView> properties,
+) => buildChannelView(
+  buildChannelModel(
+    homeyType,
+    _channelJson(
+      id,
+      category,
+      properties: properties.map((property) => property.id).toList(),
+    ),
+  ),
+  properties,
+);
+
+ChannelView _buildDeviceInformationChannel() =>
+    _buildChannel(deviceInformationChannelId, 'device_information', [
+      _buildProperty(
+        id: manufacturerPropertyId,
+        channel: deviceInformationChannelId,
+        category: 'manufacturer',
+        dataType: 'string',
+        value: 'Athom',
+      ),
+      _buildProperty(
+        id: modelPropertyId,
+        channel: deviceInformationChannelId,
+        category: 'model',
+        dataType: 'string',
+        value: 'Homey fixture',
+      ),
+      _buildProperty(
+        id: serialNumberPropertyId,
+        channel: deviceInformationChannelId,
+        category: 'serial_number',
+        dataType: 'string',
+        value: 'sanitized-fixture',
+      ),
+    ]);
+
+List<ChannelView> _representativeChannels(String category) {
+  final deviceInformation = _buildDeviceInformationChannel();
+
+  switch (category) {
+    case 'lighting':
+      return [
+        deviceInformation,
+        _buildChannel(lightChannelId, 'light', [
+          _buildProperty(
+            id: propertyId,
+            channel: lightChannelId,
+            category: 'on',
+            dataType: 'bool',
+            value: true,
+            permissions: const ['rw'],
+          ),
+        ]),
+      ];
+    case 'sensor':
+      return [
+        deviceInformation,
+        _buildChannel(temperatureChannelId, 'temperature', [
+          _buildProperty(
+            id: propertyId,
+            channel: temperatureChannelId,
+            category: 'temperature',
+            dataType: 'float',
+            value: 21.5,
+            unit: '°C',
+          ),
+        ]),
+      ];
+    case 'thermostat':
+      return [
+        deviceInformation,
+        _buildChannel(temperatureChannelId, 'temperature', [
+          _buildProperty(
+            id: propertyId,
+            channel: temperatureChannelId,
+            category: 'temperature',
+            dataType: 'float',
+            value: 21.5,
+            unit: '°C',
+          ),
+        ]),
+        _buildChannel(thermostatChannelId, 'thermostat', const []),
+      ];
+    case 'window_covering':
+      return [
+        deviceInformation,
+        _buildChannel(coverChannelId, 'window_covering', [
+          _buildProperty(
+            id: propertyId,
+            channel: coverChannelId,
+            category: 'status',
+            dataType: 'enum',
+            value: 'opened',
+            format: const ['opened', 'closed', 'opening', 'closing', 'stopped'],
+          ),
+          _buildProperty(
+            id: secondPropertyId,
+            channel: coverChannelId,
+            category: 'command',
+            dataType: 'enum',
+            value: 'stop',
+            permissions: const ['wo'],
+            format: const ['open', 'close', 'stop'],
+          ),
+          _buildProperty(
+            id: thirdPropertyId,
+            channel: coverChannelId,
+            category: 'position',
+            dataType: 'uchar',
+            value: 75,
+            permissions: const ['rw'],
+            format: const [0, 100],
+          ),
+          _buildProperty(
+            id: fourthPropertyId,
+            channel: coverChannelId,
+            category: 'type',
+            dataType: 'enum',
+            value: 'roller',
+            format: const ['roller'],
+          ),
+        ]),
+      ];
+    case 'lock':
+      return [
+        deviceInformation,
+        _buildChannel(lockChannelId, 'lock', [
+          _buildProperty(
+            id: propertyId,
+            channel: lockChannelId,
+            category: 'on',
+            dataType: 'bool',
+            value: true,
+            permissions: const ['rw'],
+          ),
+          _buildProperty(
+            id: secondPropertyId,
+            channel: lockChannelId,
+            category: 'status',
+            dataType: 'enum',
+            value: 'locked',
+            format: const ['locked', 'unlocked'],
+          ),
+        ]),
+      ];
+  }
+
+  throw ArgumentError.value(category, 'category');
+}
+
+DeviceView _buildRepresentativeDevice(String category) {
+  final channels = _representativeChannels(category);
+  final model = buildDeviceModel(
+    homeyType,
+    _deviceJson(
+      category,
+      channels: channels.map((channel) => channel.id).toList(),
+    ),
+  );
+
+  return buildDeviceView(model, channels);
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  registerFallbackValue(TimeRange.oneDay);
+
+  setUpAll(() async {
+    await locator.reset();
+
+    locator.registerSingleton<ScreenService>(
+      ScreenService(screenWidth: 1280, screenHeight: 800, pixelRatio: 1),
+      dispose: (service) => service.dispose(),
+    );
+    locator.registerSingleton<VisualDensityService>(
+      VisualDensityService(pixelRatio: 1),
+    );
+    locator.registerSingleton<DevicesService>(_MockDevicesService());
+    locator.registerSingleton<DisplayRepository>(_MockDisplayRepository());
+    locator.registerSingleton<ConfigModuleService>(_MockConfigModuleService());
+    locator.registerSingleton<EventBus>(EventBus());
+    locator.registerSingleton<DeviceControlStateService>(
+      DeviceControlStateService(),
+      dispose: (service) => service.dispose(),
+    );
+
+    final timeseriesService = _MockPropertyTimeseriesService();
+    when(
+      () => timeseriesService.getTimeseries(
+        channelId: any(named: 'channelId'),
+        propertyId: any(named: 'propertyId'),
+        timeRange: any(named: 'timeRange'),
+      ),
+    ).thenAnswer((_) async => PropertyTimeseries(points: []));
+    locator.registerSingleton<PropertyTimeseriesService>(timeseriesService);
+  });
+
+  tearDownAll(locator.reset);
+
   group('Homey generic device pipeline', () {
     final deviceCases =
-        <({String category, Matcher viewMatcher, Matcher widgetMatcher})>[
+        <({String category, Matcher viewMatcher, Type widgetType})>[
           (
             category: 'lighting',
             viewMatcher: isA<LightingDeviceView>(),
-            widgetMatcher: isA<LightingDeviceDetail>(),
+            widgetType: LightingDeviceDetail,
           ),
           (
             category: 'sensor',
             viewMatcher: isA<SensorDeviceView>(),
-            widgetMatcher: isA<SensorDeviceDetail>(),
+            widgetType: SensorDeviceDetail,
           ),
           (
             category: 'thermostat',
             viewMatcher: isA<ThermostatDeviceView>(),
-            widgetMatcher: isA<ThermostatDeviceDetail>(),
+            widgetType: ThermostatDeviceDetail,
           ),
           (
             category: 'window_covering',
             viewMatcher: isA<WindowCoveringDeviceView>(),
-            widgetMatcher: isA<WindowCoveringDeviceDetail>(),
+            widgetType: WindowCoveringDeviceDetail,
           ),
           (
             category: 'lock',
             viewMatcher: isA<LockDeviceView>(),
-            widgetMatcher: isA<LockDeviceDetail>(),
+            widgetType: LockDeviceDetail,
           ),
         ];
 
     for (final testCase in deviceCases) {
-      test(
-        'loads ${testCase.category} through the normal model and detail widget mappers',
-        () {
+      testWidgets(
+        'renders ${testCase.category} through the normal model and detail widget mappers',
+        (tester) async {
+          tester.view.physicalSize = const Size(1280, 800);
+          tester.view.devicePixelRatio = 1;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+
           expect(deviceModelMappers, isNot(contains(homeyType)));
 
-          final model = buildDeviceModel(
-            homeyType,
-            _deviceJson(testCase.category),
-          );
-          final view = buildDeviceView(model, const []);
+          final view = _buildRepresentativeDevice(testCase.category);
 
-          expect(model.type, homeyType);
           expect(view, testCase.viewMatcher);
           expect(view.type, homeyType);
-          expect(buildDeviceWidget(view), testCase.widgetMatcher);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: buildDeviceWidget(view),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.byType(testCase.widgetType), findsOneWidget);
+          expect(tester.takeException(), isNull);
         },
       );
     }

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1302,6 +1302,48 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('clears an idempotent property command from its baseline', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      final renderedDevice =
+          _buildRepresentativeDevice('lighting', lightOn: true)
+              as LightingDeviceView;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LightingDeviceDetail(device: renderedDevice),
+        ),
+      );
+
+      controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      controlState.setSettling(deviceId, lightChannelId, propertyId);
+
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+
+      expect(
+        controlState.getState(deviceId, lightChannelId, propertyId),
+        isNull,
+        reason: 'Homey need not emit an event for an already-equal value',
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('ignores grouped repository echoes as color confirmation', (
       tester,
     ) async {

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -905,19 +905,153 @@ void main() {
         await tester.pump();
 
         expect(
-          controlState.getState(deviceId, lightChannelId, propertyId),
-          isNull,
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isPending,
+          isTrue,
+          reason: 'a pre-ack provider snapshot cannot confirm this generation',
         );
 
         commandResult.complete(sent!);
         await tester.pump();
 
         expect(
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isSettling,
+          isTrue,
+          reason: 'the current acknowledgment starts its settling window',
+        );
+
+        updateHost(() {
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: true,
+            lightOnLastUpdated: authoritativeEventAt.add(
+              const Duration(milliseconds: 1),
+            ),
+          ) as LightingDeviceView;
+        });
+        await tester.pump();
+
+        expect(
           controlState.getState(deviceId, lightChannelId, propertyId),
           isNull,
-          reason: 'the later acknowledgment must not reopen confirmed state',
+          reason: 'a post-ack provider snapshot confirms the generation',
         );
         expect(find.byType(LightingDeviceDetail), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'keeps the current single-property generation through a delayed ABA match',
+      (tester) async {
+        tester.view.physicalSize = const Size(1280, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final controlState = locator<DeviceControlStateService>();
+        controlState.clearForDevice(deviceId);
+        addTearDown(() => controlState.clearForDevice(deviceId));
+        final devicesService = locator<DevicesService>() as _MockDevicesService;
+        reset(devicesService);
+        final commandResults = List.generate(3, (_) => Completer<bool>());
+        var commandIndex = 0;
+        when(
+          () => devicesService.setPropertyValue(propertyId, any()),
+        ).thenAnswer((_) => commandResults[commandIndex++].future);
+
+        var renderedDevice =
+            _buildRepresentativeDevice('lighting', lightOn: false)
+                as LightingDeviceView;
+        late StateSetter updateHost;
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                updateHost = setState;
+                return LightingDeviceDetail(device: renderedDevice);
+              },
+            ),
+          ),
+        );
+
+        final controller = LightingDeviceController(
+          device: renderedDevice,
+          controlState: controlState,
+          devicesService: devicesService,
+        );
+        controller.setPower(true);
+        controller.setPower(false);
+        controller.setPower(true);
+        final thirdState = controlState.getState(
+          deviceId,
+          lightChannelId,
+          propertyId,
+        )!;
+        final thirdGeneration = thirdState.generation;
+
+        updateHost(() {
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: true,
+            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+          ) as LightingDeviceView;
+        });
+        await tester.pump();
+
+        final stillPending = controlState.getState(
+          deviceId,
+          lightChannelId,
+          propertyId,
+        );
+        expect(stillPending?.isPending, isTrue);
+        expect(identical(stillPending?.generation, thirdGeneration), isTrue);
+
+        commandResults[2].complete(true);
+        await tester.pump();
+
+        final settling = controlState.getState(
+          deviceId,
+          lightChannelId,
+          propertyId,
+        );
+        expect(settling?.isSettling, isTrue);
+        expect(identical(settling?.generation, thirdGeneration), isTrue);
+
+        commandResults[0].complete(true);
+        commandResults[1].complete(true);
+        await tester.pump();
+
+        expect(
+          identical(
+            controlState
+                .getState(deviceId, lightChannelId, propertyId)
+                ?.generation,
+            thirdGeneration,
+          ),
+          isTrue,
+          reason: 'older acknowledgments cannot mutate the current generation',
+        );
+
+        updateHost(() {
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: true,
+            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+          ) as LightingDeviceView;
+        });
+        await tester.pump();
+
+        expect(
+          controlState.getState(deviceId, lightChannelId, propertyId),
+          isNull,
+          reason: 'only a post-ack provider snapshot confirms the command',
+        );
         expect(tester.takeException(), isNull);
       },
     );
@@ -1099,6 +1233,24 @@ void main() {
           'lighting',
           lightOn: true,
           lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isPending,
+        isTrue,
+        reason: 'pre-ack provider data cannot confirm the pending generation',
+      );
+
+      controlState.setSettling(deviceId, lightChannelId, propertyId);
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightOn: true,
+          lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
         ) as LightingDeviceView;
       });
       await tester.pump();

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -123,6 +123,7 @@ Map<String, dynamic> _propertyJson({
   String mappingName = 'fixture-mapping',
   String? unit,
   List<dynamic>? format,
+  String lastUpdated = '2026-08-24T10:00:00.000Z',
 }) => {
   'id': id,
   'type': homeyType,
@@ -136,7 +137,7 @@ Map<String, dynamic> _propertyJson({
   'invalid': null,
   'step': null,
   'default_value': null,
-  'value': {'value': value, 'last_updated': '2026-08-24T10:00:00.000Z'},
+  'value': {'value': value, 'last_updated': lastUpdated},
   'homey_capability_id': capabilityId,
   'homey_mapping_name': mappingName,
   'created_at': '2026-08-24T10:00:00.000Z',
@@ -183,6 +184,7 @@ ChannelPropertyView _buildProperty({
   List<String> permissions = const ['ro'],
   List<dynamic>? format,
   String? unit,
+  DateTime? lastUpdated,
 }) => buildChannelPropertyView(
   buildChannelPropertyModel(
     homeyType,
@@ -197,6 +199,8 @@ ChannelPropertyView _buildProperty({
       mappingName: 'fixture-$category',
       format: format,
       unit: unit,
+      lastUpdated: lastUpdated?.toUtc().toIso8601String() ??
+          '2026-08-24T10:00:00.000Z',
     ),
   ),
 );
@@ -245,7 +249,9 @@ ChannelView _buildDeviceInformationChannel() =>
 List<ChannelView> _representativeChannels(
   String category, {
   bool? lightOn = true,
+  DateTime? lightOnLastUpdated,
   List<int>? lightRgb,
+  List<DateTime?>? lightRgbLastUpdated,
 }) {
   final deviceInformation = _buildDeviceInformationChannel();
 
@@ -261,6 +267,7 @@ List<ChannelView> _representativeChannels(
             dataType: 'bool',
             value: lightOn,
             permissions: const ['rw'],
+            lastUpdated: lightOnLastUpdated,
           ),
           if (lightRgb != null) ...[
             _buildProperty(
@@ -271,6 +278,7 @@ List<ChannelView> _representativeChannels(
               value: lightRgb[0],
               permissions: const ['rw'],
               format: const [0, 255],
+              lastUpdated: lightRgbLastUpdated?[0],
             ),
             _buildProperty(
               id: greenPropertyId,
@@ -280,6 +288,7 @@ List<ChannelView> _representativeChannels(
               value: lightRgb[1],
               permissions: const ['rw'],
               format: const [0, 255],
+              lastUpdated: lightRgbLastUpdated?[1],
             ),
             _buildProperty(
               id: bluePropertyId,
@@ -289,6 +298,7 @@ List<ChannelView> _representativeChannels(
               value: lightRgb[2],
               permissions: const ['rw'],
               format: const [0, 255],
+              lastUpdated: lightRgbLastUpdated?[2],
             ),
           ],
         ]),
@@ -412,12 +422,16 @@ List<ChannelView> _representativeChannels(
 DeviceView _buildRepresentativeDevice(
   String category, {
   bool? lightOn = true,
+  DateTime? lightOnLastUpdated,
   List<int>? lightRgb,
+  List<DateTime?>? lightRgbLastUpdated,
 }) {
   final channels = _representativeChannels(
     category,
     lightOn: lightOn,
+    lightOnLastUpdated: lightOnLastUpdated,
     lightRgb: lightRgb,
+    lightRgbLastUpdated: lightRgbLastUpdated,
   );
   final model = buildDeviceModel(
     homeyType,
@@ -800,6 +814,9 @@ void main() {
         expect(pending?.isPending, isTrue);
         expect(pending?.desiredValue, isTrue);
         expect(controller.isOn, isTrue);
+        final authoritativeEventAt = pending!.createdAt.add(
+          const Duration(milliseconds: 1),
+        );
 
         final sent = await tester.runAsync(
           () => propertiesRepository.setValue(propertyId, true),
@@ -866,9 +883,11 @@ void main() {
         expect(authoritativeValue, isTrue);
 
         updateHost(() {
-          renderedDevice =
-              _buildRepresentativeDevice('lighting', lightOn: true)
-                  as LightingDeviceView;
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: true,
+            lightOnLastUpdated: authoritativeEventAt,
+          ) as LightingDeviceView;
         });
         await tester.pump();
 
@@ -920,11 +939,17 @@ void main() {
       );
 
       controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      final authoritativeEventAt = controlState
+          .getState(deviceId, lightChannelId, propertyId)!
+          .createdAt
+          .add(const Duration(milliseconds: 1));
 
       updateHost(() {
-        renderedDevice =
-            _buildRepresentativeDevice('lighting', lightOn: null)
-                as LightingDeviceView;
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightOn: null,
+          lightOnLastUpdated: authoritativeEventAt,
+        ) as LightingDeviceView;
       });
       await tester.pump();
 
@@ -989,11 +1014,23 @@ void main() {
         deviceId,
         LightChannelController.colorGroupId,
       );
+      final colorState = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      )!;
+      final firstEventAt = colorState.createdAt.add(
+        const Duration(milliseconds: 1),
+      );
+      final secondEventAt = colorState.createdAt.add(
+        const Duration(milliseconds: 2),
+      );
 
       updateHost(() {
-        renderedDevice =
-            _buildRepresentativeDevice('lighting', lightRgb: const [10, 0, 0])
-                as LightingDeviceView;
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 0, 0],
+          lightRgbLastUpdated: [firstEventAt, null, null],
+        ) as LightingDeviceView;
       });
       await tester.pump();
 
@@ -1006,9 +1043,129 @@ void main() {
       );
 
       updateHost(() {
-        renderedDevice =
-            _buildRepresentativeDevice('lighting', lightRgb: const [10, 20, 25])
-                as LightingDeviceView;
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 25],
+          lightRgbLastUpdated: [firstEventAt, secondEventAt, secondEventAt],
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('ignores late color events from the previous command', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 40,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 50,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 60,
+          ),
+        ],
+      );
+      final activeState = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      )!;
+      final previousCommandEventAt = activeState.createdAt.subtract(
+        const Duration(milliseconds: 1),
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(3, previousCommandEventAt),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isPending,
+        isTrue,
+        reason: 'events predating the active generation belong to its predecessor',
+      );
+
+      final activeCommandEventAt = activeState.createdAt.add(
+        const Duration(milliseconds: 1),
+      );
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [40, 50, 60],
+          lightRgbLastUpdated: List.filled(3, activeCommandEventAt),
+        ) as LightingDeviceView;
       });
       await tester.pump();
 

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -968,6 +968,13 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getState(deviceId, lightChannelId, propertyId),
         isNull,
       );
@@ -1025,9 +1032,17 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isSettling,
+        isTrue,
+        reason: 'divergence remains deferred during the settling window',
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getState(deviceId, lightChannelId, propertyId),
         isNull,
-        reason: 'the retained divergence is authoritative after acknowledgment',
+        reason: 'stable divergence is authoritative after settling expires',
       );
       expect(tester.takeException(), isNull);
     });
@@ -1360,6 +1375,13 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
@@ -1646,6 +1668,19 @@ void main() {
             ?.isPending,
         isTrue,
         reason: 'provider clock skew must not make stale values confirm the active generation',
+      );
+
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      await tester.pump();
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'pre-ack stale components must not clear on acknowledgment',
       );
 
       final activeCommandEventAt = activeState.createdAt.subtract(

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -123,7 +123,7 @@ Map<String, dynamic> _propertyJson({
   String mappingName = 'fixture-mapping',
   String? unit,
   List<dynamic>? format,
-  String lastUpdated = '2026-08-24T10:00:00.000Z',
+  String? lastUpdated = '2026-08-24T10:00:00.000Z',
 }) => {
   'id': id,
   'type': homeyType,
@@ -185,6 +185,7 @@ ChannelPropertyView _buildProperty({
   List<dynamic>? format,
   String? unit,
   DateTime? lastUpdated,
+  bool includeLastUpdated = true,
 }) => buildChannelPropertyView(
   buildChannelPropertyModel(
     homeyType,
@@ -199,8 +200,10 @@ ChannelPropertyView _buildProperty({
       mappingName: 'fixture-$category',
       format: format,
       unit: unit,
-      lastUpdated: lastUpdated?.toUtc().toIso8601String() ??
-          '2026-08-24T10:00:00.000Z',
+      lastUpdated: includeLastUpdated
+          ? lastUpdated?.toUtc().toIso8601String() ??
+              '2026-08-24T10:00:00.000Z'
+          : null,
     ),
   ),
 );
@@ -250,8 +253,10 @@ List<ChannelView> _representativeChannels(
   String category, {
   bool? lightOn = true,
   DateTime? lightOnLastUpdated,
+  bool lightOnAuthoritative = true,
   List<int>? lightRgb,
   List<DateTime?>? lightRgbLastUpdated,
+  bool lightRgbAuthoritative = true,
 }) {
   final deviceInformation = _buildDeviceInformationChannel();
 
@@ -268,6 +273,7 @@ List<ChannelView> _representativeChannels(
             value: lightOn,
             permissions: const ['rw'],
             lastUpdated: lightOnLastUpdated,
+            includeLastUpdated: lightOnAuthoritative,
           ),
           if (lightRgb != null) ...[
             _buildProperty(
@@ -279,6 +285,7 @@ List<ChannelView> _representativeChannels(
               permissions: const ['rw'],
               format: const [0, 255],
               lastUpdated: lightRgbLastUpdated?[0],
+              includeLastUpdated: lightRgbAuthoritative,
             ),
             _buildProperty(
               id: greenPropertyId,
@@ -289,6 +296,7 @@ List<ChannelView> _representativeChannels(
               permissions: const ['rw'],
               format: const [0, 255],
               lastUpdated: lightRgbLastUpdated?[1],
+              includeLastUpdated: lightRgbAuthoritative,
             ),
             _buildProperty(
               id: bluePropertyId,
@@ -299,6 +307,7 @@ List<ChannelView> _representativeChannels(
               permissions: const ['rw'],
               format: const [0, 255],
               lastUpdated: lightRgbLastUpdated?[2],
+              includeLastUpdated: lightRgbAuthoritative,
             ),
           ],
         ]),
@@ -423,15 +432,19 @@ DeviceView _buildRepresentativeDevice(
   String category, {
   bool? lightOn = true,
   DateTime? lightOnLastUpdated,
+  bool lightOnAuthoritative = true,
   List<int>? lightRgb,
   List<DateTime?>? lightRgbLastUpdated,
+  bool lightRgbAuthoritative = true,
 }) {
   final channels = _representativeChannels(
     category,
     lightOn: lightOn,
     lightOnLastUpdated: lightOnLastUpdated,
+    lightOnAuthoritative: lightOnAuthoritative,
     lightRgb: lightRgb,
     lightRgbLastUpdated: lightRgbLastUpdated,
+    lightRgbAuthoritative: lightRgbAuthoritative,
   );
   final model = buildDeviceModel(
     homeyType,
@@ -1019,6 +1032,157 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('ignores the repository optimistic echo as confirmation', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightOn: false)
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setPending(deviceId, lightChannelId, propertyId, true);
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightOn: true,
+          lightOnAuthoritative: false,
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isPending,
+        isTrue,
+        reason: 'a local value without measurement metadata is not authoritative',
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightOn: true,
+          lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getState(deviceId, lightChannelId, propertyId),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('ignores grouped repository echoes as color confirmation', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbAuthoritative: false,
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isPending,
+        isTrue,
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('waits for every authoritative grouped color component', (
       tester,
     ) async {
@@ -1298,6 +1462,92 @@ void main() {
           LightChannelController.colorGroupId,
         ),
         isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('accepts complete post-ack color divergence after settling', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [5, 15, 25],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+      );
+
+      await tester.pump(const Duration(milliseconds: 900));
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+        reason: 'stable authoritative divergence wins after settling expires',
       );
       expect(tester.takeException(), isNull);
     });

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -935,9 +935,16 @@ void main() {
         await tester.pump();
 
         expect(
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isSettling,
+          isTrue,
+          reason: 'post-ack provider data remains protected while settling',
+        );
+        await tester.pump(const Duration(milliseconds: 900));
+        expect(
           controlState.getState(deviceId, lightChannelId, propertyId),
           isNull,
-          reason: 'a post-ack provider snapshot confirms the generation',
         );
         expect(find.byType(LightingDeviceDetail), findsOneWidget);
         expect(tester.takeException(), isNull);
@@ -995,23 +1002,6 @@ void main() {
         )!;
         final thirdGeneration = thirdState.generation;
 
-        updateHost(() {
-          renderedDevice = _buildRepresentativeDevice(
-            'lighting',
-            lightOn: true,
-            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
-          ) as LightingDeviceView;
-        });
-        await tester.pump();
-
-        final stillPending = controlState.getState(
-          deviceId,
-          lightChannelId,
-          propertyId,
-        );
-        expect(stillPending?.isPending, isTrue);
-        expect(identical(stillPending?.generation, thirdGeneration), isTrue);
-
         commandResults[2].complete(true);
         await tester.pump();
 
@@ -1022,6 +1012,40 @@ void main() {
         );
         expect(settling?.isSettling, isTrue);
         expect(identical(settling?.generation, thirdGeneration), isTrue);
+
+        updateHost(() {
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: true,
+            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1),
+          ) as LightingDeviceView;
+        });
+        await tester.pump();
+
+        expect(
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isSettling,
+          isTrue,
+          reason: 'a stale matching event cannot clear the settling generation',
+        );
+
+        updateHost(() {
+          renderedDevice = _buildRepresentativeDevice(
+            'lighting',
+            lightOn: false,
+            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+          ) as LightingDeviceView;
+        });
+        await tester.pump();
+
+        expect(
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isSettling,
+          isTrue,
+          reason: 'the delayed intermediate event remains behind the lock',
+        );
 
         commandResults[0].complete(true);
         commandResults[1].complete(true);
@@ -1042,15 +1066,23 @@ void main() {
           renderedDevice = _buildRepresentativeDevice(
             'lighting',
             lightOn: true,
-            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+            lightOnLastUpdated: DateTime.utc(2026, 8, 24, 10, 1, 0, 2),
           ) as LightingDeviceView;
         });
         await tester.pump();
 
         expect(
+          controlState
+              .getState(deviceId, lightChannelId, propertyId)
+              ?.isSettling,
+          isTrue,
+          reason: 'the latest provider snapshot is retained until timeout',
+        );
+        await tester.pump(const Duration(milliseconds: 900));
+        expect(
           controlState.getState(deviceId, lightChannelId, propertyId),
           isNull,
-          reason: 'only a post-ack provider snapshot confirms the command',
+          reason: 'settling consumes the newest generation-scoped snapshot',
         );
         expect(tester.takeException(), isNull);
       },
@@ -1255,6 +1287,14 @@ void main() {
       });
       await tester.pump();
 
+      expect(
+        controlState
+            .getState(deviceId, lightChannelId, propertyId)
+            ?.isSettling,
+        isTrue,
+        reason: 'post-ack confirmation remains protected while settling',
+      );
+      await tester.pump(const Duration(milliseconds: 900));
       expect(
         controlState.getState(deviceId, lightChannelId, propertyId),
         isNull,

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1595,6 +1595,85 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('confirms unchanged grouped color components from baseline', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [10, 20, 30])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 40,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [40, 20, 30],
+          lightRgbLastUpdated: [
+            DateTime.utc(2026, 8, 24, 10, 1),
+            null,
+            null,
+          ],
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+        reason: 'unchanged components do not receive Homey capability events',
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('retains pre-ack grouped color divergence for settling', (
       tester,
     ) async {

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -11,10 +11,12 @@ import 'package:fastybird_smart_panel/core/services/visual_density.dart';
 import 'package:fastybird_smart_panel/l10n/app_localizations.dart';
 import 'package:fastybird_smart_panel/modules/config/module.dart';
 import 'package:fastybird_smart_panel/modules/devices/constants.dart';
+import 'package:fastybird_smart_panel/modules/devices/controllers/channels/light.dart';
 import 'package:fastybird_smart_panel/modules/devices/controllers/devices/lighting.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/channel.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/device.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/property.dart';
+import 'package:fastybird_smart_panel/modules/devices/models/control_state.dart';
 import 'package:fastybird_smart_panel/modules/devices/models/properties/generic_properties.dart';
 import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/lighting.dart';
 import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/lock.dart';
@@ -69,6 +71,9 @@ const fourthPropertyId = 'c3119230-cfd9-4bbe-896d-322bd68bfa63';
 const manufacturerPropertyId = '4b649dac-fb01-40db-9d26-69f75b6079dc';
 const modelPropertyId = '0c631313-c94d-4de2-9455-0d87ff6b5743';
 const serialNumberPropertyId = '4bbd00b7-87ff-44f5-a69f-fddf72d2c356';
+const redPropertyId = 'beeeef2b-4aa3-4d87-b3ca-dc182eef1027';
+const greenPropertyId = 'f68afe04-7aeb-4b40-84ca-32d4b3c078f9';
+const bluePropertyId = '8cd39807-f5dd-4519-b3eb-8ae62b8ad41d';
 
 Map<String, dynamic> _deviceJson(
   String category, {
@@ -240,6 +245,7 @@ ChannelView _buildDeviceInformationChannel() =>
 List<ChannelView> _representativeChannels(
   String category, {
   bool lightOn = true,
+  List<int>? lightRgb,
 }) {
   final deviceInformation = _buildDeviceInformationChannel();
 
@@ -256,6 +262,35 @@ List<ChannelView> _representativeChannels(
             value: lightOn,
             permissions: const ['rw'],
           ),
+          if (lightRgb != null) ...[
+            _buildProperty(
+              id: redPropertyId,
+              channel: lightChannelId,
+              category: 'color_red',
+              dataType: 'uchar',
+              value: lightRgb[0],
+              permissions: const ['rw'],
+              format: const [0, 255],
+            ),
+            _buildProperty(
+              id: greenPropertyId,
+              channel: lightChannelId,
+              category: 'color_green',
+              dataType: 'uchar',
+              value: lightRgb[1],
+              permissions: const ['rw'],
+              format: const [0, 255],
+            ),
+            _buildProperty(
+              id: bluePropertyId,
+              channel: lightChannelId,
+              category: 'color_blue',
+              dataType: 'uchar',
+              value: lightRgb[2],
+              permissions: const ['rw'],
+              format: const [0, 255],
+            ),
+          ],
         ]),
         _buildChannel(powerChannelId, 'electrical_power', [
           _buildProperty(
@@ -374,8 +409,16 @@ List<ChannelView> _representativeChannels(
   throw ArgumentError.value(category, 'category');
 }
 
-DeviceView _buildRepresentativeDevice(String category, {bool lightOn = true}) {
-  final channels = _representativeChannels(category, lightOn: lightOn);
+DeviceView _buildRepresentativeDevice(
+  String category, {
+  bool lightOn = true,
+  List<int>? lightRgb,
+}) {
+  final channels = _representativeChannels(
+    category,
+    lightOn: lightOn,
+    lightRgb: lightRgb,
+  );
   final model = buildDeviceModel(
     homeyType,
     _deviceJson(
@@ -834,5 +877,92 @@ void main() {
         expect(tester.takeException(), isNull);
       },
     );
+
+    testWidgets('waits for every grouped color component to converge', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 10,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 20,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 30,
+          ),
+        ],
+      );
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+
+      updateHost(() {
+        renderedDevice =
+            _buildRepresentativeDevice('lighting', lightRgb: const [10, 0, 0])
+                as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'one Homey RGB component does not confirm the whole group',
+      );
+
+      updateHost(() {
+        renderedDevice =
+            _buildRepresentativeDevice('lighting', lightRgb: const [10, 20, 30])
+                as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:event_bus/event_bus.dart';
 import 'package:fastybird_smart_panel/api/devices_module/devices_module_client.dart';
@@ -9,6 +11,7 @@ import 'package:fastybird_smart_panel/core/services/visual_density.dart';
 import 'package:fastybird_smart_panel/l10n/app_localizations.dart';
 import 'package:fastybird_smart_panel/modules/config/module.dart';
 import 'package:fastybird_smart_panel/modules/devices/constants.dart';
+import 'package:fastybird_smart_panel/modules/devices/controllers/devices/lighting.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/channel.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/device.dart';
 import 'package:fastybird_smart_panel/modules/devices/mappers/property.dart';
@@ -234,7 +237,10 @@ ChannelView _buildDeviceInformationChannel() =>
       ),
     ]);
 
-List<ChannelView> _representativeChannels(String category) {
+List<ChannelView> _representativeChannels(
+  String category, {
+  bool lightOn = true,
+}) {
   final deviceInformation = _buildDeviceInformationChannel();
 
   switch (category) {
@@ -247,8 +253,28 @@ List<ChannelView> _representativeChannels(String category) {
             channel: lightChannelId,
             category: 'on',
             dataType: 'bool',
-            value: true,
+            value: lightOn,
             permissions: const ['rw'],
+          ),
+        ]),
+        _buildChannel(powerChannelId, 'electrical_power', [
+          _buildProperty(
+            id: thirdPropertyId,
+            channel: powerChannelId,
+            category: 'power',
+            dataType: 'float',
+            value: 42.5,
+            unit: 'W',
+          ),
+        ]),
+        _buildChannel(energyChannelId, 'electrical_energy', [
+          _buildProperty(
+            id: fourthPropertyId,
+            channel: energyChannelId,
+            category: 'consumption',
+            dataType: 'float',
+            value: 12.75,
+            unit: 'kWh',
           ),
         ]),
       ];
@@ -348,8 +374,8 @@ List<ChannelView> _representativeChannels(String category) {
   throw ArgumentError.value(category, 'category');
 }
 
-DeviceView _buildRepresentativeDevice(String category) {
-  final channels = _representativeChannels(category);
+DeviceView _buildRepresentativeDevice(String category, {bool lightOn = true}) {
+  final channels = _representativeChannels(category, lightOn: lightOn);
   final model = buildDeviceModel(
     homeyType,
     _deviceJson(
@@ -635,7 +661,7 @@ void main() {
 
   group('Homey state and control pipeline', () {
     test(
-      'applies authoritative updates and dispatches commands without Homey credentials',
+      'drives optimistic control to authoritative Homey state without credentials',
       () async {
         final apiClient = DevicesModuleClient(
           Dio(),
@@ -683,9 +709,42 @@ void main() {
           isFalse,
         );
 
+        final controlState = DeviceControlStateService();
+        addTearDown(controlState.dispose);
+        final devicesService = _MockDevicesService();
+        final commandResult = Completer<bool>();
+        when(
+          () => devicesService.setPropertyValue(propertyId, true),
+        ).thenAnswer((_) => commandResult.future);
+
+        final controller = LightingDeviceController(
+          device:
+              _buildRepresentativeDevice('lighting', lightOn: false)
+                  as LightingDeviceView,
+          controlState: controlState,
+          devicesService: devicesService,
+        );
+
+        controller.setPower(true);
+
+        final pending = controlState.getState(
+          deviceId,
+          lightChannelId,
+          propertyId,
+        );
+        expect(pending?.isPending, isTrue);
+        expect(pending?.desiredValue, isTrue);
+        expect(controller.isOn, isTrue);
+
         final sent = await propertiesRepository.setValue(propertyId, true);
+        commandResult.complete(sent);
+        await Future<void>.delayed(Duration.zero);
 
         expect(sent, isTrue);
+        expect(
+          controlState.isSettling(deviceId, lightChannelId, propertyId),
+          isTrue,
+        );
         expect(socket.lastEvent, DevicesModuleConstants.setPropertyEvent);
         expect(socket.lastHandler, DevicesModuleEventHandlerName.setProperty);
         expect(socket.lastData, {
@@ -710,7 +769,7 @@ void main() {
             channel: lightChannelId,
             category: 'on',
             dataType: 'bool',
-            value: false,
+            value: true,
             permissions: const ['rw'],
             capabilityId: 'onoff',
             mappingName: 'light-power',
@@ -719,7 +778,29 @@ void main() {
 
         final synchronized = propertiesRepository.getItem(propertyId)!;
         expect(synchronized, isA<GenericChannelPropertyModel>());
-        expect((synchronized.value as BooleanValueType).value, isFalse);
+        final authoritativeValue =
+            (synchronized.value as BooleanValueType).value;
+        expect(authoritativeValue, isTrue);
+
+        controlState.checkPropertyConvergence(
+          deviceId,
+          lightChannelId,
+          propertyId,
+          authoritativeValue,
+        );
+
+        expect(
+          controlState.getState(deviceId, lightChannelId, propertyId),
+          isNull,
+        );
+        final synchronizedController = LightingDeviceController(
+          device:
+              _buildRepresentativeDevice('lighting', lightOn: true)
+                  as LightingDeviceView,
+          controlState: controlState,
+          devicesService: devicesService,
+        );
+        expect(synchronizedController.isOn, isTrue);
       },
     );
   });

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -244,7 +244,7 @@ ChannelView _buildDeviceInformationChannel() =>
 
 List<ChannelView> _representativeChannels(
   String category, {
-  bool lightOn = true,
+  bool? lightOn = true,
   List<int>? lightRgb,
 }) {
   final deviceInformation = _buildDeviceInformationChannel();
@@ -411,7 +411,7 @@ List<ChannelView> _representativeChannels(
 
 DeviceView _buildRepresentativeDevice(
   String category, {
-  bool lightOn = true,
+  bool? lightOn = true,
   List<int>? lightRgb,
 }) {
   final channels = _representativeChannels(
@@ -890,7 +890,52 @@ void main() {
       },
     );
 
-    testWidgets('waits for every grouped color component to converge', (
+    testWidgets('accepts an authoritative null as lighting divergence', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightOn: false)
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setPending(deviceId, lightChannelId, propertyId, true);
+
+      updateHost(() {
+        renderedDevice =
+            _buildRepresentativeDevice('lighting', lightOn: null)
+                as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getState(deviceId, lightChannelId, propertyId),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('waits for every authoritative grouped color component', (
       tester,
     ) async {
       tester.view.physicalSize = const Size(1280, 800);
@@ -962,7 +1007,7 @@ void main() {
 
       updateHost(() {
         renderedDevice =
-            _buildRepresentativeDevice('lighting', lightRgb: const [10, 20, 30])
+            _buildRepresentativeDevice('lighting', lightRgb: const [10, 20, 25])
                 as LightingDeviceView;
       });
       await tester.pump();

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1104,7 +1104,7 @@ void main() {
       updateHost(() {
         renderedDevice = _buildRepresentativeDevice(
           'lighting',
-          lightRgb: const [10, 20, 25],
+          lightRgb: const [10, 20, 30],
           lightRgbLastUpdated: [firstEventAt, secondEventAt, secondEventAt],
         ) as LightingDeviceView;
       });
@@ -1193,6 +1193,103 @@ void main() {
         deviceId,
         LightChannelController.colorGroupId,
       );
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('does not correlate post-ack color from an older command', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      controlState.setGroupPending(
+        deviceId,
+        LightChannelController.colorGroupId,
+        const [
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: redPropertyId,
+            desiredValue: 40,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: greenPropertyId,
+            desiredValue: 50,
+          ),
+          PropertyConfig(
+            channelId: lightChannelId,
+            propertyId: bluePropertyId,
+            desiredValue: 60,
+          ),
+        ],
+      );
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isSettling,
+        isTrue,
+        reason: 'post-ack divergence is not correlated to the active command',
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [40, 50, 60],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 2),
+          ),
+        ) as LightingDeviceView;
+      });
       await tester.pump();
 
       expect(

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1,0 +1,455 @@
+import 'package:dio/dio.dart';
+import 'package:fastybird_smart_panel/api/devices_module/devices_module_client.dart';
+import 'package:fastybird_smart_panel/core/services/command_dispatch.dart';
+import 'package:fastybird_smart_panel/core/services/socket.dart';
+import 'package:fastybird_smart_panel/modules/devices/constants.dart';
+import 'package:fastybird_smart_panel/modules/devices/mappers/channel.dart';
+import 'package:fastybird_smart_panel/modules/devices/mappers/device.dart';
+import 'package:fastybird_smart_panel/modules/devices/mappers/property.dart';
+import 'package:fastybird_smart_panel/modules/devices/models/properties/generic_properties.dart';
+import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/lighting.dart';
+import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/lock.dart';
+import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/sensor.dart';
+import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/thermostat.dart';
+import 'package:fastybird_smart_panel/modules/devices/presentation/device_details/window_covering.dart';
+import 'package:fastybird_smart_panel/modules/devices/repositories/channel_properties.dart';
+import 'package:fastybird_smart_panel/modules/devices/repositories/channels.dart';
+import 'package:fastybird_smart_panel/modules/devices/repositories/devices.dart';
+import 'package:fastybird_smart_panel/modules/devices/types/values.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/electrical_energy.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/electrical_power.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/light.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/lock.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/temperature.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/thermostat.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/channels/window_covering.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/lighting.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/lock.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/sensor.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/thermostat.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/devices/window_covering.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/properties/consumption.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/properties/on.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/properties/power.dart';
+import 'package:fastybird_smart_panel/modules/devices/views/properties/temperature.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const homeyType = 'devices-homey';
+const deviceId = '046f5102-1a8b-4e7d-a70e-20fe1fa836b1';
+const lightChannelId = '7833d7c9-250c-46e6-9c27-438ac92f0a39';
+const temperatureChannelId = '00f25c17-488b-44db-a413-59c31bd1803c';
+const thermostatChannelId = '5f59626d-5b9a-4207-a195-c959a4467f50';
+const lockChannelId = '6a9e7c5a-cbd4-4ded-9368-cbe7cd7d8b48';
+const coverChannelId = '31204c4e-b38e-4f8b-a06b-816ac1310b18';
+const powerChannelId = '26673bf2-63f4-44e1-8476-28ccca1c78d0';
+const energyChannelId = '625b095a-5c13-47f0-89aa-837056eda993';
+const propertyId = '80aa6c9c-918c-4751-af94-837a689f31dc';
+const secondPropertyId = '349ebbb0-bce1-4248-982e-a320b91dfd5b';
+
+Map<String, dynamic> _deviceJson(
+  String category, {
+  List<String> channels = const [],
+}) => {
+  'id': deviceId,
+  'type': homeyType,
+  'category': category,
+  'identifier': 'homey-device-fixture',
+  'name': 'Homey fixture',
+  'description': null,
+  'enabled': true,
+  'controls': <dynamic>[],
+  'channels': channels,
+  'zone_ids': <String>[],
+  'status': {'online': true, 'last_changed': '2026-08-24T10:00:00.000Z'},
+  'created_at': '2026-08-24T10:00:00.000Z',
+  'updated_at': null,
+};
+
+Map<String, dynamic> _channelJson(
+  String id,
+  String category, {
+  List<String> properties = const [],
+}) => {
+  'id': id,
+  'type': homeyType,
+  'category': category,
+  'device': deviceId,
+  'name': category,
+  'description': null,
+  'parent': null,
+  'controls': <dynamic>[],
+  'properties': properties,
+  'created_at': '2026-08-24T10:00:00.000Z',
+  'updated_at': null,
+};
+
+Map<String, dynamic> _propertyJson({
+  required String id,
+  required String channel,
+  required String category,
+  required String dataType,
+  required dynamic value,
+  List<String> permissions = const ['ro'],
+  String capabilityId = 'measure_fixture',
+  String mappingName = 'fixture-mapping',
+  String? unit,
+  List<dynamic>? format,
+}) => {
+  'id': id,
+  'type': homeyType,
+  'channel': channel,
+  'category': category,
+  'name': category,
+  'permissions': permissions,
+  'data_type': dataType,
+  'unit': unit,
+  'format': format,
+  'invalid': null,
+  'step': null,
+  'default_value': null,
+  'value': {'value': value, 'last_updated': '2026-08-24T10:00:00.000Z'},
+  'homey_capability_id': capabilityId,
+  'homey_mapping_name': mappingName,
+  'created_at': '2026-08-24T10:00:00.000Z',
+  'updated_at': null,
+};
+
+class _FakeSocketService extends SocketService {
+  String? lastEvent;
+  dynamic lastData;
+  String? lastHandler;
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  Future<void> sendCommand(
+    String event,
+    dynamic data,
+    String handler, {
+    Function(SocketCommandResponseModel?)? onAck,
+  }) async {
+    lastEvent = event;
+    lastData = data;
+    lastHandler = handler;
+    onAck?.call(SocketCommandResponseModel(status: true, message: 'accepted'));
+  }
+}
+
+void main() {
+  group('Homey generic device pipeline', () {
+    final deviceCases =
+        <({String category, Matcher viewMatcher, Matcher widgetMatcher})>[
+          (
+            category: 'lighting',
+            viewMatcher: isA<LightingDeviceView>(),
+            widgetMatcher: isA<LightingDeviceDetail>(),
+          ),
+          (
+            category: 'sensor',
+            viewMatcher: isA<SensorDeviceView>(),
+            widgetMatcher: isA<SensorDeviceDetail>(),
+          ),
+          (
+            category: 'thermostat',
+            viewMatcher: isA<ThermostatDeviceView>(),
+            widgetMatcher: isA<ThermostatDeviceDetail>(),
+          ),
+          (
+            category: 'window_covering',
+            viewMatcher: isA<WindowCoveringDeviceView>(),
+            widgetMatcher: isA<WindowCoveringDeviceDetail>(),
+          ),
+          (
+            category: 'lock',
+            viewMatcher: isA<LockDeviceView>(),
+            widgetMatcher: isA<LockDeviceDetail>(),
+          ),
+        ];
+
+    for (final testCase in deviceCases) {
+      test(
+        'loads ${testCase.category} through the normal model and detail widget mappers',
+        () {
+          expect(deviceModelMappers, isNot(contains(homeyType)));
+
+          final model = buildDeviceModel(
+            homeyType,
+            _deviceJson(testCase.category),
+          );
+          final view = buildDeviceView(model, const []);
+
+          expect(model.type, homeyType);
+          expect(view, testCase.viewMatcher);
+          expect(view.type, homeyType);
+          expect(buildDeviceWidget(view), testCase.widgetMatcher);
+        },
+      );
+    }
+
+    test(
+      'maps representative Homey channels and properties to existing views',
+      () {
+        final onModel = buildChannelPropertyModel(
+          homeyType,
+          _propertyJson(
+            id: propertyId,
+            channel: lightChannelId,
+            category: 'on',
+            dataType: 'bool',
+            value: true,
+            permissions: const ['rw'],
+            capabilityId: 'onoff',
+            mappingName: 'light-power',
+          ),
+        );
+        final onView = buildChannelPropertyView(onModel);
+        final lightView = buildChannelView(
+          buildChannelModel(
+            homeyType,
+            _channelJson(
+              lightChannelId,
+              'light',
+              properties: const [propertyId],
+            ),
+          ),
+          [onView],
+        );
+
+        final temperatureView = buildChannelPropertyView(
+          buildChannelPropertyModel(
+            homeyType,
+            _propertyJson(
+              id: secondPropertyId,
+              channel: temperatureChannelId,
+              category: 'temperature',
+              dataType: 'float',
+              value: 21.5,
+              capabilityId: 'measure_temperature',
+              mappingName: 'sensor-temperature',
+              unit: '°C',
+            ),
+          ),
+        );
+
+        final powerView = buildChannelPropertyView(
+          buildChannelPropertyModel(
+            homeyType,
+            _propertyJson(
+              id: propertyId,
+              channel: powerChannelId,
+              category: 'power',
+              dataType: 'float',
+              value: 42.5,
+              capabilityId: 'measure_power',
+              mappingName: 'instantaneous-power',
+              unit: 'W',
+            ),
+          ),
+        );
+        final energyView = buildChannelPropertyView(
+          buildChannelPropertyModel(
+            homeyType,
+            _propertyJson(
+              id: secondPropertyId,
+              channel: energyChannelId,
+              category: 'consumption',
+              dataType: 'float',
+              value: 12.75,
+              capabilityId: 'meter_power',
+              mappingName: 'accumulated-energy',
+              unit: 'kWh',
+            ),
+          ),
+        );
+
+        final powerChannel = buildChannelView(
+          buildChannelModel(
+            homeyType,
+            _channelJson(
+              powerChannelId,
+              'electrical_power',
+              properties: const [propertyId],
+            ),
+          ),
+          [powerView],
+        );
+        final energyChannel = buildChannelView(
+          buildChannelModel(
+            homeyType,
+            _channelJson(
+              energyChannelId,
+              'electrical_energy',
+              properties: const [secondPropertyId],
+            ),
+          ),
+          [energyView],
+        );
+        final lightingDevice = buildDeviceView(
+          buildDeviceModel(
+            homeyType,
+            _deviceJson(
+              'lighting',
+              channels: const [lightChannelId, powerChannelId, energyChannelId],
+            ),
+          ),
+          [lightView, powerChannel, energyChannel],
+        );
+
+        expect(onModel, isA<GenericChannelPropertyModel>());
+        expect(
+          (onModel as GenericChannelPropertyModel)
+              .configuration['homey_capability_id'],
+          'onoff',
+        );
+        expect(onView, isA<OnChannelPropertyView>());
+        expect(lightView, isA<LightChannelView>());
+        expect(temperatureView, isA<TemperatureChannelPropertyView>());
+        expect(
+          buildChannelView(
+            buildChannelModel(
+              homeyType,
+              _channelJson(temperatureChannelId, 'temperature'),
+            ),
+            [temperatureView],
+          ),
+          isA<TemperatureChannelView>(),
+        );
+        expect(
+          buildChannelView(
+            buildChannelModel(
+              homeyType,
+              _channelJson(thermostatChannelId, 'thermostat'),
+            ),
+            const [],
+          ),
+          isA<ThermostatChannelView>(),
+        );
+        expect(
+          buildChannelView(
+            buildChannelModel(homeyType, _channelJson(lockChannelId, 'lock')),
+            const [],
+          ),
+          isA<LockChannelView>(),
+        );
+        expect(
+          buildChannelView(
+            buildChannelModel(
+              homeyType,
+              _channelJson(coverChannelId, 'window_covering'),
+            ),
+            const [],
+          ),
+          isA<WindowCoveringChannelView>(),
+        );
+        expect(powerView, isA<PowerChannelPropertyView>());
+        expect(powerChannel, isA<ElectricalPowerChannelView>());
+        expect((powerChannel as ElectricalPowerChannelView).power, 42.5);
+        expect(energyView, isA<ConsumptionChannelPropertyView>());
+        expect(energyChannel, isA<ElectricalEnergyChannelView>());
+        expect(
+          (energyChannel as ElectricalEnergyChannelView).consumption,
+          12.75,
+        );
+        expect(lightingDevice, isA<LightingDeviceView>());
+        expect(
+          (lightingDevice as LightingDeviceView).electricalPowerChannel?.power,
+          42.5,
+        );
+        expect(lightingDevice.electricalEnergyChannel?.consumption, 12.75);
+        expect(buildDeviceWidget(lightingDevice), isA<LightingDeviceDetail>());
+      },
+    );
+  });
+
+  group('Homey state and control pipeline', () {
+    test(
+      'applies authoritative updates and dispatches commands without Homey credentials',
+      () async {
+        final apiClient = DevicesModuleClient(
+          Dio(),
+          baseUrl: 'http://localhost',
+        );
+        final socket = _FakeSocketService();
+        final propertiesRepository = ChannelPropertiesRepository(
+          apiClient: apiClient,
+          commandDispatch: CommandDispatchService(socketService: socket),
+        );
+        final channelsRepository = ChannelsRepository(
+          apiClient: apiClient,
+          channelPropertiesRepository: propertiesRepository,
+        );
+        final devicesRepository = DevicesRepository(
+          apiClient: apiClient,
+          channelsRepository: channelsRepository,
+        );
+
+        propertiesRepository.setChannelsRepository(channelsRepository);
+        propertiesRepository.setDevicesRepository(devicesRepository);
+
+        devicesRepository.insert([
+          _deviceJson('lighting', channels: const [lightChannelId]),
+        ]);
+        channelsRepository.insert([
+          _channelJson(lightChannelId, 'light', properties: const [propertyId]),
+        ]);
+        propertiesRepository.insert([
+          _propertyJson(
+            id: propertyId,
+            channel: lightChannelId,
+            category: 'on',
+            dataType: 'bool',
+            value: false,
+            permissions: const ['rw'],
+            capabilityId: 'onoff',
+            mappingName: 'light-power',
+          ),
+        ]);
+
+        expect(
+          (propertiesRepository.getItem(propertyId)!.value as BooleanValueType)
+              .value,
+          isFalse,
+        );
+
+        final sent = await propertiesRepository.setValue(propertyId, true);
+
+        expect(sent, isTrue);
+        expect(socket.lastEvent, DevicesModuleConstants.setPropertyEvent);
+        expect(socket.lastHandler, DevicesModuleEventHandlerName.setProperty);
+        expect(socket.lastData, {
+          'request_id': isA<String>(),
+          'properties': [
+            {
+              'device': deviceId,
+              'channel': lightChannelId,
+              'property': propertyId,
+              'value': true,
+            },
+          ],
+        });
+        expect(
+          (socket.lastData as Map<String, dynamic>).keys,
+          isNot(contains('api_key')),
+        );
+
+        propertiesRepository.insert([
+          _propertyJson(
+            id: propertyId,
+            channel: lightChannelId,
+            category: 'on',
+            dataType: 'bool',
+            value: false,
+            permissions: const ['rw'],
+            capabilityId: 'onoff',
+            mappingName: 'light-power',
+          ),
+        ]);
+
+        final synchronized = propertiesRepository.getItem(propertyId)!;
+        expect(synchronized, isA<GenericChannelPropertyModel>());
+        expect((synchronized.value as BooleanValueType).value, isFalse);
+      },
+    );
+  });
+}

--- a/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
+++ b/apps/panel/test/plugins/devices_homey/homey_device_pipeline_test.dart
@@ -1341,11 +1341,155 @@ void main() {
       await tester.pump();
 
       expect(
+        controlState
+            .getGroupState(deviceId, LightChannelController.colorGroupId)
+            ?.isPending,
+        isTrue,
+        reason: 'pre-ack color data cannot confirm the pending generation',
+      );
+
+      controlState.setGroupSettling(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
         controlState.getGroupState(
           deviceId,
           LightChannelController.colorGroupId,
         ),
         isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('keeps the current color generation through a delayed ABA match', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controlState = locator<DeviceControlStateService>();
+      controlState.clearForDevice(deviceId);
+      addTearDown(() => controlState.clearForDevice(deviceId));
+      final devicesService = locator<DevicesService>() as _MockDevicesService;
+      reset(devicesService);
+      final commandResults = List.generate(9, (_) => Completer<bool>());
+      var commandIndex = 0;
+      when(
+        () => devicesService.setPropertyValue(any(), any()),
+      ).thenAnswer((_) => commandResults[commandIndex++].future);
+
+      var renderedDevice =
+          _buildRepresentativeDevice('lighting', lightRgb: const [0, 0, 0])
+              as LightingDeviceView;
+      late StateSetter updateHost;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return LightingDeviceDetail(device: renderedDevice);
+            },
+          ),
+        ),
+      );
+
+      final controller = LightingDeviceController(
+        device: renderedDevice,
+        controlState: controlState,
+        devicesService: devicesService,
+      ).light;
+      controller.setColorRGB(10, 20, 30);
+      controller.setColorRGB(40, 50, 60);
+      controller.setColorRGB(10, 20, 30);
+      final thirdState = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      )!;
+      final thirdGeneration = thirdState.generation;
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      final stillPending = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      expect(stillPending?.isPending, isTrue);
+      expect(identical(stillPending?.generation, thirdGeneration), isTrue);
+
+      for (var index = 6; index < 9; index++) {
+        commandResults[index].complete(true);
+      }
+      await tester.pump();
+
+      final settling = controlState.getGroupState(
+        deviceId,
+        LightChannelController.colorGroupId,
+      );
+      expect(settling?.isSettling, isTrue);
+      expect(identical(settling?.generation, thirdGeneration), isTrue);
+
+      for (var index = 0; index < 6; index++) {
+        commandResults[index].complete(true);
+      }
+      await tester.pump();
+
+      expect(
+        identical(
+          controlState
+              .getGroupState(deviceId, LightChannelController.colorGroupId)
+              ?.generation,
+          thirdGeneration,
+        ),
+        isTrue,
+        reason: 'older color acknowledgments cannot mutate the generation',
+      );
+
+      updateHost(() {
+        renderedDevice = _buildRepresentativeDevice(
+          'lighting',
+          lightRgb: const [10, 20, 30],
+          lightRgbLastUpdated: List.filled(
+            3,
+            DateTime.utc(2026, 8, 24, 10, 1, 0, 1),
+          ),
+        ) as LightingDeviceView;
+      });
+      await tester.pump();
+
+      expect(
+        controlState.getGroupState(
+          deviceId,
+          LightChannelController.colorGroupId,
+        ),
+        isNull,
+        reason: 'only post-ack color snapshots confirm immediately',
       );
       expect(tester.takeException(), isNull);
     });

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -508,20 +508,18 @@ remains scoped to Task 5.3. All six supported admin locales carry the same non-e
 
 ### Task 5.2: Implement secret-safe configuration UI
 
-- [x] Add mode selection with local mode active and cloud mode marked unavailable until Phase 7.
+- [ ] Add mode selection with local mode active and cloud mode marked unavailable until Phase 7.
 - [x] Add URL, API-key replacement input, explicit clear action, bounded timeout/interval inputs, and enabled state.
 - [x] Show only whether an API key is configured; never populate the key field from GET data.
 - [x] Preserve the stored key when the field is untouched.
-- [x] Add separate test actions/payloads for the fully saved configuration and a complete candidate URL/newly entered key pair; disable candidate testing until both fields are present.
-- [x] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
-- [x] Unit-test initial state, preserve/replace/clear payloads, saved-vs-candidate test payloads, candidate URL without a new key, validation, working state, successful test, and categorized failures.
+- [ ] Add separate test actions/payloads for the fully saved configuration and a complete candidate URL/newly entered key pair; disable candidate testing until both fields are present.
+- [ ] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
+- [ ] Unit-test initial state, preserve/replace/clear payloads, saved-vs-candidate test payloads, candidate URL without a new key, validation, working state, successful test, and categorized failures.
 
-The Homey configuration form now exposes local mode while reserving cloud mode for Milestone 7. It validates and
-normalizes the endpoint and bounded timing fields, treats the API key as a write-only preserve/replace/clear value, and
-keeps saved-configuration testing separate from complete candidate credentials. Operational status is presented with
-Homey identity, version, synchronization/event timestamps, and localized sanitized failure guidance. Focused schemas,
-utilities, stores, and component tests cover secret handling, validation, request modes, concurrent requests, stale
-results, and disposal.
+The current Homey configuration form covers enabled state, endpoint, bounded timing fields, and write-only API-key
+replacement while preserving an untouched stored key. The status/test stores and schemas are registered, but the mode
+selector, saved-versus-candidate test actions, connector health presentation, and their component coverage remain to be
+implemented before this task can close.
 
 ### Task 5.3: Implement the generic wizard adapter
 
@@ -530,18 +528,17 @@ results, and disposal.
 - [x] Start/load Homey inventory and expose normalized wizard rows.
 - [x] Map name, model/class, zone, capability count, availability, and support/adoption status into built-in/extra cells.
 - [x] Provide stable device ID keys, suggested name/category, and category options.
-- [x] Fetch or derive read-only mapping summaries for confirmation.
+- [ ] Expose fetched read-only mapping summaries on confirmation rows.
 - [x] Submit batch adoption and translate per-device results.
 - [x] Clean up polling/subscriptions on wizard disposal.
 - [x] Handle offline, empty, loading, reconnect, unsupported, already adopted, and partial-success states.
 - [x] Add adapter/store/component tests using generated API mocks.
 
 The shared wizard adapter loads inventory before rendering selection rows, preserves full Homey identifiers, derives
-category choices and mapping summaries, and submits bounded batch adoption with per-device outcomes. Inventory,
-preview, refresh, and adoption requests are isolated from stale or disposed sessions; partial transport and provider
-results remain visible instead of discarding successful work. Tests cover empty/offline inventory, unsupported and
-already-adopted rows, refresh serialization, mapping failures, mixed batch outcomes, cancellation, and Unicode-safe
-adoption input validation.
+category choices, and submits bounded batch adoption with per-device outcomes. It fetches mapping previews for
+readiness and suggested category, but does not yet expose the channel/property summary on confirmation rows. Inventory,
+preview, refresh, and adoption requests remain isolated from stale or disposed sessions; partial transport and provider
+results remain visible instead of discarding successful work.
 
 ### Task 5.4: Generate OpenAPI clients and verify the admin app
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -508,33 +508,51 @@ remains scoped to Task 5.3. All six supported admin locales carry the same non-e
 
 ### Task 5.2: Implement secret-safe configuration UI
 
-- [ ] Add mode selection with local mode active and cloud mode marked unavailable until Phase 7.
-- [ ] Add URL, API-key replacement input, explicit clear action, bounded timeout/interval inputs, and enabled state.
-- [ ] Show only whether an API key is configured; never populate the key field from GET data.
-- [ ] Preserve the stored key when the field is untouched.
-- [ ] Add separate test actions/payloads for the fully saved configuration and a complete candidate URL/newly entered key pair; disable candidate testing until both fields are present.
-- [ ] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
-- [ ] Unit-test initial state, preserve/replace/clear payloads, saved-vs-candidate test payloads, candidate URL without a new key, validation, working state, successful test, and categorized failures.
+- [x] Add mode selection with local mode active and cloud mode marked unavailable until Phase 7.
+- [x] Add URL, API-key replacement input, explicit clear action, bounded timeout/interval inputs, and enabled state.
+- [x] Show only whether an API key is configured; never populate the key field from GET data.
+- [x] Preserve the stored key when the field is untouched.
+- [x] Add separate test actions/payloads for the fully saved configuration and a complete candidate URL/newly entered key pair; disable candidate testing until both fields are present.
+- [x] Display connector state, Homey identity/version, last sync/event, and sanitized error guidance.
+- [x] Unit-test initial state, preserve/replace/clear payloads, saved-vs-candidate test payloads, candidate URL without a new key, validation, working state, successful test, and categorized failures.
+
+The Homey configuration form now exposes local mode while reserving cloud mode for Milestone 7. It validates and
+normalizes the endpoint and bounded timing fields, treats the API key as a write-only preserve/replace/clear value, and
+keeps saved-configuration testing separate from complete candidate credentials. Operational status is presented with
+Homey identity, version, synchronization/event timestamps, and localized sanitized failure guidance. Focused schemas,
+utilities, stores, and component tests cover secret handling, validation, request modes, concurrent requests, stale
+results, and disposal.
 
 ### Task 5.3: Implement the generic wizard adapter
 
 **Reference:** `apps/admin/src/modules/devices/components/wizard/device-wizard.types.ts` and current Shelly/Z2M factories.
 
-- [ ] Start/load Homey inventory and expose normalized wizard rows.
-- [ ] Map name, model/class, zone, capability count, availability, and support/adoption status into built-in/extra cells.
-- [ ] Provide stable device ID keys, suggested name/category, and category options.
-- [ ] Fetch or derive read-only mapping summaries for confirmation.
-- [ ] Submit batch adoption and translate per-device results.
-- [ ] Clean up polling/subscriptions on wizard disposal.
-- [ ] Handle offline, empty, loading, reconnect, unsupported, already adopted, and partial-success states.
-- [ ] Add adapter/store/component tests using generated API mocks.
+- [x] Start/load Homey inventory and expose normalized wizard rows.
+- [x] Map name, model/class, zone, capability count, availability, and support/adoption status into built-in/extra cells.
+- [x] Provide stable device ID keys, suggested name/category, and category options.
+- [x] Fetch or derive read-only mapping summaries for confirmation.
+- [x] Submit batch adoption and translate per-device results.
+- [x] Clean up polling/subscriptions on wizard disposal.
+- [x] Handle offline, empty, loading, reconnect, unsupported, already adopted, and partial-success states.
+- [x] Add adapter/store/component tests using generated API mocks.
+
+The shared wizard adapter loads inventory before rendering selection rows, preserves full Homey identifiers, derives
+category choices and mapping summaries, and submits bounded batch adoption with per-device outcomes. Inventory,
+preview, refresh, and adoption requests are isolated from stale or disposed sessions; partial transport and provider
+results remain visible instead of discarding successful work. Tests cover empty/offline inventory, unsupported and
+already-adopted rows, refresh serialization, mapping failures, mixed batch outcomes, cancellation, and Unicode-safe
+adoption input validation.
 
 ### Task 5.4: Generate OpenAPI clients and verify the admin app
 
-- [ ] Run `pnpm run generate:openapi` after Swagger models/controllers stabilize.
-- [ ] Update manually maintained `apps/admin/src/openapi.constants.ts` exports only if needed.
-- [ ] Fix admin compile/test issues against generated types without editing `apps/admin/src/openapi.ts`.
-- [ ] Run admin unit tests, build, and JS lint/type checks.
+- [x] Run `pnpm run generate:openapi` after Swagger models/controllers stabilize.
+- [x] Update manually maintained `apps/admin/src/openapi.constants.ts` exports only if needed.
+- [x] Fix admin compile/test issues against generated types without editing `apps/admin/src/openapi.ts`.
+- [x] Run admin unit tests, build, and JS lint/type checks.
+
+The backend-generated OpenAPI contract includes Homey config, status, inventory, preview, adoption, and provider entity
+models. The admin constants expose only the required generated types and enums. The complete 2,224-test admin suite,
+type-check, lint, and CI web build pass without manual edits to generated sources.
 
 **Verification:**
 
@@ -547,12 +565,19 @@ pnpm run lint:js
 
 ### Task 5.5: Integrate and verify the panel
 
-- [ ] Determine whether the new backend entity discriminator needs plugin-specific Dart model mappers.
-- [ ] If required, add minimal mappers/registration under `apps/panel/lib/plugins/devices-homey/` following current provider patterns.
-- [ ] Do not add a Homey HTTP/Socket.IO client or credentials to Flutter.
-- [ ] Regenerate API/spec clients with `melos rebuild-all` after backend generation.
-- [ ] Add/extend tests for representative Homey-backed lighting, sensor, thermostat, cover, lock, and energy device rendering/control.
-- [ ] Run `melos analyze` and relevant Flutter tests.
+- [x] Determine whether the new backend entity discriminator needs plugin-specific Dart model mappers.
+- [x] If required, add minimal mappers/registration under `apps/panel/lib/plugins/devices-homey/` following current provider patterns.
+- [x] Do not add a Homey HTTP/Socket.IO client or credentials to Flutter.
+- [x] Regenerate API/spec clients with `melos rebuild-all` after backend generation.
+- [x] Add/extend tests for representative Homey-backed lighting, sensor, thermostat, cover, lock, and energy device rendering/control.
+- [x] Run `melos analyze` and relevant Flutter tests.
+
+No Homey-specific Dart model mapper is required. The panel's generic provider models preserve the `devices-homey`
+discriminator and unconsumed provider metadata while the existing category mappers construct the standard lighting,
+sensor, thermostat, window-covering, lock, and energy views. A focused pipeline suite proves normal API model loading,
+detail-widget selection, authoritative property replacement, and credential-free WebSocket command dispatch. Flutter
+contains no Homey endpoint, API key, or transport client. Regenerated clients/specs and analysis pass; the full panel
+suite completes with 1,032 passing tests and five existing locator-dependent skips.
 
 ---
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -131,23 +131,23 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 ### Admin
 
-- [ ] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
-- [ ] The form never repopulates or displays a stored API key.
-- [ ] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
-- [ ] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
-- [ ] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
-- [ ] Confirm rows provide sensible names/categories and a read-only mapping summary.
-- [ ] Batch results show created, updated, skipped, and failed outcomes with sanitized errors.
-- [ ] Stores/composables handle offline, empty, mixed-support, partial-success, and reconnect states.
-- [ ] All required locale files and locale schema tests are updated.
+- [x] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
+- [x] The form never repopulates or displays a stored API key.
+- [x] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
+- [x] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
+- [x] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
+- [x] Confirm rows provide sensible names/categories and a read-only mapping summary.
+- [x] Batch results show created, updated, skipped, and failed outcomes with sanitized errors.
+- [x] Stores/composables handle offline, empty, mixed-support, partial-success, and reconnect states.
+- [x] All required locale files and locale schema tests are updated.
 
 ### Panel
 
-- [ ] Adopted Homey devices load through the normal Devices API without Homey credentials.
-- [ ] Real-time property changes use the existing Smart Panel WebSocket/state path.
-- [ ] Representative lighting, sensor, thermostat, cover, lock, and energy devices render in existing detail widgets.
-- [ ] Supported commands follow existing panel optimistic/confirmation behavior.
-- [ ] `melos rebuild-all` and `melos analyze` succeed after generated API/spec changes.
+- [x] Adopted Homey devices load through the normal Devices API without Homey credentials.
+- [x] Real-time property changes use the existing Smart Panel WebSocket/state path.
+- [x] Representative lighting, sensor, thermostat, cover, lock, and energy devices render in existing detail widgets.
+- [x] Supported commands follow existing panel optimistic/confirmation behavior.
+- [x] `melos rebuild-all` and `melos analyze` succeed after generated API/spec changes.
 
 ### Tests and quality
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -131,12 +131,12 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 ### Admin
 
-- [x] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
+- [ ] The Homey plugin configuration form supports local URL, write-only API key, test connection, and health display.
 - [x] The form never repopulates or displays a stored API key.
-- [x] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
+- [ ] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
 - [x] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
 - [x] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
-- [x] Confirm rows provide sensible names/categories and a read-only mapping summary.
+- [ ] Confirm rows provide sensible names/categories and a read-only mapping summary.
 - [x] Batch results show created, updated, skipped, and failed outcomes with sanitized errors.
 - [x] Stores/composables handle offline, empty, mixed-support, partial-success, and reconnect states.
 - [x] All required locale files and locale schema tests are updated.


### PR DESCRIPTION
## Summary

- verify adopted Homey devices use the panel's generic provider models and existing category views without a Homey-specific mapper
- cover lighting, sensor, thermostat, window-covering, lock, power, and energy presentation paths
- prove authoritative property updates and credential-free WebSocket command dispatch use the normal Devices pipeline
- record the completed Homey admin, OpenAPI, and panel milestones in the implementation plan and epic checklist

## Architecture decision

Homey does not need a Flutter transport, credential store, or plugin-specific model mapper. The generic provider models preserve the devices-homey discriminator and unconsumed provider metadata, while existing category mappers select the standard detail views and control flow.

## Verification

- melos rebuild-all
- melos analyze
- flutter test test/plugins/devices_homey/homey_device_pipeline_test.dart — 7 passed
- flutter test — 1,032 passed, 5 existing locator-dependent skips
- git diff --check
