### PR TITLE
fix(cross): package the Homey SDK as a runtime dependency

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -128,6 +128,7 @@
     "discord.js": "^14.16.3",
     "dotenv": "^17.3.1",
     "fastify": "^5.10.0",
+    "homey-api": "3.19.2",
     "influx": "^5.12.0",
     "inquirer": "^13.3.0",
     "lodash.isundefined": "^3.0.1",
@@ -182,7 +183,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.4.0",
-    "homey-api": "3.19.2",
     "jest": "^30.3.0",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.8.1",
@@ -196,7 +196,7 @@
     "typescript-eslint": "^8.57.0"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "npm": ">=10"
   }
 }

--- a/apps/backend/src/plugins/devices-homey/dto/test-connection.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/test-connection.dto.ts
@@ -3,7 +3,7 @@ import { IsDefined, IsEnum, IsIn, IsNotEmpty, IsObject, IsString, Matches, Valid
 
 import { ApiProperty, ApiSchema, getSchemaPath } from '@nestjs/swagger';
 
-import { IsSafeHomeyUrl } from '../validators/homey-url.validator';
+import { IsSafeHomeyUrl, MAX_HOMEY_URL_LENGTH } from '../validators/homey-url.validator';
 
 export enum HomeyTestConnectionMode {
 	SAVED = 'saved',
@@ -53,12 +53,13 @@ export class HomeyTestCandidateConnectionDto {
 	@ApiProperty({
 		description: 'Complete unsaved Homey local API URL',
 		example: 'http://homey.local:4859',
+		maxLength: MAX_HOMEY_URL_LENGTH,
 	})
 	@Expose()
 	@IsDefined({ message: '[{"field":"url","reason":"Candidate URL is required."}]' })
 	@IsNotEmpty({ message: '[{"field":"url","reason":"Candidate URL is required."}]' })
 	@IsSafeHomeyUrl({
-		message: '[{"field":"url","reason":"URL must use HTTP or HTTPS without embedded credentials."}]',
+		message: `[{"field":"url","reason":"URL must be at most ${MAX_HOMEY_URL_LENGTH} characters and use HTTP or HTTPS without embedded credentials."}]`,
 	})
 	url: string;
 

--- a/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
+++ b/apps/backend/src/plugins/devices-homey/dto/update-config.dto.ts
@@ -13,7 +13,7 @@ import {
 	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
 	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
 } from '../devices-homey.constants';
-import { IsSafeHomeyUrl } from '../validators/homey-url.validator';
+import { IsSafeHomeyUrl, MAX_HOMEY_URL_LENGTH } from '../validators/homey-url.validator';
 
 @ApiSchema({ name: 'DevicesHomeyPluginUpdateConfig' })
 export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
@@ -28,12 +28,13 @@ export class HomeyUpdatePluginConfigDto extends UpdatePluginConfigDto {
 	@ApiPropertyOptional({
 		description: 'Homey local API base URL',
 		example: 'http://homey.local:4859',
+		maxLength: MAX_HOMEY_URL_LENGTH,
 		nullable: true,
 	})
 	@Expose()
 	@IsOptional()
 	@IsSafeHomeyUrl({
-		message: '[{"field":"url","reason":"URL must use HTTP or HTTPS without embedded credentials."}]',
+		message: `[{"field":"url","reason":"URL must be at most ${MAX_HOMEY_URL_LENGTH} characters and use HTTP or HTTPS without embedded credentials."}]`,
 	})
 	url?: string | null;
 

--- a/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.spec.ts
@@ -3,6 +3,7 @@ import { validateSync } from 'class-validator';
 
 import { ConfigSecretsService } from '../../../modules/config/services/config-secrets.service';
 import { HomeyUpdatePluginConfigDto } from '../dto/update-config.dto';
+import { MAX_HOMEY_URL_LENGTH, isSafeHomeyUrl } from '../validators/homey-url.validator';
 
 import { HomeyConfigModel } from './config.model';
 
@@ -61,6 +62,19 @@ describe('Homey configuration', () => {
 			url,
 		});
 
+		expect(validateSync(config)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
+		expect(validateSync(update)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
+	});
+
+	it('rejects URLs above the bounded SDK transport input length', () => {
+		const url = `http://homey.local/${'a'.repeat(MAX_HOMEY_URL_LENGTH)}`;
+		const config = Object.assign(new HomeyConfigModel(), { url });
+		const update = plainToInstance(HomeyUpdatePluginConfigDto, {
+			type: 'devices-homey-plugin',
+			url,
+		});
+
+		expect(isSafeHomeyUrl(url)).toBe(false);
 		expect(validateSync(config)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
 		expect(validateSync(update)).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'url' })]));
 	});

