### PR TITLE
fix(cross): harden Homey live capture evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -82,5 +82,8 @@ corpus. The filename records the observation date and SHS version. Each report m
 labels, booleans, ordering numbers, public dependency versions, and non-sensitive status codes, and must have a focused
 test that re-applies the report safety assertions. The 2026-08-14 SDK session evidence records connection,
 subscription, cleanup, and invalid-key behavior only; it does not claim capability-event, write, or reconnect coverage.
+The 2026-08-26 mDNS evidence records the Homey and co-hosted HAP service types, ports, and TXT key names observed on SHS
+`13.4.1`; it contains no service instance names, hosts, addresses, or TXT values and does not by itself establish
+restart stability or authorize automatic discovery.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json
@@ -1,0 +1,30 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mdns",
+		"schemaVersion": 1
+	},
+	"observation": {
+		"durationMs": 10000,
+		"matchedServices": 3,
+		"services": [
+			{
+				"port": 47756,
+				"protocol": "tcp",
+				"txtKeys": ["c#", "ci", "ff", "id", "md", "pv", "s#", "sf", "sh"],
+				"type": "hap"
+			},
+			{
+				"port": 48000,
+				"protocol": "tcp",
+				"txtKeys": ["c#", "ci", "ff", "id", "md", "pv", "s#", "sf", "sh"],
+				"type": "hap"
+			},
+			{
+				"port": 4859,
+				"protocol": "tcp",
+				"txtKeys": ["id", "model", "name", "version"],
+				"type": "homey"
+			}
+		]
+	}
+}

