### PR TITLE
test(backend): add Homey originated event evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -111,5 +111,10 @@ records healthy connection, authoritative inventory availability, and cleanup. T
 records the initial `RECONNECTING` state and successful scheduled retry after operator-controlled restoration of only
 the test SHS network path. Neither report contains an endpoint, host, credential, Homey identity, inventory content or
 count, device or zone identifier, event payload, firewall rule, response body, or raw error.
+The three 2026-08-28 origin-event reports record physical-control, Homey-app, and Homey-Flow changes against SHS
+`13.4.1`. Each report proves a matching subscribed capability event and authoritative read-back, followed by a
+same-origin restoration event, final baseline read-back, and complete teardown. They contain no endpoint, credential,
+Homey identity, device or capability identifier, capability value, inventory content, event payload, Flow identity,
+response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-flow.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-flow.json
@@ -1,0 +1,82 @@
+{
+	"metadata": {
+		"probe": "homey-shs-origin-event",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"baselineRead": true,
+		"changeEventObserved": true,
+		"changeReadBackMatched": true,
+		"restorationEventObserved": true,
+		"restorationReadBackMatched": true,
+		"restored": true,
+		"scenario": "flow"
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.read.resolved",
+				"order": 3
+			},
+			{
+				"event": "device.subscribe.resolved",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "change.window.open",
+				"order": 6
+			},
+			{
+				"event": "change.event.observed",
+				"order": 7
+			},
+			{
+				"event": "change.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restore.window.open",
+				"order": 9
+			},
+			{
+				"event": "restore.event.observed",
+				"order": 10
+			},
+			{
+				"event": "restore.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 12
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 13
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 14
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 15
+			}
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-homey.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-homey.json
@@ -1,0 +1,82 @@
+{
+	"metadata": {
+		"probe": "homey-shs-origin-event",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"baselineRead": true,
+		"changeEventObserved": true,
+		"changeReadBackMatched": true,
+		"restorationEventObserved": true,
+		"restorationReadBackMatched": true,
+		"restored": true,
+		"scenario": "homey"
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.read.resolved",
+				"order": 3
+			},
+			{
+				"event": "device.subscribe.resolved",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "change.window.open",
+				"order": 6
+			},
+			{
+				"event": "change.event.observed",
+				"order": 7
+			},
+			{
+				"event": "change.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restore.window.open",
+				"order": 9
+			},
+			{
+				"event": "restore.event.observed",
+				"order": 10
+			},
+			{
+				"event": "restore.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 12
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 13
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 14
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 15
+			}
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-physical.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-physical.json
@@ -1,0 +1,82 @@
+{
+	"metadata": {
+		"probe": "homey-shs-origin-event",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"baselineRead": true,
+		"changeEventObserved": true,
+		"changeReadBackMatched": true,
+		"restorationEventObserved": true,
+		"restorationReadBackMatched": true,
+		"restored": true,
+		"scenario": "physical"
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "sdk.create.resolved",
+				"order": 1
+			},
+			{
+				"event": "manager.subscribe.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.read.resolved",
+				"order": 3
+			},
+			{
+				"event": "device.subscribe.resolved",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "change.window.open",
+				"order": 6
+			},
+			{
+				"event": "change.event.observed",
+				"order": 7
+			},
+			{
+				"event": "change.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restore.window.open",
+				"order": 9
+			},
+			{
+				"event": "restore.event.observed",
+				"order": 10
+			},
+			{
+				"event": "restore.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "device.unsubscribe.resolved",
+				"order": 12
+			},
+			{
+				"event": "manager.unsubscribe.resolved",
+				"order": 13
+			},
+			{
+				"event": "socket.disconnect.resolved",
+				"order": 14
+			},
+			{
+				"event": "sdk.destroyed",
+				"order": 15
+			}
+		],
+		"managerSubscribed": true
+	}
+}

--- a/apps/backend/test/homey-shs-origin-event.homey-spike.ts
+++ b/apps/backend/test/homey-shs-origin-event.homey-spike.ts
@@ -250,6 +250,39 @@ describe('Homey SHS origin-event probe', () => {
 		).toThrow();
 	});
 
