### PR TITLE
feat(admin): show Homey mapping summaries

### DIFF
--- a/apps/admin/src/plugins/devices-homey/composables/useDevicesWizard.spec.ts
+++ b/apps/admin/src/plugins/devices-homey/composables/useDevicesWizard.spec.ts
@@ -10,7 +10,18 @@ type MockPreview = {
 	suggestedCategory: DevicesModuleDeviceCategory;
 	validCategories: DevicesModuleDeviceCategory[];
 	readyToAdopt: boolean;
+	channels: { properties: unknown[] }[];
+	warnings: unknown[];
 };
+
+const mappingPreview = (overrides: Partial<MockPreview> = {}): MockPreview => ({
+	suggestedCategory: DevicesModuleDeviceCategory.lighting,
+	validCategories: [DevicesModuleDeviceCategory.lighting],
+	readyToAdopt: true,
+	channels: [],
+	warnings: [],
+	...overrides,
+});
 
 const flashMessage = { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() };
 const inventory = {
@@ -73,11 +84,9 @@ describe('Homey useDevicesWizard', () => {
 		inventory.findById.mockImplementation((id) => (id === 'homey-light' ? device() : null));
 		inventory.fetch.mockResolvedValue([]);
 		inventory.preview.mockImplementation(async (id) => {
-			const preview = {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
+			const preview = mappingPreview({
 				validCategories: [DevicesModuleDeviceCategory.lighting, DevicesModuleDeviceCategory.generic],
-				readyToAdopt: true,
-			};
+			});
 			inventory.previews[id] = preview;
 
 			return preview;
@@ -92,11 +101,9 @@ describe('Homey useDevicesWizard', () => {
 		inventory.findById.mockReturnValue(adopted);
 		devicesStore.findById.mockReturnValue({ name: 'Custom desk lamp', category: DevicesModuleDeviceCategory.generic });
 		inventory.previews = {
-			'homey-light': {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
+			'homey-light': mappingPreview({
 				validCategories: [DevicesModuleDeviceCategory.lighting, DevicesModuleDeviceCategory.generic],
-				readyToAdopt: true,
-			},
+			}),
 		};
 		inventory.fetch.mockResolvedValue([adopted]);
 		inventory.adoptBatch.mockResolvedValue([{ deviceId: 'homey-light', status: 'skipped' }]);
@@ -130,19 +137,11 @@ describe('Homey useDevicesWizard', () => {
 		inventory.findById.mockReturnValue(adopted);
 		devicesStore.findById.mockReturnValue({ name: 'Custom desk lamp', category: DevicesModuleDeviceCategory.generic });
 		inventory.previews = {
-			'homey-light': {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
-				readyToAdopt: true,
-			},
+			'homey-light': mappingPreview(),
 		};
 		inventory.fetch.mockResolvedValue([adopted]);
 		inventory.preview.mockImplementation(async (id) => {
-			const preview = {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
-				readyToAdopt: true,
-			};
+			const preview = mappingPreview();
 			inventory.previews[id] = preview;
 
 			return preview;
@@ -261,11 +260,9 @@ describe('Homey useDevicesWizard', () => {
 		const supported = device();
 		inventory.fetch.mockResolvedValue([supported]);
 		inventory.preview.mockImplementation(async (id) => {
-			const preview = {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
+			const preview = mappingPreview({
 				readyToAdopt: false,
-			};
+			});
 			inventory.previews[id] = preview;
 
 			return preview;
@@ -283,6 +280,43 @@ describe('Homey useDevicesWizard', () => {
 		);
 	});
 
+	it('exposes fetched mapping summaries only on confirmation rows', async () => {
+		const cleanDevice = device({ id: 'homey-light', name: 'Desk light' });
+		const warningDevice = device({ id: 'homey-switch', name: 'Hall switch' });
+		inventory.findAll.mockReturnValue([cleanDevice, warningDevice]);
+		inventory.fetch.mockResolvedValue([cleanDevice, warningDevice]);
+		inventory.preview.mockImplementation(async (id) => {
+			const preview = mappingPreview({
+				channels: [{ properties: [{}, {}] }, { properties: [{}] }],
+				warnings: id === 'homey-switch' ? [{}] : [],
+			});
+			inventory.previews[id] = preview;
+
+			return preview;
+		});
+		const adapter = useDevicesWizard();
+
+		await adapter.start();
+
+		expect(adapter.columns).toContainEqual({
+			key: 'mapping',
+			label: 'devicesHomeyPlugin.wizard.columns.mapping',
+			steps: ['confirm'],
+			minWidth: 220,
+		});
+		expect(adapter.rows.value.find((row) => row.key === 'homey-light')?.cells?.mapping).toEqual({
+			render: 'tag',
+			value: 'devicesHomeyPlugin.wizard.values.mappingSummary:{"channels":2,"properties":3}',
+			variant: 'success',
+		});
+		expect(adapter.rows.value.find((row) => row.key === 'homey-switch')?.cells?.mapping).toEqual({
+			render: 'tag',
+			value: 'devicesHomeyPlugin.wizard.values.mappingSummary:{"channels":2,"properties":3}',
+			variant: 'warning',
+			tooltip: 'devicesHomeyPlugin.wizard.values.mappingWarnings:{"count":1}',
+		});
+	});
+
 	it('isolates a mapping-preview failure to the affected device', async () => {
 		const readyDevice = device({ id: 'homey-light' });
 		const failedDevice = device({ id: 'homey-switch', name: 'Hall switch' });
@@ -290,11 +324,7 @@ describe('Homey useDevicesWizard', () => {
 		inventory.fetch.mockResolvedValue([readyDevice, failedDevice]);
 		inventory.preview.mockImplementation(async (id) => {
 			if (id === 'homey-switch') throw new Error('Device disappeared');
-			const preview = {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
-				readyToAdopt: true,
-			};
+			const preview = mappingPreview();
 			inventory.previews[id] = preview;
 
 			return preview;
@@ -322,11 +352,7 @@ describe('Homey useDevicesWizard', () => {
 			maximumActivePreviews = Math.max(maximumActivePreviews, activePreviews);
 			await Promise.resolve();
 			activePreviews -= 1;
-			const preview = {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
-				readyToAdopt: true,
-			};
+			const preview = mappingPreview();
 			inventory.previews[id] = preview;
 
 			return preview;
@@ -372,11 +398,7 @@ describe('Homey useDevicesWizard', () => {
 			await Promise.resolve();
 			activePreviews -= 1;
 
-			return {
-				suggestedCategory: DevicesModuleDeviceCategory.lighting,
-				validCategories: [DevicesModuleDeviceCategory.lighting],
-				readyToAdopt: true,
-			};
+			return mappingPreview();
 		});
 		inventory.adoptBatch.mockImplementation(async (requests: IHomeyAdoptSelection[]) =>
 			requests.map(({ deviceId }) => ({ deviceId, status: DevicesHomeyPluginAdoptionStatus.updated }))
@@ -433,11 +455,7 @@ describe('Homey useDevicesWizard', () => {
 		const adopted = device({ adopted: true, adoptedDeviceId: 'panel-light' });
 		inventory.findById.mockReturnValue(adopted);
 		devicesStore.findById.mockReturnValue({ name: 'Custom desk lamp', category: DevicesModuleDeviceCategory.generic });
-		inventory.preview.mockResolvedValue({
-			suggestedCategory: DevicesModuleDeviceCategory.lighting,
-			validCategories: [DevicesModuleDeviceCategory.lighting],
-			readyToAdopt: true,
-		});
+		inventory.preview.mockResolvedValue(mappingPreview());
 		const adapter = useDevicesWizard();
 
 		const results = await adapter.adopt([{ key: 'homey-light', name: 'Custom desk lamp', category: DevicesModuleDeviceCategory.generic }]);
@@ -547,11 +565,7 @@ describe('Homey useDevicesWizard', () => {
 		const operation = adapter.adopt([{ key: 'homey-light', name: 'Custom desk lamp', category: DevicesModuleDeviceCategory.lighting }]);
 		expect(adapter.busy.value).toBe(true);
 
-		resolvePreview({
-			suggestedCategory: DevicesModuleDeviceCategory.lighting,
-			validCategories: [DevicesModuleDeviceCategory.lighting],
-			readyToAdopt: true,
-		});
+		resolvePreview(mappingPreview());
 		await operation;
 
 		expect(adapter.busy.value).toBe(false);

--- a/apps/admin/src/plugins/devices-homey/composables/useDevicesWizard.ts
+++ b/apps/admin/src/plugins/devices-homey/composables/useDevicesWizard.ts
@@ -9,6 +9,7 @@ import { devicesStoreKey } from '../../../modules/devices';
 import type {
 	IDeviceWizardAdapter,
 	IWizardAdoptSelection,
+	IWizardCell,
 	IWizardControl,
 	IWizardResult,
 	IWizardRow,
@@ -62,6 +63,19 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 	let loadAbortController: AbortController | null = null;
 	const adoptionAbortControllers = new Set<AbortController>();
 	let disposed = false;
+
+	const mappingSummaryCell = (preview: IHomeyMappingPreview): IWizardCell => {
+		const channels = preview.channels.length;
+		const properties = preview.channels.reduce((count, channel) => count + channel.properties.length, 0);
+		const warnings = preview.warnings.length;
+
+		return {
+			render: 'tag',
+			value: t('devicesHomeyPlugin.wizard.values.mappingSummary', { channels, properties }),
+			variant: warnings > 0 ? 'warning' : 'success',
+			...(warnings > 0 ? { tooltip: t('devicesHomeyPlugin.wizard.values.mappingWarnings', { count: warnings }) } : {}),
+		};
+	};
 
 	const devices = computed(() =>
 		orderBy(
@@ -120,6 +134,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 								value: t('devicesHomeyPlugin.wizard.values.capabilities', { count: device.capabilities.length }),
 								variant: device.supportState === 'supported' ? 'success' : 'warning',
 							},
+							...(preview === undefined ? {} : { mapping: mappingSummaryCell(preview) }),
 						},
 					};
 				})
@@ -344,6 +359,7 @@ export const useDevicesWizard = (): IDeviceWizardAdapter => {
 			{ key: 'class', label: t('devicesHomeyPlugin.wizard.columns.class'), steps: ['discover'], width: 140 },
 			{ key: 'zone', label: t('devicesHomeyPlugin.wizard.columns.zone'), steps: ['discover'], minWidth: 160 },
 			{ key: 'capabilities', label: t('devicesHomeyPlugin.wizard.columns.capabilities'), steps: ['discover'], width: 140 },
+			{ key: 'mapping', label: t('devicesHomeyPlugin.wizard.columns.mapping'), steps: ['confirm'], minWidth: 220 },
 		],
 		controls,
 		sessionKey: computed(() => (sessionGeneration.value === 0 ? null : `homey-session-${sessionGeneration.value}`)),

--- a/apps/admin/src/plugins/devices-homey/locales/cs-CZ.json
+++ b/apps/admin/src/plugins/devices-homey/locales/cs-CZ.json
@@ -78,8 +78,13 @@
 		"title": "Přidat zařízení Homey",
 		"subtitle": "Vyberte podporovaná zařízení z připojeného Homey",
 		"breadcrumb": "Homey",
-		"columns": { "identifier": "ID zařízení Homey", "class": "Třída", "zone": "Zóna", "capabilities": "Funkce" },
-		"values": { "noZone": "Bez zóny", "capabilities": "Počet funkcí: {count}" },
+		"columns": { "identifier": "ID zařízení Homey", "class": "Třída", "zone": "Zóna", "capabilities": "Funkce", "mapping": "Mapování" },
+		"values": {
+			"noZone": "Bez zóny",
+			"capabilities": "Počet funkcí: {count}",
+			"mappingSummary": "{channels} kanálů · {properties} vlastností",
+			"mappingWarnings": "Počet upozornění mapování: {count}"
+		},
 		"statuses": { "unavailable": "V Homey není dostupné", "needsAttention": "Zkontrolujte mapování zařízení Homey" },
 		"actions": { "refresh": "Obnovit inventář", "openConfig": "Otevřít nastavení Homey" },
 		"errors": {

--- a/apps/admin/src/plugins/devices-homey/locales/de-DE.json
+++ b/apps/admin/src/plugins/devices-homey/locales/de-DE.json
@@ -80,8 +80,13 @@
 		"title": "Homey-Geräte hinzufügen",
 		"subtitle": "Unterstützte Geräte aus dem verbundenen Homey-Inventar auswählen",
 		"breadcrumb": "Homey",
-		"columns": { "identifier": "Homey-Geräte-ID", "class": "Klasse", "zone": "Zone", "capabilities": "Funktionen" },
-		"values": { "noZone": "Keine Zone", "capabilities": "{count} Funktionen" },
+		"columns": { "identifier": "Homey-Geräte-ID", "class": "Klasse", "zone": "Zone", "capabilities": "Funktionen", "mapping": "Zuordnung" },
+		"values": {
+			"noZone": "Keine Zone",
+			"capabilities": "{count} Funktionen",
+			"mappingSummary": "{channels} Kanäle · {properties} Eigenschaften",
+			"mappingWarnings": "{count} Zuordnungswarnungen"
+		},
 		"statuses": { "unavailable": "In Homey nicht verfügbar", "needsAttention": "Homey-Gerätezuordnung prüfen" },
 		"actions": { "refresh": "Inventar aktualisieren", "openConfig": "Homey-Konfiguration öffnen" },
 		"errors": {

--- a/apps/admin/src/plugins/devices-homey/locales/en-US.json
+++ b/apps/admin/src/plugins/devices-homey/locales/en-US.json
@@ -92,11 +92,14 @@
 			"identifier": "Homey device ID",
 			"class": "Class",
 			"zone": "Zone",
-			"capabilities": "Capabilities"
+			"capabilities": "Capabilities",
+			"mapping": "Mapping"
 		},
 		"values": {
 			"noZone": "No zone",
-			"capabilities": "{count} capabilities"
+			"capabilities": "{count} capabilities",
+			"mappingSummary": "{channels} channels · {properties} properties",
+			"mappingWarnings": "{count} mapping warnings"
 		},
 		"statuses": {
 			"unavailable": "Unavailable in Homey",

--- a/apps/admin/src/plugins/devices-homey/locales/es-ES.json
+++ b/apps/admin/src/plugins/devices-homey/locales/es-ES.json
@@ -80,8 +80,13 @@
 		"title": "Añadir dispositivos Homey",
 		"subtitle": "Selecciona dispositivos compatibles del inventario de Homey conectado",
 		"breadcrumb": "Homey",
-		"columns": { "identifier": "ID de dispositivo Homey", "class": "Clase", "zone": "Zona", "capabilities": "Capacidades" },
-		"values": { "noZone": "Sin zona", "capabilities": "{count} capacidades" },
+		"columns": { "identifier": "ID de dispositivo Homey", "class": "Clase", "zone": "Zona", "capabilities": "Capacidades", "mapping": "Mapeo" },
+		"values": {
+			"noZone": "Sin zona",
+			"capabilities": "{count} capacidades",
+			"mappingSummary": "{channels} canales · {properties} propiedades",
+			"mappingWarnings": "{count} advertencias de mapeo"
+		},
 		"statuses": { "unavailable": "No disponible en Homey", "needsAttention": "Revisa la asignación del dispositivo Homey" },
 		"actions": { "refresh": "Actualizar inventario", "openConfig": "Abrir configuración de Homey" },
 		"errors": {

--- a/apps/admin/src/plugins/devices-homey/locales/pl-PL.json
+++ b/apps/admin/src/plugins/devices-homey/locales/pl-PL.json
@@ -80,8 +80,13 @@
 		"title": "Dodaj urządzenia Homey",
 		"subtitle": "Wybierz obsługiwane urządzenia z inwentarza połączonego Homey",
 		"breadcrumb": "Homey",
-		"columns": { "identifier": "ID urządzenia Homey", "class": "Klasa", "zone": "Strefa", "capabilities": "Możliwości" },
-		"values": { "noZone": "Bez strefy", "capabilities": "Możliwości: {count}" },
+		"columns": { "identifier": "ID urządzenia Homey", "class": "Klasa", "zone": "Strefa", "capabilities": "Możliwości", "mapping": "Mapowanie" },
+		"values": {
+			"noZone": "Bez strefy",
+			"capabilities": "Możliwości: {count}",
+			"mappingSummary": "{channels} kanałów · {properties} właściwości",
+			"mappingWarnings": "Liczba ostrzeżeń mapowania: {count}"
+		},
 		"statuses": { "unavailable": "Niedostępne w Homey", "needsAttention": "Sprawdź mapowanie urządzenia Homey" },
 		"actions": { "refresh": "Odśwież inwentarz", "openConfig": "Otwórz konfigurację Homey" },
 		"errors": {

--- a/apps/admin/src/plugins/devices-homey/locales/sk-SK.json
+++ b/apps/admin/src/plugins/devices-homey/locales/sk-SK.json
@@ -78,8 +78,13 @@
 		"title": "Pridať zariadenia Homey",
 		"subtitle": "Vyberte podporované zariadenia z pripojeného Homey",
 		"breadcrumb": "Homey",
-		"columns": { "identifier": "ID zariadenia Homey", "class": "Trieda", "zone": "Zóna", "capabilities": "Funkcie" },
-		"values": { "noZone": "Bez zóny", "capabilities": "Počet funkcií: {count}" },
+		"columns": { "identifier": "ID zariadenia Homey", "class": "Trieda", "zone": "Zóna", "capabilities": "Funkcie", "mapping": "Mapovanie" },
+		"values": {
+			"noZone": "Bez zóny",
+			"capabilities": "Počet funkcií: {count}",
+			"mappingSummary": "{channels} kanálov · {properties} vlastností",
+			"mappingWarnings": "Počet upozornení mapovania: {count}"
+		},
 		"statuses": { "unavailable": "V Homey nie je dostupné", "needsAttention": "Skontrolujte mapovanie zariadenia Homey" },
 		"actions": { "refresh": "Obnoviť inventár", "openConfig": "Otvoriť nastavenie Homey" },
 		"errors": {

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -532,17 +532,18 @@ the form is reopened; the complete 2,252-test admin suite and production build p
 - [x] Start/load Homey inventory and expose normalized wizard rows.
 - [x] Map name, model/class, zone, capability count, availability, and support/adoption status into built-in/extra cells.
 - [x] Provide stable device ID keys, suggested name/category, and category options.
-- [ ] Expose fetched read-only mapping summaries on confirmation rows.
+- [x] Expose fetched read-only mapping summaries on confirmation rows.
 - [x] Submit batch adoption and translate per-device results.
 - [x] Clean up polling/subscriptions on wizard disposal.
 - [x] Handle offline, empty, loading, reconnect, unsupported, already adopted, and partial-success states.
 - [x] Add adapter/store/component tests using generated API mocks.
 
 The shared wizard adapter loads inventory before rendering selection rows, preserves full Homey identifiers, derives
-category choices, and submits bounded batch adoption with per-device outcomes. It fetches mapping previews for
-readiness and suggested category, but does not yet expose the channel/property summary on confirmation rows. Inventory,
-preview, refresh, and adoption requests remain isolated from stale or disposed sessions; partial transport and provider
-results remain visible instead of discarding successful work.
+category choices, and submits bounded batch adoption with per-device outcomes. Its confirmation rows expose the fetched
+preview as a read-only channel/property count, using warning styling and a warning-count tooltip when mapping review is
+needed. Inventory, preview, refresh, and adoption requests remain isolated from stale or disposed sessions; partial
+transport and provider results remain visible instead of discarding successful work. The complete 2,253-test admin
+suite, type-check, lint, and production build pass.
 
 ### Task 5.4: Generate OpenAPI clients and verify the admin app
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -136,7 +136,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [x] The form distinguishes testing the fully saved configuration from testing a complete candidate URL/new-key pair and never submits an endpoint override without a new key.
 - [x] A `deviceWizardAdapter` integrates Homey with the shared three-step adoption wizard.
 - [x] Discovery rows show name, identifier, class/model, zone, availability, capability count, and adoption/support status.
-- [ ] Confirm rows provide sensible names/categories and a read-only mapping summary.
+- [x] Confirm rows provide sensible names/categories and a read-only mapping summary.
 - [x] Batch results show created, updated, skipped, and failed outcomes with sanitized errors.
 - [x] Stores/composables handle offline, empty, mixed-support, partial-success, and reconnect states.
 - [x] All required locale files and locale schema tests are updated.


### PR DESCRIPTION
## Summary

- show fetched Homey mapping previews as read-only channel and property counts on confirmation rows
- highlight previews with mapping warnings and expose a warning-count tooltip
- add all six locale strings and close the remaining Task 5.3 acceptance item

## Verification

- focused Homey and generic wizard suites: 52 tests passed
- full admin suite: 300 files and 2,253 tests passed
- admin production build and Vue type-check passed
- full admin ESLint passed with four pre-existing wizard-spec warnings
- Prettier and git diff checks passed