### PR TITLE
test(cross): record Homey startup recovery evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -106,5 +106,10 @@ inventory read-backs verified every omitted-event transition. A repeat run retai
 ten-second post-read-back event window and produced the same sanitized result, confirming absence for the synthetic
 test driver without making a claim about physical/Homey-originated events. The report contains no endpoint, Homey
 identity, credential, device or zone identifier, name, inventory content, event payload, response body, or raw error.
+The two startup reports exercise a newly constructed production `HomeyService` against SHS `13.4.1`. The online report
+records healthy connection, authoritative inventory availability, and cleanup. The offline-recovery report additionally
+records the initial `RECONNECTING` state and successful scheduled retry after operator-controlled restoration of only
+the test SHS network path. Neither report contains an endpoint, host, credential, Homey identity, inventory content or
+count, device or zone identifier, event payload, firewall rule, response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-offline-recovery.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-offline-recovery.json
@@ -1,0 +1,47 @@
+{
+	"metadata": {
+		"probe": "homey-shs-startup",
+		"scenario": "offline-recovery",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"startup": {
+		"cleanupCompleted": true,
+		"initialUnavailableVerified": true,
+		"inventoryVerified": true,
+		"recoveryObserved": true,
+		"serviceConnected": true
+	},
+	"session": {
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "initial.reconnecting.verified",
+				"order": 3
+			},
+			{
+				"event": "recovery.window.open",
+				"order": 4
+			},
+			{
+				"event": "service.connected.observed",
+				"order": 5
+			},
+			{
+				"event": "inventory.verified",
+				"order": 6
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 7
+			}
+		]
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-online.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-online.json
@@ -1,0 +1,39 @@
+{
+	"metadata": {
+		"probe": "homey-shs-startup",
+		"scenario": "online",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"startup": {
+		"cleanupCompleted": true,
+		"initialUnavailableVerified": false,
+		"inventoryVerified": true,
+		"recoveryObserved": false,
+		"serviceConnected": true
+	},
+	"session": {
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "service.connected.observed",
+				"order": 3
+			},
+			{
+				"event": "inventory.verified",
+				"order": 4
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 5
+			}
+		]
+	}
+}

