### PR TITLE
test(cross): add Homey event and command latency gate

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -73,6 +73,7 @@
     "test:oauth-spike": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest --config ./test/jest-oauth-spike.json --runInBand",
     "test:buddy-context-soak": "jest --config ./test/jest-buddy-context-soak.json --runInBand",
     "homey:performance-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-inventory-performance.homey-spike.ts",
+    "homey:latency-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-event-command-performance.homey-spike.ts",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",

--- a/apps/backend/test/homey-event-command-performance.homey-spike.ts
+++ b/apps/backend/test/homey-event-command-performance.homey-spike.ts
@@ -1,0 +1,241 @@
+import { performance } from 'node:perf_hooks';
+
+import { ConfigService } from '../src/modules/config/services/config.service';
+import { HomeyConnectorFactory } from '../src/plugins/devices-homey/connectors/homey-connector.factory';
+import { HomeyConnector } from '../src/plugins/devices-homey/connectors/homey-connector.interface';
+import { HomeyEventListener, HomeyUnsubscribe } from '../src/plugins/devices-homey/connectors/homey-connector.types';
+import {
+	DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+} from '../src/plugins/devices-homey/devices-homey.constants';
+import { HomeyConfigModel } from '../src/plugins/devices-homey/models/config.model';
+import {
+	HomeyCapabilityType,
+	HomeyCapabilityValue,
+	createHomeyCapability,
+} from '../src/plugins/devices-homey/models/homey-capability.model';
+import { HomeyDevice } from '../src/plugins/devices-homey/models/homey-device.model';
+import { HomeyEvent, HomeyEventType } from '../src/plugins/devices-homey/models/homey-event.model';
+import { HomeySystemInfo } from '../src/plugins/devices-homey/models/homey-system-info.model';
+import { HomeyZone } from '../src/plugins/devices-homey/models/homey-zone.model';
+import { HomeySynchronizerService } from '../src/plugins/devices-homey/services/homey-synchronizer.service';
+import { HomeyService } from '../src/plugins/devices-homey/services/homey.service';
+
+const SAMPLE_COUNT = 30;
+const WARMUP_COUNT = 3;
+const P95_DESIGN_TARGET_MS = 250;
+
+const systemInfo: HomeySystemInfo = {
+	id: 'performance-homey',
+	name: 'Performance Homey',
+	version: '13.4.0',
+	tier: 'pro',
+	model: 'Homey Pro',
+};
+
+const zones: readonly HomeyZone[] = [
+	{ id: 'performance-zone', name: 'Performance zone', parentId: null, active: true, path: ['Performance zone'] },
+];
+
+const device: HomeyDevice = {
+	id: 'performance-device',
+	name: 'Performance device',
+	class: 'light',
+	zoneId: 'performance-zone',
+	zoneName: 'Performance zone',
+	zonePath: ['Performance zone'],
+	available: true,
+	availabilityMessage: null,
+	driverId: 'homey:app:driver:performance-light',
+	manufacturer: 'Performance fixture',
+	model: 'Performance light',
+	energy: null,
+	capabilities: [
+		createHomeyCapability({
+			id: 'onoff',
+			title: 'On/off',
+			value: false,
+			type: HomeyCapabilityType.BOOLEAN,
+			unit: null,
+			minimum: null,
+			maximum: null,
+			step: null,
+			enumValues: [],
+			readable: true,
+			writable: true,
+			available: true,
+			lastUpdatedAt: null,
+		}),
+	],
+};
+
+const percentile = (samples: readonly number[], ratio: number): number => {
+	const sorted = [...samples].sort((left, right) => left - right);
+	const index = Math.max(0, Math.ceil(sorted.length * ratio) - 1);
+
+	return sorted[index] ?? 0;
+};
+
+describe('Homey event and command performance gate', () => {
+	it('meets the event-handoff and command-start p95 targets without per-event inventory reads', async () => {
+		let listener: HomeyEventListener | null = null;
+		let sequence = 0;
+		let resolveEventHandoff: ((latencyMs: number) => void) | null = null;
+		let eventReceivedAt = 0;
+		let resolveCommandStart: ((latencyMs: number) => void) | null = null;
+		let commandReceivedAt = 0;
+		const config = Object.assign(new HomeyConfigModel(), {
+			enabled: true,
+			url: 'http://127.0.0.1:4859',
+			apiKey: 'performance-test-key',
+			connectionTimeout: DEFAULT_HOMEY_CONNECTION_TIMEOUT_MS,
+			reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		});
+		const configService = {
+			getPluginConfig: jest.fn().mockReturnValue(config),
+		};
+		const connector: jest.Mocked<HomeyConnector> = {
+			connect: jest.fn().mockResolvedValue(undefined),
+			disconnect: jest.fn().mockResolvedValue(undefined),
+			getSystemInfo: jest.fn().mockResolvedValue(systemInfo),
+			getZones: jest.fn().mockResolvedValue(zones),
+			getDevices: jest.fn().mockResolvedValue([device]),
+			getDevice: jest.fn().mockResolvedValue(device),
+			setCapabilityValue: jest.fn((deviceId: string, capabilityId: string, value: unknown): Promise<void> => {
+				resolveCommandStart?.(performance.now() - commandReceivedAt);
+				resolveCommandStart = null;
+				sequence += 1;
+				queueMicrotask(() => {
+					void listener?.({
+						type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+						deviceId,
+						capabilityId,
+						value: value as HomeyCapabilityValue,
+						lastUpdatedAt: null,
+						occurredAt: null,
+						sequence,
+					});
+				});
+
+				return Promise.resolve();
+			}),
+			subscribe: jest.fn((nextListener: HomeyEventListener): Promise<HomeyUnsubscribe> => {
+				listener = nextListener;
+
+				return Promise.resolve(() => undefined);
+			}),
+		};
+		const connectorFactory: jest.Mocked<HomeyConnectorFactory> = {
+			create: jest.fn().mockReturnValue(connector),
+		};
+		const synchronizer = {
+			filterEvents: jest.fn((events: readonly HomeyEvent[]) => [...events]),
+			getOperationalDiagnostics: jest.fn().mockResolvedValue({
+				adopted: 1,
+				adoptedDevices: [{ panelDeviceId: 'panel-device', homeyDeviceId: device.id }],
+				missing: 0,
+				unsupported: 0,
+				unavailable: 0,
+			}),
+			hasReadableCapabilityBinding: jest.fn().mockResolvedValue(true),
+			invalidateIndex: jest.fn(),
+			synchronizeSnapshot: jest.fn().mockResolvedValue({
+				updated: 0,
+				ignored: 0,
+				failed: 0,
+				acceptedEvents: [],
+				acceptedCapabilityValues: [{ deviceId: device.id, capabilityId: 'onoff', value: false }],
+			}),
+			synchronizeDevices: jest.fn().mockResolvedValue({
+				updated: 0,
+				ignored: 0,
+				failed: 0,
+				acceptedEvents: [],
+				acceptedCapabilityValues: [],
+			}),
+			synchronizeEvents: jest.fn((events: readonly HomeyEvent[]) => {
+				resolveEventHandoff?.(performance.now() - eventReceivedAt);
+				resolveEventHandoff = null;
+
+				return Promise.resolve({ updated: 0, ignored: 0, failed: 0, acceptedEvents: [...events] });
+			}),
+			reset: jest.fn(),
+		};
+		const service = new HomeyService(
+			configService as unknown as ConfigService,
+			synchronizer as unknown as HomeySynchronizerService,
+			connectorFactory,
+		);
+
+		await service.start();
+		connector.getDevice.mockClear();
+
+		const measureEventHandoff = (value: boolean): Promise<number> => {
+			const handoff = new Promise<number>((resolve) => {
+				resolveEventHandoff = resolve;
+			});
+			sequence += 1;
+			eventReceivedAt = performance.now();
+			void listener?.({
+				type: HomeyEventType.CAPABILITY_VALUE_CHANGED,
+				deviceId: device.id,
+				capabilityId: 'onoff',
+				value,
+				lastUpdatedAt: null,
+				occurredAt: null,
+				sequence,
+			});
+
+			return handoff;
+		};
+		const measureCommandStart = async (value: boolean): Promise<number> => {
+			const transportStarted = new Promise<number>((resolve) => {
+				resolveCommandStart = resolve;
+			});
+			commandReceivedAt = performance.now();
+			const command = service.executeCapabilityCommand(device.id, 'onoff', value);
+			const latencyMs = await transportStarted;
+
+			await expect(command).resolves.toBe(true);
+
+			return latencyMs;
+		};
+
+		for (let index = 0; index < WARMUP_COUNT; index += 1) {
+			await measureEventHandoff(index % 2 === 0);
+		}
+
+		const eventHandoffSamples: number[] = [];
+
+		for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+			eventHandoffSamples.push(await measureEventHandoff(index % 2 === 0));
+		}
+
+		expect(connector.getDevices.mock.calls).toHaveLength(1);
+		expect(connector.getDevice.mock.calls).toHaveLength(0);
+
+		for (let index = 0; index < WARMUP_COUNT; index += 1) {
+			await measureCommandStart(index % 2 === 0);
+		}
+
+		const commandStartSamples: number[] = [];
+
+		for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+			commandStartSamples.push(await measureCommandStart(index % 2 === 0));
+		}
+
+		const eventP95Ms = percentile(eventHandoffSamples, 0.95);
+		const commandP95Ms = percentile(commandStartSamples, 0.95);
+
+		expect(eventP95Ms).toBeLessThan(P95_DESIGN_TARGET_MS);
+		expect(commandP95Ms).toBeLessThan(P95_DESIGN_TARGET_MS);
+		expect(connector.getDevices.mock.calls).toHaveLength(1);
+		expect(connector.getDevice.mock.calls).toHaveLength(0);
+
+		process.stdout.write(
+			`Homey latency gate: event handoff p95=${eventP95Ms.toFixed(2)}ms, command start p95=${commandP95Ms.toFixed(2)}ms.\n`,
+		);
+
+		await service.stop();
+	}, 45_000);
+});

