### PR TITLE
test(cross): add Homey inventory performance gate

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -72,6 +72,7 @@
     "test:homey-spike": "jest --config ./test/jest-homey-spike.json --runInBand",
     "test:oauth-spike": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest --config ./test/jest-oauth-spike.json --runInBand",
     "test:buddy-context-soak": "jest --config ./test/jest-buddy-context-soak.json --runInBand",
+    "homey:performance-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-inventory-performance.homey-spike.ts",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",

--- a/apps/backend/test/homey-inventory-performance.homey-spike.ts
+++ b/apps/backend/test/homey-inventory-performance.homey-spike.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+import {
+	transformHomeyLocalDevices,
+	transformHomeyLocalZones,
+} from '../src/plugins/devices-homey/connectors/homey-local.transformer';
+import { HomeyMappingLoaderService } from '../src/plugins/devices-homey/mappings/mapping-loader.service';
+
+interface HomeyFixtureManifest {
+	fixtures: string[];
+}
+
+type JsonRecord = Record<string, unknown>;
+
+const INVENTORY_SIZE = 250;
+const SAMPLE_COUNT = 30;
+const WARMUP_COUNT = 3;
+const P95_REGRESSION_BUDGET_MS = 1000;
+const FIXTURE_ROOT = resolve(__dirname, '../src/plugins/devices-homey/__fixtures__/current');
+
+const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
+
+const percentile = (samples: readonly number[], ratio: number): number => {
+	const sorted = [...samples].sort((left, right) => left - right);
+	const index = Math.max(0, Math.ceil(sorted.length * ratio) - 1);
+
+	return sorted[index] ?? 0;
+};
+
+const buildFixtureGeneratedInventory = (): JsonRecord => {
+	const manifest = readJson(resolve(FIXTURE_ROOT, 'manifest.json')) as HomeyFixtureManifest;
+	const sourceDevices = manifest.fixtures.map(
+		(fixturePath) => readJson(resolve(FIXTURE_ROOT, fixturePath)) as JsonRecord,
+	);
+
+	if (sourceDevices.length === 0) {
+		throw new Error('Homey performance gate requires at least one captured device fixture');
+	}
+
+	return Object.fromEntries(
+		Array.from({ length: INVENTORY_SIZE }, (_, index) => {
+			const source = structuredClone(sourceDevices[index % sourceDevices.length]);
+			const id = `performance-device-${index.toString().padStart(3, '0')}`;
+
+			source.id = id;
+			source.name = `Performance device ${index.toString().padStart(3, '0')}`;
+
+			return [id, source];
+		}),
+	);
+};
+
+describe('Homey inventory performance gate', () => {
+	it('normalizes and resolves mappings for 250 fixture-generated devices within the regression budget', () => {
+		const rawInventory = buildFixtureGeneratedInventory();
+		const zones = transformHomeyLocalZones(readJson(resolve(FIXTURE_ROOT, 'zones.json')));
+		const loader = new HomeyMappingLoaderService();
+		loader.loadAllMappings();
+		let normalizedCount = 0;
+		let conflictCount = 0;
+		let propertyBindingCount = 0;
+
+		const run = (): number => {
+			const startedAt = performance.now();
+			const devices = transformHomeyLocalDevices(rawInventory, zones);
+			let conflicts = 0;
+			let propertyBindings = 0;
+
+			for (const device of devices) {
+				const deviceResolution = loader.resolveDeviceMappings(device);
+				const channelResolution = loader.resolveChannelMappings(device);
+				const propertyResolution = loader.resolvePropertyMappings(device);
+
+				conflicts +=
+					deviceResolution.conflicts.length + channelResolution.conflicts.length + propertyResolution.conflicts.length;
+				propertyBindings += propertyResolution.mappings.length;
+			}
+
+			normalizedCount = devices.length;
+			conflictCount = conflicts;
+			propertyBindingCount = propertyBindings;
+
+			return performance.now() - startedAt;
+		};
+
+		for (let index = 0; index < WARMUP_COUNT; index += 1) {
+			run();
+		}
+
+		const samples = Array.from({ length: SAMPLE_COUNT }, run);
+		const p50Ms = percentile(samples, 0.5);
+		const p95Ms = percentile(samples, 0.95);
+		const maximumMs = Math.max(...samples);
+
+		expect(normalizedCount).toBe(INVENTORY_SIZE);
+		expect(conflictCount).toBe(0);
+		expect(propertyBindingCount).toBeGreaterThan(0);
+		expect(p95Ms).toBeLessThan(P95_REGRESSION_BUDGET_MS);
+
+		process.stdout.write(
+			`Homey ${INVENTORY_SIZE}-device inventory gate: p50=${p50Ms.toFixed(2)}ms, p95=${p95Ms.toFixed(2)}ms, max=${maximumMs.toFixed(2)}ms.\n`,
+		);
+	});
+});

--- a/apps/backend/test/homey-inventory-performance.homey-spike.ts
+++ b/apps/backend/test/homey-inventory-performance.homey-spike.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
 
@@ -19,6 +20,8 @@ const SAMPLE_COUNT = 30;
 const WARMUP_COUNT = 3;
 const P95_REGRESSION_BUDGET_MS = 1000;
 const FIXTURE_ROOT = resolve(__dirname, '../src/plugins/devices-homey/__fixtures__/current');
