### PR TITLE
test(cross): record Homey mapping-family control evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -116,5 +116,11 @@ The three 2026-08-28 origin-event reports record physical-control, Homey-app, an
 same-origin restoration event, final baseline read-back, and complete teardown. They contain no endpoint, credential,
 Homey identity, device or capability identifier, capability value, inventory content, event payload, Flow identity,
 response body, or raw error.
+The three 2026-08-28 mapping-control reports cover every reversible writable family reported by live SHS `13.4.1`
+inventory: lighting, switch, and cover. Each report proves production Smart Panel mapping and platform command
+acceptance, fresh read-back, exact baseline restoration through the same path, final read-back, and clean service
+shutdown. The inventory exposed no eligible lock family. The reports contain no endpoint, credential, Homey identity,
+device or capability identifier, capability value, inventory content or count, event payload, response body, or raw
+error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-cover.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-cover.json
@@ -1,0 +1,72 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mapping-control",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"availableFamilies": ["cover", "lighting", "switch"],
+		"baselineRead": true,
+		"commandReadBackMatched": true,
+		"family": "cover",
+		"mappingName": "window-covering-position",
+		"panelCommandAccepted": true,
+		"restorationAccepted": true,
+		"restorationReadBackMatched": true,
+		"restored": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.verified",
+				"order": 3
+			},
+			{
+				"event": "target.bound",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "panel.command.requested",
+				"order": 6
+			},
+			{
+				"event": "panel.command.resolved",
+				"order": 7
+			},
+			{
+				"event": "command.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restoration.requested",
+				"order": 9
+			},
+			{
+				"event": "restoration.resolved",
+				"order": 10
+			},
+			{
+				"event": "restoration.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 12
+			}
+		],
+		"serviceStarted": true
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-lighting.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-lighting.json
@@ -1,0 +1,72 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mapping-control",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"availableFamilies": ["cover", "lighting", "switch"],
+		"baselineRead": true,
+		"commandReadBackMatched": true,
+		"family": "lighting",
+		"mappingName": "light-power",
+		"panelCommandAccepted": true,
+		"restorationAccepted": true,
+		"restorationReadBackMatched": true,
+		"restored": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.verified",
+				"order": 3
+			},
+			{
+				"event": "target.bound",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "panel.command.requested",
+				"order": 6
+			},
+			{
+				"event": "panel.command.resolved",
+				"order": 7
+			},
+			{
+				"event": "command.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restoration.requested",
+				"order": 9
+			},
+			{
+				"event": "restoration.resolved",
+				"order": 10
+			},
+			{
+				"event": "restoration.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 12
+			}
+		],
+		"serviceStarted": true
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-switch.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-switch.json
@@ -1,0 +1,72 @@
+{
+	"metadata": {
+		"probe": "homey-shs-mapping-control",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"availableFamilies": ["cover", "lighting", "switch"],
+		"baselineRead": true,
+		"commandReadBackMatched": true,
+		"family": "switch",
+		"mappingName": "outlet-power",
+		"panelCommandAccepted": true,
+		"restorationAccepted": true,
+		"restorationReadBackMatched": true,
+		"restored": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.verified",
+				"order": 3
+			},
+			{
+				"event": "target.bound",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "panel.command.requested",
+				"order": 6
+			},
+			{
+				"event": "panel.command.resolved",
+				"order": 7
+			},
+			{
+				"event": "command.readback.verified",
+				"order": 8
+			},
+			{
+				"event": "restoration.requested",
+				"order": 9
+			},
+			{
+				"event": "restoration.resolved",
+				"order": 10
+			},
+			{
+				"event": "restoration.readback.verified",
+				"order": 11
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 12
+			}
+		],
+		"serviceStarted": true
+	}
+}

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -71,6 +71,7 @@ const PUBLIC_SYNTHETIC_PERSONAL_VALUES = new Set([
 	'Synthetic mode B',
 	'Synthetic mode C',
 ]);
