### PR TITLE
test(cross): add Homey restart event-flow probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -85,6 +85,7 @@
     "homey:probe-recovery": "ts-node --project tsconfig.json test/support/homey-shs-recovery-probe.ts",
     "homey:probe-lifecycle": "ts-node --project tsconfig.json test/support/homey-shs-lifecycle-probe.ts",
     "homey:probe-startup": "ts-node --project tsconfig.json test/support/homey-shs-startup-probe.ts",
+    "homey:probe-restart-event-flow": "ts-node --project tsconfig.json test/support/homey-shs-restart-event-flow-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",
     "typeorm:migration:generate": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:generate -d ./src/dataSource.ts",

--- a/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
+++ b/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
@@ -1,0 +1,223 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { type HomeyDevice, type HomeySdkClient, type HomeySdkFactory } from './support/homey-shs-realtime-probe';
+import {
+	type HomeyShsRestartEventFlowConfig,
+	assertHomeyShsRestartEventFlowReportSafe,
+	loadHomeyShsRestartEventFlowConfig,
+	probeHomeyShsRestartEventFlow,
+	writeHomeyShsRestartEventFlowReport,
+} from './support/homey-shs-restart-event-flow-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'test-api-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_RESTART_EVENT_FLOW_ENABLE: 'I_WILL_RESTART_THE_TEST_SHS_WHILE_A_DISPOSABLE_CAPABILITY_IS_CHANGED',
+	FB_HOMEY_SHS_RESTART_EVENT_FLOW_EVENT_OBSERVE_MS: '1000',
+	FB_HOMEY_SHS_RESTART_EVENT_FLOW_RECOVERY_OBSERVE_MS: '1000',
+	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+	FB_HOMEY_SHS_WRITE_CAPABILITY_ID: 'test-capability-that-must-not-leak',
+	FB_HOMEY_SHS_WRITE_DEVICE_ID: 'test-device-that-must-not-leak',
+	FB_HOMEY_SHS_WRITE_ENABLE: 'I_ACKNOWLEDGE_THIS_CHANGES_A_TEST_DEVICE',
+	FB_HOMEY_SHS_WRITE_VALUE: 'true',
+};
+
+class FakeDevice extends EventEmitter implements HomeyDevice {
+	capabilitiesObj = { 'test-capability-that-must-not-leak': { setable: true, type: 'boolean' } };
+	connectCount = 0;
+	disconnectCount = 0;
+
+	connect(): Promise<void> {
+		this.connectCount += 1;
+		return Promise.resolve();
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+		return Promise.resolve();
+	}
+}
+
+class FakeManager extends EventEmitter {
+	connected = false;
+	readonly device = new FakeDevice();
+	value = false;
+	writes: unknown[] = [];
+
+	connect(): Promise<void> {
+		this.connected = true;
+		return Promise.resolve();
+	}
+
+	disconnect(): Promise<void> {
+		this.connected = false;
+		return Promise.resolve();
+	}
+
+	getCapabilityValue(): Promise<unknown> {
+		return Promise.resolve(this.value);
+	}
+
+	getDevices(): Promise<Record<string, HomeyDevice>> {
+		return Promise.resolve({ 'test-device-that-must-not-leak': this.device });
+	}
+
+	isConnected(): boolean {
+		return this.connected;
+	}
+
+	setCapabilityValue(options: { capabilityId: string; value: unknown }): Promise<void> {
+		this.value = options.value as boolean;
+		this.writes.push(options.value);
+		this.device.emit('capability', { capabilityId: options.capabilityId, value: options.value });
+		return Promise.resolve();
+	}
+}
+
+class FakeClient extends EventEmitter implements HomeySdkClient {
+	destroyCount = 0;
+	disconnectCount = 0;
+	readonly devices = new FakeManager();
+
+	destroy(): void {
+		this.destroyCount += 1;
+	}
+
+	disconnect(): Promise<void> {
+		this.disconnectCount += 1;
+		return Promise.resolve();
+	}
+
+	restart(): void {
+		this.devices.connected = false;
+		this.emit('disconnect');
+		this.emit('reconnect_attempt');
+		this.devices.connected = true;
+		this.emit('reconnect');
+	}
+}
+
+const createFactory = (): { client: FakeClient; factory: HomeySdkFactory } => {
+	const client = new FakeClient();
+	return { client, factory: { createLocalApi: () => Promise.resolve(client) } };
+};
+
+const config = (overrides: Partial<HomeyShsRestartEventFlowConfig> = {}): HomeyShsRestartEventFlowConfig => ({
+	...loadHomeyShsRestartEventFlowConfig(BASE_ENVIRONMENT, '/tmp/homey-restart-event-flow'),
+	...overrides,
+});
+
+describe('Homey SHS restart event-flow probe', () => {
+	it('requires exact mutation acknowledgements and rejects unrelated probe gates', () => {
+		expect(loadHomeyShsRestartEventFlowConfig(BASE_ENVIRONMENT).write.value).toBe(true);
+		expect(() =>
+			loadHomeyShsRestartEventFlowConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_RESTART_EVENT_FLOW_ENABLE: 'yes',
+			}),
+		).toThrow('required acknowledgement');
+		expect(() => loadHomeyShsRestartEventFlowConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_RECOVERY_ENABLE: '' })).toThrow(
+			'must be unset',
+		);
+		expect(() =>
+			loadHomeyShsRestartEventFlowConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_WRITE_VALUE: undefined }),
+		).toThrow('All four FB_HOMEY_SHS_WRITE_* variables');
+	});
+
+	it('verifies one event before restart and restoration event after recovery', async () => {
+		const { client, factory } = createFactory();
+		const restartWindow = jest.fn(() => client.restart());
+		const report = await probeHomeyShsRestartEventFlow(config(), factory, () => Promise.resolve(), restartWindow);
+
+		expect(report.flow).toStrictEqual({
+			disconnectObserved: true,
+			managerResubscribed: true,
+			postRestartEventObserved: true,
+			preRestartEventObserved: true,
+			preRestartReadBackMatched: true,
+			restorationReadBackMatched: true,
+			restored: true,
+			transportReconnected: true,
+		});
+		expect(client.devices.writes).toStrictEqual([true, false]);
+		expect(client.devices.value).toBe(false);
+		expect(client.devices.device.disconnectCount).toBe(1);
+		expect(client.disconnectCount).toBe(1);
+		expect(client.destroyCount).toBe(1);
+		expect(() => assertHomeyShsRestartEventFlowReportSafe(report, config())).not.toThrow();
+	});
+
+	it('restores the original value and cleans up when restart observation fails', async () => {
+		const { client, factory } = createFactory();
+		let now = 0;
+		const dateNow = jest.spyOn(Date, 'now').mockImplementation(() => now);
+		const advancePastDeadline = (): Promise<void> => {
+			now = 1_001;
+
+			return Promise.resolve();
+		};
+
+		try {
+			await expect(probeHomeyShsRestartEventFlow(config(), factory, advancePastDeadline)).rejects.toThrow(
+				'operator restart recovery timed out',
+			);
+			expect(client.devices.writes).toStrictEqual([true, false]);
+			expect(client.devices.value).toBe(false);
+			expect(client.destroyCount).toBe(1);
+		} finally {
+			dateNow.mockRestore();
+		}
+	});
+
+	it('rejects extra schema fields, reordered evidence, and private values', async () => {
+		const { client, factory } = createFactory();
+		const report = await probeHomeyShsRestartEventFlow(
+			config(),
+			factory,
+			() => Promise.resolve(),
+			() => client.restart(),
+		);
+
+		expect(() => assertHomeyShsRestartEventFlowReportSafe({ ...report, extra: true }, config())).toThrow(
+			'root schema is invalid',
+		);
+		expect(() =>
+			assertHomeyShsRestartEventFlowReportSafe(
+				{ ...report, session: { ...report.session, events: [...report.session.events].reverse() } },
+				config(),
+			),
+		).toThrow();
+		expect(() =>
+			assertHomeyShsRestartEventFlowReportSafe(
+				{ ...report, metadata: { ...report.metadata, sdkVersion: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY } },
+				config(),
+			),
+		).toThrow();
+	});
+
+	it('writes the report beneath a private non-overwriting directory', async () => {
+		const { client, factory } = createFactory();
+		const report = await probeHomeyShsRestartEventFlow(
+			config(),
+			factory,
+			() => Promise.resolve(),
+			() => client.restart(),
+		);
+		const root = await mkdtemp(join(tmpdir(), 'homey-restart-event-flow-'));
+
+		try {
+			const directory = await writeHomeyShsRestartEventFlowReport(report, root);
+			const path = join(directory, 'report.json');
+			expect((await stat(directory)).mode & 0o777).toBe(0o700);
+			expect((await stat(path)).mode & 0o777).toBe(0o600);
+			expect(JSON.parse(await readFile(path, 'utf8'))).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
+++ b/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
@@ -46,6 +46,7 @@ class FakeDevice extends EventEmitter implements HomeyDevice {
 class FakeManager extends EventEmitter {
 	connected = false;
 	readonly device = new FakeDevice();
+	readonly inventoryOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
 	value = false;
 	writes: unknown[] = [];
 
@@ -63,7 +64,11 @@ class FakeManager extends EventEmitter {
 		return Promise.resolve(this.value);
 	}
 
-	getDevices(): Promise<Record<string, HomeyDevice>> {
+	getDevices(
+		options: { $cache?: boolean; $timeout?: number; $updateCache?: boolean } = {},
+	): Promise<Record<string, HomeyDevice>> {
+		this.inventoryOptions.push(options);
+
 		return Promise.resolve({ 'test-device-that-must-not-leak': this.device });
 	}
 
@@ -145,6 +150,10 @@ describe('Homey SHS restart event-flow probe', () => {
 			transportReconnected: true,
 		});
 		expect(client.devices.writes).toStrictEqual([true, false]);
+		expect(client.devices.inventoryOptions).toStrictEqual([
+			{ $timeout: 1000 },
+			{ $cache: false, $timeout: 1000, $updateCache: true },
+		]);
 		expect(client.devices.value).toBe(false);
 		expect(client.devices.device.disconnectCount).toBe(1);
 		expect(client.disconnectCount).toBe(1);

--- a/apps/backend/test/support/homey-shs-realtime-probe.ts
+++ b/apps/backend/test/support/homey-shs-realtime-probe.ts
@@ -31,7 +31,7 @@ const SAFE_EVENT_LABELS = new Set([
 	'socket.reconnect_error',
 ]);
 
-type HomeyScalar = boolean | number | string;
+export type HomeyScalar = boolean | number | string;
 type EventListener = (...arguments_: unknown[]) => void;
 
 class HomeyShsSdkTimeoutError extends Error {
@@ -46,7 +46,7 @@ interface EventSource {
 	off?(event: string, listener: EventListener): unknown;
 }
 
-interface HomeyCapabilityMetadata {
+export interface HomeyCapabilityMetadata {
 	max?: unknown;
 	min?: unknown;
 	setable?: unknown;
@@ -55,13 +55,13 @@ interface HomeyCapabilityMetadata {
 	values?: unknown;
 }
 
-interface HomeyDevice extends EventSource {
+export interface HomeyDevice extends EventSource {
 	capabilitiesObj?: Record<string, HomeyCapabilityMetadata>;
 	connect(): Promise<void>;
 	disconnect(): Promise<void>;
 }
 
-interface HomeyDevicesManager extends EventSource {
+export interface HomeyDevicesManager extends EventSource {
 	connect(): Promise<void>;
 	disconnect(): Promise<void>;
 	getCapabilityValue(options: { $timeout?: number; capabilityId: string; deviceId: string }): Promise<unknown>;
@@ -74,7 +74,7 @@ interface HomeyDevicesManager extends EventSource {
 	}): Promise<unknown>;
 }
 
-interface HomeySdkClient extends EventSource {
+export interface HomeySdkClient extends EventSource {
 	destroy(): void;
 	disconnect(): Promise<void>;
 	devices: HomeyDevicesManager;
@@ -84,7 +84,7 @@ export interface HomeySdkFactory {
 	createLocalApi(options: { address: string; token: string }): Promise<HomeySdkClient>;
 }
 
-interface HomeyShsWriteConfig {
+export interface HomeyShsWriteConfig {
 	capabilityId: string;
 	deviceId: string;
 	value: HomeyScalar;
@@ -120,7 +120,7 @@ export interface HomeyShsRealtimeReport {
 	};
 }
 
-const sdkFactory: HomeySdkFactory = {
+export const homeyRealtimeSdkFactory: HomeySdkFactory = {
 	createLocalApi: async ({ address, token }) =>
 		(await HomeyAPI.createLocalAPI({ address, token, debug: null })) as HomeySdkClient,
 };
@@ -236,7 +236,7 @@ const parseWriteValue = (value: string): HomeyScalar => {
 	return parsed as HomeyScalar;
 };
 
-const parseWriteConfig = (environment: NodeJS.ProcessEnv): HomeyShsWriteConfig | null => {
+export const parseHomeyShsWriteConfig = (environment: NodeJS.ProcessEnv): HomeyShsWriteConfig | null => {
 	const names = [
 		'FB_HOMEY_SHS_WRITE_ENABLE',
 		'FB_HOMEY_SHS_WRITE_DEVICE_ID',
@@ -274,7 +274,7 @@ export const loadHomeyShsRealtimeProbeConfig = (
 ): HomeyShsRealtimeProbeConfig => ({
 	...loadHomeyShsProbeConfig(environment, workingDirectory),
 	observeMs: parseObserveMs(environment.FB_HOMEY_SHS_REALTIME_OBSERVE_MS),
-	write: parseWriteConfig(environment),
+	write: parseHomeyShsWriteConfig(environment),
 });
 
 const sleep = async (milliseconds: number): Promise<void> => {
@@ -330,7 +330,11 @@ const settleSdkClientCreation = async (
 	}
 };
 
-const runSdkOperation = async <T>(label: string, timeoutMs: number, operation: () => Promise<T>): Promise<T> => {
+export const runHomeyShsSdkOperation = async <T>(
+	label: string,
+	timeoutMs: number,
+	operation: () => Promise<T>,
+): Promise<T> => {
 	try {
 		return await settleSdkOperation(label, timeoutMs, operation);
 	} catch (error: unknown) {
@@ -347,7 +351,7 @@ const runSdkOperation = async <T>(label: string, timeoutMs: number, operation: (
 	}
 };
 
-const runSdkClientCreation = async (
+export const runHomeyShsSdkClientCreation = async (
 	label: string,
 	timeoutMs: number,
 	operation: () => Promise<HomeySdkClient>,
@@ -376,10 +380,13 @@ const statusCodeOf = (error: unknown): number | null => {
 	return typeof error.statusCode === 'number' ? error.statusCode : null;
 };
 
-const scalarCapabilityValue = (response: unknown): unknown =>
+export const homeyScalarCapabilityValue = (response: unknown): unknown =>
 	isRecord(response) && Object.hasOwn(response, 'value') ? response.value : response;
 
-const assertSafeWriteTarget = (devices: Record<string, HomeyDevice>, write: HomeyShsWriteConfig): HomeyDevice => {
+export const assertSafeHomeyWriteTarget = (
+	devices: Record<string, HomeyDevice>,
+	write: HomeyShsWriteConfig,
+): HomeyDevice => {
 	const device = devices[write.deviceId];
 	const capability = device?.capabilitiesObj?.[write.capabilityId];
 
@@ -414,7 +421,7 @@ const assertSafeWriteTarget = (devices: Record<string, HomeyDevice>, write: Home
 	return device;
 };
 
-const assertRestorableOriginalValue = (value: unknown, writeValue: HomeyScalar): HomeyScalar => {
+export const assertRestorableHomeyValue = (value: unknown, writeValue: HomeyScalar): HomeyScalar => {
 	if (!['boolean', 'number', 'string'].includes(typeof value)) {
 		throw new Error('The allowlisted Homey capability has no safely restorable scalar value');
 	}
@@ -489,7 +496,9 @@ const assertInvalidKeyRejected = async (
 		let cleanupFailed = false;
 
 		try {
-			await runSdkOperation('invalid-key client disconnect', config.timeoutMs, () => invalidClient.disconnect());
+			await runHomeyShsSdkOperation('invalid-key client disconnect', config.timeoutMs, () =>
+				invalidClient.disconnect(),
+			);
 		} catch {
 			cleanupFailed = true;
 		}
@@ -518,7 +527,7 @@ const assertInvalidKeyRejected = async (
 
 export const probeHomeyShsRealtime = async (
 	config: HomeyShsRealtimeProbeConfig,
-	factory: HomeySdkFactory = sdkFactory,
+	factory: HomeySdkFactory = homeyRealtimeSdkFactory,
 	wait: (milliseconds: number) => Promise<void> = sleep,
 ): Promise<HomeyShsRealtimeReport> => {
 	const report: HomeyShsRealtimeReport = {
@@ -533,7 +542,7 @@ export const probeHomeyShsRealtime = async (
 			restored: false,
 		},
 	};
-	const client = await runSdkClientCreation('client creation', config.timeoutMs, () =>
+	const client = await runHomeyShsSdkClientCreation('client creation', config.timeoutMs, () =>
 		factory.createLocalApi({ address: config.origin.origin, token: config.apiKey }),
 	);
 	report.session.events.push({ event: 'sdk.create.resolved', order: 1 });
@@ -553,7 +562,7 @@ export const probeHomeyShsRealtime = async (
 	const cleanupFailures: string[] = [];
 
 	try {
-		await runSdkOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
+		await runHomeyShsSdkOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
 		report.session.managerSubscribed = true;
 		report.session.events.push({ event: 'manager.subscribe.resolved', order: report.session.events.length + 1 });
 
@@ -561,10 +570,10 @@ export const probeHomeyShsRealtime = async (
 			await wait(config.observeMs);
 		} else {
 			const write = config.write;
-			const devices = await runSdkOperation('device inventory read', config.timeoutMs, () =>
+			const devices = await runHomeyShsSdkOperation('device inventory read', config.timeoutMs, () =>
 				client.devices.getDevices({ $timeout: config.timeoutMs }),
 			);
-			const device = assertSafeWriteTarget(devices, write);
+			const device = assertSafeHomeyWriteTarget(devices, write);
 			connectedDevice = device;
 			let acceptCapabilityEvents = false;
 			const capabilityListener = (payload: unknown): void => {
@@ -585,10 +594,10 @@ export const probeHomeyShsRealtime = async (
 			device.on('capability', capabilityListener);
 
 			try {
-				await runSdkOperation('device subscription', config.timeoutMs, () => device.connect());
-				const originalValue = assertRestorableOriginalValue(
-					scalarCapabilityValue(
-						await runSdkOperation('pre-write capability read', config.timeoutMs, () =>
+				await runHomeyShsSdkOperation('device subscription', config.timeoutMs, () => device.connect());
+				const originalValue = assertRestorableHomeyValue(
+					homeyScalarCapabilityValue(
+						await runHomeyShsSdkOperation('pre-write capability read', config.timeoutMs, () =>
 							client.devices.getCapabilityValue({
 								$timeout: config.timeoutMs,
 								capabilityId: write.capabilityId,
@@ -604,7 +613,7 @@ export const probeHomeyShsRealtime = async (
 					acceptCapabilityEvents = true;
 
 					try {
-						await runSdkOperation('capability write', config.timeoutMs, () =>
+						await runHomeyShsSdkOperation('capability write', config.timeoutMs, () =>
 							client.devices.setCapabilityValue({
 								$timeout: config.timeoutMs,
 								capabilityId: write.capabilityId,
@@ -617,8 +626,8 @@ export const probeHomeyShsRealtime = async (
 						acceptCapabilityEvents = false;
 					}
 
-					const readBack = scalarCapabilityValue(
-						await runSdkOperation('post-write capability read', config.timeoutMs, () =>
+					const readBack = homeyScalarCapabilityValue(
+						await runHomeyShsSdkOperation('post-write capability read', config.timeoutMs, () =>
 							client.devices.getCapabilityValue({
 								$timeout: config.timeoutMs,
 								capabilityId: write.capabilityId,
@@ -630,7 +639,7 @@ export const probeHomeyShsRealtime = async (
 					report.write.readBackMatched = Object.is(readBack, write.value);
 				} finally {
 					if (report.write.attempted) {
-						await runSdkOperation('capability restoration', config.timeoutMs, () =>
+						await runHomeyShsSdkOperation('capability restoration', config.timeoutMs, () =>
 							client.devices.setCapabilityValue({
 								$timeout: config.timeoutMs,
 								capabilityId: write.capabilityId,
@@ -639,8 +648,8 @@ export const probeHomeyShsRealtime = async (
 							}),
 						);
 						report.write.restored = true;
-						const restored = scalarCapabilityValue(
-							await runSdkOperation('restoration capability read', config.timeoutMs, () =>
+						const restored = homeyScalarCapabilityValue(
+							await runHomeyShsSdkOperation('restoration capability read', config.timeoutMs, () =>
 								client.devices.getCapabilityValue({
 									$timeout: config.timeoutMs,
 									capabilityId: write.capabilityId,
@@ -667,7 +676,7 @@ export const probeHomeyShsRealtime = async (
 			operation: () => Promise<unknown>,
 		): Promise<void> => {
 			try {
-				await runSdkOperation(label, config.timeoutMs, operation);
+				await runHomeyShsSdkOperation(label, config.timeoutMs, operation);
 				report.session.events.push({ event: resolvedEvent, order: report.session.events.length + 1 });
 			} catch {
 				cleanupFailures.push(label);

--- a/apps/backend/test/support/homey-shs-realtime-probe.ts
+++ b/apps/backend/test/support/homey-shs-realtime-probe.ts
@@ -65,7 +65,11 @@ export interface HomeyDevicesManager extends EventSource {
 	connect(): Promise<void>;
 	disconnect(): Promise<void>;
 	getCapabilityValue(options: { $timeout?: number; capabilityId: string; deviceId: string }): Promise<unknown>;
-	getDevices(options?: { $timeout?: number }): Promise<Record<string, HomeyDevice>>;
+	getDevices(options?: {
+		$cache?: boolean;
+		$timeout?: number;
+		$updateCache?: boolean;
+	}): Promise<Record<string, HomeyDevice>>;
 	setCapabilityValue(options: {
 		$timeout?: number;
 		capabilityId: string;

--- a/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
+++ b/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
@@ -1,0 +1,532 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+import {
+	type HomeyDevice,
+	type HomeyScalar,
+	type HomeySdkClient,
+	type HomeySdkFactory,
+	type HomeyShsWriteConfig,
+	assertRestorableHomeyValue,
+	assertSafeHomeyWriteTarget,
+	homeyRealtimeSdkFactory,
+	homeyScalarCapabilityValue,
+	parseHomeyShsWriteConfig,
+	runHomeyShsSdkClientCreation,
+	runHomeyShsSdkOperation,
+} from './homey-shs-realtime-probe';
+
+const ACKNOWLEDGEMENT = 'I_WILL_RESTART_THE_TEST_SHS_WHILE_A_DISPOSABLE_CAPABILITY_IS_CHANGED';
+const SDK_VERSION = '3.19.2';
+const DEFAULT_RECOVERY_OBSERVE_MS = 90_000;
+const DEFAULT_EVENT_OBSERVE_MS = 10_000;
+const MIN_OBSERVE_MS = 1_000;
+const MAX_OBSERVE_MS = 300_000;
+const POLL_MS = 100;
+const CONFLICTING_PREFIXES = [
+	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
+	'FB_HOMEY_SHS_LIFECYCLE_',
+	'FB_HOMEY_SHS_REALTIME_',
+	'FB_HOMEY_SHS_RECOVERY_',
+	'FB_HOMEY_SHS_REPLACEMENT_',
+	'FB_HOMEY_SHS_STARTUP_',
+];
+const SAFE_EVENTS = new Set([
+	'device.subscribe.resolved',
+	'device.unsubscribe.failed',
+	'device.unsubscribe.resolved',
+	'inventory.read.resolved',
+	'manager.resubscribe.observed',
+	'manager.subscribe.resolved',
+	'manager.unsubscribe.failed',
+	'manager.unsubscribe.resolved',
+	'pre.write.event.observed',
+	'pre.write.readback.verified',
+	'pre.write.requested',
+	'restart.window.open',
+	'restore.readback.verified',
+	'restore.write.event.observed',
+	'restore.write.requested',
+	'sdk.create.resolved',
+	'sdk.destroy.failed',
+	'sdk.destroyed',
+	'socket.connect',
+	'socket.disconnect',
+	'socket.disconnect.failed',
+	'socket.disconnect.resolved',
+	'socket.reconnect',
+	'socket.reconnect_attempt',
+	'socket.reconnect_error',
+	'socket.reconnecting',
+]);
+
+type EventListener = (...arguments_: unknown[]) => void;
+type CapabilityPhase = 'pre' | 'restore' | null;
+
+export interface HomeyShsRestartEventFlowConfig extends HomeyShsProbeConfig {
+	eventObserveMs: number;
+	recoveryObserveMs: number;
+	write: HomeyShsWriteConfig;
+}
+
+export interface HomeyShsRestartEventFlowReport {
+	metadata: { probe: 'homey-shs-restart-event-flow'; schemaVersion: 1; sdkVersion: string };
+	flow: {
+		disconnectObserved: boolean;
+		managerResubscribed: boolean;
+		postRestartEventObserved: boolean;
+		preRestartEventObserved: boolean;
+		preRestartReadBackMatched: boolean;
+		restorationReadBackMatched: boolean;
+		restored: boolean;
+		transportReconnected: boolean;
+	};
+	session: {
+		cleanupCompleted: boolean;
+		events: Array<{ event: string; order: number }>;
+		managerSubscribed: boolean;
+	};
+}
+
+export type HomeyRestartEventFlowWait = (milliseconds: number) => Promise<void>;
+
+const sleep: HomeyRestartEventFlowWait = async (milliseconds) =>
+	new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+
+const parseObserveMs = (name: string, value: string | undefined, fallback: number): number => {
+	if (value === undefined) {
+		return fallback;
+	}
+
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_OBSERVE_MS || parsed > MAX_OBSERVE_MS) {
+		throw new Error(`${name} must be an integer between ${MIN_OBSERVE_MS} and ${MAX_OBSERVE_MS}`);
+	}
+
+	return parsed;
+};
+
+export const loadHomeyShsRestartEventFlowConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsRestartEventFlowConfig => {
+	if (environment.FB_HOMEY_SHS_RESTART_EVENT_FLOW_ENABLE !== ACKNOWLEDGEMENT) {
+		throw new Error('FB_HOMEY_SHS_RESTART_EVENT_FLOW_ENABLE does not contain the required acknowledgement');
+	}
+
+	if (Object.keys(environment).some((name) => CONFLICTING_PREFIXES.some((prefix) => name.startsWith(prefix)))) {
+		throw new Error('Unrelated Homey probe gates must be unset during the restart event-flow probe');
+	}
+
+	const write = parseHomeyShsWriteConfig(environment);
+
+	if (write === null) {
+		throw new Error('The complete Homey write allowlist is required for the restart event-flow probe');
+	}
+
+	return {
+		...loadHomeyShsProbeConfig(environment, workingDirectory),
+		eventObserveMs: parseObserveMs(
+			'FB_HOMEY_SHS_RESTART_EVENT_FLOW_EVENT_OBSERVE_MS',
+			environment.FB_HOMEY_SHS_RESTART_EVENT_FLOW_EVENT_OBSERVE_MS,
+			DEFAULT_EVENT_OBSERVE_MS,
+		),
+		recoveryObserveMs: parseObserveMs(
+			'FB_HOMEY_SHS_RESTART_EVENT_FLOW_RECOVERY_OBSERVE_MS',
+			environment.FB_HOMEY_SHS_RESTART_EVENT_FLOW_RECOVERY_OBSERVE_MS,
+			DEFAULT_RECOVERY_OBSERVE_MS,
+		),
+		write,
+	};
+};
+
+const appendEvent = (report: HomeyShsRestartEventFlowReport, event: string): void => {
+	report.session.events.push({ event, order: report.session.events.length + 1 });
+};
+
+const waitUntil = async (
+	label: string,
+	timeoutMs: number,
+	predicate: () => boolean,
+	wait: HomeyRestartEventFlowWait,
+): Promise<void> => {
+	const deadline = Date.now() + timeoutMs;
+
+	while (!predicate()) {
+		const remaining = deadline - Date.now();
+
+		if (remaining <= 0) {
+			throw new Error(`Homey restart event-flow ${label} timed out after ${timeoutMs} ms`);
+		}
+
+		await wait(Math.min(POLL_MS, remaining));
+	}
+};
+
+const managerConnected = (client: HomeySdkClient): boolean => {
+	const manager = client.devices as HomeySdkClient['devices'] & { isConnected?: () => boolean };
+
+	return manager.isConnected?.() === true;
+};
+
+const scalarRead = async (client: HomeySdkClient, config: HomeyShsRestartEventFlowConfig): Promise<unknown> =>
+	homeyScalarCapabilityValue(
+		await runHomeyShsSdkOperation('capability read', config.timeoutMs, () =>
+			client.devices.getCapabilityValue({
+				$timeout: config.timeoutMs,
+				capabilityId: config.write.capabilityId,
+				deviceId: config.write.deviceId,
+			}),
+		),
+	);
+
+const capabilityWrite = async (
+	client: HomeySdkClient,
+	config: HomeyShsRestartEventFlowConfig,
+	value: HomeyScalar,
+): Promise<void> => {
+	await runHomeyShsSdkOperation('capability write', config.timeoutMs, () =>
+		client.devices.setCapabilityValue({
+			$timeout: config.timeoutMs,
+			capabilityId: config.write.capabilityId,
+			deviceId: config.write.deviceId,
+			value,
+		}),
+	);
+};
+
+export const probeHomeyShsRestartEventFlow = async (
+	config: HomeyShsRestartEventFlowConfig,
+	factory: HomeySdkFactory = homeyRealtimeSdkFactory,
+	wait: HomeyRestartEventFlowWait = sleep,
+	onRestartWindowOpen: () => void = () => undefined,
+): Promise<HomeyShsRestartEventFlowReport> => {
+	const report: HomeyShsRestartEventFlowReport = {
+		metadata: { probe: 'homey-shs-restart-event-flow', schemaVersion: 1, sdkVersion: SDK_VERSION },
+		flow: {
+			disconnectObserved: false,
+			managerResubscribed: false,
+			postRestartEventObserved: false,
+			preRestartEventObserved: false,
+			preRestartReadBackMatched: false,
+			restorationReadBackMatched: false,
+			restored: false,
+			transportReconnected: false,
+		},
+		session: { cleanupCompleted: false, events: [], managerSubscribed: false },
+	};
+	const client = await runHomeyShsSdkClientCreation('client creation', config.timeoutMs, () =>
+		factory.createLocalApi({ address: config.origin.origin, token: config.apiKey }),
+	);
+	appendEvent(report, 'sdk.create.resolved');
+	let device: HomeyDevice | undefined;
+	let originalValue: HomeyScalar | undefined;
+	let writeAttempted = false;
+	let restartWindowOpen = false;
+	let phase: CapabilityPhase = null;
+	let operationError: unknown;
+	const cleanupFailures: string[] = [];
+	const cleanupListeners: Array<() => void> = [];
+	const attach = (
+		source: {
+			on(event: string, listener: EventListener): unknown;
+			off?(event: string, listener: EventListener): unknown;
+		},
+		event: string,
+		listener: EventListener,
+	): void => {
+		source.on(event, listener);
+		cleanupListeners.push(() => source.off?.(event, listener));
+	};
+
+	attach(client, 'disconnect', () => {
+		if (restartWindowOpen && !report.flow.disconnectObserved) {
+			report.flow.disconnectObserved = true;
+			appendEvent(report, 'socket.disconnect');
+		}
+	});
+	for (const event of ['reconnect_attempt', 'reconnect_error', 'reconnecting']) {
+		attach(client, event, () => {
+			if (restartWindowOpen && report.flow.disconnectObserved && !report.flow.transportReconnected) {
+				appendEvent(report, `socket.${event}`);
+			}
+		});
+	}
+	for (const event of ['connect', 'reconnect']) {
+		attach(client, event, () => {
+			if (restartWindowOpen && report.flow.disconnectObserved && !report.flow.transportReconnected) {
+				report.flow.transportReconnected = true;
+				appendEvent(report, `socket.${event}`);
+			}
+		});
+	}
+
+	try {
+		await runHomeyShsSdkOperation('manager subscription', config.timeoutMs, () => client.devices.connect());
+		report.session.managerSubscribed = true;
+		appendEvent(report, 'manager.subscribe.resolved');
+		const devices = await runHomeyShsSdkOperation('device inventory read', config.timeoutMs, () =>
+			client.devices.getDevices({ $timeout: config.timeoutMs }),
+		);
+		device = assertSafeHomeyWriteTarget(devices, config.write);
+		const boundDevice = device;
+		attach(boundDevice, 'capability', (payload: unknown) => {
+			if (typeof payload !== 'object' || payload === null) return;
+			const event = payload as { capabilityId?: unknown; value?: unknown };
+			if (event.capabilityId !== config.write.capabilityId) return;
+			if (phase === 'pre' && Object.is(event.value, config.write.value) && !report.flow.preRestartEventObserved) {
+				report.flow.preRestartEventObserved = true;
+				appendEvent(report, 'pre.write.event.observed');
+			}
+			if (phase === 'restore' && Object.is(event.value, originalValue) && !report.flow.postRestartEventObserved) {
+				report.flow.postRestartEventObserved = true;
+				appendEvent(report, 'restore.write.event.observed');
+			}
+		});
+		await runHomeyShsSdkOperation('device subscription', config.timeoutMs, () => boundDevice.connect());
+		appendEvent(report, 'device.subscribe.resolved');
+		originalValue = assertRestorableHomeyValue(await scalarRead(client, config), config.write.value);
+
+		phase = 'pre';
+		writeAttempted = true;
+		appendEvent(report, 'pre.write.requested');
+		await capabilityWrite(client, config, config.write.value);
+		await waitUntil(
+			'pre-restart capability event',
+			config.eventObserveMs,
+			() => report.flow.preRestartEventObserved,
+			wait,
+		);
+		report.flow.preRestartReadBackMatched = Object.is(await scalarRead(client, config), config.write.value);
+		if (!report.flow.preRestartReadBackMatched) throw new Error('Homey pre-restart capability read-back failed');
+		appendEvent(report, 'pre.write.readback.verified');
+
+		phase = null;
+		restartWindowOpen = true;
+		appendEvent(report, 'restart.window.open');
+		onRestartWindowOpen();
+		await waitUntil(
+			'operator restart recovery',
+			config.recoveryObserveMs,
+			() => report.flow.disconnectObserved && report.flow.transportReconnected,
+			wait,
+		);
+		await waitUntil('manager resubscription', config.timeoutMs, () => managerConnected(client), wait);
+		report.flow.managerResubscribed = true;
+		appendEvent(report, 'manager.resubscribe.observed');
+		await runHomeyShsSdkOperation('post-restart inventory read', config.timeoutMs, () =>
+			client.devices.getDevices({ $timeout: config.timeoutMs }),
+		);
+		appendEvent(report, 'inventory.read.resolved');
+
+		phase = 'restore';
+		appendEvent(report, 'restore.write.requested');
+		await capabilityWrite(client, config, originalValue);
+		report.flow.restored = true;
+		await waitUntil(
+			'post-restart restoration event',
+			config.eventObserveMs,
+			() => report.flow.postRestartEventObserved,
+			wait,
+		);
+		report.flow.restorationReadBackMatched = Object.is(await scalarRead(client, config), originalValue);
+		if (!report.flow.restorationReadBackMatched) throw new Error('Homey restoration read-back failed');
+		appendEvent(report, 'restore.readback.verified');
+	} catch (error: unknown) {
+		operationError =
+			error instanceof Error && error.message.startsWith('Homey ')
+				? error
+				: new Error('Homey restart event-flow verification failed');
+	} finally {
+		restartWindowOpen = false;
+		phase = null;
+		if (writeAttempted && originalValue !== undefined && !report.flow.restorationReadBackMatched) {
+			try {
+				await capabilityWrite(client, config, originalValue);
+				report.flow.restored = true;
+				report.flow.restorationReadBackMatched = Object.is(await scalarRead(client, config), originalValue);
+				if (!report.flow.restorationReadBackMatched) cleanupFailures.push('capability restoration');
+			} catch {
+				cleanupFailures.push('capability restoration');
+			}
+		}
+		const cleanup = async (
+			label: string,
+			resolved: string,
+			failed: string,
+			operation: () => Promise<unknown>,
+		): Promise<void> => {
+			try {
+				await runHomeyShsSdkOperation(label, config.timeoutMs, operation);
+				appendEvent(report, resolved);
+			} catch {
+				cleanupFailures.push(label);
+				appendEvent(report, failed);
+			}
+		};
+		if (device !== undefined)
+			await cleanup('device unsubscribe', 'device.unsubscribe.resolved', 'device.unsubscribe.failed', () =>
+				device.disconnect(),
+			);
+		await cleanup('manager unsubscribe', 'manager.unsubscribe.resolved', 'manager.unsubscribe.failed', () =>
+			client.devices.disconnect(),
+		);
+		await cleanup('socket disconnect', 'socket.disconnect.resolved', 'socket.disconnect.failed', () =>
+			client.disconnect(),
+		);
+		cleanupListeners.forEach((cleanupListener) => cleanupListener());
+		try {
+			client.destroy();
+			appendEvent(report, 'sdk.destroyed');
+		} catch {
+			cleanupFailures.push('client destroy');
+			appendEvent(report, 'sdk.destroy.failed');
+		}
+		report.session.cleanupCompleted = cleanupFailures.length === 0;
+	}
+
+	if (cleanupFailures.length > 0)
+		throw new Error(`Homey restart event-flow cleanup failed: ${cleanupFailures.join(', ')}`);
+	if (operationError !== undefined) throw operationError;
+	return report;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireExactKeys = (value: unknown, keys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value) || Object.keys(value).sort().join() !== [...keys].sort().join()) {
+		throw new Error(`Homey restart event-flow report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+export function assertHomeyShsRestartEventFlowReportSafe(
+	value: unknown,
+	config: HomeyShsRestartEventFlowConfig,
+): asserts value is HomeyShsRestartEventFlowReport {
+	const report = requireExactKeys(value, ['flow', 'metadata', 'session'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const flow = requireExactKeys(
+		report.flow,
+		[
+			'disconnectObserved',
+			'managerResubscribed',
+			'postRestartEventObserved',
+			'preRestartEventObserved',
+			'preRestartReadBackMatched',
+			'restorationReadBackMatched',
+			'restored',
+			'transportReconnected',
+		],
+		'flow',
+	);
+	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'managerSubscribed'], 'session');
+
+	if (
+		metadata.probe !== 'homey-shs-restart-event-flow' ||
+		metadata.schemaVersion !== 1 ||
+		metadata.sdkVersion !== SDK_VERSION
+	)
+		throw new Error('Homey restart event-flow report metadata is invalid');
+	if (Object.values(flow).some((result) => result !== true))
+		throw new Error('Homey restart event-flow report did not verify the complete flow');
+	if (session.cleanupCompleted !== true || session.managerSubscribed !== true || !Array.isArray(session.events))
+		throw new Error('Homey restart event-flow report session is invalid');
+	for (const [index, item] of session.events.entries()) {
+		if (
+			!isRecord(item) ||
+			Object.keys(item).sort().join() !== 'event,order' ||
+			typeof item.event !== 'string' ||
+			!SAFE_EVENTS.has(item.event) ||
+			item.order !== index + 1
+		)
+			throw new Error('Homey restart event-flow report event is invalid');
+	}
+	const labels = session.events.map((item) => (item as { event: string }).event);
+	let previousIndex = -1;
+	for (const label of [
+		'manager.subscribe.resolved',
+		'device.subscribe.resolved',
+		'pre.write.requested',
+		'pre.write.event.observed',
+		'pre.write.readback.verified',
+		'restart.window.open',
+		'socket.disconnect',
+		'manager.resubscribe.observed',
+		'inventory.read.resolved',
+		'restore.write.requested',
+		'restore.write.event.observed',
+		'restore.readback.verified',
+	]) {
+		const index = labels.indexOf(label);
+
+		if (index <= previousIndex) throw new Error('Homey restart event-flow report ordering is invalid');
+		previousIndex = index;
+	}
+	const disconnectIndex = labels.indexOf('socket.disconnect');
+	const resubscribeIndex = labels.indexOf('manager.resubscribe.observed');
+	const reconnectIndex = labels.findIndex(
+		(label, index) => index > disconnectIndex && (label === 'socket.connect' || label === 'socket.reconnect'),
+	);
+
+	if (reconnectIndex <= disconnectIndex || reconnectIndex >= resubscribeIndex) {
+		throw new Error('Homey restart event-flow report recovery ordering is invalid');
+	}
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbidden = [
+		config.apiKey,
+		config.expectedHost,
+		config.write.deviceId,
+		config.write.capabilityId,
+		...config.privateTerms,
+		...(typeof config.write.value === 'string' ? [config.write.value] : []),
+	]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !['home', 'homey'].includes(item));
+	if (
+		forbidden.some((item) => serialized.includes(item)) ||
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized)
+	)
+		throw new Error('Sanitized Homey restart event-flow report contains a private value');
+}
+
+export const writeHomeyShsRestartEventFlowReport = async (
+	report: HomeyShsRestartEventFlowReport,
+	outputRoot: string,
+): Promise<string> => {
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `restart-event-flow-${suffix}`);
+	await mkdir(outputDirectory, { mode: 0o700, recursive: true });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+	return outputDirectory;
+};
+
+const run = async (): Promise<void> => {
+	const config = loadHomeyShsRestartEventFlowConfig(process.env);
+	const report = await probeHomeyShsRestartEventFlow(config, homeyRealtimeSdkFactory, sleep, () => {
+		process.stdout.write(
+			`Homey restart event-flow window is open for ${config.recoveryObserveMs} ms. Restart only the test SHS now.\n`,
+		);
+	});
+	assertHomeyShsRestartEventFlowReportSafe(report, config);
+	const outputDirectory = await writeHomeyShsRestartEventFlowReport(report, config.outputRoot);
+	process.stdout.write(`Sanitized Homey restart event-flow report written to ${outputDirectory}.\n`);
+};
+
+if (require.main === module) {
+	void run().catch((error: unknown) => {
+		process.stderr.write(`${error instanceof Error ? error.message : 'Homey restart event-flow probe failed'}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
+++ b/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
@@ -318,7 +318,7 @@ export const probeHomeyShsRestartEventFlow = async (
 		report.flow.managerResubscribed = true;
 		appendEvent(report, 'manager.resubscribe.observed');
 		await runHomeyShsSdkOperation('post-restart inventory read', config.timeoutMs, () =>
-			client.devices.getDevices({ $timeout: config.timeoutMs }),
+			client.devices.getDevices({ $cache: false, $timeout: config.timeoutMs, $updateCache: true }),
 		);
 		appendEvent(report, 'inventory.read.resolved');
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -362,6 +362,44 @@ authoritative inventory snapshot, and stopped cleanly. The reviewed reports are 
 `__fixtures__/evidence/2026-08-27-shs-13.4.1-startup-offline-recovery.json`. They contain no endpoint, host, credential,
 Homey identity, inventory content or count, device or zone identifier, event payload, firewall rule, or raw error.
 
+## Operator-controlled restart during capability event flow
+
+This mutating probe combines the previously proven allowlisted capability write with a real SHS restart in one
+subscribed SDK session. It writes the validated disposable value and requires its matching event and read-back before
+opening the restart window. After the operator restarts only the test SHS, it requires socket disconnect/reconnect,
+manager resubscription, and a fresh inventory read. It then restores the in-memory original value and requires the
+matching post-restart event and final read-back before cleanup and report creation.
+
+Use the same disposable device, capability, and harmless alternative value as the successful realtime write probe.
+Unset all other probe families, then enable the dedicated restart-event-flow acknowledgement:
+
+```bash
+unset FB_HOMEY_SHS_LIFECYCLE_ENABLE FB_HOMEY_SHS_LIFECYCLE_OPERATIONS
+unset FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER FB_HOMEY_SHS_LIFECYCLE_DRIVER_ID
+unset FB_HOMEY_SHS_LIFECYCLE_OWNER_URI FB_HOMEY_SHS_LIFECYCLE_INITIAL_NAME
+unset FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID
+unset FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID FB_HOMEY_SHS_LIFECYCLE_ADD_WINDOW_MS
+unset FB_HOMEY_SHS_LIFECYCLE_OBSERVE_MS
+unset FB_HOMEY_SHS_RECOVERY_ENABLE FB_HOMEY_SHS_RECOVERY_SCENARIO FB_HOMEY_SHS_RECOVERY_OBSERVE_MS
+unset FB_HOMEY_SHS_STARTUP_ENABLE FB_HOMEY_SHS_STARTUP_SCENARIO FB_HOMEY_SHS_STARTUP_OBSERVE_MS
+unset FB_HOMEY_SHS_CREDENTIAL_ROTATION_ENABLE FB_HOMEY_SHS_CREDENTIAL_ROTATION_OBSERVE_MS
+unset FB_HOMEY_SHS_REPLACEMENT_API_KEY
+unset FB_HOMEY_SHS_REALTIME_OBSERVE_MS
+export FB_HOMEY_SHS_WRITE_ENABLE=I_ACKNOWLEDGE_THIS_CHANGES_A_TEST_DEVICE
+export FB_HOMEY_SHS_RESTART_EVENT_FLOW_ENABLE=I_WILL_RESTART_THE_TEST_SHS_WHILE_A_DISPOSABLE_CAPABILITY_IS_CHANGED
+export FB_HOMEY_SHS_RESTART_EVENT_FLOW_RECOVERY_OBSERVE_MS=90000
+export FB_HOMEY_SHS_RESTART_EVENT_FLOW_EVENT_OBSERVE_MS=10000
+pnpm run homey:probe-restart-event-flow
+```
+
+Keep the test SHS online until the probe prints `Homey restart event-flow window is open`, then restart only that SHS
+instance. Do not change the capability manually. `FB_HOMEY_SHS_RESTART_EVENT_FLOW_RECOVERY_OBSERVE_MS` accepts `1000`
+through `300000` milliseconds and defaults to `90000`; the event window uses the same range and defaults to `10000`.
+Every SDK operation remains independently bounded by `FB_HOMEY_SHS_TIMEOUT_MS`. If restart recovery or the
+post-restart event fails, the probe still attempts exact original-value restoration before disconnecting. Check the
+test device manually after any failed run. No report can claim success unless both events, both read-backs, restoration,
+manager recovery, and complete cleanup pass.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -641,6 +641,12 @@ the offline run first verified `RECONNECTING`, then recovered through the schedu
 restored the firewall, published a fresh authoritative inventory snapshot, incremented the reconnect counter, and
 stopped cleanly. The two reviewed exact-schema reports contain only fixed event labels and completion booleans.
 
+A separately gated restart-event-flow probe is prepared for the next unchecked item. It uses the same exact disposable
+device/capability/value allowlist as the proven write probe, requires a matching capability event and read-back before
+opening the operator restart window, verifies transport and manager recovery, then restores the original value and
+requires a second matching event and read-back after restart. Failure cleanup still attempts the exact in-memory
+original-value restoration before disconnecting, and no report is written without complete restoration and teardown.
+
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow
 criterion above because no capability or availability event was observed before and after that restart.


### PR DESCRIPTION
## Summary

- add a separately gated probe that spans a capability event across an operator-controlled SHS restart
- require an exact allowlisted write event and read-back before opening the restart window
- verify socket disconnect/reconnect, manager resubscription, and a fresh post-restart inventory read
- restore the in-memory original value after recovery and require a second matching event and read-back
- reuse the reviewed realtime write validation and bounded SDK-operation helpers
- enforce restoration and complete teardown on failure before any report can be written

## Safety

- requires both the existing disposable write acknowledgement and a distinct restart-event-flow acknowledgement
- rejects lifecycle, recovery, startup, credential-rotation, replacement-key, and ordinary realtime probe gates, including empty exported values
- stores only fixed event labels and completion booleans; endpoints, credentials, identifiers, values, payloads, firewall state, and raw errors are excluded
- the probe never restarts SHS itself

## Verification

- pnpm run homey:security-gate
  - 13 Homey spike suites / 175 tests passed
  - 39 Homey and config suites / 483 tests passed
- pnpm run type-check
- focused ESLint
- restart-event-flow plus realtime suites / 20 tests passed

## Live evidence

This PR prepares the guarded harness only. The SHS restart-during-event-flow matrix item remains open until an operator run produces a reviewed sanitized report and confirms final value restoration.