### PR TITLE
test(cross): record Homey permission scope evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -89,6 +89,8 @@ SHS restart and a temporary Smart Panel-to-SHS port block, respectively. These r
 names, hosts, addresses, TXT values, endpoint, credential, firewall rule, inventory content, or event payload.
 The error-matrix report records only the five fixed validation, authentication, authorization, timeout, and unavailable
 categories plus non-sensitive HTTP status codes. It contains no URL, address, key, identifier, response body, or raw
-transport error.
+transport error. The permission-scope report records three independently valid restricted credentials completing an
+allowed read with `200` and receiving `403` for the omitted system, zone, or device permission. It contains no endpoint,
+Homey identity, credential, inventory data, response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-permission-scopes.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-permission-scopes.json
@@ -1,0 +1,26 @@
+{
+	"metadata": {
+		"probe": "homey-shs-permission-scopes",
+		"schemaVersion": 1
+	},
+	"scenarios": {
+		"missingDevicePermission": {
+			"allowedRequestStatusCode": 200,
+			"category": "authorization",
+			"rejected": true,
+			"statusCode": 403
+		},
+		"missingSystemPermission": {
+			"allowedRequestStatusCode": 200,
+			"category": "authorization",
+			"rejected": true,
+			"statusCode": 403
+		},
+		"missingZonePermission": {
+			"allowedRequestStatusCode": 200,
+			"category": "authorization",
+			"rejected": true,
+			"statusCode": 403
+		}
+	}
+}

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -58,6 +58,7 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-plugin-connection',
 	'homey-plugin-device-mapping',
 	'homey-reconnect-backoff',
+	'homey-shs-permission-scopes',
 ]);
 const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Locked',