+const PUBLIC_EVIDENCE_PERSONAL_VALUES = new Set(['light-power', 'outlet-power', 'window-covering-position']);
 const PUBLIC_SYNTHETIC_IDENTIFIER_VALUES = new Set([
 	'123e4567-e89b-12d3-a456-426614174000',
 	'550e8400-e29b-41d4-a716-446655440000',
@@ -5860,7 +5861,8 @@ const isSafePersonalValue = (value: unknown): boolean =>
 	value === false ||
 	value === '[~2~]' ||
 	isHomeyGeneratedPseudonym(value) ||
-	(typeof value === 'string' && PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value));
+	(typeof value === 'string' &&
+		(PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value) || PUBLIC_EVIDENCE_PERSONAL_VALUES.has(value)));
 
 const containsStructuredAddress = (value: unknown): boolean => {
 	if (Array.isArray(value)) {
@@ -6596,6 +6598,12 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a structured address value',
 		);
 		expect(() => assertFixtureTextSafe('unsafe fixture', '{"name":"Alice Bedroom"}', '.json')).toThrow(
+			'unsafe fixture contains a structured personal value',
+		);
+		expect(() =>
+			assertFixtureTextSafe('safe fixture', '{"mappingName":"window-covering-position"}', '.json'),
+		).not.toThrow();
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"mappingName":"private-cover"}', '.json')).toThrow(
 			'unsafe fixture contains a structured personal value',
 		);
 		expect(() =>

--- a/apps/backend/test/homey-security-artifact.homey-spike.ts
+++ b/apps/backend/test/homey-security-artifact.homey-spike.ts
@@ -5861,8 +5861,7 @@ const isSafePersonalValue = (value: unknown): boolean =>
 	value === false ||
 	value === '[~2~]' ||
 	isHomeyGeneratedPseudonym(value) ||
-	(typeof value === 'string' &&
-		(PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value) || PUBLIC_EVIDENCE_PERSONAL_VALUES.has(value)));
+	(typeof value === 'string' && PUBLIC_SYNTHETIC_PERSONAL_VALUES.has(value));
 
 const containsStructuredAddress = (value: unknown): boolean => {
 	if (Array.isArray(value)) {
@@ -5878,9 +5877,9 @@ const containsStructuredAddress = (value: unknown): boolean => {
 	});
 };
 
