### PR TITLE
fix(cross): separate Homey lifecycle observation windows

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -102,7 +102,9 @@ response body, raw error, or identifier.
 The device-lifecycle report records the complete guarded disposable-device lifecycle on SHS `13.4.1`: exact add,
 rename, zone move, unavailable state, restoration, removal, final absence, and cleanup. SHS omitted the manager create
 event and all bound-device update events during the run, while the delete event was observed; bounded, cache-bypassing
-inventory read-backs verified every omitted-event transition. The report contains no endpoint, Homey identity,
-credential, device or zone identifier, name, inventory content, event payload, response body, or raw error.
+inventory read-backs verified every omitted-event transition. A repeat run retained each listener through the full
+ten-second post-read-back event window and produced the same sanitized result, confirming absence for the synthetic
+test driver without making a claim about physical/Homey-originated events. The report contains no endpoint, Homey
+identity, credential, device or zone identifier, name, inventory content, event payload, response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -505,6 +505,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		const config = loadHomeyShsLifecycleProbeConfig(BASE_ENVIRONMENT, '/tmp/homey-lifecycle-spike');
 
 		expect(config).toMatchObject({
+			addWindowMs: 90_000,
 			apiKey: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY,
 			availabilityControl: 'operator',
 			expectedHost: '127.0.0.1',
@@ -519,6 +520,15 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(() =>
 			loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS: '300001' }),
 		).toThrow('between 10000 and 300000');