@@ -169,6 +170,8 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_API_KEY,
 		process.env.FB_HOMEY_SHS_REPLACEMENT_API_KEY,
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY,
+		process.env.FB_HOMEY_SHS_WITHOUT_DEVICE_API_KEY,
+		process.env.FB_HOMEY_SHS_WITHOUT_ZONE_API_KEY,
 		configuredExpectedHost(),
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID,
@@ -6646,6 +6649,10 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() => assertTextSafe('unsafe fixture', '{"value":"prefix_homey_abcdefghijklmnop"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
+		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-permission-scopes"}')).not.toThrow();
+		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-permission-scopes-private"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() =>

--- a/apps/backend/test/homey-shs-scopes.homey-spike.ts
+++ b/apps/backend/test/homey-shs-scopes.homey-spike.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import {
 	type HomeyScopeProbeFetch,
@@ -89,6 +89,18 @@ const createFetch = (config: HomeyShsScopeProbeConfig): jest.MockedFunction<Home
 	});
 
 describe('Homey SHS permission-scope compatibility probe', () => {
+	it('preserves the sanitized live SHS permission-scope evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-permission-scopes.json',
+		);
+		const evidence: unknown = JSON.parse(await readFile(evidencePath, 'utf8'));
+		const config = createConfig();
+
+		expect(evidence).toStrictEqual(EXPECTED_REPORT);
+		expect(() => assertHomeyShsScopeReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires three distinct restricted credentials and isolated read-only gates', () => {
 		for (const name of [
 			'FB_HOMEY_SHS_DEVICE_ONLY_API_KEY',

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
 restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
-remaining permission-scope, lifecycle, and credential-rotation evidence is pending
+lifecycle, and credential-rotation evidence is pending
 
 **Started:** 2026-08-12
 
@@ -26,7 +26,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
 | Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity                |
 | Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
-| Error classification                                  | Five-scenario slice passed                               | Test keys missing zone and device permissions                        |
+| Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                                 |
 | API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
 | Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                    |
 | mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery     |
@@ -39,7 +39,7 @@ Complete this table after the live run. Values committed here must remain non-se
 
 | Field                                    | Recorded value                                    |
 | ---------------------------------------- | ------------------------------------------------- |
-| Capture date                             | `2026-08-13`, `2026-08-26`                        |
+| Capture date                             | `2026-08-13`, `2026-08-26`, `2026-08-27`          |
 | Realtime SDK probe date                  | `2026-08-14`, `2026-08-26`                        |
 | mDNS observation date                    | `2026-08-14`, `2026-08-26`                        |
 | SHS version                              | `13.4.0`, `13.4.1`                                |
@@ -488,11 +488,11 @@ does not claim. It first performs an unauthenticated Homey ping and requires the
 after that identity check does it send three distinct restricted credentials to the pinned SHS origin. Each credential
 must complete one allowed read with `200` before the probe accepts `403` for the independently omitted permission:
 
-| Credential | Required permissions | Allowed proof | Required denial |
-| ---------- | -------------------- | ------------- | --------------- |
-| Device only | `homey.device.readonly` | Device inventory | System information |
-| Without zone | `homey.system.readonly`, `homey.device.readonly` | Device inventory | Zone inventory |
-| Without device | `homey.system.readonly`, `homey.zone.readonly` | Zone inventory | Device inventory |
+| Credential     | Required permissions                             | Allowed proof    | Required denial    |
+| -------------- | ------------------------------------------------ | ---------------- | ------------------ |
+| Device only    | `homey.device.readonly`                          | Device inventory | System information |
+| Without zone   | `homey.system.readonly`, `homey.device.readonly` | Device inventory | Zone inventory     |
+| Without device | `homey.system.readonly`, `homey.zone.readonly`   | Zone inventory   | Device inventory   |
 
 Create the two additional disposable restricted keys, enter them without adding their values to shell history, and run
 the probe from the same interactive shell. The previously configured device-only key is reused for the missing-system
@@ -521,8 +521,12 @@ bounded by `FB_HOMEY_SHS_TIMEOUT_MS`.
 
 The exact-schema report contains only the three fixed permission labels, `200`/`403` status codes, the authorization
 category, and rejection booleans. It has no fields for endpoints, Homey identities, credentials, inventory data,
-response bodies, or raw errors. A report is written only after all three allowed/denied pairs pass. Until that operator
-report is reviewed and promoted, the broad missing-scope matrix remains pending.
+response bodies, or raw errors. A report is written only after all three allowed/denied pairs pass.
+
+The operator-controlled run on 2026-08-27 against SHS `13.4.1` passed all three pairs. Each independently valid
+restricted credential completed its allowed inventory request with `200`, then received `403` for the omitted system,
+zone, or device permission. The exact generated report is committed as
+`__fixtures__/evidence/2026-08-27-shs-13.4.1-permission-scopes.json`; it contains no private value or response payload.
 
 ## SDK artifact review
 
@@ -580,7 +584,7 @@ Fill this matrix using synthetic aliases only.
 | HTTPS `4860` ping and authenticated reads | Pending                             |                                                                                                                                                      |
 | Invalid key                               | Pass                                | Both the SDK session probe and error-matrix probe rejected independently generated invalid keys with HTTP `401`                                      |
 | Missing system scope on device-only key   | Pass                                | The restricted key completed the allowed device inventory read with `200`, then the system-information read returned `403`                           |
-| Missing zone and device scopes            | Pending                             | Exercise independently valid keys that omit each permission before closing the broad missing-scope matrix                                            |
+| Missing zone and device scopes            | Pass                                | Independently valid restricted keys completed allowed inventory reads with `200`, then each omitted permission returned `403`                        |
 | Bad URL and unavailable host              | Pass                                | Shared validation rejected a non-HTTP URL; a probe-owned closed loopback port produced the unavailable category                                      |
 | Request timeout                           | Pass                                | A probe-owned loopback server that withheld its response produced the timeout category within the local simulation cap                               |
 | Complete inventory and individual read    | Pass                                | Complete inventory captured: 118 devices and 16 zones; the selected individual-device response matched its pseudonymized inventory identity          |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -70,7 +70,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [x] Capture capabilities with values, types, units, ranges, enums, readable/writable flags, and repeated/suffixed IDs.
 - [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
 - [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
-- [ ] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
+- [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.


### PR DESCRIPTION
## Summary

- preserve the sanitized SHS 13.4.1 permission-scope report as reviewed compatibility evidence
- prove independently valid restricted credentials can read their allowed inventory and receive 403 for omitted system, zone, and device permissions
- reapply the exact-schema and private-data safety assertions in the offline Homey suite
- mark the broad missing-scope matrix complete in the compatibility record and implementation plan

## Live evidence

The operator-generated schema-v1 report is an exact canonical match with the committed fixture. Each of the three restricted credentials completed its allowed read with 200 before the omitted permission returned 403.

The report contains only fixed scenario/category labels, rejection booleans, and non-sensitive status codes. It contains no endpoint, Homey identity, credential, inventory data, response body, or raw error.

## Verification

- exact canonical comparison with the operator capture
- focused evidence and repository privacy suites: 12 tests passed
- full Homey compatibility suite: 142 tests passed
- Homey config/plugin suite: 483 tests passed
- backend build and OpenAPI generation passed
- formatting and diff checks passed