### PR TITLE
test(cross): record Homey restart recovery evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -83,7 +83,8 @@ labels, booleans, ordering numbers, public dependency versions, and non-sensitiv
 test that re-applies the report safety assertions. The 2026-08-14 SDK session evidence records connection,
 subscription, cleanup, and invalid-key behavior only; it does not claim capability-event, write, or reconnect coverage.
 The 2026-08-26 mDNS evidence records the Homey and co-hosted HAP service types, ports, and TXT key names observed on SHS
-`13.4.1`; it contains no service instance names, hosts, addresses, or TXT values and does not by itself establish
-restart stability or authorize automatic discovery.
+`13.4.1`; the pre-restart and post-restart reports are exact matches. The restart-recovery report records the ordered
+SDK disconnect, reconnect, manager resubscription, fresh inventory read, and cleanup evidence. These reports contain no
+service instance names, hosts, addresses, TXT values, endpoint, credential, inventory content, or event payload.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-post-restart.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-post-restart.json
@@ -1,0 +1,30 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mdns",
+		"schemaVersion": 1
+	},
+	"observation": {
+		"durationMs": 10000,
+		"matchedServices": 3,
+		"services": [
+			{
+				"port": 47756,
+				"protocol": "tcp",
+				"txtKeys": ["c#", "ci", "ff", "id", "md", "pv", "s#", "sf", "sh"],
+				"type": "hap"
+			},
+			{
+				"port": 48000,
+				"protocol": "tcp",
+				"txtKeys": ["c#", "ci", "ff", "id", "md", "pv", "s#", "sf", "sh"],
+				"type": "hap"
+			},
+			{
+				"port": 4859,
+				"protocol": "tcp",
+				"txtKeys": ["id", "model", "name", "version"],
+				"type": "homey"
+			}
+		]
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-restart-recovery.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-restart-recovery.json
@@ -1,0 +1,35 @@
+{
+	"metadata": {
+		"probe": "homey-shs-recovery",
+		"scenario": "restart",
+		"schemaVersion": 2,
+		"sdkVersion": "3.19.2"
+	},
+	"recovery": {
+		"disconnectObserved": true,
+		"inventoryReadSucceeded": true,
+		"managerResubscribed": true,
+		"transportReconnected": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{ "event": "sdk.create.resolved", "order": 1 },
+			{ "event": "manager.subscribe.resolved", "order": 2 },
+			{ "event": "recovery.window.open", "order": 3 },
+			{ "event": "socket.disconnect", "order": 4 },
+			{ "event": "socket.reconnect_attempt", "order": 5 },
+			{ "event": "socket.reconnecting", "order": 6 },
+			{ "event": "socket.reconnect_error", "order": 7 },
+			{ "event": "socket.reconnect_attempt", "order": 8 },
+			{ "event": "socket.reconnecting", "order": 9 },
+			{ "event": "socket.reconnect", "order": 10 },
+			{ "event": "manager.resubscribe.observed", "order": 11 },
+			{ "event": "inventory.read.resolved", "order": 12 },
+			{ "event": "manager.unsubscribe.resolved", "order": 13 },
+			{ "event": "socket.disconnect.resolved", "order": 14 },
+			{ "event": "sdk.destroyed", "order": 15 }
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/test/homey-shs-mdns.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mdns.homey-spike.ts
@@ -93,21 +93,29 @@ describe('Homey SHS mDNS compatibility probe', () => {
 	});
 
 	it('preserves the sanitized live Homey and HAP advertisement evidence', async () => {
-		const evidencePath = resolve(
+		const preRestartEvidencePath = resolve(
 			__dirname,
 			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json',
 		);
-		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const postRestartEvidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-post-restart.json',
+		);
+		const evidence = JSON.parse(await readFile(preRestartEvidencePath, 'utf8')) as unknown;
+		const postRestartEvidence = JSON.parse(await readFile(postRestartEvidencePath, 'utf8')) as unknown;
 		const config = loadHomeyShsMdnsProbeConfig(BASE_ENVIRONMENT);
 
 		assertHomeyShsMdnsReportSchema(evidence);
+		assertHomeyShsMdnsReportSchema(postRestartEvidence);
 		expect(evidence.observation.services).toContainEqual({
 			port: 4859,
 			protocol: 'tcp',
 			txtKeys: ['id', 'model', 'name', 'version'],
 			type: 'homey',
 		});
+		expect(postRestartEvidence).toStrictEqual(evidence);
 		expect(() => assertHomeyShsMdnsReportSafe(evidence, config)).not.toThrow();
+		expect(() => assertHomeyShsMdnsReportSafe(postRestartEvidence, config)).not.toThrow();
 	});
 
 	it('loads a key-free, exact-host configuration with bounded observation', () => {

--- a/apps/backend/test/homey-shs-recovery.homey-spike.ts
+++ b/apps/backend/test/homey-shs-recovery.homey-spike.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import {
 	type HomeyRecoverySdkFactory,
@@ -161,6 +161,25 @@ const fastConfig = (overrides: Partial<HomeyShsRecoveryProbeConfig> = {}): Homey
 });
 
 describe('Homey SHS recovery compatibility probe', () => {
+	it('preserves the sanitized live SHS restart recovery evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-restart-recovery.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const config = loadHomeyShsRecoveryProbeConfig(BASE_ENVIRONMENT);
+
+		assertHomeyShsRecoveryReportSchema(evidence);
+		expect(evidence.recovery).toStrictEqual({
+			disconnectObserved: true,
+			inventoryReadSucceeded: true,
+			managerResubscribed: true,
+			transportReconnected: true,
+		});
+		expect(evidence.session.events).toHaveLength(15);
+		expect(() => assertHomeyShsRecoveryReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires the exact operator acknowledgement and refuses mutation gates', () => {
 		expect(() =>
 			loadHomeyShsRecoveryProbeConfig({

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -9,10 +9,10 @@ and adopt them, keeps their state synchronized, and sends supported controls bac
 <Callout type="warning">
   **The Homey release gate is not complete.** Current live evidence covers Homey
   SHS 13.4.0 and 13.4.1 over HTTP port 4859 for sanitized inventory capture and
-  limited SDK connection/session behavior. Homey Pro, HTTPS, capability
-  writes/events, restart and network recovery, and credential rotation have not
-  completed the required live matrix. Use this integration for evaluation, not
-  as a production-ready support claim.
+  limited SDK connection/session behavior and SHS restart recovery. Homey Pro,
+  HTTPS, capability writes/events, network recovery, and credential rotation
+  have not completed the required live matrix. Use this integration for
+  evaluation, not as a production-ready support claim.
 </Callout>
 
 Only a **local Homey connection** is implemented. Homey Cloud/OAuth is not available yet. Smart Panel does not pair,
@@ -100,8 +100,9 @@ Panel requires a new key for the unsaved connection test; it never sends a store
 ### Manual Server Selection
 
 Enter the Homey URL manually. Smart Panel does not currently offer automatic Homey server discovery. A Homey-specific
-advertisement has been observed, but its restart stability, safe identity deduplication, and endpoint verification have
-not completed the release gate. Device discovery begins only after a Homey connection has been configured.
+advertisement remained stable across a controlled restart, but safe identity deduplication and spoof-resistant endpoint
+verification have not completed the release gate. Device discovery begins only after a Homey connection has been
+configured.
 
 ## Discover and Adopt Devices
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory and SDK session/cleanup evidence captured, automatic mDNS discovery explicitly
-deferred for the local MVP, and live capability-event, write, error-matrix, reconnect, recovery, and
-credential-rotation evidence pending
+**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart recovery, and stable restart-spanning mDNS
+evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write, error-matrix, network
+recovery, lifecycle, and credential-rotation evidence is pending
 
 **Started:** 2026-08-12
 
@@ -19,19 +19,19 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                               | Evidence still required                                              |
-| ----------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859` | Repeat over HTTPS `4860` if enabled                                  |
-| System, zone, device inventory, and individual device | Captured and sanitized                               | Add lifecycle delta evidence on the disposable test device           |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read         | Add allowlisted write and read-back evidence                         |
-| Socket.IO events and reconnect                        | Passive sessions passed; recovery runs pending       | Capture capability/availability events and both recovery orderings   |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled               | Use only the designated harmless test capability                     |
-| Error classification                                  | SDK invalid key returned `401`; matrix pending       | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
-| API-key revocation and replacement                    | Operator-controlled probe ready                      | Revoke only a dedicated test key during the gated observation window |
-| Disposable-device lifecycle                           | Guarded operator probe ready                         | Use only the separately gated virtual/test device                    |
-| mDNS discovery                                        | Homey-specific service observed; manual URL remains  | Verify stability before and after restart                            |
-| SDK decision                                          | SDK selected behind connector boundary               | Re-evaluate the pinned package and audit result on every upgrade     |
-| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture          | Add event/reconnect fixtures from the remaining live lifecycle runs  |
+| Area                                                  | Status                                                   | Evidence still required                                              |
+| ----------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                  |
+| System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device           |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
+| Socket.IO events and reconnect                        | SHS restart recovery passed                              | Capture capability/availability events and network recovery ordering |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
+| Error classification                                  | SDK invalid key returned `401`; matrix pending           | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
+| API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
+| Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                    |
+| mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery     |
+| SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade     |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add event/reconnect fixtures from the remaining live lifecycle runs  |
 
 ## Installation evidence
 
@@ -288,8 +288,13 @@ operator window from `10000` through `300000` milliseconds and defaults to `9000
 post-reconnect verification, and cleanup remain independently bounded by `FB_HOMEY_SHS_TIMEOUT_MS`. A timeout or cleanup
 failure writes no report and exposes only a fixed sanitized error.
 
-This runbook does not authorize Smart Panel tooling or an automated agent to restart SHS. Live evidence remains pending
-until an operator intentionally performs the restart while the gated probe is open.
+This runbook does not authorize Smart Panel tooling or an automated agent to restart SHS. Only an operator may perform
+the restart while the gated probe is open.
+
+The operator-controlled run on 2026-08-26 against SHS `13.4.1` recorded the required disconnect, reconnect, manager
+resubscription, and fresh inventory read, followed by successful manager unsubscription, socket disconnect, and SDK
+destruction. The reviewed 15-event report is committed as
+`__fixtures__/evidence/2026-08-26-shs-13.4.1-restart-recovery.json`. Capability values were not changed during the run.
 
 ### Operator-controlled network interruption and restoration
 
@@ -397,17 +402,18 @@ discovery discriminator.
 
 A ten-second observation on 2026-08-26 after SHS `13.4.1` started on TrueNAS matched `_homey._tcp` on port `4859`, with
 the TXT key names `id`, `model`, `name`, and `version`. It also matched two co-hosted `_hap._tcp` services. The reviewed
-report is committed as `__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json`. The service names,
-hosts, addresses, and all TXT values remain excluded. This establishes one attributable Homey-specific observation,
-but it does not yet prove stability across an SHS restart.
+pre-restart report is committed as `__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-homey-advertisement.json`. A second
+ten-second observation after the controlled restart produced an exact canonical match and is committed as
+`__fixtures__/evidence/2026-08-26-shs-13.4.1-mdns-post-restart.json`. The service names, hosts, addresses, and all TXT
+values remain excluded.
 
 ### Server-discovery decision
 
 Automatic Homey server discovery remains explicitly deferred for the local MVP. Smart Panel does not register a Homey
 mDNS discoverer and does not expose Homey server-discovery or rescan endpoints. The `_homey._tcp` observation is
-attributable, but it has not completed the required before/after-restart stability check. TXT values are intentionally
-excluded from evidence, so identity deduplication and endpoint verification also require a reviewed design before the
-advertisement can become a safe discovery input.
+attributable and stable across the controlled restart, but TXT values are intentionally excluded from evidence. Safe
+identity deduplication, spoof-resistant endpoint verification, expiry, and duplicate-record behavior still require a
+reviewed design before the advertisement can become a discovery input.
 
 Administrators configure the local Homey URL manually through the plugin configuration and can verify either the
 fully saved configuration or a complete candidate URL/new-key pair through the connection-test endpoint. Manual setup
@@ -483,8 +489,8 @@ Artifact snapshot inspected on 2026-08-12 and rechecked on 2026-08-25:
 HTTP remains the independent read-only compatibility/capture path, not the production realtime transport. The decision
 is based on the live SHS session and cleanup evidence, the SDK-native manager/capability contract, and the production
 adapter suites covering bounded creation and operations, subscription cleanup, reconnect coalescing, duplicate-listener
-prevention, late-client disposal, and normalized error handling. The outstanding live restart/network matrix remains a
-release-evidence gap, not an SDK abstraction gap.
+prevention, late-client disposal, and normalized error handling. Live SHS restart recovery now passes; the outstanding
+network-interruption matrix remains a release-evidence gap, not an SDK abstraction gap.
 
 The package license permits use with Homey products. Smart Panel loads it only for a user-configured Homey integration,
 does not copy or modify its proprietary source, and preserves the package's own `LICENSE` in installed production
@@ -524,10 +530,10 @@ Fill this matrix using synthetic aliases only.
 | Capability and availability events        | Pending                             |                                                                                                                                                      |
 | Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
 | Network interruption and restoration      | Pending                             |                                                                                                                                                      |
-| SHS restart and reconnect                 | Pending                             |                                                                                                                                                      |
+| SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, bounded reconnect attempts, resubscription, fresh inventory read, and complete cleanup                          |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
-| Stable mDNS service before/after restart  | Partial                             | SHS `13.4.1` advertised `_homey._tcp` on `4859` once after startup; repeat before and after a controlled restart                                     |
+| Stable mDNS service before/after restart  | Pass                                | Ten-second pre/post observations were exact matches: `_homey._tcp` on `4859` plus two co-hosted `_hap._tcp` services                                 |
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -73,13 +73,13 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
-- [ ] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
+- [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
 - [ ] If Homey Pro hardware is available, repeat the minimum inventory/event/write suite against its local API.
 
 ### Task 0.3: Decide SDK vs. direct protocol
 
 - [x] Review the exact `homey-api` package version, license text, transitive dependencies, Node 24 support, release activity, and bundle/runtime implications.
-- [ ] Exercise connect/disconnect, timeouts, subscription cleanup, and reconnect behavior in a disposable spike.
+- [x] Exercise connect/disconnect, timeouts, subscription cleanup, and reconnect behavior in a disposable spike.
 - [x] Record one decision: `use SDK behind connector` or `use documented HTTP/Socket.IO directly`.
 - [x] Record replacement considerations so the rest of the plugin does not depend on SDK-specific objects.
 - [x] Do not add the dependency to production packages until this decision is reviewed.
@@ -89,8 +89,8 @@ crosses into normalized device services. The package license permits use with Ho
 the dependency. Its Node 24 engine is now reflected in root, backend, and packaged-server manifests. The legacy Socket.IO
 chain's unpatched moderate `parseuri` advisory is accepted only with the documented HTTP(S), credential, 2,048-character,
 administrator-only endpoint boundary and bounded operations. A direct documented HTTP/Socket.IO adapter is the recorded
-replacement and must pass the existing connector contract. Live restart/network evidence remains open above and in
-Task 6.2.
+replacement and must pass the existing connector contract. Live restart recovery passed on SHS `13.4.1`; network
+interruption evidence remains open above and in Task 6.2.
 
 ### Task 0.4: Build the sanitized fixture corpus
 
@@ -618,7 +618,7 @@ representative lifecycle failure paths.
 
 - [ ] Fresh startup with SHS online.
 - [ ] Startup with SHS offline, then recovery.
-- [ ] SHS restart during event flow.
+- [x] SHS restart during event flow.
 - [ ] Network interruption/restoration.
 - [ ] API key revoked, replaced, and insufficiently scoped.
 - [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -618,7 +618,7 @@ representative lifecycle failure paths.
 
 - [ ] Fresh startup with SHS online.
 - [ ] Startup with SHS offline, then recovery.
-- [x] SHS restart during event flow.
+- [ ] SHS restart during event flow.
 - [ ] Network interruption/restoration.
 - [ ] API key revoked, replaced, and insufficiently scoped.
 - [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
@@ -626,6 +626,10 @@ representative lifecycle failure paths.
 - [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.
 - [ ] Plugin disable/enable and backend shutdown with no leaked connections/timers.
+
+The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
+reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow
+criterion above because no capability or availability event was observed before and after that restart.
 
 ### Task 6.3: Validate performance and security
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -82,9 +82,9 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] SHS version, image digest, network topology, ports, and test date are recorded.
 - [ ] A least-privilege API key can read devices, zones, system information, and current capability values.
 - [ ] A designated harmless writable capability can be controlled and its resulting event observed.
-- [ ] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
+- [x] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
 - [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
-- [x] mDNS behavior is verified; automatic discovery is explicitly deferred because no attributable stable Homey service was observed.
+- [x] mDNS behavior is verified; automatic discovery remains deferred pending safe identity and endpoint verification.
 - [x] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
 - [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.
 - [x] Fixture-backed tests can run without live SHS access.


### PR DESCRIPTION
## Summary

- preserve the sanitized 15-event SHS 13.4.1 restart-recovery report
- verify disconnect, bounded reconnect attempts, manager resubscription, fresh inventory read, and complete SDK cleanup
- preserve exact-match pre/post-restart Homey and HAP mDNS reports
- update the compatibility record, implementation plan, feature task, and operator guide to close the restart gate
- keep automatic server discovery deferred pending safe identity and endpoint verification

## Live evidence

- operator restarted only the designated Homey SHS app during the gated observation window
- transport disconnect and reconnect were observed
- the devices manager resubscribed and completed a fresh inventory read
- cleanup unsubscribed the manager, disconnected the socket, and destroyed the SDK
- ten-second mDNS observations before and after restart were exact canonical matches
- no capability write, lifecycle mutation, credential change, endpoint, identifier, inventory payload, or TXT value is recorded

## Validation

- focused recovery and mDNS suites — 27 tests passed
- `pnpm run test:homey-spike` — 10 suites, 132 tests passed
- `pnpm run homey:security-gate` — Homey suites plus 39 focused suites and 483 tests passed
- `pnpm run build` in `apps/website` — passed
- committed recovery and post-restart mDNS evidence exactly match the ignored live reports