### PR TITLE
test(cross): record Homey plugin lifecycle evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -122,5 +122,10 @@ acceptance, fresh read-back, exact baseline restoration through the same path, f
 shutdown. The inventory exposed no eligible lock family. The reports contain no endpoint, credential, Homey identity,
 device or capability identifier, capability value, inventory content or count, event payload, response body, or raw
 error.
+The 2026-08-28 plugin-lifecycle report records production manager bootstrap, disable, re-enable with a fresh connector,
+and backend shutdown against live SHS `13.4.1`. Both disable and shutdown remained fully disconnected and quiescent for
+35 seconds, longer than the minimum reconciliation interval. The report contains no endpoint, credential, Homey
+identity, device or zone identifier, inventory data or count, connector count, event payload, response body, or raw
+error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-plugin-lifecycle.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-plugin-lifecycle.json
@@ -1,0 +1,69 @@
+{
+	"metadata": {
+		"probe": "homey-shs-plugin-lifecycle",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"backendShutdownDisconnected": true,
+		"backendShutdownQuiescent": true,
+		"disableDisconnected": true,
+		"disableQuiescent": true,
+		"freshConnectorAfterEnable": true,
+		"initialStartupConnected": true,
+		"reenableConnected": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "manager.bootstrap.requested",
+				"order": 1
+			},
+			{
+				"event": "manager.bootstrap.resolved",
+				"order": 2
+			},
+			{
+				"event": "plugin.initial.connected.verified",
+				"order": 3
+			},
+			{
+				"event": "plugin.disable.requested",
+				"order": 4
+			},
+			{
+				"event": "plugin.disable.resolved",
+				"order": 5
+			},
+			{
+				"event": "plugin.disable.quiescence.verified",
+				"order": 6
+			},
+			{
+				"event": "plugin.enable.requested",
+				"order": 7
+			},
+			{
+				"event": "plugin.enable.resolved",
+				"order": 8
+			},
+			{
+				"event": "plugin.reenabled.connected.verified",
+				"order": 9
+			},
+			{
+				"event": "backend.shutdown.requested",
+				"order": 10
+			},
+			{
+				"event": "backend.shutdown.resolved",
+				"order": 11
+			},
+			{
+				"event": "backend.shutdown.quiescence.verified",
+				"order": 12
+			}
+		]
+	}
+}

--- a/apps/backend/test/homey-shs-plugin-lifecycle.homey-spike.ts
+++ b/apps/backend/test/homey-shs-plugin-lifecycle.homey-spike.ts
@@ -402,6 +402,29 @@ describe('Homey SHS plugin-lifecycle probe', () => {
 		).toThrow();
 	});
 