--- a/apps/backend/test/homey-shs-compatibility.homey-spike.ts
+++ b/apps/backend/test/homey-shs-compatibility.homey-spike.ts
@@ -321,6 +321,14 @@ describe('Homey SHS compatibility probe', () => {
 
 		expect(() => assertHomeyCaptureSafe(capture, [])).toThrow('unredacted metadata, icons, or host fingerprint');
 
+		capture.systemInfo = sanitizeHomeyPublishedMetadata({
+			dateHuman: 'Private capture date',
+			country: 'Private country',
+			timezone: 'Private/timezone',
+		});
+
+		expect(() => assertHomeyCaptureSafe(capture, [])).not.toThrow();
+
 		capture.systemInfo = {};
 		capture.devices = { 'device-000001': { country: 'Private country' } };
 
@@ -335,6 +343,9 @@ describe('Homey SHS compatibility probe', () => {
 
 		expect(zones['zone-000001']).toMatchObject({ icon: '[~2~]' });
 		expect(() => assertHomeyCaptureSafe(sanitizedCapture, [])).not.toThrow();
+		expect(() =>
+			assertHomeyCaptureSafe({ ...sanitizedCapture, zones: { 'zone-000001': { icon: null } } }, []),
+		).not.toThrow();
 		expect(() =>
 			assertHomeyCaptureSafe({ ...sanitizedCapture, zones: { 'zone-000001': { icon: 'private-room-kind' } } }, []),
 		).toThrow('unredacted metadata, icons, or host fingerprint');
@@ -373,6 +384,9 @@ describe('Homey SHS compatibility probe', () => {
 			loadavg: [0, 0, 0],
 		});
 		expect(() => assertHomeyCaptureSafe(capture, [])).not.toThrow();
+		expect(() =>
+			assertHomeyCaptureSafe({ ...capture, devices: { 'device-000001': { icon: null, iconOverride: null } } }, []),
+		).not.toThrow();
 
 		capture.devices = { 'device-000001': { icon: 'private-device-icon' } };
 

--- a/apps/backend/test/homey-shs-mdns.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mdns.homey-spike.ts
@@ -92,6 +92,24 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		expect(() => assertHomeyShsMdnsReportSafe(evidence, config)).not.toThrow();
 	});
 
+	it('preserves the sanitized live Homey and HAP advertisement evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+
+		assertHomeyShsMdnsReportSchema(evidence);
+		expect(evidence.observation.services).toContainEqual({
+			port: 4859,
+			protocol: 'tcp',
+			txtKeys: ['id', 'model', 'name', 'version'],
+			type: 'homey',
+		});
+		expect(() => assertHomeyShsMdnsReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('loads a key-free, exact-host configuration with bounded observation', () => {
 		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-mdns-spike');
 
@@ -188,6 +206,28 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		expect(() => assertHomeyShsMdnsReportSafe(report, config)).not.toThrow();
 	});
 
+	it('accepts standard HomeKit TXT counter keys without recording their values', async () => {
+		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
+		const harness = createMdnsHarness();
+		const report = await probeHomeyShsMdns(config, harness.factory, () => {
+			harness.emit({
+				addresses: ['192.0.2.10'],
+				port: 48000,
+				protocol: 'tcp',
+				txt: { 'c#': 'private counter', 's#': 'private state' },
+				type: 'hap',
+			});
+
+			return Promise.resolve();
+		});
+
+		expect(report.observation.services).toStrictEqual([
+			{ port: 48000, protocol: 'tcp', txtKeys: ['c#', 's#'], type: 'hap' },
+		]);
+		expect(JSON.stringify(report)).not.toContain('private');
+		expect(() => assertHomeyShsMdnsReportSafe(report, config)).not.toThrow();
+	});
+
 	it('rejects unsafe matched metadata with a fixed error and still cleans up', async () => {
 		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
 		const harness = createMdnsHarness();
@@ -207,6 +247,22 @@ describe('Homey SHS mDNS compatibility probe', () => {
 		).rejects.toThrow('Homey mDNS service metadata was not safe to record');
 		expect(harness.isStopped()).toBe(true);
 		expect(harness.isDestroyed()).toBe(true);
+
+		const hashHarness = createMdnsHarness();
+
+		await expect(
+			probeHomeyShsMdns(config, hashHarness.factory, () => {
+				hashHarness.emit({
+					addresses: ['192.0.2.10'],
+					port: 4859,
+					protocol: 'tcp',
+					txt: { 'unsafe#key': 'value' },
+					type: 'homey',
+				});
+
+				return Promise.resolve();
+			}),
+		).rejects.toThrow('Homey mDNS service metadata was not safe to record');
 	});
 
 	it('sanitizes observer and cleanup errors while attempting all cleanup', async () => {

--- a/apps/backend/test/support/homey-shs-mdns-probe.ts
+++ b/apps/backend/test/support/homey-shs-mdns-probe.ts
@@ -7,6 +7,7 @@ const DEFAULT_OBSERVE_MS = 5_000;
 const MIN_OBSERVE_MS = 1_000;
 const MAX_OBSERVE_MS = 30_000;
 const PUBLIC_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+const PUBLIC_TXT_KEY_PATTERN = /^(?:[A-Za-z0-9._-]{1,64}|[cs]#)$/;
 const URL_PATTERN = /(?:https?|wss?):\/\//i;
 const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 const IPV4_PATTERN = /(?:^|[^\d])(?:\d{1,3}\.){3}\d{1,3}(?:$|[^\d])/;
@@ -198,7 +199,7 @@ const toSafeServiceReport = (service: HomeyMdnsService): HomeyShsMdnsServiceRepo
 
 	const txtKeys = Object.keys(service.txt ?? {}).sort();
 
-	if (txtKeys.some((key) => !PUBLIC_IDENTIFIER_PATTERN.test(key))) {
+	if (txtKeys.some((key) => !PUBLIC_TXT_KEY_PATTERN.test(key))) {
 		throw new Error('Homey mDNS service metadata was not safe to record');
 	}
 
@@ -322,7 +323,7 @@ export function assertHomeyShsMdnsReportSchema(value: unknown): asserts value is
 			service.port < 1 ||
 			service.port > 65_535 ||
 			!Array.isArray(service.txtKeys) ||
-			service.txtKeys.some((key) => typeof key !== 'string' || !PUBLIC_IDENTIFIER_PATTERN.test(key))
+			service.txtKeys.some((key) => typeof key !== 'string' || !PUBLIC_TXT_KEY_PATTERN.test(key))
 		) {
 			throw new Error('Homey mDNS report service schema is invalid');
 		}

--- a/apps/backend/test/support/homey-shs-probe.ts
+++ b/apps/backend/test/support/homey-shs-probe.ts
@@ -1669,11 +1669,15 @@ export const assertHomeyCaptureSafe = (
 					return nestedValue !== REDACTION.privateTerm;
 				}
 
-				if (section === 'zones' && nestedKey === 'icon') {
+				if (section === 'zones' && nestedKey === 'icon' && nestedValue !== null) {
 					return nestedValue !== REDACTION.privateTerm;
 				}
 
-				if ((section === 'devices' || section === 'individualDevice') && DEVICE_ICON_KEY_PATTERN.test(nestedKey)) {
+				if (
+					nestedValue !== null &&
+					(section === 'devices' || section === 'individualDevice') &&
+					DEVICE_ICON_KEY_PATTERN.test(nestedKey)
+				) {
 					return nestedValue !== REDACTION.privateTerm;
 				}
 
@@ -1705,7 +1709,7 @@ export const assertHomeyCaptureSafe = (
 			});
 		}
 
-		return HUMAN_TIMESTAMP_KEY_PATTERN.test(key) || LOCATION_METADATA_KEY_PATTERN.test(key);
+		return false;
 	};
 
 	if (containsUnredactedSourceMetadata(capture)) {

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -8,11 +8,11 @@ and adopt them, keeps their state synchronized, and sends supported controls bac
 
 <Callout type="warning">
   **The Homey release gate is not complete.** Current live evidence covers Homey
-  SHS 13.4.0 over HTTP port 4859 for sanitized inventory capture and limited SDK
-  connection/session behavior. Homey Pro, HTTPS, capability writes/events,
-  restart and network recovery, and credential rotation have not completed the
-  required live matrix. Use this integration for evaluation, not as a
-  production-ready support claim.
+  SHS 13.4.0 and 13.4.1 over HTTP port 4859 for sanitized inventory capture and
+  limited SDK connection/session behavior. Homey Pro, HTTPS, capability
+  writes/events, restart and network recovery, and credential rotation have not
+  completed the required live matrix. Use this integration for evaluation, not
+  as a production-ready support claim.
 </Callout>
 
 Only a **local Homey connection** is implemented. Homey Cloud/OAuth is not available yet. Smart Panel does not pair,
@@ -47,6 +47,15 @@ For SHS installation and network settings, follow Homey's platform-specific inst
 [port-forwarding guide](https://support.homey.app/hc/en-us/articles/24722267664156-Set-up-port-forwarding-for-Homey-Self-Hosted-Server)
 documents the default HTTPS port, but port forwarding is not required when Smart Panel and Homey can communicate on
 the same private network.
+
+<Callout type="warning">
+  **TrueNAS requires specific host settings.** Follow Homey's [TrueNAS
+  installation
+  guide](https://support.homey.app/hc/en-us/articles/23981543357596-How-to-install-Homey-Self-Hosted-Server-on-TrueNAS):
+  disable TrueNAS's mDNS option, enable **Host Network** and **Privileged** for
+  the trusted SHS app, and restart the app. If TrueNAS mDNS remains enabled, SHS
+  can exit before ports `4859` and `4860` start listening.
+</Callout>
 
 ## Create a Least-Privilege API Key
 
@@ -90,9 +99,9 @@ Panel requires a new key for the unsaved connection test; it never sends a store
 
 ### Manual Server Selection
 
-Enter the Homey URL manually. Smart Panel does not currently offer automatic Homey server discovery because the local
-network advertisements observed during compatibility testing did not provide a stable, Homey-specific identity that
-could be selected safely. Device discovery begins only after a Homey connection has been configured.
+Enter the Homey URL manually. Smart Panel does not currently offer automatic Homey server discovery. A Homey-specific
+advertisement has been observed, but its restart stability, safe identity deduplication, and endpoint verification have
+not completed the release gate. Device discovery begins only after a Homey connection has been configured.
 
 ## Discover and Adopt Devices
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -19,39 +19,44 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                          | Evidence still required                                              |
-| ----------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------- |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` over HTTP `4859`         | Repeat over HTTPS `4860` if enabled                                  |
-| System, zone, device inventory, and individual device | Captured and sanitized                          | Add lifecycle delta evidence on the disposable test device           |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read    | Add allowlisted write and read-back evidence                         |
-| Socket.IO events and reconnect                        | Restart/network probes ready; live runs pending | Capture capability/availability events and both recovery orderings   |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled          | Use only the designated harmless test capability                     |
-| Error classification                                  | SDK invalid key returned `401`; matrix pending  | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
-| API-key revocation and replacement                    | Operator-controlled probe ready                 | Revoke only a dedicated test key during the gated observation window |
-| Disposable-device lifecycle                           | Guarded operator probe ready                    | Use only the separately gated virtual/test device                    |
-| mDNS discovery                                        | Deferred; manual URL only for local MVP         | Revisit only after an attributable stable service is verified        |
-| SDK decision                                          | SDK selected behind connector boundary          | Re-evaluate the pinned package and audit result on every upgrade     |
-| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture     | Add event/reconnect fixtures from the remaining live lifecycle runs  |
+| Area                                                  | Status                                               | Evidence still required                                              |
+| ----------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859` | Repeat over HTTPS `4860` if enabled                                  |
+| System, zone, device inventory, and individual device | Captured and sanitized                               | Add lifecycle delta evidence on the disposable test device           |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read         | Add allowlisted write and read-back evidence                         |
+| Socket.IO events and reconnect                        | Passive sessions passed; recovery runs pending       | Capture capability/availability events and both recovery orderings   |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled               | Use only the designated harmless test capability                     |
+| Error classification                                  | SDK invalid key returned `401`; matrix pending       | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
+| API-key revocation and replacement                    | Operator-controlled probe ready                      | Revoke only a dedicated test key during the gated observation window |
+| Disposable-device lifecycle                           | Guarded operator probe ready                         | Use only the separately gated virtual/test device                    |
+| mDNS discovery                                        | Homey-specific service observed; manual URL remains  | Verify stability before and after restart                            |
+| SDK decision                                          | SDK selected behind connector boundary               | Re-evaluate the pinned package and audit result on every upgrade     |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture          | Add event/reconnect fixtures from the remaining live lifecycle runs  |
 
 ## Installation evidence
 
 Complete this table after the live run. Values committed here must remain non-sensitive.
 
-| Field                                    | Recorded value                                                       |
-| ---------------------------------------- | -------------------------------------------------------------------- |
-| Capture date                             | `2026-08-13`                                                         |
-| Realtime SDK probe date                  | `2026-08-14`                                                         |
-| mDNS observation date                    | `2026-08-14`                                                         |
-| SHS version                              | `13.4.0`                                                             |
-| Container image tag and immutable digest | Pending                                                              |
-| Host operating system/architecture       | Pending                                                              |
-| Topology                                 | Pending; describe generically, for example `same LAN, separate host` |
-| Smart Panel to SHS network path          | Pending; do not record addresses                                     |
-| HTTP port `4859`                         | Confirmed for reads and the SDK Socket.IO session                    |
-| HTTPS port `4860`                        | Pending                                                              |
-| TLS certificate behavior                 | Pending                                                              |
-| Disposable capability alias              | Pending synthetic alias                                              |
-| Disposable lifecycle-device alias        | Pending synthetic alias                                              |
+| Field                                    | Recorded value                                    |
+| ---------------------------------------- | ------------------------------------------------- |
+| Capture date                             | `2026-08-13`, `2026-08-26`                        |
+| Realtime SDK probe date                  | `2026-08-14`, `2026-08-26`                        |
+| mDNS observation date                    | `2026-08-14`, `2026-08-26`                        |
+| SHS version                              | `13.4.0`, `13.4.1`                                |
+| Container image tag and immutable digest | Pending                                           |
+| Host operating system/architecture       | TrueNAS; version and architecture pending         |
+| Topology                                 | Same LAN, separate host                           |
+| Smart Panel to SHS network path          | Direct private-LAN connection                     |
+| HTTP port `4859`                         | Confirmed for reads and the SDK Socket.IO session |
+| HTTPS port `4860`                        | Pending                                           |
+| TLS certificate behavior                 | Pending                                           |
+| Disposable capability alias              | Pending synthetic alias                           |
+| Disposable lifecycle-device alias        | Pending synthetic alias                           |
+
+On 2026-08-26, the TrueNAS host was reachable but SHS stopped before opening its API ports because its required Avahi
+daemon could not start. The deployment recovered after applying Homey's documented TrueNAS settings: disable the host
+mDNS option, run the trusted SHS image with host networking and privileged mode, and restart the app. See the official
+[Homey TrueNAS installation guide](https://support.homey.app/hc/en-us/articles/23981543357596-How-to-install-Homey-Self-Hosted-Server-on-TrueNAS).
 
 ## Published protocol baseline
 
@@ -365,9 +370,9 @@ not create, revoke, rotate, or otherwise administer Homey credentials.
 
 ## Privacy-safe mDNS observation probe
 
-The mDNS probe performs a bounded wildcard DNS-SD observation because SHS's service type has not been established. It
-does not read or send `FB_HOMEY_SHS_API_KEY`. Although the browser necessarily receives other LAN advertisements in
-memory, the probe immediately discards every service whose hostname or address does not exactly match
+The mDNS probe performs a bounded wildcard DNS-SD observation so it can compare Homey with other services advertised by
+the same host. It does not read or send `FB_HOMEY_SHS_API_KEY`. Although the browser necessarily receives other LAN
+advertisements in memory, the probe immediately discards every service whose hostname or address does not exactly match
 `FB_HOMEY_SHS_EXPECTED_HOST`. The persisted exact-schema report contains only the matched service type, protocol, port,
 and sorted TXT key names. Service names, hostnames, addresses, TXT values, referer data, FQDNs, URLs, credentials, and
 raw errors have no report fields.
@@ -390,12 +395,19 @@ Two consecutive five-second observations on 2026-08-14 produced the same sanitiz
 is not either documented SHS API port, this does not establish that SHS owns the advertisement or provide a safe
 discovery discriminator.
 
+A ten-second observation on 2026-08-26 after SHS `13.4.1` started on TrueNAS matched `_homey._tcp` on port `4859`, with
+the TXT key names `id`, `model`, `name`, and `version`. It also matched two co-hosted `_hap._tcp` services. The reviewed
+report is committed as `__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json`. The service names,
+hosts, addresses, and all TXT values remain excluded. This establishes one attributable Homey-specific observation,
+but it does not yet prove stability across an SHS restart.
+
 ### Server-discovery decision
 
-Automatic Homey server discovery is explicitly deferred for the local MVP. Smart Panel does not register a Homey
-mDNS discoverer and does not expose Homey server-discovery or rescan endpoints. Shipping `_http._tcp` port `80` as a
-Homey discriminator could present unrelated LAN services as Homey instances, so the observed record is insufficient
-even if a later observation finds it again after an SHS restart.
+Automatic Homey server discovery remains explicitly deferred for the local MVP. Smart Panel does not register a Homey
+mDNS discoverer and does not expose Homey server-discovery or rescan endpoints. The `_homey._tcp` observation is
+attributable, but it has not completed the required before/after-restart stability check. TXT values are intentionally
+excluded from evidence, so identity deduplication and endpoint verification also require a reviewed design before the
+advertisement can become a safe discovery input.
 
 Administrators configure the local Homey URL manually through the plugin configuration and can verify either the
 fully saved configuration or a complete candidate URL/new-key pair through the connection-test endpoint. Manual setup
@@ -515,7 +527,7 @@ Fill this matrix using synthetic aliases only.
 | SHS restart and reconnect                 | Pending                             |                                                                                                                                                      |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
-| Stable mDNS service before/after restart  | Deferred for local MVP              | Two identical windows matched only generic `_http._tcp` port `80` with no TXT keys; the record cannot be safely attributed to SHS                    |
+| Stable mDNS service before/after restart  | Partial                             | SHS `13.4.1` advertised `_homey._tcp` on `4859` once after startup; repeat before and after a controlled restart                                     |
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- accept already-sanitized human timestamps and nullable Homey icon metadata without weakening raw-value rejection
- support standard HomeKit `c#` and `s#` TXT keys while keeping mDNS service values, hosts, addresses, and instance names excluded
- record reviewed SHS 13.4.1 Homey/HAP mDNS evidence and document the required TrueNAS mDNS, host-network, and privileged settings
- retain manual Homey server selection until restart stability and safe identity verification are proven

## Live evidence

- Homey SHS 13.4.1 over HTTP 4859
- sanitized inventory: 118 devices and 16 zones
- passive SDK session: 7 ordered events with clean teardown and writes disabled
- mDNS: Homey service on 4859 plus two co-hosted HAP services
- no raw endpoint, key, address, device identity, service instance name, or TXT value is committed

## Validation

- `pnpm run test:homey-spike` — 10 suites, 131 tests passed
- `pnpm run homey:security-gate` — Homey spike suites plus 39 focused suites and 483 tests passed
- `pnpm run build` in `apps/website` — passed
- live inventory, passive realtime, and sanitized mDNS probes — passed