### PR TITLE
docs(cross): add Homey operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A smart touchscreen interface for your smart home.
 
 **FastyBird Smart Panel** is a modular and extensible **user interface platform** designed to bring your smart home system to life on touchscreen displays.
 
-It provides a seamless way to interact with your home setup, acting as a **real-time control dashboard** for systems like Home Assistant, Homey, Shelly, Zigbee2MQTT, WLED, and more.
+It provides a seamless way to interact with your home setup, acting as a **real-time control dashboard** for systems like Home Assistant, Shelly, Zigbee2MQTT, WLED, and more, with an experimental Homey integration under validation.
 
 ---
 
@@ -50,7 +50,7 @@ Crafted with **Flutter**, the display app runs smoothly on Raspberry Pi and othe
 | Integration | Protocol | Description |
 |-------------|----------|-------------|
 | **Home Assistant** | WebSocket API | Full entity sync with Home Assistant instances |
-| **Homey** | Local API / Socket.IO | Reviewed adoption, real-time state, reconciliation, and control for local Homey Pro and Homey SHS instances |
+| **Homey (Experimental)** | Local API / Socket.IO | Local adoption, state, reconciliation, and controls; required live release validation is still in progress |
 | **Shelly (Gen 2+)** | HTTP/CoAP | Native support for Shelly Gen 2+ (NG) devices |
 | **Shelly (Gen 1)** | HTTP/CoAP | Support for Shelly Gen 1 devices |
 | **Zigbee2MQTT** | MQTT | Integration with Zigbee devices via Zigbee2MQTT |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A smart touchscreen interface for your smart home.
 
 **FastyBird Smart Panel** is a modular and extensible **user interface platform** designed to bring your smart home system to life on touchscreen displays.
 
-It provides a seamless way to interact with your home setup, acting as a **real-time control dashboard** for systems like Home Assistant, Shelly, Zigbee2MQTT, WLED, and more.
+It provides a seamless way to interact with your home setup, acting as a **real-time control dashboard** for systems like Home Assistant, Homey, Shelly, Zigbee2MQTT, WLED, and more.
 
 ---
 
@@ -50,6 +50,7 @@ Crafted with **Flutter**, the display app runs smoothly on Raspberry Pi and othe
 | Integration | Protocol | Description |
 |-------------|----------|-------------|
 | **Home Assistant** | WebSocket API | Full entity sync with Home Assistant instances |
+| **Homey** | Local API / Socket.IO | Reviewed adoption, real-time state, reconciliation, and control for local Homey Pro and Homey SHS instances |
 | **Shelly (Gen 2+)** | HTTP/CoAP | Native support for Shelly Gen 2+ (NG) devices |
 | **Shelly (Gen 1)** | HTTP/CoAP | Support for Shelly Gen 1 devices |
 | **Zigbee2MQTT** | MQTT | Integration with Zigbee devices via Zigbee2MQTT |

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -43,23 +43,13 @@ known secret, private-address, email, identifier, and private-term shapes before
 
 1. Create a dedicated read-only API key with `homey.system.readonly`, `homey.zone.readonly`, and
    `homey.device.readonly`. Do not use a household administrator key.
-2. From `apps/backend`, enter the live values interactively so the key does not appear in shell history:
+2. From `apps/backend`, follow the interactive read-only capture commands in the repository's Homey compatibility
+   document. Enter the URL, exact expected host, API key, and comma-separated private-term defense list without placing
+   the key in shell history, then run `pnpm run homey:probe`. That document is the source of truth for environment
+   variable names, validation rules, and optional bounds.
 
-   ```bash
-   read -r FB_HOMEY_SHS_URL
-   read -r FB_HOMEY_SHS_EXPECTED_HOST
-   read -r -s FB_HOMEY_SHS_API_KEY
-   read -r FB_HOMEY_SHS_PRIVATE_TERMS
-   export FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
-   pnpm run homey:probe
-   ```
-
-   `FB_HOMEY_SHS_EXPECTED_HOST` must exactly match the URL host. `FB_HOMEY_SHS_PRIVATE_TERMS` is a comma-separated
-   defense-in-depth list of household names or other strings that must never survive sanitization. See
-   `docs/homey-shs-compatibility.md` for the complete probe contract and optional bounds.
-
-3. Record the Homey/SHS version, deployment image digest, network topology, ports, and test date in
-   `docs/homey-shs-compatibility.md`. Never record the API key, private host, private addresses, or household names.
+3. Record the Homey/SHS version, deployment image digest, network topology, ports, and test date in the same compatibility
+   document. Never record the API key, private host, private addresses, or household names.
 4. Inspect the generated capture under `test/.homey-shs-captures/`. Review every key and value even though the probe
    passed. The full capture remains ignored and local; never add it to Git.
 5. Promote only the smallest representative subset:
