### PR TITLE
test(cross): record Homey device lifecycle evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -99,5 +99,10 @@ Homey identity, credential, inventory data, response body, or raw error.
 The credential-rotation report records the fixed identity, preflight, operator-window, revocation, and replacement
 validation sequence plus the expected `401`. It contains no endpoint, Homey identity, credential, inventory data,
 response body, raw error, or identifier.
+The device-lifecycle report records the complete guarded disposable-device lifecycle on SHS `13.4.1`: exact add,
+rename, zone move, unavailable state, restoration, removal, final absence, and cleanup. SHS omitted the manager create
+event and all bound-device update events during the run, while the delete event was observed; bounded, cache-bypassing
+inventory read-backs verified every omitted-event transition. The report contains no endpoint, Homey identity,
+credential, device or zone identifier, name, inventory content, event payload, response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-device-lifecycle.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-device-lifecycle.json
@@ -1,0 +1,137 @@
+{
+	"lifecycle": {
+		"addVerified": true,
+		"availabilityRestored": true,
+		"finalAbsenceVerified": true,
+		"flowAbsenceVerified": true,
+		"removeVerified": true,
+		"renameVerified": true,
+		"unavailableVerified": true,
+		"zoneMoveVerified": true
+	},
+	"metadata": {
+		"probe": "homey-shs-lifecycle",
+		"schemaVersion": 3,
+		"sdkVersion": "3.19.2"
+	},
+	"session": {
+		"availabilityRestoreEventObserved": false,
+		"cleanupCompleted": true,
+		"createEventObserved": false,
+		"deleteEventObserved": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "baseline.absence.verified",
+				"order": 3
+			},
+			{
+				"event": "add.window.open",
+				"order": 4
+			},
+			{
+				"event": "device.create.not-observed",
+				"order": 5
+			},
+			{
+				"event": "add.readback.resolved",
+				"order": 6
+			},
+			{
+				"event": "device.subscribe.resolved",
+				"order": 7
+			},
+			{
+				"event": "flows.absence.verified",
+				"order": 8
+			},
+			{
+				"event": "device.rename.requested",
+				"order": 9
+			},
+			{
+				"event": "device.update.rename.not-observed",
+				"order": 10
+			},
+			{
+				"event": "rename.readback.resolved",
+				"order": 11
+			},
+			{
+				"event": "device.zone-move.requested",
+				"order": 12
+			},
+			{
+				"event": "device.update.zone-move.not-observed",
+				"order": 13
+			},
+			{
+				"event": "zone-move.readback.resolved",
+				"order": 14
+			},
+			{
+				"event": "availability.unavailable.requested",
+				"order": 15
+			},
+			{
+				"event": "device.update.unavailable.not-observed",
+				"order": 16
+			},
+			{
+				"event": "unavailable.readback.resolved",
+				"order": 17
+			},
+			{
+				"event": "availability.restore.requested",
+				"order": 18
+			},
+			{
+				"event": "device.update.available.not-observed",
+				"order": 19
+			},
+			{
+				"event": "availability.readback.resolved",
+				"order": 20
+			},
+			{
+				"event": "device.remove.requested",
+				"order": 21
+			},
+			{
+				"event": "device.delete.observed",
+				"order": 22
+			},
+			{
+				"event": "final.absence.verified",
+				"order": 23
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 24
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 25
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 26
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 27
+			}
+		],
+		"managerSubscribed": true,
+		"renameEventObserved": false,
+		"unavailableEventObserved": false,
+		"zoneMoveEventObserved": false
+	}
+}

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -19,7 +19,7 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
 	FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID: 'destination-zone-that-must-not-leak',
 	FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER: 'fbsp-lifecycle-test-marker-that-must-not-leak',
-	FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:test-owner-that-must-not-leak:driver:test-driver-that-must-not-leak',
+	FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:test-owner-that-must-not-leak:test-driver-that-must-not-leak',
 	FB_HOMEY_SHS_LIFECYCLE_ENABLE: 'I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE',
 	FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME: 'FBSP Lifecycle Initial Private Name',
 	FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS: '10000',