+
+let userDataPath: string;
 
 const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
 
@@ -53,10 +56,18 @@ const buildFixtureGeneratedInventory = (): JsonRecord => {
 };
 
 describe('Homey inventory performance gate', () => {
+	beforeAll(() => {
+		userDataPath = mkdtempSync(resolve(tmpdir(), 'homey-inventory-performance-'));
+	});
+
+	afterAll(() => {
+		rmSync(userDataPath, { force: true, recursive: true });
+	});
+
 	it('normalizes and resolves mappings for 250 fixture-generated devices within the regression budget', () => {
 		const rawInventory = buildFixtureGeneratedInventory();
 		const zones = transformHomeyLocalZones(readJson(resolve(FIXTURE_ROOT, 'zones.json')));
-		const loader = new HomeyMappingLoaderService();
+		const loader = new HomeyMappingLoaderService({ userDataPath });
 		loader.loadAllMappings();
 		let normalizedCount = 0;
 		let conflictCount = 0;

--- a/apps/backend/test/homey-inventory-performance.homey-spike.ts
+++ b/apps/backend/test/homey-inventory-performance.homey-spike.ts
@@ -102,5 +102,5 @@ describe('Homey inventory performance gate', () => {
 		process.stdout.write(
 			`Homey ${INVENTORY_SIZE}-device inventory gate: p50=${p50Ms.toFixed(2)}ms, p95=${p95Ms.toFixed(2)}ms, max=${maximumMs.toFixed(2)}ms.\n`,
 		);
-	});
+	}, 45_000);
 });

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -601,8 +601,8 @@ suite completes with 1,032 passing tests and five existing locator-dependent ski
 - [x] OpenAPI/spec generation is clean and generated diffs are intentional.
 - [x] Default CI requires no live Homey/SHS access.
 
-The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, seven credential-free compatibility
-spike suites with 123 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
+The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, eight credential-free compatibility
+and performance suites with 124 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
 pipeline tests. OpenAPI plus device/channel spec regeneration produced no diff. PR #828 also passed the default backend
 unit/E2E, admin, panel, testing-app, web-build, schema, and analysis jobs; its Homey spike job received no live SHS
 credentials, while every live or mutating probe remains protected by its explicit environment gate and allowlist.
@@ -629,12 +629,20 @@ representative lifecycle failure paths.
 
 ### Task 6.3: Validate performance and security
 
-- [ ] Measure inventory/normalization with up to 250 fixture-generated devices and on supported panel/backend hardware where available.
+- [x] Measure inventory/normalization with up to 250 fixture-generated devices and on supported panel/backend hardware where available.
 - [ ] Measure capability event handoff and command-start latency against design targets.
 - [ ] Confirm no full inventory call occurs per event.
 - [ ] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
 - [ ] Verify all external calls have timeouts and reconnect loops have upper bounds.
 - [ ] Verify no route or service can delete/pair/rename an upstream Homey device.
+
+The 2026-08-25 credential-free inventory gate generated 250 unique devices by cycling the nine immutable live raw
+fixtures, then ran the production local transformer plus all built-in device/channel/property mapping resolution. After
+three warm-up passes, 30 measured Node 24 runs on the available development backend host completed at p50 `14.35 ms`,
+p95 `19.13 ms`, and maximum `23.01 ms`, with all 250 devices normalized and no mapping conflicts. The repeatable gate is
+`pnpm run homey:performance-gate`; its deliberately generous `1,000 ms` p95 CI budget detects major regressions and is
+not a Homey network-latency guarantee. No supported panel/backend appliance was available in this workspace, so the same
+command should be rerun there when hardware is available without reopening the credential-free corpus requirement.
 
 ### Task 6.4: Documentation and release checklist
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -640,9 +640,10 @@ The 2026-08-25 credential-free inventory gate generated 250 unique devices by cy
 fixtures, then ran the production local transformer plus all built-in device/channel/property mapping resolution. After
 three warm-up passes, 30 measured Node 24 runs on the available development backend host completed at p50 `14.35 ms`,
 p95 `19.13 ms`, and maximum `23.01 ms`, with all 250 devices normalized and no mapping conflicts. The repeatable gate is
-`pnpm run homey:performance-gate`; its deliberately generous `1,000 ms` p95 CI budget detects major regressions and is
-not a Homey network-latency guarantee. No supported panel/backend appliance was available in this workspace, so the same
-command should be rerun there when hardware is available without reopening the credential-free corpus requirement.
+`pnpm --filter ./apps/backend run homey:performance-gate`; its deliberately generous `1,000 ms` p95 CI budget detects
+major regressions and is not a Homey network-latency guarantee. No supported panel/backend appliance was available in
+this workspace, so the same command should be rerun there when hardware is available without reopening the
+credential-free corpus requirement.
 
 ### Task 6.4: Documentation and release checklist
 


### PR DESCRIPTION
## Summary

- add a reproducible 250-device Homey inventory normalization and mapping benchmark
- expose the focused benchmark through the backend homey:performance-gate script
- record the measured evidence and close the corresponding implementation-plan item

## Validation

- pnpm run homey:performance-gate (p95 17.39 ms)
- pnpm run test:homey-spike (8 suites, 124 tests)
- pnpm exec eslint test/homey-inventory-performance.homey-spike.ts
- Prettier checks
- git diff --check