### PR TITLE
test(cross): record Homey credential rotation evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -92,5 +92,8 @@ categories plus non-sensitive HTTP status codes. It contains no URL, address, ke
 transport error. The permission-scope report records three independently valid restricted credentials completing an
 allowed read with `200` and receiving `403` for the omitted system, zone, or device permission. It contains no endpoint,
 Homey identity, credential, inventory data, response body, or raw error.
+The credential-rotation report records the fixed identity, preflight, operator-window, revocation, and replacement
+validation sequence plus the expected `401`. It contains no endpoint, Homey identity, credential, inventory data,
+response body, raw error, or identifier.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-credential-rotation.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-credential-rotation.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"probe": "homey-shs-credential-rotation",
+		"schemaVersion": 1
+	},
+	"rotation": {
+		"primaryKeyInitiallyValid": true,
+		"replacementKeyInitiallyValid": true,
+		"replacementKeyValidAfterRevocation": true,
+		"revocationObserved": true,
+		"revocationStatusCode": 401
+	},
+	"session": {
+		"events": [
+			{
+				"event": "endpoint.identity.resolved",
+				"order": 1
+			},
+			{
+				"event": "primary.validation.resolved",
+				"order": 2
+			},
+			{
+				"event": "replacement.preflight.resolved",
+				"order": 3
+			},
+			{
+				"event": "rotation.window.open",
+				"order": 4
+			},
+			{
+				"event": "primary.revocation.observed",
+				"order": 5
+			},
+			{
+				"event": "replacement.validation.resolved",
+				"order": 6
+			}
+		]
+	}
+}

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -58,6 +58,7 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-plugin-connection',
 	'homey-plugin-device-mapping',
 	'homey-reconnect-backoff',
+	'homey-shs-credential-rotation',
 	'homey-shs-permission-scopes',
 ]);
 const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
@@ -6653,6 +6654,10 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-permission-scopes"}')).not.toThrow();
 		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-permission-scopes-private"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
+		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-credential-rotation"}')).not.toThrow();
+		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-credential-rotation-private"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() =>

