### PR TITLE
test(cross): enforce Homey production boundaries

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts
@@ -1,0 +1,136 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { extname, relative, resolve } from 'node:path';
+
+import { HomeyConnector } from './homey-connector.interface';
+import { HomeyLocalTransport } from './homey-local.transport';
+import {
+	HomeySdkClient,
+	HomeySdkDevice,
+	HomeySdkDevicesManager,
+	HomeySdkSystemManager,
+	HomeySdkZonesManager,
+} from './homey-sdk.client';
+
+const CONNECTOR_SURFACE = {
+	connect: true,
+	disconnect: true,
+	getDevice: true,
+	getDevices: true,
+	getSystemInfo: true,
+	getZones: true,
+	setCapabilityValue: true,
+	subscribe: true,
+} satisfies Record<keyof HomeyConnector, true>;
+
+const LOCAL_TRANSPORT_SURFACE = {
+	connect: true,
+	disconnect: true,
+	getDevice: true,
+	getDevices: true,
+	getSystemInfo: true,
+	getZones: true,
+	setCapabilityValue: true,
+	subscribe: true,
+} satisfies Record<keyof HomeyLocalTransport, true>;
+
+const SDK_CLIENT_SURFACE = {
+	destroy: true,
+	devices: true,
+	disconnect: true,
+	id: true,
+	name: true,
+	system: true,
+	version: true,
+	zones: true,
+} satisfies Record<keyof HomeySdkClient, true>;
+
+const SDK_DEVICE_SURFACE = {
+	available: true,
+	connect: true,
+	disconnect: true,
+	id: true,
+	off: true,
+	on: true,
+} satisfies Record<keyof HomeySdkDevice, true>;
+
+const SDK_DEVICES_MANAGER_SURFACE = {
+	connect: true,
+	disconnect: true,
+	getDevice: true,
+	getDevices: true,
+	off: true,
+	on: true,
+	setCapabilityValue: true,
+} satisfies Record<keyof HomeySdkDevicesManager, true>;
+
+const SDK_SYSTEM_MANAGER_SURFACE = {
+	getInfo: true,
+} satisfies Record<keyof HomeySdkSystemManager, true>;
+
+const SDK_ZONES_MANAGER_SURFACE = {
+	connect: true,
+	disconnect: true,
+	getZones: true,
+	off: true,
+	on: true,
+} satisfies Record<keyof HomeySdkZonesManager, true>;
+
+const FORBIDDEN_UPSTREAM_OPERATIONS = new Set([
+	'addDevice',
+	'createDevice',
+	'createPairSession',
+	'deleteDevice',
+	'drivers',
+	'getPairSession',
+	'pairDevice',
+	'removeDevice',
+	'renameDevice',
+	'updateDevice',
+]);
+
+const PLUGIN_ROOT = resolve(__dirname, '..');
+const SDK_CLIENT_PATH = resolve(__dirname, 'homey-sdk.client.ts');
+
+const collectProductionTypescript = (root: string): readonly string[] =>
+	readdirSync(root, { withFileTypes: true }).flatMap((entry): readonly string[] => {
+		const path = resolve(root, entry.name);
+
+		if (entry.isDirectory()) {
+			return collectProductionTypescript(path);
+		}
+
+		return entry.isFile() && extname(path) === '.ts' && !path.endsWith('.spec.ts') ? [path] : [];
+	});
+
+describe('Homey production boundary', () => {
+	it('locks the provider boundary to reads, subscriptions, and capability writes', () => {
+		expect(Object.keys(CONNECTOR_SURFACE).sort()).toStrictEqual(Object.keys(LOCAL_TRANSPORT_SURFACE).sort());
+		expect(
+			Object.keys(CONNECTOR_SURFACE).filter((operation) => FORBIDDEN_UPSTREAM_OPERATIONS.has(operation)),
+		).toStrictEqual([]);
+	});
+
+	it('keeps the reviewed SDK surface free of upstream lifecycle mutations', () => {
+		const sdkSurface = [
+			...Object.keys(SDK_CLIENT_SURFACE),
+			...Object.keys(SDK_DEVICE_SURFACE),
+			...Object.keys(SDK_DEVICES_MANAGER_SURFACE),
+			...Object.keys(SDK_SYSTEM_MANAGER_SURFACE),
+			...Object.keys(SDK_ZONES_MANAGER_SURFACE),
+		];
+
+		expect(sdkSurface.filter((operation) => FORBIDDEN_UPSTREAM_OPERATIONS.has(operation))).toStrictEqual([]);
+	});
+
+	it('allows only the reviewed SDK client adapter to import homey-api', () => {
+		const importers = collectProductionTypescript(PLUGIN_ROOT)
+			.filter((path) => {
+				const source = readFileSync(path, 'utf8');
+
+				return source.includes("'homey-api'") || source.includes('"homey-api"');
+			})
+			.map((path) => relative(PLUGIN_ROOT, path));
+
+		expect(importers).toStrictEqual([relative(PLUGIN_ROOT, SDK_CLIENT_PATH)]);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { extname, relative, resolve } from 'node:path';
+import ts from 'typescript';
 
 import { HomeyConnector } from './homey-connector.interface';
 import { HomeyLocalTransport } from './homey-local.transport';
@@ -75,19 +76,6 @@ const SDK_ZONES_MANAGER_SURFACE = {
 	on: true,
 } satisfies Record<keyof HomeySdkZonesManager, true>;
 
-const FORBIDDEN_UPSTREAM_OPERATIONS = new Set([
-	'addDevice',
-	'createDevice',
-	'createPairSession',
-	'deleteDevice',
-	'drivers',
-	'getPairSession',
-	'pairDevice',
-	'removeDevice',
-	'renameDevice',
-	'updateDevice',
-]);
-
 const PLUGIN_ROOT = resolve(__dirname, '..');
 const SDK_CLIENT_PATH = resolve(__dirname, 'homey-sdk.client.ts');
 
@@ -102,35 +90,117 @@ const collectProductionTypescript = (root: string): readonly string[] =>
 		return entry.isFile() && extname(path) === '.ts' && !path.endsWith('.spec.ts') ? [path] : [];
 	});
 
+const homeyApiModuleSpecifiers = (source: string): readonly string[] => {
+	const sourceFile = ts.createSourceFile('production.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	const specifiers: string[] = [];
+	const addSpecifier = (node: ts.Expression | undefined): void => {
+		if (
+			node !== undefined &&
+			ts.isStringLiteralLike(node) &&
+			(node.text === 'homey-api' || node.text.startsWith('homey-api/'))
+		) {
+			specifiers.push(node.text);
+		}
+	};
+	const visit = (node: ts.Node): void => {
+		if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+			addSpecifier(node.moduleSpecifier);
+		} else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+			addSpecifier(node.moduleReference.expression);
+		} else if (
+			ts.isCallExpression(node) &&
+			(node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+				(ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+		) {
+			addSpecifier(node.arguments[0]);
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+
+	return specifiers;
+};
+
 describe('Homey production boundary', () => {
 	it('locks the provider boundary to reads, subscriptions, and capability writes', () => {
-		expect(Object.keys(CONNECTOR_SURFACE).sort()).toStrictEqual(Object.keys(LOCAL_TRANSPORT_SURFACE).sort());
-		expect(
-			Object.keys(CONNECTOR_SURFACE).filter((operation) => FORBIDDEN_UPSTREAM_OPERATIONS.has(operation)),
-		).toStrictEqual([]);
+		const allowedOperations = [
+			'connect',
+			'disconnect',
+			'getDevice',
+			'getDevices',
+			'getSystemInfo',
+			'getZones',
+			'setCapabilityValue',
+			'subscribe',
+		];
+
+		expect(Object.keys(CONNECTOR_SURFACE).sort()).toStrictEqual(allowedOperations);
+		expect(Object.keys(LOCAL_TRANSPORT_SURFACE).sort()).toStrictEqual(allowedOperations);
 	});
 
 	it('keeps the reviewed SDK surface free of upstream lifecycle mutations', () => {
-		const sdkSurface = [
-			...Object.keys(SDK_CLIENT_SURFACE),
-			...Object.keys(SDK_DEVICE_SURFACE),
-			...Object.keys(SDK_DEVICES_MANAGER_SURFACE),
-			...Object.keys(SDK_SYSTEM_MANAGER_SURFACE),
-			...Object.keys(SDK_ZONES_MANAGER_SURFACE),
-		];
-
-		expect(sdkSurface.filter((operation) => FORBIDDEN_UPSTREAM_OPERATIONS.has(operation))).toStrictEqual([]);
+		expect(Object.keys(SDK_CLIENT_SURFACE).sort()).toStrictEqual([
+			'destroy',
+			'devices',
+			'disconnect',
+			'id',
+			'name',
+			'system',
+			'version',
+			'zones',
+		]);
+		expect(Object.keys(SDK_DEVICE_SURFACE).sort()).toStrictEqual([
+			'available',
+			'connect',
+			'disconnect',
+			'id',
+			'off',
+			'on',
+		]);
+		expect(Object.keys(SDK_DEVICES_MANAGER_SURFACE).sort()).toStrictEqual([
+			'connect',
+			'disconnect',
+			'getDevice',
+			'getDevices',
+			'off',
+			'on',
+			'setCapabilityValue',
+		]);
+		expect(Object.keys(SDK_SYSTEM_MANAGER_SURFACE)).toStrictEqual(['getInfo']);
+		expect(Object.keys(SDK_ZONES_MANAGER_SURFACE).sort()).toStrictEqual([
+			'connect',
+			'disconnect',
+			'getZones',
+			'off',
+			'on',
+		]);
 	});
 
 	it('allows only the reviewed SDK client adapter to import homey-api', () => {
 		const importers = collectProductionTypescript(PLUGIN_ROOT)
-			.filter((path) => {
-				const source = readFileSync(path, 'utf8');
-
-				return source.includes("'homey-api'") || source.includes('"homey-api"');
-			})
+			.filter((path) => homeyApiModuleSpecifiers(readFileSync(path, 'utf8')).length > 0)
 			.map((path) => relative(PLUGIN_ROOT, path));
 
 		expect(importers).toStrictEqual([relative(PLUGIN_ROOT, SDK_CLIENT_PATH)]);
+	});
+
+	it('detects package-root and subpath module specifiers without matching ordinary text', () => {
+		expect(
+			homeyApiModuleSpecifiers(`
+				import root from 'homey-api';
+				export { default as local } from 'homey-api/lib/HomeyAPI/HomeyAPIV3Local';
+				const dynamic = import('homey-api/lib/HomeyAPI');
+				const legacy = require('homey-api/lib/ManagerDevices');
+				const ordinary = 'homey-api/lib/not-an-import';
+				// import ignored from 'homey-api/lib/comment';
+			`),
+		).toStrictEqual([
+			'homey-api',
+			'homey-api/lib/HomeyAPI/HomeyAPIV3Local',
+			'homey-api/lib/HomeyAPI',
+			'homey-api/lib/ManagerDevices',
+		]);
 	});
 });

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -633,8 +633,8 @@ representative lifecycle failure paths.
 - [x] Measure capability event handoff and command-start latency against design targets.
 - [x] Confirm no full inventory call occurs per event.
 - [x] Scan config responses, logs, fixtures, snapshots, build artifacts, and generated OpenAPI examples for secrets/private data.
-- [ ] Verify all external calls have timeouts and reconnect loops have upper bounds.
-- [ ] Verify no route or service can delete/pair/rename an upstream Homey device.
+- [x] Verify all external calls have timeouts and reconnect loops have upper bounds.
+- [x] Verify no route or service can delete/pair/rename an upstream Homey device.
 
 The 2026-08-25 credential-free inventory gate generated 250 unique devices by cycling the nine immutable live raw
 fixtures, then ran the production local transformer plus all built-in device/channel/property mapping resolution. After
@@ -662,6 +662,17 @@ shapes, serialized secrets, and any configured live-test private values. It then
 performance, and security suites (129 tests) plus 37 Homey/config security suites (469 tests), including the response,
 logging, redaction, and error-sanitization coverage. Run the complete gate from `apps/backend` with
 `pnpm run homey:security-gate`; the scan reports only the artifact and violation category, never the matched value.
+
+The 2026-08-26 production-boundary audit confirmed that the exact-pinned SDK is imported only by the reviewed client
+adapter and that every promise-returning SDK operation is invoked through the adapter's outer connection-timeout
+watchdog. SDK reads and the sole allowed upstream mutation, a capability-value write, also receive the SDK-native
+`$timeout`. Configuration bounds the connection timeout to 1–60 seconds; reconnect calculation and scheduling cap every
+attempt at 30 seconds, including non-finite and very large attempt counters. `homey-production-boundary.spec.ts` locks
+the production connector, local transport, client, device, and manager type surfaces so adding a pairing, device
+creation/update/rename, or deletion operation requires an explicit security-gate change. It also enforces that no other
+production plugin file imports `homey-api`. Controllers and services depend only on the locked `HomeyConnector` surface,
+whose only upstream state mutation is `setCapabilityValue`; upstream lifecycle operations remain confined to separately
+gated compatibility probes under `test/`.
 
 ### Task 6.4: Documentation and release checklist
 


### PR DESCRIPTION
## Summary

- lock the Homey connector, local transport, and reviewed SDK type surfaces to reads, subscriptions, and capability writes
- ensure only the reviewed SDK client adapter imports `homey-api`
- record bounded timeout/reconnect and non-destructive upstream-operation evidence, completing implementation-plan Task 6.3

## Verification

- `pnpm exec eslint src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts`
- `pnpm exec jest --runInBand src/plugins/devices-homey/connectors/homey-production-boundary.spec.ts src/plugins/devices-homey/connectors/homey-sdk.transport.spec.ts src/plugins/devices-homey/services/homey-reconnect-backoff.spec.ts` (3 suites, 27 tests)
- `pnpm run homey:security-gate` (10/129 credential-free suites; 39/482 Homey/config suites)
- OpenAPI generation produced no diff