+	it('preserves the sanitized live SHS plugin-lifecycle evidence', async () => {
+		const evidencePath = join(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-plugin-lifecycle.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+
+		assertHomeyShsPluginLifecycleReportSafe(evidence, config());
+		expect(evidence).toMatchObject({
+			observation: {
+				backendShutdownDisconnected: true,
+				backendShutdownQuiescent: true,
+				disableDisconnected: true,
+				disableQuiescent: true,
+				freshConnectorAfterEnable: true,
+				initialStartupConnected: true,
+				reenableConnected: true,
+			},
+			session: { cleanupCompleted: true },
+		});
+		expect(evidence.session.events).toHaveLength(12);
+	});
+
 	it('writes the report beneath a private non-overwriting directory', async () => {
 		const { report } = await successfulProbe();
 		const parent = await mkdtemp(join(tmpdir(), 'homey-plugin-lifecycle-'));

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -616,6 +616,13 @@ The two observation windows make the run take at least 70 seconds. A success rep
 and completion booleans; it excludes the endpoint, credential, Homey identity, inventory data/count, connector counts,
 event payload, response body, and raw error.
 
+On 2026-08-28, the read-only probe passed against live SHS `13.4.1`. The production manager bootstrapped an enabled
+plugin, disabled it through the configuration-update path, re-enabled it with a fresh connector, and completed its Nest
+module-destroy hook. Both post-disable and post-shutdown snapshots remained stopped, disconnected, unsubscribed, free
+of scheduled SDK/service work, and unchanged for 35 seconds. The reviewed report is committed as
+`__fixtures__/evidence/2026-08-28-shs-13.4.1-plugin-lifecycle.json`; it contains only fixed event labels, ordering
+numbers, public SDK version, and completion booleans.
+
 ## Operator-controlled restart recovery probe
 
 The recovery probe measures the SDK's behavior across a real SHS restart without performing the restart itself. It
@@ -963,7 +970,7 @@ Fill this matrix using synthetic aliases only.
 | Allowlisted write, event, and read-back    | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
 | Smart Panel mapped-family control          | Pass                                | Cover, lighting, and switch passed through production mappings and control; no eligible live lock family was present                                 |
 | Burst updates and concurrent commands      | Pending                             |                                                                                                                                                      |
-| Plugin disable/enable and backend shutdown | Pending                             |                                                                                                                                                      |
+| Plugin disable/enable and backend shutdown | Pass                                | Managed disable, fresh-connector re-enable, and backend shutdown each completed; both 35-second post-stop windows remained fully quiescent           |
 | Network interruption and restoration       | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                  | Pass                                | A 23-event write/restart/restore run proved events and read-backs across recovery; the earlier 15-event run independently proved transport recovery  |
 | API-key revocation and replacement         | Pass                                | Primary and replacement keys passed preflight; revocation returned `401`, and the replacement key remained valid                                     |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -627,7 +627,7 @@ representative lifecycle failure paths.
 - [x] Physical/Homey/flow-originated state changes.
 - [x] Allowlisted Smart Panel control for every writable MVP mapping family available.
 - [ ] Burst updates and concurrent commands.
-- [ ] Plugin disable/enable and backend shutdown with no leaked connections/timers.
+- [x] Plugin disable/enable and backend shutdown with no leaked connections/timers.
 
 A separately gated burst-command probe now prepares the remaining concurrency run. It binds one exact reversible
 writable mapping through the production service and platform path, submits `target → baseline → target` concurrently,
@@ -635,11 +635,13 @@ requires all three matching realtime capability events in order plus an authorit
 exact baseline before shutdown. Its exact-schema report contains only fixed event labels and completion booleans. The
 matrix item remains open until this guarded probe passes against live SHS and the sanitized report is reviewed.
 
-A separately gated, read-only plugin-lifecycle probe now prepares the final managed-shutdown run. It uses the production
-`PluginServiceManagerService` to bootstrap Homey, disable it through the configuration event path, enable it with a fresh
-connector, and invoke the manager's Nest module-destroy hook. Instrumented connector activity must remain unchanged for
-longer than the minimum reconciliation interval after both disable and shutdown, with no active connection or
-subscription. The matrix item remains open until live SHS evidence is reviewed.
+The separately gated, read-only plugin-lifecycle probe passed on 2026-08-28 against live SHS `13.4.1`. The production
+`PluginServiceManagerService` bootstrapped Homey, disabled it through the configuration event path, re-enabled it with a
+fresh connector, and invoked the manager's Nest module-destroy hook. After both disable and shutdown, the complete
+runtime snapshot remained stopped with no active connector, subscription, service timer, SDK socket/listener,
+reconnect, refresh, or manager work and no SDK activity revision change for 35 seconds, longer than the minimum
+reconciliation interval. The reviewed exact-schema report contains only fixed event labels, ordering numbers, public
+SDK version, and completion booleans.
 
 A guarded startup probe now exercises a newly constructed production `HomeyService`, the local connector factory, and
 the pinned SDK transport while replacing persistence with a no-op synchronizer. Its online scenario requires healthy

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -97,7 +97,7 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] Connection testing reuses the stored key only for an explicit fully saved configuration request; every candidate/overridden URL requires a newly supplied key and can never fall back to the stored secret.
 - [ ] Secrets are absent from logs, exceptions, telemetry, OpenAPI examples, tests, and fixtures.
 - [ ] URLs, schemes, timeouts, intervals, and permission errors are validated and sanitized.
-- [ ] Disabling the plugin closes subscriptions, stops timers, and disconnects the connector cleanly.
+- [x] Disabling the plugin closes subscriptions, stops timers, and disconnects the connector cleanly.
 
 ### Backend local provider
 


### PR DESCRIPTION
## Summary

- record the sanitized SHS 13.4.1 managed plugin lifecycle report
- verify the committed report with the probe's exact-schema privacy assertions
- close the disable/enable and backend-shutdown live matrix item in the compatibility record and implementation plan

## Live evidence

The production plugin manager bootstrapped Homey, disabled it through the configuration-update path, re-enabled it with a fresh connector, and completed backend shutdown. Both post-stop windows remained disconnected and quiescent for 35 seconds, beyond the minimum reconciliation interval.

The committed report contains only fixed event labels, ordering numbers, public SDK version, and completion booleans.

## Verification

- `pnpm exec jest --config test/jest-homey-spike.json --runInBand test/homey-shs-plugin-lifecycle.homey-spike.ts`
- `pnpm exec eslint test/homey-shs-plugin-lifecycle.homey-spike.ts`
- `pnpm run homey:security-gate` (17 suites / 242 tests plus 39 suites / 484 tests)
- `git diff --check`