### PR TITLE
test(cross): add Homey security artifact gate

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -74,7 +74,7 @@
     "test:buddy-context-soak": "jest --config ./test/jest-buddy-context-soak.json --runInBand",
     "homey:performance-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-inventory-performance.homey-spike.ts",
     "homey:latency-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-event-command-performance.homey-spike.ts",
-    "homey:security-gate": "pnpm run generate:openapi && pnpm run build && HOMEY_SECURITY_REQUIRE_BUILD=1 jest --config ./test/jest-homey-spike.json --runInBand && jest --runInBand src/modules/config/services/config.service.spec.ts src/plugins/devices-homey",
+    "homey:security-gate": "pnpm run generate:openapi && pnpm run build && HOMEY_SECURITY_REQUIRE_BUILD=1 jest --config ./test/jest-homey-spike.json --runInBand && jest --runInBand src/modules/config/controllers/config.controller.spec.ts src/modules/config/services/config.service.spec.ts src/plugins/devices-homey",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -74,6 +74,7 @@
     "test:buddy-context-soak": "jest --config ./test/jest-buddy-context-soak.json --runInBand",
     "homey:performance-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-inventory-performance.homey-spike.ts",
     "homey:latency-gate": "jest --config ./test/jest-homey-spike.json --runInBand test/homey-event-command-performance.homey-spike.ts",
+    "homey:security-gate": "pnpm run generate:openapi && pnpm run build && HOMEY_SECURITY_REQUIRE_BUILD=1 jest --config ./test/jest-homey-spike.json --runInBand && jest --runInBand src/modules/config/services/config.service.spec.ts src/plugins/devices-homey",
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -702,6 +702,64 @@ const containsUnsafeCompiledAlias = (
 			return inspectCallable(initializer, new Set(resolving).add(callee.text));
 		}
 
+		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
+			const propertyName = ts.isPropertyAccessExpression(callee)
+				? callee.name.text
+				: callee.argumentExpression !== undefined &&
+					  (ts.isStringLiteral(callee.argumentExpression) || ts.isNumericLiteral(callee.argumentExpression))
+					? callee.argumentExpression.text
+					: undefined;
+			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
+				if (propertyName === undefined) {
+					return false;
+				}
+
+				if (ts.isIdentifier(receiver)) {
+					const initializer = resolveCompiledAlias(receiver);
+
+					if (initializer === undefined || nestedResolving.has(receiver.text)) {
+						return false;
+					}
+
+					return inspectCallableProperty(initializer, new Set(nestedResolving).add(receiver.text));
+				}
+
+				if (
+					ts.isParenthesizedExpression(receiver) ||
+					ts.isAsExpression(receiver) ||
+					ts.isTypeAssertionExpression(receiver) ||
+					ts.isNonNullExpression(receiver) ||
+					ts.isSatisfiesExpression(receiver)
+				) {
+					return inspectCallableProperty(receiver.expression, nestedResolving);
+				}
+
+				if (ts.isObjectLiteralExpression(receiver)) {
+					return receiver.properties.some((property) => {
+						if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+							return inspectCallable(property.initializer, nestedResolving);
+						}
+
+						if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+							return inspectCallable(property.name, nestedResolving);
+						}
+
+						return ts.isSpreadAssignment(property) && inspectCallableProperty(property.expression, nestedResolving);
+					});
+				}
+
+				if (ts.isArrayLiteralExpression(receiver) && /^\d+$/.test(propertyName)) {
+					const element = receiver.elements[Number(propertyName)];
+
+					return element !== undefined && ts.isExpression(element) && inspectCallable(element, nestedResolving);
+				}
+
+				return false;
+			};
+
+			return inspectCallableProperty(callee.expression, resolving);
+		}
+
 		if (
 			ts.isParenthesizedExpression(callee) ||
 			ts.isAsExpression(callee) ||
@@ -2293,6 +2351,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const fallback = value => 'opaque-secret'; const apiKey = fallback('');",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source['fallback']();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1286,10 +1286,15 @@ const containsUnsafeCompiledAlias = (
 		};
 
 		parameters.forEach((parameter, index) => {
-			const argument = arguments_[index] ?? parameter.initializer;
+			const argumentValues =
+				parameter.dotDotDotToken === undefined
+					? [arguments_[index] ?? parameter.initializer].filter(
+							(argument): argument is ts.Expression => argument !== undefined,
+						)
+					: arguments_.slice(index);
 
-			if (argument !== undefined) {
-				bindArgument(parameter.name, parameter, [argument]);
+			if (argumentValues.length > 0) {
+				bindArgument(parameter.name, parameter, argumentValues);
 			}
 		});
 
@@ -1602,6 +1607,35 @@ const containsUnsafeCompiledAlias = (
 					const nestedReceiverResolving =
 						receiverBinding === undefined ? nestedResolving : new Set(nestedResolving).add(receiverBinding.declaration);
 					const classDeclaration = receiverBinding?.classDeclaration;
+					const parameterArguments =
+						receiverBinding === undefined ? undefined : activeParameterArguments.get(receiverBinding.declaration);
+
+					if (
+						parameterArguments !== undefined &&
+						receiverBinding !== undefined &&
+						!nestedResolving.has(receiverBinding.declaration)
+					) {
+						if (
+							ts.isParameter(receiverBinding.declaration) &&
+							receiverBinding.declaration.dotDotDotToken !== undefined &&
+							/^\d+$/.test(selectedPropertyName)
+						) {
+							const argument = parameterArguments[Number(selectedPropertyName)];
+
+							return (
+								argument !== undefined &&
+								(containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedReceiverResolving))
+							);
+						}
+
+						if (
+							parameterArguments.some((argument) =>
+								inspectProperty(argument, nestedReceiverResolving, selectedPropertyName, resolvingProperties),
+							)
+						) {
+							return true;
+						}
+					}
 
 					if (
 						receiverBinding !== undefined &&
@@ -2029,6 +2063,29 @@ const containsUnsafeCompiledAlias = (
 					const nestedReceiverResolving =
 						receiverBinding === undefined ? nestedResolving : new Set(nestedResolving).add(receiverBinding.declaration);
 					const classDeclaration = receiverBinding?.classDeclaration;
+					const parameterArguments =
+						receiverBinding === undefined ? undefined : activeParameterArguments.get(receiverBinding.declaration);
+
+					if (
+						parameterArguments !== undefined &&
+						receiverBinding !== undefined &&
+						!nestedResolving.has(receiverBinding.declaration)
+					) {
+						if (
+							ts.isParameter(receiverBinding.declaration) &&
+							receiverBinding.declaration.dotDotDotToken !== undefined &&
+							/^\d+$/.test(propertyName)
+						) {
+							const argument = parameterArguments[Number(propertyName)];
+
+							return argument !== undefined && inspectCallable(argument, nestedReceiverResolving);
+						}
+
+						if (parameterArguments.some((argument) => inspectCallableProperty(argument, nestedReceiverResolving))) {
+							return true;
+						}
+					}
+
 					const inspectStaticClassCallable = (
 						declaration: ts.ClassDeclaration,
 						resolvingClasses = new Set<ts.ClassDeclaration>(),
@@ -4609,6 +4666,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"function make([value]) { return { value }; } const apiKey = make(['opaque-secret']).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function make(...values) { return { value: values[1] }; } const apiKey = make('', 'opaque-secret').value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2355,9 +2355,23 @@ const containsUnsafeCompiledAlias = (
 			return false;
 		}
 	};
-	const resolveClassReceiver = (expression: ts.Expression): ts.ClassLikeDeclaration | undefined => {
+	function resolveClassReceiver(
+		expression: ts.Expression,
+		resolving = new Set<ts.Node>(),
+	): ts.ClassLikeDeclaration | undefined {
 		if (ts.isIdentifier(expression)) {
-			return resolveCompiledBinding(expression)?.classDeclaration;
+			const binding = resolveCompiledBinding(expression);
+
+			if (binding === undefined || resolving.has(binding.declaration)) {
+				return undefined;
+			}
+
+			return (
+				binding.classDeclaration ??
+				(binding.initializer === undefined
+					? undefined
+					: resolveClassReceiver(binding.initializer, new Set(resolving).add(binding.declaration)))
+			);
 		}
 
 		if (ts.isClassExpression(expression)) {
@@ -2371,11 +2385,75 @@ const containsUnsafeCompiledAlias = (
 			ts.isNonNullExpression(expression) ||
 			ts.isSatisfiesExpression(expression)
 		) {
-			return resolveClassReceiver(expression.expression);
+			return resolveClassReceiver(expression.expression, resolving);
+		}
+
+		if (ts.isCallExpression(expression)) {
+			return resolveReturnedClass(expression.expression, resolving);
 		}
 
 		return undefined;
-	};
+	}
+	function resolveReturnedClass(callee: ts.Expression, resolving: Set<ts.Node>): ts.ClassLikeDeclaration | undefined {
+		const resolveBodyReturn = (body: ts.Block, nestedResolving: Set<ts.Node>): ts.ClassLikeDeclaration | undefined => {
+			let returnedClass: ts.ClassLikeDeclaration | undefined;
+			const visitReturn = (node: ts.Node): void => {
+				if (returnedClass !== undefined) {
+					return;
+				}
+
+				if (ts.isReturnStatement(node) && node.expression !== undefined) {
+					returnedClass = resolveClassReceiver(node.expression, nestedResolving);
+				}
+
+				if (returnedClass === undefined) {
+					ts.forEachChild(node, visitReturn);
+				}
+			};
+
+			visitReturn(body);
+
+			return returnedClass;
+		};
+
+		if (ts.isIdentifier(callee)) {
+			for (const binding of resolveCompiledBindings(callee, visibleThroughPosition)) {
+				if (resolving.has(binding.declaration)) {
+					continue;
+				}
+
+				const nestedResolving = new Set(resolving).add(binding.declaration);
+				const resolvedInitializer =
+					binding.initializer === undefined ? undefined : resolveReturnedClass(binding.initializer, nestedResolving);
+				const resolvedCallable =
+					binding.callable?.body === undefined ? undefined : resolveBodyReturn(binding.callable.body, nestedResolving);
+
+				if (resolvedInitializer !== undefined || resolvedCallable !== undefined) {
+					return resolvedInitializer ?? resolvedCallable;
+				}
+			}
+
+			return undefined;
+		}
+
+		if (
+			ts.isParenthesizedExpression(callee) ||
+			ts.isAsExpression(callee) ||
+			ts.isTypeAssertionExpression(callee) ||
+			ts.isNonNullExpression(callee) ||
+			ts.isSatisfiesExpression(callee)
+		) {
+			return resolveReturnedClass(callee.expression, resolving);
+		}
+
+		if (ts.isArrowFunction(callee)) {
+			return ts.isBlock(callee.body)
+				? resolveBodyReturn(callee.body, resolving)
+				: resolveClassReceiver(callee.body, resolving);
+		}
+
+		return ts.isFunctionExpression(callee) ? resolveBodyReturn(callee.body, resolving) : undefined;
+	}
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression, visibleThroughPosition);
@@ -2671,9 +2749,7 @@ const containsUnsafeCompiledAlias = (
 										?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 										.some((clause) =>
 											clause.types.some((type) => {
-												const baseClass = ts.isIdentifier(type.expression)
-													? resolveCompiledBinding(type.expression)?.classDeclaration
-													: undefined;
+												const baseClass = resolveClassReceiver(type.expression);
 
 												return baseClass !== undefined && inspectDynamicClassProperties(baseClass, nestedClasses);
 											}),
@@ -2729,9 +2805,7 @@ const containsUnsafeCompiledAlias = (
 							?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 							.some((clause) =>
 								clause.types.some((type) => {
-									const baseClass = ts.isIdentifier(type.expression)
-										? resolveCompiledBinding(type.expression)?.classDeclaration
-										: undefined;
+									const baseClass = resolveClassReceiver(type.expression);
 
 									return (
 										baseClass !== undefined &&
@@ -3053,9 +3127,7 @@ const containsUnsafeCompiledAlias = (
 											?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 											.some((clause) =>
 												clause.types.some((type) => {
-													const baseClass = ts.isIdentifier(type.expression)
-														? resolveCompiledBinding(type.expression)?.classDeclaration
-														: undefined;
+													const baseClass = resolveClassReceiver(type.expression);
 
 													return baseClass !== undefined && inspectClassMethod(baseClass, expectStatic, nestedClasses);
 												}),
@@ -3561,9 +3633,7 @@ const containsUnsafeCompiledAlias = (
 								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 								.some((clause) =>
 									clause.types.some((type) => {
-										const baseClass = ts.isIdentifier(type.expression)
-											? resolveCompiledBinding(type.expression)?.classDeclaration
-											: undefined;
+										const baseClass = resolveClassReceiver(type.expression);
 
 										return baseClass !== undefined && inspectStaticClassCallable(baseClass, nestedClasses);
 									}),
@@ -3861,9 +3931,7 @@ const containsUnsafeCompiledAlias = (
 								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 								.some((clause) =>
 									clause.types.some((type) => {
-										const baseClass = ts.isIdentifier(type.expression)
-											? resolveCompiledBinding(type.expression)?.classDeclaration
-											: undefined;
+										const baseClass = resolveClassReceiver(type.expression);
 
 										return baseClass !== undefined && inspectClassValue(baseClass, memberName, nestedValues);
 									}),
@@ -3940,9 +4008,7 @@ const containsUnsafeCompiledAlias = (
 								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
 								.some((clause) =>
 									clause.types.some((type) => {
-										const baseClass = ts.isIdentifier(type.expression)
-											? resolveCompiledBinding(type.expression)?.classDeclaration
-											: undefined;
+										const baseClass = resolveClassReceiver(type.expression);
 
 										return baseClass !== undefined && inspectClassCallable(baseClass, nestedClasses);
 									}),
@@ -6448,6 +6514,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Base { value = 'opaque-secret'; } class Source extends Base {} const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function makeBase() { return class { value = 'opaque-secret'; }; } const apiKey = new (class extends makeBase() {})().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -51,7 +51,7 @@ const LOOSE_PROPERTY_PATTERN = /^\s*(?:[-*]\s+)?["'`]?([A-Za-z][A-Za-z0-9_.-]*)[
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
-		pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
+		pattern: /(?:\d{1,3}\.){3}\d{1,3}/,
 	},
 	{
 		label: 'a MAC address',
@@ -199,6 +199,10 @@ const compiledPropertyName = (name: ts.PropertyName): string | undefined => {
 };
 
 const compiledAssignedPropertyName = (expression: ts.Expression): string | undefined => {
+	if (ts.isIdentifier(expression)) {
+		return expression.text;
+	}
+
 	if (ts.isPropertyAccessExpression(expression)) {
 		return expression.name.text;
 	}
@@ -583,6 +587,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const api_key = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
+		expect(() => assertTextSafe('unsafe compiled module', "api_key = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const credentials = { value: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -590,6 +597,9 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains an IPv4 address',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"169.254.1.20"}')).toThrow(
+			'unsafe fixture contains an IPv4 address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"prefix192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"fe80::1%en0"}')).toThrow(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -563,6 +563,61 @@ const containsUnsafeCompiledAlias = (
 			return containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving);
 		}
 
+		if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+			const propertyName = ts.isPropertyAccessExpression(expression)
+				? expression.name.text
+				: expression.argumentExpression !== undefined &&
+					  (ts.isStringLiteral(expression.argumentExpression) || ts.isNumericLiteral(expression.argumentExpression))
+					? expression.argumentExpression.text
+					: undefined;
+			const inspectProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
+				if (propertyName === undefined) {
+					return false;
+				}
+
+				if (ts.isIdentifier(receiver)) {
+					const initializer = resolveCompiledAlias(receiver);
+
+					if (initializer === undefined || nestedResolving.has(receiver.text)) {
+						return false;
+					}
+
+					return inspectProperty(initializer, new Set(nestedResolving).add(receiver.text));
+				}
+
+				if (
+					ts.isParenthesizedExpression(receiver) ||
+					ts.isAsExpression(receiver) ||
+					ts.isTypeAssertionExpression(receiver) ||
+					ts.isNonNullExpression(receiver) ||
+					ts.isSatisfiesExpression(receiver)
+				) {
+					return inspectProperty(receiver.expression, nestedResolving);
+				}
+
+				if (ts.isObjectLiteralExpression(receiver)) {
+					return receiver.properties.some((property) => {
+						if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+							return (
+								containsUnsafeCompiledLiteral(property.initializer, safeStrings) ||
+								inspect(property.initializer, nestedResolving)
+							);
+						}
+
+						if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+							return inspect(property.name, nestedResolving);
+						}
+
+						return ts.isSpreadAssignment(property) && inspectProperty(property.expression, nestedResolving);
+					});
+				}
+
+				return false;
+			};
+
+			return inspectProperty(expression.expression, resolving);
+		}
+
 		if (ts.isArrayLiteralExpression(expression)) {
 			return expression.elements.some((element) =>
 				ts.isSpreadElement(element)
@@ -766,6 +821,15 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				('body' in node && node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body)) ||
 				(node.type !== undefined && containsUnsafeCompiledType(node.type));
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isCompiledSecretName(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined && containsUnsafeCompiledValue(parameter.initializer)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body)) ||
+				(node.type !== undefined && containsUnsafeCompiledType(node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found =
 				isCompiledSecretName(node.name.text) &&
@@ -848,6 +912,16 @@ const containsCompiledAddress = (text: string): boolean => {
 					isHomeyAddressKey(name) &&
 					containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
 				unsafeAddressType(name, node.type);
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isHomeyAddressKey(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, SAFE_COMPILED_ADDRESS_STRINGS)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+				unsafeAddressType(node.name.text, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeAddress(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
@@ -934,6 +1008,16 @@ const containsCompiledIdentifier = (text: string): boolean => {
 					privateReferenceMethod &&
 					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)) ||
 				(privateReferenceMethod && unsafeIdentifierType(name, node.type));
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isHomeyReferenceKey(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledIdentifierValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledIdentifierValue)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)) ||
+				unsafeIdentifierType(node.name.text, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeIdentifier(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
@@ -1005,6 +1089,16 @@ const containsCompiledEndpoint = (text: string): boolean => {
 					endpointName &&
 					containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)) ||
 				(endpointName && unsafeEndpointType(name, node.type));
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isEndpointValueName(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, isSafeEndpointValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeEndpointValue)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)) ||
+				unsafeEndpointType(node.name.text, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeEndpoint(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
@@ -1090,6 +1184,16 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 					personalName &&
 					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)) ||
 				(personalName && unsafePersonalType(name, node.type));
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isCompiledPersonalName(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledPersonalValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledPersonalValue)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)) ||
+				unsafePersonalType(node.name.text, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafePersonalValue(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
@@ -1162,6 +1266,16 @@ const containsCompiledIcon = (text: string): boolean => {
 					iconName &&
 					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIconValue)) ||
 				(iconName && unsafeIconType(name, node.type));
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined && isHomeyIconKey(node.name.text)) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledIconValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledIconValue)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIconValue)) ||
+				unsafeIconType(node.name.text, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeIcon(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
@@ -2288,6 +2402,38 @@ describe('Homey security artifact gate', () => {
 				"const source = { value: 'custom-household-icon' }; const { value: icon } = source;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled icon value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'opaque-secret' }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'opaque-secret' }; const apiKey = source['value'];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function apiKey() { return 'opaque-secret'; }", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function hostname() { return 'family-homey.local'; }", true),
+		).toThrow('unsafe compiled module contains a compiled address value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function deviceId() { return 'opaque-household-id'; }", true),
+		).toThrow('unsafe compiled module contains a compiled identifier value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function endpoint() { return 'private-homey.local:4859'; }", true),
+		).toThrow('unsafe compiled module contains a compiled endpoint value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function deviceName() { return 'Alice Bedroom'; }", true),
+		).toThrow('unsafe compiled module contains a compiled personal value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function icon() { return 'custom-household-icon'; }", true),
 		).toThrow('unsafe compiled module contains a compiled icon value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "class Config { get apiKey() { return 'opaque-secret'; } }", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -53,7 +53,7 @@ const PUBLIC_ARTIFACT_URLS = new Set([
 const PUBLIC_HOMEY_HOSTS = new Set(['homey', 'homey.local']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN =
-	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
+	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_. -]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
@@ -276,6 +276,33 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 		return containsUnsafeCompiledLiteral(node.whenTrue) || containsUnsafeCompiledLiteral(node.whenFalse);
 	}
 
+	if (ts.isCallExpression(node)) {
+		return node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument));
+	}
+
+	if (ts.isNewExpression(node)) {
+		return node.arguments?.some((argument) => containsUnsafeCompiledLiteral(argument)) ?? false;
+	}
+
+	if (ts.isTemplateExpression(node)) {
+		return (
+			node.head.text.length > 0 ||
+			node.templateSpans.some((span) => span.literal.text.length > 0 || containsUnsafeCompiledLiteral(span.expression))
+		);
+	}
+
+	if (ts.isTaggedTemplateExpression(node)) {
+		return containsUnsafeCompiledLiteral(node.template);
+	}
+
+	if (ts.isAwaitExpression(node)) {
+		return containsUnsafeCompiledLiteral(node.expression);
+	}
+
+	if (ts.isPrefixUnaryExpression(node)) {
+		return containsUnsafeCompiledLiteral(node.operand);
+	}
+
 	return false;
 };
 
@@ -389,7 +416,7 @@ const containsStructuredAddress = (value: unknown): boolean => {
 
 const containsLooseSecretAssignment = (text: string): boolean =>
 	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].some((match) => {
-		const key = match[1];
+		const key = match[1]?.trim();
 		const rawValue = (match[3] ?? match[4])?.replace(/\s+#.*$/, '').trim();
 
 		if (key === undefined || rawValue === undefined || !isHomeySecretKey(key)) {
@@ -649,6 +676,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertFixtureTextSafe('unsafe fixture', "Captured payload: { api_key: 'opaque-secret' }", '.md'),
 		).toThrow('unsafe fixture contains a structured secret value');
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'API key: opaque-secret-value', '.md')).toThrow(
+			'unsafe fixture contains a structured secret value',
+		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'endpoint: http://private-homey.local:4859', '.yaml')).toThrow(
 			'unsafe fixture contains a URL',
 		);
@@ -700,6 +730,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = process.env.API_KEY ?? 'opaque-secret';", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = String('opaque-secret');", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const endpoint = 'http://private-homey.local:4859';", true),
 		).toThrow('unsafe compiled module contains a private URL');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -3070,7 +3070,7 @@ const containsUnsafeCompiledAlias = (
 					return element !== undefined && ts.isExpression(element) && inspectCallable(element, nestedResolving);
 				}
 
-				return false;
+				return containsUnsafeCompiledLiteral(receiver, safeStrings) || inspect(receiver, nestedResolving);
 			};
 
 			return inspectCallableProperty(callee.expression, resolving);
@@ -5388,6 +5388,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const source = ['opaque-secret']; const apiKey = source[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values.at(0);", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values[index];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -75,6 +75,22 @@ const collectFiles = (root: string, include: (path: string) => boolean): string[
 	});
 };
 
+const configuredWriteStringValue = (): string | undefined => {
+	const rawValue = process.env.FB_HOMEY_SHS_WRITE_VALUE;
+
+	if (rawValue === undefined) {
+		return undefined;
+	}
+
+	try {
+		const value = JSON.parse(rawValue) as unknown;
+
+		return typeof value === 'string' ? value : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
 const configuredPrivateValues = (): readonly string[] =>
 	[
 		process.env.FB_HOMEY_SHS_API_KEY,
@@ -88,6 +104,9 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID,
+		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID,
+		process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID,
+		configuredWriteStringValue(),
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
 		.map((value) => value?.trim())
@@ -175,6 +194,20 @@ const compiledPropertyName = (name: ts.PropertyName): string | undefined => {
 	return undefined;
 };
 
+const compiledAssignedPropertyName = (expression: ts.Expression): string | undefined => {
+	if (ts.isPropertyAccessExpression(expression)) {
+		return expression.name.text;
+	}
+
+	if (ts.isElementAccessExpression(expression) && ts.isStringLiteral(expression.argumentExpression)) {
+		return COMPILED_SYMBOL_NAME_PATTERN.test(expression.argumentExpression.text)
+			? undefined
+			: expression.argumentExpression.text;
+	}
+
+	return undefined;
+};
+
 const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 		return node.text.length > 0 && node.text !== '[~3~]';
@@ -211,6 +244,14 @@ const containsCompiledSecret = (text: string): boolean => {
 			const name = compiledPropertyName(node.name);
 
 			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isPropertyDeclaration(node) && node.initializer !== undefined) {
+			const name = compiledPropertyName(node.name);
+
+			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+			const name = compiledAssignedPropertyName(node.left);
+
+			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -454,6 +495,12 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe compiled module', "config.api_key = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "config['accessToken'] = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);
@@ -473,11 +520,17 @@ describe('Homey security artifact gate', () => {
 		const previousReplacementApiKey = process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
 		const previousDeviceOnlyApiKey = process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
 		const previousLifecycleDeviceMarker = process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
+		const previousWriteDeviceId = process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID;
+		const previousWriteCapabilityId = process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID;
+		const previousWriteValue = process.env.FB_HOMEY_SHS_WRITE_VALUE;
 
 		process.env.FB_HOMEY_SHS_PRIVATE_TERMS = 'Ada';
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY = 'opaque-replacement-value';
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = 'opaque-device-value';
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = 'private-lifecycle-marker';
+		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID = 'private-write-device';
+		process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'private-write-capability';
+		process.env.FB_HOMEY_SHS_WRITE_VALUE = '"private-write-value"';
 
 		try {
 			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
@@ -492,6 +545,11 @@ describe('Homey security artifact gate', () => {
 			expect(() => assertTextSafe('unsafe fixture', '{"value":"private-lifecycle-marker"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);
+			for (const privateWriteValue of ['private-write-device', 'private-write-capability', 'private-write-value']) {
+				expect(() => assertTextSafe('unsafe fixture', `{"value":"${privateWriteValue}"}`)).toThrow(
+					'unsafe fixture contains a configured private Homey value',
+				);
+			}
 		} finally {
 			if (previousPrivateTerms === undefined) {
 				delete process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
@@ -515,6 +573,24 @@ describe('Homey security artifact gate', () => {
 				delete process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
 			} else {
 				process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = previousLifecycleDeviceMarker;
+			}
+
+			if (previousWriteDeviceId === undefined) {
+				delete process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID;
+			} else {
+				process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID = previousWriteDeviceId;
+			}
+
+			if (previousWriteCapabilityId === undefined) {
+				delete process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID;
+			} else {
+				process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = previousWriteCapabilityId;
+			}
+
+			if (previousWriteValue === undefined) {
+				delete process.env.FB_HOMEY_SHS_WRITE_VALUE;
+			} else {
+				process.env.FB_HOMEY_SHS_WRITE_VALUE = previousWriteValue;
 			}
 		}
 	});

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1178,6 +1178,106 @@ const containsUnsafeCompiledAlias = (
 					return inspectProperty(receiver.expression, nestedResolving, selectedPropertyName, resolvingProperties);
 				}
 
+				if (ts.isCallExpression(receiver)) {
+					const inspectReturnedProperty = (callee: ts.Expression, resolvingCalls: Set<string>): boolean => {
+						const inspectReturnBody = (body: ts.Block, nestedCalls: Set<string>): boolean => {
+							let found = false;
+							const visitReturn = (child: ts.Node): void => {
+								if (found) {
+									return;
+								}
+
+								if (ts.isReturnStatement(child) && child.expression !== undefined) {
+									found = inspectProperty(child.expression, nestedCalls, selectedPropertyName, resolvingProperties);
+								}
+
+								if (!found) {
+									ts.forEachChild(child, visitReturn);
+								}
+							};
+
+							visitReturn(body);
+
+							return found;
+						};
+
+						if (ts.isIdentifier(callee)) {
+							if (resolvingCalls.has(callee.text)) {
+								return false;
+							}
+
+							const nestedCalls = new Set(resolvingCalls).add(callee.text);
+
+							return resolveCompiledBindings(callee).some(
+								(binding) =>
+									[binding.initializer, binding.fallbackInitializer].some(
+										(initializer) => initializer !== undefined && inspectReturnedProperty(initializer, nestedCalls),
+									) ||
+									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedCalls)),
+							);
+						}
+
+						if (
+							ts.isParenthesizedExpression(callee) ||
+							ts.isAsExpression(callee) ||
+							ts.isTypeAssertionExpression(callee) ||
+							ts.isNonNullExpression(callee) ||
+							ts.isSatisfiesExpression(callee)
+						) {
+							return inspectReturnedProperty(callee.expression, resolvingCalls);
+						}
+
+						if (ts.isArrowFunction(callee)) {
+							return ts.isBlock(callee.body)
+								? inspectReturnBody(callee.body, resolvingCalls)
+								: inspectProperty(callee.body, resolvingCalls, selectedPropertyName, resolvingProperties);
+						}
+
+						if (ts.isFunctionExpression(callee)) {
+							return inspectReturnBody(callee.body, resolvingCalls);
+						}
+
+						return ts.isCallExpression(callee) && inspectReturnedProperty(callee.expression, resolvingCalls);
+					};
+
+					return inspectReturnedProperty(receiver.expression, nestedResolving);
+				}
+
+				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+
+					return (
+						classDeclaration?.members.some((member) => {
+							if (!('name' in member)) {
+								return false;
+							}
+
+							const staticMember =
+								ts.canHaveModifiers(member) &&
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
+
+							if (staticMember || compiledPropertyName(member.name) !== selectedPropertyName) {
+								return false;
+							}
+
+							if (ts.isPropertyDeclaration(member)) {
+								return (
+									(member.initializer !== undefined &&
+										(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
+											inspect(member.initializer, nestedResolving))) ||
+									(member.type !== undefined && containsUnsafeCompiledType(member.type, safeStrings))
+								);
+							}
+
+							return (
+								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
+								member.body !== undefined &&
+								inspectCallableBody(member.body, nestedResolving)
+							);
+						}) ?? false
+					);
+				}
+
 				if (ts.isObjectLiteralExpression(receiver)) {
 					const propertyReference = `${receiver.pos}:${selectedPropertyName}`;
 
@@ -1439,7 +1539,32 @@ const containsUnsafeCompiledAlias = (
 						}
 
 						if (ts.isMethodDeclaration(property) && compiledPropertyName(property.name) === propertyName) {
-							return property.body !== undefined && inspectCallableBody(property.body, nestedResolving);
+							if (property.body === undefined) {
+								return false;
+							}
+
+							let returnsReceiverProperty = false;
+							const visitReturn = (child: ts.Node): void => {
+								if (
+									ts.isReturnStatement(child) &&
+									child.expression !== undefined &&
+									compiledThisPropertyName(child.expression) !== undefined
+								) {
+									returnsReceiverProperty = true;
+								}
+
+								if (!returnsReceiverProperty) {
+									ts.forEachChild(child, visitReturn);
+								}
+							};
+
+							visitReturn(property.body);
+
+							return (
+								(returnsReceiverProperty &&
+									(containsUnsafeCompiledLiteral(receiver, safeStrings) || inspect(receiver, nestedResolving))) ||
+								inspectCallableBody(property.body, nestedResolving)
+							);
 						}
 
 						return ts.isSpreadAssignment(property) && inspectCallableProperty(property.expression, nestedResolving);
@@ -3064,6 +3189,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { stored: 'opaque-secret', fallback() { return this.stored; } }; const apiKey = source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source['fallback']();",
 				true,
 			),
@@ -3413,6 +3545,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { static get value() { return 'opaque-secret'; } } const apiKey = Source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { get value() { return 'opaque-secret'; } } const source = new Source(); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const fallback = () => ({ value: 'opaque-secret' }); const apiKey = fallback().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -4,6 +4,8 @@ import { isIP } from 'node:net';
 import { extname, resolve } from 'node:path';
 import ts from 'typescript';
 
+import { isHomeySecretKey } from './support/homey-shs-probe';
+
 type JsonRecord = Record<string, unknown>;
 
 interface OpenApiDocument {
@@ -26,14 +28,11 @@ const OPENAPI_PATH = resolve(REPOSITORY_ROOT, 'spec/api/v1/openapi.json');
 const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
 const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
-const SECRET_PROPERTY_PATTERN =
-	/^(?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)$/i;
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
 const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
-const SERIALIZED_SECRET_PATTERN =
-	/["'](?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)["']\s*:\s*(["'])([^"']*)\1/gi;
+const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
@@ -64,6 +63,8 @@ const collectFiles = (root: string, include: (path: string) => boolean): string[
 const configuredPrivateValues = (): readonly string[] =>
 	[
 		process.env.FB_HOMEY_SHS_API_KEY,
+		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY,
+		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY,
 		process.env.FB_HOMEY_SHS_EXPECTED_HOST,
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
@@ -123,10 +124,11 @@ const containsHomeyToken = (text: string, compiledSource: boolean): boolean => {
 };
 
 const containsSerializedSecret = (text: string): boolean =>
-	[...text.matchAll(SERIALIZED_SECRET_PATTERN)].some((match) => {
-		const value = match[2];
+	[...text.matchAll(SERIALIZED_STRING_PROPERTY_PATTERN)].some((match) => {
+		const key = match[2];
+		const value = match[4];
 
-		return value !== undefined && value.length > 0 && value !== '[~3~]';
+		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
 	});
 
 const assertTextSafe = (label: string, text: string, compiledSource = false): void => {
@@ -169,16 +171,18 @@ const visitSchema = (schemaName: string, value: unknown, path: readonly string[]
 	for (const [key, child] of Object.entries(value as JsonRecord)) {
 		const childPath = [...path, key];
 
-		if (SECRET_PROPERTY_PATTERN.test(key) && child !== null && typeof child === 'object') {
+		if (child !== null && typeof child === 'object') {
 			const secretSchema = child as JsonRecord;
 
-			if (secretSchema.writeOnly !== true) {
-				throw new Error(`${schemaName}.${childPath.join('.')} is not write-only`);
-			}
+			if (isHomeySecretKey(key) && secretSchema.type !== 'boolean') {
+				if (secretSchema.writeOnly !== true) {
+					throw new Error(`${schemaName}.${childPath.join('.')} is not write-only`);
+				}
 
-			for (const forbiddenKeyword of ['default', 'enum', 'example', 'examples']) {
-				if (forbiddenKeyword in secretSchema) {
-					throw new Error(`${schemaName}.${childPath.join('.')} publishes ${forbiddenKeyword}`);
+				for (const forbiddenKeyword of ['default', 'enum', 'example', 'examples']) {
+					if (forbiddenKeyword in secretSchema) {
+						throw new Error(`${schemaName}.${childPath.join('.')} publishes ${forbiddenKeyword}`);
+					}
 				}
 			}
 		}
@@ -248,7 +252,20 @@ describe('Homey security artifact gate', () => {
 				properties: { api_key: { type: 'string', writeOnly: true, example: 'must-not-be-reported' } },
 			}),
 		).toThrow('UnsafeHomeySchema.properties.api_key publishes example');
+		expect(() =>
+			visitSchema('UnsafeHomeySchema', {
+				properties: { accessToken: { type: 'string' } },
+			}),
+		).toThrow('UnsafeHomeySchema.properties.accessToken is not write-only');
+		expect(() =>
+			visitSchema('UnsafeHomeySchema', {
+				properties: { pinCode: { type: 'string' } },
+			}),
+		).toThrow('UnsafeHomeySchema.properties.pinCode is not write-only');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
+			'unsafe fixture contains a serialized secret value',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"cookie":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"[~3~]unredacted-password"}')).toThrow(
@@ -273,11 +290,21 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains an IPv6 address',
 		);
 		const previousPrivateTerms = process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
+		const previousReplacementApiKey = process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
+		const previousDeviceOnlyApiKey = process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
 
 		process.env.FB_HOMEY_SHS_PRIVATE_TERMS = 'Ada';
+		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY = 'opaque-replacement-value';
+		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = 'opaque-device-value';
 
 		try {
 			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
+			expect(() => assertTextSafe('unsafe fixture', '{"value":"opaque-replacement-value"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
+			expect(() => assertTextSafe('unsafe fixture', '{"value":"opaque-device-value"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);
 		} finally {
@@ -285,6 +312,18 @@ describe('Homey security artifact gate', () => {
 				delete process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
 			} else {
 				process.env.FB_HOMEY_SHS_PRIVATE_TERMS = previousPrivateTerms;
+			}
+
+			if (previousReplacementApiKey === undefined) {
+				delete process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
+			} else {
+				process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY = previousReplacementApiKey;
+			}
+
+			if (previousDeviceOnlyApiKey === undefined) {
+				delete process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
+			} else {
+				process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = previousDeviceOnlyApiKey;
 			}
 		}
 	});

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1333,6 +1333,13 @@ const containsUnsafeCompiledAlias = (
 			return inspectCallableBody(callee.body, resolving);
 		}
 
+		if (ts.isCallExpression(callee)) {
+			return (
+				inspectCallable(callee.expression, resolving) ||
+				callee.arguments.some((argument) => inspect(argument, resolving))
+			);
+		}
+
 		return false;
 	};
 
@@ -2869,6 +2876,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const fallback = () => 'opaque-secret'; const apiKey = fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const fallback = () => () => 'opaque-secret'; const apiKey = fallback()();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1418,11 +1418,11 @@ const compiledPropertyWriteValues = (
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
 
 		if (methodName === 'push' || methodName === 'unshift') {
-			return call.arguments;
+			return expandMutationSources(call.arguments);
 		}
 
 		if (methodName === 'splice') {
-			return call.arguments.slice(2);
+			return expandMutationSources(call.arguments.slice(2));
 		}
 
 		return methodName === 'fill' ? call.arguments.slice(0, 1) : [];
@@ -2153,16 +2153,22 @@ const containsUnsafeCompiledAlias = (
 				? undefined
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
 
-		if (methodName !== 'concat') {
+		if (
+			methodName !== 'concat' &&
+			!['filter', 'reverse', 'slice', 'sort', 'toReversed', 'toSorted', 'with'].includes(methodName ?? '')
+		) {
 			return [];
 		}
 
-		const values = [call.expression.expression, ...call.arguments].flatMap(
-			(expression): readonly ts.Expression[] => resolveArrayElements(expression, new Set()) ?? [expression],
-		);
+		const values =
+			methodName === 'concat'
+				? [call.expression.expression, ...call.arguments].flatMap(
+						(expression): readonly ts.Expression[] => resolveArrayElements(expression, new Set()) ?? [expression],
+					)
+				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
 		const index = Number(selectedPropertyName);
 
-		return values.slice(index, index + 1);
+		return methodName === 'filter' ? values : values.slice(index, index + 1);
 	};
 	const objectEntriesResultValues = (
 		call: ts.CallExpression,
@@ -2854,6 +2860,7 @@ const containsUnsafeCompiledAlias = (
 					if (
 						[
 							...collectionTransformResultValues(receiver),
+							...concatenatedResultValues(receiver, selectedPropertyName),
 							...descriptorQueryValues(receiver, selectedPropertyName),
 							...objectKeysResultValues(receiver, selectedPropertyName),
 							...objectValuesResultValues(receiver, selectedPropertyName),
@@ -6724,6 +6731,16 @@ describe('Homey security artifact gate', () => {
 				"const source = []; source.push('opaque-secret'); const apiKey = source[0];",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push(...['opaque-secret']); const apiKey = source[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].slice()[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -14,7 +14,9 @@ import {
 	isHomeyPersonalKey,
 	isHomeyReferenceArrayKey,
 	isHomeyReferenceKey,
+	isHomeySanitizedCapabilityIdentifier,
 	isHomeySecretKey,
+	isHomeyTimestampKey,
 	isHomeyUuid,
 	isPublicHomeyCapabilityBase,
 } from './support/homey-shs-probe';
@@ -80,6 +82,8 @@ const PUBLIC_ARTIFACT_URLS = new Set([
 	'https://smart-panel.fastybird.com/docs',
 ]);
 const PUBLIC_HOMEY_HOSTS = new Set(['homey', 'homey.local']);
+const FIXTURE_TIMESTAMP = '2000-01-01T00:00:00.000Z';
+const PUBLIC_FIXTURE_DATES = new Set(['2026-08-13']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN =
 	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_. -]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
@@ -892,6 +896,27 @@ const containsStructuredEndpoint = (value: unknown): boolean => {
 	);
 };
 
+const isSafeTimestampValue = (value: unknown): boolean =>
+	value === null ||
+	value === 0 ||
+	value === false ||
+	value === FIXTURE_TIMESTAMP ||
+	(typeof value === 'string' && PUBLIC_FIXTURE_DATES.has(value));
+
+const containsStructuredTimestamp = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredTimestamp(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(
+		([key, child]) => (isHomeyTimestampKey(key) && !isSafeTimestampValue(child)) || containsStructuredTimestamp(child),
+	);
+};
+
 const isCapabilityIdentifierPath = (key: string, path: readonly string[], syntheticProtocolRoot: boolean): boolean => {
 	const directCapabilityEntry =
 		path.length === 2 &&
@@ -929,6 +954,18 @@ const containsStructuredIdentifier = (
 
 	return Object.entries(record).some(([key, child]) => {
 		const childPath = [...path, key];
+		const capabilityIdentifierPath = isCapabilityIdentifierPath(key, path, nestedSyntheticProtocolRoot);
+		const capabilityIdentifierValue = capabilityIdentifierPath && !isHomeySanitizedCapabilityIdentifier(child);
+		const capabilityListValue =
+			key === 'capabilities' &&
+			Array.isArray(child) &&
+			child.some((entry) => typeof entry === 'string' && !isHomeySanitizedCapabilityIdentifier(entry));
+		const capabilityMapKey =
+			(key === 'capabilitiesObj' || key === 'capabilityOptions') &&
+			child !== null &&
+			typeof child === 'object' &&
+			!Array.isArray(child) &&
+			Object.keys(child as JsonRecord).some((entryKey) => !isHomeySanitizedCapabilityIdentifier(entryKey));
 		const identifierMapValue =
 			isHomeyIdentifierMapKey(key) &&
 			child !== null &&
@@ -940,13 +977,16 @@ const containsStructuredIdentifier = (
 		const identifierValue =
 			!isHomeyReferenceArrayKey(key) &&
 			(isHomeyReferenceKey(key) || isHomeyIdentifierKey(key)) &&
-			!isCapabilityIdentifierPath(key, path, nestedSyntheticProtocolRoot) &&
+			!capabilityIdentifierPath &&
 			!isSafeIdentifierValue(child);
 		const referenceArrayValue =
 			isHomeyReferenceArrayKey(key) &&
 			(Array.isArray(child) ? child.some((entry) => !isSafeIdentifierValue(entry)) : !isSafeIdentifierValue(child));
 
 		return (
+			capabilityIdentifierValue ||
+			capabilityListValue ||
+			capabilityMapKey ||
 			identifierMapValue ||
 			identifierValue ||
 			referenceArrayValue ||
@@ -999,6 +1039,14 @@ const containsLooseIdentifierAssignment = (text: string): boolean =>
 			unambiguousIdentifierKey && !['0', '[]', 'false', 'null'].includes(rawValue) && !isSafeIdentifierValue(rawValue)
 		);
 	});
+
+const containsLooseTimestampAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(
+		([key, rawValue]) =>
+			isHomeyTimestampKey(key) &&
+			!['0', 'false', 'null', FIXTURE_TIMESTAMP].includes(rawValue) &&
+			!PUBLIC_FIXTURE_DATES.has(rawValue),
+	);
 
 const containsStructuredUrl = (value: unknown): boolean => {
 	if (typeof value === 'string') {
@@ -1087,6 +1135,15 @@ const assertFixtureTextSafe = (
 
 	if (containsEndpoint) {
 		throw new Error(`${label} contains a structured endpoint value`);
+	}
+
+	const containsTimestamp =
+		structuredValue === undefined
+			? containsLooseTimestampAssignment(text)
+			: containsStructuredTimestamp(structuredValue);
+
+	if (containsTimestamp) {
+		throw new Error(`${label} contains a structured timestamp value`);
 	}
 
 	const containsSecret =
@@ -1397,6 +1454,15 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"endpoint":"private-homey.local:4859"}', '.json')).toThrow(
 			'unsafe fixture contains a structured endpoint value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"capabilities":["onoff.private-device"]}', '.json')).toThrow(
+			'unsafe fixture contains a structured identifier value',
+		);
+		expect(() =>
+			assertFixtureTextSafe('safe fixture', '{"capabilities":["onoff.capability-suffix-000001"]}', '.json'),
+		).not.toThrow();
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"updatedAt":"2026-08-25T12:34:56.000Z"}', '.json')).toThrow(
+			'unsafe fixture contains a structured timestamp value',
 		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -45,6 +45,7 @@ const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
 const PUBLIC_SCHEMA_URLS = new Set(['http://homey.local:4859', 'http://json-schema.org/draft-07/schema#']);
+const PUBLIC_HOMEY_HOSTS = new Set(['homey', 'homey.local']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN =
 	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
@@ -95,12 +96,19 @@ const configuredWriteStringValue = (): string | undefined => {
 	}
 };
 
+const configuredExpectedHost = (): string | undefined => {
+	const value = process.env.FB_HOMEY_SHS_EXPECTED_HOST?.trim();
+	const normalizedValue = value?.toLowerCase().replace(/\.$/, '');
+
+	return normalizedValue === undefined || PUBLIC_HOMEY_HOSTS.has(normalizedValue) ? undefined : value;
+};
+
 const configuredPrivateValues = (): readonly string[] =>
 	[
 		process.env.FB_HOMEY_SHS_API_KEY,
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY,
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY,
-		process.env.FB_HOMEY_SHS_EXPECTED_HOST,
+		configuredExpectedHost(),
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_OWNER_URI,
@@ -634,6 +642,7 @@ describe('Homey security artifact gate', () => {
 		const previousPrivateTerms = process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
 		const previousReplacementApiKey = process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
 		const previousDeviceOnlyApiKey = process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
+		const previousExpectedHost = process.env.FB_HOMEY_SHS_EXPECTED_HOST;
 		const previousLifecycleDeviceMarker = process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
 		const previousWriteDeviceId = process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID;
 		const previousWriteCapabilityId = process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID;
@@ -642,12 +651,14 @@ describe('Homey security artifact gate', () => {
 		process.env.FB_HOMEY_SHS_PRIVATE_TERMS = 'Ada';
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY = 'opaque-replacement-value';
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = 'opaque-device-value';
+		process.env.FB_HOMEY_SHS_EXPECTED_HOST = 'homey.local';
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = 'private-lifecycle-marker';
 		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID = 'private-write-device';
 		process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'private-write-capability';
 		process.env.FB_HOMEY_SHS_WRITE_VALUE = '"private-write-value"';
 
 		try {
+			expect(() => assertTextSafe('safe fixture', '{"url":"http://homey.local:4859"}')).not.toThrow();
 			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);
@@ -682,6 +693,12 @@ describe('Homey security artifact gate', () => {
 				delete process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
 			} else {
 				process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = previousDeviceOnlyApiKey;
+			}
+
+			if (previousExpectedHost === undefined) {
+				delete process.env.FB_HOMEY_SHS_EXPECTED_HOST;
+			} else {
+				process.env.FB_HOMEY_SHS_EXPECTED_HOST = previousExpectedHost;
 			}
 
 			if (previousLifecycleDeviceMarker === undefined) {

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2245,6 +2245,51 @@ const containsUnsafeCompiledAlias = (
 			...compiledPropertyWriteValues(receiver, String(selectedIndex), call.getStart(call.getSourceFile())),
 		];
 	};
+	const iteratorResultValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		if (
+			selectedPropertyName !== 'value' ||
+			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression))
+		) {
+			return [];
+		}
+
+		const terminalMethodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+		if (terminalMethodName !== 'next' || !ts.isCallExpression(call.expression.expression)) {
+			return [];
+		}
+
+		const iteratorCall = call.expression.expression;
+
+		if (
+			!ts.isPropertyAccessExpression(iteratorCall.expression) &&
+			!ts.isElementAccessExpression(iteratorCall.expression)
+		) {
+			return [];
+		}
+
+		const iteratorMethodName = ts.isPropertyAccessExpression(iteratorCall.expression)
+			? iteratorCall.expression.name.text
+			: iteratorCall.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(iteratorCall.expression.argumentExpression);
+		const iteratorExpressionText = iteratorCall.expression.getText(iteratorCall.getSourceFile());
+
+		if (
+			!['entries', 'keys', 'values'].includes(iteratorMethodName ?? '') &&
+			!iteratorExpressionText.endsWith('[Symbol.iterator]')
+		) {
+			return [];
+		}
+
+		const source = iteratorCall.expression.expression;
+
+		return [source, ...compiledPropertyWriteValues(source, '0', call.getStart(call.getSourceFile()))];
+	};
 	const objectEntriesResultValues = (
 		call: ts.CallExpression,
 		entryPropertyName: string,
@@ -2954,6 +2999,7 @@ const containsUnsafeCompiledAlias = (
 							...concatenatedResultValues(receiver.expression, receiverPropertyName),
 							...objectValuesResultValues(receiver.expression, receiverPropertyName),
 							...transparentCallResultValues(receiver.expression),
+							...iteratorResultValues(receiver.expression, receiverPropertyName),
 						].some(
 							(value) =>
 								containsUnsafeCompiledLiteral(value, safeStrings) ||
@@ -3037,6 +3083,7 @@ const containsUnsafeCompiledAlias = (
 							...descriptorQueryValues(receiver, selectedPropertyName),
 							...objectKeysResultValues(receiver, selectedPropertyName),
 							...objectValuesResultValues(receiver, selectedPropertyName),
+							...iteratorResultValues(receiver, selectedPropertyName),
 						].some((value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving))
 					) {
 						return true;
@@ -6986,6 +7033,34 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = Array.from(source)[0][1];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = source.values().next().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Set(); source.add('opaque-secret'); const apiKey = source.values().next().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = ['opaque-secret']; const apiKey = source[Symbol.iterator]().next().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = source.entries().next().value[1];",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -669,6 +669,65 @@ const containsCompiledIdentifier = (text: string): boolean => {
 	return found;
 };
 
+const containsCompiledEndpoint = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const isEndpointValueName = (name: string | undefined): name is string =>
+		name !== undefined && isHomeyEndpointKey(name) && !/^(?:assert|is|validate)/i.test(name);
+	const unsafeEndpoint = (name: string | undefined, expression: ts.Expression): boolean =>
+		isEndpointValueName(name) && containsUnsafeCompiledLiteral(expression, isSafeEndpointValue);
+	const unsafeEndpointType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
+		isEndpointValueName(name) && type !== undefined && containsUnsafeCompiledType(type, isSafeEndpointValue);
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node)) {
+			found = unsafeEndpoint(compiledPropertyName(node.name), node.initializer);
+		} else if (ts.isPropertyDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				(node.initializer !== undefined && unsafeEndpoint(name, node.initializer)) ||
+				unsafeEndpointType(name, node.type);
+		} else if (ts.isPropertySignature(node)) {
+			found = unsafeEndpointType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+			const name = compiledPropertyName(node.name);
+			const endpointName = isEndpointValueName(name);
+
+			found =
+				('body' in node &&
+					node.body !== undefined &&
+					endpointName &&
+					containsUnsafeReturnedLiteral(node.body, isSafeEndpointValue)) ||
+				(endpointName && unsafeEndpointType(name, node.type));
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeEndpoint(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeEndpoint(node.name.text, node.initializer);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = unsafeEndpoint(name, node.initializer);
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
+			found = unsafeEndpoint(compiledAssignedPropertyName(node.left), node.right);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
 const compiledStaticString = (node: ts.Expression): string | undefined => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 		return node.text;
@@ -990,6 +1049,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 
 	if (compiledSource && containsCompiledIdentifier(text)) {
 		throw new Error(`${label} contains a compiled identifier value`);
+	}
+
+	if (compiledSource && containsCompiledEndpoint(text)) {
+		throw new Error(`${label} contains a compiled endpoint value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -1411,6 +1474,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const deviceId = 'opaque-household-id';", true)).toThrow(
 			'unsafe compiled module contains a compiled identifier value',
 		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const endpoint = 'private-homey.local:4859';", true),
+		).toThrow('unsafe compiled module contains a compiled endpoint value');
 		expect(() =>
 			assertTextSafe('unsafe declaration', "interface Config { hostname: 'family-homey.local' }", true),
 		).toThrow('unsafe declaration contains a compiled address value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, readdirSync, readlinkSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import ts from 'typescript';
 import { parse as parseYaml } from 'yaml';
@@ -46,6 +46,7 @@ const OPENAPI_PATH = resolve(REPOSITORY_ROOT, 'spec/api/v1/openapi.json');
 const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map', '.yaml', '.yml']);
 const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
+const HOMEY_API_TAG = 'Devices Homey plugin';
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
 const HOMEY_TOKEN_PATTERN = /(?:homey|hpat|pat)[_-][A-Za-z0-9_-]{16,}/gi;
 const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
@@ -194,7 +195,31 @@ const trackedFixtureFiles = (): readonly string[] => {
 		.split('\0')
 		.filter((path) => path.length > 0)
 		.map((path) => resolve(REPOSITORY_ROOT, path))
-		.filter((path) => lstatSync(path).isFile());
+		.filter((path) => {
+			const stats = lstatSync(path);
+
+			return stats.isFile() || stats.isSymbolicLink();
+		});
+};
+
+const isHomeyOpenApiPath = (path: string, pathItem: unknown): boolean => {
+	if (path.startsWith('/plugins/devices-homey')) {
+		return true;
+	}
+
+	return (
+		pathItem !== null &&
+		typeof pathItem === 'object' &&
+		Object.values(pathItem).some((operation: unknown) => {
+			if (operation === null || typeof operation !== 'object') {
+				return false;
+			}
+
+			const tags = (operation as Record<string, unknown>).tags;
+
+			return Array.isArray(tags) && (tags as unknown[]).includes(HOMEY_API_TAG);
+		})
+	);
 };
 
 const containsIpv6Address = (text: string): boolean =>
@@ -5611,9 +5636,11 @@ describe('Homey security artifact gate', () => {
 			Object.entries(document.components?.schemas ?? {}).filter(([name]) => name.startsWith('DevicesHomey')),
 		);
 		const homeyPaths = Object.fromEntries(
-			Object.entries(document.paths ?? {}).filter(([, path]) => JSON.stringify(path).includes('DevicesHomey')),
+			Object.entries(document.paths ?? {}).filter(([path, pathItem]) => isHomeyOpenApiPath(path, pathItem)),
 		);
 
+		expect(isHomeyOpenApiPath('/plugins/devices-homey/no-content', { post: { tags: ['Common'] } })).toBe(true);
+		expect(isHomeyOpenApiPath('/shared/homey-status', { get: { tags: [HOMEY_API_TAG] } })).toBe(true);
 		expect(Object.keys(homeySchemas).length).toBeGreaterThan(0);
 		expect(Object.keys(homeyPaths).length).toBeGreaterThan(0);
 		Object.entries(homeySchemas).forEach(([name, schema]) => visitSchema(name, schema));
@@ -5625,16 +5652,26 @@ describe('Homey security artifact gate', () => {
 
 	it('keeps committed Homey fixtures and snapshots free of private values', () => {
 		const fixtureFiles = trackedFixtureFiles();
-		const unsupportedFiles = fixtureFiles.filter((path) => !FIXTURE_EXTENSIONS.has(extname(path)));
+		const unsupportedFiles = fixtureFiles.filter(
+			(path) => !lstatSync(path).isSymbolicLink() && !FIXTURE_EXTENSIONS.has(extname(path)),
+		);
+		const symlinkFiles = fixtureFiles.filter((path) => lstatSync(path).isSymbolicLink());
 		const snapshotFiles = collectFiles(SNAPSHOT_ROOT, (path) => path.endsWith('.snap')).filter(
 			(path) => path.toLocaleLowerCase().includes('homey') || readFileSync(path, 'utf8').includes('devices-homey'),
 		);
 
 		expect(fixtureFiles.length).toBeGreaterThan(0);
+		expect(symlinkFiles.length).toBeGreaterThan(0);
 		expect(unsupportedFiles).toEqual([]);
 
 		for (const path of [...fixtureFiles, ...snapshotFiles]) {
-			assertFixtureTextSafe(path.slice(REPOSITORY_ROOT.length + 1), readFileSync(path, 'utf8'), extname(path));
+			const symlink = lstatSync(path).isSymbolicLink();
+
+			assertFixtureTextSafe(
+				path.slice(REPOSITORY_ROOT.length + 1),
+				symlink ? readlinkSync(path) : readFileSync(path, 'utf8'),
+				symlink ? '.txt' : extname(path),
+			);
 		}
 	});
 

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -429,6 +429,7 @@ const containsUnsafeCompiledLiteral = (
 };
 
 interface CompiledBinding {
+	readonly callable?: ts.FunctionDeclaration;
 	readonly declaration: ts.Declaration;
 	readonly initializer?: ts.Expression;
 	readonly scope: ts.Node;
@@ -487,7 +488,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
-			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
+			addBinding(node.name.text, { callable: node, declaration: node, scope: compiledBindingScope(node) });
 		}
 
 		ts.forEachChild(node, visit);
@@ -525,7 +526,7 @@ const compiledScopeDepth = (scope: ts.Node): number => {
 	return depth;
 };
 
-const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined => {
+const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | undefined => {
 	const sourceFile = identifier.getSourceFile();
 	const usePosition = identifier.getStart(sourceFile);
 	const visibleBindings = (compiledBindings(sourceFile).get(identifier.text) ?? [])
@@ -542,14 +543,63 @@ const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefi
 				: right.declaration.getStart(sourceFile) - left.declaration.getStart(sourceFile);
 		});
 
-	return visibleBindings[0]?.initializer;
+	return visibleBindings[0];
 };
+
+const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined =>
+	resolveCompiledBinding(identifier)?.initializer;
 
 const containsUnsafeCompiledAlias = (
 	node: ts.Expression,
 	safeStrings: SafeCompiledString,
 	resolvingAliases = new Set<string>(),
 ): boolean => {
+	const resolveArrayElements = (
+		expression: ts.Expression,
+		resolving: Set<string>,
+	): readonly ts.Expression[] | undefined => {
+		if (ts.isIdentifier(expression)) {
+			const initializer = resolveCompiledAlias(expression);
+
+			return initializer === undefined || resolving.has(expression.text)
+				? undefined
+				: resolveArrayElements(initializer, new Set(resolving).add(expression.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(expression) ||
+			ts.isAsExpression(expression) ||
+			ts.isTypeAssertionExpression(expression) ||
+			ts.isNonNullExpression(expression) ||
+			ts.isSatisfiesExpression(expression)
+		) {
+			return resolveArrayElements(expression.expression, resolving);
+		}
+
+		if (!ts.isArrayLiteralExpression(expression)) {
+			return undefined;
+		}
+
+		const elements: ts.Expression[] = [];
+
+		for (const element of expression.elements) {
+			if (ts.isSpreadElement(element)) {
+				const spreadElements = resolveArrayElements(element.expression, resolving);
+
+				if (spreadElements === undefined) {
+					return undefined;
+				}
+
+				elements.push(...spreadElements);
+			} else if (ts.isExpression(element)) {
+				elements.push(element);
+			} else {
+				return undefined;
+			}
+		}
+
+		return elements;
+	};
 	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const initializer = resolveCompiledAlias(expression);
@@ -612,8 +662,8 @@ const containsUnsafeCompiledAlias = (
 					});
 				}
 
-				if (ts.isArrayLiteralExpression(receiver) && /^\d+$/.test(propertyName)) {
-					const element = receiver.elements[Number(propertyName)];
+				if (/^\d+$/.test(propertyName)) {
+					const element = resolveArrayElements(receiver, nestedResolving)?.[Number(propertyName)];
 
 					if (element === undefined) {
 						return false;
@@ -691,15 +741,39 @@ const containsUnsafeCompiledAlias = (
 
 		return false;
 	};
+	const inspectCallableBody = (body: ts.Block, resolving: Set<string>): boolean => {
+		let found = false;
+		const visitReturn = (child: ts.Node): void => {
+			if (found) {
+				return;
+			}
+
+			if (ts.isReturnStatement(child) && child.expression !== undefined) {
+				found = containsUnsafeCompiledLiteral(child.expression, safeStrings) || inspect(child.expression, resolving);
+			}
+
+			if (!found) {
+				ts.forEachChild(child, visitReturn);
+			}
+		};
+
+		visitReturn(body);
+
+		return found;
+	};
 	const inspectCallable = (callee: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(callee)) {
-			const initializer = resolveCompiledAlias(callee);
+			const binding = resolveCompiledBinding(callee);
 
-			if (initializer === undefined || resolving.has(callee.text)) {
+			if (binding === undefined || resolving.has(callee.text)) {
 				return false;
 			}
 
-			return inspectCallable(initializer, new Set(resolving).add(callee.text));
+			const nestedResolving = new Set(resolving).add(callee.text);
+
+			return binding.initializer !== undefined
+				? inspectCallable(binding.initializer, nestedResolving)
+				: binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving);
 		}
 
 		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
@@ -748,8 +822,8 @@ const containsUnsafeCompiledAlias = (
 					});
 				}
 
-				if (ts.isArrayLiteralExpression(receiver) && /^\d+$/.test(propertyName)) {
-					const element = receiver.elements[Number(propertyName)];
+				if (/^\d+$/.test(propertyName)) {
+					const element = resolveArrayElements(receiver, nestedResolving)?.[Number(propertyName)];
 
 					return element !== undefined && ts.isExpression(element) && inspectCallable(element, nestedResolving);
 				}
@@ -774,25 +848,12 @@ const containsUnsafeCompiledAlias = (
 			return containsUnsafeCompiledLiteral(callee.body, safeStrings) || inspect(callee.body, resolving);
 		}
 
-		if (ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)) {
-			let found = false;
-			const visitReturn = (child: ts.Node): void => {
-				if (found) {
-					return;
-				}
+		if (ts.isArrowFunction(callee)) {
+			return ts.isBlock(callee.body) && inspectCallableBody(callee.body, resolving);
+		}
 
-				if (ts.isReturnStatement(child) && child.expression !== undefined) {
-					found = containsUnsafeCompiledLiteral(child.expression, safeStrings) || inspect(child.expression, resolving);
-				}
-
-				if (!found) {
-					ts.forEachChild(child, visitReturn);
-				}
-			};
-
-			visitReturn(callee.body);
-
-			return found;
+		if (ts.isFunctionExpression(callee)) {
+			return inspectCallableBody(callee.body, resolving);
 		}
 
 		return false;
@@ -2371,6 +2432,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function fallback() { return 'opaque-secret'; } const apiKey = fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"function first() { const fallback = 'opaque-secret'; const apiKey = fallback; } function second() { const fallback = ''; return fallback; }",
 				true,
 			),
@@ -2559,6 +2627,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const source = ['opaque-secret']; const apiKey = source[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = [...['safe', 'opaque-secret']]; const apiKey = source[1];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "function apiKey() { return 'opaque-secret'; }", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -41,9 +41,11 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-plugin-device-mapping',
 	'homey-reconnect-backoff',
 ]);
+const PUBLIC_COMPILED_SECRET_NAMES = new Set(['secretFields']);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
+const PUBLIC_SCHEMA_URLS = new Set(['http://json-schema.org/draft-07/schema#']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN = /^\s*(?:[-*]\s+)?["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(.*?)\s*$/gm;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
@@ -231,8 +233,17 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 		return node.elements.some((element) => ts.isExpression(element) && containsUnsafeCompiledLiteral(element));
 	}
 
+	if (ts.isObjectLiteralExpression(node)) {
+		return node.properties.some(
+			(property) => ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer),
+		);
+	}
+
 	return false;
 };
+
+const isCompiledSecretName = (name: string | undefined): name is string =>
+	name !== undefined && !PUBLIC_COMPILED_SECRET_NAMES.has(name) && isHomeySecretKey(name);
 
 const containsCompiledSecret = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
@@ -245,17 +256,17 @@ const containsCompiledSecret = (text: string): boolean => {
 		if (ts.isPropertyAssignment(node)) {
 			const name = compiledPropertyName(node.name);
 
-			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isPropertyDeclaration(node) && node.initializer !== undefined) {
 			const name = compiledPropertyName(node.name);
 
-			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = isHomeySecretKey(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
 			const name = compiledAssignedPropertyName(node.left);
 
-			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.right);
+			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -313,6 +324,22 @@ const containsLooseSecretAssignment = (text: string): boolean =>
 		return !['', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(value);
 	});
 
+const containsStructuredUrl = (value: unknown): boolean => {
+	if (typeof value === 'string') {
+		return !PUBLIC_SCHEMA_URLS.has(value) && URL_PATTERN.test(value);
+	}
+
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredUrl(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.values(value as JsonRecord).some((entry) => containsStructuredUrl(entry));
+};
+
 const assertTextSafe = (label: string, text: string, compiledSource = false): void => {
 	for (const forbidden of FORBIDDEN_PATTERNS) {
 		if (forbidden.pattern.test(text)) {
@@ -346,16 +373,17 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 const assertFixtureTextSafe = (label: string, text: string, extension: string): void => {
 	assertTextSafe(label, text);
 
-	if (URL_PATTERN.test(text)) {
-		throw new Error(`${label} contains a URL`);
-	}
-
 	const structuredValue =
 		extension === '.json'
 			? (JSON.parse(text) as unknown)
 			: extension === '.yaml' || extension === '.yml'
 				? (parseYaml(text) as unknown)
 				: undefined;
+
+	if (structuredValue === undefined ? URL_PATTERN.test(text) : containsStructuredUrl(structuredValue)) {
+		throw new Error(`${label} contains a URL`);
+	}
+
 	const containsSecret =
 		structuredValue === undefined ? containsLooseSecretAssignment(text) : containsStructuredSecret(structuredValue);
 
@@ -470,7 +498,7 @@ describe('Homey security artifact gate', () => {
 			const extension = extname(path);
 			const label = path.slice(BACKEND_ROOT.length + 1);
 
-			if (extension === '.yaml' || extension === '.yml') {
+			if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
 				assertFixtureTextSafe(label, text, extension);
 			} else {
 				assertTextSafe(label, text, path.endsWith('.js') || path.endsWith('.d.ts'));
@@ -555,6 +583,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const api_key = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const credentials = { value: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -896,11 +896,19 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			const sourceElements = resolveBindingArrayElements(source, new Set());
 
 			target.elements.forEach((element, index) => {
+				const writeValues = [
+					...compiledPropertyWriteValues(source, String(index), declaration.getStart(sourceFile)),
+					...compiledReceiverWriteValues(source, declaration.getStart(sourceFile)),
+				];
+				const selectedValue = sourceElements?.[index] ?? writeValues.at(-1);
+
 				if (ts.isSpreadElement(element)) {
 					addAssignmentPatternBindings(
 						element.expression,
 						sourceElements === undefined
-							? undefined
+							? writeValues.length === 0
+								? undefined
+								: ts.factory.createArrayLiteralExpression(writeValues)
 							: ts.factory.createArrayLiteralExpression(
 									sourceElements
 										.slice(index)
@@ -909,7 +917,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 						declaration,
 					);
 				} else if (ts.isExpression(element) && !ts.isOmittedExpression(element)) {
-					addAssignmentPatternBindings(element, sourceElements?.[index], declaration);
+					addAssignmentPatternBindings(element, selectedValue, declaration);
 				}
 			});
 		}
@@ -1570,8 +1578,25 @@ const compiledReceiverWriteValues = (
 			values.push(node.right);
 		} else if (ts.isCallExpression(node)) {
 			const helperName = compiledMutationHelperName(node.expression);
+			const methodReceiver =
+				ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)
+					? node.expression.expression
+					: undefined;
+			const methodName = ts.isPropertyAccessExpression(node.expression)
+				? node.expression.name.text
+				: ts.isElementAccessExpression(node.expression) && node.expression.argumentExpression !== undefined
+					? compiledStaticPropertyExpressionName(node.expression.argumentExpression)
+					: undefined;
 
-			if (node.arguments[0] !== undefined && sameReceiver(node.arguments[0])) {
+			if (methodReceiver !== undefined && sameReceiver(methodReceiver)) {
+				if (['add', 'push', 'set', 'unshift'].includes(methodName ?? '')) {
+					values.push(...node.arguments);
+				} else if (methodName === 'splice') {
+					values.push(...node.arguments.slice(2));
+				} else if (methodName === 'fill' && node.arguments[0] !== undefined) {
+					values.push(node.arguments[0]);
+				}
+			} else if (node.arguments[0] !== undefined && sameReceiver(node.arguments[0])) {
 				if (helperName === 'Object.assign') {
 					values.push(...node.arguments.slice(1));
 				} else if (
@@ -2326,6 +2351,10 @@ const containsUnsafeCompiledAlias = (
 		const receiver = call.expression.expression;
 		const elements = resolveArrayElements(receiver, new Set());
 
+		if (methodName === 'get') {
+			return [receiver, ...compiledPropertyWriteValues(receiver, '0', call.getStart(call.getSourceFile()))];
+		}
+
 		if (methodName === 'pop' || methodName === 'shift') {
 			const selectedIndex = methodName === 'pop' ? Math.max((elements?.length ?? 1) - 1, 0) : 0;
 			const element = elements?.[selectedIndex];
@@ -2505,14 +2534,15 @@ const containsUnsafeCompiledAlias = (
 			});
 		};
 		const values = resolveEntryValues(call.arguments[0]);
+		const writeValues = compiledReceiverWriteValues(call.arguments[0], call.getStart(call.getSourceFile()));
 
 		if (values === undefined) {
-			return [call.arguments[0]];
+			return [call.arguments[0], ...writeValues];
 		}
 
 		return /^\d+$/.test(entryPropertyName)
-			? values.slice(Number(entryPropertyName), Number(entryPropertyName) + 1)
-			: values;
+			? [...values.slice(Number(entryPropertyName), Number(entryPropertyName) + 1), ...writeValues]
+			: [...values, ...writeValues];
 	};
 	const pluralDescriptorQueryValues = (
 		call: ts.CallExpression,
@@ -4975,6 +5005,30 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				constructor !== undefined &&
 				secretCallArguments([{ boundArguments: [], parameters: constructor.parameters }], node.arguments ?? []);
+		} else if (
+			ts.isBinaryExpression(node) &&
+			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			ts.isArrayLiteralExpression(node.left)
+		) {
+			const targetContainsSecret = node.left.elements.some((element) => {
+				if (ts.isOmittedExpression(element)) {
+					return false;
+				}
+
+				const target = ts.isSpreadElement(element) ? element.expression : element;
+				const unwrapTarget = (expression: ts.Expression): ts.Expression =>
+					ts.isBinaryExpression(expression) && expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+						? unwrapTarget(expression.left)
+						: ts.isParenthesizedExpression(expression)
+							? unwrapTarget(expression.expression)
+							: expression;
+				const unwrappedTarget = unwrapTarget(target);
+
+				return ts.isIdentifier(unwrappedTarget) && isCompiledSecretName(unwrappedTarget.text);
+			});
+			const assignedValues = [node.right, ...compiledReceiverWriteValues(node.right, node.getStart(sourceFile))];
+
+			found = targetContainsSecret && assignedValues.some((value) => containsUnsafeCompiledValue(value));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -6888,6 +6942,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"let apiKey; const source = []; source.push('opaque-secret'); [apiKey] = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = ['safe']; source.push('opaque-secret'); const [, apiKey] = source;",
 				true,
 			),
@@ -7363,6 +7424,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; source.value = 'opaque-secret'; const apiKey = Object.entries(source)[0][1];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -7513,6 +7581,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = Array.from(source)[0][1];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map(); source.set('', 'opaque-secret'); const apiKey = source.get('');",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map([['', 'opaque-secret']]); const apiKey = source.get('');",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -7,8 +7,10 @@ import { parse as parseYaml } from 'yaml';
 import {
 	findHomeyIpv6Range,
 	isHomeyAddressKey,
+	isHomeyEndpointKey,
 	isHomeyGeneratedPseudonym,
 	isHomeyIdentifierKey,
+	isHomeyIdentifierMapKey,
 	isHomeyPersonalKey,
 	isHomeyReferenceArrayKey,
 	isHomeyReferenceKey,
@@ -66,6 +68,7 @@ const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set([
 	'synthetic-lock-device',
 	'synthetic_mode',
 ]);
+const PUBLIC_COMPILED_IDENTIFIER_LABELS = new Set(['event device id', 'event zone id']);
 const REDACTION_SENTINEL_PATTERN = /^\[~[0-7]~\]$/;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
@@ -261,13 +264,17 @@ const compiledAssignedPropertyName = (expression: ts.Expression): string | undef
 
 const SAFE_COMPILED_SECRET_STRINGS = new Set(['', '[~3~]']);
 const SAFE_COMPILED_ADDRESS_STRINGS = new Set(['[~0~]']);
+type SafeCompiledString = ReadonlySet<string> | ((value: string) => boolean);
+
+const isSafeCompiledString = (value: string, safeStrings: SafeCompiledString): boolean =>
+	typeof safeStrings === 'function' ? safeStrings(value) : safeStrings.has(value);
 
 const containsUnsafeCompiledLiteral = (
 	node: ts.Expression,
-	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
 ): boolean => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-		return !safeStrings.has(node.text);
+		return !isSafeCompiledString(node.text, safeStrings);
 	}
 
 	if (ts.isNumericLiteral(node)) {
@@ -419,7 +426,7 @@ const isPublicSecretFieldsDescriptor = (node: ts.Expression): boolean => {
 
 const containsUnsafeCompiledType = (
 	type: ts.TypeNode,
-	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
 ): boolean => {
 	let found = false;
 	const visit = (node: ts.Node): void => {
@@ -444,7 +451,7 @@ const isAssignmentOperatorKind = (kind: ts.SyntaxKind): boolean =>
 
 const containsUnsafeReturnedLiteral = (
 	body: ts.Block,
-	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
 ): boolean => {
 	let found = false;
 	const visit = (node: ts.Node): void => {
@@ -578,6 +585,80 @@ const containsCompiledAddress = (text: string): boolean => {
 			found = unsafeAddress(name, node.initializer);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeAddress(compiledAssignedPropertyName(node.left), node.right);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
+const containsCompiledIdentifier = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const isPrivateIdentifierName = (name: string | undefined): name is string =>
+		name !== undefined &&
+		(isHomeyReferenceKey(name) || isHomeyIdentifierKey(name)) &&
+		!['DEVICES_HOMEY_CONNECTOR_SERVICE_ID', 'baseId', 'id', 'operationId', 'serviceId'].includes(name) &&
+		!/^capabilit(?:y|ies)(?:Id|Ids|Identifier|Identifiers)$/i.test(name);
+	const isSafeCompiledIdentifierValue = (value: string): boolean =>
+		isSafeIdentifierValue(value) || PUBLIC_COMPILED_IDENTIFIER_LABELS.has(value);
+	const unsafeIdentifier = (name: string | undefined, expression: ts.Expression): boolean =>
+		isPrivateIdentifierName(name) && containsUnsafeCompiledLiteral(expression, isSafeCompiledIdentifierValue);
+	const unsafeIdentifierType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
+		isPrivateIdentifierName(name) &&
+		type !== undefined &&
+		containsUnsafeCompiledType(type, isSafeCompiledIdentifierValue);
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node)) {
+			found = unsafeIdentifier(compiledPropertyName(node.name), node.initializer);
+		} else if (ts.isPropertyDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				(node.initializer !== undefined && unsafeIdentifier(name, node.initializer)) ||
+				unsafeIdentifierType(name, node.type);
+		} else if (ts.isPropertySignature(node)) {
+			found = unsafeIdentifierType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isGetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				(node.body !== undefined &&
+					isPrivateIdentifierName(name) &&
+					containsUnsafeReturnedLiteral(node.body, isSafeCompiledIdentifierValue)) ||
+				unsafeIdentifierType(name, node.type);
+		} else if (ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+			const name = compiledPropertyName(node.name);
+			const privateReferenceMethod = name !== undefined && isHomeyReferenceKey(name);
+
+			found =
+				('body' in node &&
+					node.body !== undefined &&
+					privateReferenceMethod &&
+					containsUnsafeReturnedLiteral(node.body, isSafeCompiledIdentifierValue)) ||
+				(privateReferenceMethod && unsafeIdentifierType(name, node.type));
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeIdentifier(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeIdentifier(node.name.text, node.initializer);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = unsafeIdentifier(name, node.initializer);
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
+			found = unsafeIdentifier(compiledAssignedPropertyName(node.left), node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -731,6 +812,27 @@ const isSafeIdentifierValue = (value: unknown): boolean =>
 	(typeof value === 'string' &&
 		(REDACTION_SENTINEL_PATTERN.test(value) || PUBLIC_SYNTHETIC_IDENTIFIER_VALUES.has(value)));
 
+const isSafeEndpointValue = (value: unknown): boolean =>
+	value === null ||
+	value === 0 ||
+	value === false ||
+	value === '[~5~]' ||
+	(typeof value === 'string' && PUBLIC_ARTIFACT_URLS.has(value));
+
+const containsStructuredEndpoint = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredEndpoint(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(
+		([key, child]) => (isHomeyEndpointKey(key) && !isSafeEndpointValue(child)) || containsStructuredEndpoint(child),
+	);
+};
+
 const isCapabilityIdentifierPath = (key: string, path: readonly string[], syntheticProtocolRoot: boolean): boolean => {
 	const directCapabilityEntry =
 		path.length === 2 &&
@@ -768,6 +870,14 @@ const containsStructuredIdentifier = (
 
 	return Object.entries(record).some(([key, child]) => {
 		const childPath = [...path, key];
+		const identifierMapValue =
+			isHomeyIdentifierMapKey(key) &&
+			child !== null &&
+			typeof child === 'object' &&
+			!Array.isArray(child) &&
+			Object.keys(child as JsonRecord).some(
+				(entryKey) => !isHomeyGeneratedPseudonym(entryKey) && !PUBLIC_SYNTHETIC_IDENTIFIER_VALUES.has(entryKey),
+			);
 		const identifierValue =
 			!isHomeyReferenceArrayKey(key) &&
 			(isHomeyReferenceKey(key) || isHomeyIdentifierKey(key)) &&
@@ -778,6 +888,7 @@ const containsStructuredIdentifier = (
 			(Array.isArray(child) ? child.some((entry) => !isSafeIdentifierValue(entry)) : !isSafeIdentifierValue(child));
 
 		return (
+			identifierMapValue ||
 			identifierValue ||
 			referenceArrayValue ||
 			containsStructuredIdentifier(child, childPath, nestedSyntheticProtocolRoot)
@@ -816,6 +927,9 @@ const containsLoosePersonalAssignment = (text: string): boolean =>
 			!isHomeyGeneratedPseudonym(rawValue) &&
 			!PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(rawValue),
 	);
+
+const containsLooseEndpointAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(([key, rawValue]) => isHomeyEndpointKey(key) && !isSafeEndpointValue(rawValue));
 
 const containsLooseIdentifierAssignment = (text: string): boolean =>
 	loosePropertyAssignments(text).some(([key, rawValue]) => {
@@ -874,6 +988,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 		throw new Error(`${label} contains a compiled address value`);
 	}
 
+	if (compiledSource && containsCompiledIdentifier(text)) {
+		throw new Error(`${label} contains a compiled identifier value`);
+	}
+
 	for (const privateValue of configuredPrivateValues()) {
 		if (text.toLocaleLowerCase().includes(privateValue.toLocaleLowerCase())) {
 			throw new Error(`${label} contains a configured private Homey value`);
@@ -899,6 +1017,13 @@ const assertFixtureTextSafe = (
 
 	if (structuredValue === undefined ? URL_PATTERN.test(text) : containsStructuredUrl(structuredValue)) {
 		throw new Error(`${label} contains a URL`);
+	}
+
+	const containsEndpoint =
+		structuredValue === undefined ? containsLooseEndpointAssignment(text) : containsStructuredEndpoint(structuredValue);
+
+	if (containsEndpoint) {
+		throw new Error(`${label} contains a structured endpoint value`);
 	}
 
 	const containsSecret =
@@ -976,6 +1101,7 @@ const visitPublishedValues = (
 	addressParameter = false,
 	personalParameter = false,
 	identifierParameter = false,
+	endpointParameter = false,
 ): void => {
 	if (Array.isArray(value)) {
 		value.forEach((entry, index) =>
@@ -987,6 +1113,7 @@ const visitPublishedValues = (
 				addressParameter,
 				personalParameter,
 				identifierParameter,
+				endpointParameter,
 			),
 		);
 
@@ -1006,6 +1133,8 @@ const visitPublishedValues = (
 	const nestedIdentifierParameter =
 		identifierParameter ||
 		(parameterName !== undefined && (isHomeyReferenceKey(parameterName) || isHomeyIdentifierKey(parameterName)));
+	const nestedEndpointParameter =
+		endpointParameter || (parameterName !== undefined && isHomeyEndpointKey(parameterName));
 
 	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
@@ -1017,6 +1146,10 @@ const visitPublishedValues = (
 
 			if (containsStructuredUrl(child)) {
 				throw new Error(`${label}.${childPath.join('.')} publishes a URL`);
+			}
+
+			if (containsStructuredEndpoint(child) || (nestedEndpointParameter && !isSafeEndpointValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes an endpoint value`);
 			}
 
 			if (containsStructuredAddress(child) || (nestedAddressParameter && !isSafeAddressValue(child))) {
@@ -1040,6 +1173,7 @@ const visitPublishedValues = (
 			nestedAddressParameter,
 			nestedPersonalParameter,
 			nestedIdentifierParameter,
+			nestedEndpointParameter,
 		);
 	}
 };
@@ -1153,6 +1287,11 @@ describe('Homey security artifact gate', () => {
 				example: { deviceId: 'opaque-household-id' },
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes an identifier value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { endpoint: 'private-homey.local:4859' },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes an endpoint value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -1190,6 +1329,12 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertFixtureTextSafe('unsafe fixture', '{"capabilities":[{"metadata":{"id":"opaque-household-id"}}]}', '.json'),
 		).toThrow('unsafe fixture contains a structured identifier value');
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"devices":{"abc123":{}}}', '.json')).toThrow(
+			'unsafe fixture contains a structured identifier value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"endpoint":"private-homey.local:4859"}', '.json')).toThrow(
+			'unsafe fixture contains a structured endpoint value',
+		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
@@ -1262,6 +1407,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "const hostname = 'family-homey.local';", true)).toThrow(
 			'unsafe compiled module contains a compiled address value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "const deviceId = 'opaque-household-id';", true)).toThrow(
+			'unsafe compiled module contains a compiled identifier value',
 		);
 		expect(() =>
 			assertTextSafe('unsafe declaration', "interface Config { hostname: 'family-homey.local' }", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -44,9 +44,10 @@ const PUBLIC_COMPILED_SECRET_NAMES = new Set(['secretFields']);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
-const PUBLIC_SCHEMA_URLS = new Set(['http://json-schema.org/draft-07/schema#']);
+const PUBLIC_SCHEMA_URLS = new Set(['http://homey.local:4859', 'http://json-schema.org/draft-07/schema#']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
-const LOOSE_PROPERTY_PATTERN = /^\s*(?:[-*]\s+)?["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(.*?)\s*$/gm;
+const LOOSE_PROPERTY_PATTERN =
+	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
@@ -264,6 +265,10 @@ const containsCompiledSecret = (text: string): boolean => {
 			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isBindingElement(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -311,18 +316,13 @@ const containsStructuredSecret = (value: unknown): boolean => {
 const containsLooseSecretAssignment = (text: string): boolean =>
 	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].some((match) => {
 		const key = match[1];
-		const rawValue = match[2]
-			?.replace(/\s+#.*$/, '')
-			.replace(/[,;]\s*$/, '')
-			.trim();
+		const rawValue = (match[3] ?? match[4])?.replace(/\s+#.*$/, '').trim();
 
 		if (key === undefined || rawValue === undefined || !isHomeySecretKey(key)) {
 			return false;
 		}
 
-		const value = rawValue.replace(/^(["'`])(.*)\1$/, '$2');
-
-		return !['', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(value);
+		return !['', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(rawValue);
 	});
 
 const containsStructuredUrl = (value: unknown): boolean => {
@@ -441,8 +441,14 @@ const visitPublishedValues = (label: string, value: unknown, path: readonly stri
 	for (const [key, child] of Object.entries(value as JsonRecord)) {
 		const childPath = [...path, key];
 
-		if (['default', 'enum', 'example', 'examples'].includes(key) && containsStructuredSecret(child)) {
-			throw new Error(`${label}.${childPath.join('.')} publishes a secret value`);
+		if (['default', 'enum', 'example', 'examples'].includes(key)) {
+			if (containsStructuredSecret(child)) {
+				throw new Error(`${label}.${childPath.join('.')} publishes a secret value`);
+			}
+
+			if (containsStructuredUrl(child)) {
+				throw new Error(`${label}.${childPath.join('.')} publishes a URL`);
+			}
 		}
 
 		visitPublishedValues(label, child, childPath);
@@ -533,6 +539,11 @@ describe('Homey security artifact gate', () => {
 				example: { pinCode: 1234 },
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes a secret value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: 'http://private-homey.local:4859',
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes a URL');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -548,6 +559,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'config: { api_key: opaque-secret-value }', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', "Captured payload: { api_key: 'opaque-secret' }", '.md'),
+		).toThrow('unsafe fixture contains a structured secret value');
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'endpoint: http://private-homey.local:4859', '.yaml')).toThrow(
 			'unsafe fixture contains a URL',
 		);
@@ -589,6 +603,9 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const credentials = { value: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function connect(apiKey = 'opaque-secret') {}", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { isIP } from 'node:net';
 import { extname, resolve } from 'node:path';
 
 type JsonRecord = Record<string, unknown>;
@@ -24,15 +25,17 @@ const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
 const SECRET_PROPERTY_PATTERN =
 	/^(?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)$/i;
+const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
-		label: 'private IPv4 address',
-		pattern: /\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b/,
+		label: 'an IPv4 address',
+		pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
 	},
-	{ label: 'email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
-	{ label: 'Homey personal access token', pattern: /\b(?:hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
+	{ label: 'a MAC address', pattern: /\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b/i },
+	{ label: 'an email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
+	{ label: 'a Homey personal access token', pattern: /\b(?:hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
 	{
-		label: 'serialized secret value',
+		label: 'a serialized secret value',
 		pattern:
 			/["'](?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)["']\s*:\s*["'](?!\[~3~\])[^"]+["']/i,
 	},
@@ -63,13 +66,24 @@ const configuredPrivateValues = (): readonly string[] =>
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
 		.map((value) => value?.trim())
-		.filter((value): value is string => value !== undefined && value.length >= 4);
+		.filter((value): value is string => value !== undefined && value.length >= 3);
+
+const containsIpv6Address = (text: string): boolean =>
+	[...text.matchAll(IP_ADDRESS_CANDIDATE_PATTERN)].some((match) => {
+		const candidate = match[0].replace(/^\.+|\.+$/g, '').split('%')[0];
+
+		return candidate !== undefined && candidate !== '::' && isIP(candidate) === 6;
+	});
 
 const assertTextSafe = (label: string, text: string): void => {
 	for (const forbidden of FORBIDDEN_PATTERNS) {
 		if (forbidden.pattern.test(text)) {
-			throw new Error(`${label} contains a ${forbidden.label}`);
+			throw new Error(`${label} contains ${forbidden.label}`);
 		}
+	}
+
+	if (containsIpv6Address(text)) {
+		throw new Error(`${label} contains an IPv6 address`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -171,7 +185,28 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a serialized secret value',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
-			'unsafe fixture contains a private IPv4 address',
+			'unsafe fixture contains an IPv4 address',
 		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"169.254.1.20"}')).toThrow(
+			'unsafe fixture contains an IPv4 address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"fe80::1%en0"}')).toThrow(
+			'unsafe fixture contains an IPv6 address',
+		);
+		const previousPrivateTerms = process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
+
+		process.env.FB_HOMEY_SHS_PRIVATE_TERMS = 'Ada';
+
+		try {
+			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
+		} finally {
+			if (previousPrivateTerms === undefined) {
+				delete process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
+			} else {
+				process.env.FB_HOMEY_SHS_PRIVATE_TERMS = previousPrivateTerms;
+			}
+		}
 	});
 });

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -9,8 +9,10 @@ import {
 	isHomeyAddressKey,
 	isHomeyEndpointKey,
 	isHomeyGeneratedPseudonym,
+	isHomeyIconKey,
 	isHomeyIdentifierKey,
 	isHomeyIdentifierMapKey,
+	isHomeyIsoTimestamp,
 	isHomeyPersonalKey,
 	isHomeyReferenceArrayKey,
 	isHomeyReferenceKey,
@@ -298,15 +300,18 @@ const containsUnsafeCompiledLiteral = (
 	}
 
 	if (ts.isArrayLiteralExpression(node)) {
-		return node.elements.some(
-			(element) => ts.isExpression(element) && containsUnsafeCompiledLiteral(element, safeStrings),
+		return node.elements.some((element) =>
+			ts.isSpreadElement(element)
+				? containsUnsafeCompiledLiteral(element.expression, safeStrings)
+				: ts.isExpression(element) && containsUnsafeCompiledLiteral(element, safeStrings),
 		);
 	}
 
 	if (ts.isObjectLiteralExpression(node)) {
 		return node.properties.some(
 			(property) =>
-				ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer, safeStrings),
+				(ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer, safeStrings)) ||
+				(ts.isSpreadAssignment(property) && containsUnsafeCompiledLiteral(property.expression, safeStrings)),
 		);
 	}
 
@@ -903,13 +908,30 @@ const isSafeTimestampValue = (value: unknown): boolean =>
 	value === FIXTURE_TIMESTAMP ||
 	(typeof value === 'string' && PUBLIC_FIXTURE_DATES.has(value));
 
+const isSafeIconValue = (value: unknown): boolean =>
+	value === null || value === 0 || value === false || value === '[~2~]';
+
+const containsStructuredIcon = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredIcon(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(
+		([key, child]) => (isHomeyIconKey(key) && !isSafeIconValue(child)) || containsStructuredIcon(child),
+	);
+};
+
 const containsStructuredTimestamp = (value: unknown): boolean => {
 	if (Array.isArray(value)) {
 		return value.some((entry) => containsStructuredTimestamp(entry));
 	}
 
 	if (value === null || typeof value !== 'object') {
-		return false;
+		return typeof value === 'string' && isHomeyIsoTimestamp(value) && !isSafeTimestampValue(value);
 	}
 
 	return Object.entries(value as JsonRecord).some(
@@ -1043,9 +1065,15 @@ const containsLooseIdentifierAssignment = (text: string): boolean =>
 const containsLooseTimestampAssignment = (text: string): boolean =>
 	loosePropertyAssignments(text).some(
 		([key, rawValue]) =>
-			isHomeyTimestampKey(key) &&
-			!['0', 'false', 'null', FIXTURE_TIMESTAMP].includes(rawValue) &&
-			!PUBLIC_FIXTURE_DATES.has(rawValue),
+			(isHomeyTimestampKey(key) &&
+				!['0', 'false', 'null', FIXTURE_TIMESTAMP].includes(rawValue) &&
+				!PUBLIC_FIXTURE_DATES.has(rawValue)) ||
+			(isHomeyIsoTimestamp(rawValue) && !isSafeTimestampValue(rawValue)),
+	);
+
+const containsLooseIconAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(
+		([key, rawValue]) => isHomeyIconKey(key) && !['0', '[~2~]', 'false', 'null'].includes(rawValue),
 	);
 
 const containsStructuredUrl = (value: unknown): boolean => {
@@ -1144,6 +1172,13 @@ const assertFixtureTextSafe = (
 
 	if (containsTimestamp) {
 		throw new Error(`${label} contains a structured timestamp value`);
+	}
+
+	const containsIcon =
+		structuredValue === undefined ? containsLooseIconAssignment(text) : containsStructuredIcon(structuredValue);
+
+	if (containsIcon) {
+		throw new Error(`${label} contains a structured icon value`);
 	}
 
 	const containsSecret =
@@ -1464,6 +1499,12 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"updatedAt":"2026-08-25T12:34:56.000Z"}', '.json')).toThrow(
 			'unsafe fixture contains a structured timestamp value',
 		);
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', '{"observation":"2026-08-25T12:34:56.000Z"}', '.json'),
+		).toThrow('unsafe fixture contains a structured timestamp value');
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"icon":"custom-household-icon"}', '.json')).toThrow(
+			'unsafe fixture contains a structured icon value',
+		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
@@ -1549,6 +1590,12 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = { ...{ value: 'opaque-secret' } };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = [...['opaque-secret']];", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
 		expect(() => assertTextSafe('unsafe compiled module', "config.api_key = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -90,6 +90,7 @@ const PUBLIC_ARTIFACT_URLS = new Set([
 const PUBLIC_HOMEY_HOSTS = new Set(['homey', 'homey.local']);
 const FIXTURE_TIMESTAMP = '2000-01-01T00:00:00.000Z';
 const PUBLIC_FIXTURE_DATES = new Set(['2026-08-13']);
+const PUBLIC_OPENAPI_TIMESTAMPS = new Set(['2025-01-18T12:00:00Z', '2025-01-25T12:00:00Z']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN =
 	/(?=(?:^|[{\s,;])["'`]?([A-Za-z][A-Za-z0-9_. -]*)["'`]?\s*[:=]\s*(?:(["'`])([^"'`\r\n]*)\2|([^,;}\r\n`]+)))/gm;
@@ -402,6 +403,126 @@ const containsUnsafeCompiledLiteral = (
 	return false;
 };
 
+const COMPILED_ALIAS_CACHE = new WeakMap<ts.SourceFile, ReadonlyMap<string, ts.Expression>>();
+
+const compiledConstantAliases = (sourceFile: ts.SourceFile): ReadonlyMap<string, ts.Expression> => {
+	const cached = COMPILED_ALIAS_CACHE.get(sourceFile);
+
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const candidates = new Map<string, ts.Expression | undefined>();
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isVariableDeclaration(node) &&
+			ts.isIdentifier(node.name) &&
+			node.initializer !== undefined &&
+			ts.isVariableDeclarationList(node.parent) &&
+			(node.parent.flags & ts.NodeFlags.Const) !== 0
+		) {
+			candidates.set(node.name.text, candidates.has(node.name.text) ? undefined : node.initializer);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	const aliases = new Map(
+		[...candidates.entries()].filter((entry): entry is [string, ts.Expression] => entry[1] !== undefined),
+	);
+
+	COMPILED_ALIAS_CACHE.set(sourceFile, aliases);
+
+	return aliases;
+};
+
+const containsUnsafeCompiledAlias = (
+	node: ts.Expression,
+	safeStrings: SafeCompiledString,
+	resolvingAliases = new Set<string>(),
+): boolean => {
+	const aliases = compiledConstantAliases(node.getSourceFile());
+	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
+		if (ts.isIdentifier(expression)) {
+			const initializer = aliases.get(expression.text);
+
+			if (initializer === undefined || resolving.has(expression.text)) {
+				return false;
+			}
+
+			const nestedResolving = new Set(resolving).add(expression.text);
+
+			return containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving);
+		}
+
+		if (ts.isArrayLiteralExpression(expression)) {
+			return expression.elements.some((element) =>
+				ts.isSpreadElement(element)
+					? inspect(element.expression, resolving)
+					: ts.isExpression(element) && inspect(element, resolving),
+			);
+		}
+
+		if (ts.isObjectLiteralExpression(expression)) {
+			return expression.properties.some(
+				(property) =>
+					(ts.isPropertyAssignment(property) && inspect(property.initializer, resolving)) ||
+					(ts.isSpreadAssignment(property) && inspect(property.expression, resolving)),
+			);
+		}
+
+		if (ts.isBinaryExpression(expression)) {
+			return inspect(expression.left, resolving) || inspect(expression.right, resolving);
+		}
+
+		if (
+			ts.isParenthesizedExpression(expression) ||
+			ts.isAsExpression(expression) ||
+			ts.isTypeAssertionExpression(expression) ||
+			ts.isNonNullExpression(expression) ||
+			ts.isSatisfiesExpression(expression) ||
+			ts.isAwaitExpression(expression)
+		) {
+			return inspect(expression.expression, resolving);
+		}
+
+		if (ts.isConditionalExpression(expression)) {
+			return inspect(expression.whenTrue, resolving) || inspect(expression.whenFalse, resolving);
+		}
+
+		if (ts.isCallExpression(expression)) {
+			return expression.arguments.some((argument) => inspect(argument, resolving));
+		}
+
+		if (ts.isNewExpression(expression)) {
+			return expression.arguments?.some((argument) => inspect(argument, resolving)) ?? false;
+		}
+
+		if (ts.isTemplateExpression(expression)) {
+			return expression.templateSpans.some((span) => inspect(span.expression, resolving));
+		}
+
+		if (ts.isTaggedTemplateExpression(expression)) {
+			return inspect(expression.template, resolving);
+		}
+
+		if (ts.isPrefixUnaryExpression(expression)) {
+			return inspect(expression.operand, resolving);
+		}
+
+		return false;
+	};
+
+	return inspect(node, resolvingAliases);
+};
+
+const containsUnsafeCompiledValue = (
+	node: ts.Expression,
+	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
+): boolean => containsUnsafeCompiledLiteral(node, safeStrings) || containsUnsafeCompiledAlias(node, safeStrings);
+
 const isCompiledSecretName = (name: string | undefined): name is string => name !== undefined && isHomeySecretKey(name);
 
 const isPublicSecretFieldsDescriptor = (node: ts.Expression): boolean => {
@@ -481,7 +602,7 @@ const containsUnsafeCompiledBodyLiteral = (
 			return;
 		}
 
-		if (ts.isExpression(node) && containsUnsafeCompiledLiteral(node, safeStrings)) {
+		if (ts.isExpression(node) && containsUnsafeCompiledValue(node, safeStrings)) {
 			found = true;
 
 			return;
@@ -509,13 +630,13 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				isCompiledSecretName(name) &&
 				!(name === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
-				containsUnsafeCompiledLiteral(node.initializer);
+				containsUnsafeCompiledValue(node.initializer);
 		} else if (ts.isPropertyDeclaration(node)) {
 			const name = compiledPropertyName(node.name);
 
 			found =
 				isCompiledSecretName(name) &&
-				((node.initializer !== undefined && containsUnsafeCompiledLiteral(node.initializer)) ||
+				((node.initializer !== undefined && containsUnsafeCompiledValue(node.initializer)) ||
 					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
 		} else if (ts.isPropertySignature(node)) {
 			const name = compiledPropertyName(node.name);
@@ -525,7 +646,7 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				node.parameters.some(
 					(parameter) =>
-						(parameter.initializer !== undefined && containsUnsafeCompiledLiteral(parameter.initializer)) ||
+						(parameter.initializer !== undefined && containsUnsafeCompiledValue(parameter.initializer)) ||
 						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type)),
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body));
@@ -540,9 +661,12 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				isCompiledSecretName(node.name.text) &&
 				!(node.name.text === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
-				containsUnsafeCompiledLiteral(node.initializer);
-		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+				containsUnsafeCompiledValue(node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				isCompiledSecretName(node.name.text) &&
+				((node.initializer !== undefined && containsUnsafeCompiledValue(node.initializer)) ||
+					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
 			const name =
 				node.propertyName !== undefined
@@ -551,11 +675,11 @@ const containsCompiledSecret = (text: string): boolean => {
 						? node.name.text
 						: undefined;
 
-			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
+			found = isCompiledSecretName(name) && containsUnsafeCompiledValue(node.initializer);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
-			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.right);
+			found = isCompiledSecretName(name) && containsUnsafeCompiledValue(node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -572,7 +696,7 @@ const containsCompiledAddress = (text: string): boolean => {
 	const unsafeAddress = (name: string | undefined, expression: ts.Expression): boolean =>
 		name !== undefined &&
 		isHomeyAddressKey(name) &&
-		containsUnsafeCompiledLiteral(expression, SAFE_COMPILED_ADDRESS_STRINGS);
+		containsUnsafeCompiledValue(expression, SAFE_COMPILED_ADDRESS_STRINGS);
 	const unsafeAddressType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
 		name !== undefined &&
 		isHomeyAddressKey(name) &&
@@ -601,7 +725,7 @@ const containsCompiledAddress = (text: string): boolean => {
 				(node.parameters.some(
 					(parameter) =>
 						(parameter.initializer !== undefined &&
-							containsUnsafeCompiledLiteral(parameter.initializer, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+							containsUnsafeCompiledValue(parameter.initializer, SAFE_COMPILED_ADDRESS_STRINGS)) ||
 						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, SAFE_COMPILED_ADDRESS_STRINGS)),
 				) ||
 					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)));
@@ -617,8 +741,10 @@ const containsCompiledAddress = (text: string): boolean => {
 				unsafeAddressType(name, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeAddress(node.name.text, node.initializer);
-		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeAddress(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeAddress(node.name.text, node.initializer)) ||
+				unsafeAddressType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
 			const name =
 				node.propertyName !== undefined
@@ -651,7 +777,7 @@ const containsCompiledIdentifier = (text: string): boolean => {
 	const isSafeCompiledIdentifierValue = (value: string): boolean =>
 		isSafeIdentifierValue(value) || PUBLIC_COMPILED_IDENTIFIER_LABELS.has(value);
 	const unsafeIdentifier = (name: string | undefined, expression: ts.Expression): boolean =>
-		isPrivateIdentifierName(name) && containsUnsafeCompiledLiteral(expression, isSafeCompiledIdentifierValue);
+		isPrivateIdentifierName(name) && containsUnsafeCompiledValue(expression, isSafeCompiledIdentifierValue);
 	const unsafeIdentifierType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
 		isPrivateIdentifierName(name) &&
 		type !== undefined &&
@@ -679,7 +805,7 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				(node.parameters.some(
 					(parameter) =>
 						(parameter.initializer !== undefined &&
-							containsUnsafeCompiledLiteral(parameter.initializer, isSafeCompiledIdentifierValue)) ||
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledIdentifierValue)) ||
 						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledIdentifierValue)),
 				) ||
 					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)));
@@ -703,8 +829,10 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				(privateReferenceMethod && unsafeIdentifierType(name, node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeIdentifier(node.name.text, node.initializer);
-		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeIdentifier(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeIdentifier(node.name.text, node.initializer)) ||
+				unsafeIdentifierType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
 			const name =
 				node.propertyName !== undefined
@@ -732,7 +860,7 @@ const containsCompiledEndpoint = (text: string): boolean => {
 	const isEndpointValueName = (name: string | undefined): name is string =>
 		name !== undefined && isHomeyEndpointKey(name) && !/^(?:assert|is|validate)/i.test(name);
 	const unsafeEndpoint = (name: string | undefined, expression: ts.Expression): boolean =>
-		isEndpointValueName(name) && containsUnsafeCompiledLiteral(expression, isSafeEndpointValue);
+		isEndpointValueName(name) && containsUnsafeCompiledValue(expression, isSafeEndpointValue);
 	const unsafeEndpointType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
 		isEndpointValueName(name) && type !== undefined && containsUnsafeCompiledType(type, isSafeEndpointValue);
 	const visit = (node: ts.Node): void => {
@@ -758,7 +886,7 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				(node.parameters.some(
 					(parameter) =>
 						(parameter.initializer !== undefined &&
-							containsUnsafeCompiledLiteral(parameter.initializer, isSafeEndpointValue)) ||
+							containsUnsafeCompiledValue(parameter.initializer, isSafeEndpointValue)) ||
 						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeEndpointValue)),
 				) ||
 					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)));
@@ -774,8 +902,10 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				(endpointName && unsafeEndpointType(name, node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeEndpoint(node.name.text, node.initializer);
-		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeEndpoint(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeEndpoint(node.name.text, node.initializer)) ||
+				unsafeEndpointType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
 			const name =
 				node.propertyName !== undefined
@@ -817,7 +947,7 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 		isHomeySecretKey(value) ||
 		isHomeyTimestampKey(value);
 	const unsafePersonalValue = (name: string | undefined, expression: ts.Expression): boolean =>
-		isCompiledPersonalName(name) && containsUnsafeCompiledLiteral(expression, isSafeCompiledPersonalValue);
+		isCompiledPersonalName(name) && containsUnsafeCompiledValue(expression, isSafeCompiledPersonalValue);
 	const unsafePersonalType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
 		isCompiledPersonalName(name) && type !== undefined && containsUnsafeCompiledType(type, isSafeCompiledPersonalValue);
 	const visit = (node: ts.Node): void => {
@@ -843,7 +973,7 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 				(node.parameters.some(
 					(parameter) =>
 						(parameter.initializer !== undefined &&
-							containsUnsafeCompiledLiteral(parameter.initializer, isSafeCompiledPersonalValue)) ||
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledPersonalValue)) ||
 						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledPersonalValue)),
 				) ||
 					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)));
@@ -859,8 +989,10 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 				(personalName && unsafePersonalType(name, node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafePersonalValue(node.name.text, node.initializer);
-		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafePersonalValue(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafePersonalValue(node.name.text, node.initializer)) ||
+				unsafePersonalType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
 			const name =
 				node.propertyName !== undefined
@@ -1051,7 +1183,7 @@ const isSafeTimestampValue = (value: unknown): boolean =>
 	value === 0 ||
 	value === false ||
 	value === FIXTURE_TIMESTAMP ||
-	(typeof value === 'string' && PUBLIC_FIXTURE_DATES.has(value));
+	(typeof value === 'string' && (PUBLIC_FIXTURE_DATES.has(value) || PUBLIC_OPENAPI_TIMESTAMPS.has(value)));
 
 const isSafeIconValue = (value: unknown): boolean =>
 	value === null || value === 0 || value === false || value === '[~2~]';
@@ -1409,6 +1541,7 @@ const visitPublishedValues = (
 	identifierParameter = false,
 	endpointParameter = false,
 	iconParameter = false,
+	timestampParameter = false,
 ): void => {
 	if (Array.isArray(value)) {
 		value.forEach((entry, index) =>
@@ -1422,6 +1555,7 @@ const visitPublishedValues = (
 				identifierParameter,
 				endpointParameter,
 				iconParameter,
+				timestampParameter,
 			),
 		);
 
@@ -1444,6 +1578,8 @@ const visitPublishedValues = (
 	const nestedEndpointParameter =
 		endpointParameter || (parameterName !== undefined && isHomeyEndpointKey(parameterName));
 	const nestedIconParameter = iconParameter || (parameterName !== undefined && isHomeyIconKey(parameterName));
+	const nestedTimestampParameter =
+		timestampParameter || (parameterName !== undefined && isHomeyTimestampKey(parameterName));
 
 	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
@@ -1463,6 +1599,10 @@ const visitPublishedValues = (
 
 			if (containsStructuredIcon(child) || (nestedIconParameter && !isSafeIconValue(child))) {
 				throw new Error(`${label}.${childPath.join('.')} publishes an icon value`);
+			}
+
+			if (containsStructuredTimestamp(child) || (nestedTimestampParameter && !isSafeTimestampValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes a timestamp value`);
 			}
 
 			if (containsStructuredAddress(child) || (nestedAddressParameter && !isSafeAddressValue(child))) {
@@ -1488,6 +1628,7 @@ const visitPublishedValues = (
 			nestedIdentifierParameter,
 			nestedEndpointParameter,
 			nestedIconParameter,
+			nestedTimestampParameter,
 		);
 	}
 };
@@ -1611,6 +1752,11 @@ describe('Homey security artifact gate', () => {
 				example: { icon: 'custom-household-icon' },
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes an icon value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { updatedAt: '2026-08-25T12:34:56.000Z' },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes a timestamp value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -1749,6 +1895,28 @@ describe('Homey security artifact gate', () => {
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const fallback = 'opaque-secret'; const apiKey = fallback;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),
+		).toThrow('unsafe declaration contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe declaration', "declare function connect(hostname: 'family-homey.local'): void", true),
+		).toThrow('unsafe declaration contains a compiled address value');
+		expect(() =>
+			assertTextSafe('unsafe declaration', "declare function connect(deviceId: 'opaque-household-id'): void", true),
+		).toThrow('unsafe declaration contains a compiled identifier value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe declaration',
+				"declare function connect(endpoint: 'private-homey.local:4859'): void",
+				true,
+			),
+		).toThrow('unsafe declaration contains a compiled endpoint value');
+		expect(() =>
+			assertTextSafe('unsafe declaration', "declare function connect(deviceName: 'Alice Bedroom'): void", true),
+		).toThrow('unsafe declaration contains a compiled personal value');
 		expect(() => assertTextSafe('unsafe compiled module', "const hostname = 'family-homey.local';", true)).toThrow(
 			'unsafe compiled module contains a compiled address value',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -333,6 +333,25 @@ const isCompiledSecretName = (name: string | undefined): name is string =>
 const isAssignmentOperatorKind = (kind: ts.SyntaxKind): boolean =>
 	kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
 
+const containsUnsafeReturnedLiteral = (body: ts.Block): boolean => {
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isReturnStatement(node) && node.expression !== undefined) {
+			found = containsUnsafeCompiledLiteral(node.expression);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(body);
+
+	return found;
+};
+
 const containsCompiledSecret = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let found = false;
@@ -349,6 +368,10 @@ const containsCompiledSecret = (text: string): boolean => {
 			const name = compiledPropertyName(node.name);
 
 			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if ((ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node)) && node.body !== undefined) {
+			const name = compiledPropertyName(node.name);
+
+			found = isCompiledSecretName(name) && containsUnsafeReturnedLiteral(node.body);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
@@ -472,6 +495,17 @@ const containsStructuredSecret = (value: unknown): boolean => {
 	);
 };
 
+const isSafeAddressValue = (value: unknown): boolean =>
+	value === null || value === 0 || value === false || value === '[~0~]';
+
+const isSafePersonalValue = (value: unknown): boolean =>
+	value === null ||
+	value === 0 ||
+	value === false ||
+	value === '[~2~]' ||
+	isHomeyGeneratedPseudonym(value) ||
+	(typeof value === 'string' && PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value));
+
 const containsStructuredAddress = (value: unknown): boolean => {
 	if (Array.isArray(value)) {
 		return value.some((entry) => containsStructuredAddress(entry));
@@ -482,9 +516,7 @@ const containsStructuredAddress = (value: unknown): boolean => {
 	}
 
 	return Object.entries(value as JsonRecord).some(([key, child]) => {
-		const safeAddressValue = child === null || child === 0 || child === false || child === '[~0~]';
-
-		return (isHomeyAddressKey(key) && !safeAddressValue) || containsStructuredAddress(child);
+		return (isHomeyAddressKey(key) && !isSafeAddressValue(child)) || containsStructuredAddress(child);
 	});
 };
 
@@ -498,14 +530,7 @@ const containsStructuredPersonalValue = (value: unknown): boolean => {
 	}
 
 	return Object.entries(value as JsonRecord).some(([key, child]) => {
-		const safeRedaction = child === null || child === 0 || child === false || child === '[~2~]';
-		const safePseudonym = isHomeyGeneratedPseudonym(child);
-		const safeSyntheticValue = typeof child === 'string' && PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(child);
-
-		return (
-			(isHomeyPersonalKey(key) && !safeRedaction && !safePseudonym && !safeSyntheticValue) ||
-			containsStructuredPersonalValue(child)
-		);
+		return (isHomeyPersonalKey(key) && !isSafePersonalValue(child)) || containsStructuredPersonalValue(child);
 	});
 };
 
@@ -640,9 +665,20 @@ const visitPublishedValues = (
 	value: unknown,
 	path: readonly string[] = [],
 	secretParameter = false,
+	addressParameter = false,
+	personalParameter = false,
 ): void => {
 	if (Array.isArray(value)) {
-		value.forEach((entry, index) => visitPublishedValues(label, entry, [...path, index.toString()], secretParameter));
+		value.forEach((entry, index) =>
+			visitPublishedValues(
+				label,
+				entry,
+				[...path, index.toString()],
+				secretParameter,
+				addressParameter,
+				personalParameter,
+			),
+		);
 
 		return;
 	}
@@ -652,7 +688,11 @@ const visitPublishedValues = (
 	}
 
 	const record = value as JsonRecord;
-	const nestedSecretParameter = secretParameter || (typeof record.name === 'string' && isHomeySecretKey(record.name));
+	const parameterName = typeof record.name === 'string' ? record.name : undefined;
+	const nestedSecretParameter = secretParameter || (parameterName !== undefined && isHomeySecretKey(parameterName));
+	const nestedAddressParameter = addressParameter || (parameterName !== undefined && isHomeyAddressKey(parameterName));
+	const nestedPersonalParameter =
+		personalParameter || (parameterName !== undefined && isHomeyPersonalKey(parameterName));
 
 	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
@@ -665,9 +705,24 @@ const visitPublishedValues = (
 			if (containsStructuredUrl(child)) {
 				throw new Error(`${label}.${childPath.join('.')} publishes a URL`);
 			}
+
+			if (containsStructuredAddress(child) || (nestedAddressParameter && !isSafeAddressValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes an address value`);
+			}
+
+			if (containsStructuredPersonalValue(child) || (nestedPersonalParameter && !isSafePersonalValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes a personal value`);
+			}
 		}
 
-		visitPublishedValues(label, child, childPath, nestedSecretParameter);
+		visitPublishedValues(
+			label,
+			child,
+			childPath,
+			nestedSecretParameter,
+			nestedAddressParameter,
+			nestedPersonalParameter,
+		);
 	}
 };
 
@@ -765,6 +820,16 @@ describe('Homey security artifact gate', () => {
 				parameters: [{ name: 'apiKey', schema: { example: 'opaque-secret' } }],
 			}),
 		).toThrow('UnsafeHomeyOperation.parameters.0.schema.example publishes a secret value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeyOperation', {
+				parameters: [{ name: 'hostname', schema: { example: 'family-homey.local' } }],
+			}),
+		).toThrow('UnsafeHomeyOperation.parameters.0.schema.example publishes an address value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { name: 'Alice Bedroom' },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes a personal value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -845,6 +910,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const { apiKey: key = 'opaque-secret' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "class Config { get apiKey() { return 'opaque-secret'; } }", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = process.env.API_KEY ?? 'opaque-secret';", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -282,6 +282,21 @@ const compiledAssignedPropertyName = (expression: ts.Expression): string | undef
 	return undefined;
 };
 
+const compiledBindingValues = (binding: ts.BindingElement): readonly ts.Expression[] => {
+	const values: ts.Expression[] = binding.initializer === undefined ? [] : [binding.initializer];
+	let current: ts.Node = binding.parent;
+
+	while (ts.isObjectBindingPattern(current) || ts.isArrayBindingPattern(current) || ts.isBindingElement(current)) {
+		current = current.parent;
+	}
+
+	if (ts.isVariableDeclaration(current) && current.initializer !== undefined) {
+		values.push(current.initializer);
+	}
+
+	return values;
+};
+
 const SAFE_COMPILED_SECRET_STRINGS = new Set(['', '[~3~]']);
 const SAFE_COMPILED_ADDRESS_STRINGS = new Set(['[~0~]']);
 type SafeCompiledString = ReadonlySet<string> | ((value: string) => boolean);
@@ -761,13 +776,15 @@ const containsCompiledSecret = (text: string): boolean => {
 				isCompiledSecretName(node.name.text) &&
 				((node.initializer !== undefined && containsUnsafeCompiledValue(node.initializer)) ||
 					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => isCompiledSecretName(name)) && containsUnsafeCompiledValue(node.initializer);
+			found =
+				names.some((name) => isCompiledSecretName(name)) &&
+				compiledBindingValues(node).some((value) => containsUnsafeCompiledValue(value));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -837,13 +854,13 @@ const containsCompiledAddress = (text: string): boolean => {
 			found =
 				(node.initializer !== undefined && unsafeAddress(node.name.text, node.initializer)) ||
 				unsafeAddressType(node.name.text, node.type);
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => unsafeAddress(name, node.initializer));
+			found = compiledBindingValues(node).some((value) => names.some((name) => unsafeAddress(name, value)));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeAddress(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -923,13 +940,13 @@ const containsCompiledIdentifier = (text: string): boolean => {
 			found =
 				(node.initializer !== undefined && unsafeIdentifier(node.name.text, node.initializer)) ||
 				unsafeIdentifierType(node.name.text, node.type);
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => unsafeIdentifier(name, node.initializer));
+			found = compiledBindingValues(node).some((value) => names.some((name) => unsafeIdentifier(name, value)));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeIdentifier(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -994,13 +1011,13 @@ const containsCompiledEndpoint = (text: string): boolean => {
 			found =
 				(node.initializer !== undefined && unsafeEndpoint(node.name.text, node.initializer)) ||
 				unsafeEndpointType(node.name.text, node.type);
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => unsafeEndpoint(name, node.initializer));
+			found = compiledBindingValues(node).some((value) => names.some((name) => unsafeEndpoint(name, value)));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeEndpoint(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -1079,13 +1096,13 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 			found =
 				(node.initializer !== undefined && unsafePersonalValue(node.name.text, node.initializer)) ||
 				unsafePersonalType(node.name.text, node.type);
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => unsafePersonalValue(name, node.initializer));
+			found = compiledBindingValues(node).some((value) => names.some((name) => unsafePersonalValue(name, value)));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafePersonalValue(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -1151,13 +1168,13 @@ const containsCompiledIcon = (text: string): boolean => {
 			found =
 				(node.initializer !== undefined && unsafeIcon(node.name.text, node.initializer)) ||
 				unsafeIconType(node.name.text, node.type);
-		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+		} else if (ts.isBindingElement(node)) {
 			const names = [
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
 
-			found = names.some((name) => unsafeIcon(name, node.initializer));
+			found = compiledBindingValues(node).some((value) => names.some((name) => unsafeIcon(name, value)));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeIcon(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -2229,6 +2246,48 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled personal value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const { value: icon = 'custom-household-icon' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled icon value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'opaque-secret' }; const { value: apiKey } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'family-homey.local' }; const { value: hostname } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled address value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'opaque-household-id' }; const { value: deviceId } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled identifier value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'private-homey.local:4859' }; const { value: endpoint } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled endpoint value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'Alice Bedroom' }; const { value: deviceName } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled personal value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: 'custom-household-icon' }; const { value: icon } = source;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled icon value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "class Config { get apiKey() { return 'opaque-secret'; } }", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -41,6 +41,7 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 ]);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
+const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN = /^\s*(?:[-*]\s+)?["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(.*?)\s*$/gm;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
@@ -80,6 +81,13 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY,
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY,
 		process.env.FB_HOMEY_SHS_EXPECTED_HOST,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_OWNER_URI,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID,
+		process.env.FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID,
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
 		.map((value) => value?.trim())
@@ -293,6 +301,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 const assertFixtureTextSafe = (label: string, text: string, extension: string): void => {
 	assertTextSafe(label, text);
 
+	if (URL_PATTERN.test(text)) {
+		throw new Error(`${label} contains a URL`);
+	}
+
 	const containsSecret =
 		extension === '.json' ? containsStructuredSecret(JSON.parse(text) as unknown) : containsLooseSecretAssignment(text);
 
@@ -418,6 +430,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'endpoint: http://private-homey.local:4859', '.yaml')).toThrow(
+			'unsafe fixture contains a URL',
+		);
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"[~3~]unredacted-password"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -457,10 +472,12 @@ describe('Homey security artifact gate', () => {
 		const previousPrivateTerms = process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
 		const previousReplacementApiKey = process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;
 		const previousDeviceOnlyApiKey = process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
+		const previousLifecycleDeviceMarker = process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
 
 		process.env.FB_HOMEY_SHS_PRIVATE_TERMS = 'Ada';
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY = 'opaque-replacement-value';
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = 'opaque-device-value';
+		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = 'private-lifecycle-marker';
 
 		try {
 			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
@@ -470,6 +487,9 @@ describe('Homey security artifact gate', () => {
 				'unsafe fixture contains a configured private Homey value',
 			);
 			expect(() => assertTextSafe('unsafe fixture', '{"value":"opaque-device-value"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
+			expect(() => assertTextSafe('unsafe fixture', '{"value":"private-lifecycle-marker"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);
 		} finally {
@@ -489,6 +509,12 @@ describe('Homey security artifact gate', () => {
 				delete process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
 			} else {
 				process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = previousDeviceOnlyApiKey;
+			}
+
+			if (previousLifecycleDeviceMarker === undefined) {
+				delete process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
+			} else {
+				process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = previousLifecycleDeviceMarker;
 			}
 		}
 	});

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2197,9 +2197,18 @@ const containsUnsafeCompiledAlias = (
 
 		if (
 			methodName !== 'concat' &&
-			!['filter', 'flat', 'reverse', 'slice', 'sort', 'splice', 'toReversed', 'toSorted', 'with'].includes(
-				methodName ?? '',
-			)
+			![
+				'copyWithin',
+				'filter',
+				'flat',
+				'reverse',
+				'slice',
+				'sort',
+				'splice',
+				'toReversed',
+				'toSorted',
+				'with',
+			].includes(methodName ?? '')
 		) {
 			return [];
 		}
@@ -3076,6 +3085,14 @@ const containsUnsafeCompiledAlias = (
 
 					if (
 						receiverPropertyName !== undefined &&
+						ts.isArrayLiteralExpression(receiver.expression) &&
+						inspectProperty(receiver.expression, nestedResolving, receiverPropertyName, resolvingProperties)
+					) {
+						return true;
+					}
+
+					if (
+						receiverPropertyName !== undefined &&
 						ts.isCallExpression(receiver.expression) &&
 						[
 							...objectEntriesResultValues(receiver.expression, receiverPropertyName, selectedPropertyName),
@@ -3557,7 +3574,10 @@ const containsUnsafeCompiledAlias = (
 								(candidate) =>
 									ts.isSpreadElement(candidate) &&
 									(containsUnsafeCompiledLiteral(candidate.expression, safeStrings) ||
-										inspect(candidate.expression, nestedResolving)),
+										inspect(candidate.expression, nestedResolving) ||
+										compiledPropertyWriteValues(candidate.expression, '0', visibleThroughPosition).some(
+											(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
+										)),
 							)
 						);
 					}
@@ -3577,7 +3597,10 @@ const containsUnsafeCompiledAlias = (
 		if (ts.isArrayLiteralExpression(expression)) {
 			return expression.elements.some((element) =>
 				ts.isSpreadElement(element)
-					? inspect(element.expression, resolving)
+					? inspect(element.expression, resolving) ||
+						compiledPropertyWriteValues(element.expression, '0', visibleThroughPosition).some(
+							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, resolving),
+						)
 					: ts.isExpression(element) && inspect(element, resolving),
 			);
 		}
@@ -7275,6 +7298,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].slice()[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].copyWithin(0, 0)[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = ['opaque-secret']; const apiKey = source.splice(0, 1)[0];",
@@ -7286,6 +7312,20 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [...new Set(['opaque-secret'])][0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Set(); source.add('opaque-secret'); const apiKey = [...source][0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = [...source][0][1];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1549,6 +1549,15 @@ const containsUnsafeCompiledAlias = (
 			return selectedValue === undefined ? [call.arguments[1]] : [selectedValue];
 		}
 
+		if (
+			['Object.freeze', 'Object.seal', 'Object.preventExtensions'].includes(helperName) &&
+			call.arguments.length >= 1
+		) {
+			const selectedValue = resolvePropertyValue(call.arguments[0], propertyName, new Set());
+
+			return selectedValue === undefined ? [call.arguments[0]] : [selectedValue];
+		}
+
 		return [];
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
@@ -5358,6 +5367,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.create({ value: 'opaque-secret' }).value;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = (choose && { value: 'opaque-secret' }).value;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -4500,6 +4500,53 @@ const containsCompiledSecret = (text: string): boolean => {
 			});
 		});
 	};
+	const promiseSettlementValues = (
+		expression: ts.Expression,
+		resolving = new Set<ts.Node>(),
+	): readonly ts.Expression[] => {
+		if (ts.isIdentifier(expression)) {
+			const binding = resolveCompiledBinding(expression);
+
+			return binding?.initializer === undefined || resolving.has(binding.declaration)
+				? []
+				: promiseSettlementValues(binding.initializer, new Set(resolving).add(binding.declaration));
+		}
+
+		if (
+			ts.isParenthesizedExpression(expression) ||
+			ts.isAsExpression(expression) ||
+			ts.isTypeAssertionExpression(expression) ||
+			ts.isNonNullExpression(expression) ||
+			ts.isSatisfiesExpression(expression) ||
+			ts.isAwaitExpression(expression)
+		) {
+			return promiseSettlementValues(expression.expression, resolving);
+		}
+
+		if (
+			!ts.isCallExpression(expression) ||
+			(!ts.isPropertyAccessExpression(expression.expression) && !ts.isElementAccessExpression(expression.expression))
+		) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(expression.expression)
+			? expression.expression.name.text
+			: expression.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(expression.expression.argumentExpression);
+		const receiver = expression.expression.expression;
+
+		if (
+			(methodName === 'resolve' || methodName === 'reject') &&
+			ts.isIdentifier(receiver) &&
+			receiver.text === 'Promise'
+		) {
+			return expression.arguments.slice(0, 1);
+		}
+
+		return ['catch', 'finally', 'then'].includes(methodName ?? '') ? promiseSettlementValues(receiver, resolving) : [];
+	};
 	const visit = (node: ts.Node): void => {
 		if (found) {
 			return;
@@ -4618,6 +4665,17 @@ const containsCompiledSecret = (text: string): boolean => {
 							: node.arguments;
 
 			found = secretCallArguments(resolveCallParameterSets(invokedCallee), invokedArguments);
+
+			if (
+				!found &&
+				invocationReceiver !== undefined &&
+				(invocationPropertyName === 'then' || invocationPropertyName === 'catch')
+			) {
+				const settledValues = promiseSettlementValues(invocationReceiver);
+				const callbacks = invocationPropertyName === 'then' ? node.arguments.slice(0, 2) : node.arguments.slice(0, 1);
+
+				found = callbacks.some((callback) => secretCallArguments(resolveCallParameterSets(callback), settledValues));
+			}
 		} else if (ts.isNewExpression(node)) {
 			const classDeclaration = ts.isIdentifier(node.expression)
 				? resolveCompiledBinding(node.expression)?.classDeclaration
@@ -6356,6 +6414,27 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"function connect(apiKey) {} const bound = connect.bind(null, 'opaque-secret'); bound();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; Promise.resolve(stored).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const pending = Promise.resolve(stored); function connect(apiKey) {} pending.then(connect);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; Promise.reject(stored).catch(apiKey => {});",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -3,6 +3,7 @@ import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { extname, resolve } from 'node:path';
 import ts from 'typescript';
+import { parse as parseYaml } from 'yaml';
 
 import { isHomeySecretKey } from './support/homey-shs-probe';
 
@@ -29,8 +30,9 @@ const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
 const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
-const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)[_-][A-Za-z0-9_-]{16,}\b/gi;
+const HOMEY_TOKEN_PATTERN = /(?:homey|hpat|pat)[_-][A-Za-z0-9_-]{16,}/gi;
 const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
+	'homey_capability_mapping_channel',
 	'homey-config-validator',
 	'homey-device-inventory',
 	'homey-failure-log-limiter',
@@ -248,6 +250,8 @@ const containsCompiledSecret = (text: string): boolean => {
 			const name = compiledPropertyName(node.name);
 
 			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = isHomeySecretKey(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -346,8 +350,14 @@ const assertFixtureTextSafe = (label: string, text: string, extension: string): 
 		throw new Error(`${label} contains a URL`);
 	}
 
+	const structuredValue =
+		extension === '.json'
+			? (JSON.parse(text) as unknown)
+			: extension === '.yaml' || extension === '.yml'
+				? (parseYaml(text) as unknown)
+				: undefined;
 	const containsSecret =
-		extension === '.json' ? containsStructuredSecret(JSON.parse(text) as unknown) : containsLooseSecretAssignment(text);
+		structuredValue === undefined ? containsLooseSecretAssignment(text) : containsStructuredSecret(structuredValue);
 
 	if (containsSecret) {
 		throw new Error(`${label} contains a structured secret value`);
@@ -471,6 +481,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'config: { api_key: opaque-secret-value }', '.yaml')).toThrow(
+			'unsafe fixture contains a structured secret value',
+		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'endpoint: http://private-homey.local:4859', '.yaml')).toThrow(
 			'unsafe fixture contains a URL',
 		);
@@ -481,6 +494,9 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"value":"homey-abcdefghijklmnop"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"value":"prefix_homey_abcdefghijklmnop"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() =>
@@ -499,6 +515,9 @@ describe('Homey security artifact gate', () => {
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe compiled module', "config['accessToken'] = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "const api_key = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2451,6 +2451,10 @@ const containsUnsafeCompiledAlias = (
 			return inspect(expression.whenTrue, resolving) || inspect(expression.whenFalse, resolving);
 		}
 
+		if (ts.isArrowFunction(expression) || ts.isFunctionExpression(expression)) {
+			return inspectCallable(expression, resolving);
+		}
+
 		if (ts.isCallExpression(expression)) {
 			return (
 				inspectCallable(expression.expression, resolving) ||
@@ -5089,6 +5093,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = {}; Object.defineProperty(source, 'value', { get() { return 'opaque-secret'; } }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const source = {}; Object.defineProperty(source, 'apiKey', { get: () => stored }); const apiKey = source.apiKey;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -290,7 +290,15 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 	}
 
 	if (ts.isCallExpression(node)) {
-		return node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument));
+		const receiver =
+			ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)
+				? node.expression.expression
+				: undefined;
+
+		return (
+			(receiver !== undefined && containsUnsafeCompiledLiteral(receiver)) ||
+			node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument))
+		);
 	}
 
 	if (ts.isNewExpression(node)) {
@@ -361,6 +369,25 @@ const containsCompiledSecret = (text: string): boolean => {
 	return found;
 };
 
+const compiledStaticString = (node: ts.Expression): string | undefined => {
+	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+		return node.text;
+	}
+
+	if (ts.isParenthesizedExpression(node)) {
+		return compiledStaticString(node.expression);
+	}
+
+	if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+		const left = compiledStaticString(node.left);
+		const right = compiledStaticString(node.right);
+
+		return left === undefined || right === undefined ? undefined : left + right;
+	}
+
+	return undefined;
+};
+
 const containsCompiledPrivateUrl = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let found = false;
@@ -375,6 +402,10 @@ const containsCompiledPrivateUrl = (text: string): boolean => {
 			found =
 				containsStructuredUrl(node.head.text) ||
 				node.templateSpans.some((span) => containsStructuredUrl(span.literal.text));
+		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+			const staticString = compiledStaticString(node);
+
+			found = staticString !== undefined && containsStructuredUrl(staticString);
 		}
 
 		ts.forEachChild(node, visit);
@@ -578,9 +609,14 @@ const visitSchema = (schemaName: string, value: unknown, path: readonly string[]
 	}
 };
 
-const visitPublishedValues = (label: string, value: unknown, path: readonly string[] = []): void => {
+const visitPublishedValues = (
+	label: string,
+	value: unknown,
+	path: readonly string[] = [],
+	secretParameter = false,
+): void => {
 	if (Array.isArray(value)) {
-		value.forEach((entry, index) => visitPublishedValues(label, entry, [...path, index.toString()]));
+		value.forEach((entry, index) => visitPublishedValues(label, entry, [...path, index.toString()], secretParameter));
 
 		return;
 	}
@@ -589,11 +625,14 @@ const visitPublishedValues = (label: string, value: unknown, path: readonly stri
 		return;
 	}
 
-	for (const [key, child] of Object.entries(value as JsonRecord)) {
+	const record = value as JsonRecord;
+	const nestedSecretParameter = secretParameter || (typeof record.name === 'string' && isHomeySecretKey(record.name));
+
+	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
 
 		if (['default', 'enum', 'example', 'examples'].includes(key)) {
-			if (containsStructuredSecret(child)) {
+			if (containsStructuredSecret(child) || (nestedSecretParameter && containsUnsafeSecretLeaf(child))) {
 				throw new Error(`${label}.${childPath.join('.')} publishes a secret value`);
 			}
 
@@ -602,7 +641,7 @@ const visitPublishedValues = (label: string, value: unknown, path: readonly stri
 			}
 		}
 
-		visitPublishedValues(label, child, childPath);
+		visitPublishedValues(label, child, childPath, nestedSecretParameter);
 	}
 };
 
@@ -695,6 +734,11 @@ describe('Homey security artifact gate', () => {
 				example: 'http://private-homey.local:4859',
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes a URL');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeyOperation', {
+				parameters: [{ name: 'apiKey', schema: { example: 'opaque-secret' } }],
+			}),
+		).toThrow('UnsafeHomeyOperation.parameters.0.schema.example publishes a secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -779,11 +823,17 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = String('opaque-secret');", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
+		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = 'opaque-secret'.trim();", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const endpoint = 'http://private-homey.local:4859';", true),
 		).toThrow('unsafe compiled module contains a private URL');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', 'const endpoint = `http://private-homey.local:${port}`;', true),
+		).toThrow('unsafe compiled module contains a private URL');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const endpoint = 'http://' + 'private-homey.local:4859';", true),
 		).toThrow('unsafe compiled module contains a private URL');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -26,6 +26,7 @@ const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
 const SECRET_PROPERTY_PATTERN =
 	/^(?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)$/i;
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
+const COMPILED_IDENTIFIER_PATTERN = /(?<!["'])\bhomey_[a-z0-9_]{16,}\b(?!["'])|\bHOMEY_[A-Z0-9_]{16,}\b/g;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
@@ -33,7 +34,7 @@ const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	},
 	{ label: 'a MAC address', pattern: /\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b/i },
 	{ label: 'an email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
-	{ label: 'a Homey personal access token', pattern: /\b(?:hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
+	{ label: 'a Homey personal access token', pattern: /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
 	{
 		label: 'a serialized secret value',
 		pattern:
@@ -160,13 +161,18 @@ describe('Homey security artifact gate', () => {
 			BUILD_ROOT,
 			(path) => path.endsWith('.d.ts') || BUILD_EXTENSIONS.has(extname(path)),
 		);
+		const compiledModuleFiles = buildFiles.filter((path) => path.endsWith('.d.ts') || path.endsWith('.js'));
 
 		if (process.env.HOMEY_SECURITY_REQUIRE_BUILD === '1') {
-			expect(buildFiles.length).toBeGreaterThan(0);
+			expect(compiledModuleFiles.length).toBeGreaterThan(0);
 		}
 
 		for (const path of buildFiles) {
-			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), readFileSync(path, 'utf8'));
+			const text = readFileSync(path, 'utf8');
+			const artifactText =
+				path.endsWith('.js') || path.endsWith('.d.ts') ? text.replace(COMPILED_IDENTIFIER_PATTERN, '') : text;
+
+			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), artifactText);
 		}
 	});
 
@@ -183,6 +189,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('UnsafeHomeySchema.properties.api_key publishes example');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"value":"homey_abcdefghijklmnop"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -482,7 +482,26 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		binding: ts.BindingElement,
 		index: number,
 		source: ts.Expression,
+		resolvingSources = new Set<string>(),
 	): ts.Expression | undefined => {
+		if (ts.isIdentifier(source)) {
+			const initializer = resolveCompiledAlias(source);
+
+			return initializer === undefined || resolvingSources.has(source.text)
+				? undefined
+				: selectBindingValue(pattern, binding, index, initializer, new Set(resolvingSources).add(source.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(source) ||
+			ts.isAsExpression(source) ||
+			ts.isTypeAssertionExpression(source) ||
+			ts.isNonNullExpression(source) ||
+			ts.isSatisfiesExpression(source)
+		) {
+			return selectBindingValue(pattern, binding, index, source.expression, resolvingSources);
+		}
+
 		if (ts.isObjectBindingPattern(pattern) && ts.isObjectLiteralExpression(source)) {
 			const propertyName =
 				binding.propertyName === undefined
@@ -569,8 +588,8 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		ts.forEachChild(node, visit);
 	};
 
-	visit(sourceFile);
 	COMPILED_BINDING_CACHE.set(sourceFile, bindings);
+	visit(sourceFile);
 
 	return bindings;
 };
@@ -2548,6 +2567,20 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const [fallback] = ['opaque-secret']; const apiKey = fallback;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { fallback: 'opaque-secret' }; const { fallback } = source; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = ['opaque-secret']; const [fallback] = source; const apiKey = fallback;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -539,6 +539,24 @@ const compiledBindingScope = (node: ts.Node): ts.Node => {
 	return node.getSourceFile();
 };
 
+const compiledVariableBindingScope = (declaration: ts.VariableDeclaration): ts.Node => {
+	if (ts.isVariableDeclarationList(declaration.parent) && (declaration.parent.flags & ts.NodeFlags.BlockScoped) !== 0) {
+		return compiledBindingScope(declaration);
+	}
+
+	let current: ts.Node | undefined = declaration.parent;
+
+	while (current !== undefined) {
+		if (ts.isSourceFile(current) || ts.isFunctionLike(current)) {
+			return current;
+		}
+
+		current = current.parent;
+	}
+
+	return declaration.getSourceFile();
+};
+
 const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readonly CompiledBinding[]> => {
 	const cached = COMPILED_BINDING_CACHE.get(sourceFile);
 
@@ -854,14 +872,14 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			addBinding(node.name.text, {
 				declaration: node,
 				initializer: node.initializer,
-				scope: compiledBindingScope(node),
+				scope: compiledVariableBindingScope(node),
 			});
 		} else if (
 			ts.isVariableDeclaration(node) &&
 			(ts.isObjectBindingPattern(node.name) || ts.isArrayBindingPattern(node.name)) &&
 			node.initializer !== undefined
 		) {
-			addPatternBindings(node.name, node.initializer, compiledBindingScope(node));
+			addPatternBindings(node.name, node.initializer, compiledVariableBindingScope(node));
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			addBinding(node.name.text, {
 				declaration: node,
@@ -958,60 +976,87 @@ const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | un
 const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined =>
 	resolveCompiledBinding(identifier)?.initializer;
 
-const resolveCompiledReceiverBinding = (
-	identifier: ts.Identifier,
-	resolvingBindings = new Set<ts.Node>(),
-): CompiledBinding | undefined => {
-	const binding = resolveCompiledBinding(identifier);
+interface CompiledReceiverPath {
+	readonly binding: CompiledBinding;
+	readonly properties: readonly string[];
+}
 
-	if (binding === undefined || resolvingBindings.has(binding.declaration)) {
-		return binding;
+const resolveCompiledReceiverPath = (
+	expression: ts.Expression,
+	resolvingBindings = new Set<ts.Node>(),
+): CompiledReceiverPath | undefined => {
+	if (
+		ts.isParenthesizedExpression(expression) ||
+		ts.isAsExpression(expression) ||
+		ts.isTypeAssertionExpression(expression) ||
+		ts.isNonNullExpression(expression) ||
+		ts.isSatisfiesExpression(expression)
+	) {
+		return resolveCompiledReceiverPath(expression.expression, resolvingBindings);
 	}
 
-	let initializer = binding.initializer;
+	if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+		const propertyName = ts.isPropertyAccessExpression(expression)
+			? expression.name.text
+			: expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(expression.argumentExpression);
+		const receiverPath = resolveCompiledReceiverPath(expression.expression, resolvingBindings);
 
-	while (
-		initializer !== undefined &&
-		(ts.isParenthesizedExpression(initializer) ||
+		return propertyName === undefined || receiverPath === undefined
+			? undefined
+			: { binding: receiverPath.binding, properties: [...receiverPath.properties, propertyName] };
+	}
+
+	if (!ts.isIdentifier(expression)) {
+		return undefined;
+	}
+
+	const binding = resolveCompiledBinding(expression);
+
+	if (binding === undefined || resolvingBindings.has(binding.declaration)) {
+		return binding === undefined ? undefined : { binding, properties: [] };
+	}
+
+	const initializer = binding.initializer;
+
+	return initializer !== undefined &&
+		(ts.isIdentifier(initializer) ||
+			ts.isPropertyAccessExpression(initializer) ||
+			ts.isElementAccessExpression(initializer) ||
+			ts.isParenthesizedExpression(initializer) ||
 			ts.isAsExpression(initializer) ||
 			ts.isTypeAssertionExpression(initializer) ||
 			ts.isNonNullExpression(initializer) ||
 			ts.isSatisfiesExpression(initializer))
-	) {
-		initializer = initializer.expression;
-	}
-
-	return initializer !== undefined && ts.isIdentifier(initializer)
-		? resolveCompiledReceiverBinding(initializer, new Set(resolvingBindings).add(binding.declaration))
-		: binding;
+		? resolveCompiledReceiverPath(initializer, new Set(resolvingBindings).add(binding.declaration))
+		: { binding, properties: [] };
 };
 
-const compiledPropertyWriteValues = (identifier: ts.Identifier, propertyName: string): readonly ts.Expression[] => {
-	const sourceFile = identifier.getSourceFile();
-	const targetBinding = resolveCompiledReceiverBinding(identifier);
-	const usePosition = identifier.getStart(sourceFile);
+const compiledPropertyWriteValues = (receiver: ts.Expression, propertyName: string): readonly ts.Expression[] => {
+	const sourceFile = receiver.getSourceFile();
+	const targetPath = resolveCompiledReceiverPath(receiver);
+	const usePosition = receiver.getStart(sourceFile);
 	const values: ts.Expression[] = [];
 
-	if (targetBinding === undefined) {
+	if (targetPath === undefined) {
 		return values;
 	}
+
+	const expectedProperties = [...targetPath.properties, propertyName];
 
 	const visit = (node: ts.Node): void => {
 		if (
 			ts.isBinaryExpression(node) &&
 			node.getStart(sourceFile) < usePosition &&
-			isAssignmentOperatorKind(node.operatorToken.kind) &&
-			compiledAssignedPropertyName(node.left) === propertyName
+			isAssignmentOperatorKind(node.operatorToken.kind)
 		) {
-			const receiver =
-				ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left)
-					? node.left.expression
-					: undefined;
+			const writePath = resolveCompiledReceiverPath(node.left);
 
 			if (
-				receiver !== undefined &&
-				ts.isIdentifier(receiver) &&
-				resolveCompiledReceiverBinding(receiver)?.declaration === targetBinding.declaration
+				writePath?.binding.declaration === targetPath.binding.declaration &&
+				writePath.properties.length === expectedProperties.length &&
+				writePath.properties.every((property, index) => property === expectedProperties[index])
 			) {
 				values.push(node.right);
 			}
@@ -1076,6 +1121,69 @@ const containsUnsafeCompiledAlias = (
 
 		return elements;
 	};
+	const resolvePropertyValue = (
+		receiver: ts.Expression,
+		propertyName: string,
+		resolving: Set<string>,
+	): ts.Expression | undefined => {
+		if (ts.isIdentifier(receiver)) {
+			const initializer = resolveCompiledAlias(receiver);
+
+			return initializer === undefined || resolving.has(receiver.text)
+				? undefined
+				: resolvePropertyValue(initializer, propertyName, new Set(resolving).add(receiver.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(receiver) ||
+			ts.isAsExpression(receiver) ||
+			ts.isTypeAssertionExpression(receiver) ||
+			ts.isNonNullExpression(receiver) ||
+			ts.isSatisfiesExpression(receiver)
+		) {
+			return resolvePropertyValue(receiver.expression, propertyName, resolving);
+		}
+
+		if (ts.isPropertyAccessExpression(receiver) || ts.isElementAccessExpression(receiver)) {
+			const receiverPropertyName = ts.isPropertyAccessExpression(receiver)
+				? receiver.name.text
+				: receiver.argumentExpression === undefined
+					? undefined
+					: compiledStaticPropertyExpressionName(receiver.argumentExpression);
+			const resolvedReceiver =
+				receiverPropertyName === undefined
+					? undefined
+					: resolvePropertyValue(receiver.expression, receiverPropertyName, resolving);
+
+			return resolvedReceiver === undefined
+				? undefined
+				: resolvePropertyValue(resolvedReceiver, propertyName, resolving);
+		}
+
+		if (!ts.isObjectLiteralExpression(receiver)) {
+			return undefined;
+		}
+
+		for (const property of [...receiver.properties].reverse()) {
+			if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+				return property.initializer;
+			}
+
+			if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+				return property.name;
+			}
+
+			if (ts.isSpreadAssignment(property)) {
+				const spreadValue = resolvePropertyValue(property.expression, propertyName, resolving);
+
+				if (spreadValue !== undefined) {
+					return spreadValue;
+				}
+			}
+		}
+
+		return undefined;
+	};
 	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression);
@@ -1111,50 +1219,95 @@ const containsUnsafeCompiledAlias = (
 					return false;
 				}
 
+				if (
+					compiledPropertyWriteValues(receiver, selectedPropertyName).some(
+						(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
+					)
+				) {
+					return true;
+				}
+
+				const inspectClassProperty = (
+					classDeclaration: ts.ClassDeclaration,
+					expectStatic: boolean,
+					memberName: string,
+					classResolvingProperties = new Set<string>(),
+				): boolean => {
+					const propertyReference = `${classDeclaration.pos}:${expectStatic ? 'static' : 'instance'}:${memberName}`;
+
+					if (classResolvingProperties.has(propertyReference)) {
+						return false;
+					}
+
+					const nestedClassProperties = new Set(classResolvingProperties).add(propertyReference);
+
+					return classDeclaration.members.some((member) => {
+						if (!('name' in member)) {
+							return false;
+						}
+
+						const staticMember = Boolean(
+							ts.canHaveModifiers(member) &&
+							ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+						);
+
+						if (staticMember !== expectStatic || compiledPropertyName(member.name) !== memberName) {
+							return false;
+						}
+
+						if (ts.isPropertyDeclaration(member)) {
+							return (
+								(member.initializer !== undefined &&
+									(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
+										inspect(member.initializer, nestedResolving))) ||
+								(member.type !== undefined && containsUnsafeCompiledType(member.type, safeStrings))
+							);
+						}
+
+						if ((ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) && member.body !== undefined) {
+							let found = false;
+							const visitReturn = (child: ts.Node): void => {
+								if (found) {
+									return;
+								}
+
+								if (ts.isReturnStatement(child) && child.expression !== undefined) {
+									const receiverPropertyName = compiledThisPropertyName(child.expression);
+
+									found =
+										(receiverPropertyName !== undefined &&
+											inspectClassProperty(
+												classDeclaration,
+												expectStatic,
+												receiverPropertyName,
+												nestedClassProperties,
+											)) ||
+										containsUnsafeCompiledLiteral(child.expression, safeStrings) ||
+										inspect(child.expression, nestedResolving);
+								}
+
+								if (!found) {
+									ts.forEachChild(child, visitReturn);
+								}
+							};
+
+							visitReturn(member.body);
+
+							return found;
+						}
+
+						return false;
+					});
+				};
+
 				if (ts.isIdentifier(receiver)) {
 					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
 					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
 
 					if (
-						compiledPropertyWriteValues(receiver, selectedPropertyName).some(
-							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedReceiverResolving),
-						)
-					) {
-						return true;
-					}
-
-					if (
 						classDeclaration !== undefined &&
 						!nestedResolving.has(receiver.text) &&
-						classDeclaration.members.some((member) => {
-							if (!('name' in member)) {
-								return false;
-							}
-
-							const staticMember =
-								ts.canHaveModifiers(member) &&
-								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
-							const memberName = compiledPropertyName(member.name);
-
-							if (!staticMember || memberName !== selectedPropertyName) {
-								return false;
-							}
-
-							if (ts.isPropertyDeclaration(member)) {
-								return (
-									(member.initializer !== undefined &&
-										(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
-											inspect(member.initializer, nestedReceiverResolving))) ||
-									(member.type !== undefined && containsUnsafeCompiledType(member.type, safeStrings))
-								);
-							}
-
-							return (
-								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
-								member.body !== undefined &&
-								inspectCallableBody(member.body, nestedReceiverResolving)
-							);
-						})
+						inspectClassProperty(classDeclaration, true, selectedPropertyName)
 					) {
 						return true;
 					}
@@ -1176,6 +1329,23 @@ const containsUnsafeCompiledAlias = (
 					ts.isSatisfiesExpression(receiver)
 				) {
 					return inspectProperty(receiver.expression, nestedResolving, selectedPropertyName, resolvingProperties);
+				}
+
+				if (ts.isPropertyAccessExpression(receiver) || ts.isElementAccessExpression(receiver)) {
+					const receiverPropertyName = ts.isPropertyAccessExpression(receiver)
+						? receiver.name.text
+						: receiver.argumentExpression === undefined
+							? undefined
+							: compiledStaticPropertyExpressionName(receiver.argumentExpression);
+					const resolvedReceiver =
+						receiverPropertyName === undefined
+							? undefined
+							: resolvePropertyValue(receiver.expression, receiverPropertyName, nestedResolving);
+
+					return (
+						resolvedReceiver !== undefined &&
+						inspectProperty(resolvedReceiver, nestedResolving, selectedPropertyName, resolvingProperties)
+					);
 				}
 
 				if (ts.isCallExpression(receiver)) {
@@ -1227,6 +1397,20 @@ const containsUnsafeCompiledAlias = (
 							return inspectReturnedProperty(callee.expression, resolvingCalls);
 						}
 
+						if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
+							const calleePropertyName = ts.isPropertyAccessExpression(callee)
+								? callee.name.text
+								: callee.argumentExpression === undefined
+									? undefined
+									: compiledStaticPropertyExpressionName(callee.argumentExpression);
+							const callable =
+								calleePropertyName === undefined
+									? undefined
+									: resolvePropertyValue(callee.expression, calleePropertyName, resolvingCalls);
+
+							return callable !== undefined && inspectReturnedProperty(callable, resolvingCalls);
+						}
+
 						if (ts.isArrowFunction(callee)) {
 							return ts.isBlock(callee.body)
 								? inspectReturnBody(callee.body, resolvingCalls)
@@ -1246,36 +1430,7 @@ const containsUnsafeCompiledAlias = (
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
 					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
 
-					return (
-						classDeclaration?.members.some((member) => {
-							if (!('name' in member)) {
-								return false;
-							}
-
-							const staticMember =
-								ts.canHaveModifiers(member) &&
-								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
-
-							if (staticMember || compiledPropertyName(member.name) !== selectedPropertyName) {
-								return false;
-							}
-
-							if (ts.isPropertyDeclaration(member)) {
-								return (
-									(member.initializer !== undefined &&
-										(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
-											inspect(member.initializer, nestedResolving))) ||
-									(member.type !== undefined && containsUnsafeCompiledType(member.type, safeStrings))
-								);
-							}
-
-							return (
-								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
-								member.body !== undefined &&
-								inspectCallableBody(member.body, nestedResolving)
-							);
-						}) ?? false
-					);
+					return classDeclaration !== undefined && inspectClassProperty(classDeclaration, false, selectedPropertyName);
 				}
 
 				if (ts.isObjectLiteralExpression(receiver)) {
@@ -1467,17 +1622,15 @@ const containsUnsafeCompiledAlias = (
 					return false;
 				}
 
+				if (
+					compiledPropertyWriteValues(receiver, propertyName).some((value) => inspectCallable(value, nestedResolving))
+				) {
+					return true;
+				}
+
 				if (ts.isIdentifier(receiver)) {
 					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
 					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
-
-					if (
-						compiledPropertyWriteValues(receiver, propertyName).some((value) =>
-							inspectCallable(value, nestedReceiverResolving),
-						)
-					) {
-						return true;
-					}
 
 					if (
 						classDeclaration !== undefined &&
@@ -3147,6 +3300,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"if (ready) { var fallback = 'opaque-secret'; } const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const fallback = () => 'opaque-secret'; const apiKey = fallback();",
 				true,
 			),
@@ -3537,6 +3697,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { inner: { value: '' } }; source.inner.value = 'opaque-secret'; const apiKey = source.inner.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { get value() { return 'opaque-secret'; } }; const apiKey = source.value;",
 				true,
 			),
@@ -3558,7 +3725,21 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { stored = 'opaque-secret'; get value() { return this.stored; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const fallback = () => ({ value: 'opaque-secret' }); const apiKey = fallback().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const factory = { make: () => ({ value: 'opaque-secret' }) }; const apiKey = factory.make().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -353,8 +353,15 @@ const containsCompiledSecret = (text: string): boolean => {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
-		} else if (ts.isBindingElement(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -378,6 +385,22 @@ const compiledStaticString = (node: ts.Expression): string | undefined => {
 		return compiledStaticString(node.expression);
 	}
 
+	if (ts.isTemplateExpression(node)) {
+		let value = node.head.text;
+
+		for (const span of node.templateSpans) {
+			const expression = compiledStaticString(span.expression);
+
+			if (expression === undefined) {
+				return undefined;
+			}
+
+			value += expression + span.literal.text;
+		}
+
+		return value;
+	}
+
 	if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
 		const left = compiledStaticString(node.left);
 		const right = compiledStaticString(node.right);
@@ -399,7 +422,10 @@ const containsCompiledPrivateUrl = (text: string): boolean => {
 		if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 			found = containsStructuredUrl(node.text);
 		} else if (ts.isTemplateExpression(node)) {
+			const staticString = compiledStaticString(node);
+
 			found =
+				(staticString !== undefined && containsStructuredUrl(staticString)) ||
 				containsStructuredUrl(node.head.text) ||
 				node.templateSpans.some((span) => containsStructuredUrl(span.literal.text));
 		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
@@ -818,6 +844,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "function connect(apiKey = 'opaque-secret') {}", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { apiKey: key = 'opaque-secret' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = process.env.API_KEY ?? 'opaque-secret';", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = String('opaque-secret');", true)).toThrow(
@@ -834,6 +863,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a private URL');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const endpoint = 'http://' + 'private-homey.local:4859';", true),
+		).toThrow('unsafe compiled module contains a private URL');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const endpoint = `http://${'private-homey.local'}:4859`;", true),
 		).toThrow('unsafe compiled module contains a private URL');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -612,6 +612,19 @@ const containsUnsafeCompiledAlias = (
 					});
 				}
 
+				if (ts.isArrayLiteralExpression(receiver) && /^\d+$/.test(propertyName)) {
+					const element = receiver.elements[Number(propertyName)];
+
+					if (element === undefined) {
+						return false;
+					}
+
+					return ts.isSpreadElement(element)
+						? inspect(element.expression, nestedResolving)
+						: ts.isExpression(element) &&
+								(containsUnsafeCompiledLiteral(element, safeStrings) || inspect(element, nestedResolving));
+				}
+
 				return false;
 			};
 
@@ -655,7 +668,7 @@ const containsUnsafeCompiledAlias = (
 
 		if (ts.isCallExpression(expression)) {
 			return (
-				(expression.arguments.length === 0 && inspect(expression.expression, resolving)) ||
+				inspectCallable(expression.expression, resolving) ||
 				expression.arguments.some((argument) => inspect(argument, resolving))
 			);
 		}
@@ -674,6 +687,54 @@ const containsUnsafeCompiledAlias = (
 
 		if (ts.isPrefixUnaryExpression(expression)) {
 			return inspect(expression.operand, resolving);
+		}
+
+		return false;
+	};
+	const inspectCallable = (callee: ts.Expression, resolving: Set<string>): boolean => {
+		if (ts.isIdentifier(callee)) {
+			const initializer = resolveCompiledAlias(callee);
+
+			if (initializer === undefined || resolving.has(callee.text)) {
+				return false;
+			}
+
+			return inspectCallable(initializer, new Set(resolving).add(callee.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(callee) ||
+			ts.isAsExpression(callee) ||
+			ts.isTypeAssertionExpression(callee) ||
+			ts.isNonNullExpression(callee) ||
+			ts.isSatisfiesExpression(callee)
+		) {
+			return inspectCallable(callee.expression, resolving);
+		}
+
+		if (ts.isArrowFunction(callee) && !ts.isBlock(callee.body)) {
+			return containsUnsafeCompiledLiteral(callee.body, safeStrings) || inspect(callee.body, resolving);
+		}
+
+		if (ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)) {
+			let found = false;
+			const visitReturn = (child: ts.Node): void => {
+				if (found) {
+					return;
+				}
+
+				if (ts.isReturnStatement(child) && child.expression !== undefined) {
+					found = containsUnsafeCompiledLiteral(child.expression, safeStrings) || inspect(child.expression, resolving);
+				}
+
+				if (!found) {
+					ts.forEachChild(child, visitReturn);
+				}
+			};
+
+			visitReturn(callee.body);
+
+			return found;
 		}
 
 		return false;
@@ -2231,6 +2292,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const fallback = value => 'opaque-secret'; const apiKey = fallback('');",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"function first() { const fallback = 'opaque-secret'; const apiKey = fallback; } function second() { const fallback = ''; return fallback; }",
 				true,
 			),
@@ -2416,6 +2484,9 @@ describe('Homey security artifact gate', () => {
 				"const source = { value: 'opaque-secret' }; const apiKey = source['value'];",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const source = ['opaque-secret']; const apiKey = source[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "function apiKey() { return 'opaque-secret'; }", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -100,7 +100,7 @@ const configuredExpectedHost = (): string | undefined => {
 	const value = process.env.FB_HOMEY_SHS_EXPECTED_HOST?.trim();
 	const normalizedValue = value?.toLowerCase().replace(/\.$/, '');
 
-	return normalizedValue === undefined || PUBLIC_HOMEY_HOSTS.has(normalizedValue) ? undefined : value;
+	return normalizedValue === undefined || PUBLIC_HOMEY_HOSTS.has(normalizedValue) ? undefined : normalizedValue;
 };
 
 const configuredPrivateValues = (): readonly string[] =>
@@ -227,8 +227,12 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 		return node.text.length > 0 && node.text !== '[~3~]';
 	}
 
-	if (ts.isNumericLiteral(node) || ts.isBigIntLiteral(node)) {
-		return true;
+	if (ts.isNumericLiteral(node)) {
+		return node.text !== '0';
+	}
+
+	if (ts.isBigIntLiteral(node)) {
+		return node.text !== '0n';
 	}
 
 	if (
@@ -247,6 +251,24 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 		return node.properties.some(
 			(property) => ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer),
 		);
+	}
+
+	if (ts.isBinaryExpression(node)) {
+		return containsUnsafeCompiledLiteral(node.left) || containsUnsafeCompiledLiteral(node.right);
+	}
+
+	if (
+		ts.isParenthesizedExpression(node) ||
+		ts.isAsExpression(node) ||
+		ts.isTypeAssertionExpression(node) ||
+		ts.isNonNullExpression(node) ||
+		ts.isSatisfiesExpression(node)
+	) {
+		return containsUnsafeCompiledLiteral(node.expression);
+	}
+
+	if (ts.isConditionalExpression(node)) {
+		return containsUnsafeCompiledLiteral(node.whenTrue) || containsUnsafeCompiledLiteral(node.whenFalse);
 	}
 
 	return false;
@@ -295,7 +317,7 @@ const containsCompiledSecret = (text: string): boolean => {
 };
 
 const containsUnsafeSecretLeaf = (value: unknown): boolean => {
-	if (value === null || value === '' || value === '[~3~]' || typeof value === 'boolean') {
+	if (value === null || value === 0 || value === '' || value === '[~3~]' || typeof value === 'boolean') {
 		return false;
 	}
 
@@ -333,7 +355,7 @@ const containsLooseSecretAssignment = (text: string): boolean =>
 			return false;
 		}
 
-		return !['', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(rawValue);
+		return !['', '0', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(rawValue);
 	});
 
 const containsStructuredUrl = (value: unknown): boolean => {
@@ -564,6 +586,7 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"pinCode":1234}', '.json')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
+		expect(() => assertFixtureTextSafe('safe fixture', '{"pinCode":0}', '.json')).not.toThrow();
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
@@ -621,6 +644,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "function connect(apiKey = 'opaque-secret') {}", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = process.env.API_KEY ?? 'opaque-secret';", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);
@@ -665,6 +691,10 @@ describe('Homey security artifact gate', () => {
 
 		try {
 			expect(() => assertTextSafe('safe fixture', '{"url":"http://homey.local:4859"}')).not.toThrow();
+			process.env.FB_HOMEY_SHS_EXPECTED_HOST = 'private-homey.local.';
+			expect(() => assertTextSafe('unsafe fixture', '{"host":"private-homey.local"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
 			expect(() => assertTextSafe('unsafe fixture', '{"name":"Ada"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1075,6 +1075,64 @@ const compiledPropertyWriteValues = (
 	}
 
 	const expectedProperties = [...targetPath.properties, propertyName];
+	const sameReceiverPath = (
+		candidate: ReturnType<typeof resolveCompiledReceiverPath>,
+		expected: ReturnType<typeof resolveCompiledReceiverPath>,
+	): boolean =>
+		candidate !== undefined &&
+		expected !== undefined &&
+		candidate.binding.declaration === expected.binding.declaration &&
+		candidate.properties.length === expected.properties.length &&
+		candidate.properties.every((property, index) => property === expected.properties[index]);
+	const mutationPropertyValues = (
+		source: ts.Expression,
+		selectedPropertyName: string,
+		resolving = new Set<ts.Node>(),
+	): readonly ts.Expression[] => {
+		if (ts.isIdentifier(source)) {
+			const binding = resolveCompiledBinding(source);
+
+			if (binding?.initializer === undefined || resolving.has(binding.declaration)) {
+				return [];
+			}
+
+			return mutationPropertyValues(
+				binding.initializer,
+				selectedPropertyName,
+				new Set(resolving).add(binding.declaration),
+			);
+		}
+
+		if (
+			ts.isParenthesizedExpression(source) ||
+			ts.isAsExpression(source) ||
+			ts.isTypeAssertionExpression(source) ||
+			ts.isNonNullExpression(source) ||
+			ts.isSatisfiesExpression(source)
+		) {
+			return mutationPropertyValues(source.expression, selectedPropertyName, resolving);
+		}
+
+		if (!ts.isObjectLiteralExpression(source)) {
+			return [];
+		}
+
+		return source.properties.flatMap((property): readonly ts.Expression[] => {
+			if (ts.isPropertyAssignment(property)) {
+				const candidateName = compiledPropertyName(property.name);
+
+				return candidateName === selectedPropertyName || candidateName === undefined ? [property.initializer] : [];
+			}
+
+			if (ts.isShorthandPropertyAssignment(property)) {
+				return property.name.text === selectedPropertyName ? [property.name] : [];
+			}
+
+			return ts.isSpreadAssignment(property)
+				? mutationPropertyValues(property.expression, selectedPropertyName, resolving)
+				: [];
+		});
+	};
 
 	const visit = (node: ts.Node): void => {
 		if (
@@ -1089,10 +1147,7 @@ const compiledPropertyWriteValues = (
 				compiledStaticPropertyExpressionName(node.left.argumentExpression) === undefined
 					? resolveCompiledReceiverPath(node.left.expression)
 					: undefined;
-			const sameDynamicReceiver =
-				dynamicWriteReceiverPath?.binding.declaration === targetPath.binding.declaration &&
-				dynamicWriteReceiverPath.properties.length === targetPath.properties.length &&
-				dynamicWriteReceiverPath.properties.every((property, index) => property === targetPath.properties[index]);
+			const sameDynamicReceiver = sameReceiverPath(dynamicWriteReceiverPath, targetPath);
 
 			if (
 				sameDynamicReceiver ||
@@ -1101,6 +1156,35 @@ const compiledPropertyWriteValues = (
 					writePath.properties.every((property, index) => property === expectedProperties[index]))
 			) {
 				values.push(node.right);
+			}
+		} else if (
+			ts.isCallExpression(node) &&
+			node.getStart(sourceFile) < usePosition &&
+			ts.isPropertyAccessExpression(node.expression) &&
+			ts.isIdentifier(node.expression.expression) &&
+			node.arguments.length > 0
+		) {
+			const helperName = `${node.expression.expression.text}.${node.expression.name.text}`;
+			const mutationTarget = resolveCompiledReceiverPath(node.arguments[0]);
+
+			if (sameReceiverPath(mutationTarget, targetPath)) {
+				if (helperName === 'Object.assign') {
+					for (const source of node.arguments.slice(1)) {
+						values.push(...mutationPropertyValues(source, propertyName));
+					}
+				} else if (helperName === 'Object.defineProperty' && node.arguments.length >= 3) {
+					const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
+
+					if (selectedName === propertyName || selectedName === undefined) {
+						values.push(...mutationPropertyValues(node.arguments[2], 'value'));
+					}
+				} else if (helperName === 'Reflect.set' && node.arguments.length >= 3) {
+					const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
+
+					if (selectedName === propertyName || selectedName === undefined) {
+						values.push(node.arguments[2]);
+					}
+				}
 			}
 		}
 
@@ -1765,6 +1849,21 @@ const containsUnsafeCompiledAlias = (
 					return (
 						inspectProperty(receiver.whenTrue, nestedResolving, selectedPropertyName, resolvingProperties) ||
 						inspectProperty(receiver.whenFalse, nestedResolving, selectedPropertyName, resolvingProperties)
+					);
+				}
+
+				if (
+					ts.isBinaryExpression(receiver) &&
+					[
+						ts.SyntaxKind.AmpersandAmpersandToken,
+						ts.SyntaxKind.BarBarToken,
+						ts.SyntaxKind.QuestionQuestionToken,
+						ts.SyntaxKind.CommaToken,
+					].includes(receiver.operatorToken.kind)
+				) {
+					return (
+						inspectProperty(receiver.left, nestedResolving, selectedPropertyName, resolvingProperties) ||
+						inspectProperty(receiver.right, nestedResolving, selectedPropertyName, resolvingProperties)
 					);
 				}
 
@@ -2602,6 +2701,21 @@ const containsUnsafeCompiledAlias = (
 					return (
 						inspectCallableProperty(receiver.whenTrue, nestedResolving) ||
 						inspectCallableProperty(receiver.whenFalse, nestedResolving)
+					);
+				}
+
+				if (
+					ts.isBinaryExpression(receiver) &&
+					[
+						ts.SyntaxKind.AmpersandAmpersandToken,
+						ts.SyntaxKind.BarBarToken,
+						ts.SyntaxKind.QuestionQuestionToken,
+						ts.SyntaxKind.CommaToken,
+					].includes(receiver.operatorToken.kind)
+				) {
+					return (
+						inspectCallableProperty(receiver.left, nestedResolving) ||
+						inspectCallableProperty(receiver.right, nestedResolving)
 					);
 				}
 
@@ -4667,6 +4781,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { value: '' }; Object.assign(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; const read = () => source.value; source.value = 'opaque-secret'; const apiKey = read();",
 				true,
 			),
@@ -4887,6 +5008,12 @@ describe('Homey security artifact gate', () => {
 				"const apiKey = (choose ? safe : { value: 'opaque-secret' }).value;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = (choose && { value: 'opaque-secret' }).value;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = (safe, { value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -329,6 +329,7 @@ const containsUnsafeCompiledLiteral = (
 				: undefined;
 
 		return (
+			containsUnsafeCompiledLiteral(node.expression, safeStrings) ||
 			(receiver !== undefined && containsUnsafeCompiledLiteral(receiver, safeStrings)) ||
 			node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument, safeStrings))
 		);
@@ -773,7 +774,8 @@ const containsStructuredIdentifier = (
 			!isCapabilityIdentifierPath(key, path, nestedSyntheticProtocolRoot) &&
 			!isSafeIdentifierValue(child);
 		const referenceArrayValue =
-			isHomeyReferenceArrayKey(key) && Array.isArray(child) && child.some((entry) => !isSafeIdentifierValue(entry));
+			isHomeyReferenceArrayKey(key) &&
+			(Array.isArray(child) ? child.some((entry) => !isSafeIdentifierValue(entry)) : !isSafeIdentifierValue(child));
 
 		return (
 			identifierValue ||
@@ -1175,6 +1177,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"driverId":"opaque-driver"}', '.json')).toThrow(
 			'unsafe fixture contains a structured identifier value',
 		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"deviceIds":"opaque-household-id"}', '.json')).toThrow(
+			'unsafe fixture contains a structured identifier value',
+		);
 		expect(() =>
 			assertFixtureTextSafe(
 				'safe fixture',
@@ -1247,6 +1252,9 @@ describe('Homey security artifact gate', () => {
 			'unsafe declaration contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = () => 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = (() => 'opaque-secret')();", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() =>

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -757,6 +757,14 @@ const containsUnsafeCompiledAlias = (
 							return inspect(property.name, nestedResolving);
 						}
 
+						if (
+							ts.isGetAccessorDeclaration(property) &&
+							compiledPropertyName(property.name) === propertyName &&
+							property.body !== undefined
+						) {
+							return inspectCallableBody(property.body, nestedResolving);
+						}
+
 						return ts.isSpreadAssignment(property) && inspectProperty(property.expression, nestedResolving);
 					});
 				}
@@ -2760,6 +2768,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: 'opaque-secret' }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { get value() { return 'opaque-secret'; } }; const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -759,7 +759,17 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		}
 
 		if (ts.isArrayBindingPattern(pattern)) {
-			return resolveBindingArrayElements(source, resolvingSources)?.[index];
+			const elements = resolveBindingArrayElements(source, resolvingSources);
+
+			if (binding.dotDotDotToken !== undefined) {
+				return elements === undefined
+					? undefined
+					: ts.factory.createArrayLiteralExpression(
+							elements.slice(index).map((element) => element ?? ts.factory.createIdentifier('undefined')),
+						);
+			}
+
+			return elements?.[index];
 		}
 
 		return undefined;
@@ -861,7 +871,19 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			const sourceElements = resolveBindingArrayElements(source, new Set());
 
 			target.elements.forEach((element, index) => {
-				if (ts.isExpression(element) && !ts.isOmittedExpression(element)) {
+				if (ts.isSpreadElement(element)) {
+					addAssignmentPatternBindings(
+						element.expression,
+						sourceElements === undefined
+							? undefined
+							: ts.factory.createArrayLiteralExpression(
+									sourceElements
+										.slice(index)
+										.map((sourceElement) => sourceElement ?? ts.factory.createIdentifier('undefined')),
+								),
+						declaration,
+					);
+				} else if (ts.isExpression(element) && !ts.isOmittedExpression(element)) {
 					addAssignmentPatternBindings(element, sourceElements?.[index], declaration);
 				}
 			});
@@ -1073,18 +1095,19 @@ const compiledPropertyWriteValues = (receiver: ts.Expression, propertyName: stri
 const containsUnsafeCompiledAlias = (
 	node: ts.Expression,
 	safeStrings: SafeCompiledString,
-	resolvingAliases = new Set<string>(),
+	resolvingAliases = new Set<ts.Node>(),
 ): boolean => {
 	const resolveArrayElements = (
 		expression: ts.Expression,
-		resolving: Set<string>,
+		resolving: Set<ts.Node>,
 	): readonly ts.Expression[] | undefined => {
 		if (ts.isIdentifier(expression)) {
-			const initializer = resolveCompiledAlias(expression);
+			const binding = resolveCompiledBinding(expression);
+			const initializer = binding?.initializer;
 
-			return initializer === undefined || resolving.has(expression.text)
+			return initializer === undefined || binding === undefined || resolving.has(binding.declaration)
 				? undefined
-				: resolveArrayElements(initializer, new Set(resolving).add(expression.text));
+				: resolveArrayElements(initializer, new Set(resolving).add(binding.declaration));
 		}
 
 		if (
@@ -1124,14 +1147,15 @@ const containsUnsafeCompiledAlias = (
 	const resolvePropertyValue = (
 		receiver: ts.Expression,
 		propertyName: string,
-		resolving: Set<string>,
+		resolving: Set<ts.Node>,
 	): ts.Expression | undefined => {
 		if (ts.isIdentifier(receiver)) {
-			const initializer = resolveCompiledAlias(receiver);
+			const binding = resolveCompiledBinding(receiver);
+			const initializer = binding?.initializer;
 
-			return initializer === undefined || resolving.has(receiver.text)
+			return initializer === undefined || binding === undefined || resolving.has(binding.declaration)
 				? undefined
-				: resolvePropertyValue(initializer, propertyName, new Set(resolving).add(receiver.text));
+				: resolvePropertyValue(initializer, propertyName, new Set(resolving).add(binding.declaration));
 		}
 
 		if (
@@ -1184,23 +1208,27 @@ const containsUnsafeCompiledAlias = (
 
 		return undefined;
 	};
-	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
+	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression);
 
-			if (bindings.length === 0 || resolving.has(expression.text)) {
+			if (bindings.length === 0) {
 				return false;
 			}
 
-			const nestedResolving = new Set(resolving).add(expression.text);
+			return bindings.some((binding) => {
+				if (resolving.has(binding.declaration)) {
+					return false;
+				}
 
-			return bindings.some((binding) =>
-				[binding.initializer, binding.fallbackInitializer].some(
+				const nestedResolving = new Set(resolving).add(binding.declaration);
+
+				return [binding.initializer, binding.fallbackInitializer].some(
 					(initializer) =>
 						initializer !== undefined &&
 						(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
-				),
-			);
+				);
+			});
 		}
 
 		if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
@@ -1211,7 +1239,7 @@ const containsUnsafeCompiledAlias = (
 					: compiledStaticPropertyExpressionName(expression.argumentExpression);
 			const inspectProperty = (
 				receiver: ts.Expression,
-				nestedResolving: Set<string>,
+				nestedResolving: Set<ts.Node>,
 				selectedPropertyName = propertyName,
 				resolvingProperties = new Set<string>(),
 			): boolean => {
@@ -1275,7 +1303,7 @@ const containsUnsafeCompiledAlias = (
 						return true;
 					}
 
-					return classDeclaration.members.some((member) => {
+					const ownMemberFound = classDeclaration.members.some((member) => {
 						if (!('name' in member)) {
 							return false;
 						}
@@ -1332,23 +1360,51 @@ const containsUnsafeCompiledAlias = (
 
 						return false;
 					});
+
+					if (ownMemberFound) {
+						return true;
+					}
+
+					return (
+						classDeclaration.heritageClauses
+							?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+							.some((clause) =>
+								clause.types.some((type) => {
+									const baseClass = ts.isIdentifier(type.expression)
+										? resolveCompiledBinding(type.expression)?.classDeclaration
+										: undefined;
+
+									return (
+										baseClass !== undefined &&
+										inspectClassProperty(baseClass, expectStatic, memberName, nestedClassProperties)
+									);
+								}),
+							) ?? false
+					);
 				};
 
 				if (ts.isIdentifier(receiver)) {
-					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
-					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
+					const receiverBinding = resolveCompiledBinding(receiver);
+					const nestedReceiverResolving =
+						receiverBinding === undefined ? nestedResolving : new Set(nestedResolving).add(receiverBinding.declaration);
+					const classDeclaration = receiverBinding?.classDeclaration;
 
 					if (
+						receiverBinding !== undefined &&
 						classDeclaration !== undefined &&
-						!nestedResolving.has(receiver.text) &&
+						!nestedResolving.has(receiverBinding.declaration) &&
 						inspectClassProperty(classDeclaration, true, selectedPropertyName)
 					) {
 						return true;
 					}
 
-					const initializer = resolveCompiledAlias(receiver);
+					const initializer = receiverBinding?.initializer;
 
-					if (initializer === undefined || nestedResolving.has(receiver.text)) {
+					if (
+						initializer === undefined ||
+						receiverBinding === undefined ||
+						nestedResolving.has(receiverBinding.declaration)
+					) {
 						return false;
 					}
 
@@ -1390,8 +1446,8 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
-					const inspectReturnedProperty = (callee: ts.Expression, resolvingCalls: Set<string>): boolean => {
-						const inspectReturnBody = (body: ts.Block, nestedCalls: Set<string>): boolean => {
+					const inspectReturnedProperty = (callee: ts.Expression, resolvingCalls: Set<ts.Node>): boolean => {
+						const inspectReturnBody = (body: ts.Block, nestedCalls: Set<ts.Node>): boolean => {
 							let found = false;
 							const visitReturn = (child: ts.Node): void => {
 								if (found) {
@@ -1413,19 +1469,20 @@ const containsUnsafeCompiledAlias = (
 						};
 
 						if (ts.isIdentifier(callee)) {
-							if (resolvingCalls.has(callee.text)) {
-								return false;
-							}
+							return resolveCompiledBindings(callee).some((binding) => {
+								if (resolvingCalls.has(binding.declaration)) {
+									return false;
+								}
 
-							const nestedCalls = new Set(resolvingCalls).add(callee.text);
+								const nestedCalls = new Set(resolvingCalls).add(binding.declaration);
 
-							return resolveCompiledBindings(callee).some(
-								(binding) =>
+								return (
 									[binding.initializer, binding.fallbackInitializer].some(
 										(initializer) => initializer !== undefined && inspectReturnedProperty(initializer, nestedCalls),
 									) ||
-									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedCalls)),
-							);
+									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedCalls))
+								);
+							});
 						}
 
 						if (
@@ -1613,7 +1670,7 @@ const containsUnsafeCompiledAlias = (
 
 		return false;
 	};
-	const inspectCallableBody = (body: ts.Block, resolving: Set<string>): boolean => {
+	const inspectCallableBody = (body: ts.Block, resolving: Set<ts.Node>): boolean => {
 		let found = false;
 		const visitReturn = (child: ts.Node): void => {
 			if (found) {
@@ -1633,23 +1690,28 @@ const containsUnsafeCompiledAlias = (
 
 		return found;
 	};
-	const inspectCallable = (callee: ts.Expression, resolving: Set<string>): boolean => {
+	const inspectCallable = (callee: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(callee)) {
 			const bindings = resolveCompiledBindings(callee);
 
-			if (bindings.length === 0 || resolving.has(callee.text)) {
+			if (bindings.length === 0) {
 				return false;
 			}
 
-			const nestedResolving = new Set(resolving).add(callee.text);
+			return bindings.some((binding) => {
+				if (resolving.has(binding.declaration)) {
+					return false;
+				}
 
-			return bindings.some(
-				(binding) =>
+				const nestedResolving = new Set(resolving).add(binding.declaration);
+
+				return (
 					[binding.initializer, binding.fallbackInitializer].some(
 						(initializer) => initializer !== undefined && inspectCallable(initializer, nestedResolving),
 					) ||
-					(binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving)),
-			);
+					(binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving))
+				);
+			});
 		}
 
 		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
@@ -1658,7 +1720,7 @@ const containsUnsafeCompiledAlias = (
 				: callee.argumentExpression === undefined
 					? undefined
 					: compiledStaticPropertyExpressionName(callee.argumentExpression);
-			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
+			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<ts.Node>): boolean => {
 				if (propertyName === undefined) {
 					return false;
 				}
@@ -1670,12 +1732,15 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isIdentifier(receiver)) {
-					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
-					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
+					const receiverBinding = resolveCompiledBinding(receiver);
+					const nestedReceiverResolving =
+						receiverBinding === undefined ? nestedResolving : new Set(nestedResolving).add(receiverBinding.declaration);
+					const classDeclaration = receiverBinding?.classDeclaration;
 
 					if (
+						receiverBinding !== undefined &&
 						classDeclaration !== undefined &&
-						!nestedResolving.has(receiver.text) &&
+						!nestedResolving.has(receiverBinding.declaration) &&
 						classDeclaration.members.some((member) => {
 							if (!('name' in member)) {
 								return false;
@@ -1703,9 +1768,13 @@ const containsUnsafeCompiledAlias = (
 						return true;
 					}
 
-					const initializer = resolveCompiledAlias(receiver);
+					const initializer = receiverBinding?.initializer;
 
-					if (initializer === undefined || nestedResolving.has(receiver.text)) {
+					if (
+						initializer === undefined ||
+						receiverBinding === undefined ||
+						nestedResolving.has(receiverBinding.declaration)
+					) {
 						return false;
 					}
 
@@ -1724,9 +1793,16 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
 					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+					const inspectClassCallable = (
+						declaration: ts.ClassDeclaration,
+						resolvingClasses = new Set<ts.ClassDeclaration>(),
+					): boolean => {
+						if (resolvingClasses.has(declaration)) {
+							return false;
+						}
 
-					return (
-						classDeclaration?.members.some((member) => {
+						const nestedClasses = new Set(resolvingClasses).add(declaration);
+						const ownMemberFound = declaration.members.some((member) => {
 							if (!('name' in member)) {
 								return false;
 							}
@@ -1749,8 +1825,26 @@ const containsUnsafeCompiledAlias = (
 								member.body !== undefined &&
 								inspectCallableBody(member.body, nestedResolving)
 							);
-						}) ?? false
-					);
+						});
+
+						return (
+							ownMemberFound ||
+							(declaration.heritageClauses
+								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+								.some((clause) =>
+									clause.types.some((type) => {
+										const baseClass = ts.isIdentifier(type.expression)
+											? resolveCompiledBinding(type.expression)?.classDeclaration
+											: undefined;
+
+										return baseClass !== undefined && inspectClassCallable(baseClass, nestedClasses);
+									}),
+								) ??
+								false)
+						);
+					};
+
+					return classDeclaration !== undefined && inspectClassCallable(classDeclaration);
 				}
 
 				if (ts.isConditionalExpression(receiver)) {
@@ -3364,6 +3458,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const fallback = () => { const fallback = 'opaque-secret'; return fallback; }; const apiKey = fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const fallback = 'opaque-secret'; const apiKey = fallback;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -3478,6 +3579,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const { safe, ...fallback } = { safe: '', value: 'opaque-secret' }; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const [safe, ...fallback] = ['', '', 'opaque-secret']; const apiKey = fallback;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -3805,6 +3913,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { stored = 'opaque-secret'; get value() { return this.stored; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Base { value = 'opaque-secret'; } class Source extends Base {} const apiKey = new Source().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -8,8 +8,12 @@ import {
 	findHomeyIpv6Range,
 	isHomeyAddressKey,
 	isHomeyGeneratedPseudonym,
+	isHomeyIdentifierKey,
 	isHomeyPersonalKey,
+	isHomeyReferenceArrayKey,
+	isHomeyReferenceKey,
 	isHomeySecretKey,
+	isHomeyUuid,
 	isPublicHomeyCapabilityBase,
 } from './support/homey-shs-probe';
 
@@ -54,6 +58,8 @@ const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Synthetic mode B',
 	'Synthetic mode C',
 ]);
+const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set(['synthetic-lock-device', 'synthetic_mode']);
+const REDACTION_SENTINEL_PATTERN = /^\[~[0-7]~\]$/;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
@@ -709,6 +715,43 @@ const containsStructuredPersonalValue = (value: unknown): boolean => {
 	});
 };
 
+const isSafeIdentifierValue = (value: unknown): boolean =>
+	value === null ||
+	value === 0 ||
+	value === false ||
+	isHomeyGeneratedPseudonym(value) ||
+	(typeof value === 'string' &&
+		(REDACTION_SENTINEL_PATTERN.test(value) || PUBLIC_SYNTHETIC_IDENTIFIER_VALUES.has(value)));
+
+const isCapabilityIdentifierPath = (key: string, path: readonly string[]): boolean =>
+	(key === 'id' || key === 'baseId') &&
+	path.some((segment) =>
+		['capabilities', 'capabilitiesObj', 'capabilityOptions', 'enumValues', 'values'].includes(segment),
+	);
+
+const containsStructuredIdentifier = (value: unknown, path: readonly string[] = []): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry, index) => containsStructuredIdentifier(entry, [...path, index.toString()]));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return typeof value === 'string' && isHomeyUuid(value);
+	}
+
+	return Object.entries(value as JsonRecord).some(([key, child]) => {
+		const childPath = [...path, key];
+		const identifierValue =
+			!isHomeyReferenceArrayKey(key) &&
+			(isHomeyReferenceKey(key) || isHomeyIdentifierKey(key)) &&
+			!isCapabilityIdentifierPath(key, path) &&
+			!isSafeIdentifierValue(child);
+		const referenceArrayValue =
+			isHomeyReferenceArrayKey(key) && Array.isArray(child) && child.some((entry) => !isSafeIdentifierValue(entry));
+
+		return identifierValue || referenceArrayValue || containsStructuredIdentifier(child, childPath);
+	});
+};
+
 const loosePropertyAssignments = (text: string): ReadonlyArray<readonly [string, string]> =>
 	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].flatMap((match) => {
 		const key = match[1]?.trim();
@@ -795,7 +838,13 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 	}
 };
 
-const assertFixtureTextSafe = (label: string, text: string, extension: string, checkPersonalValues = true): void => {
+const assertFixtureTextSafe = (
+	label: string,
+	text: string,
+	extension: string,
+	checkPersonalValues = true,
+	checkIdentifiers = true,
+): void => {
 	assertTextSafe(label, text);
 
 	const structuredValue =
@@ -830,6 +879,10 @@ const assertFixtureTextSafe = (label: string, text: string, extension: string, c
 
 	if (checkPersonalValues && containsPersonalValue) {
 		throw new Error(`${label} contains a structured personal value`);
+	}
+
+	if (checkIdentifiers && structuredValue !== undefined && containsStructuredIdentifier(structuredValue)) {
+		throw new Error(`${label} contains a structured identifier value`);
 	}
 };
 
@@ -984,7 +1037,7 @@ describe('Homey security artifact gate', () => {
 			const label = path.slice(BACKEND_ROOT.length + 1);
 
 			if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
-				assertFixtureTextSafe(label, text, extension, false);
+				assertFixtureTextSafe(label, text, extension, false, false);
 			} else {
 				assertTextSafe(label, text, path.endsWith('.js') || path.endsWith('.d.ts'));
 			}
@@ -1055,6 +1108,19 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"name":"Alice Bedroom"}', '.json')).toThrow(
 			'unsafe fixture contains a structured personal value',
 		);
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', '{"deviceId":"8d4d7584-1111-4111-8111-0123456789ab"}', '.json'),
+		).toThrow('unsafe fixture contains a structured identifier value');
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"driverId":"opaque-driver"}', '.json')).toThrow(
+			'unsafe fixture contains a structured identifier value',
+		);
+		expect(() =>
+			assertFixtureTextSafe(
+				'safe fixture',
+				'{"deviceId":"device-000001","ownerUri":"[~5~]","capabilities":[{"id":"onoff","baseId":"onoff"}]}',
+				'.json',
+			),
+		).not.toThrow();
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -971,9 +971,12 @@ const compiledScopeDepth = (scope: ts.Node): number => {
 	return depth;
 };
 
-const resolveCompiledBindings = (identifier: ts.Identifier): readonly CompiledBinding[] => {
+const resolveCompiledBindings = (
+	identifier: ts.Identifier,
+	visibleThroughPosition = identifier.getStart(identifier.getSourceFile()),
+): readonly CompiledBinding[] => {
 	const sourceFile = identifier.getSourceFile();
-	const usePosition = identifier.getStart(sourceFile);
+	const usePosition = Math.max(identifier.getStart(sourceFile), visibleThroughPosition);
 
 	return (compiledBindings(sourceFile).get(identifier.text) ?? [])
 		.filter(
@@ -1097,6 +1100,7 @@ const containsUnsafeCompiledAlias = (
 	safeStrings: SafeCompiledString,
 	resolvingAliases = new Set<ts.Node>(),
 ): boolean => {
+	const visibleThroughPosition = node.getStart(node.getSourceFile());
 	const resolveArrayElements = (
 		expression: ts.Expression,
 		resolving: Set<ts.Node>,
@@ -1210,7 +1214,7 @@ const containsUnsafeCompiledAlias = (
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
-			const bindings = resolveCompiledBindings(expression);
+			const bindings = resolveCompiledBindings(expression, visibleThroughPosition);
 
 			if (bindings.length === 0) {
 				return false;
@@ -1469,7 +1473,7 @@ const containsUnsafeCompiledAlias = (
 						};
 
 						if (ts.isIdentifier(callee)) {
-							return resolveCompiledBindings(callee).some((binding) => {
+							return resolveCompiledBindings(callee, visibleThroughPosition).some((binding) => {
 								if (resolvingCalls.has(binding.declaration)) {
 									return false;
 								}
@@ -1692,7 +1696,7 @@ const containsUnsafeCompiledAlias = (
 	};
 	const inspectCallable = (callee: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(callee)) {
-			const bindings = resolveCompiledBindings(callee);
+			const bindings = resolveCompiledBindings(callee, visibleThroughPosition);
 
 			if (bindings.length === 0) {
 				return false;
@@ -1793,6 +1797,63 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
 					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+					const inspectClassValue = (
+						declaration: ts.ClassDeclaration,
+						memberName: string,
+						resolvingValues = new Set<string>(),
+					): boolean => {
+						const reference = `${declaration.pos}:${memberName}`;
+
+						if (resolvingValues.has(reference)) {
+							return false;
+						}
+
+						const nestedValues = new Set(resolvingValues).add(reference);
+						const ownValueFound = declaration.members.some((member) => {
+							if (!('name' in member)) {
+								return false;
+							}
+
+							const staticMember = Boolean(
+								ts.canHaveModifiers(member) &&
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+							);
+
+							if (staticMember || compiledPropertyName(member.name) !== memberName) {
+								return false;
+							}
+
+							if (ts.isPropertyDeclaration(member)) {
+								return (
+									member.initializer !== undefined &&
+									(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
+										inspect(member.initializer, nestedResolving))
+								);
+							}
+
+							return (
+								ts.isGetAccessorDeclaration(member) &&
+								member.body !== undefined &&
+								inspectCallableBody(member.body, nestedResolving)
+							);
+						});
+
+						return (
+							ownValueFound ||
+							(declaration.heritageClauses
+								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+								.some((clause) =>
+									clause.types.some((type) => {
+										const baseClass = ts.isIdentifier(type.expression)
+											? resolveCompiledBinding(type.expression)?.classDeclaration
+											: undefined;
+
+										return baseClass !== undefined && inspectClassValue(baseClass, memberName, nestedValues);
+									}),
+								) ??
+								false)
+						);
+					};
 					const inspectClassCallable = (
 						declaration: ts.ClassDeclaration,
 						resolvingClasses = new Set<ts.ClassDeclaration>(),
@@ -1820,11 +1881,34 @@ const containsUnsafeCompiledAlias = (
 								return member.initializer !== undefined && inspectCallable(member.initializer, nestedResolving);
 							}
 
-							return (
+							if (
 								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
-								member.body !== undefined &&
-								inspectCallableBody(member.body, nestedResolving)
-							);
+								member.body !== undefined
+							) {
+								let receiverPropertyName: string | undefined;
+								const visitReturn = (child: ts.Node): void => {
+									if (receiverPropertyName !== undefined) {
+										return;
+									}
+
+									if (ts.isReturnStatement(child) && child.expression !== undefined) {
+										receiverPropertyName = compiledThisPropertyName(child.expression);
+									}
+
+									if (receiverPropertyName === undefined) {
+										ts.forEachChild(child, visitReturn);
+									}
+								};
+
+								visitReturn(member.body);
+
+								return (
+									(receiverPropertyName !== undefined && inspectClassValue(declaration, receiverPropertyName)) ||
+									inspectCallableBody(member.body, nestedResolving)
+								);
+							}
+
+							return false;
 						});
 
 						return (
@@ -1862,6 +1946,14 @@ const containsUnsafeCompiledAlias = (
 
 						if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
 							return inspectCallable(property.name, nestedResolving);
+						}
+
+						if (
+							ts.isGetAccessorDeclaration(property) &&
+							compiledPropertyName(property.name) === propertyName &&
+							property.body !== undefined
+						) {
+							return inspectCallableBody(property.body, nestedResolving);
 						}
 
 						if (ts.isMethodDeclaration(property) && compiledPropertyName(property.name) === propertyName) {
@@ -3465,6 +3557,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"let fallback = ''; const read = () => fallback; fallback = 'opaque-secret'; const apiKey = read();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const fallback = 'opaque-secret'; const apiKey = fallback;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -3523,6 +3622,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { fallback() { return 'opaque-secret'; } }; const apiKey = source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { get fallback() { return () => 'opaque-secret'; } }; const apiKey = source.fallback();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -3934,6 +4040,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { fallback() { return 'opaque-secret'; } } const apiKey = new Source().fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { stored = 'opaque-secret'; fallback() { return this.stored; } } const apiKey = new Source().fallback();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1165,6 +1165,157 @@ const compiledPropertyWriteValues = (
 				: [];
 		});
 	};
+	const resolveReceiverMethods = (
+		receiver: ts.Expression,
+		methodName: string,
+		resolving = new Set<ts.Node>(),
+	): readonly { body: ts.Block; parameters: readonly ts.ParameterDeclaration[] }[] => {
+		if (ts.isIdentifier(receiver)) {
+			const binding = resolveCompiledBinding(receiver);
+
+			if (binding === undefined || resolving.has(binding.declaration)) {
+				return [];
+			}
+
+			const nestedResolving = new Set(resolving).add(binding.declaration);
+			const methods =
+				binding.initializer === undefined
+					? []
+					: resolveReceiverMethods(binding.initializer, methodName, nestedResolving);
+
+			if (binding.classDeclaration === undefined) {
+				return methods;
+			}
+
+			return [
+				...methods,
+				...binding.classDeclaration.members.flatMap((member) =>
+					ts.isMethodDeclaration(member) &&
+					compiledPropertyName(member.name) === methodName &&
+					member.body !== undefined
+						? [{ body: member.body, parameters: member.parameters }]
+						: [],
+				),
+			];
+		}
+
+		if (
+			ts.isParenthesizedExpression(receiver) ||
+			ts.isAsExpression(receiver) ||
+			ts.isTypeAssertionExpression(receiver) ||
+			ts.isNonNullExpression(receiver) ||
+			ts.isSatisfiesExpression(receiver)
+		) {
+			return resolveReceiverMethods(receiver.expression, methodName, resolving);
+		}
+
+		if (ts.isNewExpression(receiver)) {
+			const classDeclaration = ts.isIdentifier(receiver.expression)
+				? resolveCompiledBinding(receiver.expression)?.classDeclaration
+				: ts.isClassExpression(receiver.expression)
+					? receiver.expression
+					: undefined;
+
+			return (
+				classDeclaration?.members.flatMap((member) =>
+					ts.isMethodDeclaration(member) &&
+					compiledPropertyName(member.name) === methodName &&
+					member.body !== undefined
+						? [{ body: member.body, parameters: member.parameters }]
+						: [],
+				) ?? []
+			);
+		}
+
+		if (!ts.isObjectLiteralExpression(receiver)) {
+			return [];
+		}
+
+		return receiver.properties.flatMap((property) => {
+			if (
+				ts.isMethodDeclaration(property) &&
+				compiledPropertyName(property.name) === methodName &&
+				property.body !== undefined
+			) {
+				return [{ body: property.body, parameters: property.parameters }];
+			}
+
+			if (ts.isSpreadAssignment(property)) {
+				return resolveReceiverMethods(property.expression, methodName, resolving);
+			}
+
+			return [];
+		});
+	};
+	const bindingNameReferences = (name: ts.BindingName, referencedName: string): boolean =>
+		ts.isIdentifier(name)
+			? name.text === referencedName
+			: name.elements.some(
+					(element) => !ts.isOmittedExpression(element) && bindingNameReferences(element.name, referencedName),
+				);
+	const methodWriteValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+		if (
+			methodName === undefined ||
+			!sameReceiverPath(resolveCompiledReceiverPath(call.expression.expression), targetPath)
+		) {
+			return [];
+		}
+
+		return resolveReceiverMethods(call.expression.expression, methodName).flatMap(({ body, parameters }) => {
+			const methodValues: ts.Expression[] = [];
+			const visitMethod = (node: ts.Node): void => {
+				if (
+					ts.isBinaryExpression(node) &&
+					isAssignmentOperatorKind(node.operatorToken.kind) &&
+					(ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left)) &&
+					node.left.expression.kind === ts.SyntaxKind.ThisKeyword &&
+					(compiledAssignedPropertyName(node.left) === selectedPropertyName ||
+						(ts.isElementAccessExpression(node.left) &&
+							node.left.argumentExpression !== undefined &&
+							compiledStaticPropertyExpressionName(node.left.argumentExpression) === undefined))
+				) {
+					methodValues.push(node.right);
+					const referencedNames = new Set<string>();
+					const visitReference = (child: ts.Node): void => {
+						if (ts.isIdentifier(child)) {
+							referencedNames.add(child.text);
+						}
+
+						ts.forEachChild(child, visitReference);
+					};
+
+					visitReference(node.right);
+					parameters.forEach((parameter, index) => {
+						if (![...referencedNames].some((name) => bindingNameReferences(parameter.name, name))) {
+							return;
+						}
+
+						methodValues.push(
+							...(parameter.dotDotDotToken === undefined
+								? call.arguments.slice(index, index + 1)
+								: call.arguments.slice(index)),
+						);
+					});
+				}
+
+				ts.forEachChild(node, visitMethod);
+			};
+
+			visitMethod(body);
+
+			return methodValues;
+		});
+	};
 
 	const visit = (node: ts.Node): void => {
 		if (
@@ -1192,6 +1343,8 @@ const compiledPropertyWriteValues = (
 		} else if (ts.isCallExpression(node) && node.getStart(sourceFile) < usePosition && node.arguments.length > 0) {
 			const helperName = compiledMutationHelperName(node.expression);
 			const mutationTarget = resolveCompiledReceiverPath(node.arguments[0]);
+
+			values.push(...methodWriteValues(node, propertyName));
 
 			if (sameReceiverPath(mutationTarget, targetPath)) {
 				if (helperName === 'Object.assign') {
@@ -3411,19 +3564,60 @@ const containsCompiledSecret = (text: string): boolean => {
 	const secretCallArguments = (
 		parameterSets: readonly (readonly ts.ParameterDeclaration[])[],
 		arguments_: readonly ts.Expression[],
-	): boolean =>
-		parameterSets.some((parameters) =>
+	): boolean => {
+		const resolveSpreadElements = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): readonly ts.Expression[] | undefined => {
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveSpreadElements(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveSpreadElements(expression.expression, resolving);
+			}
+
+			if (!ts.isArrayLiteralExpression(expression)) {
+				return undefined;
+			}
+
+			return expression.elements.flatMap((element): readonly ts.Expression[] => {
+				if (ts.isSpreadElement(element)) {
+					return resolveSpreadElements(element.expression, resolving) ?? [element.expression];
+				}
+
+				return ts.isExpression(element) ? [element] : [];
+			});
+		};
+		const expandedArguments = arguments_.flatMap((argument): readonly ts.Expression[] =>
+			ts.isSpreadElement(argument) ? (resolveSpreadElements(argument.expression) ?? [argument.expression]) : [argument],
+		);
+
+		return parameterSets.some((parameters) =>
 			parameters.some((parameter, index) => {
 				if (!bindingNameContainsSecret(parameter.name)) {
 					return false;
 				}
 
 				const parameterArguments =
-					parameter.dotDotDotToken === undefined ? arguments_.slice(index, index + 1) : arguments_.slice(index);
+					parameter.dotDotDotToken === undefined
+						? expandedArguments.slice(index, index + 1)
+						: expandedArguments.slice(index);
 
 				return parameterArguments.some((argument) => containsUnsafeCompiledValue(argument));
 			}),
 		);
+	};
 	const visit = (node: ts.Node): void => {
 		if (found) {
 			return;
@@ -5189,6 +5383,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function connect(apiKey) {} const args = ['opaque-secret']; connect(...args);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const connect = ({ apiKey }) => {}; connect({ apiKey: 'opaque-secret' });",
 				true,
 			),
@@ -5362,6 +5563,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: '' }; source['value'] = 'opaque-secret'; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: '', set(value) { this.value = value; } }; source.set('opaque-secret'); const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -58,7 +58,14 @@ const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Synthetic mode B',
 	'Synthetic mode C',
 ]);
-const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set(['synthetic-lock-device', 'synthetic_mode']);
+const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set([
+	'123e4567-e89b-12d3-a456-426614174000',
+	'550e8400-e29b-41d4-a716-446655440000',
+	'b27b7c58-76f6-407a-bc78-4068e4cfd082',
+	'f1e09ba1-429f-4c6a-a2fd-aca6a7c4a8c6',
+	'synthetic-lock-device',
+	'synthetic_mode',
+]);
 const REDACTION_SENTINEL_PATTERN = /^\[~[0-7]~\]$/;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
@@ -723,32 +730,56 @@ const isSafeIdentifierValue = (value: unknown): boolean =>
 	(typeof value === 'string' &&
 		(REDACTION_SENTINEL_PATTERN.test(value) || PUBLIC_SYNTHETIC_IDENTIFIER_VALUES.has(value)));
 
-const isCapabilityIdentifierPath = (key: string, path: readonly string[]): boolean =>
-	(key === 'id' || key === 'baseId') &&
-	path.some((segment) =>
-		['capabilities', 'capabilitiesObj', 'capabilityOptions', 'enumValues', 'values'].includes(segment),
-	);
+const isCapabilityIdentifierPath = (key: string, path: readonly string[], syntheticProtocolRoot: boolean): boolean => {
+	const directCapabilityEntry =
+		path.length === 2 &&
+		/^\d+$/.test(path[1] ?? '') &&
+		(path[0] === 'capabilities' || (syntheticProtocolRoot && path[0] === 'values'));
+	const directCapabilityMapEntry =
+		path.length === 2 && (path[0] === 'capabilitiesObj' || path[0] === 'capabilityOptions');
+	const directEnumOption =
+		path.length === 4 &&
+		/^\d+$/.test(path[3] ?? '') &&
+		((path[0] === 'capabilities' && path[2] === 'enumValues') ||
+			((path[0] === 'capabilitiesObj' || path[0] === 'capabilityOptions') && path[2] === 'values'));
 
-const containsStructuredIdentifier = (value: unknown, path: readonly string[] = []): boolean => {
+	return (key === 'id' || key === 'baseId') && (directCapabilityEntry || directCapabilityMapEntry || directEnumOption);
+};
+
+const containsStructuredIdentifier = (
+	value: unknown,
+	path: readonly string[] = [],
+	syntheticProtocolRoot = false,
+): boolean => {
 	if (Array.isArray(value)) {
-		return value.some((entry, index) => containsStructuredIdentifier(entry, [...path, index.toString()]));
+		return value.some((entry, index) =>
+			containsStructuredIdentifier(entry, [...path, index.toString()], syntheticProtocolRoot),
+		);
 	}
 
 	if (value === null || typeof value !== 'object') {
-		return typeof value === 'string' && isHomeyUuid(value);
+		return typeof value === 'string' && isHomeyUuid(value) && !isSafeIdentifierValue(value);
 	}
 
-	return Object.entries(value as JsonRecord).some(([key, child]) => {
+	const record = value as JsonRecord;
+	const nestedSyntheticProtocolRoot =
+		syntheticProtocolRoot || (path.length === 0 && record.provenance === 'synthetic-protocol-contract');
+
+	return Object.entries(record).some(([key, child]) => {
 		const childPath = [...path, key];
 		const identifierValue =
 			!isHomeyReferenceArrayKey(key) &&
 			(isHomeyReferenceKey(key) || isHomeyIdentifierKey(key)) &&
-			!isCapabilityIdentifierPath(key, path) &&
+			!isCapabilityIdentifierPath(key, path, nestedSyntheticProtocolRoot) &&
 			!isSafeIdentifierValue(child);
 		const referenceArrayValue =
 			isHomeyReferenceArrayKey(key) && Array.isArray(child) && child.some((entry) => !isSafeIdentifierValue(entry));
 
-		return identifierValue || referenceArrayValue || containsStructuredIdentifier(child, childPath);
+		return (
+			identifierValue ||
+			referenceArrayValue ||
+			containsStructuredIdentifier(child, childPath, nestedSyntheticProtocolRoot)
+		);
 	});
 };
 
@@ -783,6 +814,16 @@ const containsLoosePersonalAssignment = (text: string): boolean =>
 			!isHomeyGeneratedPseudonym(rawValue) &&
 			!PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(rawValue),
 	);
+
+const containsLooseIdentifierAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(([key, rawValue]) => {
+		const unambiguousIdentifierKey =
+			isHomeyReferenceKey(key) || (isHomeyIdentifierKey(key) && key !== 'id' && key !== 'baseId');
+
+		return (
+			unambiguousIdentifierKey && !['0', '[]', 'false', 'null'].includes(rawValue) && !isSafeIdentifierValue(rawValue)
+		);
+	});
 
 const containsStructuredUrl = (value: unknown): boolean => {
 	if (typeof value === 'string') {
@@ -881,7 +922,12 @@ const assertFixtureTextSafe = (
 		throw new Error(`${label} contains a structured personal value`);
 	}
 
-	if (checkIdentifiers && structuredValue !== undefined && containsStructuredIdentifier(structuredValue)) {
+	const containsIdentifier =
+		structuredValue === undefined
+			? containsLooseIdentifierAssignment(text)
+			: containsStructuredIdentifier(structuredValue);
+
+	if (checkIdentifiers && containsIdentifier) {
 		throw new Error(`${label} contains a structured identifier value`);
 	}
 };
@@ -927,6 +973,7 @@ const visitPublishedValues = (
 	secretParameter = false,
 	addressParameter = false,
 	personalParameter = false,
+	identifierParameter = false,
 ): void => {
 	if (Array.isArray(value)) {
 		value.forEach((entry, index) =>
@@ -937,6 +984,7 @@ const visitPublishedValues = (
 				secretParameter,
 				addressParameter,
 				personalParameter,
+				identifierParameter,
 			),
 		);
 
@@ -953,6 +1001,9 @@ const visitPublishedValues = (
 	const nestedAddressParameter = addressParameter || (parameterName !== undefined && isHomeyAddressKey(parameterName));
 	const nestedPersonalParameter =
 		personalParameter || (parameterName !== undefined && isHomeyPersonalKey(parameterName));
+	const nestedIdentifierParameter =
+		identifierParameter ||
+		(parameterName !== undefined && (isHomeyReferenceKey(parameterName) || isHomeyIdentifierKey(parameterName)));
 
 	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
@@ -973,6 +1024,10 @@ const visitPublishedValues = (
 			if (containsStructuredPersonalValue(child) || (nestedPersonalParameter && !isSafePersonalValue(child))) {
 				throw new Error(`${label}.${childPath.join('.')} publishes a personal value`);
 			}
+
+			if (containsStructuredIdentifier(child) || (nestedIdentifierParameter && !isSafeIdentifierValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes an identifier value`);
+			}
 		}
 
 		visitPublishedValues(
@@ -982,6 +1037,7 @@ const visitPublishedValues = (
 			nestedSecretParameter,
 			nestedAddressParameter,
 			nestedPersonalParameter,
+			nestedIdentifierParameter,
 		);
 	}
 };
@@ -1090,6 +1146,11 @@ describe('Homey security artifact gate', () => {
 				example: { name: 'Alice Bedroom' },
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes a personal value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { deviceId: 'opaque-household-id' },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes an identifier value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -1121,6 +1182,9 @@ describe('Homey security artifact gate', () => {
 				'.json',
 			),
 		).not.toThrow();
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', '{"capabilities":[{"metadata":{"id":"opaque-household-id"}}]}', '.json'),
+		).toThrow('unsafe fixture contains a structured identifier value');
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
@@ -1138,6 +1202,9 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'name: Alice Bedroom', '.txt')).toThrow(
 			'unsafe fixture contains a structured personal value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'deviceId: opaque-household-id', '.md')).toThrow(
+			'unsafe fixture contains a structured identifier value',
 		);
 		expect(() =>
 			assertFixtureTextSafe('safe fixture', 'hostname: [~0~]\nname: device-label-000001', '.md'),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -507,6 +507,7 @@ const containsUnsafeCompiledLiteral = (
 
 interface CompiledBinding {
 	readonly callable?: ts.FunctionDeclaration;
+	readonly classDeclaration?: ts.ClassDeclaration;
 	readonly declaration: ts.Node;
 	readonly fallbackInitializer?: ts.Expression;
 	readonly initializer?: ts.Expression;
@@ -640,6 +641,48 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 
 		return undefined;
 	};
+	const selectObjectRestValue = (
+		excludedPropertyNames: ReadonlySet<string>,
+		source: ts.Expression,
+		resolvingSources: Set<string>,
+	): ts.Expression | undefined => {
+		if (ts.isIdentifier(source)) {
+			const initializer = resolveCompiledAlias(source);
+
+			return initializer === undefined || resolvingSources.has(source.text)
+				? undefined
+				: selectObjectRestValue(excludedPropertyNames, initializer, new Set(resolvingSources).add(source.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(source) ||
+			ts.isAsExpression(source) ||
+			ts.isTypeAssertionExpression(source) ||
+			ts.isNonNullExpression(source) ||
+			ts.isSatisfiesExpression(source)
+		) {
+			return selectObjectRestValue(excludedPropertyNames, source.expression, resolvingSources);
+		}
+
+		if (!ts.isObjectLiteralExpression(source)) {
+			return undefined;
+		}
+
+		return ts.factory.createObjectLiteralExpression(
+			source.properties.filter((property) => {
+				const propertyName =
+					ts.isPropertyAssignment(property) ||
+					ts.isShorthandPropertyAssignment(property) ||
+					ts.isMethodDeclaration(property) ||
+					ts.isGetAccessorDeclaration(property) ||
+					ts.isSetAccessorDeclaration(property)
+						? compiledPropertyName(property.name)
+						: undefined;
+
+				return propertyName === undefined || !excludedPropertyNames.has(propertyName);
+			}),
+		);
+	};
 	const selectBindingValue = (
 		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
 		binding: ts.BindingElement,
@@ -666,6 +709,23 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		}
 
 		if (ts.isObjectBindingPattern(pattern)) {
+			if (binding.dotDotDotToken !== undefined) {
+				const excludedPropertyNames = new Set(
+					pattern.elements
+						.filter((element) => element !== binding && element.dotDotDotToken === undefined)
+						.map((element) =>
+							element.propertyName === undefined
+								? ts.isIdentifier(element.name)
+									? element.name.text
+									: undefined
+								: compiledPropertyName(element.propertyName),
+						)
+						.filter((name): name is string => name !== undefined),
+				);
+
+				return selectObjectRestValue(excludedPropertyNames, source, resolvingSources);
+			}
+
 			const propertyName =
 				binding.propertyName === undefined
 					? ts.isIdentifier(binding.name)
@@ -739,6 +799,17 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		}
 
 		if (ts.isObjectLiteralExpression(target)) {
+			const excludedPropertyNames = new Set(
+				target.properties
+					.filter((property) => !ts.isSpreadAssignment(property))
+					.map((property) =>
+						ts.isPropertyAssignment(property) || ts.isShorthandPropertyAssignment(property)
+							? compiledPropertyName(property.name)
+							: undefined,
+					)
+					.filter((name): name is string => name !== undefined),
+			);
+
 			for (const property of target.properties) {
 				if (ts.isPropertyAssignment(property)) {
 					const propertyName = compiledPropertyName(property.name);
@@ -754,6 +825,12 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 					addAssignmentPatternBindings(
 						property.name,
 						source === undefined ? undefined : selectObjectValue(property.name.text, source, new Set()),
+						declaration,
+					);
+				} else if (ts.isSpreadAssignment(property)) {
+					addAssignmentPatternBindings(
+						property.expression,
+						source === undefined ? undefined : selectObjectRestValue(excludedPropertyNames, source, new Set()),
 						declaration,
 					);
 				}
@@ -793,6 +870,8 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			});
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
 			addBinding(node.name.text, { callable: node, declaration: node, scope: compiledBindingScope(node) });
+		} else if (ts.isClassDeclaration(node) && node.name !== undefined) {
+			addBinding(node.name.text, { classDeclaration: node, declaration: node, scope: compiledBindingScope(node) });
 		} else if (
 			ts.isBinaryExpression(node) &&
 			ts.isIdentifier(node.left) &&
@@ -1034,11 +1113,48 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isIdentifier(receiver)) {
 					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
+					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
 
 					if (
 						compiledPropertyWriteValues(receiver, selectedPropertyName).some(
 							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedReceiverResolving),
 						)
+					) {
+						return true;
+					}
+
+					if (
+						classDeclaration !== undefined &&
+						!nestedResolving.has(receiver.text) &&
+						classDeclaration.members.some((member) => {
+							if (!('name' in member)) {
+								return false;
+							}
+
+							const staticMember =
+								ts.canHaveModifiers(member) &&
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
+							const memberName = compiledPropertyName(member.name);
+
+							if (!staticMember || memberName !== selectedPropertyName) {
+								return false;
+							}
+
+							if (ts.isPropertyDeclaration(member)) {
+								return (
+									(member.initializer !== undefined &&
+										(containsUnsafeCompiledLiteral(member.initializer, safeStrings) ||
+											inspect(member.initializer, nestedReceiverResolving))) ||
+									(member.type !== undefined && containsUnsafeCompiledType(member.type, safeStrings))
+								);
+							}
+
+							return (
+								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
+								member.body !== undefined &&
+								inspectCallableBody(member.body, nestedReceiverResolving)
+							);
+						})
 					) {
 						return true;
 					}
@@ -1253,11 +1369,42 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isIdentifier(receiver)) {
 					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
+					const classDeclaration = resolveCompiledBinding(receiver)?.classDeclaration;
 
 					if (
 						compiledPropertyWriteValues(receiver, propertyName).some((value) =>
 							inspectCallable(value, nestedReceiverResolving),
 						)
+					) {
+						return true;
+					}
+
+					if (
+						classDeclaration !== undefined &&
+						!nestedResolving.has(receiver.text) &&
+						classDeclaration.members.some((member) => {
+							if (!('name' in member)) {
+								return false;
+							}
+
+							const staticMember =
+								ts.canHaveModifiers(member) &&
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
+
+							if (!staticMember || compiledPropertyName(member.name) !== propertyName) {
+								return false;
+							}
+
+							if (ts.isPropertyDeclaration(member)) {
+								return member.initializer !== undefined && inspectCallable(member.initializer, nestedReceiverResolving);
+							}
+
+							return (
+								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
+								member.body !== undefined &&
+								inspectCallableBody(member.body, nestedReceiverResolving)
+							);
+						})
 					) {
 						return true;
 					}
@@ -2959,6 +3106,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const { safe, ...fallback } = { safe: '', value: 'opaque-secret' }; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"let fallback = ''; ({ value: fallback } = { value: 'opaque-secret' }); const apiKey = fallback;",
 				true,
 			),
@@ -3252,6 +3406,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { get value() { return 'opaque-secret'; } }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { static get value() { return 'opaque-secret'; } } const apiKey = Source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -74,6 +74,9 @@ const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set([
 	'synthetic_mode',
 ]);
 const PUBLIC_COMPILED_IDENTIFIER_LABELS = new Set(['event device id', 'event zone id']);
+const PUBLIC_COMPILED_PERSONAL_VALUES = new Set(['Homey', 'class', 'device name', 'mode', 'zone name']);
+const PUBLIC_COMPILED_PERSONAL_IDENTIFIER_PATTERN =
+	/^(?:DevicesHomey[A-Za-z0-9]*|[A-Z][A-Za-z0-9]*Error|is[A-Z][A-Za-z0-9]*|[a-z0-9]+(?:[_-][a-z0-9]+)+)$/;
 const REDACTION_SENTINEL_PATTERN = /^\[~[0-7]~\]$/;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
@@ -388,12 +391,12 @@ const containsUnsafeCompiledLiteral = (
 
 	if (ts.isArrowFunction(node)) {
 		return ts.isBlock(node.body)
-			? containsUnsafeReturnedLiteral(node.body, safeStrings)
+			? containsUnsafeCompiledBodyLiteral(node.body, safeStrings)
 			: containsUnsafeCompiledLiteral(node.body, safeStrings);
 	}
 
 	if (ts.isFunctionExpression(node)) {
-		return containsUnsafeReturnedLiteral(node.body, safeStrings);
+		return containsUnsafeCompiledBodyLiteral(node.body, safeStrings);
 	}
 
 	return false;
@@ -468,28 +471,6 @@ const containsUnsafeCompiledType = (
 const isAssignmentOperatorKind = (kind: ts.SyntaxKind): boolean =>
 	kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
 
-const containsUnsafeReturnedLiteral = (
-	body: ts.Block,
-	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
-): boolean => {
-	let found = false;
-	const visit = (node: ts.Node): void => {
-		if (found) {
-			return;
-		}
-
-		if (ts.isReturnStatement(node) && node.expression !== undefined) {
-			found = containsUnsafeCompiledLiteral(node.expression, safeStrings);
-		}
-
-		ts.forEachChild(node, visit);
-	};
-
-	visit(body);
-
-	return found;
-};
-
 const containsUnsafeCompiledBodyLiteral = (
 	body: ts.Block,
 	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
@@ -553,7 +534,7 @@ const containsCompiledSecret = (text: string): boolean => {
 			isCompiledSecretName(compiledPropertyName(node.name))
 		) {
 			found =
-				('body' in node && node.body !== undefined && containsUnsafeReturnedLiteral(node.body)) ||
+				('body' in node && node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body)) ||
 				(node.type !== undefined && containsUnsafeCompiledType(node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found =
@@ -611,6 +592,19 @@ const containsCompiledAddress = (text: string): boolean => {
 				(node.initializer !== undefined && unsafeAddress(name, node.initializer)) || unsafeAddressType(name, node.type);
 		} else if (ts.isPropertySignature(node)) {
 			found = unsafeAddressType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isSetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				name !== undefined &&
+				isHomeyAddressKey(name) &&
+				(node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledLiteral(parameter.initializer, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, SAFE_COMPILED_ADDRESS_STRINGS)),
+				) ||
+					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)));
 		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
 			const name = compiledPropertyName(node.name);
 
@@ -619,7 +613,7 @@ const containsCompiledAddress = (text: string): boolean => {
 					node.body !== undefined &&
 					name !== undefined &&
 					isHomeyAddressKey(name) &&
-					containsUnsafeReturnedLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+					containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
 				unsafeAddressType(name, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeAddress(node.name.text, node.initializer);
@@ -677,13 +671,25 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				unsafeIdentifierType(name, node.type);
 		} else if (ts.isPropertySignature(node)) {
 			found = unsafeIdentifierType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isSetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				isPrivateIdentifierName(name) &&
+				(node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledLiteral(parameter.initializer, isSafeCompiledIdentifierValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledIdentifierValue)),
+				) ||
+					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)));
 		} else if (ts.isGetAccessorDeclaration(node)) {
 			const name = compiledPropertyName(node.name);
 
 			found =
 				(node.body !== undefined &&
 					isPrivateIdentifierName(name) &&
-					containsUnsafeReturnedLiteral(node.body, isSafeCompiledIdentifierValue)) ||
+					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)) ||
 				unsafeIdentifierType(name, node.type);
 		} else if (ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
 			const name = compiledPropertyName(node.name);
@@ -693,7 +699,7 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				('body' in node &&
 					node.body !== undefined &&
 					privateReferenceMethod &&
-					containsUnsafeReturnedLiteral(node.body, isSafeCompiledIdentifierValue)) ||
+					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)) ||
 				(privateReferenceMethod && unsafeIdentifierType(name, node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeIdentifier(node.name.text, node.initializer);
@@ -744,6 +750,18 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				unsafeEndpointType(name, node.type);
 		} else if (ts.isPropertySignature(node)) {
 			found = unsafeEndpointType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isSetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				isEndpointValueName(name) &&
+				(node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledLiteral(parameter.initializer, isSafeEndpointValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeEndpointValue)),
+				) ||
+					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)));
 		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
 			const name = compiledPropertyName(node.name);
 			const endpointName = isEndpointValueName(name);
@@ -752,7 +770,7 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				('body' in node &&
 					node.body !== undefined &&
 					endpointName &&
-					containsUnsafeReturnedLiteral(node.body, isSafeEndpointValue)) ||
+					containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)) ||
 				(endpointName && unsafeEndpointType(name, node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeEndpoint(node.name.text, node.initializer);
@@ -769,6 +787,91 @@ const containsCompiledEndpoint = (text: string): boolean => {
 			found = unsafeEndpoint(name, node.initializer);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeEndpoint(compiledAssignedPropertyName(node.left), node.right);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
+const containsCompiledPersonalValue = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const isCompiledPersonalName = (name: string | undefined): name is string =>
+		name !== undefined && !COMPILED_SYMBOL_NAME_PATTERN.test(name) && isHomeyPersonalKey(name);
+	const isSafeCompiledPersonalValue = (value: string): boolean =>
+		value === '[~2~]' ||
+		isHomeyGeneratedPseudonym(value) ||
+		PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value) ||
+		PUBLIC_COMPILED_PERSONAL_VALUES.has(value) ||
+		PUBLIC_COMPILED_PERSONAL_IDENTIFIER_PATTERN.test(value) ||
+		isHomeyAddressKey(value) ||
+		isHomeyEndpointKey(value) ||
+		isHomeyIconKey(value) ||
+		isHomeyIdentifierKey(value) ||
+		isHomeyPersonalKey(value) ||
+		isHomeyReferenceKey(value) ||
+		isHomeySecretKey(value) ||
+		isHomeyTimestampKey(value);
+	const unsafePersonalValue = (name: string | undefined, expression: ts.Expression): boolean =>
+		isCompiledPersonalName(name) && containsUnsafeCompiledLiteral(expression, isSafeCompiledPersonalValue);
+	const unsafePersonalType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
+		isCompiledPersonalName(name) && type !== undefined && containsUnsafeCompiledType(type, isSafeCompiledPersonalValue);
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node)) {
+			found = unsafePersonalValue(compiledPropertyName(node.name), node.initializer);
+		} else if (ts.isPropertyDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				(node.initializer !== undefined && unsafePersonalValue(name, node.initializer)) ||
+				unsafePersonalType(name, node.type);
+		} else if (ts.isPropertySignature(node)) {
+			found = unsafePersonalType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isSetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				isCompiledPersonalName(name) &&
+				(node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledLiteral(parameter.initializer, isSafeCompiledPersonalValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledPersonalValue)),
+				) ||
+					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)));
+		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+			const name = compiledPropertyName(node.name);
+			const personalName = isCompiledPersonalName(name);
+
+			found =
+				('body' in node &&
+					node.body !== undefined &&
+					personalName &&
+					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)) ||
+				(personalName && unsafePersonalType(name, node.type));
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafePersonalValue(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafePersonalValue(node.name.text, node.initializer);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = unsafePersonalValue(name, node.initializer);
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
+			found = unsafePersonalValue(compiledAssignedPropertyName(node.left), node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -1018,6 +1121,7 @@ const containsStructuredIdentifier = (
 
 	return Object.entries(record).some(([key, child]) => {
 		const childPath = [...path, key];
+		const identifierKey = isHomeyUuid(key) && !isSafeIdentifierValue(key);
 		const capabilityIdentifierPath = isCapabilityIdentifierPath(key, path, nestedSyntheticProtocolRoot);
 		const capabilityIdentifierValue = capabilityIdentifierPath && !isHomeySanitizedCapabilityIdentifier(child);
 		const capabilityListValue =
@@ -1048,6 +1152,7 @@ const containsStructuredIdentifier = (
 			(Array.isArray(child) ? child.some((entry) => !isSafeIdentifierValue(entry)) : !isSafeIdentifierValue(child));
 
 		return (
+			identifierKey ||
 			capabilityIdentifierValue ||
 			capabilityListValue ||
 			capabilityMapKey ||
@@ -1171,6 +1276,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 
 	if (compiledSource && containsCompiledEndpoint(text)) {
 		throw new Error(`${label} contains a compiled endpoint value`);
+	}
+
+	if (compiledSource && containsCompiledPersonalValue(text)) {
+		throw new Error(`${label} contains a compiled personal value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -1299,6 +1408,7 @@ const visitPublishedValues = (
 	personalParameter = false,
 	identifierParameter = false,
 	endpointParameter = false,
+	iconParameter = false,
 ): void => {
 	if (Array.isArray(value)) {
 		value.forEach((entry, index) =>
@@ -1311,6 +1421,7 @@ const visitPublishedValues = (
 				personalParameter,
 				identifierParameter,
 				endpointParameter,
+				iconParameter,
 			),
 		);
 
@@ -1332,6 +1443,7 @@ const visitPublishedValues = (
 		(parameterName !== undefined && (isHomeyReferenceKey(parameterName) || isHomeyIdentifierKey(parameterName)));
 	const nestedEndpointParameter =
 		endpointParameter || (parameterName !== undefined && isHomeyEndpointKey(parameterName));
+	const nestedIconParameter = iconParameter || (parameterName !== undefined && isHomeyIconKey(parameterName));
 
 	for (const [key, child] of Object.entries(record)) {
 		const childPath = [...path, key];
@@ -1347,6 +1459,10 @@ const visitPublishedValues = (
 
 			if (containsStructuredEndpoint(child) || (nestedEndpointParameter && !isSafeEndpointValue(child))) {
 				throw new Error(`${label}.${childPath.join('.')} publishes an endpoint value`);
+			}
+
+			if (containsStructuredIcon(child) || (nestedIconParameter && !isSafeIconValue(child))) {
+				throw new Error(`${label}.${childPath.join('.')} publishes an icon value`);
 			}
 
 			if (containsStructuredAddress(child) || (nestedAddressParameter && !isSafeAddressValue(child))) {
@@ -1371,6 +1487,7 @@ const visitPublishedValues = (
 			nestedPersonalParameter,
 			nestedIdentifierParameter,
 			nestedEndpointParameter,
+			nestedIconParameter,
 		);
 	}
 };
@@ -1489,6 +1606,11 @@ describe('Homey security artifact gate', () => {
 				example: { endpoint: 'private-homey.local:4859' },
 			}),
 		).toThrow('UnsafeHomeySchema.example publishes an endpoint value');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { icon: 'custom-household-icon' },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes an icon value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -1509,6 +1631,9 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() =>
 			assertFixtureTextSafe('unsafe fixture', '{"deviceId":"8d4d7584-1111-4111-8111-0123456789ab"}', '.json'),
+		).toThrow('unsafe fixture contains a structured identifier value');
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', '{"metadata":{"8d4d7584-1111-4111-8111-0123456789ab":{}}}', '.json'),
 		).toThrow('unsafe fixture contains a structured identifier value');
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"driverId":"opaque-driver"}', '.json')).toThrow(
 			'unsafe fixture contains a structured identifier value',
@@ -1617,15 +1742,46 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = function () { return 'opaque-secret'; };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = () => { const value = 'opaque-secret'; return value; };",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "const hostname = 'family-homey.local';", true)).toThrow(
 			'unsafe compiled module contains a compiled address value',
 		);
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Config { set hostname(value) { this.value = value || 'family-homey.local'; } }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled address value');
 		expect(() => assertTextSafe('unsafe compiled module', "const deviceId = 'opaque-household-id';", true)).toThrow(
 			'unsafe compiled module contains a compiled identifier value',
 		);
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Config { set deviceId(value) { this.value = value || 'opaque-household-id'; } }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled identifier value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const endpoint = 'private-homey.local:4859';", true),
 		).toThrow('unsafe compiled module contains a compiled endpoint value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Config { set endpoint(value) { this.value = value || 'private-homey.local:4859'; } }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled endpoint value');
+		expect(() => assertTextSafe('unsafe compiled module', "const deviceName = 'Alice Bedroom';", true)).toThrow(
+			'unsafe compiled module contains a compiled personal value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe declaration', "interface Config { hostname: 'family-homey.local' }", true),
 		).toThrow('unsafe declaration contains a compiled address value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1404,7 +1404,13 @@ const compiledPropertyWriteValues = (
 						values.push(...mutationPropertyValues(node.arguments[2], 'value'));
 					}
 				} else if (helperName === 'Object.defineProperties' && node.arguments.length >= 2) {
-					for (const descriptor of mutationPropertyValues(node.arguments[1], propertyName)) {
+					const descriptors = mutationPropertyValues(node.arguments[1], propertyName);
+
+					if (descriptors.length === 0) {
+						values.push(node.arguments[1]);
+					}
+
+					for (const descriptor of descriptors) {
 						values.push(descriptor);
 						values.push(...mutationPropertyValues(descriptor, 'value'));
 					}
@@ -1554,6 +1560,11 @@ const containsUnsafeCompiledAlias = (
 		arguments_: readonly ts.Expression[],
 		callback: () => boolean,
 	): boolean => {
+		const expandedArguments = arguments_.flatMap((argument): readonly ts.Expression[] =>
+			ts.isSpreadElement(argument)
+				? (resolveArrayElements(argument.expression, new Set()) ?? [argument.expression])
+				: [argument],
+		);
 		const previousArguments = new Map<ts.Node, readonly ts.Expression[] | undefined>();
 		const bindArgument = (
 			bindingName: ts.BindingName,
@@ -1618,10 +1629,10 @@ const containsUnsafeCompiledAlias = (
 		parameters.forEach((parameter, index) => {
 			const argumentValues =
 				parameter.dotDotDotToken === undefined
-					? [arguments_[index] ?? parameter.initializer].filter(
+					? [expandedArguments[index] ?? parameter.initializer].filter(
 							(argument): argument is ts.Expression => argument !== undefined,
 						)
-					: arguments_.slice(index);
+					: expandedArguments.slice(index);
 
 			if (argumentValues.length > 0) {
 				bindArgument(parameter.name, parameter, argumentValues);
@@ -1995,6 +2006,89 @@ const containsUnsafeCompiledAlias = (
 		return /^\d+$/.test(selectedPropertyName)
 			? values.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1)
 			: values;
+	};
+	const objectEntriesResultValues = (
+		call: ts.CallExpression,
+		entryPropertyName: string,
+		pairPropertyName: string,
+	): readonly ts.Expression[] => {
+		if (
+			compiledMutationHelperName(call.expression) !== 'Object.entries' ||
+			call.arguments.length === 0 ||
+			pairPropertyName !== '1'
+		) {
+			return [];
+		}
+
+		const resolveEntryValues = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): readonly ts.Expression[] | undefined => {
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveEntryValues(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveEntryValues(expression.expression, resolving);
+			}
+
+			if (!ts.isObjectLiteralExpression(expression)) {
+				return undefined;
+			}
+
+			return expression.properties.flatMap((property): readonly ts.Expression[] => {
+				if (ts.isPropertyAssignment(property)) {
+					return [property.initializer];
+				}
+
+				if (ts.isShorthandPropertyAssignment(property)) {
+					return [property.name];
+				}
+
+				return ts.isSpreadAssignment(property)
+					? (resolveEntryValues(property.expression, resolving) ?? [property.expression])
+					: [];
+			});
+		};
+		const values = resolveEntryValues(call.arguments[0]);
+
+		if (values === undefined) {
+			return [call.arguments[0]];
+		}
+
+		return /^\d+$/.test(entryPropertyName)
+			? values.slice(Number(entryPropertyName), Number(entryPropertyName) + 1)
+			: values;
+	};
+	const pluralDescriptorQueryValues = (
+		call: ts.CallExpression,
+		descriptorPropertyName: string,
+		selectedPropertyName: string,
+	): readonly ts.Expression[] => {
+		if (
+			selectedPropertyName !== 'value' ||
+			compiledMutationHelperName(call.expression) !== 'Object.getOwnPropertyDescriptors' ||
+			call.arguments.length === 0
+		) {
+			return [];
+		}
+
+		const selectedValue = resolvePropertyValue(call.arguments[0], descriptorPropertyName, new Set());
+
+		return [
+			...(selectedValue === undefined ? [] : [selectedValue]),
+			...compiledPropertyWriteValues(call.arguments[0], descriptorPropertyName, call.getStart(call.getSourceFile())),
+		];
 	};
 	const isJsonParseCall = (callee: ts.Expression, resolving = new Set<ts.Node>()): boolean => {
 		if (
@@ -2539,6 +2633,18 @@ const containsUnsafeCompiledAlias = (
 						: receiver.argumentExpression === undefined
 							? undefined
 							: compiledStaticPropertyExpressionName(receiver.argumentExpression);
+
+					if (
+						receiverPropertyName !== undefined &&
+						ts.isCallExpression(receiver.expression) &&
+						[
+							...objectEntriesResultValues(receiver.expression, receiverPropertyName, selectedPropertyName),
+							...pluralDescriptorQueryValues(receiver.expression, receiverPropertyName, selectedPropertyName),
+						].some((value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving))
+					) {
+						return true;
+					}
+
 					const resolvedReceiver =
 						receiverPropertyName === undefined
 							? undefined
@@ -2822,6 +2928,42 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isNewExpression(receiver)) {
 					const classDeclaration = resolveClassReceiver(receiver.expression);
+					const returnedObjectFound =
+						classDeclaration?.members.some((member) => {
+							if (!ts.isConstructorDeclaration(member) || member.body === undefined) {
+								return false;
+							}
+
+							return withCallArguments(member.parameters, receiver.arguments ?? [], () => {
+								let found = false;
+								const visitReturn = (child: ts.Node): void => {
+									if (found) {
+										return;
+									}
+
+									if (ts.isReturnStatement(child) && child.expression !== undefined) {
+										found = inspectProperty(
+											child.expression,
+											nestedResolving,
+											selectedPropertyName,
+											resolvingProperties,
+										);
+									}
+
+									if (!found) {
+										ts.forEachChild(child, visitReturn);
+									}
+								};
+
+								visitReturn(member.body);
+
+								return found;
+							});
+						}) ?? false;
+
+					if (returnedObjectFound) {
+						return true;
+					}
 
 					if (
 						classDeclaration !== undefined &&
@@ -5922,6 +6064,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const source = {}; Object.defineProperties(source, Object.fromEntries([['value', { get: () => stored }]])); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = {}; Object.defineProperty(source, 'value', { get() { return 'opaque-secret'; } }); const apiKey = source.value;",
 				true,
 			),
@@ -6035,6 +6184,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor() { this.value = 'opaque-secret'; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; class Source { constructor() { return { value: stored }; } } const apiKey = new Source().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -6187,6 +6343,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const stored = 'opaque-secret'; function make(value) { return { value }; } const args = [stored]; const apiKey = make(...args).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"function make({ value }) { return { value }; } const apiKey = make({ value: 'opaque-secret' }).value;",
 				true,
 			),
@@ -6251,7 +6414,21 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = Object.getOwnPropertyDescriptors({ value: stored }).value.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.values({ value: 'opaque-secret' })[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = Object.entries({ value: stored })[0][1];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2155,7 +2155,7 @@ const containsUnsafeCompiledAlias = (
 
 		if (
 			methodName !== 'concat' &&
-			!['filter', 'reverse', 'slice', 'sort', 'toReversed', 'toSorted', 'with'].includes(methodName ?? '')
+			!['filter', 'flat', 'reverse', 'slice', 'sort', 'toReversed', 'toSorted', 'with'].includes(methodName ?? '')
 		) {
 			return [];
 		}
@@ -2168,7 +2168,7 @@ const containsUnsafeCompiledAlias = (
 				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
 		const index = Number(selectedPropertyName);
 
-		return methodName === 'filter' ? values : values.slice(index, index + 1);
+		return methodName === 'filter' || methodName === 'flat' ? values : values.slice(index, index + 1);
 	};
 	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
 		if (
@@ -3308,7 +3308,15 @@ const containsUnsafeCompiledAlias = (
 					const element = resolveArrayElements(receiver, nestedResolving)?.[Number(selectedPropertyName)];
 
 					if (element === undefined) {
-						return false;
+						return (
+							ts.isArrayLiteralExpression(receiver) &&
+							receiver.elements.some(
+								(candidate) =>
+									ts.isSpreadElement(candidate) &&
+									(containsUnsafeCompiledLiteral(candidate.expression, safeStrings) ||
+										inspect(candidate.expression, nestedResolving)),
+							)
+						);
 					}
 
 					return ts.isSpreadElement(element)
@@ -6813,6 +6821,12 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].slice()[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = [['opaque-secret']].flat()[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = [...new Set(['opaque-secret'])][0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2079,7 +2079,7 @@ const containsUnsafeCompiledAlias = (
 		const returnExpressions = (body: ts.Block): readonly ts.Expression[] => {
 			const values: ts.Expression[] = [];
 			const visitReturn = (node: ts.Node): void => {
-				if (ts.isReturnStatement(node) && node.expression !== undefined) {
+				if ((ts.isReturnStatement(node) || ts.isYieldExpression(node)) && node.expression !== undefined) {
 					values.push(node.expression);
 				}
 
@@ -2349,6 +2349,10 @@ const containsUnsafeCompiledAlias = (
 					)
 				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
 		const index = Number(selectedPropertyName);
+
+		if (methodName === 'with') {
+			return [...values.slice(index, index + 1), ...call.arguments.slice(1, 2)];
+		}
 
 		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice' || methodName === 'toSpliced'
 			? values
@@ -4742,7 +4746,7 @@ const containsCompiledSecret = (text: string): boolean => {
 					return;
 				}
 
-				if (ts.isReturnStatement(node) && node.expression !== undefined) {
+				if ((ts.isReturnStatement(node) || ts.isYieldExpression(node)) && node.expression !== undefined) {
 					values.push(node.expression);
 				}
 
@@ -4785,6 +4789,77 @@ const containsCompiledSecret = (text: string): boolean => {
 
 		return ts.isFunctionExpression(expression) ? bodyReturnValues(expression.body) : [];
 	};
+	const promiseExecutorSettlementValues = (
+		executor: ts.Expression,
+		resolving = new Set<ts.Node>(),
+	): readonly ts.Expression[] => {
+		const callableValues = (
+			parameters: readonly ts.ParameterDeclaration[],
+			body: ts.ConciseBody,
+		): readonly ts.Expression[] => {
+			const settlementNames = new Set(
+				parameters
+					.slice(0, 2)
+					.map((parameter) => (ts.isIdentifier(parameter.name) ? parameter.name.text : undefined))
+					.filter((name): name is string => name !== undefined),
+			);
+			const values: ts.Expression[] = [];
+			const visitSettlement = (node: ts.Node): void => {
+				if (node !== body && ts.isFunctionLike(node)) {
+					return;
+				}
+
+				if (
+					ts.isCallExpression(node) &&
+					ts.isIdentifier(node.expression) &&
+					settlementNames.has(node.expression.text) &&
+					node.arguments[0] !== undefined
+				) {
+					values.push(node.arguments[0]);
+				}
+
+				ts.forEachChild(node, visitSettlement);
+			};
+
+			visitSettlement(body);
+
+			return values;
+		};
+
+		if (ts.isIdentifier(executor)) {
+			return resolveCompiledBindings(executor, executor.getStart(sourceFile)).flatMap((binding) => {
+				if (resolving.has(binding.declaration)) {
+					return [];
+				}
+
+				const nestedResolving = new Set(resolving).add(binding.declaration);
+				const initializerValues =
+					binding.initializer === undefined
+						? []
+						: promiseExecutorSettlementValues(binding.initializer, nestedResolving);
+				const declaredValues =
+					binding.callable?.body === undefined
+						? []
+						: callableValues(binding.callable.parameters, binding.callable.body);
+
+				return [...initializerValues, ...declaredValues];
+			});
+		}
+
+		if (
+			ts.isParenthesizedExpression(executor) ||
+			ts.isAsExpression(executor) ||
+			ts.isTypeAssertionExpression(executor) ||
+			ts.isNonNullExpression(executor) ||
+			ts.isSatisfiesExpression(executor)
+		) {
+			return promiseExecutorSettlementValues(executor.expression, resolving);
+		}
+
+		return ts.isArrowFunction(executor) || ts.isFunctionExpression(executor)
+			? callableValues(executor.parameters, executor.body)
+			: [];
+	};
 	const promiseSettlementValues = (
 		expression: ts.Expression,
 		resolving = new Set<ts.Node>(),
@@ -4806,6 +4881,15 @@ const containsCompiledSecret = (text: string): boolean => {
 			ts.isAwaitExpression(expression)
 		) {
 			return promiseSettlementValues(expression.expression, resolving);
+		}
+
+		if (
+			ts.isNewExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			expression.expression.text === 'Promise' &&
+			expression.arguments?.[0] !== undefined
+		) {
+			return promiseExecutorSettlementValues(expression.arguments[0]);
 		}
 
 		if (!ts.isCallExpression(expression)) {
@@ -4919,10 +5003,21 @@ const containsCompiledSecret = (text: string): boolean => {
 							: undefined
 						: compiledPropertyName(node.propertyName);
 			const bindingValues = compiledBindingValues(node);
+			const arrayBindingSource =
+				ts.isArrayBindingPattern(node.parent) &&
+				ts.isVariableDeclaration(node.parent.parent) &&
+				node.parent.parent.initializer !== undefined
+					? node.parent.parent.initializer
+					: undefined;
+			const iterableValues =
+				arrayBindingSource !== undefined && ts.isCallExpression(arrayBindingSource)
+					? [...callableReturnValues(arrayBindingSource.expression), ...arrayBindingSource.arguments]
+					: [];
 
 			found =
 				names.some((name) => isCompiledSecretName(name)) &&
 				(bindingValues.some((value) => containsUnsafeCompiledValue(value)) ||
+					iterableValues.some((value) => containsUnsafeCompiledValue(value)) ||
 					(selectedPropertyName !== undefined &&
 						bindingValues.some((value) =>
 							compiledPropertyWriteValues(value, selectedPropertyName, node.getStart(sourceFile)).some((writeValue) =>
@@ -5063,7 +5158,13 @@ const containsCompiledSecret = (text: string): boolean => {
 
 				return ts.isIdentifier(unwrappedTarget) && isCompiledSecretName(unwrappedTarget.text);
 			});
-			const assignedValues = [node.right, ...compiledReceiverWriteValues(node.right, node.getStart(sourceFile))];
+			const assignedValues = [
+				node.right,
+				...compiledReceiverWriteValues(node.right, node.getStart(sourceFile)),
+				...(ts.isCallExpression(node.right)
+					? [...callableReturnValues(node.right.expression), ...node.right.arguments]
+					: []),
+			];
 
 			found = targetContainsSecret && assignedValues.some((value) => containsUnsafeCompiledValue(value));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
@@ -6910,6 +7011,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const stored = 'opaque-secret'; new Promise((resolve) => resolve(stored)).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const values = []; values.push('opaque-secret'); Promise.all(values).then(([apiKey]) => {});",
 				true,
 			),
@@ -7063,6 +7171,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = ['safe']; source.push('opaque-secret'); const [, apiKey] = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; function* source() { yield stored; } const [apiKey] = source();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -7799,6 +7914,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].toSpliced(0, 0)[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = [''].with(0, 'opaque-secret')[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -6027,6 +6027,51 @@ const visitSchema = (schemaName: string, value: unknown, path: readonly string[]
 	}
 };
 
+const visitRouteSchemas = (
+	label: string,
+	value: unknown,
+	componentSchemas: Readonly<Record<string, unknown>>,
+): void => {
+	const visitedReferences = new Set<string>();
+	const visitReferences = (candidate: unknown, path: readonly string[] = []): void => {
+		if (Array.isArray(candidate)) {
+			candidate.forEach((entry, index) => visitReferences(entry, [...path, index.toString()]));
+
+			return;
+		}
+
+		if (candidate === null || typeof candidate !== 'object') {
+			return;
+		}
+
+		const record = candidate as JsonRecord;
+		const reference = typeof record.$ref === 'string' ? record.$ref : undefined;
+
+		if (reference?.startsWith('#/components/schemas/') === true) {
+			const schemaName = reference.slice('#/components/schemas/'.length).replaceAll('~1', '/').replaceAll('~0', '~');
+			const schema = componentSchemas[schemaName];
+
+			if (schema !== undefined && !visitedReferences.has(schemaName)) {
+				visitedReferences.add(schemaName);
+				visitSchema(schemaName, schema);
+				visitReferences(schema, ['components', 'schemas', schemaName]);
+			}
+		}
+
+		for (const [key, child] of Object.entries(record)) {
+			const childPath = [...path, key];
+
+			if (key === 'schema' && child !== null && typeof child === 'object') {
+				visitSchema(label, child, childPath);
+			}
+
+			visitReferences(child, childPath);
+		}
+	};
+
+	visitReferences(value);
+};
+
 const visitPublishedValues = (
 	label: string,
 	value: unknown,
@@ -6144,6 +6189,7 @@ describe('Homey security artifact gate', () => {
 		expect(Object.keys(homeySchemas).length).toBeGreaterThan(0);
 		expect(Object.keys(homeyPaths).length).toBeGreaterThan(0);
 		Object.entries(homeySchemas).forEach(([name, schema]) => visitSchema(name, schema));
+		visitRouteSchemas('generated Homey OpenAPI routes', homeyPaths, document.components?.schemas ?? {});
 		visitPublishedValues('generated Homey OpenAPI schemas', homeySchemas);
 		visitPublishedValues('generated Homey OpenAPI routes', homeyPaths);
 		assertTextSafe('generated Homey OpenAPI schemas', JSON.stringify(homeySchemas));
@@ -6200,6 +6246,22 @@ describe('Homey security artifact gate', () => {
 	});
 
 	it('rejects unsafe secret schemas and private artifact values without echoing them', () => {
+		expect(() =>
+			visitRouteSchemas(
+				'UnsafeHomeyOperation',
+				{
+					requestBody: { content: { 'application/json': { schema: { properties: { apiKey: { type: 'string' } } } } } },
+				},
+				{},
+			),
+		).toThrow('UnsafeHomeyOperation.requestBody.content.application/json.schema.properties.apiKey is not write-only');
+		expect(() =>
+			visitRouteSchemas(
+				'UnsafeHomeyOperation',
+				{ requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/SharedConfig' } } } } },
+				{ SharedConfig: { properties: { apiKey: { type: 'string' } } } },
+			),
+		).toThrow('SharedConfig.properties.apiKey is not write-only');
 		expect(() =>
 			visitSchema('UnsafeHomeySchema', {
 				properties: { api_key: { type: 'string', example: 'must-not-be-reported' } },

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1832,6 +1832,18 @@ const containsUnsafeCompiledAlias = (
 			}
 		}
 	};
+	const objectAssignSourceValues = (
+		source: ts.Expression,
+		propertyName: string,
+		visibleThroughPosition: number,
+	): readonly ts.Expression[] => {
+		const selectedValue = resolvePropertyValue(source, propertyName, new Set());
+
+		return [
+			...(selectedValue === undefined ? [source] : [selectedValue]),
+			...compiledPropertyWriteValues(source, propertyName, visibleThroughPosition),
+		];
+	};
 	const constructorMutationValues = (node: ts.Node, propertyName: string): readonly ts.Expression[] => {
 		if (
 			!ts.isCallExpression(node) ||
@@ -1844,11 +1856,9 @@ const containsUnsafeCompiledAlias = (
 		const helperName = compiledMutationHelperName(node.expression);
 
 		if (helperName === 'Object.assign') {
-			return node.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
-				const selectedValue = resolvePropertyValue(source, propertyName, new Set());
-
-				return selectedValue === undefined ? [source] : [selectedValue];
-			});
+			return node.arguments
+				.slice(1)
+				.flatMap((source) => objectAssignSourceValues(source, propertyName, node.getStart(node.getSourceFile())));
 		}
 
 		if (['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') && node.arguments.length >= 3) {
@@ -1898,11 +1908,9 @@ const containsUnsafeCompiledAlias = (
 		const helperName = compiledMutationHelperName(call.expression);
 
 		if (helperName === 'Object.assign') {
-			return call.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
-				const selectedValue = resolvePropertyValue(source, propertyName, new Set());
-
-				return selectedValue === undefined ? [source] : [selectedValue];
-			});
+			return call.arguments
+				.slice(1)
+				.flatMap((source) => objectAssignSourceValues(source, propertyName, call.getStart(call.getSourceFile())));
 		}
 
 		if (['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') && call.arguments.length >= 3) {
@@ -2028,13 +2036,25 @@ const containsUnsafeCompiledAlias = (
 			ts.isIdentifier(call.expression.expression) &&
 			call.expression.expression.text === 'Array'
 		) {
+			const arrayOfValues = (): readonly ts.Expression[] =>
+				call.arguments.flatMap((argument): readonly ts.Expression[] => {
+					if (!ts.isSpreadElement(argument)) {
+						return [argument];
+					}
+
+					return [
+						...(resolveArrayElements(argument.expression, new Set()) ?? [argument.expression]),
+						...compiledReceiverWriteValues(argument.expression, call.getStart(call.getSourceFile())),
+					];
+				});
+
 			return call.expression.name.text === 'from' && call.arguments[0] !== undefined
 				? [
 						call.arguments[0],
 						...compiledPropertyWriteValues(call.arguments[0], '0', call.getStart(call.getSourceFile())),
 					]
 				: call.expression.name.text === 'of'
-					? call.arguments
+					? arrayOfValues()
 					: [];
 		}
 
@@ -2333,6 +2353,7 @@ const containsUnsafeCompiledAlias = (
 				'reverse',
 				'slice',
 				'sort',
+				'split',
 				'splice',
 				'toReversed',
 				'toSpliced',
@@ -2351,7 +2372,28 @@ const containsUnsafeCompiledAlias = (
 		const writeValues = sourceExpressions.flatMap((expression) =>
 			compiledReceiverWriteValues(expression, call.getStart(call.getSourceFile())),
 		);
+		const nestedWriteValues = (
+			expressions: readonly ts.Expression[],
+			resolvingExpressions = new Set<ts.Node>(),
+		): readonly ts.Expression[] =>
+			expressions.flatMap((expression): readonly ts.Expression[] => {
+				if (resolvingExpressions.has(expression)) {
+					return [];
+				}
+
+				const nestedValues = resolveArrayElements(expression, new Set());
+				const nestedResolving = new Set(resolvingExpressions).add(expression);
+
+				return [
+					...compiledReceiverWriteValues(expression, call.getStart(call.getSourceFile())),
+					...(nestedValues === undefined ? [] : nestedWriteValues(nestedValues, nestedResolving)),
+				];
+			});
 		const index = Number(selectedPropertyName);
+
+		if (methodName === 'split') {
+			return [call.expression.expression];
+		}
 
 		if (methodName === 'fill') {
 			return [...values.slice(index, index + 1), ...call.arguments.slice(0, 1), ...writeValues];
@@ -2362,7 +2404,7 @@ const containsUnsafeCompiledAlias = (
 		}
 
 		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice' || methodName === 'toSpliced'
-			? [...values, ...writeValues]
+			? [...values, ...writeValues, ...(methodName === 'flat' ? nestedWriteValues(values) : [])]
 			: [...values.slice(index, index + 1), ...writeValues];
 	};
 	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
@@ -7671,6 +7713,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; source.value = 'opaque-secret'; const apiKey = Object.assign({}, source).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.create({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -7899,6 +7948,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = Array.of(...source)[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = new Map(); source.set('', 'opaque-secret'); const apiKey = source.get('');",
 				true,
 			),
@@ -8032,6 +8088,16 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [['opaque-secret']].flat()[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = [source].flat()[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = 'prefix:opaque-secret'.split(':')[1];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [...new Set(['opaque-secret'])][0];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1790,6 +1790,78 @@ const containsUnsafeCompiledAlias = (
 
 		return [];
 	};
+	const isJsonParseCall = (callee: ts.Expression, resolving = new Set<ts.Node>()): boolean => {
+		if (
+			ts.isPropertyAccessExpression(callee) &&
+			ts.isIdentifier(callee.expression) &&
+			callee.expression.text === 'JSON' &&
+			callee.name.text === 'parse'
+		) {
+			return true;
+		}
+
+		if (ts.isIdentifier(callee)) {
+			const binding = resolveCompiledBinding(callee);
+
+			return (
+				binding?.initializer !== undefined &&
+				!resolving.has(binding.declaration) &&
+				isJsonParseCall(binding.initializer, new Set(resolving).add(binding.declaration))
+			);
+		}
+
+		if (
+			ts.isParenthesizedExpression(callee) ||
+			ts.isAsExpression(callee) ||
+			ts.isTypeAssertionExpression(callee) ||
+			ts.isNonNullExpression(callee) ||
+			ts.isSatisfiesExpression(callee)
+		) {
+			return isJsonParseCall(callee.expression, resolving);
+		}
+
+		return false;
+	};
+	const jsonParsedPropertyIsUnsafe = (call: ts.CallExpression, propertyName: string): boolean => {
+		if (!isJsonParseCall(call.expression) || call.arguments.length === 0) {
+			return false;
+		}
+
+		const serialized = compiledStaticString(call.arguments[0]);
+
+		if (serialized === undefined) {
+			return false;
+		}
+
+		try {
+			const parsed = JSON.parse(serialized) as unknown;
+			const selectedValue =
+				parsed !== null && typeof parsed === 'object' ? (parsed as Record<string, unknown>)[propertyName] : undefined;
+			const inspectValue = (value: unknown): boolean => {
+				if (typeof value === 'string') {
+					return !isSafeCompiledString(value, safeStrings);
+				}
+
+				if (typeof value === 'number') {
+					return value !== 0;
+				}
+
+				if (typeof value === 'bigint') {
+					return value !== 0n;
+				}
+
+				if (Array.isArray(value)) {
+					return value.some(inspectValue);
+				}
+
+				return value !== null && typeof value === 'object' && Object.values(value).some(inspectValue);
+			};
+
+			return inspectValue(selectedValue);
+		} catch {
+			return false;
+		}
+	};
 	const resolveClassReceiver = (expression: ts.Expression): ts.ClassLikeDeclaration | undefined => {
 		if (ts.isIdentifier(expression)) {
 			return resolveCompiledBinding(expression)?.classDeclaration;
@@ -2291,6 +2363,10 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
+					if (jsonParsedPropertyIsUnsafe(receiver, selectedPropertyName)) {
+						return true;
+					}
+
 					if (
 						mutationResultValues(receiver, selectedPropertyName).some(
 							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
@@ -3687,7 +3763,27 @@ const containsCompiledSecret = (text: string): boolean => {
 				names.some((name) => isCompiledSecretName(name)) &&
 				compiledBindingValues(node).some((value) => containsUnsafeCompiledValue(value));
 		} else if (ts.isCallExpression(node)) {
-			found = secretCallArguments(resolveCallParameterSets(node.expression), node.arguments);
+			const invocationPropertyName =
+				ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)
+					? ts.isPropertyAccessExpression(node.expression)
+						? node.expression.name.text
+						: node.expression.argumentExpression === undefined
+							? undefined
+							: compiledStaticPropertyExpressionName(node.expression.argumentExpression)
+					: undefined;
+			const invokedCallee =
+				(invocationPropertyName === 'call' || invocationPropertyName === 'apply') &&
+				(ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression))
+					? node.expression.expression
+					: node.expression;
+			const invokedArguments: readonly ts.Expression[] =
+				invocationPropertyName === 'call'
+					? node.arguments.slice(1)
+					: invocationPropertyName === 'apply' && node.arguments[1] !== undefined
+						? [ts.factory.createSpreadElement(node.arguments[1])]
+						: node.arguments;
+
+			found = secretCallArguments(resolveCallParameterSets(invokedCallee), invokedArguments);
 		} else if (ts.isNewExpression(node)) {
 			const classDeclaration = ts.isIdentifier(node.expression)
 				? resolveCompiledBinding(node.expression)?.classDeclaration
@@ -5390,6 +5486,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function connect(apiKey) {} connect.call(null, 'opaque-secret');",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function connect(apiKey) {} connect.apply(null, ['opaque-secret']);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const connect = ({ apiKey }) => {}; connect({ apiKey: 'opaque-secret' });",
 				true,
 			),
@@ -5850,6 +5960,9 @@ describe('Homey security artifact gate', () => {
 				"const apiKey = structuredClone({ value: 'opaque-secret' }).value;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', `const apiKey = JSON.parse('{"value":"opaque-secret"}').value;`, true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1959,14 +1959,13 @@ const containsUnsafeCompiledAlias = (
 			return resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression];
 		}
 
-		const callbackIndex =
-			methodName === 'map' || methodName === 'flatMap'
-				? 0
-				: methodName === 'from' &&
-					  ts.isIdentifier(call.expression.expression) &&
-					  call.expression.expression.text === 'Array'
-					? 1
-					: undefined;
+		const callbackIndex = ['flatMap', 'map', 'reduce', 'reduceRight'].includes(methodName ?? '')
+			? 0
+			: methodName === 'from' &&
+				  ts.isIdentifier(call.expression.expression) &&
+				  call.expression.expression.text === 'Array'
+				? 1
+				: undefined;
 		const callback = callbackIndex === undefined ? undefined : call.arguments[callbackIndex];
 
 		if (callback === undefined) {
@@ -2027,7 +2026,17 @@ const containsUnsafeCompiledAlias = (
 			return ts.isFunctionExpression(expression) ? returnExpressions(expression.body) : [];
 		};
 
-		return resolveCallbackValues(callback, resolving);
+		const callbackValues = resolveCallbackValues(callback, resolving);
+
+		if (methodName !== 'reduce' && methodName !== 'reduceRight') {
+			return callbackValues;
+		}
+
+		return [
+			...callbackValues,
+			...(resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]),
+			...call.arguments.slice(1, 2),
+		];
 	};
 	const descriptorQueryValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
 		if (
@@ -2246,6 +2255,59 @@ const containsUnsafeCompiledAlias = (
 		];
 	};
 	const iteratorResultValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		const generatorResultValues = (callee: ts.Expression, resolving = new Set<ts.Node>()): readonly ts.Expression[] => {
+			const bodyValues = (body: ts.Block): readonly ts.Expression[] => {
+				const values: ts.Expression[] = [];
+				const visitBody = (node: ts.Node): void => {
+					if (node !== body && ts.isFunctionLike(node)) {
+						return;
+					}
+
+					if (ts.isYieldExpression(node) && node.expression !== undefined) {
+						values.push(node.expression);
+					} else if (ts.isReturnStatement(node) && node.expression !== undefined) {
+						values.push(node.expression);
+					}
+
+					ts.forEachChild(node, visitBody);
+				};
+
+				visitBody(body);
+
+				return values;
+			};
+
+			if (ts.isIdentifier(callee)) {
+				return resolveCompiledBindings(callee, visibleThroughPosition).flatMap((binding) => {
+					if (resolving.has(binding.declaration)) {
+						return [];
+					}
+
+					const nestedResolving = new Set(resolving).add(binding.declaration);
+					const initializerValues =
+						binding.initializer === undefined ? [] : generatorResultValues(binding.initializer, nestedResolving);
+					const callableValues =
+						binding.callable?.asteriskToken === undefined || binding.callable.body === undefined
+							? []
+							: bodyValues(binding.callable.body);
+
+					return [...initializerValues, ...callableValues];
+				});
+			}
+
+			if (
+				ts.isParenthesizedExpression(callee) ||
+				ts.isAsExpression(callee) ||
+				ts.isTypeAssertionExpression(callee) ||
+				ts.isNonNullExpression(callee) ||
+				ts.isSatisfiesExpression(callee)
+			) {
+				return generatorResultValues(callee.expression, resolving);
+			}
+
+			return ts.isFunctionExpression(callee) && callee.asteriskToken !== undefined ? bodyValues(callee.body) : [];
+		};
+
 		if (
 			selectedPropertyName !== 'value' ||
 			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression))
@@ -2269,7 +2331,9 @@ const containsUnsafeCompiledAlias = (
 			!ts.isPropertyAccessExpression(iteratorCall.expression) &&
 			!ts.isElementAccessExpression(iteratorCall.expression)
 		) {
-			return [];
+			const yieldedValues = generatorResultValues(iteratorCall.expression);
+
+			return yieldedValues.length === 0 ? [] : [...yieldedValues, ...iteratorCall.arguments];
 		}
 
 		const iteratorMethodName = ts.isPropertyAccessExpression(iteratorCall.expression)
@@ -4537,12 +4601,17 @@ const containsCompiledSecret = (text: string): boolean => {
 				: compiledStaticPropertyExpressionName(expression.expression.argumentExpression);
 		const receiver = expression.expression.expression;
 
-		if (
-			(methodName === 'resolve' || methodName === 'reject') &&
-			ts.isIdentifier(receiver) &&
-			receiver.text === 'Promise'
-		) {
-			return expression.arguments.slice(0, 1);
+		if (ts.isIdentifier(receiver) && receiver.text === 'Promise' && expression.arguments[0] !== undefined) {
+			if (methodName === 'resolve' || methodName === 'reject') {
+				return expression.arguments.slice(0, 1);
+			}
+
+			if (['all', 'allSettled', 'any', 'race'].includes(methodName ?? '')) {
+				return [
+					expression.arguments[0],
+					...compiledPropertyWriteValues(expression.arguments[0], '0', expression.getStart(expression.getSourceFile())),
+				];
+			}
 		}
 
 		return ['catch', 'finally', 'then'].includes(methodName ?? '') ? promiseSettlementValues(receiver, resolving) : [];
@@ -6441,6 +6510,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const stored = 'opaque-secret'; Promise.all([stored]).then(([apiKey]) => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const connect = ({ apiKey }) => {}; connect({ apiKey: 'opaque-secret' });",
 				true,
 			),
@@ -7097,6 +7173,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = [{ value: stored }].reduce((value) => value).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = { value: 'opaque-secret' }; const apiKey = [].reduceRight(() => stored, {}).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const apiKey = Array.from({ length: 1 }, () => ({ value: 'opaque-secret' }))[0].value;",
 				true,
 			),
@@ -7140,6 +7230,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = source.entries().next().value[1];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; function* source() { yield stored; } const apiKey = source().next().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = function* (value) { yield value; }; const apiKey = source('opaque-secret').next().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -507,7 +507,7 @@ const containsUnsafeCompiledLiteral = (
 
 interface CompiledBinding {
 	readonly callable?: ts.FunctionDeclaration;
-	readonly declaration: ts.Declaration;
+	readonly declaration: ts.Node;
 	readonly fallbackInitializer?: ts.Expression;
 	readonly initializer?: ts.Expression;
 	readonly scope: ts.Node;
@@ -681,16 +681,9 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 	};
 	const visit = (node: ts.Node): void => {
 		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-			const constantInitializer =
-				node.initializer !== undefined &&
-				ts.isVariableDeclarationList(node.parent) &&
-				(node.parent.flags & ts.NodeFlags.Const) !== 0
-					? node.initializer
-					: undefined;
-
 			addBinding(node.name.text, {
 				declaration: node,
-				initializer: constantInitializer,
+				initializer: node.initializer,
 				scope: compiledBindingScope(node),
 			});
 		} else if (
@@ -705,6 +698,20 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
 			addBinding(node.name.text, { callable: node, declaration: node, scope: compiledBindingScope(node) });
+		} else if (
+			ts.isBinaryExpression(node) &&
+			ts.isIdentifier(node.left) &&
+			isAssignmentOperatorKind(node.operatorToken.kind)
+		) {
+			const target = resolveCompiledBinding(node.left);
+
+			if (target !== undefined) {
+				addBinding(node.left.text, {
+					declaration: node,
+					initializer: node.right,
+					scope: target.scope,
+				});
+			}
 		}
 
 		ts.forEachChild(node, visit);
@@ -742,10 +749,11 @@ const compiledScopeDepth = (scope: ts.Node): number => {
 	return depth;
 };
 
-const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | undefined => {
+const resolveCompiledBindings = (identifier: ts.Identifier): readonly CompiledBinding[] => {
 	const sourceFile = identifier.getSourceFile();
 	const usePosition = identifier.getStart(sourceFile);
-	const visibleBindings = (compiledBindings(sourceFile).get(identifier.text) ?? [])
+
+	return (compiledBindings(sourceFile).get(identifier.text) ?? [])
 		.filter(
 			(binding) =>
 				isNodeWithin(identifier, binding.scope) &&
@@ -760,9 +768,10 @@ const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | un
 				? depthDifference
 				: right.declaration.getStart(sourceFile) - left.declaration.getStart(sourceFile);
 		});
-
-	return visibleBindings[0];
 };
+
+const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | undefined =>
+	resolveCompiledBindings(identifier)[0];
 
 const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined =>
 	resolveCompiledBinding(identifier)?.initializer;
@@ -820,18 +829,20 @@ const containsUnsafeCompiledAlias = (
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(expression)) {
-			const binding = resolveCompiledBinding(expression);
+			const bindings = resolveCompiledBindings(expression);
 
-			if (binding === undefined || resolving.has(expression.text)) {
+			if (bindings.length === 0 || resolving.has(expression.text)) {
 				return false;
 			}
 
 			const nestedResolving = new Set(resolving).add(expression.text);
 
-			return [binding.initializer, binding.fallbackInitializer].some(
-				(initializer) =>
-					initializer !== undefined &&
-					(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
+			return bindings.some((binding) =>
+				[binding.initializer, binding.fallbackInitializer].some(
+					(initializer) =>
+						initializer !== undefined &&
+						(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
+				),
 			);
 		}
 
@@ -1037,19 +1048,20 @@ const containsUnsafeCompiledAlias = (
 	};
 	const inspectCallable = (callee: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(callee)) {
-			const binding = resolveCompiledBinding(callee);
+			const bindings = resolveCompiledBindings(callee);
 
-			if (binding === undefined || resolving.has(callee.text)) {
+			if (bindings.length === 0 || resolving.has(callee.text)) {
 				return false;
 			}
 
 			const nestedResolving = new Set(resolving).add(callee.text);
 
-			return (
-				[binding.initializer, binding.fallbackInitializer].some(
-					(initializer) => initializer !== undefined && inspectCallable(initializer, nestedResolving),
-				) ||
-				(binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving))
+			return bindings.some(
+				(binding) =>
+					[binding.initializer, binding.fallbackInitializer].some(
+						(initializer) => initializer !== undefined && inspectCallable(initializer, nestedResolving),
+					) ||
+					(binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving)),
 			);
 		}
 
@@ -2657,6 +2669,16 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const fallback = 'opaque-secret'; const apiKey = fallback;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "let fallback = 'opaque-secret'; const apiKey = fallback;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"let fallback = ''; fallback = 'opaque-secret'; const apiKey = fallback;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1198,7 +1198,10 @@ const compiledPropertyWriteValues = (
 					for (const source of node.arguments.slice(1)) {
 						values.push(...mutationPropertyValues(source, propertyName));
 					}
-				} else if (helperName === 'Object.defineProperty' && node.arguments.length >= 3) {
+				} else if (
+					['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') &&
+					node.arguments.length >= 3
+				) {
 					const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
 
 					if (selectedName === propertyName || selectedName === undefined) {
@@ -1461,7 +1464,7 @@ const containsUnsafeCompiledAlias = (
 			});
 		}
 
-		if (helperName === 'Object.defineProperty' && node.arguments.length >= 3) {
+		if (['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') && node.arguments.length >= 3) {
 			const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
 
 			if (selectedName !== propertyName && selectedName !== undefined) {
@@ -1515,7 +1518,7 @@ const containsUnsafeCompiledAlias = (
 			});
 		}
 
-		if (helperName === 'Object.defineProperty' && call.arguments.length >= 3) {
+		if (['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') && call.arguments.length >= 3) {
 			const selectedName = compiledStaticPropertyExpressionName(call.arguments[1]);
 
 			if (selectedName !== propertyName && selectedName !== undefined) {
@@ -1600,6 +1603,59 @@ const containsUnsafeCompiledAlias = (
 
 		return [];
 	};
+	const transparentCallResultValues = (call: ts.CallExpression): readonly ts.Expression[] => {
+		if (ts.isIdentifier(call.expression)) {
+			if (call.expression.text === 'structuredClone' || call.expression.text === 'Object') {
+				return call.arguments.slice(0, 1);
+			}
+
+			return [];
+		}
+
+		if (
+			ts.isPropertyAccessExpression(call.expression) &&
+			ts.isIdentifier(call.expression.expression) &&
+			call.expression.expression.text === 'Promise' &&
+			call.expression.name.text === 'resolve'
+		) {
+			return call.arguments.slice(0, 1);
+		}
+
+		if (
+			ts.isPropertyAccessExpression(call.expression) &&
+			ts.isIdentifier(call.expression.expression) &&
+			call.expression.expression.text === 'Array'
+		) {
+			return call.expression.name.text === 'from'
+				? call.arguments.slice(0, 1)
+				: call.expression.name.text === 'of'
+					? call.arguments
+					: [];
+		}
+
+		return [];
+	};
+	const resolveClassReceiver = (expression: ts.Expression): ts.ClassLikeDeclaration | undefined => {
+		if (ts.isIdentifier(expression)) {
+			return resolveCompiledBinding(expression)?.classDeclaration;
+		}
+
+		if (ts.isClassExpression(expression)) {
+			return expression;
+		}
+
+		if (
+			ts.isParenthesizedExpression(expression) ||
+			ts.isAsExpression(expression) ||
+			ts.isTypeAssertionExpression(expression) ||
+			ts.isNonNullExpression(expression) ||
+			ts.isSatisfiesExpression(expression)
+		) {
+			return resolveClassReceiver(expression.expression);
+		}
+
+		return undefined;
+	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression, visibleThroughPosition);
@@ -1664,7 +1720,7 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				const inspectClassProperty = (
-					classDeclaration: ts.ClassDeclaration,
+					classDeclaration: ts.ClassLikeDeclaration,
 					expectStatic: boolean,
 					memberName: string,
 					classResolvingProperties = new Set<string>(),
@@ -1852,8 +1908,8 @@ const containsUnsafeCompiledAlias = (
 						if ((ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) && member.body !== undefined) {
 							let found = false;
 							const inspectDynamicClassProperties = (
-								declaration: ts.ClassDeclaration,
-								resolvingClasses = new Set<ts.ClassDeclaration>(),
+								declaration: ts.ClassLikeDeclaration,
+								resolvingClasses = new Set<ts.ClassLikeDeclaration>(),
 							): boolean => {
 								if (resolvingClasses.has(declaration)) {
 									return false;
@@ -2170,9 +2226,9 @@ const containsUnsafeCompiledAlias = (
 								}
 
 								const inspectClassMethod = (
-									declaration: ts.ClassDeclaration,
+									declaration: ts.ClassLikeDeclaration,
 									expectStatic: boolean,
-									resolvingClasses = new Set<ts.ClassDeclaration>(),
+									resolvingClasses = new Set<ts.ClassLikeDeclaration>(),
 								): boolean => {
 									if (resolvingClasses.has(declaration)) {
 										return false;
@@ -2255,8 +2311,8 @@ const containsUnsafeCompiledAlias = (
 									return inspectMethodProperty(methodReceiver.expression, resolvingMethods);
 								}
 
-								if (ts.isNewExpression(methodReceiver) && ts.isIdentifier(methodReceiver.expression)) {
-									const classDeclaration = resolveCompiledBinding(methodReceiver.expression)?.classDeclaration;
+								if (ts.isNewExpression(methodReceiver)) {
+									const classDeclaration = resolveClassReceiver(methodReceiver.expression);
 
 									return classDeclaration !== undefined && inspectClassMethod(classDeclaration, false);
 								}
@@ -2305,13 +2361,16 @@ const containsUnsafeCompiledAlias = (
 						);
 					};
 
-					return inspectReturnedProperty(receiver.expression, nestedResolving, receiver.arguments);
+					return (
+						inspectReturnedProperty(receiver.expression, nestedResolving, receiver.arguments) ||
+						transparentCallResultValues(receiver).some(
+							(argument) => containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving),
+						)
+					);
 				}
 
 				if (ts.isNewExpression(receiver)) {
-					const classDeclaration = ts.isIdentifier(receiver.expression)
-						? resolveCompiledBinding(receiver.expression)?.classDeclaration
-						: undefined;
+					const classDeclaration = resolveClassReceiver(receiver.expression);
 
 					if (
 						classDeclaration !== undefined &&
@@ -2626,8 +2685,8 @@ const containsUnsafeCompiledAlias = (
 					}
 
 					const inspectStaticClassCallable = (
-						declaration: ts.ClassDeclaration,
-						resolvingClasses = new Set<ts.ClassDeclaration>(),
+						declaration: ts.ClassLikeDeclaration,
+						resolvingClasses = new Set<ts.ClassLikeDeclaration>(),
 					): boolean => {
 						if (resolvingClasses.has(declaration)) {
 							return false;
@@ -2858,13 +2917,21 @@ const containsUnsafeCompiledAlias = (
 						);
 					};
 
-					return inspectReturnedReceiver(receiver.expression, nestedResolving, receiver.arguments);
+					return (
+						inspectReturnedReceiver(receiver.expression, nestedResolving, receiver.arguments) ||
+						transparentCallResultValues(receiver).some(
+							(argument) =>
+								inspectCallable(argument, nestedResolving) ||
+								containsUnsafeCompiledLiteral(argument, safeStrings) ||
+								inspect(argument, nestedResolving),
+						)
+					);
 				}
 
-				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
-					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+				if (ts.isNewExpression(receiver)) {
+					const classDeclaration = resolveClassReceiver(receiver.expression);
 					const inspectClassValue = (
-						declaration: ts.ClassDeclaration,
+						declaration: ts.ClassLikeDeclaration,
 						memberName: string,
 						resolvingValues = new Set<string>(),
 					): boolean => {
@@ -2968,8 +3035,8 @@ const containsUnsafeCompiledAlias = (
 						);
 					};
 					const inspectClassCallable = (
-						declaration: ts.ClassDeclaration,
-						resolvingClasses = new Set<ts.ClassDeclaration>(),
+						declaration: ts.ClassLikeDeclaration,
+						resolvingClasses = new Set<ts.ClassLikeDeclaration>(),
 					): boolean => {
 						if (resolvingClasses.has(declaration)) {
 							return false;
@@ -5168,6 +5235,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = {}; Reflect.defineProperty(source, 'value', { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const stored = 'opaque-secret'; const source = {}; Object.defineProperty(source, 'apiKey', { get: () => stored }); const apiKey = source.apiKey;",
 				true,
 			),
@@ -5272,6 +5346,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = new Proxy({ value: 'opaque-secret' }, {}).value;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = new (class { value = 'opaque-secret' })().value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(
@@ -5460,6 +5537,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = structuredClone({ value: 'opaque-secret' }).value;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -493,7 +493,10 @@ const containsUnsafeCompiledAlias = (
 		}
 
 		if (ts.isCallExpression(expression)) {
-			return expression.arguments.some((argument) => inspect(argument, resolving));
+			return (
+				(expression.arguments.length === 0 && inspect(expression.expression, resolving)) ||
+				expression.arguments.some((argument) => inspect(argument, resolving))
+			);
 		}
 
 		if (ts.isNewExpression(expression)) {
@@ -1014,6 +1017,80 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 	return found;
 };
 
+const containsCompiledIcon = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const isSafeCompiledIconValue = (value: string): boolean => value === '[~2~]';
+	const unsafeIcon = (name: string | undefined, expression: ts.Expression): boolean =>
+		name !== undefined && isHomeyIconKey(name) && containsUnsafeCompiledValue(expression, isSafeCompiledIconValue);
+	const unsafeIconType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
+		name !== undefined &&
+		isHomeyIconKey(name) &&
+		type !== undefined &&
+		containsUnsafeCompiledType(type, isSafeCompiledIconValue);
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node)) {
+			found = unsafeIcon(compiledPropertyName(node.name), node.initializer);
+		} else if (ts.isPropertyDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found = (node.initializer !== undefined && unsafeIcon(name, node.initializer)) || unsafeIconType(name, node.type);
+		} else if (ts.isPropertySignature(node)) {
+			found = unsafeIconType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isSetAccessorDeclaration(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				name !== undefined &&
+				isHomeyIconKey(name) &&
+				(node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined &&
+							containsUnsafeCompiledValue(parameter.initializer, isSafeCompiledIconValue)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type, isSafeCompiledIconValue)),
+				) ||
+					(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIconValue)));
+		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+			const name = compiledPropertyName(node.name);
+			const iconName = name !== undefined && isHomeyIconKey(name);
+
+			found =
+				('body' in node &&
+					node.body !== undefined &&
+					iconName &&
+					containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIconValue)) ||
+				(iconName && unsafeIconType(name, node.type));
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeIcon(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeIcon(node.name.text, node.initializer)) ||
+				unsafeIconType(node.name.text, node.type);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = unsafeIcon(name, node.initializer);
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
+			found = unsafeIcon(compiledAssignedPropertyName(node.left), node.right);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
 const compiledStaticString = (node: ts.Expression): string | undefined => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 		return node.text;
@@ -1070,6 +1147,34 @@ const containsCompiledPrivateUrl = (text: string): boolean => {
 			const staticString = compiledStaticString(node);
 
 			found = staticString !== undefined && containsStructuredUrl(staticString);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
+const containsCompiledTimestamp = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+			found = isHomeyIsoTimestamp(node.text) && !isSafeTimestampValue(node.text);
+		} else if (ts.isTemplateExpression(node)) {
+			const staticString = compiledStaticString(node);
+
+			found = staticString !== undefined && isHomeyIsoTimestamp(staticString) && !isSafeTimestampValue(staticString);
+		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+			const staticString = compiledStaticString(node);
+
+			found = staticString !== undefined && isHomeyIsoTimestamp(staticString) && !isSafeTimestampValue(staticString);
 		}
 
 		ts.forEachChild(node, visit);
@@ -1412,6 +1517,14 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 
 	if (compiledSource && containsCompiledPersonalValue(text)) {
 		throw new Error(`${label} contains a compiled personal value`);
+	}
+
+	if (compiledSource && containsCompiledIcon(text)) {
+		throw new Error(`${label} contains a compiled icon value`);
+	}
+
+	if (compiledSource && containsCompiledTimestamp(text)) {
+		throw new Error(`${label} contains a compiled timestamp value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -1899,6 +2012,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const fallback = 'opaque-secret'; const apiKey = fallback;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const fallback = () => 'opaque-secret'; const apiKey = fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),
 		).toThrow('unsafe declaration contains a compiled secret value');
 		expect(() =>
@@ -1950,6 +2070,12 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const deviceName = 'Alice Bedroom';", true)).toThrow(
 			'unsafe compiled module contains a compiled personal value',
 		);
+		expect(() => assertTextSafe('unsafe compiled module', "const icon = 'custom-household-icon';", true)).toThrow(
+			'unsafe compiled module contains a compiled icon value',
+		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const updatedAt = '2026-08-25T12:34:56.000Z';", true),
+		).toThrow('unsafe compiled module contains a compiled timestamp value');
 		expect(() =>
 			assertTextSafe('unsafe declaration', "interface Config { hostname: 'family-homey.local' }", true),
 		).toThrow('unsafe declaration contains a compiled address value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1533,6 +1533,65 @@ const compiledPropertyWriteValues = (
 	return values;
 };
 
+const compiledReceiverWriteValues = (
+	receiver: ts.Expression,
+	visibleThroughPosition = receiver.getStart(receiver.getSourceFile()),
+): readonly ts.Expression[] => {
+	const sourceFile = receiver.getSourceFile();
+	const targetPath = resolveCompiledReceiverPath(receiver);
+	const usePosition = Math.max(receiver.getStart(sourceFile), visibleThroughPosition);
+	const values: ts.Expression[] = [];
+
+	if (targetPath === undefined) {
+		return values;
+	}
+
+	const sameReceiver = (candidate: ts.Expression): boolean => {
+		const candidatePath = resolveCompiledReceiverPath(candidate);
+
+		return (
+			candidatePath !== undefined &&
+			candidatePath.binding.declaration === targetPath.binding.declaration &&
+			candidatePath.properties.length === targetPath.properties.length &&
+			candidatePath.properties.every((property, index) => property === targetPath.properties[index])
+		);
+	};
+	const visit = (node: ts.Node): void => {
+		if (node.getStart(sourceFile) >= usePosition) {
+			return;
+		}
+
+		if (
+			ts.isBinaryExpression(node) &&
+			isAssignmentOperatorKind(node.operatorToken.kind) &&
+			(ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left)) &&
+			sameReceiver(node.left.expression)
+		) {
+			values.push(node.right);
+		} else if (ts.isCallExpression(node)) {
+			const helperName = compiledMutationHelperName(node.expression);
+
+			if (node.arguments[0] !== undefined && sameReceiver(node.arguments[0])) {
+				if (helperName === 'Object.assign') {
+					values.push(...node.arguments.slice(1));
+				} else if (
+					['Object.defineProperty', 'Object.defineProperties', 'Reflect.defineProperty'].includes(helperName ?? '')
+				) {
+					values.push(...node.arguments.slice(1));
+				} else if (helperName === 'Reflect.set' && node.arguments[2] !== undefined) {
+					values.push(node.arguments[2]);
+				}
+			}
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return values;
+};
+
 const containsUnsafeCompiledAlias = (
 	node: ts.Expression,
 	safeStrings: SafeCompiledString,
@@ -2033,6 +2092,29 @@ const containsUnsafeCompiledAlias = (
 
 		const callbackValues = resolveCallbackValues(callback, resolving);
 
+		if (methodName === 'map' || methodName === 'flatMap') {
+			const receiver = call.expression.expression;
+
+			return [
+				...callbackValues,
+				...(resolveArrayElements(receiver, new Set()) ?? [receiver]),
+				...compiledPropertyWriteValues(receiver, '0', call.getStart(call.getSourceFile())),
+			];
+		}
+
+		if (
+			methodName === 'from' &&
+			ts.isIdentifier(call.expression.expression) &&
+			call.expression.expression.text === 'Array' &&
+			call.arguments[0] !== undefined
+		) {
+			return [
+				...callbackValues,
+				call.arguments[0],
+				...compiledPropertyWriteValues(call.arguments[0], '0', call.getStart(call.getSourceFile())),
+			];
+		}
+
 		if (methodName !== 'reduce' && methodName !== 'reduceRight') {
 			return callbackValues;
 		}
@@ -2117,14 +2199,15 @@ const containsUnsafeCompiledAlias = (
 			});
 		};
 		const values = resolveObjectValues(call.arguments[0]);
+		const writeValues = compiledReceiverWriteValues(call.arguments[0], call.getStart(call.getSourceFile()));
 
 		if (values === undefined) {
-			return [call.arguments[0]];
+			return [call.arguments[0], ...writeValues];
 		}
 
 		return /^\d+$/.test(selectedPropertyName)
-			? values.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1)
-			: values;
+			? [...values.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1), ...writeValues]
+			: [...values, ...writeValues];
 	};
 	const objectKeysResultValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
 		if (compiledMutationHelperName(call.expression) !== 'Object.keys' || call.arguments.length === 0) {
@@ -4769,12 +4852,15 @@ const containsCompiledSecret = (text: string): boolean => {
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
+			const arrayBindingIndex = ts.isArrayBindingPattern(node.parent) ? node.parent.elements.indexOf(node) : -1;
 			const selectedPropertyName =
-				node.propertyName === undefined
-					? ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined
-					: compiledPropertyName(node.propertyName);
+				arrayBindingIndex >= 0
+					? String(arrayBindingIndex)
+					: node.propertyName === undefined
+						? ts.isIdentifier(node.name)
+							? node.name.text
+							: undefined
+						: compiledPropertyName(node.propertyName);
 			const bindingValues = compiledBindingValues(node);
 
 			found =
@@ -6795,6 +6881,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const [apiKey] = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = ['safe']; source.push('opaque-secret'); const [, apiKey] = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; source[key] = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
@@ -7239,6 +7339,20 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; source.value = 'opaque-secret'; const apiKey = Object.values(source)[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; source.other = 'opaque-secret'; const apiKey = Object.values(source)[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.keys({ 'opaque-secret': 0 })[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -7324,6 +7438,20 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['safe'].map(() => 'opaque-secret')[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = [stored].map((value) => value)[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = [[stored]].flatMap((value) => value)[0];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1294,24 +1294,70 @@ const compiledPropertyWriteValues = (
 					(element) => !ts.isOmittedExpression(element) && bindingNameReferences(element.name, referencedName),
 				);
 	const methodWriteValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
-		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
+		const resolveMethodReference = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): { methodName: string; receiver: ts.Expression } | undefined => {
+			if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+				const methodName = ts.isPropertyAccessExpression(expression)
+					? expression.name.text
+					: expression.argumentExpression === undefined
+						? undefined
+						: compiledStaticPropertyExpressionName(expression.argumentExpression);
+
+				return methodName === undefined ? undefined : { methodName, receiver: expression.expression };
+			}
+
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveMethodReference(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveMethodReference(expression.expression, resolving);
+			}
+
+			return undefined;
+		};
+		const invocation = resolveMethodReference(call.expression);
+
+		if (invocation === undefined) {
 			return [];
 		}
 
-		const methodName = ts.isPropertyAccessExpression(call.expression)
-			? call.expression.name.text
-			: call.expression.argumentExpression === undefined
-				? undefined
-				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+		const detachedInvocation =
+			invocation.methodName === 'call' || invocation.methodName === 'apply'
+				? resolveMethodReference(invocation.receiver)
+				: undefined;
+		const methodName = detachedInvocation?.methodName ?? invocation.methodName;
+		const methodReceiver = detachedInvocation?.receiver ?? invocation.receiver;
+		const effectiveReceiver = detachedInvocation === undefined ? invocation.receiver : call.arguments[0];
+		const effectiveArguments =
+			detachedInvocation === undefined
+				? call.arguments
+				: invocation.methodName === 'call'
+					? call.arguments.slice(1)
+					: call.arguments[1] === undefined
+						? []
+						: expandMutationSources([ts.factory.createSpreadElement(call.arguments[1])]);
 
 		if (
-			methodName === undefined ||
-			!sameReceiverPath(resolveCompiledReceiverPath(call.expression.expression), targetPath)
+			effectiveReceiver === undefined ||
+			!sameReceiverPath(resolveCompiledReceiverPath(effectiveReceiver), targetPath)
 		) {
 			return [];
 		}
 
-		return resolveReceiverMethods(call.expression.expression, methodName).flatMap(({ body, parameters }) => {
+		return resolveReceiverMethods(methodReceiver, methodName).flatMap(({ body, parameters }) => {
 			const methodValues: ts.Expression[] = [];
 			const visitMethod = (node: ts.Node): void => {
 				if (
@@ -1342,8 +1388,8 @@ const compiledPropertyWriteValues = (
 
 						methodValues.push(
 							...(parameter.dotDotDotToken === undefined
-								? call.arguments.slice(index, index + 1)
-								: call.arguments.slice(index)),
+								? effectiveArguments.slice(index, index + 1)
+								: effectiveArguments.slice(index)),
 						);
 					});
 				}
@@ -1355,6 +1401,31 @@ const compiledPropertyWriteValues = (
 
 			return methodValues;
 		});
+	};
+	const arrayMutationValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		if (
+			!/^\d+$/.test(selectedPropertyName) ||
+			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) ||
+			!sameReceiverPath(resolveCompiledReceiverPath(call.expression.expression), targetPath)
+		) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+		if (methodName === 'push' || methodName === 'unshift') {
+			return call.arguments;
+		}
+
+		if (methodName === 'splice') {
+			return call.arguments.slice(2);
+		}
+
+		return methodName === 'fill' ? call.arguments.slice(0, 1) : [];
 	};
 
 	const visit = (node: ts.Node): void => {
@@ -1385,6 +1456,7 @@ const compiledPropertyWriteValues = (
 			const mutationTarget = resolveCompiledReceiverPath(node.arguments[0]);
 
 			values.push(...methodWriteValues(node, propertyName));
+			values.push(...arrayMutationValues(node, propertyName));
 
 			if (sameReceiverPath(mutationTarget, targetPath)) {
 				if (helperName === 'Object.assign') {
@@ -3090,6 +3162,15 @@ const containsUnsafeCompiledAlias = (
 							return (
 								containsUnsafeCompiledLiteral(property.initializer, safeStrings) ||
 								inspect(property.initializer, nestedResolving)
+							);
+						}
+
+						if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === '__proto__') {
+							return inspectProperty(
+								property.initializer,
+								nestedResolving,
+								selectedPropertyName,
+								nestedResolvingProperties,
 							);
 						}
 
@@ -6237,6 +6318,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { value: '', set(value) { this.value = value; } }; const set = source.set; set.call(source, 'opaque-secret'); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; const alias = source; alias.value = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
@@ -6526,6 +6614,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const apiKey = ({ __proto__: { value: 'opaque-secret' } }).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const apiKey = Object.getOwnPropertyDescriptor({ value: 'opaque-secret' }, 'value').value;",
 				true,
 			),
@@ -6620,6 +6715,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const apiKey = [].concat([{ value: 'opaque-secret' }])[0].value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = source[0];",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -255,6 +255,9 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 const isCompiledSecretName = (name: string | undefined): name is string =>
 	name !== undefined && !PUBLIC_COMPILED_SECRET_NAMES.has(name) && isHomeySecretKey(name);
 
+const isAssignmentOperatorKind = (kind: ts.SyntaxKind): boolean =>
+	kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+
 const containsCompiledSecret = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let found = false;
@@ -277,7 +280,7 @@ const containsCompiledSecret = (text: string): boolean => {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBindingElement(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
-		} else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
 			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.right);
@@ -598,6 +601,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "config.api_key = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "config.apiKey ??= 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe compiled module', "config['accessToken'] = 'opaque-secret';", true)).toThrow(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2438,6 +2438,37 @@ const containsUnsafeCompiledAlias = (
 						}
 
 						const nestedValues = new Set(resolvingValues).add(reference);
+						const constructorValueFound = declaration.members.some((member) => {
+							if (!ts.isConstructorDeclaration(member) || member.body === undefined) {
+								return false;
+							}
+
+							let found = false;
+							const visitConstructorWrite = (child: ts.Node): void => {
+								if (
+									ts.isBinaryExpression(child) &&
+									isAssignmentOperatorKind(child.operatorToken.kind) &&
+									compiledAssignedPropertyName(child.left) === memberName &&
+									(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
+									child.left.expression.kind === ts.SyntaxKind.ThisKeyword
+								) {
+									found = withCallArguments(
+										member.parameters,
+										receiver.arguments ?? [],
+										() =>
+											containsUnsafeCompiledLiteral(child.right, safeStrings) || inspect(child.right, nestedResolving),
+									);
+								}
+
+								if (!found) {
+									ts.forEachChild(child, visitConstructorWrite);
+								}
+							};
+
+							visitConstructorWrite(member.body);
+
+							return found;
+						});
 						const ownValueFound = declaration.members.some((member) => {
 							if (!('name' in member)) {
 								return false;
@@ -2468,6 +2499,7 @@ const containsUnsafeCompiledAlias = (
 						});
 
 						return (
+							constructorValueFound ||
 							ownValueFound ||
 							(declaration.heritageClauses
 								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
@@ -2597,13 +2629,23 @@ const containsUnsafeCompiledAlias = (
 							}
 
 							let returnsReceiverProperty = false;
+							const collectReceiverProperties = (child: ts.Node): void => {
+								if (ts.isExpression(child)) {
+									if (compiledThisPropertyName(child) !== undefined) {
+										returnsReceiverProperty = true;
+									} else if (
+										ts.isElementAccessExpression(child) &&
+										child.expression.kind === ts.SyntaxKind.ThisKeyword
+									) {
+										returnsReceiverProperty = true;
+									}
+								}
+
+								ts.forEachChild(child, collectReceiverProperties);
+							};
 							const visitReturn = (child: ts.Node): void => {
-								if (
-									ts.isReturnStatement(child) &&
-									child.expression !== undefined &&
-									compiledThisPropertyName(child.expression) !== undefined
-								) {
-									returnsReceiverProperty = true;
+								if (ts.isReturnStatement(child) && child.expression !== undefined) {
+									collectReceiverProperties(child.expression);
 								}
 
 								if (!returnsReceiverProperty) {
@@ -4277,6 +4319,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { safe: '', stored: 'opaque-secret', fallback() { return flag ? this.safe : this.stored; } }; const apiKey = source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source['fallback']();",
 				true,
 			),
@@ -4738,6 +4787,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { stored = 'opaque-secret'; fallback() { return this.stored; } } const apiKey = new Source().fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; class Source { constructor(value) { this.stored = value; } fallback() { return this.stored; } } const apiKey = new Source(stored).fallback();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -776,7 +776,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 	};
 	const addPatternBindings = (
 		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
-		source: ts.Expression,
+		source: ts.Expression | undefined,
 		scope: ts.Node,
 	): void => {
 		pattern.elements.forEach((element, index) => {
@@ -784,7 +784,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				return;
 			}
 
-			const selectedValue = selectBindingValue(pattern, element, index, source);
+			const selectedValue = source === undefined ? undefined : selectBindingValue(pattern, element, index, source);
 
 			if (ts.isIdentifier(element.name)) {
 				addBinding(element.name.text, {
@@ -793,7 +793,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 					initializer: selectedValue ?? element.initializer,
 					scope,
 				});
-			} else if (selectedValue !== undefined) {
+			} else {
 				addPatternBindings(element.name, selectedValue, scope);
 			}
 		});
@@ -908,6 +908,8 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				initializer: node.initializer,
 				scope: compiledBindingScope(node),
 			});
+		} else if (ts.isParameter(node) && (ts.isObjectBindingPattern(node.name) || ts.isArrayBindingPattern(node.name))) {
+			addPatternBindings(node.name, node.initializer, compiledBindingScope(node));
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
 			addBinding(node.name.text, { callable: node, declaration: node, scope: compiledBindingScope(node) });
 		} else if (ts.isClassDeclaration(node) && node.name !== undefined) {
@@ -1105,7 +1107,7 @@ const containsUnsafeCompiledAlias = (
 	resolvingAliases = new Set<ts.Node>(),
 ): boolean => {
 	const visibleThroughPosition = node.getStart(node.getSourceFile());
-	const activeParameterArguments = new Map<ts.ParameterDeclaration, ts.Expression>();
+	const activeParameterArguments = new Map<ts.Node, readonly ts.Expression[]>();
 	const resolveArrayElements = (
 		expression: ts.Expression,
 		resolving: Set<ts.Node>,
@@ -1222,29 +1224,83 @@ const containsUnsafeCompiledAlias = (
 		arguments_: readonly ts.Expression[],
 		callback: () => boolean,
 	): boolean => {
-		const previousArguments = new Map<ts.ParameterDeclaration, ts.Expression | undefined>();
+		const previousArguments = new Map<ts.Node, readonly ts.Expression[] | undefined>();
+		const bindArgument = (
+			bindingName: ts.BindingName,
+			declaration: ts.Node,
+			values: readonly ts.Expression[],
+		): void => {
+			if (ts.isIdentifier(bindingName)) {
+				previousArguments.set(declaration, activeParameterArguments.get(declaration));
+				activeParameterArguments.set(declaration, values);
 
-		parameters.forEach((parameter, index) => {
-			if (!ts.isIdentifier(parameter.name)) {
 				return;
 			}
 
+			bindingName.elements.forEach((element, index) => {
+				if (ts.isOmittedExpression(element)) {
+					return;
+				}
+
+				const selectedValues: ts.Expression[] = [];
+
+				for (const value of values) {
+					if (ts.isObjectBindingPattern(bindingName)) {
+						if (element.dotDotDotToken !== undefined) {
+							selectedValues.push(value);
+
+							continue;
+						}
+
+						const propertyName =
+							element.propertyName === undefined
+								? ts.isIdentifier(element.name)
+									? element.name.text
+									: undefined
+								: compiledPropertyName(element.propertyName);
+						const selectedValue =
+							propertyName === undefined ? undefined : resolvePropertyValue(value, propertyName, new Set());
+
+						if (selectedValue !== undefined) {
+							selectedValues.push(selectedValue);
+						}
+
+						continue;
+					}
+
+					const elements = resolveArrayElements(value, new Set());
+
+					if (elements !== undefined) {
+						selectedValues.push(
+							...(element.dotDotDotToken === undefined ? elements.slice(index, index + 1) : elements.slice(index)),
+						);
+					}
+				}
+
+				if (selectedValues.length === 0 && element.initializer !== undefined) {
+					selectedValues.push(element.initializer);
+				}
+
+				bindArgument(element.name, element, selectedValues);
+			});
+		};
+
+		parameters.forEach((parameter, index) => {
 			const argument = arguments_[index] ?? parameter.initializer;
 
 			if (argument !== undefined) {
-				previousArguments.set(parameter, activeParameterArguments.get(parameter));
-				activeParameterArguments.set(parameter, argument);
+				bindArgument(parameter.name, parameter, [argument]);
 			}
 		});
 
 		try {
 			return callback();
 		} finally {
-			for (const [parameter, previousArgument] of previousArguments) {
+			for (const [declaration, previousArgument] of previousArguments) {
 				if (previousArgument === undefined) {
-					activeParameterArguments.delete(parameter);
+					activeParameterArguments.delete(declaration);
 				} else {
-					activeParameterArguments.set(parameter, previousArgument);
+					activeParameterArguments.set(declaration, previousArgument);
 				}
 			}
 		}
@@ -1263,14 +1319,15 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				const nestedResolving = new Set(resolving).add(binding.declaration);
-				const parameterArgument = ts.isParameter(binding.declaration)
-					? activeParameterArguments.get(binding.declaration)
-					: undefined;
+				const parameterArguments = activeParameterArguments.get(binding.declaration);
 
 				return (
-					(parameterArgument !== undefined &&
-						(containsUnsafeCompiledLiteral(parameterArgument, safeStrings) ||
-							inspect(parameterArgument, nestedResolving))) ||
+					(parameterArguments !== undefined &&
+						parameterArguments.some(
+							(parameterArgument) =>
+								containsUnsafeCompiledLiteral(parameterArgument, safeStrings) ||
+								inspect(parameterArgument, nestedResolving),
+						)) ||
 					[binding.initializer, binding.fallbackInitializer].some(
 						(initializer) =>
 							initializer !== undefined &&
@@ -1286,6 +1343,13 @@ const containsUnsafeCompiledAlias = (
 				: expression.argumentExpression === undefined
 					? undefined
 					: compiledStaticPropertyExpressionName(expression.argumentExpression);
+
+			if (propertyName === undefined) {
+				return (
+					containsUnsafeCompiledLiteral(expression.expression, safeStrings) || inspect(expression.expression, resolving)
+				);
+			}
+
 			const inspectProperty = (
 				receiver: ts.Expression,
 				nestedResolving: Set<ts.Node>,
@@ -1946,11 +2010,12 @@ const containsUnsafeCompiledAlias = (
 				: callee.argumentExpression === undefined
 					? undefined
 					: compiledStaticPropertyExpressionName(callee.argumentExpression);
-			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<ts.Node>): boolean => {
-				if (propertyName === undefined) {
-					return false;
-				}
 
+			if (propertyName === undefined) {
+				return containsUnsafeCompiledLiteral(callee.expression, safeStrings) || inspect(callee.expression, resolving);
+			}
+
+			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<ts.Node>): boolean => {
 				if (
 					compiledPropertyWriteValues(receiver, propertyName, visibleThroughPosition).some((value) =>
 						inspectCallable(value, nestedResolving),
@@ -4536,6 +4601,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function make({ value }) { return { value }; } const apiKey = make({ value: 'opaque-secret' }).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function make([value]) { return { value }; } const apiKey = make(['opaque-secret']).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const factory = () => ({ fallback: () => 'opaque-secret' }); const apiKey = factory().fallback();",
 				true,
 			),
@@ -4577,6 +4656,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const source = ['opaque-secret']; const apiKey = source[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values[index];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1442,7 +1442,7 @@ const compiledPropertyWriteValues = (
 				? undefined
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
 
-		if (methodName === 'add' || methodName === 'push' || methodName === 'unshift') {
+		if (['add', 'push', 'set', 'unshift'].includes(methodName ?? '')) {
 			return expandMutationSources(call.arguments);
 		}
 
@@ -1954,6 +1954,11 @@ const containsUnsafeCompiledAlias = (
 			: call.expression.argumentExpression === undefined
 				? undefined
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+		if (methodName === 'find' || methodName === 'findLast') {
+			return resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression];
+		}
+
 		const callbackIndex =
 			methodName === 'map' || methodName === 'flatMap'
 				? 0
@@ -2183,7 +2188,9 @@ const containsUnsafeCompiledAlias = (
 
 		if (
 			methodName !== 'concat' &&
-			!['filter', 'flat', 'reverse', 'slice', 'sort', 'toReversed', 'toSorted', 'with'].includes(methodName ?? '')
+			!['filter', 'flat', 'reverse', 'slice', 'sort', 'splice', 'toReversed', 'toSorted', 'with'].includes(
+				methodName ?? '',
+			)
 		) {
 			return [];
 		}
@@ -2196,7 +2203,9 @@ const containsUnsafeCompiledAlias = (
 				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
 		const index = Number(selectedPropertyName);
 
-		return methodName === 'filter' || methodName === 'flat' ? values : values.slice(index, index + 1);
+		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice'
+			? values
+			: values.slice(index, index + 1);
 	};
 	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
 		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
@@ -2944,7 +2953,13 @@ const containsUnsafeCompiledAlias = (
 							...collectionTransformResultValues(receiver.expression),
 							...concatenatedResultValues(receiver.expression, receiverPropertyName),
 							...objectValuesResultValues(receiver.expression, receiverPropertyName),
-						].some((value) => inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties))
+							...transparentCallResultValues(receiver.expression),
+						].some(
+							(value) =>
+								containsUnsafeCompiledLiteral(value, safeStrings) ||
+								inspect(value, nestedResolving) ||
+								inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties),
+						)
 					) {
 						return true;
 					}
@@ -6942,6 +6957,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const apiKey = [{ value: 'opaque-secret' }].find(() => true).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = [{ value: 'opaque-secret' }].findLast(() => true).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const apiKey = Array.from({ length: 1 }, () => ({ value: 'opaque-secret' }))[0].value;",
 				true,
 			),
@@ -6950,6 +6979,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = new Set(); source.add('opaque-secret'); const apiKey = Array.from(source)[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Map(); source.set('x', 'opaque-secret'); const apiKey = Array.from(source)[0][1];",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -6979,6 +7015,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].slice()[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = ['opaque-secret']; const apiKey = source.splice(0, 1)[0];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [['opaque-secret']].flat()[0];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1938,6 +1938,64 @@ const containsUnsafeCompiledAlias = (
 			...compiledPropertyWriteValues(call.arguments[0], propertyName, call.getStart(call.getSourceFile())),
 		];
 	};
+	const objectValuesResultValues = (
+		call: ts.CallExpression,
+		selectedPropertyName: string,
+	): readonly ts.Expression[] => {
+		if (compiledMutationHelperName(call.expression) !== 'Object.values' || call.arguments.length === 0) {
+			return [];
+		}
+
+		const resolveObjectValues = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): readonly ts.Expression[] | undefined => {
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveObjectValues(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveObjectValues(expression.expression, resolving);
+			}
+
+			if (!ts.isObjectLiteralExpression(expression)) {
+				return undefined;
+			}
+
+			return expression.properties.flatMap((property): readonly ts.Expression[] => {
+				if (ts.isPropertyAssignment(property)) {
+					return [property.initializer];
+				}
+
+				if (ts.isShorthandPropertyAssignment(property)) {
+					return [property.name];
+				}
+
+				return ts.isSpreadAssignment(property)
+					? (resolveObjectValues(property.expression, resolving) ?? [property.expression])
+					: [];
+			});
+		};
+		const values = resolveObjectValues(call.arguments[0]);
+
+		if (values === undefined) {
+			return [call.arguments[0]];
+		}
+
+		return /^\d+$/.test(selectedPropertyName)
+			? values.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1)
+			: values;
+	};
 	const isJsonParseCall = (callee: ts.Expression, resolving = new Set<ts.Node>()): boolean => {
 		if (
 			ts.isPropertyAccessExpression(callee) &&
@@ -2523,6 +2581,7 @@ const containsUnsafeCompiledAlias = (
 						[
 							...collectionTransformResultValues(receiver),
 							...descriptorQueryValues(receiver, selectedPropertyName),
+							...objectValuesResultValues(receiver, selectedPropertyName),
 						].some((value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving))
 					) {
 						return true;
@@ -6190,6 +6249,9 @@ describe('Homey security artifact gate', () => {
 				"const apiKey = Object.getOwnPropertyDescriptor({ value: 'opaque-secret' }, 'value').value;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = Object.values({ value: 'opaque-secret' })[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -4,7 +4,7 @@ import { extname, resolve } from 'node:path';
 import ts from 'typescript';
 import { parse as parseYaml } from 'yaml';
 
-import { findHomeyIpv6Range, isHomeySecretKey } from './support/homey-shs-probe';
+import { findHomeyIpv6Range, isHomeyAddressKey, isHomeySecretKey } from './support/homey-shs-probe';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -44,7 +44,12 @@ const PUBLIC_COMPILED_SECRET_NAMES = new Set(['secretFields']);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
-const PUBLIC_SCHEMA_URLS = new Set(['http://homey.local:4859', 'http://json-schema.org/draft-07/schema#']);
+const PUBLIC_ARTIFACT_URLS = new Set([
+	'http://homey.local:4859',
+	'http://json-schema.org/draft-07/schema#',
+	'https://github.com/FastyBird/smart-panel',
+	'https://smart-panel.fastybird.com/docs',
+]);
 const PUBLIC_HOMEY_HOSTS = new Set(['homey', 'homey.local']);
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
 const LOOSE_PROPERTY_PATTERN =
@@ -316,6 +321,26 @@ const containsCompiledSecret = (text: string): boolean => {
 	return found;
 };
 
+const containsCompiledPrivateUrl = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+			found = containsStructuredUrl(node.text);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
 const containsUnsafeSecretLeaf = (value: unknown): boolean => {
 	if (value === null || value === 0 || value === '' || value === '[~3~]' || typeof value === 'boolean') {
 		return false;
@@ -346,6 +371,22 @@ const containsStructuredSecret = (value: unknown): boolean => {
 	);
 };
 
+const containsStructuredAddress = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredAddress(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(([key, child]) => {
+		const safeAddressValue = child === null || child === 0 || child === false || child === '[~0~]';
+
+		return (isHomeyAddressKey(key) && !safeAddressValue) || containsStructuredAddress(child);
+	});
+};
+
 const containsLooseSecretAssignment = (text: string): boolean =>
 	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].some((match) => {
 		const key = match[1];
@@ -360,7 +401,7 @@ const containsLooseSecretAssignment = (text: string): boolean =>
 
 const containsStructuredUrl = (value: unknown): boolean => {
 	if (typeof value === 'string') {
-		return !PUBLIC_SCHEMA_URLS.has(value) && URL_PATTERN.test(value);
+		return !PUBLIC_ARTIFACT_URLS.has(value) && URL_PATTERN.test(value);
 	}
 
 	if (Array.isArray(value)) {
@@ -397,6 +438,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 		throw new Error(`${label} contains a compiled secret value`);
 	}
 
+	if (compiledSource && containsCompiledPrivateUrl(text)) {
+		throw new Error(`${label} contains a private URL`);
+	}
+
 	for (const privateValue of configuredPrivateValues()) {
 		if (text.toLocaleLowerCase().includes(privateValue.toLocaleLowerCase())) {
 			throw new Error(`${label} contains a configured private Homey value`);
@@ -423,6 +468,10 @@ const assertFixtureTextSafe = (label: string, text: string, extension: string): 
 
 	if (containsSecret) {
 		throw new Error(`${label} contains a structured secret value`);
+	}
+
+	if (structuredValue !== undefined && containsStructuredAddress(structuredValue)) {
+		throw new Error(`${label} contains a structured address value`);
 	}
 };
 
@@ -587,6 +636,10 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a structured secret value',
 		);
 		expect(() => assertFixtureTextSafe('safe fixture', '{"pinCode":0}', '.json')).not.toThrow();
+		expect(() => assertFixtureTextSafe('safe fixture', '{"hostname":"[~0~]"}', '.json')).not.toThrow();
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"hostname":"family-homey.local"}', '.json')).toThrow(
+			'unsafe fixture contains a structured address value',
+		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
@@ -647,6 +700,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = process.env.API_KEY ?? 'opaque-secret';", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const endpoint = 'http://private-homey.local:4859';", true),
+		).toThrow('unsafe compiled module contains a private URL');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2170,6 +2170,36 @@ const containsUnsafeCompiledAlias = (
 
 		return methodName === 'filter' ? values : values.slice(index, index + 1);
 	};
+	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
+		if (
+			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) ||
+			call.arguments.length === 0
+		) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+		const indexArgument = call.arguments[0];
+
+		if (methodName !== 'at' || !ts.isNumericLiteral(indexArgument)) {
+			return [];
+		}
+
+		const receiver = call.expression.expression;
+		const elements = resolveArrayElements(receiver, new Set());
+		const index = Number(indexArgument.text);
+		const selectedIndex = index < 0 && elements !== undefined ? elements.length + index : index;
+		const element = elements?.[selectedIndex];
+
+		return [
+			...(element === undefined ? [] : [element]),
+			...compiledPropertyWriteValues(receiver, String(selectedIndex), call.getStart(call.getSourceFile())),
+		];
+	};
 	const objectEntriesResultValues = (
 		call: ts.CallExpression,
 		entryPropertyName: string,
@@ -2801,6 +2831,7 @@ const containsUnsafeCompiledAlias = (
 						receiverPropertyName !== undefined &&
 						ts.isCallExpression(receiver.expression) &&
 						[
+							...collectionTransformResultValues(receiver.expression),
 							...concatenatedResultValues(receiver.expression, receiverPropertyName),
 							...objectValuesResultValues(receiver.expression, receiverPropertyName),
 						].some((value) => inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties))
@@ -2855,6 +2886,23 @@ const containsUnsafeCompiledAlias = (
 				if (ts.isCallExpression(receiver)) {
 					if (jsonParsedPropertyIsUnsafe(receiver, selectedPropertyName)) {
 						return true;
+					}
+
+					if (
+						compiledMutationHelperName(receiver.expression) === 'Reflect.construct' &&
+						receiver.arguments.length >= 2
+					) {
+						const classDeclaration = resolveClassReceiver(receiver.arguments[0]);
+						const constructorArguments = resolveArrayElements(receiver.arguments[1], new Set()) ?? [
+							receiver.arguments[1],
+						];
+
+						if (
+							classDeclaration !== undefined &&
+							inspectClassProperty(classDeclaration, false, selectedPropertyName, new Set(), constructorArguments)
+						) {
+							return true;
+						}
 					}
 
 					if (
@@ -3347,6 +3395,9 @@ const containsUnsafeCompiledAlias = (
 
 		if (ts.isCallExpression(expression)) {
 			return (
+				arrayElementCallValues(expression).some(
+					(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, resolving),
+				) ||
 				inspectCallable(expression.expression, resolving) ||
 				expression.arguments.some((argument) => inspect(argument, resolving))
 			);
@@ -6416,6 +6467,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { constructor(value) { this.value = value; } } const apiKey = Reflect.construct(Source, ['opaque-secret']).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"class Source { constructor(value) { this[key] = value; } } const apiKey = new Source('opaque-secret').value;",
 				true,
 			),
@@ -6713,7 +6771,21 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values.at(0);", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source[0] = 'opaque-secret'; const apiKey = source.at(0);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['safe'].map(() => 'opaque-secret')[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = Array.from({ length: 1 }, () => ({ value: 'opaque-secret' }))[0].value;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values[index];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -346,6 +346,16 @@ const containsUnsafeCompiledLiteral = (
 		return containsUnsafeCompiledLiteral(node.operand, safeStrings);
 	}
 
+	if (ts.isArrowFunction(node)) {
+		return ts.isBlock(node.body)
+			? containsUnsafeReturnedLiteral(node.body, safeStrings)
+			: containsUnsafeCompiledLiteral(node.body, safeStrings);
+	}
+
+	if (ts.isFunctionExpression(node)) {
+		return containsUnsafeReturnedLiteral(node.body, safeStrings);
+	}
+
 	return false;
 };
 
@@ -393,7 +403,10 @@ const isPublicSecretFieldsDescriptor = (node: ts.Expression): boolean => {
 	);
 };
 
-const containsUnsafeCompiledType = (type: ts.TypeNode): boolean => {
+const containsUnsafeCompiledType = (
+	type: ts.TypeNode,
+	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+): boolean => {
 	let found = false;
 	const visit = (node: ts.Node): void => {
 		if (found) {
@@ -401,7 +414,7 @@ const containsUnsafeCompiledType = (type: ts.TypeNode): boolean => {
 		}
 
 		if (ts.isLiteralTypeNode(node) && ts.isExpression(node.literal)) {
-			found = containsUnsafeCompiledLiteral(node.literal);
+			found = containsUnsafeCompiledLiteral(node.literal, safeStrings);
 		}
 
 		ts.forEachChild(node, visit);
@@ -507,20 +520,35 @@ const containsCompiledAddress = (text: string): boolean => {
 		name !== undefined &&
 		isHomeyAddressKey(name) &&
 		containsUnsafeCompiledLiteral(expression, SAFE_COMPILED_ADDRESS_STRINGS);
+	const unsafeAddressType = (name: string | undefined, type: ts.TypeNode | undefined): boolean =>
+		name !== undefined &&
+		isHomeyAddressKey(name) &&
+		type !== undefined &&
+		containsUnsafeCompiledType(type, SAFE_COMPILED_ADDRESS_STRINGS);
 	const visit = (node: ts.Node): void => {
 		if (found) {
 			return;
 		}
 
-		if (ts.isPropertyAssignment(node) || (ts.isPropertyDeclaration(node) && node.initializer !== undefined)) {
+		if (ts.isPropertyAssignment(node)) {
 			found = unsafeAddress(compiledPropertyName(node.name), node.initializer);
-		} else if ((ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node)) && node.body !== undefined) {
+		} else if (ts.isPropertyDeclaration(node)) {
 			const name = compiledPropertyName(node.name);
 
 			found =
-				name !== undefined &&
-				isHomeyAddressKey(name) &&
-				containsUnsafeReturnedLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS);
+				(node.initializer !== undefined && unsafeAddress(name, node.initializer)) || unsafeAddressType(name, node.type);
+		} else if (ts.isPropertySignature(node)) {
+			found = unsafeAddressType(compiledPropertyName(node.name), node.type);
+		} else if (ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				('body' in node &&
+					node.body !== undefined &&
+					name !== undefined &&
+					isHomeyAddressKey(name) &&
+					containsUnsafeReturnedLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
+				unsafeAddressType(name, node.type);
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = unsafeAddress(node.name.text, node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
@@ -1085,9 +1113,18 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe declaration', "interface Config { apiKey: 'opaque-secret' }", true)).toThrow(
 			'unsafe declaration contains a compiled secret value',
 		);
+		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = () => 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = function () { return 'opaque-secret'; };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "const hostname = 'family-homey.local';", true)).toThrow(
 			'unsafe compiled module contains a compiled address value',
 		);
+		expect(() =>
+			assertTextSafe('unsafe declaration', "interface Config { hostname: 'family-homey.local' }", true),
+		).toThrow('unsafe declaration contains a compiled address value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1060,6 +1060,38 @@ const resolveCompiledReceiverPath = (
 		: { binding, properties: [] };
 };
 
+const compiledMutationHelperName = (expression: ts.Expression, resolving = new Set<ts.Node>()): string | undefined => {
+	if (
+		ts.isPropertyAccessExpression(expression) &&
+		ts.isIdentifier(expression.expression) &&
+		['Object', 'Reflect'].includes(expression.expression.text)
+	) {
+		return `${expression.expression.text}.${expression.name.text}`;
+	}
+
+	if (ts.isIdentifier(expression)) {
+		const binding = resolveCompiledBinding(expression);
+
+		if (binding?.initializer === undefined || resolving.has(binding.declaration)) {
+			return undefined;
+		}
+
+		return compiledMutationHelperName(binding.initializer, new Set(resolving).add(binding.declaration));
+	}
+
+	if (
+		ts.isParenthesizedExpression(expression) ||
+		ts.isAsExpression(expression) ||
+		ts.isTypeAssertionExpression(expression) ||
+		ts.isNonNullExpression(expression) ||
+		ts.isSatisfiesExpression(expression)
+	) {
+		return compiledMutationHelperName(expression.expression, resolving);
+	}
+
+	return undefined;
+};
+
 const compiledPropertyWriteValues = (
 	receiver: ts.Expression,
 	propertyName: string,
@@ -1157,14 +1189,8 @@ const compiledPropertyWriteValues = (
 			) {
 				values.push(node.right);
 			}
-		} else if (
-			ts.isCallExpression(node) &&
-			node.getStart(sourceFile) < usePosition &&
-			ts.isPropertyAccessExpression(node.expression) &&
-			ts.isIdentifier(node.expression.expression) &&
-			node.arguments.length > 0
-		) {
-			const helperName = `${node.expression.expression.text}.${node.expression.name.text}`;
+		} else if (ts.isCallExpression(node) && node.getStart(sourceFile) < usePosition && node.arguments.length > 0) {
+			const helperName = compiledMutationHelperName(node.expression);
 			const mutationTarget = resolveCompiledReceiverPath(node.arguments[0]);
 
 			if (sameReceiverPath(mutationTarget, targetPath)) {
@@ -1419,15 +1445,13 @@ const containsUnsafeCompiledAlias = (
 	const constructorMutationValues = (node: ts.Node, propertyName: string): readonly ts.Expression[] => {
 		if (
 			!ts.isCallExpression(node) ||
-			!ts.isPropertyAccessExpression(node.expression) ||
-			!ts.isIdentifier(node.expression.expression) ||
 			node.arguments.length === 0 ||
 			node.arguments[0].kind !== ts.SyntaxKind.ThisKeyword
 		) {
 			return [];
 		}
 
-		const helperName = `${node.expression.expression.text}.${node.expression.name.text}`;
+		const helperName = compiledMutationHelperName(node.expression);
 
 		if (helperName === 'Object.assign') {
 			return node.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
@@ -1477,15 +1501,11 @@ const containsUnsafeCompiledAlias = (
 		return [];
 	};
 	const mutationResultValues = (call: ts.CallExpression, propertyName: string): readonly ts.Expression[] => {
-		if (
-			!ts.isPropertyAccessExpression(call.expression) ||
-			!ts.isIdentifier(call.expression.expression) ||
-			call.arguments.length === 0
-		) {
+		if (call.arguments.length === 0) {
 			return [];
 		}
 
-		const helperName = `${call.expression.expression.text}.${call.expression.name.text}`;
+		const helperName = compiledMutationHelperName(call.expression);
 
 		if (helperName === 'Object.assign') {
 			return call.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
@@ -1739,9 +1759,12 @@ const containsUnsafeCompiledAlias = (
 									if (
 										ts.isBinaryExpression(child) &&
 										isAssignmentOperatorKind(child.operatorToken.kind) &&
-										compiledAssignedPropertyName(child.left) === memberName &&
 										(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
-										child.left.expression.kind === ts.SyntaxKind.ThisKeyword
+										child.left.expression.kind === ts.SyntaxKind.ThisKeyword &&
+										(compiledAssignedPropertyName(child.left) === memberName ||
+											(ts.isElementAccessExpression(child.left) &&
+												child.left.argumentExpression !== undefined &&
+												compiledStaticPropertyExpressionName(child.left.argumentExpression) === undefined))
 									) {
 										const referencedArguments: ts.Expression[] = [];
 										const visitParameterReference = (rightChild: ts.Node): void => {
@@ -2285,12 +2308,22 @@ const containsUnsafeCompiledAlias = (
 					return inspectReturnedProperty(receiver.expression, nestedResolving, receiver.arguments);
 				}
 
-				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
-					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+				if (ts.isNewExpression(receiver)) {
+					const classDeclaration = ts.isIdentifier(receiver.expression)
+						? resolveCompiledBinding(receiver.expression)?.classDeclaration
+						: undefined;
 
-					return (
+					if (
 						classDeclaration !== undefined &&
 						inspectClassProperty(classDeclaration, false, selectedPropertyName, new Set(), receiver.arguments ?? [])
+					) {
+						return true;
+					}
+
+					return (
+						receiver.arguments?.some(
+							(argument) => containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving),
+						) ?? false
 					);
 				}
 
@@ -2852,9 +2885,12 @@ const containsUnsafeCompiledAlias = (
 								if (
 									ts.isBinaryExpression(child) &&
 									isAssignmentOperatorKind(child.operatorToken.kind) &&
-									compiledAssignedPropertyName(child.left) === memberName &&
 									(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
-									child.left.expression.kind === ts.SyntaxKind.ThisKeyword
+									child.left.expression.kind === ts.SyntaxKind.ThisKeyword &&
+									(compiledAssignedPropertyName(child.left) === memberName ||
+										(ts.isElementAccessExpression(child.left) &&
+											child.left.argumentExpression !== undefined &&
+											compiledStaticPropertyExpressionName(child.left.argumentExpression) === undefined))
 								) {
 									found = withCallArguments(
 										member.parameters,
@@ -3011,7 +3047,13 @@ const containsUnsafeCompiledAlias = (
 						);
 					};
 
-					return classDeclaration !== undefined && inspectClassCallable(classDeclaration);
+					return (
+						(classDeclaration !== undefined && inspectClassCallable(classDeclaration)) ||
+						(receiver.arguments?.some(
+							(argument) => containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving),
+						) ??
+							false)
+					);
 				}
 
 				if (ts.isConditionalExpression(receiver)) {
@@ -5105,6 +5147,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const assign = Object.assign; const source = {}; assign(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; Object.defineProperties(source, { value: { value: 'opaque-secret' } }); const apiKey = source.value;",
 				true,
 			),
@@ -5213,6 +5262,16 @@ describe('Homey security artifact gate', () => {
 				"class Source { constructor(value) { this.value = value; } } const apiKey = new Source('opaque-secret').value;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor(value) { this[key] = value; } } const apiKey = new Source('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = new Proxy({ value: 'opaque-secret' }, {}).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -33,12 +33,17 @@ const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i;
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
+const LOOSE_PROPERTY_PATTERN = /^\s*(?:[-*]\s+)?["'`]?([A-Za-z][A-Za-z0-9_.-]*)["'`]?\s*[:=]\s*(.*?)\s*$/gm;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
 		pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
 	},
-	{ label: 'a MAC address', pattern: /\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b/i },
+	{
+		label: 'a MAC address',
+		pattern:
+			/\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b|\b[0-9a-f]{4}(?:\.[0-9a-f]{4}){2}\b|(?<![0-9a-f-])[0-9a-f]{12}(?![0-9a-f-])/i,
+	},
 	{ label: 'an email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
 ];
 
@@ -111,8 +116,15 @@ const containsHomeyToken = (text: string, compiledSource: boolean): boolean => {
 			node.kind === ts.SyntaxKind.TemplateTail
 		) {
 			const value = (node as ts.StringLiteralLike).text;
+			const parent = node.parent;
+			const isPublicSymbolDescription =
+				COMPILED_SYMBOL_NAME_PATTERN.test(value) &&
+				ts.isCallExpression(parent) &&
+				ts.isIdentifier(parent.expression) &&
+				parent.expression.text === 'Symbol' &&
+				parent.arguments[0] === node;
 
-			found = !COMPILED_SYMBOL_NAME_PATTERN.test(value) && HOMEY_TOKEN_PATTERN.test(value);
+			found = !isPublicSymbolDescription && HOMEY_TOKEN_PATTERN.test(value);
 		}
 
 		ts.forEachChild(node, visit);
@@ -129,6 +141,53 @@ const containsSerializedSecret = (text: string): boolean =>
 		const value = match[4];
 
 		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
+	});
+
+const containsUnsafeSecretLeaf = (value: unknown): boolean => {
+	if (value === null || value === '' || value === '[~3~]' || typeof value === 'boolean') {
+		return false;
+	}
+
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsUnsafeSecretLeaf(entry));
+	}
+
+	if (typeof value === 'object') {
+		return Object.values(value as JsonRecord).some((entry) => containsUnsafeSecretLeaf(entry));
+	}
+
+	return true;
+};
+
+const containsStructuredSecret = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredSecret(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(
+		([key, child]) => (isHomeySecretKey(key) && containsUnsafeSecretLeaf(child)) || containsStructuredSecret(child),
+	);
+};
+
+const containsLooseSecretAssignment = (text: string): boolean =>
+	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].some((match) => {
+		const key = match[1];
+		const rawValue = match[2]
+			?.replace(/\s+#.*$/, '')
+			.replace(/[,;]\s*$/, '')
+			.trim();
+
+		if (key === undefined || rawValue === undefined || !isHomeySecretKey(key)) {
+			return false;
+		}
+
+		const value = rawValue.replace(/^(["'`])(.*)\1$/, '$2');
+
+		return !['', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(value);
 	});
 
 const assertTextSafe = (label: string, text: string, compiledSource = false): void => {
@@ -154,6 +213,17 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 		if (text.toLocaleLowerCase().includes(privateValue.toLocaleLowerCase())) {
 			throw new Error(`${label} contains a configured private Homey value`);
 		}
+	}
+};
+
+const assertFixtureTextSafe = (label: string, text: string, extension: string): void => {
+	assertTextSafe(label, text);
+
+	const containsSecret =
+		extension === '.json' ? containsStructuredSecret(JSON.parse(text) as unknown) : containsLooseSecretAssignment(text);
+
+	if (containsSecret) {
+		throw new Error(`${label} contains a structured secret value`);
 	}
 };
 
@@ -219,7 +289,7 @@ describe('Homey security artifact gate', () => {
 		expect(unsupportedFiles).toEqual([]);
 
 		for (const path of [...fixtureFiles, ...snapshotFiles]) {
-			assertTextSafe(path.slice(REPOSITORY_ROOT.length + 1), readFileSync(path, 'utf8'));
+			assertFixtureTextSafe(path.slice(REPOSITORY_ROOT.length + 1), readFileSync(path, 'utf8'), extname(path));
 		}
 	});
 
@@ -268,6 +338,12 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe fixture', '{"cookie":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"pinCode":1234}', '.json')).toThrow(
+			'unsafe fixture contains a structured secret value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
+			'unsafe fixture contains a structured secret value',
+		);
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"[~3~]unredacted-password"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
@@ -277,6 +353,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', 'throw new Error("request failed for homey_abcdefghijklmnop")', true),
 		).toThrow('unsafe compiled module contains a Homey personal access token');
+		expect(() => assertTextSafe('unsafe compiled module', 'const leaked = "HOMEY_ABCDEFGHIJKLMNOP";', true)).toThrow(
+			'unsafe compiled module contains a Homey personal access token',
+		);
 		expect(() =>
 			assertTextSafe('safe compiled module', 'const homey_local_connector_factory_1 = {};', true),
 		).not.toThrow();
@@ -288,6 +367,12 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"fe80::1%en0"}')).toThrow(
 			'unsafe fixture contains an IPv6 address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"mac":"aabb.ccdd.eeff"}')).toThrow(
+			'unsafe fixture contains a MAC address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"mac":"aabbccddeeff"}')).toThrow(
+			'unsafe fixture contains a MAC address',
 		);
 		const previousPrivateTerms = process.env.FB_HOMEY_SHS_PRIVATE_TERMS;
 		const previousReplacementApiKey = process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY;

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1083,11 +1083,22 @@ const compiledPropertyWriteValues = (
 			isAssignmentOperatorKind(node.operatorToken.kind)
 		) {
 			const writePath = resolveCompiledReceiverPath(node.left);
+			const dynamicWriteReceiverPath =
+				ts.isElementAccessExpression(node.left) &&
+				node.left.argumentExpression !== undefined &&
+				compiledStaticPropertyExpressionName(node.left.argumentExpression) === undefined
+					? resolveCompiledReceiverPath(node.left.expression)
+					: undefined;
+			const sameDynamicReceiver =
+				dynamicWriteReceiverPath?.binding.declaration === targetPath.binding.declaration &&
+				dynamicWriteReceiverPath.properties.length === targetPath.properties.length &&
+				dynamicWriteReceiverPath.properties.every((property, index) => property === targetPath.properties[index]);
 
 			if (
-				writePath?.binding.declaration === targetPath.binding.declaration &&
-				writePath.properties.length === expectedProperties.length &&
-				writePath.properties.every((property, index) => property === expectedProperties[index])
+				sameDynamicReceiver ||
+				(writePath?.binding.declaration === targetPath.binding.declaration &&
+					writePath.properties.length === expectedProperties.length &&
+					writePath.properties.every((property, index) => property === expectedProperties[index]))
 			) {
 				values.push(node.right);
 			}
@@ -1477,9 +1488,14 @@ const containsUnsafeCompiledAlias = (
 										const visitParameterReference = (rightChild: ts.Node): void => {
 											if (ts.isIdentifier(rightChild)) {
 												member.parameters.forEach((parameter, parameterIndex) => {
-													const argument = constructorArguments[parameterIndex] ?? parameter.initializer;
+													const parameterArguments =
+														parameter.dotDotDotToken === undefined
+															? [constructorArguments[parameterIndex] ?? parameter.initializer].filter(
+																	(argument): argument is ts.Expression => argument !== undefined,
+																)
+															: constructorArguments.slice(parameterIndex);
 
-													if (argument !== undefined) {
+													for (const argument of parameterArguments) {
 														referencedArguments.push(
 															...selectParameterValues(parameter.name, rightChild.text, argument),
 														);
@@ -1540,6 +1556,59 @@ const containsUnsafeCompiledAlias = (
 
 						if ((ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) && member.body !== undefined) {
 							let found = false;
+							const inspectDynamicClassProperties = (
+								declaration: ts.ClassDeclaration,
+								resolvingClasses = new Set<ts.ClassDeclaration>(),
+							): boolean => {
+								if (resolvingClasses.has(declaration)) {
+									return false;
+								}
+
+								const nestedClasses = new Set(resolvingClasses).add(declaration);
+								const propertyNames = new Set<string>();
+
+								for (const candidate of declaration.members) {
+									if ('name' in candidate) {
+										const staticMember = Boolean(
+											ts.canHaveModifiers(candidate) &&
+											ts.getModifiers(candidate)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+										);
+										const candidateName = compiledPropertyName(candidate.name);
+
+										if (staticMember === expectStatic && candidateName !== undefined) {
+											propertyNames.add(candidateName);
+										}
+									}
+								}
+
+								if (
+									[...propertyNames].some((candidateName) =>
+										inspectClassProperty(
+											classDeclaration,
+											expectStatic,
+											candidateName,
+											nestedClassProperties,
+											constructorArguments,
+										),
+									)
+								) {
+									return true;
+								}
+
+								return (
+									declaration.heritageClauses
+										?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+										.some((clause) =>
+											clause.types.some((type) => {
+												const baseClass = ts.isIdentifier(type.expression)
+													? resolveCompiledBinding(type.expression)?.classDeclaration
+													: undefined;
+
+												return baseClass !== undefined && inspectDynamicClassProperties(baseClass, nestedClasses);
+											}),
+										) ?? false
+								);
+							};
 							const visitReturn = (child: ts.Node): void => {
 								if (found) {
 									return;
@@ -1547,6 +1616,11 @@ const containsUnsafeCompiledAlias = (
 
 								if (ts.isReturnStatement(child) && child.expression !== undefined) {
 									const receiverPropertyName = compiledThisPropertyName(child.expression);
+									const dynamicThisProperty =
+										ts.isElementAccessExpression(child.expression) &&
+										child.expression.expression.kind === ts.SyntaxKind.ThisKeyword &&
+										child.expression.argumentExpression !== undefined &&
+										compiledStaticPropertyExpressionName(child.expression.argumentExpression) === undefined;
 
 									found =
 										(receiverPropertyName !== undefined &&
@@ -1557,6 +1631,7 @@ const containsUnsafeCompiledAlias = (
 												nestedClassProperties,
 												constructorArguments,
 											)) ||
+										(dynamicThisProperty && inspectDynamicClassProperties(classDeclaration)) ||
 										containsUnsafeCompiledLiteral(child.expression, safeStrings) ||
 										inspect(child.expression, nestedResolving);
 								}
@@ -4504,6 +4579,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { value: '' }; source[key] = 'opaque-secret'; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; const read = () => source.value; source.value = 'opaque-secret'; const apiKey = read();",
 				true,
 			),
@@ -4560,6 +4642,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { stored = 'opaque-secret'; get value() { return this[key]; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"class Base { value = 'opaque-secret'; } class Source extends Base {} const apiKey = new Source().value;",
 				true,
 			),
@@ -4589,6 +4678,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor([value]) { this.value = value; } } const apiKey = new Source(['opaque-secret']).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor(...values) { this.value = values[1]; } } const apiKey = new Source('', 'opaque-secret').value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -325,7 +325,17 @@ const containsUnsafeCompiledLiteral = (
 		return node.properties.some(
 			(property) =>
 				(ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer, safeStrings)) ||
-				(ts.isSpreadAssignment(property) && containsUnsafeCompiledLiteral(property.expression, safeStrings)),
+				(ts.isSpreadAssignment(property) && containsUnsafeCompiledLiteral(property.expression, safeStrings)) ||
+				(ts.isShorthandPropertyAssignment(property) && containsUnsafeCompiledValue(property.name, safeStrings)) ||
+				((ts.isMethodDeclaration(property) || ts.isGetAccessorDeclaration(property)) &&
+					property.body !== undefined &&
+					containsUnsafeCompiledBodyLiteral(property.body, safeStrings)) ||
+				(ts.isSetAccessorDeclaration(property) &&
+					(property.parameters.some(
+						(parameter) =>
+							parameter.initializer !== undefined && containsUnsafeCompiledValue(parameter.initializer, safeStrings),
+					) ||
+						(property.body !== undefined && containsUnsafeCompiledBodyLiteral(property.body, safeStrings)))),
 		);
 	}
 
@@ -403,39 +413,121 @@ const containsUnsafeCompiledLiteral = (
 	return false;
 };
 
-const COMPILED_ALIAS_CACHE = new WeakMap<ts.SourceFile, ReadonlyMap<string, ts.Expression>>();
+interface CompiledBinding {
+	readonly declaration: ts.Declaration;
+	readonly initializer?: ts.Expression;
+	readonly scope: ts.Node;
+}
 
-const compiledConstantAliases = (sourceFile: ts.SourceFile): ReadonlyMap<string, ts.Expression> => {
-	const cached = COMPILED_ALIAS_CACHE.get(sourceFile);
+const COMPILED_BINDING_CACHE = new WeakMap<ts.SourceFile, ReadonlyMap<string, readonly CompiledBinding[]>>();
+
+const compiledBindingScope = (node: ts.Node): ts.Node => {
+	let current: ts.Node | undefined = node.parent;
+
+	while (current !== undefined) {
+		if (
+			ts.isSourceFile(current) ||
+			ts.isBlock(current) ||
+			ts.isModuleBlock(current) ||
+			ts.isCaseBlock(current) ||
+			ts.isForStatement(current) ||
+			ts.isForInStatement(current) ||
+			ts.isForOfStatement(current) ||
+			ts.isFunctionLike(current)
+		) {
+			return current;
+		}
+
+		current = current.parent;
+	}
+
+	return node.getSourceFile();
+};
+
+const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readonly CompiledBinding[]> => {
+	const cached = COMPILED_BINDING_CACHE.get(sourceFile);
 
 	if (cached !== undefined) {
 		return cached;
 	}
 
-	const candidates = new Map<string, ts.Expression | undefined>();
+	const bindings = new Map<string, CompiledBinding[]>();
+	const addBinding = (name: string, binding: CompiledBinding): void => {
+		bindings.set(name, [...(bindings.get(name) ?? []), binding]);
+	};
 	const visit = (node: ts.Node): void => {
-		if (
-			ts.isVariableDeclaration(node) &&
-			ts.isIdentifier(node.name) &&
-			node.initializer !== undefined &&
-			ts.isVariableDeclarationList(node.parent) &&
-			(node.parent.flags & ts.NodeFlags.Const) !== 0
-		) {
-			candidates.set(node.name.text, candidates.has(node.name.text) ? undefined : node.initializer);
+		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			const constantInitializer =
+				node.initializer !== undefined &&
+				ts.isVariableDeclarationList(node.parent) &&
+				(node.parent.flags & ts.NodeFlags.Const) !== 0
+					? node.initializer
+					: undefined;
+
+			addBinding(node.name.text, {
+				declaration: node,
+				initializer: constantInitializer,
+				scope: compiledBindingScope(node),
+			});
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
+		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
 		}
 
 		ts.forEachChild(node, visit);
 	};
 
 	visit(sourceFile);
+	COMPILED_BINDING_CACHE.set(sourceFile, bindings);
 
-	const aliases = new Map(
-		[...candidates.entries()].filter((entry): entry is [string, ts.Expression] => entry[1] !== undefined),
-	);
+	return bindings;
+};
 
-	COMPILED_ALIAS_CACHE.set(sourceFile, aliases);
+const isNodeWithin = (node: ts.Node, ancestor: ts.Node): boolean => {
+	let current: ts.Node | undefined = node;
 
-	return aliases;
+	while (current !== undefined) {
+		if (current === ancestor) {
+			return true;
+		}
+
+		current = current.parent;
+	}
+
+	return false;
+};
+
+const compiledScopeDepth = (scope: ts.Node): number => {
+	let depth = 0;
+	let current: ts.Node | undefined = scope;
+
+	while (current !== undefined) {
+		depth += 1;
+		current = current.parent;
+	}
+
+	return depth;
+};
+
+const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined => {
+	const sourceFile = identifier.getSourceFile();
+	const usePosition = identifier.getStart(sourceFile);
+	const visibleBindings = (compiledBindings(sourceFile).get(identifier.text) ?? [])
+		.filter(
+			(binding) =>
+				isNodeWithin(identifier, binding.scope) &&
+				(ts.isParameter(binding.declaration) || binding.declaration.getStart(sourceFile) < usePosition),
+		)
+		.sort((left, right) => {
+			const depthDifference = compiledScopeDepth(right.scope) - compiledScopeDepth(left.scope);
+
+			return depthDifference !== 0
+				? depthDifference
+				: right.declaration.getStart(sourceFile) - left.declaration.getStart(sourceFile);
+		});
+
+	return visibleBindings[0]?.initializer;
 };
 
 const containsUnsafeCompiledAlias = (
@@ -443,10 +535,9 @@ const containsUnsafeCompiledAlias = (
 	safeStrings: SafeCompiledString,
 	resolvingAliases = new Set<string>(),
 ): boolean => {
-	const aliases = compiledConstantAliases(node.getSourceFile());
 	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(expression)) {
-			const initializer = aliases.get(expression.text);
+			const initializer = resolveCompiledAlias(expression);
 
 			if (initializer === undefined || resolving.has(expression.text)) {
 				return false;
@@ -671,14 +762,12 @@ const containsCompiledSecret = (text: string): boolean => {
 				((node.initializer !== undefined && containsUnsafeCompiledValue(node.initializer)) ||
 					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = isCompiledSecretName(name) && containsUnsafeCompiledValue(node.initializer);
+			found = names.some((name) => isCompiledSecretName(name)) && containsUnsafeCompiledValue(node.initializer);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -749,14 +838,12 @@ const containsCompiledAddress = (text: string): boolean => {
 				(node.initializer !== undefined && unsafeAddress(node.name.text, node.initializer)) ||
 				unsafeAddressType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = unsafeAddress(name, node.initializer);
+			found = names.some((name) => unsafeAddress(name, node.initializer));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeAddress(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -837,14 +924,12 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				(node.initializer !== undefined && unsafeIdentifier(node.name.text, node.initializer)) ||
 				unsafeIdentifierType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = unsafeIdentifier(name, node.initializer);
+			found = names.some((name) => unsafeIdentifier(name, node.initializer));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeIdentifier(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -910,14 +995,12 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				(node.initializer !== undefined && unsafeEndpoint(node.name.text, node.initializer)) ||
 				unsafeEndpointType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = unsafeEndpoint(name, node.initializer);
+			found = names.some((name) => unsafeEndpoint(name, node.initializer));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeEndpoint(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -997,14 +1080,12 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 				(node.initializer !== undefined && unsafePersonalValue(node.name.text, node.initializer)) ||
 				unsafePersonalType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = unsafePersonalValue(name, node.initializer);
+			found = names.some((name) => unsafePersonalValue(name, node.initializer));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafePersonalValue(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -1071,14 +1152,12 @@ const containsCompiledIcon = (text: string): boolean => {
 				(node.initializer !== undefined && unsafeIcon(node.name.text, node.initializer)) ||
 				unsafeIconType(node.name.text, node.type);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
-			const name =
-				node.propertyName !== undefined
-					? compiledPropertyName(node.propertyName)
-					: ts.isIdentifier(node.name)
-						? node.name.text
-						: undefined;
+			const names = [
+				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
+				ts.isIdentifier(node.name) ? node.name.text : undefined,
+			];
 
-			found = unsafeIcon(name, node.initializer);
+			found = names.some((name) => unsafeIcon(name, node.initializer));
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			found = unsafeIcon(compiledAssignedPropertyName(node.left), node.right);
 		}
@@ -2019,6 +2098,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function first() { const fallback = 'opaque-secret'; const apiKey = fallback; } function second() { const fallback = ''; return fallback; }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),
 		).toThrow('unsafe declaration contains a compiled secret value');
 		expect(() =>
@@ -2083,6 +2169,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = { read() { return 'opaque-secret'; } };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = { ...{ value: 'opaque-secret' } };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = [...['opaque-secret']];", true)).toThrow(
@@ -2119,6 +2208,28 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const { apiKey: key = 'opaque-secret' } = config;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { value: apiKey = 'opaque-secret' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { value: hostname = 'family-homey.local' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled address value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { value: deviceId = 'opaque-household-id' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled identifier value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const { value: endpoint = 'private-homey.local:4859' } = config;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled endpoint value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { value: deviceName = 'Alice Bedroom' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled personal value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const { value: icon = 'custom-household-icon' } = config;", true),
+		).toThrow('unsafe compiled module contains a compiled icon value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "class Config { get apiKey() { return 'opaque-secret'; } }", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1178,6 +1178,10 @@ const compiledPropertyWriteValues = (
 					if (selectedName === propertyName || selectedName === undefined) {
 						values.push(...mutationPropertyValues(node.arguments[2], 'value'));
 					}
+				} else if (helperName === 'Object.defineProperties' && node.arguments.length >= 2) {
+					for (const descriptor of mutationPropertyValues(node.arguments[1], propertyName)) {
+						values.push(...mutationPropertyValues(descriptor, 'value'));
+					}
 				} else if (helperName === 'Reflect.set' && node.arguments.length >= 3) {
 					const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
 
@@ -4782,6 +4786,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: '' }; Object.assign(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: '' }; Object.defineProperties(source, { value: { value: 'opaque-secret' } }); const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -689,13 +689,15 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 		} else if (
 			ts.isVariableDeclaration(node) &&
 			(ts.isObjectBindingPattern(node.name) || ts.isArrayBindingPattern(node.name)) &&
-			node.initializer !== undefined &&
-			ts.isVariableDeclarationList(node.parent) &&
-			(node.parent.flags & ts.NodeFlags.Const) !== 0
+			node.initializer !== undefined
 		) {
 			addPatternBindings(node.name, node.initializer, compiledBindingScope(node));
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
-			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
+			addBinding(node.name.text, {
+				declaration: node,
+				initializer: node.initializer,
+				scope: compiledBindingScope(node),
+			});
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
 			addBinding(node.name.text, { callable: node, declaration: node, scope: compiledBindingScope(node) });
 		} else if (
@@ -775,6 +777,45 @@ const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | un
 
 const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined =>
 	resolveCompiledBinding(identifier)?.initializer;
+
+const compiledPropertyWriteValues = (identifier: ts.Identifier, propertyName: string): readonly ts.Expression[] => {
+	const sourceFile = identifier.getSourceFile();
+	const targetBinding = resolveCompiledBinding(identifier);
+	const usePosition = identifier.getStart(sourceFile);
+	const values: ts.Expression[] = [];
+
+	if (targetBinding === undefined) {
+		return values;
+	}
+
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isBinaryExpression(node) &&
+			node.getStart(sourceFile) < usePosition &&
+			isAssignmentOperatorKind(node.operatorToken.kind) &&
+			compiledAssignedPropertyName(node.left) === propertyName
+		) {
+			const receiver =
+				ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left)
+					? node.left.expression
+					: undefined;
+
+			if (
+				receiver !== undefined &&
+				ts.isIdentifier(receiver) &&
+				resolveCompiledBinding(receiver)?.declaration === targetBinding.declaration
+			) {
+				values.push(node.right);
+			}
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return values;
+};
 
 const containsUnsafeCompiledAlias = (
 	node: ts.Expression,
@@ -863,18 +904,23 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isIdentifier(receiver)) {
+					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
+
+					if (
+						compiledPropertyWriteValues(receiver, selectedPropertyName).some(
+							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedReceiverResolving),
+						)
+					) {
+						return true;
+					}
+
 					const initializer = resolveCompiledAlias(receiver);
 
 					if (initializer === undefined || nestedResolving.has(receiver.text)) {
 						return false;
 					}
 
-					return inspectProperty(
-						initializer,
-						new Set(nestedResolving).add(receiver.text),
-						selectedPropertyName,
-						resolvingProperties,
-					);
+					return inspectProperty(initializer, nestedReceiverResolving, selectedPropertyName, resolvingProperties);
 				}
 
 				if (
@@ -1077,13 +1123,23 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isIdentifier(receiver)) {
+					const nestedReceiverResolving = new Set(nestedResolving).add(receiver.text);
+
+					if (
+						compiledPropertyWriteValues(receiver, propertyName).some((value) =>
+							inspectCallable(value, nestedReceiverResolving),
+						)
+					) {
+						return true;
+					}
+
 					const initializer = resolveCompiledAlias(receiver);
 
 					if (initializer === undefined || nestedResolving.has(receiver.text)) {
 						return false;
 					}
 
-					return inspectCallableProperty(initializer, new Set(nestedResolving).add(receiver.text));
+					return inspectCallableProperty(initializer, nestedReceiverResolving);
 				}
 
 				if (
@@ -2697,6 +2753,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const fallback = (value = 'opaque-secret') => value; const apiKey = fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source.fallback();",
 				true,
 			),
@@ -2740,6 +2803,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const { fallback } = { fallback: 'opaque-secret' }; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"let { fallback } = { fallback: 'opaque-secret' }; const apiKey = fallback;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -2997,6 +3067,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: 'opaque-secret' }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: '' }; source.value = 'opaque-secret'; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: '' }; source['value'] = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1977,11 +1977,10 @@ const containsUnsafeCompiledAlias = (
 		}
 
 		if (helperName === 'Object.fromEntries' && call.arguments.length >= 1) {
-			const entries = resolveArrayElements(call.arguments[0], new Set());
-
-			if (entries === undefined) {
-				return [call.arguments[0]];
-			}
+			const entries = [
+				...(resolveArrayElements(call.arguments[0], new Set()) ?? [call.arguments[0]]),
+				...compiledReceiverWriteValues(call.arguments[0], call.getStart(call.getSourceFile())),
+			];
 
 			return entries.flatMap((entry): readonly ts.Expression[] => {
 				const pair = resolveArrayElements(entry, new Set());
@@ -2401,6 +2400,10 @@ const containsUnsafeCompiledAlias = (
 
 		if (methodName === 'with') {
 			return [...values.slice(index, index + 1), ...call.arguments.slice(1, 2), ...writeValues];
+		}
+
+		if (methodName === 'toSpliced') {
+			return [...values, ...call.arguments.slice(2), ...writeValues];
 		}
 
 		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice' || methodName === 'toSpliced'
@@ -7812,6 +7815,13 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push(['value', 'opaque-secret']); const apiKey = Object.fromEntries(source).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = (choose && { value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -8068,6 +8078,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].toSpliced(0, 0)[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = [''].toSpliced(0, 1, 'opaque-secret')[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [''].with(0, 'opaque-secret')[0];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1176,10 +1176,12 @@ const compiledPropertyWriteValues = (
 					const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
 
 					if (selectedName === propertyName || selectedName === undefined) {
+						values.push(node.arguments[2]);
 						values.push(...mutationPropertyValues(node.arguments[2], 'value'));
 					}
 				} else if (helperName === 'Object.defineProperties' && node.arguments.length >= 2) {
 					for (const descriptor of mutationPropertyValues(node.arguments[1], propertyName)) {
+						values.push(descriptor);
 						values.push(...mutationPropertyValues(descriptor, 'value'));
 					}
 				} else if (helperName === 'Reflect.set' && node.arguments.length >= 3) {
@@ -1409,6 +1411,106 @@ const containsUnsafeCompiledAlias = (
 			}
 		}
 	};
+	const constructorMutationValues = (node: ts.Node, propertyName: string): readonly ts.Expression[] => {
+		if (
+			!ts.isCallExpression(node) ||
+			!ts.isPropertyAccessExpression(node.expression) ||
+			!ts.isIdentifier(node.expression.expression) ||
+			node.arguments.length === 0 ||
+			node.arguments[0].kind !== ts.SyntaxKind.ThisKeyword
+		) {
+			return [];
+		}
+
+		const helperName = `${node.expression.expression.text}.${node.expression.name.text}`;
+
+		if (helperName === 'Object.assign') {
+			return node.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
+				const selectedValue = resolvePropertyValue(source, propertyName, new Set());
+
+				return selectedValue === undefined ? [source] : [selectedValue];
+			});
+		}
+
+		if (helperName === 'Object.defineProperty' && node.arguments.length >= 3) {
+			const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
+
+			if (selectedName !== propertyName && selectedName !== undefined) {
+				return [];
+			}
+
+			const descriptor = node.arguments[2];
+			const selectedValue = resolvePropertyValue(descriptor, 'value', new Set());
+
+			return selectedValue === undefined ? [descriptor] : [descriptor, selectedValue];
+		}
+
+		if (helperName === 'Object.defineProperties' && node.arguments.length >= 2) {
+			const descriptor = resolvePropertyValue(node.arguments[1], propertyName, new Set());
+
+			if (descriptor === undefined) {
+				return [node.arguments[1]];
+			}
+
+			const selectedValue = resolvePropertyValue(descriptor, 'value', new Set());
+
+			return selectedValue === undefined ? [descriptor] : [descriptor, selectedValue];
+		}
+
+		if (helperName === 'Reflect.set' && node.arguments.length >= 3) {
+			const selectedName = compiledStaticPropertyExpressionName(node.arguments[1]);
+
+			return selectedName === propertyName || selectedName === undefined ? [node.arguments[2]] : [];
+		}
+
+		return [];
+	};
+	const mutationResultValues = (call: ts.CallExpression, propertyName: string): readonly ts.Expression[] => {
+		if (
+			!ts.isPropertyAccessExpression(call.expression) ||
+			!ts.isIdentifier(call.expression.expression) ||
+			call.arguments.length === 0
+		) {
+			return [];
+		}
+
+		const helperName = `${call.expression.expression.text}.${call.expression.name.text}`;
+
+		if (helperName === 'Object.assign') {
+			return call.arguments.slice(1).flatMap((source): readonly ts.Expression[] => {
+				const selectedValue = resolvePropertyValue(source, propertyName, new Set());
+
+				return selectedValue === undefined ? [source] : [selectedValue];
+			});
+		}
+
+		if (helperName === 'Object.defineProperty' && call.arguments.length >= 3) {
+			const selectedName = compiledStaticPropertyExpressionName(call.arguments[1]);
+
+			if (selectedName !== propertyName && selectedName !== undefined) {
+				return [];
+			}
+
+			const descriptor = call.arguments[2];
+			const selectedValue = resolvePropertyValue(descriptor, 'value', new Set());
+
+			return selectedValue === undefined ? [descriptor] : [descriptor, selectedValue];
+		}
+
+		if (helperName === 'Object.defineProperties' && call.arguments.length >= 2) {
+			const descriptor = resolvePropertyValue(call.arguments[1], propertyName, new Set());
+
+			if (descriptor === undefined) {
+				return [call.arguments[1]];
+			}
+
+			const selectedValue = resolvePropertyValue(descriptor, 'value', new Set());
+
+			return selectedValue === undefined ? [descriptor] : [descriptor, selectedValue];
+		}
+
+		return [];
+	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression, visibleThroughPosition);
@@ -1603,6 +1705,19 @@ const containsUnsafeCompiledAlias = (
 											) ||
 											containsUnsafeCompiledLiteral(child.right, safeStrings) ||
 											inspect(child.right, nestedResolving);
+									}
+
+									if (!constructorWriteFound) {
+										const mutationValues = constructorMutationValues(child, memberName);
+
+										if (mutationValues.length > 0) {
+											constructorWriteFound = withCallArguments(member.parameters, constructorArguments, () =>
+												mutationValues.some(
+													(value) =>
+														containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
+												),
+											);
+										}
 									}
 
 									if (!constructorWriteFound) {
@@ -1872,6 +1987,14 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
+					if (
+						mutationResultValues(receiver, selectedPropertyName).some(
+							(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
+						)
+					) {
+						return true;
+					}
+
 					const inspectReturnedProperty = (
 						callee: ts.Expression,
 						resolvingCalls: Set<ts.Node>,
@@ -2380,6 +2503,10 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
+					if (mutationResultValues(receiver, propertyName).some((value) => inspectCallable(value, nestedResolving))) {
+						return true;
+					}
+
 					const inspectReturnedReceiver = (
 						factory: ts.Expression,
 						resolvingFactories: Set<ts.Node>,
@@ -2561,6 +2688,18 @@ const containsUnsafeCompiledAlias = (
 										() =>
 											containsUnsafeCompiledLiteral(child.right, safeStrings) || inspect(child.right, nestedResolving),
 									);
+								}
+
+								if (!found) {
+									const mutationValues = constructorMutationValues(child, memberName);
+
+									if (mutationValues.length > 0) {
+										found = withCallArguments(member.parameters, receiver.arguments ?? [], () =>
+											mutationValues.some(
+												(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
+											),
+										);
+									}
 								}
 
 								if (!found) {
@@ -4799,6 +4938,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = {}; Object.defineProperty(source, 'value', { get() { return 'opaque-secret'; } }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; const read = () => source.value; source.value = 'opaque-secret'; const apiKey = read();",
 				true,
 			),
@@ -4877,6 +5023,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor(value) { this.value = value; } } const apiKey = new Source('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor(value) { Object.assign(this, { value }); } } const apiKey = new Source('opaque-secret').value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -5017,6 +5170,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const apiKey = (choose ? safe : { value: 'opaque-secret' }).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = Object.assign({}, { value: 'opaque-secret' }).value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2390,7 +2390,14 @@ const containsUnsafeCompiledAlias = (
 					}
 
 					if (ts.isYieldExpression(node) && node.expression !== undefined) {
-						values.push(node.expression);
+						if (node.asteriskToken !== undefined && ts.isCallExpression(node.expression)) {
+							values.push(
+								...generatorResultValues(node.expression.expression, resolving),
+								...node.expression.arguments,
+							);
+						} else {
+							values.push(node.expression);
+						}
 					} else if (ts.isReturnStatement(node) && node.expression !== undefined) {
 						values.push(node.expression);
 					}
@@ -4782,11 +4789,12 @@ const containsCompiledSecret = (text: string): boolean => {
 			return promiseSettlementValues(expression.expression, resolving);
 		}
 
-		if (
-			!ts.isCallExpression(expression) ||
-			(!ts.isPropertyAccessExpression(expression.expression) && !ts.isElementAccessExpression(expression.expression))
-		) {
+		if (!ts.isCallExpression(expression)) {
 			return [];
+		}
+
+		if (!ts.isPropertyAccessExpression(expression.expression) && !ts.isElementAccessExpression(expression.expression)) {
+			return [...callableReturnValues(expression.expression), ...expression.arguments];
 		}
 
 		const methodName = ts.isPropertyAccessExpression(expression.expression)
@@ -4948,7 +4956,17 @@ const containsCompiledSecret = (text: string): boolean => {
 				const settledValues = promiseSettlementValues(invocationReceiver);
 				const callbacks = invocationPropertyName === 'then' ? node.arguments.slice(0, 2) : node.arguments.slice(0, 1);
 
-				found = callbacks.some((callback) => secretCallArguments(resolveCallParameterSets(callback), settledValues));
+				found = callbacks.some((callback) => {
+					const parameterSets = resolveCallParameterSets(callback);
+
+					return (
+						secretCallArguments(parameterSets, settledValues) ||
+						(parameterSets.some(({ parameters }) =>
+							parameters.some((parameter) => bindingNameContainsSecret(parameter.name)),
+						) &&
+							settledValues.some((value) => containsUnsafeCompiledValue(value)))
+					);
+				});
 			}
 
 			if (!found && invocationReceiver !== undefined) {
@@ -6801,6 +6819,20 @@ describe('Homey security artifact gate', () => {
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; async function load() { return stored; } load().then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const values = []; values.push('opaque-secret'); Promise.all(values).then(([apiKey]) => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "['opaque-secret'].forEach(apiKey => {});", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
@@ -7630,6 +7662,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const stored = 'opaque-secret'; function* source() { yield stored; } const apiKey = source().next().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; function* base() { yield stored; } function* source() { yield* base(); } const apiKey = source().next().value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2327,6 +2327,7 @@ const containsUnsafeCompiledAlias = (
 			methodName !== 'concat' &&
 			![
 				'copyWithin',
+				'fill',
 				'filter',
 				'flat',
 				'reverse',
@@ -2342,21 +2343,27 @@ const containsUnsafeCompiledAlias = (
 			return [];
 		}
 
-		const values =
-			methodName === 'concat'
-				? [call.expression.expression, ...call.arguments].flatMap(
-						(expression): readonly ts.Expression[] => resolveArrayElements(expression, new Set()) ?? [expression],
-					)
-				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
+		const sourceExpressions =
+			methodName === 'concat' ? [call.expression.expression, ...call.arguments] : [call.expression.expression];
+		const values = sourceExpressions.flatMap(
+			(expression): readonly ts.Expression[] => resolveArrayElements(expression, new Set()) ?? [expression],
+		);
+		const writeValues = sourceExpressions.flatMap((expression) =>
+			compiledReceiverWriteValues(expression, call.getStart(call.getSourceFile())),
+		);
 		const index = Number(selectedPropertyName);
 
+		if (methodName === 'fill') {
+			return [...values.slice(index, index + 1), ...call.arguments.slice(0, 1), ...writeValues];
+		}
+
 		if (methodName === 'with') {
-			return [...values.slice(index, index + 1), ...call.arguments.slice(1, 2)];
+			return [...values.slice(index, index + 1), ...call.arguments.slice(1, 2), ...writeValues];
 		}
 
 		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice' || methodName === 'toSpliced'
-			? values
-			: values.slice(index, index + 1);
+			? [...values, ...writeValues]
+			: [...values.slice(index, index + 1), ...writeValues];
 	};
 	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
 		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
@@ -4797,25 +4804,74 @@ const containsCompiledSecret = (text: string): boolean => {
 			parameters: readonly ts.ParameterDeclaration[],
 			body: ts.ConciseBody,
 		): readonly ts.Expression[] => {
-			const settlementNames = new Set(
-				parameters
-					.slice(0, 2)
-					.map((parameter) => (ts.isIdentifier(parameter.name) ? parameter.name.text : undefined))
-					.filter((name): name is string => name !== undefined),
-			);
+			const settlementParameters = new Set<ts.Node>(parameters.slice(0, 2));
+			const isSettlementReference = (expression: ts.Expression, resolvingReferences = new Set<ts.Node>()): boolean => {
+				if (
+					ts.isParenthesizedExpression(expression) ||
+					ts.isAsExpression(expression) ||
+					ts.isTypeAssertionExpression(expression) ||
+					ts.isNonNullExpression(expression) ||
+					ts.isSatisfiesExpression(expression)
+				) {
+					return isSettlementReference(expression.expression, resolvingReferences);
+				}
+
+				if (!ts.isIdentifier(expression)) {
+					return false;
+				}
+
+				const binding = resolveCompiledBinding(expression);
+
+				if (binding === undefined || resolvingReferences.has(binding.declaration)) {
+					return false;
+				}
+
+				if (settlementParameters.has(binding.declaration)) {
+					return true;
+				}
+
+				return (
+					binding.initializer !== undefined &&
+					isSettlementReference(binding.initializer, new Set(resolvingReferences).add(binding.declaration))
+				);
+			};
+			const settlementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
+				if (isSettlementReference(call.expression)) {
+					return call.arguments.slice(0, 1);
+				}
+
+				if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
+					return [];
+				}
+
+				const methodName = ts.isPropertyAccessExpression(call.expression)
+					? call.expression.name.text
+					: call.expression.argumentExpression === undefined
+						? undefined
+						: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+				if (!isSettlementReference(call.expression.expression)) {
+					return [];
+				}
+
+				if (methodName === 'call') {
+					return call.arguments.slice(1, 2);
+				}
+
+				if (methodName !== 'apply' || call.arguments[1] === undefined) {
+					return [];
+				}
+
+				return [call.arguments[1]];
+			};
 			const values: ts.Expression[] = [];
 			const visitSettlement = (node: ts.Node): void => {
 				if (node !== body && ts.isFunctionLike(node)) {
 					return;
 				}
 
-				if (
-					ts.isCallExpression(node) &&
-					ts.isIdentifier(node.expression) &&
-					settlementNames.has(node.expression.text) &&
-					node.arguments[0] !== undefined
-				) {
-					values.push(node.arguments[0]);
+				if (ts.isCallExpression(node)) {
+					values.push(...settlementCallValues(node));
 				}
 
 				ts.forEachChild(node, visitSettlement);
@@ -7018,6 +7074,27 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"new Promise((resolve) => { const settle = resolve; settle('opaque-secret'); }).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"new Promise((resolve) => resolve.call(null, 'opaque-secret')).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"new Promise((resolve) => resolve.apply(null, ['opaque-secret'])).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const values = []; values.push('opaque-secret'); Promise.all(values).then(([apiKey]) => {});",
 				true,
 			),
@@ -7910,6 +7987,27 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].slice()[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = source.slice()[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = source.reverse()[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = source.concat([])[0];",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].copyWithin(0, 0)[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -7917,6 +8015,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = [''].with(0, 'opaque-secret')[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const apiKey = [''].fill(stored)[0];",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1956,7 +1956,12 @@ const containsUnsafeCompiledAlias = (
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
 
 		if (methodName === 'find' || methodName === 'findLast') {
-			return resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression];
+			const receiver = call.expression.expression;
+
+			return [
+				...(resolveArrayElements(receiver, new Set()) ?? [receiver]),
+				...compiledPropertyWriteValues(receiver, '0', call.getStart(call.getSourceFile())),
+			];
 		}
 
 		const callbackIndex = ['flatMap', 'map', 'reduce', 'reduceRight'].includes(methodName ?? '')
@@ -4587,6 +4592,60 @@ const containsCompiledSecret = (text: string): boolean => {
 			});
 		});
 	};
+	const callableReturnValues = (
+		expression: ts.Expression,
+		resolving = new Set<ts.Node>(),
+	): readonly ts.Expression[] => {
+		const bodyReturnValues = (body: ts.Block): readonly ts.Expression[] => {
+			const values: ts.Expression[] = [];
+			const visitReturn = (node: ts.Node): void => {
+				if (node !== body && ts.isFunctionLike(node)) {
+					return;
+				}
+
+				if (ts.isReturnStatement(node) && node.expression !== undefined) {
+					values.push(node.expression);
+				}
+
+				ts.forEachChild(node, visitReturn);
+			};
+
+			visitReturn(body);
+
+			return values;
+		};
+
+		if (ts.isIdentifier(expression)) {
+			return resolveCompiledBindings(expression, expression.getStart(sourceFile)).flatMap((binding) => {
+				if (resolving.has(binding.declaration)) {
+					return [];
+				}
+
+				const nestedResolving = new Set(resolving).add(binding.declaration);
+				const initializerValues =
+					binding.initializer === undefined ? [] : callableReturnValues(binding.initializer, nestedResolving);
+				const declaredValues = binding.callable?.body === undefined ? [] : bodyReturnValues(binding.callable.body);
+
+				return [...initializerValues, ...declaredValues];
+			});
+		}
+
+		if (
+			ts.isParenthesizedExpression(expression) ||
+			ts.isAsExpression(expression) ||
+			ts.isTypeAssertionExpression(expression) ||
+			ts.isNonNullExpression(expression) ||
+			ts.isSatisfiesExpression(expression)
+		) {
+			return callableReturnValues(expression.expression, resolving);
+		}
+
+		if (ts.isArrowFunction(expression)) {
+			return ts.isBlock(expression.body) ? bodyReturnValues(expression.body) : [expression.body];
+		}
+
+		return ts.isFunctionExpression(expression) ? bodyReturnValues(expression.body) : [];
+	};
 	const promiseSettlementValues = (
 		expression: ts.Expression,
 		resolving = new Set<ts.Node>(),
@@ -4637,7 +4696,14 @@ const containsCompiledSecret = (text: string): boolean => {
 			}
 		}
 
-		return ['catch', 'finally', 'then'].includes(methodName ?? '') ? promiseSettlementValues(receiver, resolving) : [];
+		if (methodName === 'then' || methodName === 'catch') {
+			return [
+				...promiseSettlementValues(receiver, resolving),
+				...expression.arguments.flatMap((callback) => callableReturnValues(callback)),
+			];
+		}
+
+		return methodName === 'finally' ? promiseSettlementValues(receiver, resolving) : [];
 	};
 	const visit = (node: ts.Node): void => {
 		if (found) {
@@ -6581,6 +6647,20 @@ describe('Homey security artifact gate', () => {
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; Promise.resolve().then(() => stored).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; function load() { return stored; } Promise.resolve().then(load).then(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "['opaque-secret'].forEach(apiKey => {});", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
@@ -7256,6 +7336,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const apiKey = [{ value: 'opaque-secret' }].findLast(() => true).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push({ value: 'opaque-secret' }); const apiKey = source.find(Boolean).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.unshift({ value: 'opaque-secret' }); const apiKey = source.findLast(Boolean).value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -29,7 +29,16 @@ const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
 const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
-const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i;
+const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)[_-][A-Za-z0-9_-]{16,}\b/gi;
+const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
+	'homey-config-validator',
+	'homey-device-inventory',
+	'homey-failure-log-limiter',
+	'homey-plugin-batch-adoption',
+	'homey-plugin-connection',
+	'homey-plugin-device-mapping',
+	'homey-reconnect-backoff',
+]);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const SERIALIZED_STRING_PROPERTY_PATTERN = /(["'])([^"']+)\1\s*:\s*(["'])([^"']*)\3/g;
@@ -96,13 +105,16 @@ const containsIpv6Address = (text: string): boolean =>
 		return candidate !== undefined && candidate !== '::' && isIP(candidate) === 6;
 	});
 
+const containsHomeyTokenCandidate = (text: string): boolean =>
+	[...text.matchAll(HOMEY_TOKEN_PATTERN)].some((match) => !PUBLIC_HOMEY_TOKEN_COLLISIONS.has(match[0].toLowerCase()));
+
 const containsHomeyToken = (text: string, compiledSource: boolean): boolean => {
 	if (!compiledSource) {
-		return HOMEY_TOKEN_PATTERN.test(text);
+		return containsHomeyTokenCandidate(text);
 	}
 
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-	let found = [...text.matchAll(COMMENT_PATTERN)].some((match) => HOMEY_TOKEN_PATTERN.test(match[0]));
+	let found = [...text.matchAll(COMMENT_PATTERN)].some((match) => containsHomeyTokenCandidate(match[0]));
 	const visit = (node: ts.Node): void => {
 		if (found) {
 			return;
@@ -124,7 +136,7 @@ const containsHomeyToken = (text: string, compiledSource: boolean): boolean => {
 				parent.expression.text === 'Symbol' &&
 				parent.arguments[0] === node;
 
-			found = !isPublicSymbolDescription && HOMEY_TOKEN_PATTERN.test(value);
+			found = !isPublicSymbolDescription && containsHomeyTokenCandidate(value);
 		}
 
 		ts.forEachChild(node, visit);
@@ -142,6 +154,64 @@ const containsSerializedSecret = (text: string): boolean =>
 
 		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
 	});
+
+const compiledPropertyName = (name: ts.PropertyName): string | undefined => {
+	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+		return name.text;
+	}
+
+	if (ts.isComputedPropertyName(name) && ts.isStringLiteral(name.expression)) {
+		return name.expression.text;
+	}
+
+	return undefined;
+};
+
+const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
+	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+		return node.text.length > 0 && node.text !== '[~3~]';
+	}
+
+	if (ts.isNumericLiteral(node) || ts.isBigIntLiteral(node)) {
+		return true;
+	}
+
+	if (
+		node.kind === ts.SyntaxKind.TrueKeyword ||
+		node.kind === ts.SyntaxKind.FalseKeyword ||
+		node.kind === ts.SyntaxKind.NullKeyword
+	) {
+		return false;
+	}
+
+	if (ts.isArrayLiteralExpression(node)) {
+		return node.elements.some((element) => ts.isExpression(element) && containsUnsafeCompiledLiteral(element));
+	}
+
+	return false;
+};
+
+const containsCompiledSecret = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node)) {
+			const name = compiledPropertyName(node.name);
+
+			found = name !== undefined && isHomeySecretKey(name) && containsUnsafeCompiledLiteral(node.initializer);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
 
 const containsUnsafeSecretLeaf = (value: unknown): boolean => {
 	if (value === null || value === '' || value === '[~3~]' || typeof value === 'boolean') {
@@ -207,6 +277,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 
 	if (containsSerializedSecret(text)) {
 		throw new Error(`${label} contains a serialized secret value`);
+	}
+
+	if (compiledSource && containsCompiledSecret(text)) {
+		throw new Error(`${label} contains a compiled secret value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -350,6 +424,9 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe fixture', '{"value":"homey_abcdefghijklmnop"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
+		expect(() => assertTextSafe('unsafe fixture', '{"value":"homey-abcdefghijklmnop"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', 'throw new Error("request failed for homey_abcdefghijklmnop")', true),
 		).toThrow('unsafe compiled module contains a Homey personal access token');
@@ -359,6 +436,9 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('safe compiled module', 'const homey_local_connector_factory_1 = {};', true),
 		).not.toThrow();
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -47,7 +47,6 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-plugin-device-mapping',
 	'homey-reconnect-backoff',
 ]);
-const PUBLIC_COMPILED_SECRET_NAMES = new Set(['secretFields']);
 const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Locked',
 	'Synthetic lock contract',
@@ -247,9 +246,15 @@ const compiledAssignedPropertyName = (expression: ts.Expression): string | undef
 	return undefined;
 };
 
-const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
+const SAFE_COMPILED_SECRET_STRINGS = new Set(['', '[~3~]']);
+const SAFE_COMPILED_ADDRESS_STRINGS = new Set(['[~0~]']);
+
+const containsUnsafeCompiledLiteral = (
+	node: ts.Expression,
+	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+): boolean => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-		return node.text.length > 0 && node.text !== '[~3~]';
+		return !safeStrings.has(node.text);
 	}
 
 	if (ts.isNumericLiteral(node)) {
@@ -269,17 +274,22 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 	}
 
 	if (ts.isArrayLiteralExpression(node)) {
-		return node.elements.some((element) => ts.isExpression(element) && containsUnsafeCompiledLiteral(element));
+		return node.elements.some(
+			(element) => ts.isExpression(element) && containsUnsafeCompiledLiteral(element, safeStrings),
+		);
 	}
 
 	if (ts.isObjectLiteralExpression(node)) {
 		return node.properties.some(
-			(property) => ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer),
+			(property) =>
+				ts.isPropertyAssignment(property) && containsUnsafeCompiledLiteral(property.initializer, safeStrings),
 		);
 	}
 
 	if (ts.isBinaryExpression(node)) {
-		return containsUnsafeCompiledLiteral(node.left) || containsUnsafeCompiledLiteral(node.right);
+		return (
+			containsUnsafeCompiledLiteral(node.left, safeStrings) || containsUnsafeCompiledLiteral(node.right, safeStrings)
+		);
 	}
 
 	if (
@@ -289,11 +299,14 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 		ts.isNonNullExpression(node) ||
 		ts.isSatisfiesExpression(node)
 	) {
-		return containsUnsafeCompiledLiteral(node.expression);
+		return containsUnsafeCompiledLiteral(node.expression, safeStrings);
 	}
 
 	if (ts.isConditionalExpression(node)) {
-		return containsUnsafeCompiledLiteral(node.whenTrue) || containsUnsafeCompiledLiteral(node.whenFalse);
+		return (
+			containsUnsafeCompiledLiteral(node.whenTrue, safeStrings) ||
+			containsUnsafeCompiledLiteral(node.whenFalse, safeStrings)
+		);
 	}
 
 	if (ts.isCallExpression(node)) {
@@ -303,44 +316,109 @@ const containsUnsafeCompiledLiteral = (node: ts.Expression): boolean => {
 				: undefined;
 
 		return (
-			(receiver !== undefined && containsUnsafeCompiledLiteral(receiver)) ||
-			node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument))
+			(receiver !== undefined && containsUnsafeCompiledLiteral(receiver, safeStrings)) ||
+			node.arguments.some((argument) => containsUnsafeCompiledLiteral(argument, safeStrings))
 		);
 	}
 
 	if (ts.isNewExpression(node)) {
-		return node.arguments?.some((argument) => containsUnsafeCompiledLiteral(argument)) ?? false;
+		return node.arguments?.some((argument) => containsUnsafeCompiledLiteral(argument, safeStrings)) ?? false;
 	}
 
 	if (ts.isTemplateExpression(node)) {
 		return (
 			node.head.text.length > 0 ||
-			node.templateSpans.some((span) => span.literal.text.length > 0 || containsUnsafeCompiledLiteral(span.expression))
+			node.templateSpans.some(
+				(span) => span.literal.text.length > 0 || containsUnsafeCompiledLiteral(span.expression, safeStrings),
+			)
 		);
 	}
 
 	if (ts.isTaggedTemplateExpression(node)) {
-		return containsUnsafeCompiledLiteral(node.template);
+		return containsUnsafeCompiledLiteral(node.template, safeStrings);
 	}
 
 	if (ts.isAwaitExpression(node)) {
-		return containsUnsafeCompiledLiteral(node.expression);
+		return containsUnsafeCompiledLiteral(node.expression, safeStrings);
 	}
 
 	if (ts.isPrefixUnaryExpression(node)) {
-		return containsUnsafeCompiledLiteral(node.operand);
+		return containsUnsafeCompiledLiteral(node.operand, safeStrings);
 	}
 
 	return false;
 };
 
-const isCompiledSecretName = (name: string | undefined): name is string =>
-	name !== undefined && !PUBLIC_COMPILED_SECRET_NAMES.has(name) && isHomeySecretKey(name);
+const isCompiledSecretName = (name: string | undefined): name is string => name !== undefined && isHomeySecretKey(name);
+
+const isPublicSecretFieldsDescriptor = (node: ts.Expression): boolean => {
+	if (!ts.isArrayLiteralExpression(node) || node.elements.length !== 1) {
+		return false;
+	}
+
+	const [descriptor] = node.elements;
+
+	if (!ts.isObjectLiteralExpression(descriptor) || descriptor.properties.length !== 3) {
+		return false;
+	}
+
+	const properties = new Map(
+		descriptor.properties.flatMap((property) => {
+			if (!ts.isPropertyAssignment(property)) {
+				return [];
+			}
+
+			const name = compiledPropertyName(property.name);
+
+			return name === undefined ? [] : [[name, property.initializer] as const];
+		}),
+	);
+	const path = properties.get('path');
+	const configuredPath = properties.get('configuredPath');
+	const inputPaths = properties.get('inputPaths');
+
+	return (
+		properties.size === 3 &&
+		path !== undefined &&
+		ts.isStringLiteral(path) &&
+		path.text === 'api_key' &&
+		configuredPath !== undefined &&
+		ts.isStringLiteral(configuredPath) &&
+		configuredPath.text === 'api_key_configured' &&
+		inputPaths !== undefined &&
+		ts.isArrayLiteralExpression(inputPaths) &&
+		inputPaths.elements.length === 1 &&
+		ts.isStringLiteral(inputPaths.elements[0]) &&
+		inputPaths.elements[0].text === 'apiKey'
+	);
+};
+
+const containsUnsafeCompiledType = (type: ts.TypeNode): boolean => {
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isLiteralTypeNode(node) && ts.isExpression(node.literal)) {
+			found = containsUnsafeCompiledLiteral(node.literal);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(type);
+
+	return found;
+};
 
 const isAssignmentOperatorKind = (kind: ts.SyntaxKind): boolean =>
 	kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
 
-const containsUnsafeReturnedLiteral = (body: ts.Block): boolean => {
+const containsUnsafeReturnedLiteral = (
+	body: ts.Block,
+	safeStrings: ReadonlySet<string> = SAFE_COMPILED_SECRET_STRINGS,
+): boolean => {
 	let found = false;
 	const visit = (node: ts.Node): void => {
 		if (found) {
@@ -348,7 +426,7 @@ const containsUnsafeReturnedLiteral = (body: ts.Block): boolean => {
 		}
 
 		if (ts.isReturnStatement(node) && node.expression !== undefined) {
-			found = containsUnsafeCompiledLiteral(node.expression);
+			found = containsUnsafeCompiledLiteral(node.expression, safeStrings);
 		}
 
 		ts.forEachChild(node, visit);
@@ -370,17 +448,33 @@ const containsCompiledSecret = (text: string): boolean => {
 		if (ts.isPropertyAssignment(node)) {
 			const name = compiledPropertyName(node.name);
 
-			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
-		} else if (ts.isPropertyDeclaration(node) && node.initializer !== undefined) {
+			found =
+				isCompiledSecretName(name) &&
+				!(name === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
+				containsUnsafeCompiledLiteral(node.initializer);
+		} else if (ts.isPropertyDeclaration(node)) {
 			const name = compiledPropertyName(node.name);
 
-			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.initializer);
-		} else if ((ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node)) && node.body !== undefined) {
+			found =
+				isCompiledSecretName(name) &&
+				((node.initializer !== undefined && containsUnsafeCompiledLiteral(node.initializer)) ||
+					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
+		} else if (ts.isPropertySignature(node)) {
 			const name = compiledPropertyName(node.name);
 
-			found = isCompiledSecretName(name) && containsUnsafeReturnedLiteral(node.body);
+			found = isCompiledSecretName(name) && node.type !== undefined && containsUnsafeCompiledType(node.type);
+		} else if (
+			(ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) &&
+			isCompiledSecretName(compiledPropertyName(node.name))
+		) {
+			found =
+				('body' in node && node.body !== undefined && containsUnsafeReturnedLiteral(node.body)) ||
+				(node.type !== undefined && containsUnsafeCompiledType(node.type));
 		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
+			found =
+				isCompiledSecretName(node.name.text) &&
+				!(node.name.text === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
+				containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
 			found = isCompiledSecretName(node.name.text) && containsUnsafeCompiledLiteral(node.initializer);
 		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
@@ -396,6 +490,52 @@ const containsCompiledSecret = (text: string): boolean => {
 			const name = compiledAssignedPropertyName(node.left);
 
 			found = isCompiledSecretName(name) && containsUnsafeCompiledLiteral(node.right);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
+const containsCompiledAddress = (text: string): boolean => {
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = false;
+	const unsafeAddress = (name: string | undefined, expression: ts.Expression): boolean =>
+		name !== undefined &&
+		isHomeyAddressKey(name) &&
+		containsUnsafeCompiledLiteral(expression, SAFE_COMPILED_ADDRESS_STRINGS);
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isPropertyAssignment(node) || (ts.isPropertyDeclaration(node) && node.initializer !== undefined)) {
+			found = unsafeAddress(compiledPropertyName(node.name), node.initializer);
+		} else if ((ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node)) && node.body !== undefined) {
+			const name = compiledPropertyName(node.name);
+
+			found =
+				name !== undefined &&
+				isHomeyAddressKey(name) &&
+				containsUnsafeReturnedLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeAddress(node.name.text, node.initializer);
+		} else if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+			found = unsafeAddress(node.name.text, node.initializer);
+		} else if (ts.isBindingElement(node) && node.initializer !== undefined) {
+			const name =
+				node.propertyName !== undefined
+					? compiledPropertyName(node.propertyName)
+					: ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined;
+
+			found = unsafeAddress(name, node.initializer);
+		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
+			found = unsafeAddress(compiledAssignedPropertyName(node.left), node.right);
 		}
 
 		ts.forEachChild(node, visit);
@@ -614,6 +754,10 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 
 	if (compiledSource && containsCompiledPrivateUrl(text)) {
 		throw new Error(`${label} contains a private URL`);
+	}
+
+	if (compiledSource && containsCompiledAddress(text)) {
+		throw new Error(`${label} contains a compiled address value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -928,6 +1072,22 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('safe compiled module', 'const homey_local_connector_factory_1 = {};', true),
 		).not.toThrow();
+		expect(() =>
+			assertTextSafe(
+				'safe compiled module',
+				"const secretFields = [{ path: 'api_key', configuredPath: 'api_key_configured', inputPaths: ['apiKey'] }];",
+				true,
+			),
+		).not.toThrow();
+		expect(() => assertTextSafe('unsafe compiled module', "const secretFields = ['opaque-secret'];", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe declaration', "interface Config { apiKey: 'opaque-secret' }", true)).toThrow(
+			'unsafe declaration contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "const hostname = 'family-homey.local';", true)).toThrow(
+			'unsafe compiled module contains a compiled address value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1740,19 +1740,24 @@ const containsUnsafeCompiledAlias = (
 					const nestedReceiverResolving =
 						receiverBinding === undefined ? nestedResolving : new Set(nestedResolving).add(receiverBinding.declaration);
 					const classDeclaration = receiverBinding?.classDeclaration;
+					const inspectStaticClassCallable = (
+						declaration: ts.ClassDeclaration,
+						resolvingClasses = new Set<ts.ClassDeclaration>(),
+					): boolean => {
+						if (resolvingClasses.has(declaration)) {
+							return false;
+						}
 
-					if (
-						receiverBinding !== undefined &&
-						classDeclaration !== undefined &&
-						!nestedResolving.has(receiverBinding.declaration) &&
-						classDeclaration.members.some((member) => {
+						const nestedClasses = new Set(resolvingClasses).add(declaration);
+						const ownMemberFound = declaration.members.some((member) => {
 							if (!('name' in member)) {
 								return false;
 							}
 
-							const staticMember =
+							const staticMember = Boolean(
 								ts.canHaveModifiers(member) &&
-								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+							);
 
 							if (!staticMember || compiledPropertyName(member.name) !== propertyName) {
 								return false;
@@ -1767,7 +1772,30 @@ const containsUnsafeCompiledAlias = (
 								member.body !== undefined &&
 								inspectCallableBody(member.body, nestedReceiverResolving)
 							);
-						})
+						});
+
+						return (
+							ownMemberFound ||
+							(declaration.heritageClauses
+								?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+								.some((clause) =>
+									clause.types.some((type) => {
+										const baseClass = ts.isIdentifier(type.expression)
+											? resolveCompiledBinding(type.expression)?.classDeclaration
+											: undefined;
+
+										return baseClass !== undefined && inspectStaticClassCallable(baseClass, nestedClasses);
+									}),
+								) ??
+								false)
+						);
+					};
+
+					if (
+						receiverBinding !== undefined &&
+						classDeclaration !== undefined &&
+						!nestedResolving.has(receiverBinding.declaration) &&
+						inspectStaticClassCallable(classDeclaration)
 					) {
 						return true;
 					}
@@ -1793,6 +1821,72 @@ const containsUnsafeCompiledAlias = (
 					ts.isSatisfiesExpression(receiver)
 				) {
 					return inspectCallableProperty(receiver.expression, nestedResolving);
+				}
+
+				if (ts.isCallExpression(receiver)) {
+					const inspectReturnedReceiver = (factory: ts.Expression, resolvingFactories: Set<ts.Node>): boolean => {
+						const inspectReturnBody = (body: ts.Block, nestedFactories: Set<ts.Node>): boolean => {
+							let found = false;
+							const visitReturn = (child: ts.Node): void => {
+								if (found) {
+									return;
+								}
+
+								if (ts.isReturnStatement(child) && child.expression !== undefined) {
+									found = inspectCallableProperty(child.expression, nestedFactories);
+								}
+
+								if (!found) {
+									ts.forEachChild(child, visitReturn);
+								}
+							};
+
+							visitReturn(body);
+
+							return found;
+						};
+
+						if (ts.isIdentifier(factory)) {
+							return resolveCompiledBindings(factory, visibleThroughPosition).some((binding) => {
+								if (resolvingFactories.has(binding.declaration)) {
+									return false;
+								}
+
+								const nestedFactories = new Set(resolvingFactories).add(binding.declaration);
+
+								return (
+									[binding.initializer, binding.fallbackInitializer].some(
+										(initializer) => initializer !== undefined && inspectReturnedReceiver(initializer, nestedFactories),
+									) ||
+									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedFactories))
+								);
+							});
+						}
+
+						if (
+							ts.isParenthesizedExpression(factory) ||
+							ts.isAsExpression(factory) ||
+							ts.isTypeAssertionExpression(factory) ||
+							ts.isNonNullExpression(factory) ||
+							ts.isSatisfiesExpression(factory)
+						) {
+							return inspectReturnedReceiver(factory.expression, resolvingFactories);
+						}
+
+						if (ts.isArrowFunction(factory)) {
+							return ts.isBlock(factory.body)
+								? inspectReturnBody(factory.body, resolvingFactories)
+								: inspectCallableProperty(factory.body, resolvingFactories);
+						}
+
+						if (ts.isFunctionExpression(factory)) {
+							return inspectReturnBody(factory.body, resolvingFactories);
+						}
+
+						return ts.isCallExpression(factory) && inspectReturnedReceiver(factory.expression, resolvingFactories);
+					};
+
+					return inspectReturnedReceiver(receiver.expression, nestedResolving);
 				}
 
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
@@ -1885,17 +1979,22 @@ const containsUnsafeCompiledAlias = (
 								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
 								member.body !== undefined
 							) {
-								let receiverPropertyName: string | undefined;
+								const receiverPropertyNames = new Set<string>();
+								const collectReceiverProperties = (child: ts.Node): void => {
+									if (ts.isExpression(child)) {
+										const receiverPropertyName = compiledThisPropertyName(child);
+
+										if (receiverPropertyName !== undefined) {
+											receiverPropertyNames.add(receiverPropertyName);
+										}
+									}
+
+									ts.forEachChild(child, collectReceiverProperties);
+								};
 								const visitReturn = (child: ts.Node): void => {
-									if (receiverPropertyName !== undefined) {
-										return;
-									}
-
 									if (ts.isReturnStatement(child) && child.expression !== undefined) {
-										receiverPropertyName = compiledThisPropertyName(child.expression);
-									}
-
-									if (receiverPropertyName === undefined) {
+										collectReceiverProperties(child.expression);
+									} else {
 										ts.forEachChild(child, visitReturn);
 									}
 								};
@@ -1903,8 +2002,9 @@ const containsUnsafeCompiledAlias = (
 								visitReturn(member.body);
 
 								return (
-									(receiverPropertyName !== undefined && inspectClassValue(declaration, receiverPropertyName)) ||
-									inspectCallableBody(member.body, nestedResolving)
+									[...receiverPropertyNames].some((receiverPropertyName) =>
+										inspectClassValue(declaration, receiverPropertyName),
+									) || inspectCallableBody(member.body, nestedResolving)
 								);
 							}
 
@@ -4053,6 +4153,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { safe = ''; stored = 'opaque-secret'; fallback(flag) { return flag ? this.safe : this.stored; } } const apiKey = new Source().fallback(false);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Base { static fallback() { return 'opaque-secret'; } } class Source extends Base {} const apiKey = Source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const fallback = () => ({ value: 'opaque-secret' }); const apiKey = fallback().value;",
 				true,
 			),
@@ -4061,6 +4175,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const factory = { make: () => ({ value: 'opaque-secret' }) }; const apiKey = factory.make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const factory = () => ({ fallback: () => 'opaque-secret' }); const apiKey = factory().fallback();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1964,11 +1964,43 @@ const containsUnsafeCompiledAlias = (
 
 								if (ts.isReturnStatement(child) && child.expression !== undefined) {
 									const returned = child.expression;
-									const receiverPropertyName = compiledThisPropertyName(returned);
+									const receiverPropertyNames = new Set<string>();
+									let dynamicReceiverProperty = false;
+									const collectReceiverProperties = (returnedChild: ts.Node): void => {
+										if (ts.isExpression(returnedChild)) {
+											const receiverPropertyName = compiledThisPropertyName(returnedChild);
+
+											if (receiverPropertyName !== undefined) {
+												receiverPropertyNames.add(receiverPropertyName);
+											} else if (
+												ts.isElementAccessExpression(returnedChild) &&
+												returnedChild.expression.kind === ts.SyntaxKind.ThisKeyword
+											) {
+												dynamicReceiverProperty = true;
+											}
+										}
+
+										ts.forEachChild(returnedChild, collectReceiverProperties);
+									};
+
+									collectReceiverProperties(returned);
+
+									if (dynamicReceiverProperty) {
+										for (const candidate of receiver.properties) {
+											if ('name' in candidate) {
+												const candidateName = compiledPropertyName(candidate.name);
+
+												if (candidateName !== undefined) {
+													receiverPropertyNames.add(candidateName);
+												}
+											}
+										}
+									}
 
 									found =
-										(receiverPropertyName !== undefined &&
-											inspectProperty(receiver, nestedResolving, receiverPropertyName, nestedResolvingProperties)) ||
+										[...receiverPropertyNames].some((receiverPropertyName) =>
+											inspectProperty(receiver, nestedResolving, receiverPropertyName, nestedResolvingProperties),
+										) ||
 										containsUnsafeCompiledLiteral(returned, safeStrings) ||
 										inspect(returned, nestedResolving);
 								}
@@ -4804,6 +4836,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { stored: 'opaque-secret', get value() { return this.stored; } }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { safe: '', stored: 'opaque-secret', get value() { return flag ? this.safe : this.stored; } }; const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -593,6 +593,53 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 
 		return elements;
 	};
+	const selectObjectValue = (
+		propertyName: string,
+		source: ts.Expression,
+		resolvingSources: Set<string>,
+	): ts.Expression | undefined => {
+		if (ts.isIdentifier(source)) {
+			const initializer = resolveCompiledAlias(source);
+
+			return initializer === undefined || resolvingSources.has(source.text)
+				? undefined
+				: selectObjectValue(propertyName, initializer, new Set(resolvingSources).add(source.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(source) ||
+			ts.isAsExpression(source) ||
+			ts.isTypeAssertionExpression(source) ||
+			ts.isNonNullExpression(source) ||
+			ts.isSatisfiesExpression(source)
+		) {
+			return selectObjectValue(propertyName, source.expression, resolvingSources);
+		}
+
+		if (!ts.isObjectLiteralExpression(source)) {
+			return undefined;
+		}
+
+		for (const property of [...source.properties].reverse()) {
+			if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+				return property.initializer;
+			}
+
+			if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+				return property.name;
+			}
+
+			if (ts.isSpreadAssignment(property)) {
+				const spreadValue = selectObjectValue(propertyName, property.expression, resolvingSources);
+
+				if (spreadValue !== undefined) {
+					return spreadValue;
+				}
+			}
+		}
+
+		return undefined;
+	};
 	const selectBindingValue = (
 		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
 		binding: ts.BindingElement,
@@ -618,7 +665,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			return selectBindingValue(pattern, binding, index, source.expression, resolvingSources);
 		}
 
-		if (ts.isObjectBindingPattern(pattern) && ts.isObjectLiteralExpression(source)) {
+		if (ts.isObjectBindingPattern(pattern)) {
 			const propertyName =
 				binding.propertyName === undefined
 					? ts.isIdentifier(binding.name)
@@ -630,23 +677,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				return undefined;
 			}
 
-			for (const property of [...source.properties].reverse()) {
-				if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
-					return property.initializer;
-				}
-
-				if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
-					return property.name;
-				}
-
-				if (ts.isSpreadAssignment(property)) {
-					const spreadValue = selectBindingValue(pattern, binding, index, property.expression, resolvingSources);
-
-					if (spreadValue !== undefined) {
-						return spreadValue;
-					}
-				}
-			}
+			return selectObjectValue(propertyName, source, resolvingSources);
 		}
 
 		if (ts.isArrayBindingPattern(pattern)) {
@@ -678,6 +709,68 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				addPatternBindings(element.name, selectedValue, scope);
 			}
 		});
+	};
+	const addAssignmentPatternBindings = (
+		target: ts.Expression,
+		source: ts.Expression | undefined,
+		declaration: ts.BinaryExpression,
+	): void => {
+		if (ts.isParenthesizedExpression(target)) {
+			addAssignmentPatternBindings(target.expression, source, declaration);
+
+			return;
+		}
+
+		if (ts.isIdentifier(target)) {
+			const binding = resolveCompiledBinding(target);
+
+			if (binding !== undefined && source !== undefined) {
+				addBinding(target.text, { declaration, initializer: source, scope: binding.scope });
+			}
+
+			return;
+		}
+
+		if (ts.isBinaryExpression(target) && target.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+			addAssignmentPatternBindings(target.left, source, declaration);
+			addAssignmentPatternBindings(target.left, target.right, declaration);
+
+			return;
+		}
+
+		if (ts.isObjectLiteralExpression(target)) {
+			for (const property of target.properties) {
+				if (ts.isPropertyAssignment(property)) {
+					const propertyName = compiledPropertyName(property.name);
+
+					addAssignmentPatternBindings(
+						property.initializer,
+						propertyName === undefined || source === undefined
+							? undefined
+							: selectObjectValue(propertyName, source, new Set()),
+						declaration,
+					);
+				} else if (ts.isShorthandPropertyAssignment(property)) {
+					addAssignmentPatternBindings(
+						property.name,
+						source === undefined ? undefined : selectObjectValue(property.name.text, source, new Set()),
+						declaration,
+					);
+				}
+			}
+
+			return;
+		}
+
+		if (ts.isArrayLiteralExpression(target) && source !== undefined) {
+			const sourceElements = resolveBindingArrayElements(source, new Set());
+
+			target.elements.forEach((element, index) => {
+				if (ts.isExpression(element) && !ts.isOmittedExpression(element)) {
+					addAssignmentPatternBindings(element, sourceElements?.[index], declaration);
+				}
+			});
+		}
 	};
 	const visit = (node: ts.Node): void => {
 		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
@@ -714,6 +807,14 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 					scope: target.scope,
 				});
 			}
+		} else if (
+			ts.isBinaryExpression(node) &&
+			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			(ts.isObjectLiteralExpression(node.left) ||
+				ts.isArrayLiteralExpression(node.left) ||
+				ts.isParenthesizedExpression(node.left))
+		) {
+			addAssignmentPatternBindings(node.left, node.right, node);
 		}
 
 		ts.forEachChild(node, visit);
@@ -778,9 +879,37 @@ const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | un
 const resolveCompiledAlias = (identifier: ts.Identifier): ts.Expression | undefined =>
 	resolveCompiledBinding(identifier)?.initializer;
 
+const resolveCompiledReceiverBinding = (
+	identifier: ts.Identifier,
+	resolvingBindings = new Set<ts.Node>(),
+): CompiledBinding | undefined => {
+	const binding = resolveCompiledBinding(identifier);
+
+	if (binding === undefined || resolvingBindings.has(binding.declaration)) {
+		return binding;
+	}
+
+	let initializer = binding.initializer;
+
+	while (
+		initializer !== undefined &&
+		(ts.isParenthesizedExpression(initializer) ||
+			ts.isAsExpression(initializer) ||
+			ts.isTypeAssertionExpression(initializer) ||
+			ts.isNonNullExpression(initializer) ||
+			ts.isSatisfiesExpression(initializer))
+	) {
+		initializer = initializer.expression;
+	}
+
+	return initializer !== undefined && ts.isIdentifier(initializer)
+		? resolveCompiledReceiverBinding(initializer, new Set(resolvingBindings).add(binding.declaration))
+		: binding;
+};
+
 const compiledPropertyWriteValues = (identifier: ts.Identifier, propertyName: string): readonly ts.Expression[] => {
 	const sourceFile = identifier.getSourceFile();
-	const targetBinding = resolveCompiledBinding(identifier);
+	const targetBinding = resolveCompiledReceiverBinding(identifier);
 	const usePosition = identifier.getStart(sourceFile);
 	const values: ts.Expression[] = [];
 
@@ -803,7 +932,7 @@ const compiledPropertyWriteValues = (identifier: ts.Identifier, propertyName: st
 			if (
 				receiver !== undefined &&
 				ts.isIdentifier(receiver) &&
-				resolveCompiledBinding(receiver)?.declaration === targetBinding.declaration
+				resolveCompiledReceiverBinding(receiver)?.declaration === targetBinding.declaration
 			) {
 				values.push(node.right);
 			}
@@ -2816,6 +2945,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"let fallback = ''; ({ value: fallback } = { value: 'opaque-secret' }); const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"let fallback = ''; [, fallback] = ['safe', 'opaque-secret']; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const { fallback = 'opaque-secret' } = {}; const apiKey = fallback;",
 				true,
 			),
@@ -3081,6 +3224,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: '' }; source['value'] = 'opaque-secret'; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { value: '' }; const alias = source; alias.value = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2009,6 +2009,21 @@ const containsUnsafeCompiledAlias = (
 		}
 
 		if (
+			(ts.isPropertyAccessExpression(call.expression) || ts.isElementAccessExpression(call.expression)) &&
+			call.arguments.length === 0
+		) {
+			const methodName = ts.isPropertyAccessExpression(call.expression)
+				? call.expression.name.text
+				: call.expression.argumentExpression === undefined
+					? undefined
+					: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+			if (methodName === 'valueOf') {
+				return [call.expression.expression];
+			}
+		}
+
+		if (
 			ts.isPropertyAccessExpression(call.expression) &&
 			ts.isIdentifier(call.expression.expression) &&
 			call.expression.expression.text === 'Array'
@@ -2319,6 +2334,7 @@ const containsUnsafeCompiledAlias = (
 				'sort',
 				'splice',
 				'toReversed',
+				'toSpliced',
 				'toSorted',
 				'with',
 			].includes(methodName ?? '')
@@ -2334,7 +2350,7 @@ const containsUnsafeCompiledAlias = (
 				: (resolveArrayElements(call.expression.expression, new Set()) ?? [call.expression.expression]);
 		const index = Number(selectedPropertyName);
 
-		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice'
+		return methodName === 'filter' || methodName === 'flat' || methodName === 'splice' || methodName === 'toSpliced'
 			? values
 			: values.slice(index, index + 1);
 	};
@@ -3521,7 +3537,10 @@ const containsUnsafeCompiledAlias = (
 					return (
 						inspectReturnedProperty(receiver.expression, nestedResolving, receiver.arguments) ||
 						transparentCallResultValues(receiver).some(
-							(argument) => containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving),
+							(argument) =>
+								containsUnsafeCompiledLiteral(argument, safeStrings) ||
+								inspect(argument, nestedResolving) ||
+								inspectProperty(argument, nestedResolving, selectedPropertyName, resolvingProperties),
 						)
 					);
 				}
@@ -7530,6 +7549,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = {}; source.value = 'opaque-secret'; const apiKey = source.valueOf().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const apiKey = structuredClone({ value: 'opaque-secret' }).value;",
 				true,
 			),
@@ -7770,6 +7796,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].copyWithin(0, 0)[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = ['opaque-secret'].toSpliced(0, 0)[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1290,11 +1290,13 @@ const containsCompiledSecret = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body)) ||
 				(node.type !== undefined && containsUnsafeCompiledType(node.type));
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
 			found =
 				isCompiledSecretName(node.name.text) &&
-				!(node.name.text === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
-				containsUnsafeCompiledValue(node.initializer);
+				((node.initializer !== undefined &&
+					!(node.name.text === 'secretFields' && isPublicSecretFieldsDescriptor(node.initializer)) &&
+					containsUnsafeCompiledValue(node.initializer)) ||
+					(node.type !== undefined && containsUnsafeCompiledType(node.type)));
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				isCompiledSecretName(node.name.text) &&
@@ -1382,8 +1384,10 @@ const containsCompiledAddress = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, SAFE_COMPILED_ADDRESS_STRINGS)) ||
 				unsafeAddressType(node.name.text, node.type);
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeAddress(node.name.text, node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeAddress(node.name.text, node.initializer)) ||
+				unsafeAddressType(node.name.text, node.type);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				(node.initializer !== undefined && unsafeAddress(node.name.text, node.initializer)) ||
@@ -1478,8 +1482,10 @@ const containsCompiledIdentifier = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIdentifierValue)) ||
 				unsafeIdentifierType(node.name.text, node.type);
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeIdentifier(node.name.text, node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeIdentifier(node.name.text, node.initializer)) ||
+				unsafeIdentifierType(node.name.text, node.type);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				(node.initializer !== undefined && unsafeIdentifier(node.name.text, node.initializer)) ||
@@ -1559,8 +1565,10 @@ const containsCompiledEndpoint = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeEndpointValue)) ||
 				unsafeEndpointType(node.name.text, node.type);
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeEndpoint(node.name.text, node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeEndpoint(node.name.text, node.initializer)) ||
+				unsafeEndpointType(node.name.text, node.type);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				(node.initializer !== undefined && unsafeEndpoint(node.name.text, node.initializer)) ||
@@ -1654,8 +1662,10 @@ const containsCompiledPersonalValue = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledPersonalValue)) ||
 				unsafePersonalType(node.name.text, node.type);
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafePersonalValue(node.name.text, node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafePersonalValue(node.name.text, node.initializer)) ||
+				unsafePersonalType(node.name.text, node.type);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				(node.initializer !== undefined && unsafePersonalValue(node.name.text, node.initializer)) ||
@@ -1736,8 +1746,10 @@ const containsCompiledIcon = (text: string): boolean => {
 				) ||
 				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body, isSafeCompiledIconValue)) ||
 				unsafeIconType(node.name.text, node.type);
-		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer !== undefined) {
-			found = unsafeIcon(node.name.text, node.initializer);
+		} else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			found =
+				(node.initializer !== undefined && unsafeIcon(node.name.text, node.initializer)) ||
+				unsafeIconType(node.name.text, node.type);
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			found =
 				(node.initializer !== undefined && unsafeIcon(node.name.text, node.initializer)) ||
@@ -2743,6 +2755,24 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),
 		).toThrow('unsafe declaration contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe declaration', "declare const apiKey: 'opaque-secret';", true)).toThrow(
+			'unsafe declaration contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe declaration', "declare const hostname: 'family-homey.local';", true)).toThrow(
+			'unsafe declaration contains a compiled address value',
+		);
+		expect(() => assertTextSafe('unsafe declaration', "declare const deviceId: 'opaque-household-id';", true)).toThrow(
+			'unsafe declaration contains a compiled identifier value',
+		);
+		expect(() =>
+			assertTextSafe('unsafe declaration', "declare const endpoint: 'private-homey.local:4859';", true),
+		).toThrow('unsafe declaration contains a compiled endpoint value');
+		expect(() => assertTextSafe('unsafe declaration', "declare const deviceName: 'Alice Bedroom';", true)).toThrow(
+			'unsafe declaration contains a compiled personal value',
+		);
+		expect(() => assertTextSafe('unsafe declaration', "declare const icon: 'custom-household-icon';", true)).toThrow(
+			'unsafe declaration contains a compiled icon value',
+		);
 		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(hostname: 'family-homey.local'): void", true),
 		).toThrow('unsafe declaration contains a compiled address value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1830,6 +1830,114 @@ const containsUnsafeCompiledAlias = (
 
 		return [];
 	};
+	const collectionTransformResultValues = (
+		call: ts.CallExpression,
+		resolving = new Set<ts.Node>(),
+	): readonly ts.Expression[] => {
+		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+		const callbackIndex =
+			methodName === 'map' || methodName === 'flatMap'
+				? 0
+				: methodName === 'from' &&
+					  ts.isIdentifier(call.expression.expression) &&
+					  call.expression.expression.text === 'Array'
+					? 1
+					: undefined;
+		const callback = callbackIndex === undefined ? undefined : call.arguments[callbackIndex];
+
+		if (callback === undefined) {
+			return [];
+		}
+
+		const returnExpressions = (body: ts.Block): readonly ts.Expression[] => {
+			const values: ts.Expression[] = [];
+			const visitReturn = (node: ts.Node): void => {
+				if (ts.isReturnStatement(node) && node.expression !== undefined) {
+					values.push(node.expression);
+				}
+
+				ts.forEachChild(node, visitReturn);
+			};
+
+			visitReturn(body);
+
+			return values;
+		};
+		const resolveCallbackValues = (
+			expression: ts.Expression,
+			nestedResolving: Set<ts.Node>,
+		): readonly ts.Expression[] => {
+			if (ts.isIdentifier(expression)) {
+				return resolveCompiledBindings(expression, visibleThroughPosition).flatMap((binding) => {
+					if (nestedResolving.has(binding.declaration)) {
+						return [];
+					}
+
+					const nextResolving = new Set(nestedResolving).add(binding.declaration);
+					const values = [binding.initializer, binding.fallbackInitializer].flatMap((initializer) =>
+						initializer === undefined ? [] : resolveCallbackValues(initializer, nextResolving),
+					);
+
+					if (binding.callable?.body === undefined) {
+						return values;
+					}
+
+					return [...values, ...returnExpressions(binding.callable.body)];
+				});
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveCallbackValues(expression.expression, nestedResolving);
+			}
+
+			if (ts.isArrowFunction(expression)) {
+				return ts.isBlock(expression.body) ? returnExpressions(expression.body) : [expression.body];
+			}
+
+			return ts.isFunctionExpression(expression) ? returnExpressions(expression.body) : [];
+		};
+
+		return resolveCallbackValues(callback, resolving);
+	};
+	const descriptorQueryValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		if (
+			selectedPropertyName !== 'value' ||
+			call.arguments.length < 2 ||
+			!ts.isPropertyAccessExpression(call.expression) ||
+			!ts.isIdentifier(call.expression.expression) ||
+			!['Object', 'Reflect'].includes(call.expression.expression.text) ||
+			call.expression.name.text !== 'getOwnPropertyDescriptor'
+		) {
+			return [];
+		}
+
+		const propertyName = compiledStaticPropertyExpressionName(call.arguments[1]);
+
+		if (propertyName === undefined) {
+			return [call.arguments[0]];
+		}
+
+		const selectedValue = resolvePropertyValue(call.arguments[0], propertyName, new Set());
+
+		return [
+			...(selectedValue === undefined ? [] : [selectedValue]),
+			...compiledPropertyWriteValues(call.arguments[0], propertyName, call.getStart(call.getSourceFile())),
+		];
+	};
 	const isJsonParseCall = (callee: ts.Expression, resolving = new Set<ts.Node>()): boolean => {
 		if (
 			ts.isPropertyAccessExpression(callee) &&
@@ -2363,6 +2471,10 @@ const containsUnsafeCompiledAlias = (
 					return inspectProperty(receiver.expression, nestedResolving, selectedPropertyName, resolvingProperties);
 				}
 
+				if (ts.isClassExpression(receiver)) {
+					return inspectClassProperty(receiver, true, selectedPropertyName);
+				}
+
 				if (ts.isPropertyAccessExpression(receiver) || ts.isElementAccessExpression(receiver)) {
 					const receiverPropertyName = ts.isPropertyAccessExpression(receiver)
 						? receiver.name.text
@@ -2404,6 +2516,15 @@ const containsUnsafeCompiledAlias = (
 
 				if (ts.isCallExpression(receiver)) {
 					if (jsonParsedPropertyIsUnsafe(receiver, selectedPropertyName)) {
+						return true;
+					}
+
+					if (
+						[
+							...collectionTransformResultValues(receiver),
+							...descriptorQueryValues(receiver, selectedPropertyName),
+						].some((value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving))
+					) {
 						return true;
 					}
 
@@ -5819,6 +5940,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const apiKey = (class { static get value() { return 'opaque-secret'; } }).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"class Source { get value() { return 'opaque-secret'; } } const source = new Source(); const apiKey = source.value;",
 				true,
 			),
@@ -6057,6 +6185,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.create({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = Object.getOwnPropertyDescriptor({ value: 'opaque-secret' }, 'value').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -6108,6 +6243,9 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values.at(0);", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = ['safe'].map(() => 'opaque-secret')[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values[index];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1442,7 +1442,7 @@ const compiledPropertyWriteValues = (
 				? undefined
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
 
-		if (methodName === 'push' || methodName === 'unshift') {
+		if (methodName === 'add' || methodName === 'push' || methodName === 'unshift') {
 			return expandMutationSources(call.arguments);
 		}
 
@@ -1929,8 +1929,11 @@ const containsUnsafeCompiledAlias = (
 			ts.isIdentifier(call.expression.expression) &&
 			call.expression.expression.text === 'Array'
 		) {
-			return call.expression.name.text === 'from'
-				? call.arguments.slice(0, 1)
+			return call.expression.name.text === 'from' && call.arguments[0] !== undefined
+				? [
+						call.arguments[0],
+						...compiledPropertyWriteValues(call.arguments[0], '0', call.getStart(call.getSourceFile())),
+					]
 				: call.expression.name.text === 'of'
 					? call.arguments
 					: [];
@@ -2196,10 +2199,7 @@ const containsUnsafeCompiledAlias = (
 		return methodName === 'filter' || methodName === 'flat' ? values : values.slice(index, index + 1);
 	};
 	const arrayElementCallValues = (call: ts.CallExpression): readonly ts.Expression[] => {
-		if (
-			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) ||
-			call.arguments.length === 0
-		) {
+		if (!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) {
 			return [];
 		}
 
@@ -2208,14 +2208,25 @@ const containsUnsafeCompiledAlias = (
 			: call.expression.argumentExpression === undefined
 				? undefined
 				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+		const receiver = call.expression.expression;
+		const elements = resolveArrayElements(receiver, new Set());
+
+		if (methodName === 'pop' || methodName === 'shift') {
+			const selectedIndex = methodName === 'pop' ? Math.max((elements?.length ?? 1) - 1, 0) : 0;
+			const element = elements?.[selectedIndex];
+
+			return [
+				...(element === undefined ? [] : [element]),
+				...compiledPropertyWriteValues(receiver, String(selectedIndex), call.getStart(call.getSourceFile())),
+			];
+		}
+
 		const indexArgument = call.arguments[0];
 
-		if (methodName !== 'at' || !ts.isNumericLiteral(indexArgument)) {
+		if (methodName !== 'at' || indexArgument === undefined || !ts.isNumericLiteral(indexArgument)) {
 			return [];
 		}
 
-		const receiver = call.expression.expression;
-		const elements = resolveArrayElements(receiver, new Set());
 		const index = Number(indexArgument.text);
 		const selectedIndex = index < 0 && elements !== undefined ? elements.length + index : index;
 		const element = elements?.[selectedIndex];
@@ -3248,6 +3259,15 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isNewExpression(receiver)) {
+					if (
+						ts.isIdentifier(receiver.expression) &&
+						receiver.expression.text === 'Proxy' &&
+						receiver.arguments?.[0] !== undefined &&
+						inspectProperty(receiver.arguments[0], nestedResolving, selectedPropertyName, resolvingProperties)
+					) {
+						return true;
+					}
+
 					const classDeclaration = resolveClassReceiver(receiver.expression);
 					const returnedObjectFound =
 						classDeclaration?.members.some((member) => {
@@ -6600,6 +6620,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const apiKey = new Proxy({ value: 'opaque-secret' }, {}).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const target = {}; target.value = 'opaque-secret'; const apiKey = new Proxy(target, {}).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = new (class { value = 'opaque-secret' })().value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -6896,12 +6923,33 @@ describe('Homey security artifact gate', () => {
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.push('opaque-secret'); const apiKey = source.pop();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = []; source.unshift('opaque-secret'); const apiKey = source.shift();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = ['safe'].map(() => 'opaque-secret')[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
 				"const apiKey = Array.from({ length: 1 }, () => ({ value: 'opaque-secret' }))[0].value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Set(); source.add('opaque-secret'); const apiKey = Array.from(source)[0];",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1165,6 +1165,46 @@ const compiledPropertyWriteValues = (
 				: [];
 		});
 	};
+	const expandMutationSources = (sources: readonly ts.Expression[]): readonly ts.Expression[] => {
+		const resolveSpreadSources = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): readonly ts.Expression[] | undefined => {
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveSpreadSources(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveSpreadSources(expression.expression, resolving);
+			}
+
+			if (!ts.isArrayLiteralExpression(expression)) {
+				return undefined;
+			}
+
+			return expression.elements.flatMap((element): readonly ts.Expression[] => {
+				if (ts.isSpreadElement(element)) {
+					return resolveSpreadSources(element.expression, resolving) ?? [element.expression];
+				}
+
+				return ts.isExpression(element) ? [element] : [];
+			});
+		};
+
+		return sources.flatMap((source): readonly ts.Expression[] =>
+			ts.isSpreadElement(source) ? (resolveSpreadSources(source.expression) ?? [source.expression]) : [source],
+		);
+	};
 	const resolveReceiverMethods = (
 		receiver: ts.Expression,
 		methodName: string,
@@ -1348,7 +1388,7 @@ const compiledPropertyWriteValues = (
 
 			if (sameReceiverPath(mutationTarget, targetPath)) {
 				if (helperName === 'Object.assign') {
-					for (const source of node.arguments.slice(1)) {
+					for (const source of expandMutationSources(node.arguments.slice(1))) {
 						const sourceValues = mutationPropertyValues(source, propertyName);
 
 						values.push(...(sourceValues.length === 0 ? [source] : sourceValues));
@@ -3600,7 +3640,7 @@ const containsCompiledSecret = (text: string): boolean => {
 	const resolveCallParameterSets = (
 		callee: ts.Expression,
 		resolving = new Set<ts.Node>(),
-	): readonly (readonly ts.ParameterDeclaration[])[] => {
+	): readonly { boundArguments: readonly ts.Expression[]; parameters: readonly ts.ParameterDeclaration[] }[] => {
 		if (ts.isIdentifier(callee)) {
 			return resolveCompiledBindings(callee, callee.getStart(sourceFile)).flatMap((binding) => {
 				if (resolving.has(binding.declaration)) {
@@ -3608,7 +3648,7 @@ const containsCompiledSecret = (text: string): boolean => {
 				}
 
 				if (binding.callable !== undefined) {
-					return [binding.callable.parameters];
+					return [{ boundArguments: [], parameters: binding.callable.parameters }];
 				}
 
 				const initializer = binding.initializer;
@@ -3622,7 +3662,25 @@ const containsCompiledSecret = (text: string): boolean => {
 		}
 
 		if (ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)) {
-			return [callee.parameters];
+			return [{ boundArguments: [], parameters: callee.parameters }];
+		}
+
+		if (
+			ts.isCallExpression(callee) &&
+			(ts.isPropertyAccessExpression(callee.expression) || ts.isElementAccessExpression(callee.expression))
+		) {
+			const invocationPropertyName = ts.isPropertyAccessExpression(callee.expression)
+				? callee.expression.name.text
+				: callee.expression.argumentExpression === undefined
+					? undefined
+					: compiledStaticPropertyExpressionName(callee.expression.argumentExpression);
+
+			if (invocationPropertyName === 'bind') {
+				return resolveCallParameterSets(callee.expression.expression, resolving).map((resolved) => ({
+					boundArguments: [...resolved.boundArguments, ...callee.arguments.slice(1)],
+					parameters: resolved.parameters,
+				}));
+			}
 		}
 
 		if (
@@ -3638,7 +3696,10 @@ const containsCompiledSecret = (text: string): boolean => {
 		return [];
 	};
 	const secretCallArguments = (
-		parameterSets: readonly (readonly ts.ParameterDeclaration[])[],
+		parameterSets: readonly {
+			boundArguments: readonly ts.Expression[];
+			parameters: readonly ts.ParameterDeclaration[];
+		}[],
 		arguments_: readonly ts.Expression[],
 	): boolean => {
 		const resolveSpreadElements = (
@@ -3675,24 +3736,30 @@ const containsCompiledSecret = (text: string): boolean => {
 				return ts.isExpression(element) ? [element] : [];
 			});
 		};
-		const expandedArguments = arguments_.flatMap((argument): readonly ts.Expression[] =>
-			ts.isSpreadElement(argument) ? (resolveSpreadElements(argument.expression) ?? [argument.expression]) : [argument],
-		);
+		const expandArguments = (values: readonly ts.Expression[]): readonly ts.Expression[] =>
+			values.flatMap((argument): readonly ts.Expression[] =>
+				ts.isSpreadElement(argument)
+					? (resolveSpreadElements(argument.expression) ?? [argument.expression])
+					: [argument],
+			);
+		const expandedArguments = expandArguments(arguments_);
 
-		return parameterSets.some((parameters) =>
-			parameters.some((parameter, index) => {
+		return parameterSets.some(({ boundArguments, parameters }) => {
+			const effectiveArguments = [...expandArguments(boundArguments), ...expandedArguments];
+
+			return parameters.some((parameter, index) => {
 				if (!bindingNameContainsSecret(parameter.name)) {
 					return false;
 				}
 
 				const parameterArguments =
 					parameter.dotDotDotToken === undefined
-						? expandedArguments.slice(index, index + 1)
-						: expandedArguments.slice(index);
+						? effectiveArguments.slice(index, index + 1)
+						: effectiveArguments.slice(index);
 
 				return parameterArguments.some((argument) => containsUnsafeCompiledValue(argument));
-			}),
-		);
+			});
+		});
 	};
 	const visit = (node: ts.Node): void => {
 		if (found) {
@@ -3758,10 +3825,23 @@ const containsCompiledSecret = (text: string): boolean => {
 				node.propertyName === undefined ? undefined : compiledPropertyName(node.propertyName),
 				ts.isIdentifier(node.name) ? node.name.text : undefined,
 			];
+			const selectedPropertyName =
+				node.propertyName === undefined
+					? ts.isIdentifier(node.name)
+						? node.name.text
+						: undefined
+					: compiledPropertyName(node.propertyName);
+			const bindingValues = compiledBindingValues(node);
 
 			found =
 				names.some((name) => isCompiledSecretName(name)) &&
-				compiledBindingValues(node).some((value) => containsUnsafeCompiledValue(value));
+				(bindingValues.some((value) => containsUnsafeCompiledValue(value)) ||
+					(selectedPropertyName !== undefined &&
+						bindingValues.some((value) =>
+							compiledPropertyWriteValues(value, selectedPropertyName, node.getStart(sourceFile)).some((writeValue) =>
+								containsUnsafeCompiledValue(writeValue),
+							),
+						)));
 		} else if (ts.isCallExpression(node)) {
 			const invocationPropertyName =
 				ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)
@@ -3772,12 +3852,14 @@ const containsCompiledSecret = (text: string): boolean => {
 							: compiledStaticPropertyExpressionName(node.expression.argumentExpression)
 					: undefined;
 			const invokedCallee =
-				(invocationPropertyName === 'call' || invocationPropertyName === 'apply') &&
+				(invocationPropertyName === 'call' ||
+					invocationPropertyName === 'apply' ||
+					invocationPropertyName === 'bind') &&
 				(ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression))
 					? node.expression.expression
 					: node.expression;
 			const invokedArguments: readonly ts.Expression[] =
-				invocationPropertyName === 'call'
+				invocationPropertyName === 'call' || invocationPropertyName === 'bind'
 					? node.arguments.slice(1)
 					: invocationPropertyName === 'apply' && node.arguments[1] !== undefined
 						? [ts.factory.createSpreadElement(node.arguments[1])]
@@ -3792,7 +3874,9 @@ const containsCompiledSecret = (text: string): boolean => {
 					: undefined;
 			const constructor = classDeclaration?.members.find(ts.isConstructorDeclaration);
 
-			found = constructor !== undefined && secretCallArguments([constructor.parameters], node.arguments ?? []);
+			found =
+				constructor !== undefined &&
+				secretCallArguments([{ boundArguments: [], parameters: constructor.parameters }], node.arguments ?? []);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -5500,6 +5584,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function connect(apiKey) {} const bound = connect.bind(null, 'opaque-secret'); bound();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const connect = ({ apiKey }) => {}; connect({ apiKey: 'opaque-secret' });",
 				true,
 			),
@@ -5602,6 +5693,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { value: '' }; source.value = 'opaque-secret'; const { value: apiKey } = source;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; source[key] = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
@@ -5610,6 +5708,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { value: '' }; Object.assign(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; Object.assign(source, ...[{ value: 'opaque-secret' }]); const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -21,6 +21,7 @@ import {
 	isHomeyTimestampKey,
 	isHomeyUuid,
 	isPublicHomeyCapabilityBase,
+	isPublicHomeyEnumState,
 } from './support/homey-shs-probe';
 
 type JsonRecord = Record<string, unknown>;
@@ -136,6 +137,15 @@ const configuredWriteStringValue = (): string | undefined => {
 	}
 };
 
+const configuredPrivateWriteStringValue = (): string | undefined => {
+	const value = configuredWriteStringValue();
+	const capabilityId = process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID?.trim();
+
+	return value !== undefined && capabilityId !== undefined && isPublicHomeyEnumState(capabilityId, value)
+		? undefined
+		: value;
+};
+
 const configuredExpectedHost = (): string | undefined => {
 	const value = process.env.FB_HOMEY_SHS_EXPECTED_HOST?.trim();
 	const normalizedValue = value?.toLowerCase().replace(/\.$/, '');
@@ -164,7 +174,7 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID,
 		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID,
 		configuredWriteCapabilityId(),
-		configuredWriteStringValue(),
+		configuredPrivateWriteStringValue(),
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
 		.map((value) => value?.trim())
@@ -480,6 +490,30 @@ const containsUnsafeReturnedLiteral = (
 	return found;
 };
 
+const containsUnsafeCompiledBodyLiteral = (
+	body: ts.Block,
+	safeStrings: SafeCompiledString = SAFE_COMPILED_SECRET_STRINGS,
+): boolean => {
+	let found = false;
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (ts.isExpression(node) && containsUnsafeCompiledLiteral(node, safeStrings)) {
+			found = true;
+
+			return;
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(body);
+
+	return found;
+};
+
 const containsCompiledSecret = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let found = false;
@@ -506,6 +540,14 @@ const containsCompiledSecret = (text: string): boolean => {
 			const name = compiledPropertyName(node.name);
 
 			found = isCompiledSecretName(name) && node.type !== undefined && containsUnsafeCompiledType(node.type);
+		} else if (ts.isSetAccessorDeclaration(node) && isCompiledSecretName(compiledPropertyName(node.name))) {
+			found =
+				node.parameters.some(
+					(parameter) =>
+						(parameter.initializer !== undefined && containsUnsafeCompiledLiteral(parameter.initializer)) ||
+						(parameter.type !== undefined && containsUnsafeCompiledType(parameter.type)),
+				) ||
+				(node.body !== undefined && containsUnsafeCompiledBodyLiteral(node.body));
 		} else if (
 			(ts.isGetAccessorDeclaration(node) || ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) &&
 			isCompiledSecretName(compiledPropertyName(node.name))
@@ -1596,6 +1638,13 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe compiled module', "const apiKey = [...['opaque-secret']];", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Config { set apiKey(value) { this.value = value || 'opaque-secret'; } }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() => assertTextSafe('unsafe compiled module', "config.api_key = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
@@ -1712,7 +1761,11 @@ describe('Homey security artifact gate', () => {
 
 			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'onoff';
 			expect(() => assertTextSafe('safe fixture', '{"capability":"onoff"}')).not.toThrow();
+			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'power_on_behavior';
+			process.env.FB_HOMEY_SHS_WRITE_VALUE = '"off"';
+			expect(() => assertTextSafe('safe fixture', '{"value":"off"}')).not.toThrow();
 			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'onoff.private-device';
+			process.env.FB_HOMEY_SHS_WRITE_VALUE = '"private-write-value"';
 			expect(() => assertTextSafe('unsafe fixture', '{"capability":"onoff.private-device"}')).toThrow(
 				'unsafe fixture contains a configured private Homey value',
 			);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -3356,6 +3356,74 @@ const containsUnsafeCompiledBodyLiteral = (
 const containsCompiledSecret = (text: string): boolean => {
 	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let found = false;
+	const bindingNameContainsSecret = (name: ts.BindingName): boolean => {
+		if (ts.isIdentifier(name)) {
+			return isCompiledSecretName(name.text);
+		}
+
+		return name.elements.some(
+			(element) =>
+				!ts.isOmittedExpression(element) &&
+				((element.propertyName !== undefined && isCompiledSecretName(compiledPropertyName(element.propertyName))) ||
+					bindingNameContainsSecret(element.name)),
+		);
+	};
+	const resolveCallParameterSets = (
+		callee: ts.Expression,
+		resolving = new Set<ts.Node>(),
+	): readonly (readonly ts.ParameterDeclaration[])[] => {
+		if (ts.isIdentifier(callee)) {
+			return resolveCompiledBindings(callee, callee.getStart(sourceFile)).flatMap((binding) => {
+				if (resolving.has(binding.declaration)) {
+					return [];
+				}
+
+				if (binding.callable !== undefined) {
+					return [binding.callable.parameters];
+				}
+
+				const initializer = binding.initializer;
+
+				if (initializer === undefined) {
+					return [];
+				}
+
+				return resolveCallParameterSets(initializer, new Set(resolving).add(binding.declaration));
+			});
+		}
+
+		if (ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)) {
+			return [callee.parameters];
+		}
+
+		if (
+			ts.isParenthesizedExpression(callee) ||
+			ts.isAsExpression(callee) ||
+			ts.isTypeAssertionExpression(callee) ||
+			ts.isNonNullExpression(callee) ||
+			ts.isSatisfiesExpression(callee)
+		) {
+			return resolveCallParameterSets(callee.expression, resolving);
+		}
+
+		return [];
+	};
+	const secretCallArguments = (
+		parameterSets: readonly (readonly ts.ParameterDeclaration[])[],
+		arguments_: readonly ts.Expression[],
+	): boolean =>
+		parameterSets.some((parameters) =>
+			parameters.some((parameter, index) => {
+				if (!bindingNameContainsSecret(parameter.name)) {
+					return false;
+				}
+
+				const parameterArguments =
+					parameter.dotDotDotToken === undefined ? arguments_.slice(index, index + 1) : arguments_.slice(index);
+
+				return parameterArguments.some((argument) => containsUnsafeCompiledValue(argument));
+			}),
+		);
 	const visit = (node: ts.Node): void => {
 		if (found) {
 			return;
@@ -3424,6 +3492,17 @@ const containsCompiledSecret = (text: string): boolean => {
 			found =
 				names.some((name) => isCompiledSecretName(name)) &&
 				compiledBindingValues(node).some((value) => containsUnsafeCompiledValue(value));
+		} else if (ts.isCallExpression(node)) {
+			found = secretCallArguments(resolveCallParameterSets(node.expression), node.arguments);
+		} else if (ts.isNewExpression(node)) {
+			const classDeclaration = ts.isIdentifier(node.expression)
+				? resolveCompiledBinding(node.expression)?.classDeclaration
+				: ts.isClassExpression(node.expression)
+					? node.expression
+					: undefined;
+			const constructor = classDeclaration?.members.find(ts.isConstructorDeclaration);
+
+			found = constructor !== undefined && secretCallArguments([constructor.parameters], node.arguments ?? []);
 		} else if (ts.isBinaryExpression(node) && isAssignmentOperatorKind(node.operatorToken.kind)) {
 			const name = compiledAssignedPropertyName(node.left);
 
@@ -5103,6 +5182,16 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "function connect(apiKey = 'opaque-secret') {}", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "function connect(apiKey) {} connect('opaque-secret');", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const connect = ({ apiKey }) => {}; connect({ apiKey: 'opaque-secret' });",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const { apiKey: key = 'opaque-secret' } = config;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2007,6 +2007,91 @@ const containsUnsafeCompiledAlias = (
 			? values.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1)
 			: values;
 	};
+	const objectKeysResultValues = (call: ts.CallExpression, selectedPropertyName: string): readonly ts.Expression[] => {
+		if (compiledMutationHelperName(call.expression) !== 'Object.keys' || call.arguments.length === 0) {
+			return [];
+		}
+
+		const resolveObjectKeys = (
+			expression: ts.Expression,
+			resolving = new Set<ts.Node>(),
+		): readonly ts.Expression[] | undefined => {
+			if (ts.isIdentifier(expression)) {
+				const binding = resolveCompiledBinding(expression);
+
+				return binding?.initializer === undefined || resolving.has(binding.declaration)
+					? undefined
+					: resolveObjectKeys(binding.initializer, new Set(resolving).add(binding.declaration));
+			}
+
+			if (
+				ts.isParenthesizedExpression(expression) ||
+				ts.isAsExpression(expression) ||
+				ts.isTypeAssertionExpression(expression) ||
+				ts.isNonNullExpression(expression) ||
+				ts.isSatisfiesExpression(expression)
+			) {
+				return resolveObjectKeys(expression.expression, resolving);
+			}
+
+			if (!ts.isObjectLiteralExpression(expression)) {
+				return undefined;
+			}
+
+			return expression.properties.flatMap((property): readonly ts.Expression[] => {
+				if (ts.isSpreadAssignment(property)) {
+					return resolveObjectKeys(property.expression, resolving) ?? [property.expression];
+				}
+
+				if (!('name' in property)) {
+					return [];
+				}
+
+				if (ts.isComputedPropertyName(property.name)) {
+					return [property.name.expression];
+				}
+
+				return ts.isStringLiteral(property.name) || ts.isNumericLiteral(property.name) ? [property.name] : [];
+			});
+		};
+		const keys = resolveObjectKeys(call.arguments[0]);
+
+		if (keys === undefined) {
+			return [call.arguments[0]];
+		}
+
+		return /^\d+$/.test(selectedPropertyName)
+			? keys.slice(Number(selectedPropertyName), Number(selectedPropertyName) + 1)
+			: keys;
+	};
+	const concatenatedResultValues = (
+		call: ts.CallExpression,
+		selectedPropertyName: string,
+	): readonly ts.Expression[] => {
+		if (
+			(!ts.isPropertyAccessExpression(call.expression) && !ts.isElementAccessExpression(call.expression)) ||
+			!/^\d+$/.test(selectedPropertyName)
+		) {
+			return [];
+		}
+
+		const methodName = ts.isPropertyAccessExpression(call.expression)
+			? call.expression.name.text
+			: call.expression.argumentExpression === undefined
+				? undefined
+				: compiledStaticPropertyExpressionName(call.expression.argumentExpression);
+
+		if (methodName !== 'concat') {
+			return [];
+		}
+
+		const values = [call.expression.expression, ...call.arguments].flatMap(
+			(expression): readonly ts.Expression[] => resolveArrayElements(expression, new Set()) ?? [expression],
+		);
+		const index = Number(selectedPropertyName);
+
+		return values.slice(index, index + 1);
+	};
 	const objectEntriesResultValues = (
 		call: ts.CallExpression,
 		entryPropertyName: string,
@@ -2637,6 +2722,16 @@ const containsUnsafeCompiledAlias = (
 					if (
 						receiverPropertyName !== undefined &&
 						ts.isCallExpression(receiver.expression) &&
+						concatenatedResultValues(receiver.expression, receiverPropertyName).some((value) =>
+							inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties),
+						)
+					) {
+						return true;
+					}
+
+					if (
+						receiverPropertyName !== undefined &&
+						ts.isCallExpression(receiver.expression) &&
 						[
 							...objectEntriesResultValues(receiver.expression, receiverPropertyName, selectedPropertyName),
 							...pluralDescriptorQueryValues(receiver.expression, receiverPropertyName, selectedPropertyName),
@@ -2687,6 +2782,7 @@ const containsUnsafeCompiledAlias = (
 						[
 							...collectionTransformResultValues(receiver),
 							...descriptorQueryValues(receiver, selectedPropertyName),
+							...objectKeysResultValues(receiver, selectedPropertyName),
 							...objectValuesResultValues(receiver, selectedPropertyName),
 						].some((value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving))
 					) {
@@ -6424,6 +6520,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.values({ value: 'opaque-secret' })[0];", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = Object.keys({ 'opaque-secret': 0 })[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
 				"const stored = 'opaque-secret'; const apiKey = Object.entries({ value: stored })[0][1];",
@@ -6488,6 +6587,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const values = ['opaque-secret']; const apiKey = values[index];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = [].concat([{ value: 'opaque-secret' }])[0].value;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -10,6 +10,7 @@ import {
 	isHomeyGeneratedPseudonym,
 	isHomeyPersonalKey,
 	isHomeySecretKey,
+	isPublicHomeyCapabilityBase,
 } from './support/homey-shs-probe';
 
 type JsonRecord = Record<string, unknown>;
@@ -121,6 +122,12 @@ const configuredExpectedHost = (): string | undefined => {
 	return normalizedValue === undefined || PUBLIC_HOMEY_HOSTS.has(normalizedValue) ? undefined : normalizedValue;
 };
 
+const configuredWriteCapabilityId = (): string | undefined => {
+	const value = process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID?.trim();
+
+	return value === undefined || isPublicHomeyCapabilityBase(value) ? undefined : value;
+};
+
 const configuredPrivateValues = (): readonly string[] =>
 	[
 		process.env.FB_HOMEY_SHS_API_KEY,
@@ -135,7 +142,7 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID,
 		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID,
-		process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID,
+		configuredWriteCapabilityId(),
 		configuredWriteStringValue(),
 		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
 	]
@@ -534,17 +541,37 @@ const containsStructuredPersonalValue = (value: unknown): boolean => {
 	});
 };
 
-const containsLooseSecretAssignment = (text: string): boolean =>
-	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].some((match) => {
+const loosePropertyAssignments = (text: string): ReadonlyArray<readonly [string, string]> =>
+	[...text.matchAll(LOOSE_PROPERTY_PATTERN)].flatMap((match) => {
 		const key = match[1]?.trim();
 		const rawValue = (match[3] ?? match[4])?.replace(/\s+#.*$/, '').trim();
 
-		if (key === undefined || rawValue === undefined || !isHomeySecretKey(key)) {
-			return false;
+		if (key === undefined || rawValue === undefined) {
+			return [];
 		}
 
-		return !['', '0', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(rawValue);
+		return [[key, rawValue] as const];
 	});
+
+const containsLooseSecretAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(
+		([key, rawValue]) =>
+			isHomeySecretKey(key) && !['', '0', '[~3~]', 'false', 'null', 'true', 'undefined'].includes(rawValue),
+	);
+
+const containsLooseAddressAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(
+		([key, rawValue]) => isHomeyAddressKey(key) && !['0', '[~0~]', 'false', 'null'].includes(rawValue),
+	);
+
+const containsLoosePersonalAssignment = (text: string): boolean =>
+	loosePropertyAssignments(text).some(
+		([key, rawValue]) =>
+			isHomeyPersonalKey(key) &&
+			!['0', '[~2~]', 'false', 'null'].includes(rawValue) &&
+			!isHomeyGeneratedPseudonym(rawValue) &&
+			!PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(rawValue),
+	);
 
 const containsStructuredUrl = (value: unknown): boolean => {
 	if (typeof value === 'string') {
@@ -617,11 +644,19 @@ const assertFixtureTextSafe = (label: string, text: string, extension: string, c
 		throw new Error(`${label} contains a structured secret value`);
 	}
 
-	if (structuredValue !== undefined && containsStructuredAddress(structuredValue)) {
+	const containsAddress =
+		structuredValue === undefined ? containsLooseAddressAssignment(text) : containsStructuredAddress(structuredValue);
+
+	if (containsAddress) {
 		throw new Error(`${label} contains a structured address value`);
 	}
 
-	if (checkPersonalValues && structuredValue !== undefined && containsStructuredPersonalValue(structuredValue)) {
+	const containsPersonalValue =
+		structuredValue === undefined
+			? containsLoosePersonalAssignment(text)
+			: containsStructuredPersonalValue(structuredValue);
+
+	if (checkPersonalValues && containsPersonalValue) {
 		throw new Error(`${label} contains a structured personal value`);
 	}
 };
@@ -860,6 +895,15 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'API key: opaque-secret-value', '.md')).toThrow(
 			'unsafe fixture contains a structured secret value',
 		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'hostname: family-homey.local', '.md')).toThrow(
+			'unsafe fixture contains a structured address value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', 'name: Alice Bedroom', '.txt')).toThrow(
+			'unsafe fixture contains a structured personal value',
+		);
+		expect(() =>
+			assertFixtureTextSafe('safe fixture', 'hostname: [~0~]\nname: device-label-000001', '.md'),
+		).not.toThrow();
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'endpoint: http://private-homey.local:4859', '.yaml')).toThrow(
 			'unsafe fixture contains a URL',
 		);
@@ -1000,6 +1044,13 @@ describe('Homey security artifact gate', () => {
 					'unsafe fixture contains a configured private Homey value',
 				);
 			}
+
+			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'onoff';
+			expect(() => assertTextSafe('safe fixture', '{"capability":"onoff"}')).not.toThrow();
+			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'onoff.private-device';
+			expect(() => assertTextSafe('unsafe fixture', '{"capability":"onoff.private-device"}')).toThrow(
+				'unsafe fixture contains a configured private Homey value',
+			);
 		} finally {
 			if (previousPrivateTerms === undefined) {
 				delete process.env.FB_HOMEY_SHS_PRIVATE_TERMS;

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1,11 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
-import { isIP } from 'node:net';
 import { extname, resolve } from 'node:path';
 import ts from 'typescript';
 import { parse as parseYaml } from 'yaml';
 
-import { isHomeySecretKey } from './support/homey-shs-probe';
+import { findHomeyIpv6Range, isHomeySecretKey } from './support/homey-shs-probe';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -130,11 +129,9 @@ const trackedFixtureFiles = (): readonly string[] => {
 };
 
 const containsIpv6Address = (text: string): boolean =>
-	[...text.matchAll(IP_ADDRESS_CANDIDATE_PATTERN)].some((match) => {
-		const candidate = match[0].replace(/^\.+|\.+$/g, '').split('%')[0];
-
-		return candidate !== undefined && candidate !== '::' && isIP(candidate) === 6;
-	});
+	[...text.matchAll(IP_ADDRESS_CANDIDATE_PATTERN)].some(
+		(match) => match[0] !== '::' && findHomeyIpv6Range(match[0]) !== null,
+	);
 
 const containsHomeyTokenCandidate = (text: string): boolean =>
 	[...text.matchAll(HOMEY_TOKEN_PATTERN)].some((match) => !PUBLIC_HOMEY_TOKEN_COLLISIONS.has(match[0].toLowerCase()));
@@ -603,6 +600,12 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains an IPv4 address',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"fe80::1%en0"}')).toThrow(
+			'unsafe fixture contains an IPv6 address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"host-fe80::1"}')).toThrow(
+			'unsafe fixture contains an IPv6 address',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"prefix2001:db8::1"}')).toThrow(
 			'unsafe fixture contains an IPv6 address',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"mac":"aabb.ccdd.eeff"}')).toThrow(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1058,10 +1058,14 @@ const resolveCompiledReceiverPath = (
 		: { binding, properties: [] };
 };
 
-const compiledPropertyWriteValues = (receiver: ts.Expression, propertyName: string): readonly ts.Expression[] => {
+const compiledPropertyWriteValues = (
+	receiver: ts.Expression,
+	propertyName: string,
+	visibleThroughPosition = receiver.getStart(receiver.getSourceFile()),
+): readonly ts.Expression[] => {
 	const sourceFile = receiver.getSourceFile();
 	const targetPath = resolveCompiledReceiverPath(receiver);
-	const usePosition = receiver.getStart(sourceFile);
+	const usePosition = Math.max(receiver.getStart(sourceFile), visibleThroughPosition);
 	const values: ts.Expression[] = [];
 
 	if (targetPath === undefined) {
@@ -1252,7 +1256,7 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (
-					compiledPropertyWriteValues(receiver, selectedPropertyName).some(
+					compiledPropertyWriteValues(receiver, selectedPropertyName, visibleThroughPosition).some(
 						(value) => containsUnsafeCompiledLiteral(value, safeStrings) || inspect(value, nestedResolving),
 					)
 				) {
@@ -1278,6 +1282,75 @@ const containsUnsafeCompiledAlias = (
 					if (!expectStatic) {
 						for (const member of classDeclaration.members) {
 							if (ts.isConstructorDeclaration(member) && member.body !== undefined) {
+								const selectParameterValues = (
+									bindingName: ts.BindingName,
+									referencedName: string,
+									argument: ts.Expression,
+								): readonly ts.Expression[] => {
+									if (ts.isIdentifier(bindingName)) {
+										return bindingName.text === referencedName ? [argument] : [];
+									}
+
+									if (ts.isObjectBindingPattern(bindingName)) {
+										const values: ts.Expression[] = [];
+
+										for (const element of bindingName.elements) {
+											if (element.dotDotDotToken !== undefined) {
+												values.push(...selectParameterValues(element.name, referencedName, argument));
+
+												continue;
+											}
+
+											const propertyName =
+												element.propertyName === undefined
+													? ts.isIdentifier(element.name)
+														? element.name.text
+														: undefined
+													: compiledPropertyName(element.propertyName);
+											const selectedValue =
+												propertyName === undefined
+													? undefined
+													: resolvePropertyValue(argument, propertyName, new Set());
+											const parameterValue = selectedValue ?? element.initializer;
+
+											if (parameterValue !== undefined) {
+												values.push(...selectParameterValues(element.name, referencedName, parameterValue));
+											}
+										}
+
+										return values;
+									}
+
+									const argumentElements = resolveArrayElements(argument, new Set());
+
+									if (argumentElements === undefined) {
+										return [];
+									}
+
+									const values: ts.Expression[] = [];
+
+									bindingName.elements.forEach((element, index) => {
+										if (ts.isOmittedExpression(element)) {
+											return;
+										}
+
+										if (element.dotDotDotToken !== undefined) {
+											for (const argumentElement of argumentElements.slice(index)) {
+												values.push(...selectParameterValues(element.name, referencedName, argumentElement));
+											}
+
+											return;
+										}
+
+										const parameterValue = argumentElements[index] ?? element.initializer;
+
+										if (parameterValue !== undefined) {
+											values.push(...selectParameterValues(element.name, referencedName, parameterValue));
+										}
+									});
+
+									return values;
+								};
 								const visitConstructorWrite = (child: ts.Node): void => {
 									if (constructorWriteFound) {
 										return;
@@ -1290,16 +1363,18 @@ const containsUnsafeCompiledAlias = (
 										(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
 										child.left.expression.kind === ts.SyntaxKind.ThisKeyword
 									) {
-										const referencedParameterIndexes = new Set<number>();
+										const referencedArguments: ts.Expression[] = [];
 										const visitParameterReference = (rightChild: ts.Node): void => {
 											if (ts.isIdentifier(rightChild)) {
-												const parameterIndex = member.parameters.findIndex(
-													(parameter) => ts.isIdentifier(parameter.name) && parameter.name.text === rightChild.text,
-												);
+												member.parameters.forEach((parameter, parameterIndex) => {
+													const argument = constructorArguments[parameterIndex] ?? parameter.initializer;
 
-												if (parameterIndex >= 0) {
-													referencedParameterIndexes.add(parameterIndex);
-												}
+													if (argument !== undefined) {
+														referencedArguments.push(
+															...selectParameterValues(parameter.name, rightChild.text, argument),
+														);
+													}
+												});
 											}
 
 											ts.forEachChild(rightChild, visitParameterReference);
@@ -1308,14 +1383,10 @@ const containsUnsafeCompiledAlias = (
 										visitParameterReference(child.right);
 
 										constructorWriteFound =
-											[...referencedParameterIndexes].some((parameterIndex) => {
-												const argument = constructorArguments[parameterIndex];
-
-												return (
-													argument !== undefined &&
-													(containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving))
-												);
-											}) ||
+											referencedArguments.some(
+												(argument) =>
+													containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving),
+											) ||
 											containsUnsafeCompiledLiteral(child.right, safeStrings) ||
 											inspect(child.right, nestedResolving);
 									}
@@ -1767,7 +1838,9 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (
-					compiledPropertyWriteValues(receiver, propertyName).some((value) => inspectCallable(value, nestedResolving))
+					compiledPropertyWriteValues(receiver, propertyName, visibleThroughPosition).some((value) =>
+						inspectCallable(value, nestedResolving),
+					)
 				) {
 					return true;
 				}
@@ -4113,6 +4186,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { value: '' }; const read = () => source.value; source.value = 'opaque-secret'; const apiKey = read();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; source['value'] = 'opaque-secret'; const apiKey = source.value;",
 				true,
 			),
@@ -4177,6 +4257,20 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor(value) { this.value = value; } } const apiKey = new Source('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor({ value }) { this.value = value; } } const apiKey = new Source({ value: 'opaque-secret' }).value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor([value]) { this.value = value; } } const apiKey = new Source(['opaque-secret']).value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1240,6 +1240,40 @@ const containsUnsafeCompiledAlias = (
 					}
 
 					const nestedClassProperties = new Set(classResolvingProperties).add(propertyReference);
+					let constructorWriteFound = false;
+
+					if (!expectStatic) {
+						const visitConstructorWrite = (child: ts.Node): void => {
+							if (constructorWriteFound) {
+								return;
+							}
+
+							if (
+								ts.isBinaryExpression(child) &&
+								isAssignmentOperatorKind(child.operatorToken.kind) &&
+								compiledAssignedPropertyName(child.left) === memberName &&
+								(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
+								child.left.expression.kind === ts.SyntaxKind.ThisKeyword
+							) {
+								constructorWriteFound =
+									containsUnsafeCompiledLiteral(child.right, safeStrings) || inspect(child.right, nestedResolving);
+							}
+
+							if (!constructorWriteFound) {
+								ts.forEachChild(child, visitConstructorWrite);
+							}
+						};
+
+						for (const member of classDeclaration.members) {
+							if (ts.isConstructorDeclaration(member) && member.body !== undefined) {
+								visitConstructorWrite(member.body);
+							}
+						}
+					}
+
+					if (constructorWriteFound) {
+						return true;
+					}
 
 					return classDeclaration.members.some((member) => {
 						if (!('name' in member)) {
@@ -1345,6 +1379,13 @@ const containsUnsafeCompiledAlias = (
 					return (
 						resolvedReceiver !== undefined &&
 						inspectProperty(resolvedReceiver, nestedResolving, selectedPropertyName, resolvingProperties)
+					);
+				}
+
+				if (ts.isConditionalExpression(receiver)) {
+					return (
+						inspectProperty(receiver.whenTrue, nestedResolving, selectedPropertyName, resolvingProperties) ||
+						inspectProperty(receiver.whenFalse, nestedResolving, selectedPropertyName, resolvingProperties)
 					);
 				}
 
@@ -1679,6 +1720,44 @@ const containsUnsafeCompiledAlias = (
 					ts.isSatisfiesExpression(receiver)
 				) {
 					return inspectCallableProperty(receiver.expression, nestedResolving);
+				}
+
+				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
+
+					return (
+						classDeclaration?.members.some((member) => {
+							if (!('name' in member)) {
+								return false;
+							}
+
+							const staticMember = Boolean(
+								ts.canHaveModifiers(member) &&
+								ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+							);
+
+							if (staticMember || compiledPropertyName(member.name) !== propertyName) {
+								return false;
+							}
+
+							if (ts.isPropertyDeclaration(member)) {
+								return member.initializer !== undefined && inspectCallable(member.initializer, nestedResolving);
+							}
+
+							return (
+								(ts.isGetAccessorDeclaration(member) || ts.isMethodDeclaration(member)) &&
+								member.body !== undefined &&
+								inspectCallableBody(member.body, nestedResolving)
+							);
+						}) ?? false
+					);
+				}
+
+				if (ts.isConditionalExpression(receiver)) {
+					return (
+						inspectCallableProperty(receiver.whenTrue, nestedResolving) ||
+						inspectCallableProperty(receiver.whenFalse, nestedResolving)
+					);
 				}
 
 				if (ts.isObjectLiteralExpression(receiver)) {
@@ -3732,6 +3811,20 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { constructor() { this.value = 'opaque-secret'; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { fallback() { return 'opaque-secret'; } } const apiKey = new Source().fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const fallback = () => ({ value: 'opaque-secret' }); const apiKey = fallback().value;",
 				true,
 			),
@@ -3740,6 +3833,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const factory = { make: () => ({ value: 'opaque-secret' }) }; const apiKey = factory.make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = (choose ? safe : { value: 'opaque-secret' }).value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -252,10 +252,52 @@ const containsSerializedSecret = (text: string): boolean =>
 		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
 	});
 
-const compiledStaticPropertyExpressionName = (expression: ts.Expression): string | undefined =>
-	ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression) || ts.isNumericLiteral(expression)
-		? expression.text
-		: undefined;
+const compiledStaticString = (node: ts.Expression): string | undefined => {
+	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+		return node.text;
+	}
+
+	if (ts.isParenthesizedExpression(node)) {
+		return compiledStaticString(node.expression);
+	}
+
+	if (ts.isTemplateExpression(node)) {
+		let value = node.head.text;
+
+		for (const span of node.templateSpans) {
+			const expression = compiledStaticString(span.expression);
+
+			if (expression === undefined) {
+				return undefined;
+			}
+
+			value += expression + span.literal.text;
+		}
+
+		return value;
+	}
+
+	if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+		const left = compiledStaticString(node.left);
+		const right = compiledStaticString(node.right);
+
+		return left === undefined || right === undefined ? undefined : left + right;
+	}
+
+	return undefined;
+};
+
+const compiledStaticPropertyExpressionName = (expression: ts.Expression): string | undefined => {
+	if (
+		ts.isStringLiteral(expression) ||
+		ts.isNoSubstitutionTemplateLiteral(expression) ||
+		ts.isNumericLiteral(expression)
+	) {
+		return expression.text;
+	}
+
+	return compiledStaticString(expression);
+};
 
 const compiledPropertyName = (name: ts.PropertyName): string | undefined => {
 	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
@@ -285,6 +327,28 @@ const compiledAssignedPropertyName = (expression: ts.Expression): string | undef
 	}
 
 	return undefined;
+};
+
+const compiledThisPropertyName = (expression: ts.Expression): string | undefined => {
+	if (
+		ts.isParenthesizedExpression(expression) ||
+		ts.isAsExpression(expression) ||
+		ts.isTypeAssertionExpression(expression) ||
+		ts.isNonNullExpression(expression) ||
+		ts.isSatisfiesExpression(expression)
+	) {
+		return compiledThisPropertyName(expression.expression);
+	}
+
+	if (ts.isPropertyAccessExpression(expression) && expression.expression.kind === ts.SyntaxKind.ThisKeyword) {
+		return expression.name.text;
+	}
+
+	return ts.isElementAccessExpression(expression) &&
+		expression.expression.kind === ts.SyntaxKind.ThisKeyword &&
+		expression.argumentExpression !== undefined
+		? compiledStaticPropertyExpressionName(expression.argumentExpression)
+		: undefined;
 };
 
 const compiledBindingValues = (binding: ts.BindingElement): readonly ts.Expression[] => {
@@ -522,6 +586,14 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
 					return property.name;
 				}
+
+				if (ts.isSpreadAssignment(property)) {
+					const spreadValue = selectBindingValue(pattern, binding, index, property.expression, resolvingSources);
+
+					if (spreadValue !== undefined) {
+						return spreadValue;
+					}
+				}
 			}
 		}
 
@@ -719,8 +791,13 @@ const containsUnsafeCompiledAlias = (
 				: expression.argumentExpression === undefined
 					? undefined
 					: compiledStaticPropertyExpressionName(expression.argumentExpression);
-			const inspectProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
-				if (propertyName === undefined) {
+			const inspectProperty = (
+				receiver: ts.Expression,
+				nestedResolving: Set<string>,
+				selectedPropertyName = propertyName,
+				resolvingProperties = new Set<string>(),
+			): boolean => {
+				if (selectedPropertyName === undefined) {
 					return false;
 				}
 
@@ -731,7 +808,12 @@ const containsUnsafeCompiledAlias = (
 						return false;
 					}
 
-					return inspectProperty(initializer, new Set(nestedResolving).add(receiver.text));
+					return inspectProperty(
+						initializer,
+						new Set(nestedResolving).add(receiver.text),
+						selectedPropertyName,
+						resolvingProperties,
+					);
 				}
 
 				if (
@@ -741,36 +823,71 @@ const containsUnsafeCompiledAlias = (
 					ts.isNonNullExpression(receiver) ||
 					ts.isSatisfiesExpression(receiver)
 				) {
-					return inspectProperty(receiver.expression, nestedResolving);
+					return inspectProperty(receiver.expression, nestedResolving, selectedPropertyName, resolvingProperties);
 				}
 
 				if (ts.isObjectLiteralExpression(receiver)) {
+					const propertyReference = `${receiver.pos}:${selectedPropertyName}`;
+
+					if (resolvingProperties.has(propertyReference)) {
+						return false;
+					}
+
+					const nestedResolvingProperties = new Set(resolvingProperties).add(propertyReference);
+
 					return receiver.properties.some((property) => {
-						if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+						if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === selectedPropertyName) {
 							return (
 								containsUnsafeCompiledLiteral(property.initializer, safeStrings) ||
 								inspect(property.initializer, nestedResolving)
 							);
 						}
 
-						if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+						if (ts.isShorthandPropertyAssignment(property) && property.name.text === selectedPropertyName) {
 							return inspect(property.name, nestedResolving);
 						}
 
 						if (
 							ts.isGetAccessorDeclaration(property) &&
-							compiledPropertyName(property.name) === propertyName &&
+							compiledPropertyName(property.name) === selectedPropertyName &&
 							property.body !== undefined
 						) {
-							return inspectCallableBody(property.body, nestedResolving);
+							let found = false;
+							const visitReturn = (child: ts.Node): void => {
+								if (found) {
+									return;
+								}
+
+								if (ts.isReturnStatement(child) && child.expression !== undefined) {
+									const returned = child.expression;
+									const receiverPropertyName = compiledThisPropertyName(returned);
+
+									found =
+										(receiverPropertyName !== undefined &&
+											inspectProperty(receiver, nestedResolving, receiverPropertyName, nestedResolvingProperties)) ||
+										containsUnsafeCompiledLiteral(returned, safeStrings) ||
+										inspect(returned, nestedResolving);
+								}
+
+								if (!found) {
+									ts.forEachChild(child, visitReturn);
+								}
+							};
+
+							visitReturn(property.body);
+
+							return found;
 						}
 
-						return ts.isSpreadAssignment(property) && inspectProperty(property.expression, nestedResolving);
+						return (
+							ts.isSpreadAssignment(property) &&
+							inspectProperty(property.expression, nestedResolving, selectedPropertyName, nestedResolvingProperties)
+						);
 					});
 				}
 
-				if (/^\d+$/.test(propertyName)) {
-					const element = resolveArrayElements(receiver, nestedResolving)?.[Number(propertyName)];
+				if (/^\d+$/.test(selectedPropertyName)) {
+					const element = resolveArrayElements(receiver, nestedResolving)?.[Number(selectedPropertyName)];
 
 					if (element === undefined) {
 						return false;
@@ -1588,41 +1705,6 @@ const containsCompiledIcon = (text: string): boolean => {
 	visit(sourceFile);
 
 	return found;
-};
-
-const compiledStaticString = (node: ts.Expression): string | undefined => {
-	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-		return node.text;
-	}
-
-	if (ts.isParenthesizedExpression(node)) {
-		return compiledStaticString(node.expression);
-	}
-
-	if (ts.isTemplateExpression(node)) {
-		let value = node.head.text;
-
-		for (const span of node.templateSpans) {
-			const expression = compiledStaticString(span.expression);
-
-			if (expression === undefined) {
-				return undefined;
-			}
-
-			value += expression + span.literal.text;
-		}
-
-		return value;
-	}
-
-	if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-		const left = compiledStaticString(node.left);
-		const right = compiledStaticString(node.right);
-
-		return left === undefined || right === undefined ? undefined : left + right;
-	}
-
-	return undefined;
 };
 
 const containsCompiledPrivateUrl = (text: string): boolean => {
@@ -2658,6 +2740,12 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const config = { [`apiKey`]: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const config = { ['api' + 'Key']: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const config = { [`api${'Key'}`]: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = { read() { return 'opaque-secret'; } };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -2732,6 +2820,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { ...{ fallback: 'opaque-secret' } }; const { fallback } = source; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: 'family-homey.local' }; const { value: hostname } = source;",
 				true,
 			),
@@ -2775,6 +2870,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { get value() { return 'opaque-secret'; } }; const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { stored: 'opaque-secret', get value() { return this.stored; } }; const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1190,6 +1190,10 @@ const compiledPropertyWriteValues = (
 					if (selectedName === propertyName || selectedName === undefined) {
 						values.push(node.arguments[2]);
 					}
+				} else if (helperName === 'Object.setPrototypeOf' && node.arguments.length >= 2) {
+					const prototypeValues = mutationPropertyValues(node.arguments[1], propertyName);
+
+					values.push(...(prototypeValues.length === 0 ? [node.arguments[1]] : prototypeValues));
 				}
 			}
 		}
@@ -1275,7 +1279,8 @@ const containsUnsafeCompiledAlias = (
 			ts.isAsExpression(receiver) ||
 			ts.isTypeAssertionExpression(receiver) ||
 			ts.isNonNullExpression(receiver) ||
-			ts.isSatisfiesExpression(receiver)
+			ts.isSatisfiesExpression(receiver) ||
+			ts.isAwaitExpression(receiver)
 		) {
 			return resolvePropertyValue(receiver.expression, propertyName, resolving);
 		}
@@ -1463,6 +1468,12 @@ const containsUnsafeCompiledAlias = (
 			return selectedName === propertyName || selectedName === undefined ? [node.arguments[2]] : [];
 		}
 
+		if (helperName === 'Object.setPrototypeOf' && node.arguments.length >= 2) {
+			const selectedValue = resolvePropertyValue(node.arguments[1], propertyName, new Set());
+
+			return selectedValue === undefined ? [node.arguments[1]] : [selectedValue];
+		}
+
 		return [];
 	};
 	const mutationResultValues = (call: ts.CallExpression, propertyName: string): readonly ts.Expression[] => {
@@ -1530,6 +1541,12 @@ const containsUnsafeCompiledAlias = (
 			}
 
 			return values;
+		}
+
+		if (helperName === 'Object.setPrototypeOf' && call.arguments.length >= 2) {
+			const selectedValue = resolvePropertyValue(call.arguments[1], propertyName, new Set());
+
+			return selectedValue === undefined ? [call.arguments[1]] : [selectedValue];
 		}
 
 		return [];
@@ -1965,7 +1982,8 @@ const containsUnsafeCompiledAlias = (
 					ts.isAsExpression(receiver) ||
 					ts.isTypeAssertionExpression(receiver) ||
 					ts.isNonNullExpression(receiver) ||
-					ts.isSatisfiesExpression(receiver)
+					ts.isSatisfiesExpression(receiver) ||
+					ts.isAwaitExpression(receiver)
 				) {
 					return inspectProperty(receiver.expression, nestedResolving, selectedPropertyName, resolvingProperties);
 				}
@@ -2099,6 +2117,64 @@ const containsUnsafeCompiledAlias = (
 									return false;
 								}
 
+								const inspectClassMethod = (
+									declaration: ts.ClassDeclaration,
+									expectStatic: boolean,
+									resolvingClasses = new Set<ts.ClassDeclaration>(),
+								): boolean => {
+									if (resolvingClasses.has(declaration)) {
+										return false;
+									}
+
+									const nestedClasses = new Set(resolvingClasses).add(declaration);
+									const ownMethodFound = declaration.members.some((member) => {
+										if (!('name' in member) || compiledPropertyName(member.name) !== calleePropertyName) {
+											return false;
+										}
+
+										const staticMember = Boolean(
+											ts.canHaveModifiers(member) &&
+											ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
+										);
+
+										if (staticMember !== expectStatic) {
+											return false;
+										}
+
+										if (ts.isMethodDeclaration(member) && member.body !== undefined) {
+											return withCallArguments(member.parameters, callArguments, () =>
+												inspectReturnBody(member.body, resolvingMethods),
+											);
+										}
+
+										if (ts.isPropertyDeclaration(member) && member.initializer !== undefined) {
+											return inspectReturnedProperty(member.initializer, resolvingMethods, callArguments);
+										}
+
+										return (
+											ts.isGetAccessorDeclaration(member) &&
+											member.body !== undefined &&
+											inspectReturnBody(member.body, resolvingMethods)
+										);
+									});
+
+									return (
+										ownMethodFound ||
+										(declaration.heritageClauses
+											?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+											.some((clause) =>
+												clause.types.some((type) => {
+													const baseClass = ts.isIdentifier(type.expression)
+														? resolveCompiledBinding(type.expression)?.classDeclaration
+														: undefined;
+
+													return baseClass !== undefined && inspectClassMethod(baseClass, expectStatic, nestedClasses);
+												}),
+											) ??
+											false)
+									);
+								};
+
 								if (ts.isIdentifier(methodReceiver)) {
 									return resolveCompiledBindings(methodReceiver, visibleThroughPosition).some((binding) => {
 										if (resolvingMethods.has(binding.declaration)) {
@@ -2107,8 +2183,11 @@ const containsUnsafeCompiledAlias = (
 
 										const nestedMethods = new Set(resolvingMethods).add(binding.declaration);
 
-										return [binding.initializer, binding.fallbackInitializer].some(
-											(initializer) => initializer !== undefined && inspectMethodProperty(initializer, nestedMethods),
+										return (
+											(binding.classDeclaration !== undefined && inspectClassMethod(binding.classDeclaration, true)) ||
+											[binding.initializer, binding.fallbackInitializer].some(
+												(initializer) => initializer !== undefined && inspectMethodProperty(initializer, nestedMethods),
+											)
 										);
 									});
 								}
@@ -2118,9 +2197,16 @@ const containsUnsafeCompiledAlias = (
 									ts.isAsExpression(methodReceiver) ||
 									ts.isTypeAssertionExpression(methodReceiver) ||
 									ts.isNonNullExpression(methodReceiver) ||
-									ts.isSatisfiesExpression(methodReceiver)
+									ts.isSatisfiesExpression(methodReceiver) ||
+									ts.isAwaitExpression(methodReceiver)
 								) {
 									return inspectMethodProperty(methodReceiver.expression, resolvingMethods);
+								}
+
+								if (ts.isNewExpression(methodReceiver) && ts.isIdentifier(methodReceiver.expression)) {
+									const classDeclaration = resolveCompiledBinding(methodReceiver.expression)?.classDeclaration;
+
+									return classDeclaration !== undefined && inspectClassMethod(classDeclaration, false);
 								}
 
 								if (!ts.isObjectLiteralExpression(methodReceiver)) {
@@ -2299,11 +2385,42 @@ const containsUnsafeCompiledAlias = (
 		}
 
 		if (ts.isObjectLiteralExpression(expression)) {
-			return expression.properties.some(
-				(property) =>
-					(ts.isPropertyAssignment(property) && inspect(property.initializer, resolving)) ||
-					(ts.isSpreadAssignment(property) && inspect(property.expression, resolving)),
-			);
+			return expression.properties.some((property) => {
+				if (ts.isPropertyAssignment(property)) {
+					return inspect(property.initializer, resolving);
+				}
+
+				if (ts.isSpreadAssignment(property)) {
+					return inspect(property.expression, resolving);
+				}
+
+				if (
+					(ts.isMethodDeclaration(property) || ts.isGetAccessorDeclaration(property)) &&
+					property.body !== undefined
+				) {
+					let found = false;
+					const visitReturn = (child: ts.Node): void => {
+						if (found) {
+							return;
+						}
+
+						if (ts.isReturnStatement(child) && child.expression !== undefined) {
+							found =
+								containsUnsafeCompiledLiteral(child.expression, safeStrings) || inspect(child.expression, resolving);
+						}
+
+						if (!found) {
+							ts.forEachChild(child, visitReturn);
+						}
+					};
+
+					visitReturn(property.body);
+
+					return found;
+				}
+
+				return false;
+			});
 		}
 
 		if (ts.isBinaryExpression(expression)) {
@@ -2520,7 +2637,8 @@ const containsUnsafeCompiledAlias = (
 					ts.isAsExpression(receiver) ||
 					ts.isTypeAssertionExpression(receiver) ||
 					ts.isNonNullExpression(receiver) ||
-					ts.isSatisfiesExpression(receiver)
+					ts.isSatisfiesExpression(receiver) ||
+					ts.isAwaitExpression(receiver)
 				) {
 					return inspectCallableProperty(receiver.expression, nestedResolving);
 				}
@@ -4968,6 +5086,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = {}; Object.setPrototypeOf(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { value: '' }; const read = () => source.value; source.value = 'opaque-secret'; const apiKey = read();",
 				true,
 			),
@@ -5059,6 +5184,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"class Source { constructor(value) { Object.defineProperty(this, 'value', { get() { return value; } }); } } const apiKey = new Source('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"class Source { constructor({ value }) { this.value = value; } } const apiKey = new Source({ value: 'opaque-secret' }).value;",
 				true,
 			),
@@ -5137,6 +5269,27 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const factory = { make() { return { value: 'opaque-secret' }; } }; const apiKey = factory.make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { static make() { return { value: 'opaque-secret' }; } } const apiKey = Source.make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { make() { return { value: 'opaque-secret' }; } } const apiKey = new Source().make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"async function make() { return { value: 'opaque-secret' }; } async function load() { const apiKey = (await make()).value; }",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -4768,6 +4768,50 @@ const containsCompiledSecret = (text: string): boolean => {
 
 				found = callbacks.some((callback) => secretCallArguments(resolveCallParameterSets(callback), settledValues));
 			}
+
+			if (!found && invocationReceiver !== undefined) {
+				const collectionCallbackMethods = new Set([
+					'every',
+					'filter',
+					'find',
+					'findIndex',
+					'findLast',
+					'findLastIndex',
+					'flatMap',
+					'forEach',
+					'map',
+					'reduce',
+					'reduceRight',
+					'some',
+					'sort',
+					'toSorted',
+				]);
+				const isArrayFrom =
+					invocationPropertyName === 'from' &&
+					ts.isIdentifier(invocationReceiver) &&
+					invocationReceiver.text === 'Array';
+				const callback = isArrayFrom ? node.arguments[1] : node.arguments[0];
+				const collectionSource = isArrayFrom ? node.arguments[0] : invocationReceiver;
+
+				if (
+					callback !== undefined &&
+					collectionSource !== undefined &&
+					(isArrayFrom || collectionCallbackMethods.has(invocationPropertyName ?? ''))
+				) {
+					const callbackAcceptsSecret = resolveCallParameterSets(callback).some(({ parameters }) =>
+						parameters.some((parameter) => bindingNameContainsSecret(parameter.name)),
+					);
+					const callbackValues = [
+						collectionSource,
+						...compiledPropertyWriteValues(collectionSource, '0', node.getStart(sourceFile)),
+						...(invocationPropertyName === 'reduce' || invocationPropertyName === 'reduceRight'
+							? node.arguments.slice(1, 2)
+							: []),
+					];
+
+					found = callbackAcceptsSecret && callbackValues.some((value) => containsUnsafeCompiledValue(value));
+				}
+			}
 		} else if (ts.isNewExpression(node)) {
 			const classDeclaration = ts.isIdentifier(node.expression)
 				? resolveCompiledBinding(node.expression)?.classDeclaration
@@ -6536,6 +6580,28 @@ describe('Homey security artifact gate', () => {
 				"const stored = 'opaque-secret'; Promise.all([stored]).then(([apiKey]) => {});",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe compiled module', "['opaque-secret'].forEach(apiKey => {});", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "new Map([['x', 'opaque-secret']]).forEach(apiKey => {});", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = new Set(); source.add('opaque-secret'); source.forEach(apiKey => {});",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() => assertTextSafe('unsafe compiled module', "['opaque-secret'].some(apiKey => true);", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "['safe'].reduce((apiKey) => apiKey, 'opaque-secret');", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "Array.from(['opaque-secret'], apiKey => apiKey);", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -252,13 +252,18 @@ const containsSerializedSecret = (text: string): boolean =>
 		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
 	});
 
+const compiledStaticPropertyExpressionName = (expression: ts.Expression): string | undefined =>
+	ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression) || ts.isNumericLiteral(expression)
+		? expression.text
+		: undefined;
+
 const compiledPropertyName = (name: ts.PropertyName): string | undefined => {
 	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
 		return name.text;
 	}
 
-	if (ts.isComputedPropertyName(name) && ts.isStringLiteral(name.expression)) {
-		return name.expression.text;
+	if (ts.isComputedPropertyName(name)) {
+		return compiledStaticPropertyExpressionName(name.expression);
 	}
 
 	return undefined;
@@ -273,10 +278,10 @@ const compiledAssignedPropertyName = (expression: ts.Expression): string | undef
 		return expression.name.text;
 	}
 
-	if (ts.isElementAccessExpression(expression) && ts.isStringLiteral(expression.argumentExpression)) {
-		return COMPILED_SYMBOL_NAME_PATTERN.test(expression.argumentExpression.text)
-			? undefined
-			: expression.argumentExpression.text;
+	if (ts.isElementAccessExpression(expression) && expression.argumentExpression !== undefined) {
+		const name = compiledStaticPropertyExpressionName(expression.argumentExpression);
+
+		return name === undefined || COMPILED_SYMBOL_NAME_PATTERN.test(name) ? undefined : name;
 	}
 
 	return undefined;
@@ -616,10 +621,9 @@ const containsUnsafeCompiledAlias = (
 		if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
 			const propertyName = ts.isPropertyAccessExpression(expression)
 				? expression.name.text
-				: expression.argumentExpression !== undefined &&
-					  (ts.isStringLiteral(expression.argumentExpression) || ts.isNumericLiteral(expression.argumentExpression))
-					? expression.argumentExpression.text
-					: undefined;
+				: expression.argumentExpression === undefined
+					? undefined
+					: compiledStaticPropertyExpressionName(expression.argumentExpression);
 			const inspectProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
 				if (propertyName === undefined) {
 					return false;
@@ -779,10 +783,9 @@ const containsUnsafeCompiledAlias = (
 		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
 			const propertyName = ts.isPropertyAccessExpression(callee)
 				? callee.name.text
-				: callee.argumentExpression !== undefined &&
-					  (ts.isStringLiteral(callee.argumentExpression) || ts.isNumericLiteral(callee.argumentExpression))
-					? callee.argumentExpression.text
-					: undefined;
+				: callee.argumentExpression === undefined
+					? undefined
+					: compiledStaticPropertyExpressionName(callee.argumentExpression);
 			const inspectCallableProperty = (receiver: ts.Expression, nestedResolving: Set<string>): boolean => {
 				if (propertyName === undefined) {
 					return false;
@@ -2508,6 +2511,9 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const config = { api_key: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe('unsafe compiled module', "const config = { [`apiKey`]: 'opaque-secret' };", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = { read() { return 'opaque-secret'; } };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -2530,6 +2536,9 @@ describe('Homey security artifact gate', () => {
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe compiled module', "config['accessToken'] = 'opaque-secret';", true)).toThrow(
+			'unsafe compiled module contains a compiled secret value',
+		);
+		expect(() => assertTextSafe('unsafe compiled module', "config[`accessToken`] = 'opaque-secret';", true)).toThrow(
 			'unsafe compiled module contains a compiled secret value',
 		);
 		expect(() => assertTextSafe('unsafe compiled module', "const api_key = 'opaque-secret';", true)).toThrow(

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -252,20 +252,28 @@ const containsSerializedSecret = (text: string): boolean =>
 		return key !== undefined && isHomeySecretKey(key) && value !== undefined && value.length > 0 && value !== '[~3~]';
 	});
 
-const compiledStaticString = (node: ts.Expression): string | undefined => {
+const compiledStaticString = (node: ts.Expression, resolvingAliases = new Set<string>()): string | undefined => {
 	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 		return node.text;
 	}
 
+	if (ts.isIdentifier(node)) {
+		const initializer = resolveCompiledAlias(node);
+
+		return initializer === undefined || resolvingAliases.has(node.text)
+			? undefined
+			: compiledStaticString(initializer, new Set(resolvingAliases).add(node.text));
+	}
+
 	if (ts.isParenthesizedExpression(node)) {
-		return compiledStaticString(node.expression);
+		return compiledStaticString(node.expression, resolvingAliases);
 	}
 
 	if (ts.isTemplateExpression(node)) {
 		let value = node.head.text;
 
 		for (const span of node.templateSpans) {
-			const expression = compiledStaticString(span.expression);
+			const expression = compiledStaticString(span.expression, resolvingAliases);
 
 			if (expression === undefined) {
 				return undefined;
@@ -278,8 +286,8 @@ const compiledStaticString = (node: ts.Expression): string | undefined => {
 	}
 
 	if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-		const left = compiledStaticString(node.left);
-		const right = compiledStaticString(node.right);
+		const left = compiledStaticString(node.left, resolvingAliases);
+		const right = compiledStaticString(node.right, resolvingAliases);
 
 		return left === undefined || right === undefined ? undefined : left + right;
 	}
@@ -541,6 +549,50 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 	const addBinding = (name: string, binding: CompiledBinding): void => {
 		bindings.set(name, [...(bindings.get(name) ?? []), binding]);
 	};
+	const resolveBindingArrayElements = (
+		source: ts.Expression,
+		resolvingSources: Set<string>,
+	): readonly (ts.Expression | undefined)[] | undefined => {
+		if (ts.isIdentifier(source)) {
+			const initializer = resolveCompiledAlias(source);
+
+			return initializer === undefined || resolvingSources.has(source.text)
+				? undefined
+				: resolveBindingArrayElements(initializer, new Set(resolvingSources).add(source.text));
+		}
+
+		if (
+			ts.isParenthesizedExpression(source) ||
+			ts.isAsExpression(source) ||
+			ts.isTypeAssertionExpression(source) ||
+			ts.isNonNullExpression(source) ||
+			ts.isSatisfiesExpression(source)
+		) {
+			return resolveBindingArrayElements(source.expression, resolvingSources);
+		}
+
+		if (!ts.isArrayLiteralExpression(source)) {
+			return undefined;
+		}
+
+		const elements: (ts.Expression | undefined)[] = [];
+
+		for (const element of source.elements) {
+			if (ts.isSpreadElement(element)) {
+				const spreadElements = resolveBindingArrayElements(element.expression, resolvingSources);
+
+				if (spreadElements === undefined) {
+					return undefined;
+				}
+
+				elements.push(...spreadElements);
+			} else {
+				elements.push(ts.isExpression(element) ? element : undefined);
+			}
+		}
+
+		return elements;
+	};
 	const selectBindingValue = (
 		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
 		binding: ts.BindingElement,
@@ -578,7 +630,7 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				return undefined;
 			}
 
-			for (const property of source.properties) {
+			for (const property of [...source.properties].reverse()) {
 				if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
 					return property.initializer;
 				}
@@ -597,10 +649,8 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 			}
 		}
 
-		if (ts.isArrayBindingPattern(pattern) && ts.isArrayLiteralExpression(source)) {
-			const element = source.elements[index];
-
-			return element !== undefined && ts.isExpression(element) ? element : undefined;
+		if (ts.isArrayBindingPattern(pattern)) {
+			return resolveBindingArrayElements(source, resolvingSources)?.[index];
 		}
 
 		return undefined;
@@ -1042,6 +1092,10 @@ const containsUnsafeCompiledAlias = (
 
 						if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
 							return inspectCallable(property.name, nestedResolving);
+						}
+
+						if (ts.isMethodDeclaration(property) && compiledPropertyName(property.name) === propertyName) {
+							return property.body !== undefined && inspectCallableBody(property.body, nestedResolving);
 						}
 
 						return ts.isSpreadAssignment(property) && inspectCallableProperty(property.expression, nestedResolving);
@@ -2616,6 +2670,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const source = { fallback() { return 'opaque-secret'; } }; const apiKey = source.fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const source = { fallback: () => 'opaque-secret' }; const apiKey = source['fallback']();",
 				true,
 			),
@@ -2669,6 +2730,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = ['opaque-secret']; const [fallback] = source; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const [safe, fallback] = [...['safe', 'opaque-secret']]; const apiKey = fallback;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
@@ -2746,6 +2814,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe('unsafe compiled module', "const config = { [`api${'Key'}`]: 'opaque-secret' };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const key = 'apiKey'; const config = { [key]: 'opaque-secret' };",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = { read() { return 'opaque-secret'; } };", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
@@ -2821,6 +2896,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const source = { ...{ fallback: 'opaque-secret' } }; const { fallback } = source; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = { fallback: '', ...{ fallback: 'opaque-secret' } }; const { fallback } = source; const apiKey = fallback;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1290,18 +1290,32 @@ const containsUnsafeCompiledAlias = (
 										(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
 										child.left.expression.kind === ts.SyntaxKind.ThisKeyword
 									) {
-										const rightName = ts.isIdentifier(child.right) ? child.right.text : undefined;
-										const parameterIndex =
-											rightName !== undefined
-												? member.parameters.findIndex(
-														(parameter) => ts.isIdentifier(parameter.name) && parameter.name.text === rightName,
-													)
-												: -1;
-										const argument = parameterIndex < 0 ? undefined : constructorArguments[parameterIndex];
+										const referencedParameterIndexes = new Set<number>();
+										const visitParameterReference = (rightChild: ts.Node): void => {
+											if (ts.isIdentifier(rightChild)) {
+												const parameterIndex = member.parameters.findIndex(
+													(parameter) => ts.isIdentifier(parameter.name) && parameter.name.text === rightChild.text,
+												);
+
+												if (parameterIndex >= 0) {
+													referencedParameterIndexes.add(parameterIndex);
+												}
+											}
+
+											ts.forEachChild(rightChild, visitParameterReference);
+										};
+
+										visitParameterReference(child.right);
 
 										constructorWriteFound =
-											(argument !== undefined &&
-												(containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving))) ||
+											[...referencedParameterIndexes].some((parameterIndex) => {
+												const argument = constructorArguments[parameterIndex];
+
+												return (
+													argument !== undefined &&
+													(containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving))
+												);
+											}) ||
 											containsUnsafeCompiledLiteral(child.right, safeStrings) ||
 											inspect(child.right, nestedResolving);
 									}
@@ -4163,6 +4177,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor(value) { this.value = value; } } const apiKey = new Source('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor(value) { this.value = String(value); } } const apiKey = new Source('opaque-secret').value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1558,6 +1558,26 @@ const containsUnsafeCompiledAlias = (
 			return selectedValue === undefined ? [call.arguments[0]] : [selectedValue];
 		}
 
+		if (helperName === 'Object.fromEntries' && call.arguments.length >= 1) {
+			const entries = resolveArrayElements(call.arguments[0], new Set());
+
+			if (entries === undefined) {
+				return [call.arguments[0]];
+			}
+
+			return entries.flatMap((entry): readonly ts.Expression[] => {
+				const pair = resolveArrayElements(entry, new Set());
+
+				if (pair === undefined || pair.length < 2) {
+					return [entry];
+				}
+
+				const selectedName = compiledStaticPropertyExpressionName(pair[0]);
+
+				return selectedName === propertyName || selectedName === undefined ? [pair[1]] : [];
+			});
+		}
+
 		return [];
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
@@ -5381,6 +5401,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.freeze({ value: 'opaque-secret' }).value;", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const stored = 'opaque-secret'; const entries = [['value', stored]]; const apiKey = Object.fromEntries(entries).value;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = (choose && { value: 'opaque-secret' }).value;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -4,7 +4,13 @@ import { extname, resolve } from 'node:path';
 import ts from 'typescript';
 import { parse as parseYaml } from 'yaml';
 
-import { findHomeyIpv6Range, isHomeyAddressKey, isHomeySecretKey } from './support/homey-shs-probe';
+import {
+	findHomeyIpv6Range,
+	isHomeyAddressKey,
+	isHomeyGeneratedPseudonym,
+	isHomeyPersonalKey,
+	isHomeySecretKey,
+} from './support/homey-shs-probe';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -41,6 +47,13 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-reconnect-backoff',
 ]);
 const PUBLIC_COMPILED_SECRET_NAMES = new Set(['secretFields']);
+const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
+	'Locked',
+	'Synthetic lock contract',
+	'Synthetic mode A',
+	'Synthetic mode B',
+	'Synthetic mode C',
+]);
 const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
 const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
 const URL_PATTERN = /(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i;
@@ -358,6 +371,10 @@ const containsCompiledPrivateUrl = (text: string): boolean => {
 
 		if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
 			found = containsStructuredUrl(node.text);
+		} else if (ts.isTemplateExpression(node)) {
+			found =
+				containsStructuredUrl(node.head.text) ||
+				node.templateSpans.some((span) => containsStructuredUrl(span.literal.text));
 		}
 
 		ts.forEachChild(node, visit);
@@ -411,6 +428,27 @@ const containsStructuredAddress = (value: unknown): boolean => {
 		const safeAddressValue = child === null || child === 0 || child === false || child === '[~0~]';
 
 		return (isHomeyAddressKey(key) && !safeAddressValue) || containsStructuredAddress(child);
+	});
+};
+
+const containsStructuredPersonalValue = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((entry) => containsStructuredPersonalValue(entry));
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	return Object.entries(value as JsonRecord).some(([key, child]) => {
+		const safeRedaction = child === null || child === 0 || child === false || child === '[~2~]';
+		const safePseudonym = isHomeyGeneratedPseudonym(child);
+		const safeSyntheticValue = typeof child === 'string' && PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(child);
+
+		return (
+			(isHomeyPersonalKey(key) && !safeRedaction && !safePseudonym && !safeSyntheticValue) ||
+			containsStructuredPersonalValue(child)
+		);
 	});
 };
 
@@ -476,7 +514,7 @@ const assertTextSafe = (label: string, text: string, compiledSource = false): vo
 	}
 };
 
-const assertFixtureTextSafe = (label: string, text: string, extension: string): void => {
+const assertFixtureTextSafe = (label: string, text: string, extension: string, checkPersonalValues = true): void => {
 	assertTextSafe(label, text);
 
 	const structuredValue =
@@ -499,6 +537,10 @@ const assertFixtureTextSafe = (label: string, text: string, extension: string): 
 
 	if (structuredValue !== undefined && containsStructuredAddress(structuredValue)) {
 		throw new Error(`${label} contains a structured address value`);
+	}
+
+	if (checkPersonalValues && structuredValue !== undefined && containsStructuredPersonalValue(structuredValue)) {
+		throw new Error(`${label} contains a structured personal value`);
 	}
 };
 
@@ -615,7 +657,7 @@ describe('Homey security artifact gate', () => {
 			const label = path.slice(BACKEND_ROOT.length + 1);
 
 			if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
-				assertFixtureTextSafe(label, text, extension);
+				assertFixtureTextSafe(label, text, extension, false);
 			} else {
 				assertTextSafe(label, text, path.endsWith('.js') || path.endsWith('.d.ts'));
 			}
@@ -664,8 +706,12 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertFixtureTextSafe('safe fixture', '{"pinCode":0}', '.json')).not.toThrow();
 		expect(() => assertFixtureTextSafe('safe fixture', '{"hostname":"[~0~]"}', '.json')).not.toThrow();
+		expect(() => assertFixtureTextSafe('safe fixture', '{"name":"device-label-000001"}', '.json')).not.toThrow();
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"hostname":"family-homey.local"}', '.json')).toThrow(
 			'unsafe fixture contains a structured address value',
+		);
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"name":"Alice Bedroom"}', '.json')).toThrow(
+			'unsafe fixture contains a structured personal value',
 		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', 'api_key: opaque-secret-value', '.yaml')).toThrow(
 			'unsafe fixture contains a structured secret value',
@@ -735,6 +781,9 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const endpoint = 'http://private-homey.local:4859';", true),
+		).toThrow('unsafe compiled module contains a private URL');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', 'const endpoint = `http://private-homey.local:${port}`;', true),
 		).toThrow('unsafe compiled module contains a private URL');
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -27,7 +27,7 @@ const BUILD_ROOT = resolve(BACKEND_ROOT, 'dist/plugins/devices-homey');
 const FIXTURE_REPOSITORY_PATH = 'apps/backend/src/plugins/devices-homey/__fixtures__';
 const OPENAPI_PATH = resolve(REPOSITORY_ROOT, 'spec/api/v1/openapi.json');
 const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
-const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
+const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map', '.yaml', '.yml']);
 const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
 const HOMEY_TOKEN_PATTERN = /(?:homey|hpat|pat)[_-][A-Za-z0-9_-]{16,}/gi;
@@ -398,6 +398,28 @@ const visitSchema = (schemaName: string, value: unknown, path: readonly string[]
 	}
 };
 
+const visitPublishedValues = (label: string, value: unknown, path: readonly string[] = []): void => {
+	if (Array.isArray(value)) {
+		value.forEach((entry, index) => visitPublishedValues(label, entry, [...path, index.toString()]));
+
+		return;
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return;
+	}
+
+	for (const [key, child] of Object.entries(value as JsonRecord)) {
+		const childPath = [...path, key];
+
+		if (['default', 'enum', 'example', 'examples'].includes(key) && containsStructuredSecret(child)) {
+			throw new Error(`${label}.${childPath.join('.')} publishes a secret value`);
+		}
+
+		visitPublishedValues(label, child, childPath);
+	}
+};
+
 describe('Homey security artifact gate', () => {
 	it('keeps generated Homey OpenAPI schemas and routes secret-safe', () => {
 		const document = readJson(OPENAPI_PATH) as OpenApiDocument;
@@ -411,6 +433,8 @@ describe('Homey security artifact gate', () => {
 		expect(Object.keys(homeySchemas).length).toBeGreaterThan(0);
 		expect(Object.keys(homeyPaths).length).toBeGreaterThan(0);
 		Object.entries(homeySchemas).forEach(([name, schema]) => visitSchema(name, schema));
+		visitPublishedValues('generated Homey OpenAPI schemas', homeySchemas);
+		visitPublishedValues('generated Homey OpenAPI routes', homeyPaths);
 		assertTextSafe('generated Homey OpenAPI schemas', JSON.stringify(homeySchemas));
 		assertTextSafe('generated Homey OpenAPI routes', JSON.stringify(homeyPaths));
 	});
@@ -443,8 +467,14 @@ describe('Homey security artifact gate', () => {
 
 		for (const path of buildFiles) {
 			const text = readFileSync(path, 'utf8');
+			const extension = extname(path);
+			const label = path.slice(BACKEND_ROOT.length + 1);
 
-			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), text, path.endsWith('.js') || path.endsWith('.d.ts'));
+			if (extension === '.yaml' || extension === '.yml') {
+				assertFixtureTextSafe(label, text, extension);
+			} else {
+				assertTextSafe(label, text, path.endsWith('.js') || path.endsWith('.d.ts'));
+			}
 		}
 	});
 
@@ -469,6 +499,11 @@ describe('Homey security artifact gate', () => {
 				properties: { pinCode: { type: 'string' } },
 			}),
 		).toThrow('UnsafeHomeySchema.properties.pinCode is not write-only');
+		expect(() =>
+			visitPublishedValues('UnsafeHomeySchema', {
+				example: { pinCode: 1234 },
+			}),
+		).toThrow('UnsafeHomeySchema.example publishes a secret value');
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1105,6 +1105,7 @@ const containsUnsafeCompiledAlias = (
 	resolvingAliases = new Set<ts.Node>(),
 ): boolean => {
 	const visibleThroughPosition = node.getStart(node.getSourceFile());
+	const activeParameterArguments = new Map<ts.ParameterDeclaration, ts.Expression>();
 	const resolveArrayElements = (
 		expression: ts.Expression,
 		resolving: Set<ts.Node>,
@@ -1216,6 +1217,38 @@ const containsUnsafeCompiledAlias = (
 
 		return undefined;
 	};
+	const withCallArguments = (
+		parameters: readonly ts.ParameterDeclaration[],
+		arguments_: readonly ts.Expression[],
+		callback: () => boolean,
+	): boolean => {
+		const previousArguments = new Map<ts.ParameterDeclaration, ts.Expression | undefined>();
+
+		parameters.forEach((parameter, index) => {
+			if (!ts.isIdentifier(parameter.name)) {
+				return;
+			}
+
+			const argument = arguments_[index] ?? parameter.initializer;
+
+			if (argument !== undefined) {
+				previousArguments.set(parameter, activeParameterArguments.get(parameter));
+				activeParameterArguments.set(parameter, argument);
+			}
+		});
+
+		try {
+			return callback();
+		} finally {
+			for (const [parameter, previousArgument] of previousArguments) {
+				if (previousArgument === undefined) {
+					activeParameterArguments.delete(parameter);
+				} else {
+					activeParameterArguments.set(parameter, previousArgument);
+				}
+			}
+		}
+	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
 		if (ts.isIdentifier(expression)) {
 			const bindings = resolveCompiledBindings(expression, visibleThroughPosition);
@@ -1230,11 +1263,19 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				const nestedResolving = new Set(resolving).add(binding.declaration);
+				const parameterArgument = ts.isParameter(binding.declaration)
+					? activeParameterArguments.get(binding.declaration)
+					: undefined;
 
-				return [binding.initializer, binding.fallbackInitializer].some(
-					(initializer) =>
-						initializer !== undefined &&
-						(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
+				return (
+					(parameterArgument !== undefined &&
+						(containsUnsafeCompiledLiteral(parameterArgument, safeStrings) ||
+							inspect(parameterArgument, nestedResolving))) ||
+					[binding.initializer, binding.fallbackInitializer].some(
+						(initializer) =>
+							initializer !== undefined &&
+							(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
+					)
 				);
 			});
 		}
@@ -1555,7 +1596,11 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
-					const inspectReturnedProperty = (callee: ts.Expression, resolvingCalls: Set<ts.Node>): boolean => {
+					const inspectReturnedProperty = (
+						callee: ts.Expression,
+						resolvingCalls: Set<ts.Node>,
+						callArguments: readonly ts.Expression[],
+					): boolean => {
 						const inspectReturnBody = (body: ts.Block, nestedCalls: Set<ts.Node>): boolean => {
 							let found = false;
 							const visitReturn = (child: ts.Node): void => {
@@ -1584,12 +1629,17 @@ const containsUnsafeCompiledAlias = (
 								}
 
 								const nestedCalls = new Set(resolvingCalls).add(binding.declaration);
+								const callable = binding.callable;
 
 								return (
 									[binding.initializer, binding.fallbackInitializer].some(
-										(initializer) => initializer !== undefined && inspectReturnedProperty(initializer, nestedCalls),
+										(initializer) =>
+											initializer !== undefined && inspectReturnedProperty(initializer, nestedCalls, callArguments),
 									) ||
-									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedCalls))
+									(callable?.body !== undefined &&
+										withCallArguments(callable.parameters, callArguments, () =>
+											inspectReturnBody(callable.body, nestedCalls),
+										))
 								);
 							});
 						}
@@ -1601,7 +1651,7 @@ const containsUnsafeCompiledAlias = (
 							ts.isNonNullExpression(callee) ||
 							ts.isSatisfiesExpression(callee)
 						) {
-							return inspectReturnedProperty(callee.expression, resolvingCalls);
+							return inspectReturnedProperty(callee.expression, resolvingCalls, callArguments);
 						}
 
 						if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
@@ -1615,23 +1665,87 @@ const containsUnsafeCompiledAlias = (
 									? undefined
 									: resolvePropertyValue(callee.expression, calleePropertyName, resolvingCalls);
 
-							return callable !== undefined && inspectReturnedProperty(callable, resolvingCalls);
+							if (callable !== undefined && inspectReturnedProperty(callable, resolvingCalls, callArguments)) {
+								return true;
+							}
+
+							const inspectMethodProperty = (
+								methodReceiver: ts.Expression,
+								resolvingMethods: Set<ts.Node>,
+							): boolean => {
+								if (calleePropertyName === undefined) {
+									return false;
+								}
+
+								if (ts.isIdentifier(methodReceiver)) {
+									return resolveCompiledBindings(methodReceiver, visibleThroughPosition).some((binding) => {
+										if (resolvingMethods.has(binding.declaration)) {
+											return false;
+										}
+
+										const nestedMethods = new Set(resolvingMethods).add(binding.declaration);
+
+										return [binding.initializer, binding.fallbackInitializer].some(
+											(initializer) => initializer !== undefined && inspectMethodProperty(initializer, nestedMethods),
+										);
+									});
+								}
+
+								if (
+									ts.isParenthesizedExpression(methodReceiver) ||
+									ts.isAsExpression(methodReceiver) ||
+									ts.isTypeAssertionExpression(methodReceiver) ||
+									ts.isNonNullExpression(methodReceiver) ||
+									ts.isSatisfiesExpression(methodReceiver)
+								) {
+									return inspectMethodProperty(methodReceiver.expression, resolvingMethods);
+								}
+
+								if (!ts.isObjectLiteralExpression(methodReceiver)) {
+									return false;
+								}
+
+								return methodReceiver.properties.some((property) => {
+									if (
+										ts.isMethodDeclaration(property) &&
+										compiledPropertyName(property.name) === calleePropertyName &&
+										property.body !== undefined
+									) {
+										return withCallArguments(property.parameters, callArguments, () =>
+											inspectReturnBody(property.body, resolvingMethods),
+										);
+									}
+
+									return (
+										ts.isSpreadAssignment(property) && inspectMethodProperty(property.expression, resolvingMethods)
+									);
+								});
+							};
+
+							return inspectMethodProperty(callee.expression, resolvingCalls);
 						}
 
 						if (ts.isArrowFunction(callee)) {
-							return ts.isBlock(callee.body)
-								? inspectReturnBody(callee.body, resolvingCalls)
-								: inspectProperty(callee.body, resolvingCalls, selectedPropertyName, resolvingProperties);
+							return withCallArguments(callee.parameters, callArguments, () =>
+								ts.isBlock(callee.body)
+									? inspectReturnBody(callee.body, resolvingCalls)
+									: inspectProperty(callee.body, resolvingCalls, selectedPropertyName, resolvingProperties),
+							);
 						}
 
 						if (ts.isFunctionExpression(callee)) {
-							return inspectReturnBody(callee.body, resolvingCalls);
+							return withCallArguments(callee.parameters, callArguments, () =>
+								inspectReturnBody(callee.body, resolvingCalls),
+							);
 						}
 
-						return ts.isCallExpression(callee) && inspectReturnedProperty(callee.expression, resolvingCalls);
+						return (
+							ts.isCallExpression(callee) &&
+							inspectReturnedProperty(callee.expression, resolvingCalls, callee.arguments)
+						);
 					};
 
-					return inspectReturnedProperty(receiver.expression, nestedResolving);
+					return inspectReturnedProperty(receiver.expression, nestedResolving, receiver.arguments);
 				}
 
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
@@ -1934,7 +2048,11 @@ const containsUnsafeCompiledAlias = (
 				}
 
 				if (ts.isCallExpression(receiver)) {
-					const inspectReturnedReceiver = (factory: ts.Expression, resolvingFactories: Set<ts.Node>): boolean => {
+					const inspectReturnedReceiver = (
+						factory: ts.Expression,
+						resolvingFactories: Set<ts.Node>,
+						callArguments: readonly ts.Expression[],
+					): boolean => {
 						const inspectReturnBody = (body: ts.Block, nestedFactories: Set<ts.Node>): boolean => {
 							let found = false;
 							const visitReturn = (child: ts.Node): void => {
@@ -1963,12 +2081,17 @@ const containsUnsafeCompiledAlias = (
 								}
 
 								const nestedFactories = new Set(resolvingFactories).add(binding.declaration);
+								const callable = binding.callable;
 
 								return (
 									[binding.initializer, binding.fallbackInitializer].some(
-										(initializer) => initializer !== undefined && inspectReturnedReceiver(initializer, nestedFactories),
+										(initializer) =>
+											initializer !== undefined && inspectReturnedReceiver(initializer, nestedFactories, callArguments),
 									) ||
-									(binding.callable?.body !== undefined && inspectReturnBody(binding.callable.body, nestedFactories))
+									(callable?.body !== undefined &&
+										withCallArguments(callable.parameters, callArguments, () =>
+											inspectReturnBody(callable.body, nestedFactories),
+										))
 								);
 							});
 						}
@@ -1980,23 +2103,96 @@ const containsUnsafeCompiledAlias = (
 							ts.isNonNullExpression(factory) ||
 							ts.isSatisfiesExpression(factory)
 						) {
-							return inspectReturnedReceiver(factory.expression, resolvingFactories);
+							return inspectReturnedReceiver(factory.expression, resolvingFactories, callArguments);
+						}
+
+						if (ts.isPropertyAccessExpression(factory) || ts.isElementAccessExpression(factory)) {
+							const factoryPropertyName = ts.isPropertyAccessExpression(factory)
+								? factory.name.text
+								: factory.argumentExpression === undefined
+									? undefined
+									: compiledStaticPropertyExpressionName(factory.argumentExpression);
+							const callable =
+								factoryPropertyName === undefined
+									? undefined
+									: resolvePropertyValue(factory.expression, factoryPropertyName, resolvingFactories);
+
+							if (callable !== undefined && inspectReturnedReceiver(callable, resolvingFactories, callArguments)) {
+								return true;
+							}
+
+							const inspectMethodFactory = (methodReceiver: ts.Expression, resolvingMethods: Set<ts.Node>): boolean => {
+								if (factoryPropertyName === undefined) {
+									return false;
+								}
+
+								if (ts.isIdentifier(methodReceiver)) {
+									return resolveCompiledBindings(methodReceiver, visibleThroughPosition).some((binding) => {
+										if (resolvingMethods.has(binding.declaration)) {
+											return false;
+										}
+
+										const nestedMethods = new Set(resolvingMethods).add(binding.declaration);
+
+										return [binding.initializer, binding.fallbackInitializer].some(
+											(initializer) => initializer !== undefined && inspectMethodFactory(initializer, nestedMethods),
+										);
+									});
+								}
+
+								if (
+									ts.isParenthesizedExpression(methodReceiver) ||
+									ts.isAsExpression(methodReceiver) ||
+									ts.isTypeAssertionExpression(methodReceiver) ||
+									ts.isNonNullExpression(methodReceiver) ||
+									ts.isSatisfiesExpression(methodReceiver)
+								) {
+									return inspectMethodFactory(methodReceiver.expression, resolvingMethods);
+								}
+
+								if (!ts.isObjectLiteralExpression(methodReceiver)) {
+									return false;
+								}
+
+								return methodReceiver.properties.some((property) => {
+									if (
+										ts.isMethodDeclaration(property) &&
+										compiledPropertyName(property.name) === factoryPropertyName &&
+										property.body !== undefined
+									) {
+										return withCallArguments(property.parameters, callArguments, () =>
+											inspectReturnBody(property.body, resolvingMethods),
+										);
+									}
+
+									return ts.isSpreadAssignment(property) && inspectMethodFactory(property.expression, resolvingMethods);
+								});
+							};
+
+							return inspectMethodFactory(factory.expression, resolvingFactories);
 						}
 
 						if (ts.isArrowFunction(factory)) {
-							return ts.isBlock(factory.body)
-								? inspectReturnBody(factory.body, resolvingFactories)
-								: inspectCallableProperty(factory.body, resolvingFactories);
+							return withCallArguments(factory.parameters, callArguments, () =>
+								ts.isBlock(factory.body)
+									? inspectReturnBody(factory.body, resolvingFactories)
+									: inspectCallableProperty(factory.body, resolvingFactories),
+							);
 						}
 
 						if (ts.isFunctionExpression(factory)) {
-							return inspectReturnBody(factory.body, resolvingFactories);
+							return withCallArguments(factory.parameters, callArguments, () =>
+								inspectReturnBody(factory.body, resolvingFactories),
+							);
 						}
 
-						return ts.isCallExpression(factory) && inspectReturnedReceiver(factory.expression, resolvingFactories);
+						return (
+							ts.isCallExpression(factory) &&
+							inspectReturnedReceiver(factory.expression, resolvingFactories, factory.arguments)
+						);
 					};
 
-					return inspectReturnedReceiver(receiver.expression, nestedResolving);
+					return inspectReturnedReceiver(receiver.expression, nestedResolving, receiver.arguments);
 				}
 
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
@@ -4326,7 +4522,35 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const factory = { make() { return { value: 'opaque-secret' }; } }; const apiKey = factory.make().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function make(value) { return { value }; } const apiKey = make('opaque-secret').value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"const factory = () => ({ fallback: () => 'opaque-secret' }); const apiKey = factory().fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"function make(value) { return { fallback: () => value }; } const apiKey = make('opaque-secret').fallback();",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const factory = { make() { return { fallback: () => 'opaque-secret' }; } }; const apiKey = factory.make().fallback();",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -2722,9 +2722,10 @@ const containsUnsafeCompiledAlias = (
 					if (
 						receiverPropertyName !== undefined &&
 						ts.isCallExpression(receiver.expression) &&
-						concatenatedResultValues(receiver.expression, receiverPropertyName).some((value) =>
-							inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties),
-						)
+						[
+							...concatenatedResultValues(receiver.expression, receiverPropertyName),
+							...objectValuesResultValues(receiver.expression, receiverPropertyName),
+						].some((value) => inspectProperty(value, nestedResolving, selectedPropertyName, resolvingProperties))
 					) {
 						return true;
 					}
@@ -4269,19 +4270,32 @@ const containsCompiledSecret = (text: string): boolean => {
 							? undefined
 							: compiledStaticPropertyExpressionName(node.expression.argumentExpression)
 					: undefined;
-			const invokedCallee =
-				(invocationPropertyName === 'call' ||
-					invocationPropertyName === 'apply' ||
-					invocationPropertyName === 'bind') &&
-				(ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression))
+			const invocationReceiver =
+				ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)
 					? node.expression.expression
-					: node.expression;
+					: undefined;
+			const isReflectApply =
+				invocationPropertyName === 'apply' &&
+				invocationReceiver !== undefined &&
+				ts.isIdentifier(invocationReceiver) &&
+				invocationReceiver.text === 'Reflect';
+			const invokedCallee =
+				isReflectApply && node.arguments[0] !== undefined
+					? node.arguments[0]
+					: (invocationPropertyName === 'call' ||
+								invocationPropertyName === 'apply' ||
+								invocationPropertyName === 'bind') &&
+						  invocationReceiver !== undefined
+						? invocationReceiver
+						: node.expression;
 			const invokedArguments: readonly ts.Expression[] =
-				invocationPropertyName === 'call' || invocationPropertyName === 'bind'
-					? node.arguments.slice(1)
-					: invocationPropertyName === 'apply' && node.arguments[1] !== undefined
-						? [ts.factory.createSpreadElement(node.arguments[1])]
-						: node.arguments;
+				isReflectApply && node.arguments[2] !== undefined
+					? [ts.factory.createSpreadElement(node.arguments[2])]
+					: invocationPropertyName === 'call' || invocationPropertyName === 'bind'
+						? node.arguments.slice(1)
+						: invocationPropertyName === 'apply' && node.arguments[1] !== undefined
+							? [ts.factory.createSpreadElement(node.arguments[1])]
+							: node.arguments;
 
 			found = secretCallArguments(resolveCallParameterSets(invokedCallee), invokedArguments);
 		} else if (ts.isNewExpression(node)) {
@@ -6002,6 +6016,13 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"function connect(apiKey) {} Reflect.apply(connect, null, ['opaque-secret']);",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"function connect(apiKey) {} const bound = connect.bind(null, 'opaque-secret'); bound();",
 				true,
 			),
@@ -6518,6 +6539,13 @@ describe('Homey security artifact gate', () => {
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.values({ value: 'opaque-secret' })[0];", true),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const apiKey = Object.values({ x: { value: 'opaque-secret' } })[0].value;",
+				true,
+			),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = Object.keys({ 'opaque-secret': 0 })[0];", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1264,6 +1264,7 @@ const containsUnsafeCompiledAlias = (
 					expectStatic: boolean,
 					memberName: string,
 					classResolvingProperties = new Set<string>(),
+					constructorArguments: readonly ts.Expression[] = [],
 				): boolean => {
 					const propertyReference = `${classDeclaration.pos}:${expectStatic ? 'static' : 'instance'}:${memberName}`;
 
@@ -1275,29 +1276,41 @@ const containsUnsafeCompiledAlias = (
 					let constructorWriteFound = false;
 
 					if (!expectStatic) {
-						const visitConstructorWrite = (child: ts.Node): void => {
-							if (constructorWriteFound) {
-								return;
-							}
-
-							if (
-								ts.isBinaryExpression(child) &&
-								isAssignmentOperatorKind(child.operatorToken.kind) &&
-								compiledAssignedPropertyName(child.left) === memberName &&
-								(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
-								child.left.expression.kind === ts.SyntaxKind.ThisKeyword
-							) {
-								constructorWriteFound =
-									containsUnsafeCompiledLiteral(child.right, safeStrings) || inspect(child.right, nestedResolving);
-							}
-
-							if (!constructorWriteFound) {
-								ts.forEachChild(child, visitConstructorWrite);
-							}
-						};
-
 						for (const member of classDeclaration.members) {
 							if (ts.isConstructorDeclaration(member) && member.body !== undefined) {
+								const visitConstructorWrite = (child: ts.Node): void => {
+									if (constructorWriteFound) {
+										return;
+									}
+
+									if (
+										ts.isBinaryExpression(child) &&
+										isAssignmentOperatorKind(child.operatorToken.kind) &&
+										compiledAssignedPropertyName(child.left) === memberName &&
+										(ts.isPropertyAccessExpression(child.left) || ts.isElementAccessExpression(child.left)) &&
+										child.left.expression.kind === ts.SyntaxKind.ThisKeyword
+									) {
+										const rightName = ts.isIdentifier(child.right) ? child.right.text : undefined;
+										const parameterIndex =
+											rightName !== undefined
+												? member.parameters.findIndex(
+														(parameter) => ts.isIdentifier(parameter.name) && parameter.name.text === rightName,
+													)
+												: -1;
+										const argument = parameterIndex < 0 ? undefined : constructorArguments[parameterIndex];
+
+										constructorWriteFound =
+											(argument !== undefined &&
+												(containsUnsafeCompiledLiteral(argument, safeStrings) || inspect(argument, nestedResolving))) ||
+											containsUnsafeCompiledLiteral(child.right, safeStrings) ||
+											inspect(child.right, nestedResolving);
+									}
+
+									if (!constructorWriteFound) {
+										ts.forEachChild(child, visitConstructorWrite);
+									}
+								};
+
 								visitConstructorWrite(member.body);
 							}
 						}
@@ -1347,6 +1360,7 @@ const containsUnsafeCompiledAlias = (
 												expectStatic,
 												receiverPropertyName,
 												nestedClassProperties,
+												constructorArguments,
 											)) ||
 										containsUnsafeCompiledLiteral(child.expression, safeStrings) ||
 										inspect(child.expression, nestedResolving);
@@ -1380,7 +1394,13 @@ const containsUnsafeCompiledAlias = (
 
 									return (
 										baseClass !== undefined &&
-										inspectClassProperty(baseClass, expectStatic, memberName, nestedClassProperties)
+										inspectClassProperty(
+											baseClass,
+											expectStatic,
+											memberName,
+											nestedClassProperties,
+											constructorArguments,
+										)
 									);
 								}),
 							) ?? false
@@ -1532,7 +1552,10 @@ const containsUnsafeCompiledAlias = (
 				if (ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
 					const classDeclaration = resolveCompiledBinding(receiver.expression)?.classDeclaration;
 
-					return classDeclaration !== undefined && inspectClassProperty(classDeclaration, false, selectedPropertyName);
+					return (
+						classDeclaration !== undefined &&
+						inspectClassProperty(classDeclaration, false, selectedPropertyName, new Set(), receiver.arguments ?? [])
+					);
 				}
 
 				if (ts.isObjectLiteralExpression(receiver)) {
@@ -4133,6 +4156,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"class Source { constructor() { this.value = 'opaque-secret'; } } const apiKey = new Source().value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"class Source { constructor(value) { this.value = value; } } const apiKey = new Source('opaque-secret').value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -436,6 +436,7 @@ const containsUnsafeCompiledLiteral = (
 interface CompiledBinding {
 	readonly callable?: ts.FunctionDeclaration;
 	readonly declaration: ts.Declaration;
+	readonly fallbackInitializer?: ts.Expression;
 	readonly initializer?: ts.Expression;
 	readonly scope: ts.Node;
 }
@@ -476,6 +477,67 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 	const addBinding = (name: string, binding: CompiledBinding): void => {
 		bindings.set(name, [...(bindings.get(name) ?? []), binding]);
 	};
+	const selectBindingValue = (
+		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
+		binding: ts.BindingElement,
+		index: number,
+		source: ts.Expression,
+	): ts.Expression | undefined => {
+		if (ts.isObjectBindingPattern(pattern) && ts.isObjectLiteralExpression(source)) {
+			const propertyName =
+				binding.propertyName === undefined
+					? ts.isIdentifier(binding.name)
+						? binding.name.text
+						: undefined
+					: compiledPropertyName(binding.propertyName);
+
+			if (propertyName === undefined) {
+				return undefined;
+			}
+
+			for (const property of source.properties) {
+				if (ts.isPropertyAssignment(property) && compiledPropertyName(property.name) === propertyName) {
+					return property.initializer;
+				}
+
+				if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
+					return property.name;
+				}
+			}
+		}
+
+		if (ts.isArrayBindingPattern(pattern) && ts.isArrayLiteralExpression(source)) {
+			const element = source.elements[index];
+
+			return element !== undefined && ts.isExpression(element) ? element : undefined;
+		}
+
+		return undefined;
+	};
+	const addPatternBindings = (
+		pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
+		source: ts.Expression,
+		scope: ts.Node,
+	): void => {
+		pattern.elements.forEach((element, index) => {
+			if (ts.isOmittedExpression(element)) {
+				return;
+			}
+
+			const selectedValue = selectBindingValue(pattern, element, index, source);
+
+			if (ts.isIdentifier(element.name)) {
+				addBinding(element.name.text, {
+					declaration: element,
+					fallbackInitializer: selectedValue === undefined ? undefined : element.initializer,
+					initializer: selectedValue ?? element.initializer,
+					scope,
+				});
+			} else if (selectedValue !== undefined) {
+				addPatternBindings(element.name, selectedValue, scope);
+			}
+		});
+	};
 	const visit = (node: ts.Node): void => {
 		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
 			const constantInitializer =
@@ -490,6 +552,14 @@ const compiledBindings = (sourceFile: ts.SourceFile): ReadonlyMap<string, readon
 				initializer: constantInitializer,
 				scope: compiledBindingScope(node),
 			});
+		} else if (
+			ts.isVariableDeclaration(node) &&
+			(ts.isObjectBindingPattern(node.name) || ts.isArrayBindingPattern(node.name)) &&
+			node.initializer !== undefined &&
+			ts.isVariableDeclarationList(node.parent) &&
+			(node.parent.flags & ts.NodeFlags.Const) !== 0
+		) {
+			addPatternBindings(node.name, node.initializer, compiledBindingScope(node));
 		} else if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
 			addBinding(node.name.text, { declaration: node, scope: compiledBindingScope(node) });
 		} else if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
@@ -538,7 +608,9 @@ const resolveCompiledBinding = (identifier: ts.Identifier): CompiledBinding | un
 		.filter(
 			(binding) =>
 				isNodeWithin(identifier, binding.scope) &&
-				(ts.isParameter(binding.declaration) || binding.declaration.getStart(sourceFile) < usePosition),
+				(ts.isParameter(binding.declaration) ||
+					ts.isFunctionDeclaration(binding.declaration) ||
+					binding.declaration.getStart(sourceFile) < usePosition),
 		)
 		.sort((left, right) => {
 			const depthDifference = compiledScopeDepth(right.scope) - compiledScopeDepth(left.scope);
@@ -607,15 +679,19 @@ const containsUnsafeCompiledAlias = (
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<string>): boolean => {
 		if (ts.isIdentifier(expression)) {
-			const initializer = resolveCompiledAlias(expression);
+			const binding = resolveCompiledBinding(expression);
 
-			if (initializer === undefined || resolving.has(expression.text)) {
+			if (binding === undefined || resolving.has(expression.text)) {
 				return false;
 			}
 
 			const nestedResolving = new Set(resolving).add(expression.text);
 
-			return containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving);
+			return [binding.initializer, binding.fallbackInitializer].some(
+				(initializer) =>
+					initializer !== undefined &&
+					(containsUnsafeCompiledLiteral(initializer, safeStrings) || inspect(initializer, nestedResolving)),
+			);
 		}
 
 		if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
@@ -775,9 +851,12 @@ const containsUnsafeCompiledAlias = (
 
 			const nestedResolving = new Set(resolving).add(callee.text);
 
-			return binding.initializer !== undefined
-				? inspectCallable(binding.initializer, nestedResolving)
-				: binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving);
+			return (
+				[binding.initializer, binding.fallbackInitializer].some(
+					(initializer) => initializer !== undefined && inspectCallable(initializer, nestedResolving),
+				) ||
+				(binding.callable?.body !== undefined && inspectCallableBody(binding.callable.body, nestedResolving))
+			);
 		}
 
 		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
@@ -2442,9 +2521,33 @@ describe('Homey security artifact gate', () => {
 		expect(() =>
 			assertTextSafe(
 				'unsafe compiled module',
+				"const apiKey = fallback(); function fallback() { return 'opaque-secret'; }",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
 				"function first() { const fallback = 'opaque-secret'; const apiKey = fallback; } function second() { const fallback = ''; return fallback; }",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const { fallback } = { fallback: 'opaque-secret' }; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const { fallback = 'opaque-secret' } = {}; const apiKey = fallback;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const [fallback] = ['opaque-secret']; const apiKey = fallback;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe declaration', "declare function connect(apiKey: 'opaque-secret'): void", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1196,7 +1196,9 @@ const compiledPropertyWriteValues = (
 			if (sameReceiverPath(mutationTarget, targetPath)) {
 				if (helperName === 'Object.assign') {
 					for (const source of node.arguments.slice(1)) {
-						values.push(...mutationPropertyValues(source, propertyName));
+						const sourceValues = mutationPropertyValues(source, propertyName);
+
+						values.push(...(sourceValues.length === 0 ? [source] : sourceValues));
 					}
 				} else if (
 					['Object.defineProperty', 'Reflect.defineProperty'].includes(helperName ?? '') &&
@@ -5215,6 +5217,13 @@ describe('Homey security artifact gate', () => {
 			assertTextSafe(
 				'unsafe compiled module',
 				"const assign = Object.assign; const source = {}; assign(source, { value: 'opaque-secret' }); const apiKey = source.value;",
+				true,
+			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe(
+				'unsafe compiled module',
+				"const source = {}; Object.assign(source, Object.fromEntries([['value', 'opaque-secret']])); const apiKey = source.value;",
 				true,
 			),
 		).toThrow('unsafe compiled module contains a compiled secret value');

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1509,6 +1509,29 @@ const containsUnsafeCompiledAlias = (
 			return selectedValue === undefined ? [descriptor] : [descriptor, selectedValue];
 		}
 
+		if (helperName === 'Object.create') {
+			const values: ts.Expression[] = [];
+			const prototypeValue = resolvePropertyValue(call.arguments[0], propertyName, new Set());
+
+			values.push(prototypeValue ?? call.arguments[0]);
+
+			if (call.arguments.length >= 2) {
+				const descriptor = resolvePropertyValue(call.arguments[1], propertyName, new Set());
+
+				if (descriptor !== undefined) {
+					values.push(descriptor);
+
+					const selectedValue = resolvePropertyValue(descriptor, 'value', new Set());
+
+					if (selectedValue !== undefined) {
+						values.push(selectedValue);
+					}
+				}
+			}
+
+			return values;
+		}
+
 		return [];
 	};
 	const inspect = (expression: ts.Expression, resolving: Set<ts.Node>): boolean => {
@@ -5179,6 +5202,9 @@ describe('Homey security artifact gate', () => {
 				"const apiKey = Object.assign({}, { value: 'opaque-secret' }).value;",
 				true,
 			),
+		).toThrow('unsafe compiled module contains a compiled secret value');
+		expect(() =>
+			assertTextSafe('unsafe compiled module', "const apiKey = Object.create({ value: 'opaque-secret' }).value;", true),
 		).toThrow('unsafe compiled module contains a compiled secret value');
 		expect(() =>
 			assertTextSafe('unsafe compiled module', "const apiKey = (choose && { value: 'opaque-secret' }).value;", true),

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1,6 +1,8 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { extname, resolve } from 'node:path';
+import ts from 'typescript';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -19,14 +21,19 @@ interface ForbiddenPattern {
 const BACKEND_ROOT = resolve(__dirname, '..');
 const REPOSITORY_ROOT = resolve(__dirname, '../../..');
 const BUILD_ROOT = resolve(BACKEND_ROOT, 'dist/plugins/devices-homey');
-const FIXTURE_ROOT = resolve(BACKEND_ROOT, 'src/plugins/devices-homey/__fixtures__');
+const FIXTURE_REPOSITORY_PATH = 'apps/backend/src/plugins/devices-homey/__fixtures__';
 const OPENAPI_PATH = resolve(REPOSITORY_ROOT, 'spec/api/v1/openapi.json');
 const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
 const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
+const FIXTURE_EXTENSIONS = new Set(['.json', '.md', '.txt', '.yaml', '.yml']);
 const SECRET_PROPERTY_PATTERN =
 	/^(?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)$/i;
 const IP_ADDRESS_CANDIDATE_PATTERN = /[A-Za-z0-9:.%_-]{2,}/g;
-const COMPILED_IDENTIFIER_PATTERN = /(?<!["'])\bhomey_[a-z0-9_]{16,}\b(?!["'])|\bHOMEY_[A-Z0-9_]{16,}\b/g;
+const HOMEY_TOKEN_PATTERN = /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i;
+const COMPILED_SYMBOL_NAME_PATTERN = /^[A-Z][A-Z0-9_]+$/;
+const COMMENT_PATTERN = /\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g;
+const SERIALIZED_SECRET_PATTERN =
+	/["'](?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)["']\s*:\s*(["'])([^"']*)\1/gi;
 const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	{
 		label: 'an IPv4 address',
@@ -34,12 +41,6 @@ const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 	},
 	{ label: 'a MAC address', pattern: /\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b/i },
 	{ label: 'an email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
-	{ label: 'a Homey personal access token', pattern: /\b(?:homey|hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
-	{
-		label: 'a serialized secret value',
-		pattern:
-			/["'](?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)["']\s*:\s*["'](?!\[~3~\])[^"]+["']/i,
-	},
 ];
 
 const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
@@ -69,6 +70,19 @@ const configuredPrivateValues = (): readonly string[] =>
 		.map((value) => value?.trim())
 		.filter((value): value is string => value !== undefined && value.length >= 3);
 
+const trackedFixtureFiles = (): readonly string[] => {
+	const output = execFileSync('git', ['ls-files', '-z', '--', FIXTURE_REPOSITORY_PATH], {
+		cwd: REPOSITORY_ROOT,
+		encoding: 'utf8',
+	});
+
+	return output
+		.split('\0')
+		.filter((path) => path.length > 0)
+		.map((path) => resolve(REPOSITORY_ROOT, path))
+		.filter((path) => lstatSync(path).isFile());
+};
+
 const containsIpv6Address = (text: string): boolean =>
 	[...text.matchAll(IP_ADDRESS_CANDIDATE_PATTERN)].some((match) => {
 		const candidate = match[0].replace(/^\.+|\.+$/g, '').split('%')[0];
@@ -76,7 +90,46 @@ const containsIpv6Address = (text: string): boolean =>
 		return candidate !== undefined && candidate !== '::' && isIP(candidate) === 6;
 	});
 
-const assertTextSafe = (label: string, text: string): void => {
+const containsHomeyToken = (text: string, compiledSource: boolean): boolean => {
+	if (!compiledSource) {
+		return HOMEY_TOKEN_PATTERN.test(text);
+	}
+
+	const sourceFile = ts.createSourceFile('artifact.ts', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	let found = [...text.matchAll(COMMENT_PATTERN)].some((match) => HOMEY_TOKEN_PATTERN.test(match[0]));
+	const visit = (node: ts.Node): void => {
+		if (found) {
+			return;
+		}
+
+		if (
+			ts.isStringLiteral(node) ||
+			ts.isNoSubstitutionTemplateLiteral(node) ||
+			node.kind === ts.SyntaxKind.TemplateHead ||
+			node.kind === ts.SyntaxKind.TemplateMiddle ||
+			node.kind === ts.SyntaxKind.TemplateTail
+		) {
+			const value = (node as ts.StringLiteralLike).text;
+
+			found = !COMPILED_SYMBOL_NAME_PATTERN.test(value) && HOMEY_TOKEN_PATTERN.test(value);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return found;
+};
+
+const containsSerializedSecret = (text: string): boolean =>
+	[...text.matchAll(SERIALIZED_SECRET_PATTERN)].some((match) => {
+		const value = match[2];
+
+		return value !== undefined && value.length > 0 && value !== '[~3~]';
+	});
+
+const assertTextSafe = (label: string, text: string, compiledSource = false): void => {
 	for (const forbidden of FORBIDDEN_PATTERNS) {
 		if (forbidden.pattern.test(text)) {
 			throw new Error(`${label} contains ${forbidden.label}`);
@@ -85,6 +138,14 @@ const assertTextSafe = (label: string, text: string): void => {
 
 	if (containsIpv6Address(text)) {
 		throw new Error(`${label} contains an IPv6 address`);
+	}
+
+	if (containsHomeyToken(text, compiledSource)) {
+		throw new Error(`${label} contains a Homey personal access token`);
+	}
+
+	if (containsSerializedSecret(text)) {
+		throw new Error(`${label} contains a serialized secret value`);
 	}
 
 	for (const privateValue of configuredPrivateValues()) {
@@ -144,12 +205,14 @@ describe('Homey security artifact gate', () => {
 	});
 
 	it('keeps committed Homey fixtures and snapshots free of private values', () => {
-		const fixtureFiles = collectFiles(FIXTURE_ROOT, (path) => extname(path) === '.json');
+		const fixtureFiles = trackedFixtureFiles();
+		const unsupportedFiles = fixtureFiles.filter((path) => !FIXTURE_EXTENSIONS.has(extname(path)));
 		const snapshotFiles = collectFiles(SNAPSHOT_ROOT, (path) => path.endsWith('.snap')).filter(
 			(path) => path.toLocaleLowerCase().includes('homey') || readFileSync(path, 'utf8').includes('devices-homey'),
 		);
 
 		expect(fixtureFiles.length).toBeGreaterThan(0);
+		expect(unsupportedFiles).toEqual([]);
 
 		for (const path of [...fixtureFiles, ...snapshotFiles]) {
 			assertTextSafe(path.slice(REPOSITORY_ROOT.length + 1), readFileSync(path, 'utf8'));
@@ -169,10 +232,8 @@ describe('Homey security artifact gate', () => {
 
 		for (const path of buildFiles) {
 			const text = readFileSync(path, 'utf8');
-			const artifactText =
-				path.endsWith('.js') || path.endsWith('.d.ts') ? text.replace(COMPILED_IDENTIFIER_PATTERN, '') : text;
 
-			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), artifactText);
+			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), text, path.endsWith('.js') || path.endsWith('.d.ts'));
 		}
 	});
 
@@ -190,9 +251,18 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
 			'unsafe fixture contains a serialized secret value',
 		);
+		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"[~3~]unredacted-password"}')).toThrow(
+			'unsafe fixture contains a serialized secret value',
+		);
 		expect(() => assertTextSafe('unsafe fixture', '{"value":"homey_abcdefghijklmnop"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
+		expect(() =>
+			assertTextSafe('unsafe compiled module', 'throw new Error("request failed for homey_abcdefghijklmnop")', true),
+		).toThrow('unsafe compiled module contains a Homey personal access token');
+		expect(() =>
+			assertTextSafe('safe compiled module', 'const homey_local_connector_factory_1 = {};', true),
+		).not.toThrow();
 		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
 			'unsafe fixture contains an IPv4 address',
 		);

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -1,0 +1,177 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { extname, resolve } from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+
+interface OpenApiDocument {
+	components?: {
+		schemas?: Record<string, unknown>;
+	};
+	paths?: Record<string, unknown>;
+}
+
+interface ForbiddenPattern {
+	readonly label: string;
+	readonly pattern: RegExp;
+}
+
+const BACKEND_ROOT = resolve(__dirname, '..');
+const REPOSITORY_ROOT = resolve(__dirname, '../../..');
+const BUILD_ROOT = resolve(BACKEND_ROOT, 'dist/plugins/devices-homey');
+const FIXTURE_ROOT = resolve(BACKEND_ROOT, 'src/plugins/devices-homey/__fixtures__');
+const OPENAPI_PATH = resolve(REPOSITORY_ROOT, 'spec/api/v1/openapi.json');
+const SNAPSHOT_ROOT = resolve(REPOSITORY_ROOT, 'apps');
+const BUILD_EXTENSIONS = new Set(['.js', '.json', '.map']);
+const SECRET_PROPERTY_PATTERN =
+	/^(?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)$/i;
+const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
+	{
+		label: 'private IPv4 address',
+		pattern: /\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b/,
+	},
+	{ label: 'email address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
+	{ label: 'Homey personal access token', pattern: /\b(?:hpat|pat)_[A-Za-z0-9_-]{16,}\b/i },
+	{
+		label: 'serialized secret value',
+		pattern:
+			/["'](?:access[_-]?token|api[_-]?key|authorization|credential|password|refresh[_-]?token|secret)["']\s*:\s*["'](?!\[~3~\])[^"]+["']/i,
+	},
+];
+
+const readJson = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8')) as unknown;
+
+const collectFiles = (root: string, include: (path: string) => boolean): string[] => {
+	if (!existsSync(root)) {
+		return [];
+	}
+
+	return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+		const path = resolve(root, entry.name);
+
+		if (entry.isDirectory()) {
+			return collectFiles(path, include);
+		}
+
+		return entry.isFile() && include(path) ? [path] : [];
+	});
+};
+
+const configuredPrivateValues = (): readonly string[] =>
+	[
+		process.env.FB_HOMEY_SHS_API_KEY,
+		process.env.FB_HOMEY_SHS_EXPECTED_HOST,
+		...(process.env.FB_HOMEY_SHS_PRIVATE_TERMS?.split(',') ?? []),
+	]
+		.map((value) => value?.trim())
+		.filter((value): value is string => value !== undefined && value.length >= 4);
+
+const assertTextSafe = (label: string, text: string): void => {
+	for (const forbidden of FORBIDDEN_PATTERNS) {
+		if (forbidden.pattern.test(text)) {
+			throw new Error(`${label} contains a ${forbidden.label}`);
+		}
+	}
+
+	for (const privateValue of configuredPrivateValues()) {
+		if (text.toLocaleLowerCase().includes(privateValue.toLocaleLowerCase())) {
+			throw new Error(`${label} contains a configured private Homey value`);
+		}
+	}
+};
+
+const visitSchema = (schemaName: string, value: unknown, path: readonly string[] = []): void => {
+	if (Array.isArray(value)) {
+		value.forEach((entry, index) => visitSchema(schemaName, entry, [...path, index.toString()]));
+
+		return;
+	}
+
+	if (value === null || typeof value !== 'object') {
+		return;
+	}
+
+	for (const [key, child] of Object.entries(value as JsonRecord)) {
+		const childPath = [...path, key];
+
+		if (SECRET_PROPERTY_PATTERN.test(key) && child !== null && typeof child === 'object') {
+			const secretSchema = child as JsonRecord;
+
+			if (secretSchema.writeOnly !== true) {
+				throw new Error(`${schemaName}.${childPath.join('.')} is not write-only`);
+			}
+
+			for (const forbiddenKeyword of ['default', 'enum', 'example', 'examples']) {
+				if (forbiddenKeyword in secretSchema) {
+					throw new Error(`${schemaName}.${childPath.join('.')} publishes ${forbiddenKeyword}`);
+				}
+			}
+		}
+
+		visitSchema(schemaName, child, childPath);
+	}
+};
+
+describe('Homey security artifact gate', () => {
+	it('keeps generated Homey OpenAPI schemas and routes secret-safe', () => {
+		const document = readJson(OPENAPI_PATH) as OpenApiDocument;
+		const homeySchemas = Object.fromEntries(
+			Object.entries(document.components?.schemas ?? {}).filter(([name]) => name.startsWith('DevicesHomey')),
+		);
+		const homeyPaths = Object.fromEntries(
+			Object.entries(document.paths ?? {}).filter(([, path]) => JSON.stringify(path).includes('DevicesHomey')),
+		);
+
+		expect(Object.keys(homeySchemas).length).toBeGreaterThan(0);
+		expect(Object.keys(homeyPaths).length).toBeGreaterThan(0);
+		Object.entries(homeySchemas).forEach(([name, schema]) => visitSchema(name, schema));
+		assertTextSafe('generated Homey OpenAPI schemas', JSON.stringify(homeySchemas));
+		assertTextSafe('generated Homey OpenAPI routes', JSON.stringify(homeyPaths));
+	});
+
+	it('keeps committed Homey fixtures and snapshots free of private values', () => {
+		const fixtureFiles = collectFiles(FIXTURE_ROOT, (path) => extname(path) === '.json');
+		const snapshotFiles = collectFiles(SNAPSHOT_ROOT, (path) => path.endsWith('.snap')).filter(
+			(path) => path.toLocaleLowerCase().includes('homey') || readFileSync(path, 'utf8').includes('devices-homey'),
+		);
+
+		expect(fixtureFiles.length).toBeGreaterThan(0);
+
+		for (const path of [...fixtureFiles, ...snapshotFiles]) {
+			assertTextSafe(path.slice(REPOSITORY_ROOT.length + 1), readFileSync(path, 'utf8'));
+		}
+	});
+
+	it('keeps compiled Homey backend artifacts free of private values', () => {
+		const buildFiles = collectFiles(
+			BUILD_ROOT,
+			(path) => path.endsWith('.d.ts') || BUILD_EXTENSIONS.has(extname(path)),
+		);
+
+		if (process.env.HOMEY_SECURITY_REQUIRE_BUILD === '1') {
+			expect(buildFiles.length).toBeGreaterThan(0);
+		}
+
+		for (const path of buildFiles) {
+			assertTextSafe(path.slice(BACKEND_ROOT.length + 1), readFileSync(path, 'utf8'));
+		}
+	});
+
+	it('rejects unsafe secret schemas and private artifact values without echoing them', () => {
+		expect(() =>
+			visitSchema('UnsafeHomeySchema', {
+				properties: { api_key: { type: 'string', example: 'must-not-be-reported' } },
+			}),
+		).toThrow('UnsafeHomeySchema.properties.api_key is not write-only');
+		expect(() =>
+			visitSchema('UnsafeHomeySchema', {
+				properties: { api_key: { type: 'string', writeOnly: true, example: 'must-not-be-reported' } },
+			}),
+		).toThrow('UnsafeHomeySchema.properties.api_key publishes example');
+		expect(() => assertTextSafe('unsafe fixture', '{"api_key":"must-not-be-reported"}')).toThrow(
+			'unsafe fixture contains a serialized secret value',
+		);
+		expect(() => assertTextSafe('unsafe fixture', '{"address":"192.168.1.23"}')).toThrow(
+			'unsafe fixture contains a private IPv4 address',
+		);
+	});
+});

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -457,14 +457,18 @@ const sanitizeCapabilityIdentifier = (value: string, aliases: SanitizationAliase
 	return `${safeBase}.${pseudonym('capability-suffix', value.slice(separator + 1), aliases)}`;
 };
 
-const assertSanitizedCapabilityIdentifier = (value: unknown): void => {
+export const isHomeySanitizedCapabilityIdentifier = (value: unknown): value is string => {
 	if (typeof value !== 'string') {
-		throw new Error('Sanitized Homey capture contains an unredacted sensitive field');
+		return false;
 	}
 
 	const separator = value.indexOf('.');
 
-	if (separator >= 0 && !GENERATED_PSEUDONYM_PATTERN.test(value.slice(separator + 1))) {
+	return separator < 0 || GENERATED_PSEUDONYM_PATTERN.test(value.slice(separator + 1));
+};
+
+const assertSanitizedCapabilityIdentifier = (value: unknown): void => {
+	if (!isHomeySanitizedCapabilityIdentifier(value)) {
 		throw new Error('Sanitized Homey capture contains an unredacted sensitive field');
 	}
 };
@@ -491,6 +495,8 @@ const isTimestampKey = (key: string): boolean =>
 	CAMEL_CASE_TIMESTAMP_KEY_PATTERN.test(key) ||
 	BOUNDED_TIMESTAMP_KEY_PATTERN.test(key) ||
 	HUMAN_TIMESTAMP_KEY_PATTERN.test(key);
+
+export const isHomeyTimestampKey = (key: string): boolean => isTimestampKey(key);
 
 export const isHomeyAddressKey = (key: string): boolean =>
 	CAMEL_CASE_ADDRESS_KEY_PATTERN.test(key) || BOUNDED_ADDRESS_KEY_PATTERN.test(key);

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -406,7 +406,7 @@ const isCapabilityEnumOptionIdentifier = (
 	path[3] === 'values' &&
 	/^\d+$/.test(path[4]);
 
-const isPublicHomeyEnumState = (capabilityId: string, value: string): boolean => {
+export const isPublicHomeyEnumState = (capabilityId: string, value: string): boolean => {
 	const separator = capabilityId.indexOf('.');
 	const capabilityBase = separator < 0 ? capabilityId : capabilityId.slice(0, separator);
 

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -236,7 +236,7 @@ export interface SanitizationAliases {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const isSecretKey = (key: string): boolean =>
+export const isHomeySecretKey = (key: string): boolean =>
 	SECRET_KEY_PATTERN.test(key) ||
 	CAMEL_CASE_SECRET_CODE_KEY_PATTERN.test(key) ||
 	BOUNDED_SECRET_CODE_KEY_PATTERN.test(key);
@@ -536,7 +536,7 @@ const redactScalar = (value: unknown, marker: string): unknown => {
 const sanitizeValue = (value: unknown, key: string, context: SanitizerContext): unknown => {
 	const capabilityMapEntry = isCapabilityMap(context.path, context.rootKind);
 
-	if (!capabilityMapEntry && isSecretKey(key)) {
+	if (!capabilityMapEntry && isHomeySecretKey(key)) {
 		return redactScalar(value, REDACTION.secret);
 	}
 
@@ -1102,7 +1102,7 @@ const assertHomeyPayloadRedacted = (value: unknown, rootKind: SanitizerContext['
 			return;
 		}
 
-		if (!capabilityMapEntry && isSecretKey(key)) {
+		if (!capabilityMapEntry && isHomeySecretKey(key)) {
 			assertRedactedScalar(nestedValue, REDACTION.secret);
 			return;
 		}

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -474,6 +474,15 @@ const isDriverMetadata = (path: string[]): boolean => path.includes('data') || p
 const isIdentifierMap = (key: string): boolean =>
 	CAMEL_CASE_IDENTIFIER_MAP_KEY_PATTERN.test(key) || BOUNDED_IDENTIFIER_MAP_KEY_PATTERN.test(key);
 
+export const isHomeyIdentifierKey = (key: string): boolean => IDENTIFIER_KEY_PATTERN.test(key);
+
+export const isHomeyReferenceKey = (key: string): boolean => REFERENCE_KEY_PATTERN.test(key);
+
+export const isHomeyReferenceArrayKey = (key: string): boolean =>
+	CAMEL_CASE_REFERENCE_ARRAY_KEY_PATTERN.test(key) || BOUNDED_REFERENCE_ARRAY_KEY_PATTERN.test(key);
+
+export const isHomeyUuid = (value: string): boolean => UUID_PATTERN.test(value);
+
 const isTimestampKey = (key: string): boolean =>
 	CAMEL_CASE_TIMESTAMP_KEY_PATTERN.test(key) ||
 	BOUNDED_TIMESTAMP_KEY_PATTERN.test(key) ||
@@ -490,8 +499,7 @@ export const isHomeyPersonalKey = (key: string): boolean =>
 export const isHomeyGeneratedPseudonym = (value: unknown): value is string =>
 	typeof value === 'string' && GENERATED_PSEUDONYM_PATTERN.test(value);
 
-const isReferenceArrayKey = (key: string): boolean =>
-	CAMEL_CASE_REFERENCE_ARRAY_KEY_PATTERN.test(key) || BOUNDED_REFERENCE_ARRAY_KEY_PATTERN.test(key);
+const isReferenceArrayKey = (key: string): boolean => isHomeyReferenceArrayKey(key);
 
 const referenceArrayKind = (key: string): 'device' | 'reference' | 'zone' => {
 	const normalizedKey = key.replaceAll(/[_-]/g, '').toLowerCase();

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -314,7 +314,7 @@ const escapeRegularExpression = (value: string): string => value.replace(/[.*+?^
 
 const ipv6Address = (candidate: string): string => candidate.split('%', 1)[0];
 
-const findIpv6Range = (candidate: string): { end: number; start: number } | null => {
+export const findHomeyIpv6Range = (candidate: string): { end: number; start: number } | null => {
 	const addressCandidate = ipv6Address(candidate);
 	let bestRange: { end: number; start: number } | null = null;
 
@@ -348,12 +348,12 @@ const findIpv6Range = (candidate: string): { end: number; start: number } | null
 const replaceIpv6Candidate = (candidate: string, replacement: string): string => {
 	let remainder = candidate;
 	let sanitized = '';
-	let range = findIpv6Range(remainder);
+	let range = findHomeyIpv6Range(remainder);
 
 	while (range !== null) {
 		sanitized += `${remainder.slice(0, range.start)}${replacement}`;
 		remainder = remainder.slice(range.end);
-		range = findIpv6Range(remainder);
+		range = findHomeyIpv6Range(remainder);
 	}
 
 	return sanitized + remainder;

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -174,6 +174,9 @@ const PUBLIC_HOMEY_CAPABILITY_BASES = new Set([
 	'windowcoverings_state',
 	'windowcoverings_tilt_set',
 ]);
+
+export const isPublicHomeyCapabilityBase = (value: string): boolean => PUBLIC_HOMEY_CAPABILITY_BASES.has(value);
+
 const PUBLIC_HOMEY_ENUM_STATES = new Map<string, ReadonlySet<string>>([
 	['battery_charging_state', new Set(['charging', 'discharging', 'full'])],
 	['light_mode', new Set(['color', 'temperature'])],

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -479,10 +479,13 @@ const isTimestampKey = (key: string): boolean =>
 export const isHomeyAddressKey = (key: string): boolean =>
 	CAMEL_CASE_ADDRESS_KEY_PATTERN.test(key) || BOUNDED_ADDRESS_KEY_PATTERN.test(key);
 
-const isPersonalKey = (key: string): boolean =>
+export const isHomeyPersonalKey = (key: string): boolean =>
 	CAMEL_CASE_PERSONAL_KEY_PATTERN.test(key) ||
 	BOUNDED_PERSONAL_KEY_PATTERN.test(key) ||
 	LOCATION_METADATA_KEY_PATTERN.test(key);
+
+export const isHomeyGeneratedPseudonym = (value: unknown): value is string =>
+	typeof value === 'string' && GENERATED_PSEUDONYM_PATTERN.test(value);
 
 const isReferenceArrayKey = (key: string): boolean =>
 	CAMEL_CASE_REFERENCE_ARRAY_KEY_PATTERN.test(key) || BOUNDED_REFERENCE_ARRAY_KEY_PATTERN.test(key);
@@ -540,7 +543,7 @@ const sanitizeValue = (value: unknown, key: string, context: SanitizerContext): 
 		return redactScalar(value, REDACTION.secret);
 	}
 
-	if (isPersonalKey(key)) {
+	if (isHomeyPersonalKey(key)) {
 		return redactScalar(value, REDACTION.privateTerm);
 	}
 
@@ -1107,7 +1110,7 @@ const assertHomeyPayloadRedacted = (value: unknown, rootKind: SanitizerContext['
 			return;
 		}
 
-		if (isPersonalKey(key)) {
+		if (isHomeyPersonalKey(key)) {
 			if (key !== 'name' || typeof nestedValue !== 'string' || !GENERATED_PSEUDONYM_PATTERN.test(nestedValue)) {
 				assertRedactedScalar(nestedValue, REDACTION.privateTerm);
 			}

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -482,6 +482,10 @@ export const isHomeyIdentifierMapKey = (key: string): boolean => isIdentifierMap
 
 export const isHomeyEndpointKey = (key: string): boolean => ENDPOINT_KEY_PATTERN.test(key);
 
+export const isHomeyIconKey = (key: string): boolean => DEVICE_ICON_KEY_PATTERN.test(key);
+
+export const isHomeyIsoTimestamp = (value: string): boolean => ISO_TIMESTAMP_PATTERN.test(value);
+
 export const isHomeyIdentifierKey = (key: string): boolean => IDENTIFIER_KEY_PATTERN.test(key);
 
 export const isHomeyReferenceKey = (key: string): boolean => REFERENCE_KEY_PATTERN.test(key);

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -474,6 +474,10 @@ const isDriverMetadata = (path: string[]): boolean => path.includes('data') || p
 const isIdentifierMap = (key: string): boolean =>
 	CAMEL_CASE_IDENTIFIER_MAP_KEY_PATTERN.test(key) || BOUNDED_IDENTIFIER_MAP_KEY_PATTERN.test(key);
 
+export const isHomeyIdentifierMapKey = (key: string): boolean => isIdentifierMap(key);
+
+export const isHomeyEndpointKey = (key: string): boolean => ENDPOINT_KEY_PATTERN.test(key);
+
 export const isHomeyIdentifierKey = (key: string): boolean => IDENTIFIER_KEY_PATTERN.test(key);
 
 export const isHomeyReferenceKey = (key: string): boolean => REFERENCE_KEY_PATTERN.test(key);

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -476,7 +476,7 @@ const isTimestampKey = (key: string): boolean =>
 	BOUNDED_TIMESTAMP_KEY_PATTERN.test(key) ||
 	HUMAN_TIMESTAMP_KEY_PATTERN.test(key);
 
-const isAddressKey = (key: string): boolean =>
+export const isHomeyAddressKey = (key: string): boolean =>
 	CAMEL_CASE_ADDRESS_KEY_PATTERN.test(key) || BOUNDED_ADDRESS_KEY_PATTERN.test(key);
 
 const isPersonalKey = (key: string): boolean =>
@@ -548,7 +548,7 @@ const sanitizeValue = (value: unknown, key: string, context: SanitizerContext): 
 		return redactScalar(value, FIXTURE_TIMESTAMP);
 	}
 
-	if (value !== null && !capabilityMapEntry && isAddressKey(key)) {
+	if (value !== null && !capabilityMapEntry && isHomeyAddressKey(key)) {
 		return redactScalar(value, REDACTION.address);
 	}
 
@@ -1119,7 +1119,7 @@ const assertHomeyPayloadRedacted = (value: unknown, rootKind: SanitizerContext['
 			return;
 		}
 
-		if (nestedValue !== null && !capabilityMapEntry && isAddressKey(key)) {
+		if (nestedValue !== null && !capabilityMapEntry && isHomeyAddressKey(key)) {
 			assertRedactedScalar(nestedValue, REDACTION.address);
 			return;
 		}
@@ -1474,7 +1474,7 @@ export const assertHomeyCaptureSafe = (
 			if (typeof value === 'string') {
 				const endpointShaped =
 					globallyIdentifiableHost ||
-					isAddressKey(key) ||
+					isHomeyAddressKey(key) ||
 					ENDPOINT_KEY_PATTERN.test(key) ||
 					value.includes('://') ||
 					new RegExp(`${escapedHost}:\\d+`, 'i').test(value);
@@ -1491,7 +1491,7 @@ export const assertHomeyCaptureSafe = (
 
 				Object.entries(value).forEach(([nestedKey, nestedValue]) => {
 					const endpointShapedKey =
-						isAddressKey(nestedKey) ||
+						isHomeyAddressKey(nestedKey) ||
 						ENDPOINT_KEY_PATTERN.test(nestedKey) ||
 						nestedKey.includes('://') ||
 						new RegExp(`${escapedHost}:\\d+`, 'i').test(nestedKey);

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -601,8 +601,8 @@ suite completes with 1,032 passing tests and five existing locator-dependent ski
 - [x] OpenAPI/spec generation is clean and generated diffs are intentional.
 - [x] Default CI requires no live Homey/SHS access.
 
-The 2026-08-25 automated local gate passed 36 Homey backend suites with 449 tests, nine credential-free compatibility
-and performance suites with 125 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
+The 2026-08-25 automated local gate passed 37 Homey/security backend suites with 469 tests, ten credential-free
+compatibility, performance, and security suites with 129 tests, the complete 300-file/2,253-test admin suite, and all 23 representative Homey panel
 pipeline tests. OpenAPI plus device/channel spec regeneration produced no diff. PR #828 also passed the default backend
 unit/E2E, admin, panel, testing-app, web-build, schema, and analysis jobs; its Homey spike job received no live SHS
 credentials, while every live or mutating probe remains protected by its explicit environment gate and allowlist.
@@ -632,7 +632,7 @@ representative lifecycle failure paths.
 - [x] Measure inventory/normalization with up to 250 fixture-generated devices and on supported panel/backend hardware where available.
 - [x] Measure capability event handoff and command-start latency against design targets.
 - [x] Confirm no full inventory call occurs per event.
-- [ ] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
+- [x] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
 - [ ] Verify all external calls have timeouts and reconnect loops have upper bounds.
 - [ ] Verify no route or service can delete/pair/rename an upstream Homey device.
 
@@ -654,6 +654,14 @@ The gate also asserts that capability updates leave the startup inventory call c
 device reads. Run it from the repository root with
 `pnpm --filter ./apps/backend run homey:latency-gate`; the measurements cover backend scheduling and synchronization-queue
 overhead and deliberately exclude Homey network response time and subsequent command confirmation.
+
+The 2026-08-25 credential-free security gate regenerated OpenAPI without a diff, compiled the backend, structurally
+verified that every Homey secret property remains write-only and publishes no example/default value, and scanned the
+Homey routes, fixture/evidence corpus, snapshots, and compiled artifacts for private addresses, email addresses, token
+shapes, serialized secrets, and any configured live-test private values. It then passed all ten compatibility,
+performance, and security suites (129 tests) plus 37 Homey/config security suites (469 tests), including the response,
+logging, redaction, and error-sanitization coverage. Run the complete gate from `apps/backend` with
+`pnpm run homey:security-gate`; the scan reports only the artifact and violation category, never the matched value.
 
 ### Task 6.4: Documentation and release checklist
 


### PR DESCRIPTION
## Summary

- add a credential-free scanner for Homey OpenAPI schemas, routes, fixtures, snapshots, and compiled artifacts
- reject published secret examples/defaults, serialized credentials, private addresses, email addresses, token shapes, and configured live-test private values
- add a complete gate covering OpenAPI regeneration, backend compilation, compatibility spikes, config responses, logs, redaction, and sanitized errors
- record the Task 6.3 security evidence

## Validation

- pnpm run homey:security-gate
  - 10 Homey spike suites, 129 tests
  - 37 Homey/config backend suites, 469 tests
- pnpm run type-check
- pnpm exec eslint test/homey-security-artifact.homey-spike.ts
- Prettier checks
- git diff --check
- generated OpenAPI remained unchanged