--- a/apps/backend/test/homey-event-command-performance.homey-spike.ts
+++ b/apps/backend/test/homey-event-command-performance.homey-spike.ts
@@ -22,6 +22,7 @@ import { HomeySynchronizerService } from '../src/plugins/devices-homey/services/
 import { HomeyService } from '../src/plugins/devices-homey/services/homey.service';
 
 const SAMPLE_COUNT = 30;
+const SYNCHRONIZATION_BACKLOG_MS = 25;
 const WARMUP_COUNT = 3;
 const P95_DESIGN_TARGET_MS = 250;
 
@@ -75,6 +76,11 @@ const percentile = (samples: readonly number[], ratio: number): number => {
 
 	return sorted[index] ?? 0;
 };
+
+const wait = (durationMs: number): Promise<void> =>
+	new Promise((resolve) => {
+		setTimeout(resolve, durationMs);
+	});
 
 describe('Homey event and command performance gate', () => {
 	it('meets the event-handoff and command-start p95 targets without per-event inventory reads', async () => {
@@ -153,11 +159,12 @@ describe('Homey event and command performance gate', () => {
 				acceptedEvents: [],
 				acceptedCapabilityValues: [],
 			}),
-			synchronizeEvents: jest.fn((events: readonly HomeyEvent[]) => {
+			synchronizeEvents: jest.fn(async (events: readonly HomeyEvent[]) => {
 				resolveEventHandoff?.(performance.now() - eventReceivedAt);
 				resolveEventHandoff = null;
+				await wait(SYNCHRONIZATION_BACKLOG_MS);
 
-				return Promise.resolve({ updated: 0, ignored: 0, failed: 0, acceptedEvents: [...events] });
+				return { updated: 0, ignored: 0, failed: 0, acceptedEvents: [...events] };
 			}),
 			reset: jest.fn(),
 		};
@@ -233,7 +240,7 @@ describe('Homey event and command performance gate', () => {
 		expect(connector.getDevice.mock.calls).toHaveLength(0);
 
 		process.stdout.write(
-			`Homey latency gate: event handoff p95=${eventP95Ms.toFixed(2)}ms, command start p95=${commandP95Ms.toFixed(2)}ms.\n`,
+			`Homey latency gate (${SYNCHRONIZATION_BACKLOG_MS}ms synchronization backlog): event handoff p95=${eventP95Ms.toFixed(2)}ms, command start p95=${commandP95Ms.toFixed(2)}ms.\n`,
 		);
 
 		await service.stop();

--- a/apps/backend/test/homey-event-command-performance.homey-spike.ts
+++ b/apps/backend/test/homey-event-command-performance.homey-spike.ts
@@ -196,6 +196,12 @@ describe('Homey event and command performance gate', () => {
 			return handoff;
 		};
 		const measureCommandStart = async (value: boolean): Promise<number> => {
+			const blockerTransportStarted = new Promise<number>((resolve) => {
+				resolveCommandStart = resolve;
+			});
+			commandReceivedAt = performance.now();
+			const blocker = service.executeCapabilityCommand(device.id, 'onoff', !value);
+			await blockerTransportStarted;
 			const transportStarted = new Promise<number>((resolve) => {
 				resolveCommandStart = resolve;
 			});
@@ -203,7 +209,7 @@ describe('Homey event and command performance gate', () => {
 			const command = service.executeCapabilityCommand(device.id, 'onoff', value);
 			const latencyMs = await transportStarted;
 
-			await expect(command).resolves.toBe(true);
+			await expect(Promise.all([blocker, command])).resolves.toEqual([true, true]);
 
 			return latencyMs;
 		};
@@ -240,7 +246,7 @@ describe('Homey event and command performance gate', () => {
 		expect(connector.getDevice.mock.calls).toHaveLength(0);
 
 		process.stdout.write(
-			`Homey latency gate (${SYNCHRONIZATION_BACKLOG_MS}ms synchronization backlog): event handoff p95=${eventP95Ms.toFixed(2)}ms, command start p95=${commandP95Ms.toFixed(2)}ms.\n`,
+			`Homey latency gate (${SYNCHRONIZATION_BACKLOG_MS}ms synchronization backlog): event handoff p95=${eventP95Ms.toFixed(2)}ms, queued command start p95=${commandP95Ms.toFixed(2)}ms.\n`,
 		);
 
 		await service.stop();

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -647,10 +647,11 @@ credential-free corpus requirement.
 
 The 2026-08-25 credential-free latency gate ran the production `HomeyService` event queue and serialized command path
 against instrumented connector and Devices synchronizer boundaries. After three warm-up passes, 30 measured samples
-completed at p95 `0.10 ms` from connector event receipt to the Devices synchronization handoff and p95 `0.02 ms` from
-validated command invocation to connector transport start, both below the `250 ms` design targets. The gate also asserts
-that capability updates leave the startup inventory call count unchanged and issue no targeted device reads. Run it from
-the repository root with `pnpm --filter ./apps/backend run homey:latency-gate`; the measurements cover backend scheduling
+completed at p95 `28.58 ms` from connector event receipt to the Devices synchronization handoff while each preceding
+synchronization remained busy for `25 ms`, and p95 `0.12 ms` from validated command invocation to connector transport
+start. Both remain below the `250 ms` design targets. The gate also asserts that capability updates leave the startup
+inventory call count unchanged and issue no targeted device reads. Run it from the repository root with
+`pnpm --filter ./apps/backend run homey:latency-gate`; the measurements cover backend scheduling and synchronization-queue
 overhead and deliberately exclude Homey network response time and subsequent command confirmation.
 
 ### Task 6.4: Documentation and release checklist

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -601,8 +601,8 @@ suite completes with 1,032 passing tests and five existing locator-dependent ski
 - [x] OpenAPI/spec generation is clean and generated diffs are intentional.
 - [x] Default CI requires no live Homey/SHS access.
 
-The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, eight credential-free compatibility
-and performance suites with 124 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
+The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, nine credential-free compatibility
+and performance suites with 125 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
 pipeline tests. OpenAPI plus device/channel spec regeneration produced no diff. PR #828 also passed the default backend
 unit/E2E, admin, panel, testing-app, web-build, schema, and analysis jobs; its Homey spike job received no live SHS
 credentials, while every live or mutating probe remains protected by its explicit environment gate and allowlist.
@@ -630,8 +630,8 @@ representative lifecycle failure paths.
 ### Task 6.3: Validate performance and security
 
 - [x] Measure inventory/normalization with up to 250 fixture-generated devices and on supported panel/backend hardware where available.
-- [ ] Measure capability event handoff and command-start latency against design targets.
-- [ ] Confirm no full inventory call occurs per event.
+- [x] Measure capability event handoff and command-start latency against design targets.
+- [x] Confirm no full inventory call occurs per event.
 - [ ] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
 - [ ] Verify all external calls have timeouts and reconnect loops have upper bounds.
 - [ ] Verify no route or service can delete/pair/rename an upstream Homey device.
@@ -644,6 +644,14 @@ p95 `19.13 ms`, and maximum `23.01 ms`, with all 250 devices normalized and no m
 major regressions and is not a Homey network-latency guarantee. No supported panel/backend appliance was available in
 this workspace, so the same command should be rerun there when hardware is available without reopening the
 credential-free corpus requirement.
+
+The 2026-08-25 credential-free latency gate ran the production `HomeyService` event queue and serialized command path
+against instrumented connector and Devices synchronizer boundaries. After three warm-up passes, 30 measured samples
+completed at p95 `0.10 ms` from connector event receipt to the Devices synchronization handoff and p95 `0.02 ms` from
+validated command invocation to connector transport start, both below the `250 ms` design targets. The gate also asserts
+that capability updates leave the startup inventory call count unchanged and issue no targeted device reads. Run it from
+the repository root with `pnpm --filter ./apps/backend run homey:latency-gate`; the measurements cover backend scheduling
+overhead and deliberately exclude Homey network response time and subsequent command confirmation.
 
 ### Task 6.4: Documentation and release checklist
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -647,10 +647,11 @@ credential-free corpus requirement.
 
 The 2026-08-25 credential-free latency gate ran the production `HomeyService` event queue and serialized command path
 against instrumented connector and Devices synchronizer boundaries. After three warm-up passes, 30 measured samples
-completed at p95 `28.58 ms` from connector event receipt to the Devices synchronization handoff while each preceding
-synchronization remained busy for `25 ms`, and p95 `0.12 ms` from validated command invocation to connector transport
-start. Both remain below the `250 ms` design targets. The gate also asserts that capability updates leave the startup
-inventory call count unchanged and issue no targeted device reads. Run it from the repository root with
+completed at p95 `29.66 ms` from connector event receipt to the Devices synchronization handoff while each preceding
+synchronization remained busy for `25 ms`, and p95 `28.55 ms` from validated command invocation to connector transport
+start while queued behind an in-flight command on the same capability. Both remain below the `250 ms` design targets.
+The gate also asserts that capability updates leave the startup inventory call count unchanged and issue no targeted
+device reads. Run it from the repository root with
 `pnpm --filter ./apps/backend run homey:latency-gate`; the measurements cover backend scheduling and synchronization-queue
 overhead and deliberately exclude Homey network response time and subsequent command confirmation.
 


### PR DESCRIPTION
## Summary

- add a credential-free gate for Homey capability-event handoff and command transport-start latency
- exercise the synchronization queue under a deliberate 25 ms representative backlog
- measure commands queued behind an in-flight command on the same capability
- assert capability updates do not trigger full inventory or targeted-device reads
- expose the focused backend command and record the Task 6.3 evidence

## Results

- event handoff p95: 29.66 ms with a 25 ms synchronization backlog
- queued command transport start p95: 28.55 ms
- both remain below the 250 ms design target

## Validation

- pnpm --filter ./apps/backend run homey:latency-gate
- pnpm --filter ./apps/backend run test:homey-spike (9 suites, 125 tests)
- pnpm --filter ./apps/backend run type-check
- pnpm exec eslint test/homey-event-command-performance.homey-spike.ts
- Prettier checks
- git diff --check