### PR TITLE
test(cross): record Homey restart event-flow evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-restart-event-flow.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-restart-event-flow.json
@@ -1,0 +1,115 @@
+{
+	"metadata": {
+		"probe": "homey-shs-restart-event-flow",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"flow": {
+		"disconnectObserved": true,
+		"managerResubscribed": true,
+		"postRestartEventObserved": true,
+		"preRestartEventObserved": true,
+		"preRestartReadBackMatched": true,
+		"restorationReadBackMatched": true,
+		"restored": true,
+		"transportReconnected": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "device.subscribe.resolved",
+				"order": 3
+			},
+			{
+				"event": "pre.write.requested",
+				"order": 4
+			},
+			{
+				"event": "pre.write.event.observed",
+				"order": 5
+			},
+			{
+				"event": "pre.write.readback.verified",
+				"order": 6
+			},
+			{
+				"event": "restart.window.open",
+				"order": 7
+			},
+			{
+				"event": "socket.disconnect",
+				"order": 8
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 9
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 10
+			},
+			{
+				"event": "socket.reconnect_error",
+				"order": 11
+			},
+			{
+				"event": "socket.reconnect_attempt",
+				"order": 12
+			},
+			{
+				"event": "socket.reconnecting",
+				"order": 13
+			},
+			{
+				"event": "socket.reconnect",
+				"order": 14
+			},
+			{
+				"event": "manager.resubscribe.observed",
+				"order": 15
+			},
+			{
+				"event": "inventory.read.resolved",
+				"order": 16
+			},
+			{
+				"event": "restore.write.requested",
+				"order": 17
+			},
+			{
+				"event": "restore.write.event.observed",
+				"order": 18
+			},
+			{
+				"event": "restore.readback.verified",
+				"order": 19
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 20
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 21
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 22
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 23
+			}
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -60,6 +60,7 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-reconnect-backoff',
 	'homey-shs-credential-rotation',
 	'homey-shs-permission-scopes',
+	'homey-shs-restart-event-flow',
 ]);
 const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Locked',