-const containsStructuredPersonalValue = (value: unknown): boolean => {
+const containsStructuredPersonalValue = (value: unknown, path: readonly string[] = []): boolean => {
 	if (Array.isArray(value)) {
-		return value.some((entry) => containsStructuredPersonalValue(entry));
+		return value.some((entry, index) => containsStructuredPersonalValue(entry, [...path, index.toString()]));
 	}
 
 	if (value === null || typeof value !== 'object') {
@@ -5888,7 +5887,17 @@ const containsStructuredPersonalValue = (value: unknown): boolean => {
 	}
 
 	return Object.entries(value as JsonRecord).some(([key, child]) => {
-		return (isHomeyPersonalKey(key) && !isSafePersonalValue(child)) || containsStructuredPersonalValue(child);
+		const publicEvidenceMappingName =
+			path.length === 1 &&
+			path[0] === 'observation' &&
+			key === 'mappingName' &&
+			typeof child === 'string' &&
+			PUBLIC_EVIDENCE_PERSONAL_VALUES.has(child);
+
+		return (
+			(isHomeyPersonalKey(key) && !isSafePersonalValue(child) && !publicEvidenceMappingName) ||
+			containsStructuredPersonalValue(child, [...path, key])
+		);
 	});
 };
 
@@ -6601,11 +6610,14 @@ describe('Homey security artifact gate', () => {
 			'unsafe fixture contains a structured personal value',
 		);
 		expect(() =>
-			assertFixtureTextSafe('safe fixture', '{"mappingName":"window-covering-position"}', '.json'),
+			assertFixtureTextSafe('safe fixture', '{"observation":{"mappingName":"window-covering-position"}}', '.json'),
 		).not.toThrow();
-		expect(() => assertFixtureTextSafe('unsafe fixture', '{"mappingName":"private-cover"}', '.json')).toThrow(
+		expect(() => assertFixtureTextSafe('unsafe fixture', '{"name":"light-power"}', '.json')).toThrow(
 			'unsafe fixture contains a structured personal value',
 		);
+		expect(() =>
+			assertFixtureTextSafe('unsafe fixture', '{"observation":{"mappingName":"private-cover"}}', '.json'),
+		).toThrow('unsafe fixture contains a structured personal value');
 		expect(() =>
 			assertFixtureTextSafe('unsafe fixture', '{"deviceId":"8d4d7584-1111-4111-8111-0123456789ab"}', '.json'),
 		).toThrow('unsafe fixture contains a structured identifier value');

--- a/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
+++ b/apps/backend/test/homey-shs-mapping-control.homey-spike.ts
@@ -176,11 +176,11 @@ describe('Homey SHS mapping-control probe', () => {
 		).toThrow('must be unset');
 	});
 
-	it('accepts authoritative read-back only while the device and capability remain available', () => {
+	it('rejects authoritative read-back from unavailable devices or explicitly unavailable capabilities', () => {
 		expect(homeyMappingControlReadBackMatches(readBackDevice(), 'onoff', true)).toBe(true);
 		expect(homeyMappingControlReadBackMatches(readBackDevice(false), 'onoff', true)).toBe(false);
 		expect(homeyMappingControlReadBackMatches(readBackDevice(true, false), 'onoff', true)).toBe(false);
-		expect(homeyMappingControlReadBackMatches(readBackDevice(true, null), 'onoff', true)).toBe(false);
+		expect(homeyMappingControlReadBackMatches(readBackDevice(true, null), 'onoff', true)).toBe(true);
 		expect(homeyMappingControlReadBackMatches(readBackDevice(), 'onoff', false)).toBe(false);
 	});
 
@@ -316,6 +316,48 @@ describe('Homey SHS mapping-control probe', () => {
 			),
 		).toThrow();
 	});
+
+	it.each([
+		{
+			family: 'cover',
+			filename: '2026-08-28-shs-13.4.1-mapping-control-cover.json',
+			mappingName: 'window-covering-position',
+		},
+		{
+			family: 'lighting',
+			filename: '2026-08-28-shs-13.4.1-mapping-control-lighting.json',
+			mappingName: 'light-power',
+		},
+		{
+			family: 'switch',
+			filename: '2026-08-28-shs-13.4.1-mapping-control-switch.json',
+			mappingName: 'outlet-power',
+		},
+	] as const)(
+		'preserves the sanitized live SHS $family mapping-control evidence',
+		async ({ family, filename, mappingName }) => {
+			const evidencePath = join(__dirname, '../src/plugins/devices-homey/__fixtures__/evidence', filename);
+			const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+			const evidenceConfig = config({ family, mappingName });
+
+			assertHomeyShsMappingControlReportSafe(evidence, evidenceConfig);
+			expect(evidence).toMatchObject({
+				observation: {
+					availableFamilies: ['cover', 'lighting', 'switch'],
+					baselineRead: true,
+					commandReadBackMatched: true,
+					family,
+					mappingName,
+					panelCommandAccepted: true,
+					restorationAccepted: true,
+					restorationReadBackMatched: true,
+					restored: true,
+				},
+				session: { cleanupCompleted: true, serviceStarted: true },
+			});
+			expect(evidence.session.events).toHaveLength(12);
+		},
+	);
 
 	it('writes the report beneath a private non-overwriting directory', async () => {
 		const { report } = await successfulProbe();

--- a/apps/backend/test/support/homey-shs-mapping-control-probe.ts
+++ b/apps/backend/test/support/homey-shs-mapping-control-probe.ts
@@ -181,7 +181,7 @@ export const homeyMappingControlReadBackMatches = (
 	const capability = device.capabilities.find((candidate) => candidate.id === capabilityId);
 
 	return (
-		capability !== undefined && capability.available === true && homeyCapabilityValuesEqual(capability.value, expected)
+		capability !== undefined && capability.available !== false && homeyCapabilityValuesEqual(capability.value, expected)
 	);
 };
 

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -26,6 +26,7 @@ file. Live results use synthetic aliases and sanitized captures only.
 | Capability metadata and suffixed IDs                  | Inventory, explicit read, and write read-back passed     | None                                                             |
 | Socket.IO events and reconnect                        | Capability event, restart, and network recovery passed   | Capture physical/Homey-originated availability-event continuity  |
 | Allowlisted capability write                          | Passed on SHS `13.4.1`                                   | None                                                             |
+| Smart Panel mapped-family control                     | Cover, lighting, and switch passed on SHS `13.4.1`       | None; no writable lock family was present in live inventory      |
 | Error and permission-scope classification             | Five failure scenarios and three omitted scopes passed   | None                                                             |
 | API-key revocation and replacement                    | Passed on SHS `13.4.1`                                   | None                                                             |
 | Disposable-device lifecycle                           | Passed on SHS `13.4.1`                                   | None                                                             |
@@ -38,21 +39,21 @@ file. Live results use synthetic aliases and sanitized captures only.
 
 Complete this table after the live run. Values committed here must remain non-sensitive.
 
-| Field                                    | Recorded value                                    |
-| ---------------------------------------- | ------------------------------------------------- |
-| Capture date                             | `2026-08-13`, `2026-08-26`, `2026-08-27`          |
-| Realtime SDK probe date                  | `2026-08-14`, `2026-08-26`                        |
-| mDNS observation date                    | `2026-08-14`, `2026-08-26`                        |
-| SHS version                              | `13.4.0`, `13.4.1`                                |
-| Container image tag and immutable digest | Pending                                           |
-| Host operating system/architecture       | TrueNAS; version and architecture pending         |
-| Topology                                 | Same LAN, separate host                           |
-| Smart Panel to SHS network path          | Direct private-LAN connection                     |
-| HTTP port `4859`                         | Confirmed for reads and the SDK Socket.IO session |
-| HTTPS port `4860`                        | Pending                                           |
-| TLS certificate behavior                 | Pending                                           |
-| Disposable capability alias              | Pending synthetic alias                           |
-| Disposable lifecycle-device alias        | `fbsp-lifecycle-disposable-device`                |
+| Field                                    | Recorded value                                         |
+| ---------------------------------------- | ------------------------------------------------------ |
+| Capture date                             | `2026-08-13`, `2026-08-26`, `2026-08-27`, `2026-08-28` |
+| Realtime SDK probe date                  | `2026-08-14`, `2026-08-26`                             |
+| mDNS observation date                    | `2026-08-14`, `2026-08-26`                             |
+| SHS version                              | `13.4.0`, `13.4.1`                                     |
+| Container image tag and immutable digest | Pending                                                |
+| Host operating system/architecture       | TrueNAS; version and architecture pending              |
+| Topology                                 | Same LAN, separate host                                |
+| Smart Panel to SHS network path          | Direct private-LAN connection                          |
+| HTTP port `4859`                         | Confirmed for reads and the SDK Socket.IO session      |
+| HTTPS port `4860`                        | Pending                                                |
+| TLS certificate behavior                 | Pending                                                |
+| Disposable capability alias              | Pending synthetic alias                                |
+| Disposable lifecycle-device alias        | `fbsp-lifecycle-disposable-device`                     |
 
 On 2026-08-26, the TrueNAS host was reachable but SHS stopped before opening its API ports because its required Avahi
 daemon could not start. The deployment recovered after applying Homey's documented TrueNAS settings: disable the host
@@ -529,6 +530,20 @@ unless the requested command, fresh read-back, exact restoration, restoration re
 The report contains no endpoint, credential, Homey identity, device or capability identifier, capability value,
 inventory content/count, event payload, response body, or raw error.
 
+When a device exposes repeated instances of the requested capability base, choose the exact unsuffixed capability when
+present; otherwise choose the lexicographically first full suffixed ID. This mirrors the production mapping loader's
+deterministic primary-instance rule. SHS may omit independent capability availability while still reporting the whole
+device as available. The normalized `null` means that no independent signal was exposed: the probe requires the fresh
+device to remain available, rejects an explicitly unavailable capability, and accepts an omitted capability-level flag.
+
+On 2026-08-28, the guarded probe passed once for every reversible writable family reported by the live SHS `13.4.1`
+inventory: lighting through `light-power`, switch through `outlet-power`, and cover through
+`window-covering-position`. Every run used the production mapping, platform, service, and connector path; verified the
+requested value with a fresh authoritative read; restored the exact baseline through the same path; verified the
+restoration; and stopped cleanly. The live inventory reported no eligible lock family, so synthetic lock contract tests
+remain the available lock coverage and are not presented as live control evidence. The three exact-schema reports are
+committed as `__fixtures__/evidence/2026-08-28-shs-13.4.1-mapping-control-{lighting,switch,cover}.json`.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It
@@ -874,6 +889,7 @@ Fill this matrix using synthetic aliases only.
 | Capability events                         | Pass                                | The allowlisted write produced its matching capability update inside the guarded observation window                                                  |
 | Availability events                       | Absent for synthetic test driver    | Unavailable/restored read-backs passed after full ten-second event windows; physical/Homey-originated evidence remains pending                       |
 | Allowlisted write, event, and read-back   | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
+| Smart Panel mapped-family control         | Pass                                | Cover, lighting, and switch passed through production mappings and control; no eligible live lock family was present                                 |
 | Network interruption and restoration      | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                 | Pass                                | A 23-event write/restart/restore run proved events and read-backs across recovery; the earlier 15-event run independently proved transport recovery  |
 | API-key revocation and replacement        | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -625,7 +625,7 @@ representative lifecycle failure paths.
 - [x] API key revoked, replaced, and insufficiently scoped.
 - [x] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [x] Physical/Homey/flow-originated state changes.
-- [ ] Allowlisted Smart Panel control for every writable MVP mapping family available.
+- [x] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.
 - [ ] Plugin disable/enable and backend shutdown with no leaked connections/timers.
 
@@ -655,13 +655,14 @@ The three reviewed exact-schema reports retain only fixed scenario/event labels,
 and completion booleans; they contain no endpoint, credential, Homey identity, device or capability identifier,
 capability value, inventory content, event payload, Flow identity, response body, or raw error.
 
-A separately gated mapping-control probe is prepared for the next unchecked live-matrix item. It starts the production
-`HomeyService`, loads the current mapping catalog, and routes one exact allowlisted target through
-`HomeyDevicePlatform`. Only reversible bidirectional lighting, switch, cover, and lock mappings are eligible. Each run
-requires the transformed Smart Panel command and fresh authoritative read-back, followed by restoration through the
-same platform path, a final read-back, and complete service shutdown. It records the fixed set of eligible families
-detected in live inventory but no counts, identities, capability values, inventory content, payloads, or raw errors.
-The matrix item remains unchecked until reviewed live evidence covers every family reported as available.
+The separately gated mapping-control probe passed on 2026-08-28 against SHS `13.4.1` for every reversible writable
+family reported by live inventory: lighting through `light-power`, switch through `outlet-power`, and cover through
+`window-covering-position`. Each run started the production `HomeyService`, loaded the current mapping catalog, routed
+the exact allowlisted target through `HomeyDevicePlatform`, verified the transformed command with a fresh authoritative
+read, restored the exact baseline through the same path, verified restoration, and stopped cleanly. No eligible lock
+family was present, so the synthetic published-protocol lock fixture remains contract coverage rather than live control
+evidence. The three reviewed reports contain only fixed family/mapping/event labels, booleans, ordering numbers, and the
+public SDK version.
 
 The 2026-08-26 SHS `13.4.1` restart probe closed the transport/session recovery slice: it observed disconnect,
 reconnect, manager resubscription, a fresh inventory read, and complete cleanup. This does not close the event-flow


### PR DESCRIPTION
## Summary

- promote sanitized SHS 13.4.1 reports for every reversible writable family present in live inventory: cover, lighting, and switch
- treat omitted per-capability availability as no independent signal while still rejecting unavailable devices and explicitly unavailable capabilities
- close the mapping-family live-matrix item and document deterministic primary capability selection
- extend fixture evidence and privacy regression coverage without retaining targets, values, identities, or payloads

## Verification

- pnpm run homey:security-gate
- focused mapping-control suite: 23 tests passed
- compatibility/security suites: 15 suites, 214 tests passed
- Homey/config suites: 39 suites, 484 tests passed
- backend type-check and focused lint passed