+		expect(() =>
+			loadHomeyShsLifecycleProbeConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS: '9999' }),
+		).toThrow('between 10000 and 300000');
+		expect(
+			loadHomeyShsLifecycleProbeConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS: '120000',
+			}).addWindowMs,
+		).toBe(120_000);
 	});
 
 	it('enables setting-based availability only for the complete bundled test-app identity', () => {
@@ -730,6 +740,31 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 
 		expect(report).toStrictEqual(completeReport({ createEventObserved: false }));
 		expect(harness.client.devices.inventory).toStrictEqual({});
+	});
+
+	it('keeps the operator add window independent from the event observation window', async () => {
+		const config = fastConfig({ addWindowMs: 350, observeMs: 25 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-slow-operator-add-id';
+		const device = makeOwnedDevice(config, deviceId);
+		const reportPromise = probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				setTimeout(() => {
+					harness.client.devices.inventory[deviceId] = device;
+					harness.client.devices.emit('device.create', device);
+				}, 275);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		await expect(reportPromise).resolves.toStrictEqual(completeReport());
 	});
 
 	it('observes a create event that arrives after the former 250 ms grace period', async () => {
@@ -1035,7 +1070,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 	});
 
 	it('does not let wrong create events satisfy the add stage and never deletes an unbound device', async () => {
-		const config = fastConfig({ observeMs: 5 });
+		const config = fastConfig({ addWindowMs: 5, observeMs: 5 });
 		const harness = createHarness(config);
 		const unrelatedId = 'ordinary-device-id';
 		const unrelated = makeOwnedDevice(config, unrelatedId, {
@@ -1059,7 +1094,7 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 	});
 
 	it('attempts every transport cleanup step and returns only a fixed cleanup error', async () => {
-		const config = fastConfig({ observeMs: 5 });
+		const config = fastConfig({ addWindowMs: 5, observeMs: 5 });
 		const harness = createHarness(config);
 
 		harness.client.devices.failDisconnect = true;

--- a/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-lifecycle.homey-spike.ts
@@ -854,6 +854,38 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 		expect(report).toStrictEqual(completeReport());
 	});
 
+	it('starts the delete event window after a delayed absence read-back', async () => {
+		const config = fastConfig({ observeMs: 1_100 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-slow-delete-readback-id';
+		const device = makeOwnedDevice(config, deviceId);
+
+		jest.spyOn(harness.client.devices, 'deleteDevice').mockImplementation((options) => {
+			harness.client.devices.deleteRequests.push(options);
+			setTimeout(() => delete harness.client.devices.inventory[options.id], 50);
+			setTimeout(() => harness.client.devices.emit('device.delete', { id: options.id }), 1_250);
+
+			return Promise.resolve();
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+	});
+
 	it('uses exact read-back when SHS omits every bound-device update event', async () => {
 		const config = {
 			...loadHomeyShsLifecycleProbeConfig(TEST_APP_ENVIRONMENT, '/tmp/homey-lifecycle-spike'),
@@ -910,6 +942,46 @@ describe('Homey SHS disposable-device lifecycle compatibility probe', () => {
 			if (updateCount === 1) {
 				setTimeout(() => device.emit('update', { ...options.device }), 275);
 			} else {
+				device.emit('update', { ...options.device });
+			}
+
+			return Promise.resolve(device);
+		});
+
+		const report = await probeHomeyShsLifecycle(config, harness.factory, {
+			onAddWindowOpen: () => {
+				harness.client.devices.inventory[deviceId] = device;
+				harness.client.devices.emit('device.create', device);
+			},
+			onAvailabilityRestoreRequested: () => {
+				device.available = true;
+				device.emit('update', { available: true });
+			},
+			onUnavailableRequested: () => {
+				device.available = false;
+				device.emit('update', { available: false });
+			},
+		});
+
+		expect(report).toStrictEqual(completeReport());
+	});
+
+	it('starts the update event window after a delayed state read-back', async () => {
+		const config = fastConfig({ observeMs: 1_100 });
+		const harness = createHarness(config);
+		const deviceId = 'runtime-bound-slow-update-readback-id';
+		const device = makeOwnedDevice(config, deviceId);
+		let updateCount = 0;
+
+		jest.spyOn(harness.client.devices, 'updateDevice').mockImplementation((options) => {
+			harness.client.devices.updateRequests.push(options);
+			updateCount += 1;
+
+			if (updateCount === 1) {
+				setTimeout(() => Object.assign(device, options.device), 50);
+				setTimeout(() => device.emit('update', { ...options.device }), 1_250);
+			} else {
+				Object.assign(device, options.device);
 				device.emit('update', { ...options.device });
 			}
 

--- a/apps/backend/test/support/homey-lifecycle-test-app/README.md
+++ b/apps/backend/test/support/homey-lifecycle-test-app/README.md
@@ -31,8 +31,13 @@ values in Git.
 
    ```bash
    cd apps/backend
+   export FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS=90000
+   export FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS=10000
    pnpm run homey:probe-lifecycle
    ```
+
+   The add window gives the operator 90 seconds to pair, while each post-read-back event check remains bounded to 10
+   seconds.
 
 3. Wait until the probe prints that the add window is open. In Homey, add `Lifecycle Test Device`, keep its generated
    name unchanged, and place it in the configured source zone. Do not pair it before the add window opens.

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -16,6 +16,7 @@ const TEST_APP_PROFILE = {
 	initialName: 'FBSP Lifecycle Initial',
 	renamedName: 'FBSP Lifecycle Renamed',
 } as const;
+const DEFAULT_ADD_WINDOW_MS = 90_000;
 const DEFAULT_OBSERVE_MS = 90_000;
 const MIN_OBSERVE_MS = 10_000;
 const MAX_OBSERVE_MS = 300_000;
@@ -139,6 +140,7 @@ export interface HomeyLifecycleSdkFactory {
 }
 
 export interface HomeyShsLifecycleProbeConfig extends HomeyShsProbeConfig {
+	addWindowMs: number;
 	availabilityControl: 'operator' | 'test-app-setting';
 	destinationZoneId: string;
 	deviceMarker: string;
@@ -227,6 +229,22 @@ const parseObserveMs = (value: string | undefined): number => {
 	return parsed;
 };
 
+const parseAddWindowMs = (value: string | undefined): number => {
+	if (value === undefined) {
+		return DEFAULT_ADD_WINDOW_MS;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(
+			`FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`,
+		);
+	}
+
+	return parsed;
+};
+
 const requireEnvironmentValue = (environment: NodeJS.ProcessEnv, name: string): string => {
 	const value = environment[name]?.trim();
 
@@ -296,6 +314,7 @@ export const loadHomeyShsLifecycleProbeConfig = (
 
 	return {
 		...loadHomeyShsProbeConfig(environment, workingDirectory),
+		addWindowMs: parseAddWindowMs(environment.FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS),
 		availabilityControl:
 			deviceMarker === TEST_APP_PROFILE.deviceMarker &&
 			expectedDriverId === TEST_APP_PROFILE.expectedDriverId &&
@@ -502,11 +521,12 @@ const observeDeviceCreation = async (
 	let observationError: unknown;
 	let result: { device: HomeyLifecycleDevice; eventObserved: boolean } | undefined;
 	let inventoryDevice: HomeyLifecycleDevice | undefined;
+	let eventDeadline: number | undefined;
 	let listenerRemovalFailed = false;
 
 	try {
 		await runObservationTrigger('operator add observation', trigger);
-		const deadline = Date.now() + config.observeMs;
+		const addDeadline = Date.now() + config.addWindowMs;
 
 		while (result === undefined) {
 			if (eventDevice !== undefined) {
@@ -514,6 +534,7 @@ const observeDeviceCreation = async (
 				break;
 			}
 
+			const deadline = eventDeadline ?? addDeadline;
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
@@ -522,7 +543,7 @@ const observeDeviceCreation = async (
 					break;
 				}
 
-				throw new HomeyShsLifecycleTimeoutError('operator add observation', config.observeMs);
+				throw new HomeyShsLifecycleTimeoutError('operator add observation', config.addWindowMs);
 			}
 
 			if (inventoryDevice !== undefined) {
@@ -540,10 +561,11 @@ const observeDeviceCreation = async (
 			if (matches.length === 1) {
 				inventoryDevice = matches[0];
 				bindDevice(inventoryDevice);
+				eventDeadline = Date.now() + config.observeMs;
 				continue;
 			}
 
-			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, deadline - Date.now()));
+			const pollMs = Math.min(INVENTORY_POLL_MS, Math.max(0, addDeadline - Date.now()));
 
 			if (pollMs > 0) {
 				await waitForSignal(eventSignal, pollMs);

--- a/apps/backend/test/support/homey-shs-lifecycle-probe.ts
+++ b/apps/backend/test/support/homey-shs-lifecycle-probe.ts
@@ -631,10 +631,12 @@ const observeDeviceDeletion = async (
 
 	try {
 		await runObservationTrigger('delete event observation', trigger);
-		const deadline = Date.now() + config.observeMs;
+		const readbackDeadline = Date.now() + config.observeMs;
 		let absenceVerified = false;
+		let eventDeadline: number | undefined;
 
 		while (!eventObserved) {
+			const deadline = eventDeadline ?? readbackDeadline;
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
@@ -654,6 +656,7 @@ const observeDeviceDeletion = async (
 
 			if (!hasLifecycleResidue(inventory, config, boundDeviceId)) {
 				absenceVerified = true;
+				eventDeadline = Date.now() + config.observeMs;
 				continue;
 			}
 
@@ -718,10 +721,12 @@ const observeDeviceUpdate = async (
 
 	try {
 		await runObservationTrigger(label, trigger);
-		const deadline = Date.now() + config.observeMs;
+		const readbackDeadline = Date.now() + config.observeMs;
 		let readbackVerified = false;
+		let eventDeadline: number | undefined;
 
 		while (!eventObserved) {
+			const deadline = eventDeadline ?? readbackDeadline;
 			const remainingMs = deadline - Date.now();
 
 			if (remainingMs <= 0) {
@@ -742,6 +747,7 @@ const observeDeviceUpdate = async (
 
 			if (readbackPredicate(currentDevice)) {
 				readbackVerified = true;
+				eventDeadline = Date.now() + config.observeMs;
 				continue;
 			}
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
 **Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, disposable-device
-lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and live
-availability-event continuity is pending
+lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and
+physical/Homey-originated availability-event continuity is pending
 
 **Started:** 2026-08-12
 
@@ -24,14 +24,14 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Credential-safe read probe                            | Passed on SHS `13.4.0` and `13.4.1` over HTTP `4859`     | Repeat over HTTPS `4860` if enabled                              |
 | System, zone, device inventory, and individual device | Captured and sanitized                                   | None                                                             |
 | Capability metadata and suffixed IDs                  | Inventory, explicit read, and write read-back passed     | None                                                             |
-| Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture availability event-flow continuity                       |
+| Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture physical/Homey-originated availability-event continuity  |
 | Allowlisted capability write                          | Passed on SHS `13.4.1`                                   | None                                                             |
 | Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                             |
 | API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                             |
 | Disposable-device lifecycle                           | Passed on SHS `13.4.1`                                   | None                                                             |
 | mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery |
 | SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade |
-| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add live availability-event evidence                             |
+| Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add physical/Homey-originated availability-event evidence        |
 
 ## Installation evidence
 
@@ -249,8 +249,11 @@ pnpm run homey:probe-lifecycle
 The probe fails closed unless the acknowledgement and ordered operation list match those exact values. The device
 marker must start with `fbsp-lifecycle-`, and both names must start with `FBSP Lifecycle`. The driver ID must belong to
 the exact owner URI using Homey's `<owner-uri>:<driver>` form. Driver ID, owner URI, initial and renamed names,
-and both distinct zone IDs are exact allowlist values. `FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS` optionally sets the bounded
-time available for each requested operator action from `10000` through `300000` milliseconds and defaults to `90000`.
+and both distinct zone IDs are exact allowlist values. `FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS` optionally sets the
+bounded operator pairing window from `10000` through `300000` milliseconds and defaults to `90000`.
+`FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS` independently sets the post-read-back event window for each lifecycle transition
+over the same range and default. Keeping the add window long and the event window short gives the operator time to pair
+without extending every absent-event check.
 
 Never add, rename, move, make unavailable, or remove an ordinary household device. Use a dedicated test driver where
 possible, and do not pair or discover physical equipment as part of this run. Successful completion requires the
@@ -267,7 +270,8 @@ unset FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
 unset FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID
 unset FB_HOMEY_SHS_LIFECYCLE_OWNER_URI FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME
 unset FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID
-unset FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
+unset FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS
+unset FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
 unset FB_HOMEY_SHS_API_KEY
 ```
 
@@ -277,7 +281,14 @@ cleanup. SHS did not emit the manager create event or any of the bound-device up
 probe recorded those omissions and verified every resulting state with bounded, cache-bypassing inventory read-back;
 the delete event was observed. The sanitized report is committed as
 `__fixtures__/evidence/2026-08-27-shs-13.4.1-device-lifecycle.json`. This closes the lifecycle inventory-delta slice but
-does not close live availability-event continuity.
+does not close physical/Homey-originated availability-event continuity.
+
+The lifecycle run was repeated after the probe began retaining each listener through the full configured event
+deadline. A separate 90-second operator add window allowed pairing without lengthening the transition checks; each
+post-read-back event window remained open for 10 seconds. The result was semantically identical: no create, rename,
+zone-move, unavailable, or availability-restoration event arrived, while delete was observed and every state read-back
+and cleanup check passed. This confirms event absence for the synthetic lifecycle driver rather than extrapolating it
+to physical devices or Homey/flow-originated changes.
 
 ## Operator-controlled restart recovery probe
 
@@ -539,7 +550,8 @@ unset FB_HOMEY_SHS_LIFECYCLE_DEVICE_ID FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER
 unset FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID FB_HOMEY_SHS_LIFECYCLE_OWNER_URI
 unset FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME
 unset FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID
-unset FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_SCENARIO
+unset FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
+unset FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_SCENARIO
 unset FB_HOMEY_SHS_RECOVERY_OBSERVE_MS FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE
 unset FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS FB_HOMEY_SHS_REPLACEMENT_API_KEY
 pnpm run homey:probe-scopes
@@ -621,7 +633,7 @@ Fill this matrix using synthetic aliases only.
 | Suffixed capability IDs                   | Pass in inventory and explicit read | 1,142 capability entries, including 170 suffixed entries; 55 devices repeat a base ID; an explicit suffixed capability GET returned a numeric scalar |
 | Socket.IO connect and subscribe           | Pass                                | SDK creation, socket connect, manager subscribe/unsubscribe, socket disconnect, disconnect resolution, and SDK destruction completed in strict order |
 | Capability events                         | Pass                                | The allowlisted write produced its matching capability update inside the guarded observation window                                                  |
-| Availability events                       | Pending                             |                                                                                                                                                      |
+| Availability events                       | Absent for synthetic test driver    | Unavailable/restored read-backs passed after full ten-second event windows; physical/Homey-originated evidence remains pending                       |
 | Allowlisted write, event, and read-back   | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -650,6 +650,11 @@ cleanup. SHS omitted the manager create event and every bound-device update even
 event was observed; the sanitized report records each omission explicitly. This does not close availability-event
 continuity or physical/Homey/flow-originated state changes.
 
+A repeat lifecycle run separated the 90-second operator pairing window from the full ten-second event window retained
+after each exact read-back. It produced the same result: create and all bound-device update events remained absent,
+delete was observed, and cleanup passed. This characterizes the synthetic test driver's availability behavior without
+closing physical/Homey/flow-originated event continuity.
+
 The 2026-08-26 SHS `13.4.1` error probe recorded a non-mutating five-scenario slice: generated invalid-key
 authentication, a device-read-only key's missing system scope, shared bad-URL validation, and probe-owned loopback
 unavailable/timeout simulations all produced their expected sanitized categories. The 2026-08-27 permission-scope


### PR DESCRIPTION
## Summary

- separate the human-operated pairing window from post-read-back lifecycle event observation
- keep the default add window at 90 seconds while allowing ten-second event checks
- record the corrected SHS availability result without extrapolating synthetic-driver behavior to physical devices

## Live verification

- repeated the guarded lifecycle run against SHS 13.4.1 with a 90-second add window and full ten-second event windows
- verified add, rename, zone move, unavailable, restoration, removal, final absence, and cleanup
- observed delete; create and bound-device update events remained absent with every transition verified by exact cache-bypassing read-back
- the new sanitized report was semantically identical to the committed evidence, so no duplicate artifact was added

## Automated verification

- lifecycle compatibility suite: 45 tests
- Homey security gate: 154 spike tests and 483 config/plugin tests
- lifecycle probe ESLint and backend type-check