--- a/apps/backend/src/plugins/devices-homey/models/config.model.ts
+++ b/apps/backend/src/plugins/devices-homey/models/config.model.ts
@@ -13,7 +13,7 @@ import {
 	MIN_HOMEY_CONNECTION_TIMEOUT_MS,
 	MIN_HOMEY_RECONCILIATION_INTERVAL_MS,
 } from '../devices-homey.constants';
-import { IsSafeHomeyUrl } from '../validators/homey-url.validator';
+import { IsSafeHomeyUrl, MAX_HOMEY_URL_LENGTH } from '../validators/homey-url.validator';
 
 @ApiSchema({ name: 'DevicesHomeyPluginDataConfig' })
 export class HomeyConfigModel extends PluginConfigModel {
@@ -28,6 +28,7 @@ export class HomeyConfigModel extends PluginConfigModel {
 	@ApiPropertyOptional({
 		description: 'Homey local API base URL',
 		example: 'http://homey.local:4859',
+		maxLength: MAX_HOMEY_URL_LENGTH,
 		nullable: true,
 	})
 	@Expose()

--- a/apps/backend/src/plugins/devices-homey/validators/homey-url.validator.ts
+++ b/apps/backend/src/plugins/devices-homey/validators/homey-url.validator.ts
@@ -1,7 +1,9 @@
 import { ValidateBy, ValidationOptions } from 'class-validator';
 
+export const MAX_HOMEY_URL_LENGTH = 2048;
+
 export const isSafeHomeyUrl = (value: unknown): value is string => {
-	if (typeof value !== 'string') {
+	if (typeof value !== 'string' || value.length > MAX_HOMEY_URL_LENGTH) {
 		return false;
 	}
 
@@ -20,7 +22,8 @@ export const IsSafeHomeyUrl = (validationOptions?: ValidationOptions): PropertyD
 			name: 'isSafeHomeyUrl',
 			validator: {
 				validate: isSafeHomeyUrl,
-				defaultMessage: () => 'Homey URL must use HTTP or HTTPS without embedded credentials',
+				defaultMessage: () =>
+					`Homey URL must be at most ${MAX_HOMEY_URL_LENGTH} characters and use HTTP or HTTPS without embedded credentials`,
 			},
 		},
 		validationOptions,

--- a/apps/backend/test/homey-shs-compatibility.homey-spike.ts
+++ b/apps/backend/test/homey-shs-compatibility.homey-spike.ts
@@ -2,7 +2,7 @@ import { lstatSync, readFileSync, readlinkSync } from 'node:fs';
 import { mkdir, mkdtemp, readlink, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import {
 	assertDistinctHomeyEnumCapabilityOptionIds,
@@ -44,6 +44,37 @@ const jsonResponse = (body: unknown, status = 200, headers: Record<string, strin
 	new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json', ...headers } });
 
 describe('Homey SHS compatibility probe', () => {
+	it('keeps the reviewed Homey SDK available to production installs with its license', () => {
+		const rootPackage = JSON.parse(readFileSync(resolve(__dirname, '../../../package.json'), 'utf8')) as {
+			engines: { node: string };
+		};
+		const backendPackage = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8')) as {
+			dependencies: Record<string, string>;
+			devDependencies: Record<string, string>;
+			engines: { node: string };
+		};
+		const packagedServer = JSON.parse(readFileSync(resolve(__dirname, '../../../build/package.json'), 'utf8')) as {
+			engines: { node: string };
+		};
+		const homeyPackagePath = require.resolve('homey-api/package.json');
+		const homeyPackage = JSON.parse(readFileSync(homeyPackagePath, 'utf8')) as {
+			engines: { node: string };
+			license: string;
+			version: string;
+		};
+		const license = readFileSync(resolve(dirname(homeyPackagePath), 'LICENSE'), 'utf8');
+
+		expect(backendPackage.dependencies['homey-api']).toBe('3.19.2');
+		expect(backendPackage.devDependencies).not.toHaveProperty('homey-api');
+		expect([rootPackage.engines.node, backendPackage.engines.node, packagedServer.engines.node]).toEqual([
+			'>=24',
+			'>=24',
+			'>=24',
+		]);
+		expect(homeyPackage).toMatchObject({ engines: { node: '>=24' }, license: 'SEE LICENSE', version: '3.19.2' });
+		expect(license).toContain('Package may be used freely with Homey products');
+	});
+
 	it('keeps the Homey Socket.IO 2 client on its callback-based parser generation', () => {
 		const requireFromHomeyApi = createRequire(require.resolve('homey-api/package.json'));
 		const socketIoClientPackagePath = requireFromHomeyApi.resolve('socket.io-client/package.json');

--- a/build/package.json
+++ b/build/package.json
@@ -59,7 +59,7 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "os": [
     "linux"

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -11,8 +11,8 @@ credential-rotation evidence pending
 ## Purpose
 
 This record is the evidence gate for the Homey local connector. It separates facts established from published artifacts
-and offline tests from behavior observed against the subscribed Homey Self-Hosted Server (SHS). A production connector,
-Socket.IO choice, or mDNS implementation must not be finalized from assumptions in this document.
+and offline tests from behavior observed against the subscribed Homey Self-Hosted Server (SHS). Production connector,
+Socket.IO, and mDNS decisions below identify which evidence supports them and which live gaps remain open.
 
 Never add a real endpoint, Homey ID, API key, device ID, zone or device name, private address, or raw response to this
 file. Live results use synthetic aliases and sanitized captures only.
@@ -30,8 +30,8 @@ file. Live results use synthetic aliases and sanitized captures only.
 | API-key revocation and replacement                    | Operator-controlled probe ready                 | Revoke only a dedicated test key during the gated observation window |
 | Disposable-device lifecycle                           | Guarded operator probe ready                    | Use only the separately gated virtual/test device                    |
 | mDNS discovery                                        | Deferred; manual URL only for local MVP         | Revisit only after an attributable stable service is verified        |
-| SDK decision                                          | Live session/cleanup passed; provisional hold   | Complete event, timeout, cleanup-failure, and reconnect comparison   |
-| Sanitized fixture corpus                              | Nine representative live fixtures promoted      | Add event/reconnect fixtures and missing capability families/classes |
+| SDK decision                                          | SDK selected behind connector boundary          | Re-evaluate the pinned package and audit result on every upgrade     |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture     | Add event/reconnect fixtures from the remaining live lifecycle runs  |
 
 ## Installation evidence
 
@@ -122,7 +122,7 @@ Automation is not a substitute for review. Before promoting any capture into com
 
 ## Realtime SDK probe and live mutation gate
 
-The realtime probe exercises the reviewed `homey-api` `3.19.2` package as a development-only compatibility tool. It
+The realtime probe exercises the same reviewed `homey-api` `3.19.2` package used by the production local connector. It
 connects and subscribes to the devices manager, records only allowlisted event labels and ordering, disconnects and
 destroys the client, then verifies that a generated invalid key is rejected by the same pinned SHS endpoint. Raw event
 payloads, errors, endpoints, keys, IDs, and values are never written to the report. Run it from the same interactive
@@ -451,36 +451,48 @@ under the same ignored capture root and restrictive directory/file modes as the 
 
 ## SDK artifact review
 
-Artifact snapshot inspected on 2026-08-12:
+Artifact snapshot inspected on 2026-08-12 and rechecked on 2026-08-25:
 
-| Property             | Finding                                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Package              | `homey-api` `3.19.2`, published 2026-07-29; installed as a development-only spike dependency               |
-| Runtime declaration  | Node.js `>=24`; current agent/workspace guidance requires 24, while package manifests still declare `>=20` |
-| License              | Use permitted with Homey products; source proprietary to Athom B.V.; no warranty                           |
-| Installed size       | Approximately 1.19 MB unpacked across 128 files                                                            |
-| Runtime dependencies | `engine.io-client ^3.5.5`, `socket.io-client ^2.5.0`, `node-fetch ^2.6.7`, `form-data ^4.0.0`              |
-| Local entry point    | `HomeyAPI.createLocalAPI({ address, token })`                                                              |
-| HTTP behavior        | Bearer authentication and generated manager paths described above                                          |
-| Realtime behavior    | WebSocket-only Socket.IO; live connect, subscribe, unsubscribe, disconnect, and destroy order verified     |
+| Property             | Finding                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Package              | `homey-api` `3.19.2`, published 2026-07-29 and pinned exactly as a production dependency                      |
+| Release activity     | Eight releases from 2026-03-25 through 2026-07-29; `3.19.2` remained the latest on 2026-08-25                 |
+| Runtime declaration  | Node.js `>=24`; root, backend, and packaged-server engine declarations are aligned to `>=24`                  |
+| License              | Use permitted with Homey products; source proprietary to Athom B.V.; no warranty; packaged `LICENSE` retained |
+| Installed size       | Approximately 1.19 MB unpacked across 128 files                                                               |
+| Runtime dependencies | Resolved to `engine.io-client 3.5.6`, `socket.io-client 2.5.0`, `node-fetch 2.7.0`, `form-data 4.0.6`         |
+| Local entry point    | `HomeyAPI.createLocalAPI({ address, token })`                                                                 |
+| HTTP behavior        | Bearer authentication and generated manager paths described above                                             |
+| Realtime behavior    | WebSocket-only Socket.IO; live connect, subscribe, unsubscribe, disconnect, and destroy order verified        |
 
-### Provisional dependency decision
+### Final dependency decision
 
-Do not move `homey-api` into production dependencies yet. Use direct, built-in HTTP for read-only inventory and fixture
-capture; the development-only SDK probe exists solely to measure realtime behavior. The final connector decision
-remains open until the live spike compares:
+**Decision:** use the official `homey-api` SDK behind the local connector boundary for the local MVP. Direct built-in
+HTTP remains the independent read-only compatibility/capture path, not the production realtime transport. The decision
+is based on the live SHS session and cleanup evidence, the SDK-native manager/capability contract, and the production
+adapter suites covering bounded creation and operations, subscription cleanup, reconnect coalescing, duplicate-listener
+prevention, late-client disposal, and normalized error handling. The outstanding live restart/network matrix remains a
+release-evidence gap, not an SDK abstraction gap.
 
-- Socket.IO authentication and manager subscription behavior;
-- disconnect and idempotent cleanup;
-- automatic reconnect, restart recovery, and duplicate listeners;
-- request and subscription timeout control;
-- error classification for invalid/revoked keys and missing scopes; and
-- the maintenance and security implications of the SDK's older HTTP and Socket.IO dependency chain; and
-- whether adopting the SDK also requires raising the public Node.js engine declaration from `>=20` to `>=24`.
+The package license permits use with Homey products. Smart Panel loads it only for a user-configured Homey integration,
+does not copy or modify its proprietary source, and preserves the package's own `LICENSE` in installed production
+dependencies. Because backend source imports the SDK at runtime and production installers omit development dependencies,
+`homey-api` is a production dependency. Its exact pin prevents an unreviewed proprietary/runtime update from entering a
+release.
 
-If the SDK passes, it remains behind `HomeyConnector` and no SDK object enters mapping, adoption, synchronization, or
-control services. If it fails, the replacement is direct documented HTTP plus a connector-owned Socket.IO transport.
-Either route must retain plain normalized models and the same connector contract tests.
+The 2026-08-25 `pnpm audit` reported one moderate advisory on this dependency path:
+`homey-api > engine.io-client > parseuri 0.0.6` ([GHSA-6fx8-h7jm-663j](https://github.com/advisories/GHSA-6fx8-h7jm-663j)).
+No patched `parseuri` release exists for that legacy chain. The affected parser receives only an administrator-supplied
+Homey endpoint; Smart Panel restricts it to credential-free HTTP(S), caps it at 2,048 characters before the SDK sees it,
+and applies bounded connect/operation timeouts. This accepted residual risk must be rechecked on every SDK upgrade and
+blocks relaxing the endpoint validation.
+
+Only production `homey-sdk.client.ts` imports `homey-api`; compatibility probes import it independently under `test/`.
+SDK values stay behind `HomeySdkClient`/`HomeyLocalTransport` interfaces, and the connector transforms them into plain
+normalized models before mapping, adoption, synchronization, or control code can consume them. The replacement is a
+connector-owned adapter using the documented HTTP and Socket.IO protocol. It must pass the existing transport,
+connector-contract, normalization, lifecycle, and command suites without changing any downstream service or stored
+device model.
 
 ## Live result matrix
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -80,9 +80,17 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 
 - [x] Review the exact `homey-api` package version, license text, transitive dependencies, Node 24 support, release activity, and bundle/runtime implications.
 - [ ] Exercise connect/disconnect, timeouts, subscription cleanup, and reconnect behavior in a disposable spike.
-- [ ] Record one decision: `use SDK behind connector` or `use documented HTTP/Socket.IO directly`.
-- [ ] Record replacement considerations so the rest of the plugin does not depend on SDK-specific objects.
-- [ ] Do not add the dependency to production packages until this decision is reviewed.
+- [x] Record one decision: `use SDK behind connector` or `use documented HTTP/Socket.IO directly`.
+- [x] Record replacement considerations so the rest of the plugin does not depend on SDK-specific objects.
+- [x] Do not add the dependency to production packages until this decision is reviewed.
+
+The local MVP uses exact-pinned `homey-api` `3.19.2` behind `HomeySdkClient` and `HomeyLocalTransport`; no SDK object
+crosses into normalized device services. The package license permits use with Homey products and remains packaged with
+the dependency. Its Node 24 engine is now reflected in root, backend, and packaged-server manifests. The legacy Socket.IO
+chain's unpatched moderate `parseuri` advisory is accepted only with the documented HTTP(S), credential, 2,048-character,
+administrator-only endpoint boundary and bounded operations. A direct documented HTTP/Socket.IO adapter is the recorded
+replacement and must pass the existing connector contract. Live restart/network evidence remains open above and in
+Task 6.2.
 
 ### Task 0.4: Build the sanitized fixture corpus
 
@@ -593,8 +601,8 @@ suite completes with 1,032 passing tests and five existing locator-dependent ski
 - [x] OpenAPI/spec generation is clean and generated diffs are intentional.
 - [x] Default CI requires no live Homey/SHS access.
 
-The 2026-08-25 automated local gate passed 36 Homey backend suites with 448 tests, seven credential-free compatibility
-spike suites with 122 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
+The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, seven credential-free compatibility
+spike suites with 123 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
 pipeline tests. OpenAPI plus device/channel spec regeneration produced no diff. PR #828 also passed the default backend
 unit/E2E, admin, panel, testing-app, web-build, schema, and analysis jobs; its Homey spike job received no live SHS
 credentials, while every live or mutating probe remains protected by its explicit environment gate and allowlist.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "husky": "^9.1.7"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.11.0
+      homey-api:
+        specifier: 3.19.2
+        version: 3.19.2(encoding@0.1.13)
       influx:
         specifier: ^5.12.0
         version: 5.12.0
@@ -617,9 +620,6 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.8.0
-      homey-api:
-        specifier: 3.19.2
-        version: 3.19.2(encoding@0.1.13)
       jest:
         specifier: ^30.3.0
         version: 30.4.2(@types/node@24.12.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@5.9.3))

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -85,7 +85,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
 - [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
 - [x] mDNS behavior is verified; automatic discovery is explicitly deferred because no attributable stable Homey service was observed.
-- [ ] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
+- [x] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
 - [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.
 - [x] Fixture-backed tests can run without live SHS access.
 
@@ -156,7 +156,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [x] Live SHS tests are environment-gated; write tests require an explicit device/capability allowlist.
 - [x] Backend unit tests, admin unit tests, JS lint/type checks, OpenAPI generation, and relevant panel tests pass.
 - [x] The plugin remains fully testable after the one-month SHS subscription expires.
-- [ ] No new dependency is merged without its license, maintenance, runtime, and replacement implications being documented.
+- [x] No new dependency is merged without its license, maintenance, runtime, and replacement implications being documented.
 
 ### Phase 2 cloud
 


### PR DESCRIPTION
## Summary

- finalize the local MVP decision to use exact-pinned `homey-api` behind the existing connector boundary and move it into production dependencies
- align root, backend, and packaged-server engine declarations with the SDK requirement of Node.js 24
- document license/distribution, release activity, runtime footprint, maintenance policy, audit risk, and the direct HTTP/Socket.IO replacement contract
- cap Homey endpoint input at 2,048 characters and expose that bound in OpenAPI as a compensating control for the legacy `parseuri` ReDoS advisory
- guard production dependency placement, engine alignment, and packaged SDK license in credential-free compatibility tests

## Security note

`homey-api` remains pinned at `3.19.2`; this PR reclassifies the already-installed package as runtime-required. Its legacy Socket.IO chain includes the existing moderate `parseuri` advisory with no patched release. The accepted residual risk and controls are recorded: administrator-only credential-free HTTP(S) endpoints, a 2,048-character limit before SDK parsing, and bounded connector operations.

## Testing

- Homey backend: 36 suites, 449 tests
- credential-free Homey spike: 7 suites, 123 tests
- focused ESLint
- OpenAPI generation and Spectral validation
- backend production build
- frozen offline lockfile verification
- production dependency classification verification
- `git diff --check`