### PR TITLE
test(cross): record Homey error scenario evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -87,5 +87,8 @@ The 2026-08-26 mDNS evidence records the Homey and co-hosted HAP service types, 
 record ordered SDK disconnect, reconnect, manager resubscription, fresh inventory read, and cleanup evidence across an
 SHS restart and a temporary Smart Panel-to-SHS port block, respectively. These reports contain no service instance
 names, hosts, addresses, TXT values, endpoint, credential, firewall rule, inventory content, or event payload.
+The error-matrix report records only the five fixed validation, authentication, authorization, timeout, and unavailable
+categories plus non-sensitive HTTP status codes. It contains no URL, address, key, identifier, response body, or raw
+transport error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json
@@ -1,17 +1,17 @@
 {
 	"metadata": {
 		"probe": "homey-shs-errors",
-		"schemaVersion": 1
+		"schemaVersion": 2
 	},
 	"scenarios": {
-		"badUrl": {
-			"category": "validation",
-			"rejected": true
-		},
-		"invalidKey": {
+		"authenticationRejection": {
 			"category": "authentication",
 			"rejected": true,
 			"statusCode": 401
+		},
+		"badUrlValidation": {
+			"category": "validation",
+			"rejected": true
 		},
 		"missingScope": {
 			"allowedRequestStatusCode": 200,
@@ -23,7 +23,7 @@
 			"category": "timeout",
 			"rejected": true
 		},
-		"unavailableHost": {
+		"unavailableSimulation": {
 			"category": "unavailable",
 			"rejected": true
 		}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json
@@ -1,0 +1,31 @@
+{
+	"metadata": {
+		"probe": "homey-shs-errors",
+		"schemaVersion": 1
+	},
+	"scenarios": {
+		"badUrl": {
+			"category": "validation",
+			"rejected": true
+		},
+		"invalidKey": {
+			"category": "authentication",
+			"rejected": true,
+			"statusCode": 401
+		},
+		"missingScope": {
+			"allowedRequestStatusCode": 200,
+			"category": "authorization",
+			"rejected": true,
+			"statusCode": 403
+		},
+		"requestTimeout": {
+			"category": "timeout",
+			"rejected": true
+		},
+		"unavailableHost": {
+			"category": "unavailable",
+			"rejected": true
+		}
+	}
+}

--- a/apps/backend/test/homey-shs-errors.homey-spike.ts
+++ b/apps/backend/test/homey-shs-errors.homey-spike.ts
@@ -18,9 +18,9 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
 };
 
-const LOCAL_FAILURES: Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableHost'> = {
+const LOCAL_FAILURES: Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableSimulation'> = {
 	requestTimeout: { category: 'timeout', rejected: true },
-	unavailableHost: { category: 'unavailable', rejected: true },
+	unavailableSimulation: { category: 'unavailable', rejected: true },
 };
 
 const createLiveFetch = (): jest.MockedFunction<HomeyShsProbeFetch> =>
@@ -50,10 +50,10 @@ describe('Homey SHS error compatibility probe', () => {
 		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT);
 
 		expect(evidence).toStrictEqual({
-			metadata: { probe: 'homey-shs-errors', schemaVersion: 1 },
+			metadata: { probe: 'homey-shs-errors', schemaVersion: 2 },
 			scenarios: {
-				badUrl: { category: 'validation', rejected: true },
-				invalidKey: { category: 'authentication', rejected: true, statusCode: 401 },
+				authenticationRejection: { category: 'authentication', rejected: true, statusCode: 401 },
+				badUrlValidation: { category: 'validation', rejected: true },
 				missingScope: {
 					allowedRequestStatusCode: 200,
 					category: 'authorization',
@@ -61,7 +61,7 @@ describe('Homey SHS error compatibility probe', () => {
 					statusCode: 403,
 				},
 				requestTimeout: { category: 'timeout', rejected: true },
-				unavailableHost: { category: 'unavailable', rejected: true },
+				unavailableSimulation: { category: 'unavailable', rejected: true },
 			},
 		});
 		expect(() => assertHomeyShsErrorReportSafe(evidence, config)).not.toThrow();
@@ -89,10 +89,10 @@ describe('Homey SHS error compatibility probe', () => {
 		const report = await probeHomeyShsErrors(config, fetchImplementation, () => Promise.resolve(LOCAL_FAILURES));
 
 		expect(report).toEqual({
-			metadata: { probe: 'homey-shs-errors', schemaVersion: 1 },
+			metadata: { probe: 'homey-shs-errors', schemaVersion: 2 },
 			scenarios: {
-				badUrl: { category: 'validation', rejected: true },
-				invalidKey: { category: 'authentication', rejected: true, statusCode: 401 },
+				authenticationRejection: { category: 'authentication', rejected: true, statusCode: 401 },
+				badUrlValidation: { category: 'validation', rejected: true },
 				missingScope: {
 					allowedRequestStatusCode: 200,
 					category: 'authorization',

--- a/apps/backend/test/homey-shs-errors.homey-spike.ts
+++ b/apps/backend/test/homey-shs-errors.homey-spike.ts
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
 import {
 	type HomeyShsErrorReport,
 	type HomeyShsProbeFetch,
@@ -38,6 +41,32 @@ const createLiveFetch = (): jest.MockedFunction<HomeyShsProbeFetch> =>
 	});
 
 describe('Homey SHS error compatibility probe', () => {
+	it('preserves the sanitized live SHS error-matrix evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as HomeyShsErrorReport;
+		const config = loadHomeyShsErrorProbeConfig(BASE_ENVIRONMENT);
+
+		expect(evidence).toStrictEqual({
+			metadata: { probe: 'homey-shs-errors', schemaVersion: 1 },
+			scenarios: {
+				badUrl: { category: 'validation', rejected: true },
+				invalidKey: { category: 'authentication', rejected: true, statusCode: 401 },
+				missingScope: {
+					allowedRequestStatusCode: 200,
+					category: 'authorization',
+					rejected: true,
+					statusCode: 403,
+				},
+				requestTimeout: { category: 'timeout', rejected: true },
+				unavailableHost: { category: 'unavailable', rejected: true },
+			},
+		});
+		expect(() => assertHomeyShsErrorReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires a distinct device-only key for missing-scope evidence', () => {
 		expect(() =>
 			loadHomeyShsErrorProbeConfig({

--- a/apps/backend/test/support/homey-shs-error-probe.ts
+++ b/apps/backend/test/support/homey-shs-error-probe.ts
@@ -7,7 +7,7 @@ import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-p
 
 const DEVICE_PATH = '/api/manager/devices/device';
 const SYSTEM_PATH = '/api/manager/system/';
-const REPORT_SCHEMA_VERSION = 1;
+const REPORT_SCHEMA_VERSION = 2;
 const MAX_LOCAL_SIMULATION_TIMEOUT_MS = 250;
 const LOCAL_REFUSAL_TIMEOUT_MS = 250;
 
@@ -22,11 +22,11 @@ export interface HomeyShsErrorProbeConfig extends HomeyShsProbeConfig {
 export interface HomeyShsErrorReport {
 	metadata: {
 		probe: 'homey-shs-errors';
-		schemaVersion: 1;
+		schemaVersion: 2;
 	};
 	scenarios: {
-		badUrl: { category: 'validation'; rejected: true };
-		invalidKey: { category: 'authentication'; rejected: true; statusCode: 401 | 403 };
+		badUrlValidation: { category: 'validation'; rejected: true };
+		authenticationRejection: { category: 'authentication'; rejected: true; statusCode: 401 | 403 };
 		missingScope: {
 			allowedRequestStatusCode: number;
 			category: 'authorization';
@@ -34,7 +34,7 @@ export interface HomeyShsErrorReport {
 			statusCode: 403;
 		};
 		requestTimeout: { category: 'timeout'; rejected: true };
-		unavailableHost: { category: 'unavailable'; rejected: true };
+		unavailableSimulation: { category: 'unavailable'; rejected: true };
 	};
 }
 
@@ -105,7 +105,7 @@ const requireResponse = (result: Response | ClassifiedFailure, label: string): R
 	throw new Error(`Homey ${label} request failed as ${result.category}`);
 };
 
-const verifyBadUrlValidation = (): HomeyShsErrorReport['scenarios']['badUrl'] => {
+const verifyBadUrlValidation = (): HomeyShsErrorReport['scenarios']['badUrlValidation'] => {
 	try {
 		loadHomeyShsProbeConfig({
 			FB_HOMEY_SHS_API_KEY: 'synthetic-invalid-url-key',
@@ -124,7 +124,7 @@ const verifyBadUrlValidation = (): HomeyShsErrorReport['scenarios']['badUrl'] =>
 const verifyInvalidKey = async (
 	config: HomeyShsErrorProbeConfig,
 	fetchImplementation: HomeyShsProbeFetch,
-): Promise<HomeyShsErrorReport['scenarios']['invalidKey']> => {
+): Promise<HomeyShsErrorReport['scenarios']['authenticationRejection']> => {
 	const invalidKey = `invalid-homey-probe-${randomBytes(24).toString('hex')}`;
 	const response = requireResponse(
 		await request(new URL(SYSTEM_PATH, config.origin), config.timeoutMs, fetchImplementation, invalidKey),
@@ -220,7 +220,7 @@ const close = async (server: Server): Promise<void> => {
 export const probeLocalNetworkFailures = async (
 	timeoutMs: number,
 	fetchImplementation: HomeyShsProbeFetch = fetch,
-): Promise<Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableHost'>> => {
+): Promise<Pick<HomeyShsErrorReport['scenarios'], 'requestTimeout' | 'unavailableSimulation'>> => {
 	const simulationTimeoutMs = Math.min(timeoutMs, MAX_LOCAL_SIMULATION_TIMEOUT_MS);
 	const unavailableServer = createServer();
 	const unavailablePort = await listen(unavailableServer);
@@ -266,7 +266,7 @@ export const probeLocalNetworkFailures = async (
 
 	return {
 		requestTimeout: { category: 'timeout', rejected: true },
-		unavailableHost: { category: 'unavailable', rejected: true },
+		unavailableSimulation: { category: 'unavailable', rejected: true },
 	};
 };
 
@@ -280,8 +280,8 @@ export const probeHomeyShsErrors = async (
 	return {
 		metadata: { probe: 'homey-shs-errors', schemaVersion: REPORT_SCHEMA_VERSION },
 		scenarios: {
-			badUrl: verifyBadUrlValidation(),
-			invalidKey: await verifyInvalidKey(config, fetchImplementation),
+			badUrlValidation: verifyBadUrlValidation(),
+			authenticationRejection: await verifyInvalidKey(config, fetchImplementation),
 			missingScope: await verifyMissingScope(config, fetchImplementation),
 			...localFailures,
 		},

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
 restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
-error-matrix, lifecycle, and credential-rotation evidence is pending
+lifecycle, and credential-rotation evidence is pending
 
 **Started:** 2026-08-12
 
@@ -26,7 +26,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
 | Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity                |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
-| Error classification                                  | SDK invalid key returned `401`; matrix pending           | Verify missing-scope, bad-URL, unavailable, and timeout behavior     |
+| Error classification                                  | Live auth plus local failure simulations passed          | Repeat after an SHS or connector transport upgrade                   |
 | API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
 | Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                    |
 | mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery     |
@@ -474,6 +474,12 @@ keys anywhere except the configured SHS origin. Every request uses `GET`, blocks
 URLs, addresses, keys, and private terms are never written. A report is created only after all five scenarios pass,
 under the same ignored capture root and restrictive directory/file modes as the inventory and realtime probes.
 
+The 2026-08-26 combined live/local run passed all five classifications. Against SHS `13.4.1`, a generated invalid key
+returned `401`; a device-read-only key first completed an allowed inventory request with `200` and then received `403`
+for the forbidden system-information request. The shared validator rejected the non-HTTP candidate, while probe-owned
+loopback servers produced the unavailable and timeout categories. The reviewed report is committed as
+`__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json`. It does not prove API-key revocation or replacement.
+
 ## SDK artifact review
 
 Artifact snapshot inspected on 2026-08-12 and rechecked on 2026-08-25:
@@ -528,10 +534,10 @@ Fill this matrix using synthetic aliases only.
 | ----------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | HTTP `4859` ping and authenticated reads  | Pass                                | Read-only system, zone, and device requests completed without redirects                                                                              |
 | HTTPS `4860` ping and authenticated reads | Pending                             |                                                                                                                                                      |
-| Invalid key                               | Partial pass                        | The SDK local factory rejected a generated invalid key with HTTP `401`; revocation and the restricted-scope matrix remain pending                    |
-| Missing system/zone/device scope          | Pending                             |                                                                                                                                                      |
-| Bad URL and unavailable host              | Pending                             |                                                                                                                                                      |
-| Request timeout                           | Pending                             |                                                                                                                                                      |
+| Invalid key                               | Pass                                | Both the SDK session probe and error-matrix probe rejected independently generated invalid keys with HTTP `401`                                      |
+| Missing system scope on device-only key   | Pass                                | The restricted key completed the allowed device inventory read with `200`, then the system-information read returned `403`                           |
+| Bad URL and unavailable host              | Pass                                | Shared validation rejected a non-HTTP URL; a probe-owned closed loopback port produced the unavailable category                                      |
+| Request timeout                           | Pass                                | A probe-owned loopback server that withheld its response produced the timeout category within the local simulation cap                               |
 | Complete inventory and individual read    | Pass                                | Complete inventory captured: 118 devices and 16 zones; the selected individual-device response matched its pseudonymized inventory identity          |
 | Suffixed capability IDs                   | Pass in inventory and explicit read | 1,142 capability entries, including 170 suffixed entries; 55 devices repeat a base ID; an explicit suffixed capability GET returned a numeric scalar |
 | Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
 restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
-lifecycle, and credential-rotation evidence is pending
+remaining permission-scope, lifecycle, and credential-rotation evidence is pending
 
 **Started:** 2026-08-12
 
@@ -26,7 +26,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
 | Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity                |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
-| Error classification                                  | Live auth plus local failure simulations passed          | Repeat after an SHS or connector transport upgrade                   |
+| Error classification                                  | Five-scenario slice passed                               | Test keys missing zone and device permissions                        |
 | API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
 | Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                    |
 | mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery     |
@@ -536,6 +536,7 @@ Fill this matrix using synthetic aliases only.
 | HTTPS `4860` ping and authenticated reads | Pending                             |                                                                                                                                                      |
 | Invalid key                               | Pass                                | Both the SDK session probe and error-matrix probe rejected independently generated invalid keys with HTTP `401`                                      |
 | Missing system scope on device-only key   | Pass                                | The restricted key completed the allowed device inventory read with `200`, then the system-information read returned `403`                           |
+| Missing zone and device scopes            | Pending                             | Exercise independently valid keys that omit each permission before closing the broad missing-scope matrix                                            |
 | Bad URL and unavailable host              | Pass                                | Shared validation rejected a non-HTTP URL; a probe-owned closed loopback port produced the unavailable category                                      |
 | Request timeout                           | Pass                                | A probe-owned loopback server that withheld its response produced the timeout category within the local simulation cap                               |
 | Complete inventory and individual read    | Pass                                | Complete inventory captured: 118 devices and 16 zones; the selected individual-device response matched its pseudonymized inventory identity          |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -70,7 +70,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [x] Capture capabilities with values, types, units, ranges, enums, readable/writable flags, and repeated/suffixed IDs.
 - [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
 - [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
-- [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
+- [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
@@ -636,6 +636,11 @@ firewall rule blocked only the test host's path to SHS ports `4859` and `4860` f
 report proved disconnect, nine reconnect attempts during that finite interruption, reconnect, manager resubscription,
 a fresh inventory read, and complete cleanup. It does not close the event-flow criterion because no capability or
 availability event was observed across the interruption.
+
+The 2026-08-26 SHS `13.4.1` error probe closed the non-mutating error-classification matrix: generated invalid-key
+authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback
+unavailable/timeout simulations all produced their expected sanitized categories. This closes only the insufficiently
+scoped sub-slice of the API-key lifecycle item above; revocation and replacement remain open.
 
 ### Task 6.3: Validate performance and security
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -70,7 +70,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [x] Capture capabilities with values, types, units, ranges, enums, readable/writable flags, and repeated/suffixed IDs.
 - [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
 - [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
-- [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
+- [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
@@ -637,9 +637,10 @@ report proved disconnect, nine reconnect attempts during that finite interruptio
 a fresh inventory read, and complete cleanup. It does not close the event-flow criterion because no capability or
 availability event was observed across the interruption.
 
-The 2026-08-26 SHS `13.4.1` error probe closed the non-mutating error-classification matrix: generated invalid-key
+The 2026-08-26 SHS `13.4.1` error probe recorded a non-mutating five-scenario slice: generated invalid-key
 authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback
-unavailable/timeout simulations all produced their expected sanitized categories. This closes only the insufficiently
+unavailable/timeout simulations all produced their expected sanitized categories. The broad task remains open until
+independently valid keys missing zone and device permissions are exercised. This also closes only the insufficiently
 scoped sub-slice of the API-key lifecycle item above; revocation and replacement remain open.
 
 ### Task 6.3: Validate performance and security


### PR DESCRIPTION
## Summary

- preserve the sanitized SHS 13.4.1 five-scenario error report as reviewed compatibility evidence
- assert the exact artifact and reapply secret, endpoint, and private-data safety checks in the Homey spike suite
- record the proven invalid-key, missing-system-scope, bad-URL, unavailable, and timeout cases while keeping missing zone/device scopes and credential rotation open

## Live evidence

The live portion used three GET requests against the pinned SHS origin. A generated invalid key returned 401. A distinct device-read-only key first completed its allowed inventory request with 200, then received 403 for the forbidden system-information request.

Bad-URL validation was exercised locally. Unavailable-host and timeout classifications used probe-owned loopback servers; those two scenarios were not network failures against SHS. The report contains only fixed category labels, booleans, and non-sensitive status codes. Report schema v2 uses neutral scenario labels so the repository privacy scanner can continue treating fields ending in URL, host, and key as fail-closed private-data candidates.

This PR does not close the broad permission-scope matrix. Independently valid keys missing zone and device permissions remain untested, as do API-key revocation and replacement.

## Verification

- focused error and repository privacy suites (12 tests)
- pnpm run homey:security-gate (134 Homey spike tests and 483 Homey/config tests)
- backend build passed
- OpenAPI regeneration produced no diff
- operator-generated schema-v2 report exactly matches the committed sanitized evidence artifact