--- a/apps/backend/test/homey-shs-startup.homey-spike.ts
+++ b/apps/backend/test/homey-shs-startup.homey-spike.ts
@@ -131,6 +131,27 @@ const completeReport = (scenario: 'offline-recovery' | 'online' = 'online'): Hom
 };
 
 describe('Homey SHS startup compatibility probe', () => {
+	it.each([
+		{
+			environment: BASE_ENVIRONMENT,
+			filename: '2026-08-27-shs-13.4.1-startup-online.json',
+			scenario: 'online',
+		},
+		{
+			environment: OFFLINE_ENVIRONMENT,
+			filename: '2026-08-27-shs-13.4.1-startup-offline-recovery.json',
+			scenario: 'offline-recovery',
+		},
+	] as const)('preserves the sanitized live $scenario startup evidence', async ({ environment, filename }) => {
+		const evidencePath = join(__dirname, '../src/plugins/devices-homey/__fixtures__/evidence', filename);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+		const config = loadHomeyShsStartupProbeConfig(environment);
+
+		assertHomeyShsStartupReportSchema(evidence);
+		expect(evidence).toStrictEqual(completeReport(config.scenario));
+		expect(() => assertHomeyShsStartupReportSafe(evidence, config)).not.toThrow();
+	});
+
 	it('requires a scenario-specific acknowledgement and rejects every conflicting gate', () => {
 		expect(loadHomeyShsStartupProbeConfig(BASE_ENVIRONMENT).scenario).toBe('online');
 		expect(loadHomeyShsStartupProbeConfig(OFFLINE_ENVIRONMENT).scenario).toBe('offline-recovery');

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory, SDK session/cleanup, SHS restart and network recovery, disposable-device
-lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS discovery remains deferred, and
-physical/Homey-originated availability-event continuity is pending
+**Status:** In progress; safe inventory, production-service startup/recovery, SDK session/cleanup, SHS restart and
+network recovery, disposable-device lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS
+discovery remains deferred, and physical/Homey-originated availability-event continuity is pending
 
 **Started:** 2026-08-12
 
@@ -29,7 +29,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                             |
 | API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                             |
 | Disposable-device lifecycle                           | Passed on SHS `13.4.1`                                   | None                                                             |
-| Production-service startup                            | Guarded online/offline-recovery probe ready              | Run both scenarios against SHS `13.4.1`                          |
+| Production-service startup                            | Online and offline-recovery passed on SHS `13.4.1`       | None                                                             |
 | mDNS discovery                                        | Stable across one controlled restart; manual URL remains | Design safe identity verification before reconsidering discovery |
 | SDK decision                                          | SDK selected behind connector boundary                   | Re-evaluate the pinned package and audit result on every upgrade |
 | Sanitized fixture corpus                              | Nine live plus one synthetic device fixture              | Add physical/Homey-originated availability-event evidence        |
@@ -351,6 +351,16 @@ After both runs, restore the firewall and clear the startup gate:
 ```bash
 unset FB_HOMEY_SHS_STARTUP_SCENARIO FB_HOMEY_SHS_STARTUP_ENABLE FB_HOMEY_SHS_STARTUP_OBSERVE_MS
 ```
+
+Both guarded runs passed on 2026-08-27 against SHS `13.4.1`. The fresh-online run constructed the production service,
+reached healthy `CONNECTED` state after authoritative inventory synchronization, exposed the inventory snapshot, and
+stopped cleanly. The offline-recovery run began with only the test host's SHS path blocked, verified unhealthy
+`RECONNECTING` state after the initial unavailable attempt, then used the production retry path after the operator
+restored the firewall. It reached healthy `CONNECTED` state with an incremented reconnect counter, exposed a fresh
+authoritative inventory snapshot, and stopped cleanly. The reviewed reports are committed as
+`__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-online.json` and
+`__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-offline-recovery.json`. They contain no endpoint, host, credential,
+Homey identity, inventory content or count, device or zone identifier, event payload, firewall rule, or raw error.
 
 ## Operator-controlled restart recovery probe
 

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -618,8 +618,8 @@ representative lifecycle failure paths.
 
 ### Task 6.2: Run the live lifecycle matrix
 
-- [ ] Fresh startup with SHS online.
-- [ ] Startup with SHS offline, then recovery.
+- [x] Fresh startup with SHS online.
+- [x] Startup with SHS offline, then recovery.
 - [ ] SHS restart during event flow.
 - [x] Network interruption/restoration.
 - [x] API key revoked, replaced, and insufficiently scoped.
@@ -633,8 +633,13 @@ A guarded startup probe now exercises a newly constructed production `HomeyServi
 the pinned SDK transport while replacing persistence with a no-op synchronizer. Its online scenario requires healthy
 connection, authoritative inventory availability, and clean shutdown. Its offline-recovery scenario additionally
 requires the initial unavailable attempt to leave the service in `RECONNECTING`, followed by a scheduled production
-reconnect and incremented reconnect counter after the operator restores only the test SHS network path. Both Task 6.2
-startup boxes remain open until the reviewed live reports are recorded.
+reconnect and incremented reconnect counter after the operator restores only the test SHS network path.
+
+Both guarded startup scenarios passed on 2026-08-27 against SHS `13.4.1`. The online run reached healthy connected
+state after authoritative inventory synchronization and stopped cleanly. With only the test host's SHS path blocked,
+the offline run first verified `RECONNECTING`, then recovered through the scheduled production retry after the operator
+restored the firewall, published a fresh authoritative inventory snapshot, incremented the reconnect counter, and
+stopped cleanly. The two reviewed exact-schema reports contain only fixed event labels and completion booleans.
 
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow


### PR DESCRIPTION
## Summary

- promote the sanitized fresh-online and offline-at-boot recovery reports from SHS 13.4.1
- preserve both reports through exact-schema, scenario, event-order, and privacy assertions
- record healthy production-service startup, authoritative inventory availability, scheduled reconnect recovery, and clean teardown
- close only the two corresponding Task 6.2 startup matrix items

## Live observations

- fresh online startup reached healthy CONNECTED state after authoritative inventory synchronization and stopped cleanly
- with only the test host SHS path blocked, startup first reached RECONNECTING; after operator restoration, the scheduled production retry connected, published a fresh authoritative inventory snapshot, incremented reconnect accounting, and stopped cleanly
- neither committed report contains an endpoint, host, credential, Homey identity, inventory content or count, identifier, event payload, firewall rule, or raw error

## Verification

- pnpm run homey:security-gate
  - 12 Homey spike suites / 170 tests passed
  - 39 Homey and config suites / 483 tests passed
- pnpm run type-check
- focused ESLint and startup evidence suite / 14 tests passed

## Remaining scope

This does not close SHS restart during event flow, physical or Homey-originated state continuity, mapping-family write coverage, burst/concurrent behavior, or plugin/backend lifecycle cleanup.