### PR TITLE
test(cross): record Homey network recovery evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -83,8 +83,9 @@ labels, booleans, ordering numbers, public dependency versions, and non-sensitiv
 test that re-applies the report safety assertions. The 2026-08-14 SDK session evidence records connection,
 subscription, cleanup, and invalid-key behavior only; it does not claim capability-event, write, or reconnect coverage.
 The 2026-08-26 mDNS evidence records the Homey and co-hosted HAP service types, ports, and TXT key names observed on SHS
-`13.4.1`; the pre-restart and post-restart reports are exact matches. The restart-recovery report records the ordered
-SDK disconnect, reconnect, manager resubscription, fresh inventory read, and cleanup evidence. These reports contain no
-service instance names, hosts, addresses, TXT values, endpoint, credential, inventory content, or event payload.
+`13.4.1`; the pre-restart and post-restart reports are exact matches. The restart-recovery and network-recovery reports
+record ordered SDK disconnect, reconnect, manager resubscription, fresh inventory read, and cleanup evidence across an
+SHS restart and a temporary Smart Panel-to-SHS port block, respectively. These reports contain no service instance
+names, hosts, addresses, TXT values, endpoint, credential, firewall rule, inventory content, or event payload.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-network-recovery.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-network-recovery.json
@@ -1,0 +1,164 @@
+{
+	"metadata": {
+		"probe": "homey-shs-recovery",
+		"scenario": "network-interruption",
+		"schemaVersion": 2,
+		"sdkVersion": "3.19.2"
+	},
+	"recovery": {
+		"disconnectObserved": true,
+		"inventoryReadSucceeded": true,
+		"managerResubscribed": true,
+		"transportReconnected": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "recovery.window.open",
+				"order": 3
+			},
+			{
+				"event": "socket.disconnect",
+				"order": 4
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 5
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 6
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 7
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 8
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 9
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 10
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 11
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 12
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 13
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 14
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 15
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 16
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 17
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 18
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 19
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 20
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 21
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 22
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 23
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 24
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 25
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 26
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 27
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 28
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 29
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 30
+			},
+			{
+				"event": "socket.reconnect",
+				"order": 31
+			},
+			{
+				"event": "manager.resubscribe.observed",
+				"order": 32
+			},
+			{
+				"event": "inventory.read.resolved",
+				"order": 33
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 34
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 35
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 36
+			}
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/test/homey-shs-recovery.homey-spike.ts
+++ b/apps/backend/test/homey-shs-recovery.homey-spike.ts
@@ -180,6 +180,25 @@ describe('Homey SHS recovery compatibility probe', () => {
 		expect(() => assertHomeyShsRecoveryReportSafe(evidence, config)).not.toThrow();
 	});
 
+	it('preserves the sanitized live SHS network recovery evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-network-recovery.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const config = loadHomeyShsRecoveryProbeConfig(NETWORK_ENVIRONMENT);
+
+		assertHomeyShsRecoveryReportSchema(evidence);
+		expect(evidence.recovery).toStrictEqual({
+			disconnectObserved: true,
+			inventoryReadSucceeded: true,
+			managerResubscribed: true,
+			transportReconnected: true,
+		});
+		expect(evidence.session.events).toHaveLength(36);
+		expect(() => assertHomeyShsRecoveryReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires the exact operator acknowledgement and refuses mutation gates', () => {
 		expect(() =>
 			loadHomeyShsRecoveryProbeConfig({

--- a/apps/website/app/docs/extensions/device-integrations/page.mdx
+++ b/apps/website/app/docs/extensions/device-integrations/page.mdx
@@ -19,7 +19,7 @@ device → channel → property hierarchy.
 | Plugin | Protocol | Discovery | Description |
 |--------|----------|-----------|-------------|
 | **Home Assistant** | WebSocket | Automatic | Imports devices and entities from a Home Assistant instance. Bidirectional real-time sync — state changes and commands flow both ways instantly. Requires a long-lived access token. |
-| [**Homey (Experimental)**](/docs/extensions/homey) | Local API / Socket.IO | Manual server, automatic device inventory | Implements reviewed adoption, synchronization, and supported controls for local Homey APIs. The live release gate is incomplete; verified live scope is currently limited to SHS 13.4.0 over HTTP for inventory and selected session behavior. |
+| [**Homey (Experimental)**](/docs/extensions/homey) | Local API / Socket.IO | Manual server, automatic device inventory | Implements reviewed adoption, synchronization, and supported controls for local Homey APIs. The live release gate is incomplete; verified live scope includes SHS 13.4.0 and 13.4.1 inventory plus selected session, restart, and network-recovery behavior over HTTP. |
 | **Shelly NG** | mDNS / RPC | Automatic | Discovers and controls Shelly Next-Generation devices (Plus, Pro, BLU series) on the local network. No cloud dependency — all communication stays local. |
 | **Shelly v1** | HTTP / CoAP | Automatic | Support for first-generation Shelly devices using the original HTTP and CoAP APIs. |
 | **WLED** | HTTP | Automatic | Controls WLED-based LED strips and lights discovered on the local network. |

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -202,9 +202,9 @@ The event connection is unavailable or was interrupted. Smart Panel continues bo
 reconnects with bounded backoff. Check Homey and proxy support for long-lived Socket.IO/WebSocket connections. If the
 state does not recover, test the saved connection and inspect the sanitized backend logs.
 
-A controlled 60-second interruption of only the Smart Panel-to-SHS API ports recovered the SDK session, subscription,
-and inventory reconciliation on SHS `13.4.1`. Capability-event continuity across an interruption remains part of the
-unfinished live release matrix.
+A controlled 60-second interruption of only the Smart Panel-to-SHS API ports recovered the SDK session and subscription,
+then completed a fresh inventory read on SHS `13.4.1`. Capability-event continuity across an interruption remains part
+of the unfinished live release matrix.
 
 ### A device is missing or unsupported
 

--- a/apps/website/app/docs/extensions/homey/page.mdx
+++ b/apps/website/app/docs/extensions/homey/page.mdx
@@ -9,10 +9,10 @@ and adopt them, keeps their state synchronized, and sends supported controls bac
 <Callout type="warning">
   **The Homey release gate is not complete.** Current live evidence covers Homey
   SHS 13.4.0 and 13.4.1 over HTTP port 4859 for sanitized inventory capture and
-  limited SDK connection/session behavior and SHS restart recovery. Homey Pro,
-  HTTPS, capability writes/events, network recovery, and credential rotation
-  have not completed the required live matrix. Use this integration for
-  evaluation, not as a production-ready support claim.
+  limited SDK connection/session behavior plus SHS restart and network recovery.
+  Homey Pro, HTTPS, capability writes/events, and credential rotation have not
+  completed the required live matrix. Use this integration for evaluation, not
+  as a production-ready support claim.
 </Callout>
 
 Only a **local Homey connection** is implemented. Homey Cloud/OAuth is not available yet. Smart Panel does not pair,
@@ -201,6 +201,10 @@ administrator access.
 The event connection is unavailable or was interrupted. Smart Panel continues bounded reconciliation where possible and
 reconnects with bounded backoff. Check Homey and proxy support for long-lived Socket.IO/WebSocket connections. If the
 state does not recover, test the saved connection and inspect the sanitized backend logs.
+
+A controlled 60-second interruption of only the Smart Panel-to-SHS API ports recovered the SDK session, subscription,
+and inventory reconciliation on SHS `13.4.1`. Capability-event continuity across an interruption remains part of the
+unfinished live release matrix.
 
 ### A device is missing or unsupported
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -322,9 +322,9 @@ ordinary Homey installation. The restart acknowledgement is rejected in network 
 is rejected in restart mode, preventing one operator authorization from being reused for a different action.
 
 The operator-controlled run on 2026-08-26 against SHS `13.4.1` temporarily blocked only the Smart Panel test host's
-path to SHS ports `4859` and `4860` for 60 seconds. The reviewed 36-event report proved disconnect, bounded reconnect
-attempts, transport reconnection, manager resubscription, a fresh inventory read, and complete cleanup. No capability,
-device, or credential was changed. The report is committed as
+path to SHS ports `4859` and `4860` for 60 seconds. The reviewed 36-event report proved disconnect, nine reconnect
+attempts during that finite interruption, transport reconnection, manager resubscription, a fresh inventory read, and
+complete cleanup. No capability, device, or credential was changed. The report is committed as
 `__fixtures__/evidence/2026-08-26-shs-13.4.1-network-recovery.json`; it contains neither the firewall rule nor any
 address, endpoint, inventory, credential, or payload.
 
@@ -537,8 +537,8 @@ Fill this matrix using synthetic aliases only.
 | Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |
 | Capability and availability events        | Pending                             |                                                                                                                                                      |
 | Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
-| Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, bounded reconnect attempts, resubscription, fresh inventory read, and complete cleanup                          |
-| SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, bounded reconnect attempts, resubscription, fresh inventory read, and complete cleanup                          |
+| Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
+| SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
 | Stable mDNS service before/after restart  | Pass                                | Ten-second pre/post observations were exact matches: `_homey._tcp` on `4859` plus two co-hosted `_hap._tcp` services                                 |

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart recovery, and stable restart-spanning mDNS
-evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write, error-matrix, network
-recovery, lifecycle, and credential-rotation evidence is pending
+**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
+restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
+error-matrix, lifecycle, and credential-rotation evidence is pending
 
 **Started:** 2026-08-12
 
@@ -24,7 +24,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                  |
 | System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device           |
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
-| Socket.IO events and reconnect                        | SHS restart recovery passed                              | Capture capability/availability events and network recovery ordering |
+| Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity                |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
 | Error classification                                  | SDK invalid key returned `401`; matrix pending           | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
 | API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
@@ -321,6 +321,13 @@ disconnect observed` before restoring it. Do not interrupt the broader household
 ordinary Homey installation. The restart acknowledgement is rejected in network mode and the network acknowledgement
 is rejected in restart mode, preventing one operator authorization from being reused for a different action.
 
+The operator-controlled run on 2026-08-26 against SHS `13.4.1` temporarily blocked only the Smart Panel test host's
+path to SHS ports `4859` and `4860` for 60 seconds. The reviewed 36-event report proved disconnect, bounded reconnect
+attempts, transport reconnection, manager resubscription, a fresh inventory read, and complete cleanup. No capability,
+device, or credential was changed. The report is committed as
+`__fixtures__/evidence/2026-08-26-shs-13.4.1-network-recovery.json`; it contains neither the firewall rule nor any
+address, endpoint, inventory, credential, or payload.
+
 After the run, restore the default restart mode explicitly or clear the scenario and acknowledgement:
 
 ```bash
@@ -489,8 +496,9 @@ Artifact snapshot inspected on 2026-08-12 and rechecked on 2026-08-25:
 HTTP remains the independent read-only compatibility/capture path, not the production realtime transport. The decision
 is based on the live SHS session and cleanup evidence, the SDK-native manager/capability contract, and the production
 adapter suites covering bounded creation and operations, subscription cleanup, reconnect coalescing, duplicate-listener
-prevention, late-client disposal, and normalized error handling. Live SHS restart recovery now passes; the outstanding
-network-interruption matrix remains a release-evidence gap, not an SDK abstraction gap.
+prevention, late-client disposal, and normalized error handling. Live SHS restart and network-interruption session
+recovery now pass; capability and availability event-flow continuity remains a release-evidence gap, not an SDK
+abstraction gap.
 
 The package license permits use with Homey products. Smart Panel loads it only for a user-configured Homey integration,
 does not copy or modify its proprietary source, and preserves the package's own `LICENSE` in installed production
@@ -529,7 +537,7 @@ Fill this matrix using synthetic aliases only.
 | Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |
 | Capability and availability events        | Pending                             |                                                                                                                                                      |
 | Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
-| Network interruption and restoration      | Pending                             |                                                                                                                                                      |
+| Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, bounded reconnect attempts, resubscription, fresh inventory read, and complete cleanup                          |
 | SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, bounded reconnect attempts, resubscription, fresh inventory read, and complete cleanup                          |
 | API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -633,9 +633,9 @@ criterion above because no capability or availability event was observed before 
 
 The 2026-08-26 SHS `13.4.1` network probe closed the network interruption/restoration session-recovery slice. A precise
 firewall rule blocked only the test host's path to SHS ports `4859` and `4860` for 60 seconds; the sanitized 36-event
-report proved disconnect, bounded reconnect attempts, reconnect, manager resubscription, a fresh inventory read, and
-complete cleanup. It does not close the event-flow criterion because no capability or availability event was observed
-across the interruption.
+report proved disconnect, nine reconnect attempts during that finite interruption, reconnect, manager resubscription,
+a fresh inventory read, and complete cleanup. It does not close the event-flow criterion because no capability or
+availability event was observed across the interruption.
 
 ### Task 6.3: Validate performance and security
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -89,8 +89,8 @@ crosses into normalized device services. The package license permits use with Ho
 the dependency. Its Node 24 engine is now reflected in root, backend, and packaged-server manifests. The legacy Socket.IO
 chain's unpatched moderate `parseuri` advisory is accepted only with the documented HTTP(S), credential, 2,048-character,
 administrator-only endpoint boundary and bounded operations. A direct documented HTTP/Socket.IO adapter is the recorded
-replacement and must pass the existing connector contract. Live restart recovery passed on SHS `13.4.1`; network
-interruption evidence remains open above and in Task 6.2.
+replacement and must pass the existing connector contract. Live restart and network-interruption session recovery
+passed on SHS `13.4.1`; capability and availability event-flow continuity remains open above and in Task 6.2.
 
 ### Task 0.4: Build the sanitized fixture corpus
 
@@ -619,7 +619,7 @@ representative lifecycle failure paths.
 - [ ] Fresh startup with SHS online.
 - [ ] Startup with SHS offline, then recovery.
 - [ ] SHS restart during event flow.
-- [ ] Network interruption/restoration.
+- [x] Network interruption/restoration.
 - [ ] API key revoked, replaced, and insufficiently scoped.
 - [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [ ] Physical/Homey/flow-originated state changes.
@@ -630,6 +630,12 @@ representative lifecycle failure paths.
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow
 criterion above because no capability or availability event was observed before and after that restart.
+
+The 2026-08-26 SHS `13.4.1` network probe closed the network interruption/restoration session-recovery slice. A precise
+firewall rule blocked only the test host's path to SHS ports `4859` and `4860` for 60 seconds; the sanitized 36-event
+report proved disconnect, bounded reconnect attempts, reconnect, manager resubscription, a fresh inventory read, and
+complete cleanup. It does not close the event-flow criterion because no capability or availability event was observed
+across the interruption.
 
 ### Task 6.3: Validate performance and security
 


### PR DESCRIPTION
## Summary

- preserve the sanitized SHS 13.4.1 network-interruption recovery report as reviewed compatibility evidence
- verify the live report schema, scenario, recovery outcome, ordering, cleanup, and privacy boundaries in the Homey spike suite
- update the compatibility record, implementation plan, and operator documentation while keeping capability-event continuity explicitly open

## Live evidence

A controlled 60-second block of only the Smart Panel test host path to SHS ports 4859 and 4860 produced 36 ordered events. The report proves disconnect, nine reconnect attempts during that finite interruption, transport recovery, manager resubscription, a fresh inventory read, and complete cleanup. It contains no address, endpoint, firewall rule, credential, inventory data, device identity, or event payload.

This closes the network interruption/restoration session-recovery slice only. It does not claim a retry cap or capability/availability event continuity across the interruption.

## Verification

- pnpm run test:homey-spike -- --runTestsByPath test/homey-shs-recovery.homey-spike.ts (14 tests)
- pnpm run test:homey-spike (133 tests)
- pnpm run homey:security-gate (133 Homey spike tests and 483 Homey/config tests)
- pnpm run build in apps/website
- OpenAPI regeneration produced no diff
- committed evidence matches the locally generated sanitized report after canonical JSON sorting
