### PR TITLE
test(backend): add Homey mapping-family control probe

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,6 +87,7 @@
     "homey:probe-startup": "ts-node --project tsconfig.json test/support/homey-shs-startup-probe.ts",
     "homey:probe-restart-event-flow": "ts-node --project tsconfig.json test/support/homey-shs-restart-event-flow-probe.ts",
     "homey:probe-origin-event": "ts-node --project tsconfig.json test/support/homey-shs-origin-event-probe.ts",
+    "homey:probe-mapping-control": "ts-node --project tsconfig.json test/support/homey-shs-mapping-control-probe.ts",
     "homey:promote-fixtures": "ts-node --project tsconfig.json test/support/promote-homey-shs-fixtures.ts",
     "type-check": "tsc --noEmit",
     "typeorm:migration:generate": "ts-node-esm --project tsconfig.json --transpile-only ./node_modules/typeorm/cli.js migration:generate -d ./src/dataSource.ts",

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.spec.ts
@@ -1483,6 +1483,28 @@ describe('HomeyService', () => {
 		await expect(second).resolves.toBe(false);
 	});
 
+	it('waits for a retained timed-out capability write to become idle', async () => {
+		const pendingWrite = deferred();
+		let idle = false;
+
+		connector.setCapabilityValue.mockClear().mockImplementationOnce(() => pendingWrite.promise);
+		await service.start();
+		const command = service.executeCapabilityCommand(staleDevice.id, 'onoff', true);
+		await flushMicrotasks();
+		await jest.advanceTimersByTimeAsync(HOMEY_COMMAND_WRITE_TIMEOUT_MS);
+		await expect(command).resolves.toBe(false);
+		const waiting = service.waitForCapabilityCommandIdle(staleDevice.id, 'onoff').then(() => {
+			idle = true;
+		});
+
+		await flushMicrotasks();
+		expect(idle).toBe(false);
+		pendingWrite.resolve();
+		await waiting;
+		expect(idle).toBe(true);
+		await service.stop();
+	});
+
 	it('cancels an active write and its queued successor when the connector stops', async () => {
 		await service.start();
 		connector.setCapabilityValue.mockClear().mockImplementationOnce(() => new Promise(() => undefined));

--- a/apps/backend/src/plugins/devices-homey/services/homey.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey.service.ts
@@ -348,6 +348,24 @@ export class HomeyService extends BaseManagedPluginService {
 		return successful;
 	}
 
+	async waitForCapabilityCommandIdle(deviceId: string, capabilityId: string): Promise<void> {
+		const key = this.commandKey(deviceId, capabilityId);
+
+		while (true) {
+			const tail = this.commandTails.get(key);
+
+			if (tail === undefined) {
+				return;
+			}
+
+			await tail;
+
+			if (this.commandTails.get(key) === tail) {
+				return;
+			}
+		}
+	}
+
 	async getFreshDevice(deviceId: string): Promise<HomeyDevice | null> {
 		const connector = this.connector;
 

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -59,6 +59,7 @@ const PUBLIC_HOMEY_TOKEN_COLLISIONS = new Set([
 	'homey-plugin-device-mapping',
 	'homey-reconnect-backoff',
 	'homey-shs-credential-rotation',
+	'homey-shs-mapping-control',
 	'homey-shs-origin-event',
 	'homey-shs-permission-scopes',
 	'homey-shs-restart-event-flow',
@@ -174,6 +175,20 @@ const configuredOriginEventCapabilityId = (): string | undefined => {
 	return value === undefined || isPublicHomeyCapabilityBase(value) ? undefined : value;
 };
 
+const configuredMappingControlCapabilityId = (): string | undefined => {
+	const value = process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID?.trim();
+
+	return value === undefined || isPublicHomeyCapabilityBase(value) ? undefined : value;
+};
+
+const configuredPrivateMappingControlPanelValue = (): string | undefined => {
+	const value = process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE?.trim();
+
+	return value === undefined || ['true', 'false'].includes(value.toLowerCase()) || Number.isFinite(Number(value))
+		? undefined
+		: value;
+};
+
 const configuredPrivateValues = (): readonly string[] =>
 	[
 		process.env.FB_HOMEY_SHS_API_KEY,
@@ -189,6 +204,9 @@ const configuredPrivateValues = (): readonly string[] =>
 		process.env.FB_HOMEY_SHS_LIFECYCLE_RENAMED_NAME,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_SOURCE_ZONE_ID,
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DESTINATION_ZONE_ID,
+		process.env.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID,
+		configuredMappingControlCapabilityId(),
+		configuredPrivateMappingControlPanelValue(),
 		process.env.FB_HOMEY_SHS_ORIGIN_EVENT_DEVICE_ID,
 		configuredOriginEventCapabilityId(),
 		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID,
@@ -6678,6 +6696,10 @@ describe('Homey security artifact gate', () => {
 		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-origin-event-private"}')).toThrow(
 			'unsafe fixture contains a Homey personal access token',
 		);
+		expect(() => assertTextSafe('safe fixture', '{"probe":"homey-shs-mapping-control"}')).not.toThrow();
+		expect(() => assertTextSafe('unsafe fixture', '{"probe":"homey-shs-mapping-control-private"}')).toThrow(
+			'unsafe fixture contains a Homey personal access token',
+		);
 		expect(() =>
 			assertTextSafe('unsafe compiled module', 'throw new Error("request failed for homey_abcdefghijklmnop")', true),
 		).toThrow('unsafe compiled module contains a Homey personal access token');
@@ -8237,6 +8259,9 @@ describe('Homey security artifact gate', () => {
 		const previousDeviceOnlyApiKey = process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY;
 		const previousExpectedHost = process.env.FB_HOMEY_SHS_EXPECTED_HOST;
 		const previousLifecycleDeviceMarker = process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER;
+		const previousMappingControlDeviceId = process.env.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID;
+		const previousMappingControlCapabilityId = process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID;
+		const previousMappingControlPanelValue = process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE;
 		const previousOriginEventDeviceId = process.env.FB_HOMEY_SHS_ORIGIN_EVENT_DEVICE_ID;
 		const previousOriginEventCapabilityId = process.env.FB_HOMEY_SHS_ORIGIN_EVENT_CAPABILITY_ID;
 		const previousWriteDeviceId = process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID;
@@ -8248,6 +8273,9 @@ describe('Homey security artifact gate', () => {
 		process.env.FB_HOMEY_SHS_DEVICE_ONLY_API_KEY = 'opaque-device-value';
 		process.env.FB_HOMEY_SHS_EXPECTED_HOST = 'homey.local';
 		process.env.FB_HOMEY_SHS_LIFECYCLE_DEVICE_MARKER = 'private-lifecycle-marker';
+		process.env.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID = 'private-mapping-control-device';
+		process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID = 'private-mapping-control-capability';
+		process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE = 'private-mapping-control-value';
 		process.env.FB_HOMEY_SHS_ORIGIN_EVENT_DEVICE_ID = 'private-origin-device';
 		process.env.FB_HOMEY_SHS_ORIGIN_EVENT_CAPABILITY_ID = 'private-origin-capability';
 		process.env.FB_HOMEY_SHS_WRITE_DEVICE_ID = 'private-write-device';
@@ -8277,6 +8305,15 @@ describe('Homey security artifact gate', () => {
 					'unsafe fixture contains a configured private Homey value',
 				);
 			}
+			for (const privateMappingControlValue of [
+				'private-mapping-control-device',
+				'private-mapping-control-capability',
+				'private-mapping-control-value',
+			]) {
+				expect(() => assertTextSafe('unsafe fixture', `{"value":"${privateMappingControlValue}"}`)).toThrow(
+					'unsafe fixture contains a configured private Homey value',
+				);
+			}
 			for (const privateWriteValue of ['private-write-device', 'private-write-capability', 'private-write-value']) {
 				expect(() => assertTextSafe('unsafe fixture', `{"value":"${privateWriteValue}"}`)).toThrow(
 					'unsafe fixture contains a configured private Homey value',
@@ -8285,6 +8322,8 @@ describe('Homey security artifact gate', () => {
 
 			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'onoff';
 			process.env.FB_HOMEY_SHS_ORIGIN_EVENT_CAPABILITY_ID = 'onoff';
+			process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID = 'onoff';
+			process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE = 'true';
 			expect(() => assertTextSafe('safe fixture', '{"capability":"onoff"}')).not.toThrow();
 			process.env.FB_HOMEY_SHS_WRITE_CAPABILITY_ID = 'power_on_behavior';
 			process.env.FB_HOMEY_SHS_WRITE_VALUE = '"off"';
@@ -8329,6 +8368,24 @@ describe('Homey security artifact gate', () => {
 				delete process.env.FB_HOMEY_SHS_ORIGIN_EVENT_DEVICE_ID;
 			} else {
 				process.env.FB_HOMEY_SHS_ORIGIN_EVENT_DEVICE_ID = previousOriginEventDeviceId;
+			}
+
+			if (previousMappingControlDeviceId === undefined) {
+				delete process.env.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID;
+			} else {
+				process.env.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID = previousMappingControlDeviceId;
+			}
+
+			if (previousMappingControlCapabilityId === undefined) {
+				delete process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID;
+			} else {
+				process.env.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID = previousMappingControlCapabilityId;
+			}
+
+			if (previousMappingControlPanelValue === undefined) {
+				delete process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE;
+			} else {
+				process.env.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE = previousMappingControlPanelValue;
 			}
 
 			if (previousOriginEventCapabilityId === undefined) {

--- a/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
@@ -38,6 +38,7 @@ class FakeBinding implements HomeyMappingControlBinding {
 	readonly baselinePanelValue = false;
 	readonly targetPanelValue = true;
 	readonly commands: Array<string | number | boolean> = [];
+	afterCommand: ((value: string | number | boolean) => void) | undefined;
 	current: string | number | boolean = false;
 	failCommandAt = new Set<number>();
 	failReadBackAt = new Set<number>();
@@ -46,6 +47,7 @@ class FakeBinding implements HomeyMappingControlBinding {
 	command(value: string | number | boolean): Promise<boolean> {
 		this.commands.push(value);
 		this.current = value;
+		this.afterCommand?.(value);
 
 		return Promise.resolve(!this.failCommandAt.has(this.commands.length));
 	}
@@ -54,6 +56,10 @@ class FakeBinding implements HomeyMappingControlBinding {
 		this.readBackCount += 1;
 
 		return Promise.resolve(this.current === value && !this.failReadBackAt.has(this.readBackCount));
+	}
+
+	waitForCommandIdle(): Promise<void> {
+		return Promise.resolve();
 	}
 }
 
@@ -169,10 +175,60 @@ describe('Homey SHS mapping-control probe', () => {
 		expect(runtime.stopCount).toBe(1);
 	});
 
+	it('waits for a timed-out command tail before restoring the baseline', async () => {
+		const runtime = new FakeRuntime();
+		let releaseCommandTail = (): void => undefined;
+		const commandTail = new Promise<void>((resolve) => {
+			releaseCommandTail = resolve;
+		});
+		let idleWaits = 0;
+
+		runtime.binding.failCommandAt.add(1);
+		runtime.binding.waitForCommandIdle = async (): Promise<void> => {
+			idleWaits += 1;
+
+			if (idleWaits === 1) await commandTail;
+		};
+		const probe = probeHomeyShsMappingControl(config(), () => runtime);
+
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(runtime.binding.commands).toStrictEqual([true]);
+		releaseCommandTail();
+		await expect(probe).rejects.toThrow('rejected or unconfirmed');
+		expect(runtime.binding.commands).toStrictEqual([true, false]);
+		expect(runtime.binding.current).toBe(false);
+		expect(runtime.stopCount).toBe(1);
+	});
+
+	it.each(['SIGINT', 'SIGTERM'] as const)('restores and stops before completing %s termination', async (signal) => {
+		const runtime = new FakeRuntime();
+		const listeners = new Map<string, () => void>();
+		const signalSource = {
+			on: (name: string, listener: () => void): void => {
+				listeners.set(name, listener);
+			},
+			off: (name: string, listener: () => void): void => {
+				if (listeners.get(name) === listener) listeners.delete(name);
+			},
+		};
+		runtime.binding.afterCommand = (value): void => {
+			if (value === runtime.binding.targetPanelValue) listeners.get(signal)?.();
+		};
+
+		await expect(probeHomeyShsMappingControl(config(), () => runtime, signalSource)).rejects.toThrow(
+			`received ${signal}; restoration completed before termination`,
+		);
+		expect(runtime.binding.commands).toStrictEqual([true, false]);
+		expect(runtime.binding.current).toBe(false);
+		expect(runtime.stopCount).toBe(1);
+		expect(listeners.size).toBe(0);
+	});
+
 	it('fails closed when restoration cannot be confirmed and always stops the service', async () => {
 		const runtime = new FakeRuntime();
 		runtime.binding.failCommandAt.add(2);
 		runtime.binding.failCommandAt.add(3);
+		runtime.binding.failReadBackAt.add(2);
 
 		await expect(probeHomeyShsMappingControl(config(), () => runtime)).rejects.toThrow(
 			'cleanup failed: capability restoration',

--- a/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
@@ -1,0 +1,233 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	HOMEY_MAPPING_CONTROL_MAPPINGS,
+	type HomeyMappingControlBinding,
+	type HomeyMappingControlRuntime,
+	type HomeyShsMappingControlConfig,
+	assertHomeyShsMappingControlReportSafe,
+	loadHomeyShsMappingControlConfig,
+	probeHomeyShsMappingControl,
+	writeHomeyShsMappingControlReport,
+} from './support/homey-shs-mapping-control-probe';
+
+const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
+	FB_HOMEY_SHS_API_KEY: 'test-api-key-that-must-not-leak',
+	FB_HOMEY_SHS_EXPECTED_HOST: '127.0.0.1',
+	FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID: 'test-capability-that-must-not-leak',
+	FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID: 'test-device-that-must-not-leak',
+	FB_HOMEY_SHS_MAPPING_CONTROL_ENABLE:
+		'I_WILL_USE_SMART_PANEL_TO_CONTROL_AND_RESTORE_ONLY_THE_ALLOWLISTED_HOMEY_MAPPING_TARGET',
+	FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY: 'lighting',
+	FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME: 'light-power',
+	FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE: 'true',
+	FB_HOMEY_SHS_PRIVATE_TERMS: 'Private Room,Private Device',
+	FB_HOMEY_SHS_TIMEOUT_MS: '1000',
+	FB_HOMEY_SHS_URL: 'http://127.0.0.1:4859',
+};
+
+const config = (overrides: Partial<HomeyShsMappingControlConfig> = {}): HomeyShsMappingControlConfig => ({
+	...loadHomeyShsMappingControlConfig(BASE_ENVIRONMENT, '/tmp/homey-mapping-control'),
+	...overrides,
+});
+
+class FakeBinding implements HomeyMappingControlBinding {
+	readonly availableFamilies = ['cover', 'lighting', 'switch'] as const;
+	readonly baselinePanelValue = false;
+	readonly targetPanelValue = true;
+	readonly commands: Array<string | number | boolean> = [];
+	current: string | number | boolean = false;
+	failCommandAt = new Set<number>();
+	failReadBackAt = new Set<number>();
+	readBackCount = 0;
+
+	command(value: string | number | boolean): Promise<boolean> {
+		this.commands.push(value);
+		this.current = value;
+
+		return Promise.resolve(!this.failCommandAt.has(this.commands.length));
+	}
+
+	readBackMatches(value: string | number | boolean): Promise<boolean> {
+		this.readBackCount += 1;
+
+		return Promise.resolve(this.current === value && !this.failReadBackAt.has(this.readBackCount));
+	}
+}
+
+class FakeRuntime implements HomeyMappingControlRuntime {
+	readonly binding = new FakeBinding();
+	bindCount = 0;
+	startCount = 0;
+	stopCount = 0;
+
+	bind(): Promise<HomeyMappingControlBinding> {
+		this.bindCount += 1;
+
+		return Promise.resolve(this.binding);
+	}
+
+	start(): Promise<void> {
+		this.startCount += 1;
+
+		return Promise.resolve();
+	}
+
+	stop(): Promise<void> {
+		this.stopCount += 1;
+
+		return Promise.resolve();
+	}
+}
+
+const successfulProbe = async () => {
+	const runtime = new FakeRuntime();
+	const report = await probeHomeyShsMappingControl(config(), () => runtime);
+
+	return { report, runtime };
+};
+
+describe('Homey SHS mapping-control probe', () => {
+	it.each([
+		['cover', 'window-covering-position'],
+		['cover', 'window-covering-tilt'],
+		['lighting', 'light-power'],
+		['lighting', 'light-brightness'],
+		['lighting', 'light-hue'],
+		['lighting', 'light-saturation'],
+		['lighting', 'light-color-temperature'],
+		['lock', 'lock-on'],
+		['switch', 'outlet-power'],
+		['switch', 'generic-switch-power'],
+	] as const)('accepts the reversible %s mapping %s', (family, mappingName) => {
+		expect(
+			loadHomeyShsMappingControlConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY: family,
+				FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME: mappingName,
+			}).mappingName,
+		).toBe(mappingName);
+		expect(HOMEY_MAPPING_CONTROL_MAPPINGS[family]).toContain(mappingName);
+	});
+
+	it('requires the exact gate, family, mapping, target, and panel value while rejecting unrelated gates', () => {
+		expect(() =>
+			loadHomeyShsMappingControlConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_MAPPING_CONTROL_ENABLE: 'yes' }),
+		).toThrow('required acknowledgement');
+		expect(() =>
+			loadHomeyShsMappingControlConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY: 'sensor' }),
+		).toThrow('must be exactly cover, lighting, lock, or switch');
+		expect(() =>
+			loadHomeyShsMappingControlConfig({
+				...BASE_ENVIRONMENT,
+				FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME: 'outlet-power',
+			}),
+		).toThrow('not allowed for the selected family');
+		expect(() =>
+			loadHomeyShsMappingControlConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID: ' ' }),
+		).toThrow('target and panel value are required');
+		expect(() =>
+			loadHomeyShsMappingControlConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_ORIGIN_EVENT_ENABLE: '' }),
+		).toThrow('must be unset');
+	});
+
+	it('uses the Smart Panel command path once and restores the exact baseline before stopping', async () => {
+		const { report, runtime } = await successfulProbe();
+
+		expect(() => assertHomeyShsMappingControlReportSafe(report, config())).not.toThrow();
+		expect(report).toMatchObject({
+			observation: {
+				availableFamilies: ['cover', 'lighting', 'switch'],
+				baselineRead: true,
+				commandReadBackMatched: true,
+				family: 'lighting',
+				mappingName: 'light-power',
+				panelCommandAccepted: true,
+				restorationAccepted: true,
+				restorationReadBackMatched: true,
+				restored: true,
+			},
+			session: { cleanupCompleted: true, serviceStarted: true },
+		});
+		expect(report.session.events).toHaveLength(12);
+		expect(runtime.binding.commands).toStrictEqual([true, false]);
+		expect(runtime.binding.current).toBe(false);
+		expect(runtime.startCount).toBe(1);
+		expect(runtime.bindCount).toBe(1);
+		expect(runtime.stopCount).toBe(1);
+	});
+
+	it('attempts baseline restoration and stops when the requested command is unconfirmed', async () => {
+		const runtime = new FakeRuntime();
+		runtime.binding.failCommandAt.add(1);
+
+		await expect(probeHomeyShsMappingControl(config(), () => runtime)).rejects.toThrow('rejected or unconfirmed');
+		expect(runtime.binding.commands).toStrictEqual([true, false]);
+		expect(runtime.binding.current).toBe(false);
+		expect(runtime.stopCount).toBe(1);
+	});
+
+	it('fails closed when restoration cannot be confirmed and always stops the service', async () => {
+		const runtime = new FakeRuntime();
+		runtime.binding.failCommandAt.add(2);
+		runtime.binding.failCommandAt.add(3);
+
+		await expect(probeHomeyShsMappingControl(config(), () => runtime)).rejects.toThrow(
+			'cleanup failed: capability restoration',
+		);
+		expect(runtime.binding.commands).toStrictEqual([true, false, false]);
+		expect(runtime.stopCount).toBe(1);
+	});
+
+	it('rejects extra fields, invalid family ordering, reordered evidence, and private values', async () => {
+		const { report } = await successfulProbe();
+
+		expect(() => assertHomeyShsMappingControlReportSafe({ ...report, extra: true }, config())).toThrow(
+			'root schema is invalid',
+		);
+		expect(() =>
+			assertHomeyShsMappingControlReportSafe(
+				{
+					...report,
+					observation: { ...report.observation, availableFamilies: ['lighting', 'cover', 'switch'] },
+				},
+				config(),
+			),
+		).toThrow('available families are invalid');
+		expect(() =>
+			assertHomeyShsMappingControlReportSafe(
+				{ ...report, observation: { ...report.observation, family: 'switch', mappingName: 'outlet-power' } },
+				config(),
+			),
+		).toThrow('target is invalid');
+		expect(() =>
+			assertHomeyShsMappingControlReportSafe(
+				{ ...report, session: { ...report.session, events: [...report.session.events].reverse() } },
+				config(),
+			),
+		).toThrow();
+		expect(() =>
+			assertHomeyShsMappingControlReportSafe(
+				{ ...report, metadata: { ...report.metadata, sdkVersion: BASE_ENVIRONMENT.FB_HOMEY_SHS_API_KEY } },
+				config(),
+			),
+		).toThrow();
+	});
+
+	it('writes the report beneath a private non-overwriting directory', async () => {
+		const { report } = await successfulProbe();
+		const root = await mkdtemp(join(tmpdir(), 'homey-mapping-control-'));
+
+		try {
+			const directory = await writeHomeyShsMappingControlReport(report, root);
+			const path = join(directory, 'report.json');
+			expect((await stat(directory)).mode & 0o777).toBe(0o700);
+			expect((await stat(path)).mode & 0o777).toBe(0o600);
+			expect(JSON.parse(await readFile(path, 'utf8'))).toStrictEqual(report);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
@@ -2,12 +2,16 @@ import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { HomeyCapabilityType } from '../src/plugins/devices-homey/models/homey-capability.model';
+import { type HomeyDevice } from '../src/plugins/devices-homey/models/homey-device.model';
+
 import {
 	HOMEY_MAPPING_CONTROL_MAPPINGS,
 	type HomeyMappingControlBinding,
 	type HomeyMappingControlRuntime,
 	type HomeyShsMappingControlConfig,
 	assertHomeyShsMappingControlReportSafe,
+	homeyMappingControlReadBackMatches,
 	loadHomeyShsMappingControlConfig,
 	probeHomeyShsMappingControl,
 	writeHomeyShsMappingControlReport,
@@ -31,6 +35,39 @@ const BASE_ENVIRONMENT: NodeJS.ProcessEnv = {
 const config = (overrides: Partial<HomeyShsMappingControlConfig> = {}): HomeyShsMappingControlConfig => ({
 	...loadHomeyShsMappingControlConfig(BASE_ENVIRONMENT, '/tmp/homey-mapping-control'),
 	...overrides,
+});
+
+const readBackDevice = (deviceAvailable = true, capabilityAvailable: boolean | null = true): HomeyDevice => ({
+	availabilityMessage: null,
+	available: deviceAvailable,
+	capabilities: [
+		{
+			available: capabilityAvailable,
+			baseId: 'onoff',
+			enumValues: [],
+			id: 'onoff',
+			lastUpdatedAt: null,
+			maximum: null,
+			minimum: null,
+			readable: true,
+			step: null,
+			title: 'On/off',
+			type: HomeyCapabilityType.BOOLEAN,
+			unit: null,
+			value: true,
+			writable: true,
+		},
+	],
+	class: 'light',
+	driverId: null,
+	energy: null,
+	id: 'test-device',
+	manufacturer: null,
+	model: null,
+	name: 'Test device',
+	zoneId: null,
+	zoneName: null,
+	zonePath: [],
 });
 
 class FakeBinding implements HomeyMappingControlBinding {
@@ -137,6 +174,14 @@ describe('Homey SHS mapping-control probe', () => {
 		expect(() =>
 			loadHomeyShsMappingControlConfig({ ...BASE_ENVIRONMENT, FB_HOMEY_SHS_ORIGIN_EVENT_ENABLE: '' }),
 		).toThrow('must be unset');
+	});
+
+	it('accepts authoritative read-back only while the device and capability remain available', () => {
+		expect(homeyMappingControlReadBackMatches(readBackDevice(), 'onoff', true)).toBe(true);
+		expect(homeyMappingControlReadBackMatches(readBackDevice(false), 'onoff', true)).toBe(false);
+		expect(homeyMappingControlReadBackMatches(readBackDevice(true, false), 'onoff', true)).toBe(false);
+		expect(homeyMappingControlReadBackMatches(readBackDevice(true, null), 'onoff', true)).toBe(false);
+		expect(homeyMappingControlReadBackMatches(readBackDevice(), 'onoff', false)).toBe(false);
 	});
 
 	it('uses the Smart Panel command path once and restores the exact baseline before stopping', async () => {

--- a/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
@@ -218,16 +218,18 @@ describe('Homey SHS mapping-control probe', () => {
 
 	it('writes the report beneath a private non-overwriting directory', async () => {
 		const { report } = await successfulProbe();
-		const root = await mkdtemp(join(tmpdir(), 'homey-mapping-control-'));
+		const parent = await mkdtemp(join(tmpdir(), 'homey-mapping-control-'));
+		const root = join(parent, 'new-capture-root');
 
 		try {
 			const directory = await writeHomeyShsMappingControlReport(report, root);
 			const path = join(directory, 'report.json');
+			expect((await stat(root)).mode & 0o777).toBe(0o700);
 			expect((await stat(directory)).mode & 0o777).toBe(0o700);
 			expect((await stat(path)).mode & 0o777).toBe(0o600);
 			expect(JSON.parse(await readFile(path, 'utf8'))).toStrictEqual(report);
 		} finally {
-			await rm(root, { force: true, recursive: true });
+			await rm(parent, { force: true, recursive: true });
 		}
 	});
 });

--- a/apps/backend/test/support/homey-shs-mapping-control-probe.ts
+++ b/apps/backend/test/support/homey-shs-mapping-control-probe.ts
@@ -1,0 +1,660 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { ConfigService } from '../../src/modules/config/services/config.service';
+import { ChannelCategory, PermissionType } from '../../src/modules/devices/devices.constants';
+import { PropertyCommandValue } from '../../src/modules/devices/utils/property-command-value.utils';
+import { validatePropertyCommandValue } from '../../src/modules/devices/utils/property-command-value.utils';
+import { HomeyLocalConnectorFactory } from '../../src/plugins/devices-homey/connectors/homey-local-connector.factory';
+import { HomeySdkClientFactoryService } from '../../src/plugins/devices-homey/connectors/homey-sdk.client';
+import {
+	DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+	DEVICES_HOMEY_PLUGIN_NAME,
+} from '../../src/plugins/devices-homey/devices-homey.constants';
+import {
+	HomeyChannelEntity,
+	HomeyChannelPropertyEntity,
+	HomeyDeviceEntity,
+} from '../../src/plugins/devices-homey/entities/devices-homey.entity';
+import { HomeyMappingLoaderService } from '../../src/plugins/devices-homey/mappings/mapping-loader.service';
+import { HomeyMappingTransformerService } from '../../src/plugins/devices-homey/mappings/mapping-transformer.service';
+import { ResolvedHomeyPropertyMapping } from '../../src/plugins/devices-homey/mappings/mapping.types';
+import { HomeyConfigModel } from '../../src/plugins/devices-homey/models/config.model';
+import { HomeyCapability } from '../../src/plugins/devices-homey/models/homey-capability.model';
+import { HomeyDevice } from '../../src/plugins/devices-homey/models/homey-device.model';
+import { homeyCapabilityValuesEqual } from '../../src/plugins/devices-homey/platforms/homey-command-value';
+import {
+	HomeyDevicePlatform,
+	HomeyDevicePropertyData,
+} from '../../src/plugins/devices-homey/platforms/homey-device.platform';
+import {
+	type HomeyOperationalDiagnostics,
+	HomeySynchronizerService,
+} from '../../src/plugins/devices-homey/services/homey-synchronizer.service';
+import { HomeyService } from '../../src/plugins/devices-homey/services/homey.service';
+
+import { type HomeyShsProbeConfig, loadHomeyShsProbeConfig } from './homey-shs-probe';
+
+const SDK_VERSION = '3.19.2';
+const ENABLE_ACKNOWLEDGEMENT =
+	'I_WILL_USE_SMART_PANEL_TO_CONTROL_AND_RESTORE_ONLY_THE_ALLOWLISTED_HOMEY_MAPPING_TARGET';
+const PUBLIC_HOMEY_TERMS = new Set(['home', 'homey']);
+const CONFLICTING_PREFIXES = [
+	'FB_HOMEY_SHS_CREDENTIAL_ROTATION_',
+	'FB_HOMEY_SHS_LIFECYCLE_',
+	'FB_HOMEY_SHS_ORIGIN_EVENT_',
+	'FB_HOMEY_SHS_REALTIME_',
+	'FB_HOMEY_SHS_RECOVERY_',
+	'FB_HOMEY_SHS_REPLACEMENT_',
+	'FB_HOMEY_SHS_RESTART_EVENT_FLOW_',
+	'FB_HOMEY_SHS_STARTUP_',
+	'FB_HOMEY_SHS_WRITE_',
+] as const;
+
+export const HOMEY_MAPPING_CONTROL_FAMILIES = ['cover', 'lighting', 'lock', 'switch'] as const;
+export type HomeyMappingControlFamily = (typeof HOMEY_MAPPING_CONTROL_FAMILIES)[number];
+
+export const HOMEY_MAPPING_CONTROL_MAPPINGS: Readonly<Record<HomeyMappingControlFamily, readonly string[]>> = {
+	cover: ['window-covering-position', 'window-covering-tilt'],
+	lighting: ['light-power', 'light-brightness', 'light-hue', 'light-saturation', 'light-color-temperature'],
+	lock: ['lock-on'],
+	switch: ['outlet-power', 'generic-switch-power'],
+};
+
+type MappingControlEvent =
+	| 'baseline.read.verified'
+	| 'command.readback.verified'
+	| 'inventory.verified'
+	| 'panel.command.requested'
+	| 'panel.command.resolved'
+	| 'restoration.readback.verified'
+	| 'restoration.requested'
+	| 'restoration.resolved'
+	| 'service.start.requested'
+	| 'service.start.resolved'
+	| 'service.stop.resolved'
+	| 'target.bound';
+
+const SAFE_EVENTS: ReadonlySet<MappingControlEvent> = new Set([
+	'baseline.read.verified',
+	'command.readback.verified',
+	'inventory.verified',
+	'panel.command.requested',
+	'panel.command.resolved',
+	'restoration.readback.verified',
+	'restoration.requested',
+	'restoration.resolved',
+	'service.start.requested',
+	'service.start.resolved',
+	'service.stop.resolved',
+	'target.bound',
+]);
+
+export interface HomeyShsMappingControlConfig extends HomeyShsProbeConfig {
+	family: HomeyMappingControlFamily;
+	mappingName: string;
+	panelValue: string;
+	target: {
+		deviceId: string;
+		capabilityId: string;
+	};
+}
+
+export interface HomeyShsMappingControlReport {
+	metadata: {
+		probe: 'homey-shs-mapping-control';
+		schemaVersion: 1;
+		sdkVersion: string;
+	};
+	observation: {
+		availableFamilies: HomeyMappingControlFamily[];
+		baselineRead: boolean;
+		commandReadBackMatched: boolean;
+		family: HomeyMappingControlFamily;
+		mappingName: string;
+		panelCommandAccepted: boolean;
+		restorationAccepted: boolean;
+		restorationReadBackMatched: boolean;
+		restored: boolean;
+	};
+	session: {
+		cleanupCompleted: boolean;
+		events: Array<{ event: MappingControlEvent; order: number }>;
+		serviceStarted: boolean;
+	};
+}
+
+export interface HomeyMappingControlBinding {
+	readonly availableFamilies: readonly HomeyMappingControlFamily[];
+	readonly baselinePanelValue: PropertyCommandValue;
+	readonly targetPanelValue: PropertyCommandValue;
+	command(value: PropertyCommandValue): Promise<boolean>;
+	readBackMatches(value: PropertyCommandValue): Promise<boolean>;
+}
+
+export interface HomeyMappingControlRuntime {
+	bind(config: HomeyShsMappingControlConfig): Promise<HomeyMappingControlBinding>;
+	start(): Promise<void>;
+	stop(): Promise<void>;
+}
+
+export type HomeyMappingControlRuntimeFactory = (config: HomeyShsMappingControlConfig) => HomeyMappingControlRuntime;
+
+const EMPTY_DIAGNOSTICS: HomeyOperationalDiagnostics = {
+	adopted: 0,
+	adoptedDevices: [],
+	missing: 0,
+	unsupported: 0,
+	unavailable: 0,
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isPropertyCommandValue = (value: unknown): value is PropertyCommandValue =>
+	typeof value === 'boolean' || typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value));
+
+const familyForMapping = (mappingName: string): HomeyMappingControlFamily | null =>
+	HOMEY_MAPPING_CONTROL_FAMILIES.find((family) => HOMEY_MAPPING_CONTROL_MAPPINGS[family].includes(mappingName)) ?? null;
+
+const isReversibleWritableBinding = (
+	device: HomeyDevice,
+	capability: HomeyCapability,
+	mapping: ResolvedHomeyPropertyMapping,
+): boolean =>
+	device.available &&
+	capability.available !== false &&
+	capability.readable &&
+	capability.writable &&
+	capability.value !== null &&
+	mapping.property.direction === 'bidirectional' &&
+	familyForMapping(mapping.name) !== null;
+
+const availableFamiliesFor = (
+	inventory: readonly HomeyDevice[],
+	mappingLoader: HomeyMappingLoaderService,
+): HomeyMappingControlFamily[] => {
+	const available = new Set<HomeyMappingControlFamily>();
+
+	for (const device of inventory) {
+		const capabilities = new Map(device.capabilities.map((capability) => [capability.id, capability]));
+
+		for (const binding of mappingLoader.resolvePropertyMappings(device).mappings) {
+			const family = familyForMapping(binding.mapping.name);
+			const capability = capabilities.get(binding.capabilityId);
+
+			if (
+				family !== null &&
+				capability !== undefined &&
+				isReversibleWritableBinding(device, capability, binding.mapping)
+			) {
+				available.add(family);
+			}
+		}
+	}
+
+	return HOMEY_MAPPING_CONTROL_FAMILIES.filter((family) => available.has(family));
+};
+
+const createProbeProperty = (
+	config: HomeyShsMappingControlConfig,
+	mapping: ResolvedHomeyPropertyMapping,
+): HomeyDevicePropertyData => {
+	const device = Object.assign(new HomeyDeviceEntity(), {
+		enabled: true,
+		id: 'homey-mapping-control-probe-device',
+		identifier: config.target.deviceId,
+		name: 'Homey mapping control probe device',
+	});
+	const channel = Object.assign(new HomeyChannelEntity(), {
+		category: ChannelCategory.GENERIC,
+		device,
+		id: 'homey-mapping-control-probe-channel',
+		identifier: mapping.property.channel,
+		name: 'Homey mapping control probe channel',
+	});
+	const range = mapping.property.range;
+	const format =
+		range !== undefined && (range.minimum !== undefined || range.maximum !== undefined)
+			? ([range.minimum ?? null, range.maximum ?? null] as unknown as number[])
+			: null;
+	const property = Object.assign(new HomeyChannelPropertyEntity(), {
+		category: mapping.property.category,
+		channel,
+		dataType: mapping.property.dataType,
+		format,
+		homeyCapabilityId: config.target.capabilityId,
+		homeyMappingName: mapping.name,
+		id: 'homey-mapping-control-probe-property',
+		identifier: config.target.capabilityId,
+		invalid: null,
+		name: 'Homey mapping control probe property',
+		permissions: [PermissionType.READ_WRITE],
+		step: range?.step ?? null,
+	});
+
+	return { channel, device, property, value: false };
+};
+
+const createSynchronizer = (): HomeySynchronizerService =>
+	({
+		filterEvents: (events: readonly unknown[]): readonly unknown[] => [...events],
+		getOperationalDiagnostics: (): Promise<HomeyOperationalDiagnostics> => Promise.resolve(EMPTY_DIAGNOSTICS),
+		hasReadableCapabilityBinding: (): Promise<boolean> => Promise.resolve(true),
+		invalidateIndex: (): void => undefined,
+		reset: (): void => undefined,
+		synchronizeDevices: (_devices: readonly unknown[], _missing: readonly string[], events: readonly unknown[]) =>
+			Promise.resolve({ acceptedCapabilityValues: [], acceptedEvents: [...events], failed: 0, ignored: 0, updated: 0 }),
+		synchronizeEvents: (events: readonly unknown[]) =>
+			Promise.resolve({ acceptedEvents: [...events], failed: 0, ignored: 0, updated: 0 }),
+		synchronizeSnapshot: (_devices: readonly unknown[], events: readonly unknown[] = []) =>
+			Promise.resolve({ acceptedCapabilityValues: [], acceptedEvents: [...events], failed: 0, ignored: 0, updated: 0 }),
+	}) as unknown as HomeySynchronizerService;
+
+export const createHomeyMappingControlRuntime: HomeyMappingControlRuntimeFactory = (config) => {
+	const pluginConfig = Object.assign(new HomeyConfigModel(), {
+		apiKey: config.apiKey,
+		connectionTimeout: config.timeoutMs,
+		enabled: true,
+		reconciliationInterval: DEFAULT_HOMEY_RECONCILIATION_INTERVAL_MS,
+		url: config.origin.origin,
+	});
+	const configService = {
+		getPluginConfig: (pluginName: string): HomeyConfigModel => {
+			if (pluginName !== DEVICES_HOMEY_PLUGIN_NAME) {
+				throw new Error('Homey mapping-control probe requested an unexpected plugin configuration');
+			}
+
+			return pluginConfig;
+		},
+	};
+	const mappingLoader = new HomeyMappingLoaderService();
+	mappingLoader.loadAllMappings();
+	const transformer = new HomeyMappingTransformerService();
+	const service = new HomeyService(
+		configService as unknown as ConfigService,
+		createSynchronizer(),
+		new HomeyLocalConnectorFactory(new HomeySdkClientFactoryService()),
+	);
+	const platform = new HomeyDevicePlatform(service, mappingLoader, transformer);
+
+	return {
+		start: () => service.start(),
+		stop: () => service.stop(),
+		bind: async (runtimeConfig): Promise<HomeyMappingControlBinding> => {
+			const inventory = service.getInventorySnapshot();
+
+			if (inventory === null) throw new Error('Homey mapping-control inventory is unavailable');
+			const availableFamilies = availableFamiliesFor(inventory, mappingLoader);
+
+			if (!availableFamilies.includes(runtimeConfig.family)) {
+				throw new Error('The requested Homey mapping-control family is not available in the live inventory');
+			}
+			const device = inventory.find((candidate) => candidate.id === runtimeConfig.target.deviceId);
+			const capability = device?.capabilities.find((candidate) => candidate.id === runtimeConfig.target.capabilityId);
+			const binding =
+				device === undefined
+					? undefined
+					: mappingLoader
+							.resolvePropertyMappings(device)
+							.mappings.find(
+								(candidate) =>
+									candidate.capabilityId === runtimeConfig.target.capabilityId &&
+									candidate.mapping.name === runtimeConfig.mappingName,
+							);
+
+			if (
+				device === undefined ||
+				capability === undefined ||
+				binding === undefined ||
+				!isReversibleWritableBinding(device, capability, binding.mapping)
+			) {
+				throw new Error('The exact reversible Homey mapping-control target was not found');
+			}
+			const freshDevice = await service.getFreshDevice(device.id);
+			const freshCapability = freshDevice?.capabilities.find((candidate) => candidate.id === capability.id);
+
+			if (
+				freshDevice === null ||
+				freshCapability === undefined ||
+				!isReversibleWritableBinding(freshDevice, freshCapability, binding.mapping)
+			) {
+				throw new Error('The Homey mapping-control target failed fresh ownership and capability validation');
+			}
+			const baselineHomeyValue = freshCapability.value;
+			const baselinePanelValue = transformer.read(binding.mapping, baselineHomeyValue);
+			const commandTarget = createProbeProperty(runtimeConfig, binding.mapping);
+			const baselineValidation = validatePropertyCommandValue(commandTarget.property, baselinePanelValue);
+			const targetValidation = validatePropertyCommandValue(commandTarget.property, runtimeConfig.panelValue);
+
+			if (
+				!baselineValidation.valid ||
+				!isPropertyCommandValue(baselineValidation.value) ||
+				!targetValidation.valid ||
+				!isPropertyCommandValue(targetValidation.value)
+			) {
+				throw new Error('The Homey mapping-control baseline or requested panel value is invalid');
+			}
+			if (
+				!homeyCapabilityValuesEqual(transformer.write(binding.mapping, baselineValidation.value), baselineHomeyValue)
+			) {
+				throw new Error('The Homey mapping-control baseline is not exactly reversible through the selected mapping');
+			}
+			if (homeyCapabilityValuesEqual(transformer.write(binding.mapping, targetValidation.value), baselineHomeyValue)) {
+				throw new Error('The Homey mapping-control panel value must change the authoritative capability value');
+			}
+
+			const command = (value: PropertyCommandValue): Promise<boolean> => platform.process({ ...commandTarget, value });
+			const readBackMatches = async (value: PropertyCommandValue): Promise<boolean> => {
+				const expected = transformer.write(binding.mapping, value);
+				const readBack = await service.getFreshDevice(device.id);
+				const readBackCapability = readBack?.capabilities.find((candidate) => candidate.id === capability.id);
+
+				return readBackCapability !== undefined && homeyCapabilityValuesEqual(readBackCapability.value, expected);
+			};
+
+			return {
+				availableFamilies,
+				baselinePanelValue: baselineValidation.value,
+				command,
+				readBackMatches,
+				targetPanelValue: targetValidation.value,
+			};
+		},
+	};
+};
+
+export const loadHomeyShsMappingControlConfig = (
+	environment: NodeJS.ProcessEnv,
+	workingDirectory = process.cwd(),
+): HomeyShsMappingControlConfig => {
+	if (environment.FB_HOMEY_SHS_MAPPING_CONTROL_ENABLE !== ENABLE_ACKNOWLEDGEMENT) {
+		throw new Error('FB_HOMEY_SHS_MAPPING_CONTROL_ENABLE does not contain the required acknowledgement');
+	}
+	if (Object.keys(environment).some((name) => CONFLICTING_PREFIXES.some((prefix) => name.startsWith(prefix)))) {
+		throw new Error('Unrelated Homey mutation and recovery probe gates must be unset during the mapping-control probe');
+	}
+	const family = environment.FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY?.trim() as HomeyMappingControlFamily | undefined;
+
+	if (family === undefined || !HOMEY_MAPPING_CONTROL_FAMILIES.includes(family)) {
+		throw new Error('FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY must be exactly cover, lighting, lock, or switch');
+	}
+	const mappingName = environment.FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME?.trim() ?? '';
+
+	if (!HOMEY_MAPPING_CONTROL_MAPPINGS[family].includes(mappingName)) {
+		throw new Error('FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME is not allowed for the selected family');
+	}
+	const deviceId = environment.FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID?.trim() ?? '';
+	const capabilityId = environment.FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID?.trim() ?? '';
+	const panelValue = environment.FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE?.trim() ?? '';
+
+	if (deviceId.length === 0 || capabilityId.length === 0 || panelValue.length === 0) {
+		throw new Error('The exact Homey mapping-control target and panel value are required');
+	}
+
+	return {
+		...loadHomeyShsProbeConfig(environment, workingDirectory),
+		family,
+		mappingName,
+		panelValue,
+		target: { capabilityId, deviceId },
+	};
+};
+
+export const probeHomeyShsMappingControl = async (
+	config: HomeyShsMappingControlConfig,
+	runtimeFactory: HomeyMappingControlRuntimeFactory = createHomeyMappingControlRuntime,
+): Promise<HomeyShsMappingControlReport> => {
+	const runtime = runtimeFactory(config);
+	const events: Array<{ event: MappingControlEvent; order: number }> = [];
+	const record = (event: MappingControlEvent): void => {
+		events.push({ event, order: events.length + 1 });
+	};
+	let binding: HomeyMappingControlBinding | undefined;
+	let commandAttempted = false;
+	let restored = false;
+	let operationError: unknown;
+	const cleanupFailures: string[] = [];
+
+	try {
+		record('service.start.requested');
+		await runtime.start();
+		record('service.start.resolved');
+		binding = await runtime.bind(config);
+		record('inventory.verified');
+		record('target.bound');
+		record('baseline.read.verified');
+		record('panel.command.requested');
+		commandAttempted = true;
+		if (!(await binding.command(binding.targetPanelValue))) {
+			throw new Error('Homey mapping-control Smart Panel command was rejected or unconfirmed');
+		}
+		record('panel.command.resolved');
+		if (!(await binding.readBackMatches(binding.targetPanelValue))) {
+			throw new Error('Homey mapping-control command read-back did not match');
+		}
+		record('command.readback.verified');
+		record('restoration.requested');
+		if (!(await binding.command(binding.baselinePanelValue))) {
+			throw new Error('Homey mapping-control restoration was rejected or unconfirmed');
+		}
+		record('restoration.resolved');
+		if (!(await binding.readBackMatches(binding.baselinePanelValue))) {
+			throw new Error('Homey mapping-control restoration read-back did not match');
+		}
+		record('restoration.readback.verified');
+		restored = true;
+	} catch (error) {
+		operationError = error;
+	} finally {
+		if (commandAttempted && binding !== undefined && !restored) {
+			try {
+				const accepted = await binding.command(binding.baselinePanelValue);
+				const matched = accepted && (await binding.readBackMatches(binding.baselinePanelValue));
+
+				if (!matched) cleanupFailures.push('capability restoration');
+				else restored = true;
+			} catch {
+				cleanupFailures.push('capability restoration');
+			}
+		}
+
+		try {
+			await runtime.stop();
+			record('service.stop.resolved');
+		} catch {
+			cleanupFailures.push('service stop');
+		}
+	}
+
+	if (cleanupFailures.length > 0) {
+		throw new Error(`Homey mapping-control cleanup failed: ${cleanupFailures.join(', ')}`);
+	}
+	if (operationError !== undefined) throw operationError;
+	if (binding === undefined || !restored) throw new Error('Homey mapping-control verification failed');
+
+	return {
+		metadata: { probe: 'homey-shs-mapping-control', schemaVersion: 1, sdkVersion: SDK_VERSION },
+		observation: {
+			availableFamilies: [...binding.availableFamilies],
+			baselineRead: true,
+			commandReadBackMatched: true,
+			family: config.family,
+			mappingName: config.mappingName,
+			panelCommandAccepted: true,
+			restorationAccepted: true,
+			restorationReadBackMatched: true,
+			restored: true,
+		},
+		session: { cleanupCompleted: true, events, serviceStarted: true },
+	};
+};
+
+const requireExactKeys = (value: unknown, keys: readonly string[], label: string): Record<string, unknown> => {
+	if (!isRecord(value) || Object.keys(value).sort().join() !== [...keys].sort().join()) {
+		throw new Error(`Homey mapping-control report ${label} schema is invalid`);
+	}
+
+	return value;
+};
+
+export function assertHomeyShsMappingControlReportSafe(
+	value: unknown,
+	config: HomeyShsMappingControlConfig,
+): asserts value is HomeyShsMappingControlReport {
+	const report = requireExactKeys(value, ['metadata', 'observation', 'session'], 'root');
+	const metadata = requireExactKeys(report.metadata, ['probe', 'schemaVersion', 'sdkVersion'], 'metadata');
+	const observation = requireExactKeys(
+		report.observation,
+		[
+			'availableFamilies',
+			'baselineRead',
+			'commandReadBackMatched',
+			'family',
+			'mappingName',
+			'panelCommandAccepted',
+			'restorationAccepted',
+			'restorationReadBackMatched',
+			'restored',
+		],
+		'observation',
+	);
+	const session = requireExactKeys(report.session, ['cleanupCompleted', 'events', 'serviceStarted'], 'session');
+
+	if (
+		metadata.probe !== 'homey-shs-mapping-control' ||
+		metadata.schemaVersion !== 1 ||
+		metadata.sdkVersion !== SDK_VERSION
+	) {
+		throw new Error('Homey mapping-control report metadata is invalid');
+	}
+	if (
+		!HOMEY_MAPPING_CONTROL_FAMILIES.includes(observation.family as HomeyMappingControlFamily) ||
+		typeof observation.mappingName !== 'string' ||
+		!HOMEY_MAPPING_CONTROL_MAPPINGS[observation.family as HomeyMappingControlFamily].includes(
+			observation.mappingName,
+		) ||
+		observation.family !== config.family ||
+		observation.mappingName !== config.mappingName
+	) {
+		throw new Error('Homey mapping-control report target is invalid');
+	}
+	if (!Array.isArray(observation.availableFamilies)) {
+		throw new Error('Homey mapping-control report available families are invalid');
+	}
+	const availableFamilies = observation.availableFamilies as unknown[];
+	const normalizedAvailableFamilies = HOMEY_MAPPING_CONTROL_FAMILIES.filter((family) =>
+		availableFamilies.includes(family),
+	);
+
+	if (
+		availableFamilies.length === 0 ||
+		availableFamilies.some((family) => !HOMEY_MAPPING_CONTROL_FAMILIES.includes(family as HomeyMappingControlFamily)) ||
+		normalizedAvailableFamilies.length !== availableFamilies.length ||
+		availableFamilies.some((family, index) => family !== normalizedAvailableFamilies[index]) ||
+		!availableFamilies.includes(observation.family)
+	) {
+		throw new Error('Homey mapping-control report available families are invalid');
+	}
+	for (const key of [
+		'baselineRead',
+		'commandReadBackMatched',
+		'panelCommandAccepted',
+		'restorationAccepted',
+		'restorationReadBackMatched',
+		'restored',
+	] as const) {
+		if (observation[key] !== true) throw new Error('Homey mapping-control report did not verify the complete command');
+	}
+	if (session.cleanupCompleted !== true || session.serviceStarted !== true || !Array.isArray(session.events)) {
+		throw new Error('Homey mapping-control report session is invalid');
+	}
+	for (const [index, event] of session.events.entries()) {
+		if (
+			!isRecord(event) ||
+			Object.keys(event).sort().join() !== 'event,order' ||
+			typeof event.event !== 'string' ||
+			!SAFE_EVENTS.has(event.event as MappingControlEvent) ||
+			event.order !== index + 1
+		) {
+			throw new Error('Homey mapping-control report event is invalid');
+		}
+	}
+	const labels = session.events.map((event) => (event as { event: string }).event);
+	let previousIndex = -1;
+
+	for (const label of [
+		'service.start.requested',
+		'service.start.resolved',
+		'inventory.verified',
+		'target.bound',
+		'baseline.read.verified',
+		'panel.command.requested',
+		'panel.command.resolved',
+		'command.readback.verified',
+		'restoration.requested',
+		'restoration.resolved',
+		'restoration.readback.verified',
+		'service.stop.resolved',
+	]) {
+		const index = labels.indexOf(label);
+
+		if (index <= previousIndex) throw new Error('Homey mapping-control report ordering is invalid');
+		previousIndex = index;
+	}
+	const serialized = JSON.stringify(value).toLowerCase();
+	const forbidden = [
+		config.apiKey,
+		config.expectedHost,
+		config.target.deviceId,
+		config.target.capabilityId,
+		...config.privateTerms,
+	]
+		.map((item) => item.trim().toLowerCase())
+		.filter((item) => item.length >= 3 && !PUBLIC_HOMEY_TERMS.has(item));
+
+	if (
+		forbidden.some((item) => serialized.includes(item)) ||
+		/(?:\d{1,3}\.){3}\d{1,3}/.test(serialized) ||
+		/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(serialized) ||
+		/(?:[A-Z][A-Z0-9+.-]*:)?\/\/[^\s"']+/i.test(serialized)
+	) {
+		throw new Error('Sanitized Homey mapping-control report contains a private value');
+	}
+}
+
+export const writeHomeyShsMappingControlReport = async (
+	report: HomeyShsMappingControlReport,
+	outputRoot: string,
+): Promise<string> => {
+	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
+	const outputDirectory = resolve(outputRoot, `mapping-control-${suffix}`);
+
+	await mkdir(outputDirectory, { mode: 0o700, recursive: false });
+	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
+		encoding: 'utf8',
+		flag: 'wx',
+		mode: 0o600,
+	});
+
+	return outputDirectory;
+};
+
+const main = async (): Promise<void> => {
+	try {
+		const config = loadHomeyShsMappingControlConfig(process.env);
+		process.stdout.write(
+			`Homey ${config.family} mapping-control probe is using the Smart Panel production command path and will restore the original value.\n`,
+		);
+		const report = await probeHomeyShsMappingControl(config);
+		assertHomeyShsMappingControlReportSafe(report, config);
+		const outputDirectory = await writeHomeyShsMappingControlReport(report, config.outputRoot);
+		process.stdout.write(`Sanitized Homey mapping-control report written to ${outputDirectory}.\n`);
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : 'Homey mapping-control probe failed'}\n`);
+		process.exitCode = 1;
+	}
+};
+
+if (require.main === module) void main();

--- a/apps/backend/test/support/homey-shs-mapping-control-probe.ts
+++ b/apps/backend/test/support/homey-shs-mapping-control-probe.ts
@@ -21,7 +21,7 @@ import { HomeyMappingLoaderService } from '../../src/plugins/devices-homey/mappi
 import { HomeyMappingTransformerService } from '../../src/plugins/devices-homey/mappings/mapping-transformer.service';
 import { ResolvedHomeyPropertyMapping } from '../../src/plugins/devices-homey/mappings/mapping.types';
 import { HomeyConfigModel } from '../../src/plugins/devices-homey/models/config.model';
-import { HomeyCapability } from '../../src/plugins/devices-homey/models/homey-capability.model';
+import { HomeyCapability, HomeyCapabilityValue } from '../../src/plugins/devices-homey/models/homey-capability.model';
 import { HomeyDevice } from '../../src/plugins/devices-homey/models/homey-device.model';
 import { homeyCapabilityValuesEqual } from '../../src/plugins/devices-homey/platforms/homey-command-value';
 import {
@@ -168,6 +168,22 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isPropertyCommandValue = (value: unknown): value is PropertyCommandValue =>
 	typeof value === 'boolean' || typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value));
+
+export const homeyMappingControlReadBackMatches = (
+	device: HomeyDevice | null,
+	capabilityId: string,
+	expected: HomeyCapabilityValue,
+): boolean => {
+	if (device === null || !device.available) {
+		return false;
+	}
+
+	const capability = device.capabilities.find((candidate) => candidate.id === capabilityId);
+
+	return (
+		capability !== undefined && capability.available === true && homeyCapabilityValuesEqual(capability.value, expected)
+	);
+};
 
 const familyForMapping = (mappingName: string): HomeyMappingControlFamily | null =>
 	HOMEY_MAPPING_CONTROL_FAMILIES.find((family) => HOMEY_MAPPING_CONTROL_MAPPINGS[family].includes(mappingName)) ?? null;
@@ -363,9 +379,8 @@ export const createHomeyMappingControlRuntime: HomeyMappingControlRuntimeFactory
 			const readBackMatches = async (value: PropertyCommandValue): Promise<boolean> => {
 				const expected = transformer.write(binding.mapping, value);
 				const readBack = await service.getFreshDevice(device.id);
-				const readBackCapability = readBack?.capabilities.find((candidate) => candidate.id === capability.id);
 
-				return readBackCapability !== undefined && homeyCapabilityValuesEqual(readBackCapability.value, expected);
+				return homeyMappingControlReadBackMatches(readBack, capability.id, expected);
 			};
 
 			return {

--- a/apps/backend/test/support/homey-shs-mapping-control-probe.ts
+++ b/apps/backend/test/support/homey-shs-mapping-control-probe.ts
@@ -131,6 +131,7 @@ export interface HomeyMappingControlBinding {
 	readonly targetPanelValue: PropertyCommandValue;
 	command(value: PropertyCommandValue): Promise<boolean>;
 	readBackMatches(value: PropertyCommandValue): Promise<boolean>;
+	waitForCommandIdle(): Promise<void>;
 }
 
 export interface HomeyMappingControlRuntime {
@@ -140,6 +141,19 @@ export interface HomeyMappingControlRuntime {
 }
 
 export type HomeyMappingControlRuntimeFactory = (config: HomeyShsMappingControlConfig) => HomeyMappingControlRuntime;
+
+type HomeyMappingControlTerminationSignal = 'SIGINT' | 'SIGTERM';
+
+export interface HomeyMappingControlSignalSource {
+	on(signal: HomeyMappingControlTerminationSignal, listener: () => void): unknown;
+	off(signal: HomeyMappingControlTerminationSignal, listener: () => void): unknown;
+}
+
+class HomeyMappingControlTerminationError extends Error {
+	constructor(readonly signal: HomeyMappingControlTerminationSignal) {
+		super(`Homey mapping-control probe received ${signal}; restoration completed before termination`);
+	}
+}
 
 const EMPTY_DIAGNOSTICS: HomeyOperationalDiagnostics = {
 	adopted: 0,
@@ -360,6 +374,7 @@ export const createHomeyMappingControlRuntime: HomeyMappingControlRuntimeFactory
 				command,
 				readBackMatches,
 				targetPanelValue: targetValidation.value,
+				waitForCommandIdle: () => service.waitForCapabilityCommandIdle(device.id, capability.id),
 			};
 		},
 	};
@@ -405,6 +420,7 @@ export const loadHomeyShsMappingControlConfig = (
 export const probeHomeyShsMappingControl = async (
 	config: HomeyShsMappingControlConfig,
 	runtimeFactory: HomeyMappingControlRuntimeFactory = createHomeyMappingControlRuntime,
+	signalSource: HomeyMappingControlSignalSource = process,
 ): Promise<HomeyShsMappingControlReport> => {
 	const runtime = runtimeFactory(config);
 	const events: Array<{ event: MappingControlEvent; order: number }> = [];
@@ -416,33 +432,69 @@ export const probeHomeyShsMappingControl = async (
 	let restored = false;
 	let operationError: unknown;
 	const cleanupFailures: string[] = [];
+	let terminationSignal: HomeyMappingControlTerminationSignal | undefined;
+	const handleSigint = (): void => {
+		terminationSignal ??= 'SIGINT';
+	};
+	const handleSigterm = (): void => {
+		terminationSignal ??= 'SIGTERM';
+	};
+	const throwIfTerminated = (): void => {
+		if (terminationSignal !== undefined) {
+			throw new HomeyMappingControlTerminationError(terminationSignal);
+		}
+	};
+	const restoreBaseline = async (): Promise<boolean> => {
+		if (binding === undefined) {
+			return false;
+		}
+
+		await binding.waitForCommandIdle();
+		await binding.command(binding.baselinePanelValue);
+		await binding.waitForCommandIdle();
+
+		return binding.readBackMatches(binding.baselinePanelValue);
+	};
+
+	signalSource.on('SIGINT', handleSigint);
+	signalSource.on('SIGTERM', handleSigterm);
 
 	try {
 		record('service.start.requested');
 		await runtime.start();
+		throwIfTerminated();
 		record('service.start.resolved');
 		binding = await runtime.bind(config);
+		throwIfTerminated();
 		record('inventory.verified');
 		record('target.bound');
 		record('baseline.read.verified');
 		record('panel.command.requested');
 		commandAttempted = true;
-		if (!(await binding.command(binding.targetPanelValue))) {
+		const commandAccepted = await binding.command(binding.targetPanelValue);
+		throwIfTerminated();
+		if (!commandAccepted) {
 			throw new Error('Homey mapping-control Smart Panel command was rejected or unconfirmed');
 		}
 		record('panel.command.resolved');
 		if (!(await binding.readBackMatches(binding.targetPanelValue))) {
 			throw new Error('Homey mapping-control command read-back did not match');
 		}
+		throwIfTerminated();
 		record('command.readback.verified');
 		record('restoration.requested');
-		if (!(await binding.command(binding.baselinePanelValue))) {
+		await binding.waitForCommandIdle();
+		const restorationAccepted = await binding.command(binding.baselinePanelValue);
+		throwIfTerminated();
+		if (!restorationAccepted) {
 			throw new Error('Homey mapping-control restoration was rejected or unconfirmed');
 		}
 		record('restoration.resolved');
+		await binding.waitForCommandIdle();
 		if (!(await binding.readBackMatches(binding.baselinePanelValue))) {
 			throw new Error('Homey mapping-control restoration read-back did not match');
 		}
+		throwIfTerminated();
 		record('restoration.readback.verified');
 		restored = true;
 	} catch (error) {
@@ -450,10 +502,7 @@ export const probeHomeyShsMappingControl = async (
 	} finally {
 		if (commandAttempted && binding !== undefined && !restored) {
 			try {
-				const accepted = await binding.command(binding.baselinePanelValue);
-				const matched = accepted && (await binding.readBackMatches(binding.baselinePanelValue));
-
-				if (!matched) cleanupFailures.push('capability restoration');
+				if (!(await restoreBaseline())) cleanupFailures.push('capability restoration');
 				else restored = true;
 			} catch {
 				cleanupFailures.push('capability restoration');
@@ -466,10 +515,16 @@ export const probeHomeyShsMappingControl = async (
 		} catch {
 			cleanupFailures.push('service stop');
 		}
+
+		signalSource.off('SIGINT', handleSigint);
+		signalSource.off('SIGTERM', handleSigterm);
 	}
 
 	if (cleanupFailures.length > 0) {
 		throw new Error(`Homey mapping-control cleanup failed: ${cleanupFailures.join(', ')}`);
+	}
+	if (terminationSignal !== undefined && !(operationError instanceof HomeyMappingControlTerminationError)) {
+		throw new HomeyMappingControlTerminationError(terminationSignal);
 	}
 	if (operationError !== undefined) throw operationError;
 	if (binding === undefined || !restored) throw new Error('Homey mapping-control verification failed');

--- a/apps/backend/test/support/homey-shs-mapping-control-probe.ts
+++ b/apps/backend/test/support/homey-shs-mapping-control-probe.ts
@@ -631,6 +631,7 @@ export const writeHomeyShsMappingControlReport = async (
 	const suffix = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomBytes(4).toString('hex')}`;
 	const outputDirectory = resolve(outputRoot, `mapping-control-${suffix}`);
 
+	await mkdir(outputRoot, { mode: 0o700, recursive: true });
 	await mkdir(outputDirectory, { mode: 0o700, recursive: false });
 	await writeFile(resolve(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, {
 		encoding: 'utf8',

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -468,6 +468,67 @@ SDK teardown. The reviewed reports are committed as
 device or capability identifier, capability value, inventory content, event payload, Flow identity, response body, or
 raw error.
 
+## Allowlisted Smart Panel mapping-family control
+
+This probe validates the production Smart Panel command path rather than calling the SDK directly. It starts a fresh
+production `HomeyService`, loads the current built-in and user mapping catalog, binds one exact device/capability/mapping,
+and invokes `HomeyDevicePlatform` with an operator-selected panel value. The platform revalidates the live inventory,
+property constraints, mapping binding, and inverse transformation before `HomeyService` performs the bounded write and
+authoritative confirmation. A fresh device read must match, after which the original value is restored through the same
+platform path and verified again before shutdown.
+
+Only reversible bidirectional mappings are allowed. The guarded family catalog is:
+
+| Family     | Allowed mapping names                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| `lighting` | `light-power`, `light-brightness`, `light-hue`, `light-saturation`, `light-color-temperature` |
+| `switch`   | `outlet-power`, `generic-switch-power`                                                        |
+| `cover`    | `window-covering-position`, `window-covering-tilt`                                            |
+| `lock`     | `lock-on`                                                                                     |
+
+Climate control is not part of this gate because the approved local mapping catalog intentionally defers target and
+mode projection until a verified actual-activity signal is available. Sensor, safety, battery, and energy families are
+read-only. The probe derives the full set of reversible writable families currently available in the live inventory
+and records only their fixed family labels, never counts or target details.
+
+Use the Homey inventory endpoint locally to select harmless targets. Keep the output private: it contains device names
+and identifiers. For every family reported as available, choose one exact capability and a safe panel value different
+from its current value. The probe rejects a baseline that cannot round-trip exactly and always attempts restoration if
+the command path was entered.
+
+Start from the base URL, expected-host, API-key, timeout, and private-term variables used by the read probe. Clear every
+other live-probe family, then set one target at a time without putting its identifiers in repository files:
+
+```bash
+for variable in $(env | awk -F= '
+  /^FB_HOMEY_SHS_(CREDENTIAL_ROTATION|LIFECYCLE|ORIGIN_EVENT|REALTIME|RECOVERY|REPLACEMENT|RESTART_EVENT_FLOW|STARTUP|WRITE)_/ {
+    print $1
+  }
+'); do
+  unset "$variable"
+done
+
+export FB_HOMEY_SHS_MAPPING_CONTROL_ENABLE=I_WILL_USE_SMART_PANEL_TO_CONTROL_AND_RESTORE_ONLY_THE_ALLOWLISTED_HOMEY_MAPPING_TARGET
+export FB_HOMEY_SHS_MAPPING_CONTROL_FAMILY=lighting
+export FB_HOMEY_SHS_MAPPING_CONTROL_MAPPING_NAME=light-brightness
+
+read -r FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID
+read -r FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID
+read -r FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE
+export FB_HOMEY_SHS_MAPPING_CONTROL_DEVICE_ID
+export FB_HOMEY_SHS_MAPPING_CONTROL_CAPABILITY_ID
+export FB_HOMEY_SHS_MAPPING_CONTROL_PANEL_VALUE
+
+pnpm run homey:probe-mapping-control
+```
+
+Repeat with a representative mapping for each family that the first successful report lists in `availableFamilies`.
+Boolean panel values are entered as `true` or `false`; mapped percentages, angles, hue, and color temperature are
+entered in Smart Panel units. Inspect the controlled equipment after any failed run. No success report is written
+unless the requested command, fresh read-back, exact restoration, restoration read-back, and service shutdown all pass.
+The report contains no endpoint, credential, Homey identity, device or capability identifier, capability value,
+inventory content/count, event payload, response body, or raw error.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -655,6 +655,14 @@ The three reviewed exact-schema reports retain only fixed scenario/event labels,
 and completion booleans; they contain no endpoint, credential, Homey identity, device or capability identifier,
 capability value, inventory content, event payload, Flow identity, response body, or raw error.
 
+A separately gated mapping-control probe is prepared for the next unchecked live-matrix item. It starts the production
+`HomeyService`, loads the current mapping catalog, and routes one exact allowlisted target through
+`HomeyDevicePlatform`. Only reversible bidirectional lighting, switch, cover, and lock mappings are eligible. Each run
+requires the transformed Smart Panel command and fresh authoritative read-back, followed by restoration through the
+same platform path, a final read-back, and complete service shutdown. It records the fixed set of eligible families
+detected in live inventory but no counts, identities, capability values, inventory content, payloads, or raw errors.
+The matrix item remains unchecked until reviewed live evidence covers every family reported as available.
+
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow
 criterion above because no capability or availability event was observed before and after that restart.


### PR DESCRIPTION
## Summary

- add a guarded live probe that routes commands through the production HomeyService and HomeyDevicePlatform path
- require an exact family, device, capability, mapping, and panel-value allowlist
- verify authoritative command read-back, restore through the same Smart Panel path, and require final read-back plus shutdown
- support reversible lighting, switch, cover, and lock mappings while recording only fixed available-family labels

## Safety

The probe refuses unrelated mutation gates, read-only or write-only mappings, unavailable targets, invalid panel values, and baselines that cannot round-trip exactly. It writes no success report unless command confirmation, fresh read-back, exact restoration, restoration read-back, and service cleanup all pass.

Reports contain no endpoint, credential, Homey identity, device or capability identifier, capability value, inventory content or count, payload, response body, or raw error.

## Verification

- focused mapping-control and security-artifact suites: 2 suites / 20 tests passed
- pnpm run type-check
- ESLint on changed TypeScript files
- pnpm run homey:security-gate: 15 suites / 207 tests and 39 suites / 483 tests passed
- git diff --check

## Live evidence

The probe and runbook are ready. The mapping-family live-matrix item remains unchecked until every family reported as available has reviewed sanitized evidence.