--- a/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
+++ b/apps/backend/test/homey-shs-credential-rotation.homey-spike.ts
@@ -1,10 +1,11 @@
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import {
 	type HomeyCredentialRotationFetch,
 	type HomeyShsCredentialRotationProbeConfig,
+	type HomeyShsCredentialRotationReport,
 	assertHomeyShsCredentialRotationReportSafe,
 	assertHomeyShsCredentialRotationReportSchema,
 	loadHomeyShsCredentialRotationProbeConfig,
@@ -21,6 +22,27 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_REPLACEMENT_API_KEY: 'replacement-test-key-that-must-not-leak',
 	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const EXPECTED_REPORT: HomeyShsCredentialRotationReport = {
+	metadata: { probe: 'homey-shs-credential-rotation', schemaVersion: 1 },
+	rotation: {
+		primaryKeyInitiallyValid: true,
+		replacementKeyInitiallyValid: true,
+		replacementKeyValidAfterRevocation: true,
+		revocationObserved: true,
+		revocationStatusCode: 401,
+	},
+	session: {
+		events: [
+			{ event: 'endpoint.identity.resolved', order: 1 },
+			{ event: 'primary.validation.resolved', order: 2 },
+			{ event: 'replacement.preflight.resolved', order: 3 },
+			{ event: 'rotation.window.open', order: 4 },
+			{ event: 'primary.revocation.observed', order: 5 },
+			{ event: 'replacement.validation.resolved', order: 6 },
+		],
+	},
 };
 
 const createConfig = (
@@ -47,6 +69,18 @@ const homeyPingResponse = (): Response =>
 	});
 
 describe('Homey SHS credential rotation compatibility probe', () => {
+	it('preserves the sanitized live SHS credential-rotation evidence', async () => {
+		const evidencePath = resolve(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-credential-rotation.json',
+		);
+		const evidence: unknown = JSON.parse(await readFile(evidencePath, 'utf8'));
+		const config = createConfig();
+
+		expect(evidence).toStrictEqual(EXPECTED_REPORT);
+		expect(() => assertHomeyShsCredentialRotationReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires the exact acknowledgement, distinct replacement key, and isolated gates', () => {
 		expect(() =>
 			loadHomeyShsCredentialRotationProbeConfig({
@@ -136,26 +170,7 @@ describe('Homey SHS credential rotation compatibility probe', () => {
 			() => nowMs,
 		);
 
-		expect(report).toStrictEqual({
-			metadata: { probe: 'homey-shs-credential-rotation', schemaVersion: 1 },
-			rotation: {
-				primaryKeyInitiallyValid: true,
-				replacementKeyInitiallyValid: true,
-				replacementKeyValidAfterRevocation: true,
-				revocationObserved: true,
-				revocationStatusCode: 401,
-			},
-			session: {
-				events: [
-					{ event: 'endpoint.identity.resolved', order: 1 },
-					{ event: 'primary.validation.resolved', order: 2 },
-					{ event: 'replacement.preflight.resolved', order: 3 },
-					{ event: 'rotation.window.open', order: 4 },
-					{ event: 'primary.revocation.observed', order: 5 },
-					{ event: 'replacement.validation.resolved', order: 6 },
-				],
-			},
-		});
+		expect(report).toStrictEqual(EXPECTED_REPORT);
 		expect(fetchImplementation).toHaveBeenCalledTimes(6);
 		expect(isPingRequest(fetchImplementation.mock.calls[0][0])).toBe(true);
 		expect(new Headers(fetchImplementation.mock.calls[0][1].headers).has('authorization')).toBe(false);

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
 restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
-lifecycle, and credential-rotation evidence is pending
+lifecycle evidence is pending
 
 **Started:** 2026-08-12
 
@@ -19,19 +19,19 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                                   | Evidence still required                                              |
-| ----------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------- |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                  |
-| System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device           |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                         |
-| Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity                |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                     |
-| Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                                 |
-| API-key revocation and replacement                    | Operator-controlled probe ready                          | Revoke only a dedicated test key during the gated observation window |
-| Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                    |
-| mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery     |
-| SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade     |
-| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add event/reconnect fixtures from the remaining live lifecycle runs  |
+| Area                                                  | Status                                                   | Evidence still required                                             |
+| ----------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                 |
+| System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device          |
+| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                        |
+| Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity               |
+| Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                    |
+| Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                                |
+| API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                                |
+| Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                   |
+| mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery    |
+| SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade    |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add event/reconnect fixtures from the remaining live lifecycle runs |
 
 ## Installation evidence
 
@@ -380,6 +380,12 @@ unset FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS
 This runbook authorizes only the operator to revoke the dedicated primary test key. The probe and automated agents do
 not create, revoke, rotate, or otherwise administer Homey credentials.
 
+The operator-controlled run on 2026-08-27 against SHS `13.4.1` recorded the exact six-event sequence. Both disposable
+keys completed the initial inventory read, the operator revoked only the primary key after the observation window
+opened, the probe observed `401`, and the replacement key completed the final inventory read. The reviewed report is
+committed as `__fixtures__/evidence/2026-08-27-shs-13.4.1-credential-rotation.json`; it contains no endpoint, Homey
+identity, credential, inventory data, response body, raw error, or identifier.
+
 ## Privacy-safe mDNS observation probe
 
 The mDNS probe performs a bounded wildcard DNS-SD observation so it can compare Homey with other services advertised by
@@ -594,7 +600,7 @@ Fill this matrix using synthetic aliases only.
 | Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |
-| API-key revocation and replacement        | Pending                             |                                                                                                                                                      |
+| API-key revocation and replacement        | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |
 | Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
 | Stable mDNS service before/after restart  | Pass                                | Ten-second pre/post observations were exact matches: `_homey._tcp` on `4859` plus two co-hosted `_hap._tcp` services                                 |
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -71,7 +71,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
 - [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
 - [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
-- [ ] Test SHS restart, network interruption/restoration, and API-key revocation.
+- [x] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
 - [ ] If Homey Pro hardware is available, repeat the minimum inventory/event/write suite against its local API.
@@ -620,7 +620,7 @@ representative lifecycle failure paths.
 - [ ] Startup with SHS offline, then recovery.
 - [ ] SHS restart during event flow.
 - [x] Network interruption/restoration.
-- [ ] API key revoked, replaced, and insufficiently scoped.
+- [x] API key revoked, replaced, and insufficiently scoped.
 - [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [ ] Physical/Homey/flow-originated state changes.
 - [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
@@ -639,9 +639,10 @@ availability event was observed across the interruption.
 
 The 2026-08-26 SHS `13.4.1` error probe recorded a non-mutating five-scenario slice: generated invalid-key
 authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback
-unavailable/timeout simulations all produced their expected sanitized categories. The broad task remains open until
-independently valid keys missing zone and device permissions are exercised. This also closes only the insufficiently
-scoped sub-slice of the API-key lifecycle item above; revocation and replacement remain open.
+unavailable/timeout simulations all produced their expected sanitized categories. The 2026-08-27 permission-scope
+report independently proved missing system, zone, and device permissions after an allowed `200` read. The same day's
+credential-rotation report proved the primary key returned `401` after operator revocation and the replacement key
+remained valid, closing the API-key lifecycle item above.
 
 ### Task 6.3: Validate performance and security
 


### PR DESCRIPTION
## Summary

- preserve the sanitized SHS 13.4.1 credential-rotation report as reviewed compatibility evidence
- record primary and replacement preflight, operator-controlled revocation observed as 401, and successful replacement validation
- reapply the exact report schema and private-data assertions in the offline Homey suite
- recognize only the exact public rotation probe discriminator in the token scanner while continuing to reject extended lookalikes
- close the API-key revocation, replacement, and insufficient-scope compatibility items

## Live evidence

The operator-generated schema-v1 report is an exact canonical match with the committed fixture. Both disposable keys completed initial inventory reads, the operator revoked only the primary key after the observation window opened, the probe observed 401, and the replacement key completed the final inventory read.

The report contains only six fixed ordered event labels, completion booleans, and the non-sensitive 401 status. It contains no endpoint, Homey identity, credential, inventory data, response body, raw error, or identifier.

## Safety boundary

The probe performs only bounded GET requests and never creates, revokes, rotates, or administers credentials. Revocation was performed manually by the operator against a dedicated disposable test key.

## Verification

- exact canonical comparison with the operator capture
- focused rotation and repository privacy suites: 14 tests passed
- full Homey compatibility suite: 143 tests passed
- Homey config/plugin suite: 483 tests passed
- backend build and OpenAPI generation passed
- ESLint, formatting, and diff checks passed