### PR TITLE
test(cross): add Homey permission scope probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -78,6 +78,7 @@
     "homey:probe": "ts-node --project tsconfig.json test/support/homey-shs-probe.ts",
     "homey:probe-credential-rotation": "ts-node --project tsconfig.json test/support/homey-shs-credential-rotation-probe.ts",
     "homey:probe-errors": "ts-node --project tsconfig.json test/support/homey-shs-error-probe.ts",
+    "homey:probe-scopes": "ts-node --project tsconfig.json test/support/homey-shs-scope-probe.ts",
     "homey:generate-normalized-fixtures": "ts-node --project tsconfig.json test/support/generate-homey-normalized-fixtures.ts",
     "homey:probe-realtime": "ts-node --project tsconfig.json test/support/homey-shs-realtime-probe.ts",
     "homey:probe-mdns": "ts-node --project tsconfig.json test/support/homey-shs-mdns-probe.ts",

--- a/apps/backend/test/homey-shs-scopes.homey-spike.ts
+++ b/apps/backend/test/homey-shs-scopes.homey-spike.ts
@@ -1,0 +1,206 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	type HomeyScopeProbeFetch,
+	type HomeyShsScopeProbeConfig,
+	assertHomeyShsScopeReportSafe,
+	assertHomeyShsScopeReportSchema,
+	loadHomeyShsScopeProbeConfig,
+	probeHomeyShsScopes,
+	writeHomeyShsScopeReport,
+} from './support/homey-shs-scope-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'full-read-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_DEVICE_ONLY_API_KEY: 'device-only-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+	FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY: 'without-device-test-key-that-must-not-leak',
+	FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY: 'without-zone-test-key-that-must-not-leak',
+};
+
+const EXPECTED_REPORT = {
+	metadata: { probe: 'homey-shs-permission-scopes', schemaVersion: 1 },
+	scenarios: {
+		missingDevicePermission: {
+			allowedRequestStatusCode: 200,
+			category: 'authorization',
+			rejected: true,
+			statusCode: 403,
+		},
+		missingSystemPermission: {
+			allowedRequestStatusCode: 200,
+			category: 'authorization',
+			rejected: true,
+			statusCode: 403,
+		},
+		missingZonePermission: {
+			allowedRequestStatusCode: 200,
+			category: 'authorization',
+			rejected: true,
+			statusCode: 403,
+		},
+	},
+} as const;
+
+const createConfig = (): HomeyShsScopeProbeConfig =>
+	loadHomeyShsScopeProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-scope-spike');
+
+const homeyPingResponse = (): Response =>
+	new Response(null, {
+		headers: { 'x-homey-id': 'synthetic-homey-id', 'x-homey-version': '13.4.1' },
+		status: 200,
+	});
+
+const authorizationToken = (init: RequestInit): string | null => {
+	const authorization = new Headers(init.headers).get('authorization');
+
+	return authorization?.replace(/^Bearer /, '') ?? null;
+};
+
+const createFetch = (config: HomeyShsScopeProbeConfig): jest.MockedFunction<HomeyScopeProbeFetch> =>
+	jest.fn<Promise<Response>, [URL, RequestInit]>((input, init) => {
+		if (input.pathname === '/api/manager/system/ping') {
+			return Promise.resolve(homeyPingResponse());
+		}
+
+		const token = authorizationToken(init);
+
+		if (token === config.withoutDeviceApiKey) {
+			return Promise.resolve(new Response(null, { status: input.pathname === '/api/manager/zones/zone' ? 200 : 403 }));
+		}
+
+		if (token === config.deviceOnlyApiKey) {
+			return Promise.resolve(
+				new Response(null, { status: input.pathname === '/api/manager/devices/device' ? 200 : 403 }),
+			);
+		}
+
+		if (token === config.withoutZoneApiKey) {
+			return Promise.resolve(
+				new Response(null, { status: input.pathname === '/api/manager/devices/device' ? 200 : 403 }),
+			);
+		}
+
+		return Promise.reject(new Error('unexpected credential'));
+	});
+
+describe('Homey SHS permission-scope compatibility probe', () => {
+	it('requires three distinct restricted credentials and isolated read-only gates', () => {
+		for (const name of [
+			'FB_HOMEY_SHS_DEVICE_ONLY_API_KEY',
+			'FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY',
+			'FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY',
+		]) {
+			expect(() => loadHomeyShsScopeProbeConfig({ ...BASE_ENVIRONMENT, [name]: undefined })).toThrow(
+				`${name} is required`,
+			);
+		}
+
+		expect(() =>
+			loadHomeyShsScopeProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY: BASE_ENVIRONMENT.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY,
+			}),
+		).toThrow('credentials must all be distinct');
+		expect(() =>
+			loadHomeyShsScopeProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_REPLACEMENT_API_KEY: 'rotation-key-that-must-not-be-used',
+			}),
+		).toThrow('gates must be unset');
+	});
+
+	it('proves each missing permission after an allowed read', async () => {
+		const config = createConfig();
+		const fetchImplementation = createFetch(config);
+		const report = await probeHomeyShsScopes(config, fetchImplementation);
+
+		expect(report).toStrictEqual(EXPECTED_REPORT);
+		expect(fetchImplementation).toHaveBeenCalledTimes(7);
+		expect(fetchImplementation.mock.calls[0][0].pathname).toBe('/api/manager/system/ping');
+		expect(new Headers(fetchImplementation.mock.calls[0][1].headers).has('authorization')).toBe(false);
+		expect(fetchImplementation.mock.calls.every(([, init]) => init.method === 'GET' && init.redirect === 'error')).toBe(
+			true,
+		);
+		expect(fetchImplementation.mock.calls.slice(1).every(([, init]) => authorizationToken(init) !== null)).toBe(true);
+		expect(() => assertHomeyShsScopeReportSafe(report, config)).not.toThrow();
+
+		const serialized = JSON.stringify(report);
+
+		expect(serialized).not.toContain(config.apiKey);
+		expect(serialized).not.toContain(config.deviceOnlyApiKey);
+		expect(serialized).not.toContain(config.withoutDeviceApiKey);
+		expect(serialized).not.toContain(config.withoutZoneApiKey);
+	});
+
+	it('validates Homey identity before sending restricted credentials', async () => {
+		const config = createConfig();
+		const fetchImplementation = jest.fn<Promise<Response>, [URL, RequestInit]>(() =>
+			Promise.resolve(new Response(null, { status: 200 })),
+		);
+
+		await expect(probeHomeyShsScopes(config, fetchImplementation)).rejects.toThrow(
+			'endpoint identity validation failed',
+		);
+		expect(fetchImplementation).toHaveBeenCalledTimes(1);
+		expect(new Headers(fetchImplementation.mock.calls[0][1].headers).has('authorization')).toBe(false);
+	});
+
+	it('does not misclassify an invalid restricted credential as missing permission', async () => {
+		const config = createConfig();
+		const fetchImplementation = createFetch(config);
+
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(homeyPingResponse()));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+
+		await expect(probeHomeyShsScopes(config, fetchImplementation)).rejects.toThrow(
+			'device credential did not authenticate for its allowed read',
+		);
+	});
+
+	it('requires the omitted permission to return 403', async () => {
+		const config = createConfig();
+		const fetchImplementation = createFetch(config);
+
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(homeyPingResponse()));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 200 })));
+		fetchImplementation.mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 401 })));
+
+		await expect(probeHomeyShsScopes(config, fetchImplementation)).rejects.toThrow(
+			'device credential did not return an authorization rejection',
+		);
+	});
+
+	it('rejects extra report fields and configured private values', async () => {
+		const config = createConfig();
+		const report = await probeHomeyShsScopes(config, createFetch(config));
+		const withExtraField = { ...report, unexpected: true };
+
+		expect(() => assertHomeyShsScopeReportSchema(withExtraField)).toThrow('root schema is invalid');
+
+		expect(() => assertHomeyShsScopeReportSafe(report, { ...config, privateTerms: ['authorization'] })).toThrow(
+			'configured secret or private value',
+		);
+	});
+
+	it('writes only the exact schema with restrictive permissions', async () => {
+		const config = createConfig();
+		const report = await probeHomeyShsScopes(config, createFetch(config));
+		const outputRoot = await mkdtemp(join(tmpdir(), 'homey-scope-report-'));
+
+		try {
+			const outputDirectory = await writeHomeyShsScopeReport(report, outputRoot);
+			const reportPath = join(outputDirectory, 'report.json');
+
+			expect(JSON.parse(await readFile(reportPath, 'utf8'))).toStrictEqual(EXPECTED_REPORT);
+			expect((await stat(outputDirectory)).mode & 0o777).toBe(0o700);
+			expect((await stat(reportPath)).mode & 0o777).toBe(0o600);
+		} finally {
+			await rm(outputRoot, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/support/homey-shs-scope-probe.ts
+++ b/apps/backend/test/support/homey-shs-scope-probe.ts
@@ -1,0 +1,329 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const DEVICE_PATH = '/api/manager/devices/device';
+const PING_PATH = '/api/manager/system/ping';
+const SYSTEM_PATH = '/api/manager/system/';
+const ZONE_PATH = '/api/manager/zones/zone';
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
+const INCOMPATIBLE_GATE_PREFIXES = [
+	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
+	'FB_HOMEY_SHS_LIFECYCLE_',
+	'FB_HOMEY_SHS_RECOVERY_',
+	'FB_HOMEY_SHS_REPLACEMENT_',
+	'FB_HOMEY_SHS_WRITE_',
+];
+
+export type HomeyScopeProbeFetch = (input: URL, init: RequestInit) => Promise<Response>;
+
+export interface HomeyShsScopeProbeConfig extends HomeyShsProbeConfig {
+	deviceOnlyApiKey: string;
+	withoutDeviceApiKey: string;
+	withoutZoneApiKey: string;
+}
+
+interface MissingPermissionEvidence {
+	allowedRequestStatusCode: 200;
+	category: 'authorization';
+	rejected: true;
+	statusCode: 403;
+}
+
+export interface HomeyShsScopeReport {
+	metadata: {
+		probe: 'homey-shs-permission-scopes';
+		schemaVersion: 1;
+	};
+	scenarios: {
+		missingDevicePermission: MissingPermissionEvidence;
+		missingSystemPermission: MissingPermissionEvidence;
+		missingZonePermission: MissingPermissionEvidence;
+	};
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, expectedKeys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw new Error(`Homey permission-scope report ${label} schema is invalid`);
+	}
+
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpectedKeys = [...expectedKeys].sort();
+
+	if (
+		actualKeys.length !== sortedExpectedKeys.length ||
+		actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+	) {
+		throw new Error(`Homey permission-scope report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+const requireCredential = (environment: NodeJS.ProcessEnv, name: string): string => {
+	const value = environment[name];
+
+	if (value === undefined || value.trim() === '') {
+		throw new Error(`${name} is required`);
+	}
+
+	return value;
+};
+
+export const loadHomeyShsScopeProbeConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsScopeProbeConfig => {
+	const incompatibleGate = Object.keys(environment).find((name) =>
+		INCOMPATIBLE_GATE_PREFIXES.some((prefix) => name.startsWith(prefix)),
+	);
+
+	if (incompatibleGate !== undefined) {
+		throw new Error('Homey mutation, recovery, and credential-rotation gates must be unset during the scope probe');
+	}
+
+	const config = loadHomeyShsProbeConfig(environment, workingDirectory);
+	const deviceOnlyApiKey = requireCredential(environment, 'FB_HOMEY_SHS_DEVICE_ONLY_API_KEY');
+	const withoutDeviceApiKey = requireCredential(environment, 'FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY');
+	const withoutZoneApiKey = requireCredential(environment, 'FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY');
+	const credentials = [config.apiKey, deviceOnlyApiKey, withoutDeviceApiKey, withoutZoneApiKey];
+
+	if (new Set(credentials).size !== credentials.length) {
+		throw new Error('Homey permission-scope probe credentials must all be distinct');
+	}
+
+	return { ...config, deviceOnlyApiKey, withoutDeviceApiKey, withoutZoneApiKey };
+};
+
+const discardResponse = async (response: Response): Promise<void> => {
+	try {
+		await response.body?.cancel();
+	} catch {
+		throw new Error('Homey permission-scope response cleanup failed');
+	}
+};
+
+const request = async (
+	config: HomeyShsScopeProbeConfig,
+	path: string,
+	fetchImplementation: HomeyScopeProbeFetch,
+	token?: string,
+): Promise<Response> => {
+	const headers = new Headers({ accept: 'application/json' });
+
+	if (token !== undefined) {
+		headers.set('authorization', `Bearer ${token}`);
+	}
+
+	try {
+		return await fetchImplementation(new URL(path, config.origin), {
+			headers,
+			method: 'GET',
+			redirect: 'error',
+			signal: AbortSignal.timeout(config.timeoutMs),
+		});
+	} catch {
+		// Raw transport errors may contain the pinned endpoint or private network detail.
+		throw new Error('Homey permission-scope request failed');
+	}
+};
+
+const verifyHomeyIdentity = async (
+	config: HomeyShsScopeProbeConfig,
+	fetchImplementation: HomeyScopeProbeFetch,
+): Promise<void> => {
+	const response = await request(config, PING_PATH, fetchImplementation);
+
+	try {
+		const homeyId = response.headers.get('x-homey-id');
+		const homeyVersion = response.headers.get('x-homey-version');
+
+		if (
+			!response.ok ||
+			homeyId === null ||
+			homeyId.trim() === '' ||
+			homeyVersion === null ||
+			homeyVersion.trim() === ''
+		) {
+			throw new Error('Homey permission-scope endpoint identity validation failed');
+		}
+	} finally {
+		await discardResponse(response);
+	}
+};
+
+const verifyMissingPermission = async (
+	config: HomeyShsScopeProbeConfig,
+	credential: string,
+	allowedPath: string,
+	deniedPath: string,
+	label: 'device' | 'system' | 'zone',
+	fetchImplementation: HomeyScopeProbeFetch,
+): Promise<MissingPermissionEvidence> => {
+	const allowedResponse = await request(config, allowedPath, fetchImplementation, credential);
+
+	try {
+		if (allowedResponse.status !== 200) {
+			throw new Error(`Homey permission-scope ${label} credential did not authenticate for its allowed read`);
+		}
+	} finally {
+		await discardResponse(allowedResponse);
+	}
+
+	const deniedResponse = await request(config, deniedPath, fetchImplementation, credential);
+
+	try {
+		if (deniedResponse.status !== 403) {
+			throw new Error(`Homey permission-scope ${label} credential did not return an authorization rejection`);
+		}
+
+		return {
+			allowedRequestStatusCode: 200,
+			category: 'authorization',
+			rejected: true,
+			statusCode: 403,
+		};
+	} finally {
+		await discardResponse(deniedResponse);
+	}
+};
+
+export const probeHomeyShsScopes = async (
+	config: HomeyShsScopeProbeConfig,
+	fetchImplementation: HomeyScopeProbeFetch = fetch,
+): Promise<HomeyShsScopeReport> => {
+	await verifyHomeyIdentity(config, fetchImplementation);
+
+	return {
+		metadata: { probe: 'homey-shs-permission-scopes', schemaVersion: 1 },
+		scenarios: {
+			missingDevicePermission: await verifyMissingPermission(
+				config,
+				config.withoutDeviceApiKey,
+				ZONE_PATH,
+				DEVICE_PATH,
+				'device',
+				fetchImplementation,
+			),
+			missingSystemPermission: await verifyMissingPermission(
+				config,
+				config.deviceOnlyApiKey,
+				DEVICE_PATH,
+				SYSTEM_PATH,
+				'system',
+				fetchImplementation,
+			),
+			missingZonePermission: await verifyMissingPermission(
+				config,
+				config.withoutZoneApiKey,
+				DEVICE_PATH,
+				ZONE_PATH,
+				'zone',
+				fetchImplementation,
+			),
+		},
+	};
+};
+
+const assertMissingPermissionEvidence = (value: unknown, label: string): void => {
+	const evidence = requireExactKeys(value, ['allowedRequestStatusCode', 'category', 'rejected', 'statusCode'], label);
+
+	if (
+		evidence.allowedRequestStatusCode !== 200 ||
+		evidence.category !== 'authorization' ||
+		evidence.rejected !== true ||
+		evidence.statusCode !== 403
+	) {
+		throw new Error(`Homey permission-scope report ${label} state schema is invalid`);
+	}
+};
+
+export function assertHomeyShsScopeReportSchema(value: unknown): asserts value is HomeyShsScopeReport {
+	const report = requireExactKeys(value, ['metadata', 'scenarios'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion'], 'metadata');
+	const scenarios = requireExactKeys(
+		report.scenarios,
+		['missingDevicePermission', 'missingSystemPermission', 'missingZonePermission'],
+		'scenarios',
+	);
+
+	if (metadata.probe !== 'homey-shs-permission-scopes' || metadata.schemaVersion !== 1) {
+		throw new Error('Homey permission-scope report metadata state schema is invalid');
+	}
+
+	assertMissingPermissionEvidence(scenarios.missingDevicePermission, 'missing-device');
+	assertMissingPermissionEvidence(scenarios.missingSystemPermission, 'missing-system');
+	assertMissingPermissionEvidence(scenarios.missingZonePermission, 'missing-zone');
+}
+
+export function assertHomeyShsScopeReportSafe(
+	value: unknown,
+	config: HomeyShsScopeProbeConfig,
+): asserts value is HomeyShsScopeReport {
+	assertHomeyShsScopeReportSchema(value);
+
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbiddenValues = [
+		config.apiKey,
+		config.deviceOnlyApiKey,
+		config.withoutDeviceApiKey,
+		config.withoutZoneApiKey,
+		config.expectedHost,
+		...config.privateTerms,
+	]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
+
+	if (forbiddenValues.some((item) => serialized.includes(item))) {
+		throw new Error('Sanitized Homey permission-scope report contains a configured secret or private value');
+	}
+
+	if (
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized)
+	) {
+		throw new Error('Sanitized Homey permission-scope report contains an address, email, or URL');
+	}
+}
+
+export const writeHomeyShsScopeReport = async (report: HomeyShsScopeReport, outputRoot: string): Promise<string> => {
+	assertHomeyShsScopeReportSchema(report);
+
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `permission-scopes-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsScopeProbeConfig(process.env);
+	const report = await probeHomeyShsScopes(config);
+
+	assertHomeyShsScopeReportSafe(report, config);
+
+	const outputDirectory = await writeHomeyShsScopeReport(report, config.outputRoot);
+
+	process.stdout.write(`Sanitized Homey permission-scope report written to ${outputDirectory} (3 scenarios).\n`);
+};
+
+if (require.main === module) {
+	run().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : 'Homey SHS permission-scope probe failed';
+
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -464,6 +464,7 @@ After the last probe you intend to run, clear every credential and private value
 
 ```bash
 unset FB_HOMEY_SHS_DEVICE_ONLY_API_KEY FB_HOMEY_SHS_URL FB_HOMEY_SHS_EXPECTED_HOST FB_HOMEY_SHS_API_KEY
+unset FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY
 unset FB_HOMEY_SHS_PRIVATE_TERMS
 ```
 
@@ -479,6 +480,49 @@ returned `401`; a device-read-only key first completed an allowed inventory requ
 for the forbidden system-information request. The shared validator rejected the non-HTTP candidate, while probe-owned
 loopback servers produced the unavailable and timeout categories. The reviewed report is committed as
 `__fixtures__/evidence/2026-08-26-shs-13.4.1-error-matrix.json`. It does not prove API-key revocation or replacement.
+
+## Complete permission-scope matrix probe
+
+The separate permission-scope probe closes the two permission cases that the error-classification report intentionally
+does not claim. It first performs an unauthenticated Homey ping and requires the identity and version headers. Only
+after that identity check does it send three distinct restricted credentials to the pinned SHS origin. Each credential
+must complete one allowed read with `200` before the probe accepts `403` for the independently omitted permission:
+
+| Credential | Required permissions | Allowed proof | Required denial |
+| ---------- | -------------------- | ------------- | --------------- |
+| Device only | `homey.device.readonly` | Device inventory | System information |
+| Without zone | `homey.system.readonly`, `homey.device.readonly` | Device inventory | Zone inventory |
+| Without device | `homey.system.readonly`, `homey.zone.readonly` | Zone inventory | Device inventory |
+
+Create the two additional disposable restricted keys, enter them without adding their values to shell history, and run
+the probe from the same interactive shell. The previously configured device-only key is reused for the missing-system
+case:
+
+```bash
+read -r -s FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY
+read -r -s FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY
+export FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY
+unset FB_HOMEY_SHS_WRITE_ENABLE FB_HOMEY_SHS_WRITE_DEVICE_ID FB_HOMEY_SHS_WRITE_CAPABILITY_ID
+unset FB_HOMEY_SHS_WRITE_VALUE FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+unset FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER
+unset FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID FB_HOMEY_SHS_LIFECYCLE_OWNER_URI
+unset FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME
+unset FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_SCENARIO
+unset FB_HOMEY_SHS_RECOVERY_OBSERVE_MS FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE
+unset FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS FB_HOMEY_SHS_REPLACEMENT_API_KEY
+pnpm run homey:probe-scopes
+```
+
+All four configured credentials must be distinct. The full-read key is validated by the shared configuration loader but
+is not sent by this probe. Mutation, recovery, and credential-rotation gate variables must be completely unset; even an
+empty or disabled-looking value is rejected. The seven requests are GET-only, redirect-blocked, and independently
+bounded by `FB_HOMEY_SHS_TIMEOUT_MS`.
+
+The exact-schema report contains only the three fixed permission labels, `200`/`403` status codes, the authorization
+category, and rejection booleans. It has no fields for endpoints, Homey identities, credentials, inventory data,
+response bodies, or raw errors. A report is written only after all three allowed/denied pairs pass. Until that operator
+report is reviewed and promoted, the broad missing-scope matrix remains pending.
 
 ## SDK artifact review
 


### PR DESCRIPTION
## Summary

- add a dedicated read-only Homey permission-scope probe for independently missing system, zone, and device permissions
- require Homey identity verification and a successful allowed read before accepting each omitted permission as a 403 authorization result
- persist only an exact privacy-safe three-scenario report and reject overlapping credentials or active mutation, recovery, and rotation gates
- document the disposable restricted-key setup and operator workflow

## Safety boundaries

- performs only seven bounded GET requests against the pinned SHS origin
- sends no credential until the unauthenticated Homey identity check succeeds
- never records endpoints, Homey identities, credentials, inventories, response bodies, or raw errors
- does not claim the missing-scope matrix complete until an operator-generated report is reviewed and promoted

## Verification

- focused Homey scope/error suites: 15 tests passed
- full Homey compatibility suite: 141 tests passed
- Homey config/plugin suite: 483 tests passed
- TypeScript type check and ESLint passed
- backend build and OpenAPI generation passed with no generated diff