@@ -74,12 +64,8 @@ known secret, private-address, email, identifier, and private-term shapes before
    and the complete Git diff. Promotion must not turn an unobserved capability into live evidence. Use a separately
    versioned, explicitly synthetic published-protocol fixture when a contract needs coverage but no physical device was
    observed.
-7. Run `pnpm run homey:security-gate` before committing. Unset every live variable afterward:
-
-   ```bash
-   unset FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
-   unset FB_HOMEY_SHS_TIMEOUT_MS FB_HOMEY_SHS_CAPTURE_DIR
-   ```
+7. Run `pnpm run homey:security-gate` before committing. Unset every live Homey probe variable listed in the
+   compatibility document afterward.
 
 If any command reports a possible secret or private value, stop. Expand the sanitizer/private-term coverage and produce
 a new capture; never edit a leaked value out of a capture and treat the remainder as trusted.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -36,14 +36,53 @@ contracts live outside `versions/` and are pinned independently through `synthet
 generation and tests cannot treat them as captured inventory. A future live capture produced by the corrected probe may
 replace these gaps; promotion now rejects redacted or duplicate enum IDs.
 
-To regenerate the selected subset from an ignored sanitized capture:
+## Refreshing fixtures for a new Homey or SHS version
 
-```bash
-cd apps/backend
-pnpm run homey:promote-fixtures -- test/.homey-shs-captures/<capture-directory>
-pnpm run homey:generate-normalized-fixtures
-pnpm run test:homey-spike
-```
+Never promote raw Homey responses. The capture command writes a locally ignored, already sanitized corpus and rejects
+known secret, private-address, email, identifier, and private-term shapes before reporting success.
+
+1. Create a dedicated read-only API key with `homey.system.readonly`, `homey.zone.readonly`, and
+   `homey.device.readonly`. Do not use a household administrator key.
+2. From `apps/backend`, enter the live values interactively so the key does not appear in shell history:
+
+   ```bash
+   read -r FB_HOMEY_SHS_URL
+   read -r FB_HOMEY_SHS_EXPECTED_HOST
+   read -r -s FB_HOMEY_SHS_API_KEY
+   read -r FB_HOMEY_SHS_PRIVATE_TERMS
+   export FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
+   pnpm run homey:probe
+   ```
+
+   `FB_HOMEY_SHS_EXPECTED_HOST` must exactly match the URL host. `FB_HOMEY_SHS_PRIVATE_TERMS` is a comma-separated
+   defense-in-depth list of household names or other strings that must never survive sanitization. See
+   `docs/homey-shs-compatibility.md` for the complete probe contract and optional bounds.
+
+3. Record the Homey/SHS version, deployment image digest, network topology, ports, and test date in
+   `docs/homey-shs-compatibility.md`. Never record the API key, private host, private addresses, or household names.
+4. Inspect the generated capture under `test/.homey-shs-captures/`. Review every key and value even though the probe
+   passed. The full capture remains ignored and local; never add it to Git.
+5. Promote only the smallest representative subset:
+
+   ```bash
+   pnpm run homey:promote-fixtures -- test/.homey-shs-captures/<capture-directory>
+   pnpm run homey:generate-normalized-fixtures
+   pnpm run test:homey-spike
+   ```
+
+6. Review the new immutable raw version, the `current` symlink change, manifest evidence gaps, normalized golden output,
+   and the complete Git diff. Promotion must not turn an unobserved capability into live evidence. Use a separately
+   versioned, explicitly synthetic published-protocol fixture when a contract needs coverage but no physical device was
+   observed.
+7. Run `pnpm run homey:security-gate` before committing. Unset every live variable afterward:
+
+   ```bash
+   unset FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY FB_HOMEY_SHS_PRIVATE_TERMS
+   unset FB_HOMEY_SHS_TIMEOUT_MS FB_HOMEY_SHS_CAPTURE_DIR
+   ```
+
+If any command reports a possible secret or private value, stop. Expand the sanitizer/private-term coverage and produce
+a new capture; never edit a leaked value out of a capture and treat the remainder as trusted.
 
 `expected/v1` contains the reviewed transport-neutral output for every representative device and the complete zone
 hierarchy. Its manifest pins the immutable raw fixture version used as input. These files are golden expectations, not

--- a/apps/website/app/docs/extensions/_meta.js
+++ b/apps/website/app/docs/extensions/_meta.js
@@ -1,6 +1,7 @@
 export default {
   overview: "Overview",
   "device-integrations": "Device Integrations",
+  homey: "Homey",
   "extension-development": {
     type: "separator",
     title: "For Developers",

--- a/apps/website/app/docs/extensions/_meta.js
+++ b/apps/website/app/docs/extensions/_meta.js
@@ -1,7 +1,7 @@
 export default {
   overview: "Overview",
   "device-integrations": "Device Integrations",
-  homey: "Homey",
+  homey: "Homey (Experimental)",
   "extension-development": {
     type: "separator",
     title: "For Developers",

--- a/apps/website/app/docs/extensions/device-integrations/page.mdx
+++ b/apps/website/app/docs/extensions/device-integrations/page.mdx
@@ -19,7 +19,7 @@ device → channel → property hierarchy.
 | Plugin | Protocol | Discovery | Description |
 |--------|----------|-----------|-------------|
 | **Home Assistant** | WebSocket | Automatic | Imports devices and entities from a Home Assistant instance. Bidirectional real-time sync — state changes and commands flow both ways instantly. Requires a long-lived access token. |
-| [**Homey**](/docs/extensions/homey) | Local API / Socket.IO | Manual server, automatic device inventory | Connects to Homey Pro or Homey Self-Hosted Server on the local network. Provides reviewed adoption, real-time state, reconciliation, and supported controls through a least-privilege API key. |
+| [**Homey (Experimental)**](/docs/extensions/homey) | Local API / Socket.IO | Manual server, automatic device inventory | Implements reviewed adoption, synchronization, and supported controls for local Homey APIs. The live release gate is incomplete; verified live scope is currently limited to SHS 13.4.0 over HTTP for inventory and selected session behavior. |
 | **Shelly NG** | mDNS / RPC | Automatic | Discovers and controls Shelly Next-Generation devices (Plus, Pro, BLU series) on the local network. No cloud dependency — all communication stays local. |
 | **Shelly v1** | HTTP / CoAP | Automatic | Support for first-generation Shelly devices using the original HTTP and CoAP APIs. |
 | **WLED** | HTTP | Automatic | Controls WLED-based LED strips and lights discovered on the local network. |

--- a/apps/website/app/docs/extensions/device-integrations/page.mdx
+++ b/apps/website/app/docs/extensions/device-integrations/page.mdx
@@ -19,6 +19,7 @@ device → channel → property hierarchy.
 | Plugin | Protocol | Discovery | Description |
 |--------|----------|-----------|-------------|
 | **Home Assistant** | WebSocket | Automatic | Imports devices and entities from a Home Assistant instance. Bidirectional real-time sync — state changes and commands flow both ways instantly. Requires a long-lived access token. |
+| [**Homey**](/docs/extensions/homey) | Local API / Socket.IO | Manual server, automatic device inventory | Connects to Homey Pro or Homey Self-Hosted Server on the local network. Provides reviewed adoption, real-time state, reconciliation, and supported controls through a least-privilege API key. |
 | **Shelly NG** | mDNS / RPC | Automatic | Discovers and controls Shelly Next-Generation devices (Plus, Pro, BLU series) on the local network. No cloud dependency — all communication stays local. |
 | **Shelly v1** | HTTP / CoAP | Automatic | Support for first-generation Shelly devices using the original HTTP and CoAP APIs. |
 | **WLED** | HTTP | Automatic | Controls WLED-based LED strips and lights discovered on the local network. |
@@ -51,7 +52,8 @@ API tokens, or polling intervals.
 
 <Callout>
 	Plugins with automatic discovery require minimal configuration — often just enabling the plugin
-	is enough. Third-party devices are the exception, as each device is created individually.
+	is enough. Homey requires a manual local server URL and API key before its device inventory becomes available.
+	Third-party devices are created individually.
 </Callout>
 
 ---
@@ -59,4 +61,5 @@ API tokens, or polling intervals.
 ## What's Next?
 
 - [**Building Extensions**](/docs/extensions/building-extensions) — create your own device plugin
+- [**Homey setup**](/docs/extensions/homey) — connect, adopt, and troubleshoot Homey devices
 - [**API Reference**](https://fastybird.stoplight.io/docs/smart-panel) — full endpoint documentation for plugin APIs

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -1,0 +1,201 @@
+import { Callout } from "nextra/components";
+
+# Homey
+
+The Homey integration connects Smart Panel directly to a Homey Pro or Homey Self-Hosted Server (SHS) on the local
+network. It imports logical devices already managed by Homey, lets an administrator review and adopt them, keeps their
+state synchronized, and sends supported controls back to Homey.
+
+<Callout type="warning">
+  This release supports a **local Homey connection only**. Homey Cloud/OAuth is
+  not available yet. Smart Panel also does not pair, rename, move, or remove
+  devices in Homey.
+</Callout>
+
+## Before You Start
+
+You need:
+
+- a configured Homey Pro or [Homey Self-Hosted Server](https://support.homey.app/hc/en-us/articles/23975096785948-How-to-install-Homey-Self-Hosted-Server-on-Linux);
+- network access from the **Smart Panel backend** to Homey's local API;
+- the complete local API URL, including `http://` or `https://` and any non-standard port; and
+- a dedicated Homey API key with only the permissions Smart Panel needs.
+
+SHS uses port `4859` for HTTP and `4860` for HTTPS by default. Those ports can be overridden in the SHS deployment.
+Use the address and port reachable from the machine or container running Smart Panel, which may differ from an address
+that works in your desktop browser.
+
+Examples:
+
+```text
+http://192.168.1.50:4859
+https://homey.example.net
+```
+
+Do not put a username, password, API path, query string, or API key in the URL. Prefer HTTPS when the network endpoint
+has a certificate trusted by the Smart Panel host. Do not expose the local API directly to the public internet merely
+to connect Smart Panel; use a private network or a correctly secured reverse proxy when the services are on different
+networks.
+
+For SHS installation and network settings, follow Homey's platform-specific installation guide. Homey's
+[port-forwarding guide](https://support.homey.app/hc/en-us/articles/24722267664156-Set-up-port-forwarding-for-Homey-Self-Hosted-Server)
+documents the default HTTPS port, but port forwarding is not required when Smart Panel and Homey can communicate on
+the same private network.
+
+## Create a Least-Privilege API Key
+
+In the [Homey Web App](https://my.homey.app), open **Settings → API Keys**, choose **New API Key**, give the key a name
+such as `Smart Panel`, and grant:
+
+| Permission              | Why Smart Panel needs it                                   |
+| ----------------------- | ---------------------------------------------------------- |
+| `homey.system.readonly` | Test the connection and identify the Homey instance        |
+| `homey.zone.readonly`   | Read the zone hierarchy shown during adoption              |
+| `homey.device.readonly` | Discover devices, read capabilities, and synchronize state |
+| `homey.device.control`  | Send commands to supported writable capabilities           |
+
+Omit `homey.device.control` for a read-only display. Do not grant device-management, pairing, app, Flow, user, or
+administrator permissions. Smart Panel's production integration has no upstream create, rename, move, or delete
+operation.
+
+Create the key, copy it immediately, and store a recovery copy in your password manager. Homey displays the key only
+once. You can revoke it later from the same **API Keys** page. See Homey's
+[API key guide](https://support.homey.app/hc/en-us/articles/8178797067292-Create-and-use-API-Keys-on-Homey-Pro) for the current
+Homey UI.
+
+## Configure the Connection
+
+1. In the Smart Panel Admin UI, open **Config → Plugins → Homey**.
+2. Keep **Connection mode** set to **Local**.
+3. Enter the local API URL and the new API key.
+4. Leave the connection timeout and reconciliation interval at their defaults unless your network needs tuning.
+5. Choose **Test entered URL and key**. This test is available only when both fields contain a complete candidate
+   connection.
+6. Save the form and enable the plugin.
+7. Confirm that **Connection status** changes to **Connected** and identifies the expected Homey.
+
+After saving, the key field is empty by design. The configured indicator confirms that a key exists, but neither the
+Admin UI nor the configuration API can read it back. Leaving the replacement field untouched preserves the saved key;
+entering a new value replaces it, and the field's explicit clear action removes it.
+
+Use **Test saved configuration** to test the URL and key already stored by the backend. If you change the URL, Smart
+Panel requires a new key for the unsaved connection test; it never sends a stored key to an overridden address.
+
+### Manual Server Selection
+
+Enter the Homey URL manually. Smart Panel does not currently offer automatic Homey server discovery because the local
+network advertisements observed during compatibility testing did not provide a stable, Homey-specific identity that
+could be selected safely. Device discovery begins only after a Homey connection has been configured.
+
+## Discover and Adopt Devices
+
+1. Open **Devices** in the Admin UI and choose **Add device**.
+2. Select **Homey** to open the Homey adoption wizard.
+3. Review the discovered Homey device name, identifier, class, model, zone, availability, capability count, and support
+   status. Refresh the inventory if Homey changed while the wizard was open.
+4. Select supported devices and continue to the confirmation step.
+5. Review each suggested Smart Panel category, name, mapping summary, and any warnings.
+6. Confirm the batch. The results identify devices that were created, updated, skipped, or failed.
+
+Adoption is idempotent: selecting the same Homey device again updates its mapping instead of creating a duplicate.
+Unsupported capabilities appear as warnings and do not prevent adoption when the device still has a complete supported
+mapping. Devices that cannot form a supported mapping remain visible in the inventory but cannot be adopted.
+
+Once adopted, devices use the normal Smart Panel device, space, dashboard, real-time state, and control paths. The
+panel display never receives the Homey URL or API key.
+
+## Supported Capability Families
+
+Support depends on both Homey's device class and its standardized capability IDs. The local MVP includes:
+
+| Family                      | Supported state and controls                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| Lights                      | Power, brightness, hue, saturation, and color temperature                                |
+| Outlets and switches        | Power; outlets can also expose instantaneous power and accumulated energy                |
+| Environmental sensors       | Temperature, humidity, pressure, illuminance, and carbon dioxide                         |
+| Safety and presence sensors | Motion, contact, smoke, and carbon monoxide alarms                                       |
+| Thermostats                 | Current temperature for devices exposing the complete standard thermostat capability set |
+| Window coverings            | Open, close, stop, position, and tilt when exposed by the device                         |
+| Locks                       | Locked/unlocked state and control                                                        |
+| Battery                     | Percentage and low/OK status                                                             |
+
+Smart Panel preserves full suffixed Homey capability IDs, so independent repeated capabilities are not collapsed into
+one value. Vendor-specific classes or capabilities may be reported as unsupported or omitted from the mapping preview.
+
+<Callout type="info">
+  Thermostat target temperature and operating-mode control are intentionally not
+  exposed in this release. Smart Panel does not infer heating/cooling activity
+  from a configured mode when Homey provides no authoritative activity signal.
+</Callout>
+
+## Synchronization and Availability
+
+The integration subscribes to Homey events for real-time updates. It also runs a bounded periodic reconciliation to
+populate initial values and repair events missed during a connection interruption. A reconnect is followed by a full
+reconciliation before the connection is considered healthy.
+
+If event subscription is unavailable while reads still work, the connection reports **Degraded polling** and continues
+to reconcile. If an adopted device disappears from Homey, Smart Panel marks it unavailable/orphaned; it never deletes
+the Smart Panel device and never sends an unpair or delete request to Homey. An operator can later decide what to do
+with the local Smart Panel device.
+
+## API Keys and Backups
+
+Treat a Smart Panel system backup as a credential. Configuration APIs and the Admin UI expose only whether the Homey
+key is configured, but system backups include the resolved configuration needed to restore the integration. Smart
+Panel backups are not encrypted by the application.
+
+- Store and transfer backups only through trusted, access-controlled locations.
+- Do not attach a backup to an issue or support request.
+- After restoring onto a replacement host, retire or isolate the old host before enabling both copies.
+- If a backup or either host may have been exposed, revoke the Homey key, create a new least-privilege key, save it in
+  Smart Panel, and test the connection again.
+
+Write-only configuration prevents accidental disclosure through normal API reads; it is not a substitute for backup,
+host, and filesystem security.
+
+## Troubleshooting
+
+### The connection test cannot run
+
+For **Test entered URL and key**, provide both a valid HTTP(S) URL and a new, non-blank key. To reuse the existing
+write-only key, save the URL first and use **Test saved configuration**.
+
+### Authentication failed
+
+The key is missing, revoked, or invalid. Create or copy a new key, replace the saved value, and run the saved connection
+test. The integration avoids rapid reconnect attempts after an authentication failure.
+
+### Authorization failed
+
+Review the four permissions above. Read-only operation needs the three `readonly` permissions; device control also
+needs `homey.device.control`. Do not solve this by granting broad device-management or administrator access.
+
+### Timeout or Homey unavailable
+
+- Verify the URL, scheme, and port from the Smart Panel backend host or container.
+- Check firewall, VLAN, guest-network, container, reverse-proxy, DNS, and certificate-trust rules.
+- Confirm that SHS is running and listening on the configured port.
+- Increase the connection timeout only after checking the network path.
+
+### Degraded polling or reconnecting
+
+The event connection is unavailable or was interrupted. Smart Panel continues bounded reconciliation where possible and
+reconnects with bounded backoff. Check Homey and proxy support for long-lived Socket.IO/WebSocket connections. If the
+state does not recover, test the saved connection and inspect the sanitized backend logs.
+
+### A device is missing or unsupported
+
+Refresh the wizard inventory and verify that the device is available in Homey. Adoption is based on Homey's logical
+device class and standardized capabilities, not only its product name. Vendor-specific capability sets may require a
+future mapping. A previously adopted device that disappeared upstream remains in Smart Panel as unavailable.
+
+## Current Limitations
+
+- Local Homey Pro/SHS connections only; Homey Cloud/OAuth is a later phase.
+- Manual Homey URL configuration; no automatic server discovery.
+- No pairing, commissioning, renaming, zone moves, removal, app, Flow, firmware, backup, or user administration in
+  Homey.
+- No automatic deletion of Smart Panel devices that disappear from Homey.
+- No exhaustive mapping for vendor-specific capabilities.
+- Thermostat target, mode, and activity control remain deferred as described above.

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -1,16 +1,22 @@
 import { Callout } from "nextra/components";
 
-# Homey
+# Homey (Experimental)
 
-The Homey integration connects Smart Panel directly to a Homey Pro or Homey Self-Hosted Server (SHS) on the local
-network. It imports logical devices already managed by Homey, lets an administrator review and adopt them, keeps their
-state synchronized, and sends supported controls back to Homey.
+The experimental Homey integration is designed to connect Smart Panel directly to a Homey Pro or Homey Self-Hosted
+Server (SHS) on the local network. It imports logical devices already managed by Homey, lets an administrator review
+and adopt them, keeps their state synchronized, and sends supported controls back to Homey.
 
 <Callout type="warning">
-  This release supports a **local Homey connection only**. Homey Cloud/OAuth is
-  not available yet. Smart Panel also does not pair, rename, move, or remove
-  devices in Homey.
+  **The Homey release gate is not complete.** Current live evidence covers Homey
+  SHS 13.4.0 over HTTP port 4859 for sanitized inventory capture and limited SDK
+  connection/session behavior. Homey Pro, HTTPS, capability writes/events,
+  restart and network recovery, and credential rotation have not completed the
+  required live matrix. Use this integration for evaluation, not as a
+  production-ready support claim.
 </Callout>
+
+Only a **local Homey connection** is implemented. Homey Cloud/OAuth is not available yet. Smart Panel does not pair,
+rename, move, or remove devices in Homey.
 
 ## Before You Start
 
@@ -45,7 +51,7 @@ the same private network.
 ## Create a Least-Privilege API Key
 
 In the [Homey Web App](https://my.homey.app), open **Settings → API Keys**, choose **New API Key**, give the key a name
-such as `Smart Panel`, and grant:
+such as `Smart Panel`, and grant all four permissions:
 
 | Permission              | Why Smart Panel needs it                                   |
 | ----------------------- | ---------------------------------------------------------- |
@@ -54,9 +60,10 @@ such as `Smart Panel`, and grant:
 | `homey.device.readonly` | Discover devices, read capabilities, and synchronize state |
 | `homey.device.control`  | Send commands to supported writable capabilities           |
 
-Omit `homey.device.control` for a read-only display. Do not grant device-management, pairing, app, Flow, user, or
-administrator permissions. Smart Panel's production integration has no upstream create, rename, move, or delete
-operation.
+`homey.device.control` is currently mandatory because adopted writable mappings remain visible as controls in Smart
+Panel. A scope-aware read-only presentation is not implemented, so omitting this permission would leave visible commands
+that fail authorization. Do not grant device-management, pairing, app, Flow, user, or administrator permissions. Smart
+Panel's integration has no upstream create, rename, move, or delete operation.
 
 Create the key, copy it immediately, and store a recovery copy in your password manager. Homey displays the key only
 once. You can revoke it later from the same **API Keys** page. See Homey's
@@ -168,8 +175,9 @@ test. The integration avoids rapid reconnect attempts after an authentication fa
 
 ### Authorization failed
 
-Review the four permissions above. Read-only operation needs the three `readonly` permissions; device control also
-needs `homey.device.control`. Do not solve this by granting broad device-management or administrator access.
+Review all four required permissions above. The current UI does not downgrade writable mappings when
+`homey.device.control` is absent. Do not solve authorization failures by granting broad device-management or
+administrator access.
 
 ### Timeout or Homey unavailable
 
@@ -192,6 +200,7 @@ future mapping. A previously adopted device that disappeared upstream remains in
 
 ## Current Limitations
 
+- Experimental status while the required live compatibility matrix remains incomplete.
 - Local Homey Pro/SHS connections only; Homey Cloud/OAuth is a later phase.
 - Manual Homey URL configuration; no automatic server discovery.
 - No pairing, commissioning, renaming, zone moves, removal, app, Flow, firmware, backup, or user administration in

--- a/apps/website/app/docs/extensions/overview/page.mdx
+++ b/apps/website/app/docs/extensions/overview/page.mdx
@@ -67,7 +67,7 @@ Connect Smart Panel to external smart home platforms and protocols. See
 | Plugin | Description |
 |--------|-------------|
 | **Home Assistant** | Imports devices and entities via WebSocket API |
-| [**Homey**](/docs/extensions/homey) | Adopts, synchronizes, and controls devices from a local Homey Pro or Homey SHS instance |
+| [**Homey (Experimental)**](/docs/extensions/homey) | Implements local Homey adoption, synchronization, and controls; the live release gate remains incomplete |
 | **Shelly NG** | Discovers and controls Shelly Next-Generation devices via mDNS/RPC |
 | **Shelly v1** | Support for first-generation Shelly devices |
 | **Third-Party** | Generic HTTP API for custom devices — any platform, any language |

--- a/apps/website/app/docs/extensions/overview/page.mdx
+++ b/apps/website/app/docs/extensions/overview/page.mdx
@@ -57,7 +57,7 @@ These modules ship with every Smart Panel installation and provide the system's 
 
 ## Built-in Plugins
 
-Smart Panel ships with **34 built-in plugins** organized into the following categories.
+Smart Panel ships with built-in plugins organized into the following categories.
 
 ### Device Integrations
 
@@ -67,6 +67,7 @@ Connect Smart Panel to external smart home platforms and protocols. See
 | Plugin | Description |
 |--------|-------------|
 | **Home Assistant** | Imports devices and entities via WebSocket API |
+| [**Homey**](/docs/extensions/homey) | Adopts, synchronizes, and controls devices from a local Homey Pro or Homey SHS instance |
 | **Shelly NG** | Discovers and controls Shelly Next-Generation devices via mDNS/RPC |
 | **Shelly v1** | Support for first-generation Shelly devices |
 | **Third-Party** | Generic HTTP API for custom devices — any platform, any language |

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,7 +36,7 @@ FastyBird Smart Panel is an open-source smart home control platform designed for
 ### Key Highlights
 
 - **Wall-mounted touch control** - Purpose-built for embedded touch displays
-- **Multi-ecosystem support** - Integrates Home Assistant, Shelly, Zigbee2MQTT, WLED, and more
+- **Multi-ecosystem support** - Integrates Home Assistant, Homey, Shelly, Zigbee2MQTT, WLED, and more
 - **Offline-first architecture** - Works without cloud dependency; local processing and control
 - **AI-powered assistant** - Built-in Buddy AI with support for Claude, OpenAI, and local Ollama models
 - **Modular & extensible** - Plugin-based architecture with an Extension SDK for custom integrations
@@ -100,6 +100,23 @@ Smart Panel connects to multiple smart home ecosystems through dedicated integra
   - YAML-based configuration mappings
 
 **Supported HA domains**: climate, cover, light, switch, lock, media_player, camera, sensor, humidifier, thermostat, valve, vacuum, water_heater, fan, binary_sensor, and 24+ more.
+
+### Homey
+
+- **Protocol**: Local HTTP(S) API and Socket.IO events
+- **Targets**: Homey Pro and Homey Self-Hosted Server reachable on the local network
+- **Features**:
+  - Manual server configuration with a write-only, least-privilege API key
+  - Authenticated logical-device inventory and reviewed batch adoption
+  - Mapping preview with unsupported-capability warnings
+  - Real-time state updates with bounded reconnect and periodic reconciliation
+  - Supported controls for lights, outlets/switches, covers, and locks
+  - Sensors for temperature, humidity, pressure, illuminance, CO₂, motion, contact, smoke, carbon monoxide, power,
+    energy, and battery state
+  - Missing upstream devices are marked unavailable and are never automatically deleted
+
+Homey Cloud/OAuth, automatic Homey server discovery, upstream pairing/device management, and thermostat target/mode
+control are not part of the current local integration.
 
 ### Shelly (Generation 2+ / Next Generation)
 
@@ -863,20 +880,20 @@ The Vue.js admin interface provides comprehensive management for the entire syst
 
 ## Integration Coverage Matrix
 
-| Device Type | Home Assistant | Shelly NG | Shelly V1 | Zigbee2MQTT | WLED | Simulator |
-|------------|:-:|:-:|:-:|:-:|:-:|:-:|
-| Lighting | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Switches/Outlets | ✅ | ✅ | ✅ | ✅ | - | ✅ |
-| Covers/Blinds | ✅ | ✅ | - | ✅ | - | ✅ |
-| Climate/HVAC | ✅ | - | - | ✅ | - | ✅ |
-| Sensors | ✅ | ✅ | ✅ | ✅ | - | ✅ |
-| Locks | ✅ | - | - | ✅ | - | ✅ |
-| Cameras | ✅ | - | - | - | - | ✅ |
-| Media Players | ✅ | - | - | - | - | ✅ |
-| Fans | ✅ | - | - | ✅ | - | ✅ |
-| Vacuums | ✅ | - | - | - | - | ✅ |
-| Valves | ✅ | - | - | ✅ | - | - |
-| Auto-Discovery | ✅ | ✅ | ✅ | ✅ | ✅ | - |
+| Device Type | Home Assistant | Homey | Shelly NG | Shelly V1 | Zigbee2MQTT | WLED | Simulator |
+|------------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| Lighting | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Switches/Outlets | ✅ | ✅ | ✅ | ✅ | ✅ | - | ✅ |
+| Covers/Blinds | ✅ | ✅ | ✅ | - | ✅ | - | ✅ |
+| Climate/HVAC | ✅ | Current temperature | - | - | ✅ | - | ✅ |
+| Sensors | ✅ | ✅ | ✅ | ✅ | ✅ | - | ✅ |
+| Locks | ✅ | ✅ | - | - | ✅ | - | ✅ |
+| Cameras | ✅ | - | - | - | - | - | ✅ |
+| Media Players | ✅ | - | - | - | - | - | ✅ |
+| Fans | ✅ | - | - | - | ✅ | - | ✅ |
+| Vacuums | ✅ | - | - | - | - | - | ✅ |
+| Valves | ✅ | - | - | - | ✅ | - | - |
+| Auto-Discovery | ✅ | Manual server | ✅ | ✅ | ✅ | ✅ | - |
 
 ---
 
@@ -886,7 +903,7 @@ The Vue.js admin interface provides comprehensive management for the entire syst
 
 | Metric | Count |
 |--------|-------|
-| Device integration plugins | 7 |
+| Device integration plugins | 8 |
 | Supported device categories | 31 |
 | Channel types | 45+ |
 | Property types | 120+ |

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,7 +36,7 @@ FastyBird Smart Panel is an open-source smart home control platform designed for
 ### Key Highlights
 
 - **Wall-mounted touch control** - Purpose-built for embedded touch displays
-- **Multi-ecosystem support** - Integrates Home Assistant, Homey, Shelly, Zigbee2MQTT, WLED, and more
+- **Multi-ecosystem support** - Integrates Home Assistant, Shelly, Zigbee2MQTT, WLED, and more, with experimental Homey support under validation
 - **Offline-first architecture** - Works without cloud dependency; local processing and control
 - **AI-powered assistant** - Built-in Buddy AI with support for Claude, OpenAI, and local Ollama models
 - **Modular & extensible** - Plugin-based architecture with an Extension SDK for custom integrations
@@ -101,7 +101,10 @@ Smart Panel connects to multiple smart home ecosystems through dedicated integra
 
 **Supported HA domains**: climate, cover, light, switch, lock, media_player, camera, sensor, humidifier, thermostat, valve, vacuum, water_heater, fan, binary_sensor, and 24+ more.
 
-### Homey
+### Homey (Experimental)
+
+The implementation is not yet a production support claim. Live evidence currently covers Homey SHS 13.4.0 over HTTP
+for sanitized inventory and selected connection/session behavior; the remaining live release matrix is still pending.
 
 - **Protocol**: Local HTTP(S) API and Socket.IO events
 - **Targets**: Homey Pro and Homey Self-Hosted Server reachable on the local network
@@ -880,7 +883,7 @@ The Vue.js admin interface provides comprehensive management for the entire syst
 
 ## Integration Coverage Matrix
 
-| Device Type | Home Assistant | Homey | Shelly NG | Shelly V1 | Zigbee2MQTT | WLED | Simulator |
+| Device Type | Home Assistant | Homey (experimental) | Shelly NG | Shelly V1 | Zigbee2MQTT | WLED | Simulator |
 |------------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | Lighting | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Switches/Outlets | ✅ | ✅ | ✅ | ✅ | ✅ | - | ✅ |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -683,11 +683,15 @@ gated compatibility probes under `test/`.
 - `docs/homey-shs-compatibility.md`
 - Plugin README or module documentation if current plugins use one
 
-- [ ] Document SHS installation/network/port assumptions and least-privilege API-key creation.
-- [ ] Document local configuration, discovery/manual URL, adoption, supported capability families, limitations, and troubleshooting.
-- [ ] Document backups/secret behavior without revealing storage internals unnecessarily.
-- [ ] Document fixture refresh procedure for future SHS/Homey versions.
+- [x] Document SHS installation/network/port assumptions and least-privilege API-key creation.
+- [x] Document local configuration, discovery/manual URL, adoption, supported capability families, limitations, and troubleshooting.
+- [x] Document backups/secret behavior without revealing storage internals unnecessarily.
+- [x] Document fixture refresh procedure for future SHS/Homey versions.
 - [ ] Update `FEATURE-PLUGIN-HOMEY` acceptance checkboxes and status to `review` only when evidence is recorded.
+
+The operator guide is published at `apps/website/app/docs/extensions/homey/page.mdx`; the fixture refresh runbook is
+maintained beside the reviewed fixture corpus. The feature remains `in-progress`: Task 6.2 live-matrix observations and
+the unchecked acceptance evidence above are still required before the final checklist/status update.
 
 **Local MVP gate:** All Phase 0 and Phase 1 acceptance criteria in `tasks/features/FEATURE-PLUGIN-HOMEY.md` are checked or carry an approved, explicit deferral. Cloud criteria remain unchecked.
 


### PR DESCRIPTION
## Summary

- add an explicitly experimental local Homey Pro/SHS operator guide covering least-privilege credentials, networking, setup, adoption, implemented mappings, synchronization, backups, limitations, and troubleshooting
- constrain public claims to the verified SHS 13.4.0 HTTP inventory/session scope and identify the incomplete live release matrix
- document the sanitized fixture refresh and promotion procedure for future Homey/SHS versions
- add Homey to project and website integration listings and record completion of the documentation checklist

## Validation

- `pnpm --filter @fastybird/smart-panel-website run build`
- `pnpm --filter @fastybird/smart-panel-backend test:homey-spike` (10 suites, 129 tests)
- `git diff --check`

## Remaining epic work

The Homey feature remains `in-progress` and is labeled experimental throughout the public documentation. Task 6.2 live-matrix observations and the remaining evidence-backed acceptance checklist update are intentionally not claimed by this documentation PR.