@@ -6658,6 +6659,10 @@ describe('Homey security artifact gate', () => {
 		);
 		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-credential-rotation"}')).not.toThrow();
 		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-credential-rotation-private"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
+		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-restart-event-flow"}')).not.toThrow();
+		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-restart-event-flow-private"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
 		expect(() =>

--- a/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
+++ b/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
@@ -46,8 +46,12 @@ class FakeDevice extends EventEmitter implements HomeyDevice {
 class FakeManager extends EventEmitter {
 	connected = false;
 	readonly device = new FakeDevice();
+	emitCapabilityEvents = true;
 	readonly inventoryOptions: Array<{ $cache?: boolean; $timeout?: number; $updateCache?: boolean }> = [];
+	readFailuresRemaining = 0;
+	restoreFailuresRemaining = 0;
 	value = false;
+	writeAttempts: unknown[] = [];
 	writes: unknown[] = [];
 
 	connect(): Promise<void> {
@@ -61,6 +65,12 @@ class FakeManager extends EventEmitter {
 	}
 
 	getCapabilityValue(): Promise<unknown> {
+		if (this.readFailuresRemaining > 0) {
+			this.readFailuresRemaining -= 1;
+
+			return Promise.reject(new Error('raw restart read readiness detail'));
+		}
+
 		return Promise.resolve(this.value);
 	}
 
@@ -77,9 +87,18 @@ class FakeManager extends EventEmitter {
 	}
 
 	setCapabilityValue(options: { capabilityId: string; value: unknown }): Promise<void> {
+		this.writeAttempts.push(options.value);
+
+		if (options.value === false && this.restoreFailuresRemaining > 0) {
+			this.restoreFailuresRemaining -= 1;
+
+			return Promise.reject(new Error('raw restart readiness detail'));
+		}
+
 		this.value = options.value as boolean;
 		this.writes.push(options.value);
-		this.device.emit('capability', { capabilityId: options.capabilityId, value: options.value });
+		if (this.emitCapabilityEvents)
+			this.device.emit('capability', { capabilityId: options.capabilityId, value: options.value });
 		return Promise.resolve();
 	}
 }
@@ -161,6 +180,50 @@ describe('Homey SHS restart event-flow probe', () => {
 		expect(() => assertHomeyShsRestartEventFlowReportSafe(report, config())).not.toThrow();
 	});
 
+	it('uses authoritative read-back before a bounded restoration retry after restart', async () => {
+		const { client, factory } = createFactory();
+		client.devices.restoreFailuresRemaining = 1;
+		const report = await probeHomeyShsRestartEventFlow(
+			config(),
+			factory,
+			() => Promise.resolve(),
+			() => {
+				client.restart();
+				client.devices.readFailuresRemaining = 1;
+			},
+		);
+
+		expect(report.flow.restored).toBe(true);
+		expect(client.devices.writeAttempts).toStrictEqual([true, false, false]);
+		expect(client.devices.writes).toStrictEqual([true, false]);
+		expect(client.devices.restoreFailuresRemaining).toBe(0);
+	});
+
+	it('rejects the run when restoration succeeds without a post-restart capability event', async () => {
+		const { client, factory } = createFactory();
+		let now = 0;
+		const dateNow = jest.spyOn(Date, 'now').mockImplementation(() => now);
+		const advance = (milliseconds: number): Promise<void> => {
+			now += milliseconds;
+
+			return Promise.resolve();
+		};
+
+		try {
+			await expect(
+				probeHomeyShsRestartEventFlow(config(), factory, advance, () => {
+					client.restart();
+					client.devices.emitCapabilityEvents = false;
+				}),
+			).rejects.toThrow('post-restart restoration event timed out');
+			expect(client.devices.writes).toStrictEqual([true, false]);
+			expect(client.devices.value).toBe(false);
+			expect(client.destroyCount).toBe(1);
+		} finally {
+			dateNow.mockRestore();
+		}
+	});
+
 	it('restores the original value and cleans up when restart observation fails', async () => {
 		const { client, factory } = createFactory();
 		let now = 0;
@@ -207,6 +270,29 @@ describe('Homey SHS restart event-flow probe', () => {
 				config(),
 			),
 		).toThrow();
+	});
+
+	it('preserves the sanitized live SHS restart event-flow evidence', async () => {
+		const evidencePath = join(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-27-shs-13.4.1-restart-event-flow.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+
+		assertHomeyShsRestartEventFlowReportSafe(evidence, config());
+		expect(evidence).toMatchObject({
+			flow: {
+				disconnectObserved: true,
+				managerResubscribed: true,
+				postRestartEventObserved: true,
+				preRestartEventObserved: true,
+				restorationReadBackMatched: true,
+				restored: true,
+				transportReconnected: true,
+			},
+			session: { cleanupCompleted: true, managerSubscribed: true },
+		});
+		expect(evidence.session.events).toHaveLength(23);
 	});
 
 	it('writes the report beneath a private non-overwriting directory', async () => {

--- a/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
+++ b/apps/backend/test/homey-shs-restart-event-flow.homey-spike.ts
@@ -180,7 +180,7 @@ describe('Homey SHS restart event-flow probe', () => {
 		expect(() => assertHomeyShsRestartEventFlowReportSafe(report, config())).not.toThrow();
 	});
 
-	it('uses authoritative read-back before a bounded restoration retry after restart', async () => {
+	it('counts only writes against the restoration budget while SHS readiness reads fail', async () => {
 		const { client, factory } = createFactory();
 		client.devices.restoreFailuresRemaining = 1;
 		const report = await probeHomeyShsRestartEventFlow(
@@ -189,7 +189,7 @@ describe('Homey SHS restart event-flow probe', () => {
 			() => Promise.resolve(),
 			() => {
 				client.restart();
-				client.devices.readFailuresRemaining = 1;
+				client.devices.readFailuresRemaining = 3;
 			},
 		);
 

--- a/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
+++ b/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
@@ -25,6 +25,8 @@ const DEFAULT_EVENT_OBSERVE_MS = 10_000;
 const MIN_OBSERVE_MS = 1_000;
 const MAX_OBSERVE_MS = 300_000;
 const POLL_MS = 100;
+const RESTORE_RETRY_MS = 5_000;
+const MAX_RESTORE_ATTEMPTS = 3;
 const CONFLICTING_PREFIXES = [
 	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
 	'FB_HOMEY_SHS_LIFECYCLE_',
@@ -198,6 +200,47 @@ const capabilityWrite = async (
 	);
 };
 
+const restoreCapabilityValue = async (
+	client: HomeySdkClient,
+	config: HomeyShsRestartEventFlowConfig,
+	originalValue: HomeyScalar,
+	wait: HomeyRestartEventFlowWait,
+): Promise<boolean> => {
+	const deadline = Date.now() + config.recoveryObserveMs;
+
+	for (let attempt = 0; attempt < MAX_RESTORE_ATTEMPTS; attempt += 1) {
+		if (attempt > 0 && Date.now() >= deadline) break;
+		let currentValue: unknown;
+
+		try {
+			currentValue = await scalarRead(client, config);
+		} catch {
+			// SHS can accept its socket namespace before the device API is ready after a container restart.
+		}
+
+		if (currentValue !== undefined) {
+			if (Object.is(currentValue, originalValue)) return true;
+
+			try {
+				await capabilityWrite(client, config, originalValue);
+			} catch {
+				// Read back before retrying because an idempotent write may apply despite a timed-out response.
+			}
+		}
+
+		const remaining = deadline - Date.now();
+
+		if (remaining <= 0) break;
+		await wait(Math.min(RESTORE_RETRY_MS, remaining));
+	}
+
+	try {
+		return Object.is(await scalarRead(client, config), originalValue);
+	} catch {
+		return false;
+	}
+};
+
 export const probeHomeyShsRestartEventFlow = async (
 	config: HomeyShsRestartEventFlowConfig,
 	factory: HomeySdkFactory = homeyRealtimeSdkFactory,
@@ -317,15 +360,16 @@ export const probeHomeyShsRestartEventFlow = async (
 		await waitUntil('manager resubscription', config.timeoutMs, () => managerConnected(client), wait);
 		report.flow.managerResubscribed = true;
 		appendEvent(report, 'manager.resubscribe.observed');
-		await runHomeyShsSdkOperation('post-restart inventory read', config.timeoutMs, () =>
+		const recoveredDevices = await runHomeyShsSdkOperation('post-restart inventory read', config.timeoutMs, () =>
 			client.devices.getDevices({ $cache: false, $timeout: config.timeoutMs, $updateCache: true }),
 		);
 		appendEvent(report, 'inventory.read.resolved');
+		assertSafeHomeyWriteTarget(recoveredDevices, config.write);
 
 		phase = 'restore';
 		appendEvent(report, 'restore.write.requested');
-		await capabilityWrite(client, config, originalValue);
-		report.flow.restored = true;
+		report.flow.restored = await restoreCapabilityValue(client, config, originalValue, wait);
+		if (!report.flow.restored) throw new Error('Homey capability restoration timed out after SHS restart');
 		await waitUntil(
 			'post-restart restoration event',
 			config.eventObserveMs,
@@ -342,17 +386,12 @@ export const probeHomeyShsRestartEventFlow = async (
 				: new Error('Homey restart event-flow verification failed');
 	} finally {
 		restartWindowOpen = false;
-		phase = null;
 		if (writeAttempted && originalValue !== undefined && !report.flow.restorationReadBackMatched) {
-			try {
-				await capabilityWrite(client, config, originalValue);
-				report.flow.restored = true;
-				report.flow.restorationReadBackMatched = Object.is(await scalarRead(client, config), originalValue);
-				if (!report.flow.restorationReadBackMatched) cleanupFailures.push('capability restoration');
-			} catch {
-				cleanupFailures.push('capability restoration');
-			}
+			report.flow.restored = await restoreCapabilityValue(client, config, originalValue, wait);
+			report.flow.restorationReadBackMatched = report.flow.restored;
+			if (!report.flow.restorationReadBackMatched) cleanupFailures.push('capability restoration');
 		}
+		phase = null;
 		const cleanup = async (
 			label: string,
 			resolved: string,

--- a/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
+++ b/apps/backend/test/support/homey-shs-restart-event-flow-probe.ts
@@ -207,9 +207,9 @@ const restoreCapabilityValue = async (
 	wait: HomeyRestartEventFlowWait,
 ): Promise<boolean> => {
 	const deadline = Date.now() + config.recoveryObserveMs;
+	let writeAttempts = 0;
 
-	for (let attempt = 0; attempt < MAX_RESTORE_ATTEMPTS; attempt += 1) {
-		if (attempt > 0 && Date.now() >= deadline) break;
+	while (Date.now() <= deadline) {
 		let currentValue: unknown;
 
 		try {
@@ -220,25 +220,29 @@ const restoreCapabilityValue = async (
 
 		if (currentValue !== undefined) {
 			if (Object.is(currentValue, originalValue)) return true;
+			if (writeAttempts >= MAX_RESTORE_ATTEMPTS) return false;
+			writeAttempts += 1;
 
 			try {
 				await capabilityWrite(client, config, originalValue);
 			} catch {
 				// Read back before retrying because an idempotent write may apply despite a timed-out response.
 			}
+
+			try {
+				if (Object.is(await scalarRead(client, config), originalValue)) return true;
+			} catch {
+				// A failed confirmation consumes no additional write attempt; readiness is checked again below.
+			}
 		}
 
 		const remaining = deadline - Date.now();
 
-		if (remaining <= 0) break;
+		if (remaining <= 0) return false;
 		await wait(Math.min(RESTORE_RETRY_MS, remaining));
 	}
 
-	try {
-		return Object.is(await scalarRead(client, config), originalValue);
-	} catch {
-		return false;
-	}
+	return false;
 };
 
 export const probeHomeyShsRestartEventFlow = async (

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -1,8 +1,8 @@
 # Homey SHS Compatibility Record
 
-**Status:** In progress; safe inventory, production-service startup/recovery, SDK session/cleanup, SHS restart and
-network recovery, disposable-device lifecycle, and stable restart-spanning mDNS evidence captured; automatic mDNS
-discovery remains deferred, and physical/Homey-originated availability-event continuity is pending
+**Status:** In progress; safe inventory, production-service startup/recovery, SDK session/cleanup, restart-spanning
+capability events, network recovery, disposable-device lifecycle, and stable restart-spanning mDNS evidence captured;
+automatic mDNS discovery remains deferred, and physical/Homey-originated availability-event continuity is pending
 
 **Started:** 2026-08-12
 
@@ -400,6 +400,13 @@ post-restart event fails, the probe still attempts exact original-value restorat
 test device manually after any failed run. No report can claim success unless both events, both read-backs, restoration,
 manager recovery, and complete cleanup pass.
 
+On 2026-08-27, the guarded probe passed against SHS `13.4.1`. Its 23 ordered events prove the allowlisted request,
+matching event, and read-back before restart; socket disconnect, two reconnect attempts, manager resubscription, and a
+fresh uncached inventory read during recovery; then original-value restoration, its matching post-restart event and
+read-back, and complete teardown. The exact-schema report is committed as
+`__fixtures__/evidence/2026-08-27-shs-13.4.1-restart-event-flow.json` and contains no endpoint, credential, Homey or
+device identity, capability identifier/value, inventory content, or raw error.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It
@@ -746,7 +753,7 @@ Fill this matrix using synthetic aliases only.
 | Availability events                       | Absent for synthetic test driver    | Unavailable/restored read-backs passed after full ten-second event windows; physical/Homey-originated evidence remains pending                       |
 | Allowlisted write, event, and read-back   | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
-| SHS restart and reconnect                 | Pass                                | 15 ordered events proved disconnect, two observed retries, resubscription, fresh inventory read, and complete cleanup                                |
+| SHS restart and reconnect                 | Pass                                | A 23-event write/restart/restore run proved events and read-backs across recovery; the earlier 15-event run independently proved transport recovery  |
 | API-key revocation and replacement        | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |
 | Disposable-device lifecycle sequence      | Pass                                | Exact add, rename, zone move, unavailable, restore, removal, and final absence passed; omitted create/update events were recorded and read back      |
 | Stable mDNS service before/after restart  | Pass                                | Ten-second pre/post observations were exact matches: `_homey._tcp` on `4859` plus two co-hosted `_hap._tcp` services                                 |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -620,7 +620,7 @@ representative lifecycle failure paths.
 
 - [x] Fresh startup with SHS online.
 - [x] Startup with SHS offline, then recovery.
-- [ ] SHS restart during event flow.
+- [x] SHS restart during event flow.
 - [x] Network interruption/restoration.
 - [x] API key revoked, replaced, and insufficiently scoped.
 - [x] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
@@ -641,11 +641,12 @@ the offline run first verified `RECONNECTING`, then recovered through the schedu
 restored the firewall, published a fresh authoritative inventory snapshot, incremented the reconnect counter, and
 stopped cleanly. The two reviewed exact-schema reports contain only fixed event labels and completion booleans.
 
-A separately gated restart-event-flow probe is prepared for the next unchecked item. It uses the same exact disposable
-device/capability/value allowlist as the proven write probe, requires a matching capability event and read-back before
-opening the operator restart window, verifies transport and manager recovery, then restores the original value and
-requires a second matching event and read-back after restart. Failure cleanup still attempts the exact in-memory
-original-value restoration before disconnecting, and no report is written without complete restoration and teardown.
+The separately gated restart-event-flow probe passed on 2026-08-27 against SHS `13.4.1`. Its 23 ordered events prove a
+matching capability event and read-back before restart, socket disconnect and reconnect, manager resubscription, a
+fresh uncached inventory read, then original-value restoration with a second matching event and read-back after
+restart. Complete device, manager, socket, and SDK cleanup followed. The reviewed exact-schema report contains only
+fixed event labels and completion booleans; failure cleanup uses state-aware, bounded restoration and never writes a
+success report without complete restoration and teardown.
 
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow


### PR DESCRIPTION
## Summary

- preserve the sanitized 23-event SHS restart event-flow report
- require capability events and authoritative read-backs before and after restart
- harden restoration with bounded, state-aware retries after SHS recovery
- mark the restart-during-event-flow compatibility item complete

## Live evidence

The guarded SHS 13.4.1 run observed the allowlisted capability event and read-back before restart, socket disconnect and reconnect attempts, manager resubscription, a fresh uncached inventory read, restoration event and read-back after restart, and complete cleanup. The committed exact-schema fixture contains no endpoint, credential, Homey/device identity, capability identifier/value, inventory content, or raw error.

## Verification

- `pnpm run homey:security-gate`
  - 13 Homey spike suites / 178 tests
  - 39 Homey/config suites / 483 tests
- focused realtime and restart-event-flow suites / 23 tests
- backend type-check and ESLint
- OpenAPI generation and backend build