### PR TITLE
test(backend): record live Homey write confirmation

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -82,6 +82,10 @@ corpus. The filename records the observation date and SHS version. Each report m
 labels, booleans, ordering numbers, public dependency versions, and non-sensitive status codes, and must have a focused
 test that re-applies the report safety assertions. The 2026-08-14 SDK session evidence records connection,
 subscription, cleanup, and invalid-key behavior only; it does not claim capability-event, write, or reconnect coverage.
+The 2026-08-27 write-confirmation evidence records one allowlisted capability write, its matching event and read-back,
+restoration of the original value with a second matching read-back, complete cleanup, and invalid-key rejection on SHS
+`13.4.1`. It contains no endpoint, Homey identity, credential, device or capability identifier, value, inventory data,
+event payload, response body, or raw error.
 The 2026-08-26 mDNS evidence records the Homey and co-hosted HAP service types, ports, and TXT key names observed on SHS
 `13.4.1`; the pre-restart and post-restart reports are exact matches. The restart-recovery and network-recovery reports
 record ordered SDK disconnect, reconnect, manager resubscription, fresh inventory read, and cleanup evidence across an

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-write-confirmation.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-write-confirmation.json
@@ -1,0 +1,61 @@
+{
+	"invalidKey": {
+		"category": "authentication",
+		"rejected": true,
+		"statusCode": 401
+	},
+	"metadata": {
+		"probe": "homey-shs-realtime",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "socket.connect",
+				"order": 2
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 3
+			},
+			{
+				"event": "capability.update",
+				"order": 4
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 5
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 6
+			},
+			{
+				"event": "socket.disconnect",
+				"order": 7
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 8
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 9
+			}
+		],
+		"managerSubscribed": true
+	},
+	"write": {
+		"attempted": true,
+		"eventObserved": true,
+		"readBackMatched": true,
+		"restoreReadBackMatched": true,
+		"restored": true
+	}
+}

--- a/apps/backend/test/homey-shs-realtime.homey-spike.ts
+++ b/apps/backend/test/homey-shs-realtime.homey-spike.ts
@@ -19,11 +19,8 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
 };
 
-const loadLiveEvidence = (): unknown => {
-	const evidencePath = resolve(
-		__dirname,
-		'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-14-shs-13.4.0-sdk-session.json',
-	);
+const loadLiveEvidence = (filename = '2026-08-14-shs-13.4.0-sdk-session.json'): unknown => {
+	const evidencePath = resolve(__dirname, '../src/plugins/devices-homey/__fixtures__/evidence', filename);
 
 	return JSON.parse(readFileSync(evidencePath, 'utf8')) as unknown;
 };
@@ -200,6 +197,34 @@ describe('Homey SHS realtime compatibility probe', () => {
 			readBackMatched: false,
 			restoreReadBackMatched: false,
 			restored: false,
+		});
+		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).not.toThrow();
+	});
+
+	it('preserves the sanitized live SHS write-confirmation evidence', () => {
+		const report = loadLiveEvidence('2026-08-27-shs-13.4.1-write-confirmation.json');
+		const config = loadHomeyShsRealtimeProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-realtime-spike');
+
+		assertHomeyShsRealtimeReportSchema(report);
+		expect(report.session.events.map(({ event, order }) => ({ event, order }))).toStrictEqual([
+			{ event: 'sdk.create.resolved', order: 1 },
+			{ event: 'socket.connect', order: 2 },
+			{ event: 'manager.subscribe.resolved', order: 3 },
+			{ event: 'capability.update', order: 4 },
+			{ event: 'device.unsubscribe.resolved', order: 5 },
+			{ event: 'manager.unsubscribe.resolved', order: 6 },
+			{ event: 'socket.disconnect', order: 7 },
+			{ event: 'socket.disconnect.resolved', order: 8 },
+			{ event: 'sdk.destroyed', order: 9 },
+		]);
+		expect(report.session).toMatchObject({ cleanupCompleted: true, managerSubscribed: true });
+		expect(report.invalidKey).toStrictEqual({ category: 'authentication', rejected: true, statusCode: 401 });
+		expect(report.write).toStrictEqual({
+			attempted: true,
+			eventObserved: true,
+			readBackMatched: true,
+			restoreReadBackMatched: true,
+			restored: true,
 		});
 		expect(() => assertHomeyShsRealtimeReportSafe(report, config)).not.toThrow();
 	});

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,7 +1,7 @@
 # Homey SHS Compatibility Record
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
-restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live capability-event, write,
+restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live availability-event and
 lifecycle evidence is pending
 
 **Started:** 2026-08-12
@@ -23,9 +23,9 @@ file. Live results use synthetic aliases and sanitized captures only.
 | ----------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------- |
 | Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                 |
 | System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device          |
-| Capability metadata and suffixed IDs                  | Captured from inventory and an explicit read             | Add allowlisted write and read-back evidence                        |
-| Socket.IO events and reconnect                        | SHS restart and network recovery passed                  | Capture capability/availability event-flow continuity               |
-| Allowlisted capability write                          | Hard-gated probe implemented, disabled                   | Use only the designated harmless test capability                    |
+| Capability metadata and suffixed IDs                  | Inventory, explicit read, and write read-back passed     | None                                                                |
+| Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture availability event-flow continuity                          |
+| Allowlisted capability write                          | Passed on SHS `13.4.1`                                   | None                                                                |
 | Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                                |
 | API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                                |
 | Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                   |