+	it.each([
+		{
+			filename: '2026-08-28-shs-13.4.1-origin-physical.json',
+			scenario: 'physical',
+		},
+		{
+			filename: '2026-08-28-shs-13.4.1-origin-homey.json',
+			scenario: 'homey',
+		},
+		{
+			filename: '2026-08-28-shs-13.4.1-origin-flow.json',
+			scenario: 'flow',
+		},
+	] as const)('preserves the sanitized live SHS $scenario-origin evidence', async ({ filename, scenario }) => {
+		const evidencePath = join(__dirname, '../src/plugins/devices-homey/__fixtures__/evidence', filename);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+
+		assertHomeyShsOriginEventReportSafe(evidence, config({ scenario }));
+		expect(evidence).toMatchObject({
+			observation: {
+				baselineRead: true,
+				changeEventObserved: true,
+				changeReadBackMatched: true,
+				restorationEventObserved: true,
+				restorationReadBackMatched: true,
+				restored: true,
+				scenario,
+			},
+			session: { cleanupCompleted: true, managerSubscribed: true },
+		});
+		expect(evidence.session.events).toHaveLength(15);
+	});
+
 	it('writes the report beneath a private non-overwriting directory', async () => {
 		const { report } = await successfulProbe();
 		const root = await mkdtemp(join(tmpdir(), 'homey-origin-event-'));

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -458,6 +458,16 @@ run cannot restore the target itself because all Smart Panel write gates are pro
 second operator action did not complete. `FB_HOMEY_SHS_ORIGIN_EVENT_OBSERVE_MS` accepts `1000` through `300000`
 milliseconds and independently bounds both operator windows and each read-back convergence window.
 
+On 2026-08-28, all three scenarios passed against SHS `13.4.1`. Physical control, the Homey app, and a designated
+Homey Flow each produced the subscribed capability-change event and matching authoritative read-back; the same origin
+then restored the baseline with a second event and final read-back. Every run completed device, manager, socket, and
+SDK teardown. The reviewed reports are committed as
+`__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-physical.json`,
+`__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-homey.json`, and
+`__fixtures__/evidence/2026-08-28-shs-13.4.1-origin-flow.json`. They contain no endpoint, credential, Homey identity,
+device or capability identifier, capability value, inventory content, event payload, Flow identity, response body, or
+raw error.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -624,7 +624,7 @@ representative lifecycle failure paths.
 - [x] Network interruption/restoration.
 - [x] API key revoked, replaced, and insufficiently scoped.
 - [x] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
-- [ ] Physical/Homey/flow-originated state changes.
+- [x] Physical/Homey/flow-originated state changes.
 - [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.
 - [ ] Plugin disable/enable and backend shutdown with no leaked connections/timers.
@@ -648,12 +648,12 @@ restart. Complete device, manager, socket, and SDK cleanup followed. The reviewe
 fixed event labels and completion booleans; failure cleanup uses state-aware, bounded restoration and never writes a
 success report without complete restoration and teardown.
 
-A separately gated, non-writing origin-event probe is prepared for the next unchecked item. It binds one exact
-device/capability and accepts `physical`, `homey`, or `flow` as fixed scenario labels. For each run it requires an
-operator-originated scalar change event plus authoritative read-back, then a same-origin restoration event and final
-baseline read-back before complete teardown. Baseline and changed values remain in memory only, all Smart Panel write
-gates are prohibited, and the matrix item remains unchecked until reviewed live evidence exists for the required
-origins.
+The separately gated, non-writing origin-event probe passed all three scenarios on 2026-08-28 against SHS `13.4.1`.
+Physical control, the Homey app, and a designated Homey Flow each produced a matching subscribed capability event and
+authoritative read-back, followed by a same-origin restoration event, final baseline read-back, and complete teardown.
+The three reviewed exact-schema reports retain only fixed scenario/event labels, ordering numbers, public SDK version,
+and completion booleans; they contain no endpoint, credential, Homey identity, device or capability identifier,
+capability value, inventory content, event payload, Flow identity, response body, or raw error.
 
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow


### PR DESCRIPTION
## Summary

- promote reviewed SHS 13.4.1 reports for physical-control, Homey-app, and Homey-Flow capability changes
- prove matching subscribed events, authoritative read-backs, same-origin restoration, and complete teardown
- add focused safety assertions and close the corresponding Task 6.2 live-matrix item

## Privacy

The reports contain only fixed scenario/event labels, event ordering, public SDK version, and completion booleans. They contain no endpoint, credential, Homey identity, device or capability identifier, capability value, inventory content, event payload, Flow identity, response body, or raw error.

## Verification

- focused origin-event and security-artifact suites: 2 suites / 17 tests passed
- pnpm run type-check
- ESLint on the changed TypeScript test
- pnpm run homey:security-gate: 14 suites / 191 tests and 39 suites / 483 tests passed
- semantic comparison of every promoted report with its private capture source
- git diff --check