@@ -35,7 +35,7 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 const TEST_APP_ENVIRONMENT: NodeJS.ProcessEnv = {
 	...BASE_ENVIRONMENT,
 	FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER: 'fbsp-lifecycle-disposable-device',
-	FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:com.fastybird.smartpanel.lifecycletest:driver:lifecycle-test-device',
+	FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:com.fastybird.smartpanel.lifecycletest:lifecycle-test-device',
 	FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME: 'FBSP Lifecycle Initial',
 	FB_HOMEY_SHS_LIFECYCLE_OWNER_URI: 'homey:app:com.fastybird.smartpanel.lifecycletest',
 	FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME: 'FBSP Lifecycle Renamed',
@@ -48,6 +48,7 @@ const COMPLETE_EVENTS = [
 	'add.window.open',
 	'device.create.observed',
 	'add.readback.resolved',
+	'device.subscribe.resolved',
 	'flows.absence.verified',
 	'device.rename.requested',
 	'device.update.rename.observed',
@@ -64,34 +65,79 @@ const COMPLETE_EVENTS = [
 	'device.remove.requested',
 	'device.delete.observed',
 	'final.absence.verified',
+	'device.unsubscribe.resolved',
 	'manager.unsubscribe.resolved',
 	'socket.disconnect.resolved',
 	'sdk.destroyed',
 ] as const;
 
-const completeReport = (): HomeyShsLifecycleReport => ({
-	lifecycle: {
-		addVerified: true,
-		availabilityRestored: true,
-		finalAbsenceVerified: true,
-		flowAbsenceVerified: true,
-		removeVerified: true,
-		renameVerified: true,
-		unavailableVerified: true,
-		zoneMoveVerified: true,
-	},
-	metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 1, sdkVersion: '3.19.2' },
-	session: {
-		cleanupCompleted: true,
-		events: COMPLETE_EVENTS.map((event, index) => ({ event, order: index + 1 })),
-		managerSubscribed: true,
-	},
-});
+const completeReport = ({
+	availabilityRestoreEventObserved = true,
+	createEventObserved = true,
+	deleteEventObserved = true,
+	renameEventObserved = true,
+	unavailableEventObserved = true,
+	zoneMoveEventObserved = true,
+}: {
+	availabilityRestoreEventObserved?: boolean;
+	createEventObserved?: boolean;
+	deleteEventObserved?: boolean;
+	renameEventObserved?: boolean;
+	unavailableEventObserved?: boolean;
+	zoneMoveEventObserved?: boolean;
+} = {}): HomeyShsLifecycleReport => {
+	const eventObserved = new Map<string, boolean>([
+		['device.create.observed', createEventObserved],
+		['device.delete.observed', deleteEventObserved],
+		['device.update.available.observed', availabilityRestoreEventObserved],
+		['device.update.rename.observed', renameEventObserved],
+		['device.update.unavailable.observed', unavailableEventObserved],
+		['device.update.zone-move.observed', zoneMoveEventObserved],
+	]);
+	const missingEvents = new Map<string, HomeyShsLifecycleReport['session']['events'][number]['event']>([
+		['device.create.observed', 'device.create.not-observed'],
+		['device.delete.observed', 'device.delete.not-observed'],
+		['device.update.available.observed', 'device.update.available.not-observed'],
+		['device.update.rename.observed', 'device.update.rename.not-observed'],
+		['device.update.unavailable.observed', 'device.update.unavailable.not-observed'],
+		['device.update.zone-move.observed', 'device.update.zone-move.not-observed'],
+	]);
+
+	return {
+		lifecycle: {
+			addVerified: true,
+			availabilityRestored: true,
+			finalAbsenceVerified: true,
+			flowAbsenceVerified: true,
+			removeVerified: true,
+			renameVerified: true,
+			unavailableVerified: true,
+			zoneMoveVerified: true,
+		},
+		metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 3, sdkVersion: '3.19.2' },
+		session: {
+			availabilityRestoreEventObserved,
+			cleanupCompleted: true,
+			createEventObserved,
+			deleteEventObserved,
+			events: COMPLETE_EVENTS.map((event, index) => ({
+				event: eventObserved.get(event) === false ? (missingEvents.get(event) ?? event) : event,
+				order: index + 1,
+			})),
+			managerSubscribed: true,
+			renameEventObserved,
+			unavailableEventObserved,
+			zoneMoveEventObserved,
+		},
+	};
+};
 
 type FakeDevice = EventEmitter &
 	Record<string, unknown> & {
 		available: boolean;
+		connect(): Promise<void>;
 		data: { id: string };
+		disconnect(): Promise<void>;
 		driverId: string;
 		id: string;
 		name: string;
@@ -293,7 +339,9 @@ const makeOwnedDevice = (
 ): FakeDevice =>
 	Object.assign(new EventEmitter(), {
 		available: true,
+		connect: () => Promise.resolve(),
 		data: { id: config.deviceMarker },
+		disconnect: () => Promise.resolve(),
 		driverId: config.expectedDriverId,
 		id,
 		name: config.initialName,
@@ -323,6 +371,46 @@ const createHarness = (
 };
 
 describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
+	it('preserves the sanitized live SHS device-lifecycle evidence', async () => {
+		const evidencePath = join(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-device-lifecycle.json',
+		);
+		const evidence: unknown = JSON.parse(await readFile(evidencePath, 'utf8'));
+		const config = loadHomeyShsLifecycleProbeConfig(TEST_APP_ENVIRONMENT, '/tmp/homey-lifecycle-spike');
+
+		expect(() => assertHomeyShsLifecycleReportSafe(evidence, config)).not.toThrow();
+		assertHomeyShsLifecycleReportSchema(evidence);
+
+		expect(evidence).toMatchObject({
+			lifecycle: {
+				addVerified: true,
+				availabilityRestored: true,
+				finalAbsenceVerified: true,
+				flowAbsenceVerified: true,
+				removeVerified: true,
+				renameVerified: true,
+				unavailableVerified: true,
+				zoneMoveVerified: true,
+			},
+			metadata: {
+				probe: 'homey-shs-lifecycle',
+				schemaVersion: 3,
+				sdkVersion: '3.19.2',
+			},
+			session: {
+				availabilityRestoreEventObserved: false,
+				cleanupCompleted: true,
+				createEventObserved: false,
+				deleteEventObserved: true,
+				managerSubscribed: true,
+				renameEventObserved: false,
+				unavailableEventObserved: false,
+				zoneMoveEventObserved: false,
+			},
+		});
+	});
+
 	it('requires the exact lifecycle acknowledgement and canonical operation list', () => {
 		for (const enable of [undefined, '', 'yes', 'I_ACKNOWLEDGE_THIS_MUTATES_A_DISPOSABLE_DEVICE ']) {
 			expect(() =>
@@ -390,7 +478,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(() =>
 			loadHomeyShsLifecycleProbeConfig({
 				...BASE_ENVIRONMENT,
-				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:another-owner:driver:test-driver',
+				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: 'homey:app:another-owner:test-driver',
 			}),
 		).toThrow('must belong to the dedicated Homey test app');
 		expect(() =>
@@ -402,7 +490,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(() =>
 			loadHomeyShsLifecycleProbeConfig({
 				...BASE_ENVIRONMENT,
-				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: `${BASE_ENVIRONMENT.FB_HOMEY_SHS_LIFECYCLE_OWNER_URI}:driver:`,
+				FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID: `${BASE_ENVIRONMENT.FB_HOMEY_SHS_LIFECYCLE_OWNER_URI}:`,
 			}),
 		).toThrow('must belong to the dedicated Homey test app');
 		expect(() =>
@@ -621,6 +709,102 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(harness.client.devices.inventory).toStrictEqual({});
 	});
 
+	it('uses exact inventory read-back when SHS omits the manager create event', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-inventory-device-id';
+		const device = makeOwnedDevice(config, deviceId);
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport({ createEventObserved: false }));
+		expect(harness.client.devices.inventory).toStrictEqual({});
+	});
+
+	it('records final absence when SHS omits every delete event', async () => {
+		const config = fastConfig();
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-delete-fallback-id';
+		const device = makeOwnedDevice(config, deviceId);
+
+		jest.spyOn(harness.client.devices, 'deleteDevice').mockImplementation((options) => {
+			harness.client.devices.deleteRequests.push(options);
+			delete harness.client.devices.inventory[options.id];
+
+			return Promise.resolve();
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport({ deleteEventObserved: false }));
+		expect(harness.client.devices.inventory).toStrictEqual({});
+	});
+
+	it('uses exact read-back when SHS omits every bound-device update event', async () => {
+		const config = {
+			...loadHomeyShsLifecycleProbeConfig(TEST_APP_ENVIRONMENT, '/tmp/homey-lifecycle-spike'),
+			observeMs: 25,
+			timeoutMs: 25,
+		};
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-update-fallback-id';
+		const device = makeOwnedDevice(config, deviceId);
+
+		jest.spyOn(harness.client.devices, 'updateDevice').mockImplementation((options) => {
+			harness.client.devices.updateRequests.push(options);
+			Object.assign(device, options.device);
+
+			return Promise.resolve(device);
+		});
+		jest.spyOn(harness.client.devices, 'setDeviceSettings').mockImplementation((options) => {
+			harness.client.devices.settingsRequests.push(options);
+			device.available = options.settings.fbsp_lifecycle_availability === 'available';
+
+			return Promise.resolve(device);
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+		});
+
+		expect(report).toStrictEqual(
+			completeReport({
+				availabilityRestoreEventObserved: false,
+				renameEventObserved: false,
+				unavailableEventObserved: false,
+				zoneMoveEventObserved: false,
+			}),
+		);
+		expect(harness.client.devices.inventory).toStrictEqual({});
+	});
+
 	it('requires a newly bound device to start available and leaves it for manual cleanup otherwise', async () => {
 		const config = fastConfig();
 		const harness = createHarness(config);
@@ -669,8 +853,8 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(harness.client.devices.inventory[ownedId]).toBe(owned);
 	});
 
-	it('does not mistake an aggregate manager update for the rename delta', async () => {
-		const config = fastConfig({ observeMs: 5 });
+	it('does not count aggregate manager updates as bound-device update events', async () => {
+		const config = fastConfig();
 		const harness = createHarness(config);
 		const ownedId = 'freshly-owned-device-id';
 		const owned = makeOwnedDevice(config, ownedId);
@@ -683,14 +867,22 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 			return Promise.resolve(owned);
 		});
 
-		await expect(
-			probeHomeyShsLifecycle(config, harness.factory, {
-				onAddWindowOpen: () => {
-					harness.client.devices.inventory[ownedId] = owned;
-					harness.client.devices.emit('device.create', owned);
-				},
-			}),
-		).rejects.toThrow('rename event observation timed out after 5 ms');
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[ownedId] = owned;
+				harness.client.devices.emit('device.create', owned);
+			},
+			onAvailabilityRestoreRequested: () => {
+				owned.available = true;
+				owned.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				owned.available = false;
+				owned.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport({ renameEventObserved: false, zoneMoveEventObserved: false }));
 		expect(harness.client.devices.deleteRequests).toStrictEqual([{ $timeout: 25, id: ownedId }]);
 	});
 
@@ -754,7 +946,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		const unrelatedId = 'ordinary-device-id';
 		const unrelated = makeOwnedDevice(config, unrelatedId, {
 			data: { id: 'fbsp-lifecycle-unrelated-marker' },
-			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			driverId: 'homey:app:ordinary-owner:ordinary-driver',
 			name: 'Ordinary Device',
 			ownerUri: 'homey:app:ordinary-owner',
 		});
@@ -864,7 +1056,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		const owned = makeOwnedDevice(config, ownedId);
 		const unrelated = makeOwnedDevice(config, unrelatedId, {
 			data: { id: 'fbsp-lifecycle-unrelated-marker' },
-			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			driverId: 'homey:app:ordinary-owner:ordinary-driver',
 			name: 'Ordinary Device',
 			ownerUri: 'homey:app:ordinary-owner',
 		});
@@ -976,7 +1168,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		const owned = makeOwnedDevice(config, ownedId);
 		const unrelated = makeOwnedDevice(config, unrelatedId, {
 			data: { id: 'fbsp-lifecycle-unrelated-marker' },
-			driverId: 'homey:app:ordinary-owner:driver:ordinary-driver',
+			driverId: 'homey:app:ordinary-owner:ordinary-driver',
 			name: 'Ordinary Device',
 			ownerUri: 'homey:app:ordinary-owner',
 		});
@@ -1009,7 +1201,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		{
 			label: 'ownership drift',
 			mutate: (device: FakeDevice, _client: FakeLifecycleClient): void => {
-				device.driverId = 'homey:app:unexpected-owner:driver:unexpected-driver';
+				device.driverId = 'homey:app:unexpected-owner:unexpected-driver';
 			},
 		},
 	])('does not use stale cleanup authorization after $label', async ({ mutate }) => {

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -805,6 +805,45 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(harness.client.devices.inventory).toStrictEqual({});
 	});
 
+	it('observes a bound-device event that arrives after the former 250 ms grace period', async () => {
+		const config = fastConfig({ observeMs: 350 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-delayed-update-id';
+		const device = makeOwnedDevice(config, deviceId);
+		let updateCount = 0;
+
+		jest.spyOn(harness.client.devices, 'updateDevice').mockImplementation((options) => {
+			harness.client.devices.updateRequests.push(options);
+			Object.assign(device, options.device);
+			updateCount += 1;
+
+			if (updateCount === 1) {
+				setTimeout(() => device.emit('update', { ...options.device }), 275);
+			} else {
+				device.emit('update', { ...options.device });
+			}
+
+			return Promise.resolve(device);
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+	});
+
 	it('requires a newly bound device to start available and leaves it for manual cleanup otherwise', async () => {
 		const config = fastConfig();
 		const harness = createHarness(config);

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -732,6 +732,29 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(harness.client.devices.inventory).toStrictEqual({});
 	});
 
+	it('observes a create event that arrives after the former 250 ms grace period', async () => {
+		const config = fastConfig({ observeMs: 350 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-delayed-create-id';
+		const device = makeOwnedDevice(config, deviceId);
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				setTimeout(() => harness.client.devices.emit('device.create', device), 275);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+	});
+
 	it('records final absence when SHS omits every delete event', async () => {
 		const config = fastConfig();
 		const harness = createHarness(config);
@@ -762,6 +785,38 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 
 		expect(report).toStrictEqual(completeReport({ deleteEventObserved: false }));
 		expect(harness.client.devices.inventory).toStrictEqual({});
+	});
+
+	it('observes a delete event that arrives after the absence read-back', async () => {
+		const config = fastConfig({ observeMs: 350 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-delayed-delete-id';
+		const device = makeOwnedDevice(config, deviceId);
+
+		jest.spyOn(harness.client.devices, 'deleteDevice').mockImplementation((options) => {
+			harness.client.devices.deleteRequests.push(options);
+			delete harness.client.devices.inventory[options.id];
+			setTimeout(() => harness.client.devices.emit('device.delete', { id: options.id }), 275);
+
+			return Promise.resolve();
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
 	});
 
 	it('uses exact read-back when SHS omits every bound-device update event', async () => {

--- a/apps/backend/test/support/homey-lifecycle-test-app/README.md
+++ b/apps/backend/test/support/homey-lifecycle-test-app/README.md
@@ -8,7 +8,7 @@ Smart Panel runtime dependency, must not be published, and must never be used fo
 ```text
 FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER=fbsp-lifecycle-disposable-device
 FB_HOMEY_SHS_LIFECYCLE_OWNER_URI=homey:app:com.fastybird.smartpanel.lifecycletest
-FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID=homey:app:com.fastybird.smartpanel.lifecycletest:driver:lifecycle-test-device
+FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID=homey:app:com.fastybird.smartpanel.lifecycletest:lifecycle-test-device
 FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME=FBSP Lifecycle Initial
 FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME=FBSP Lifecycle Renamed
 ```

--- a/apps/backend/test/support/homey-lifecycle-test-app/app.json
+++ b/apps/backend/test/support/homey-lifecycle-test-app/app.json
@@ -1,73 +1,83 @@
 {
-  "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
-  "id": "com.fastybird.smartpanel.lifecycletest",
-  "version": "1.0.0",
-  "compatibility": ">=12.4.0",
-  "sdk": 3,
-  "runtime": "nodejs",
-  "platforms": [
-    "local"
-  ],
-  "name": {
-    "en": "Smart Panel Lifecycle Test"
-  },
-  "description": {
-    "en": "Creates one disposable virtual device for Smart Panel lifecycle evidence."
-  },
-  "category": [
-    "tools"
-  ],
-  "permissions": [],
-  "images": {
-    "small": "/assets/images/small.png",
-    "large": "/assets/images/large.png",
-    "xlarge": "/assets/images/xlarge.png"
-  },
-  "author": {
-    "name": "Studio81 Labs s.r.o.",
-    "email": "dev@studio81.cz"
-  },
-  "drivers": [
-    {
-      "name": {
-        "en": "Lifecycle Test Device"
-      },
-      "class": "other",
-      "capabilities": [],
-      "platforms": [
-        "local"
-      ],
-      "connectivity": [],
-      "images": {
-        "small": "/drivers/lifecycle-test-device/assets/images/small.png",
-        "large": "/drivers/lifecycle-test-device/assets/images/large.png",
-        "xlarge": "/drivers/lifecycle-test-device/assets/images/xlarge.png"
-      },
-      "id": "lifecycle-test-device",
-      "settings": [
-        {
-          "id": "fbsp_lifecycle_availability",
-          "type": "dropdown",
-          "value": "available",
-          "label": {
-            "en": "Lifecycle availability"
-          },
-          "values": [
-            {
-              "id": "available",
-              "label": {
-                "en": "Available"
-              }
-            },
-            {
-              "id": "unavailable",
-              "label": {
-                "en": "Unavailable"
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ]
+	"_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
+	"id": "com.fastybird.smartpanel.lifecycletest",
+	"version": "1.0.0",
+	"compatibility": ">=12.4.0",
+	"sdk": 3,
+	"runtime": "nodejs",
+	"platforms": ["local"],
+	"name": {
+		"en": "Smart Panel Lifecycle Test"
+	},
+	"description": {
+		"en": "Creates one disposable virtual device for Smart Panel lifecycle evidence."
+	},
+	"category": ["tools"],
+	"permissions": [],
+	"images": {
+		"small": "/assets/images/small.png",
+		"large": "/assets/images/large.png",
+		"xlarge": "/assets/images/xlarge.png"
+	},
+	"author": {
+		"name": "Studio81 Labs s.r.o.",
+		"email": "dev@studio81.cz"
+	},
+	"drivers": [
+		{
+			"name": {
+				"en": "Lifecycle Test Device"
+			},
+			"class": "other",
+			"capabilities": [],
+			"platforms": ["local"],
+			"connectivity": [],
+			"pair": [
+				{
+					"id": "list_devices",
+					"template": "list_devices",
+					"navigation": {
+						"next": "add_devices"
+					},
+					"options": {
+						"singular": true
+					}
+				},
+				{
+					"id": "add_devices",
+					"template": "add_devices"
+				}
+			],
+			"images": {
+				"small": "/drivers/lifecycle-test-device/assets/images/small.png",
+				"large": "/drivers/lifecycle-test-device/assets/images/large.png",
+				"xlarge": "/drivers/lifecycle-test-device/assets/images/xlarge.png"
+			},
+			"id": "lifecycle-test-device",
+			"settings": [
+				{
+					"id": "fbsp_lifecycle_availability",
+					"type": "dropdown",
+					"value": "available",
+					"label": {
+						"en": "Lifecycle availability"
+					},
+					"values": [
+						{
+							"id": "available",
+							"label": {
+								"en": "Available"
+							}
+						},
+						{
+							"id": "unavailable",
+							"label": {
+								"en": "Unavailable"
+							}
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/apps/backend/test/support/homey-lifecycle-test-app/drivers/lifecycle-test-device/driver-manifest.test.js
+++ b/apps/backend/test/support/homey-lifecycle-test-app/drivers/lifecycle-test-device/driver-manifest.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const manifest = require('./driver.compose.json');
+
+test('declares the device-list and add-device pairing flow', () => {
+	assert.deepEqual(manifest.pair, [
+		{
+			id: 'list_devices',
+			template: 'list_devices',
+			navigation: { next: 'add_devices' },
+			options: { singular: true },
+		},
+		{
+			id: 'add_devices',
+			template: 'add_devices',
+		},
+	]);
+});

--- a/apps/backend/test/support/homey-lifecycle-test-app/drivers/lifecycle-test-device/driver.compose.json
+++ b/apps/backend/test/support/homey-lifecycle-test-app/drivers/lifecycle-test-device/driver.compose.json
@@ -6,6 +6,22 @@
 	"capabilities": [],
 	"platforms": ["local"],
 	"connectivity": [],
+	"pair": [
+		{
+			"id": "list_devices",
+			"template": "list_devices",
+			"navigation": {
+				"next": "add_devices"
+			},
+			"options": {
+				"singular": true
+			}
+		},
+		{
+			"id": "add_devices",
+			"template": "add_devices"
+		}
+	],
 	"images": {
 		"small": "{{driverAssetsPath}}/images/small.png",
 		"large": "{{driverAssetsPath}}/images/large.png",

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -670,25 +670,30 @@ const observeDeviceUpdate = async (
 	try {
 		await runObservationTrigger(label, trigger);
 		const deadline = Date.now() + config.observeMs;
+		let readbackVerified = false;
 
 		while (!eventObserved) {
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
+				if (readbackVerified) {
+					break;
+				}
+
 				throw new HomeyShsLifecycleTimeoutError(label, config.observeMs);
+			}
+
+			if (readbackVerified) {
+				await Promise.race([eventSignal, pause(remainingMs)]);
+				break;
 			}
 
 			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
 			const currentDevice = requireSingleOwnedDevice(inventory, config, boundDeviceId);
 
 			if (readbackPredicate(currentDevice)) {
-				const eventGraceMs = Math.min(250, Math.max(0, deadline - Date.now()));
-
-				if (eventGraceMs > 0) {
-					await Promise.race([eventSignal, pause(eventGraceMs)]);
-				}
-
-				break;
+				readbackVerified = true;
+				continue;
 			}
 
 			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -432,9 +432,23 @@ const hasLifecycleResidue = (
 		(device) => deviceMarkerOf(device) === config.deviceMarker || device.ownerUri === config.expectedOwnerUri,
 	);
 
-const pause = async (milliseconds: number): Promise<void> =>
+const waitForSignal = async (signal: Promise<void>, timeoutMs: number): Promise<boolean> =>
 	new Promise((resolvePromise) => {
-		setTimeout(resolvePromise, milliseconds);
+		let settled = false;
+		const timeout = setTimeout(() => {
+			settled = true;
+			resolvePromise(false);
+		}, timeoutMs);
+
+		void signal.then(() => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			clearTimeout(timeout);
+			resolvePromise(true);
+		});
 	});
 
 const runObservationTrigger = async (label: string, trigger: () => Promise<void> | void): Promise<void> => {
@@ -487,6 +501,7 @@ const observeDeviceCreation = async (
 
 	let observationError: unknown;
 	let result: { device: HomeyLifecycleDevice; eventObserved: boolean } | undefined;
+	let inventoryDevice: HomeyLifecycleDevice | undefined;
 	let listenerRemovalFailed = false;
 
 	try {
@@ -502,7 +517,17 @@ const observeDeviceCreation = async (
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
+				if (inventoryDevice !== undefined) {
+					result = { device: inventoryDevice, eventObserved: false };
+					break;
+				}
+
 				throw new HomeyShsLifecycleTimeoutError('operator add observation', config.observeMs);
+			}
+
+			if (inventoryDevice !== undefined) {
+				await waitForSignal(eventSignal, remainingMs);
+				continue;
 			}
 
 			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
@@ -513,24 +538,15 @@ const observeDeviceCreation = async (
 			}
 
 			if (matches.length === 1) {
-				const eventGraceMs = Math.min(250, Math.max(0, deadline - Date.now()));
-
-				if (eventDevice === undefined && eventGraceMs > 0) {
-					await Promise.race([eventSignal, pause(eventGraceMs)]);
-				}
-
-				result = {
-					device: eventDevice ?? matches[0],
-					eventObserved: eventDevice !== undefined,
-				};
-				bindDevice(result.device);
-				break;
+				inventoryDevice = matches[0];
+				bindDevice(inventoryDevice);
+				continue;
 			}
 
 			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
 
 			if (pollMs > 0) {
-				await Promise.race([eventSignal, pause(pollMs)]);
+				await waitForSignal(eventSignal, pollMs);
 			}
 		}
 	} catch (error: unknown) {
@@ -594,24 +610,35 @@ const observeDeviceDeletion = async (
 	try {
 		await runObservationTrigger('delete event observation', trigger);
 		const deadline = Date.now() + config.observeMs;
+		let absenceVerified = false;
 
-		while (true) {
+		while (!eventObserved) {
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
+				if (absenceVerified) {
+					break;
+				}
+
 				throw new HomeyShsLifecycleTimeoutError('delete event observation', config.observeMs);
+			}
+
+			if (absenceVerified) {
+				await waitForSignal(eventSignal, remainingMs);
+				break;
 			}
 
 			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
 
 			if (!hasLifecycleResidue(inventory, config, boundDeviceId)) {
-				break;
+				absenceVerified = true;
+				continue;
 			}
 
 			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
 
 			if (pollMs > 0) {
-				await Promise.race([eventSignal, pause(pollMs)]);
+				await waitForSignal(eventSignal, pollMs);
 			}
 		}
 	} catch (error: unknown) {
@@ -684,7 +711,7 @@ const observeDeviceUpdate = async (
 			}
 
 			if (readbackVerified) {
-				await Promise.race([eventSignal, pause(remainingMs)]);
+				await waitForSignal(eventSignal, remainingMs);
 				break;
 			}
 
@@ -699,7 +726,7 @@ const observeDeviceUpdate = async (
 			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
 
 			if (pollMs > 0) {
-				await Promise.race([eventSignal, pause(pollMs)]);
+				await waitForSignal(eventSignal, pollMs);
 			}
 		}
 	} catch (error: unknown) {

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -11,7 +11,7 @@ const LIFECYCLE_OPERATIONS = 'add,rename,zone-move,availability,remove';
 const TEST_APP_AVAILABILITY_SETTING_ID = 'fbsp_lifecycle_availability';
 const TEST_APP_PROFILE = {
 	deviceMarker: 'fbsp-lifecycle-disposable-device',
-	expectedDriverId: 'homey:app:com.fastybird.smartpanel.lifecycletest:driver:lifecycle-test-device',
+	expectedDriverId: 'homey:app:com.fastybird.smartpanel.lifecycletest:lifecycle-test-device',
 	expectedOwnerUri: 'homey:app:com.fastybird.smartpanel.lifecycletest',
 	initialName: 'FBSP Lifecycle Initial',
 	renamedName: 'FBSP Lifecycle Renamed',
@@ -19,6 +19,7 @@ const TEST_APP_PROFILE = {
 const DEFAULT_OBSERVE_MS = 90_000;
 const MIN_OBSERVE_MS = 10_000;
 const MAX_OBSERVE_MS = 300_000;
+const INVENTORY_POLL_MS = 1_000;
 const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
 const CONFLICTING_GATE_PREFIXES = [
 	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
@@ -32,6 +33,7 @@ const EXPECTED_EVENTS = [
 	'add.window.open',
 	'device.create.observed',
 	'add.readback.resolved',
+	'device.subscribe.resolved',
 	'flows.absence.verified',
 	'device.rename.requested',
 	'device.update.rename.observed',
@@ -48,13 +50,21 @@ const EXPECTED_EVENTS = [
 	'device.remove.requested',
 	'device.delete.observed',
 	'final.absence.verified',
+	'device.unsubscribe.resolved',
 	'manager.unsubscribe.resolved',
 	'socket.disconnect.resolved',
 	'sdk.destroyed',
 ] as const;
 
 type EventListener = (...arguments_: unknown[]) => void;
-type LifecycleEvent = (typeof EXPECTED_EVENTS)[number];
+type LifecycleEvent =
+	| (typeof EXPECTED_EVENTS)[number]
+	| 'device.create.not-observed'
+	| 'device.delete.not-observed'
+	| 'device.update.available.not-observed'
+	| 'device.update.rename.not-observed'
+	| 'device.update.unavailable.not-observed'
+	| 'device.update.zone-move.not-observed';
 
 class HomeyShsLifecycleTimeoutError extends Error {
 	constructor(label: string, timeoutMs: number) {
@@ -70,7 +80,9 @@ interface EventSource {
 
 interface HomeyLifecycleDevice extends EventSource, Record<string, unknown> {
 	available?: unknown;
+	connect(): Promise<void>;
 	data?: unknown;
+	disconnect(): Promise<void>;
 	driverId?: unknown;
 	id: string;
 	name?: unknown;
@@ -151,13 +163,19 @@ export interface HomeyShsLifecycleReport {
 	};
 	metadata: {
 		probe: 'homey-shs-lifecycle';
-		schemaVersion: 1;
+		schemaVersion: 3;
 		sdkVersion: string;
 	};
 	session: {
+		availabilityRestoreEventObserved: boolean;
 		cleanupCompleted: boolean;
+		createEventObserved: boolean;
+		deleteEventObserved: boolean;
 		events: Array<{ event: LifecycleEvent; order: number }>;
 		managerSubscribed: boolean;
+		renameEventObserved: boolean;
+		unavailableEventObserved: boolean;
+		zoneMoveEventObserved: boolean;
 	};
 }
 
@@ -265,7 +283,7 @@ export const loadHomeyShsLifecycleProbeConfig = (
 		throw new Error('FB_HOMEY_SHS_LIFECYCLE_OWNER_URI must identify the dedicated Homey test app');
 	}
 
-	const driverPrefix = `${expectedOwnerUri}:driver:`;
+	const driverPrefix = `${expectedOwnerUri}:`;
 	const driverId = expectedDriverId.slice(driverPrefix.length);
 
 	if (!expectedDriverId.startsWith(driverPrefix) || !/^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/.test(driverId)) {
@@ -369,9 +387,10 @@ const isInitialDevice = (device: HomeyLifecycleDevice, config: HomeyShsLifecycle
 const freshDevices = async (
 	client: HomeyLifecycleClient,
 	config: HomeyShsLifecycleProbeConfig,
+	timeoutMs = config.timeoutMs,
 ): Promise<Record<string, HomeyLifecycleDevice>> =>
-	runOperation('fresh inventory read', config.timeoutMs, () =>
-		client.devices.getDevices({ $cache: false, $timeout: config.timeoutMs, $updateCache: false }),
+	runOperation('fresh inventory read', timeoutMs, () =>
+		client.devices.getDevices({ $cache: false, $timeout: timeoutMs, $updateCache: false }),
 	);
 
 const requireSingleOwnedDevice = (
@@ -413,67 +432,276 @@ const hasLifecycleResidue = (
 		(device) => deviceMarkerOf(device) === config.deviceMarker || device.ownerUri === config.expectedOwnerUri,
 	);
 
-const observeManagerEvent = async (
-	source: EventSource,
-	event: string,
-	label: string,
-	timeoutMs: number,
-	predicate: (payload: unknown) => boolean,
+const pause = async (milliseconds: number): Promise<void> =>
+	new Promise((resolvePromise) => {
+		setTimeout(resolvePromise, milliseconds);
+	});
+
+const runObservationTrigger = async (label: string, trigger: () => Promise<void> | void): Promise<void> => {
+	try {
+		await trigger();
+	} catch (error: unknown) {
+		if (
+			error instanceof HomeyShsLifecycleTimeoutError ||
+			(error instanceof Error && error.message.startsWith('Homey lifecycle '))
+		) {
+			throw error;
+		}
+
+		// eslint-disable-next-line preserve-caught-error -- Operator/SDK hook errors may contain private detail.
+		throw new Error(`Homey lifecycle ${label} trigger failed`);
+	}
+};
+
+const observeDeviceCreation = async (
+	client: HomeyLifecycleClient,
+	config: HomeyShsLifecycleProbeConfig,
 	trigger: () => Promise<void> | void,
-): Promise<unknown> => {
-	let timeout: ReturnType<typeof setTimeout> | undefined;
-	let resolveEvent: (payload: unknown) => void = () => undefined;
-	const eventPromise = new Promise<unknown>((resolvePromise) => {
-		resolveEvent = resolvePromise;
+	onBound: (device: HomeyLifecycleDevice) => void,
+): Promise<{ device: HomeyLifecycleDevice; eventObserved: boolean }> => {
+	let eventDevice: HomeyLifecycleDevice | undefined;
+	let deviceBound = false;
+	const bindDevice = (device: HomeyLifecycleDevice): void => {
+		if (!deviceBound) {
+			deviceBound = true;
+			onBound(device);
+		}
+	};
+	let signalEvent: () => void = () => undefined;
+	const eventSignal = new Promise<void>((resolvePromise) => {
+		signalEvent = resolvePromise;
 	});
 	const listener: EventListener = (payload: unknown): void => {
-		if (predicate(payload)) {
-			resolveEvent(payload);
+		if (isRecord(payload) && isInitialDevice(payload as HomeyLifecycleDevice, config)) {
+			eventDevice = payload as HomeyLifecycleDevice;
+			bindDevice(eventDevice);
+			signalEvent();
 		}
 	};
 
 	try {
-		source.on(event, listener);
+		client.devices.on('device.create', listener);
+	} catch {
+		throw new Error('Homey lifecycle operator add observation listener registration failed');
+	}
+
+	let observationError: unknown;
+	let result: { device: HomeyLifecycleDevice; eventObserved: boolean } | undefined;
+	let listenerRemovalFailed = false;
+
+	try {
+		await runObservationTrigger('operator add observation', trigger);
+		const deadline = Date.now() + config.observeMs;
+
+		while (result === undefined) {
+			if (eventDevice !== undefined) {
+				result = { device: eventDevice, eventObserved: true };
+				break;
+			}
+
+			const remainingMs = deadline - Date.now();
+
+			if (remainingMs <= 0) {
+				throw new HomeyShsLifecycleTimeoutError('operator add observation', config.observeMs);
+			}
+
+			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
+			const matches = Object.values(inventory).filter((device) => isInitialDevice(device, config));
+
+			if (matches.length > 1) {
+				throw new Error('Homey lifecycle ownership verification failed');
+			}
+
+			if (matches.length === 1) {
+				const eventGraceMs = Math.min(250, Math.max(0, deadline - Date.now()));
+
+				if (eventDevice === undefined && eventGraceMs > 0) {
+					await Promise.race([eventSignal, pause(eventGraceMs)]);
+				}
+
+				result = {
+					device: eventDevice ?? matches[0],
+					eventObserved: eventDevice !== undefined,
+				};
+				bindDevice(result.device);
+				break;
+			}
+
+			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
+
+			if (pollMs > 0) {
+				await Promise.race([eventSignal, pause(pollMs)]);
+			}
+		}
+	} catch (error: unknown) {
+		observationError = error;
+	} finally {
+		try {
+			client.devices.off?.('device.create', listener);
+		} catch {
+			listenerRemovalFailed = true;
+		}
+	}
+
+	if (listenerRemovalFailed) {
+		throw new Error('Homey lifecycle operator add observation listener removal failed');
+	}
+
+	if (observationError !== undefined) {
+		throw observationError;
+	}
+
+	if (result === undefined) {
+		throw new Error('Homey lifecycle operator add observation failed');
+	}
+
+	return result;
+};
+
+const observeDeviceDeletion = async (
+	client: HomeyLifecycleClient,
+	device: HomeyLifecycleDevice,
+	config: HomeyShsLifecycleProbeConfig,
+	boundDeviceId: string,
+	trigger: () => Promise<void> | void,
+): Promise<boolean> => {
+	let eventObserved = false;
+	let signalEvent: () => void = () => undefined;
+	const eventSignal = new Promise<void>((resolvePromise) => {
+		signalEvent = resolvePromise;
+	});
+	const managerListener: EventListener = (payload: unknown): void => {
+		if (deviceIdOf(payload) === boundDeviceId) {
+			eventObserved = true;
+			signalEvent();
+		}
+	};
+	const deviceListener: EventListener = (): void => {
+		eventObserved = true;
+		signalEvent();
+	};
+
+	try {
+		client.devices.on('device.delete', managerListener);
+		device.on('delete', deviceListener);
+	} catch {
+		throw new Error('Homey lifecycle delete event observation listener registration failed');
+	}
+
+	let observationError: unknown;
+	let listenerRemovalFailed = false;
+
+	try {
+		await runObservationTrigger('delete event observation', trigger);
+		const deadline = Date.now() + config.observeMs;
+
+		while (true) {
+			const remainingMs = deadline - Date.now();
+
+			if (remainingMs <= 0) {
+				throw new HomeyShsLifecycleTimeoutError('delete event observation', config.observeMs);
+			}
+
+			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
+
+			if (!hasLifecycleResidue(inventory, config, boundDeviceId)) {
+				break;
+			}
+
+			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
+
+			if (pollMs > 0) {
+				await Promise.race([eventSignal, pause(pollMs)]);
+			}
+		}
+	} catch (error: unknown) {
+		observationError = error;
+	} finally {
+		try {
+			client.devices.off?.('device.delete', managerListener);
+			device.off?.('delete', deviceListener);
+		} catch {
+			listenerRemovalFailed = true;
+		}
+	}
+
+	if (listenerRemovalFailed) {
+		throw new Error('Homey lifecycle delete event observation listener removal failed');
+	}
+
+	if (observationError !== undefined) {
+		throw observationError;
+	}
+
+	return eventObserved;
+};
+
+const observeDeviceUpdate = async (
+	client: HomeyLifecycleClient,
+	device: HomeyLifecycleDevice,
+	config: HomeyShsLifecycleProbeConfig,
+	boundDeviceId: string,
+	label: string,
+	eventPredicate: (payload: unknown) => boolean,
+	readbackPredicate: (device: HomeyLifecycleDevice) => boolean,
+	trigger: () => Promise<void> | void,
+): Promise<boolean> => {
+	let eventObserved = false;
+	let signalEvent: () => void = () => undefined;
+	const eventSignal = new Promise<void>((resolvePromise) => {
+		signalEvent = resolvePromise;
+	});
+	const listener: EventListener = (payload: unknown): void => {
+		if (eventPredicate(payload)) {
+			eventObserved = true;
+			signalEvent();
+		}
+	};
+
+	try {
+		device.on('update', listener);
 	} catch {
 		throw new Error(`Homey lifecycle ${label} listener registration failed`);
 	}
 
-	const timeoutPromise = new Promise<never>((_resolvePromise, rejectPromise) => {
-		timeout = setTimeout(() => rejectPromise(new HomeyShsLifecycleTimeoutError(label, timeoutMs)), timeoutMs);
-	});
-
-	const triggerPromise = Promise.resolve().then(async () => {
-		try {
-			await trigger();
-		} catch (error: unknown) {
-			if (
-				error instanceof HomeyShsLifecycleTimeoutError ||
-				(error instanceof Error && error.message.startsWith('Homey lifecycle '))
-			) {
-				throw error;
-			}
-
-			// eslint-disable-next-line preserve-caught-error -- Operator/SDK hook errors may contain private detail.
-			throw new Error(`Homey lifecycle ${label} trigger failed`);
-		}
-	});
 	let observationError: unknown;
-	let observationFailed = false;
 	let listenerRemovalFailed = false;
-	let result: unknown;
 
 	try {
-		await Promise.race([triggerPromise, timeoutPromise]);
-		result = await Promise.race([eventPromise, timeoutPromise]);
+		await runObservationTrigger(label, trigger);
+		const deadline = Date.now() + config.observeMs;
+
+		while (!eventObserved) {
+			const remainingMs = deadline - Date.now();
+
+			if (remainingMs <= 0) {
+				throw new HomeyShsLifecycleTimeoutError(label, config.observeMs);
+			}
+
+			const inventory = await freshDevices(client, config, Math.min(config.timeoutMs, remainingMs));
+			const currentDevice = requireSingleOwnedDevice(inventory, config, boundDeviceId);
+
+			if (readbackPredicate(currentDevice)) {
+				const eventGraceMs = Math.min(250, Math.max(0, deadline - Date.now()));
+
+				if (eventGraceMs > 0) {
+					await Promise.race([eventSignal, pause(eventGraceMs)]);
+				}
+
+				break;
+			}
+
+			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
+
+			if (pollMs > 0) {
+				await Promise.race([eventSignal, pause(pollMs)]);
+			}
+		}
 	} catch (error: unknown) {
 		observationError = error;
-		observationFailed = true;
 	} finally {
-		if (timeout !== undefined) {
-			clearTimeout(timeout);
-		}
 		try {
-			source.off?.(event, listener);
+			device.off?.('update', listener);
 		} catch {
 			listenerRemovalFailed = true;
 		}
@@ -483,11 +711,11 @@ const observeManagerEvent = async (
 		throw new Error(`Homey lifecycle ${label} listener removal failed`);
 	}
 
-	if (observationFailed) {
+	if (observationError !== undefined) {
 		throw observationError;
 	}
 
-	return result;
+	return eventObserved;
 };
 
 const flowCardReferencesDevice = (card: unknown, deviceUri: string): boolean => {
@@ -643,12 +871,23 @@ export const probeHomeyShsLifecycle = async (
 			unavailableVerified: true,
 			zoneMoveVerified: true,
 		},
-		metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 1, sdkVersion: SDK_VERSION },
-		session: { cleanupCompleted: true, events: [], managerSubscribed: true },
+		metadata: { probe: 'homey-shs-lifecycle', schemaVersion: 3, sdkVersion: SDK_VERSION },
+		session: {
+			availabilityRestoreEventObserved: false,
+			cleanupCompleted: true,
+			createEventObserved: false,
+			deleteEventObserved: false,
+			events: [],
+			managerSubscribed: true,
+			renameEventObserved: false,
+			unavailableEventObserved: false,
+			zoneMoveEventObserved: false,
+		},
 	} as HomeyShsLifecycleReport;
 	const client = await createClient(config, factory);
 	appendEvent(report, 'sdk.create.resolved');
 	let boundDeviceId: string | undefined;
+	let connectedDevice: HomeyLifecycleDevice | undefined;
 	let createdDuringRun = false;
 	let deletionAuthorized = false;
 	let deleteAttempted = false;
@@ -672,23 +911,17 @@ export const probeHomeyShsLifecycle = async (
 
 		appendEvent(report, 'baseline.absence.verified');
 		appendEvent(report, 'add.window.open');
-		const createdPayload = await observeManagerEvent(
-			client.devices,
-			'device.create',
-			'operator add observation',
-			config.observeMs,
-			(payload) => {
-				const matches = isRecord(payload) && isInitialDevice(payload as HomeyLifecycleDevice, config);
-
-				if (matches) {
-					boundDeviceId = deviceIdOf(payload) ?? undefined;
-					manualCleanupRequired = boundDeviceId !== undefined;
-				}
-
-				return matches;
-			},
+		const creation = await observeDeviceCreation(
+			client,
+			config,
 			() => hooks.onAddWindowOpen?.(),
+			(device) => {
+				boundDeviceId = deviceIdOf(device) ?? undefined;
+				manualCleanupRequired = boundDeviceId !== undefined;
+			},
 		);
+		const createdPayload = creation.device;
+		report.session.createEventObserved = creation.eventObserved;
 		boundDeviceId = deviceIdOf(createdPayload) ?? undefined;
 		manualCleanupRequired = boundDeviceId !== undefined;
 
@@ -696,10 +929,10 @@ export const probeHomeyShsLifecycle = async (
 			throw new Error('Homey lifecycle create event did not contain a device identifier');
 		}
 
-		appendEvent(report, 'device.create.observed');
+		appendEvent(report, creation.eventObserved ? 'device.create.observed' : 'device.create.not-observed');
 		const createdInventory = await freshDevices(client, config);
 		const createdDevice = requireSingleOwnedDevice(createdInventory, config, boundDeviceId);
-		const boundEventDevice = createdPayload as HomeyLifecycleDevice;
+		const boundEventDevice = createdPayload;
 
 		if (!isInitialDevice(createdDevice, config)) {
 			throw new Error('The created Homey lifecycle device failed its fresh identity read-back');
@@ -717,16 +950,21 @@ export const probeHomeyShsLifecycle = async (
 		manualCleanupRequired = false;
 		assertDedicatedOwnerIsolation(createdInventory, config, boundDeviceId);
 		appendEvent(report, 'add.readback.resolved');
+		await runOperation('device subscription', config.timeoutMs, () => boundEventDevice.connect());
+		connectedDevice = boundEventDevice;
+		appendEvent(report, 'device.subscribe.resolved');
 		await assertNoAttachedFlows(client, boundDeviceId, config);
 		deletionAuthorized = true;
 		appendEvent(report, 'flows.absence.verified');
 
-		await observeManagerEvent(
+		report.session.renameEventObserved = await observeDeviceUpdate(
+			client,
 			boundEventDevice,
-			'update',
+			config,
+			boundDeviceId,
 			'rename event observation',
-			config.observeMs,
 			(payload) => isRecord(payload) && payload.name === config.renamedName,
+			(device) => device.name === config.renamedName,
 			async () => {
 				appendEvent(report, 'device.rename.requested');
 				await runOperation('device rename', config.timeoutMs, () =>
@@ -738,7 +976,10 @@ export const probeHomeyShsLifecycle = async (
 				);
 			},
 		);
-		appendEvent(report, 'device.update.rename.observed');
+		appendEvent(
+			report,
+			report.session.renameEventObserved ? 'device.update.rename.observed' : 'device.update.rename.not-observed',
+		);
 		const renamedDevice = requireSingleOwnedDevice(await freshDevices(client, config), config, boundDeviceId);
 
 		if (renamedDevice.name !== config.renamedName) {
@@ -747,12 +988,14 @@ export const probeHomeyShsLifecycle = async (
 
 		appendEvent(report, 'rename.readback.resolved');
 
-		await observeManagerEvent(
+		report.session.zoneMoveEventObserved = await observeDeviceUpdate(
+			client,
 			boundEventDevice,
-			'update',
+			config,
+			boundDeviceId,
 			'zone-move event observation',
-			config.observeMs,
 			(payload) => isRecord(payload) && payload.zone === config.destinationZoneId,
+			(device) => device.zone === config.destinationZoneId,
 			async () => {
 				appendEvent(report, 'device.zone-move.requested');
 				await runOperation('device zone move', config.timeoutMs, () =>
@@ -764,7 +1007,12 @@ export const probeHomeyShsLifecycle = async (
 				);
 			},
 		);
-		appendEvent(report, 'device.update.zone-move.observed');
+		appendEvent(
+			report,
+			report.session.zoneMoveEventObserved
+				? 'device.update.zone-move.observed'
+				: 'device.update.zone-move.not-observed',
+		);
 		const movedDevice = requireSingleOwnedDevice(await freshDevices(client, config), config, boundDeviceId);
 
 		if (movedDevice.zone !== config.destinationZoneId) {
@@ -781,12 +1029,14 @@ export const probeHomeyShsLifecycle = async (
 		}
 
 		appendEvent(report, 'availability.unavailable.requested');
-		await observeManagerEvent(
+		report.session.unavailableEventObserved = await observeDeviceUpdate(
+			client,
 			boundEventDevice,
-			'update',
+			config,
+			boundDeviceId,
 			'unavailable event observation',
-			config.observeMs,
 			(payload) => isRecord(payload) && payload.available === false,
+			(device) => device.available === false,
 			async () => {
 				hooks.onUnavailableRequested?.();
 
@@ -801,7 +1051,12 @@ export const probeHomeyShsLifecycle = async (
 				}
 			},
 		);
-		appendEvent(report, 'device.update.unavailable.observed');
+		appendEvent(
+			report,
+			report.session.unavailableEventObserved
+				? 'device.update.unavailable.observed'
+				: 'device.update.unavailable.not-observed',
+		);
 		const unavailableInventory = await freshDevices(client, config);
 		const unavailableDevice = requireSingleOwnedDevice(unavailableInventory, config, boundDeviceId);
 		assertDedicatedOwnerIsolation(unavailableInventory, config, boundDeviceId);
@@ -812,12 +1067,14 @@ export const probeHomeyShsLifecycle = async (
 
 		appendEvent(report, 'unavailable.readback.resolved');
 		appendEvent(report, 'availability.restore.requested');
-		await observeManagerEvent(
+		report.session.availabilityRestoreEventObserved = await observeDeviceUpdate(
+			client,
 			boundEventDevice,
-			'update',
+			config,
+			boundDeviceId,
 			'availability restoration event observation',
-			config.observeMs,
 			(payload) => isRecord(payload) && payload.available === true,
+			(device) => device.available === true,
 			async () => {
 				hooks.onAvailabilityRestoreRequested?.();
 
@@ -832,7 +1089,12 @@ export const probeHomeyShsLifecycle = async (
 				}
 			},
 		);
-		appendEvent(report, 'device.update.available.observed');
+		appendEvent(
+			report,
+			report.session.availabilityRestoreEventObserved
+				? 'device.update.available.observed'
+				: 'device.update.available.not-observed',
+		);
 		const availableInventory = await freshDevices(client, config);
 		const availableDevice = requireSingleOwnedDevice(availableInventory, config, boundDeviceId);
 		assertDedicatedOwnerIsolation(availableInventory, config, boundDeviceId);
@@ -847,19 +1109,18 @@ export const probeHomeyShsLifecycle = async (
 		deletionAuthorized = true;
 		appendEvent(report, 'device.remove.requested');
 		deleteAttempted = true;
-		await observeManagerEvent(
-			client.devices,
-			'device.delete',
-			'delete event observation',
-			config.observeMs,
-			(payload) => deviceIdOf(payload) === boundDeviceId,
+		report.session.deleteEventObserved = await observeDeviceDeletion(
+			client,
+			boundEventDevice,
+			config,
+			boundDeviceId,
 			async () => {
 				await runOperation('device removal', config.timeoutMs, () =>
 					client.devices.deleteDevice({ $timeout: config.timeoutMs, id: boundDeviceId }),
 				);
 			},
 		);
-		appendEvent(report, 'device.delete.observed');
+		appendEvent(report, report.session.deleteEventObserved ? 'device.delete.observed' : 'device.delete.not-observed');
 
 		if (hasLifecycleResidue(await freshDevices(client, config), config, boundDeviceId)) {
 			throw new Error('The disposable Homey lifecycle device still exists after removal');
@@ -894,6 +1155,15 @@ export const probeHomeyShsLifecycle = async (
 			}
 
 			manualCleanupRequired ||= !finalAbsenceVerified;
+		}
+
+		if (connectedDevice !== undefined) {
+			try {
+				await runOperation('device unsubscribe', config.timeoutMs, () => connectedDevice.disconnect());
+				if (operationError === undefined) appendEvent(report, 'device.unsubscribe.resolved');
+			} catch {
+				transportCleanupFailures.push('device unsubscribe');
+			}
 		}
 
 		try {
@@ -951,9 +1221,23 @@ export function assertHomeyShsLifecycleReportSchema(value: unknown): asserts val
 		],
 		'lifecycle',
 	);
-	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
+	const session = requireExactKeys(
+		report.session,
+		[
+			'availabilityRestoreEventObserved',
+			'cleanupCompleted',
+			'createEventObserved',
+			'deleteEventObserved',
+			'events',
+			'managerSubscribed',
+			'renameEventObserved',
+			'unavailableEventObserved',
+			'zoneMoveEventObserved',
+		],
+		'session',
+	);
 
-	if (metadata.probe !== 'homey-shs-lifecycle' || metadata.schemaVersion !== 1 || metadata.sdkVersion !== SDK_VERSION) {
+	if (metadata.probe !== 'homey-shs-lifecycle' || metadata.schemaVersion !== 3 || metadata.sdkVersion !== SDK_VERSION) {
 		throw new Error('Homey lifecycle report metadata schema is invalid');
 	}
 
@@ -961,7 +1245,17 @@ export function assertHomeyShsLifecycleReportSchema(value: unknown): asserts val
 		throw new Error('Homey lifecycle report result schema is invalid');
 	}
 
-	if (session.cleanupCompleted !== true || session.managerSubscribed !== true || !Array.isArray(session.events)) {
+	if (
+		session.cleanupCompleted !== true ||
+		typeof session.availabilityRestoreEventObserved !== 'boolean' ||
+		typeof session.createEventObserved !== 'boolean' ||
+		typeof session.deleteEventObserved !== 'boolean' ||
+		session.managerSubscribed !== true ||
+		typeof session.renameEventObserved !== 'boolean' ||
+		typeof session.unavailableEventObserved !== 'boolean' ||
+		typeof session.zoneMoveEventObserved !== 'boolean' ||
+		!Array.isArray(session.events)
+	) {
 		throw new Error('Homey lifecycle report session schema is invalid');
 	}
 
@@ -969,10 +1263,38 @@ export function assertHomeyShsLifecycleReportSchema(value: unknown): asserts val
 		throw new Error('Homey lifecycle report event schema is invalid');
 	}
 
+	const expectedEvents: readonly LifecycleEvent[] = EXPECTED_EVENTS.map((event) => {
+		if (event === 'device.create.observed' && session.createEventObserved === false) {
+			return 'device.create.not-observed';
+		}
+
+		if (event === 'device.delete.observed' && session.deleteEventObserved === false) {
+			return 'device.delete.not-observed';
+		}
+
+		if (event === 'device.update.rename.observed' && session.renameEventObserved === false) {
+			return 'device.update.rename.not-observed';
+		}
+
+		if (event === 'device.update.zone-move.observed' && session.zoneMoveEventObserved === false) {
+			return 'device.update.zone-move.not-observed';
+		}
+
+		if (event === 'device.update.unavailable.observed' && session.unavailableEventObserved === false) {
+			return 'device.update.unavailable.not-observed';
+		}
+
+		if (event === 'device.update.available.observed' && session.availabilityRestoreEventObserved === false) {
+			return 'device.update.available.not-observed';
+		}
+
+		return event;
+	});
+
 	for (const [index, eventValue] of session.events.entries()) {
 		const event = requireExactKeys(eventValue, ['event', 'order'], 'event');
 
-		if (event.event !== EXPECTED_EVENTS[index] || event.order !== index + 1) {
+		if (event.event !== expectedEvents[index] || event.order !== index + 1) {
 			throw new Error('Homey lifecycle report event schema is invalid');
 		}
 	}
@@ -1052,6 +1374,25 @@ const run = async (): Promise<void> => {
 			);
 		},
 	});
+
+	if (!report.session.createEventObserved) {
+		process.stdout.write('Homey lifecycle create event was absent; exact inventory read-back verified the add.\n');
+	}
+
+	if (!report.session.deleteEventObserved) {
+		process.stdout.write('Homey lifecycle delete event was absent; exact inventory read-back verified removal.\n');
+	}
+
+	if (
+		!report.session.renameEventObserved ||
+		!report.session.zoneMoveEventObserved ||
+		!report.session.unavailableEventObserved ||
+		!report.session.availabilityRestoreEventObserved
+	) {
+		process.stdout.write(
+			'One or more Homey lifecycle update events were absent; exact read-back verified each state.\n',
+		);
+	}
 
 	assertHomeyShsLifecycleReportSafe(report, config);
 	const outputDirectory = await writeHomeyShsLifecycleReport(report, config.outputRoot);

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, and stable
-restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live availability-event and
-lifecycle evidence is pending
+**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, disposable-device
+lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live
+availability-event continuity is pending
 
 **Started:** 2026-08-12
 
@@ -19,19 +19,19 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 ## Current gate status
 
-| Area                                                  | Status                                                   | Evidence still required                                             |
-| ----------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------- |
-| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                                 |
-| System, zone, device inventory, and individual device | Captured and sanitized                                   | Add lifecycle delta evidence on the disposable test device          |
-| Capability metadata and suffixed IDs                  | Inventory, explicit read, and write read-back passed     | None                                                                |
-| Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture availability event-flow continuity                          |
-| Allowlisted capability write                          | Passed on SHS `13.4.1`                                   | None                                                                |
-| Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                                |
-| API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                                |
-| Disposable-device lifecycle                           | Guarded operator probe ready                             | Use only the separately gated virtual/test device                   |
-| mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery    |
-| SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade    |
-| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add event/reconnect fixtures from the remaining live lifecycle runs |
+| Area                                                  | Status                                                   | Evidence still required                                          |
+| ----------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                              |
+| System, zone, device inventory, and individual device | Captured and sanitized                                   | None                                                             |
+| Capability metadata and suffixed IDs                  | Inventory, explicit read, and write read-back passed     | None                                                             |
+| Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture availability event-flow continuity                       |
+| Allowlisted capability write                          | Passed on SHS `13.4.1`                                   | None                                                             |
+| Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                             |
+| API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                             |
+| Disposable-device lifecycle                           | Passed on SHS `13.4.1`                                   | None                                                             |
+| mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery |
+| SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add live availability-event evidence                             |
 
 ## Installation evidence
 
@@ -51,7 +51,7 @@ Complete this table after the live run. Values committed here must remain non-se
 | HTTPS port `4860`                        | Pending                                           |
 | TLS certificate behavior                 | Pending                                           |
 | Disposable capability alias              | Pending synthetic alias                           |
-| Disposable lifecycle-device alias        | Pending synthetic alias                           |
+| Disposable lifecycle-device alias        | `fbsp-lifecycle-disposable-device`                |
 
 On 2026-08-26, the TrueNAS host was reachable but SHS stopped before opening its API ports because its required Avahi
 daemon could not start. The deployment recovered after applying Homey's documented TrueNAS settings: disable the host
@@ -215,11 +215,15 @@ and moves the bound device, it changes the driver's fixed lifecycle setting only
 active. The driver applies the requested unavailable or available state from that setting. This keeps lifecycle evidence
 isolated from household apps and removes manual timing and slow-operation races from both availability stages.
 
-After the `device.create` event exactly matches the marker, driver, owner, initial name, and source zone allowlist, the
-probe binds the new runtime device ID in memory. Only after that binding may it use the bounded local API operations
-to rename the device, move it to the destination zone, and remove it. The probe observes `device.update` for rename,
-zone, and availability changes and `device.delete` for removal, with fresh reads after mutations. It never accepts the
-first unrelated lifecycle event and never writes an identifier, name, event payload, or raw error to the report.
+After a `device.create` event or fresh inventory item exactly matches the marker, driver, owner, initial name, and source
+zone allowlist, the probe binds the new runtime device ID in memory. If SHS omits the manager-level create/delete event
+or a bound-device update event, the probe uses bounded, cache-bypassing inventory reads to verify the same complete
+identity, requested state, or final absence and records each omitted event explicitly in the sanitized report. It never
+treats an event-free inventory match as proof that an event was observed. Only after that binding may it use the bounded
+local API operations to rename the device, move it to the destination zone, and remove it. The probe attempts to observe
+`device.update` for rename, zone, and availability changes and `device.delete` for removal, with exact fresh reads after
+mutations. It never accepts the first unrelated lifecycle event and never writes an identifier, name, event payload, or
+raw error to the report.
 
 Start from the base URL, expected-host, and private-term environment used by the safe read probe, but replace
 `FB_HOMEY_SHS_API_KEY` with the dedicated lifecycle key. Enter all private values interactively:
@@ -244,7 +248,7 @@ pnpm run homey:probe-lifecycle
 
 The probe fails closed unless the acknowledgement and ordered operation list match those exact values. The device
 marker must start with `fbsp-lifecycle-`, and both names must start with `FBSP Lifecycle`. The driver ID must belong to
-the exact owner URI using Homey's `<owner-uri>:driver:<driver>` form. Driver ID, owner URI, initial and renamed names,
+the exact owner URI using Homey's `<owner-uri>:<driver>` form. Driver ID, owner URI, initial and renamed names,
 and both distinct zone IDs are exact allowlist values. `FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS` optionally sets the bounded
 time available for each requested operator action from `10000` through `300000` milliseconds and defaults to `90000`.
 
@@ -266,6 +270,14 @@ unset FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID
 unset FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
 unset FB_HOMEY_SHS_API_KEY
 ```
+
+On 2026-08-27, the guarded lifecycle probe passed against SHS `13.4.1`. It verified the exact disposable device add,
+rename, zone move, unavailable state, availability restoration, removal, and final absence, with flow checks and full
+cleanup. SHS did not emit the manager create event or any of the bound-device update events during this run, so the
+probe recorded those omissions and verified every resulting state with bounded, cache-bypassing inventory read-back;
+the delete event was observed. The sanitized report is committed as
+`__fixtures__/evidence/2026-08-27-shs-13.4.1-device-lifecycle.json`. This closes the lifecycle inventory-delta slice but
+does not close live availability-event continuity.
 
 ## Operator-controlled restart recovery probe
 
@@ -614,7 +626,7 @@ Fill this matrix using synthetic aliases only.
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |
 | API-key revocation and replacement        | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |
-| Disposable-device lifecycle sequence      | Pending                             |                                                                                                                                                      |
+| Disposable-device lifecycle sequence      | Pass                                | Exact add, rename, zone move, unavailable, restore, removal, and final absence passed; omitted create/update events were recorded and read back      |
 | Stable mDNS service before/after restart  | Pass                                | Ten-second pre/post observations were exact matches: `_homey._tcp` on `4859` plus two co-hosted `_hap._tcp` services                                 |
 
 ## Verification

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -49,13 +49,13 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [ ] Give SHS a stable LAN address; prefer host networking or a dedicated address consistent with Homey guidance.
 - [ ] Create a least-privilege API key with only device read/control, zone read, and system read permissions required by the design.
 - [ ] Designate one harmless writable test capability; record only a synthetic alias in repository documents.
-- [ ] Designate one disposable virtual/test device for lifecycle mutations. It must not represent household equipment, and repository documents record only its synthetic alias.
+- [x] Designate one disposable virtual/test device for lifecycle mutations. It must not represent household equipment, and repository documents record only its synthetic alias.
 - [x] Define environment variables for live tests. Do not store secret values in shell history, fixtures, `.env` files, or repository config.
 - [x] Add an explicit live-write allowlist contract requiring both device ID and capability ID.
 - [x] Add a separately enabled lifecycle-mutation allowlist with an immutable synthetic marker, exact test
       driver/owner/names/zones, and the canonical operations: add, rename, zone move, availability change, and remove.
-      Bind the runtime device ID only after a matching create event and fresh ownership read-back because Homey assigns
-      the top-level ID during creation.
+      Bind the runtime device ID only after a matching create event or exact cache-bypassing inventory read-back, then
+      require fresh ownership verification because Homey assigns the top-level ID during creation.
 
 **Verification:** Review the compatibility document for secret/private data before committing it.
 
@@ -72,7 +72,7 @@ Local MVP total: approximately 25–36 engineering days. Backend and admin tasks
 - [x] Write the allowlisted test capability and confirm the resulting event plus subsequent read.
 - [x] Test invalid key, missing scopes, bad URL, unavailable host, and request timeout behavior.
 - [x] Test SHS restart, network interruption/restoration, and API-key revocation.
-- [ ] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
+- [x] On the separately gated disposable device only, test add, rename, zone move, unavailable, and removal events or inventory deltas; clean up the disposable device after capture.
 - [x] Inspect mDNS advertisements before and after restart. Record exact service type/TXT fields only if stable.
 - [ ] If Homey Pro hardware is available, repeat the minimum inventory/event/write suite against its local API.
 
@@ -623,7 +623,7 @@ representative lifecycle failure paths.
 - [ ] SHS restart during event flow.
 - [x] Network interruption/restoration.
 - [x] API key revoked, replaced, and insufficiently scoped.
-- [ ] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
+- [x] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [ ] Physical/Homey/flow-originated state changes.
 - [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.
@@ -643,6 +643,12 @@ The 2026-08-27 SHS `13.4.1` guarded write probe closed the single allowlisted ca
 produced a matching event and read-back, and the original value was restored with a second matching read-back before
 cleanup. This does not close availability-event coverage, physical/Homey/flow-originated updates, or Smart Panel
 control for every writable MVP mapping family.
+
+The 2026-08-27 SHS `13.4.1` guarded lifecycle probe closed the disposable inventory-delta slice. Exact read-backs
+verified add, rename, zone move, unavailable state, availability restoration, removal, final absence, and complete
+cleanup. SHS omitted the manager create event and every bound-device update event during this run, while the delete
+event was observed; the sanitized report records each omission explicitly. This does not close availability-event
+continuity or physical/Homey/flow-originated state changes.
 
 The 2026-08-26 SHS `13.4.1` error probe recorded a non-mutating five-scenario slice: generated invalid-key
 authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -83,7 +83,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] A least-privilege API key can read devices, zones, system information, and current capability values.
 - [x] A designated harmless writable capability can be controlled and its resulting event observed.
 - [x] Socket.IO connection, subscription, disconnect, restart, and reconnect behavior are recorded.
-- [ ] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
+- [x] Device add, rename, zone move, unavailable, and removal behavior is captured only with a separately gated, explicitly allowlisted disposable virtual/test device; suffixed-capability behavior may use read-only fixtures/devices.
 - [x] mDNS behavior is verified; automatic discovery remains deferred pending safe identity and endpoint verification.
 - [x] The SDK license/distribution decision and SDK-vs-direct-protocol choice are recorded.
 - [ ] Sanitized fixtures contain no API keys, household identifiers, private IP addresses, or personal names.


### PR DESCRIPTION
## Summary

- fix the private Homey lifecycle test app pairing flow and canonical driver identity
- make the guarded lifecycle probe record omitted SHS create/update events while requiring exact cache-bypassing inventory read-backs
- promote the sanitized SHS 13.4.1 lifecycle report and update the compatibility record and epic checklist

## Live evidence

- verified add, rename, zone move, unavailable, availability restoration, removal, and final absence
- observed the delete event; SHS omitted the manager create event and bound-device update events
- completed flow-safety checks and cleanup without retaining private identifiers, values, endpoints, credentials, or payloads

## Verification

- `pnpm exec jest --config ./test/jest-homey-spike.json --runInBand test/homey-shs-lifecycle.homey-spike.ts` (41 tests)
- `pnpm exec eslint test/support/homey-shs-lifecycle-probe.ts test/homey-shs-lifecycle.homey-spike.ts`
- `pnpm run type-check`
- lifecycle test app unit and formatting checks (5 tests)
- `pnpm run homey:security-gate` (11/150 spike tests and 39/483 config/plugin tests)