@@ -183,6 +183,12 @@ capability is settable, validates type/range/enum constraints, and performs a fr
 original value. The requested value must differ from that original. It then requires the requested-value event and
 read-back, restores the original value in `finally`, and requires a second read-back confirming restoration before the
 sanitized report can be written.
+
+On 2026-08-27, the guarded probe passed against SHS `13.4.1`: the requested write produced a matching capability event
+and read-back, the original value was restored with a second matching read-back, all subscriptions and SDK resources
+were cleaned up, and the independent invalid key was rejected with `401`. The sanitized nine-event report is committed
+as `__fixtures__/evidence/2026-08-27-shs-13.4.1-write-confirmation.json`; it retains no device or capability identifier,
+requested or original value, endpoint, credential, inventory content, or event payload.
 
 ## Operator-controlled disposable-device lifecycle probe
 
@@ -557,8 +563,7 @@ HTTP remains the independent read-only compatibility/capture path, not the produ
 is based on the live SHS session and cleanup evidence, the SDK-native manager/capability contract, and the production
 adapter suites covering bounded creation and operations, subscription cleanup, reconnect coalescing, duplicate-listener
 prevention, late-client disposal, and normalized error handling. Live SHS restart and network-interruption session
-recovery now pass; capability and availability event-flow continuity remains a release-evidence gap, not an SDK
-abstraction gap.
+recovery now pass; availability event-flow continuity remains a release-evidence gap, not an SDK abstraction gap.
 
 The package license permits use with Homey products. Smart Panel loads it only for a user-configured Homey integration,
 does not copy or modify its proprietary source, and preserves the package's own `LICENSE` in installed production
@@ -596,8 +601,9 @@ Fill this matrix using synthetic aliases only.
 | Complete inventory and individual read    | Pass                                | Complete inventory captured: 118 devices and 16 zones; the selected individual-device response matched its pseudonymized inventory identity          |
 | Suffixed capability IDs                   | Pass in inventory and explicit read | 1,142 capability entries, including 170 suffixed entries; 55 devices repeat a base ID; an explicit suffixed capability GET returned a numeric scalar |
 | Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |
-| Capability and availability events        | Pending                             |                                                                                                                                                      |
-| Allowlisted write, event, and read-back   | Pending                             |                                                                                                                                                      |
+| Capability events                         | Pass                                | The allowlisted write produced its matching capability update inside the guarded observation window                                                  |
+| Availability events                       | Pending                             |                                                                                                                                                      |
+| Allowlisted write, event, and read-back   | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |
 | API-key revocation and replacement        | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -69,7 +69,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [x] Capture the complete device inventory and individual device objects.
 - [x] Capture capabilities with values, types, units, ranges, enums, readable/writable flags, and repeated/suffixed IDs.
 - [ ] Verify Socket.IO connection and record subscription/event ordering for capability changes and availability changes.
-- [ ] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
+- [x] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
 - [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [x] Test SHS restart, network interruption/restoration, and API-key revocation.
 - [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
@@ -90,7 +90,9 @@ the dependency. Its Node 24 engine is now reflected in root, backend, and packag
 chain's unpatched moderate `parseuri` advisory is accepted only with the documented HTTP(S), credential, 2,048-character,
 administrator-only endpoint boundary and bounded operations. A direct documented HTTP/Socket.IO adapter is the recorded
 replacement and must pass the existing connector contract. Live restart and network-interruption session recovery
-passed on SHS `13.4.1`; capability and availability event-flow continuity remains open above and in Task 6.2.
+passed on SHS `13.4.1`. The 2026-08-27 guarded write run also proved one requested capability update, matching event and
+read-back, restoration, and restoration read-back. Availability event-flow continuity remains open above and in Task
+6.2.
 
 ### Task 0.4: Build the sanitized fixture corpus
 
@@ -636,6 +638,11 @@ firewall rule blocked only the test host's path to SHS ports `4859` and `4860` f
 report proved disconnect, nine reconnect attempts during that finite interruption, reconnect, manager resubscription,
 a fresh inventory read, and complete cleanup. It does not close the event-flow criterion because no capability or
 availability event was observed across the interruption.
+
+The 2026-08-27 SHS `13.4.1` guarded write probe closed the single allowlisted capability slice: the requested value
+produced a matching event and read-back, and the original value was restored with a second matching read-back before
+cleanup. This does not close availability-event coverage, physical/Homey/flow-originated updates, or Smart Panel
+control for every writable MVP mapping family.
 
 The 2026-08-26 SHS `13.4.1` error probe recorded a non-mutating five-scenario slice: generated invalid-key
 authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -81,7 +81,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 
 - [ ] SHS version, image digest, network topology, ports, and test date are recorded.
 - [ ] A least-privilege API key can read devices, zones, system information, and current capability values.
-- [ ] A designated harmless writable capability can be controlled and its resulting event observed.
+- [x] A designated harmless writable capability can be controlled and its resulting event observed.
 - [x] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
 - [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
 - [x] mDNS behavior is verified; automatic discovery remains deferred pending safe identity and endpoint verification.


### PR DESCRIPTION
## Summary

- promote the sanitized SHS 13.4.1 allowlisted write-confirmation report
- assert the exact realtime event order, write/read-back, restoration, cleanup, and invalid-key result
- update the compatibility record, implementation plan, and epic while leaving availability and lifecycle evidence open

## Verification

- pnpm exec jest --config ./test/jest-homey-spike.json --runInBand test/homey-shs-realtime.homey-spike.ts test/homey-security-artifact.homey-spike.ts
- pnpm run homey:security-gate